### PR TITLE
1st stab at docker demo, inside Vagrant, of course

### DIFF
--- a/demo/docker-cluster/Dockerfile
+++ b/demo/docker-cluster/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y unzip wget
+
+RUN wget https://dl.bintray.com/mitchellh/consul/0.1.0_linux_amd64.zip -O /tmp/consul.zip
+RUN unzip /tmp/consul.zip && mv /tmp/consul /usr/bin
+RUN sudo chmod +x /usr/bin/consul
+
+EXPOSE 8300 8301 8302 8400 8500 8600

--- a/demo/docker-cluster/README.md
+++ b/demo/docker-cluster/README.md
@@ -1,0 +1,22 @@
+# Vagrant + Docker Consul Demo
+
+This demo provides a simple Vagrantfile that launches multiple Docker containers inside a single VM. All containers are running a standard Ubuntu 12.04 distribution, and Consul is installed and configured.
+
+To get started, you can start the cluster by just doing:
+
+    $ vagrant up
+
+Once it is finished, you should be able to see the following:
+
+    $ vagrant status
+    Current machine states:
+    default                   running (vmware_fusion)
+
+At this point the VM is running and you can check the running containers
+
+    $ vagrant ssh
+    $ TODO: add examples here
+
+To learn more about starting Consul, joining nodes and interacting with the agent,
+checkout the [getting started guide](http://www.consul.io/intro/getting-started/install.html).
+

--- a/demo/docker-cluster/Vagrantfile
+++ b/demo/docker-cluster/Vagrantfile
@@ -1,0 +1,21 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise64"
+
+  config.vm.provision "docker" do |d|
+    d.build_image "./", args: "-t user/consul"
+
+    # d.run "n1", image: "user/consul"
+    # d.run "n2", image: "user/consul"
+    # d.run "n3", image: "user/consul"
+    # d.run "n4", image: "user/consul"
+    # d.run "n5", image: "user/consul"
+  end
+
+  config.vm.network "private_network", ip: "172.20.20.10"
+end


### PR DESCRIPTION
Adding a Docker Consul cluster inside of Vagrant. The `README` will also inform users they can bypass Vagrant if they have Docker running on their host.

This is a WIP so please don't merge or analyze too critically yet. This work will hopefully be used in upcoming Jepsen tests!

/cc @armon 
