### PR TITLE
Replace YmFy by bar

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -152,7 +152,7 @@
 									<p>       "ModifyIndex": 200,</p>
 									<p>       "Key": "foo",</p>
 									<p>       "Flags": 0,</p>
-									<p>       "Value": <span class="txt-p">"YmFy"</span></p>
+									<p>       "Value": <span class="txt-p">"bar"</span></p>
 									<p>    }</p>
 									<p>]</p>
 									<p class="command"><span class="txt-r">admin@hashicorp</span>: <span class="cursor">&nbsp;</span></p>


### PR DESCRIPTION
Should the value be `bar` instead of `YmFy`?
