### PR TITLE
Ensure we write json header before writing bytes

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -124,8 +124,8 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			if err = enc.Encode(obj); err != nil {
 				goto HAS_ERR
 			}
-			resp.Write(buf.Bytes())
 			resp.Header().Set("Content-Type", "application/json")
+			resp.Write(buf.Bytes())
 		}
 	}
 	return f


### PR DESCRIPTION
In net/http once we've issued a Write() the response is sent
over the wire including the header! The tests didn't catch
this because I used a net/http/httptest.RequestRecorder
which doesn't follow those semantics.
