### PR TITLE
Remove SRV from DNS query tag example

### DIFF
--- a/website/source/intro/getting-started/services.html.markdown
+++ b/website/source/intro/getting-started/services.html.markdown
@@ -109,7 +109,7 @@ the example below, we ask Consul for all web services with the "rails"
 tag. We get a response since we registered our service with that tag.
 
 ```
-$ dig @127.0.0.1 -p 8600 rails.web.service.consul SRV
+$ dig @127.0.0.1 -p 8600 rails.web.service.consul
 ...
 
 ;; QUESTION SECTION:


### PR DESCRIPTION
The results show the A record, not the SRV record
