### PR TITLE
Close the HTTP body after use

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -143,6 +143,8 @@ func (s *HTTPServer) Index(resp http.ResponseWriter, req *http.Request) {
 
 // decodeBody is used to decode a JSON request body
 func decodeBody(req *http.Request, out interface{}, cb func(interface{}) error) error {
+	defer req.Body.Close()
+
 	var raw interface{}
 	dec := json.NewDecoder(req.Body)
 	if err := dec.Decode(&raw); err != nil {


### PR DESCRIPTION
According to my understanding of the go net/http spec the application is responsible for closing the req.Body after use. I attempted to `git grep` but was unable to find any instance of this being done already.
