### PR TITLE
Case insensitive durations

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -118,10 +118,17 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 		if !ok {
 			return nil
 		}
-		check, ok := rawMap["check"]
-		if !ok {
+
+		var check interface{}
+		for k, v := range rawMap {
+			if strings.ToLower(k) == "check" {
+				check = v
+			}
+		}
+		if check == nil {
 			return nil
 		}
+
 		return FixupCheckType(check)
 	}
 	if err := decodeBody(req, &args, decodeCB); err != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -265,23 +265,38 @@ func FixupCheckType(raw interface{}) error {
 	if !ok {
 		return nil
 	}
-	if ttl, ok := rawMap["ttl"]; ok {
+
+	var ttlKey string
+	for k, _ := range rawMap {
+		if strings.ToLower(k) == "ttl" {
+			ttlKey = k
+		}
+	}
+	var intervalKey string
+	for k, _ := range rawMap {
+		if strings.ToLower(k) == "interval" {
+			intervalKey = k
+		}
+	}
+
+	if ttl, ok := rawMap[ttlKey]; ok {
 		ttlS, ok := ttl.(string)
 		if ok {
 			if dur, err := time.ParseDuration(ttlS); err != nil {
 				return err
 			} else {
-				rawMap["ttl"] = dur
+				rawMap[ttlKey] = dur
 			}
 		}
 	}
-	if interval, ok := rawMap["interval"]; ok {
+
+	if interval, ok := rawMap[intervalKey]; ok {
 		intervalS, ok := interval.(string)
 		if ok {
 			if dur, err := time.ParseDuration(intervalS); err != nil {
 				return err
 			} else {
-				rawMap["interval"] = dur
+				rawMap[intervalKey] = dur
 			}
 		}
 	}


### PR DESCRIPTION
As it currently stands the example input for '/v1/agent/service/register' on the [Consul Docs](http://www.consul.io/docs/agent/http.html) fails with following errors:

```
Request decode failed: 2 error(s) decoding:

* 'Check.Interval' expected type 'time.Duration', got unconvertible type 'string'
* 'Check.TTL' expected type 'time.Duration', got unconvertible type 'string'
```

I've adjusted the mangling of JSON to do case insensitive searches for the keys that need to be adjusted.

On a side note rather than mucking around with interface{} would it be worth defining a wrapper around time.Duration with a custom Unmarshaler?

Something along the lines of:

```
type JSONDuration struct {
    time.Duration
}

func (j *JSONDuration) UnmarshalJSON([]byte) error {
    dur, err := time.ParseDuration(intervalS)
    if err != nil {
        return err
    }
    j.Duration = dur
    return nil
}
```

Granted it does require a bit more work when you want to access the Duration.
