### PR TITLE
Return exit code 2 if member filter doesn't match any node

### DIFF
--- a/command/members.go
+++ b/command/members.go
@@ -102,6 +102,11 @@ func (c *MembersCommand) Run(args []string) int {
 		result = append(result, line)
 	}
 
+	// No matching members
+	if len(result) == 0 {
+		return 2
+	}
+
 	// Generate the columnized version
 	output := columnize.SimpleFormat(result)
 	c.Ui.Output(string(output))

--- a/command/members_test.go
+++ b/command/members_test.go
@@ -80,12 +80,16 @@ func TestMembersCommandRun_statusFilter_failed(t *testing.T) {
 	}
 
 	code := c.Run(args)
-	if code != 0 {
+	if code == 1 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
 
 	if strings.Contains(ui.OutputWriter.String(), a1.config.NodeName) {
 		t.Fatalf("bad: %#v", ui.OutputWriter.String())
+	}
+
+	if code != 2 {
+		t.Fatalf("bad: %d", code)
 	}
 }
 
@@ -122,11 +126,15 @@ func TestMembersCommandRun_roleFilter_failed(t *testing.T) {
 	}
 
 	code := c.Run(args)
-	if code != 0 {
+	if code == 1 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
 	}
 
 	if strings.Contains(ui.OutputWriter.String(), a1.config.NodeName) {
 		t.Fatalf("bad: %#v", ui.OutputWriter.String())
+	}
+
+	if code != 2 {
+		t.Fatalf("bad: %d", code)
 	}
 }


### PR DESCRIPTION
Reported in hashicorp/consul#114

This will make `consul members --role=not_found` return exit code 2 instead of 0. It will also remove the linefeed previously printed on no match.

I chose exit code 2 to make it easier to separate from other errors returning 1.
