### PR TITLE
Add cancel button to key edit

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -210,6 +210,7 @@
                   {{ textarea value=model.valueDecoded class="form-control"}}
                 </div>
                 <button {{ action "updateKey"}} {{bind-attr disabled=isLoading }} {{ bind-attr class=":btn isLoading:btn-warning:btn-success" }}>Update</button>
+                <button {{ action "cancelEdit"}} {{bind-attr disabled=isLoading }} {{ bind-attr class=":btn isLoading:btn-warning:btn-default" }}>Cancel</button>
                 <button {{ action "deleteKey"}} {{bind-attr disabled=isLoading }} {{ bind-attr class=":btn :pull-right isLoading:btn-warning:btn-danger" }}>Delete</button>
               </form>
             </div>

--- a/ui/javascripts/app/controllers.js
+++ b/ui/javascripts/app/controllers.js
@@ -143,6 +143,12 @@ App.KvEditController = Ember.Controller.extend({
       })
     },
 
+    cancelEdit: function() {
+      this.set('isLoading', true);
+      this.transitionToRoute('kv.show', this.get("model").get('parentKey'));
+      this.set('isLoading', false);
+    },
+
     deleteKey: function() {
       this.set('isLoading', true);
       var key = this.get("model");


### PR DESCRIPTION
Adds option to cancel key edit and return to parent show view.

![screen shot 2014-05-05 at 01 04 32](https://cloud.githubusercontent.com/assets/190349/2874300/9f90b6de-d3e0-11e3-9bb0-993ac91648bf.png)
