### PR TITLE
Use shell expansion and add format task to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 PACKAGES = $(shell go list ./...)
 
-all: deps
+all: deps format
 	@mkdir -p bin/
 	@bash --norc -i ./scripts/build.sh
 
@@ -10,8 +10,9 @@ cov:
 	open /tmp/coverage.html
 
 deps:
-	go get -d -v ./...
-	echo $(DEPS) | xargs -n1 go get -d
+	@echo "--> Installing build dependencies"
+	@go get -d -v ./...
+	@echo $(DEPS) | xargs -n1 go get -d
 
 test: deps
 	go list ./... | xargs -n1 go test
@@ -20,7 +21,8 @@ integ:
 	go list ./... | INTEG_TESTS=yes xargs -n1 go test
 
 format:
-	go fmt $(PACKAGES)
+	@echo "--> Running go fmt"
+	@go fmt $(PACKAGES)
 
 web:
 	./scripts/website_run.sh


### PR DESCRIPTION
The README mentions a `make format` task that runs `go fmt` on the entire project, but it doesn't actually exist. This PR adds that task. It also fixes a bug in which the dependencies were not actually being expanded for the `go get` command because no shell command was run in resolution.

Additionally, it adds the new `format` task to the build task and silences some of the large, ugly `echo` output.
