### PR TITLE
use empty slice instead of nil slice when no tags exist for /v1/catalog/services

### DIFF
--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -449,6 +449,11 @@ func TestCatalogListServices(t *testing.T) {
 	if len(out.Services) != 2 {
 		t.Fatalf("bad: %v", out)
 	}
+	for _, s := range out.Services {
+		if s == nil {
+			t.Fatalf("bad: %v", s)
+		}
+	}
 	// Consul service should auto-register
 	if _, ok := out.Services["consul"]; !ok {
 		t.Fatalf("bad: %v", out)

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -480,7 +480,7 @@ func (s *StateStore) Services() (uint64, map[string][]string) {
 		srv := r.(*structs.ServiceNode)
 		tags, ok := services[srv.ServiceName]
 		if !ok {
-			services[srv.ServiceName] = tags
+			services[srv.ServiceName] = make([]string, 0)
 		}
 
 		for _, tag := range srv.ServiceTags {


### PR DESCRIPTION
the docs for [/v1/catalog/services](http://www.consul.io/docs/agent/http.html#toc_22) show that the result should be like:

``` json
{
    "consul": [],
    "redis": [],
    "postgresql": [
        "master",
        "slave"
    ]
}
```

but it was actually like:

``` json
{
    "consul": null,
    "redis": null,
    "postgresql": [
        "master",
        "slave"
    ]
}
```

however, other endpoints (/v1/catalog/service/&lt;service&gt; and /v1/catalog/node/&lt;node&gt;) are documented to and actually return nulls for empty tags.  for consistency, maybe it makes more sense to update the docs for /v1/catalog/services to reflect the current behavior?
