### PR TITLE
Allow multiple PEM-encoded certificates in the ca_file.

### DIFF
--- a/consul/config_test.go
+++ b/consul/config_test.go
@@ -2,17 +2,19 @@ package consul
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"testing"
 )
 
-func TestConfig_CACertificate_None(t *testing.T) {
+func TestConfig_AppendCA_None(t *testing.T) {
 	conf := &Config{}
-	cert, err := conf.CACertificate()
+	pool := x509.NewCertPool()
+	err := conf.AppendCA(pool)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if cert != nil {
-		t.Fatalf("bad: %v", cert)
+	if len(pool.Subjects()) != 0 {
+		t.Fatalf("bad: %v", pool.Subjects())
 	}
 }
 
@@ -20,11 +22,12 @@ func TestConfig_CACertificate_Valid(t *testing.T) {
 	conf := &Config{
 		CAFile: "../test/ca/root.cer",
 	}
-	cert, err := conf.CACertificate()
+	pool := x509.NewCertPool()
+	err := conf.AppendCA(pool)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if cert == nil {
+	if len(pool.Subjects()) == 0 {
 		t.Fatalf("expected cert")
 	}
 }


### PR DESCRIPTION
fixes #167

This should be what I want. This is pretty common practice: Some examples I found offhand of software that accepts a CA file and decodes multiple PEM-encoded certs:
- `openssl verify`'s `-CAfile` option
- mutt's `certificate_file` option
- curl's `--cacert` option
- puppet's `ssl_server_ca_auth` and `ssl_client_ca_auth` options
