### PR TITLE
Add support for hidden keys

### DIFF
--- a/consul/kvs_endpoint.go
+++ b/consul/kvs_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/consul/structs"
+	"strings"
 	"time"
 )
 
@@ -97,7 +98,7 @@ func pruneHiddenEntries(ents structs.DirEntries) structs.DirEntries {
 
 	idx := 0
 	for _, e := range ents {
-		if e.Key[0] != '.' {
+		if e.Key[0] != '.' && strings.Index(e.Key, "/.") == -1 {
 			newEnts[idx] = e
 			idx++
 		}
@@ -111,7 +112,7 @@ func pruneHiddenKeys(keys []string) []string {
 
 	idx := 0
 	for _, e := range keys {
-		if e[0] != '.' {
+		if e[0] != '.' && strings.Index(e, "/.") == -1 {
 			newKeys[idx] = e
 			idx++
 		}


### PR DESCRIPTION
Very simply, this makes it so any key that begins with a . is not returned when a request for a list of keys is done. This makes these entries hidden and a client must know the exact key name to access it.

This can be used to implement some simple security semantics (though any secure values stored in hidden values should also be cryptographically authenticated).
