### PR TITLE
fix freebsd build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -26,14 +26,21 @@ if [ "$(go env GOOS)" = "windows" ]; then
     GOPATHSINGLE=${GOPATH%%;*}
 fi
 
+if [ "$(go env GOOS)" = "freebsd" ]; then
+  export CC="clang"
+  export CGO_LDFLAGS="$CGO_LDFLAGS -extld clang" # Workaround for https://code.google.com/p/go/issues/detail?id=6845
+fi
+
 # Install dependencies
 echo "--> Installing dependencies to speed up builds..."
-go get ./...
+go get \
+  -ldflags "${CGO_LDFLAGS}" \
+  ./...
 
 # Build!
 echo "--> Building..."
 go build \
-    -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
     -v \
     -o bin/consul${EXTENSION}
 cp bin/consul${EXTENSION} ${GOPATHSINGLE}/bin


### PR DESCRIPTION
On FreeBSD, clang is the default C compiler (and the only C compiler in the base system since 10.0).
Current Go release requires explicit `CC` variable and `-extld` option to use clang instead of the nonexistent gcc.
[Docker uses nearly the same workaround](https://github.com/dotcloud/docker/blob/v0.11.1/hack/make.sh#L110).

I've also sumbitted [a pull request](https://github.com/armon/gomdb/pull/2) to armon/gomdb that adds an option required for FreeBSD support.
