### PR TITLE
fix make dependency for the format target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test: deps
 integ:
 	go list ./... | INTEG_TESTS=yes xargs -n1 go test
 
-format:
+format: deps
 	@echo "--> Running go fmt"
 	@go fmt $(PACKAGES)
 


### PR DESCRIPTION
While packaging consul for Gentoo Linux I came across a little glitch in the Makefile.

The **format** target needs to depend on the **deps** because when GNU make is called with MAKEOPTS="-jX" where X > 1, the build will fail.

To reproduce, just follow the building procedure and use `make -j3`.

Cheers ;)
