### PR TITLE
Fix typo in TTL check update endpoints

### DIFF
--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -420,7 +420,7 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to "passing",
 and the TTL clock is reset.
 
-The optional "?node=" query parameter can be used to associate output with
+The optional "?note=" query parameter can be used to associate output with
 the status of the check. This should be human readable for operators.
 
 The return code is 200 on success.
@@ -431,7 +431,7 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to "warning",
 and the TTL clock is reset.
 
-The optional "?node=" query parameter can be used to associate output with
+The optional "?note=" query parameter can be used to associate output with
 the status of the check. This should be human readable for operators.
 
 The return code is 200 on success.
@@ -442,7 +442,7 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to "critical",
 and the TTL clock is reset.
 
-The optional "?node=" query parameter can be used to associate output with
+The optional "?note=" query parameter can be used to associate output with
 the status of the check. This should be human readable for operators.
 
 The return code is 200 on success.


### PR DESCRIPTION
The current website says that you can send output with the update of a check using the `?node` parameter. It wasn't working and I checked [the source](https://github.com/hashicorp/consul/blob/387449837498df43b0ce9b89fea52693ec35addc/command/agent/agent_endpoint.go#L110) to find that it was (the more logical noun of) note, dah!

I changed the indication to replace `?node` for `?note`

Consul's amazing, thanks for releasing this!
