### PR TITLE
Semantic change to dns guide

### DIFF
--- a/website/source/docs/guides/dns-cache.html.markdown
+++ b/website/source/docs/guides/dns-cache.html.markdown
@@ -41,7 +41,7 @@ of the leader.
 
 ## TTL Values
 
-TTL values can be set to allow DNS results to be cached upstream
+TTL values can be set to allow DNS results to be cached downstream
 of Consul which can be reduce the number of lookups and to amortize
 the latency of doing a DNS lookup. By default, all TTLs are zero,
 preventing any caching.


### PR DESCRIPTION
I separated this from my textual fixes, because it represents a semantic change. Wouldn't changing the TTL value affect "downstream" DNS servers which had requested the entries from this "upstream" authoritative source? http://en.wikipedia.org/wiki/Upstream_server mentions that the upstream server provides the service to the downstream servers, although, to be fair, it mentions that the term downstream is rarely used, so maybe I'm just being weird. 
