### PR TITLE
Improve clarity around changing the `-client` param

### DIFF
--- a/website/source/docs/agent/basics.html.markdown
+++ b/website/source/docs/agent/basics.html.markdown
@@ -65,9 +65,9 @@ There are several important components that `consul agent` outputs:
   address is used for other `consul` commands. Other Consul commands such
   as `consul members` connect to a running agent and use RPC to query and
   control the agent. By default, this binds only to localhost. If you
-  change this address or port, you'll have to specify an `-rpc-addr` to commands
-  such as `consul members` so they know how to talk to the agent. This is also
-  the address other applications can use over [RPC to control Consul](/docs/agent/rpc.html).
+  change this address or port, you'll have to specify an `-rpc-addr` whenever
+  you run commands such as `consul members` so they know how to talk to the
+  agent. This is also the address other applications can use over [RPC to control Consul](/docs/agent/rpc.html).
 
 * **Cluster Addr**: This is the address and ports used for communication between
   Consul agents in a cluster. Every Consul agent in a cluster does not have to


### PR DESCRIPTION
This is a small change that (IMO) makes more explicit the effect of changing `-client` -- namely, that you'll have to provide `-rpc-addr` to every other consul command you run.
