### PR TITLE
MaxServiceResponses renamed and configurable

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -55,6 +55,10 @@ type DNSConfig struct {
 	// stale read is performed.
 	MaxStale    time.Duration `mapstructure:"-"`
 	MaxStaleRaw string        `mapstructure:"max_stale" json:"-"`
+
+	// MaxUDPResponses is used to restrict the number of
+	// responses if the network is not TCP
+	MaxUDPResponses int `mapstructure:"max_udp_responses" json"-"`
 }
 
 // Config is the configuration that can be set for an Agent.
@@ -240,7 +244,8 @@ func DefaultConfig() *Config {
 			Server:  8300,
 		},
 		DNSConfig: DNSConfig{
-			MaxStale: 5 * time.Second,
+			MaxStale:        5 * time.Second,
+			MaxUDPResponses: 3,
 		},
 		SyslogFacility:      "LOCAL0",
 		Protocol:            consul.ProtocolVersionMax,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -346,6 +346,17 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Max UDP Response
+	input = `{"dns_config": {"max_udp_responses": 3}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.DNSConfig.MaxUDPResponses != 3 {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// CheckUpdateInterval
 	input = `{"check_update_interval": "10m"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -13,10 +13,9 @@ import (
 )
 
 const (
-	testQuery           = "_test.consul."
-	consulDomain        = "consul."
-	maxServiceResponses = 3 // For UDP only
-	maxRecurseRecords   = 3
+	testQuery         = "_test.consul."
+	consulDomain      = "consul."
+	maxRecurseRecords = 3
 )
 
 // DNSServer is used to wrap an Agent and expose various
@@ -454,8 +453,8 @@ RPC:
 	shuffleServiceNodes(out.Nodes)
 
 	// If the network is not TCP, restrict the number of responses
-	if network != "tcp" && len(out.Nodes) > maxServiceResponses {
-		out.Nodes = out.Nodes[:maxServiceResponses]
+	if network != "tcp" && len(out.Nodes) > d.config.MaxUDPResponses {
+		out.Nodes = out.Nodes[:d.config.MaxUDPResponses]
 	}
 
 	// Add various responses depending on the request

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -781,6 +781,10 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
+	config := &DNSConfig{
+		MaxUDPResponses: 5,
+	}
+
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -788,7 +792,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
 	// Register nodes
-	for i := 0; i < 3*maxServiceResponses; i++ {
+	for i := 0; i < 3*config.MaxUDPResponses; i++ {
 		args := &structs.RegisterRequest{
 			Datacenter: "dc1",
 			Node:       fmt.Sprintf("foo%d", i),
@@ -820,7 +824,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 
 		// Response length should be truncated
 		// We should get an A record for each response
-		if len(in.Answer) != maxServiceResponses {
+		if len(in.Answer) != config.MaxUDPResponses {
 			t.Fatalf("Bad: %#v", len(in.Answer))
 		}
 


### PR DESCRIPTION
Hi, 

I renamed the "MaxServiceResponses" constant to "MaxUDPResponses" because is usable only for UDP network responses and I made it configurable using "max_udp_responses" in "dns_config".

[]s
@rogerlz
