### PR TITLE
make failure? - suggest "go get -u ./..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Next, clone this repository into `$GOPATH/src/github.com/hashicorp/consul` and
 then just type `make`. In a few moments, you'll have a working `consul` executable:
 
 ```
+$ go get -u ./...
 $ make
 ...
 $ bin/consul


### PR DESCRIPTION
```
$ git pull
$ make
--> Installing build dependencies
github.com/armon/consul-api (download)
github.com/armon/go-radix (download)
github.com/hashicorp/golang-lru (download)
github.com/hashicorp/hcl (download)
github.com/hashicorp/terraform (download)
github.com/hashicorp/yamux (download)
--> Running go fmt
bin/consul--> Installing dependencies to speed up builds...

# github.com/armon/gomdb
../../armon/gomdb/mdb.c:8507:46: warning: data argument not used by format string [-Wformat-extra-args]
/usr/include/secure/_stdio.h:49:56: note: expanded from macro 'sprintf'
# github.com/hashicorp/consul/consul
consul/serf.go:233: s.raft.SetPeers undefined (type *raft.Raft has no field or method SetPeers)
make: *** [all] Error 2
```
