### PR TITLE
Change default token to empty string instead of undefined

### DIFF
--- a/ui/javascripts/app/controllers.js
+++ b/ui/javascripts/app/controllers.js
@@ -501,6 +501,7 @@ App.SettingsController = Ember.ObjectController.extend({
       if (window.confirm("Are your sure you want to reset your settings?")) {
         localStorage.clear();
         controller.set('content', App.Settings.create());
+        App.set('settings.token', '');
         notify('Settings reset', 3000);
         this.set('isLoading', false);
       }

--- a/ui/javascripts/app/router.js
+++ b/ui/javascripts/app/router.js
@@ -8,6 +8,7 @@ Ember.Application.initializer({
 
   initialize: function(container, application) {
     application.set('settings', App.Settings.create());
+    App.set('settings.token', '');
   }
 });
 


### PR DESCRIPTION
fixes #329 

When ACL is turned on, the UI sends requests with `token=undefined` request parameter. This cause the 403 error.

By defaulting the token to empty string fixes this issue. 
## Alternative solution

Quote from the [ACL documentation](http://www.consul.io/docs/internals/acl.html)

> This is handled by the special "anonymous" token. Anytime there is no token provided, the rules defined by that token are automatically applied. 

So maybe `token=anonymous` would be more explicit. What do you think guys?
