### PR TITLE
removed repeated 'can' Watches documentation

### DIFF
--- a/website/source/docs/agent/watches.html.markdown
+++ b/website/source/docs/agent/watches.html.markdown
@@ -16,7 +16,7 @@ Watches are implemented using blocking queries in the [HTTP API](/docs/agent/htt
 Agent's automatically make the proper API calls to watch for changes,
 and inform a handler when the data view has updated.
 
-Watches can can be configured as part of the [agent's configuration](/docs/agent/options.html),
+Watches can be configured as part of the [agent's configuration](/docs/agent/options.html),
 causing them to run once the agent is initialized. Reloading the agent configuration
 allows for adding or removing watches dynamically.
 


### PR DESCRIPTION
removed repeated 'can' from Watches documentation 
