### PR TITLE
Remove redundant assignment

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -367,7 +367,6 @@ func (c *Command) Run(args []string) int {
 	if config == nil {
 		return 1
 	}
-	c.args = args
 
 	// Check GOMAXPROCS
 	if runtime.GOMAXPROCS(0) == 1 {


### PR DESCRIPTION
c.args is already assigned on line 365:
https://github.com/hashicorp/consul/blob/master/command/agent/command.go#L365 
