### PR TITLE
In FreeBSD bash is located at /usr/local/bin/bash instead of /bin/bash

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,7 +28,6 @@ fi
 
 if [ "$(go env GOOS)" = "freebsd" ]; then
   export CC="clang"
-  export CGO_LDFLAGS="$CGO_LDFLAGS -extld clang" # Workaround for https://code.google.com/p/go/issues/detail?id=6845
 fi
 
 # On OSX, we need to use an older target to ensure binaries are


### PR DESCRIPTION
While attempting to build consul on FreeBSD 10, the build script won't run without alteration.  I changed the #!/bin/bash line to use /usr/bin/env to get the location of bash from the environment.  This should allow it to build on Linux/Mac OS X/FreeBSD.

Tested on:
Fedora 20
Ubuntu 14.04
Mac OS X 10.9
FreeBSD 10
