### PR TITLE
Fix mistake in the watches documentation

### DIFF
--- a/website/source/docs/agent/watches.html.markdown
+++ b/website/source/docs/agent/watches.html.markdown
@@ -213,7 +213,7 @@ Here is an example configuration:
 
     {
         "type": "service",
-        "key": "redis",
+        "service": "redis",
         "handler": "/usr/bin/my-service-handler.sh"
     }
 


### PR DESCRIPTION
I noticed a small mistake in the watches documentation, for a "service" watch you need to use the key "service", not "key".
