### PR TITLE
Install curl in vagrant-cluster demo's Vagrantfile

### DIFF
--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -3,7 +3,7 @@
 $script = <<SCRIPT
 
 echo Installing dependencies...
-sudo apt-get install -y unzip
+sudo apt-get install -y unzip curl
 
 echo Fetching Consul...
 cd /tmp/


### PR DESCRIPTION
The getting started guide mentions has several examples using curl, so
preinstall curl on the Vagrant box to make the guide easier to follow.
