### PR TITLE
Fix spelling of "separator" in the HTTP API docs

### DIFF
--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -155,7 +155,7 @@ It is possible to also only list keys without their values by using the
 a list of the keys under the given prefix. The optional "?separator="
 can be used to list only up to a given separator.
 
-For example, listing "/web/" with a "/" seperator may return:
+For example, listing "/web/" with a "/" separator may return:
 
 ```javascript
 [


### PR DESCRIPTION
Fixes spelling change missed out by #101.
