### PR TITLE
Add multiple service definition support

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -392,9 +392,20 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 
 	// Check the result type
 	if obj, ok := raw.(map[string]interface{}); ok {
-		// Check for a "service" or "check" key, meaning
+		// Check for a "services", "service" or "check" key, meaning
 		// this is actually a definition entry
-		if sub, ok := obj["service"]; ok {
+		if sub, ok := obj["services"]; ok {
+			if list, ok := sub.([]interface{}); ok {
+				for _, srv := range list {
+					service, err := DecodeServiceDefinition(srv)
+					if err != nil {
+						return nil, err
+					}
+					result.Services = append(result.Services, service)
+				}
+				return &result, nil
+			}
+		} else if sub, ok := obj["service"]; ok {
 			service, err := DecodeServiceDefinition(sub)
 			result.Services = append(result.Services, service)
 			return &result, err

--- a/website/source/docs/agent/services.html.markdown
+++ b/website/source/docs/agent/services.html.markdown
@@ -62,3 +62,41 @@ end in the ".json" extension to be loaded by Consul. Check definitions can
 also be updated by sending a `SIGHUP` to the agent. Alternatively, the
 service can be registered dynamically using the [HTTP API](/docs/agent/http.html).
 
+## Multiple Service Definitions
+
+Multiple services definitions can be provided at once. Single and mutiple service definitions can't be provided together in one configuration file.
+
+```javascript
+{
+  "services": [
+    {
+      "id": "red0",
+      "name": "redis",
+      "tags": [
+        "master"
+      ],
+      "port": 6000,
+      "check": {
+        "script": "/bin/check_redis -p 6000",
+        "interval": "5s",
+        "ttl": "20s"
+      }
+    },
+    {
+      "id": "red1",
+      "name": "redis",
+      "tags": [
+        "delayed",
+        "slave"
+      ],
+      "port": 7000,
+      "check": {
+        "script": "/bin/check_redis -p 7000",
+        "interval": "30s",
+        "ttl": "60s"
+      }
+    },
+    ...
+  ]
+}
+```


### PR DESCRIPTION
This change-set adds another key to the configuration decoding called `services`, which is expected to be a list of service definitions. It follows the established convention of only allowing one of the keys:
`service`, `check`, `services`. For every entry in the list it calls the corresponding decode method and appends it to the Servics of the resulting Config.

While a similar result could be achieved with changing the Services member of the Config struct to have named mapstruct tag it lacks the proper time conversions provided by DecodeServiceDefinition.

---

Adresses hashicorp/consul#419

For some context we have the use-case that we want our schedulers to dump their state all at once into a single file to not cope with out-dated information and run a reload on the agent.

Happy to hear concerns regarding the naive implementation, discuss extended documentation and tests.
