### PR TITLE
Redirect old WebUI downloads page to new one

### DIFF
--- a/website/config.ru
+++ b/website/config.ru
@@ -4,6 +4,11 @@ require "rack/contrib/response_headers"
 require "rack/contrib/static_cache"
 require "rack/contrib/try_static"
 
+require "rake/rewrite"
+use Rack::Rewrite do
+  r301 "/downloads_web_ui.html", "/downloads.html"
+end
+
 # Properly compress the output if the client can handle it.
 use Rack::Deflater
 


### PR DESCRIPTION
There are currently a number of sites on the Internet that link to the old
downloads_web_ui.html page, including some popular blog posts. Since the WebUI
has been moved onto the Consul page itself, these links are now broken.

This commit adds a 301 (to preserve SEO) redirect from the old page to the new
one.

/cc @armon @ryanuber 

If this looks good, we should merge it ASAP so we don't loose the existing SEO.
