### PR TITLE
Add multiple recursor definition support

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -302,7 +302,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 		}
 
 		server, err := NewDNSServer(agent, &config.DNSConfig, logOutput,
-			config.Domain, dnsAddr.String(), config.DNSRecursor)
+			config.Domain, dnsAddr.String(), config.DNSRecursors)
 		if err != nil {
 			agent.Shutdown()
 			c.Ui.Error(fmt.Sprintf("Error starting dns server: %s", err))

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -97,9 +97,9 @@ type Config struct {
 	// DataDir is the directory to store our state in
 	DataDir string `mapstructure:"data_dir"`
 
-	// DNSRecursor can be set to allow the DNS server to recursively
+	// DNSRecursors can be set to allow the DNS servers to recursively
 	// resolve non-consul domains
-	DNSRecursor string `mapstructure:"recursor"`
+	DNSRecursors []string `mapstructure:"recursors"`
 
 	// DNS configuration
 	DNSConfig DNSConfig `mapstructure:"dns_config"`
@@ -623,9 +623,12 @@ func MergeConfig(a, b *Config) *Config {
 	if b.DataDir != "" {
 		result.DataDir = b.DataDir
 	}
-	if b.DNSRecursor != "" {
-		result.DNSRecursor = b.DNSRecursor
-	}
+
+	// Copy the dns recursors
+	result.DNSRecursors = make([]string, 0, len(a.DNSRecursors)+len(b.DNSRecursors))
+	result.DNSRecursors = append(result.DNSRecursors, a.DNSRecursors...)
+	result.DNSRecursors = append(result.DNSRecursors, b.DNSRecursors...)
+
 	if b.Domain != "" {
 		result.Domain = b.Domain
 	}

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -109,7 +109,7 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// DNS setup
-	input = `{"ports": {"dns": 8500}, "recursor": "8.8.8.8", "domain": "foobar"}`
+	input = `{"ports": {"dns": 8500}, "recursor": ["8.8.8.8","8.8.4.4"], "domain": "foobar"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -119,7 +119,13 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
-	if config.DNSRecursor != "8.8.8.8" {
+	if len(config.DNSRecursors) != 2 {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.DNSRecursors[0] != "8.8.8.8" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.DNSRecursors[1] != "8.8.4.4" {
 		t.Fatalf("bad: %#v", config)
 	}
 
@@ -791,7 +797,6 @@ func TestMergeConfig(t *testing.T) {
 		BootstrapExpect:        0,
 		Datacenter:             "dc1",
 		DataDir:                "/tmp/foo",
-		DNSRecursor:            "127.0.0.1:1001",
 		Domain:                 "basic",
 		LogLevel:               "debug",
 		NodeName:               "foo",
@@ -811,7 +816,7 @@ func TestMergeConfig(t *testing.T) {
 		BootstrapExpect: 3,
 		Datacenter:      "dc2",
 		DataDir:         "/tmp/bar",
-		DNSRecursor:     "127.0.0.2:1001",
+		DNSRecursors:    []string{"127.0.0.2:1001"},
 		DNSConfig: DNSConfig{
 			NodeTTL: 10 * time.Second,
 			ServiceTTL: map[string]time.Duration{

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -22,7 +22,7 @@ func makeDNSServerConfig(t *testing.T, config *DNSConfig) (string, *DNSServer) {
 	addr, _ := conf.ClientListener(conf.Addresses.DNS, conf.Ports.DNS)
 	dir, agent := makeAgent(t, conf)
 	server, err := NewDNSServer(agent, config, agent.logOutput,
-		conf.Domain, addr.String(), "8.8.8.8:53")
+		conf.Domain, addr.String(), []string{"8.8.8.8:53"})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/website/source/docs/agent/dns.html.markdown
+++ b/website/source/docs/agent/dns.html.markdown
@@ -20,14 +20,14 @@ provide the redis service, located in the "east-aws" datacenter,
 with no failing health checks. It's that simple!
 
 There are a number of [configuration options](/docs/agent/options.html) that
-are important for the DNS interface. They are `client_addr`, `ports.dns`, `recursor`,
+are important for the DNS interface. They are `client_addr`, `ports.dns`, `recursors`,
 `domain`, and `dns_config`. By default Consul will listen on 127.0.0.1:8600 for DNS queries
 in the "consul." domain, without support for DNS recursion. All queries are case-insensitive, a
 name lookup for `PostgreSQL.node.dc1.consul` will find all nodes named `postgresql`, no matter of case.
 
 There are a few ways to use the DNS interface. One option is to use a custom
 DNS resolver library and point it at Consul. Another option is to set Consul
-as the DNS server for a node, and provide a `recursor` so that non-Consul queries
+as the DNS server for a node, and provide `recursors` so that non-Consul queries
 can also be resolved. The last method is to forward all queries for the "consul."
 domain to a Consul agent from the existing DNS server. To play with the DNS server
 on the command line, dig can be used:

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -333,7 +333,7 @@ It returns a JSON body like this:
     "Server": true,
     "Datacenter": "dc1",
     "DataDir": "/tmp/consul",
-    "DNSRecursor": "",
+    "DNSRecursors": [],
     "Domain": "consul.",
     "LogLevel": "INFO",
     "NodeName": "foobar",

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -316,10 +316,10 @@ definitions support being updated during a reload.
 
 * `protocol` - Equivalent to the `-protocol` command-line flag.
 
-* `recursor` - This flag provides an address of an upstream DNS server that is used to
+* `recursors` - This flag provides addresses of upstream DNS servers that are used to
   recursively resolve queries if they are not inside the service domain for consul. For example,
   a node can use Consul directly as a DNS server, and if the record is outside of the "consul." domain,
-  the query will be resolved upstream using this server.
+  the query will be resolved upstream using their servers.
 
 * `rejoin_after_leave` - Equivalent to the `-rejoin` command-line flag.
 


### PR DESCRIPTION
Currently only a single recursor is supported, however I want to use multiple recursors because single server is low fault tolerance.
