### PR TITLE
Pass notes field from service checks through

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -447,7 +447,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkType *CheckType) err
 			CheckID:     fmt.Sprintf("service:%s", service.ID),
 			Name:        fmt.Sprintf("Service '%s' check", service.Service),
 			Status:      structs.HealthCritical,
-			Notes:       "",
+			Notes:       chkType.Notes,
 			ServiceID:   service.ID,
 			ServiceName: service.Service,
 		}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -115,7 +115,10 @@ func TestAgent_AddService(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	chk := &CheckType{TTL: time.Minute}
+	chk := &CheckType{
+		TTL:   time.Minute,
+		Notes: "redis health check",
+	}
 	err := agent.AddService(srv, chk)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -134,6 +137,11 @@ func TestAgent_AddService(t *testing.T) {
 	// Ensure a TTL is setup
 	if _, ok := agent.checkTTLs["service:redis"]; !ok {
 		t.Fatalf("missing redis check ttl")
+	}
+
+	// Ensure the notes are passed through
+	if agent.state.Checks()["service:redis"].Notes == "" {
+		t.Fatalf("missing redis check notes")
 	}
 }
 

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -30,6 +30,8 @@ type CheckType struct {
 	Interval time.Duration
 
 	TTL time.Duration
+
+	Notes string
 }
 
 // Valid checks if the CheckType is valid


### PR DESCRIPTION
Allows the notes field within service definitions to be passed through and appear in the registered check list of the agent.

Fixes #449.
