### PR TITLE
Typo fix for events command doc

### DIFF
--- a/website/source/docs/commands/event.html.markdown
+++ b/website/source/docs/commands/event.html.markdown
@@ -54,5 +54,5 @@ The list of available flags are:
 
 * `-tag` - Regular expression to filter to only nodes with a service that has
   a matching tag. This must be used with `-service`. As an example, you may
-  do "-server mysql -tag slave".
+  do "-service mysql -tag slave".
 


### PR DESCRIPTION
Super small change to make it clear that mysql is a service and not a server ;)
