### PR TITLE
Make the 'consul version' to return value that is from 'git describe --tags'

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -21,7 +21,7 @@ func (c *VersionCommand) Help() string {
 
 func (c *VersionCommand) Run(_ []string) int {
 	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "Consul v%s", c.Version)
+	fmt.Fprintf(&versionString, "Consul %s", c.Version)
 	if c.VersionPrerelease != "" {
 		fmt.Fprintf(&versionString, ".%s", c.VersionPrerelease)
 

--- a/commands.go
+++ b/commands.go
@@ -90,7 +90,7 @@ func init() {
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
 				Revision:          GitCommit,
-				Version:           Version,
+				Version:           GitDescribe,
 				VersionPrerelease: VersionPrerelease,
 				Ui:                ui,
 			}, nil

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,7 @@ cd $DIR
 # Get the git commit
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+GIT_DESCRIBE=$(git describe --tags)
 
 # If we're building on Windows, specify an extension
 EXTENSION=""
@@ -45,7 +46,7 @@ go get \
 # Build!
 echo "--> Building..."
 go build \
-    -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}" \
+    -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe ${GIT_DESCRIBE}" \
     -v \
     -o bin/consul${EXTENSION}
 cp bin/consul${EXTENSION} ${GOPATHSINGLE}/bin

--- a/version.go
+++ b/version.go
@@ -2,6 +2,7 @@ package main
 
 // The git commit that was compiled. This will be filled in by the compiler.
 var GitCommit string
+var GitDescribe string
 
 // The main version number that is being run at the moment.
 const Version = "0.4.1"


### PR DESCRIPTION
After the changes below  the consul I self compiled shows

> consul version
> Consul v0.4.1-70-g7145f05
> Consul Protocol: 2 (Understands back to: 1)
