### PR TITLE
Update to 'consul version' behaviour

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -88,10 +88,20 @@ func init() {
 		},
 
 		"version": func() (cli.Command, error) {
+			ver := ""
+			rel := ""
+			if len(GitDescribe) == 0 {
+				ver = Version
+				rel = "dev"
+			} else {
+				ver = GitDescribe
+				rel = VersionPrerelease
+			}
+
 			return &command.VersionCommand{
 				Revision:          GitCommit,
-				Version:           GitDescribe,
-				VersionPrerelease: VersionPrerelease,
+				Version:           ver,
+				VersionPrerelease: rel,
 				Ui:                ui,
 			}, nil
 		},


### PR DESCRIPTION
After e6b6f181728b88c2e430fc7ad71fe1f84db3418c if consul was built
with just running "go build" the GitDescribe would be empty and consul
version would be empty.

This change alters the behaviour so that if consul is build without
proper ldflags the version will be postfixed with "dev" prerelease to
indicate that it is self compiled in a wrong way.

Should someone have a bug in such a binary at least devs should easily
see from the version number that binary has not been created by
recommended means.
