### PR TITLE
Fix potential race condition on shutdown (pool.reap/server.handleConsulConn)

### DIFF
--- a/consul/pool.go
+++ b/consul/pool.go
@@ -358,12 +358,12 @@ func (p *ConnPool) RPC(addr net.Addr, version int, method string, args interface
 
 // Reap is used to close conns open over maxTime
 func (p *ConnPool) reap() {
-	for !p.shutdown {
+	for {
 		// Sleep for a while
 		select {
-		case <-time.After(time.Second):
 		case <-p.shutdownCh:
 			return
+		case <-time.After(time.Second):
 		}
 
 		// Reap all old conns


### PR DESCRIPTION
Minimal changes to avoid 2 race conditions which could easily occur since the methods are launched in separate goroutines.
