### PR TITLE
Small doc update for exec command

### DIFF
--- a/website/source/docs/commands/exec.html.markdown
+++ b/website/source/docs/commands/exec.html.markdown
@@ -49,7 +49,7 @@ The list of available flags are:
 
 * `-tag` - Regular expression to filter to only nodes with a service that has
   a matching tag. This must be used with `-service`. As an example, you may
-  do "-server mysql -tag slave".
+  do "-service mysql -tag slave".
 
 * `-wait` - Specifies the period of time in which no agent's respond before considering
   the job finished. This is basically the quiescent time required to assume completion.


### PR DESCRIPTION
The documentation for `-tag` says it must be used with `-service`, but the example shown is `-server`, which doesn't work (probably a typo or damn-you-autocorrect):

``` console
$ consul exec -server web -tag rails uptime
flag provided but not defined: -server
Usage: consul exec [options] [-|command...]
```

This PR changes `-server` to `-service`:

``` console
$ consul exec -service web -tag rails uptime
    agent-one:  04:48:53 up 36 min,  2 users,  load average: 0.16, 0.35, 0.29
    agent-one:
==> agent-one: finished with exit code 0
1 / 1 node(s) completed / acknowledged
```
