### PR TITLE
Add helios-consul to community tools page

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -55,6 +55,9 @@ description: |-
         <a href="https://github.com/ryanbreen/git2consul">git2consul</a> - Mirror the contents of a git repository into Consul KVs
       </li>
       <li>
+        <a href="https://github.com/SVT/helios-consul">helios-consul</a> - Service registrar plugin for Helios
+      </li>
+      <li>
         <a href="https://github.com/progrium/registrator">registrator</a> -Service registry bridge for Docker
       </li>
     </ul>


### PR DESCRIPTION
This PR adds a link to helios-consul on the community tools page.
Helios-consul is a Consul service registrar plugin for Helios. It is designed to run together with helios-agent and registers all deployed Docker containers to the Consul service registry.
