### PR TITLE
Add a randomized start before running CheckMonitors.

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -95,7 +95,7 @@ func (c *CheckMonitor) Stop() {
 func (c *CheckMonitor) run() {
 	// Get the randomized initial pause time
 	initialPauseTime := randomStagger(c.Interval)
-	c.Logger.Printf("[DEBUG] agent: pausing %ds before first invocation of %s", int(initialPauseTime.Seconds()), c.Script)
+	c.Logger.Printf("[DEBUG] agent: pausing %v before first invocation of %s", initialPauseTime, c.Script)
 	next := time.After(initialPauseTime)
 	for {
 		select {

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -75,17 +75,17 @@ func TestCheckMonitor_RandomStagger(t *testing.T) {
 		Notify:   mock,
 		CheckID:  "foo",
 		Script:   "exit 0",
-		Interval: 5 * time.Second,
+		Interval: 25 * time.Millisecond,
 		Logger:   log.New(os.Stderr, "", log.LstdFlags),
 	}
 	check.Start()
 	defer check.Stop()
 
-	time.Sleep(6 * time.Second)
+	time.Sleep(50 * time.Millisecond)
 
 	// Should have at least 1 update
 	if mock.updates["foo"] < 1 {
-		t.Fatalf("should have 1 updates %v", mock.updates)
+		t.Fatalf("should have 1 or more updates %v", mock.updates)
 	}
 
 	if mock.state["foo"] != structs.HealthPassing {


### PR DESCRIPTION
We have situations where systems use many checks (dozens to hundreds) with fairly long intervals (say, every 60s).  Starting them all at the same time leads to undesirable spikes in resource utilization.  This patch randomly staggers the start time of CheckMonitors to avoid this.  It should address our issue without altering behavior much in the common case.
