### PR TITLE
add ability to specify response headers on the HTTP API

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -310,6 +310,9 @@ type Config struct {
 	// send with the update check. This is used to deduplicate messages.
 	DisableAnonymousSignature bool `mapstructure:"disable_anonymous_signature"`
 
+	// HTTPAPIResponseHeaders are used to add HTTP header response fields to the HTTP API responses.
+	HTTPAPIResponseHeaders map[string]string `mapstructure:"http_api_response_headers"`
+
 	// AEInterval controls the anti-entropy interval. This is how often
 	// the agent attempts to reconcile it's local state with the server'
 	// representation of our state. Defaults to every 60s.
@@ -857,6 +860,15 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.DisableAnonymousSignature {
 		result.DisableAnonymousSignature = true
+	}
+
+	if len(b.HTTPAPIResponseHeaders) != 0 {
+		if result.HTTPAPIResponseHeaders == nil {
+			result.HTTPAPIResponseHeaders = make(map[string]string)
+		}
+		for field, value := range b.HTTPAPIResponseHeaders {
+			result.HTTPAPIResponseHeaders[field] = value
+		}
 	}
 
 	// Copy the start join addresses

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -589,6 +589,21 @@ func TestDecodeConfig(t *testing.T) {
 	if !config.DisableAnonymousSignature {
 		t.Fatalf("bad: %#v", config)
 	}
+
+	// HTTP API response header fields
+	input = `{"http_api_response_headers": {"Access-Control-Allow-Origin": "*", "X-XSS-Protection": "1; mode=block"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.HTTPAPIResponseHeaders["Access-Control-Allow-Origin"] != "*" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	if config.HTTPAPIResponseHeaders["X-XSS-Protection"] != "1; mode=block" {
+		t.Fatalf("bad: %#v", config)
+	}
 }
 
 func TestDecodeConfig_Services(t *testing.T) {
@@ -960,6 +975,9 @@ func TestMergeConfig(t *testing.T) {
 		StatsdAddr:                "127.0.0.1:7251",
 		DisableUpdateCheck:        true,
 		DisableAnonymousSignature: true,
+		HTTPAPIResponseHeaders: map[string]string{
+			"Access-Control-Allow-Origin": "*",
+		},
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -231,6 +231,8 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 // wrap is used to wrap functions to make them more convenient
 func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Request) (interface{}, error)) func(resp http.ResponseWriter, req *http.Request) {
 	f := func(resp http.ResponseWriter, req *http.Request) {
+		setHeaders(resp, s.agent.config.HTTPAPIResponseHeaders)
+
 		// Invoke the handler
 		start := time.Now()
 		defer func() {
@@ -334,6 +336,13 @@ func setMeta(resp http.ResponseWriter, m *structs.QueryMeta) {
 	setIndex(resp, m.Index)
 	setLastContact(resp, m.LastContact)
 	setKnownLeader(resp, m.KnownLeader)
+}
+
+// setHeaders is used to set canonical response header fields
+func setHeaders(resp http.ResponseWriter, headers map[string]string) {
+	for field, value := range headers {
+		resp.Header().Set(http.CanonicalHeaderKey(field), value)
+	}
 }
 
 // parseWait is used to parse the ?wait and ?index query params

--- a/ui/development_config.json
+++ b/ui/development_config.json
@@ -5,5 +5,8 @@
   "bootstrap": true,
   "server": true,
   "acl_datacenter": "dc1",
-  "acl_master_token": "dev"
+  "acl_master_token": "dev",
+  "http_api_response_headers": {
+    "Access-Control-Allow-Origin": "*"
+  }
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -172,7 +172,7 @@ being configured using a configuration management system.
 
 The configuration files are JSON formatted, making them easily readable
 and editable by both humans and computers. The configuration is formatted
-at a single JSON object with configuration within it.
+as a single JSON object with configuration within it.
 
 Configuration files are used for more than just setting up the agent,
 they are also used to provide check and service definitions. These are used
@@ -326,6 +326,18 @@ definitions support being updated during a reload.
 * `key_file` - This provides a the file path to a PEM encoded private key.
   The key is used with the certificate to verify the agents authenticity.
   Must be provided along with the `cert_file`.
+
+* `http_api_response_headers` - This object allows adding HTTP header response fields to
+  the HTTP API responses. For example, the following config can be used to enable CORS on
+  the HTTP API endpoints:
+
+    ```javascript
+      {
+        "http_api_response_headers": {
+            "Access-Control-Allow-Origin": "*"
+        }
+      }
+    ```
 
 * `leave_on_terminate` - If enabled, when the agent receives a TERM signal,
   it will send a Leave message to the rest of the cluster and gracefully


### PR DESCRIPTION
Add an configuration object that allows adding HTTP header response fields to every
HTTP API response.

Each specified header is added to every response from all HTTP API endpoints.
Each individual endpoint may overwrite the specified header, which makes sure
that Consul headers such as 'X-Consul-Index' is enforced by the API.

Closes #335 