### PR TITLE
website: fix typo, casing and links

### DIFF
--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -49,7 +49,7 @@ description: |-
 						Armon Dadgar is the creator of Consul. He researched and developed
 						most of the internals of how Consul works, including the
 						gossip layer, leader election, etc. Armon is also the creator of
-						<a href="https://github.com/hashicorp/serf">Serf</a>,
+						<a href="https://www.serfdom.io">Serf</a>,
 						<a href="https://github.com/armon/statsite">Statsite</a>, and
 						<a href="https://github.com/armon/bloomd">Bloomd</a>.
 					</div>
@@ -66,9 +66,9 @@ description: |-
 						a management role in the creation of Consul, guiding product
 						and user experience decisions on top of Armon's technical decisions.
 						Mitchell Hashimoto is also the creator of
-						<a href="http://www.vagrantup.com">Vagrant</a>,
-						<a href="http://www.packer.io">Packer</a>, and
-						<a href="http://www.serfdom.io">Serf</a>.
+						<a href="https://www.vagrantup.com">Vagrant</a>,
+						<a href="https://www.packer.io">Packer</a>, and
+						<a href="https://www.serfdom.io">Serf</a>.
 						</p>
 					</div>
 				</div>
@@ -82,11 +82,11 @@ description: |-
 						<p>
 						Jack Pearkes created and maintains the Consul web UI.
 						He is also a core committer to
-						<a href="http://www.packer.io">Packer</a> and maintains
+						<a href="https://www.packer.io">Packer</a> and maintains
 						many successful
 						<a href="https://github.com/pearkes">open source projects</a>
 						while also being an employee of
-						<a href="http://www.hashicorp.com">HashiCorp</a>.
+						<a href="https://www.hashicorp.com">HashiCorp</a>.
 						</p>
 					</div>
 				</div>

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -338,8 +338,8 @@ definitions support being updated during a reload.
 * `ports` - This is a nested object that allows setting the bind ports
    for the following keys:
     * `dns` - The DNS server, -1 to disable. Default 8600.
-    * `http` - The HTTP api, -1 to disable. Default 8500.
-    * `https` - The HTTPS api, -1 to disable. Default -1 (disabled).
+    * `http` - The HTTP API, -1 to disable. Default 8500.
+    * `https` - The HTTPS API, -1 to disable. Default -1 (disabled).
     * `rpc` - The RPC endpoint. Default 8400.
     * `serf_lan` - The Serf LAN port. Default 8301.
     * `serf_wan` - The Serf WAN port. Default 8302.

--- a/website/source/docs/agent/rpc.html.markdown
+++ b/website/source/docs/agent/rpc.html.markdown
@@ -55,8 +55,8 @@ Possible commands include:
 * handshake - Used to initialize the connection, set the version
 * force-leave - Removes a failed node from the cluster
 * join - Requests Consul join another node
-* members-lan - Returns the list of lan members
-* members-wan - Returns the list of wan members
+* members-lan - Returns the list of LAN members
+* members-wan - Returns the list of WAN members
 * monitor - Starts streaming logs over the connection
 * stop - Stops streaming logs
 * leave - Consul agent performs a graceful leave and shutdown
@@ -133,7 +133,7 @@ The body returns the number of nodes successfully joined.
 
 ### members-lan
 
-The members-lan command is used to return all the known lan members and associated
+The members-lan command is used to return all the known LAN members and associated
 information. All agents will respond to this command.
 
 There is no request body, but the response looks like:
@@ -163,7 +163,7 @@ There is no request body, but the response looks like:
 
 ### members-wan
 
-The members-wan command is used to return all the known wan members and associated
+The members-wan command is used to return all the known WAN members and associated
 information. Only agents in server mode will respond to this command.
 
 There is no request body, and the response is the same as `members-lan`

--- a/website/source/docs/guides/leader-election.html.markdown
+++ b/website/source/docs/guides/leader-election.html.markdown
@@ -114,7 +114,7 @@ curl  http://localhost:8500/v1/kv/<key>
 
 If the key has no associated `Session`, then there is no leader.
 Otherwise, the value of the key will provide all the
-application-dependent information required as a base64 encoded blog in
+application-dependent information required as a base64 encoded blob in
 the `Value` key.  You can query the `/v1/session/info` endpoint to get
 details about the session:
 

--- a/website/source/docs/internals/architecture.html.markdown
+++ b/website/source/docs/internals/architecture.html.markdown
@@ -49,7 +49,7 @@ transactions are applied to a FSM, we implicitly include the consistency of a re
 state machine. Consensus is described in more detail on [Wikipedia](http://en.wikipedia.org/wiki/Consensus_(computer_science)),
 and our implementation is described [here](/docs/internals/consensus.html).
 
-* Gossip - Consul is built on top of [Serf](http://www.serfdom.io/), which provides a full
+* Gossip - Consul is built on top of [Serf](https://www.serfdom.io/), which provides a full
 [gossip protocol](http://en.wikipedia.org/wiki/Gossip_protocol) that is used for multiple purposes.
 Serf provides membership, failure detection, and event broadcast mechanisms. Our use of these
 is described more in the [gossip documentation](/docs/internals/gossip.html). It is enough to know

--- a/website/source/docs/internals/gossip.html.markdown
+++ b/website/source/docs/internals/gossip.html.markdown
@@ -10,10 +10,10 @@ description: |-
 
 Consul uses a [gossip protocol](http://en.wikipedia.org/wiki/Gossip_protocol)
 to manage membership and broadcast messages to the cluster. All of this is provided
-through the use of the [Serf library](http://www.serfdom.io/). The gossip protocol
+through the use of the [Serf library](https://www.serfdom.io/). The gossip protocol
 used by Serf is based on
 ["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](http://www.cs.cornell.edu/~asdas/research/dsn02-swim.pdf),
-with a few minor adaptations. There are more details about [Serf's protocol here](http://www.serfdom.io/docs/internals/gossip.html).
+with a few minor adaptations. There are more details about [Serf's protocol here](https://www.serfdom.io/docs/internals/gossip.html).
 
 ~> **Advanced Topic!** This page covers technical details of
 the internals of Consul. You don't need to know these details to effectively
@@ -37,7 +37,7 @@ servers to perform cross datacenter requests. The integrated failure detection
 allows Consul to gracefully handle an entire datacenter losing connectivity, or just
 a single server in a remote datacenter.
 
-All of these features are provided by leveraging [Serf](http://www.serfdom.io/). It
+All of these features are provided by leveraging [Serf](https://www.serfdom.io/). It
 is used as an embedded library to provide these features. From a user perspective,
 this is not important, since the abstraction should be masked by Consul. It can be useful
 however as a developer to understand how this library is leveraged.

--- a/website/source/docs/internals/security.html.markdown
+++ b/website/source/docs/internals/security.html.markdown
@@ -13,9 +13,9 @@ to provide various features. Both of the systems have different security
 mechanisms that stem from their designs. However, the overall goal
 of Consul's security model is to provide [confidentiality, integrity and authentication](http://en.wikipedia.org/wiki/Information_security).
 
-The [gossip protocol](/docs/internals/gossip.html) is powered by [Serf](http://www.serfdom.io/),
+The [gossip protocol](/docs/internals/gossip.html) is powered by [Serf](https://www.serfdom.io/),
 which uses a symmetric key, or shared secret, cryptosystem. There are more
-details on the security of [Serf here](http://www.serfdom.io/docs/internals/security.html).
+details on the security of [Serf here](https://www.serfdom.io/docs/internals/security.html).
 
 The RPC system supports using end-to-end TLS, with optional client authentication.
 [TLS](http://en.wikipedia.org/wiki/Transport_Layer_Security) is a widely deployed asymmetric

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -55,16 +55,16 @@ description: |-
 
     <ul>
       <li>
-        <a href="https://github.com/kelseyhightower/confd">confd</a> - Manage local application configuration files using templates and data from etcd or consul
+        <a href="https://github.com/kelseyhightower/confd">confd</a> - Manage local application configuration files using templates and data from etcd or Consul
       </li>
       <li>
-        <a href="http://xordataexchange.github.io/crypt/">crypt</a> - Store and retrieve encrypted configuration parameters from etcd or consul
+        <a href="http://xordataexchange.github.io/crypt/">crypt</a> - Store and retrieve encrypted configuration parameters from etcd or Consul
       </li>
       <li>
         <a href="https://github.com/progrium/docker-consul">docker-consul</a> - Dockerized Consul Agent
       </li>
       <li>
-        <a href="https://github.com/ryanbreen/git2consul">git2consul</a> - Mirror the contents of a git repository into Consul KVs
+        <a href="https://github.com/ryanbreen/git2consul">git2consul</a> - Mirror the contents of a Git repository into Consul KVs
       </li>
       <li>
         <a href="https://github.com/SVT/helios-consul">helios-consul</a> - Service registrar plugin for Helios

--- a/website/source/intro/vs/serf.html.markdown
+++ b/website/source/intro/vs/serf.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Consul vs. Serf
 
-[Serf](http://www.serfdom.io) is a node discovery and orchestration tool and is the only
+[Serf](https://www.serfdom.io) is a node discovery and orchestration tool and is the only
 tool discussed so far that is built on an eventually consistent gossip model,
 with no centralized servers. It provides a number of features, including group
 membership, failure detection, event broadcasts and a query mechanism. However,

--- a/website/source/layouts/_footer.erb
+++ b/website/source/layouts/_footer.erb
@@ -10,14 +10,14 @@
 
 			<ul class="buttons nav navbar-nav rls-sb">
 				<li class="first download outline-btn purple"><a href="/downloads.html">Download</a></li>
-				<li class="github outline-btn purple"><a href="https://github.com/hashicorp/consul">Github</a></li>
+				<li class="github outline-btn purple"><a href="https://github.com/hashicorp/consul">GitHub</a></li>
 			</ul>
 		</div>
 		<div class="footer-logo">
 			<span></span>
 		</div>
 		<div class="footer-hashi os">
-			<span>Copyright &copy; <%= Time.now.year %>. A <a href="http://www.hashicorp.com">HashiCorp</a> Project.</span>
+			<span>Copyright &copy; <%= Time.now.year %>. A <a href="https://www.hashicorp.com">HashiCorp</a> Project.</span>
 			<a class="hashi-logo" href="http://www.hashicorp.com"><%= image_tag 'footer-hashicorp-logo.png' %></a>
 		</div>
 	</div>

--- a/website/source/layouts/_header.erb
+++ b/website/source/layouts/_header.erb
@@ -42,7 +42,7 @@
     		<nav class="collapse navbar-collapse bs-navbar-collapse" role="navigation">
     			<ul class="buttons nav navbar-nav navbar-right rls-sb">
     				<li class="first download outline-btn"><a href="/downloads.html">Download</a></li>
-    				<li class="github outline-btn"><a href="https://github.com/hashicorp/consul">Github</a></li>
+    				<li class="github outline-btn"><a href="https://github.com/hashicorp/consul">GitHub</a></li>
     			</ul>
 
     			<ul class="main-links nav navbar-nav navbar-right rls-sb">


### PR DESCRIPTION
Fix typo in Leader Election guide: s/blog/blob/

Also fix various casing issues and prefer HTTPS links
for HashiCorp projects.