### PR TITLE
DNSConfig EnableTruncate to true by default.

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -360,7 +360,8 @@ func DefaultConfig() *Config {
 			Server:  8300,
 		},
 		DNSConfig: DNSConfig{
-			MaxStale: 5 * time.Second,
+			MaxStale:       5 * time.Second,
+			EnableTruncate: true,
 		},
 		SyslogFacility:      "LOCAL0",
 		Protocol:            consul.ProtocolVersionMax,

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -329,7 +329,7 @@ PARSE:
 		// Support RFC 2782 style syntax
 		if n == 3 && strings.HasPrefix(labels[n-2], "_") && strings.HasPrefix(labels[n-3], "_") {
 
-			// Grab the tag since we make nuke it if it's tcp
+			// Grab the tag since we may nuke it if it's tcp
 			tag := labels[n-2][1:]
 
 			// Treat _name._tcp.service.consul as a default, no need to filter on that tag
@@ -597,7 +597,7 @@ func (d *DNSServer) serviceNodeRecords(nodes structs.CheckServiceNodes, req, res
 	}
 }
 
-// serviceARecords is used to add the SRV records for a service lookup
+// serviceSRVRecords is used to add the SRV records for a service lookup
 func (d *DNSServer) serviceSRVRecords(dc string, nodes structs.CheckServiceNodes, req, resp *dns.Msg, ttl time.Duration) {
 	handled := make(map[string]struct{})
 	for _, node := range nodes {

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -525,11 +525,11 @@ RPC:
 	// Filter out any service nodes due to health checks
 	out.Nodes = d.filterServiceNodes(out.Nodes)
 
-	// Perform a random shuffle
-	shuffleServiceNodes(out.Nodes)
-
 	// If the network is not TCP, restrict the number of responses
 	if network != "tcp" && len(out.Nodes) > maxServiceResponses {
+		// Perform a random shuffle
+		shuffleServiceNodes(out.Nodes)
+
 		out.Nodes = out.Nodes[:maxServiceResponses]
 		// Flag that there are more records to return in the UDP response
 		if d.config.EnableTruncate == true {


### PR DESCRIPTION
Set the EnableTruncate to true for the default config.
It's my opinion that this is in keeping with POLA, as I was a bit confused about the responses I was getting.

Also, maxServiceResponses should probably be cranked, but without pulling another number out of thin air, some calculations should probably be done on the fly, I'll look into that as well. 
It seems the original number was due to https://github.com/miekg/dns/issues/83 which has since been fixed upstream.

Is there also any strong attachment to the random shuffle ?
I find that behaviour a bit weird but opted for a411322 rather then removing it.