### PR TITLE
agent: reject config with invalid options

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -335,6 +335,13 @@ type Config struct {
 
 	// WatchPlans contains the compiled watches
 	WatchPlans []*watch.WatchPlan `mapstructure:"-" json:"-"`
+
+	// Allow the following fields to be present in configuration files without
+	// mapstructure erroring on them.
+	_ interface{} `mapstructure:"services"`
+	_ interface{} `mapstructure:"checks"`
+	_ interface{} `mapstructure:"service"`
+	_ interface{} `mapstructure:"check"`
 }
 
 type dirEnts []os.FileInfo
@@ -463,8 +470,9 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 	// Decode
 	var md mapstructure.Metadata
 	msdec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Metadata: &md,
-		Result:   &result,
+		Metadata:    &md,
+		Result:      &result,
+		ErrorUnused: true,
 	})
 	if err != nil {
 		return nil, err

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -588,6 +589,14 @@ func TestDecodeConfig(t *testing.T) {
 	}
 	if !config.DisableAnonymousSignature {
 		t.Fatalf("bad: %#v", config)
+	}
+}
+
+func TestDecodeConfig_invalidKeys(t *testing.T) {
+	input := `{"bad": "no way jose"}`
+	_, err := DecodeConfig(bytes.NewReader([]byte(input)))
+	if err == nil || !strings.Contains(err.Error(), "invalid keys") {
+		t.Fatalf("should have rejected invalid config keys")
 	}
 }
 


### PR DESCRIPTION
This helps by rejecting configurations with invalid keys. Mapstructure supports this already, but the way we parse services and checks doesn't use straight mapstructure decoding, so there are a few discarded fields in the config struct. AFAIK there wasn't a better way to allow this.

/cc @armon @mitchellh