### PR TITLE
Adding KV tombstones to fix non-monotonic index on deletes

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -158,7 +158,7 @@ type Config struct {
 	// "allow" can be used to allow all requests. This is not recommended.
 	ACLDownPolicy string
 
-	// TombstoneGC is used to control how long KV tombstones are retained.
+	// TombstoneTTL is used to control how long KV tombstones are retained.
 	// This provides a window of time where the X-Consul-Index is monotonic.
 	// Outside this window, the index may not be monotonic. This is a result
 	// of a few trade offs:
@@ -174,7 +174,12 @@ type Config struct {
 	// It is also possible to set this to an incredibly long time, thereby
 	// simulating infinite retention. This is not recommended however.
 	//
-	TombstoneGC time.Duration
+	TombstoneTTL time.Duration
+
+	// TombstoneTTLGranularity is used to control how granular the timers are
+	// for the Tombstone GC. This is used to batch the GC of many keys together
+	// to reduce overhead. It is unlikely a user would ever need to tune this.
+	TombstoneTTLGranularity time.Duration
 
 	// ServerUp callback can be used to trigger a notification that
 	// a Consul server is now up and known about.
@@ -223,18 +228,19 @@ func DefaultConfig() *Config {
 	}
 
 	conf := &Config{
-		Datacenter:        DefaultDC,
-		NodeName:          hostname,
-		RPCAddr:           DefaultRPCAddr,
-		RaftConfig:        raft.DefaultConfig(),
-		SerfLANConfig:     serf.DefaultConfig(),
-		SerfWANConfig:     serf.DefaultConfig(),
-		ReconcileInterval: 60 * time.Second,
-		ProtocolVersion:   ProtocolVersionMax,
-		ACLTTL:            30 * time.Second,
-		ACLDefaultPolicy:  "allow",
-		ACLDownPolicy:     "extend-cache",
-		TombstoneGC:       15 * time.Minute,
+		Datacenter:              DefaultDC,
+		NodeName:                hostname,
+		RPCAddr:                 DefaultRPCAddr,
+		RaftConfig:              raft.DefaultConfig(),
+		SerfLANConfig:           serf.DefaultConfig(),
+		SerfWANConfig:           serf.DefaultConfig(),
+		ReconcileInterval:       60 * time.Second,
+		ProtocolVersion:         ProtocolVersionMax,
+		ACLTTL:                  30 * time.Second,
+		ACLDefaultPolicy:        "allow",
+		ACLDownPolicy:           "extend-cache",
+		TombstoneTTL:            15 * time.Minute,
+		TombstoneTTLGranularity: 30 * time.Second,
 	}
 
 	// Increase our reap interval to 3 days instead of 24h.

--- a/consul/fsm.go
+++ b/consul/fsm.go
@@ -85,6 +85,8 @@ func (c *consulFSM) Apply(log *raft.Log) interface{} {
 		return c.applySessionOperation(buf[1:], log.Index)
 	case structs.ACLRequestType:
 		return c.applyACLOperation(buf[1:], log.Index)
+	case structs.TombstoneReapRequestType:
+		return c.applyTombstoneReapOperation(buf[1:], log.Index)
 	default:
 		panic(fmt.Errorf("failed to apply request: %#v", buf))
 	}
@@ -213,6 +215,14 @@ func (c *consulFSM) applyACLOperation(buf []byte, index uint64) interface{} {
 		c.logger.Printf("[WARN] consul.fsm: Invalid ACL operation '%s'", req.Op)
 		return fmt.Errorf("Invalid ACL operation '%s'", req.Op)
 	}
+}
+
+func (c *consulFSM) applyTombstoneReapOperation(buf []byte, index uint64) interface{} {
+	var req structs.TombstoneReapRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+	return nil
 }
 
 func (c *consulFSM) Snapshot() (raft.FSMSnapshot, error) {

--- a/consul/fsm_test.go
+++ b/consul/fsm_test.go
@@ -42,7 +42,7 @@ func TestFSM_RegisterNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestFSM_RegisterNode_Service(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestFSM_DeregisterService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestFSM_DeregisterCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -328,7 +328,7 @@ func TestFSM_SnapshotRestore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -372,7 +372,7 @@ func TestFSM_SnapshotRestore(t *testing.T) {
 	}
 
 	// Try to restore on a new FSM
-	fsm2, err := NewFSM(path, os.Stderr)
+	fsm2, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestFSM_KVSSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -492,7 +492,7 @@ func TestFSM_KVSDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -542,7 +542,7 @@ func TestFSM_KVSDeleteTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -593,7 +593,7 @@ func TestFSM_KVSCheckAndSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -654,7 +654,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -738,7 +738,7 @@ func TestFSM_KVSLock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -787,7 +787,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -854,7 +854,7 @@ func TestFSM_ACL_Set_Delete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/consul/issue_test.go
+++ b/consul/issue_test.go
@@ -15,7 +15,7 @@ func TestHealthCheckRace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	fsm, err := NewFSM(path, os.Stderr)
+	fsm, err := NewFSM(nil, path, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -536,6 +536,7 @@ func (s *Server) removeConsulServer(m serf.Member, port int) error {
 // through Raft to ensure consistency. We do this outside the leader loop
 // to avoid blocking.
 func (s *Server) reapTombstones(index uint64) {
+	defer metrics.MeasureSince([]string{"consul", "leader", "reapTombstones"}, time.Now())
 	req := structs.TombstoneRequest{
 		Datacenter:   s.config.Datacenter,
 		Op:           structs.TombstoneReap,

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -536,12 +536,13 @@ func (s *Server) removeConsulServer(m serf.Member, port int) error {
 // through Raft to ensure consistency. We do this outside the leader loop
 // to avoid blocking.
 func (s *Server) reapTombstones(index uint64) {
-	req := structs.TombstoneReapRequest{
+	req := structs.TombstoneRequest{
 		Datacenter:   s.config.Datacenter,
+		Op:           structs.TombstoneReap,
 		ReapIndex:    index,
 		WriteRequest: structs.WriteRequest{Token: s.config.ACLToken},
 	}
-	_, err := s.raftApply(structs.TombstoneReapRequestType, &req)
+	_, err := s.raftApply(structs.TombstoneRequestType, &req)
 	if err != nil {
 		s.logger.Printf("[ERR] consul: failed to reap tombstones up to %d: %v",
 			index, err)

--- a/consul/mdb_table.go
+++ b/consul/mdb_table.go
@@ -389,10 +389,32 @@ func (t *MDBTable) GetTxn(tx *MDBTxn, index string, parts ...string) ([]interfac
 
 	// Accumulate the results
 	var results []interface{}
-	err = idx.iterate(tx, key, func(encRowId, res []byte) bool {
+	err = idx.iterate(tx, key, func(encRowId, res []byte) (bool, bool) {
 		obj := t.Decoder(res)
 		results = append(results, obj)
-		return false
+		return false, false
+	})
+
+	return results, err
+}
+
+// GetTxnLimit is like GetTxn limits the maximum number of
+// rows it will return
+func (t *MDBTable) GetTxnLimit(tx *MDBTxn, limit int, index string, parts ...string) ([]interface{}, error) {
+	// Get the associated index
+	idx, key, err := t.getIndex(index, parts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Accumulate the results
+	var results []interface{}
+	num := 0
+	err = idx.iterate(tx, key, func(encRowId, res []byte) (bool, bool) {
+		num++
+		obj := t.Decoder(res)
+		results = append(results, obj)
+		return false, num == limit
 	})
 
 	return results, err
@@ -412,10 +434,10 @@ func (t *MDBTable) StreamTxn(stream chan<- interface{}, tx *MDBTxn, index string
 	}
 
 	// Stream the results
-	err = idx.iterate(tx, key, func(encRowId, res []byte) bool {
+	err = idx.iterate(tx, key, func(encRowId, res []byte) (bool, bool) {
 		obj := t.Decoder(res)
 		stream <- obj
-		return false
+		return false, false
 	})
 
 	return err
@@ -508,7 +530,7 @@ func (t *MDBTable) innerDeleteWithIndex(tx *MDBTxn, idx *MDBIndex, key []byte) (
 	}()
 
 	// Delete everything as we iterate
-	err = idx.iterate(tx, key, func(encRowId, res []byte) bool {
+	err = idx.iterate(tx, key, func(encRowId, res []byte) (bool, bool) {
 		// Get the object
 		obj := t.Decoder(res)
 
@@ -542,7 +564,7 @@ func (t *MDBTable) innerDeleteWithIndex(tx *MDBTxn, idx *MDBIndex, key []byte) (
 
 		// Delete the object
 		num++
-		return true
+		return true, false
 	})
 	if err != nil {
 		return 0, err
@@ -644,7 +666,7 @@ func (i *MDBIndex) keyFromParts(parts ...string) []byte {
 // and invoking the cb with each row. We dereference the rowid,
 // and only return the object row
 func (i *MDBIndex) iterate(tx *MDBTxn, prefix []byte,
-	cb func(encRowId, res []byte) bool) error {
+	cb func(encRowId, res []byte) (bool, bool)) error {
 	table := tx.dbis[i.table.Name]
 
 	// If virtual, use the correct DBI
@@ -667,8 +689,9 @@ func (i *MDBIndex) iterate(tx *MDBTxn, prefix []byte,
 
 	var key, encRowId, objBytes []byte
 	first := true
+	shouldStop := false
 	shouldDelete := false
-	for {
+	for !shouldStop {
 		if first && len(prefix) > 0 {
 			first = false
 			key, encRowId, err = cursor.Get(prefix, mdb.SET_RANGE)
@@ -708,7 +731,8 @@ func (i *MDBIndex) iterate(tx *MDBTxn, prefix []byte,
 		}
 
 		// Invoke the cb
-		if shouldDelete = cb(encRowId, objBytes); shouldDelete {
+		shouldDelete, shouldStop = cb(encRowId, objBytes)
+		if shouldDelete {
 			if err := cursor.Del(0); err != nil {
 				return fmt.Errorf("delete failed: %v", err)
 			}

--- a/consul/mdb_table_test.go
+++ b/consul/mdb_table_test.go
@@ -2,12 +2,13 @@ package consul
 
 import (
 	"bytes"
-	"github.com/armon/gomdb"
-	"github.com/hashicorp/go-msgpack/codec"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/armon/gomdb"
+	"github.com/hashicorp/go-msgpack/codec"
 )
 
 type MockData struct {
@@ -968,5 +969,80 @@ func TestMDBTableStream(t *testing.T) {
 
 	if idx != 3 {
 		t.Fatalf("bad index: %d", idx)
+	}
+}
+
+func TestMDBTableGetTxnLimit(t *testing.T) {
+	dir, env := testMDBEnv(t)
+	defer os.RemoveAll(dir)
+	defer env.Close()
+
+	table := &MDBTable{
+		Env:  env,
+		Name: "test",
+		Indexes: map[string]*MDBIndex{
+			"id": &MDBIndex{
+				Unique: true,
+				Fields: []string{"Key"},
+			},
+			"name": &MDBIndex{
+				Fields: []string{"First", "Last"},
+			},
+			"country": &MDBIndex{
+				Fields: []string{"Country"},
+			},
+		},
+		Encoder: MockEncoder,
+		Decoder: MockDecoder,
+	}
+	if err := table.Init(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	objs := []*MockData{
+		&MockData{
+			Key:     "1",
+			First:   "Kevin",
+			Last:    "Smith",
+			Country: "USA",
+		},
+		&MockData{
+			Key:     "2",
+			First:   "Kevin",
+			Last:    "Wang",
+			Country: "USA",
+		},
+		&MockData{
+			Key:     "3",
+			First:   "Bernardo",
+			Last:    "Torres",
+			Country: "Mexico",
+		},
+	}
+
+	// Insert some mock objects
+	for idx, obj := range objs {
+		if err := table.Insert(obj); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if err := table.SetLastIndex(uint64(idx + 1)); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Start a readonly txn
+	tx, err := table.StartTxn(true, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer tx.Abort()
+
+	// Verify with some gets
+	res, err := table.GetTxnLimit(tx, 2, "id")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("expect 2 result: %#v", res)
 	}
 }

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -1212,7 +1212,10 @@ func (s *StateStore) kvsDeleteWithIndex(index uint64, tableIndex string, parts .
 		return err
 	}
 	defer tx.Abort()
-	return s.kvsDeleteWithIndexTxn(index, tx, tableIndex, parts...)
+	if err := s.kvsDeleteWithIndexTxn(index, tx, tableIndex, parts...); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // kvsDeleteWithIndexTxn does a delete within an existing transaction
@@ -1259,7 +1262,7 @@ func (s *StateStore) kvsDeleteWithIndexTxn(index uint64, tx *MDBTxn, tableIndex 
 			}
 		})
 	}
-	return tx.Commit()
+	return nil
 }
 
 // KVSCheckAndSet is used to perform an atomic check-and-set

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -1417,6 +1417,7 @@ func (s *StateStore) ReapTombstones(index uint64) error {
 		s.logger.Printf("[ERR] consul.state: Failed to scan tombstones: %v", err)
 		return fmt.Errorf("failed to scan tombstones: %v", err)
 	}
+	<-doneCh
 
 	// Delete each tombstone
 	if len(toDelete) > 0 {

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -296,6 +296,12 @@ func (s *StateStore) initialize() error {
 				Unique: true,
 				Fields: []string{"Key"},
 			},
+			"id_prefix": &MDBIndex{
+				Virtual:   true,
+				RealIndex: "id",
+				Fields:    []string{"Key"},
+				IdxFunc:   DefaultIndexPrefixFunc,
+			},
 		},
 		Decoder: func(buf []byte) interface{} {
 			out := new(structs.DirEntry)

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -1237,8 +1237,10 @@ func (s *StateStore) kvsDeleteWithIndexTxn(index uint64, tx *MDBTxn, tableIndex 
 			if err := s.tombstoneTable.InsertTxn(tx, ent); err != nil {
 				return err
 			}
-			if _, err := s.kvsTable.DeleteTxn(tx, "id", ent.Key); err != nil {
+			if num, err := s.kvsTable.DeleteTxn(tx, "id", ent.Key); err != nil {
 				return err
+			} else if num != 1 {
+				return fmt.Errorf("Failed to delete key '%s'", ent.Key)
 			}
 		}
 

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -1458,19 +1458,19 @@ func (s *StateStore) ReapTombstones(index uint64) error {
 		}
 	}()
 	if err := s.tombstoneTable.StreamTxn(streamCh, tx, "id"); err != nil {
-		s.logger.Printf("[ERR] consul.state: Failed to scan tombstones: %v", err)
+		s.logger.Printf("[ERR] consul.state: failed to scan tombstones: %v", err)
 		return fmt.Errorf("failed to scan tombstones: %v", err)
 	}
 	<-doneCh
 
 	// Delete each tombstone
 	if len(toDelete) > 0 {
-		s.logger.Printf("[DEBUG] consul.state: Reaping %d tombstones", len(toDelete))
+		s.logger.Printf("[DEBUG] consul.state: reaping %d tombstones up to %d", len(toDelete), index)
 	}
 	for _, key := range toDelete {
 		num, err := s.tombstoneTable.DeleteTxn(tx, "id", key)
 		if err != nil {
-			s.logger.Printf("[ERR] consul.state: Failed to delete tombstone: %v", err)
+			s.logger.Printf("[ERR] consul.state: failed to delete tombstone: %v", err)
 			return fmt.Errorf("failed to delete tombstone: %v", err)
 		}
 		if num != 1 {

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -132,6 +132,7 @@ func NewStateStorePath(gc *TombstoneGC, path string, logOutput io.Writer) (*Stat
 		env:       env,
 		watch:     make(map[*MDBTable]*NotifyGroup),
 		lockDelay: make(map[string]time.Time),
+		gc:        gc,
 	}
 
 	// Ensure we can initialize

--- a/consul/state_store_test.go
+++ b/consul/state_store_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func testStateStore() (*StateStore, error) {
-	return NewStateStore(os.Stderr)
+	return NewStateStore(nil, os.Stderr)
 }
 
 func TestEnsureRegistration(t *testing.T) {
@@ -1413,6 +1413,14 @@ func TestKVSDelete(t *testing.T) {
 	}
 	defer store.Close()
 
+	ttl := 10 * time.Millisecond
+	gran := 5 * time.Millisecond
+	gc, err := NewTombstoneGC(ttl, gran)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	store.gc = gc
+
 	// Create the entry
 	d := &structs.DirEntry{Key: "/foo", Flags: 42, Value: []byte("test")}
 	if err := store.KVSSet(1000, d); err != nil {
@@ -1434,6 +1442,16 @@ func TestKVSDelete(t *testing.T) {
 	}
 	if d != nil {
 		t.Fatalf("bad: %v", d)
+	}
+
+	// Check that we get a delete
+	select {
+	case idx := <-gc.ExpireCh():
+		if idx != 1020 {
+			t.Fatalf("bad %d", idx)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatalf("should expire")
 	}
 }
 
@@ -1737,6 +1755,14 @@ func TestKVSDeleteTree(t *testing.T) {
 	}
 	defer store.Close()
 
+	ttl := 10 * time.Millisecond
+	gran := 5 * time.Millisecond
+	gc, err := NewTombstoneGC(ttl, gran)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	store.gc = gc
+
 	// Should not exist
 	err = store.KVSDeleteTree(1000, "/web")
 	if err != nil {
@@ -1773,6 +1799,16 @@ func TestKVSDeleteTree(t *testing.T) {
 	}
 	if len(ents) != 0 {
 		t.Fatalf("bad: %v", ents)
+	}
+
+	// Check that we get a delete
+	select {
+	case idx := <-gc.ExpireCh():
+		if idx != 1010 {
+			t.Fatalf("bad %d", idx)
+		}
+	case <-time.After(20 * time.Millisecond):
+		t.Fatalf("should expire")
 	}
 }
 

--- a/consul/state_store_test.go
+++ b/consul/state_store_test.go
@@ -1472,6 +1472,7 @@ func TestKVSDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	gc.SetEnabled(true)
 	store.gc = gc
 
 	// Create the entry
@@ -1934,6 +1935,7 @@ func TestKVSDeleteTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	gc.SetEnabled(true)
 	store.gc = gc
 
 	// Should not exist
@@ -2015,6 +2017,7 @@ func TestReapTombstones(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	gc.SetEnabled(true)
 	store.gc = gc
 
 	// Should not exist

--- a/consul/state_store_test.go
+++ b/consul/state_store_test.go
@@ -1444,6 +1444,15 @@ func TestKVSDelete(t *testing.T) {
 		t.Fatalf("bad: %v", d)
 	}
 
+	// Check tombstone exists
+	_, res, err := store.tombstoneTable.Get("id", "/foo")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res == nil || res[0].(*structs.DirEntry).ModifyIndex != 1020 {
+		t.Fatalf("bad: %#v", d)
+	}
+
 	// Check that we get a delete
 	select {
 	case idx := <-gc.ExpireCh():
@@ -1799,6 +1808,20 @@ func TestKVSDeleteTree(t *testing.T) {
 	}
 	if len(ents) != 0 {
 		t.Fatalf("bad: %v", ents)
+	}
+
+	// Check tombstones exists
+	_, res, err := store.tombstoneTable.Get("id_prefix", "/web")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("bad: %#v", d)
+	}
+	for _, r := range res {
+		if r.(*structs.DirEntry).ModifyIndex != 1010 {
+			t.Fatalf("bad: %#v", r)
+		}
 	}
 
 	// Check that we get a delete

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -23,6 +23,7 @@ const (
 	KVSRequestType
 	SessionRequestType
 	ACLRequestType
+	TombstoneReapRequestType
 )
 
 const (
@@ -529,6 +530,17 @@ func (r *EventFireRequest) RequestDatacenter() string {
 // EventFireResponse is used to respond to a fire request.
 type EventFireResponse struct {
 	QueryMeta
+}
+
+// TombstoneReapRequest is used to trigger a reaping of the tombstones
+type TombstoneReapRequest struct {
+	Datacenter string
+	ReapIndex  uint64
+	WriteRequest
+}
+
+func (r *TombstoneReapRequest) RequestDatacenter() string {
+	return r.Datacenter
 }
 
 // msgpackHandle is a shared handle for encoding/decoding of structs

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -23,7 +23,7 @@ const (
 	KVSRequestType
 	SessionRequestType
 	ACLRequestType
-	TombstoneReapRequestType
+	TombstoneRequestType
 )
 
 const (
@@ -532,14 +532,21 @@ type EventFireResponse struct {
 	QueryMeta
 }
 
-// TombstoneReapRequest is used to trigger a reaping of the tombstones
-type TombstoneReapRequest struct {
+type TombstoneOp string
+
+const (
+	TombstoneReap TombstoneOp = "reap"
+)
+
+// TombstoneRequest is used to trigger a reaping of the tombstones
+type TombstoneRequest struct {
 	Datacenter string
+	Op         TombstoneOp
 	ReapIndex  uint64
 	WriteRequest
 }
 
-func (r *TombstoneReapRequest) RequestDatacenter() string {
+func (r *TombstoneRequest) RequestDatacenter() string {
 	return r.Datacenter
 }
 

--- a/consul/tombstone_gc.go
+++ b/consul/tombstone_gc.go
@@ -1,0 +1,104 @@
+package consul
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// TombstoneGC is used to track creation of tombstones
+// so that they can be garbage collected after their TTL
+// expires. The tombstones allow queries to provide monotonic
+// index values within the TTL window. The GC is used to
+// prevent monotonic growth in storage usage. This is a trade off
+// between the length of the TTL and the storage overhead.
+//
+// In practice, this is required to fix the issue of delete
+// visibility. When data is deleted from the KV store, the
+// "latest" row can go backwards if the newest row is removed.
+// The tombstones provide a way to ensure time doesn't move
+// backwards within some interval.
+//
+type TombstoneGC struct {
+	ttl         time.Duration
+	granularity time.Duration
+
+	// expires maps the time of expiration to the highest
+	// tombstone value that should be expired.
+	expires     map[time.Time]uint64
+	expiresLock sync.Mutex
+
+	// expireCh is used to stream expiration
+	expireCh chan uint64
+}
+
+// NewTombstoneGC is used to construct a new TombstoneGC given
+// a TTL for tombstones and a tracking granularity. Longer TTLs
+// ensure correct behavior for more time, but use more storage.
+// A shorter granularity increases the number of Raft transactions
+// and reduce how far past the TTL we perform GC.
+func NewTombstoneGC(ttl, granularity time.Duration) (*TombstoneGC, error) {
+	// Sanity check the inputs
+	if ttl <= 0 || granularity <= 0 {
+		return nil, fmt.Errorf("Tombstone TTL and granularity must be positive")
+	}
+
+	t := &TombstoneGC{
+		ttl:         ttl,
+		granularity: granularity,
+		expires:     make(map[time.Time]uint64),
+		expireCh:    make(chan uint64, 1),
+	}
+	return t, nil
+}
+
+// ExpireCh is used to return a channel that streams the next index
+// that should be expired
+func (t *TombstoneGC) ExpireCh() <-chan uint64 {
+	return t.expireCh
+}
+
+// Hint is used to indicate that keys at the given index have been
+// deleted, and that their GC should be scheduled.
+func (t *TombstoneGC) Hint(index uint64) {
+	expires := t.nextExpires()
+
+	t.expiresLock.Lock()
+	defer t.expiresLock.Unlock()
+
+	// Check for an existing expiration timer
+	existing, ok := t.expires[expires]
+	if ok {
+		// Increment the highest index to be expired at that time
+		if index > existing {
+			t.expires[expires] = index
+		}
+		return
+	}
+
+	// Create new expiration time
+	t.expires[expires] = index
+	time.AfterFunc(expires.Sub(time.Now()), func() {
+		t.expireTime(expires)
+	})
+}
+
+// nextExpires is used to calculate the next experation time
+func (t *TombstoneGC) nextExpires() time.Time {
+	expires := time.Now().Add(t.ttl)
+	remain := expires.UnixNano() % int64(t.granularity)
+	adj := expires.Add(t.granularity - time.Duration(remain))
+	return adj
+}
+
+// expireTime is used to expire the entries at the given time
+func (t *TombstoneGC) expireTime(expires time.Time) {
+	// Get the maximum index and clear the entry
+	t.expiresLock.Lock()
+	index := t.expires[expires]
+	delete(t.expires, expires)
+	t.expiresLock.Unlock()
+
+	// Notify the expires channel
+	t.expireCh <- index
+}

--- a/consul/tombstone_gc.go
+++ b/consul/tombstone_gc.go
@@ -102,6 +102,13 @@ func (t *TombstoneGC) Hint(index uint64) {
 	}
 }
 
+// PendingExpiration is used to check if any expirations are pending
+func (t *TombstoneGC) PendingExpiration() bool {
+	t.expiresLock.Lock()
+	defer t.expiresLock.Unlock()
+	return len(t.expires) > 0
+}
+
 // nextExpires is used to calculate the next experation time
 func (t *TombstoneGC) nextExpires() time.Time {
 	expires := time.Now().Add(t.ttl)

--- a/consul/tombstone_gc_test.go
+++ b/consul/tombstone_gc_test.go
@@ -1,0 +1,68 @@
+package consul
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTombstoneGC_invalid(t *testing.T) {
+	_, err := NewTombstoneGC(0, 0)
+	if err == nil {
+		t.Fatalf("should fail")
+	}
+
+	_, err = NewTombstoneGC(time.Second, 0)
+	if err == nil {
+		t.Fatalf("should fail")
+	}
+
+	_, err = NewTombstoneGC(0, time.Second)
+	if err == nil {
+		t.Fatalf("should fail")
+	}
+}
+
+func TestTombstoneGC(t *testing.T) {
+	ttl := 20 * time.Millisecond
+	gran := 5 * time.Millisecond
+	gc, err := NewTombstoneGC(ttl, gran)
+	if err != nil {
+		t.Fatalf("should fail")
+	}
+
+	start := time.Now()
+	gc.Hint(100)
+
+	time.Sleep(2 * gran)
+	start2 := time.Now()
+	gc.Hint(120)
+	gc.Hint(125)
+
+	select {
+	case index := <-gc.ExpireCh():
+		end := time.Now()
+		if end.Sub(start) < ttl {
+			t.Fatalf("expired early")
+		}
+		if index != 100 {
+			t.Fatalf("bad index: %d", index)
+		}
+
+	case <-time.After(ttl * 2):
+		t.Fatalf("should get expiration")
+	}
+
+	select {
+	case index := <-gc.ExpireCh():
+		end := time.Now()
+		if end.Sub(start2) < ttl {
+			t.Fatalf("expired early")
+		}
+		if index != 125 {
+			t.Fatalf("bad index: %d", index)
+		}
+
+	case <-time.After(ttl * 2):
+		t.Fatalf("should get expiration")
+	}
+}

--- a/consul/tombstone_gc_test.go
+++ b/consul/tombstone_gc_test.go
@@ -66,3 +66,21 @@ func TestTombstoneGC(t *testing.T) {
 		t.Fatalf("should get expiration")
 	}
 }
+
+func TestTombstoneGC_Expire(t *testing.T) {
+	ttl := 10 * time.Millisecond
+	gran := 5 * time.Millisecond
+	gc, err := NewTombstoneGC(ttl, gran)
+	if err != nil {
+		t.Fatalf("should fail")
+	}
+
+	gc.Hint(100)
+	gc.Reset()
+
+	select {
+	case <-gc.ExpireCh():
+		t.Fatalf("shoudl be reset")
+	case <-time.After(20 * time.Millisecond):
+	}
+}

--- a/consul/tombstone_gc_test.go
+++ b/consul/tombstone_gc_test.go
@@ -29,6 +29,7 @@ func TestTombstoneGC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should fail")
 	}
+	gc.SetEnabled(true)
 
 	if gc.PendingExpiration() {
 		t.Fatalf("should not be pending")
@@ -82,13 +83,14 @@ func TestTombstoneGC_Expire(t *testing.T) {
 	if err != nil {
 		t.Fatalf("should fail")
 	}
+	gc.SetEnabled(true)
 
 	if gc.PendingExpiration() {
 		t.Fatalf("should not be pending")
 	}
 
 	gc.Hint(100)
-	gc.Reset()
+	gc.SetEnabled(false)
 
 	if gc.PendingExpiration() {
 		t.Fatalf("should not be pending")

--- a/consul/tombstone_gc_test.go
+++ b/consul/tombstone_gc_test.go
@@ -30,6 +30,10 @@ func TestTombstoneGC(t *testing.T) {
 		t.Fatalf("should fail")
 	}
 
+	if gc.PendingExpiration() {
+		t.Fatalf("should not be pending")
+	}
+
 	start := time.Now()
 	gc.Hint(100)
 
@@ -37,6 +41,10 @@ func TestTombstoneGC(t *testing.T) {
 	start2 := time.Now()
 	gc.Hint(120)
 	gc.Hint(125)
+
+	if !gc.PendingExpiration() {
+		t.Fatalf("should be pending")
+	}
 
 	select {
 	case index := <-gc.ExpireCh():
@@ -75,8 +83,16 @@ func TestTombstoneGC_Expire(t *testing.T) {
 		t.Fatalf("should fail")
 	}
 
+	if gc.PendingExpiration() {
+		t.Fatalf("should not be pending")
+	}
+
 	gc.Hint(100)
 	gc.Reset()
+
+	if gc.PendingExpiration() {
+		t.Fatalf("should not be pending")
+	}
 
 	select {
 	case <-gc.ExpireCh():


### PR DESCRIPTION
Fixes #195. The visible issue from the outside of Consul is that if you are watching a prefix for changes (say service/web/config) for changes, and a key is deleted from the folder then the X-Consul-Index value either doesn't change or goes backward. This means that long-polling for changes breaks during a deletion. The reason for this is that the index is calculated as the Max(ModifyTime) of all the entries. The Max() function however is only monotonic if the inputs are also monotonic. A delete breaks this by removing entries, causing the Max value to slide backward or to stagnate. Because of this, blocking queries get "stuck". This is what a user experiences.

To fix this, we need to ensure X-Consul-Index is monotonic, even with deletes. This is tricky because you need to detect the absence of data. One way to do this is to never actually delete, but only soft delete and filter the results. Unfortunately, this causes unbounded data usage. The trade off we make is to soft delete by creating a "tombstone" entry. These are kept around for a configurable amount of time (default 15 minutes) and then GC'd later. This prevents unbounded data growth. However, while the tombstones are around, we use them to calculate the X-Consul-Index value and ensure the inputs are monotonic. Because of the tradeoff with unbounded storage growth, this only papers over the issue until the GC happens, at which point the index may slide backwards again.

In practice, this fixes the issues with replication and change detection and so works well enough. The only clients that would be affected by the GC are ones that are doing blocking queries extremely infrequently (less often than the GC runs). This is an edge case, and the behavior will be no worse than it currently is for them.
