### PR TITLE
Optimize performance of KV watchers

### DIFF
--- a/consul/kvs_endpoint.go
+++ b/consul/kvs_endpoint.go
@@ -90,10 +90,13 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 
 	// Get the local state
 	state := k.srv.fsm.State()
-	return k.srv.blockingRPC(&args.QueryOptions,
-		&reply.QueryMeta,
-		state.QueryTables("KVSGet"),
-		func() error {
+	opts := blockingRPCOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		tables:    nil,
+		kvWatch:   true,
+		kvPrefix:  args.Key,
+		run: func() error {
 			index, ent, err := state.KVSGet(args.Key)
 			if err != nil {
 				return err
@@ -115,7 +118,9 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 				reply.Entries = structs.DirEntries{ent}
 			}
 			return nil
-		})
+		},
+	}
+	return k.srv.blockingRPCOpt(&opts)
 }
 
 // List is used to list all keys with a given prefix
@@ -131,10 +136,13 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 
 	// Get the local state
 	state := k.srv.fsm.State()
-	return k.srv.blockingRPC(&args.QueryOptions,
-		&reply.QueryMeta,
-		state.QueryTables("KVSList"),
-		func() error {
+	opts := blockingRPCOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		tables:    nil,
+		kvWatch:   true,
+		kvPrefix:  args.Key,
+		run: func() error {
 			tombIndex, index, ent, err := state.KVSList(args.Key)
 			if err != nil {
 				return err
@@ -166,7 +174,9 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 				reply.Entries = ent
 			}
 			return nil
-		})
+		},
+	}
+	return k.srv.blockingRPCOpt(&opts)
 }
 
 // ListKeys is used to list all keys with a given prefix to a seperator
@@ -182,10 +192,13 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 
 	// Get the local state
 	state := k.srv.fsm.State()
-	return k.srv.blockingRPC(&args.QueryOptions,
-		&reply.QueryMeta,
-		state.QueryTables("KVSListKeys"),
-		func() error {
+	opts := blockingRPCOptions{
+		queryOpts: &args.QueryOptions,
+		queryMeta: &reply.QueryMeta,
+		tables:    nil,
+		kvWatch:   true,
+		kvPrefix:  args.Prefix,
+		run: func() error {
 			index, keys, err := state.KVSListKeys(args.Prefix, args.Seperator)
 			reply.Index = index
 			if acl != nil {
@@ -193,5 +206,8 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 			}
 			reply.Keys = keys
 			return err
-		})
+
+		},
+	}
+	return k.srv.blockingRPCOpt(&opts)
 }

--- a/consul/kvs_endpoint.go
+++ b/consul/kvs_endpoint.go
@@ -93,7 +93,6 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 	opts := blockingRPCOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
-		tables:    nil,
 		kvWatch:   true,
 		kvPrefix:  args.Key,
 		run: func() error {
@@ -139,7 +138,6 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 	opts := blockingRPCOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
-		tables:    nil,
 		kvWatch:   true,
 		kvPrefix:  args.Key,
 		run: func() error {
@@ -195,7 +193,6 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 	opts := blockingRPCOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
-		tables:    nil,
 		kvWatch:   true,
 		kvPrefix:  args.Prefix,
 		run: func() error {


### PR DESCRIPTION
Previously a single NotifyGroup was used to watch for changes in the KV table. This meant that any update to the table would trigger all the blocking queries to check for an update. This meant having many watchers would add a dramatic load under high write conditions. With this change, we scope the watchers under a prefix, and only trigger watchers that may be affected by a write operation. This should vastly reduce the number of watchers that are triggered in practice, making them much more scalable.