### PR TITLE
replaced consul domain with configured domain. Fixes #582

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -201,7 +201,7 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 			if arpa == qName {
 				ptr := &dns.PTR{
 					Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: 0},
-					Ptr: fmt.Sprintf("%s.node.%s.consul.", n.Node, datacenter),
+					Ptr: fmt.Sprintf("%s.node.%s.%s.", n.Node, datacenter, d.domain),
 				}
 				m.Answer = append(m.Answer, ptr)
 				break


### PR DESCRIPTION
I'm getting test failures for the reverse lookups but I'm not sure if it's something to do with my env. I can't see how this change would have caused this though.

--- FAIL: TestDNS_ReverseLookup (2.10s)
	dns_test.go:333: err: read udp 127.0.0.1:19059: i/o timeout
--- FAIL: TestDNS_ReverseLookup_IPV6 (2.11s)
	dns_test.go:375: err: read udp 127.0.0.1:19060: i/o timeout