### PR TITLE
RPC and HTTP interfaces fully generically-sockified so Unix is supported...

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -249,7 +249,7 @@ func (r *request) toHTTP() (*http.Request, error) {
 	req.Host = r.url.Host
 
 	// Setup auth
-	if err == nil && r.config.HttpAuth != nil {
+	if r.config.HttpAuth != nil {
 		req.SetBasicAuth(r.config.HttpAuth.Username, r.config.HttpAuth.Password)
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,7 +20,7 @@ type testServer struct {
 	configFile string
 }
 
-type TestPortConfig struct {
+type testPortConfig struct {
 	DNS     int `json:"dns,omitempty"`
 	HTTP    int `json:"http,omitempty"`
 	RPC     int `json:"rpc,omitempty"`
@@ -29,31 +29,33 @@ type TestPortConfig struct {
 	Server  int `json:"server,omitempty"`
 }
 
-type TestAddressConfig struct {
+type testAddressConfig struct {
 	HTTP string `json:"http,omitempty"`
 }
 
-type TestServerConfig struct {
+type testServerConfig struct {
 	Bootstrap bool               `json:"bootstrap,omitempty"`
 	Server    bool               `json:"server,omitempty"`
 	DataDir   string             `json:"data_dir,omitempty"`
 	LogLevel  string             `json:"log_level,omitempty"`
-	Addresses *TestAddressConfig `json:"addresses,omitempty"`
-	Ports     TestPortConfig     `json:"ports,omitempty"`
+	Addresses *testAddressConfig `json:"addresses,omitempty"`
+	Ports     testPortConfig     `json:"ports,omitempty"`
 }
 
-var consulConfig = &TestServerConfig{
-	Bootstrap: true,
-	Server:    true,
-	LogLevel:  "debug",
-	Ports: TestPortConfig{
-		DNS:     19000,
-		HTTP:    18800,
-		RPC:     18600,
-		SerfLan: 18200,
-		SerfWan: 18400,
-		Server:  18000,
-	},
+func defaultConfig() *testServerConfig {
+	return &testServerConfig{
+		Bootstrap: true,
+		Server:    true,
+		LogLevel:  "debug",
+		Ports: testPortConfig{
+			DNS:     19000,
+			HTTP:    18800,
+			RPC:     18600,
+			SerfLan: 18200,
+			SerfWan: 18400,
+			Server:  18000,
+		},
+	}
 }
 
 func (s *testServer) stop() {
@@ -67,10 +69,10 @@ func (s *testServer) stop() {
 }
 
 func newTestServer(t *testing.T) *testServer {
-	return newTestServerWithConfig(t, func(c *TestServerConfig) {})
+	return newTestServerWithConfig(t, func(c *testServerConfig) {})
 }
 
-func newTestServerWithConfig(t *testing.T, cb func(c *TestServerConfig)) *testServer {
+func newTestServerWithConfig(t *testing.T, cb func(c *testServerConfig)) *testServer {
 	if path, err := exec.LookPath("consul"); err != nil || path == "" {
 		t.Log("consul not found on $PATH, skipping")
 		t.SkipNow()
@@ -93,6 +95,7 @@ func newTestServerWithConfig(t *testing.T, cb func(c *TestServerConfig)) *testSe
 		t.Fatalf("err: %s", err)
 	}
 
+	consulConfig := defaultConfig()
 	consulConfig.DataDir = dataDir
 
 	cb(consulConfig)
@@ -125,10 +128,10 @@ func newTestServerWithConfig(t *testing.T, cb func(c *TestServerConfig)) *testSe
 func makeClient(t *testing.T) (*Client, *testServer) {
 	return makeClientWithConfig(t, func(c *Config) {
 		c.Address = "127.0.0.1:18800"
-	}, func(c *TestServerConfig) {})
+	}, func(c *testServerConfig) {})
 }
 
-func makeClientWithConfig(t *testing.T, clientConfig func(c *Config), serverConfig func(c *TestServerConfig)) (*Client, *testServer) {
+func makeClientWithConfig(t *testing.T, clientConfig func(c *Config), serverConfig func(c *testServerConfig)) (*Client, *testServer) {
 	server := newTestServerWithConfig(t, serverConfig)
 	conf := DefaultConfig()
 	clientConfig(conf)

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,11 +1,56 @@
 package api
 
 import (
+	"io/ioutil"
+	"os/user"
+	"runtime"
 	"testing"
 )
 
-func TestStatusLeader(t *testing.T) {
+func TestStatusLeaderTCP(t *testing.T) {
 	c, s := makeClient(t)
+	defer s.stop()
+
+	status := c.Status()
+
+	leader, err := status.Leader()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if leader == "" {
+		t.Fatalf("Expected leader")
+	}
+}
+
+func TestStatusLeaderUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	tempdir, err := ioutil.TempDir("", "consul-test-")
+	if err != nil {
+		t.Fatal("Could not create a working directory")
+	}
+
+	socket := "unix://" + tempdir + "/unix-http-test.sock"
+
+	clientConfig := func(c *Config) {
+		c.Address = socket
+	}
+
+	serverConfig := func(c *TestServerConfig) {
+		user, err := user.Current()
+		if err != nil {
+			t.Fatal("Could not get current user")
+		}
+
+		if c.Addresses == nil {
+			c.Addresses = &TestAddressConfig{}
+		}
+		c.Addresses.HTTP = socket + ";" + user.Uid + ";" + user.Gid + ";640"
+	}
+
+	c, s := makeClientWithConfig(t, clientConfig, serverConfig)
 	defer s.stop()
 
 	status := c.Status()

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -38,14 +38,14 @@ func TestStatusLeaderUnix(t *testing.T) {
 		c.Address = socket
 	}
 
-	serverConfig := func(c *TestServerConfig) {
+	serverConfig := func(c *testServerConfig) {
 		user, err := user.Current()
 		if err != nil {
 			t.Fatal("Could not get current user")
 		}
 
 		if c.Addresses == nil {
-			c.Addresses = &TestAddressConfig{}
+			c.Addresses = &testAddressConfig{}
 		}
 		c.Addresses.HTTP = socket + ";" + user.Uid + ";" + user.Gid + ";640"
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -123,8 +125,37 @@ func TestAgentStartStop(t *testing.T) {
 	}
 }
 
-func TestAgent_RPCPing(t *testing.T) {
+func TestAgent_RPCPingTCP(t *testing.T) {
 	dir, agent := makeAgent(t, nextConfig())
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	var out struct{}
+	if err := agent.RPC("Status.Ping", struct{}{}, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_RPCPingUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	nextConf := nextConfig()
+
+	tempdir, err := ioutil.TempDir("", "consul-test-")
+	if err != nil {
+		t.Fatal("Could not create a working directory")
+	}
+
+	user, err := user.Current()
+	if err != nil {
+		t.Fatal("Could not get current user")
+	}
+
+	nextConf.Addresses.RPC = "unix://" + tempdir + "/unix-rpc-test.sock;" + user.Uid + ";" + user.Gid + ";640"
+
+	dir, agent := makeAgent(t, nextConf)
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -589,7 +589,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Get the new client http listener addr
-	httpAddr, err := config.ClientListenerAddr(config.Addresses.HTTP, config.Ports.HTTP)
+	httpAddr, err := config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to determine HTTP address: %v", err))
 	}
@@ -599,7 +599,7 @@ func (c *Command) Run(args []string) int {
 		go func(wp *watch.WatchPlan) {
 			wp.Handler = makeWatchHandler(logOutput, wp.Exempt["handler"])
 			wp.LogOutput = c.logOutput
-			if err := wp.Run(httpAddr); err != nil {
+			if err := wp.Run(httpAddr.String()); err != nil {
 				c.Ui.Error(fmt.Sprintf("Error running watch: %v", err))
 			}
 		}(wp)
@@ -758,7 +758,7 @@ func (c *Command) handleReload(config *Config) *Config {
 	}
 
 	// Get the new client listener addr
-	httpAddr, err := newConf.ClientListenerAddr(config.Addresses.HTTP, config.Ports.HTTP)
+	httpAddr, err := newConf.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to determine HTTP address: %v", err))
 	}
@@ -773,7 +773,7 @@ func (c *Command) handleReload(config *Config) *Config {
 		go func(wp *watch.WatchPlan) {
 			wp.Handler = makeWatchHandler(c.logOutput, wp.Exempt["handler"])
 			wp.LogOutput = c.logOutput
-			if err := wp.Run(httpAddr); err != nil {
+			if err := wp.Run(httpAddr.String()); err != nil {
 				c.Ui.Error(fmt.Sprintf("Error running watch: %v", err))
 			}
 		}(wp)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -500,24 +500,17 @@ func (c *Config) ClientListener(override string, port int) (net.Addr, error) {
 		if ip == nil {
 			return nil, fmt.Errorf("Failed to parse IP: %v", addr)
 		}
+
+		if ip.IsUnspecified() {
+			ip = net.ParseIP("127.0.0.1")
+		}
+
+		if ip == nil {
+			return nil, fmt.Errorf("Failed to parse IP 127.0.0.1")
+		}
+
 		return &net.TCPAddr{IP: ip, Port: port}, nil
 	}
-}
-
-// ClientListenerAddr is used to format an address for a
-// port on a ClientAddr, handling the zero IP.
-func (c *Config) ClientListenerAddr(override string, port int) (string, error) {
-	addr, err := c.ClientListener(override, port)
-	if err != nil {
-		return "", err
-	}
-
-	if ipAddr, ok := addr.(*net.TCPAddr); ok {
-		if ipAddr.IP.IsUnspecified() {
-			ipAddr.IP = net.ParseIP("127.0.0.1")
-		}
-	}
-	return addr.String(), nil
 }
 
 // DecodeConfig reads the configuration from the given reader in JSON

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -384,15 +384,14 @@ func populateUnixSocket(addr string) (*UnixSocket, error) {
 	} else {
 		userVal, err = user.Lookup(splitAddr[1])
 	}
-
 	if err != nil {
 		return nil, fmt.Errorf("Invalid user given for Unix socket ownership: %v", splitAddr[1])
+	}
+
+	if uid64, err := strconv.ParseInt(userVal.Uid, 10, 32); err != nil {
+		return nil, fmt.Errorf("Failed to parse given user ID of %v into integer", userVal.Uid)
 	} else {
-		if uid64, err := strconv.ParseInt(userVal.Uid, 10, 32); err != nil {
-			return nil, fmt.Errorf("Failed to parse given user ID of %v into integer", userVal.Uid)
-		} else {
-			ret.Uid = int(uid64)
-		}
+		ret.Uid = int(uid64)
 	}
 
 	// Go doesn't currently have a way to look up gid from group name,

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -345,6 +347,82 @@ type Config struct {
 	WatchPlans []*watch.WatchPlan `mapstructure:"-" json:"-"`
 }
 
+// UnixSocket contains the parameters for a Unix socket interface
+type UnixSocket struct {
+	// Path to the socket on-disk
+	Path string
+
+	// uid of the owner of the socket
+	Uid int
+
+	// gid of the group of the socket
+	Gid int
+
+	// Permissions for the socket file
+	Permissions os.FileMode
+}
+
+func populateUnixSocket(addr string) (*UnixSocket, error) {
+	if !strings.HasPrefix(addr, "unix://") {
+		return nil, fmt.Errorf("Failed to parse Unix address, format is [path];[user];[group];[mode]: %v", addr)
+	}
+
+	splitAddr := strings.Split(strings.TrimPrefix(addr, "unix://"), ";")
+	if len(splitAddr) != 4 {
+		return nil, fmt.Errorf("Failed to parse Unix address, format is [path];[user];[group];[mode]: %v", addr)
+	}
+
+	ret := &UnixSocket{Path: splitAddr[0]}
+
+	if userVal, err := user.Lookup(splitAddr[1]); err != nil {
+		return nil, fmt.Errorf("Invalid user given for Unix socket ownership: %v", splitAddr[1])
+	} else {
+		if uid64, err := strconv.ParseInt(userVal.Uid, 10, 32); err != nil {
+			return nil, fmt.Errorf("Failed to parse given user ID of %v into integer", userVal.Uid)
+		} else {
+			ret.Uid = int(uid64)
+		}
+	}
+
+	// Go doesn't currently have a way to look up gid from group name,
+	// so require a numeric gid; see
+	// https://codereview.appspot.com/101310044
+	if gid64, err := strconv.ParseInt(splitAddr[2], 10, 32); err != nil {
+		return nil, fmt.Errorf("Socket group must be given as numeric gid. Failed to parse given group ID of %v into integer", splitAddr[2])
+	} else {
+		ret.Gid = int(gid64)
+	}
+
+	if mode, err := strconv.ParseUint(splitAddr[3], 8, 32); err != nil {
+		return nil, fmt.Errorf("Failed to parse given mode of %v into integer", splitAddr[3])
+	} else {
+		if mode > 0777 {
+			return nil, fmt.Errorf("Given mode is invalid; must be an octal number between 0 and 777")
+		} else {
+			ret.Permissions = os.FileMode(mode)
+		}
+	}
+
+	return ret, nil
+}
+
+func adjustUnixSocketPermissions(addr string) error {
+	sock, err := populateUnixSocket(addr)
+	if err != nil {
+		return err
+	}
+
+	if err = os.Chown(sock.Path, sock.Uid, sock.Gid); err != nil {
+		return fmt.Errorf("Error attempting to change socket permissions to userid %v and groupid %v: %v", sock.Uid, sock.Gid, err)
+	}
+
+	if err = os.Chmod(sock.Path, sock.Permissions); err != nil {
+		return fmt.Errorf("Error attempting to change socket permissions to mode %v: %v", sock.Permissions, err)
+	}
+
+	return nil
+}
+
 type dirEnts []os.FileInfo
 
 // DefaultConfig is used to return a sane default configuration
@@ -389,18 +467,30 @@ func (c *Config) EncryptBytes() ([]byte, error) {
 
 // ClientListener is used to format a listener for a
 // port on a ClientAddr
-func (c *Config) ClientListener(override string, port int) (*net.TCPAddr, error) {
+func (c *Config) ClientListener(override string, port int) (net.Addr, error) {
 	var addr string
 	if override != "" {
 		addr = override
 	} else {
 		addr = c.ClientAddr
 	}
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return nil, fmt.Errorf("Failed to parse IP: %v", addr)
+
+	switch {
+	case strings.HasPrefix(addr, "unix://"):
+		sock, err := populateUnixSocket(addr)
+		if err != nil {
+			return nil, err
+		}
+
+		return &net.UnixAddr{Name: sock.Path, Net: "unix"}, nil
+
+	default:
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			return nil, fmt.Errorf("Failed to parse IP: %v", addr)
+		}
+		return &net.TCPAddr{IP: ip, Port: port}, nil
 	}
-	return &net.TCPAddr{IP: ip, Port: port}, nil
 }
 
 // ClientListenerAddr is used to format an address for a
@@ -410,8 +500,11 @@ func (c *Config) ClientListenerAddr(override string, port int) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if addr.IP.IsUnspecified() {
-		addr.IP = net.ParseIP("127.0.0.1")
+
+	if ipAddr, ok := addr.(*net.TCPAddr); ok {
+		if ipAddr.IP.IsUnspecified() {
+			ipAddr.IP = net.ParseIP("127.0.0.1")
+		}
 	}
 	return addr.String(), nil
 }

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -85,9 +85,14 @@ func NewRPCClient(addr string) (*RPCClient, error) {
 	if len(sanedAddr) == 0 {
 		sanedAddr = addr
 	}
+
 	mode := "tcp"
+
 	if strings.HasPrefix(sanedAddr, "unix://") {
 		sanedAddr = strings.TrimPrefix(sanedAddr, "unix://")
+	}
+
+	if strings.HasPrefix(sanedAddr, "/") {
 		mode = "unix"
 	}
 

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -7,6 +7,8 @@ import (
 	"github.com/hashicorp/logutils"
 	"log"
 	"net"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -34,7 +36,7 @@ type seqHandler interface {
 type RPCClient struct {
 	seq uint64
 
-	conn      *net.TCPConn
+	conn      net.Conn
 	reader    *bufio.Reader
 	writer    *bufio.Writer
 	dec       *codec.Decoder
@@ -79,8 +81,18 @@ func (c *RPCClient) send(header *requestHeader, obj interface{}) error {
 // NewRPCClient is used to create a new RPC client given the address.
 // This will properly dial, handshake, and start listening
 func NewRPCClient(addr string) (*RPCClient, error) {
+	sanedAddr := os.Getenv("CONSUL_RPC_ADDR")
+	if len(sanedAddr) == 0 {
+		sanedAddr = addr
+	}
+	mode := "tcp"
+	if strings.HasPrefix(sanedAddr, "unix://") {
+		sanedAddr = strings.TrimPrefix(sanedAddr, "unix://")
+		mode = "unix"
+	}
+
 	// Try to dial to agent
-	conn, err := net.Dial("tcp", addr)
+	conn, err := net.Dial(mode, sanedAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +100,7 @@ func NewRPCClient(addr string) (*RPCClient, error) {
 	// Create the client
 	client := &RPCClient{
 		seq:        0,
-		conn:       conn.(*net.TCPConn),
+		conn:       conn,
 		reader:     bufio.NewReader(conn),
 		writer:     bufio.NewWriter(conn),
 		dispatch:   make(map[uint64]seqHandler),

--- a/command/agent/rpc_client_test.go
+++ b/command/agent/rpc_client_test.go
@@ -223,12 +223,12 @@ func TestRPCClientStatsUnix(t *testing.T) {
 
 	tempdir, err := ioutil.TempDir("", "consul-test-")
 	if err != nil {
-		t.Fatal("Could not create a working directory")
+		t.Fatal("Could not create a working directory: ", err)
 	}
 
 	user, err := user.Current()
 	if err != nil {
-		t.Fatal("Could not get current user")
+		t.Fatal("Could not get current user: ", err)
 	}
 
 	cb := func(c *Config) {

--- a/command/rpc.go
+++ b/command/rpc.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/consul/command/agent"
 )
 
-// RPCAddrEnvName defines the environment variable name, which can set
-// a default RPC address in case there is no -rpc-addr specified.
+// RPCAddrEnvName defines an environment variable name which sets
+// an RPC address if there is no -rpc-addr specified.
 const RPCAddrEnvName = "CONSUL_RPC_ADDR"
 
 // RPCAddrFlag returns a pointer to a string that will be populated
@@ -43,7 +43,12 @@ func HTTPClient(addr string) (*consulapi.Client, error) {
 // HTTPClientDC returns a new Consul HTTP client with the given address and datacenter
 func HTTPClientDC(addr, dc string) (*consulapi.Client, error) {
 	conf := consulapi.DefaultConfig()
-	conf.Address = addr
+	switch {
+	case len(os.Getenv("CONSUL_HTTP_ADDR")) > 0:
+		conf.Address = os.Getenv("CONSUL_HTTP_ADDR")
+	default:
+		conf.Address = addr
+	}
 	conf.Datacenter = dc
 	return consulapi.NewClient(conf)
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -239,8 +239,17 @@ definitions support being updated during a reload.
    However, because the caches are not actively invalidated, ACL policy may be stale
    up to the TTL value.
 
-* `addresses` - This is a nested object that allows setting the bind address
-  for the following keys:
+* `addresses` - This is a nested object that allows setting bind addresses. For `rpc`
+   and `http`, a Unix socket can be specified in the following form:
+   unix://[/path/to/socket];[username|uid];[gid];[mode]. The socket will be created
+   in the specified location with the given username or uid, gid, and mode. The
+   user Consul is running as must have appropriate permissions to change the socket
+   ownership to the given uid or gid. When running Consul agent commands against
+   Unix socket interfaces, use the `-rpc-addr` or `-http-addr` arguments to specify
+   the path to the socket, e.g. "unix://path/to/socket". You can also place the desired
+   values in `CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR` environment variables. For TCP
+   addresses, these should be in the form ip:port.
+   The following keys are valid:
     * `dns` - The DNS server. Defaults to `client_addr`
     * `http` - The HTTP API. Defaults to `client_addr`
     * `rpc` - The RPC endpoint. Defaults to `client_addr`


### PR DESCRIPTION
....

Client works for RPC; will honor CONSUL_RPC_ADDR. HTTP works via consul/api;
honors CONSUL_HTTP_ADDR.

The format of a Unix socket in configuration data is:
"unix://[/path/to/socket];[username or uid];[gid];[mode]"

Obviously, the user must have appropriate permissions to create the socket
file in the given path and assign the requested uid/gid. Also note that Go does
not support gid lookups from group name, so gid must be numeric. See
https://codereview.appspot.com/101310044

When connecting from the client, the format is just the first part of the
above line:
"unix://[/path/to/socket]"

This code is copyright 2014 Akamai Technologies, Inc. <opensource@akamai.com>