### PR TITLE
Add support for DELETE with CAS

### DIFF
--- a/consul/fsm.go
+++ b/consul/fsm.go
@@ -149,6 +149,13 @@ func (c *consulFSM) applyKVSOperation(buf []byte, index uint64) interface{} {
 		return c.state.KVSSet(index, &req.DirEnt)
 	case structs.KVSDelete:
 		return c.state.KVSDelete(index, req.DirEnt.Key)
+	case structs.KVSDeleteCAS:
+		act, err := c.state.KVSDeleteCheckAndSet(index, req.DirEnt.Key, req.DirEnt.ModifyIndex)
+		if err != nil {
+			return err
+		} else {
+			return act
+		}
 	case structs.KVSDeleteTree:
 		return c.state.KVSDeleteTree(index, req.DirEnt.Key)
 	case structs.KVSCAS:

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -1329,7 +1329,10 @@ func (s *StateStore) KVSDeleteCheckAndSet(index uint64, key string, casIndex uin
 	}
 
 	// Do the actual delete
-	return true, s.kvsDeleteWithIndex(index, "id", key)
+	if err := s.kvsDeleteWithIndexTxn(index, tx, "id", key); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
 }
 
 // KVSDeleteTree is used to delete all keys with a given prefix

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -330,6 +330,7 @@ type KVSOp string
 const (
 	KVSSet        KVSOp = "set"
 	KVSDelete           = "delete"
+	KVSDeleteCAS        = "delete-cas" // Delete with check-and-set
 	KVSDeleteTree       = "delete-tree"
 	KVSCAS              = "cas"    // Check-and-set
 	KVSLock             = "lock"   // Lock a key

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -212,9 +212,17 @@ then the update has not taken place.
 ### DELETE method
 
 Lastly, the `DELETE` method can be used to delete a single key or all
-keys sharing a prefix. If the "?recurse" query parameter is provided,
-then all keys with the prefix are deleted, otherwise only the specified
-key.
+keys sharing a prefix.  There are a number of patameters that can
+be used with a DELETE request:
+
+* ?recurse : This is used to delete all keys which have the specified prefix.
+  Without this, only a key with an exact match will be deleted.
+
+* ?cas=\<index\> : This flag is used to turn the `DELETE` into a Check-And-Set
+  operation. This is very useful as it allows clients to build more complex
+  synchronization primitives on top. If the index is 0, then Consul will only
+  delete the key if it does not already exist (noop). If the index is non-zero, then
+  the key is only deleted if the index matches the `ModifyIndex` of that key.
 
 ## <a name="agent"></a> Agent
 


### PR DESCRIPTION
This PR adds support for the ?cas= flag when doing a DELETE on a key. It can be used for protected deletes and is useful as a synchronization primitive. Fixes #348.