### PR TITLE
Support multiple health checks per service

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -41,18 +41,20 @@ type AgentMember struct {
 
 // AgentServiceRegistration is used to register a new service
 type AgentServiceRegistration struct {
-	ID    string   `json:",omitempty"`
-	Name  string   `json:",omitempty"`
-	Tags  []string `json:",omitempty"`
-	Port  int      `json:",omitempty"`
-	Check *AgentServiceCheck
+	ID     string   `json:",omitempty"`
+	Name   string   `json:",omitempty"`
+	Tags   []string `json:",omitempty"`
+	Port   int      `json:",omitempty"`
+	Check  *AgentServiceCheck
+	Checks AgentServiceChecks
 }
 
 // AgentCheckRegistration is used to register a new check
 type AgentCheckRegistration struct {
-	ID    string `json:",omitempty"`
-	Name  string `json:",omitempty"`
-	Notes string `json:",omitempty"`
+	ID        string `json:",omitempty"`
+	Name      string `json:",omitempty"`
+	Notes     string `json:",omitempty"`
+	ServiceID string `json:",omitempty"`
 	AgentServiceCheck
 }
 
@@ -63,6 +65,7 @@ type AgentServiceCheck struct {
 	Interval string `json:",omitempty"`
 	TTL      string `json:",omitempty"`
 }
+type AgentServiceChecks []*AgentServiceCheck
 
 // Agent can be used to query the Agent endpoints
 type Agent struct {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -161,15 +161,17 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	ns := args.NodeService()
 
 	// Verify the check type
-	chkType := args.CheckType()
-	if chkType != nil && !chkType.Valid() {
-		resp.WriteHeader(400)
-		resp.Write([]byte("Must provide TTL or Script and Interval!"))
-		return nil, nil
+	chkTypes := args.CheckTypes()
+	for _, check := range chkTypes {
+		if !check.Valid() {
+			resp.WriteHeader(400)
+			resp.Write([]byte("Must provide TTL or Script and Interval!"))
+			return nil, nil
+		}
 	}
 
 	// Add the check
-	return nil, s.agent.AddService(ns, chkType, true)
+	return nil, s.agent.AddService(ns, chkTypes, true)
 }
 
 func (s *HTTPServer) AgentDeregisterService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -132,17 +132,25 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 			return nil
 		}
 
-		var check interface{}
 		for k, v := range rawMap {
-			if strings.ToLower(k) == "check" {
-				check = v
+			switch strings.ToLower(k) {
+			case "check":
+				if err := FixupCheckType(v); err != nil {
+					return err
+				}
+			case "checks":
+				chkTypes, ok := v.([]interface{})
+				if !ok {
+					return nil
+				}
+				for _, chkType := range chkTypes {
+					if err := FixupCheckType(chkType); err != nil {
+						return err
+					}
+				}
 			}
 		}
-		if check == nil {
-			return nil
-		}
-
-		return FixupCheckType(check)
+		return nil
 	}
 	if err := decodeBody(req, &args, decodeCB); err != nil {
 		resp.WriteHeader(400)

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -430,6 +430,14 @@ func TestHTTPAgentRegisterService(t *testing.T) {
 		Check: CheckType{
 			TTL: 15 * time.Second,
 		},
+		Checks: CheckTypes{
+			&CheckType{
+				TTL: 20 * time.Second,
+			},
+			&CheckType{
+				TTL: 30 * time.Second,
+			},
+		},
 	}
 	req.Body = encodeReq(args)
 
@@ -447,12 +455,13 @@ func TestHTTPAgentRegisterService(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	if _, ok := srv.agent.state.Checks()["service:test"]; !ok {
-		t.Fatalf("missing test check")
+	checks := srv.agent.state.Checks()
+	if len(checks) != 3 {
+		t.Fatalf("bad: %v", checks)
 	}
 
-	if _, ok := srv.agent.checkTTLs["service:test"]; !ok {
-		t.Fatalf("missing test check ttl")
+	if len(srv.agent.checkTTLs) != 3 {
+		t.Fatalf("missing test check ttls: %v", srv.agent.checkTTLs)
 	}
 }
 

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -40,6 +40,7 @@ type CheckType struct {
 
 	Notes string
 }
+type CheckTypes []*CheckType
 
 // Valid checks if the CheckType is valid
 func (c *CheckType) Valid() bool {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -568,7 +568,6 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 
 // DecodeServiceDefinition is used to decode a service definition
 func DecodeServiceDefinition(raw interface{}) (*ServiceDefinition, error) {
-	var sub interface{}
 	rawMap, ok := raw.(map[string]interface{})
 	if !ok {
 		goto AFTER_FIX
@@ -582,16 +581,22 @@ func DecodeServiceDefinition(raw interface{}) (*ServiceDefinition, error) {
 	}
 
 	for k, v := range rawMap {
-		if strings.ToLower(k) == "check" {
-			sub = v
-			break
+		switch strings.ToLower(k) {
+		case "check":
+			if err := FixupCheckType(v); err != nil {
+				return nil, err
+			}
+		case "checks":
+			chkTypes, ok := v.([]interface{})
+			if !ok {
+				goto AFTER_FIX
+			}
+			for _, chkType := range chkTypes {
+				if err := FixupCheckType(chkType); err != nil {
+					return nil, err
+				}
+			}
 		}
-	}
-	if sub == nil {
-		goto AFTER_FIX
-	}
-	if err := FixupCheckType(sub); err != nil {
-		return nil, err
 	}
 AFTER_FIX:
 	var md mapstructure.Metadata
@@ -610,22 +615,23 @@ AFTER_FIX:
 }
 
 func FixupCheckType(raw interface{}) error {
+	var ttlKey, intervalKey string
+
 	// Handle decoding of time durations
 	rawMap, ok := raw.(map[string]interface{})
 	if !ok {
 		return nil
 	}
 
-	var ttlKey string
-	for k, _ := range rawMap {
-		if strings.ToLower(k) == "ttl" {
+	for k, v := range rawMap {
+		switch strings.ToLower(k) {
+		case "ttl":
 			ttlKey = k
-		}
-	}
-	var intervalKey string
-	for k, _ := range rawMap {
-		if strings.ToLower(k) == "interval" {
+		case "interval":
 			intervalKey = k
+		case "service_id":
+			rawMap["serviceid"] = v
+			delete(rawMap, "service_id")
 		}
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -640,7 +640,17 @@ func TestDecodeConfig_Services(t *testing.T) {
 					"script": "/bin/check_redis -p 6000",
 					"interval": "5s",
 					"ttl": "20s"
-				}
+				},
+				"checks": [
+					{
+						"script": "/bin/check_redis_read",
+						"interval": "1m"
+					},
+					{
+						"script": "/bin/check_redis_write",
+						"interval": "1m"
+					}
+				]
 			},
 			{
 				"id": "red1",
@@ -671,6 +681,16 @@ func TestDecodeConfig_Services(t *testing.T) {
 					Interval: 5 * time.Second,
 					Script:   "/bin/check_redis -p 6000",
 					TTL:      20 * time.Second,
+				},
+				Checks: CheckTypes{
+					&CheckType{
+						Interval: time.Minute,
+						Script:   "/bin/check_redis_read",
+					},
+					&CheckType{
+						Interval: time.Minute,
+						Script:   "/bin/check_redis_write",
+					},
 				},
 				ID:   "red0",
 				Name: "redis",
@@ -715,6 +735,13 @@ func TestDecodeConfig_Checks(t *testing.T) {
 				"name": "cpu",
 				"script": "/bin/check_cpu",
 				"interval": "10s"
+			},
+			{
+				"id": "chk3",
+				"name": "service:redis:tx",
+				"script": "/bin/check_redis_tx",
+				"interval": "1m",
+				"service_id": "redis"
 			}
 		]
 	}`
@@ -740,6 +767,15 @@ func TestDecodeConfig_Checks(t *testing.T) {
 				CheckType: CheckType{
 					Script:   "/bin/check_cpu",
 					Interval: 10 * time.Second,
+				},
+			},
+			&CheckDefinition{
+				ID:        "chk3",
+				Name:      "service:redis:tx",
+				ServiceID: "redis",
+				CheckType: CheckType{
+					Script:   "/bin/check_redis_tx",
+					Interval: time.Minute,
 				},
 			},
 		},

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -450,6 +450,9 @@ func (l *localState) syncService(id string) error {
 		WriteRequest: structs.WriteRequest{Token: l.config.ACLToken},
 	}
 
+	// If the service has associated checks that are out of sync,
+	// piggyback them on the service sync so they are part of the
+	// same transaction and are registered atomically.
 	var checks structs.HealthChecks
 	for _, check := range l.checks {
 		if check.ServiceID == id {
@@ -459,6 +462,7 @@ func (l *localState) syncService(id string) error {
 		}
 	}
 
+	// Backwards-compatibility for Consul < 0.5
 	if len(checks) == 1 {
 		req.Check = checks[0]
 	} else {

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -53,11 +53,15 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 	}
 
 	if args.Check != nil {
-		if args.Check.CheckID == "" && args.Check.Name != "" {
-			args.Check.CheckID = args.Check.Name
+		args.Checks = append(args.Checks, args.Check)
+		args.Check = nil
+	}
+	for _, check := range args.Checks {
+		if check.CheckID == "" && check.Name != "" {
+			check.CheckID = check.Name
 		}
-		if args.Check.Node == "" {
-			args.Check.Node = args.Node
+		if check.Node == "" {
+			check.Node = args.Node
 		}
 	}
 
@@ -66,6 +70,7 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 		c.srv.logger.Printf("[ERR] consul.catalog: Register failed: %v", err)
 		return err
 	}
+
 	return nil
 }
 

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -497,9 +497,14 @@ func (s *StateStore) EnsureRegistration(index uint64, req *structs.RegisterReque
 		}
 	}
 
-	// Ensure the check if provided
+	// Ensure the check(s), if provided
 	if req.Check != nil {
 		if err := s.ensureCheckTxn(index, req.Check, tx); err != nil {
+			return err
+		}
+	}
+	for _, check := range req.Checks {
+		if err := s.ensureCheckTxn(index, check, tx); err != nil {
 			return err
 		}
 	}

--- a/consul/state_store_test.go
+++ b/consul/state_store_test.go
@@ -32,6 +32,15 @@ func TestEnsureRegistration(t *testing.T) {
 			Status:    structs.HealthPassing,
 			ServiceID: "api",
 		},
+		Checks: structs.HealthChecks{
+			&structs.HealthCheck{
+				Node:      "foo",
+				CheckID:   "api-cache",
+				Name:      "Can cache stuff",
+				Status:    structs.HealthPassing,
+				ServiceID: "api",
+			},
+		},
 	}
 
 	if err := store.EnsureRegistration(13, reg); err != nil {
@@ -60,7 +69,7 @@ func TestEnsureRegistration(t *testing.T) {
 	if idx != 13 {
 		t.Fatalf("bad: %v", idx)
 	}
-	if len(checks) != 1 {
+	if len(checks) != 2 {
 		t.Fatalf("check: %#v", checks)
 	}
 }

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -137,6 +137,7 @@ type RegisterRequest struct {
 	Address    string
 	Service    *NodeService
 	Check      *HealthCheck
+	Checks     HealthChecks
 	WriteRequest
 }
 

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -104,6 +104,28 @@ This is the only convention that Consul depends on. Any output of the script
 will be captured and stored in the `notes` field so that it can be viewed
 by human operators.
 
+## Service-bound checks
+
+Health checks may also be optionally bound to a specific service. This ensures
+that the status of the health check will only affect the health status of the
+given service instead of the entire node. Service-bound health checks may be
+provided by adding a `service_id` field to a check configuration:
+
+```javascript
+{
+  "check": {
+    "id": "web-app",
+    "name": "Web App Status",
+    "service_id": "web-app",
+    "ttl": "30s"
+  }
+}
+```
+
+In the above configuration, if the web-app health check begins failing, it will
+only affect the availability of the web-app service and no other services
+provided by the node.
+
 ## Multiple Check Definitions
 
 Multiple check definitions can be provided at once using the `checks` (plural)

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -469,6 +469,21 @@ An `HTTP` check will preform an HTTP GET request to the value of `HTTP` (expecte
 If a `TTL` type is used, then the TTL update APIs must be used to periodically update
 the state of the check.
 
+It is also possible to associate a new check with an existing service registered
+on the agent by providing an additional `ServiceID` field. This type of request
+must look like:
+
+```javascript
+{
+  "ID": "service:redis:tx",
+  "ServiceID": "redis",
+  "Name": "Redis test transaction",
+  "Notes": "Tests Redis SET, GET, and DELETE",
+  "Script": "/usr/local/bin/check_redis_tx.py",
+  "Interval": "1m"
+}
+```
+
 The return code is 200 on success.
 
 ### <a name="agent_check_deregister"></a> /v1/agent/check/deregister/\<checkId\>

--- a/website/source/docs/agent/services.html.markdown
+++ b/website/source/docs/agent/services.html.markdown
@@ -26,10 +26,12 @@ A service definition that is a script looks like:
     "tags": ["master"],
     "address": "127.0.0.1",
     "port": 8000,
-    "check": {
-      "script": "/usr/local/bin/check_redis.py",
-      "interval": "10s"
-    }
+    "checks": [
+      {
+        "script": "/usr/local/bin/check_redis.py",
+        "interval": "10s"
+      }
+    ]
   }
 }
 ```
@@ -58,7 +60,10 @@ There is more information about [checks here](/docs/agent/checks.html). The
 check must be of the script, HTTP or TTL type. If it is a script type, `script` and
 `interval` must be provided. If it is a HTTP type, `http` and
 `interval` must be provided. If it is a TTL type, then only `ttl` must be
-provided. The check name is automatically generated as "service:<service-id>".
+provided. The check name is automatically generated as
+`service:<service-id>`. If there are multiple service checks registered, the
+ID will be generated as `service:<service-id>:<num>`, where `<num>` is an
+incrementing number starting from `1`.
 
 To configure a service, either provide it as a `-config-file` option to the
 agent, or place it inside the `-config-dir` of the agent. The file must
@@ -82,11 +87,13 @@ Multiple services definitions can be provided at once using the `services`
       ],
       "address": "127.0.0.1",
       "port": 6000,
-      "check": {
-        "script": "/bin/check_redis -p 6000",
-        "interval": "5s",
-        "ttl": "20s"
-      }
+      "checks": [
+        {
+          "script": "/bin/check_redis -p 6000",
+          "interval": "5s",
+          "ttl": "20s"
+        }
+      ]
     },
     {
       "id": "red1",
@@ -97,11 +104,13 @@ Multiple services definitions can be provided at once using the `services`
       ],
       "address": "127.0.0.1",
       "port": 7000,
-      "check": {
-        "script": "/bin/check_redis -p 7000",
-        "interval": "30s",
-        "ttl": "60s"
-      }
+      "checks": [
+        {
+          "script": "/bin/check_redis -p 7000",
+          "interval": "30s",
+          "ttl": "60s"
+        }
+      ]
     },
     ...
   ]


### PR DESCRIPTION
Allows multiple health checks to be registered for a single service. Preserves backwards compatibility of configs by using a new `checks` field. Registering multiple health checks can be done in a few different ways:

Embedded in service definitions in the `checks` key. If there is only a single check, the check ID will be `service:<service name>`. If there are multiple checks, the service IDs will be `service:<service name>:<n>`.
```
{
  "service": {
    ...
    "checks": [
      {
        "script": "/usr/bin/true",
        "interval": "10s"
      },
      ...
    ]
  }
}
```

In check configuration files using the `service_id` key. This allows additive configuration of service checks in a `consul.d`-style directory:
```
{
  "checks": [
    {
      "name": "redis check",
      "script": "/usr/bin/true",
      "interval": "10s",
      "service_id": "redis"
    },
    ...
  ]
}
```

From the HTTP API by specifying `service_id` in the check definition. This allows adding additional health checks at runtime, and utilizes the new service/check persistence logic to restore the checks on later agent starts:
```
PUT /v1/agent/check/register
{
  "name": "redis check",
  "script": "/usr/bin/true",
  "interval": "10s",
  "service_id": "redis"
}
```

Fixes #230.