### PR TITLE
command/agent: Add simple HTTP check type

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -742,6 +742,10 @@ func (a *Agent) RemoveCheck(checkID string, persist bool) error {
 		check.Stop()
 		delete(a.checkMonitors, checkID)
 	}
+	if check, ok := a.checkHTTPs[checkID]; ok {
+		check.Stop()
+		delete(a.checkHTTPs, checkID)
+	}
 	if check, ok := a.checkTTLs[checkID]; ok {
 		check.Stop()
 		delete(a.checkTTLs, checkID)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -688,9 +687,6 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 				HTTP:     chkType.HTTP,
 				Interval: chkType.Interval,
 				Logger:   a.logger,
-				httpClient: &http.Client{
-					Timeout: chkType.Interval,
-				},
 			}
 			http.Start()
 			a.checkHTTPs[check.CheckID] = http

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -51,11 +52,16 @@ type Agent struct {
 	state localState
 
 	// checkMonitors maps the check ID to an associated monitor
-	// checkTTLs maps the check ID to an associated check TTL
-	// checkLock protects updates to either
 	checkMonitors map[string]*CheckMonitor
-	checkTTLs     map[string]*CheckTTL
-	checkLock     sync.Mutex
+
+	// checkHTTPs maps the check ID to an associated HTTP check
+	checkHTTPs map[string]*CheckHTTP
+
+	// checkTTLs maps the check ID to an associated check TTL
+	checkTTLs map[string]*CheckTTL
+
+	// checkLock protects updates to the check* maps
+	checkLock sync.Mutex
 
 	// eventCh is used to receive user events
 	eventCh chan serf.UserEvent
@@ -111,6 +117,7 @@ func Create(config *Config, logOutput io.Writer) (*Agent, error) {
 		logOutput:     logOutput,
 		checkMonitors: make(map[string]*CheckMonitor),
 		checkTTLs:     make(map[string]*CheckTTL),
+		checkHTTPs:    make(map[string]*CheckHTTP),
 		eventCh:       make(chan serf.UserEvent, 1024),
 		eventBuf:      make([]*UserEvent, 256),
 		shutdownCh:    make(chan struct{}),
@@ -379,6 +386,10 @@ func (a *Agent) Shutdown() error {
 		chk.Stop()
 	}
 	for _, chk := range a.checkTTLs {
+		chk.Stop()
+	}
+
+	for _, chk := range a.checkHTTPs {
 		chk.Stop()
 	}
 
@@ -660,6 +671,29 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 			ttl.Start()
 			a.checkTTLs[check.CheckID] = ttl
+
+		} else if chkType.IsHTTP() {
+			if existing, ok := a.checkHTTPs[check.CheckID]; ok {
+				existing.Stop()
+			}
+			if chkType.Interval < MinInterval {
+				a.logger.Println(fmt.Sprintf("[WARN] agent: check '%s' has interval below minimum of %v",
+					check.CheckID, MinInterval))
+				chkType.Interval = MinInterval
+			}
+
+			http := &CheckHTTP{
+				Notify:   &a.state,
+				CheckID:  check.CheckID,
+				HTTP:     chkType.HTTP,
+				Interval: chkType.Interval,
+				Logger:   a.logger,
+				httpClient: &http.Client{
+					Timeout: chkType.Interval,
+				},
+			}
+			http.Start()
+			a.checkHTTPs[check.CheckID] = http
 
 		} else {
 			if existing, ok := a.checkMonitors[check.CheckID]; ok {

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"fmt"
 	"github.com/hashicorp/consul/consul/structs"
 	"log"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -159,4 +162,95 @@ func TestCheckTTL(t *testing.T) {
 	if mock.state["foo"] != structs.HealthCritical {
 		t.Fatalf("should be critical %v", mock.state)
 	}
+}
+
+func mockHTTPServer(responseCode int) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(responseCode)
+		return
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func expectHTTPStatus(t *testing.T, url string, status string) {
+	mock := &MockNotify{
+		state:   make(map[string]string),
+		updates: make(map[string]int),
+		output:  make(map[string]string),
+	}
+	check := &CheckHTTP{
+		Notify:   mock,
+		CheckID:  "foo",
+		HTTP:     url,
+		Interval: 10 * time.Millisecond,
+		Logger:   log.New(os.Stderr, "", log.LstdFlags),
+	}
+	check.Start()
+	defer check.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Should have at least 2 updates
+	if mock.updates["foo"] < 2 {
+		t.Fatalf("should have 2 updates %v", mock.updates)
+	}
+
+	if mock.state["foo"] != status {
+		t.Fatalf("should be %v %v", status, mock.state)
+	}
+}
+
+func TestCheckHTTPCritical(t *testing.T) {
+	// var server *httptest.Server
+
+	server := mockHTTPServer(150)
+	fmt.Println(server.URL)
+	expectHTTPStatus(t, server.URL, "critical")
+	server.Close()
+
+	// 2xx - 1
+	server = mockHTTPServer(199)
+	expectHTTPStatus(t, server.URL, "critical")
+	server.Close()
+
+	// 2xx + 1
+	server = mockHTTPServer(300)
+	expectHTTPStatus(t, server.URL, "critical")
+	server.Close()
+
+	server = mockHTTPServer(400)
+	expectHTTPStatus(t, server.URL, "critical")
+	server.Close()
+
+	server = mockHTTPServer(500)
+	expectHTTPStatus(t, server.URL, "critical")
+	server.Close()
+}
+
+func TestCheckHTTPPassing(t *testing.T) {
+	var server *httptest.Server
+
+	server = mockHTTPServer(200)
+	expectHTTPStatus(t, server.URL, "passing")
+	server.Close()
+
+	server = mockHTTPServer(201)
+	expectHTTPStatus(t, server.URL, "passing")
+	server.Close()
+
+	server = mockHTTPServer(250)
+	expectHTTPStatus(t, server.URL, "passing")
+	server.Close()
+
+	server = mockHTTPServer(299)
+	expectHTTPStatus(t, server.URL, "passing")
+	server.Close()
+}
+
+func TestCheckHTTPWarning(t *testing.T) {
+	server := mockHTTPServer(429)
+	expectHTTPStatus(t, server.URL, "warning")
+	server.Close()
 }

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -22,7 +22,7 @@ There are three different kinds of checks:
 
  * HTTP + Interval - These checks make an `HTTP GET` request every Interval (e.g.
  every 30 seconds) to the specified URL. The status of the service depends on the HTTP Response Code.
- `200` is passing, `503` is warning and anything else is failing.
+ any `2xx` code is passing, `429 Too Many Requests` is warning and anything else is failing.
  This type of check should be preferred over a script that for example uses `curl`.
 
  * Time to Live (TTL) - These checks retain their last known state for a given TTL.

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -13,12 +13,17 @@ application level health checks. A health check is considered to be application
 level if it associated with a service. A check is defined in a configuration file,
 or added at runtime over the HTTP interface.
 
-There are two different kinds of checks:
+There are three different kinds of checks:
 
  * Script + Interval - These checks depend on invoking an external application
  that does the health check and exits with an appropriate exit code, potentially
  generating some output. A script is paired with an invocation interval (e.g.
  every 30 seconds). This is similar to the Nagios plugin system.
+
+ * HTTP + Interval - These checks make an `HTTP GET` request every Interval (e.g.
+ every 30 seconds) to the specified URL. The status of the service depends on the HTTP Response Code.
+ `200` is passing, `503` is warning and anything else is failing.
+ This type of check should be preferred over a script that for example uses `curl`.
 
  * Time to Live (TTL) - These checks retain their last known state for a given TTL.
  The state of the check must be updated periodically over the HTTP interface. If an
@@ -43,6 +48,19 @@ A check definition that is a script looks like:
 }
 ```
 
+An HTTP based check looks like:
+
+```javascript
+{
+  "check": {
+    "id": "api",
+    "name": "HTTP API on port 5000",
+    "http": "http://localhost:5000/health",
+    "interval": "10s"
+  }
+}
+```
+
 A TTL based check is very similar:
 
 ```javascript
@@ -56,7 +74,7 @@ A TTL based check is very similar:
 }
 ```
 
-Both types of definitions must include a `name`, and may optionally
+Each type of definitions must include a `name`, and may optionally
 provide an `id` and `notes` field. The `id` is set to the `name` if not
 provided. It is required that all checks have a unique ID per node, so if names
 might conflict then unique ID's should be provided.
@@ -102,6 +120,12 @@ key in your configuration file.
     },
     {
       "id": "chk2",
+      "name": "/health",
+      "http": "http://localhost:5000/health",
+      "interval": "15s"
+    },
+    {
+      "id": "chk3",
       "name": "cpu",
       "script": "/bin/check_cpu",
       "interval": "10s"

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -450,7 +450,7 @@ field is not used by Consul, and is meant to be human readable.
 If a `Script` is provided, the check type is a script, and Consul will
 evaluate the script every `Interval` to update the status.
 
-An `HTTP` check will preform an HTTP GET request to the value of `HTTP` (expected to be a URL) every `Interval`. If the response is `200` the check is passing, if the response is `503` the check is warning, otherwise the check is critical.
+An `HTTP` check will preform an HTTP GET request to the value of `HTTP` (expected to be a URL) every `Interval`. If the response is any `2xx` code the check is passing, if the response is `429 Too Many Requests` the check is warning, otherwise the check is critical.
 
 If a `TTL` type is used, then the TTL update APIs must be used to periodically update
 the state of the check.

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -422,7 +422,7 @@ The endpoint always returns 200.
 
 The register endpoint is used to add a new check to the local agent.
 There is more documentation on checks [here](/docs/agent/checks.html).
-Checks are either a script or TTL type. The agent is responsible for managing
+Checks are of script, HTTP, or TTL type. The agent is responsible for managing
 the status of the check and keeping the Catalog in sync.
 
 The register endpoint expects a JSON request body to be PUT. The request
@@ -434,20 +434,25 @@ body must look like:
   "Name": "Memory utilization",
   "Notes": "Ensure we don't oversubscribe memory",
   "Script": "/usr/local/bin/check_mem.py",
+  "HTTP": "http://example.com",
   "Interval": "10s",
   "TTL": "15s"
 }
 ```
 
-The `Name` field is mandatory, as is either `Script` and `Interval`
-or `TTL`. Only one of `Script` and `Interval` or `TTL` should be provided.
+The `Name` field is mandatory, as is one of `Script`, `HTTP` or `TTL`.
+`Script` and `HTTP` also require that `Interval` be set.
+
 If an `ID` is not provided, it is set to `Name`. You cannot have duplicate
 `ID` entries per agent, so it may be necessary to provide an ID. The `Notes`
 field is not used by Consul, and is meant to be human readable.
 
 If a `Script` is provided, the check type is a script, and Consul will
-evaluate the script every `Interval` to update the status. If a `TTL` type
-is used, then the TTL update APIs must be used to periodically update
+evaluate the script every `Interval` to update the status.
+
+An `HTTP` check will preform an HTTP GET request to the value of `HTTP` (expected to be a URL) every `Interval`. If the response is `200` the check is passing, if the response is `503` the check is warning, otherwise the check is critical.
+
+If a `TTL` type is used, then the TTL update APIs must be used to periodically update
 the state of the check.
 
 The return code is 200 on success.
@@ -515,6 +520,7 @@ body must look like:
   "Port": 8000,
   "Check": {
     "Script": "/usr/local/bin/check_redis.py",
+    "HTTP": "http://localhost:5000/health",
     "Interval": "10s",
     "TTL": "15s"
   }
@@ -523,8 +529,10 @@ body must look like:
 
 The `Name` field is mandatory,  If an `ID` is not provided, it is set to `Name`.
 You cannot have duplicate `ID` entries per agent, so it may be necessary to provide an ID.
-`Tags`, `Address`, `Port` and `Check` are optional. If `Check` is provided, only one of `Script` and `Interval`
-or `TTL` should be provided. There is more information about checks [here](/docs/agent/checks.html).
+`Tags`, `Address`, `Port` and `Check` are optional.
+If `Check` is provided, only one of `Script`, `HTTP` or `TTL` should be provided.
+`Script` and `HTTP` also require `Interval`.
+There is more information about checks [here](/docs/agent/checks.html).
 The `Address` will default to that of the agent if not provided.
 
 The created check will be named "service:\<ServiceId\>".

--- a/website/source/docs/agent/services.html.markdown
+++ b/website/source/docs/agent/services.html.markdown
@@ -55,7 +55,8 @@ a node has any failing system-level check, the DNS interface will omit that
 node from any service query.
 
 There is more information about [checks here](/docs/agent/checks.html). The
-check must be of the script or TTL type. If it is a script type, `script` and
+check must be of the script, HTTP or TTL type. If it is a script type, `script` and
+`interval` must be provided. If it is a HTTP type, `http` and
 `interval` must be provided. If it is a TTL type, then only `ttl` must be
 provided. The check name is automatically generated as "service:<service-id>".
 


### PR DESCRIPTION
We are running 20+ services that all register using consul. Consul then checks each service using curl every second (1s). On some of our lower power (dev and test) machines we are seeing a lot of CPU load from consul forking curl 20 times per second.

Add a simple HTTP check type that makes an `HTTP GET` request every Interval to the specified URL.
The status of the service depends on the HTTP Response Code.
`200` is passing, `503` is warning and anything else is failing.

An HTTP based check looks like this:
{
    "check": {
        "id": "api",
        "name": "HTTP API on port 5000 with a /health route",
        "http": "http://localhost:5000/health",
        "interval": "10s"
    }
}
