### PR TITLE
Fix go vet warnings. Add vet to 'make test'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ deps:
 test: deps
 	./scripts/verify_no_uuid.sh
 	go list ./... | xargs -n1 go test
+	go vet ./...
 
 integ:
 	go list ./... | INTEG_TESTS=yes xargs -n1 go test

--- a/command/agent/health_endpoint_test.go
+++ b/command/agent/health_endpoint_test.go
@@ -186,29 +186,29 @@ func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 
 func TestFilterNonPassing(t *testing.T) {
 	nodes := structs.CheckServiceNodes{
-		structs.CheckServiceNode{
+		0: structs.CheckServiceNode{
 			Checks: structs.HealthChecks{
-				&structs.HealthCheck{
+				0: &structs.HealthCheck{
 					Status: structs.HealthCritical,
 				},
-				&structs.HealthCheck{
+				1: &structs.HealthCheck{
 					Status: structs.HealthCritical,
 				},
 			},
 		},
-		structs.CheckServiceNode{
+		1: structs.CheckServiceNode{
 			Checks: structs.HealthChecks{
-				&structs.HealthCheck{
+				0: &structs.HealthCheck{
 					Status: structs.HealthCritical,
 				},
-				&structs.HealthCheck{
+				1: &structs.HealthCheck{
 					Status: structs.HealthCritical,
 				},
 			},
 		},
-		structs.CheckServiceNode{
+		2: structs.CheckServiceNode{
 			Checks: structs.HealthChecks{
-				&structs.HealthCheck{
+				0: &structs.HealthCheck{
 					Status: structs.HealthPassing,
 				},
 			},

--- a/command/agent/ui_endpoint_test.go
+++ b/command/agent/ui_endpoint_test.go
@@ -112,7 +112,7 @@ func TestUiNodeInfo(t *testing.T) {
 
 func TestSummarizeServices(t *testing.T) {
 	dump := structs.NodeDump{
-		&structs.NodeInfo{
+		0: &structs.NodeInfo{
 			Node:    "foo",
 			Address: "127.0.0.1",
 			Services: []*structs.NodeService{
@@ -138,7 +138,7 @@ func TestSummarizeServices(t *testing.T) {
 				},
 			},
 		},
-		&structs.NodeInfo{
+		1: &structs.NodeInfo{
 			Node:    "bar",
 			Address: "127.0.0.2",
 			Services: []*structs.NodeService{
@@ -153,7 +153,7 @@ func TestSummarizeServices(t *testing.T) {
 				},
 			},
 		},
-		&structs.NodeInfo{
+		2: &structs.NodeInfo{
 			Node:    "zip",
 			Address: "127.0.0.3",
 			Services: []*structs.NodeService{

--- a/consul/acl_endpoint.go
+++ b/consul/acl_endpoint.go
@@ -138,7 +138,7 @@ func (a *ACL) Get(args *structs.ACLSpecificRequest,
 			index, acl, err := state.ACLGet(args.ACL)
 			reply.Index = index
 			if acl != nil {
-				reply.ACLs = structs.ACLs{acl}
+				reply.ACLs = structs.ACLs{0: acl}
 			}
 			return err
 		})

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -266,7 +266,7 @@ func TestCatalogListNodes(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 
 	testutil.WaitForResult(func() (bool, error) {
 		client.Call("Catalog.ListNodes", &args, &out)
@@ -316,12 +316,12 @@ func TestCatalogListNodes_StaleRaad(t *testing.T) {
 		client = client1
 
 		// Inject fake data on the follower!
-		s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+		s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	} else {
 		client = client2
 
 		// Inject fake data on the follower!
-		s2.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+		s2.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	}
 
 	args := structs.DCSpecificRequest{
@@ -457,7 +457,7 @@ func BenchmarkCatalogListNodes(t *testing.B) {
 	defer client.Close()
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 
 	args := structs.DCSpecificRequest{
 		Datacenter: "dc1",
@@ -489,8 +489,8 @@ func TestCatalogListServices(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 
 	if err := client.Call("Catalog.ListServices", &args, &out); err != nil {
 		t.Fatalf("err: %v", err)
@@ -543,8 +543,8 @@ func TestCatalogListServices_Blocking(t *testing.T) {
 	start := time.Now()
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-		s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
+		s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+		s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 	}()
 
 	// Re-run the query
@@ -624,8 +624,8 @@ func TestCatalogListServices_Stale(t *testing.T) {
 	var out structs.IndexedServices
 
 	// Inject a fake service
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 
 	// Run the query, do not wait for leader!
 	if err := client.Call("Catalog.ListServices", &args, &out); err != nil {
@@ -665,8 +665,8 @@ func TestCatalogListServiceNodes(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
 
 	if err := client.Call("Catalog.ServiceNodes", &args, &out); err != nil {
 		t.Fatalf("err: %v", err)
@@ -708,9 +708,9 @@ func TestCatalogNodeServices(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
-	s1.fsm.State().EnsureService(3, "foo", &structs.NodeService{"web", "web", nil, "127.0.0.1", 80})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	s1.fsm.State().EnsureService(2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
+	s1.fsm.State().EnsureService(3, "foo", &structs.NodeService{ID: "web", Service: "web", Tags: nil, Address: "127.0.0.1", Port: 80})
 
 	if err := client.Call("Catalog.NodeServices", &args, &out); err != nil {
 		t.Fatalf("err: %v", err)

--- a/consul/fsm_test.go
+++ b/consul/fsm_test.go
@@ -335,12 +335,12 @@ func TestFSM_SnapshotRestore(t *testing.T) {
 	defer fsm.Close()
 
 	// Add some state
-	fsm.state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	fsm.state.EnsureNode(2, structs.Node{"baz", "127.0.0.2"})
-	fsm.state.EnsureService(3, "foo", &structs.NodeService{"web", "web", nil, "127.0.0.1", 80})
-	fsm.state.EnsureService(4, "foo", &structs.NodeService{"db", "db", []string{"primary"}, "127.0.0.1", 5000})
-	fsm.state.EnsureService(5, "baz", &structs.NodeService{"web", "web", nil, "127.0.0.2", 80})
-	fsm.state.EnsureService(6, "baz", &structs.NodeService{"db", "db", []string{"secondary"}, "127.0.0.2", 5000})
+	fsm.state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	fsm.state.EnsureNode(2, structs.Node{Node: "baz", Address: "127.0.0.2"})
+	fsm.state.EnsureService(3, "foo", &structs.NodeService{ID: "web", Service: "web", Tags: nil, Address: "127.0.0.1", Port: 80})
+	fsm.state.EnsureService(4, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000})
+	fsm.state.EnsureService(5, "baz", &structs.NodeService{ID: "web", Service: "web", Tags: nil, Address: "127.0.0.2", Port: 80})
+	fsm.state.EnsureService(6, "baz", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"secondary"}, Address: "127.0.0.2", Port: 5000})
 	fsm.state.EnsureCheck(7, &structs.HealthCheck{
 		Node:      "foo",
 		CheckID:   "web",
@@ -735,7 +735,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	}
 	defer fsm.Close()
 
-	fsm.state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	fsm.state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	fsm.state.EnsureCheck(2, &structs.HealthCheck{
 		Node:    "foo",
 		CheckID: "web",
@@ -819,7 +819,7 @@ func TestFSM_KVSLock(t *testing.T) {
 	}
 	defer fsm.Close()
 
-	fsm.state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	fsm.state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{ID: generateUUID(), Node: "foo"}
 	fsm.state.SessionCreate(2, session)
 
@@ -868,7 +868,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 	}
 	defer fsm.Close()
 
-	fsm.state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	fsm.state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{ID: generateUUID(), Node: "foo"}
 	fsm.state.SessionCreate(2, session)
 

--- a/consul/kvs_endpoint.go
+++ b/consul/kvs_endpoint.go
@@ -114,7 +114,7 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 				reply.Entries = nil
 			} else {
 				reply.Index = ent.ModifyIndex
-				reply.Entries = structs.DirEntries{ent}
+				reply.Entries = structs.DirEntries{0: ent}
 			}
 			return nil
 		},

--- a/consul/kvs_endpoint_test.go
+++ b/consul/kvs_endpoint_test.go
@@ -604,7 +604,7 @@ func TestKVS_Apply_LockDelay(t *testing.T) {
 
 	// Create and invalidate a session with a lock
 	state := s1.fsm.State()
-	if err := state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{

--- a/consul/session_endpoint.go
+++ b/consul/session_endpoint.go
@@ -116,7 +116,7 @@ func (s *Session) Get(args *structs.SessionSpecificRequest,
 			index, session, err := state.SessionGet(args.Session)
 			reply.Index = index
 			if session != nil {
-				reply.Sessions = structs.Sessions{session}
+				reply.Sessions = structs.Sessions{0: session}
 			}
 			return err
 		})
@@ -178,7 +178,7 @@ func (s *Session) Renew(args *structs.SessionSpecificRequest,
 	// Reset the session TTL timer
 	reply.Index = index
 	if session != nil {
-		reply.Sessions = structs.Sessions{session}
+		reply.Sessions = structs.Sessions{0: session}
 		if err := s.srv.resetSessionTimer(args.Session, session); err != nil {
 			s.srv.logger.Printf("[ERR] consul.session: Session renew failed: %v", err)
 			return err

--- a/consul/session_endpoint_test.go
+++ b/consul/session_endpoint_test.go
@@ -19,7 +19,7 @@ func TestSessionEndpoint_Apply(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 
 	arg := structs.SessionRequest{
 		Datacenter: "dc1",
@@ -78,7 +78,7 @@ func TestSessionEndpoint_DeleteApply(t *testing.T) {
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
 	// Just add a node
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 
 	arg := structs.SessionRequest{
 		Datacenter: "dc1",
@@ -140,7 +140,7 @@ func TestSessionEndpoint_Get(t *testing.T) {
 
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	arg := structs.SessionRequest{
 		Datacenter: "dc1",
 		Op:         structs.SessionCreate,
@@ -183,7 +183,7 @@ func TestSessionEndpoint_List(t *testing.T) {
 
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	ids := []string{}
 	for i := 0; i < 5; i++ {
 		arg := structs.SessionRequest{
@@ -234,7 +234,7 @@ func TestSessionEndpoint_ApplyTimers(t *testing.T) {
 
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	arg := structs.SessionRequest{
 		Datacenter: "dc1",
 		Op:         structs.SessionCreate,
@@ -277,7 +277,7 @@ func TestSessionEndpoint_Renew(t *testing.T) {
 	TTL := "10s" // the minimum allowed ttl
 	ttl := 10 * time.Second
 
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	ids := []string{}
 	for i := 0; i < 5; i++ {
 		arg := structs.SessionRequest{
@@ -435,8 +435,8 @@ func TestSessionEndpoint_NodeSessions(t *testing.T) {
 
 	testutil.WaitForLeader(t, client.Call, "dc1")
 
-	s1.fsm.State().EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
-	s1.fsm.State().EnsureNode(1, structs.Node{"bar", "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
+	s1.fsm.State().EnsureNode(1, structs.Node{Node: "bar", Address: "127.0.0.1"})
 	ids := []string{}
 	for i := 0; i < 10; i++ {
 		arg := structs.SessionRequest{

--- a/consul/session_ttl_test.go
+++ b/consul/session_ttl_test.go
@@ -19,7 +19,7 @@ func TestInitializeSessionTimers(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC, "dc1")
 
 	state := s1.fsm.State()
-	state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{
 		ID:   generateUUID(),
 		Node: "foo",
@@ -57,7 +57,7 @@ func TestResetSessionTimer_Fault(t *testing.T) {
 
 	// Create a session
 	state := s1.fsm.State()
-	state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{
 		ID:   generateUUID(),
 		Node: "foo",
@@ -89,7 +89,7 @@ func TestResetSessionTimer_NoTTL(t *testing.T) {
 
 	// Create a session
 	state := s1.fsm.State()
-	state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{
 		ID:   generateUUID(),
 		Node: "foo",
@@ -200,7 +200,7 @@ func TestInvalidateSession(t *testing.T) {
 
 	// Create a session
 	state := s1.fsm.State()
-	state.EnsureNode(1, structs.Node{"foo", "127.0.0.1"})
+	state.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"})
 	session := &structs.Session{
 		ID:   generateUUID(),
 		Node: "foo",

--- a/consul/state_store.go
+++ b/consul/state_store.go
@@ -485,7 +485,7 @@ func (s *StateStore) EnsureRegistration(index uint64, req *structs.RegisterReque
 	defer tx.Abort()
 
 	// Ensure the node
-	node := structs.Node{req.Node, req.Address}
+	node := structs.Node{Node: req.Node, Address: req.Address}
 	if err := s.ensureNodeTxn(index, node, tx); err != nil {
 		return err
 	}

--- a/consul/state_store_test.go
+++ b/consul/state_store_test.go
@@ -24,7 +24,7 @@ func TestEnsureRegistration(t *testing.T) {
 	reg := &structs.RegisterRequest{
 		Node:    "foo",
 		Address: "127.0.0.1",
-		Service: &structs.NodeService{"api", "api", nil, "", 5000},
+		Service: &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000},
 		Check: &structs.HealthCheck{
 			Node:      "foo",
 			CheckID:   "api",
@@ -72,7 +72,7 @@ func TestEnsureNode(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -81,7 +81,7 @@ func TestEnsureNode(t *testing.T) {
 		t.Fatalf("Bad: %v %v %v", idx, found, addr)
 	}
 
-	if err := store.EnsureNode(4, structs.Node{"foo", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(4, structs.Node{Node: "foo", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -98,11 +98,11 @@ func TestGetNodes(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(40, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(40, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(41, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(41, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -125,11 +125,11 @@ func BenchmarkGetNodes(b *testing.B) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(100, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(100, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		b.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(101, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(101, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		b.Fatalf("err: %v", err)
 	}
 
@@ -145,19 +145,19 @@ func TestEnsureService(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(10, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(10, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(11, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(11, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api", "api", nil, "", 5001}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(13, "foo", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(13, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -190,19 +190,19 @@ func TestEnsureService_DuplicateNode(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(10, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(10, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(11, "foo", &structs.NodeService{"api1", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(11, "foo", &structs.NodeService{ID: "api1", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api2", "api", nil, "", 5001}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api2", Service: "api", Tags: nil, Address: "", Port: 5001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(13, "foo", &structs.NodeService{"api3", "api", nil, "", 5002}); err != nil {
+	if err := store.EnsureService(13, "foo", &structs.NodeService{ID: "api3", Service: "api", Tags: nil, Address: "", Port: 5002}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -243,11 +243,11 @@ func TestDeleteNodeService(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(11, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(11, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -291,15 +291,15 @@ func TestDeleteNodeService_One(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(11, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(11, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(13, "foo", &structs.NodeService{"api2", "api", nil, "", 5001}); err != nil {
+	if err := store.EnsureService(13, "foo", &structs.NodeService{ID: "api2", Service: "api", Tags: nil, Address: "", Port: 5001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -328,11 +328,11 @@ func TestDeleteNode(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(20, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(20, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(21, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(21, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -383,23 +383,23 @@ func TestGetServices(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(30, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(30, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(31, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(31, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(32, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(32, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(33, "foo", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(33, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(34, "bar", &structs.NodeService{"db", "db", []string{"slave"}, "", 8000}); err != nil {
+	if err := store.EnsureService(34, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -433,31 +433,31 @@ func TestServiceNodes(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(10, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(10, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(11, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(11, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(13, "bar", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(13, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(14, "foo", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(14, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(15, "bar", &structs.NodeService{"db", "db", []string{"slave"}, "", 8000}); err != nil {
+	if err := store.EnsureService(15, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(16, "bar", &structs.NodeService{"db2", "db", []string{"slave"}, "", 8001}); err != nil {
+	if err := store.EnsureService(16, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -524,23 +524,23 @@ func TestServiceTagNodes(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(15, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(15, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(16, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(16, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(17, "foo", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(18, "foo", &structs.NodeService{"db2", "db", []string{"slave"}, "", 8001}); err != nil {
+	if err := store.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(19, "bar", &structs.NodeService{"db", "db", []string{"slave"}, "", 8000}); err != nil {
+	if err := store.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -572,23 +572,23 @@ func TestServiceTagNodes_MultipleTags(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(15, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(15, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(16, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(16, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(17, "foo", &structs.NodeService{"db", "db", []string{"master", "v2"}, "", 8000}); err != nil {
+	if err := store.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master", "v2:"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(18, "foo", &structs.NodeService{"db2", "db", []string{"slave", "v2", "dev"}, "", 8001}); err != nil {
+	if err := store.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave", "v2:", "dev"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(19, "bar", &structs.NodeService{"db", "db", []string{"slave", "v2"}, "", 8000}); err != nil {
+	if err := store.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave", "v2:"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -648,23 +648,23 @@ func TestStoreSnapshot(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(8, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(8, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureNode(9, structs.Node{"bar", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(9, structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(10, "foo", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(10, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(11, "foo", &structs.NodeService{"db2", "db", []string{"slave"}, "", 8001}); err != nil {
+	if err := store.EnsureService(11, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := store.EnsureService(12, "bar", &structs.NodeService{"db", "db", []string{"slave"}, "", 8000}); err != nil {
+	if err := store.EnsureService(12, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -849,13 +849,13 @@ func TestStoreSnapshot(t *testing.T) {
 	}
 
 	// Make some changes!
-	if err := store.EnsureService(23, "foo", &structs.NodeService{"db", "db", []string{"slave"}, "", 8000}); err != nil {
+	if err := store.EnsureService(23, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(24, "bar", &structs.NodeService{"db", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(24, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureNode(25, structs.Node{"baz", "127.0.0.3"}); err != nil {
+	if err := store.EnsureNode(25, structs.Node{Node: "baz", Address: "127.0.0.3"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	checkAfter := &structs.HealthCheck{
@@ -976,10 +976,10 @@ func TestEnsureCheck(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -1072,10 +1072,10 @@ func TestDeleteNodeCheck(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -1122,10 +1122,10 @@ func TestCheckServiceNodes(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -1203,10 +1203,10 @@ func BenchmarkCheckServiceNodes(t *testing.B) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -1241,26 +1241,26 @@ func TestSS_Register_Deregister_Query(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	srv := &structs.NodeService{
-		"statsite-box-stats",
-		"statsite-box-stats",
-		nil,
-		"",
-		0}
+		ID:      "statsite-box-stats",
+		Service: "statsite-box-stats",
+		Tags:    nil,
+		Address: "",
+		Port:    0}
 	if err := store.EnsureService(2, "foo", srv); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	srv = &structs.NodeService{
-		"statsite-share-stats",
-		"statsite-share-stats",
-		nil,
-		"",
-		0}
+		ID:      "statsite-share-stats",
+		Service: "statsite-share-stats",
+		Tags:    nil,
+		Address: "",
+		Port:    0}
 	if err := store.EnsureService(3, "foo", srv); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1285,10 +1285,10 @@ func TestNodeInfo(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -1344,16 +1344,16 @@ func TestNodeDump(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(1, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(1, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(2, "foo", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureNode(3, structs.Node{"baz", "127.0.0.2"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "baz", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(4, "baz", &structs.NodeService{"db1", "db", []string{"master"}, "", 8000}); err != nil {
+	if err := store.EnsureService(4, "baz", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2228,7 +2228,7 @@ func TestSessionCreate(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -2273,7 +2273,7 @@ func TestSessionCreate_Invalid(t *testing.T) {
 	}
 
 	// Check not registered
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if err := store.SessionCreate(1000, session); err.Error() != "Missing check 'bar' registration" {
@@ -2302,7 +2302,7 @@ func TestSession_Lookups(t *testing.T) {
 	defer store.Close()
 
 	// Create a session
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{
@@ -2387,7 +2387,7 @@ func TestSessionInvalidate_CriticalHealthCheck(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -2431,7 +2431,7 @@ func TestSessionInvalidate_DeleteHealthCheck(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -2474,7 +2474,7 @@ func TestSessionInvalidate_DeleteNode(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -2508,10 +2508,10 @@ func TestSessionInvalidate_DeleteNodeService(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(11, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(11, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := store.EnsureService(12, "foo", &structs.NodeService{"api", "api", nil, "", 5000}); err != nil {
+	if err := store.EnsureService(12, "foo", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -2556,7 +2556,7 @@ func TestKVSLock(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{ID: generateUUID(), Node: "foo"}
@@ -2629,7 +2629,7 @@ func TestKVSUnlock(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{ID: generateUUID(), Node: "foo"}
@@ -2686,7 +2686,7 @@ func TestSessionInvalidate_KeyUnlock(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	defer store.Close()
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{
@@ -2754,7 +2754,7 @@ func TestSessionInvalidate_KeyDelete(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.EnsureNode(3, structs.Node{"foo", "127.0.0.1"}); err != nil {
+	if err := store.EnsureNode(3, structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	session := &structs.Session{


### PR DESCRIPTION
The warnings were:  'composite literal uses unkeyed fields'

I admit some of the changes (e.g. command/agent/health_endpoint_test.go) seem weird to me, but I think the benefit of additional static checking from go vet is worth it.
