### PR TITLE
Add "only_passing" option to DNS config

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -74,6 +74,11 @@ type DNSConfig struct {
 	// stale read is performed.
 	MaxStale    time.Duration `mapstructure:"-"`
 	MaxStaleRaw string        `mapstructure:"max_stale" json:"-"`
+
+	// OnlyPassing is used to determine whether to filter nodes
+	// whose health checks are in any non-passing state. By
+	// default, only nodes in a critical state are excluded.
+	OnlyPassing bool `mapstructure:"only_passing"`
 }
 
 // Config is the configuration that can be set for an Agent.
@@ -834,6 +839,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.DNSConfig.MaxStale != 0 {
 		result.DNSConfig.MaxStale = b.DNSConfig.MaxStale
+	}
+	if b.DNSConfig.OnlyPassing {
+		result.DNSConfig.OnlyPassing = true
 	}
 	if b.CheckUpdateIntervalRaw != "" || b.CheckUpdateInterval != 0 {
 		result.CheckUpdateInterval = b.CheckUpdateInterval

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -472,6 +472,17 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// DNS only passing
+	input = `{"dns_config": {"only_passing": true}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !config.DNSConfig.OnlyPassing {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// CheckUpdateInterval
 	input = `{"check_update_interval": "10m"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -554,7 +554,8 @@ OUTER:
 	for i := 0; i < n; i++ {
 		node := nodes[i]
 		for _, check := range node.Checks {
-			if check.Status == structs.HealthCritical {
+			if check.Status == structs.HealthCritical ||
+				(d.config.OnlyPassing && check.Status != structs.HealthPassing) {
 				d.logger.Printf("[WARN] dns: node '%s' failing health check '%s: %s', dropping from service '%s'",
 					node.Node.Node, check.CheckID, check.Name, node.Service.Service)
 				nodes[i], nodes[n-1] = nodes[n-1], structs.CheckServiceNode{}

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -954,6 +954,26 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	args5 := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "quux",
+		Address:    "127.0.0.4",
+		Service: &structs.NodeService{
+			Service: "db",
+			Tags:    []string{"master"},
+			Port:    12345,
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "db",
+			Name:      "db",
+			ServiceID: "db",
+			Status:    structs.HealthWarning,
+		},
+	}
+	if err := srv.agent.RPC("Catalog.Register", args5, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	m := new(dns.Msg)
 	m.SetQuestion("db.service.consul.", dns.TypeANY)
 
@@ -964,14 +984,137 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Should get no answer since we are failing!
+	// Only 4 and 5 are not failing, so we should get 2 answers
+	if len(in.Answer) != 2 {
+		t.Fatalf("Bad: %#v", in)
+	}
+
+	ips := make(map[string]bool)
+	for _, resp := range in.Answer {
+		aRec := resp.(*dns.A)
+		ips[aRec.A.String()] = true
+	}
+
+	if !ips["127.0.0.3"] {
+		t.Fatalf("Bad: %#v should contain 127.0.0.3 (state healthy)", in)
+	}
+	if !ips["127.0.0.4"] {
+		t.Fatalf("Bad: %#v should contain 127.0.0.4 (state warning)", in)
+	}
+}
+
+func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
+	dir, srv := makeDNSServerConfig(t, &DNSConfig{OnlyPassing: true})
+	defer os.RemoveAll(dir)
+	defer srv.agent.Shutdown()
+
+	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
+	// Register nodes
+	args := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "foo",
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			Service: "db",
+			Tags:    []string{"master"},
+			Port:    12345,
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "db",
+			Name:      "db",
+			ServiceID: "db",
+			Status:    structs.HealthPassing,
+		},
+	}
+
+	var out struct{}
+	if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	args2 := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "bar",
+		Address:    "127.0.0.2",
+		Service: &structs.NodeService{
+			Service: "db",
+			Tags:    []string{"master"},
+			Port:    12345,
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "db",
+			Name:      "db",
+			ServiceID: "db",
+			Status:    structs.HealthWarning,
+		},
+	}
+
+	if err := srv.agent.RPC("Catalog.Register", args2, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	args3 := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "baz",
+		Address:    "127.0.0.3",
+		Service: &structs.NodeService{
+			Service: "db",
+			Tags:    []string{"master"},
+			Port:    12345,
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "db",
+			Name:      "db",
+			ServiceID: "db",
+			Status:    structs.HealthCritical,
+		},
+	}
+
+	if err := srv.agent.RPC("Catalog.Register", args3, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	args4 := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "quux",
+		Address:    "127.0.0.4",
+		Service: &structs.NodeService{
+			Service: "db",
+			Tags:    []string{"master"},
+			Port:    12345,
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "db",
+			Name:      "db",
+			ServiceID: "db",
+			Status:    structs.HealthUnknown,
+		},
+	}
+
+	if err := srv.agent.RPC("Catalog.Register", args4, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	m := new(dns.Msg)
+	m.SetQuestion("db.service.consul.", dns.TypeANY)
+
+	c := new(dns.Client)
+	addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
+	in, _, err := c.Exchange(m, addr.String())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Only 1 is passing, so we should only get 1 answer
 	if len(in.Answer) != 1 {
 		t.Fatalf("Bad: %#v", in)
 	}
 
 	resp := in.Answer[0]
 	aRec := resp.(*dns.A)
-	if aRec.A.String() != "127.0.0.3" {
+
+	if aRec.A.String() != "127.0.0.1" {
 		t.Fatalf("Bad: %#v", in.Answer[0])
 	}
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -312,6 +312,10 @@ definitions support being updated during a reload.
   will set the truncated flag, indicating to clients that they should re-query using TCP to
   get the full set of records.
 
+  * `only_passing` - If set to true, any nodes whose healthchecks are not passing will be
+  excluded from DNS results. By default (or if set to false), only nodes whose healthchecks
+  are failing as critical will be excluded.
+
 * `domain` - By default, Consul responds to DNS queries in the "consul." domain.
   This flag can be used to change that domain. All queries in this domain are assumed
   to be handled by Consul, and will not be recursively resolved.


### PR DESCRIPTION
This excludes nodes from DNS results if their healthchecks are in any non-passing state state, not just if they're critical.

In our environment, we only want to send traffic to nodes that we know are healthy. Our healthchecks often return both warning and unknown to indicate that something is wrong (the former to indicate that the node is online but we don't want to send traffic to it, e.g. for draining the node; and the latter for ¯\_(ツ)_/¯)