### PR TITLE
Support node and service maintenance mode

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -999,6 +999,8 @@ func (a *Agent) unloadChecks() error {
 	return nil
 }
 
+// EnableServiceMaintenance will register a false health check against the given
+// service ID with critical status. This will exclude the service from queries.
 func (a *Agent) EnableServiceMaintenance(serviceID string) error {
 	var service *structs.NodeService
 	for _, svc := range a.state.Services() {
@@ -1034,6 +1036,8 @@ func (a *Agent) EnableServiceMaintenance(serviceID string) error {
 	return nil
 }
 
+// DisableServiceMaintenance will deregister the fake maintenance mode check
+// if the service has been marked as in maintenance.
 func (a *Agent) DisableServiceMaintenance(serviceID string) error {
 	var service *structs.NodeService
 	for _, svc := range a.state.Services() {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -30,8 +30,9 @@ const (
 		"be left behind. If the path looks correct, remove the file " +
 		"and try again."
 
-	// The ID of the faux health check for maintenance mode
-	maintCheckID = "_maintenance_"
+	// The ID of the faux health checks for maintenance mode
+	serviceMaintCheckID = "_service_maintenance"
+	nodeMaintCheckID    = "_node_maintenenace"
 )
 
 /*
@@ -1008,14 +1009,14 @@ func (a *Agent) EnableServiceMaintenance(serviceID string) error {
 	}
 
 	// Ensure maintenance mode is not already enabled
-	if _, ok := a.state.Checks()[maintCheckID]; ok {
+	if _, ok := a.state.Checks()[serviceMaintCheckID]; ok {
 		return nil
 	}
 
 	// Create and register the critical health check
 	check := &structs.HealthCheck{
 		Node:        a.config.NodeName,
-		CheckID:     maintCheckID,
+		CheckID:     serviceMaintCheckID,
 		Name:        "Service Maintenance Mode",
 		Notes:       "Maintenance mode is enabled for this service",
 		ServiceID:   service.ID,
@@ -1035,6 +1036,29 @@ func (a *Agent) DisableServiceMaintenance(serviceID string) error {
 	}
 
 	// Deregister the maintenance check
-	a.RemoveCheck(maintCheckID, true)
+	a.RemoveCheck(serviceMaintCheckID, true)
 	return nil
+}
+
+// EnableNodeMaintenance places a node into maintenance mode.
+func (a *Agent) EnableNodeMaintenance() {
+	// Ensure node maintenance is not already enabled
+	if _, ok := a.state.Checks()[nodeMaintCheckID]; ok {
+		return
+	}
+
+	// Create and register the node maintenance check
+	check := &structs.HealthCheck{
+		Node:    a.config.NodeName,
+		CheckID: nodeMaintCheckID,
+		Name:    "Node Maintenance Mode",
+		Notes:   "Maintenance mode is enabled for this node",
+		Status:  structs.HealthCritical,
+	}
+	a.AddCheck(check, nil, true)
+}
+
+// DisableNodeMaintenance removes a node from maintenance mode
+func (a *Agent) DisableNodeMaintenance() {
+	a.RemoveCheck(nodeMaintCheckID, true)
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1031,7 +1031,7 @@ func (a *Agent) EnableServiceMaintenance(serviceID string) error {
 		ServiceName: service.Service,
 		Status:      structs.HealthCritical,
 	}
-	a.state.AddCheck(check)
+	a.AddCheck(check, nil, true)
 
 	return nil
 }
@@ -1061,7 +1061,7 @@ func (a *Agent) DisableServiceMaintenance(serviceID string) error {
 
 DEREGISTER:
 	// Deregister the maintenance check
-	a.state.RemoveCheck(maintCheckID)
+	a.RemoveCheck(maintCheckID, true)
 
 	return nil
 }

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -216,12 +216,12 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	var err error
 	if enable {
 		if err = s.agent.EnableServiceMaintenance(serviceID); err != nil {
-			resp.WriteHeader(409)
+			resp.WriteHeader(404)
 			resp.Write([]byte(err.Error()))
 		}
 	} else {
 		if err = s.agent.DisableServiceMaintenance(serviceID); err != nil {
-			resp.WriteHeader(409)
+			resp.WriteHeader(404)
 			resp.Write([]byte(err.Error()))
 		}
 	}

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -227,3 +227,39 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	}
 	return nil, err
 }
+
+func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Only PUT supported
+	if req.Method != "PUT" {
+		resp.WriteHeader(405)
+		return nil, nil
+	}
+
+	// Ensure we have some action
+	params := req.URL.Query()
+	if _, ok := params["enable"]; !ok {
+		resp.WriteHeader(400)
+		resp.Write([]byte("Missing value for enable"))
+		return nil, nil
+	}
+
+	var enable bool
+	raw := params.Get("enable")
+	switch raw {
+	case "true":
+		enable = true
+	case "false":
+		enable = false
+	default:
+		resp.WriteHeader(400)
+		resp.Write([]byte(fmt.Sprintf("Invalid value for enable: %q", raw)))
+		return nil, nil
+	}
+
+	if enable {
+		s.agent.EnableNodeMaintenance()
+	} else {
+		s.agent.DisableNodeMaintenance()
+	}
+	return nil, nil
+}

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/serf/serf"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -490,5 +491,134 @@ func TestHTTPAgentDeregisterService(t *testing.T) {
 
 	if _, ok := srv.agent.state.Checks()["test"]; ok {
 		t.Fatalf("have test check")
+	}
+}
+
+func TestHTTPAgent_ServiceMaintenanceEndpoint_BadRequest(t *testing.T) {
+	dir, srv := makeHTTPServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	// Fails on non-PUT
+	req, _ := http.NewRequest("GET", "/v1/agent/service/maintenance/test?enable=true", nil)
+	resp := httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if resp.Code != 405 {
+		t.Fatalf("expected 405 for non-PUT request")
+	}
+
+	// Fails when no enable flag provided
+	req, _ = http.NewRequest("PUT", "/v1/agent/service/maintenance/test", nil)
+	resp = httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if resp.Code != 400 {
+		t.Fatalf("expected 400 for missing enable flag")
+	}
+
+	// Fails when no service ID provided
+	req, _ = http.NewRequest("PUT", "/v1/agent/service/maintenance/?enable=true", nil)
+	resp = httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if resp.Code != 400 {
+		t.Fatalf("expected 400 for missing service ID")
+	}
+}
+
+func TestHTTPAgent_EnableServiceMaintenance(t *testing.T) {
+	dir, srv := makeHTTPServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	// Register the service
+	service := &structs.NodeService{
+		ID:      "test",
+		Service: "test",
+	}
+	if err := srv.agent.AddService(service, nil, false); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Force into maintenance mode
+	if err := srv.agent.EnableServiceMaintenance("test"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Fails when service is already in maintenance mode
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/maintenance/test?enable=true", nil)
+	resp := httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err == nil {
+		t.Fatalf("should have errored")
+	}
+	if resp.Code != 409 {
+		t.Fatalf("expected 409, got %d", resp.Code)
+	}
+
+	// Remove maintenance mode
+	if err := srv.agent.DisableServiceMaintenance("test"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Force the service into maintenance mode
+	req, _ = http.NewRequest("PUT", "/v1/agent/service/maintenance/test?enable=true", nil)
+	resp = httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if resp.Code != 200 {
+		t.Fatalf("expected 200, got %d", resp.Code)
+	}
+
+	// Ensure the maintenance check was registered
+	if _, ok := srv.agent.state.Checks()[maintCheckID]; !ok {
+		t.Fatalf("should have registered maintenance check")
+	}
+}
+
+func TestHTTPAgent_DisableServiceMaintenance(t *testing.T) {
+	dir, srv := makeHTTPServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	// Register the service
+	service := &structs.NodeService{
+		ID:      "test",
+		Service: "test",
+	}
+	if err := srv.agent.AddService(service, nil, false); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Fails when the service is not in maintenance mode
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/maintenance/test?enable=false", nil)
+	resp := httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err == nil {
+		t.Fatalf("should have failed")
+	}
+	if resp.Code != 409 {
+		t.Fatalf("expected 409, got %d", resp.Code)
+	}
+
+	// Force the service into maintenance mode
+	if err := srv.agent.EnableServiceMaintenance("test"); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Leave maintenance mode
+	req, _ = http.NewRequest("PUT", "/v1/agent/service/maintenance/test?enable=false", nil)
+	resp = httptest.NewRecorder()
+	if _, err := srv.AgentServiceMaintenance(resp, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if resp.Code != 200 {
+		t.Fatalf("expected 200, got %d", resp.Code)
 	}
 }

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -567,7 +567,7 @@ func TestHTTPAgent_EnableServiceMaintenance(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was registered
-	if _, ok := srv.agent.state.Checks()[maintCheckID]; !ok {
+	if _, ok := srv.agent.state.Checks()[serviceMaintCheckID]; !ok {
 		t.Fatalf("should have registered maintenance check")
 	}
 }
@@ -603,7 +603,7 @@ func TestHTTPAgent_DisableServiceMaintenance(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was removed
-	if _, ok := srv.agent.state.Checks()[maintCheckID]; ok {
+	if _, ok := srv.agent.state.Checks()[serviceMaintCheckID]; ok {
 		t.Fatalf("should have removed maintenance check")
 	}
 }

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -567,7 +567,8 @@ func TestHTTPAgent_EnableServiceMaintenance(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was registered
-	if _, ok := srv.agent.state.Checks()[serviceMaintCheckID]; !ok {
+	checkID := serviceMaintCheckID("test")
+	if _, ok := srv.agent.state.Checks()[checkID]; !ok {
 		t.Fatalf("should have registered maintenance check")
 	}
 }
@@ -603,7 +604,8 @@ func TestHTTPAgent_DisableServiceMaintenance(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was removed
-	if _, ok := srv.agent.state.Checks()[serviceMaintCheckID]; ok {
+	checkID := serviceMaintCheckID("test")
+	if _, ok := srv.agent.state.Checks()[checkID]; ok {
 		t.Fatalf("should have removed maintenance check")
 	}
 }

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -807,7 +807,7 @@ func TestAgent_MaintenanceMode(t *testing.T) {
 
 	// Make sure the critical health check was added
 	for _, check := range agent.state.Checks() {
-		if check.CheckID == maintCheckID {
+		if check.CheckID == serviceMaintCheckID {
 			return
 		}
 	}
@@ -822,7 +822,7 @@ func TestAgent_MaintenanceMode(t *testing.T) {
 
 	// Ensure the check was deregistered
 	for _, check := range agent.state.Checks() {
-		if check.CheckID == maintCheckID {
+		if check.CheckID == serviceMaintCheckID {
 			t.Fatalf("should have deregistered maintenance check")
 		}
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -806,7 +806,8 @@ func TestAgent_ServiceMaintenanceMode(t *testing.T) {
 	}
 
 	// Make sure the critical health check was added
-	if _, ok := agent.state.Checks()[serviceMaintCheckID]; !ok {
+	checkID := serviceMaintCheckID("redis")
+	if _, ok := agent.state.Checks()[checkID]; !ok {
 		t.Fatalf("should have registered critical maintenance check")
 	}
 
@@ -816,7 +817,7 @@ func TestAgent_ServiceMaintenanceMode(t *testing.T) {
 	}
 
 	// Ensure the check was deregistered
-	if _, ok := agent.state.Checks()[serviceMaintCheckID]; ok {
+	if _, ok := agent.state.Checks()[checkID]; ok {
 		t.Fatalf("should have deregistered maintenance check")
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -195,6 +195,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 
 	s.mux.HandleFunc("/v1/agent/service/register", s.wrap(s.AgentRegisterService))
 	s.mux.HandleFunc("/v1/agent/service/deregister/", s.wrap(s.AgentDeregisterService))
+	s.mux.HandleFunc("/v1/agent/service/maintenance/", s.wrap(s.AgentServiceMaintenance))
 
 	s.mux.HandleFunc("/v1/event/fire/", s.wrap(s.EventFire))
 	s.mux.HandleFunc("/v1/event/list", s.wrap(s.EventList))

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -181,6 +181,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/health/service/", s.wrap(s.HealthServiceNodes))
 
 	s.mux.HandleFunc("/v1/agent/self", s.wrap(s.AgentSelf))
+	s.mux.HandleFunc("/v1/agent/self/maintenance", s.wrap(s.AgentNodeMaintenance))
 	s.mux.HandleFunc("/v1/agent/services", s.wrap(s.AgentServices))
 	s.mux.HandleFunc("/v1/agent/checks", s.wrap(s.AgentChecks))
 	s.mux.HandleFunc("/v1/agent/members", s.wrap(s.AgentMembers))

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -247,6 +247,7 @@ The following endpoints are supported:
 * [`/v1/agent/check/fail/<checkID>`](#agent_check_fail) : Mark a local test as critical
 * [`/v1/agent/service/register`](#agent_service_register) : Registers a new local service
 * [`/v1/agent/service/deregister/<serviceID>`](#agent_service_deregister) : Deregister a local service
+* [`/v1/agent/service/maintenance/<serviceID>`](#agent_service_maintenance) : Service maintenance mode
 
 ### <a name="agent_checks"></a> /v1/agent/checks
 
@@ -545,6 +546,20 @@ The deregister endpoint is used to remove a service from the local agent.
 The ServiceID must be passed after the slash. The agent will take care
 of deregistering the service with the Catalog. If there is an associated
 check, that is also deregistered.
+
+The return code is 200 on success.
+
+### <a name="agent_service_maintenance"></a> /v1/agent/service/maintenance/\<serviceId\>
+
+The service maintenance endpoint allows placing a given service into
+"maintenance mode". During maintenance mode, the service will be marked as
+unavailable, and will not be present in DNS or API queries.
+
+The `?enable` flag is required, and its value must be `true` (to enter
+maintenance mode), or `false` (to resume normal operation). It is an error to
+enable maintenance mode while it is already enabled, or disable it while it is
+already disabled. You will receive a 409 if either of these conflicts are
+observed.
 
 The return code is 200 on success.
 

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -238,6 +238,7 @@ The following endpoints are supported:
 * [`/v1/agent/services`](#agent_services) : Returns the services local agent is managing
 * [`/v1/agent/members`](#agent_members) : Returns the members as seen by the local serf agent
 * [`/v1/agent/self`](#agent_self) : Returns the local node configuration
+* [`/v1/agent/self/maintenance`](#agent_self_maintenance) : Node maintenance mode
 * [`/v1/agent/join/<address>`](#agent_join) : Trigger local agent to join a node
 * [`/v1/agent/force-leave/<node>`](#agent_force_leave)>: Force remove node
 * [`/v1/agent/check/register`](#agent_check_register) : Registers a new local check
@@ -401,6 +402,18 @@ It returns a JSON body like this:
   }
 }
 ```
+
+### <a name="agent_self_maintenance"></a> /v1/agent/self/maintenance
+
+The node maintenance endpoint allows placing the agent into "maintenance mode".
+During maintenance mode, the node will be marked as unavailable, and will not be
+present in DNS or API queries. This API call is idempotent. Maintenance mode is
+persistent and will be automatically restored on agent restart.
+
+The `?enable` flag is required, and its value must be `true` (to enter
+maintenance mode), or `false` (to resume normal operation).
+
+The return code is 200 on success.
 
 ### <a name="agent_join"></a> /v1/agent/join/\<address\>
 

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -553,13 +553,12 @@ The return code is 200 on success.
 
 The service maintenance endpoint allows placing a given service into
 "maintenance mode". During maintenance mode, the service will be marked as
-unavailable, and will not be present in DNS or API queries.
+unavailable, and will not be present in DNS or API queries. This API call is
+idempotent. Maintenance mode is persistent and will be automatically restored
+on agent restart.
 
 The `?enable` flag is required, and its value must be `true` (to enter
-maintenance mode), or `false` (to resume normal operation). It is an error to
-enable maintenance mode while it is already enabled, or disable it while it is
-already disabled. You will receive a 409 if either of these conflicts are
-observed.
+maintenance mode), or `false` (to resume normal operation).
 
 The return code is 200 on success.
 


### PR DESCRIPTION
This introduces maintenance mode at both a node and service level. Maintenance mode can be invoked at either scope at runtime to immediately bring the node out of service. This is mostly health check sugar, which works by registering a critical health check right away. Maintenance mode can be enabled or disabled idempotently using the HTTP API endpoints. Maintenance mode is also persistent, so nodes and services will not re-enter the pool unless explicitly told to do so.