### PR TITLE
Refactor UNIX domain socket

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -139,7 +139,6 @@ func makeClientWithConfig(t *testing.T, cb1 configCallback, cb2 serverConfigCall
 	// Make client config
 	conf := DefaultConfig()
 	cb1(conf)
-	fmt.Printf("%#v\n", conf.HttpClient.Transport)
 
 	// Create client
 	client, err := NewClient(conf)

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,52 +1,11 @@
 package api
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"runtime"
 	"testing"
 )
 
-func TestStatusLeaderTCP(t *testing.T) {
+func TestStatusLeader(t *testing.T) {
 	c, s := makeClient(t)
-	defer s.stop()
-
-	status := c.Status()
-
-	leader, err := status.Leader()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if leader == "" {
-		t.Fatalf("Expected leader")
-	}
-}
-
-func TestStatusLeaderUnix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
-	}
-
-	tempdir, err := ioutil.TempDir("", "consul-test-")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer os.RemoveAll(tempdir)
-	socket := fmt.Sprintf("unix://%s/test.sock", tempdir)
-
-	clientConfig := func(c *Config) {
-		c.Address = socket
-	}
-
-	serverConfig := func(c *testServerConfig) {
-		if c.Addresses == nil {
-			c.Addresses = &testAddressConfig{}
-		}
-		c.Addresses.HTTP = socket
-	}
-
-	c, s := makeClientWithConfig(t, clientConfig, serverConfig)
 	defer s.stop()
 
 	status := c.Status()

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,8 +1,9 @@
 package api
 
 import (
+	"fmt"
 	"io/ioutil"
-	"os/user"
+	"os"
 	"runtime"
 	"testing"
 )
@@ -29,25 +30,20 @@ func TestStatusLeaderUnix(t *testing.T) {
 
 	tempdir, err := ioutil.TempDir("", "consul-test-")
 	if err != nil {
-		t.Fatal("Could not create a working directory")
+		t.Fatalf("err: %s", err)
 	}
-
-	socket := "unix://" + tempdir + "/unix-http-test.sock"
+	defer os.RemoveAll(tempdir)
+	socket := fmt.Sprintf("unix://%s/test.sock", tempdir)
 
 	clientConfig := func(c *Config) {
 		c.Address = socket
 	}
 
 	serverConfig := func(c *testServerConfig) {
-		user, err := user.Current()
-		if err != nil {
-			t.Fatal("Could not get current user")
-		}
-
 		if c.Addresses == nil {
 			c.Addresses = &testAddressConfig{}
 		}
-		c.Addresses.HTTP = socket + ";" + user.Uid + ";" + user.Gid + ";640"
+		c.Addresses.HTTP = socket
 	}
 
 	c, s := makeClientWithConfig(t, clientConfig, serverConfig)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -22,6 +22,13 @@ const (
 
 	// Path to save local agent checks
 	checksDir = "checks"
+
+	// errSocketFileExists is the human-friendly error message displayed when
+	// trying to bind a socket to an existing file.
+	errSocketFileExists = "A file exists at the requested socket path %q. " +
+		"If Consul was not shut down properly, the socket file may " +
+		"be left behind. If the path looks correct, remove the file " +
+		"and try again."
 )
 
 /*

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -125,37 +124,8 @@ func TestAgentStartStop(t *testing.T) {
 	}
 }
 
-func TestAgent_RPCPingTCP(t *testing.T) {
+func TestAgent_RPCPing(t *testing.T) {
 	dir, agent := makeAgent(t, nextConfig())
-	defer os.RemoveAll(dir)
-	defer agent.Shutdown()
-
-	var out struct{}
-	if err := agent.RPC("Status.Ping", struct{}{}, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-}
-
-func TestAgent_RPCPingUnix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
-	}
-
-	nextConf := nextConfig()
-
-	tempdir, err := ioutil.TempDir("", "consul-test-")
-	if err != nil {
-		t.Fatal("Could not create a working directory")
-	}
-
-	user, err := user.Current()
-	if err != nil {
-		t.Fatal("Could not get current user")
-	}
-
-	nextConf.Addresses.RPC = "unix://" + tempdir + "/unix-rpc-test.sock;" + user.Uid + ";" + user.Gid + ";640"
-
-	dir, agent := makeAgent(t, nextConf)
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -295,12 +295,11 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 		return err
 	}
 
+	// Error if we are trying to bind a domain socket to an existing path
 	if path, ok := unixSocketAddr(config.Addresses.RPC); ok {
-		// Remove the socket if it exists, or we'll get a bind error. This
-		// is necessary to avoid situations where Consul cannot start if the
-		// socket file exists in case of unexpected termination.
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			return err
+		if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
+			c.Ui.Output(fmt.Sprintf(errSocketFileExists, path))
+			return fmt.Errorf(errSocketFileExists, path)
 		}
 	}
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -299,10 +299,8 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 		// Remove the socket if it exists, or we'll get a bind error. This
 		// is necessary to avoid situations where Consul cannot start if the
 		// socket file exists in case of unexpected termination.
-		if _, err := os.Stat(path); err == nil {
-			if err := os.Remove(path); err != nil {
-				return err
-			}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
 		}
 	}
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -7,11 +7,8 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/user"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -348,89 +345,13 @@ type Config struct {
 	WatchPlans []*watch.WatchPlan `mapstructure:"-" json:"-"`
 }
 
-// UnixSocket contains the parameters for a Unix socket interface
-type UnixSocket struct {
-	// Path to the socket on-disk
-	Path string
-
-	// uid of the owner of the socket
-	Uid int
-
-	// gid of the group of the socket
-	Gid int
-
-	// Permissions for the socket file
-	Permissions os.FileMode
-}
-
-func populateUnixSocket(addr string) (*UnixSocket, error) {
+// unixSocketAddr tests if a given address describes a domain socket,
+// and returns the relevant path part of the string if it is.
+func unixSocketAddr(addr string) (string, bool) {
 	if !strings.HasPrefix(addr, "unix://") {
-		return nil, fmt.Errorf("Failed to parse Unix address, format is unix://[path];[user];[group];[mode]: %v", addr)
+		return "", false
 	}
-
-	splitAddr := strings.Split(strings.TrimPrefix(addr, "unix://"), ";")
-	if len(splitAddr) != 4 {
-		return nil, fmt.Errorf("Failed to parse Unix address, format is unix://[path];[user];[group];[mode]: %v", addr)
-	}
-
-	ret := &UnixSocket{Path: splitAddr[0]}
-
-	var userVal *user.User
-	var err error
-
-	regex := regexp.MustCompile("[\\d]+")
-	if regex.MatchString(splitAddr[1]) {
-		userVal, err = user.LookupId(splitAddr[1])
-	} else {
-		userVal, err = user.Lookup(splitAddr[1])
-	}
-	if err != nil {
-		return nil, fmt.Errorf("Invalid user given for Unix socket ownership: %v", splitAddr[1])
-	}
-
-	if uid64, err := strconv.ParseInt(userVal.Uid, 10, 32); err != nil {
-		return nil, fmt.Errorf("Failed to parse given user ID of %v into integer", userVal.Uid)
-	} else {
-		ret.Uid = int(uid64)
-	}
-
-	// Go doesn't currently have a way to look up gid from group name,
-	// so require a numeric gid; see
-	// https://codereview.appspot.com/101310044
-	if gid64, err := strconv.ParseInt(splitAddr[2], 10, 32); err != nil {
-		return nil, fmt.Errorf("Socket group must be given as numeric gid. Failed to parse given group ID of %v into integer", splitAddr[2])
-	} else {
-		ret.Gid = int(gid64)
-	}
-
-	if mode, err := strconv.ParseUint(splitAddr[3], 8, 32); err != nil {
-		return nil, fmt.Errorf("Failed to parse given mode of %v into integer", splitAddr[3])
-	} else {
-		if mode > 0777 {
-			return nil, fmt.Errorf("Given mode is invalid; must be an octal number between 0 and 777")
-		} else {
-			ret.Permissions = os.FileMode(mode)
-		}
-	}
-
-	return ret, nil
-}
-
-func adjustUnixSocketPermissions(addr string) error {
-	sock, err := populateUnixSocket(addr)
-	if err != nil {
-		return err
-	}
-
-	if err = os.Chown(sock.Path, sock.Uid, sock.Gid); err != nil {
-		return fmt.Errorf("Error attempting to change socket permissions to userid %v and groupid %v: %v", sock.Uid, sock.Gid, err)
-	}
-
-	if err = os.Chmod(sock.Path, sock.Permissions); err != nil {
-		return fmt.Errorf("Error attempting to change socket permissions to mode %v: %v", sock.Permissions, err)
-	}
-
-	return nil
+	return strings.TrimPrefix(addr, "unix://"), true
 }
 
 type dirEnts []os.FileInfo
@@ -485,31 +406,14 @@ func (c *Config) ClientListener(override string, port int) (net.Addr, error) {
 		addr = c.ClientAddr
 	}
 
-	switch {
-	case strings.HasPrefix(addr, "unix://"):
-		sock, err := populateUnixSocket(addr)
-		if err != nil {
-			return nil, err
-		}
-
-		return &net.UnixAddr{Name: sock.Path, Net: "unix"}, nil
-
-	default:
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			return nil, fmt.Errorf("Failed to parse IP: %v", addr)
-		}
-
-		if ip.IsUnspecified() {
-			ip = net.ParseIP("127.0.0.1")
-		}
-
-		if ip == nil {
-			return nil, fmt.Errorf("Failed to parse IP 127.0.0.1")
-		}
-
-		return &net.TCPAddr{IP: ip, Port: port}, nil
+	if path, ok := unixSocketAddr(addr); ok {
+		return &net.UnixAddr{Name: path, Net: "unix"}, nil
 	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return nil, fmt.Errorf("Failed to parse IP: %v", addr)
+	}
+	return &net.TCPAddr{IP: ip, Port: port}, nil
 }
 
 // DecodeConfig reads the configuration from the given reader in JSON

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -4,12 +4,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io/ioutil"
-	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1073,107 +1070,13 @@ func TestReadConfigPaths_dir(t *testing.T) {
 }
 
 func TestUnixSockets(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
+	path1, ok := unixSocketAddr("unix:///path/to/socket")
+	if !ok || path1 != "/path/to/socket" {
+		t.Fatalf("bad: %v %v", ok, path1)
 	}
 
-	usr, err := user.Current()
-	if err != nil {
-		t.Fatal("Could not get current user: ", err)
-	}
-
-	tempdir, err := ioutil.TempDir("", "consul-test-")
-	if err != nil {
-		t.Fatal("Could not create a working directory: ", err)
-	}
-
-	type SocketTestData struct {
-		Path string
-		Uid  string
-		Gid  string
-		Mode string
-	}
-
-	testUnixSocketPopulation := func(s SocketTestData) (*UnixSocket, error) {
-		return populateUnixSocket("unix://" + s.Path + ";" + s.Uid + ";" + s.Gid + ";" + s.Mode)
-	}
-
-	testUnixSocketPermissions := func(s SocketTestData) error {
-		return adjustUnixSocketPermissions("unix://" + s.Path + ";" + s.Uid + ";" + s.Gid + ";" + s.Mode)
-	}
-
-	_, err = populateUnixSocket("tcp://abc123")
-	if err == nil {
-		t.Fatal("Should have rejected invalid scheme")
-	}
-
-	_, err = populateUnixSocket("unix://x;y;z")
-	if err == nil {
-		t.Fatal("Should have rejected invalid number of parameters in Unix socket definition")
-	}
-
-	std := SocketTestData{
-		Path: tempdir + "/unix-config-test.sock",
-		Uid:  usr.Uid,
-		Gid:  usr.Gid,
-		Mode: "640",
-	}
-
-	std.Uid = "orasdfdsnfoinweroiu"
-	_, err = testUnixSocketPopulation(std)
-	if err == nil {
-		t.Fatal("Did not error on invalid username")
-	}
-
-	std.Uid = usr.Username
-	std.Gid = "foinfphawepofhewof"
-	_, err = testUnixSocketPopulation(std)
-	if err == nil {
-		t.Fatal("Did not error on invalid group (a name, must be gid)")
-	}
-
-	std.Gid = usr.Gid
-	std.Mode = "999"
-	_, err = testUnixSocketPopulation(std)
-	if err == nil {
-		t.Fatal("Did not error on invalid socket mode")
-	}
-
-	std.Uid = usr.Username
-	std.Mode = "640"
-	_, err = testUnixSocketPopulation(std)
-	if err != nil {
-		t.Fatal("Unix socket test failed (using username): ", err)
-	}
-
-	std.Uid = usr.Uid
-	sock, err := testUnixSocketPopulation(std)
-	if err != nil {
-		t.Fatal("Unix socket test failed (using uid): ", err)
-	}
-
-	addr := &net.UnixAddr{Name: sock.Path, Net: "unix"}
-	_, err = net.Listen(addr.Network(), addr.String())
-	if err != nil {
-		t.Fatal("Error creating socket for futher tests: ", err)
-	}
-
-	std.Uid = "-999999"
-	err = testUnixSocketPermissions(std)
-	if err == nil {
-		t.Fatal("Did not error on invalid uid")
-	}
-
-	std.Uid = usr.Uid
-	std.Gid = "-999999"
-	err = testUnixSocketPermissions(std)
-	if err == nil {
-		t.Fatal("Did not error on invalid uid")
-	}
-
-	std.Gid = usr.Gid
-	err = testUnixSocketPermissions(std)
-	if err != nil {
-		t.Fatal("Adjusting socket permissions failed: ", err)
+	path2, ok := unixSocketAddr("notunix://blah")
+	if ok || path2 != "" {
+		t.Fatalf("bad: %v %v", ok, path2)
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -61,10 +61,8 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 
 		if path, ok := unixSocketAddr(config.Addresses.HTTPS); ok {
 			// See command/agent/config.go
-			if _, err := os.Stat(path); err == nil {
-				if err := os.Remove(path); err != nil {
-					return nil, err
-				}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, err
 			}
 		}
 
@@ -106,10 +104,8 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 
 		if path, ok := unixSocketAddr(config.Addresses.HTTP); ok {
 			// See command/agent/config.go
-			if _, err := os.Stat(path); err == nil {
-				if err := os.Remove(path); err != nil {
-					return nil, err
-				}
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return nil, err
 			}
 		}
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 	"time"
@@ -19,7 +21,15 @@ import (
 )
 
 func makeHTTPServer(t *testing.T) (string, *HTTPServer) {
+	return makeHTTPServerWithConfig(t, nil)
+}
+
+func makeHTTPServerWithConfig(t *testing.T, cb func(c *Config)) (string, *HTTPServer) {
 	conf := nextConfig()
+	if cb != nil {
+		cb(conf)
+	}
+
 	dir, agent := makeAgent(t, conf)
 	uiDir := filepath.Join(dir, "ui")
 	if err := os.Mkdir(uiDir, 755); err != nil {
@@ -41,6 +51,54 @@ func encodeReq(obj interface{}) io.ReadCloser {
 	enc := json.NewEncoder(buf)
 	enc.Encode(obj)
 	return ioutil.NopCloser(buf)
+}
+
+func TestHTTPServer_UnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	tempDir, err := ioutil.TempDir("", "consul")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+	socket := filepath.Join(tempDir, "test.sock")
+
+	dir, srv := makeHTTPServerWithConfig(t, func(c *Config) {
+		c.Addresses.HTTP = "unix://" + socket
+	})
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	// Ensure the socket was created
+	if _, err := os.Stat(socket); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ensure we can get a response from the socket.
+	path, _ := unixSocketAddr(srv.agent.config.Addresses.HTTP)
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(_, _ string) (net.Conn, error) {
+				return net.Dial("unix", path)
+			},
+		},
+	}
+
+	// This URL doesn't look like it makes sense, but the scheme (http://) and
+	// the host (127.0.0.1) are required by the HTTP client library. In reality
+	// this will just use the custom dialer and talk to the socket.
+	resp, err := client.Get("http://127.0.0.1/v1/agent/self")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer resp.Body.Close()
+
+	if body, err := ioutil.ReadAll(resp.Body); err != nil || len(body) == 0 {
+		t.Fatalf("bad: %s %v", body, err)
+	}
 }
 
 func TestSetIndex(t *testing.T) {

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -81,24 +81,19 @@ func (c *RPCClient) send(header *requestHeader, obj interface{}) error {
 // NewRPCClient is used to create a new RPC client given the address.
 // This will properly dial, handshake, and start listening
 func NewRPCClient(addr string) (*RPCClient, error) {
-	sanedAddr := os.Getenv("CONSUL_RPC_ADDR")
-	if len(sanedAddr) == 0 {
-		sanedAddr = addr
-	}
+	var conn net.Conn
+	var err error
 
-	mode := "tcp"
-
-	if strings.HasPrefix(sanedAddr, "unix://") {
-		sanedAddr = strings.TrimPrefix(sanedAddr, "unix://")
-	}
-
-	if strings.HasPrefix(sanedAddr, "/") {
-		mode = "unix"
+	if envAddr := os.Getenv("CONSUL_RPC_ADDR"); envAddr != "" {
+		addr = envAddr
 	}
 
 	// Try to dial to agent
-	conn, err := net.Dial(mode, sanedAddr)
-	if err != nil {
+	mode := "tcp"
+	if strings.HasPrefix(addr, "/") {
+		mode = "unix"
+	}
+	if conn, err = net.Dial(mode, addr); err != nil {
 		return nil, err
 	}
 

--- a/command/agent/rpc_client_test.go
+++ b/command/agent/rpc_client_test.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/user"
 	"runtime"
 	"strings"
 	"testing"
@@ -223,19 +222,13 @@ func TestRPCClientStatsUnix(t *testing.T) {
 
 	tempdir, err := ioutil.TempDir("", "consul-test-")
 	if err != nil {
-		t.Fatal("Could not create a working directory: ", err)
+		t.Fatalf("err: %s", err)
 	}
 
-	user, err := user.Current()
-	if err != nil {
-		t.Fatal("Could not get current user: ", err)
-	}
-
-	cb := func(c *Config) {
-		c.Addresses.RPC = "unix://" + tempdir + "/unix-rpc-test.sock;" + user.Uid + ";" + user.Gid + ";640"
-	}
-
-	p1 := testRPCClientWithConfig(t, cb)
+	p1 := testRPCClientWithConfig(t, func(c *Config) {
+		c.Addresses.RPC = fmt.Sprintf("unix://%s/test.sock", tempdir)
+	})
+	defer p1.Close()
 
 	stats, err := p1.client.Stats()
 	if err != nil {

--- a/command/agent/rpc_client_test.go
+++ b/command/agent/rpc_client_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -65,6 +66,38 @@ func testRPCClientWithConfig(t *testing.T, cb func(c *Config)) *rpcParts {
 		client: rpcClient,
 		agent:  agent,
 		rpc:    rpc,
+	}
+}
+
+func TestRPCClient_UnixSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
+	tempDir, err := ioutil.TempDir("", "consul")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+	socket := filepath.Join(tempDir, "test.sock")
+
+	p1 := testRPCClientWithConfig(t, func(c *Config) {
+		c.Addresses.RPC = "unix://" + socket
+	})
+	defer p1.Close()
+
+	// Ensure the socket was created
+	if _, err := os.Stat(socket); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ensure we can talk with the socket
+	mem, err := p1.client.LANMembers()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(mem) != 1 {
+		t.Fatalf("bad: %#v", mem)
 	}
 }
 
@@ -199,35 +232,6 @@ func TestRPCClientWANMembers(t *testing.T) {
 
 func TestRPCClientStats(t *testing.T) {
 	p1 := testRPCClient(t)
-	defer p1.Close()
-
-	stats, err := p1.client.Stats()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	if _, ok := stats["agent"]; !ok {
-		t.Fatalf("bad: %#v", stats)
-	}
-
-	if _, ok := stats["consul"]; !ok {
-		t.Fatalf("bad: %#v", stats)
-	}
-}
-
-func TestRPCClientStatsUnix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
-	}
-
-	tempdir, err := ioutil.TempDir("", "consul-test-")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	p1 := testRPCClientWithConfig(t, func(c *Config) {
-		c.Addresses.RPC = fmt.Sprintf("unix://%s/test.sock", tempdir)
-	})
 	defer p1.Close()
 
 	stats, err := p1.client.Stats()

--- a/command/rpc.go
+++ b/command/rpc.go
@@ -43,12 +43,10 @@ func HTTPClient(addr string) (*consulapi.Client, error) {
 // HTTPClientDC returns a new Consul HTTP client with the given address and datacenter
 func HTTPClientDC(addr, dc string) (*consulapi.Client, error) {
 	conf := consulapi.DefaultConfig()
-	switch {
-	case len(os.Getenv("CONSUL_HTTP_ADDR")) > 0:
-		conf.Address = os.Getenv("CONSUL_HTTP_ADDR")
-	default:
-		conf.Address = addr
+	if envAddr := os.Getenv("CONSUL_HTTP_ADDR"); addr != "" {
+		addr = envAddr
 	}
+	conf.Address = addr
 	conf.Datacenter = dc
 	return consulapi.NewClient(conf)
 }

--- a/command/rpc.go
+++ b/command/rpc.go
@@ -43,7 +43,7 @@ func HTTPClient(addr string) (*consulapi.Client, error) {
 // HTTPClientDC returns a new Consul HTTP client with the given address and datacenter
 func HTTPClientDC(addr, dc string) (*consulapi.Client, error) {
 	conf := consulapi.DefaultConfig()
-	if envAddr := os.Getenv("CONSUL_HTTP_ADDR"); addr != "" {
+	if envAddr := os.Getenv("CONSUL_HTTP_ADDR"); envAddr != "" {
 		addr = envAddr
 	}
 	conf.Address = addr

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -240,16 +240,17 @@ definitions support being updated during a reload.
    up to the TTL value.
 
 * `addresses` - This is a nested object that allows setting bind addresses. For `rpc`
-   and `http`, a Unix socket can be specified in the following form:
-   unix://[/path/to/socket];[username|uid];[gid];[mode]. The socket will be created
-   in the specified location with the given username or uid, gid, and mode. The
-   user Consul is running as must have appropriate permissions to change the socket
-   ownership to the given uid or gid. When running Consul agent commands against
-   Unix socket interfaces, use the `-rpc-addr` or `-http-addr` arguments to specify
-   the path to the socket, e.g. "unix://path/to/socket". You can also place the desired
-   values in `CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR` environment variables. For TCP
-   addresses, these should be in the form ip:port.
-   The following keys are valid:
+  and `http`, a Unix socket can be specified in the following form
+  `unix:///path/to/socket`. A new domain socket will be created at the given
+  path. Any existing socket file (or any other kind of file) at the specified
+  path will be **overwritten**, so use caution when configuring this argument.
+
+  When running Consul agent commands against Unix socket interfaces, use the
+  `-rpc-addr` or `-http-addr` arguments to specify the path to the socket. You
+  can also place the desired values in `CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR`
+  environment variables. For TCP addresses, these should be in the form ip:port.
+
+  The following keys are valid:
     * `dns` - The DNS server. Defaults to `client_addr`
     * `http` - The HTTP API. Defaults to `client_addr`
     * `rpc` - The RPC endpoint. Defaults to `client_addr`

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -239,21 +239,23 @@ definitions support being updated during a reload.
    However, because the caches are not actively invalidated, ACL policy may be stale
    up to the TTL value.
 
-* `addresses` - This is a nested object that allows setting bind addresses. For `rpc`
-  and `http`, a Unix socket can be specified in the following form
-  `unix:///path/to/socket`. A new domain socket will be created at the given
-  path. Any existing socket file (or any other kind of file) at the specified
-  path will be **overwritten**, so use caution when configuring this argument.
-
+* `addresses` - This is a nested object that allows setting bind addresses.
+  <br><br>
+  Both `rpc` and `http` support binding to Unix domain sockets. A socket can be
+  specified in the form `unix:///path/to/socket`. A new domain socket will be
+  created at the given path. If the specified file path already exists, Consul
+  will refuse to start and return an error. For information on how to secure
+  socket file permissions, refer to the manual page for your operating system.
+  <br><br>
   When running Consul agent commands against Unix socket interfaces, use the
   `-rpc-addr` or `-http-addr` arguments to specify the path to the socket. You
   can also place the desired values in `CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR`
   environment variables. For TCP addresses, these should be in the form ip:port.
-
+  <br><br>
   The following keys are valid:
-    * `dns` - The DNS server. Defaults to `client_addr`
-    * `http` - The HTTP API. Defaults to `client_addr`
-    * `rpc` - The RPC endpoint. Defaults to `client_addr`
+  * `dns` - The DNS server. Defaults to `client_addr`
+  * `http` - The HTTP API. Defaults to `client_addr`
+  * `rpc` - The RPC endpoint. Defaults to `client_addr`
 
 * `advertise_addr` - Equivalent to the `-advertise` command-line flag.
 


### PR DESCRIPTION
This is a follow-on from #587. There are a couple adjustments to the functionality of the feature, which I’ll outline below. Due to these changes in functionality, a good deal of code and tests have been adjusted as well.

#### Ownership and permissions of the socket are not managed by Consul.

After an internal discussion about this, we think the best thing for Consul to do is to simply allow the socket to be created by the underlying system calls, and leave it at that. This same approach is taken by a number of other projects, and after some research, it has become more clear why that is. Looking into the OS documentation on a standard Linux distribution (`man 7 unix`), we will find that sockets in Linux obey the file permissions of their parent directory, and that some BSD and other distributions ignore the permissions on the socket files completely. Because of this, we will just accept a standard UNIX domain socket path like `unix:///path/to/file`, which unambiguously creates the socket at that path per the OS’es implementation, and allows the operator to configure permissions at the directory above.

#### Consul errors when the specified socket path already exists

This was discussed in the original PR. After some more discussions and opinions, we’ve decided to err on the side of caution, and the safest thing to do in cases where the socket path already exists is to throw an error. The socket bind error from the underlying OS might be confusing to a novice user, so we’ve added a more human-friendly error message in this case explaining that it is possible the socket file was not cleaned up due to forced shutdown.