### PR TITLE
command: address vet report in test

### DIFF
--- a/command/rpc_test.go
+++ b/command/rpc_test.go
@@ -58,7 +58,7 @@ func TestAddrFlag_default(t *testing.T) {
 		res := getParsedAddr(t, a, "", "")
 
 		if res != def {
-			t.Fatalf("Expected %s addr: %s, got: %s", def, res)
+			t.Fatalf("Expected addr: %s, got: %s", def, res)
 		}
 	}
 }


### PR DESCRIPTION
Fixes the following vet report:

`command/rpc_test.go:61: missing argument for Fatalf(%s): format reads arg 3, have only 2 args`