### PR TITLE
Makefile: update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ cov:
 
 deps:
 	@echo "--> Installing build dependencies"
-	@go get -d -v ./...
-	@echo $(DEPS) | xargs -n1 go get -d
+	@go get -d -f -u -v ./...
+	@echo $(DEPS) | xargs -n1 go get -d -f -u
 
 test: deps
 	./scripts/verify_no_uuid.sh

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ http://www.consul.io/docs
 ## Developing Consul
 
 If you wish to work on Consul itself, you'll first need [Go](http://golang.org)
-installed (version 1.2+ is _required_). Make sure you have Go properly installed,
+installed (version 1.4+ is _required_). Make sure you have Go properly installed,
 including setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH).
 
 Next, clone this repository into `$GOPATH/src/github.com/hashicorp/consul` and


### PR DESCRIPTION
Build failed for me due to `github.com/hashicorp/serf/serf` not
being up to date.

```
$ make
[...]
--> Installing dependencies to speed up builds...
# github.com/hashicorp/serf/serf
../serf/serf/serf.go:354: conf.MemberlistConfig.Merge undefined (type *memberlist.Config has no field or method Merge)
```

Add the -u flag to `go get` when downloading build dependencies to always use the tip.
