### PR TITLE
Unix domain sockets

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -23,13 +23,6 @@ const (
 	// Path to save local agent checks
 	checksDir = "checks"
 
-	// errSocketFileExists is the human-friendly error message displayed when
-	// trying to bind a socket to an existing file.
-	errSocketFileExists = "A file exists at the requested socket path %q. " +
-		"If Consul was not shut down properly, the socket file may " +
-		"be left behind. If the path looks correct, remove the file " +
-		"and try again."
-
 	// The ID of the faux health checks for maintenance mode
 	serviceMaintCheckPrefix = "_service_maintenance"
 	nodeMaintCheckID        = "_node_maintenenace"

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -188,7 +188,7 @@ func TestSetupAgent_RPCUnixSocket_FileExists(t *testing.T) {
 	conf.Addresses.RPC = "unix://" + socketPath
 
 	// Custom mode for socket file
-	conf.UnixSockets = map[string]string{"mode": "0777"}
+	conf.UnixSockets.Perms = "0777"
 
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -187,6 +187,9 @@ func TestSetupAgent_RPCUnixSocket_FileExists(t *testing.T) {
 	// Set socket address to an existing file.
 	conf.Addresses.RPC = "unix://" + socketPath
 
+	// Custom mode for socket file
+	conf.UnixSockets = map[string]string{"mode": "0777"}
+
 	shutdownCh := make(chan struct{})
 	defer close(shutdownCh)
 
@@ -210,5 +213,10 @@ func TestSetupAgent_RPCUnixSocket_FileExists(t *testing.T) {
 	}
 	if fi.Mode()&os.ModeSocket == 0 {
 		t.Fatalf("expected socket to replace file")
+	}
+
+	// Ensure permissions were applied to the socket file
+	if fi.Mode().String() != "Srwxrwxrwx" {
+		t.Fatalf("bad permissions: %s", fi.Mode())
 	}
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -348,24 +348,30 @@ type Config struct {
 	UnixSockets UnixSocketConfig `mapstructure:"unix_sockets"`
 }
 
-// UnixSocketConfig contains information about a unix socket, and
+// UnixSocketPermissions contains information about a unix socket, and
 // implements the FilePermissions interface.
-type UnixSocketConfig struct {
+type UnixSocketPermissions struct {
 	Usr   string `mapstructure:"user"`
 	Grp   string `mapstructure:"group"`
 	Perms string `mapstructure:"mode"`
 }
 
-func (u UnixSocketConfig) User() string {
+func (u UnixSocketPermissions) User() string {
 	return u.Usr
 }
 
-func (u UnixSocketConfig) Group() string {
+func (u UnixSocketPermissions) Group() string {
 	return u.Grp
 }
 
-func (u UnixSocketConfig) Mode() string {
+func (u UnixSocketPermissions) Mode() string {
 	return u.Perms
+}
+
+// UnixSocketConfig stores information about various unix sockets which
+// Consul creates and uses for communication.
+type UnixSocketConfig struct {
+	UnixSocketPermissions `mapstructure:",squash"`
 }
 
 // unixSocketAddr tests if a given address describes a domain socket,

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -345,7 +345,27 @@ type Config struct {
 	WatchPlans []*watch.WatchPlan `mapstructure:"-" json:"-"`
 
 	// UnixSockets is a map of socket configuration data
-	UnixSockets map[string]string `mapstructure:"unix_sockets"`
+	UnixSockets UnixSocketConfig `mapstructure:"unix_sockets"`
+}
+
+// UnixSocketConfig contains information about a unix socket, and
+// implements the FilePermissions interface.
+type UnixSocketConfig struct {
+	Usr   string `mapstructure:"user"`
+	Grp   string `mapstructure:"group"`
+	Perms string `mapstructure:"mode"`
+}
+
+func (u UnixSocketConfig) User() string {
+	return u.Usr
+}
+
+func (u UnixSocketConfig) Group() string {
+	return u.Grp
+}
+
+func (u UnixSocketConfig) Mode() string {
+	return u.Perms
 }
 
 // unixSocketAddr tests if a given address describes a domain socket,
@@ -886,6 +906,15 @@ func MergeConfig(a, b *Config) *Config {
 	if b.DisableAnonymousSignature {
 		result.DisableAnonymousSignature = true
 	}
+	if b.UnixSockets.Usr != "" {
+		result.UnixSockets.Usr = b.UnixSockets.Usr
+	}
+	if b.UnixSockets.Grp != "" {
+		result.UnixSockets.Grp = b.UnixSockets.Grp
+	}
+	if b.UnixSockets.Perms != "" {
+		result.UnixSockets.Perms = b.UnixSockets.Perms
+	}
 
 	if len(b.HTTPAPIResponseHeaders) != 0 {
 		if result.HTTPAPIResponseHeaders == nil {
@@ -893,15 +922,6 @@ func MergeConfig(a, b *Config) *Config {
 		}
 		for field, value := range b.HTTPAPIResponseHeaders {
 			result.HTTPAPIResponseHeaders[field] = value
-		}
-	}
-
-	if len(b.UnixSockets) != 0 {
-		if result.UnixSockets == nil {
-			result.UnixSockets = make(map[string]string)
-		}
-		for field, value := range b.UnixSockets {
-			result.UnixSockets[field] = value
 		}
 	}
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -343,6 +343,9 @@ type Config struct {
 
 	// WatchPlans contains the compiled watches
 	WatchPlans []*watch.WatchPlan `mapstructure:"-" json:"-"`
+
+	// UnixSockets is a map of socket configuration data
+	UnixSockets map[string]string `mapstructure:"unix_sockets"`
 }
 
 // unixSocketAddr tests if a given address describes a domain socket,
@@ -890,6 +893,15 @@ func MergeConfig(a, b *Config) *Config {
 		}
 		for field, value := range b.HTTPAPIResponseHeaders {
 			result.HTTPAPIResponseHeaders[field] = value
+		}
+	}
+
+	if len(b.UnixSockets) != 0 {
+		if result.UnixSockets == nil {
+			result.UnixSockets = make(map[string]string)
+		}
+		for field, value := range b.UnixSockets {
+			result.UnixSockets[field] = value
 		}
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -588,6 +588,21 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Domain socket permissions
+	input = `{"unix_sockets": {"uid": "500", "gid": "500", "mode": "0700"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(config.UnixSockets, map[string]string{
+		"uid":  "500",
+		"gid":  "500",
+		"mode": "0700",
+	}) {
+		t.Fatalf("bad: %v", config.UnixSockets)
+	}
+
 	// Disable updates
 	input = `{"disable_update_check": true, "disable_anonymous_signature": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -997,6 +1012,11 @@ func TestMergeConfig(t *testing.T) {
 		DisableAnonymousSignature: true,
 		HTTPAPIResponseHeaders: map[string]string{
 			"Access-Control-Allow-Origin": "*",
+		},
+		UnixSockets: map[string]string{
+			"uid":  "500",
+			"gid":  "500",
+			"mode": "0700",
 		},
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -589,16 +589,16 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// Domain socket permissions
-	input = `{"unix_sockets": {"uid": "500", "gid": "500", "mode": "0700"}}`
+	input = `{"unix_sockets": {"user": "500", "group": "500", "mode": "0700"}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	if !reflect.DeepEqual(config.UnixSockets, map[string]string{
-		"uid":  "500",
-		"gid":  "500",
-		"mode": "0700",
+		"user":  "500",
+		"group": "500",
+		"mode":  "0700",
 	}) {
 		t.Fatalf("bad: %v", config.UnixSockets)
 	}
@@ -1014,9 +1014,9 @@ func TestMergeConfig(t *testing.T) {
 			"Access-Control-Allow-Origin": "*",
 		},
 		UnixSockets: map[string]string{
-			"uid":  "500",
-			"gid":  "500",
-			"mode": "0700",
+			"user":  "500",
+			"group": "500",
+			"mode":  "0700",
 		},
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1016,9 +1016,11 @@ func TestMergeConfig(t *testing.T) {
 			"Access-Control-Allow-Origin": "*",
 		},
 		UnixSockets: UnixSocketConfig{
-			Usr:   "500",
-			Grp:   "500",
-			Perms: "0700",
+			UnixSocketPermissions{
+				Usr:   "500",
+				Grp:   "500",
+				Perms: "0700",
+			},
 		},
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -595,12 +595,14 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !reflect.DeepEqual(config.UnixSockets, map[string]string{
-		"user":  "500",
-		"group": "500",
-		"mode":  "0700",
-	}) {
-		t.Fatalf("bad: %v", config.UnixSockets)
+	if config.UnixSockets.Usr != "500" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.UnixSockets.Grp != "500" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.UnixSockets.Perms != "0700" {
+		t.Fatalf("bad: %#v", config)
 	}
 
 	// Disable updates
@@ -1013,10 +1015,10 @@ func TestMergeConfig(t *testing.T) {
 		HTTPAPIResponseHeaders: map[string]string{
 			"Access-Control-Allow-Origin": "*",
 		},
-		UnixSockets: map[string]string{
-			"user":  "500",
-			"group": "500",
-			"mode":  "0700",
+		UnixSockets: UnixSocketConfig{
+			Usr:   "500",
+			Grp:   "500",
+			Perms: "0700",
 		},
 	}
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -96,9 +96,13 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 		}
 
 		// Error if we are trying to bind a domain socket to an existing path
-		if path, ok := unixSocketAddr(config.Addresses.HTTP); ok {
-			if _, err := os.Stat(path); err == nil || !os.IsNotExist(err) {
-				return nil, fmt.Errorf(errSocketFileExists, path)
+		socketPath, isSocket := unixSocketAddr(config.Addresses.HTTP)
+		if isSocket {
+			if _, err := os.Stat(socketPath); !os.IsNotExist(err) {
+				agent.logger.Printf("[WARN] agent: Replacing socket %q", socketPath)
+			}
+			if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+				return nil, fmt.Errorf("error removing socket file: %s", err)
 			}
 		}
 
@@ -111,6 +115,13 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 			list = ln
 		} else {
 			list = tcpKeepAliveListener{ln.(*net.TCPListener)}
+		}
+
+		// Set up ownership/permission bits on the socket file
+		if isSocket {
+			if err := setFilePermissions(socketPath, config.UnixSockets); err != nil {
+				return nil, fmt.Errorf("Failed setting up HTTP socket: %s", err)
+			}
 		}
 
 		// Create the mux

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -70,7 +70,7 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 
 		// Only testing mode, since uid/gid might not be settable
 		// from test environment.
-		c.UnixSockets = map[string]string{"mode": "0777"}
+		c.UnixSockets = UnixSocketConfig{Perms: "0777"}
 	})
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -132,11 +132,17 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Try to start the server with the same path anyways.
-	if servers, err := NewHTTPServers(agent, conf, agent.logOutput); err == nil {
-		for _, server := range servers {
-			server.Shutdown()
-		}
-		t.Fatalf("expected socket binding error")
+	if _, err := NewHTTPServers(agent, conf, agent.logOutput); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Ensure the file was replaced by the socket
+	fi, err = os.Stat(socket)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("expected socket to replace file")
 	}
 }
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -70,7 +70,8 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 
 		// Only testing mode, since uid/gid might not be settable
 		// from test environment.
-		c.UnixSockets = UnixSocketConfig{Perms: "0777"}
+		c.UnixSockets = UnixSocketConfig{}
+		c.UnixSockets.Perms = "0777"
 	})
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -100,34 +100,47 @@ func stringHash(s string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(s)))
 }
 
+// FilePermissions is an interface which allows a struct to set
+// ownership and permissions easily on a file it describes.
+type FilePermissions interface {
+	// User returns a user ID or user name
+	User() string
+
+	// Group returns a group ID. Group names are not supported.
+	Group() string
+
+	// Mode returns a string of file mode bits e.g. "0644"
+	Mode() string
+}
+
 // setFilePermissions handles configuring ownership and permissions settings
-// on a given file. It takes a map, which defines the permissions to be set.
-// All permission/ownership settings are optional. If no user or group is
-// specified, the current user/group will be used. Mode is optional, and has
-// no default (the operation is not performed if absent). User may be
-// specified by name or ID, but group may only be specified by ID.
-func setFilePermissions(path string, perms map[string]string) error {
+// on a given file. It takes a path and any struct implementing the
+// FilePermissions interface. All permission/ownership settings are optional.
+// If no user or group is specified, the current user/group will be used. Mode
+// is optional, and has no default (the operation is not performed if absent).
+// User may be specified by name or ID, but group may only be specified by ID.
+func setFilePermissions(path string, p FilePermissions) error {
 	var err error
 	uid, gid := os.Getuid(), os.Getgid()
 
-	if _, ok := perms["user"]; ok {
-		if uid, err = strconv.Atoi(perms["user"]); err == nil {
+	if p.User() != "" {
+		if uid, err = strconv.Atoi(p.User()); err == nil {
 			goto GROUP
 		}
 
 		// Try looking up the user by name
-		if u, err := user.Lookup(perms["user"]); err == nil {
+		if u, err := user.Lookup(p.User()); err == nil {
 			uid, _ = strconv.Atoi(u.Uid)
 			goto GROUP
 		}
 
-		return fmt.Errorf("invalid user specified: %v", perms["user"])
+		return fmt.Errorf("invalid user specified: %v", p.User())
 	}
 
 GROUP:
-	if _, ok := perms["group"]; ok {
-		if gid, err = strconv.Atoi(perms["group"]); err != nil {
-			return fmt.Errorf("invalid group specified: %v", perms["group"])
+	if p.Group() != "" {
+		if gid, err = strconv.Atoi(p.Group()); err != nil {
+			return fmt.Errorf("invalid group specified: %v", p.Group())
 		}
 	}
 	if err := os.Chown(path, uid, gid); err != nil {
@@ -135,10 +148,10 @@ GROUP:
 			uid, gid, path, err)
 	}
 
-	if _, ok := perms["mode"]; ok {
-		mode, err := strconv.ParseUint(perms["mode"], 8, 32)
+	if p.Mode() != "" {
+		mode, err := strconv.ParseUint(p.Mode(), 8, 32)
 		if err != nil {
-			return fmt.Errorf("invalid mode specified: %v", perms["mode"])
+			return fmt.Errorf("invalid mode specified: %v", p.Mode())
 		}
 		if err := os.Chmod(path, os.FileMode(mode)); err != nil {
 			return fmt.Errorf("failed setting permissions to %d on %q: %s",

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -51,22 +51,22 @@ func TestSetFilePermissions(t *testing.T) {
 	defer os.Remove(path)
 
 	// Bad UID fails
-	if err := setFilePermissions(path, map[string]string{"user": "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketConfig{Usr: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Bad GID fails
-	if err := setFilePermissions(path, map[string]string{"group": "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketConfig{Grp: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Bad mode fails
-	if err := setFilePermissions(path, map[string]string{"mode": "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketConfig{Perms: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Allows omitting user/group/mode
-	if err := setFilePermissions(path, map[string]string{}); err != nil {
+	if err := setFilePermissions(path, UnixSocketConfig{}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -74,7 +74,7 @@ func TestSetFilePermissions(t *testing.T) {
 	if err := os.Chmod(path, 0700); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := setFilePermissions(path, map[string]string{}); err != nil {
+	if err := setFilePermissions(path, UnixSocketConfig{}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	fi, err := os.Stat(path)
@@ -86,7 +86,7 @@ func TestSetFilePermissions(t *testing.T) {
 	}
 
 	// Changes mode if given
-	if err := setFilePermissions(path, map[string]string{"mode": "0777"}); err != nil {
+	if err := setFilePermissions(path, UnixSocketConfig{Perms: "0777"}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	fi, err = os.Stat(path)

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -51,12 +51,12 @@ func TestSetFilePermissions(t *testing.T) {
 	defer os.Remove(path)
 
 	// Bad UID fails
-	if err := setFilePermissions(path, map[string]string{"uid": "%"}); err == nil {
+	if err := setFilePermissions(path, map[string]string{"user": "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Bad GID fails
-	if err := setFilePermissions(path, map[string]string{"gid": "%"}); err == nil {
+	if err := setFilePermissions(path, map[string]string{"group": "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -51,22 +51,22 @@ func TestSetFilePermissions(t *testing.T) {
 	defer os.Remove(path)
 
 	// Bad UID fails
-	if err := setFilePermissions(path, UnixSocketConfig{Usr: "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{Usr: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Bad GID fails
-	if err := setFilePermissions(path, UnixSocketConfig{Grp: "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{Grp: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Bad mode fails
-	if err := setFilePermissions(path, UnixSocketConfig{Perms: "%"}); err == nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{Perms: "%"}); err == nil {
 		t.Fatalf("should fail")
 	}
 
 	// Allows omitting user/group/mode
-	if err := setFilePermissions(path, UnixSocketConfig{}); err != nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -74,7 +74,7 @@ func TestSetFilePermissions(t *testing.T) {
 	if err := os.Chmod(path, 0700); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if err := setFilePermissions(path, UnixSocketConfig{}); err != nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	fi, err := os.Stat(path)
@@ -86,7 +86,7 @@ func TestSetFilePermissions(t *testing.T) {
 	}
 
 	// Changes mode if given
-	if err := setFilePermissions(path, UnixSocketConfig{Perms: "0777"}); err != nil {
+	if err := setFilePermissions(path, UnixSocketPermissions{Perms: "0777"}); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	fi, err = os.Stat(path)

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
@@ -37,5 +39,61 @@ func TestStringHash(t *testing.T) {
 
 	if out := stringHash(in); out != expected {
 		t.Fatalf("bad: %s", out)
+	}
+}
+
+func TestSetFilePermissions(t *testing.T) {
+	tempFile, err := ioutil.TempFile("", "consul")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	path := tempFile.Name()
+	defer os.Remove(path)
+
+	// Bad UID fails
+	if err := setFilePermissions(path, map[string]string{"uid": "%"}); err == nil {
+		t.Fatalf("should fail")
+	}
+
+	// Bad GID fails
+	if err := setFilePermissions(path, map[string]string{"gid": "%"}); err == nil {
+		t.Fatalf("should fail")
+	}
+
+	// Bad mode fails
+	if err := setFilePermissions(path, map[string]string{"mode": "%"}); err == nil {
+		t.Fatalf("should fail")
+	}
+
+	// Allows omitting user/group/mode
+	if err := setFilePermissions(path, map[string]string{}); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Doesn't change mode if not given
+	if err := os.Chmod(path, 0700); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := setFilePermissions(path, map[string]string{}); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if fi.Mode().String() != "-rwx------" {
+		t.Fatalf("bad: %s", fi.Mode())
+	}
+
+	// Changes mode if given
+	if err := setFilePermissions(path, map[string]string{"mode": "0777"}); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	fi, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if fi.Mode().String() != "-rwxrwxrwx" {
+		t.Fatalf("bad: %s", fi.Mode())
 	}
 }

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -441,6 +441,12 @@ definitions support being updated during a reload.
   * `group` - The group ID ownership of the socket file. Note that this option
     currently only supports numeric ID's.
   * `mode` - The permission bits to set on the file.
+  <br>
+  It is important to note that this option may have different effects on
+  different operating systems. Linux generally observes socket file permissions,
+  while many BSD variants ignore permissions on the socket file itself. It is
+  important to test this feature on your specific distribution. This feature is
+  currently not functional on Windows hosts.
 
 * `verify_incoming` - If set to True, Consul requires that all incoming
   connections make use of TLS, and that the client provides a certificate signed

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -244,8 +244,10 @@ definitions support being updated during a reload.
   Both `rpc` and `http` support binding to Unix domain sockets. A socket can be
   specified in the form `unix:///path/to/socket`. A new domain socket will be
   created at the given path. If the specified file path already exists, Consul
-  will refuse to start and return an error. For information on how to secure
-  socket file permissions, refer to the manual page for your operating system.
+  will attempt to clear the file and create the domain socket in its place.
+  <br><br>
+  The permissions of the socket file are tunable via the `unix_sockets` config
+  construct.
   <br><br>
   When running Consul agent commands against Unix socket interfaces, use the
   `-rpc-addr` or `-http-addr` arguments to specify the path to the socket. You
@@ -428,6 +430,17 @@ definitions support being updated during a reload.
   facility messages are sent to. By default, `LOCAL0` will be used.
 
 * `ui_dir` - Equivalent to the `-ui-dir` command-line flag.
+
+* `unix_sockets` - This allows tuning the ownership and permissions of the
+  Unix domain socket files created by Consul. Domain sockets are only used if
+  the HTTP or RPC addresses are configured with the `unix://` prefix. The
+  following options are valid within this construct, and apply globally to all
+  sockets created by Consul:
+  <br>
+  * `user` - The name or ID of the user who will own the socket file.
+  * `group` - The group ID ownership of the socket file. Note that this option
+    currently only supports numeric ID's.
+  * `mode` - The permission bits to set on the file.
 
 * `verify_incoming` - If set to True, Consul requires that all incoming
   connections make use of TLS, and that the client provides a certificate signed


### PR DESCRIPTION
As yet another follow-up on #587 and #612, this re-introduces the ability to set ownership and permission bits as you please on the UNIX domain sockets.

* Delete socket if it exists on agent startup, and recreate during bind.
* Set ownership of socket file including user name/id, group id, and permissions e.g. `0755` via the new `unix_sockets` config construct. This makes setting any of these optional and keeps the address fields clean and concise.

The function which handles file permissions now takes an interface, and the `unix_sockets` construct implements it. This will make it very easy to introduce separate, nested config structures in the future if we want to support setting per-interface domain socket permissions.

This functionality is new to Consul, however, it was originally implemented in #587 by @jefferai. This is merely an iteration on the design.

@jefferai @armon @sethvargo any questions/suggestions/concerns more than welcome.