### PR TITLE
Add agent service Address field to the api

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -22,6 +22,7 @@ type AgentService struct {
 	Service string
 	Tags    []string
 	Port    int
+	Address string
 }
 
 // AgentMember represents a cluster member known to the agent
@@ -41,12 +42,13 @@ type AgentMember struct {
 
 // AgentServiceRegistration is used to register a new service
 type AgentServiceRegistration struct {
-	ID     string   `json:",omitempty"`
-	Name   string   `json:",omitempty"`
-	Tags   []string `json:",omitempty"`
-	Port   int      `json:",omitempty"`
-	Check  *AgentServiceCheck
-	Checks AgentServiceChecks
+	ID      string   `json:",omitempty"`
+	Name    string   `json:",omitempty"`
+	Tags    []string `json:",omitempty"`
+	Port    int      `json:",omitempty"`
+	Address string   `json:",omitempty"`
+	Check   *AgentServiceCheck
+	Checks  AgentServiceChecks
 }
 
 // AgentCheckRegistration is used to register a new check

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -45,9 +45,10 @@ func TestAgent_Services(t *testing.T) {
 	agent := c.Agent()
 
 	reg := &AgentServiceRegistration{
-		Name: "foo",
-		Tags: []string{"bar", "baz"},
-		Port: 8000,
+		Name:    "foo",
+		Tags:    []string{"bar", "baz"},
+		Port:    8000,
+		Address: "192.168.0.42",
 		Check: &AgentServiceCheck{
 			TTL: "15s",
 		},

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -48,7 +48,6 @@ func TestAgent_Services(t *testing.T) {
 		Name:    "foo",
 		Tags:    []string{"bar", "baz"},
 		Port:    8000,
-		Address: "192.168.0.42",
 		Check: &AgentServiceCheck{
 			TTL: "15s",
 		},
@@ -71,6 +70,52 @@ func TestAgent_Services(t *testing.T) {
 	}
 	if _, ok := checks["service:foo"]; !ok {
 		t.Fatalf("missing check: %v", checks)
+	}
+
+	if err := agent.ServiceDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_ServiceAddress(t *testing.T) {
+	c, s := makeClient(t)
+	defer s.stop()
+
+	agent := c.Agent()
+
+	reg1 := &AgentServiceRegistration{
+		Name:    "foo1",
+		Port:    8000,
+		Address: "192.168.0.42",
+	}
+	reg2 := &AgentServiceRegistration{
+		Name:    "foo2",
+		Port:    8000,
+	}
+	if err := agent.ServiceRegister(reg1); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := agent.ServiceRegister(reg2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	services, err := agent.Services()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	
+	if _, ok := services["foo1"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
+	if _, ok := services["foo2"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
+
+	if services["foo1"].Address != "192.168.0.42" {
+		t.Fatalf("missing Address field in service foo1: %v", services)
+	}
+	if services["foo2"].Address != "" {
+		t.Fatalf("missing Address field in service foo2: %v", services)
 	}
 
 	if err := agent.ServiceDeregister("foo"); err != nil {


### PR DESCRIPTION
The Address field was introduced in #570. This patch extends this to the api.