### PR TITLE
agent: error from KVS endpoint if incompatible flags are passed.

### DIFF
--- a/command/agent/kvs_endpoint_test.go
+++ b/command/agent/kvs_endpoint_test.go
@@ -531,3 +531,45 @@ func TestKVSEndpoint_GET_Raw(t *testing.T) {
 		}
 	})
 }
+
+func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("PUT", "/v1/kv/test?cas=0&acquire=xxx", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		resp := httptest.NewRecorder()
+		if _, err := srv.KVSEndpoint(resp, req); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if resp.Code != 400 {
+			t.Fatalf("expected 400, got %d", resp.Code)
+		}
+		if !bytes.Contains(resp.Body.Bytes(), []byte("Conflicting")) {
+			t.Fatalf("expected conflicting args error")
+		}
+	})
+}
+
+func TestKVSEndpoint_DELETE_ConflictingFlags(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("DELETE", "/v1/kv/test?recurse&cas=0", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		resp := httptest.NewRecorder()
+		if _, err := srv.KVSEndpoint(resp, req); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if resp.Code != 400 {
+			t.Fatalf("expected 400, got %d", resp.Code)
+		}
+		if !bytes.Contains(resp.Body.Bytes(), []byte("Conflicting")) {
+			t.Fatalf("expected conflicting args error")
+		}
+	})
+}


### PR DESCRIPTION
This disambiguates behavior of the KVS endpoint when conflicting arguments are passed. As an example, providing `?cas` and `?acquire` during a PUT does not actually do both operations, and it is not clear which operation actually happens when it succeeds. This will make such requests return a 400.

Fixes #432 