### PR TITLE
command: fix Windows build

### DIFF
--- a/command/util_unix.go
+++ b/command/util_unix.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package command
+
+import (
+	"syscall"
+)
+
+// signalPid sends a sig signal to the process with process id pid.
+func signalPid(pid int, sig syscall.Signal) error {
+	return syscall.Kill(pid, sig)
+}

--- a/command/util_windows.go
+++ b/command/util_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package command
+
+import (
+	"os"
+	"syscall"
+)
+
+// signalPid sends a sig signal to the process with process id pid.
+// Interrupts et al is not implemented on Windows. Always send a SIGKILL.
+func signalPid(pid int, sig syscall.Signal) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	_ = sig
+	return p.Signal(syscall.SIGKILL)
+}


### PR DESCRIPTION
Add a per GOOS implementation to send signals to PIDs
since syscall.Kill does not exist on Windows.

It will always send a SIGKILL on Windows since there
seems to be no POSIX compatible notion.

Fixes #636