### PR TITLE
Add loose validations for HTTP Method to operations of deregistration

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -102,6 +102,12 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 }
 
 func (s *HTTPServer) AgentDeregisterCheck(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// GET not supported
+	if req.Method == "GET" {
+		resp.WriteHeader(405)
+		return nil, nil
+	}
+
 	checkID := strings.TrimPrefix(req.URL.Path, "/v1/agent/check/deregister/")
 	return nil, s.agent.RemoveCheck(checkID, true)
 }
@@ -184,6 +190,12 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 }
 
 func (s *HTTPServer) AgentDeregisterService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// GET not supported
+	if req.Method == "GET" {
+		resp.WriteHeader(405)
+		return nil, nil
+	}
+
 	serviceID := strings.TrimPrefix(req.URL.Path, "/v1/agent/service/deregister/")
 	return nil, s.agent.RemoveService(serviceID, true)
 }

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -294,7 +294,7 @@ func TestHTTPAgentDeregisterCheck(t *testing.T) {
 	}
 
 	// Register node
-	req, err := http.NewRequest("GET", "/v1/agent/check/deregister/test", nil)
+	req, err := http.NewRequest("POST", "/v1/agent/check/deregister/test", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestHTTPAgentDeregisterService(t *testing.T) {
 	}
 
 	// Register node
-	req, err := http.NewRequest("GET", "/v1/agent/service/deregister/test", nil)
+	req, err := http.NewRequest("POST", "/v1/agent/service/deregister/test", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -30,6 +30,13 @@ func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request
 
 func (s *HTTPServer) CatalogDeregister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args structs.DeregisterRequest
+
+	// GET not supported
+	if req.Method == "GET" {
+		resp.WriteHeader(405)
+		return nil, nil
+	}
+
 	if err := decodeBody(req, &args, nil); err != nil {
 		resp.WriteHeader(400)
 		resp.Write([]byte(fmt.Sprintf("Request decode failed: %v", err)))

--- a/command/agent/catalog_endpoint_test.go
+++ b/command/agent/catalog_endpoint_test.go
@@ -61,7 +61,7 @@ func TestCatalogDeregister(t *testing.T) {
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
 	// Register node
-	req, err := http.NewRequest("GET", "/v1/catalog/deregister", nil)
+	req, err := http.NewRequest("POST", "/v1/catalog/deregister", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Operation of deregistration is accepts GET method.
So for example,
```
curl -X GET http://127.0.0.1:8500/v1/agent/service/deregister/
``` 

it is accepts and deregister all services only by access to this url.

I should not change the state by GET method to prevent accidents.
And should loose validations to operations of deregistration because strict validation(Only DELETE support) is no flexibility and there is not much validation in HTTP API of Consul.