### PR TITLE
Validate ServiceID/CheckID when deregistering.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -637,6 +637,11 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 			consul.ConsulServiceID)
 	}
 
+	// Validate ServiceID
+	if serviceID == "" {
+		return fmt.Errorf("ServiceID missing")
+	}
+
 	// Remove service immeidately
 	a.state.RemoveService(serviceID)
 
@@ -757,6 +762,11 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 // RemoveCheck is used to remove a health check.
 // The agent will make a best effort to ensure it is deregistered
 func (a *Agent) RemoveCheck(checkID string, persist bool) error {
+	// Validate CheckID
+	if checkID == "" {
+		return fmt.Errorf("CheckID missing")
+	}
+
 	// Add to the local state for anti-entropy
 	a.state.RemoveCheck(checkID)
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -247,6 +247,11 @@ func TestAgent_RemoveService(t *testing.T) {
 		t.Fatalf("should have errored")
 	}
 
+	// Remove without an ID
+	if err := agent.RemoveService("", false); err == nil {
+		t.Fatalf("should have errored")
+	}
+
 	// Removing a service with a single check works
 	{
 		srv := &structs.NodeService{
@@ -404,6 +409,11 @@ func TestAgent_RemoveCheck(t *testing.T) {
 	// Remove check that doesn't exist
 	if err := agent.RemoveCheck("mem", false); err != nil {
 		t.Fatalf("err: %v", err)
+	}
+
+	// Remove without an ID
+	if err := agent.RemoveCheck("", false); err == nil {
+		t.Fatalf("should have errored")
 	}
 
 	health := &structs.HealthCheck{

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"log"
 	"reflect"
 	"strings"
@@ -408,6 +409,10 @@ func (l *localState) syncChanges() error {
 
 // deleteService is used to delete a service from the server
 func (l *localState) deleteService(id string) error {
+	if id == "" {
+		return fmt.Errorf("ServiceID missing")
+	}
+
 	req := structs.DeregisterRequest{
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
@@ -425,6 +430,10 @@ func (l *localState) deleteService(id string) error {
 
 // deleteCheck is used to delete a service from the server
 func (l *localState) deleteCheck(id string) error {
+	if id == "" {
+		return fmt.Errorf("CheckID missing")
+	}
+
 	req := structs.DeregisterRequest{
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,


### PR DESCRIPTION
I think delete an agent node unintentionally when deregistering with empty ID.
For example, 
```
# current nodes
$ curl http://127.0.0.1:8500/v1/catalog/nodes
[{"Node":"mba.local","Address":"192.168.11.5"}]

# current services
$ curl http://127.0.0.1:8500/v1/catalog/services
{"consul":[],"web":[]}

# deregister service with empty ID
$ curl http://127.0.0.1:8500/v1/agent/service/deregister/

# nodes are missing!
$ curl http://127.0.0.1:8500/v1/catalog/nodes
[]

# services are missing!
$ http://127.0.0.1:8500/v1/catalog/services
{}
```


So ignore L122 and execute L133?
https://github.com/hashicorp/consul/blob/master/consul/fsm.go#L122-L137

My PR is adding validation of empty ServiceID/CheckID when deregistering.
Please check it.