### PR TITLE
command/agent: Set initial check status to HealthUnknown

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -615,7 +615,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes CheckTypes, pe
 			Node:        a.config.NodeName,
 			CheckID:     checkID,
 			Name:        fmt.Sprintf("Service '%s' check", service.Service),
-			Status:      structs.HealthCritical,
+			Status:      structs.HealthUnknown,
 			Notes:       chkType.Notes,
 			ServiceID:   service.ID,
 			ServiceName: service.Service,


### PR DESCRIPTION
We have a cron job that searches for critical services and de-registers them automatically [1]. There exists a race condition between the time that a service registers and the first health check (there is a small random sleep there to try a spread the checks around). If our cron searches for a critical service before the fist check has happened the new service will be de-registerd.

This commit changes the initial state of the checks from critical to unknown, thereby preventing the race. As soon as the fist check has run the state will be changed appropriately.

Nicholas


[1] All our services use ephemeral ports so if the service crashes and restarts it will leave behind a critical service in consul. We use consul-template/haproxy/nginx to load balance to our cluster.