### PR TITLE
fixing version numbers RCs should be labeled x.x.x-rcx

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -357,9 +357,13 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 
 	// Setup update checking
 	if !config.DisableUpdateCheck {
+		version := config.Version
+		if config.VersionPrerelease != "" {
+			version += fmt.Sprintf("-%s", config.VersionPrerelease)
+		}
 		updateParams := &checkpoint.CheckParams{
 			Product: "consul",
-			Version: fmt.Sprintf("%s%s", config.Version, config.VersionPrerelease),
+			Version: version,
 		}
 		if !config.DisableAnonymousSignature {
 			updateParams.SignatureFile = filepath.Join(config.DataDir, "checkpoint-signature")


### PR DESCRIPTION
see conversation with ryanuber: https://github.com/hashicorp/go-checkpoint/issues/2#issuecomment-73199209