### PR TITLE
close idle connections after stopping http checks to service

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -325,6 +325,7 @@ func (c *CheckHTTP) run() {
 			c.check()
 			next = time.After(c.Interval)
 		case <-c.stopCh:
+			c.httpClient.Transport.(*http.Transport).CloseIdleConnections()
 			return
 		}
 	}

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -325,7 +325,7 @@ func (c *CheckHTTP) run() {
 			c.check()
 			next = time.After(c.Interval)
 		case <-c.stopCh:
-			c.httpClient.Transport.(*http.Transport).CloseIdleConnections()
+			http.DefaultTransport.(*http.Transport).CloseIdleConnections()
 			return
 		}
 	}


### PR DESCRIPTION
Clean up the keep-alive connection to the service after you receive the stop signal. Useful if the service monitors active connections to itself.