### PR TITLE
website: Fix list of types available to watch

### DIFF
--- a/website/source/docs/commands/watch.html.markdown
+++ b/website/source/docs/commands/watch.html.markdown
@@ -53,5 +53,5 @@ The list of available flags are:
 * `-tag` - Service tag to filter on. Optional for `service` type.
 
 * `-type` - Watch type. Required, one of "key", "keyprefix", "services",
-  "nodes", "services", "checks", or "event".
+  "nodes", "service", "checks", or "event".
 


### PR DESCRIPTION
The list of types erroneously had services listed twice in place
of 'service' and 'services'