### PR TITLE
Add support for SCADA for Atlas Integration

### DIFF
--- a/api/raw.go
+++ b/api/raw.go
@@ -1,0 +1,18 @@
+package api
+
+// Raw can be used to do raw queries against custom endpoints
+type Raw struct {
+	c *Client
+}
+
+// Raw returns a handle to query endpoints
+func (c *Client) Raw() *Raw {
+	return &Raw{c}
+}
+
+// Query is used to do a GET request against an endpoint
+// and deserialize the response into an interface using
+// standard Consul conventions.
+func (raw *Raw) Query(endpoint string, out interface{}, q *QueryOptions) (*QueryMeta, error) {
+	return raw.c.query(endpoint, out, q)
+}

--- a/api/raw.go
+++ b/api/raw.go
@@ -16,3 +16,9 @@ func (c *Client) Raw() *Raw {
 func (raw *Raw) Query(endpoint string, out interface{}, q *QueryOptions) (*QueryMeta, error) {
 	return raw.c.query(endpoint, out, q)
 }
+
+// Write is used to do a PUT request against an endpoint
+// and serialize/deserialized using the standard Consul conventions.
+func (raw *Raw) Write(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+	return raw.c.write(endpoint, in, out, q)
+}

--- a/api/session.go
+++ b/api/session.go
@@ -179,23 +179,11 @@ func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, d
 
 // Info looks up a single session
 func (s *Session) Info(id string, q *QueryOptions) (*SessionEntry, *QueryMeta, error) {
-	r := s.c.newRequest("GET", "/v1/session/info/"+id)
-	r.setQueryOptions(q)
-	rtt, resp, err := requireOK(s.c.doRequest(r))
+	var entries []*SessionEntry
+	qm, err := s.c.query("/v1/session/info/"+id, &entries, q)
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
-
-	qm := &QueryMeta{}
-	parseQueryMeta(resp, qm)
-	qm.RequestTime = rtt
-
-	var entries []*SessionEntry
-	if err := decodeBody(resp, &entries); err != nil {
-		return nil, nil, err
-	}
-
 	if len(entries) > 0 {
 		return entries[0], qm, nil
 	}
@@ -204,20 +192,9 @@ func (s *Session) Info(id string, q *QueryOptions) (*SessionEntry, *QueryMeta, e
 
 // List gets sessions for a node
 func (s *Session) Node(node string, q *QueryOptions) ([]*SessionEntry, *QueryMeta, error) {
-	r := s.c.newRequest("GET", "/v1/session/node/"+node)
-	r.setQueryOptions(q)
-	rtt, resp, err := requireOK(s.c.doRequest(r))
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	qm := &QueryMeta{}
-	parseQueryMeta(resp, qm)
-	qm.RequestTime = rtt
-
 	var entries []*SessionEntry
-	if err := decodeBody(resp, &entries); err != nil {
+	qm, err := s.c.query("/v1/session/node/"+node, &entries, q)
+	if err != nil {
 		return nil, nil, err
 	}
 	return entries, qm, nil
@@ -225,20 +202,9 @@ func (s *Session) Node(node string, q *QueryOptions) ([]*SessionEntry, *QueryMet
 
 // List gets all active sessions
 func (s *Session) List(q *QueryOptions) ([]*SessionEntry, *QueryMeta, error) {
-	r := s.c.newRequest("GET", "/v1/session/list")
-	r.setQueryOptions(q)
-	rtt, resp, err := requireOK(s.c.doRequest(r))
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	qm := &QueryMeta{}
-	parseQueryMeta(resp, qm)
-	qm.RequestTime = rtt
-
 	var entries []*SessionEntry
-	if err := decodeBody(resp, &entries); err != nil {
+	qm, err := s.c.query("/v1/session/list", &entries, q)
+	if err != nil {
 		return nil, nil, err
 	}
 	return entries, qm, nil

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -78,7 +78,7 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind server listeners to")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddr, "advertise", "", "address to advertise instead of bind addr")
 
-	cmdFlags.StringVar(&cmdConfig.AtlasCluster, "atlas-cluster", "", "cluster name in Atlas")
+	cmdFlags.StringVar(&cmdConfig.AtlasInfrastructure, "atlas", "", "infrastructure name in Atlas")
 	cmdFlags.StringVar(&cmdConfig.AtlasToken, "atlas-token", "", "authentication token for Atlas")
 	cmdFlags.BoolVar(&cmdConfig.AtlasJoin, "atlas-join", false, "auto-join with Atlas")
 
@@ -335,7 +335,7 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 
 	// Enable the SCADA integration
 	var scadaList net.Listener
-	if config.AtlasCluster != "" {
+	if config.AtlasInfrastructure != "" {
 		provider, list, err := NewProvider(config, logOutput)
 		if err != nil {
 			agent.Shutdown()
@@ -649,9 +649,9 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Determine the Atlas cluster
-	cluster := config.AtlasCluster
-	if cluster == "" {
-		cluster = "<disabled>"
+	atlas := "<disabled>"
+	if config.AtlasInfrastructure != "" {
+		atlas = fmt.Sprintf("(Infrastructure: '%s' Join: %v)", config.AtlasInfrastructure, config.AtlasJoin)
 	}
 
 	// Let the agent know we've finished registration
@@ -667,7 +667,7 @@ func (c *Command) Run(args []string) int {
 		config.Ports.SerfLan, config.Ports.SerfWan))
 	c.Ui.Info(fmt.Sprintf("Gossip encrypt: %v, RPC-TLS: %v, TLS-Incoming: %v",
 		gossipEncrypted, config.VerifyOutgoing, config.VerifyIncoming))
-	c.Ui.Info(fmt.Sprintf(" Atlas Cluster: %v", cluster))
+	c.Ui.Info(fmt.Sprintf("         Atlas: %s", atlas))
 
 	// Enable log streaming
 	c.Ui.Info("")
@@ -842,7 +842,7 @@ Usage: consul agent [options]
 Options:
 
   -advertise=addr          Sets the advertise address to use
-  -atlas-cluster=org/name  Sets the Atlas cluster name, enables SCADA.
+  -atlas=org/name          Sets the Atlas infrastructure name, enables SCADA.
   -atlas-join              Enables auto-joining the Atlas cluster
   -atlas-token=token       Provides the Atlas API token
   -bootstrap               Sets server to bootstrap mode

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -76,6 +76,9 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind server listeners to")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddr, "advertise", "", "address to advertise instead of bind addr")
 
+	cmdFlags.StringVar(&cmdConfig.AtlasCluster, "atlas-cluster", "", "cluster name in Atlas")
+	cmdFlags.StringVar(&cmdConfig.AtlasToken, "atlas-token", "", "authentication token for Atlas")
+
 	cmdFlags.IntVar(&cmdConfig.Protocol, "protocol", -1, "protocol version")
 
 	cmdFlags.BoolVar(&cmdConfig.EnableSyslog, "syslog", false,
@@ -815,6 +818,8 @@ Usage: consul agent [options]
 Options:
 
   -advertise=addr          Sets the advertise address to use
+  -atlas-cluster=org/name  Sets the Atlas cluster name, enables SCADA.
+  -atlas-token=token       Provides the Atlas API token
   -bootstrap               Sets server to bootstrap mode
   -bind=0.0.0.0            Sets the bind address for cluster communication
   -bootstrap-expect=0      Sets server to expect bootstrap mode.

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -80,6 +80,7 @@ func (c *Command) readConfig() *Config {
 
 	cmdFlags.StringVar(&cmdConfig.AtlasCluster, "atlas-cluster", "", "cluster name in Atlas")
 	cmdFlags.StringVar(&cmdConfig.AtlasToken, "atlas-token", "", "authentication token for Atlas")
+	cmdFlags.BoolVar(&cmdConfig.AtlasJoin, "atlas-join", false, "auto-join with Atlas")
 
 	cmdFlags.IntVar(&cmdConfig.Protocol, "protocol", -1, "protocol version")
 
@@ -842,6 +843,7 @@ Options:
 
   -advertise=addr          Sets the advertise address to use
   -atlas-cluster=org/name  Sets the Atlas cluster name, enables SCADA.
+  -atlas-join              Enables auto-joining the Atlas cluster
   -atlas-token=token       Provides the Atlas API token
   -bootstrap               Sets server to bootstrap mode
   -bind=0.0.0.0            Sets the bind address for cluster communication

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -322,14 +322,14 @@ type Config struct {
 	AtlasInfrastructure string `mapstructure:"atlas_infrastructure"`
 
 	// AtlasToken is our authentication token from Atlas
-	AtlasToken string `mapstructure:"atlas_token"`
+	AtlasToken string `mapstructure:"atlas_token" json:"-"`
 
 	// AtlasACLToken is applied to inbound requests if no other token
 	// is provided. This takes higher precedence than the ACLToken.
 	// Without this, the ACLToken is used. If that is not specified either,
 	// then the 'anonymous' token is used. This can be set to 'anonymous'
 	// to reduce the Atlas privileges to below that of the ACLToken.
-	AtlasACLToken string `mapstructure:"atlas_acl_token"`
+	AtlasACLToken string `mapstructure:"atlas_acl_token" json:"-"`
 
 	// AtlasJoin controls if Atlas will attempt to auto-join the node
 	// to it's cluster. Requires Atlas integration.

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -318,8 +318,8 @@ type Config struct {
 	// HTTPAPIResponseHeaders are used to add HTTP header response fields to the HTTP API responses.
 	HTTPAPIResponseHeaders map[string]string `mapstructure:"http_api_response_headers"`
 
-	// AtlasCluster is the name of the cluster we belong to. e.g. hashicorp/stage
-	AtlasCluster string `mapstructure:"atlas_cluster"`
+	// AtlasInfrastructure is the name of the infrastructure we belong to. e.g. hashicorp/stage
+	AtlasInfrastructure string `mapstructure:"atlas_infrastructure"`
 
 	// AtlasToken is our authentication token from Atlas
 	AtlasToken string `mapstructure:"atlas_token"`
@@ -958,8 +958,8 @@ func MergeConfig(a, b *Config) *Config {
 	if b.UnixSockets.Perms != "" {
 		result.UnixSockets.Perms = b.UnixSockets.Perms
 	}
-	if b.AtlasCluster != "" {
-		result.AtlasCluster = b.AtlasCluster
+	if b.AtlasInfrastructure != "" {
+		result.AtlasInfrastructure = b.AtlasInfrastructure
 	}
 	if b.AtlasToken != "" {
 		result.AtlasToken = b.AtlasToken

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -318,6 +318,19 @@ type Config struct {
 	// HTTPAPIResponseHeaders are used to add HTTP header response fields to the HTTP API responses.
 	HTTPAPIResponseHeaders map[string]string `mapstructure:"http_api_response_headers"`
 
+	// AtlasCluster is the name of the cluster we belong to. e.g. hashicorp/stage
+	AtlasCluster string `mapstructure:"atlas_cluster"`
+
+	// AtlasToken is our authentication token from Atlas
+	AtlasToken string `mapstructure:"atlas_token"`
+
+	// AtlasACLToken is applied to inbound requests if no other token
+	// is provided. This takes higher precedence than the ACLToken.
+	// Without this, the ACLToken is used. If that is not specified either,
+	// then the 'anonymous' token is used. This can be set to 'anonymous'
+	// to reduce the Atlas privileges to below that of the ACLToken.
+	AtlasACLToken string `mapstructure:"atlas_acl_token"`
+
 	// AEInterval controls the anti-entropy interval. This is how often
 	// the agent attempts to reconcile it's local state with the server'
 	// representation of our state. Defaults to every 60s.
@@ -940,6 +953,15 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.UnixSockets.Perms != "" {
 		result.UnixSockets.Perms = b.UnixSockets.Perms
+	}
+	if b.AtlasCluster != "" {
+		result.AtlasCluster = b.AtlasCluster
+	}
+	if b.AtlasToken != "" {
+		result.AtlasToken = b.AtlasToken
+	}
+	if b.AtlasACLToken != "" {
+		result.AtlasACLToken = b.AtlasACLToken
 	}
 
 	if len(b.HTTPAPIResponseHeaders) != 0 {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -331,6 +331,10 @@ type Config struct {
 	// to reduce the Atlas privileges to below that of the ACLToken.
 	AtlasACLToken string `mapstructure:"atlas_acl_token"`
 
+	// AtlasJoin controls if Atlas will attempt to auto-join the node
+	// to it's cluster. Requires Atlas integration.
+	AtlasJoin bool `mapstructure:"atlas_join"`
+
 	// AEInterval controls the anti-entropy interval. This is how often
 	// the agent attempts to reconcile it's local state with the server'
 	// representation of our state. Defaults to every 60s.
@@ -962,6 +966,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.AtlasACLToken != "" {
 		result.AtlasACLToken = b.AtlasACLToken
+	}
+	if b.AtlasJoin {
+		result.AtlasJoin = true
 	}
 
 	if len(b.HTTPAPIResponseHeaders) != 0 {

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -633,6 +633,23 @@ func TestDecodeConfig(t *testing.T) {
 	if config.HTTPAPIResponseHeaders["X-XSS-Protection"] != "1; mode=block" {
 		t.Fatalf("bad: %#v", config)
 	}
+
+	// Atlas configs
+	input = `{"atlas_cluster": "hashicorp/prod", "atlas_token": "abcdefg", "atlas_acl_token": "123456789"}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.AtlasCluster != "hashicorp/prod" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.AtlasToken != "abcdefg" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.AtlasACLToken != "123456789" {
+		t.Fatalf("bad: %#v", config)
+	}
 }
 
 func TestDecodeConfig_invalidKeys(t *testing.T) {
@@ -1096,6 +1113,9 @@ func TestMergeConfig(t *testing.T) {
 				Perms: "0700",
 			},
 		},
+		AtlasCluster:  "hashicorp/prod",
+		AtlasToken:    "123456789",
+		AtlasACLToken: "abcdefgh",
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -635,7 +635,7 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// Atlas configs
-	input = `{"atlas_cluster": "hashicorp/prod", "atlas_token": "abcdefg", "atlas_acl_token": "123456789"}`
+	input = `{"atlas_cluster": "hashicorp/prod", "atlas_token": "abcdefg", "atlas_acl_token": "123456789", "atlas_join": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -648,6 +648,9 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.AtlasACLToken != "123456789" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if !config.AtlasJoin {
 		t.Fatalf("bad: %#v", config)
 	}
 }
@@ -1116,6 +1119,7 @@ func TestMergeConfig(t *testing.T) {
 		AtlasCluster:  "hashicorp/prod",
 		AtlasToken:    "123456789",
 		AtlasACLToken: "abcdefgh",
+		AtlasJoin:     true,
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -635,13 +635,13 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// Atlas configs
-	input = `{"atlas_cluster": "hashicorp/prod", "atlas_token": "abcdefg", "atlas_acl_token": "123456789", "atlas_join": true}`
+	input = `{"atlas_infrastructure": "hashicorp/prod", "atlas_token": "abcdefg", "atlas_acl_token": "123456789", "atlas_join": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if config.AtlasCluster != "hashicorp/prod" {
+	if config.AtlasInfrastructure != "hashicorp/prod" {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.AtlasToken != "abcdefg" {
@@ -1116,10 +1116,10 @@ func TestMergeConfig(t *testing.T) {
 				Perms: "0700",
 			},
 		},
-		AtlasCluster:  "hashicorp/prod",
-		AtlasToken:    "123456789",
-		AtlasACLToken: "abcdefgh",
-		AtlasJoin:     true,
+		AtlasInfrastructure: "hashicorp/prod",
+		AtlasToken:          "123456789",
+		AtlasACLToken:       "abcdefgh",
+		AtlasJoin:           true,
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -179,7 +179,7 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 // Shutdown is used to shutdown the HTTP server
 func (s *HTTPServer) Shutdown() {
 	if s != nil {
-		s.logger.Printf("[DEBUG] http: Shutting down http server(%v)", s.addr)
+		s.logger.Printf("[DEBUG] http: Shutting down http server (%v)", s.addr)
 		s.listener.Close()
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -33,14 +33,10 @@ type HTTPServer struct {
 // NewHTTPServers starts new HTTP servers to provide an interface to
 // the agent.
 func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput io.Writer) ([]*HTTPServer, error) {
-	var tlsConfig *tls.Config
-	var list net.Listener
-	var httpAddr net.Addr
-	var err error
 	var servers []*HTTPServer
 
 	if config.Ports.HTTPS > 0 {
-		httpAddr, err = config.ClientListener(config.Addresses.HTTPS, config.Ports.HTTPS)
+		httpAddr, err := config.ClientListener(config.Addresses.HTTPS, config.Ports.HTTPS)
 		if err != nil {
 			return nil, err
 		}
@@ -54,7 +50,7 @@ func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput 
 			NodeName:       config.NodeName,
 			ServerName:     config.ServerName}
 
-		tlsConfig, err = tlsConf.IncomingTLSConfig()
+		tlsConfig, err := tlsConf.IncomingTLSConfig()
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +60,7 @@ func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput 
 			return nil, fmt.Errorf("Failed to get Listen on %s: %v", httpAddr.String(), err)
 		}
 
-		list = tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, tlsConfig)
+		list := tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, tlsConfig)
 
 		// Create the mux
 		mux := http.NewServeMux()
@@ -86,7 +82,7 @@ func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput 
 	}
 
 	if config.Ports.HTTP > 0 {
-		httpAddr, err = config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
+		httpAddr, err := config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get ClientListener address:port: %v", err)
 		}
@@ -107,6 +103,7 @@ func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput 
 			return nil, fmt.Errorf("Failed to get Listen on %s: %v", httpAddr.String(), err)
 		}
 
+		var list net.Listener
 		if isSocket {
 			// Set up ownership/permission bits on the socket file
 			if err := setFilePermissions(socketPath, config.UnixSockets); err != nil {
@@ -152,7 +149,7 @@ func NewHTTPServers(agent *Agent, config *Config, scada net.Listener, logOutput 
 		srv.registerHandlers(false) // Never allow debug for SCADA
 
 		// Start the server
-		go http.Serve(list, mux)
+		go http.Serve(scada, mux)
 		servers = append(servers, srv)
 	}
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -266,7 +266,10 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	if s.uiDir != "" {
 		// Static file serving done from /ui/
 		s.mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(http.Dir(s.uiDir))))
+	}
 
+	// Enable the special endpoints for UI or SCADA
+	if s.uiDir != "" || s.agent.config.AtlasInfrastructure != "" {
 		// API's are under /internal/ui/ to avoid conflict
 		s.mux.HandleFunc("/v1/internal/ui/nodes", s.wrap(s.UINodes))
 		s.mux.HandleFunc("/v1/internal/ui/node/", s.wrap(s.UINodeInfo))

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -36,7 +36,7 @@ func makeHTTPServerWithConfig(t *testing.T, cb func(c *Config)) (string, *HTTPSe
 		t.Fatalf("err: %v", err)
 	}
 	conf.UiDir = uiDir
-	servers, err := NewHTTPServers(agent, conf, agent.logOutput)
+	servers, err := NewHTTPServers(agent, conf, nil, agent.logOutput)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Try to start the server with the same path anyways.
-	if _, err := NewHTTPServers(agent, conf, agent.logOutput); err != nil {
+	if _, err := NewHTTPServers(agent, conf, nil, agent.logOutput); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -59,12 +60,13 @@ func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, net.Listener
 	config := ProviderConfig(c)
 	config.Logger = log.New(logOutput, "", log.LstdFlags)
 
-	// TODO: REMOVE
-	config.TLSConfig = &tls.Config{
-		InsecureSkipVerify: true,
+	// SCADA_INSECURE env variable is used for testing to disable
+	// TLS certificate verification.
+	if os.Getenv("SCADA_INSECURE") != "" {
+		config.TLSConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
 	}
-
-	// TODO: AtlasACLToken
 
 	// Create an HTTP listener and handler
 	list := newScadaListener(c.AtlasInfrastructure)

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -96,9 +96,9 @@ type scadaListener struct {
 }
 
 // newScadaListener returns a new listener
-func newScadaListener(cluster string) *scadaListener {
+func newScadaListener(infra string) *scadaListener {
 	l := &scadaListener{
-		addr:     &scadaAddr{cluster},
+		addr:     &scadaAddr{infra},
 		pending:  make(chan net.Conn),
 		closedCh: make(chan struct{}),
 	}
@@ -155,7 +155,7 @@ func (s *scadaListener) Addr() net.Addr {
 
 // scadaAddr is used to return a net.Addr for SCADA
 type scadaAddr struct {
-	cluster string
+	infra string
 }
 
 func (s *scadaAddr) Network() string {
@@ -163,7 +163,7 @@ func (s *scadaAddr) Network() string {
 }
 
 func (s *scadaAddr) String() string {
-	return fmt.Sprintf("SCADA::Atlas::%s", s.cluster)
+	return fmt.Sprintf("SCADA::Atlas::%s", s.infra)
 }
 
 type scadaRWC struct {

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -47,7 +47,7 @@ func ProviderConfig(c *Config) *client.ProviderConfig {
 		Handlers: map[string]client.CapabilityProvider{
 			"http": nil,
 		},
-		ResourceGroup: c.AtlasCluster,
+		ResourceGroup: c.AtlasInfrastructure,
 		Token:         c.AtlasToken,
 	}
 }
@@ -67,7 +67,7 @@ func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, net.Listener
 	// TODO: AtlasACLToken
 
 	// Create an HTTP listener and handler
-	list := newScadaListener(c.AtlasCluster)
+	list := newScadaListener(c.AtlasInfrastructure)
 	config.Handlers["http"] = func(capability string, meta map[string]string,
 		conn io.ReadWriteCloser) error {
 		return list.PushRWC(conn)

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -141,7 +141,6 @@ func (s *scadaListener) Close() error {
 		return nil
 	}
 	s.closed = true
-	close(s.pending)
 	close(s.closedCh)
 	return nil
 }

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+
+	"github.com/hashicorp/scada-client"
+)
+
+const (
+	// providerService is the service name we use
+	providerService = "consul"
+
+	// resourceType is the type of resource we represent
+	// when connecting to SCADA
+	resourceType = "infrastructures"
+)
+
+// ProviderService returns the service information for the provider
+func ProviderService(c *Config) *client.ProviderService {
+	return &client.ProviderService{
+		Service:        providerService,
+		ServiceVersion: fmt.Sprintf("%s%s", c.Version, c.VersionPrerelease),
+		Capabilities: map[string]int{
+			"http": 1,
+		},
+		Meta: map[string]string{
+			"type":       "",
+			"datacenter": "",
+		},
+		ResourceType: resourceType,
+	}
+}
+
+// ProviderConfig returns the configuration for the SCADA provider
+func ProviderConfig(c *Config) *client.ProviderConfig {
+	return &client.ProviderConfig{
+		Service: ProviderService(c),
+		Handlers: map[string]client.CapabilityProvider{
+			"http": nil,
+		},
+		ResourceGroup: c.AtlasCluster,
+		Token:         c.AtlasToken,
+	}
+}
+
+// NewProvider creates a new SCADA provider using the
+// given configuration. Requests are routed to the
+func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, error) {
+	// Get the configuration of the provider
+	config := ProviderConfig(c)
+	config.Logger = log.New(logOutput, "", log.LstdFlags)
+
+	// TODO: REMOVE
+	config.TLSConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	// TODO: Setup the handlers
+	config.Handlers["http"] = nil
+
+	// Create the provider
+	return client.NewProvider(config)
+}

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -120,6 +120,8 @@ func (s *scadaListener) Push(conn net.Conn) error {
 	select {
 	case s.pending <- conn:
 		return nil
+	case <-time.After(time.Second):
+		return fmt.Errorf("accept timed out")
 	case <-s.closedCh:
 		return fmt.Errorf("scada listener closed")
 	}

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -32,8 +32,9 @@ func ProviderService(c *Config) *client.ProviderService {
 			"http": 1,
 		},
 		Meta: map[string]string{
-			"server":     strconv.FormatBool(c.Server),
+			"auto-join":  strconv.FormatBool(c.AtlasJoin),
 			"datacenter": c.Datacenter,
+			"server":     strconv.FormatBool(c.Server),
 		},
 		ResourceType: resourceType,
 	}

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
+	"strconv"
 
 	"github.com/hashicorp/scada-client"
 )
@@ -27,8 +29,8 @@ func ProviderService(c *Config) *client.ProviderService {
 			"http": 1,
 		},
 		Meta: map[string]string{
-			"type":       "",
-			"datacenter": "",
+			"server":     strconv.FormatBool(c.Server),
+			"datacenter": c.Datacenter,
 		},
 		ResourceType: resourceType,
 	}
@@ -48,7 +50,7 @@ func ProviderConfig(c *Config) *client.ProviderConfig {
 
 // NewProvider creates a new SCADA provider using the
 // given configuration. Requests are routed to the
-func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, error) {
+func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, net.Listener, error) {
 	// Get the configuration of the provider
 	config := ProviderConfig(c)
 	config.Logger = log.New(logOutput, "", log.LstdFlags)
@@ -62,5 +64,9 @@ func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, error) {
 	config.Handlers["http"] = nil
 
 	// Create the provider
-	return client.NewProvider(config)
+	provider, err := client.NewProvider(config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return provider, nil, nil
 }

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strconv"
@@ -58,7 +57,7 @@ func ProviderConfig(c *Config) *client.ProviderConfig {
 func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, net.Listener, error) {
 	// Get the configuration of the provider
 	config := ProviderConfig(c)
-	config.Logger = log.New(logOutput, "", log.LstdFlags)
+	config.LogOutput = logOutput
 
 	// SCADA_INSECURE env variable is used for testing to disable
 	// TLS certificate verification.

--- a/command/agent/scada.go
+++ b/command/agent/scada.go
@@ -53,7 +53,8 @@ func ProviderConfig(c *Config) *client.ProviderConfig {
 }
 
 // NewProvider creates a new SCADA provider using the
-// given configuration. Requests are routed to the
+// given configuration. Requests for the HTTP capability
+// are passed off to the listener that is returned.
 func NewProvider(c *Config, logOutput io.Writer) (*client.Provider, net.Listener, error) {
 	// Get the configuration of the provider
 	config := ProviderConfig(c)

--- a/command/agent/scada_test.go
+++ b/command/agent/scada_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/scada-client"
+)
+
+func TestProviderService(t *testing.T) {
+	conf := DefaultConfig()
+	conf.Version = "0.5.0"
+	conf.VersionPrerelease = "rc1"
+	conf.AtlasJoin = true
+	conf.Server = true
+	ps := ProviderService(conf)
+
+	expect := &client.ProviderService{
+		Service:        "consul",
+		ServiceVersion: "0.5.0rc1",
+		Capabilities: map[string]int{
+			"http": 1,
+		},
+		Meta: map[string]string{
+			"auto-join":  "true",
+			"datacenter": "dc1",
+			"server":     "true",
+		},
+		ResourceType: "infrastructures",
+	}
+
+	if !reflect.DeepEqual(ps, expect) {
+		t.Fatalf("bad: %v", ps)
+	}
+}
+
+func TestProviderConfig(t *testing.T) {
+	conf := DefaultConfig()
+	conf.Version = "0.5.0"
+	conf.VersionPrerelease = "rc1"
+	conf.AtlasJoin = true
+	conf.Server = true
+	conf.AtlasInfrastructure = "armon/test"
+	conf.AtlasToken = "foobarbaz"
+	pc := ProviderConfig(conf)
+
+	expect := &client.ProviderConfig{
+		Service: &client.ProviderService{
+			Service:        "consul",
+			ServiceVersion: "0.5.0rc1",
+			Capabilities: map[string]int{
+				"http": 1,
+			},
+			Meta: map[string]string{
+				"auto-join":  "true",
+				"datacenter": "dc1",
+				"server":     "true",
+			},
+			ResourceType: "infrastructures",
+		},
+		Handlers: map[string]client.CapabilityProvider{
+			"http": nil,
+		},
+		ResourceGroup: "armon/test",
+		Token:         "foobarbaz",
+	}
+
+	if !reflect.DeepEqual(pc, expect) {
+		t.Fatalf("bad: %v", pc)
+	}
+}
+
+func TestSCADAListener(t *testing.T) {
+	list := newScadaListener("armon/test")
+	defer list.Close()
+
+	var raw interface{} = list
+	_, ok := raw.(net.Listener)
+	if !ok {
+		t.Fatalf("bad")
+	}
+
+	a, b := net.Pipe()
+	defer a.Close()
+	defer b.Close()
+
+	go list.Push(a)
+	out, err := list.Accept()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != a {
+		t.Fatalf("bad")
+	}
+}
+
+func TestSCADAAddr(t *testing.T) {
+	var addr interface{} = &scadaAddr{"armon/test"}
+	_, ok := addr.(net.Addr)
+	if !ok {
+		t.Fatalf("bad")
+	}
+}

--- a/website/source/docs/agent/basics.html.markdown
+++ b/website/source/docs/agent/basics.html.markdown
@@ -39,6 +39,7 @@ $ consul agent -data-dir=/tmp/consul
           Server: false (bootstrap: false)
      Client Addr: 127.0.0.1 (HTTP: 8500, DNS: 8600, RPC: 8400)
     Cluster Addr: 192.168.1.43 (LAN: 8301, WAN: 8302)
+           Atlas: (Infrastructure: 'hashicorp/test' Join: true)
 
 ==> Log data will now stream in as it occurs:
 
@@ -74,6 +75,11 @@ There are several important messages that `consul agent` outputs:
 * **Cluster Addr**: This is the address and set of ports used for communication between
   Consul agents in a cluster. Not all Consul agents in a cluster have to
   use the same port, but this address **MUST** be reachable by all other nodes.
+
+* **Atlas**: This shows the [Atlas infrastructure](https://atlas.hashicorp.com)
+  the node is registered with. It also indicates if auto join is enabled.
+  The Atlas infrastructure is set using `-atlas` and auto-join is enabled by
+  setting `-atlas-join`.
 
 ## Stopping an Agent
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -40,6 +40,17 @@ The options below are all specified on the command-line.
   If this address is not routable, the node will be in a constant flapping state
   as other nodes will treat the non-routability as a failure.
 
+* <a id="atlas"></a>`-atlas` - This flag enables [Atlas](https://atlas.hashicorp.com) integration.
+  It is used to provide the Atlas infrastructure name and the SCADA connection.
+  This enables Atlas features such as the dashboard and node auto joining.
+
+* <a id="atlas_join"></a>`-atlas-join` - When set, enables auto-join via Atlas. Atlas will track the most
+  recent members to join the infrastructure named by `-atlas` and automatically
+  join them on start. For servers, the LAN and WAN pool are both joined.
+
+* <a id="atlas_token"></a>`-atlas-token` - Provides the Atlas API authentication token. This can also be provided
+  using the `ATLAS_TOKEN` environment variable. Required for use with Atlas.
+
 * <a id="bootstrap_anchor"></a>`-bootstrap` - This flag is used to control if a server is in "bootstrap" mode. It is important that
   no more than one server *per* data center be running in this mode. Technically, a server in bootstrap mode
   is allowed to self-elect as the Raft leader. It is important that only a single node is in this mode;
@@ -259,6 +270,16 @@ definitions support being updated during a reload.
   * `rpc` - The RPC endpoint. Defaults to `client_addr`
 
 * `advertise_addr` - Equivalent to the [`-advertise` command-line flag](#advertise).
+
+* `atlas_acl_token` - When provided, any requests made by Atlas will use this ACL
+   token unless explicitly overriden. When not provided the `acl_token` is used.
+   This can be set to 'anonymous' to reduce permission below that of `acl_token`.
+
+* `atlas_infrastructure` - Equivalent to the [`-atlas` command-line flag](#atlas).
+
+* `atlas_join` - Equivalent to the [`-atlas-join` command-line flag](#atlas_join).
+
+* `atlas_token` - Equivalent to the [`-atlas-token` command-line flag](#atlas_token).
 
 * `bootstrap` - Equivalent to the [`-bootstrap` command-line flag](#bootstrap_anchor).
 

--- a/website/source/docs/faq.html.markdown
+++ b/website/source/docs/faq.html.markdown
@@ -28,4 +28,16 @@ and can be disabled.
 See [`disable_anonymous_signature`](/docs/agent/options.html#disable_anonymous_signature)
 and [`disable_update_check`](/docs/agent/options.html#disable_update_check).
 
+## Q: How does Atlas integration work? / Does Consul call home?
+
+Consul makes use of a HashiCorp service called [SCADA](http://scada.hashicorp.com)
+which stands for Supervisory Control And Data Acquisition. The SCADA system allows
+clients to maintain a long-running connection to Atlas which is used to make requests
+to Consul agents for features like the dashboard and auto joining. Standard ACLs can
+be applied to the SCADA connection, which has no enhanced or elevated privileges.
+Using the SCADA service is optional and only enabled by opt-in.
+
+See [`atlas_infrastructure`](/docs/agent/options.html#_atlas)
+and [`atlas_acl_token`](/docs/agent/options.html#atlas_acl_token).
+
 

--- a/website/source/docs/faq.html.markdown
+++ b/website/source/docs/faq.html.markdown
@@ -28,7 +28,7 @@ and can be disabled.
 See [`disable_anonymous_signature`](/docs/agent/options.html#disable_anonymous_signature)
 and [`disable_update_check`](/docs/agent/options.html#disable_update_check).
 
-## Q: How does Atlas integration work? / Does Consul call home?
+## Q: How does Atlas integration work?
 
 Consul makes use of a HashiCorp service called [SCADA](http://scada.hashicorp.com)
 which stands for Supervisory Control And Data Acquisition. The SCADA system allows
@@ -37,7 +37,5 @@ to Consul agents for features like the dashboard and auto joining. Standard ACLs
 be applied to the SCADA connection, which has no enhanced or elevated privileges.
 Using the SCADA service is optional and only enabled by opt-in.
 
-See [`atlas_infrastructure`](/docs/agent/options.html#_atlas)
-and [`atlas_acl_token`](/docs/agent/options.html#atlas_acl_token).
-
+See the [Atlas integration guide](/docs/guides/atlas.html).
 

--- a/website/source/docs/guides/atlas.html.markdown
+++ b/website/source/docs/guides/atlas.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "docs"
+page_title: "Atlas Integration"
+sidebar_current: "docs-guides-atlas"
+description: |-
+  This guide covers how to integrate Atlas with Consul to provide features like an infrastructure dashboard and automatic cluster joining.
+---
+
+# Atlas Integration
+
+[Atlas](https://atlas.hashicorp.com) is service provided by HashiCorp to deploy applications and manage infrastructure.
+Starting with Consul 0.5, it is possible to integrate Consul with Atlas. This is done by registering a node as part
+of an Atlas infrastructure (specified with the `-atlas` flag). Consul maintains a long running connection to the
+[SCADA](http://scada.hashicorp.com) service which allows Atlas to retrieve data and control nodes.
+
+Data acquisition allows Atlas to display the state of the Consul cluster in its dashboard as well as enabling
+alerts to be setup using health checks. Remote control enables Atlas to provide features like the auto joinining
+nodes.
+
+## Enabling Atlas Integration
+
+To enable Atlas integration, you must specify the name of the Atlas infrastructure and the Atlas authentication
+token. The Atlas infrastructure name can be set either with the `-atlas` CLI flag, or with the `atlas_infrastructure`
+[configuration option](/docs/agent/options.html). The Atlas token is set with the `-atlas-token` CLI flag, `atlas_token`
+configuration option, or `ATLAS_TOKEN` environment variable.
+
+To verify the integration, either run the agent with `debug` level logging or use `consul monitor -log-level=debug`
+and look for a line like:
+
+    [DEBUG] scada-client: assigned session '406ca55d-1801-f964-2942-45f5f9df3995'
+
+This shows that the Consul agent was successfully able to register with the SCADA service.
+
+## Using Auto-Join
+
+Once integrated with Atlas, the auto join feature can be used to have nodes automatically join other
+peers in their datacenter. Server nodes will automatically join peer LAN nodes and other WAN nodes.
+Client nodes will only join other LAN nodes in their datacenter.
+
+Auto join is enabled with the `-atlas-join` CLI flag or the `atlas_join` configuration option.
+
+## Securing Atlas
+
+The connection to Atlas does not have elevated privileges. API requests made by Atlas
+are served in the same way any other HTTP request is made. If ACLs are enabled, it is possible to
+force an Atlas ACL token to be used instead of the agent's default token.
+
+When ACLs are enabled, the `atlas_acl_token` configuration option can be specified. This changes
+the ACL token resolution order to be:
+
+1. Request specific token provided by `?token=`. These tokens are set in the Atlas UI.
+2. The `atlas_acl_token` if configured.
+3. The `acl_token` if configured.
+4. The `anonymous` token.
+
+Because the `acl_token` typically has elevated permissions compared to the `anonymous` token,
+the `atlas_acl_token` can be set to `anonymous` to drop privileges that would otherwise be
+inherited from the agent.
+

--- a/website/source/docs/guides/index.html.markdown
+++ b/website/source/docs/guides/index.html.markdown
@@ -14,6 +14,8 @@ guidance to do them safely.
 
 The following guides are available:
 
+* [Atlas Integration](/docs/guides/atlas.html) - This guide covers how to integrate [Atlas](https://atlas.hashicorp.com) with Consul.
+
 * [Adding/Removing Servers](/docs/guides/servers.html) - This guide covers how to safely add and remove Consul servers from the cluster. This should be done carefully to avoid availability outages.
 
 * [Bootstrapping](/docs/guides/bootstrapping.html) - This guide covers bootstrapping a new datacenter. This covers safely adding the initial Consul servers.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -196,7 +196,11 @@
 
 				<li<%= sidebar_current("docs-guides") %>>
 				<a href="/docs/guides/index.html">Guides</a>
-				<ul class="nav">
+                <ul class="nav">
+					<li<%= sidebar_current("docs-guides-atlas") %>>
+					<a href="/docs/guides/atlas.html">Atlas Integration</a>
+					</li>
+
 					<li<%= sidebar_current("docs-guides-servers") %>>
 					<a href="/docs/guides/servers.html">Adding/Removing Servers</a>
 					</li>


### PR DESCRIPTION
This PR adds support for the [SCADA service](http://scada.hashicorp.com) which is used to integrate into [Atlas](https://atlas.hashicorp.com). It makes use of the `scads-client` library to do most of the work. The only capability that is enabled via SCADA is the HTTP API, which required some minor changes to allow a dedicated listener.

/cc: @ryanuber 