### PR TITLE
consul: allow returning custom error for merge delegate

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -139,7 +139,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.SnapshotPath = filepath.Join(c.config.DataDir, path)
 	conf.ProtocolVersion = protocolVersionMap[c.config.ProtocolVersion]
 	conf.RejoinAfterLeave = c.config.RejoinAfterLeave
-	conf.Merge = &lanMergeDelegate{logger: c.logger, dc: c.config.Datacenter}
+	conf.Merge = &lanMergeDelegate{dc: c.config.Datacenter}
 	if err := ensurePath(conf.SnapshotPath, false); err != nil {
 		return nil, err
 	}

--- a/consul/server.go
+++ b/consul/server.go
@@ -311,9 +311,9 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 	conf.ProtocolVersion = protocolVersionMap[s.config.ProtocolVersion]
 	conf.RejoinAfterLeave = s.config.RejoinAfterLeave
 	if wan {
-		conf.Merge = &wanMergeDelegate{logger: s.logger}
+		conf.Merge = &wanMergeDelegate{}
 	} else {
-		conf.Merge = &lanMergeDelegate{logger: s.logger, dc: s.config.Datacenter}
+		conf.Merge = &lanMergeDelegate{dc: s.config.Datacenter}
 	}
 
 	// Until Consul supports this fully, we disable automatic resolution.


### PR DESCRIPTION
Better error messages for merge cancels. The message encapsulated by the returned `error` also gets logged by memberlist, so we don't need to pass in a logger for our merge delegate anymore.

Depends on:
hashicorp/memberlist#28
hashicorp/serf#268

Fixes #727