### PR TITLE
Consistent Semaphore

### DIFF
--- a/api/semaphore.go
+++ b/api/semaphore.go
@@ -22,6 +22,10 @@ const (
 	// a Semaphore acquisition.
 	DefaultSemaphoreWaitTime = 15 * time.Second
 
+	// DefaultSemaphoreWatchWaitTime is how long we block for at a time while watching
+	// a semaphore. This affects the minimum time it takes to stop watching.
+	DefaultSemaphoreWatchWaitTime = 5 * time.Second
+
 	// DefaultSemaphoreRetryTime is how long we wait after a failed lock acquisition
 	// before attempting to do the lock again. This is so that once a lock-delay
 	// is in affect, we do not hot loop retrying the acquisition.
@@ -71,7 +75,7 @@ type SemaphoreOptions struct {
 	Prefix      string // Must be set and have write permissions
 	Limit       int    // Must be set, and be positive
 	Value       []byte // Optional, value to associate with the contender entry
-	Session     string // OPtional, created if not specified
+	Session     string // Optional, created if not specified
 	SessionName string // Optional, defaults to DefaultLockSessionName
 	SessionTTL  string // Optional, defaults to DefaultLockSessionTTL
 }
@@ -86,7 +90,23 @@ type semaphoreLock struct {
 	// Holders is a list of all the semaphore holders and available slots.
 	// Its length is always Limit. A session ID in the list marks a slot
 	// as held, while an empty string denotes the slot is available.
-	Holders []string
+	Holders semaphoreHolders
+}
+
+// semaphoreHolders is just an alias so we can extend []string
+type semaphoreHolders []string
+
+// compare against another []string for equality
+func (h semaphoreHolders) Equals(a []string) bool {
+	if len(a) != len(h) {
+		return false
+	}
+	for i, v := range a {
+		if v != h[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // SemaphorePrefix is used to created a Semaphore which will operate
@@ -376,6 +396,90 @@ func (s *Semaphore) Destroy() error {
 	return nil
 }
 
+// Watch continuously monitors a semaphore and provides updates on its
+// result channel whenever there are changes to the semaphore's holders.
+// The updates are in the form of a [][]byte whose length is equal to the
+// Limit of the semaphore. Each entry contains the SemaphoreOptions.Value
+// for the contender who holds that slot in the semaphore. An unheld slot
+// is represented by an empty []byte.
+// Watching will continue until an error occurs or stopCh is closed.
+func (s *Semaphore) Watch(stopCh <-chan struct{}) (<-chan [][]byte, <-chan error) {
+	resultCh := make(chan [][]byte)
+	errCh := make(chan error)
+
+	go func() {
+		defer func() {
+			close(resultCh)
+			close(errCh)
+		}()
+
+		// Setup the query options
+		qOpts := &QueryOptions{
+			WaitTime: DefaultSemaphoreWatchWaitTime,
+		}
+
+		// Our last-known state of lock.Holders
+		var holders semaphoreHolders
+
+		for {
+			// Check if we should quit
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			// Read the prefix
+			kv := s.c.KV()
+			pairs, meta, err := kv.List(s.opts.Prefix, qOpts)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			// If nothing changed, continue watching
+			if qOpts.WaitIndex == meta.LastIndex {
+				continue
+			}
+			qOpts.WaitIndex = meta.LastIndex
+
+			// Find the lock
+			lockPair := s.findLock(pairs)
+			if lockPair.Flags != SemaphoreFlagValue {
+				errCh <- ErrSemaphoreConflict
+				return
+			}
+
+			// Decode the lock
+			lock, err := s.decodeLock(lockPair)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			// Prune dead holders, get Values for alive holders
+			alive := s.pruneDeadHolders(lock, pairs)
+
+			// If the lock holders didn't change, continue watching
+			if holders.Equals(lock.Holders) {
+				continue
+			}
+			holders = lock.Holders
+
+			// Gather Values for alive holders
+			values := make([][]byte, lock.Limit)
+			for i, holder := range lock.Holders {
+				if holder != "" {
+					values[i] = alive[holder]
+				}
+			}
+			resultCh <- values
+		}
+	}()
+
+	return resultCh, errCh
+}
+
 // createSession is used to create a new managed session
 func (s *Semaphore) createSession() (string, error) {
 	session := s.c.Session()
@@ -458,13 +562,14 @@ func (s *Semaphore) findSlot(lock *semaphoreLock, session string) int {
 	return -1
 }
 
-// pruneDeadHolders is used to remove all the dead lock holders
-func (s *Semaphore) pruneDeadHolders(lock *semaphoreLock, pairs KVPairs) {
+// pruneDeadHolders is used to remove all the dead lock holders.
+// The Value from each contender pair is returned for all living lock holders.
+func (s *Semaphore) pruneDeadHolders(lock *semaphoreLock, pairs KVPairs) map[string][]byte {
 	// Gather all the live holders
-	alive := make(map[string]struct{}, len(pairs))
+	alive := make(map[string][]byte, len(pairs))
 	for _, pair := range pairs {
 		if pair.Session != "" {
-			alive[pair.Session] = struct{}{}
+			alive[pair.Session] = pair.Value
 		}
 	}
 
@@ -476,6 +581,8 @@ func (s *Semaphore) pruneDeadHolders(lock *semaphoreLock, pairs KVPairs) {
 			}
 		}
 	}
+
+	return alive
 }
 
 // monitorLock is a long running routine to monitor a semaphore ownership


### PR DESCRIPTION
I'd like to just present this PR for discussion.  It is **not** backward-compatible with existing Semaphores because the data structure used for the lock has changed.

I really like the multi-holder Semaphore that was introduced in 0.5, and I was hoping I could use it as the basis for a fixed-size hash ring.  For a ring of size N, the basic requirements are:
1. Enforce that there are <= N participants
2. Nodes should not migrate when any individual node's membership changes.  i.e. Once a node claims a slot `n`, they hold slot `n` until they lose the lock.
3. Have the ability to inspect the ring: "who holds each slot?"

The existing Semaphore implementation provides (1) and some of (2).
Without changing the existing behavior of Semaphore, this PR modifies it to also accomplish the remainder of (2) and it implements (3).

For (2):  `semaphoreLock.Holders` was changed from a map to a fixed size array (slice).
This effectively turns the Semaphore into a discrete list of slots that can be held, instead of an unordered pool of lock holders.  The length of `semaphoreLock.Holders` is always equal to the Semaphore's Limit.  Each entry is the session of the holder, or "" if nobody has that slot.

Note: there is some efficiency loss because you have to search for empty slots when acquiring, and you search for yourself when monitoring.

For (3): Added `Semaphore.Watch()`
A long running goroutine is started to continuously monitor a Semaphore's lock holders.  Whenever membership changes, a slice (of length Limit) is sent to the result channel containing the new state of the Semaphore.  Instead of providing the sessionID of each lock holder, which would be useless, each Semaphore slot is represented by: either an empty `[]byte` if the slot is not held, or more interestingly, the `SemaphoreSession.Value` for the lock holder who holds that slot.

Example:
```go
re01, _ := client.SemaphoreOpts(&SemaphoreOptions{                                                
    Prefix: "semaphore/cacheRing",
    Limit:  3,
    Value:  []byte(`{"host": "re01", "port": 4000}`),
})
re01.Acquire(nil)

watcher, _ := client.SemaphorePrefix("semaphore/cacheRing", 3)
resultCh, _ := watcher.Watch(nil)
<-resultCh  // [ {"host": "re01", "port": 4000},  []byte, []byte ]

re02, _ := client.SemaphoreOpts(&SemaphoreOptions{                                                
    Prefix: "semaphore/cacheRing",
    Limit:  3,
    Value:  []byte(`{"host": "re02", "port": 4000}`),
})
re02.Acquire(nil)

<-resultCh  // [ {"host": "re01", "port": 4000},  {"host": "re02", "port": 4000}, []byte ]
```

Curious about your thoughts on supporting this behavior... and whether or not it should exist within Semaphore.  Cheers.