### PR TITLE
Add 'ServiceAddress' field to 'CatalogService's truct

### DIFF
--- a/api/catalog.go
+++ b/api/catalog.go
@@ -6,12 +6,13 @@ type Node struct {
 }
 
 type CatalogService struct {
-	Node        string
-	Address     string
-	ServiceID   string
-	ServiceName string
-	ServiceTags []string
-	ServicePort int
+	Node           string
+	Address        string
+	ServiceID      string
+	ServiceName    string
+	ServiceAddress string
+	ServiceTags    []string
+	ServicePort    int
 }
 
 type CatalogNode struct {


### PR DESCRIPTION
This fixes #753 and allows an API user to get the ServiceAddress of a Service. With the current Implementation, it is only possible to retrieve the Agent address.

