### PR TITLE
Add Terraform Variable for AWS instance type

### DIFF
--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -1,6 +1,6 @@
 resource "aws_instance" "server" {
     ami = "${lookup(var.ami, var.region)}"
-    instance_type = "m1.small"
+    instance_type = "${var.instance_type}"
     key_name = "${var.key_name}"
     count = "${var.servers}"
     security_groups = ["${aws_security_group.consul.name}"]

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -22,3 +22,8 @@ variable "servers" {
     default = "3"
     description = "The number of Consul servers to launch."
 }
+
+variable "instance_type" {
+    default = "m1.small"
+    description = "The instance type to launch."
+}


### PR DESCRIPTION
Details:
* Adds an input variable to the consul terraform template module to
  allow a user of the module to specify a different
  AWS instance type to launch.
* The default is still "m1.small".
* The module input variable is named "instance_type".