### PR TITLE
Reduce SessionTTLMin to 1 second

### DIFF
--- a/command/agent/session_endpoint_test.go
+++ b/command/agent/session_endpoint_test.go
@@ -3,12 +3,13 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/hashicorp/consul/consul"
-	"github.com/hashicorp/consul/consul/structs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/consul"
+	"github.com/hashicorp/consul/consul/structs"
 )
 
 func TestSessionCreate(t *testing.T) {
@@ -287,7 +288,7 @@ func TestSessionBadTTL(t *testing.T) {
 		body = bytes.NewBuffer(nil)
 		enc = json.NewEncoder(body)
 		raw = map[string]interface{}{
-			"TTL": "5s",
+			"TTL": "900ms",
 		}
 		enc.Encode(raw)
 

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -391,7 +391,7 @@ const (
 )
 
 const (
-	SessionTTLMin        = 10 * time.Second
+	SessionTTLMin        = 1 * time.Second
 	SessionTTLMax        = 3600 * time.Second
 	SessionTTLMultiplier = 2
 )


### PR DESCRIPTION
Reducing the minimum Session TTL.

We originally tried to make it configurable but you could accidentally have your agents and servers allow different values. We felt this was the better approach.

Signed-off-by: Michael Fraenkel <fraenkel@us.ibm.com>