### PR TITLE
Add -domain command line flag to agent

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -75,6 +75,7 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.BoolVar(&cmdConfig.Server, "server", false, "run agent as server")
 	cmdFlags.BoolVar(&cmdConfig.Bootstrap, "bootstrap", false, "enable server bootstrap mode")
 	cmdFlags.IntVar(&cmdConfig.BootstrapExpect, "bootstrap-expect", 0, "enable automatic bootstrap via expect mode")
+	cmdFlags.StringVar(&cmdConfig.Domain, "domain", "", "domain to use for DNS interface")
 
 	cmdFlags.StringVar(&cmdConfig.ClientAddr, "client", "", "address to bind client listeners to (DNS, HTTP, HTTPS, RPC)")
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind server listeners to")

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -112,6 +112,10 @@ The options below are all specified on the command-line.
   it relies on proper configuration. Nodes in the same datacenter should be on a single
   LAN.
 
+* <a name="_domain"></a><a href="#_domain">`-domain`</a> - By default, Consul responds to DNS queries
+  in the "consul." domain. This flag can be used to change that domain. All queries in this domain
+  are assumed to be handled by Consul and will not be recursively resolved.
+
 * <a name="_encrypt"></a><a href="#_encrypt">`-encrypt`</a> - Specifies the secret key to
   use for encryption of Consul
   network traffic. This key must be 16-bytes that are Base64-encoded. The
@@ -405,9 +409,8 @@ definitions support being updated during a reload.
   nodes whose healthchecks are not passing will be excluded from DNS results. By default (or
   if set to false), only nodes whose healthchecks are failing as critical will be excluded.
 
-* <a name="domain"></a><a href="#domain">`domain`</a> By default, Consul responds to DNS queries
-  in the "consul." domain. This flag can be used to change that domain. All queries in this domain
-  are assumed to be handled by Consul and will not be recursively resolved.
+* <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the
+  [`-domain` command-line flag](#_domain).
 
 * <a name="enable_debug"></a><a href="#enable_debug">`enable_debug`</a> When set, enables some
   additional debugging features. Currently, this is only used to set the runtime profiling HTTP endpoints.


### PR DESCRIPTION
This makes it possible to configure the domain on the command line
additionally to the config file.

I'm not sure why some things can be specified as command line flags and other only in the config, but I think the domain is such common option that it's worth adding it to the flags. This also makes it easier to configure consul when running as docker containers.