### PR TITLE
Handle SIGTERM when running commands

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/hashicorp/consul/command"
 	"github.com/hashicorp/consul/command/agent"
@@ -136,12 +137,12 @@ func init() {
 
 // makeShutdownCh returns a channel that can be used for shutdown
 // notifications for commands. This channel will send a message for every
-// interrupt received.
+// interrupt or SIGTERM received.
 func makeShutdownCh() <-chan struct{} {
 	resultCh := make(chan struct{})
 
 	signalCh := make(chan os.Signal, 4)
-	signal.Notify(signalCh, os.Interrupt)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		for {
 			<-signalCh


### PR DESCRIPTION
Make Consul treat SIGTERM like it does SIGINT when running commands.
This is especially important when running Consul as a daemon, since
Unix process managers send SIGTERM to restart or terminate a process.

This change is untested on Windows.

Fixes hashicorp/consul#797