### PR TITLE
Add XXX to the end of mktemp template to support more linux versions.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Create a temp dir and clean it up on exit
-TEMPDIR=`mktemp -d -t consul-test`
+TEMPDIR=`mktemp -d -t consul-test.XXX`
 trap "rm -rf $TEMPDIR" EXIT HUP INT QUIT TERM
 
 # Build the Consul binary for the API tests


### PR DESCRIPTION
From the Ubuntu 12.04 mktemp man page: 
"TEMPLATE must contain at least 3 consecutive 'X's in last component."