### PR TITLE
Allow specifying a status field when registering checks.

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -68,6 +68,7 @@ type AgentServiceCheck struct {
 	Timeout  string `json:",omitempty"`
 	TTL      string `json:",omitempty"`
 	HTTP     string `json:",omitempty"`
+	Status   string `json:",omitempty"`
 }
 type AgentServiceChecks []*AgentServiceCheck
 

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -63,17 +63,84 @@ func TestAgent_Services(t *testing.T) {
 	if _, ok := services["foo"]; !ok {
 		t.Fatalf("missing service: %v", services)
 	}
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	chk, ok := checks["service:foo"]
+	if !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+
+	// Checks should default to critical
+	if chk.Status != "critical" {
+		t.Fatalf("Bad: %#v", chk)
+	}
+
+	if err := agent.ServiceDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_Services_CheckPassing(t *testing.T) {
+	c, s := makeClient(t)
+	defer s.stop()
+
+	agent := c.Agent()
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Tags: []string{"bar", "baz"},
+		Port: 8000,
+		Check: &AgentServiceCheck{
+			TTL:    "15s",
+			Status: "passing",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	services, err := agent.Services()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := services["foo"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
 
 	checks, err := agent.Checks()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, ok := checks["service:foo"]; !ok {
+	chk, ok := checks["service:foo"]
+	if !ok {
 		t.Fatalf("missing check: %v", checks)
 	}
 
+	if chk.Status != "passing" {
+		t.Fatalf("Bad: %#v", chk)
+	}
 	if err := agent.ServiceDeregister("foo"); err != nil {
 		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_Services_CheckBadStatus(t *testing.T) {
+	c, s := makeClient(t)
+	defer s.stop()
+
+	agent := c.Agent()
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Tags: []string{"bar", "baz"},
+		Port: 8000,
+		Check: &AgentServiceCheck{
+			TTL:    "15s",
+			Status: "fluffy",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err == nil {
+		t.Fatalf("bad status accepted")
 	}
 }
 
@@ -224,8 +291,46 @@ func TestAgent_Checks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, ok := checks["foo"]; !ok {
+	chk, ok := checks["foo"]
+	if !ok {
 		t.Fatalf("missing check: %v", checks)
+	}
+	if chk.Status != "critical" {
+		t.Fatalf("check not critical: %v", chk)
+	}
+
+	if err := agent.CheckDeregister("foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestAgent_CheckStartPassing(t *testing.T) {
+	c, s := makeClient(t)
+	defer s.stop()
+
+	agent := c.Agent()
+
+	reg := &AgentCheckRegistration{
+		Name: "foo",
+		AgentServiceCheck: AgentServiceCheck{
+			Status: "passing",
+		},
+	}
+	reg.TTL = "15s"
+	if err := agent.CheckRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	chk, ok := checks["foo"]
+	if !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+	if chk.Status != "passing" {
+		t.Fatalf("check not passing: %v", chk)
 	}
 
 	if err := agent.CheckDeregister("foo"); err != nil {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -645,6 +645,9 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes CheckTypes, pe
 			ServiceID:   service.ID,
 			ServiceName: service.Service,
 		}
+		if chkType.Status != "" {
+			check.Status = chkType.Status
+		}
 		if err := a.AddCheck(check, chkType, persist); err != nil {
 			return err
 		}

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -86,6 +86,12 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 		return nil, nil
 	}
 
+	if args.Status != "" && !structs.ValidStatus(args.Status) {
+		resp.WriteHeader(400)
+		resp.Write([]byte("Bad check status"))
+		return nil, nil
+	}
+
 	// Construct the health check
 	health := args.HealthCheck(s.agent.config.NodeName)
 
@@ -192,6 +198,11 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	// Verify the check type
 	chkTypes := args.CheckTypes()
 	for _, check := range chkTypes {
+		if check.Status != "" && !structs.ValidStatus(check.Status) {
+			resp.WriteHeader(400)
+			resp.Write([]byte("Status for checks must 'passing', 'warning', 'critical', 'unknown'"))
+			return nil, nil
+		}
 		if !check.Valid() {
 			resp.WriteHeader(400)
 			resp.Write([]byte("Must provide TTL or Script and Interval!"))

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -39,6 +39,8 @@ type CheckType struct {
 	Timeout time.Duration
 	TTL     time.Duration
 
+	Status string
+
 	Notes string
 }
 type CheckTypes []*CheckType

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -45,6 +45,7 @@ type CheckDefinition struct {
 	Name      string
 	Notes     string
 	ServiceID string
+	Status    string
 	CheckType `mapstructure:",squash"`
 }
 
@@ -56,6 +57,9 @@ func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 		Status:    structs.HealthCritical,
 		Notes:     c.Notes,
 		ServiceID: c.ServiceID,
+	}
+	if c.Status != "" {
+		health.Status = c.Status
 	}
 	if health.CheckID == "" && health.Name != "" {
 		health.CheckID = health.Name

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -36,6 +36,13 @@ const (
 	HealthCritical = "critical"
 )
 
+func ValidStatus(s string) bool {
+	return s == HealthUnknown ||
+		s == HealthPassing ||
+		s == HealthWarning ||
+		s == HealthCritical
+}
+
 const (
 	// Client tokens have rules applied
 	ACLTypeClient = "client"

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -37,8 +37,7 @@ const (
 )
 
 func ValidStatus(s string) bool {
-	return s == HealthUnknown ||
-		s == HealthPassing ||
+	return s == HealthPassing ||
 		s == HealthWarning ||
 		s == HealthCritical
 }


### PR DESCRIPTION
Allow specifying a status field in the agent/service/register and agent/check/register endpoints.

This status must be one of the valid check statuses: 'passing', 'warning', 'critical', 'unknown'.
If the status field is not present or the empty string, the default of 'critical' is used.

This resolves issue #706 

Feedback welcome on anything, of course, but I'm particularly interested in:
 * Where should the ValidStatus function (in consul/structs/structs.go) go? What should it be named?
 * Should the unknown status be acceptable when creating a new check?