### PR TITLE
Return all CNAME's during service DNS resolution

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -426,13 +426,10 @@ func (d *DNSServer) formatNodeRecord(node *structs.Node, addr, qName string, qTy
 
 		// Recurse
 		more := d.resolveCNAME(cnRec.Target)
-		extra := 0
 	MORE_REC:
-		for _, rr := range more {
+		for extra, rr := range more {
 			switch rr.Header().Rrtype {
-			case dns.TypeA:
-				fallthrough
-			case dns.TypeAAAA:
+			case dns.TypeCNAME, dns.TypeA, dns.TypeAAAA:
 				records = append(records, rr)
 				extra++
 				if extra == maxRecurseRecords {

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	maxServiceResponses = 3 // For UDP only
-	maxRecurseRecords   = 3
+	maxRecurseRecords   = 5
 )
 
 // DNSServer is used to wrap an Agent and expose various
@@ -426,8 +426,9 @@ func (d *DNSServer) formatNodeRecord(node *structs.Node, addr, qName string, qTy
 
 		// Recurse
 		more := d.resolveCNAME(cnRec.Target)
+		extra := 0
 	MORE_REC:
-		for extra, rr := range more {
+		for _, rr := range more {
 			switch rr.Header().Rrtype {
 			case dns.TypeCNAME, dns.TypeA, dns.TypeAAAA:
 				records = append(records, rr)


### PR DESCRIPTION
Fixes #321. This adds all of the CNAME's in the resolution chain to the result when a service's `Address` field contains a name which chains DNS CNAME's. An example is RDS. Simple change, hard test.

Thanks to @alouche and @cwstrommer for the repro and example fix.