### PR TITLE
Integrate godep for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ ui/dist/
 
 website/.bundle
 website/vendor
+
+Godeps/_workspace

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,9 +1,9 @@
 {
 	"ImportPath": "github.com/hashicorp/consul",
 	"GoVersion": "go1.4",
-	"Packages": [
-		"./..."
-	],
+        "Packages": [
+                "./..."
+        ],
 	"Deps": [
 		{
 			"ImportPath": "github.com/armon/circbuf",
@@ -23,8 +23,8 @@
 		},
 		{
 			"ImportPath": "github.com/boltdb/bolt",
-			"Comment": "v1.0-72-g8a2a9b2",
-			"Rev": "8a2a9b2eb7123c41ea752bab494ff046909e9473"
+			"Comment": "v1.0-79-g2c04100",
+			"Rev": "2c04100eb9793f2b8541d243494e2909d2112325"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/consul-migrate/migrator",
@@ -49,7 +49,7 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/golang-lru",
-			"Rev": "d85392d6bc30546d352f52f2632814cde4201d44"
+			"Rev": "995efda3e073b6946b175ed93901d729ad47466a"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/hcl",
@@ -61,7 +61,7 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/memberlist",
-			"Rev": "dad1009e26ac60199c094f2e91cdd7769a7f46cc"
+			"Rev": "6025015f2dc659ca2c735112d37e753bda6e329d"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/net-rpc-msgpackrpc",
@@ -69,7 +69,7 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/raft",
-			"Rev": "6c2c8a2375827c2cb41d0028e2fb5fe016b10619"
+			"Rev": "a8065f298505708bf60f518c09178149f3c06f21"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/raft-boltdb",
@@ -85,8 +85,8 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/serf/serf",
-			"Comment": "v0.6.4-9-g4bd6183",
-			"Rev": "4bd6183181bad5ae211029873279fb74ceace07c"
+			"Comment": "v0.6.4-13-g558a687",
+			"Rev": "558a6876882b2c5c61df29fd3990fb1765fd71d3"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/yamux",
@@ -98,11 +98,11 @@
 		},
 		{
 			"ImportPath": "github.com/miekg/dns",
-			"Rev": "5a357a6fc5e85268b929350aa6423e2d56dcc4ff"
+			"Rev": "bb1103f648f811d2018d4bedcb2d4b2bce34a0f1"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/cli",
-			"Rev": "afc399c273e70173826fb6f518a48edff23fe897"
+			"Rev": "6cc8bc522243675a2882b81662b0b0d2e04b99c9"
 		},
 		{
 			"ImportPath": "github.com/mitchellh/mapstructure",
@@ -112,6 +112,10 @@
 			"ImportPath": "github.com/ryanuber/columnize",
 			"Comment": "v2.0.1-6-g44cb478",
 			"Rev": "44cb4788b2ec3c3d158dd3d1b50aba7d66f4b59a"
+		},
+		{
+			"ImportPath": "golang.org/x/crypto/ssh/terminal",
+			"Rev": "74f810a0152f4c50a16195f6b9ff44afc35594e8"
 		}
 	]
 }

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,117 @@
+{
+	"ImportPath": "github.com/hashicorp/consul",
+	"GoVersion": "go1.4",
+	"Packages": [
+		"./..."
+	],
+	"Deps": [
+		{
+			"ImportPath": "github.com/armon/circbuf",
+			"Rev": "f092b4f207b6e5cce0569056fba9e1a2735cb6cf"
+		},
+		{
+			"ImportPath": "github.com/armon/go-metrics",
+			"Rev": "a54701ebec11868993bc198c3f315353e9de2ed6"
+		},
+		{
+			"ImportPath": "github.com/armon/go-radix",
+			"Rev": "0bab926c3433cfd6490c6d3c504a7b471362390c"
+		},
+		{
+			"ImportPath": "github.com/armon/gomdb",
+			"Rev": "151f2e08ef45cb0e57d694b2562f351955dff572"
+		},
+		{
+			"ImportPath": "github.com/boltdb/bolt",
+			"Comment": "v1.0-72-g8a2a9b2",
+			"Rev": "8a2a9b2eb7123c41ea752bab494ff046909e9473"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/consul-migrate/migrator",
+			"Comment": "v0.1.0",
+			"Rev": "4977886fc950a0db1a6f0bbadca56dfabf170f9c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/go-checkpoint",
+			"Rev": "88326f6851319068e7b34981032128c0b1a6524d"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/go-msgpack/codec",
+			"Rev": "71c2886f5a673a35f909803f38ece5810165097b"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/go-multierror",
+			"Rev": "fcdddc395df1ddf4247c69bd436e84cfa0733f7e"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/go-syslog",
+			"Rev": "42a2b573b664dbf281bd48c3cc12c086b17a39ba"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "d85392d6bc30546d352f52f2632814cde4201d44"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/hcl",
+			"Rev": "513e04c400ee2e81e97f5e011c08fb42c6f69b84"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/logutils",
+			"Rev": "367a65d59043b4f846d179341d138f01f988c186"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/memberlist",
+			"Rev": "dad1009e26ac60199c094f2e91cdd7769a7f46cc"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/net-rpc-msgpackrpc",
+			"Rev": "d377902b7aba83dd3895837b902f6cf3f71edcb2"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/raft",
+			"Rev": "6c2c8a2375827c2cb41d0028e2fb5fe016b10619"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/raft-boltdb",
+			"Rev": "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/raft-mdb",
+			"Rev": "4ec3694ffbc74d34f7532e70ef2e9c3546a0c0b0"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/scada-client",
+			"Rev": "c26580cfe35393f6f4bf1b9ba55e6afe33176bae"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/serf/serf",
+			"Comment": "v0.6.4-9-g4bd6183",
+			"Rev": "4bd6183181bad5ae211029873279fb74ceace07c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/yamux",
+			"Rev": "b2e55852ddaf823a85c67f798080eb7d08acd71d"
+		},
+		{
+			"ImportPath": "github.com/inconshreveable/muxado",
+			"Rev": "f693c7e88ba316d1a0ae3e205e22a01aa3ec2848"
+		},
+		{
+			"ImportPath": "github.com/miekg/dns",
+			"Rev": "5a357a6fc5e85268b929350aa6423e2d56dcc4ff"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/cli",
+			"Rev": "afc399c273e70173826fb6f518a48edff23fe897"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "442e588f213303bec7936deba67901f8fc8f18b1"
+		},
+		{
+			"ImportPath": "github.com/ryanuber/columnize",
+			"Comment": "v2.0.1-6-g44cb478",
+			"Rev": "44cb4788b2ec3c3d158dd3d1b50aba7d66f4b59a"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
-PACKAGES = $(shell go list ./...)
+TEST_DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods \
          -nilfunc -printf -rangeloops -shift -structtags -unsafeptr
 
@@ -11,13 +10,16 @@ cov:
 	gocov test ./... | gocov-html > /tmp/coverage.html
 	open /tmp/coverage.html
 
-deps:
-	@echo "--> Installing build dependencies"
-	@go get -d -v ./... $(DEPS)
+deps: godep
+	@echo "--> Installing build dependencies (resets versions using godep)"
+	@godep restore ./...
 
-updatedeps: deps
+updatedeps:
 	@echo "--> Updating build dependencies"
-	@go get -d -f -u ./... $(DEPS)
+	@go get -u github.com/tools/godep
+	@go get -d -f -u ./... $(TEST_DEPS)
+	@rm -rf ./Godeps/_workspace
+	@godep save ./...
 
 test: deps
 	@./scripts/verify_no_uuid.sh
@@ -33,7 +35,7 @@ cover: deps
 
 format: deps
 	@echo "--> Running go fmt"
-	@go fmt $(PACKAGES)
+	@go fmt ./...
 
 vet:
 	@go tool vet 2>/dev/null ; if [ $$? -eq 3 ]; then \
@@ -46,10 +48,13 @@ vet:
 		echo "and fix them if necessary before submitting the code for reviewal."; \
 	fi
 
+godep:
+	@go get github.com/tools/godep
+
 web:
 	./scripts/website_run.sh
 
 web-push:
 	./scripts/website_push.sh
 
-.PHONY: all cov deps integ test vet web web-push test-nodep
+.PHONY: all cov deps integ test vet web web-push test-nodep godep

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,13 +39,14 @@ fi
 
 # Install dependencies
 echo "--> Installing dependencies to speed up builds..."
-go get \
+go get -u github.com/tools/godep
+godep go install \
   -ldflags "${CGO_LDFLAGS}" \
   ./...
 
 # Build!
 echo "--> Building..."
-go build \
+godep go build \
     -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe ${GIT_DESCRIBE}" \
     -v \
     -o bin/consul${EXTENSION}

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -30,11 +30,12 @@ del /F "%_GIT_DESCRIBE_FILE%" 2>NUL
 
 :: Install dependencies
 echo --^> Installing dependencies to speed up builds...
-go get .\...
+go get github.com/tools/godep
+godep go get .\...
 
 :: Build!
 echo --^> Building...
-go build^
+godep go build^
  -ldflags "-X main.GitCommit %_GIT_COMMIT%%_GIT_DIRTY% -X main.GitDescribe %_GIT_DESCRIBE%"^
  -v^
  -o bin\consul.exe .


### PR DESCRIPTION
Use godep for dependency managedment:

- Don't commit dependency source code, only the dependency list (Godep.json)
- Update build scripts and Makfiles to install and use godep

One problem this introduces is `make vet` now shows vet problems from dependencies in Godep/_workspace, I am planning on submitting pull requests to fix those issues.

