### PR TITLE
Allow configuring the stats prefix

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -567,7 +567,7 @@ func (c *Command) Run(args []string) int {
 	*/
 	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(inm)
-	metricsConf := metrics.DefaultConfig("consul")
+	metricsConf := metrics.DefaultConfig(config.StatsitePrefix)
 
 	// Configure the statsite sink
 	var fanout metrics.FanoutSink

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -160,6 +160,10 @@ type Config struct {
 	// metrics will be streamed to that instance.
 	StatsiteAddr string `mapstructure:"statsite_addr"`
 
+	// StatsitePrefix is the prefix used to write stats values to. By
+	// default this is set to 'consul'.
+	StatsitePrefix string `mapstructure:"statsite_prefix"`
+
 	// StatsdAddr is the address of a statsd instance. If provided,
 	// metrics will be sent to that instance.
 	StatsdAddr string `mapstructure:"statsd_addr"`
@@ -429,6 +433,7 @@ func DefaultConfig() *Config {
 		DNSConfig: DNSConfig{
 			MaxStale: 5 * time.Second,
 		},
+		StatsitePrefix:      "consul",
 		SyslogFacility:      "LOCAL0",
 		Protocol:            consul.ProtocolVersionMax,
 		CheckUpdateInterval: 5 * time.Minute,
@@ -810,6 +815,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.StatsiteAddr != "" {
 		result.StatsiteAddr = b.StatsiteAddr
+	}
+	if b.StatsitePrefix != "" {
+		result.StatsitePrefix = b.StatsitePrefix
 	}
 	if b.StatsdAddr != "" {
 		result.StatsdAddr = b.StatsdAddr

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -568,6 +568,16 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Statsite prefix
+	input = `{"statsite_prefix": "my_prefix"}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.StatsitePrefix != "my_prefix" {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// Address overrides
 	input = `{"addresses": {"dns": "0.0.0.0", "http": "127.0.0.1", "https": "127.0.0.1", "rpc": "127.0.0.1"}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1114,6 +1124,7 @@ func TestMergeConfig(t *testing.T) {
 		},
 		DisableRemoteExec:         true,
 		StatsiteAddr:              "127.0.0.1:7250",
+		StatsitePrefix:            "stats_prefix",
 		StatsdAddr:                "127.0.0.1:7251",
 		DisableUpdateCheck:        true,
 		DisableAnonymousSignature: true,

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -526,6 +526,10 @@ definitions support being updated during a reload.
   aggregation. This can be used to capture runtime information. This streams via
   TCP and can only be used with statsite.
 
+* <a name="statsite_prefix"></a><a href="#statsite_prefix">`statsite_prefix`</a>
+  The prefix used while writing all telemetry data to statsite. By default, this
+  is set to "consul".
+
 * <a name="syslog_facility"></a><a href="#syslog_facility">`syslog_facility`</a> When
   [`enable_syslog`](#enable_syslog) is provided, this controls to which
   facility messages are sent. By default, `LOCAL0` will be used.


### PR DESCRIPTION
Allows specifying a `statsite_prefix`. This can be useful to separate stats for different clusters when using a common stats backend. Fixes #898.