### PR TITLE
Support ACL upsert behavior

### DIFF
--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -2,9 +2,10 @@ package agent
 
 import (
 	"fmt"
-	"github.com/hashicorp/consul/consul/structs"
 	"net/http"
 	"strings"
+
+	"github.com/hashicorp/consul/consul/structs"
 )
 
 // aclCreateResponse is used to wrap the ACL ID
@@ -80,14 +81,8 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 		}
 	}
 
-	// Ensure there is no ID set for create
-	if !update && args.ACL.ID != "" {
-		resp.WriteHeader(400)
-		resp.Write([]byte(fmt.Sprintf("ACL ID cannot be set")))
-		return nil, nil
-	}
-
-	// Ensure there is an ID set for update
+	// Ensure there is an ID set for update. ID is optional for
+	// create, as one will be generated if not provided.
 	if update && args.ACL.ID == "" {
 		resp.WriteHeader(400)
 		resp.Write([]byte(fmt.Sprintf("ACL ID must be set")))

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -3,10 +3,11 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/hashicorp/consul/consul/structs"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hashicorp/consul/consul/structs"
 )
 
 func makeTestACL(t *testing.T, srv *HTTPServer) string {
@@ -57,6 +58,34 @@ func TestACLUpdate(t *testing.T) {
 		}
 		aclResp := obj.(aclCreateResponse)
 		if aclResp.ID != id {
+			t.Fatalf("bad: %v", aclResp)
+		}
+	})
+}
+
+func TestACLUpdate_Upsert(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		body := bytes.NewBuffer(nil)
+		enc := json.NewEncoder(body)
+		raw := map[string]interface{}{
+			"ID":    "my-old-id",
+			"Name":  "User Token 2",
+			"Type":  "client",
+			"Rules": "",
+		}
+		enc.Encode(raw)
+
+		req, err := http.NewRequest("PUT", "/v1/acl/update?token=root", body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		resp := httptest.NewRecorder()
+		obj, err := srv.ACLUpdate(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		aclResp := obj.(aclCreateResponse)
+		if aclResp.ID != "my-old-id" {
 			t.Fatalf("bad: %v", aclResp)
 		}
 	})

--- a/website/source/docs/agent/http/acl.html.markdown
+++ b/website/source/docs/agent/http/acl.html.markdown
@@ -54,6 +54,10 @@ None of the fields are mandatory. In fact, no body needs to be PUT if the
 defaults are to be used. The `Name` and `Rules` fields default to being
 blank, and the `Type` defaults to "client".
 
+The `ID` field may be provided, and if omitted a random UUID will be generated.
+The security of the ACL system depends on the difficulty of guessing the token.
+Tokens should not be generated in a predictable manner or with too little entropy.
+
 The format of the `Rules` property is [documented here](/docs/internals/acl.html).
 
 A successful response body will return the `ID` of the newly created ACL, like so:
@@ -69,8 +73,8 @@ A successful response body will return the `ID` of the newly created ACL, like s
 The update endpoint is used to modify the policy for a given ACL token. It
 is very similar to the create endpoint; however, instead of generating a new
 token ID, the `ID` field must be provided. As with [`/v1/acl/create`](#acl_create),
-requests to this endpoint must be made with a management
-token.
+requests to this endpoint must be made with a management token. If the ID does not
+exist, the ACL will be upserted. In this sense, create and update are identical.
 
 In any Consul cluster, only a single datacenter is authoritative for ACLs, so
 all requests are automatically routed to that datacenter regardless


### PR DESCRIPTION
Fixes #777. Previously, there was an ACL create endpoint, which did not permit providing an ID and always randomly generated an ID. There was also an update endpoint, which required an ID and that the ACL must exist.

This meant it was not possible to restore tokens (from backup) since the token ID was always re-generated. It also made it difficult to generate an ID external to Consul, which can be useful for systems like Vault.

This PR changes the behavior to an upsert. If an ID is not provided, a random UUID will be generated. Create and Update do not require the ACL to exist already, allowing for ACL restoration or external generation.

This should not break any existing clients, but enables some new use cases. However, there is basically no difference between create and update, but the endpoints must exist for backwards compatibility reasons.

