### PR TITLE
Multiple config dir help text

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -895,7 +895,7 @@ Options:
   -config-dir=foo          Path to a directory to read configuration files
                            from. This will read every file ending in ".json"
                            as configuration in this directory in alphabetical
-                           order.
+                           order. This can be specified multiple times.
   -data-dir=path           Path to a data directory to store agent state
   -recursor=1.2.3.4        Address of an upstream DNS server.
                            Can be specified multiple times.

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -104,8 +104,9 @@ The options below are all specified on the command-line.
   load all files in this directory with the suffix ".json". The load order
   is alphabetical, and the the same merge routine is used as with the
   [`config-file`](#_config_file) option above. This option can be specified mulitple times
-  to load multiple directories. For more information on the format of the configuration files,
-  see the [Configuration Files](#configuration_files) section.
+  to load multiple directories. Sub-directories of the config directory are not loaded.
+  For more information on the format of the configuration files, see the
+  [Configuration Files](#configuration_files) section.
 
 * <a name="_data_dir"></a><a href="#_data_dir">`-data-dir`</a> - This flag provides
   a data directory for the agent to store state.

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -103,8 +103,9 @@ The options below are all specified on the command-line.
   configuration files to load. Consul will
   load all files in this directory with the suffix ".json". The load order
   is alphabetical, and the the same merge routine is used as with the
-  [`config-file`](#_config_file) option above. For more information
-  on the format of the configuration files, see the [Configuration Files](#configuration_files) section.
+  [`config-file`](#_config_file) option above. This option can be specified mulitple times
+  to load multiple directories. For more information on the format of the configuration files,
+  see the [Configuration Files](#configuration_files) section.
 
 * <a name="_data_dir"></a><a href="#_data_dir">`-data-dir`</a> - This flag provides
   a data directory for the agent to store state.


### PR DESCRIPTION
Since the consul agent lets you specify multiple configuration directories, I thought it would be nice to document that. From reading the agent docs, it wasn't intuitive that all sub directories under a config directory are not read by default so I added documentation on that as well. 