### PR TITLE
added gradle-consul-plugin to the community tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -105,6 +105,9 @@ description: |-
       <li>
         <a href="https://github.com/progrium/registrator">registrator</a> - Service registry bridge for Docker
       </li>
+	  <li>
+		<a href="https://github.com/amirkibbar/red-apple">gradle-consul-plugin</a> - A Consul Gradle plugin
+	  </li>
     </ul>
 
     <p>


### PR DESCRIPTION
I'd like to add the gradle-consul-plugin to the community tools page. @armon requested that I'd do that using a pull request.