### PR TITLE
Cleans up Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
 SRCROOT="/opt/go"
+SRCPATH="/opt/gopath"
 
 # Get the ARCH
 ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
@@ -16,18 +17,22 @@ sudo apt-get install -y build-essential git-core
 
 # Install Go
 cd /tmp
-wget --no-check-certificate https://storage.googleapis.com/golang/go1.4.2.linux-${ARCH}.tar.gz
+wget --quiet --no-check-certificate https://storage.googleapis.com/golang/go1.4.2.linux-${ARCH}.tar.gz
 tar -xvf go1.4.2.linux-${ARCH}.tar.gz
 sudo mv go $SRCROOT
 sudo chmod 775 $SRCROOT
 sudo chown vagrant:vagrant $SRCROOT
 
-# Setup the GOPATH
-sudo mkdir -p /opt/gopath
+# Setup the GOPATH; even though the shared folder spec gives the consul
+# directory the right user/group, we need to set it properly on the
+# parent path to allow subsequent "go get" commands to work.
+sudo mkdir -p $SRCPATH
+sudo chown -R vagrant:vagrant $SRCPATH
+
 cat <<EOF >/tmp/gopath.sh
-export GOPATH="/opt/gopath"
-export GOROOT="/opt/go"
-export PATH="/opt/go/bin:\$GOPATH/bin:\$PATH"
+export GOPATH="$SRCPATH"
+export GOROOT="$SRCROOT"
+export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
 sudo mv /tmp/gopath.sh /etc/profile.d/gopath.sh
 sudo chmod 0755 /etc/profile.d/gopath.sh
@@ -38,7 +43,7 @@ go get golang.org/x/tools/cmd/cover
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.provision 'shell', inline: @script
+  config.vm.provision 'shell', inline: @script, privileged: false
   config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/consul'
 
   %w[vmware_fusion vmware_workstation].each do |_|
@@ -49,6 +54,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
+  # Note we use older boxes here to avoid glibc version check problems with
+  # the built C dependencies.
   config.vm.define '64bit' do |n1|
     n1.vm.box = 'chef/ubuntu-10.04'
   end


### PR DESCRIPTION
 * Fixes up permissions so `make` runs cleanly after bringing up an environment.
 * Adds better use of variables for Go paths.
 * Adds a note about the ancient boxes.
 * Silences wget spam while provisioning.