### PR TITLE
nit: Condense switch fallthroughs into expression lists

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -638,13 +638,7 @@ func (c *Command) Run(args []string) int {
 						c.Ui.Output(update.Op)
 						c.Ui.Info(fmt.Sprintf("%.2f%%", update.Progress))
 
-					case update.Progress-lastProgress >= 5:
-						fallthrough
-
-					case time.Now().Sub(lastFlush) > time.Second:
-						fallthrough
-
-					case update.Progress == 100:
+					case update.Progress-lastProgress >= 5, time.Now().Sub(lastFlush) > time.Second, update.Progress == 100:
 						lastFlush = time.Now()
 						lastProgress = update.Progress
 						c.Ui.Info(fmt.Sprintf("%.2f%%", update.Progress))

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -638,7 +638,13 @@ func (c *Command) Run(args []string) int {
 						c.Ui.Output(update.Op)
 						c.Ui.Info(fmt.Sprintf("%.2f%%", update.Progress))
 
-					case update.Progress-lastProgress >= 5, time.Now().Sub(lastFlush) > time.Second, update.Progress == 100:
+					case update.Progress-lastProgress >= 5:
+						fallthrough
+
+					case time.Now().Sub(lastFlush) > time.Second:
+						fallthrough
+
+					case update.Progress == 100:
 						lastFlush = time.Now()
 						lastProgress = update.Progress
 						c.Ui.Info(fmt.Sprintf("%.2f%%", update.Progress))

--- a/consul/client.go
+++ b/consul/client.go
@@ -224,9 +224,7 @@ func (c *Client) lanEventHandler() {
 			switch e.EventType() {
 			case serf.EventMemberJoin:
 				c.nodeJoin(e.(serf.MemberEvent))
-			case serf.EventMemberLeave:
-				fallthrough
-			case serf.EventMemberFailed:
+			case serf.EventMemberLeave, serf.EventMemberFailed:
 				c.nodeFail(e.(serf.MemberEvent))
 			case serf.EventUser:
 				c.localEvent(e.(serf.UserEvent))

--- a/consul/fsm.go
+++ b/consul/fsm.go
@@ -230,9 +230,7 @@ func (c *consulFSM) applyACLOperation(buf []byte, index uint64) interface{} {
 	}
 	defer metrics.MeasureSince([]string{"consul", "fsm", "acl", string(req.Op)}, time.Now())
 	switch req.Op {
-	case structs.ACLForceSet:
-		fallthrough
-	case structs.ACLSet:
+	case structs.ACLForceSet, structs.ACLSet:
 		if err := c.state.ACLSet(index, &req.ACL); err != nil {
 			return err
 		} else {

--- a/consul/serf.go
+++ b/consul/serf.go
@@ -41,9 +41,7 @@ func (s *Server) lanEventHandler() {
 				s.nodeJoin(e.(serf.MemberEvent), false)
 				s.localMemberEvent(e.(serf.MemberEvent))
 
-			case serf.EventMemberLeave:
-				fallthrough
-			case serf.EventMemberFailed:
+			case serf.EventMemberLeave, serf.EventMemberFailed:
 				s.nodeFailed(e.(serf.MemberEvent), false)
 				s.localMemberEvent(e.(serf.MemberEvent))
 
@@ -71,9 +69,7 @@ func (s *Server) wanEventHandler() {
 			switch e.EventType() {
 			case serf.EventMemberJoin:
 				s.nodeJoin(e.(serf.MemberEvent), true)
-			case serf.EventMemberLeave:
-				fallthrough
-			case serf.EventMemberFailed:
+			case serf.EventMemberLeave, serf.EventMemberFailed:
 				s.nodeFailed(e.(serf.MemberEvent), true)
 			case serf.EventMemberUpdate: // Ignore
 			case serf.EventMemberReap: // Ignore


### PR DESCRIPTION
per https://twitter.com/sdboyer/status/603355010823487489, this condenses consul's fallthrough cascades into single-case expression lists.