### PR TITLE
add Spring Cloud Consul to Community tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -108,6 +108,9 @@ description: |-
 	  <li>
 		<a href="https://github.com/amirkibbar/red-apple">gradle-consul-plugin</a> - A Consul Gradle plugin
 	  </li>
+      <li>
+        <a href="https://github.com/spring-cloud/spring-cloud-consul">Spring Cloud Consul</a> - Service discovery, configuration and events for Spring Cloud
+      </li>
     </ul>
 
     <p>


### PR DESCRIPTION
[Spring Cloud](http://projects.spring.io/spring-cloud) provides tools for JVM developers to quickly build some of the common patterns in distributed systems (e.g. configuration management, service discovery, circuit breakers, intelligent routing, micro-proxy, control bus, one-time tokens, global locks, leadership election, distributed sessions, cluster state).

We have just released the first milestone of [Spring Cloud Consul](http://cloud.spring.io/spring-cloud-consul/spring-cloud-consul.html) ([announcement blog post](https://spring.io/blog/2015/05/27/spring-cloud-consul-1-0-0-m1-available-now), [github repo](https://github.com/spring-cloud/spring-cloud-consul)). This implements configuration management, service discovery and the control bus using the Consul HTTP API. In the future we plan to implement global locks, leadership election, distributed sessions using Consul.