### PR TITLE
UI: Fix restoring state for service names containing slashes

### DIFF
--- a/ui/javascripts/app/router.js
+++ b/ui/javascripts/app/router.js
@@ -21,7 +21,7 @@ App.Router.map(function() {
     // Services represent a consul service
     this.resource("services", { path: "/services" }, function(){
       // Show an individual service
-      this.route("show", { path: "/:name" });
+      this.route("show", { path: "/*name" });
     });
     // Nodes represent a consul node
     this.resource("nodes", { path: "/nodes" }, function() {


### PR DESCRIPTION
If a service name contains slashes, the web UI shows a blank screen.