### PR TITLE
Fix confusing statement about BoltDB upgrade for 0.5.2

### DIFF
--- a/website/source/docs/upgrade-specific.html.markdown
+++ b/website/source/docs/upgrade-specific.html.markdown
@@ -20,8 +20,8 @@ Consul version 0.5.1 uses a different backend store for persisting the Raft
 log. Because of this change, a data migration is necessary to move the log
 entries out of LMDB and into the newer backend, BoltDB.
 
-Consul version 0.5.1 makes this transition seamless and easy. As a user, there
-are no special steps you need to take. When Consul 0.5.1 starts, it checks
+Consul version 0.5.1+ makes this transition seamless and easy. As a user, there
+are no special steps you need to take. When Consul starts, it checks
 for presence of the legacy LMDB data files, and migrates them automatically
 if any are found. You will see a log emitted when Raft data is migrated, like
 this:
@@ -30,10 +30,9 @@ this:
 ==> Successfully migrated raft data in 5.839642ms
 ```
 
-The automatic upgrade will only exist in Consul 0.5.1. In later versions
-(0.6.0+), the migration code will not be included in the Consul binary. It
-is still possible to upgrade directly from pre-0.5.1 versions by using the
-consul-migrate utility, which is available on the
+This automatic upgrade will only exist in Consul 0.5.1+ and it will
+be removed starting with Consul 0.6.0+. It will still be possible to upgrade directly 
+from pre-0.5.1 versions by using the consul-migrate utility, which is available on the
 [Consul Tools page](/downloads_tools.html).
 
 ## Consul 0.5


### PR DESCRIPTION
The docs were confusing as to whether or not 0.5.2 includes the migration tool, which it does. This edit should make it more clear for the end user