### PR TITLE
Send SOA with negative responses (RFC2308)

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -336,6 +336,7 @@ PARSE:
 	return
 INVALID:
 	d.logger.Printf("[WARN] dns: QName invalid: %s", qName)
+	d.addSOA(d.domain, resp)
 	resp.SetRcode(req, dns.RcodeNameError)
 }
 
@@ -373,6 +374,7 @@ RPC:
 
 	// If we have no address, return not found!
 	if out.NodeServices == nil {
+		d.addSOA(d.domain, resp)
 		resp.SetRcode(req, dns.RcodeNameError)
 		return
 	}
@@ -478,6 +480,7 @@ RPC:
 
 	// If we have no nodes, return not found!
 	if len(out.Nodes) == 0 {
+		d.addSOA(d.domain, resp)
 		resp.SetRcode(req, dns.RcodeNameError)
 		return
 	}


### PR DESCRIPTION
According to RFC:

"Name servers authoritative for a zone MUST include the SOA record of the zone in the authority section of the response when reporting an NXDOMAIN or indicating that no data of the requested type exists."

This fixes issues with DNS recursors caching negative responses too long (e.g. PowerDNS recursor)

