### PR TITLE
Bumps protocol version to 3 to get serf version 5.

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -32,6 +32,7 @@ func init() {
 	protocolVersionMap = map[uint8]uint8{
 		1: 4,
 		2: 4,
+		3: 5,
 	}
 }
 

--- a/consul/server.go
+++ b/consul/server.go
@@ -27,7 +27,7 @@ import (
 // protocol versions.
 const (
 	ProtocolVersionMin uint8 = 1
-	ProtocolVersionMax       = 2
+	ProtocolVersionMax       = 3
 )
 
 const (


### PR DESCRIPTION
This can't be merged until hashicorp/serf#293 has been merged. It ups the corresponding consul version which maps to the new serf version.