### PR TITLE
centos6 Initial commit

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -15,3 +15,5 @@ terraform apply -var 'key_name=consul' -var 'key_path=/Users/xyz/consul.pem' -va
 To run rhel6, run like below
 
 terraform apply -var 'key_name=consul' -var 'key_path=/Users/xyz/consul.pem' -var 'platform=rhel6'
+
+For centos6 platform, for the default AMI, you need to accept the AWS market place terms and conditions. When you launch first time, you will get an error with an URL to accept the terms and conditions.

--- a/terraform/aws/scripts/centos6/install.sh
+++ b/terraform/aws/scripts/centos6/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+# Read the address to join from the file we provisioned
+JOIN_ADDRS=$(cat /tmp/consul-server-addr | tr -d '\n')
+
+echo "Installing dependencies..."
+yum update -y
+yum install -y unzip wget
+
+echo "Fetching Consul..."
+cd /tmp
+wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -O consul.zip
+
+echo "Installing Consul..."
+unzip consul.zip >/dev/null
+chmod +x consul
+mv consul /usr/local/bin/consul
+mkdir -p /etc/consul.d
+mkdir -p /mnt/consul
+mkdir -p /etc/service
+
+#Enable consul port in iptables
+echo "Allow port 8301 in iptables"
+iptables -I INPUT -s 0/0 -p tcp --dport 8301 -j ACCEPT
+
+# Setup the join address
+cat >/tmp/consul-join << EOF
+export CONSUL_JOIN="${JOIN_ADDRS}"
+EOF
+mv /tmp/consul-join /etc/service/consul-join
+chmod 0644 /etc/service/consul-join
+
+echo "Installing Upstart service..."
+mv /tmp/upstart.conf /etc/init/consul.conf
+mv /tmp/upstart-join.conf /etc/init/consul-join.conf

--- a/terraform/aws/scripts/centos6/server.sh
+++ b/terraform/aws/scripts/centos6/server.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Read from the file we created
+SERVER_COUNT=$(cat /tmp/consul-server-count | tr -d '\n')
+
+# Write the flags to a temporary file
+cat >/tmp/consul_flags << EOF
+export CONSUL_FLAGS="-server -bootstrap-expect=${SERVER_COUNT} -data-dir=/mnt/consul"
+EOF
+
+# Write it to the full service file
+mv /tmp/consul_flags /etc/service/consul
+chown root:root /etc/service/consul
+chmod 0644 /etc/service/consul

--- a/terraform/aws/scripts/centos6/service.sh
+++ b/terraform/aws/scripts/centos6/service.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "Starting Consul..."
+start consul

--- a/terraform/aws/scripts/centos6/upstart-join.conf
+++ b/terraform/aws/scripts/centos6/upstart-join.conf
@@ -1,0 +1,25 @@
+description "Join the consul cluster"
+
+start on started consul
+stop on stopped consul
+
+task
+
+script
+  if [ -f "/etc/service/consul-join" ]; then
+    . /etc/service/consul-join
+  fi
+
+  # Keep trying to join until it succeeds
+  set +e
+  while :; do
+    logger -t "consul-join" "Attempting join: ${CONSUL_JOIN}"
+    /usr/local/bin/consul join \
+      ${CONSUL_JOIN} \
+      >>/var/log/consul-join.log 2>&1
+    [ $? -eq 0 ] && break
+    sleep 5
+  done
+
+  logger -t "consul-join" "Join success!"
+end script

--- a/terraform/aws/scripts/centos6/upstart.conf
+++ b/terraform/aws/scripts/centos6/upstart.conf
@@ -1,0 +1,26 @@
+description "Consul agent"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+# This is to avoid Upstart re-spawning the process upon `consul leave`
+normal exit 0 INT
+
+script
+  if [ -f "/etc/service/consul" ]; then
+    . /etc/service/consul
+  fi
+
+  # Make sure to use all our CPUs, because Consul can block a scheduler thread
+  export GOMAXPROCS=`nproc`
+
+  # Get the public IP
+  BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
+
+  exec /usr/local/bin/consul agent \
+    -config-dir="/etc/consul.d" \
+    -bind=$BIND \
+    ${CONSUL_FLAGS} \
+    >>/var/log/consul.log 2>&1
+end script

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -7,6 +7,7 @@ variable "user" {
     default = {
         ubuntu = "ubuntu"
         rhel6 = "ec2-user"
+        centos6 = "root"
     }
 }
 
@@ -17,6 +18,8 @@ variable "ami" {
         us-west-2-ubuntu = "ami-57e8d767"
         us-east-1-rhel6 = "ami-b0fed2d8"
         us-west-2-rhel6 = "ami-2faa861f"
+        us-east-1-centos6 = "ami-c2a818aa"
+        us-west-2-centos6 = "ami-81d092b1"
     }
 }
 


### PR DESCRIPTION
This change enables users to create centos6 based Consul cluster. CentOS.org does not allow launch AMIs directly since it is available only through Market place. The execution will throw an error asking to accept terms and conditions of market place one and provides a link specific to the account that is used to execute. Once you accept the terms, next execution will succeed. Another option is to replace the default AMI with another trusted centos6 AMI, the caveat is it may not be endorsed by centos.org