### PR TITLE
Add advertise_addrs.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -244,6 +244,17 @@ func (a *Agent) consulConfig() *consul.Config {
 			Port: a.config.Ports.Server,
 		}
 	}
+	if a.config.AdvertiseAddrs.SerfLan != nil {
+		base.SerfLANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddrs.SerfLan.IP.String()
+		base.SerfLANConfig.MemberlistConfig.AdvertisePort = a.config.AdvertiseAddrs.SerfLan.Port
+	}
+	if a.config.AdvertiseAddrs.SerfWan != nil {
+		base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddrs.SerfWan.IP.String()
+		base.SerfWANConfig.MemberlistConfig.AdvertisePort = a.config.AdvertiseAddrs.SerfWan.Port
+	}
+	if a.config.AdvertiseAddrs.RPC != nil {
+		base.RPCAdvertise = a.config.AdvertiseAddrs.RPC
+	}
 	if a.config.Bootstrap {
 		base.Bootstrap = true
 	}

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -208,6 +209,45 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.AdvertiseAddrWan != "127.0.0.5" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	// Advertise addresses for serflan
+	input = `{"advertise_addrs": {"serf_lan": "127.0.0.5:1234"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.AdvertiseAddrs.SerfLanRaw != "127.0.0.5:1234" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.AdvertiseAddrs.SerfLan.String() != "127.0.0.5:1234" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	// Advertise addresses for serfwan
+	input = `{"advertise_addrs": {"serf_wan": "127.0.0.5:1234"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.AdvertiseAddrs.SerfWanRaw != "127.0.0.5:1234" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.AdvertiseAddrs.SerfWan.String() != "127.0.0.5:1234" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	// Advertise addresses for rpc
+	input = `{"advertise_addrs": {"rpc": "127.0.0.5:1234"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.AdvertiseAddrs.RPCRaw != "127.0.0.5:1234" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.AdvertiseAddrs.RPC.String() != "127.0.0.5:1234" {
 		t.Fatalf("bad: %#v", config)
 	}
 
@@ -1166,6 +1206,14 @@ func TestMergeConfig(t *testing.T) {
 		AtlasJoin:           true,
 		SessionTTLMinRaw:    "1000s",
 		SessionTTLMin:       1000 * time.Second,
+		AdvertiseAddrs: AdvertiseAddrsConfig{
+			SerfLan:    &net.TCPAddr{},
+			SerfLanRaw: "127.0.0.5:1231",
+			SerfWan:    &net.TCPAddr{},
+			SerfWanRaw: "127.0.0.5:1232",
+			RPC:        &net.TCPAddr{},
+			RPCRaw:     "127.0.0.5:1233",
+		},
 	}
 
 	c := MergeConfig(a, b)

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -322,6 +322,16 @@ definitions support being updated during a reload.
 * <a name="advertise_addr"></a><a href="#advertise_addr">`advertise_addr`</a> Equivalent to
   the [`-advertise` command-line flag](#_advertise).
 
+* <a name="advertise_addrs"></a><a href="#advertise_addrs">`advertise_addrs`</a> Allows to set
+  the advertised addresses for SerfLan, SerfWan and RPC together with the port. This gives
+  you more control than (#_advertise) or (#_advertise-wan) while it serves the same purpose.
+  These settings might override (#_advertise) and (#_advertise-wan).
+  <br><br>
+  This is a nested setting that allows the following keys:
+  * `serf_lan` - The SerfLan address. Accepts values in the form of "host:port" like "10.23.31.101:8301".
+  * `serf_wan` - The SerfWan address. Accepts values in the form of "host:port" like "10.23.31.101:8302".
+  * `rpc` - The RPC address. Accepts values in the form of "host:port" like "10.23.31.101:8400".
+
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).
 


### PR DESCRIPTION
Fixes #550.
This will make it possible to configure the advertised adresses for SerfLan, SerfWan and RPC. It will enable multiple consul clients on a single host which is very useful in a container environment.

This option might override `advertise_addr` and `advertise_addr_wan` depending on the configuration.

It will be configureable with `advertise_addrs`. Example:

```` json
{
  "advertise_addrs": {
    "serf_lan": "10.0.120.91:4424",
    "serf_wan": "201.20.10.61:4423",
    "rpc": "10.20.10.61:4424"
  }
}
```