### PR TITLE
Persist check state for TTL checks

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -761,7 +761,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 
 			// Restore persisted state, if any
-			if err := a.recallCheckState(check); err != nil {
+			if err := a.loadCheckState(check); err != nil {
 				a.logger.Printf("[WARN] agent: failed restoring state for check %q: %s",
 					check.CheckID, err)
 			}
@@ -917,8 +917,8 @@ func (a *Agent) persistCheckState(check *CheckTTL, status, output string) error 
 	return nil
 }
 
-// recallCheckState is used to restore the persisted state of a check.
-func (a *Agent) recallCheckState(check *structs.HealthCheck) error {
+// loadCheckState is used to restore the persisted state of a check.
+func (a *Agent) loadCheckState(check *structs.HealthCheck) error {
 	// Try to read the persisted state for this check
 	file := filepath.Join(a.config.DataDir, checkStateDir, stringHash(check.CheckID))
 	buf, err := ioutil.ReadFile(file)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -938,7 +938,7 @@ func (a *Agent) recallCheckState(check *structs.HealthCheck) error {
 	// Check if the state has expired
 	if time.Now().Unix() >= p.Expires {
 		a.logger.Printf("[DEBUG] agent: check state expired for %q, not restoring", check.CheckID)
-		return nil
+		return a.purgeCheckState(check.CheckID)
 	}
 
 	// Restore the fields from the state

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/consul/structs"
@@ -23,7 +24,8 @@ const (
 	servicesDir = "services"
 
 	// Path to save local agent checks
-	checksDir = "checks"
+	checksDir     = "checks"
+	checkStateDir = "checks/state"
 
 	// The ID of the faux health checks for maintenance mode
 	serviceMaintCheckPrefix = "_service_maintenance"
@@ -757,6 +759,13 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 				TTL:     chkType.TTL,
 				Logger:  a.logger,
 			}
+
+			// Restore persisted state, if any
+			if err := a.recallCheckState(check); err != nil {
+				a.logger.Printf("[WARN] agent: failed restoring state for check %q: %s",
+					check.CheckID, err)
+			}
+
 			ttl.Start()
 			a.checkTTLs[check.CheckID] = ttl
 
@@ -861,6 +870,75 @@ func (a *Agent) UpdateCheck(checkID, status, output string) error {
 
 	// Set the status through CheckTTL to reset the TTL
 	check.SetStatus(status, output)
+
+	// Always persist the state for TTL checks
+	if err := a.persistCheckState(check, status, output); err != nil {
+		return fmt.Errorf("failed persisting state for check %q: %s", checkID, err)
+	}
+
+	return nil
+}
+
+// persistCheckState is used to record the check status into the data dir.
+// This allows the state to be restored on a later agent start. Currently
+// only useful for TTL based checks.
+func (a *Agent) persistCheckState(check *CheckTTL, status, output string) error {
+	// Create the persisted state
+	state := persistedCheckState{
+		CheckID: check.CheckID,
+		Status:  status,
+		Output:  output,
+		Expires: time.Now().Add(check.TTL).Unix(),
+	}
+
+	// Encode the state
+	buf, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	// Create the state dir if it doesn't exist
+	dir := filepath.Join(a.config.DataDir, checkStateDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed creating check state dir %q: %s", dir, err)
+	}
+
+	// Write the state to the file
+	file := filepath.Join(dir, stringHash(check.CheckID))
+	if err := ioutil.WriteFile(file, buf, 0600); err != nil {
+		return fmt.Errorf("failed writing file %q: %s", file, err)
+	}
+
+	return nil
+}
+
+// recallCheckState is used to restore the persisted state of a check.
+func (a *Agent) recallCheckState(check *structs.HealthCheck) error {
+	// Try to read the persisted state for this check
+	file := filepath.Join(a.config.DataDir, checkStateDir, stringHash(check.CheckID))
+	buf, err := ioutil.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed reading file %q: %s", file, err)
+	}
+
+	// Decode the state data
+	var p persistedCheckState
+	if err := json.Unmarshal(buf, &p); err != nil {
+		return fmt.Errorf("failed decoding check state: %s", err)
+	}
+
+	// Check if the state has expired
+	if time.Now().Unix() > p.Expires {
+		a.logger.Printf("[DEBUG] agent: check state expired for %q, not restoring", check.CheckID)
+		return nil
+	}
+
+	// Restore the fields from the state
+	check.Output = p.Output
+	check.Status = p.Status
 	return nil
 }
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -931,7 +931,7 @@ func (a *Agent) recallCheckState(check *structs.HealthCheck) error {
 	}
 
 	// Check if the state has expired
-	if time.Now().Unix() > p.Expires {
+	if time.Now().Unix() >= p.Expires {
 		a.logger.Printf("[DEBUG] agent: check state expired for %q, not restoring", check.CheckID)
 		return nil
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1350,7 +1350,7 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 	}
 }
 
-func TestAgent_persistCheckStatus(t *testing.T) {
+func TestAgent_persistCheckState(t *testing.T) {
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1431,6 +1431,12 @@ func TestAgent_recallCheckState(t *testing.T) {
 	}
 	if health.Output != "" {
 		t.Fatalf("bad: %#v", health)
+	}
+
+	// Should have purged the state
+	file := filepath.Join(agent.config.DataDir, checksDir, stringHash("check1"))
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Fatalf("should have purged state")
 	}
 
 	// Set a TTL which will not expire before we check it

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1441,7 +1441,7 @@ func TestAgent_persistCheckState(t *testing.T) {
 	}
 }
 
-func TestAgent_recallCheckState(t *testing.T) {
+func TestAgent_loadCheckState(t *testing.T) {
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1459,12 +1459,12 @@ func TestAgent_recallCheckState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Try to recall the state
+	// Try to load the state
 	health := &structs.HealthCheck{
 		CheckID: "check1",
 		Status:  structs.HealthCritical,
 	}
-	if err := agent.recallCheckState(health); err != nil {
+	if err := agent.loadCheckState(health); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
@@ -1489,8 +1489,8 @@ func TestAgent_recallCheckState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Try to recall
-	if err := agent.recallCheckState(health); err != nil {
+	// Try to load
+	if err := agent.loadCheckState(health); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -266,6 +266,17 @@ type persistedCheck struct {
 	Token   string
 }
 
+// persistedCheckState is used to persist the current state of a given
+// check. This is different from the check definition, and includes an
+// expiration timestamp which is used to determine staleness on later
+// agent restarts.
+type persistedCheckState struct {
+	CheckID string
+	Output  string
+	Status  string
+	Expires int64
+}
+
 // CheckHTTP is used to periodically make an HTTP request to
 // determine the health of a given check.
 // The check is passing if the response code is 2XX.

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -37,7 +37,10 @@ There are three different kinds of checks:
   set to the failed state. This mechanism, conceptually similar to a dead man's switch,
   relies on the application to directly report its health. For example, a healthy app
   can periodically `PUT` a status update to the HTTP endpoint; if the app fails, the TTL will
-  expire and the health check enters a critical state.
+  expire and the health check enters a critical state. TTL checks also persist
+  their last known status to disk. This allows the Consul agent to restore the
+  last known status of the check across restarts. Persisted check status is
+  valid through the end of the TTL from the time of the last check.
 
 ## Check Definition
 


### PR DESCRIPTION
TTL checks work on the assumption that there is an external app calling in to Consul to "ping" the check, keeping it healthy. During a Consul restart, the current behavior is to re-register the check directly into a pre-determined state. This can leave the TTL-based checks in an undesirable state for an extended period of time, depending on the TTL.

This change persists the last submitted status into the data directory. The check status, output, and an expiration timestamp are all written to disk, and restored on later agent starts. During startup, if the persisted status is still "fresh" enough (the expiration timer is based on the TTL of the check), the state and output are restored and registered as the initial status of the check.

I think we could do something similar for the other check types, but since Consul has the ability to actively run those checks, we might solve it in a different way.

Fixes #1001