### PR TITLE
testutil: support ACLMasterToken, ACLDatacenter and ACLDefaultPolicy

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -59,6 +59,9 @@ type TestServerConfig struct {
 	Bind              string             `json:"bind_addr,omitempty"`
 	Addresses         *TestAddressConfig `json:"addresses,omitempty"`
 	Ports             *TestPortConfig    `json:"ports,omitempty"`
+	ACLMasterToken    string             `json:"acl_master_token,omitempty"`
+	ACLDatacenter     string             `json:"acl_datacenter,omitempty"`
+	ACLDefaultPolicy  string             `json:"acl_default_policy,omitempty"`
 	Stdout, Stderr    io.Writer          `json:"-"`
 }
 


### PR DESCRIPTION
This patch allows to write tests with ACL enabled.

I don't understand the CONSUL_ROOT usage in the api/acl_tests.go but with the above attributes I got an acl test case running.

```shell
diff --git a/api/acl_test.go b/api/acl_test.go
index b896a18..2f1a96e 100644
--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -3,6 +3,8 @@ package api
 import (
        "os"
        "testing"
+
+       "github.com/hashicorp/consul/testutil"
 )
 
 // ROOT is a management token for the tests
@@ -17,7 +19,11 @@ func TestACL_CreateDestroy(t *testing.T) {
        if CONSUL_ROOT == "" {
                t.SkipNow()
        }
-       c, s := makeClient(t)
+       c, s := makeClientWithConfig(t, nil, func(serverConfig *testutil.TestServerConfig) {
+               serverConfig.ACLMasterToken = CONSUL_ROOT
+               serverConfig.ACLDatacenter = "dc1"
+               serverConfig.ACLDefaultPolicy = "allow"
+       })
        defer s.Stop()
 
        c.config.Token = CONSUL_ROOT
```