### PR TITLE
Service Discovery ACLs

### DIFF
--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -343,8 +343,9 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 	// Verify that we are in sync
 	req := structs.NodeSpecificRequest{
-		Datacenter: "dc1",
-		Node:       agent.config.NodeName,
+		Datacenter:   "dc1",
+		Node:         agent.config.NodeName,
+		QueryOptions: structs.QueryOptions{Token: out},
 	}
 	var services structs.IndexedNodeServices
 	if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -290,6 +290,32 @@ func (s *Server) applyDiscoveryACLs(token string, subj interface{}) error {
 			v.Nodes = append(v.Nodes[:i], v.Nodes[i+1:]...)
 			i--
 		}
+
+	// Filter node dumps
+	case *structs.IndexedNodeDump:
+		for i := 0; i < len(v.Dump); i++ {
+			dump := v.Dump[i]
+
+			// Filter the services
+			for i := 0; i < len(dump.Services); i++ {
+				svc := dump.Services[i]
+				if filt(svc.Service) {
+					continue
+				}
+				dump.Services = append(dump.Services[:i], dump.Services[i+1:]...)
+				i--
+			}
+
+			// Filter the checks
+			for i := 0; i < len(dump.Checks); i++ {
+				chk := dump.Checks[i]
+				if filt(chk.ServiceName) {
+					continue
+				}
+				dump.Checks = append(dump.Checks[:i], dump.Checks[i+1:]...)
+				i--
+			}
+		}
 	}
 
 	return nil

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -355,6 +356,9 @@ func (s *Server) filterACL(token string, subj interface{}) error {
 
 	case *structs.IndexedNodeDump:
 		filt.filterNodeDump(&v.Dump)
+
+	default:
+		panic(fmt.Errorf("Unhandled type passed to ACL filter: %#v", subj))
 	}
 
 	return nil

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"errors"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -201,6 +202,14 @@ type aclFilter struct {
 	logger *log.Logger
 }
 
+// newAclFilter constructs a new aclFilter.
+func newAclFilter(acl acl.ACL, logger *log.Logger) *aclFilter {
+	if logger == nil {
+		logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
+	return &aclFilter{acl, logger}
+}
+
 // filterService is used to determine if a service is accessible for an ACL.
 func (f *aclFilter) filterService(service string) bool {
 	if service == "" || service == ConsulServiceID {
@@ -326,7 +335,7 @@ func (s *Server) filterACL(token string, subj interface{}) error {
 	}
 
 	// Create the filter
-	filt := &aclFilter{acl, s.logger}
+	filt := newAclFilter(acl, s.logger)
 
 	switch v := subj.(type) {
 	case *structs.IndexedHealthChecks:

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -193,23 +193,6 @@ func (s *Server) useACLPolicy(id, authDC string, cached *aclCacheEntry, p *struc
 	return compiled, nil
 }
 
-// discoveryFilter is used to determine if we should return a given node
-// or service based on the ACL passed in.
-func (s *Server) discoveryFilter(node, service string, acl acl.ACL) bool {
-	if acl == nil {
-		return true
-	}
-
-	// Filter service discovery ACLs
-	if service != "" && service != ConsulServiceID && !acl.ServiceRead(service) {
-		s.logger.Printf("[DEBUG] consul: reading service '%s' denied due to ACLs", service)
-		return false
-	}
-
-	// Filtering passed
-	return true
-}
-
 // applyDiscoveryACLs is used to filter results from our service catalog based
 // on the configured rules for the request ACL. Nodes or services which do
 // not match the ACL rules will be dropped from the result.

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -307,6 +307,7 @@ func (f *aclFilter) filterNodeDump(dump *structs.NodeDump) {
 			i--
 		}
 	}
+	*dump = nd
 }
 
 // filterACL is used to filter results from our service catalog based on the

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -280,7 +280,7 @@ func (f *aclFilter) filterCheckServiceNodes(nodes *structs.CheckServiceNodes) {
 		if f.filterService(node.Service.Service) {
 			continue
 		}
-		f.logger.Printf("[DEBUG] consul: dropping node %q from result due to ACLs", node.Node)
+		f.logger.Printf("[DEBUG] consul: dropping node %q from result due to ACLs", node.Node.Node)
 		csn = append(csn[:i], csn[i+1:]...)
 		i--
 	}

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -309,10 +309,10 @@ func (f *aclFilter) filterNodeDump(dump *structs.NodeDump) {
 	}
 }
 
-// aclFilter is used to filter results from our service catalog based on the
+// filterACL is used to filter results from our service catalog based on the
 // rules configured for the provided token. The subject is scrubbed and
 // modified in-place, leaving only resources the token can access.
-func (s *Server) aclFilter(token string, subj interface{}) error {
+func (s *Server) filterACL(token string, subj interface{}) error {
 	// Get the ACL from the token
 	acl, err := s.resolveToken(token)
 	if err != nil {

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"errors"
+	"log"
 	"strings"
 	"time"
 
@@ -193,10 +194,125 @@ func (s *Server) useACLPolicy(id, authDC string, cached *aclCacheEntry, p *struc
 	return compiled, nil
 }
 
-// applyDiscoveryACLs is used to filter results from our service catalog based
-// on the configured rules for the request ACL. Nodes or services which do
-// not match the ACL rules will be dropped from the result.
-func (s *Server) applyDiscoveryACLs(token string, subj interface{}) error {
+// aclFilter is used to filter results from our state store based on ACL rules
+// configured for the provided token.
+type aclFilter struct {
+	acl    acl.ACL
+	logger *log.Logger
+}
+
+// filterService is used to determine if a service is accessible for an ACL.
+func (f *aclFilter) filterService(service string) bool {
+	if service == "" || service == ConsulServiceID {
+		return true
+	}
+	return f.acl.ServiceRead(service)
+}
+
+// filterHealthChecks is used to filter a set of health checks down based on
+// the configured ACL rules for a token.
+func (f *aclFilter) filterHealthChecks(checks *structs.HealthChecks) {
+	hc := *checks
+	for i := 0; i < len(hc); i++ {
+		check := hc[i]
+		if f.filterService(check.ServiceName) {
+			continue
+		}
+		f.logger.Printf("[DEBUG] consul: dropping check %q from result due to ACLs", check.CheckID)
+		hc = append(hc[:i], hc[i+1:]...)
+		i--
+	}
+	*checks = hc
+}
+
+// filterServices is used to filter a set of services based on ACLs.
+func (f *aclFilter) filterServices(services structs.Services) {
+	for svc, _ := range services {
+		if f.filterService(svc) {
+			continue
+		}
+		f.logger.Printf("[DEBUG] consul: dropping service %q from result due to ACLs", svc)
+		delete(services, svc)
+	}
+}
+
+// filterServiceNodes is used to filter a set of nodes for a given service
+// based on the configured ACL rules.
+func (f *aclFilter) filterServiceNodes(nodes *structs.ServiceNodes) {
+	sn := *nodes
+	for i := 0; i < len(sn); i++ {
+		node := sn[i]
+		if f.filterService(node.ServiceName) {
+			continue
+		}
+		f.logger.Printf("[DEBUG] consul: dropping node %q from result due to ACLs", node.Node)
+		sn = append(sn[:i], sn[i+1:]...)
+		i--
+	}
+	*nodes = sn
+}
+
+// filterNodeServices is used to filter services on a given node base on ACLs.
+func (f *aclFilter) filterNodeServices(services *structs.NodeServices) {
+	for svc, _ := range services.Services {
+		if f.filterService(svc) {
+			continue
+		}
+		f.logger.Printf("[DEBUG] consul: dropping service %q from result due to ACLs", svc)
+		delete(services.Services, svc)
+	}
+}
+
+// filterCheckServiceNodes is used to filter nodes based on ACL rules.
+func (f *aclFilter) filterCheckServiceNodes(nodes *structs.CheckServiceNodes) {
+	csn := *nodes
+	for i := 0; i < len(csn); i++ {
+		node := csn[i]
+		if f.filterService(node.Service.Service) {
+			continue
+		}
+		f.logger.Printf("[DEBUG] consul: dropping node %q from result due to ACLs", node.Node)
+		csn = append(csn[:i], csn[i+1:]...)
+		i--
+	}
+	*nodes = csn
+}
+
+// filterNodeDump is used to filter through all parts of a node dump and
+// remove elements the provided ACL token cannot access.
+func (f *aclFilter) filterNodeDump(dump *structs.NodeDump) {
+	nd := *dump
+	for i := 0; i < len(nd); i++ {
+		info := nd[i]
+
+		// Filter services
+		for i := 0; i < len(info.Services); i++ {
+			svc := info.Services[i].Service
+			if f.filterService(svc) {
+				continue
+			}
+			f.logger.Printf("[DEBUG] consul: dropping service %q from result due to ACLs", svc)
+			info.Services = append(info.Services[:i], info.Services[i+1:]...)
+			i--
+		}
+
+		// Filter checks
+		for i := 0; i < len(info.Checks); i++ {
+			chk := info.Checks[i]
+			if f.filterService(chk.ServiceName) {
+				continue
+			}
+			f.logger.Printf("[DEBUG] consul: dropping check %q from result due to ACLs", chk.CheckID)
+			info.Checks = append(info.Checks[:i], info.Checks[i+1:]...)
+			i--
+		}
+	}
+}
+
+// aclFilter is used to filter results from our service catalog based on the
+// rules configured for the provided token. The subject is scrubbed and
+// modified in-place, leaving only resources the token can access.
+func (s *Server) aclFilter(token string, subj interface{}) error {
 	// Get the ACL from the token
 	acl, err := s.resolveToken(token)
 	if err != nil {
@@ -208,97 +324,27 @@ func (s *Server) applyDiscoveryACLs(token string, subj interface{}) error {
 		return nil
 	}
 
-	filt := func(service string) bool {
-		// Don't filter the "consul" service or empty service names
-		if service == "" || service == ConsulServiceID {
-			return true
-		}
-
-		// Check the ACL
-		if !acl.ServiceRead(service) {
-			s.logger.Printf("[DEBUG] consul: reading service '%s' denied due to ACLs", service)
-			return false
-		}
-		return true
-	}
+	// Create the filter
+	filt := &aclFilter{acl, s.logger}
 
 	switch v := subj.(type) {
-	// Filter health checks
 	case *structs.IndexedHealthChecks:
-		for i := 0; i < len(v.HealthChecks); i++ {
-			hc := v.HealthChecks[i]
-			if filt(hc.ServiceName) {
-				continue
-			}
-			v.HealthChecks = append(v.HealthChecks[:i], v.HealthChecks[i+1:]...)
-			i--
-		}
+		filt.filterHealthChecks(&v.HealthChecks)
 
-	// Filter services
 	case *structs.IndexedServices:
-		for svc, _ := range v.Services {
-			if filt(svc) {
-				continue
-			}
-			delete(v.Services, svc)
-		}
+		filt.filterServices(v.Services)
 
-	// Filter service nodes
 	case *structs.IndexedServiceNodes:
-		for i := 0; i < len(v.ServiceNodes); i++ {
-			node := v.ServiceNodes[i]
-			if filt(node.ServiceName) {
-				continue
-			}
-			v.ServiceNodes = append(v.ServiceNodes[:i], v.ServiceNodes[i+1:]...)
-			i--
-		}
+		filt.filterServiceNodes(&v.ServiceNodes)
 
-	// Filter node services
 	case *structs.IndexedNodeServices:
-		for svc, _ := range v.NodeServices.Services {
-			if filt(svc) {
-				continue
-			}
-			delete(v.NodeServices.Services, svc)
-		}
+		filt.filterNodeServices(v.NodeServices)
 
-	// Filter check service nodes
 	case *structs.IndexedCheckServiceNodes:
-		for i := 0; i < len(v.Nodes); i++ {
-			cs := v.Nodes[i]
-			if filt(cs.Service.Service) {
-				continue
-			}
-			v.Nodes = append(v.Nodes[:i], v.Nodes[i+1:]...)
-			i--
-		}
+		filt.filterCheckServiceNodes(&v.Nodes)
 
-	// Filter node dumps
 	case *structs.IndexedNodeDump:
-		for i := 0; i < len(v.Dump); i++ {
-			dump := v.Dump[i]
-
-			// Filter the services
-			for i := 0; i < len(dump.Services); i++ {
-				svc := dump.Services[i]
-				if filt(svc.Service) {
-					continue
-				}
-				dump.Services = append(dump.Services[:i], dump.Services[i+1:]...)
-				i--
-			}
-
-			// Filter the checks
-			for i := 0; i < len(dump.Checks); i++ {
-				chk := dump.Checks[i]
-				if filt(chk.ServiceName) {
-					continue
-				}
-				dump.Checks = append(dump.Checks[:i], dump.Checks[i+1:]...)
-				i--
-			}
-		}
+		filt.filterNodeDump(&v.Dump)
 	}
 
 	return nil

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -674,6 +674,193 @@ func TestACL_MultiDC_Found(t *testing.T) {
 	}
 }
 
+func TestACL_filterHealthChecks(t *testing.T) {
+	// Create some health checks
+	hc := structs.HealthChecks{
+		&structs.HealthCheck{
+			Node:        "node1",
+			CheckID:     "check1",
+			ServiceName: "foo",
+		},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterHealthChecks(&hc)
+	if len(hc) != 1 {
+		t.Fatalf("bad: %#v", hc)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterHealthChecks(&hc)
+	if len(hc) != 0 {
+		t.Fatalf("bad: %#v", hc)
+	}
+}
+
+func TestACL_filterServices(t *testing.T) {
+	// Create some services
+	services := structs.Services{
+		"service1": []string{},
+		"service2": []string{},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterServices(services)
+	if len(services) != 2 {
+		t.Fatalf("bad: %#v", services)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterServices(services)
+	if len(services) != 0 {
+		t.Fatalf("bad: %#v", services)
+	}
+}
+
+func TestACL_filterServiceNodes(t *testing.T) {
+	// Create some service nodes
+	nodes := structs.ServiceNodes{
+		structs.ServiceNode{
+			Node:        "node1",
+			ServiceName: "foo",
+		},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterServiceNodes(&nodes)
+	if len(nodes) != 1 {
+		t.Fatalf("bad: %#v", nodes)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterServiceNodes(&nodes)
+	if len(nodes) != 0 {
+		t.Fatalf("bad: %#v", nodes)
+	}
+}
+
+func TestACL_filterNodeServices(t *testing.T) {
+	// Create some node services
+	services := structs.NodeServices{
+		Node: structs.Node{
+			Node: "node1",
+		},
+		Services: map[string]*structs.NodeService{
+			"foo": &structs.NodeService{
+				ID:      "foo",
+				Service: "foo",
+			},
+		},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterNodeServices(&services)
+	if len(services.Services) != 1 {
+		t.Fatalf("bad: %#v", services.Services)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterNodeServices(&services)
+	if len(services.Services) != 0 {
+		t.Fatalf("bad: %#v", services.Services)
+	}
+}
+
+func TestACL_filterCheckServiceNodes(t *testing.T) {
+	// Create some nodes
+	nodes := structs.CheckServiceNodes{
+		structs.CheckServiceNode{
+			Node: structs.Node{
+				Node: "node1",
+			},
+			Service: structs.NodeService{
+				ID:      "foo",
+				Service: "foo",
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:        "node1",
+					CheckID:     "check1",
+					ServiceName: "foo",
+				},
+			},
+		},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterCheckServiceNodes(&nodes)
+	if len(nodes) != 1 {
+		t.Fatalf("bad: %#v", nodes)
+	}
+	if len(nodes[0].Checks) != 1 {
+		t.Fatalf("bad: %#v", nodes[0].Checks)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterCheckServiceNodes(&nodes)
+	if len(nodes) != 0 {
+		t.Fatalf("bad: %#v", nodes)
+	}
+}
+
+func TestACL_filterNodeDump(t *testing.T) {
+	// Create a node dump
+	dump := structs.NodeDump{
+		&structs.NodeInfo{
+			Node: "node1",
+			Services: []*structs.NodeService{
+				&structs.NodeService{
+					ID:      "foo",
+					Service: "foo",
+				},
+			},
+			Checks: []*structs.HealthCheck{
+				&structs.HealthCheck{
+					Node:        "node1",
+					CheckID:     "check1",
+					ServiceName: "foo",
+				},
+			},
+		},
+	}
+
+	// Try permissive filtering
+	filt := newAclFilter(acl.AllowAll(), nil)
+	filt.filterNodeDump(&dump)
+	if len(dump) != 1 {
+		t.Fatalf("bad: %#v", dump)
+	}
+	if len(dump[0].Services) != 1 {
+		t.Fatalf("bad: %#v", dump[0].Services)
+	}
+	if len(dump[0].Checks) != 1 {
+		t.Fatalf("bad: %#v", dump[0].Checks)
+	}
+
+	// Try restrictive filtering
+	filt = newAclFilter(acl.DenyAll(), nil)
+	filt.filterNodeDump(&dump)
+	if len(dump) != 1 {
+		t.Fatalf("bad: %#v", dump)
+	}
+	if len(dump[0].Services) != 0 {
+		t.Fatalf("bad: %#v", dump[0].Services)
+	}
+	if len(dump[0].Checks) != 0 {
+		t.Fatalf("bad: %#v", dump[0].Checks)
+	}
+}
+
 var testACLPolicy = `
 key "" {
 	policy = "deny"

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -674,111 +674,11 @@ func TestACL_MultiDC_Found(t *testing.T) {
 	}
 }
 
-func TestACL_applyDiscoveryACLs(t *testing.T) {
-	dir, srv := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
-		c.ACLMasterToken = "root"
-		c.ACLDefaultPolicy = "deny"
-	})
-	defer os.RemoveAll(dir)
-	defer srv.Shutdown()
-
-	client := rpcClient(t, srv)
-	defer client.Close()
-
-	testutil.WaitForLeader(t, client.Call, "dc1")
-
-	// Create a new token
-	arg := structs.ACLRequest{
-		Datacenter: "dc1",
-		Op:         structs.ACLSet,
-		ACL: structs.ACL{
-			Name:  "User token",
-			Type:  structs.ACLTypeClient,
-			Rules: testACLPolicy,
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	var id string
-	if err := client.Call("ACL.Apply", &arg, &id); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Register a service
-	regArg := structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "redis",
-			Service: "redis",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:redis",
-			Name:      "service:redis",
-			ServiceID: "redis",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Try querying the catalog
-	opt := structs.DCSpecificRequest{
-		Datacenter: "dc1",
-		QueryOptions: structs.QueryOptions{
-			Token: id,
-		},
-	}
-	services := structs.IndexedServices{}
-	if err := client.Call("Catalog.ListServices", &opt, &services); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Check if the service was returned
-	if _, ok := services.Services["redis"]; !ok {
-		t.Fatalf("bad: %#v", services.Services)
-	}
-
-	// Register a service which should be denied
-	regArg = structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "rabbit",
-			Service: "rabbit",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:rabbit",
-			Name:      "service:rabbit",
-			ServiceID: "rabbit",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Check that the service was omitted from the result
-	services = structs.IndexedServices{}
-	if err := client.Call("Catalog.ListServices", &opt, &services); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if _, ok := services.Services["rabbit"]; ok {
-		t.Fatalf("bad: %#v", services.Services)
-	}
-}
-
 var testACLPolicy = `
 key "" {
 	policy = "deny"
 }
 key "foo/" {
 	policy = "write"
-}
-service "redis" {
-    policy = "read"
 }
 `

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -861,6 +861,23 @@ func TestACL_filterNodeDump(t *testing.T) {
 	}
 }
 
+func TestACL_unhandledFilterType(t *testing.T) {
+	defer func(t *testing.T) {
+		if recover() == nil {
+			t.Fatalf("should panic")
+		}
+	}(t)
+
+	// Create the server
+	dir, token, srv, client := testACLFilterServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer client.Close()
+
+	// Pass an unhandled type into the ACL filter.
+	srv.filterACL(token, &structs.HealthCheck{})
+}
+
 var testACLPolicy = `
 key "" {
 	policy = "deny"

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -126,7 +126,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		state.QueryTables("Nodes"),
 		func() error {
 			reply.Index, reply.Nodes = state.Nodes()
-			return c.srv.filterACL(args.Token, reply)
+			return nil
 		})
 }
 

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -126,7 +126,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		state.QueryTables("Nodes"),
 		func() error {
 			reply.Index, reply.Nodes = state.Nodes()
-			return c.srv.aclFilter(args.Token, reply)
+			return c.srv.filterACL(args.Token, reply)
 		})
 }
 
@@ -143,7 +143,7 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 		state.QueryTables("Services"),
 		func() error {
 			reply.Index, reply.Services = state.Services()
-			return c.srv.aclFilter(args.Token, reply)
+			return c.srv.filterACL(args.Token, reply)
 		})
 }
 
@@ -169,7 +169,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			} else {
 				reply.Index, reply.ServiceNodes = state.ServiceNodes(args.ServiceName)
 			}
-			return c.srv.aclFilter(args.Token, reply)
+			return c.srv.filterACL(args.Token, reply)
 		})
 
 	// Provide some metrics
@@ -203,6 +203,6 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 		state.QueryTables("NodeServices"),
 		func() error {
 			reply.Index, reply.NodeServices = state.NodeServices(args.Node)
-			return c.srv.aclFilter(args.Token, reply)
+			return c.srv.filterACL(args.Token, reply)
 		})
 }

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -126,7 +126,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		state.QueryTables("Nodes"),
 		func() error {
 			reply.Index, reply.Nodes = state.Nodes()
-			return nil
+			return c.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 
@@ -143,7 +143,7 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 		state.QueryTables("Services"),
 		func() error {
 			reply.Index, reply.Services = state.Services()
-			return nil
+			return c.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 
@@ -169,7 +169,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			} else {
 				reply.Index, reply.ServiceNodes = state.ServiceNodes(args.ServiceName)
 			}
-			return nil
+			return c.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 
 	// Provide some metrics
@@ -203,6 +203,6 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 		state.QueryTables("NodeServices"),
 		func() error {
 			reply.Index, reply.NodeServices = state.NodeServices(args.Node)
-			return nil
+			return c.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -126,7 +126,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		state.QueryTables("Nodes"),
 		func() error {
 			reply.Index, reply.Nodes = state.Nodes()
-			return c.srv.applyDiscoveryACLs(args.Token, reply)
+			return c.srv.aclFilter(args.Token, reply)
 		})
 }
 
@@ -143,7 +143,7 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 		state.QueryTables("Services"),
 		func() error {
 			reply.Index, reply.Services = state.Services()
-			return c.srv.applyDiscoveryACLs(args.Token, reply)
+			return c.srv.aclFilter(args.Token, reply)
 		})
 }
 
@@ -169,7 +169,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			} else {
 				reply.Index, reply.ServiceNodes = state.ServiceNodes(args.ServiceName)
 			}
-			return c.srv.applyDiscoveryACLs(args.Token, reply)
+			return c.srv.aclFilter(args.Token, reply)
 		})
 
 	// Provide some metrics
@@ -203,6 +203,6 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 		state.QueryTables("NodeServices"),
 		func() error {
 			reply.Index, reply.NodeServices = state.NodeServices(args.Node)
-			return c.srv.applyDiscoveryACLs(args.Token, reply)
+			return c.srv.aclFilter(args.Token, reply)
 		})
 }

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -778,7 +778,7 @@ func TestCatalogRegister_FailedCase1(t *testing.T) {
 	}
 }
 
-func TestCatalog_applyDiscoveryACLs(t *testing.T) {
+func TestCatalog_filterACL(t *testing.T) {
 	dir, srv := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -778,7 +778,7 @@ func TestCatalogRegister_FailedCase1(t *testing.T) {
 	}
 }
 
-func TestServer_applyDiscoveryACLs(t *testing.T) {
+func TestCatalog_applyDiscoveryACLs(t *testing.T) {
 	dir, srv := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -778,6 +778,162 @@ func TestCatalogRegister_FailedCase1(t *testing.T) {
 	}
 }
 
+func TestServer_applyDiscoveryACLs(t *testing.T) {
+	dir, srv := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLMasterToken = "root"
+		c.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+
+	client := rpcClient(t, srv)
+	defer client.Close()
+
+	testutil.WaitForLeader(t, client.Call, "dc1")
+
+	// Create a new token
+	arg := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name:  "User token",
+			Type:  structs.ACLTypeClient,
+			Rules: testRegisterRules,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	var id string
+	if err := client.Call("ACL.Apply", &arg, &id); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Register a service
+	regArg := structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       srv.config.NodeName,
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "foo",
+			Service: "foo",
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "service:foo",
+			Name:      "service:foo",
+			ServiceID: "foo",
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Register a service which should be denied
+	regArg = structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       srv.config.NodeName,
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "bar",
+			Service: "bar",
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "service:bar",
+			Name:      "service:bar",
+			ServiceID: "bar",
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Catalog.ListServices properly filters and returns services
+	{
+		opt := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedServices{}
+		if err := client.Call("Catalog.ListServices", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if _, ok := reply.Services["foo"]; !ok {
+			t.Fatalf("bad: %#v", reply.Services)
+		}
+		if _, ok := reply.Services["bar"]; ok {
+			t.Fatalf("bad: %#v", reply.Services)
+		}
+	}
+
+	// Catalog.ServiceNodes returns services we have access to
+	{
+		opt := structs.ServiceSpecificRequest{
+			Datacenter:   "dc1",
+			ServiceName:  "foo",
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedServiceNodes{}
+		if err := client.Call("Catalog.ServiceNodes", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		found := false
+		for _, sn := range reply.ServiceNodes {
+			if sn.ServiceID == "foo" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("bad: %#v", reply.ServiceNodes)
+		}
+	}
+
+	// Catalog.ServiceNodes filters services we can't access
+	{
+		opt := structs.ServiceSpecificRequest{
+			Datacenter:   "dc1",
+			ServiceName:  "bar",
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedServiceNodes{}
+		if err := client.Call("Catalog.ServiceNodes", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		for _, sn := range reply.ServiceNodes {
+			if sn.ServiceID == "bar" {
+				t.Fatalf("bad: %#v", reply.ServiceNodes)
+			}
+		}
+	}
+
+	// Catalog.NodeServices filters and returns services properly
+	{
+		opt := structs.NodeSpecificRequest{
+			Datacenter:   "dc1",
+			Node:         srv.config.NodeName,
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedNodeServices{}
+		if err := client.Call("Catalog.NodeServices", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		found := false
+		for _, svc := range reply.NodeServices.Services {
+			if svc.ID == "bar" {
+				t.Fatalf("bad: %#v", reply.NodeServices.Services)
+			}
+			if svc.ID == "foo" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("bad: %#v", reply.NodeServices)
+		}
+	}
+}
+
 var testRegisterRules = `
 service "foo" {
 	policy = "write"

--- a/consul/health_endpoint.go
+++ b/consul/health_endpoint.go
@@ -43,7 +43,7 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 		state.QueryTables("NodeChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.NodeChecks(args.Node)
-			return h.srv.applyDiscoveryACLs(args.Token, reply)
+			return h.srv.aclFilter(args.Token, reply)
 		})
 }
 
@@ -67,7 +67,7 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 		state.QueryTables("ServiceChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.ServiceChecks(args.ServiceName)
-			return h.srv.applyDiscoveryACLs(args.Token, reply)
+			return h.srv.aclFilter(args.Token, reply)
 		})
 }
 
@@ -93,7 +93,7 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 			} else {
 				reply.Index, reply.Nodes = state.CheckServiceNodes(args.ServiceName)
 			}
-			return h.srv.applyDiscoveryACLs(args.Token, reply)
+			return h.srv.aclFilter(args.Token, reply)
 		})
 
 	// Provide some metrics

--- a/consul/health_endpoint.go
+++ b/consul/health_endpoint.go
@@ -43,7 +43,7 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 		state.QueryTables("NodeChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.NodeChecks(args.Node)
-			return nil
+			return h.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 
@@ -67,7 +67,7 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 		state.QueryTables("ServiceChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.ServiceChecks(args.ServiceName)
-			return nil
+			return h.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 
@@ -93,7 +93,7 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 			} else {
 				reply.Index, reply.Nodes = state.CheckServiceNodes(args.ServiceName)
 			}
-			return nil
+			return h.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 
 	// Provide some metrics

--- a/consul/health_endpoint.go
+++ b/consul/health_endpoint.go
@@ -43,7 +43,7 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 		state.QueryTables("NodeChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.NodeChecks(args.Node)
-			return h.srv.aclFilter(args.Token, reply)
+			return h.srv.filterACL(args.Token, reply)
 		})
 }
 
@@ -67,7 +67,7 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 		state.QueryTables("ServiceChecks"),
 		func() error {
 			reply.Index, reply.HealthChecks = state.ServiceChecks(args.ServiceName)
-			return h.srv.aclFilter(args.Token, reply)
+			return h.srv.filterACL(args.Token, reply)
 		})
 }
 
@@ -93,7 +93,7 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 			} else {
 				reply.Index, reply.Nodes = state.CheckServiceNodes(args.ServiceName)
 			}
-			return h.srv.aclFilter(args.Token, reply)
+			return h.srv.filterACL(args.Token, reply)
 		})
 
 	// Provide some metrics

--- a/consul/health_endpoint_test.go
+++ b/consul/health_endpoint_test.go
@@ -223,7 +223,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 	}
 }
 
-func TestHealth_applyDiscoveryACLs(t *testing.T) {
+func TestHealth_filterACL(t *testing.T) {
 	dir, srv := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/consul/health_endpoint_test.go
+++ b/consul/health_endpoint_test.go
@@ -223,155 +223,96 @@ func TestHealth_ServiceNodes(t *testing.T) {
 	}
 }
 
-func TestHealth_filterACL(t *testing.T) {
-	dir, srv := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
-		c.ACLMasterToken = "root"
-		c.ACLDefaultPolicy = "deny"
-	})
+func TestHealth_NodeChecks_FilterACL(t *testing.T) {
+	dir, token, srv, client := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
-
-	client := rpcClient(t, srv)
 	defer client.Close()
 
-	testutil.WaitForLeader(t, client.Call, "dc1")
-
-	// Create a new token
-	arg := structs.ACLRequest{
-		Datacenter: "dc1",
-		Op:         structs.ACLSet,
-		ACL: structs.ACL{
-			Name:  "User token",
-			Type:  structs.ACLTypeClient,
-			Rules: testRegisterRules,
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
+	opt := structs.NodeSpecificRequest{
+		Datacenter:   "dc1",
+		Node:         srv.config.NodeName,
+		QueryOptions: structs.QueryOptions{Token: token},
 	}
-	var id string
-	if err := client.Call("ACL.Apply", &arg, &id); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Register a service we have access to
-	regArg := structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "foo",
-			Service: "foo",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:foo",
-			Name:      "service:foo",
-			ServiceID: "foo",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+	reply := structs.IndexedHealthChecks{}
+	if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	// Register a service we don't have access to
-	regArg = structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "bar",
-			Service: "bar",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:bar",
-			Name:      "service:bar",
-			ServiceID: "bar",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
+	found := false
+	for _, chk := range reply.HealthChecks {
+		switch chk.ServiceName {
+		case "foo":
+			found = true
+		case "bar":
+			t.Fatalf("bad: %#v", reply.HealthChecks)
+		}
 	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+	if !found {
+		t.Fatalf("bad: %#v", reply.HealthChecks)
+	}
+}
+
+func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
+	dir, token, srv, client := testACLFilterServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer client.Close()
+
+	opt := structs.ServiceSpecificRequest{
+		Datacenter:   "dc1",
+		ServiceName:  "foo",
+		QueryOptions: structs.QueryOptions{Token: token},
+	}
+	reply := structs.IndexedHealthChecks{}
+	if err := client.Call("Health.ServiceChecks", &opt, &reply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	// Health.NodeChecks properly filters and returns services
-	{
-		opt := structs.NodeSpecificRequest{
-			Datacenter:   "dc1",
-			Node:         srv.config.NodeName,
-			QueryOptions: structs.QueryOptions{Token: id},
-		}
-		reply := structs.IndexedHealthChecks{}
-		if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		found := false
-		for _, chk := range reply.HealthChecks {
-			switch chk.ServiceName {
-			case "foo":
-				found = true
-			case "bar":
-				t.Fatalf("bad: %#v", reply.HealthChecks)
-			}
-		}
-		if !found {
-			t.Fatalf("bad: %#v", reply.HealthChecks)
+	found := false
+	for _, chk := range reply.HealthChecks {
+		if chk.ServiceName == "foo" {
+			found = true
+			break
 		}
 	}
-
-	// Health.ServiceChecks properly filters and returns services
-	{
-		opt := structs.ServiceSpecificRequest{
-			Datacenter:   "dc1",
-			ServiceName:  "foo",
-			QueryOptions: structs.QueryOptions{Token: id},
-		}
-		reply := structs.IndexedHealthChecks{}
-		if err := client.Call("Health.ServiceChecks", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		found := false
-		for _, chk := range reply.HealthChecks {
-			if chk.ServiceName == "foo" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Fatalf("bad: %#v", reply.HealthChecks)
-		}
-
-		opt.ServiceName = "bar"
-		reply = structs.IndexedHealthChecks{}
-		if err := client.Call("Health.ServiceChecks", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if len(reply.HealthChecks) != 0 {
-			t.Fatalf("bad: %#v", reply.HealthChecks)
-		}
+	if !found {
+		t.Fatalf("bad: %#v", reply.HealthChecks)
 	}
 
-	// Health.ServiceNodes properly filters and returns services
-	{
-		opt := structs.ServiceSpecificRequest{
-			Datacenter:   "dc1",
-			ServiceName:  "foo",
-			QueryOptions: structs.QueryOptions{Token: id},
-		}
-		reply := structs.IndexedCheckServiceNodes{}
-		if err := client.Call("Health.ServiceNodes", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if len(reply.Nodes) != 1 {
-			t.Fatalf("bad: %#v", reply.Nodes)
-		}
+	opt.ServiceName = "bar"
+	reply = structs.IndexedHealthChecks{}
+	if err := client.Call("Health.ServiceChecks", &opt, &reply); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(reply.HealthChecks) != 0 {
+		t.Fatalf("bad: %#v", reply.HealthChecks)
+	}
+}
 
-		opt.ServiceName = "bar"
-		reply = structs.IndexedCheckServiceNodes{}
-		if err := client.Call("Health.ServiceNodes", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if len(reply.Nodes) != 0 {
-			t.Fatalf("bad: %#v", reply.Nodes)
-		}
+func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
+	dir, token, srv, client := testACLFilterServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer client.Close()
+
+	opt := structs.ServiceSpecificRequest{
+		Datacenter:   "dc1",
+		ServiceName:  "foo",
+		QueryOptions: structs.QueryOptions{Token: token},
+	}
+	reply := structs.IndexedCheckServiceNodes{}
+	if err := client.Call("Health.ServiceNodes", &opt, &reply); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(reply.Nodes) != 1 {
+		t.Fatalf("bad: %#v", reply.Nodes)
+	}
+
+	opt.ServiceName = "bar"
+	reply = structs.IndexedCheckServiceNodes{}
+	if err := client.Call("Health.ServiceNodes", &opt, &reply); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(reply.Nodes) != 0 {
+		t.Fatalf("bad: %#v", reply.Nodes)
 	}
 }

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -25,8 +25,12 @@ func (m *Internal) NodeInfo(args *structs.NodeSpecificRequest,
 		&reply.QueryMeta,
 		state.QueryTables("NodeInfo"),
 		func() error {
-			reply.Index, reply.Dump = state.NodeInfo(args.Node)
-			return m.srv.applyDiscoveryACLs(args.Token, reply)
+			index, dump := state.NodeInfo(args.Node)
+			if err := m.srv.aclFilter(args.Token, &dump); err != nil {
+				return err
+			}
+			reply.Index, reply.Dump = index, dump
+			return nil
 		})
 }
 
@@ -43,8 +47,12 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 		&reply.QueryMeta,
 		state.QueryTables("NodeDump"),
 		func() error {
-			reply.Index, reply.Dump = state.NodeDump()
-			return m.srv.applyDiscoveryACLs(args.Token, reply)
+			index, dump := state.NodeDump()
+			if err := m.srv.aclFilter(args.Token, &dump); err != nil {
+				return err
+			}
+			reply.Index, reply.Dump = index, dump
+			return nil
 		})
 }
 

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -25,12 +25,8 @@ func (m *Internal) NodeInfo(args *structs.NodeSpecificRequest,
 		&reply.QueryMeta,
 		state.QueryTables("NodeInfo"),
 		func() error {
-			index, dump := state.NodeInfo(args.Node)
-			if err := m.srv.aclFilter(args.Token, &dump); err != nil {
-				return err
-			}
-			reply.Index, reply.Dump = index, dump
-			return nil
+			reply.Index, reply.Dump = state.NodeInfo(args.Node)
+			return m.srv.filterACL(args.Token, reply)
 		})
 }
 
@@ -47,12 +43,8 @@ func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 		&reply.QueryMeta,
 		state.QueryTables("NodeDump"),
 		func() error {
-			index, dump := state.NodeDump()
-			if err := m.srv.aclFilter(args.Token, &dump); err != nil {
-				return err
-			}
-			reply.Index, reply.Dump = index, dump
-			return nil
+			reply.Index, reply.Dump = state.NodeDump()
+			return m.srv.filterACL(args.Token, reply)
 		})
 }
 

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -12,39 +12,39 @@ type Internal struct {
 	srv *Server
 }
 
-// ChecksInState is used to get all the checks in a given state
+// NodeInfo is used to retrieve information about a specific node.
 func (m *Internal) NodeInfo(args *structs.NodeSpecificRequest,
 	reply *structs.IndexedNodeDump) error {
 	if done, err := m.srv.forward("Internal.NodeInfo", args, args, reply); done {
 		return err
 	}
 
-	// Get the state specific checks
+	// Get the node info
 	state := m.srv.fsm.State()
 	return m.srv.blockingRPC(&args.QueryOptions,
 		&reply.QueryMeta,
 		state.QueryTables("NodeInfo"),
 		func() error {
 			reply.Index, reply.Dump = state.NodeInfo(args.Node)
-			return nil
+			return m.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 
-// ChecksInState is used to get all the checks in a given state
+// NodeDump is used to generate information about all of the nodes.
 func (m *Internal) NodeDump(args *structs.DCSpecificRequest,
 	reply *structs.IndexedNodeDump) error {
 	if done, err := m.srv.forward("Internal.NodeDump", args, args, reply); done {
 		return err
 	}
 
-	// Get the state specific checks
+	// Get all the node info
 	state := m.srv.fsm.State()
 	return m.srv.blockingRPC(&args.QueryOptions,
 		&reply.QueryMeta,
 		state.QueryTables("NodeDump"),
 		func() error {
 			reply.Index, reply.Dump = state.NodeDump()
-			return nil
+			return m.srv.applyDiscoveryACLs(args.Token, reply)
 		})
 }
 

--- a/consul/internal_endpoint_test.go
+++ b/consul/internal_endpoint_test.go
@@ -239,152 +239,89 @@ func TestInternal_KeyringOperation(t *testing.T) {
 	}
 }
 
-func TestInternal_filterACL(t *testing.T) {
-	dir, srv := testServerWithConfig(t, func(c *Config) {
-		c.ACLDatacenter = "dc1"
-		c.ACLMasterToken = "root"
-		c.ACLDefaultPolicy = "deny"
-	})
+func TestInternal_NodeInfo_FilterACL(t *testing.T) {
+	dir, token, srv, client := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
-
-	client := rpcClient(t, srv)
 	defer client.Close()
 
-	testutil.WaitForLeader(t, client.Call, "dc1")
-
-	// Create a new token
-	arg := structs.ACLRequest{
-		Datacenter: "dc1",
-		Op:         structs.ACLSet,
-		ACL: structs.ACL{
-			Name:  "User token",
-			Type:  structs.ACLTypeClient,
-			Rules: testRegisterRules,
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
+	opt := structs.NodeSpecificRequest{
+		Datacenter:   "dc1",
+		Node:         srv.config.NodeName,
+		QueryOptions: structs.QueryOptions{Token: token},
 	}
-	var id string
-	if err := client.Call("ACL.Apply", &arg, &id); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Register a service we have access to
-	regArg := structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "foo",
-			Service: "foo",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:foo",
-			Name:      "service:foo",
-			ServiceID: "foo",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+	reply := structs.IndexedNodeDump{}
+	if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	// Register a service we don't have access to
-	regArg = structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       srv.config.NodeName,
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			ID:      "bar",
-			Service: "bar",
-		},
-		Check: &structs.HealthCheck{
-			CheckID:   "service:bar",
-			Name:      "service:bar",
-			ServiceID: "bar",
-		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
-	}
-	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Internal.NodeInfo filters services properly
-	{
-		opt := structs.NodeSpecificRequest{
-			Datacenter:   "dc1",
-			Node:         srv.config.NodeName,
-			QueryOptions: structs.QueryOptions{Token: id},
-		}
-		reply := structs.IndexedNodeDump{}
-		if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		for _, info := range reply.Dump {
-			found := false
-			for _, chk := range info.Checks {
-				if chk.ServiceName == "foo" {
-					found = true
-				}
-				if chk.ServiceName == "bar" {
-					t.Fatalf("bad: %#v", info.Checks)
-				}
+	for _, info := range reply.Dump {
+		found := false
+		for _, chk := range info.Checks {
+			if chk.ServiceName == "foo" {
+				found = true
 			}
-			if !found {
+			if chk.ServiceName == "bar" {
 				t.Fatalf("bad: %#v", info.Checks)
 			}
+		}
+		if !found {
+			t.Fatalf("bad: %#v", info.Checks)
+		}
 
-			found = false
-			for _, svc := range info.Services {
-				if svc.Service == "foo" {
-					found = true
-				}
-				if svc.Service == "bar" {
-					t.Fatalf("bad: %#v", info.Services)
-				}
+		found = false
+		for _, svc := range info.Services {
+			if svc.Service == "foo" {
+				found = true
 			}
-			if !found {
+			if svc.Service == "bar" {
 				t.Fatalf("bad: %#v", info.Services)
 			}
 		}
+		if !found {
+			t.Fatalf("bad: %#v", info.Services)
+		}
 	}
+}
 
-	// Internal.NodeDump filters services properly
-	{
-		opt := structs.DCSpecificRequest{
-			Datacenter:   "dc1",
-			QueryOptions: structs.QueryOptions{Token: id},
-		}
-		reply := structs.IndexedNodeDump{}
-		if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		for _, info := range reply.Dump {
-			found := false
-			for _, chk := range info.Checks {
-				if chk.ServiceName == "foo" {
-					found = true
-				}
-				if chk.ServiceName == "bar" {
-					t.Fatalf("bad: %#v", info.Checks)
-				}
+func TestInternal_NodeDump_FilterACL(t *testing.T) {
+	dir, token, srv, client := testACLFilterServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer client.Close()
+
+	opt := structs.DCSpecificRequest{
+		Datacenter:   "dc1",
+		QueryOptions: structs.QueryOptions{Token: token},
+	}
+	reply := structs.IndexedNodeDump{}
+	if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	for _, info := range reply.Dump {
+		found := false
+		for _, chk := range info.Checks {
+			if chk.ServiceName == "foo" {
+				found = true
 			}
-			if !found {
+			if chk.ServiceName == "bar" {
 				t.Fatalf("bad: %#v", info.Checks)
 			}
+		}
+		if !found {
+			t.Fatalf("bad: %#v", info.Checks)
+		}
 
-			found = false
-			for _, svc := range info.Services {
-				if svc.Service == "foo" {
-					found = true
-				}
-				if svc.Service == "bar" {
-					t.Fatalf("bad: %#v", info.Services)
-				}
+		found = false
+		for _, svc := range info.Services {
+			if svc.Service == "foo" {
+				found = true
 			}
-			if !found {
+			if svc.Service == "bar" {
 				t.Fatalf("bad: %#v", info.Services)
 			}
+		}
+		if !found {
+			t.Fatalf("bad: %#v", info.Services)
 		}
 	}
 }

--- a/consul/internal_endpoint_test.go
+++ b/consul/internal_endpoint_test.go
@@ -238,3 +238,153 @@ func TestInternal_KeyringOperation(t *testing.T) {
 		t.Fatalf("should have two lan and one wan response")
 	}
 }
+
+func TestInternal_filterACL(t *testing.T) {
+	dir, srv := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLMasterToken = "root"
+		c.ACLDefaultPolicy = "deny"
+	})
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+
+	client := rpcClient(t, srv)
+	defer client.Close()
+
+	testutil.WaitForLeader(t, client.Call, "dc1")
+
+	// Create a new token
+	arg := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name:  "User token",
+			Type:  structs.ACLTypeClient,
+			Rules: testRegisterRules,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	var id string
+	if err := client.Call("ACL.Apply", &arg, &id); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Register a service we have access to
+	regArg := structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       srv.config.NodeName,
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "foo",
+			Service: "foo",
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "service:foo",
+			Name:      "service:foo",
+			ServiceID: "foo",
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Register a service we don't have access to
+	regArg = structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       srv.config.NodeName,
+		Address:    "127.0.0.1",
+		Service: &structs.NodeService{
+			ID:      "bar",
+			Service: "bar",
+		},
+		Check: &structs.HealthCheck{
+			CheckID:   "service:bar",
+			Name:      "service:bar",
+			ServiceID: "bar",
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	if err := client.Call("Catalog.Register", &regArg, nil); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Internal.NodeInfo filters services properly
+	{
+		opt := structs.NodeSpecificRequest{
+			Datacenter:   "dc1",
+			Node:         srv.config.NodeName,
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedNodeDump{}
+		if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		for _, info := range reply.Dump {
+			found := false
+			for _, chk := range info.Checks {
+				if chk.ServiceName == "foo" {
+					found = true
+				}
+				if chk.ServiceName == "bar" {
+					t.Fatalf("bad: %#v", info.Checks)
+				}
+			}
+			if !found {
+				t.Fatalf("bad: %#v", info.Checks)
+			}
+
+			found = false
+			for _, svc := range info.Services {
+				if svc.Service == "foo" {
+					found = true
+				}
+				if svc.Service == "bar" {
+					t.Fatalf("bad: %#v", info.Services)
+				}
+			}
+			if !found {
+				t.Fatalf("bad: %#v", info.Services)
+			}
+		}
+	}
+
+	// Internal.NodeDump filters services properly
+	{
+		opt := structs.DCSpecificRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: id},
+		}
+		reply := structs.IndexedNodeDump{}
+		if err := client.Call("Health.NodeChecks", &opt, &reply); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		for _, info := range reply.Dump {
+			found := false
+			for _, chk := range info.Checks {
+				if chk.ServiceName == "foo" {
+					found = true
+				}
+				if chk.ServiceName == "bar" {
+					t.Fatalf("bad: %#v", info.Checks)
+				}
+			}
+			if !found {
+				t.Fatalf("bad: %#v", info.Checks)
+			}
+
+			found = false
+			for _, svc := range info.Services {
+				if svc.Service == "foo" {
+					found = true
+				}
+				if svc.Service == "bar" {
+					t.Fatalf("bad: %#v", info.Services)
+				}
+			}
+			if !found {
+				t.Fatalf("bad: %#v", info.Services)
+			}
+		}
+	}
+}

--- a/website/source/docs/upgrade-specific.html.markdown
+++ b/website/source/docs/upgrade-specific.html.markdown
@@ -14,6 +14,29 @@ details provided for their upgrades as a result of new features or changed
 behavior. This page is used to document those details seperately from the
 standard upgrade flow.
 
+## Consul 0.6
+
+Consul 0.6 introduces enhancements to the ACL system which may require special
+handling:
+
+* Service ACL's are enforced during service discovery (REST + DNS)
+
+Previously, service discovery was wide open, and any client could query
+information about any service without providing a token. Consul now requires
+read-level access at a minimum when ACL's are enabled to return service
+information over the REST or DNS interfaces. If clients depend on an open
+service discovery system, then the following should be added to all ACL tokens
+which require it:
+
+    # Enable discovery of all services
+    service "" {
+        policy = "read"
+    }
+
+Note that the agent's [`acl_token`](/docs/agent/options.html#acl_token) is used
+when the DNS interface is queried, so be sure that token has sufficient
+privileges to return the DNS records you expect to retrieve from it.
+
 ## Consul 0.5.1
 
 Consul version 0.5.1 uses a different backend store for persisting the Raft


### PR DESCRIPTION
Implements a filter on top of the state store to allow restricting read access to services. This allows issuing tokens which can only see services they have explicit permissions to read. The documentation is purposely left kind of half-complete so that we can polish it off after the DNS side of this is more complete, but we can tackle that in a separate PR.