### PR TITLE
Clarify keyprefix behaviour in docs

### DIFF
--- a/website/source/docs/agent/watches.html.markdown
+++ b/website/source/docs/agent/watches.html.markdown
@@ -105,7 +105,9 @@ An example of the output of this command:
 ### <a name="keyprefix"></a>Type: keyprefix
 
 The "keyprefix" watch type is used to watch a prefix of keys in the KV store.
-It requires that the "prefix" parameter be specified.
+It requires that the "prefix" parameter be specified. Note that the watch
+returns *all* keys matching the prefix whenever *any* key matching the prefix
+changes.
 
 This maps to the `/v1/kv/` API internally.
 

--- a/website/source/docs/agent/watches.html.markdown
+++ b/website/source/docs/agent/watches.html.markdown
@@ -105,7 +105,7 @@ An example of the output of this command:
 ### <a name="keyprefix"></a>Type: keyprefix
 
 The "keyprefix" watch type is used to watch a prefix of keys in the KV store.
-It requires that the "prefix" parameter be specified. Note that the watch
+It requires that the "prefix" parameter be specified. This watch
 returns *all* keys matching the prefix whenever *any* key matching the prefix
 changes.
 


### PR DESCRIPTION
As mentioned in #410 the docs aren't overly clear that this will always return all keys. Tried to clarify.