### PR TITLE
Remove unreachable error handling in AgentRPC.listen()

### DIFF
--- a/command/agent/rpc.go
+++ b/command/agent/rpc.go
@@ -304,11 +304,6 @@ func (i *AgentRPC) listen() {
 		}
 		client.dec = codec.NewDecoder(client.reader, msgpackHandle)
 		client.enc = codec.NewEncoder(client.writer, msgpackHandle)
-		if err != nil {
-			i.logger.Printf("[ERR] agent.rpc: Failed to create decoder: %v", err)
-			conn.Close()
-			continue
-		}
 
 		// Register the client
 		i.Lock()


### PR DESCRIPTION
If there happens to be an error accepting a connection in AgentRPC.listen() it is either returning, if the agent has stopped, or its for loop is continued.

Therefor error branch in line 307 is never reached.
This seems to be the case since the initial commit of the rpc code.