### PR TITLE
Use test target for travis-ci, remove flowdock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,4 @@ branches:
 
 install: make deps
 script:
-    - make integ
-
-notifications:
-    flowdock:
-        secure: fZrcf9rlh2IrQrlch1sHkn3YI7SKvjGnAl/zyV5D6NROe1Bbr6d3QRMuCXWWdhJHzjKmXk5rIzbqJhUc0PNF7YjxGNKSzqWMQ56KcvN1k8DzlqxpqkcA3Jbs6fXCWo2fssRtZ7hj/wOP1f5n6cc7kzHDt9dgaYJ6nO2fqNPJiTc=
-
+    - make test


### PR DESCRIPTION
I don't think we use `the INTEG_TESTS` env var anywhere during the tests. This change will just use the `test` target for CI so that we can run the API tests there as well (we build the binary to a temp path in `scripts/test.sh`).

Also removed flowdock because I'm not sure what that is. If we need it I can add it back in.

/cc @armon