### PR TITLE
Event ACLs

### DIFF
--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -66,6 +66,18 @@ func TestStaticACL(t *testing.T) {
 	if none.ServiceWrite("foobar") {
 		t.Fatalf("should not allow")
 	}
+	if none.EventRead("foobar") {
+		t.Fatalf("should not allow")
+	}
+	if none.EventRead("") {
+		t.Fatalf("should not allow")
+	}
+	if none.EventWrite("foobar") {
+		t.Fatalf("should not allow")
+	}
+	if none.EventWrite("") {
+		t.Fatalf("should not allow")
+	}
 	if none.ACLList() {
 		t.Fatalf("should not noneow")
 	}
@@ -132,6 +144,20 @@ func TestPolicyACL(t *testing.T) {
 				Policy: ServicePolicyWrite,
 			},
 		},
+		Events: []*EventPolicy{
+			&EventPolicy{
+				Event:  "",
+				Policy: EventPolicyRead,
+			},
+			&EventPolicy{
+				Event:  "foo",
+				Policy: EventPolicyWrite,
+			},
+			&EventPolicy{
+				Event:  "bar",
+				Policy: EventPolicyDeny,
+			},
+		},
 	}
 	acl, err := New(all, policy)
 	if err != nil {
@@ -186,6 +212,27 @@ func TestPolicyACL(t *testing.T) {
 		}
 		if c.write != acl.ServiceWrite(c.inp) {
 			t.Fatalf("Write fail: %#v", c)
+		}
+	}
+
+	type eventcase struct {
+		inp   string
+		read  bool
+		write bool
+	}
+	eventcases := []eventcase{
+		{"foo", true, true},
+		{"foobar", true, true},
+		{"bar", false, false},
+		{"barbaz", false, false},
+		{"baz", true, false},
+	}
+	for _, c := range eventcases {
+		if c.read != acl.EventRead(c.inp) {
+			t.Fatalf("Event fail: %#v", c)
+		}
+		if c.write != acl.EventWrite(c.inp) {
+			t.Fatalf("Event fail: %#v", c)
 		}
 	}
 }

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -79,10 +79,10 @@ func TestStaticACL(t *testing.T) {
 		t.Fatalf("should not allow")
 	}
 	if none.ACLList() {
-		t.Fatalf("should not noneow")
+		t.Fatalf("should not allow")
 	}
 	if none.ACLModify() {
-		t.Fatalf("should not noneow")
+		t.Fatalf("should not allow")
 	}
 
 	if !manage.KeyRead("foobar") {

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -13,6 +13,9 @@ const (
 	ServicePolicyDeny  = "deny"
 	ServicePolicyRead  = "read"
 	ServicePolicyWrite = "write"
+	EventPolicyRead    = "read"
+	EventPolicyWrite   = "write"
+	EventPolicyDeny    = "deny"
 )
 
 // Policy is used to represent the policy specified by
@@ -21,6 +24,7 @@ type Policy struct {
 	ID       string           `hcl:"-"`
 	Keys     []*KeyPolicy     `hcl:"key,expand"`
 	Services []*ServicePolicy `hcl:"service,expand"`
+	Events   []*EventPolicy   `hcl:"event,expand"`
 }
 
 // KeyPolicy represents a policy for a key
@@ -41,6 +45,16 @@ type ServicePolicy struct {
 
 func (k *ServicePolicy) GoString() string {
 	return fmt.Sprintf("%#v", *k)
+}
+
+// EventPolicy represents a user event policy.
+type EventPolicy struct {
+	Event  string `hcl:",key"`
+	Policy string
+}
+
+func (e *EventPolicy) GoString() string {
+	return fmt.Sprintf("%#v", *e)
 }
 
 // Parse is used to parse the specified ACL rules into an
@@ -77,6 +91,17 @@ func Parse(rules string) (*Policy, error) {
 		case ServicePolicyWrite:
 		default:
 			return nil, fmt.Errorf("Invalid service policy: %#v", sp)
+		}
+	}
+
+	// Validate the user event policies
+	for _, ep := range p.Events {
+		switch ep.Policy {
+		case EventPolicyRead:
+		case EventPolicyWrite:
+		case EventPolicyDeny:
+		default:
+			return nil, fmt.Errorf("Invalid event policy: %#v", ep)
 		}
 	}
 

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -25,6 +25,15 @@ service "" {
 service "foo" {
 	policy = "read"
 }
+event "" {
+	policy = "read"
+}
+event "foo" {
+	policy = "write"
+}
+event "bar" {
+	policy = "deny"
+}
 	`
 	exp := &Policy{
 		Keys: []*KeyPolicy{
@@ -53,6 +62,20 @@ service "foo" {
 			&ServicePolicy{
 				Name:   "foo",
 				Policy: ServicePolicyRead,
+			},
+		},
+		Events: []*EventPolicy{
+			&EventPolicy{
+				Event:  "",
+				Policy: EventPolicyRead,
+			},
+			&EventPolicy{
+				Event:  "foo",
+				Policy: EventPolicyWrite,
+			},
+			&EventPolicy{
+				Event:  "bar",
+				Policy: EventPolicyDeny,
 			},
 		},
 	}
@@ -90,6 +113,17 @@ func TestParse_JSON(t *testing.T) {
 		"foo": {
 			"policy": "read"
 		}
+	},
+	"event": {
+		"": {
+			"policy": "read"
+		},
+		"foo": {
+			"policy": "write"
+		},
+		"bar": {
+			"policy": "deny"
+		}
 	}
 }`
 	exp := &Policy{
@@ -119,6 +153,20 @@ func TestParse_JSON(t *testing.T) {
 			&ServicePolicy{
 				Name:   "foo",
 				Policy: ServicePolicyRead,
+			},
+		},
+		Events: []*EventPolicy{
+			&EventPolicy{
+				Event:  "",
+				Policy: EventPolicyRead,
+			},
+			&EventPolicy{
+				Event:  "foo",
+				Policy: EventPolicyWrite,
+			},
+			&EventPolicy{
+				Event:  "bar",
+				Policy: EventPolicyDeny,
 			},
 		},
 	}

--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -62,7 +62,9 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
-		return nil, err
+		resp.WriteHeader(403)
+		resp.Write([]byte(permissionDenied))
+		return nil, nil
 	}
 
 	// Return the event

--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -36,6 +36,10 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 		return nil, nil
 	}
 
+	// Get the ACL token
+	var token string
+	s.parseToken(req, &token)
+
 	// Get the filters
 	if filt := req.URL.Query().Get("node"); filt != "" {
 		event.NodeFilter = filt
@@ -57,7 +61,7 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	}
 
 	// Try to fire the event
-	if err := s.agent.UserEvent(dc, event); err != nil {
+	if err := s.agent.UserEvent(dc, token, event); err != nil {
 		return nil, err
 	}
 

--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -62,9 +62,13 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
-		resp.WriteHeader(403)
-		resp.Write([]byte(permissionDenied))
-		return nil, nil
+		if strings.Contains(err.Error(), permissionDenied) {
+			resp.WriteHeader(403)
+			resp.Write([]byte(permissionDenied))
+			return nil, nil
+		}
+		resp.WriteHeader(500)
+		return nil, err
 	}
 
 	// Return the event

--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -13,6 +13,8 @@ import (
 
 func TestEventFire(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
 		body := bytes.NewBuffer([]byte("test"))
 		url := "/v1/event/fire/test?node=Node&service=foo&tag=bar"
 		req, err := http.NewRequest("PUT", url, body)
@@ -53,8 +55,10 @@ func TestEventFire(t *testing.T) {
 
 func TestEventList(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
 		p := &UserEvent{Name: "test"}
-		if err := srv.agent.UserEvent("", p); err != nil {
+		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -89,13 +93,15 @@ func TestEventList(t *testing.T) {
 
 func TestEventList_Filter(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
 		p := &UserEvent{Name: "test"}
-		if err := srv.agent.UserEvent("", p); err != nil {
+		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		p = &UserEvent{Name: "foo"}
-		if err := srv.agent.UserEvent("", p); err != nil {
+		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -130,8 +136,10 @@ func TestEventList_Filter(t *testing.T) {
 
 func TestEventList_Blocking(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
 		p := &UserEvent{Name: "test"}
-		if err := srv.agent.UserEvent("", p); err != nil {
+		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -159,7 +167,7 @@ func TestEventList_Blocking(t *testing.T) {
 		go func() {
 			time.Sleep(50 * time.Millisecond)
 			p := &UserEvent{Name: "second"}
-			if err := srv.agent.UserEvent("", p); err != nil {
+			if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 				t.Fatalf("err: %v", err)
 			}
 		}()
@@ -192,6 +200,8 @@ func TestEventList_Blocking(t *testing.T) {
 
 func TestEventList_EventBufOrder(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
 		// Fire some events in a non-sequential order
 		expected := &UserEvent{Name: "foo"}
 
@@ -202,7 +212,7 @@ func TestEventList_EventBufOrder(t *testing.T) {
 			expected,
 			&UserEvent{Name: "bar"},
 		} {
-			if err := srv.agent.UserEvent("", e); err != nil {
+			if err := srv.agent.UserEvent("dc1", "root", e); err != nil {
 				t.Fatalf("err: %v", err)
 			}
 		}

--- a/command/agent/user_event.go
+++ b/command/agent/user_event.go
@@ -71,7 +71,7 @@ func validateUserEventParams(params *UserEvent) error {
 }
 
 // UserEvent is used to fire an event via the Serf layer on the LAN
-func (a *Agent) UserEvent(dc string, params *UserEvent) error {
+func (a *Agent) UserEvent(dc, token string, params *UserEvent) error {
 	// Validate the params
 	if err := validateUserEventParams(params); err != nil {
 		return err
@@ -85,27 +85,21 @@ func (a *Agent) UserEvent(dc string, params *UserEvent) error {
 		return fmt.Errorf("UserEvent encoding failed: %v", err)
 	}
 
-	// Check if this is the local DC, fire locally
-	if dc == "" || dc == a.config.Datacenter {
-		if a.server != nil {
-			return a.server.UserEvent(params.Name, payload)
-		} else {
-			return a.client.UserEvent(params.Name, payload)
-		}
-	} else {
-		// Send an RPC to remote datacenter to service this
-		args := structs.EventFireRequest{
-			Datacenter: dc,
-			Name:       params.Name,
-			Payload:    payload,
-		}
-
-		// Any server can process in the remote DC, since the
-		// gossip will take over anyways
-		args.AllowStale = true
-		var out structs.EventFireResponse
-		return a.RPC("Internal.EventFire", &args, &out)
+	// Send an RPC to service this
+	args := structs.EventFireRequest{
+		Datacenter: dc,
+		Name:       params.Name,
+		Payload:    payload,
 	}
+
+	// Pass along the ACL token, if any
+	args.Token = token
+
+	// Any server can process in the remote DC, since the
+	// gossip will take over anyways
+	args.AllowStale = true
+	var out structs.EventFireResponse
+	return a.RPC("Internal.EventFire", &args, &out)
 }
 
 // handleEvents is used to process incoming user events

--- a/command/agent/user_event.go
+++ b/command/agent/user_event.go
@@ -85,15 +85,14 @@ func (a *Agent) UserEvent(dc, token string, params *UserEvent) error {
 		return fmt.Errorf("UserEvent encoding failed: %v", err)
 	}
 
-	// Send an RPC to service this
+	// Service the event fire over RPC. This ensures that we authorize
+	// the request against the token first.
 	args := structs.EventFireRequest{
-		Datacenter: dc,
-		Name:       params.Name,
-		Payload:    payload,
+		Datacenter:   dc,
+		Name:         params.Name,
+		Payload:      payload,
+		QueryOptions: structs.QueryOptions{Token: token},
 	}
-
-	// Pass along the ACL token, if any
-	args.Token = token
 
 	// Any server can process in the remote DC, since the
 	// gossip will take over anyways

--- a/command/event.go
+++ b/command/event.go
@@ -33,12 +33,14 @@ Options:
   -service=""                Regular expression to filter on service instances
   -tag=""                    Regular expression to filter on service tags. Must be used
                              with -service.
+  -token=""                  ACL token to use during requests. Defaults to that
+                             of the agent.
 `
 	return strings.TrimSpace(helpText)
 }
 
 func (c *EventCommand) Run(args []string) int {
-	var datacenter, name, node, service, tag string
+	var datacenter, name, node, service, tag, token string
 	cmdFlags := flag.NewFlagSet("event", flag.ContinueOnError)
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
 	cmdFlags.StringVar(&datacenter, "datacenter", "", "")
@@ -46,6 +48,7 @@ func (c *EventCommand) Run(args []string) int {
 	cmdFlags.StringVar(&node, "node", "", "")
 	cmdFlags.StringVar(&service, "service", "", "")
 	cmdFlags.StringVar(&tag, "tag", "", "")
+	cmdFlags.StringVar(&token, "token", "", "")
 	httpAddr := HTTPAddrFlag(cmdFlags)
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -120,6 +123,7 @@ func (c *EventCommand) Run(args []string) int {
 	}
 	opts := &consulapi.WriteOptions{
 		Datacenter: datacenter,
+		Token:      token,
 	}
 
 	// Fire the event

--- a/command/rpc.go
+++ b/command/rpc.go
@@ -47,16 +47,15 @@ func HTTPAddrFlag(f *flag.FlagSet) *string {
 
 // HTTPClient returns a new Consul HTTP client with the given address.
 func HTTPClient(addr string) (*consulapi.Client, error) {
-	return HTTPClientDC(addr, "")
+	return HTTPClientConfig(func(c *consulapi.Config) {
+		c.Address = addr
+	})
 }
 
-// HTTPClientDC returns a new Consul HTTP client with the given address and datacenter
-func HTTPClientDC(addr, dc string) (*consulapi.Client, error) {
+// HTTPClientConfig is used to return a new API client and modify its
+// configuration by passing in a config modifier function.
+func HTTPClientConfig(fn func(c *consulapi.Config)) (*consulapi.Client, error) {
 	conf := consulapi.DefaultConfig()
-	if envAddr := os.Getenv(HTTPAddrEnvName); addr == "" && envAddr != "" {
-		addr = envAddr
-	}
-	conf.Address = addr
-	conf.Datacenter = dc
+	fn(conf)
 	return consulapi.NewClient(conf)
 }

--- a/consul/client.go
+++ b/consul/client.go
@@ -201,11 +201,6 @@ func (c *Client) RemoveFailedNode(node string) error {
 	return c.serf.RemoveFailedNode(node)
 }
 
-// UserEvent is used to fire an event via the Serf layer
-func (c *Client) UserEvent(name string, payload []byte) error {
-	return c.serf.UserEvent(userEventName(name), payload, false)
-}
-
 // KeyManagerLAN returns the LAN Serf keyring manager
 func (c *Client) KeyManagerLAN() *serf.KeyManager {
 	return c.serf.KeyManager()

--- a/consul/client_test.go
+++ b/consul/client_test.go
@@ -276,26 +276,18 @@ func TestClientServer_UserEvent(t *testing.T) {
 	})
 
 	// Fire the user event
-	err := c1.UserEvent("foo", []byte("bar"))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	err = s1.UserEvent("bar", []byte("baz"))
-	if err != nil {
+	if err := s1.UserEvent("foo", []byte("baz")); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Wait for all the events
-	var serverFoo, serverBar, clientFoo, clientBar bool
-	for i := 0; i < 4; i++ {
+	var clientReceived, serverReceived bool
+	for i := 0; i < 2; i++ {
 		select {
 		case e := <-clientOut:
 			switch e.Name {
 			case "foo":
-				clientFoo = true
-			case "bar":
-				clientBar = true
+				clientReceived = true
 			default:
 				t.Fatalf("Bad: %#v", e)
 			}
@@ -303,9 +295,7 @@ func TestClientServer_UserEvent(t *testing.T) {
 		case e := <-serverOut:
 			switch e.Name {
 			case "foo":
-				serverFoo = true
-			case "bar":
-				serverBar = true
+				serverReceived = true
 			default:
 				t.Fatalf("Bad: %#v", e)
 			}
@@ -315,7 +305,7 @@ func TestClientServer_UserEvent(t *testing.T) {
 		}
 	}
 
-	if !(serverFoo && serverBar && clientFoo && clientBar) {
+	if !serverReceived || !clientReceived {
 		t.Fatalf("missing events")
 	}
 }

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -72,7 +72,7 @@ func (m *Internal) EventFire(args *structs.EventFireRequest,
 	m.srv.setQueryMeta(&reply.QueryMeta)
 
 	// Fire the event
-	return m.srv.UserEvent(args.Name, args.Payload)
+	return m.srv.serfLAN.UserEvent(args.Name, args.Payload, false)
 }
 
 // KeyringOperation will query the WAN and LAN gossip keyrings of all nodes.

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -57,6 +57,17 @@ func (m *Internal) EventFire(args *structs.EventFireRequest,
 		return err
 	}
 
+	// Check ACLs
+	acl, err := m.srv.resolveToken(args.Token)
+	if err != nil {
+		return err
+	}
+
+	if acl != nil && !acl.EventWrite(args.Name) {
+		m.srv.logger.Printf("[WARN] consul: user event %q blocked by ACLs", args.Name)
+		return permissionDeniedErr
+	}
+
 	// Set the query meta data
 	m.srv.setQueryMeta(&reply.QueryMeta)
 

--- a/consul/server.go
+++ b/consul/server.go
@@ -616,11 +616,6 @@ func (s *Server) RemoveFailedNode(node string) error {
 	return nil
 }
 
-// UserEvent is used to fire an event via the Serf layer on the LAN
-func (s *Server) UserEvent(name string, payload []byte) error {
-	return s.serfLAN.UserEvent(userEventName(name), payload, false)
-}
-
 // IsLeader checks if this server is the cluster leader
 func (s *Server) IsLeader() bool {
 	return s.raft.State() == raft.Leader

--- a/website/source/docs/commands/event.html.markdown
+++ b/website/source/docs/commands/event.html.markdown
@@ -56,3 +56,5 @@ The list of available flags are:
   a matching tag. This must be used with `-service`. As an example, you may
   do "-service mysql -tag slave".
 
+* `-token` - The ACL token to use when firing the event. This token must have
+  write-level privileges for the event specified. Defaults to that of the agent.

--- a/website/source/docs/commands/exec.html.markdown
+++ b/website/source/docs/commands/exec.html.markdown
@@ -62,3 +62,6 @@ The list of available flags are:
 
 * `-verbose` - Enables verbose output.
 
+* `-token` - The ACL token to use during requests. This token must have access
+  to the prefix in the KV store as well as exec "write" access for the _rexec
+  event. Defaults to that of the agent.

--- a/website/source/docs/internals/acl.html.markdown
+++ b/website/source/docs/internals/acl.html.markdown
@@ -258,7 +258,7 @@ This is equivalent to the following JSON input:
     "": {
       "policy": "write"
     },
-    "secure-": {
+    "destroy-": {
       "policy": "deny"
     }
   }

--- a/website/source/docs/internals/acl.html.markdown
+++ b/website/source/docs/internals/acl.html.markdown
@@ -19,7 +19,7 @@ on tokens to which fine grained rules can be applied. It is very similar to
 When the ACL system was launched in Consul 0.4, it was only possible to specify
 policies for the KV store.  In Consul 0.5, ACL policies were extended to service
 registrations. In Consul 0.6, ACL's were further extended to restrict the
-service discovery mechanisms.
+service discovery mechanisms and user events..
 
 ## ACL Design
 
@@ -126,6 +126,27 @@ The most secure way of handling service registration and discovery is to run
 Consul 0.6+ and issue tokens with explicit access for the services or service
 prefixes which are expected to run on each agent.
 
+### Blacklist mode and Events
+
+Similar to the above, if your
+[`acl_default_policy`](/docs/agent/options.html#acl_default_policy) is set to
+`deny`, the `anonymous` token will have no access to allow firing user events.
+This deviates from pre-0.6.0 builds, where user events were completely
+unrestricted.
+
+Events have their own first-class expression in the ACL syntax. To restore
+access to user events from arbitrary agents, configure an ACL rule like the
+following for the `anonymous` token:
+
+```
+event "" {
+    policy = "write"
+}
+```
+
+As always, the more secure way to handle user events is to explicitly grant
+access to each API token based on the events they should be able to fire.
+
 ### Bootstrapping ACLs
 
 Bootstrapping the ACL system is done by providing an initial [`acl_master_token`
@@ -161,6 +182,12 @@ and ACLs can be found [below](#discovery_acls).
 
 The policy for the "consul" service is always "write" as it is managed internally by Consul.
 
+User event policies are defined by coupling an event name prefix with a policy.
+The rules are enforced using a longest-prefix match policy. The default rule,
+applied to any user event without a matching policy, is provided by an empty
+string. An event policy is one of "read", "write", or "deny". Currently, only
+the "write" level is enforced during event firing. Events can always be read.
+
 We make use of
 the [HashiCorp Configuration Language (HCL)](https://github.com/hashicorp/hcl/)
 to specify policy. This language is human readable and interoperable
@@ -192,6 +219,16 @@ service "" {
 service "secure-" {
     policy = "read"
 }
+
+# Allow firing any user event by default.
+event "" {
+    policy = "write"
+}
+
+# Deny firing events prefixed with "destroy-".
+event "destroy-" {
+    policy = "deny"
+}
 ```
 
 This is equivalent to the following JSON input:
@@ -216,6 +253,14 @@ This is equivalent to the following JSON input:
       "secure-": {
           "policy": "read"
       }
+  },
+  "event": {
+    "": {
+      "policy": "write"
+    },
+    "secure-": {
+      "policy": "deny"
+    }
   }
 }
 ```


### PR DESCRIPTION
This is the first part of adding ACL guards around firing user events. This can be extended to guard reading back event data later on, and adds the framework to allow that to happen.

I tried things a few different ways, so let me explain a couple of the things in here:

1. When user events are fired by the agent, instead of just checking if the target DC is local and then firing down into the Serf layer, we always push through the RPC layer to a server in the local datacenter. This allows the policy enforcement to be done on one of the servers within the datacenter, which already knows which datacenter is authoritative for ACLs. It's possible we could do the enforcement on clients using a local ACL cache, but the difference would be that we would need to require clients to also know the authoritative datacenter. We can definitely change this later, and the change is made much easier by 2).

2. Moved the ACL caching on the server side into a re-usable struct. The intention was originally to use this on the clients to keep a local cache of the ACLs. There is no functional difference for this change in this PR, but it could be useful later on to restrict read access to event data.