### PR TITLE
Website: Delete the unnecessary backslash at the end shell command line

### DIFF
--- a/website/source/intro/getting-started/checks.html.markdown
+++ b/website/source/intro/getting-started/checks.html.markdown
@@ -30,11 +30,11 @@ Create two definition files in the Consul configuration directory of
 the second node:
 
 ```text
-vagrant@n2:~$ echo '{"check": {"name": "ping", \
+vagrant@n2:~$ echo '{"check": {"name": "ping",
   "script": "ping -c1 google.com >/dev/null", "interval": "30s"}}' \
   >/etc/consul.d/ping.json
 
-vagrant@n2:~$ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80,\
+vagrant@n2:~$ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80,
   "check": {"script": "curl localhost >/dev/null 2>&1", "interval": "10s"}}}' \
   >/etc/consul.d/web.json
 ```


### PR DESCRIPTION
Shell thinks '\<newline>' as line continuation only when it's unquoted
or in double quotes. It's not necessary to manually mark '\<newline>'
in single quotes, because when shell sees the a single quote starting, it
continues the line automatically until it sees the matching single quote
ending.

Thus,
echo 'a\
  b'
would give the following output
a\
  b

And
echo 'a
  b'
gives the following output
a
  b

Since we don't want to leave backslashes in the resulting json files, we
should remove the line continuation backslashes inside single quotes.