### PR TITLE
Keyring ACLs

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -350,14 +350,19 @@ func (p *PolicyACL) KeyringRead() bool {
 	switch p.keyringRule {
 	case KeyringPolicyRead, KeyringPolicyWrite:
 		return true
-	default:
+	case KeyringPolicyDeny:
 		return false
+	default:
+		return p.parent.KeyringRead()
 	}
 }
 
 // KeyringWrite determines if the keyring can be manipulated.
 func (p *PolicyACL) KeyringWrite() bool {
-	return p.keyringRule == KeyringPolicyWrite
+	if p.keyringRule == KeyringPolicyWrite {
+		return true
+	}
+	return p.parent.KeyringWrite()
 }
 
 // ACLList checks if listing of ACLs is allowed

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -58,6 +58,13 @@ type ACL interface {
 	// EventWrite determines if a specific event may be fired.
 	EventWrite(string) bool
 
+	// KeyringRead determines if the encryption keyring used in
+	// the gossip layer can be read.
+	KeyringRead() bool
+
+	// KeyringWrite determines if the keyring can be manipulated
+	KeyringWrite() bool
+
 	// ACLList checks for permission to list all the ACLs
 	ACLList() bool
 
@@ -98,6 +105,14 @@ func (s *StaticACL) EventRead(string) bool {
 }
 
 func (s *StaticACL) EventWrite(string) bool {
+	return s.defaultAllow
+}
+
+func (s *StaticACL) KeyringRead() bool {
+	return s.defaultAllow
+}
+
+func (s *StaticACL) KeyringWrite() bool {
 	return s.defaultAllow
 }
 
@@ -153,6 +168,11 @@ type PolicyACL struct {
 
 	// eventRules contains the user event policies
 	eventRules *radix.Tree
+
+	// keyringRules contains the keyring policies. The keyring has
+	// a very simple yes/no without prefix mathing, so here we
+	// don't need to use a radix tree.
+	keyringRules map[string]struct{}
 }
 
 // New is used to construct a policy based ACL from a set of policies
@@ -163,6 +183,7 @@ func New(parent ACL, policy *Policy) (*PolicyACL, error) {
 		keyRules:     radix.New(),
 		serviceRules: radix.New(),
 		eventRules:   radix.New(),
+		keyringRules: make(map[string]struct{}),
 	}
 
 	// Load the key policy
@@ -178,6 +199,11 @@ func New(parent ACL, policy *Policy) (*PolicyACL, error) {
 	// Load the event policy
 	for _, ep := range policy.Events {
 		p.eventRules.Insert(ep.Event, ep.Policy)
+	}
+
+	// Load the keyring policy
+	for _, krp := range policy.Keyring {
+		p.keyringRules[krp.Policy] = struct{}{}
 	}
 
 	return p, nil
@@ -319,6 +345,34 @@ func (p *PolicyACL) EventWrite(name string) bool {
 
 	// No match, use parent
 	return p.parent.EventWrite(name)
+}
+
+// KeyringRead is used to determine if the keyring can be
+// read by the current ACL token.
+func (p *PolicyACL) KeyringRead() bool {
+	// First check for an explicit deny
+	if _, ok := p.keyringRules[KeyringPolicyDeny]; ok {
+		return false
+	}
+
+	// Now check for read or write. Write implies read.
+	_, ok := p.keyringRules[KeyringPolicyRead]
+	if !ok {
+		_, ok = p.keyringRules[KeyringPolicyWrite]
+	}
+	return ok
+}
+
+// KeyringWrite determines if the keyring can be manipulated.
+func (p *PolicyACL) KeyringWrite() bool {
+	// First check for an explicit deny
+	if _, ok := p.keyringRules[KeyringPolicyDeny]; ok {
+		return false
+	}
+
+	// Check for read permission
+	_, ok := p.keyringRules[KeyringPolicyWrite]
+	return ok
 }
 
 // ACLList checks if listing of ACLs is allowed

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -245,6 +245,7 @@ func TestPolicyACL(t *testing.T) {
 		}
 	}
 
+	// Test the events
 	type eventcase struct {
 		inp   string
 		read  bool
@@ -366,6 +367,33 @@ func TestPolicyACL_Parent(t *testing.T) {
 		}
 		if c.write != acl.ServiceWrite(c.inp) {
 			t.Fatalf("Write fail: %#v", c)
+		}
+	}
+}
+
+func TestPolicyACL_Keyring(t *testing.T) {
+	// Test keyring ACLs
+	type keyringcase struct {
+		inp   string
+		read  bool
+		write bool
+	}
+	keyringcases := []keyringcase{
+		{"", false, false},
+		{KeyringPolicyRead, true, false},
+		{KeyringPolicyWrite, true, true},
+		{KeyringPolicyDeny, false, false},
+	}
+	for _, c := range keyringcases {
+		acl, err := New(DenyAll(), &Policy{Keyring: c.inp})
+		if err != nil {
+			t.Fatalf("bad: %s", err)
+		}
+		if acl.KeyringRead() != c.read {
+			t.Fatalf("bad: %#v", c)
+		}
+		if acl.KeyringWrite() != c.write {
+			t.Fatalf("bad: %#v", c)
 		}
 	}
 }

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -47,6 +47,18 @@ func TestStaticACL(t *testing.T) {
 	if !all.ServiceWrite("foobar") {
 		t.Fatalf("should allow")
 	}
+	if !all.EventRead("foobar") {
+		t.Fatalf("should allow")
+	}
+	if !all.EventWrite("foobar") {
+		t.Fatalf("should allow")
+	}
+	if !all.KeyringRead() {
+		t.Fatalf("should allow")
+	}
+	if !all.KeyringWrite() {
+		t.Fatalf("should allow")
+	}
 	if all.ACLList() {
 		t.Fatalf("should not allow")
 	}
@@ -78,6 +90,12 @@ func TestStaticACL(t *testing.T) {
 	if none.EventWrite("") {
 		t.Fatalf("should not allow")
 	}
+	if none.KeyringRead() {
+		t.Fatalf("should now allow")
+	}
+	if none.KeyringWrite() {
+		t.Fatalf("should not allow")
+	}
 	if none.ACLList() {
 		t.Fatalf("should not allow")
 	}
@@ -95,6 +113,18 @@ func TestStaticACL(t *testing.T) {
 		t.Fatalf("should allow")
 	}
 	if !manage.ServiceWrite("foobar") {
+		t.Fatalf("should allow")
+	}
+	if !manage.EventRead("foobar") {
+		t.Fatalf("should allow")
+	}
+	if !manage.EventWrite("foobar") {
+		t.Fatalf("should allow")
+	}
+	if !manage.KeyringRead() {
+		t.Fatalf("should allow")
+	}
+	if !manage.KeyringWrite() {
 		t.Fatalf("should allow")
 	}
 	if !manage.ACLList() {

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -28,7 +28,7 @@ type Policy struct {
 	Keys     []*KeyPolicy     `hcl:"key,expand"`
 	Services []*ServicePolicy `hcl:"service,expand"`
 	Events   []*EventPolicy   `hcl:"event,expand"`
-	Keyring  []*KeyringPolicy `hcl:"keyring"`
+	Keyring  string           `hcl:"keyring"`
 }
 
 // KeyPolicy represents a policy for a key
@@ -59,17 +59,6 @@ type EventPolicy struct {
 
 func (e *EventPolicy) GoString() string {
 	return fmt.Sprintf("%#v", *e)
-}
-
-// KeyringPolicy represents a policy for the encryption keyring.
-type KeyringPolicy struct {
-	// We only need a single field for the keyring, since access
-	// is binary (allowed or disallowed) and no prefix is respected.
-	Policy string
-}
-
-func (k *KeyringPolicy) GoString() string {
-	return fmt.Sprintf("%#v", *k)
 }
 
 // Parse is used to parse the specified ACL rules into an
@@ -121,14 +110,12 @@ func Parse(rules string) (*Policy, error) {
 	}
 
 	// Validate the keyring policy
-	for _, krp := range p.Keyring {
-		switch krp.Policy {
-		case KeyringPolicyRead:
-		case KeyringPolicyWrite:
-		case KeyringPolicyDeny:
-		default:
-			return nil, fmt.Errorf("Invalid keyring policy: %#v", krp)
-		}
+	switch p.Keyring {
+	case KeyringPolicyRead:
+	case KeyringPolicyWrite:
+	case KeyringPolicyDeny:
+	default:
+		return nil, fmt.Errorf("Invalid keyring policy: %#v", p.Keyring)
 	}
 
 	return p, nil

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -114,6 +114,7 @@ func Parse(rules string) (*Policy, error) {
 	case KeyringPolicyRead:
 	case KeyringPolicyWrite:
 	case KeyringPolicyDeny:
+	case "": // Special case to allow omitting the keyring policy
 	default:
 		return nil, fmt.Errorf("Invalid keyring policy: %#v", p.Keyring)
 	}

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -34,6 +34,7 @@ event "foo" {
 event "bar" {
 	policy = "deny"
 }
+keyring = "deny"
 	`
 	exp := &Policy{
 		Keys: []*KeyPolicy{
@@ -78,6 +79,7 @@ event "bar" {
 				Policy: EventPolicyDeny,
 			},
 		},
+		Keyring: KeyringPolicyDeny,
 	}
 
 	out, err := Parse(inp)
@@ -124,7 +126,8 @@ func TestParse_JSON(t *testing.T) {
 		"bar": {
 			"policy": "deny"
 		}
-	}
+	},
+	"keyring": "deny"
 }`
 	exp := &Policy{
 		Keys: []*KeyPolicy{
@@ -169,6 +172,7 @@ func TestParse_JSON(t *testing.T) {
 				Policy: EventPolicyDeny,
 			},
 		},
+		Keyring: KeyringPolicyDeny,
 	}
 
 	out, err := Parse(inp)

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -182,5 +183,20 @@ func TestParse_JSON(t *testing.T) {
 
 	if !reflect.DeepEqual(out, exp) {
 		t.Fatalf("bad: %#v %#v", out, exp)
+	}
+}
+
+func TestACLPolicy_badPolicy(t *testing.T) {
+	cases := []string{
+		`key "" { policy = "nope" }`,
+		`service "" { policy = "nope" }`,
+		`event "" { policy = "nope" }`,
+		`keyring = "nope"`,
+	}
+	for _, c := range cases {
+		_, err := Parse(c)
+		if err == nil || !strings.Contains(err.Error(), "Invalid") {
+			t.Fatalf("expected policy error, got: %#v", err)
+		}
 	}
 }

--- a/command/agent/keyring.go
+++ b/command/agent/keyring.go
@@ -128,19 +128,22 @@ func (a *Agent) ListKeys(token string) (*structs.KeyringResponses, error) {
 }
 
 // InstallKey installs a new gossip encryption key
-func (a *Agent) InstallKey(key string) (*structs.KeyringResponses, error) {
+func (a *Agent) InstallKey(key, token string) (*structs.KeyringResponses, error) {
 	args := structs.KeyringRequest{Key: key, Operation: structs.KeyringInstall}
+	args.Token = token
 	return a.keyringProcess(&args)
 }
 
 // UseKey changes the primary encryption key used to encrypt messages
-func (a *Agent) UseKey(key string) (*structs.KeyringResponses, error) {
+func (a *Agent) UseKey(key, token string) (*structs.KeyringResponses, error) {
 	args := structs.KeyringRequest{Key: key, Operation: structs.KeyringUse}
+	args.Token = token
 	return a.keyringProcess(&args)
 }
 
 // RemoveKey will remove a gossip encryption key from the keyring
-func (a *Agent) RemoveKey(key string) (*structs.KeyringResponses, error) {
+func (a *Agent) RemoveKey(key, token string) (*structs.KeyringResponses, error) {
 	args := structs.KeyringRequest{Key: key, Operation: structs.KeyringRemove}
+	args.Token = token
 	return a.keyringProcess(&args)
 }

--- a/command/agent/keyring.go
+++ b/command/agent/keyring.go
@@ -121,8 +121,9 @@ func (a *Agent) keyringProcess(args *structs.KeyringRequest) (*structs.KeyringRe
 
 // ListKeys lists out all keys installed on the collective Consul cluster. This
 // includes both servers and clients in all DC's.
-func (a *Agent) ListKeys() (*structs.KeyringResponses, error) {
+func (a *Agent) ListKeys(token string) (*structs.KeyringResponses, error) {
 	args := structs.KeyringRequest{Operation: structs.KeyringList}
+	args.Token = token
 	return a.keyringProcess(&args)
 }
 

--- a/command/agent/rpc.go
+++ b/command/agent/rpc.go
@@ -636,11 +636,11 @@ func (i *AgentRPC) handleKeyring(client *rpcClient, seq uint64, cmd, token strin
 	case listKeysCommand:
 		queryResp, err = i.agent.ListKeys(token)
 	case installKeyCommand:
-		queryResp, err = i.agent.InstallKey(req.Key)
+		queryResp, err = i.agent.InstallKey(req.Key, token)
 	case useKeyCommand:
-		queryResp, err = i.agent.UseKey(req.Key)
+		queryResp, err = i.agent.UseKey(req.Key, token)
 	case removeKeyCommand:
-		queryResp, err = i.agent.RemoveKey(req.Key)
+		queryResp, err = i.agent.RemoveKey(req.Key, token)
 	default:
 		respHeader := responseHeader{Seq: seq, Error: unsupportedCommand}
 		client.Send(&respHeader, nil)

--- a/command/agent/rpc.go
+++ b/command/agent/rpc.go
@@ -78,6 +78,7 @@ var msgpackHandle = &codec.MsgpackHandle{
 type requestHeader struct {
 	Command string
 	Seq     uint64
+	Token   string
 }
 
 // Response header is sent before each response
@@ -365,6 +366,7 @@ func (i *AgentRPC) handleRequest(client *rpcClient, reqHeader *requestHeader) er
 	// Look for a command field
 	command := reqHeader.Command
 	seq := reqHeader.Seq
+	token := reqHeader.Token
 
 	// Ensure the handshake is performed before other commands
 	if command != handshakeCommand && client.version == 0 {
@@ -406,7 +408,7 @@ func (i *AgentRPC) handleRequest(client *rpcClient, reqHeader *requestHeader) er
 		return i.handleReload(client, seq)
 
 	case installKeyCommand, useKeyCommand, removeKeyCommand, listKeysCommand:
-		return i.handleKeyring(client, seq, command)
+		return i.handleKeyring(client, seq, command, token)
 
 	default:
 		respHeader := responseHeader{Seq: seq, Error: unsupportedCommand}
@@ -618,7 +620,7 @@ func (i *AgentRPC) handleReload(client *rpcClient, seq uint64) error {
 	return client.Send(&resp, nil)
 }
 
-func (i *AgentRPC) handleKeyring(client *rpcClient, seq uint64, cmd string) error {
+func (i *AgentRPC) handleKeyring(client *rpcClient, seq uint64, cmd, token string) error {
 	var req keyringRequest
 	var queryResp *structs.KeyringResponses
 	var r keyringResponse
@@ -632,7 +634,7 @@ func (i *AgentRPC) handleKeyring(client *rpcClient, seq uint64, cmd string) erro
 
 	switch cmd {
 	case listKeysCommand:
-		queryResp, err = i.agent.ListKeys()
+		queryResp, err = i.agent.ListKeys(token)
 	case installKeyCommand:
 		queryResp, err = i.agent.InstallKey(req.Key)
 	case useKeyCommand:

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -188,10 +188,11 @@ func (c *RPCClient) WANMembers() ([]Member, error) {
 	return resp.Members, err
 }
 
-func (c *RPCClient) ListKeys() (keyringResponse, error) {
+func (c *RPCClient) ListKeys(token string) (keyringResponse, error) {
 	header := requestHeader{
 		Command: listKeysCommand,
 		Seq:     c.getSeq(),
+		Token:   token,
 	}
 	var resp keyringResponse
 	err := c.genericRPC(&header, nil, &resp)

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -199,10 +199,11 @@ func (c *RPCClient) ListKeys(token string) (keyringResponse, error) {
 	return resp, err
 }
 
-func (c *RPCClient) InstallKey(key string) (keyringResponse, error) {
+func (c *RPCClient) InstallKey(key, token string) (keyringResponse, error) {
 	header := requestHeader{
 		Command: installKeyCommand,
 		Seq:     c.getSeq(),
+		Token:   token,
 	}
 	req := keyringRequest{key}
 	var resp keyringResponse
@@ -210,10 +211,11 @@ func (c *RPCClient) InstallKey(key string) (keyringResponse, error) {
 	return resp, err
 }
 
-func (c *RPCClient) UseKey(key string) (keyringResponse, error) {
+func (c *RPCClient) UseKey(key, token string) (keyringResponse, error) {
 	header := requestHeader{
 		Command: useKeyCommand,
 		Seq:     c.getSeq(),
+		Token:   token,
 	}
 	req := keyringRequest{key}
 	var resp keyringResponse
@@ -221,10 +223,11 @@ func (c *RPCClient) UseKey(key string) (keyringResponse, error) {
 	return resp, err
 }
 
-func (c *RPCClient) RemoveKey(key string) (keyringResponse, error) {
+func (c *RPCClient) RemoveKey(key, token string) (keyringResponse, error) {
 	header := requestHeader{
 		Command: removeKeyCommand,
 		Seq:     c.getSeq(),
+		Token:   token,
 	}
 	req := keyringRequest{key}
 	var resp keyringResponse

--- a/command/agent/rpc_client_test.go
+++ b/command/agent/rpc_client_test.go
@@ -325,6 +325,7 @@ func TestRPCClientListKeys(t *testing.T) {
 	p1 := testRPCClientWithConfig(t, func(c *Config) {
 		c.EncryptKey = key1
 		c.Datacenter = "dc1"
+		c.ACLDatacenter = ""
 	})
 	defer p1.Close()
 
@@ -343,6 +344,7 @@ func TestRPCClientInstallKey(t *testing.T) {
 	key2 := "xAEZ3uVHRMZD9GcYMZaRQw=="
 	p1 := testRPCClientWithConfig(t, func(c *Config) {
 		c.EncryptKey = key1
+		c.ACLDatacenter = ""
 	})
 	defer p1.Close()
 
@@ -387,6 +389,7 @@ func TestRPCClientUseKey(t *testing.T) {
 	key2 := "xAEZ3uVHRMZD9GcYMZaRQw=="
 	p1 := testRPCClientWithConfig(t, func(c *Config) {
 		c.EncryptKey = key1
+		c.ACLDatacenter = ""
 	})
 	defer p1.Close()
 
@@ -434,7 +437,9 @@ func TestRPCClientUseKey(t *testing.T) {
 }
 
 func TestRPCClientKeyOperation_encryptionDisabled(t *testing.T) {
-	p1 := testRPCClient(t)
+	p1 := testRPCClientWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = ""
+	})
 	defer p1.Close()
 
 	r, err := p1.client.ListKeys("")

--- a/command/agent/rpc_client_test.go
+++ b/command/agent/rpc_client_test.go
@@ -361,7 +361,7 @@ func TestRPCClientInstallKey(t *testing.T) {
 	})
 
 	// install key2
-	r, err := p1.client.InstallKey(key2)
+	r, err := p1.client.InstallKey(key2, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -391,7 +391,7 @@ func TestRPCClientUseKey(t *testing.T) {
 	defer p1.Close()
 
 	// add a second key to the ring
-	r, err := p1.client.InstallKey(key2)
+	r, err := p1.client.InstallKey(key2, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -412,21 +412,21 @@ func TestRPCClientUseKey(t *testing.T) {
 	})
 
 	// can't remove key1 yet
-	r, err = p1.client.RemoveKey(key1)
+	r, err = p1.client.RemoveKey(key1, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	keyringError(t, r)
 
 	// change primary key
-	r, err = p1.client.UseKey(key2)
+	r, err = p1.client.UseKey(key2, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	keyringSuccess(t, r)
 
 	// can remove key1 now
-	r, err = p1.client.RemoveKey(key1)
+	r, err = p1.client.RemoveKey(key1, "")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -437,7 +437,7 @@ func TestRPCClientKeyOperation_encryptionDisabled(t *testing.T) {
 	p1 := testRPCClient(t)
 	defer p1.Close()
 
-	r, err := p1.client.ListKeys()
+	r, err := p1.client.ListKeys("")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -445,7 +445,7 @@ func TestRPCClientKeyOperation_encryptionDisabled(t *testing.T) {
 }
 
 func listKeys(t *testing.T, c *RPCClient) map[string]map[string]int {
-	resp, err := c.ListKeys()
+	resp, err := c.ListKeys("")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -16,7 +16,7 @@ type KeyringCommand struct {
 }
 
 func (c *KeyringCommand) Run(args []string) int {
-	var installKey, useKey, removeKey string
+	var installKey, useKey, removeKey, token string
 	var listKeys bool
 
 	cmdFlags := flag.NewFlagSet("keys", flag.ContinueOnError)
@@ -26,6 +26,7 @@ func (c *KeyringCommand) Run(args []string) int {
 	cmdFlags.StringVar(&useKey, "use", "", "use key")
 	cmdFlags.StringVar(&removeKey, "remove", "", "remove key")
 	cmdFlags.BoolVar(&listKeys, "list", false, "list keys")
+	cmdFlags.StringVar(&token, "token", "", "acl token")
 
 	rpcAddr := RPCAddrFlag(cmdFlags)
 	if err := cmdFlags.Parse(args); err != nil {
@@ -65,7 +66,7 @@ func (c *KeyringCommand) Run(args []string) int {
 
 	if listKeys {
 		c.Ui.Info("Gathering installed encryption keys...")
-		r, err := client.ListKeys()
+		r, err := client.ListKeys(token)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
@@ -199,13 +200,15 @@ Options:
 
   -install=<key>            Install a new encryption key. This will broadcast
                             the new key to all members in the cluster.
-  -use=<key>                Change the primary encryption key, which is used to
-                            encrypt messages. The key must already be installed
-                            before this operation can succeed.
+  -list                     List all keys currently in use within the cluster.
   -remove=<key>             Remove the given key from the cluster. This
                             operation may only be performed on keys which are
                             not currently the primary key.
-  -list                     List all keys currently in use within the cluster.
+  -token=""                 ACL token to use during requests. Defaults to that
+                            of the agent.
+  -use=<key>                Change the primary encryption key, which is used to
+                            encrypt messages. The key must already be installed
+                            before this operation can succeed.
   -rpc-addr=127.0.0.1:8400  RPC address of the Consul agent.
 `
 	return strings.TrimSpace(helpText)

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -80,7 +80,7 @@ func (c *KeyringCommand) Run(args []string) int {
 
 	if installKey != "" {
 		c.Ui.Info("Installing new gossip encryption key...")
-		r, err := client.InstallKey(installKey)
+		r, err := client.InstallKey(installKey, token)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
@@ -90,7 +90,7 @@ func (c *KeyringCommand) Run(args []string) int {
 
 	if useKey != "" {
 		c.Ui.Info("Changing primary gossip encryption key...")
-		r, err := client.UseKey(useKey)
+		r, err := client.UseKey(useKey, token)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
@@ -100,7 +100,7 @@ func (c *KeyringCommand) Run(args []string) int {
 
 	if removeKey != "" {
 		c.Ui.Info("Removing gossip encryption key...")
-		r, err := client.RemoveKey(removeKey)
+		r, err := client.RemoveKey(removeKey, token)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1

--- a/consul/internal_endpoint.go
+++ b/consul/internal_endpoint.go
@@ -1,6 +1,8 @@
 package consul
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/serf/serf"
 )
@@ -79,6 +81,30 @@ func (m *Internal) EventFire(args *structs.EventFireRequest,
 func (m *Internal) KeyringOperation(
 	args *structs.KeyringRequest,
 	reply *structs.KeyringResponses) error {
+
+	// Check ACLs
+	acl, err := m.srv.resolveToken(args.Token)
+	if err != nil {
+		return err
+	}
+	if acl != nil {
+		switch args.Operation {
+		case structs.KeyringList:
+			if !acl.KeyringRead() {
+				return fmt.Errorf("Reading keyring denied by ACLs")
+			}
+		case structs.KeyringInstall:
+			fallthrough
+		case structs.KeyringUse:
+			fallthrough
+		case structs.KeyringRemove:
+			if !acl.KeyringWrite() {
+				return fmt.Errorf("Modifying keyring denied due to ACLs")
+			}
+		default:
+			panic("Invalid keyring operation")
+		}
+	}
 
 	// Only perform WAN keyring querying and RPC forwarding once
 	if !args.Forwarded {


### PR DESCRIPTION
Adds ACL support for the gossip encryption keyring operations. Allows securing read-level access (for listing keys), and write-level access (for install/use/remove operations).

The new ACL entry will look slightly different since keyring access is not prefix-based in any way.
```
keyring = "write"
```