### PR TITLE
website: add marathon-consul and mesos-consul

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -114,6 +114,12 @@ description: |-
       <li>
         <a href="https://github.com/spring-cloud/spring-cloud-consul">Spring Cloud Consul</a> - Service discovery, configuration and events for Spring Cloud
       </li>
+      <li>
+        <a href="https://github.com/CiscoCloud/marathon-consul">marathon-consul</a> - Bridge from Marathon apps to the Consul K/V store
+      </li>
+      <li>
+        <a href="https://github.com/CiscoCloud/mesos-consul">mesos-consul</a> - Service registry bridge for Mesos
+      </li>
     </ul>
 
     <p>


### PR DESCRIPTION
This PR adds links to the marathon-consul and mesos-consul bridges on the website. Let me know if there's anything I need to touch up.