### PR TITLE
Fix issue #1111 - vagrant cluster demo doesn't work

### DIFF
--- a/demo/vagrant-cluster/README.md
+++ b/demo/vagrant-cluster/README.md
@@ -2,7 +2,7 @@
 
 This demo provides a very simple Vagrantfile that creates two nodes,
 one at "172.20.20.10" and another at "172.20.20.11". Both are running
-a standard Ubuntu 12.04 distribution, and Consul is pre-installed.
+a standard Debian 7 distribution, and Consul is pre-installed.
 
 To get started, you can start the cluster by just doing:
 

--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -20,7 +20,7 @@ SCRIPT
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "debian/wheezy64"
 
   config.vm.provision "shell", inline: $script
 


### PR DESCRIPTION
Switch demo Vagrantfile to use official debian 7 base box
and reflect change in the README