### PR TITLE
Fix missing config-dir in getting started guide

### DIFF
--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -14,6 +14,9 @@ unzip consul.zip
 sudo chmod +x consul
 sudo mv consul /usr/bin/consul
 
+sudo mkdir /etc/consul.d
+sudo chmod a+w /etc/consul.d
+
 SCRIPT
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!

--- a/website/source/intro/getting-started/join.html.markdown
+++ b/website/source/intro/getting-started/join.html.markdown
@@ -53,14 +53,17 @@ multiple interfaces, so specifying a `bind` address assures that you will
 never bind Consul to the wrong interface.
 
 The first node will act as our sole server in this cluster, and we indicate
-this with the [`server` switch](/docs/agent/options.html#_server).
+this with the [`server` switch](/docs/agent/options.html#_server). Finally, we
+add the [`config-dir` flag](/docs/agent/options.html#_config_dir), marking
+where service and check definitions can be found.
 
 All together, these settings yield a
 [`consul agent`](/docs/commands/agent.html) command like this:
 
 ```text
 vagrant@n1:~$ consul agent -server -bootstrap-expect 1 \
-	-data-dir /tmp/consul -node=agent-one -bind=172.20.20.10
+	-data-dir /tmp/consul -node=agent-one -bind=172.20.20.10 \
+	-config-dir /etc/consul.d
 ...
 ```
 
@@ -81,7 +84,7 @@ All together, these settings yield a
 
 ```text
 vagrant@n2:~$ consul agent -data-dir /tmp/consul -node=agent-two \
-	-bind=172.20.20.11
+	-bind=172.20.20.11 -config-dir /etc/consul.d
 ...
 ```
 


### PR DESCRIPTION
As noted in issue #897, there is a documentation bug. This PR adds a few lines detailing `config-dir`, as well as making sure the `/etc/consul.d` directory exists and is writable, to ensure later steps in the guide works (eg `echo ... > /etc/consul.d/ping.json`). Having the directory world writable might not be very advisable in a real environment, however, so maybe it shouldn't be done in the demo either?