### PR TITLE
Remove trailing slash from lock

### DIFF
--- a/command/lock.go
+++ b/command/lock.go
@@ -100,6 +100,7 @@ func (c *LockCommand) Run(args []string) int {
 		return 1
 	}
 	prefix := extra[0]
+	prefix = strings.TrimPrefix(prefix, "/")
 	script := strings.Join(extra[1:], " ")
 
 	// Calculate a session name if none provided


### PR DESCRIPTION
Lock command will remove trailing slash from path (as it is invalid).
Fixes #1136.