### PR TITLE
Add -http-port option to change the HTTP API port

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -80,7 +80,7 @@ func (c *Command) readConfig() *Config {
 
 	cmdFlags.StringVar(&cmdConfig.ClientAddr, "client", "", "address to bind client listeners to (DNS, HTTP, HTTPS, RPC)")
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind server listeners to")
-	cmdFlags.IntVar(&cmdConfig.HttpPort, "http-port", 0, "http port to use")
+	cmdFlags.IntVar(&cmdConfig.Ports.HTTP, "http-port", 0, "http port to use")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddr, "advertise", "", "address to advertise instead of bind addr")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddrWan, "advertise-wan", "", "address to advertise on wan instead of bind or advertise addr")
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -80,6 +80,7 @@ func (c *Command) readConfig() *Config {
 
 	cmdFlags.StringVar(&cmdConfig.ClientAddr, "client", "", "address to bind client listeners to (DNS, HTTP, HTTPS, RPC)")
 	cmdFlags.StringVar(&cmdConfig.BindAddr, "bind", "", "address to bind server listeners to")
+	cmdFlags.IntVar(&cmdConfig.HttpPort, "http-port", 0, "http port to use")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddr, "advertise", "", "address to advertise instead of bind addr")
 	cmdFlags.StringVar(&cmdConfig.AdvertiseAddrWan, "advertise-wan", "", "address to advertise on wan instead of bind or advertise addr")
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -927,6 +927,7 @@ Options:
   -atlas-token=token       Provides the Atlas API token
   -bootstrap               Sets server to bootstrap mode
   -bind=0.0.0.0            Sets the bind address for cluster communication
+  -http-port=8500          Sets the HTTP API port to listen on
   -bootstrap-expect=0      Sets server to expect bootstrap mode.
   -client=127.0.0.1        Sets the address to bind for client access.
                            This includes RPC, DNS, HTTP and HTTPS (if configured)

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -141,6 +141,11 @@ type Config struct {
 	// client services (DNS, HTTP, HTTPS, RPC)
 	ClientAddr string `mapstructure:"client_addr"`
 
+	// HttpPort the HTTP port to listen on.
+	// This is useful e.g. when deploying to Cloud Foundry to make
+	// the HTTP API easily routable
+	HttpPort int `mapstructure:"http_port"`
+
 	// BindAddr is used to control the address we bind to.
 	// If not specified, the first private IP we find is used.
 	// This controls the address we use for cluster facing
@@ -848,6 +853,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.BindAddr != "" {
 		result.BindAddr = b.BindAddr
+	}
+	if b.HttpPort != 0 {
+		result.Ports.HTTP = b.HttpPort
 	}
 	if b.AdvertiseAddr != "" {
 		result.AdvertiseAddr = b.AdvertiseAddr

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -141,11 +141,6 @@ type Config struct {
 	// client services (DNS, HTTP, HTTPS, RPC)
 	ClientAddr string `mapstructure:"client_addr"`
 
-	// HttpPort the HTTP port to listen on.
-	// This is useful e.g. when deploying to Cloud Foundry to make
-	// the HTTP API easily routable
-	HttpPort int `mapstructure:"http_port"`
-
 	// BindAddr is used to control the address we bind to.
 	// If not specified, the first private IP we find is used.
 	// This controls the address we use for cluster facing
@@ -854,8 +849,8 @@ func MergeConfig(a, b *Config) *Config {
 	if b.BindAddr != "" {
 		result.BindAddr = b.BindAddr
 	}
-	if b.HttpPort != 0 {
-		result.Ports.HTTP = b.HttpPort
+	if b.Ports.HTTP != 0 {
+		result.Ports.HTTP = b.Ports.HTTP
 	}
 	if b.AdvertiseAddr != "" {
 		result.AdvertiseAddr = b.AdvertiseAddr

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -849,9 +849,6 @@ func MergeConfig(a, b *Config) *Config {
 	if b.BindAddr != "" {
 		result.BindAddr = b.BindAddr
 	}
-	if b.Ports.HTTP != 0 {
-		result.Ports.HTTP = b.Ports.HTTP
-	}
 	if b.AdvertiseAddr != "" {
 		result.AdvertiseAddr = b.AdvertiseAddr
 	}

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -84,6 +84,11 @@ The options below are all specified on the command-line.
   IP address. Consul uses both TCP and UDP and the same port for both. If you
   have any firewalls, be sure to allow both protocols.
 
+* <a name="_http_port"></a><a href="#_http_port">`-http-port`</a> - the HTTP API port to listen on.
+  This overrides the default port 8500. This option is very useful when deploying Consul
+  to an environment which communicates the HTTP port through the environment e.g. PaaS like CloudFoundry, allowing
+  you to set the port directly via a Procfile.
+
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which
   Consul will bind client interfaces,
   including the HTTP, DNS, and RPC servers. By default, this is "127.0.0.1",

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -84,11 +84,6 @@ The options below are all specified on the command-line.
   IP address. Consul uses both TCP and UDP and the same port for both. If you
   have any firewalls, be sure to allow both protocols.
 
-* <a name="_http_port"></a><a href="#_http_port">`-http-port`</a> - the HTTP API port to listen on.
-  This overrides the default port 8500. This option is very useful when deploying Consul
-  to an environment which communicates the HTTP port through the environment e.g. PaaS like CloudFoundry, allowing
-  you to set the port directly via a Procfile.
-
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which
   Consul will bind client interfaces,
   including the HTTP, DNS, and RPC servers. By default, this is "127.0.0.1",
@@ -143,6 +138,11 @@ The options below are all specified on the command-line.
   agent's initial startup sequence. If it is provided after Consul has been
   initialized with an encryption key, then the provided key is ignored and
   a warning will be displayed.
+
+* <a name="_http_port"></a><a href="#_http_port">`-http-port`</a> - the HTTP API port to listen on.
+  This overrides the default port 8500. This option is very useful when deploying Consul
+  to an environment which communicates the HTTP port through the environment e.g. PaaS like CloudFoundry, allowing
+  you to set the port directly via a Procfile.
 
 * <a name="_join"></a><a href="#_join">`-join`</a> - Address of another agent
   to join upon starting up. This can be


### PR DESCRIPTION
This is useful when pushing consul to PaaS like
Cloud Foundry making the HTTP API easily routable.