### PR TITLE
Fixes #1165 by having threads wait for any outstanding connect to finish.

### DIFF
--- a/consul/pool.go
+++ b/consul/pool.go
@@ -215,7 +215,7 @@ func (p *ConnPool) acquire(dc string, addr net.Addr, version int) (*Conn, error)
 	var wait chan struct{}
 	var ok bool
 	if wait, ok = p.limiter[addr.String()]; !ok {
-		wait = make(chan struct{}, 1)
+		wait = make(chan struct{})
 		p.limiter[addr.String()] = wait
 	}
 	isLeadThread := !ok


### PR DESCRIPTION
This creates a map of channels (per-address) that throttles requests for connections to one at a time (per-address). The other threads will then quickly grab the newly-created connection one at a time and use it.

If the connection they were waiting for fails, they will all try to make a new connection, and the race condition logic for that case was preserved. This seems like the best thing to do in order to move forward, since they all could have been hanging around waiting for that one connection to go. They essentially revert to the behavior we have today, but only in the case where there's network trouble.

I was trying to find a simpler way to handle the case where the connection they are waiting on fails - we could fail all the others immediately but I think the code would be a little more complicated. Thundering a herd at a dead guy seems pretty low-impact.