### PR TITLE
consul: refactor GetPrivateIP for testability

### DIFF
--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -120,9 +120,10 @@ func TestServer_StartStop(t *testing.T) {
 	config := DefaultConfig()
 	config.DataDir = dir
 
-	private, err := GetPrivateIP()
+	// Advertise on localhost.
+	private, _, err := net.ParseCIDR("127.0.0.1/32")
 	if err != nil {
-		t.Fatalf("err: %v", err)
+		t.Fatalf("failed to parse 127.0.0.1 cidr: %v", err)
 	}
 
 	config.RPCAdvertise = &net.TCPAddr{

--- a/consul/util.go
+++ b/consul/util.go
@@ -169,6 +169,10 @@ func GetPrivateIP() (net.IP, error) {
 		return nil, fmt.Errorf("Failed to get interface addresses: %v", err)
 	}
 
+	return getPrivateIP(addresses)
+}
+
+func getPrivateIP(addresses []net.Addr) (net.IP, error) {
 	var candidates []net.IP
 
 	// Find private IPv4 address
@@ -200,6 +204,7 @@ func GetPrivateIP() (net.IP, error) {
 	default:
 		return nil, fmt.Errorf("Multiple private IPs found. Please configure one.")
 	}
+
 }
 
 // Converts bytes to an integer


### PR DESCRIPTION
When investigating the build failure on master I noticed that the test suite did not run with multiple private interfaces present. In order to prevent that I thought it might be better to configure an address that would be present. I didn't want to lower overall coverage because of that change (wouldn't be using GetPrivateIP anymore) so I broke `GetPrivateIP` apart to have a testable (didn't rely on environment) private function that I could verify independently.

I will readily admit I wasn't using the vagrantfile for development which is how I noticed this. :smile_cat: