### PR TITLE
Return SOA/NXDOMAIN when the answer is empty

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -528,6 +528,14 @@ RPC:
 	if qType == dns.TypeSRV {
 		d.serviceSRVRecords(datacenter, out.Nodes, req, resp, ttl)
 	}
+
+	// If the answer is empty, return not found
+	if len(resp.Answer) == 0 {
+		d.addSOA(d.domain, resp)
+		resp.SetRcode(req, dns.RcodeNameError)
+		return
+	}
+
 }
 
 // filterServiceNodes is used to filter out nodes that are failing


### PR DESCRIPTION
When a service has A records and no AAAA records (or vice versa), also return SOA and NXDOMAIN when asking for the AAAA records. (wrt RFC2308 and negative caching)

See PR #995 for more info