### PR TITLE
SCADA client is reload-able

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -25,6 +25,8 @@ func nextConfig() *Config {
 	idx := int(atomic.AddUint64(&offset, 1))
 	conf := DefaultConfig()
 
+	conf.Version = "a.b"
+	conf.VersionPrerelease = "c.d"
 	conf.AdvertiseAddr = "127.0.0.1"
 	conf.Bootstrap = true
 	conf.Datacenter = "dc1"

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -935,6 +935,7 @@ func (c *Command) setupScadaConn(config *Config) error {
 	}
 
 	// Create the new provider and listener
+	c.Ui.Output("Connecting to Atlas: " + config.AtlasInfrastructure)
 	provider, list, err := NewProvider(config, c.logOutput)
 	if err != nil {
 		return err

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -906,10 +906,13 @@ func (c *Command) handleReload(config *Config) *Config {
 		}(wp)
 	}
 
-	// Reload SCADA client
-	if err := c.setupScadaConn(newConf); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed reloading SCADA client: %s", err))
-		return nil
+	// Reload SCADA client if we have a change
+	if newConf.AtlasInfrastructure != config.AtlasInfrastructure ||
+		newConf.AtlasToken != config.AtlasToken {
+		if err := c.setupScadaConn(newConf); err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed reloading SCADA client: %s", err))
+			return nil
+		}
 	}
 
 	return newConf

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -346,16 +346,10 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 	c.rpcServer = NewAgentRPC(agent, rpcListener, logOutput, logWriter)
 
 	// Enable the SCADA integration
-	var scadaList net.Listener
-	if config.AtlasInfrastructure != "" {
-		provider, list, err := NewProvider(config, logOutput)
-		if err != nil {
-			agent.Shutdown()
-			c.Ui.Error(fmt.Sprintf("Error starting SCADA connection: %s", err))
-			return err
-		}
-		c.scadaProvider = provider
-		scadaList = list
+	if err := c.setupScadaConn(config); err != nil {
+		agent.Shutdown()
+		c.Ui.Error(fmt.Sprintf("Error starting SCADA connection: %s", err))
+		return err
 	}
 
 	if config.Ports.HTTP > 0 || config.Ports.HTTPS > 0 {
@@ -366,10 +360,6 @@ func (c *Command) setupAgent(config *Config, logOutput io.Writer, logWriter *log
 			return err
 		}
 		c.httpServers = servers
-	}
-
-	if scadaList != nil {
-		c.scadaHttp = newScadaHttp(agent, scadaList)
 	}
 
 	if config.Ports.DNS > 0 {
@@ -916,25 +906,39 @@ func (c *Command) handleReload(config *Config) *Config {
 		}(wp)
 	}
 
-	// Reload the SCADA client
-	if c.scadaProvider != nil {
-		// Shut down the existing SCADA listeners
-		c.scadaProvider.Shutdown()
-		if c.scadaHttp != nil {
-			c.scadaHttp.Shutdown()
-		}
-
-		// Create the new provider and listener
-		provider, list, err := NewProvider(newConf, c.logOutput)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed reloading SCADA client: %s", err))
-			return nil
-		}
-		c.scadaProvider = provider
-		c.scadaHttp = newScadaHttp(c.agent, list)
+	// Reload SCADA client
+	if err := c.setupScadaConn(newConf); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed reloading SCADA client: %s", err))
+		return nil
 	}
 
 	return newConf
+}
+
+// startScadaClient is used to start a new SCADA provider and listener,
+// replacing any existing listeners.
+func (c *Command) setupScadaConn(config *Config) error {
+	// Shut down existing SCADA listeners
+	if c.scadaProvider != nil {
+		c.scadaProvider.Shutdown()
+	}
+	if c.scadaHttp != nil {
+		c.scadaHttp.Shutdown()
+	}
+
+	// No-op if we don't have an infrastructure
+	if config.AtlasInfrastructure == "" {
+		return nil
+	}
+
+	// Create the new provider and listener
+	provider, list, err := NewProvider(config, c.logOutput)
+	if err != nil {
+		return err
+	}
+	c.scadaProvider = provider
+	c.scadaHttp = newScadaHttp(c.agent, list)
+	return nil
 }
 
 func (c *Command) Synopsis() string {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/testutil"
@@ -244,5 +245,57 @@ func TestSetupAgent_RPCUnixSocket_FileExists(t *testing.T) {
 	// Ensure permissions were applied to the socket file
 	if fi.Mode().String() != "Srwxrwxrwx" {
 		t.Fatalf("bad permissions: %s", fi.Mode())
+	}
+}
+
+func TestSetupScadaConn(t *testing.T) {
+	// Create a config and assign an infra name
+	conf1 := nextConfig()
+	conf1.AtlasInfrastructure = "hashicorp/test1"
+	conf1.AtlasToken = "abc"
+
+	dir, agent := makeAgent(t, conf1)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	cmd := &Command{
+		ShutdownCh: make(chan struct{}),
+		Ui:         new(cli.MockUi),
+		agent:      agent,
+	}
+
+	// First start creates the scada conn
+	if err := cmd.setupScadaConn(conf1); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	list := cmd.scadaHttp.listener.(*scadaListener)
+	if list == nil || list.addr.infra != "hashicorp/test1" {
+		t.Fatalf("bad: %#v", list)
+	}
+	http1 := cmd.scadaHttp
+	provider1 := cmd.scadaProvider
+
+	// Performing setup again tears down original and replaces
+	// with a new SCADA client.
+	conf2 := nextConfig()
+	conf2.AtlasInfrastructure = "hashicorp/test2"
+	conf2.AtlasToken = "123"
+	if err := cmd.setupScadaConn(conf2); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if cmd.scadaHttp == http1 || cmd.scadaProvider == provider1 {
+		t.Fatalf("bad: %#v", cmd)
+	}
+	list = cmd.scadaHttp.listener.(*scadaListener)
+	if list == nil || list.addr.infra != "hashicorp/test2" {
+		t.Fatalf("bad: %#v", list)
+	}
+
+	// Original provider and listener must be closed
+	if !provider1.IsShutdown() {
+		t.Fatalf("should be shutdown")
+	}
+	if _, err := http1.listener.Accept(); !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("should be closed")
 	}
 }

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -284,7 +284,7 @@ func TestSetupScadaConn(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if cmd.scadaHttp == http1 || cmd.scadaProvider == provider1 {
-		t.Fatalf("bad: %#v", cmd)
+		t.Fatalf("should change: %#v %#v", cmd.scadaHttp, cmd.scadaProvider)
 	}
 	list = cmd.scadaHttp.listener.(*scadaListener)
 	if list == nil || list.addr.infra != "hashicorp/test2" {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -145,6 +145,8 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 	return servers, nil
 }
 
+// newScadaHttp creates a new HTTP server wrapping the SCADA
+// listener such that HTTP calls can be sent from the brokers.
 func newScadaHttp(agent *Agent, list net.Listener) *HTTPServer {
 	// Create the mux
 	mux := http.NewServeMux()

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -38,7 +38,7 @@ func makeHTTPServerWithConfig(t *testing.T, cb func(c *Config)) (string, *HTTPSe
 		t.Fatalf("err: %v", err)
 	}
 	conf.UiDir = uiDir
-	servers, err := NewHTTPServers(agent, conf, nil, agent.logOutput)
+	servers, err := NewHTTPServers(agent, conf, agent.logOutput)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	// Try to start the server with the same path anyways.
-	if _, err := NewHTTPServers(agent, conf, nil, agent.logOutput); err != nil {
+	if _, err := NewHTTPServers(agent, conf, agent.logOutput); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -70,7 +70,7 @@ func testAgentWithConfig(t *testing.T, cb func(c *agent.Config)) *agentWrapper {
 
 	conf.Addresses.HTTP = "127.0.0.1"
 	httpAddr := fmt.Sprintf("127.0.0.1:%d", conf.Ports.HTTP)
-	http, err := agent.NewHTTPServers(a, conf, nil, os.Stderr)
+	http, err := agent.NewHTTPServers(a, conf, os.Stderr)
 	if err != nil {
 		os.RemoveAll(dir)
 		t.Fatalf(fmt.Sprintf("err: %v", err))

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -643,3 +643,5 @@ items which are reloaded include:
 * Services
 * Watches
 * HTTP Client Address
+* Atlas Token
+* Atlas Infrastructure


### PR DESCRIPTION
Makes the SCADA client able to reload its configuration when SIGHUP is received or the `reload` command is used. This is useful if the Atlas infrastructure or token are not known up-front.