### PR TITLE
command/lock: Pass stdin to child process when -pass-stdin passed.

### DIFF
--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -60,5 +60,7 @@ The list of available flags are:
 
 * `-token` - ACL token to use. Defaults to that of agent.
 
+* `-pass-stdin` - Pass stdin to child process.
+
 * `-verbose` - Enables verbose output.
 


### PR DESCRIPTION
I added `-pass-stdin` option to pass stdin to a hander process.

```
$ echo foo | bin/consul lock bar cat

$ echo foo | bin/consul lock -pass-stdin bar cat
foo
```

### Use case

I'd like to execute an arbitrary command via `consul lock` on events fired.

```
$ consul watch -type event -name foo \
  consul lock -pass-stdin bar cat
[{"ID":"4deac22a-7f00-5320-8de1-2ee5932f4599","Name":"foo","Payload":null,"NodeFilter":"","ServiceFilter":"","TagFilter":"","Version":1,"LTime":2}]
```