### PR TITLE
Bumps protocol version back down as we've made memberlist smarter.

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -32,7 +32,6 @@ func init() {
 	protocolVersionMap = map[uint8]uint8{
 		1: 4,
 		2: 4,
-		3: 5,
 	}
 }
 

--- a/consul/server.go
+++ b/consul/server.go
@@ -26,7 +26,7 @@ import (
 // protocol versions.
 const (
 	ProtocolVersionMin uint8 = 1
-	ProtocolVersionMax       = 3
+	ProtocolVersionMax       = 2
 )
 
 const (


### PR DESCRIPTION
Over on https://github.com/hashicorp/memberlist/pull/50 we made memberlist smarter about interoperating with v2/v3 so we don't need to bump the Consul protocol; this should ease rolling out newer versions of Consul.