### PR TITLE
add consul-do to community tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -97,6 +97,9 @@ description: |-
         <a href="https://github.com/CiscoCloud/consul-cli">consul-cli</a> - Command line interface to Consul HTTP API
       </li>
       <li>
+        <a href="https://github.com/zeroXten/consul-do">consul-do</a> - Do something based on leadership status
+      </li>
+      <li>
         <a href="http://xordataexchange.github.io/crypt/">crypt</a> - Store and retrieve encrypted configuration parameters from etcd or Consul
       </li>
       <li>

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -97,7 +97,7 @@ description: |-
         <a href="https://github.com/CiscoCloud/consul-cli">consul-cli</a> - Command line interface to Consul HTTP API
       </li>
       <li>
-        <a href="https://github.com/zeroXten/consul-do">consul-do</a> - Do something based on leadership status
+        <a href="https://github.com/zeroXten/consul-do">consul-do</a> - Do something, such as run HA cronjobs, based on Consul leadership status
       </li>
       <li>
         <a href="http://xordataexchange.github.io/crypt/">crypt</a> - Store and retrieve encrypted configuration parameters from etcd or Consul


### PR DESCRIPTION
adding consul-do Do something based on leadership status

https://github.com/zeroXten/consul-do

From README.md

Useful for running cronjobs in HA mode.

Run something like this on two or more servers:

* * * * * /usr/bin/consul-do JOB-1 $(/bin/hostname) && /path/to/job1
*/10 * * * * /usr/bin/consul-do JOB-2 $(/bin/hostname) && /path/to/job2
Only one of the servers will be elected leader and will therefore run the job. Should the leader fail, a follower will take over.