### PR TITLE
No NXDOMAIN when the answer is empty

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -532,7 +532,6 @@ RPC:
 	// If the answer is empty, return not found
 	if len(resp.Answer) == 0 {
 		d.addSOA(d.domain, resp)
-		resp.SetRcode(req, dns.RcodeNameError)
 		return
 	}
 }

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -2062,6 +2062,10 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 		t.Fatalf("Bad: %#v", in.Ns[0])
 	}
 
+	if in.Rcode != dns.RcodeSuccess {
+		t.Fatalf("Bad: %#v", in)
+	}
+
 	// check for ipv4 records on ipv6 only service
 	m.SetQuestion("webv6.service.consul.", dns.TypeA)
 
@@ -2081,4 +2085,9 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	if soaRec.Hdr.Ttl != 0 {
 		t.Fatalf("Bad: %#v", in.Ns[0])
 	}
+
+	if in.Rcode != dns.RcodeSuccess {
+		t.Fatalf("Bad: %#v", in)
+	}
+
 }


### PR DESCRIPTION
Subtle bug, we found in production. dig works, but some applications fail.

We only need to send the SOA record when the answer is empty, not NXDOMAIN (because the resource exists, it only doesn't have the required type), otherwise no other records will be asked.

@ryanbreen could you merge this ?