### PR TITLE
Allow :: as a bind address (binds to first public IPv6 address)

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -142,10 +142,16 @@ func Create(config *Config, logOutput io.Writer) (*Agent, error) {
 		if ip := net.ParseIP(config.AdvertiseAddr); ip == nil {
 			return nil, fmt.Errorf("Failed to parse advertise address: %v", config.AdvertiseAddr)
 		}
-	} else if config.BindAddr != "0.0.0.0" && config.BindAddr != "" {
+	} else if config.BindAddr != "0.0.0.0" && config.BindAddr != "" && config.BindAddr != "[::]" {
 		config.AdvertiseAddr = config.BindAddr
 	} else {
-		ip, err := consul.GetPrivateIP()
+		var err error
+		var ip net.IP
+		if config.BindAddr == "[::]" {
+			ip, err = consul.GetPublicIPv6()
+		} else {
+			ip, err = consul.GetPrivateIP()
+		}
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get advertise address: %v", err)
 		}

--- a/consul/util.go
+++ b/consul/util.go
@@ -264,6 +264,52 @@ func getPrivateIP(addresses []net.Addr) (net.IP, error) {
 
 }
 
+// GetPublicIPv6 is used to return the first public IP address
+// associated with an interface on the machine
+func GetPublicIPv6() (net.IP, error) {
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get interface addresses: %v", err)
+	}
+
+	return getPublicIPv6(addresses)
+}
+
+func getPublicIPv6(addresses []net.Addr) (net.IP, error) {
+	var candidates []net.IP
+
+	// Find public IPv6 address
+	for _, rawAddr := range addresses {
+		var ip net.IP
+		switch addr := rawAddr.(type) {
+		case *net.IPAddr:
+			ip = addr.IP
+		case *net.IPNet:
+			ip = addr.IP
+		default:
+			continue
+		}
+
+		if ip.To4() != nil {
+			continue
+		}
+		// do not bind link-local (fe80::/10) / ULA (fc00::/7) / loopback (::1)
+		if ip[0]|0xf == 0xff || ip[0]|0 == 0 {
+			continue
+		}
+		candidates = append(candidates, ip)
+	}
+	numIps := len(candidates)
+	switch numIps {
+	case 0:
+		return nil, fmt.Errorf("No public IPv6 address found")
+	case 1:
+		return candidates[0], nil
+	default:
+		return nil, fmt.Errorf("Multiple public IPv6 addresses found. Please configure one.")
+	}
+}
+
 // Converts bytes to an integer
 func bytesToUint64(b []byte) uint64 {
 	return binary.BigEndian.Uint64(b)

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -93,7 +93,8 @@ The options below are all specified on the command-line.
   for internal cluster communications.
   This is an IP address that should be reachable by all other nodes in the cluster.
   By default, this is "0.0.0.0", meaning Consul will use the first available private
-  IP address. Consul uses both TCP and UDP and the same port for both. If you
+  IPv4 address. If you specify "[::]", Consul will use the first available public IPv6 address.
+  Consul uses both TCP and UDP and the same port for both. If you
   have any firewalls, be sure to allow both protocols.
 
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which


### PR DESCRIPTION
This patch allows "::" to -bind (as the IPv6 counterpart for the IPv4 0.0.0.0)
The behaviour is opposite of the IPv4 though, it will look for the first public accessible IPv6 address to bind to. (instead of the first private accessible address with IPv4). 

As IPv6 does not really have private addresses (not including ULA), if you want to use IPv6 you probably want to bind to the Global Unicast Address.

With these modifications, you can run IPv6-only containers with consul without knowing the IPv6 address beforehand. And thus can setup a complete IPv6-only consul environment.

If you're interested in merging this I'll add tests too.

Impacts #725 
Fixes #529 if -bind :: is used
