### PR TITLE
Allow AAAA queries for nodeLookup

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -352,9 +352,9 @@ INVALID:
 
 // nodeLookup is used to handle a node query
 func (d *DNSServer) nodeLookup(network, datacenter, node string, req, resp *dns.Msg) {
-	// Only handle ANY and A type requests
+	// Only handle ANY, A and AAAA type requests
 	qType := req.Question[0].Qtype
-	if qType != dns.TypeANY && qType != dns.TypeA {
+	if qType != dns.TypeANY && qType != dns.TypeA && qType != dns.TypeAAAA {
 		return
 	}
 

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -293,7 +293,7 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	}
 
 	m := new(dns.Msg)
-	m.SetQuestion("bar.node.consul.", dns.TypeANY)
+	m.SetQuestion("bar.node.consul.", dns.TypeAAAA)
 
 	c := new(dns.Client)
 	addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)


### PR DESCRIPTION
Small bugfix, hopefully last patch to makes consul working completely on ipv6-only network.