### PR TITLE
Add quotes to locations in case pwd contains spaces

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@ while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 
 # Change into that directory
-cd $DIR
+cd "$DIR"
 
 # Get the git commit
 GIT_COMMIT=$(git rev-parse HEAD)
@@ -49,4 +49,4 @@ go build \
     -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe ${GIT_DESCRIBE}" \
     -v \
     -o bin/consul${EXTENSION}
-cp bin/consul${EXTENSION} ${GOPATHSINGLE}/bin
+cp bin/consul${EXTENSION} "${GOPATHSINGLE}/bin"


### PR DESCRIPTION
I ran into while building the binary with Jenkins

Jenkins creates workspace directories based on project names, and the project name happened to contain a space; therefore, pwd contained a space :-)