### PR TITLE
Fix link warnings

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,7 +46,7 @@ go get \
 # Build!
 echo "--> Building..."
 go build \
-    -ldflags "${CGO_LDFLAGS} -X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe ${GIT_DESCRIBE}" \
+    -ldflags "${CGO_LDFLAGS} -X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe=${GIT_DESCRIBE}" \
     -v \
     -o bin/consul${EXTENSION}
 cp bin/consul${EXTENSION} "${GOPATHSINGLE}/bin"

--- a/scripts/windows/build.bat
+++ b/scripts/windows/build.bat
@@ -35,7 +35,7 @@ go get .\...
 :: Build!
 echo --^> Building...
 go build^
- -ldflags "-X main.GitCommit %_GIT_COMMIT%%_GIT_DIRTY% -X main.GitDescribe %_GIT_DESCRIBE%"^
+ -ldflags "-X main.GitCommit=%_GIT_COMMIT%%_GIT_DIRTY% -X main.GitDescribe=%_GIT_DESCRIBE%"^
  -v^
  -o bin\consul.exe .
 if errorlevel 1 exit /B 1


### PR DESCRIPTION
When building from master, I was getting errors that `-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY}` was missing an equal sign and may break in a future version.

/cc @ryanuber @slackpad 