### PR TITLE
Add cfg4j-pusher to tools section

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -91,6 +91,9 @@ description: |-
         <a href="http://www.cfg4j.org">cfg4j</a> - Configuration library for Java distributed apps. Reads and auto-updates configuration from Consul KVs (and others)
       </li>
       <li>
+        <a href="https://github.com/cfg4j/cfg4j-pusher">cfg4j-pusher</a> - Command line app that pushes values from configuration files (YAML, properties, etc.) to Consul KVs
+      </li>
+      <li>
         <a href="https://github.com/kelseyhightower/confd">confd</a> - Manage local application configuration files using templates and data from etcd or Consul
       </li>
       <li>


### PR DESCRIPTION
This PR adds a link to cfg4j-pusher to tools section of the website. cfg4j-pusher is a command line app that pushes values from configuration files (YAML, properties, etc.) to Consul KVs. They can be later read (optional) using [cfg4j](http://cfg4j.org) library.