### PR TITLE
Add options to send telemetry to DogStatsD

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/datadog"
-	"github.com/hashicorp/consul-migrate/migrator"
 	"github.com/hashicorp/consul/watch"
 	"github.com/hashicorp/go-checkpoint"
 	"github.com/hashicorp/go-syslog"

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/armon/go-metrics/datadog"
+	"github.com/hashicorp/consul-migrate/migrator"
 	"github.com/hashicorp/consul/watch"
 	"github.com/hashicorp/go-checkpoint"
 	"github.com/hashicorp/go-syslog"
@@ -601,6 +603,23 @@ func (c *Command) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Failed to start statsd sink. Got: %s", err))
 			return 1
 		}
+		fanout = append(fanout, sink)
+	}
+
+	// Configure the DogStatsd sink
+	if config.DogStatsdAddr != "" {
+		var tags []string
+
+		if config.DogStatsdTags != nil {
+			tags = config.DogStatsdTags
+		}
+
+		sink, err := datadog.NewDogStatsdSink(config.DogStatsdAddr, metricsConf.HostName)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to start DogStatsd sink. Got: %s", err))
+			return 1
+		}
+		sink.SetTags(tags)
 		fanout = append(fanout, sink)
 	}
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -184,6 +184,14 @@ type Config struct {
 	// metrics will be sent to that instance.
 	StatsdAddr string `mapstructure:"statsd_addr"`
 
+	// DogStatsdAddr is the address of a dogstatsd instance. If provided,
+	// metrics will be sent to that instance
+	DogStatsdAddr string `mapstructure:"dogstatsd_addr"`
+
+	// DogStatsdTags are the global tags that should be sent with each packet to dogstatsd
+	// It is a list of strings, where each string looks like "my_tag_name:my_tag_value"
+	DogStatsdTags []string `mapstructure:"dogstatsd_tags"`
+
 	// Protocol is the Consul protocol version to use.
 	Protocol int `mapstructure:"protocol"`
 
@@ -915,6 +923,12 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.StatsdAddr != "" {
 		result.StatsdAddr = b.StatsdAddr
+	}
+	if b.DogStatsdAddr != "" {
+		result.DogStatsdAddr = b.DogStatsdAddr
+	}
+	if b.DogStatsdTags != nil {
+		result.DogStatsdTags = b.DogStatsdTags
 	}
 	if b.EnableDebug {
 		result.EnableDebug = true

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -629,6 +629,28 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// dogstatsd
+	input = `{"dogstatsd_addr": "127.0.0.1:7254", "dogstatsd_tags":["tag_1:val_1", "tag_2:val_2"]}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.DogStatsdAddr != "127.0.0.1:7254" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	if len(config.DogStatsdTags) != 2 {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	if config.DogStatsdTags[0] != "tag_1:val_1" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	if config.DogStatsdTags[1] != "tag_2:val_2" {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// Statsite prefix
 	input = `{"statsite_prefix": "my_prefix"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1216,6 +1238,8 @@ func TestMergeConfig(t *testing.T) {
 		StatsiteAddr:              "127.0.0.1:7250",
 		StatsitePrefix:            "stats_prefix",
 		StatsdAddr:                "127.0.0.1:7251",
+		DogStatsdAddr:             "127.0.0.1:7254",
+		DogStatsdTags:             []string{"tag_1:val_1", "tag_2:val_2"},
 		DisableUpdateCheck:        true,
 		DisableAnonymousSignature: true,
 		HTTPAPIResponseHeaders: map[string]string{

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -562,6 +562,15 @@ definitions support being updated during a reload.
   This can be used to capture runtime information. This sends UDP packets only and can be used with statsd
   or statsite.
 
+* <a name="dogstatsd_addr"></a><a href="#dogstatsd_addr">`dogstatsd_addr`</a> This provides the
+  address of a DogStatsD instance. DogStatsD is a protocol-compatible flavor of statsd, with the added ability
+  to decorate metrics with tags and event information. If provided, Consul will send various telemetry information
+  to that instance for aggregation. This can be used to capture runtime information.
+
+* <a name="dogstatsd_tags"></a><a href="#dogstatsd_tags">`dogstatsd_tags`</a> This provides a list of global tags
+  that will be added to all telemetry packets sent to DogStatsD. It is a list of strings, where each string
+  looks like "my_tag_name:my_tag_value".
+
 * <a name="statsite_addr"></a><a href="#statsite_addr">`statsite_addr`</a> This provides the address of a
   statsite instance. If provided, Consul will stream various telemetry information to that instance for
   aggregation. This can be used to capture runtime information. This streams via


### PR DESCRIPTION
The changeset at https://github.com/armon/go-metrics/pull/19 added a [DogStatsD](http://docs.datadoghq.com/guides/dogstatsd/) sink, that satisfies the interface Consul requires for its runtime telemetry. It would be nice to have top-level configuration options in Consul for the initialization and use of this sink, similar to the options for vanilla statsd and statsite.

This PR adds 2 configuration options:
1. `dogstatsd_addr` : The address of a DogStatsD instance
2. `dogstatsd_tags`: A list of tags of the format `["my_tag_1:my_value_1", "my_tag_2:my_value_2"]`. These tags will be appended to all runtime telemetry packets sent by Consul and can be leveraged in the Datadog graphing backend. Ref: http://docs.datadoghq.com/guides/tagging/

