### PR TITLE
Add "Edit this page" link everywhere except /

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/hashicorp/middleman-hashicorp.git
-  revision: 93983af15fd8d480bec266b50c9211a48e495815
+  revision: b152b6436348e8e1f9990436228b25b4c5c6fcb8
   specs:
     middleman-hashicorp (0.1.0)
       bootstrap-sass (~> 3.3)
@@ -27,7 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (5.2.1.3)
+    autoprefixer-rails (6.0.3)
       execjs
       json
     bootstrap-sass (3.3.5.1)
@@ -76,7 +76,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
-    kramdown (1.8.0)
+    kramdown (1.9.0)
     less (2.6.0)
       commonjs (~> 0.2.7)
     libv8 (3.16.14.11)
@@ -121,9 +121,9 @@ GEM
     middleman-syntax (2.0.0)
       middleman-core (~> 3.2)
       rouge (~> 1.0)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
-    minitest (5.8.0)
+    minitest (5.8.1)
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -148,10 +148,10 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    redcarpet (3.3.2)
+    redcarpet (3.3.3)
     ref (2.0.0)
-    rouge (1.9.1)
-    sass (3.4.18)
+    rouge (1.10.1)
+    sass (3.4.19)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -165,9 +165,9 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.3)
+    thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0)
+      eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -186,3 +186,6 @@ PLATFORMS
 
 DEPENDENCIES
   middleman-hashicorp!
+
+BUNDLED WITH
+   1.10.6

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,0 +1,10 @@
+all: build
+
+init:
+	bundle
+
+dev: init
+	bundle exec middleman server
+
+build: init
+	bundle exec middleman build

--- a/website/README.md
+++ b/website/README.md
@@ -11,12 +11,7 @@ If you find a typo or you feel like you can improve the HTML, CSS, or JavaScript
 Running the Site Locally
 ------------------------
 
-Running the site locally is simple. Clone this repo and run the following commands:
-
-```
-$ bundle
-$ bundle exec middleman server
-```
+Running the site locally is simple. Clone this repo and run `make dev`.
 
 Then open up `localhost:4567`. Note that some URLs you may need to append ".html" to make them work (in the navigation and such).
 

--- a/website/config.rb
+++ b/website/config.rb
@@ -10,6 +10,7 @@ activate :hashicorp do |h|
   h.bintray_repo    = "mitchellh/consul"
   h.bintray_user    = "mitchellh"
   h.bintray_key     = ENV["BINTRAY_API_KEY"]
+  h.github_slug     = "hashicorp/consul"
 
   # Do not include the "web" in the default list of packages
   h.bintray_exclude_proc = Proc.new do |os, filename|

--- a/website/source/layouts/_footer.erb
+++ b/website/source/layouts/_footer.erb
@@ -4,8 +4,11 @@
 			<ul class="main-links nav navbar-nav rls-sb">
 				<li class="li-under"><a href="/intro/index.html">Intro</a></li>
 				<li class="active li-under"><a href="/docs/index.html">Docs</a></li>
-                <li class="li-under"><a href="/community.html">Community</a></li>
+				<li class="li-under"><a href="/community.html">Community</a></li>
 				<li class="li-under"><a href="http://demo.consul.io/">Demo</a></li>
+				<% if current_page.url != '/' %>
+					<li class="li-under"><a href="<%= github_url :current_page %>">Edit this page</a></li>
+				<% end %>
 			</ul>
 
 			<ul class="buttons nav navbar-nav rls-sb">


### PR DESCRIPTION
This PR adds an 'Edit this page' link everywhere on the [Consul website](https://consul.io/) except the homepage. Note that — owing to some deployment issues on a different site — I closed my [last PR to this effect](https://github.com/hashicorp/consul/pull/1260) and opened this one. 

As in the other PR, I have added a `Makefile` to the `website` directory and updated the README accordingly. I have also updated the `Gemfile.lock` file to point to the latest `middleman-hashicorp` gem.