### PR TITLE
Fixed Header background

### DIFF
--- a/website/source/assets/stylesheets/_header.scss
+++ b/website/source/assets/stylesheets/_header.scss
@@ -22,6 +22,8 @@ body.page-sub{
 
     &.navbar-static-top{
         z-index: 1000;
+        position: absolute;
+        width: 100%;
     }
 
     a{

--- a/website/source/assets/stylesheets/_jumbotron.scss
+++ b/website/source/assets/stylesheets/_jumbotron.scss
@@ -6,7 +6,6 @@
   overflow: hidden;
   width: 100%;
   height: $jumbotron-total-height;
-  margin-top: $negative-hero-margin;
 }
 
 #jumbotron {
@@ -42,7 +41,7 @@
       height: 100%;
       margin-top: $header-height;
       -webkit-backface-visibility:hidden;
-      
+
       .jumbo-logo-wrap{
         margin-top: 135px;
 


### PR DESCRIPTION
@TannerFilip reported on https://webcompat.com/issues/1806 a bug about `Header` which isn't readable on Firefox (and Same on Internet explorer). 

This patch fixes the bug. 

https://github.com/webcompat/web-bugs/issues/1806