### PR TITLE
Don't use http.DefaultClient

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -119,7 +119,7 @@ func DefaultConfig() *Config {
 	config := &Config{
 		Address:    "127.0.0.1:8500",
 		Scheme:     "http",
-		HttpClient: http.DefaultClient,
+		HttpClient: &http.Client{},
 	}
 
 	if addr := os.Getenv("CONSUL_HTTP_ADDR"); addr != "" {

--- a/command/agent/ui_endpoint_test.go
+++ b/command/agent/ui_endpoint_test.go
@@ -3,8 +3,6 @@ package agent
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/consul/consul/structs"
-	"github.com/hashicorp/consul/testutil"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +11,9 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/consul/testutil"
 )
 
 func TestUiIndex(t *testing.T) {
@@ -36,7 +37,8 @@ func TestUiIndex(t *testing.T) {
 	req.URL.Host = srv.listener.Addr().String()
 
 	// Make the request
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -200,7 +200,7 @@ func NewTestServerConfig(t *testing.T, cb ServerConfigCallback) *TestServer {
 		}
 	} else {
 		httpAddr = fmt.Sprintf("127.0.0.1:%d", consulConfig.Ports.HTTP)
-		client = http.DefaultClient
+		client = &http.Client{}
 	}
 
 	server := &TestServer{


### PR DESCRIPTION
Two of the changes are in tests; the one of consequence is in the API.
As explained in #1308 this can cause conflicts with downstream programs.

Fixes #1308.