### PR TITLE
Allow specifying Consul token in an HTTP request header

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -463,9 +463,14 @@ func (s *HTTPServer) parseDC(req *http.Request, dc *string) {
 	}
 }
 
-// parseToken is used to parse the ?token query param
+// parseToken is used to parse the ?token query param or the X-Consul-Token header
 func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	if other := req.URL.Query().Get("token"); other != "" {
+		*token = other
+		return
+	}
+
+	if other := req.Header.Get("X-Consul-Token"); other != "" {
 		*token = other
 		return
 	}

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -472,6 +472,22 @@ func TestACLResolution(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Request with header token only
+	reqHeaderToken, err := http.NewRequest("GET",
+		"/v1/catalog/nodes", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	reqHeaderToken.Header.Add("X-Consul-Token", "bar")
+
+	// Request with header and querystring tokens
+	reqBothTokens, err := http.NewRequest("GET",
+		"/v1/catalog/nodes?token=baz", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	reqBothTokens.Header.Add("X-Consul-Token", "zap")
+
 	httpTest(t, func(srv *HTTPServer) {
 		// Check when no token is set
 		srv.agent.config.ACLToken = ""
@@ -511,6 +527,18 @@ func TestACLResolution(t *testing.T) {
 		// Explicit token has highest precedence
 		srv.parseToken(reqToken, &token)
 		if token != "foo" {
+			t.Fatalf("bad: %s", token)
+		}
+
+		// Header token has precedence over agent token
+		srv.parseToken(reqHeaderToken, &token)
+		if token != "bar" {
+			t.Fatalf("bad: %s", token)
+		}
+
+		// Querystring token has precendence over header and agent tokens
+		srv.parseToken(reqBothTokens, &token)
+		if token != "baz" {
 			t.Fatalf("bad: %s", token)
 		}
 	})

--- a/website/source/docs/agent/http.html.markdown
+++ b/website/source/docs/agent/http.html.markdown
@@ -91,5 +91,6 @@ on the query string, formatted JSON will be returned.
 Several endpoints in Consul use or require ACL tokens to operate. An agent
 can be configured to use a default token in requests using the `acl_token`
 configuration option. However, the token can also be specified per-request
-by using the `token` query parameter. This will take precedent over the
-default token.
+by using the `X-Consul-Token` request header or the `token` querystring
+parameter. The request header takes precedence over the default token, and
+the querystring parameter takes precedence over everything.


### PR DESCRIPTION
I would like to be able to pass the Consul authorization token via HTTP request header as well as through the querystring, for a couple of reasons related to setting up the Consul web UI and/or a general API gateway:

One, for security. Consul itself filters out tokens from its own request logs, but when behind a reverse proxy, that's another layer were tokens need to be filtered from logs.

Two, also for reverse proxy, adding values to the query string when dealing with OAuth or CAS-type authentication is often problematic. This would allow me to set the token I want to pass as a request header and avoid the complications.

I've also provided tests and documentation updates.