### PR TITLE
Add fabio - consul-aware HTTP/HTTPS lb/router

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -109,6 +109,9 @@ description: |-
         <a href="https://github.com/progrium/docker-consul">docker-consul</a> - Dockerized Consul Agent
       </li>
       <li>
+        <a href="https://github.com/eBay/fabio">fabio</a> - Fast, zero-conf, consul-aware load-balancing HTTP/HTTPS router
+      </li>
+      <li>
         <a href="https://github.com/ryanbreen/git2consul">git2consul</a> - Mirror the contents of a Git repository into Consul KVs
       </li>
       <li>


### PR DESCRIPTION
Hi hashicorp team,

I work at eBay in Amsterdam and I have written a zero-conf consul aware HTTP(S) load-balancer in Go which can be used instead of consul-template + haproxy/varnish/apache/nginx. It builds its routing table from host/path prefixes the services publish via tags and the service status. Once a change is detected it switches the routing table dynamically without restart. It also supports canary testing by routing N% of traffic to a variable number of instances of a service. 

	https://github.com/eBay/fabio

We're using it to run all of marktplaats.nl (> 5-10k req/sec peak) through it and parts of kijiji.it which are eBay classifieds sites in the Netherlands and Italy. 

The code has been under development for the last 5 months and runs now in production and I was able to open-source it a couple of days ago. 

consul has quickly become our state and coordination backend for our micro services architecture for multiple different platforms in several countries. We're very happy with the quality and ease-of-use of your products and I'm personally looking forward to testing nomad. 

It would be cool if you could list the project on your consul tools page. Please let me know whether it meets your standards and/or expectations for tools to be listed there. Feel free to ask questions.