### PR TITLE
Fix #1316: Safari 403 error on k/v page of web UI

### DIFF
--- a/ui/javascripts/app/routes.js
+++ b/ui/javascripts/app/routes.js
@@ -379,6 +379,9 @@ App.SettingsRoute = App.BaseRoute.extend({
 
 // Adds any global parameters we need to set to a url/path
 function formatUrl(url, dc, token) {
+  if (token == null) {
+    token = "";
+  }
   if (url.indexOf("?") > 0) {
     // If our url has existing params
     url = url + "&dc=" + dc;


### PR DESCRIPTION
For whatever reason, Safari is passing `null` as the value for `token` to the `formatURL` function when displaying the key-value page. When the null value is force-converted to a string, it becomes `"null"`, which then fails to pass ACL security tests (unless there actually is an ACL with a token of `"null"`).

This converts any `null` value `token` to the empty string instead, which will then render correctly.

Should fix #1316.