### PR TITLE
Handle error in api README example

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -17,13 +17,18 @@ Usage
 Below is an example of using the Consul client:
 
 ```go
-// Get a new client, with KV endpoints
-client, _ := api.NewClient(api.DefaultConfig())
+// Get a new client
+client, err := api.NewClient(api.DefaultConfig())
+if err != nil {
+    panic(err)
+}
+
+// Get a handle to the KV API
 kv := client.KV()
 
 // PUT a new KV pair
 p := &api.KVPair{Key: "foo", Value: []byte("test")}
-_, err := kv.Put(p, nil)
+_, err = kv.Put(p, nil)
 if err != nil {
     panic(err)
 }


### PR DESCRIPTION
Sorry for a rather small change. I thought that it would be a bit better to handle all the errors in the example, since people sometimes tend to just copy-paste it :)