### PR TITLE
Uses correct version for automatic upshift, sets coordinate Raft log entries to ignore.

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1602,30 +1602,3 @@ func TestAgent_GetCoordinate(t *testing.T) {
 	check(true)
 	check(false)
 }
-
-func TestAgent_CanServersUnderstandProtocol(t *testing.T) {
-	config := nextConfig()
-	dir, agent := makeAgent(t, config)
-	defer os.RemoveAll(dir)
-	defer agent.Shutdown()
-
-	min := uint8(consul.ProtocolVersionMin)
-	if !agent.CanServersUnderstandProtocol(min) {
-		t.Fatalf("should grok %d", min)
-	}
-
-	max := uint8(consul.ProtocolVersionMax)
-	if !agent.CanServersUnderstandProtocol(max) {
-		t.Fatalf("should grok %d", max)
-	}
-
-	current := uint8(config.Protocol)
-	if !agent.CanServersUnderstandProtocol(current) {
-		t.Fatalf("should grok %d", current)
-	}
-
-	future := max + 1
-	if agent.CanServersUnderstandProtocol(future) {
-		t.Fatalf("should not grok %d", future)
-	}
-}

--- a/consul/coordinate_endpoint.go
+++ b/consul/coordinate_endpoint.go
@@ -87,8 +87,12 @@ func (c *Coordinate) batchApplyUpdates() error {
 			end = size
 		}
 
+		// We set the "safe to ignore" flag on this update type so old
+		// servers don't crash if they see one of these.
+		t := structs.CoordinateBatchUpdateType | structs.IgnoreUnknownTypeFlag
+
 		slice := updates[start:end]
-		if _, err := c.srv.raftApply(structs.CoordinateBatchUpdateType, slice); err != nil {
+		if _, err := c.srv.raftApply(t, slice); err != nil {
 			return err
 		}
 	}

--- a/consul/util.go
+++ b/consul/util.go
@@ -96,8 +96,8 @@ func ensurePath(path string, dir bool) error {
 }
 
 // CanServersUnderstandProtocol checks to see if all the servers in the given
-// list understand the given protocol version or higher. If there are no servers
-// in the list then this will return false.
+// list understand the given protocol version. If there are no servers in the
+// list then this will return false.
 func CanServersUnderstandProtocol(members []serf.Member, version uint8) (bool, error) {
 	numServers, numWhoGrok := 0, 0
 	for _, m := range members {
@@ -106,13 +106,18 @@ func CanServersUnderstandProtocol(members []serf.Member, version uint8) (bool, e
 		}
 		numServers++
 
-		vsn_str := m.Tags["vsn_max"]
-		vsn, err := strconv.Atoi(vsn_str)
+		vsn_min, err := strconv.Atoi(m.Tags["vsn_min"])
 		if err != nil {
 			return false, err
 		}
 
-		if vsn >= int(version) {
+		vsn_max, err := strconv.Atoi(m.Tags["vsn_max"])
+		if err != nil {
+			return false, err
+		}
+
+		v := int(version)
+		if (v >= vsn_min) && (v <= vsn_max) {
 			numWhoGrok++
 		}
 	}

--- a/consul/util_test.go
+++ b/consul/util_test.go
@@ -136,6 +136,7 @@ func TestUtil_CanServersUnderstandProtocol(t *testing.T) {
 	// Add a non-server member.
 	members = append(members, serf.Member{
 		Tags: map[string]string{
+			"vsn_min": fmt.Sprintf("%d", ProtocolVersionMin),
 			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax),
 		},
 	})
@@ -155,6 +156,7 @@ func TestUtil_CanServersUnderstandProtocol(t *testing.T) {
 	members = append(members, serf.Member{
 		Tags: map[string]string{
 			"role":    "consul",
+			"vsn_min": fmt.Sprintf("%d", ProtocolVersionMin),
 			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax),
 		},
 	})
@@ -185,6 +187,7 @@ func TestUtil_CanServersUnderstandProtocol(t *testing.T) {
 	members = append(members, serf.Member{
 		Tags: map[string]string{
 			"role":    "consul",
+			"vsn_min": fmt.Sprintf("%d", ProtocolVersionMin),
 			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax-1),
 		},
 	})
@@ -198,6 +201,17 @@ func TestUtil_CanServersUnderstandProtocol(t *testing.T) {
 		expected := v < ProtocolVersionMax
 		if grok != expected {
 			t.Fatalf("bad: %v != %v", grok, expected)
+		}
+	}
+
+	// Try a version that's too low for the minimum.
+	{
+		grok, err := CanServersUnderstandProtocol(members, 0)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if grok {
+			t.Fatalf("server should not grok")
 		}
 	}
 }

--- a/consul/util_test.go
+++ b/consul/util_test.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"testing"
@@ -115,6 +116,89 @@ func TestIsPrivateIP(t *testing.T) {
 	}
 	if isPrivateIP("127.0.0.1") {
 		t.Fatalf("bad")
+	}
+}
+
+func TestUtil_CanServersUnderstandProtocol(t *testing.T) {
+	var members []serf.Member
+
+	// All empty list cases should return false.
+	for v := ProtocolVersionMin; v <= ProtocolVersionMax; v++ {
+		grok, err := CanServersUnderstandProtocol(members, v)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if grok {
+			t.Fatalf("empty list should always return false")
+		}
+	}
+
+	// Add a non-server member.
+	members = append(members, serf.Member{
+		Tags: map[string]string{
+			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax),
+		},
+	})
+
+	// Make sure it doesn't get counted.
+	for v := ProtocolVersionMin; v <= ProtocolVersionMax; v++ {
+		grok, err := CanServersUnderstandProtocol(members, v)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if grok {
+			t.Fatalf("non-server members should not be counted")
+		}
+	}
+
+	// Add a server member.
+	members = append(members, serf.Member{
+		Tags: map[string]string{
+			"role":    "consul",
+			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax),
+		},
+	})
+
+	// Now it should report that it understands.
+	for v := ProtocolVersionMin; v <= ProtocolVersionMax; v++ {
+		grok, err := CanServersUnderstandProtocol(members, v)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !grok {
+			t.Fatalf("server should grok")
+		}
+	}
+
+	// Nobody should understand anything from the future.
+	for v := uint8(ProtocolVersionMax + 1); v <= uint8(ProtocolVersionMax+10); v++ {
+		grok, err := CanServersUnderstandProtocol(members, v)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if grok {
+			t.Fatalf("server should not grok")
+		}
+	}
+
+	// Add an older server.
+	members = append(members, serf.Member{
+		Tags: map[string]string{
+			"role":    "consul",
+			"vsn_max": fmt.Sprintf("%d", ProtocolVersionMax-1),
+		},
+	})
+
+	// The servers should no longer understand the max version.
+	for v := ProtocolVersionMin; v <= ProtocolVersionMax; v++ {
+		grok, err := CanServersUnderstandProtocol(members, v)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		expected := v < ProtocolVersionMax
+		if grok != expected {
+			t.Fatalf("bad: %v != %v", grok, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
This should fix https://github.com/hashicorp/consul/issues/1346.