### PR TITLE
Prevents agents from considering Raft information when doing sync checks.

### DIFF
--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -385,7 +384,7 @@ func (l *localState) setSyncState() error {
 		if existing.EnableTagOverride {
 			existing.Tags = service.Tags
 		}
-		equal := reflect.DeepEqual(existing, service)
+		equal := existing.IsSame(service)
 		l.serviceStatus[id] = syncStatus{inSync: equal}
 	}
 
@@ -419,13 +418,13 @@ func (l *localState) setSyncState() error {
 		// If our definition is different, we need to update it
 		var equal bool
 		if l.config.CheckUpdateInterval == 0 {
-			equal = reflect.DeepEqual(existing, check)
+			equal = existing.IsSame(check)
 		} else {
 			eCopy := new(structs.HealthCheck)
 			*eCopy = *existing
 			eCopy.Output = ""
 			check.Output = ""
-			equal = reflect.DeepEqual(eCopy, check)
+			equal = eCopy.IsSame(check)
 		}
 
 		// Update the status

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -1079,7 +1079,7 @@ func (s *StateStore) ensureCheckTxn(tx *memdb.Txn, idx uint64, watches *DumbWatc
 
 	// Persist the check registration in the db.
 	if err := tx.Insert("checks", hc); err != nil {
-		return fmt.Errorf("failed inserting service: %s", err)
+		return fmt.Errorf("failed inserting check: %s", err)
 	}
 	if err := tx.Insert("index", &IndexEntry{"checks", idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -3,6 +3,7 @@ package structs
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/consul/acl"
@@ -318,6 +319,23 @@ type NodeService struct {
 	RaftIndex
 }
 
+// IsSame checks if one NodeService is the same as another, without looking
+// at the Raft information (that's why we didn't call it IsEqual). This is
+// useful for seeing if an update would be idempotent for all the functional
+// parts of the structure.
+func (s *NodeService) IsSame(other *NodeService) bool {
+	if s.ID != other.ID ||
+		s.Service != other.Service ||
+		!reflect.DeepEqual(s.Tags, other.Tags) ||
+		s.Address != other.Address ||
+		s.Port != other.Port ||
+		s.EnableTagOverride != other.EnableTagOverride {
+		return false
+	}
+
+	return true
+}
+
 // ToServiceNode converts the given node service to a service node.
 func (s *NodeService) ToServiceNode(node, address string) *ServiceNode {
 	return &ServiceNode{
@@ -354,6 +372,26 @@ type HealthCheck struct {
 
 	RaftIndex
 }
+
+// IsSame checks if one HealthCheck is the same as another, without looking
+// at the Raft information (that's why we didn't call it IsEqual). This is
+// useful for seeing if an update would be idempotent for all the functional
+// parts of the structure.
+func (c *HealthCheck) IsSame(other *HealthCheck) bool {
+	if c.Node != other.Node ||
+		c.CheckID != other.CheckID ||
+		c.Name != other.Name ||
+		c.Status != other.Status ||
+		c.Notes != other.Notes ||
+		c.Output != other.Output ||
+		c.ServiceID != other.ServiceID ||
+		c.ServiceName != other.ServiceName {
+		return false
+	}
+
+	return true
+}
+
 type HealthChecks []*HealthCheck
 
 // CheckServiceNode is used to provide the node, its service


### PR DESCRIPTION
When we added the Raft index information to returned `NodeService` and `HealthCheck` structs we accidentally broke the logic agents use to sync changes back to the catalog. Because they never store the Raft information locally, they always detect a mismatch with `DeepEqual` and spam the servers with updates, causing watches to fire all the time.

This PR adds some new `IsSame` methods to these structures that don't look at the Raft index information (that's why we chose `IsSame` instead of `IsEqual` for the name. This also gets rid of the use of `DeepEqual` in the agent, which should be a lot more lightweight.