### PR TITLE
Changes batch update failure to a WARN since it's nbd.

### DIFF
--- a/consul/coordinate_endpoint.go
+++ b/consul/coordinate_endpoint.go
@@ -41,7 +41,7 @@ func (c *Coordinate) batchUpdate() {
 		select {
 		case <-time.After(c.srv.config.CoordinateUpdatePeriod):
 			if err := c.batchApplyUpdates(); err != nil {
-				c.srv.logger.Printf("[ERR] consul.coordinate: Batch update failed: %v", err)
+				c.srv.logger.Printf("[WARN] consul.coordinate: Batch update failed: %v", err)
 			}
 		case <-c.srv.shutdownCh:
 			return


### PR DESCRIPTION
These might show up during leadership transitions (see #1359) so downgrading this to a warning. Also, coordinates are refreshed all the time, so losing some isn't a critical error.