### PR TITLE
Add trailing slash to avoid a redirect

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -26,7 +26,7 @@ description: |-
           verify the checksums signature file
         </a>
         which has been signed using <a href="https://hashicorp.com/security.html" target="_TOP">HashiCorp's GPG key</a>.
-        You can also <a href="https://releases.hashicorp.com/consul" target="_TOP">download older versions of Consul</a> from the releases service.
+        You can also <a href="https://releases.hashicorp.com/consul/" target="_TOP">download older versions of Consul</a> from the releases service.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This avoids a redirect by adding a trailing slash... it's the little things in life.

/cc @slackpad 