### PR TITLE
Switch exec to use bash rather than sh

### DIFF
--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -72,7 +72,9 @@ func ExecScript(script string) (*exec.Cmd, error) {
 		shell = "cmd"
 		flag = "/C"
 	} else {
-		shell = "/bin/sh"
+		// We require bash because sh compatability mode means forking our
+		// command which prevents us from controlling the child process.
+		shell = "/bin/bash"
 		flag = "-c"
 	}
 	if other := os.Getenv("SHELL"); other != "" {


### PR DESCRIPTION
Not specifying the environment variable `SHELL` (which happens in an upstart script for example) will cause the lock command to use `/bin/sh -c`. `sh` (or `dash` on ubuntu) forks and execs the arguments meaning the process we actually care about is not the pid `consul lock` thinks it is.

### Reproducing

You can reproduce this behavior like this:

    $ SHELL="" consul lock -verbose lock-test "/bin/sleep 30"

Use ps to find the pid for your consul lock process. You'll see something like:

    $ ps axo stat,ppid,pid,args | grep sleep
    Sl+  29044 29763 /usr/local/bin/consul lock -verbose service/lock-test/stage /bin/sleep 30
    S+   29763 29769 /bin/sh -c /bin/sleep 30
    S+   29769 29770 /bin/sleep 30

Send SIGTERM to the consul lock process (or kill your local agent, really either should work). Then you can see:

    $ ps axo stat,ppid,pid,args | grep sleep
    S        1 29770 /bin/sleep 30


### Considerations
I think perhaps a better solution is to make executing with a shell an option to the lock command. I did this originally, but that made the tests fail. 

I'm open to other ideas, also, I think these tests perhaps need to be written to correctly verify these scenarios.