### PR TITLE
#735 add information about leader to consul members

### DIFF
--- a/command/members.go
+++ b/command/members.go
@@ -67,6 +67,11 @@ func (c *MembersCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
+	leader, err := client.Stats()
+	if err == nil {
+		c.Ui.Output(fmt.Sprintf("Leader: %s", leader["consul"]["leader_name"]))
+	}
+
 	var members []agent.Member
 	if wan {
 		members, err = client.WANMembers()

--- a/consul/server.go
+++ b/consul/server.go
@@ -696,6 +696,7 @@ func (s *Server) Stats() map[string]map[string]string {
 		"consul": map[string]string{
 			"server":            "true",
 			"leader":            fmt.Sprintf("%v", s.IsLeader()),
+			"leader_name":       s.raft.Leader(),
 			"bootstrap":         fmt.Sprintf("%v", s.config.Bootstrap),
 			"known_datacenters": toString(uint64(len(s.remoteConsuls))),
 		},


### PR DESCRIPTION
Hi! I just added information about leader to council members. This idea related with issue #735. And it looks like
```
Leader: <address>
Node    Address             Status  Type    Build     Protocol  DC
foobar  <cluster address>  alive   server  0.6.0rc1  2         east-aws
```
What do you think?