### PR TITLE
Health check tags

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -12,6 +12,7 @@ type AgentCheck struct {
 	Status      string
 	Notes       string
 	Output      string
+	Tags        []string
 	ServiceID   string
 	ServiceName string
 }

--- a/api/health.go
+++ b/api/health.go
@@ -12,6 +12,7 @@ type HealthCheck struct {
 	Status      string
 	Notes       string
 	Output      string
+	Tags        []string
 	ServiceID   string
 	ServiceName string
 }
@@ -55,9 +56,12 @@ func (h *Health) Node(node string, q *QueryOptions) ([]*HealthCheck, *QueryMeta,
 }
 
 // Checks is used to return the checks associated with a service
-func (h *Health) Checks(service string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
+func (h *Health) Checks(service string, tag string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
 	r := h.c.newRequest("GET", "/v1/health/checks/"+service)
 	r.setQueryOptions(q)
+	if tag != "" {
+		r.params.Set("tag", tag)
+	}
 	rtt, resp, err := requireOK(h.c.doRequest(r))
 	if err != nil {
 		return nil, nil, err
@@ -106,7 +110,7 @@ func (h *Health) Service(service, tag string, passingOnly bool, q *QueryOptions)
 
 // State is used to retrieve all the checks in a given state.
 // The wildcard "any" state can also be used for all checks.
-func (h *Health) State(state string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
+func (h *Health) State(state string, tag string, q *QueryOptions) ([]*HealthCheck, *QueryMeta, error) {
 	switch state {
 	case "any":
 	case "warning":
@@ -118,6 +122,9 @@ func (h *Health) State(state string, q *QueryOptions) ([]*HealthCheck, *QueryMet
 	}
 	r := h.c.newRequest("GET", "/v1/health/state/"+state)
 	r.setQueryOptions(q)
+	if tag != "" {
+		r.params.Set("tag", tag)
+	}
 	rtt, resp, err := requireOK(h.c.doRequest(r))
 	if err != nil {
 		return nil, nil, err

--- a/command/agent/health_endpoint.go
+++ b/command/agent/health_endpoint.go
@@ -13,6 +13,11 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
+	params := req.URL.Query()
+	if _, ok := params["tag"]; ok {
+		args.TagFilter = true
+		args.Tag = params.Get("tag")
+	}
 
 	// Pull out the service name
 	args.State = strings.TrimPrefix(req.URL.Path, "/v1/health/state/")

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -50,6 +50,7 @@ type CheckDefinition struct {
 	ServiceID string
 	Token     string
 	Status    string
+	Tags      []string
 	CheckType `mapstructure:",squash"`
 }
 
@@ -60,6 +61,7 @@ func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 		Name:      c.Name,
 		Status:    structs.HealthCritical,
 		Notes:     c.Notes,
+		Tags:      c.Tags,
 		ServiceID: c.ServiceID,
 	}
 	if c.Status != "" {

--- a/command/watch.go
+++ b/command/watch.go
@@ -49,7 +49,7 @@ Watch Specification:
                              optional for 'checks' type.
   -state=val                 Specifies the states to watch. Optional for 'checks' type.
   -tag=val                   Specifies the service tag to filter on. Optional for 'service'
-                             type.
+                             and 'checks' type.
   -type=val                  Specifies the watch type. One of key, keyprefix
                              services, nodes, service, checks, or event.
 `

--- a/consul/health_endpoint.go
+++ b/consul/health_endpoint.go
@@ -25,7 +25,14 @@ func (h *Health) ChecksInState(args *structs.ChecksInStateRequest,
 		&reply.QueryMeta,
 		state.GetQueryWatch("ChecksInState"),
 		func() error {
-			index, checks, err := state.ChecksInState(args.State)
+			var index uint64
+			var checks structs.HealthChecks
+			var err error
+			if args.TagFilter {
+				index, checks, err = state.ChecksInStateTag(args.State, args.Tag)
+			} else {
+				index, checks, err = state.ChecksInState(args.State)
+			}
 			if err != nil {
 				return err
 			}

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -1150,6 +1150,46 @@ func (s *StateStore) ChecksInState(state string) (uint64, structs.HealthChecks, 
 	return s.parseChecks(idx, checks)
 }
 
+//ChecksInStateTag
+func (s *StateStore) ChecksInStateTag(state, tag string) (uint64, structs.HealthChecks, error) {
+	tx := s.db.Txn(false)
+	defer tx.Abort()
+
+	// Get the table index.
+	idx := maxIndexTxn(tx, s.getWatchTables("ChecksInState")...)
+
+	// Query all checks if HealthAny is passed
+	if state == structs.HealthAny {
+		checks, err := tx.Get("checks", "status")
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed check lookup: %s", err)
+		}
+		return s.parseChecksTag(idx, tag, checks)
+	}
+
+	// Any other state we need to query for explicitly
+	checks, err := tx.Get("checks", "status", state)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed check lookup: %s", err)
+	}
+
+	return s.parseChecksTag(idx, tag, checks)
+}
+
+//parseChecksTag
+func (s *StateStore) parseChecksTag(idx uint64, tag string, iter memdb.ResultIterator) (uint64, structs.HealthChecks, error) {
+	var results structs.HealthChecks
+	for check := iter.Next(); check != nil; check = iter.Next() {
+		checkitem := check.(*structs.HealthCheck)
+		for _, tag2 := range checkitem.Tags {
+			if tag == tag2 {
+				results = append(results, check.(*structs.HealthCheck))
+			}
+		}
+	}
+	return idx, results, nil
+}
+
 // parseChecks is a helper function used to deduplicate some
 // repetitive code for returning health checks.
 func (s *StateStore) parseChecks(idx uint64, iter memdb.ResultIterator) (uint64, structs.HealthChecks, error) {

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -234,6 +234,8 @@ type ChecksInStateRequest struct {
 	Datacenter string
 	State      string
 	Source     QuerySource
+	TagFilter  bool
+	Tag        string
 	QueryOptions
 }
 
@@ -362,13 +364,14 @@ type NodeServices struct {
 // HealthCheck represents a single check on a given node
 type HealthCheck struct {
 	Node        string
-	CheckID     string // Unique per-node ID
-	Name        string // Check name
-	Status      string // The current check status
-	Notes       string // Additional notes with the status
-	Output      string // Holds output of script runs
-	ServiceID   string // optional associated service
-	ServiceName string // optional service name
+	CheckID     string   // Unique per-node ID
+	Name        string   // Check name
+	Status      string   // The current check status
+	Notes       string   // Additional notes with the status
+	Output      string   // Holds output of script runs
+	Tags        []string // tags
+	ServiceID   string   // optional associated service
+	ServiceName string   // optional service name
 
 	RaftIndex
 }

--- a/watch/funcs.go
+++ b/watch/funcs.go
@@ -133,11 +133,14 @@ func serviceWatch(params map[string]interface{}) (WatchFunc, error) {
 
 // checksWatch is used to watch a specific checks in a given state
 func checksWatch(params map[string]interface{}) (WatchFunc, error) {
-	var service, state string
+	var service, state, tag string
 	if err := assignValue(params, "service", &service); err != nil {
 		return nil, err
 	}
 	if err := assignValue(params, "state", &state); err != nil {
+		return nil, err
+	}
+	if err := assignValue(params, "tag", &tag); err != nil {
 		return nil, err
 	}
 	if service != "" && state != "" {
@@ -154,9 +157,9 @@ func checksWatch(params map[string]interface{}) (WatchFunc, error) {
 		var meta *consulapi.QueryMeta
 		var err error
 		if state != "" {
-			checks, meta, err = health.State(state, &opts)
+			checks, meta, err = health.State(state, tag, &opts)
 		} else {
-			checks, meta, err = health.Checks(service, &opts)
+			checks, meta, err = health.Checks(service, tag, &opts)
 		}
 		if err != nil {
 			return 0, nil, err


### PR DESCRIPTION
Hi! I just added filtering of  health checks by tags in `consul watch`. This is related for #367. In config file, description of check will looks like:

```
 {
      "id": "check",
      "name": "fun",
      "script": "command",
      "interval": "5s",
      "tags": [
        "foo", "bar"
      ]
  }
```

And after execution of `consul watch -type checks -tag=foo -state=critical` we'll get all checks with critical status and with tag `foo`. Or after `consul watch -type checks -tag=foo` we'll get all checks with tag `foo`. At this stage is not supported checks with services and not provides documentation. But, if this feature will be approved, all of this will be added.
