### PR TITLE
rtt. Add randomly choosing nodes if input if empty

### DIFF
--- a/command/rtt.go
+++ b/command/rtt.go
@@ -3,6 +3,7 @@ package command
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
@@ -58,12 +59,6 @@ func (c *RTTCommand) Run(args []string) int {
 
 	// They must provide at least one node.
 	nodes := cmdFlags.Args()
-	if len(nodes) < 1 || len(nodes) > 2 {
-		c.Ui.Error("One or two node names must be specified")
-		c.Ui.Error("")
-		c.Ui.Error(c.Help())
-		return 1
-	}
 
 	// Create and test the HTTP client.
 	conf := api.DefaultConfig()
@@ -129,7 +124,7 @@ func (c *RTTCommand) Run(args []string) int {
 		source = "LAN"
 
 		// Default the second node to the agent if none was given.
-		if len(nodes) < 2 {
+		if len(nodes) == 1 {
 			agent := client.Agent()
 			node, err := agent.NodeName()
 			if err != nil {
@@ -144,6 +139,18 @@ func (c *RTTCommand) Run(args []string) int {
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error getting coordinates: %s", err))
 			return 1
+		}
+
+		// Getting randomly two nodes if input nodes is empty
+		if len(nodes) == 0 {
+			lenentries := len(entries)
+			item1 := entries[rand.Intn(lenentries)]
+			item2 := entries[rand.Intn(lenentries)]
+			coord1 = item1.Coord
+			coord2 = item2.Coord
+			nodes = append(nodes, item1.Node)
+			nodes = append(nodes, item2.Node)
+			goto SHOW_RTT
 		}
 
 		// See if the requested nodes are in there.

--- a/command/rtt_test.go
+++ b/command/rtt_test.go
@@ -20,10 +20,6 @@ func TestRTTCommand_Run_BadArgs(t *testing.T) {
 	ui := new(cli.MockUi)
 	c := &RTTCommand{Ui: ui}
 
-	if code := c.Run([]string{}); code != 1 {
-		t.Fatalf("expected return code 1, got %d", code)
-	}
-
 	if code := c.Run([]string{"node1", "node2", "node3"}); code != 1 {
 		t.Fatalf("expected return code 1, got %d", code)
 	}


### PR DESCRIPTION
Added in ```rtt``` command if input is empty ```consul rtt```, just choose randomly two nodes and continue with this nodes. At this stage, it works only for LAN and not provide enough documentation.