### PR TITLE
Health check output state

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -934,11 +934,12 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 
 			monitor := &CheckMonitor{
-				Notify:   &a.state,
-				CheckID:  check.CheckID,
-				Script:   chkType.Script,
-				Interval: chkType.Interval,
-				Logger:   a.logger,
+				Notify:      &a.state,
+				CheckID:     check.CheckID,
+				Script:      chkType.Script,
+				OutputRoute: check.OutputRoute,
+				Interval:    chkType.Interval,
+				Logger:      a.logger,
 			}
 			monitor.Start()
 			a.checkMonitors[check.CheckID] = monitor

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -106,6 +106,37 @@ func TestCheckMonitor_RandomStagger(t *testing.T) {
 	}
 }
 
+func TestCheckMonitor_OutputRoute(t *testing.T) {
+	mock := &MockNotify{
+		state:   make(map[string]string),
+		updates: make(map[string]int),
+		output:  make(map[string]string),
+	}
+	check := &CheckMonitor{
+		Notify:   mock,
+		CheckID:  "foo",
+		Script:   "echo 2",
+		OutputRoute: map[string]string {
+			"2": "warning",
+		},
+		Interval: 25 * time.Millisecond,
+		Logger:   log.New(os.Stderr, "", log.LstdFlags),
+	}
+	check.Start()
+	defer check.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Should have at least 1 update
+	if mock.updates["foo"] < 1 {
+		t.Fatalf("should have 1 or more updates %v", mock.updates)
+	}
+
+	if mock.state["foo"] != structs.HealthWarning {
+		t.Fatalf("should be %v %v", structs.HealthWarning, mock.state)
+	}
+}
+
 func TestCheckMonitor_LimitOutput(t *testing.T) {
 	mock := &MockNotify{
 		state:   make(map[string]string),

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -50,17 +50,19 @@ type CheckDefinition struct {
 	ServiceID string
 	Token     string
 	Status    string
+	Output    map[string]string
 	CheckType `mapstructure:",squash"`
 }
 
 func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 	health := &structs.HealthCheck{
-		Node:      node,
-		CheckID:   c.ID,
-		Name:      c.Name,
-		Status:    structs.HealthCritical,
-		Notes:     c.Notes,
-		ServiceID: c.ServiceID,
+		Node:        node,
+		CheckID:     c.ID,
+		Name:        c.Name,
+		Status:      structs.HealthCritical,
+		Notes:       c.Notes,
+		OutputRoute: c.Output,
+		ServiceID:   c.ServiceID,
 	}
 	if c.Status != "" {
 		health.Status = c.Status

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -362,13 +362,14 @@ type NodeServices struct {
 // HealthCheck represents a single check on a given node
 type HealthCheck struct {
 	Node        string
-	CheckID     string // Unique per-node ID
-	Name        string // Check name
-	Status      string // The current check status
-	Notes       string // Additional notes with the status
-	Output      string // Holds output of script runs
-	ServiceID   string // optional associated service
-	ServiceName string // optional service name
+	CheckID     string            // Unique per-node ID
+	Name        string            // Check name
+	Status      string            // The current check status
+	Notes       string            // Additional notes with the status
+	Output      string            // Holds output of script runs
+	OutputRoute map[string]string // Set state from output of the check
+	ServiceID   string            // optional associated service
+	ServiceName string            // optional service name
 
 	RaftIndex
 }


### PR DESCRIPTION
Apply health status depend on check output(stdout). Definition of the check will be looks like:
```
{
      "id": "checkid",
      "name": "foobar",
      "script": "script.py",
      "interval": "5s",
      "output": {
          "3": "critical",
          "2":"warning",
          "1":"passing"
      }
}
```
And if output will be 3, our check will be critical, and so on. What do you think about this?