### PR TITLE
Fixes unit test fail due to expected truncated message.

### DIFF
--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -1406,7 +1406,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
 	c := new(dns.Client)
 	in, _, err := c.Exchange(m, addr.String())
-	if err != nil {
+	if err != nil && err != dns.ErrTruncated {
 		t.Fatalf("err: %v", err)
 	}
 


### PR DESCRIPTION
This recent commit to the DNS client library bubbles up an error when the client parses a truncated message - https://github.com/miekg/dns/commit/2d2c2ebcfc8f39f0393c32b2728e7757abc93761.

This is causing one of the DNS unit tests to fail, so we need to add a check to push on if it's the error we expected.