### PR TITLE
Extends the session TTL max to 24 hours, and adds a warning to the docs.

### DIFF
--- a/consul/session_endpoint_test.go
+++ b/consul/session_endpoint_test.go
@@ -522,18 +522,18 @@ func TestSessionEndpoint_Apply_BadTTL(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != "Invalid Session TTL '5000000000', must be between [10s=1h0m0s]" {
+	if err.Error() != "Invalid Session TTL '5000000000', must be between [10s=24h0m0s]" {
 		t.Fatalf("incorrect error message: %s", err.Error())
 	}
 
 	// more than SessionTTLMax
-	arg.Session.TTL = "4000s"
+	arg.Session.TTL = "100000s"
 
 	err = msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if err.Error() != "Invalid Session TTL '4000000000000', must be between [10s=1h0m0s]" {
+	if err.Error() != "Invalid Session TTL '100000000000000', must be between [10s=24h0m0s]" {
 		t.Fatalf("incorrect error message: %s", err.Error())
 	}
 }

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -547,7 +547,7 @@ const (
 )
 
 const (
-	SessionTTLMax        = 3600 * time.Second
+	SessionTTLMax        = 24 * time.Hour
 	SessionTTLMultiplier = 2
 )
 

--- a/website/source/docs/agent/http/session.html.markdown
+++ b/website/source/docs/agent/http/session.html.markdown
@@ -65,10 +65,13 @@ causes any locks that are held to be deleted. `delete` is useful for creating ep
 key/value entries.
 
 The `TTL` field is a duration string, and like `LockDelay` it can use "s" as
-a suffix for seconds. If specified, it must be between 10s and 3600s currently.
+a suffix for seconds. If specified, it must be between 10s and 86400s currently.
 When provided, the session is invalidated if it is not renewed before the TTL
-expires. See the [session internals page](/docs/internals/sessions.html) for more
-documentation of this feature.
+expires. The lowest practical TTL should be used to keep the number of managed
+sessions low. When locks are forcibly expired, such as during a leader election,
+sessions may not be reaped for up to double this TTL, so long TTL values (>1 hour)
+should be avoided. See the [session internals page](/docs/internals/sessions.html)
+for more documentation of this feature.
 
 The return code is 200 on success and returns the ID of the created session:
 


### PR DESCRIPTION
This should address #1104.