### PR TITLE
Fixes nil slices leading to null fields in HTTP JSON responses

### DIFF
--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -176,6 +176,11 @@ func (s *HTTPServer) ACLGet(resp http.ResponseWriter, req *http.Request) (interf
 	if err := s.agent.RPC("ACL.Get", &args, &out); err != nil {
 		return nil, err
 	}
+
+	// Use empty list instead of nil
+	if out.ACLs == nil {
+		out.ACLs = make(structs.ACLs, 0)
+	}
 	return out.ACLs, nil
 }
 
@@ -192,6 +197,11 @@ func (s *HTTPServer) ACLList(resp http.ResponseWriter, req *http.Request) (inter
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("ACL.List", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.ACLs == nil {
+		out.ACLs = make(structs.ACLs, 0)
 	}
 	return out.ACLs, nil
 }

--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -94,14 +94,29 @@ func TestACLUpdate_Upsert(t *testing.T) {
 func TestACLDestroy(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestACL(t, srv)
-		req, err := http.NewRequest("PUT", "/v1/session/destroy/"+id+"?token=root", nil)
+		req, err := http.NewRequest("PUT", "/v1/acl/destroy/"+id+"?token=root", nil)
 		resp := httptest.NewRecorder()
 		obj, err := srv.ACLDestroy(resp, req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if resp := obj.(bool); !resp {
+		if resp, ok := obj.(bool); !ok || !resp {
 			t.Fatalf("should work")
+		}
+
+		req, err = http.NewRequest("GET",
+			"/v1/acl/info/"+id, nil)
+		resp = httptest.NewRecorder()
+		obj, err = srv.ACLGet(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respObj, ok := obj.(structs.ACLs)
+		if !ok {
+			t.Fatalf("should work")
+		}
+		if len(respObj) != 0 {
+			t.Fatalf("bad: %v", respObj)
 		}
 	})
 }
@@ -143,6 +158,22 @@ func TestACLClone(t *testing.T) {
 }
 
 func TestACLGet(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("GET", "/v1/acl/info/nope", nil)
+		resp := httptest.NewRecorder()
+		obj, err := srv.ACLGet(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respObj, ok := obj.(structs.ACLs)
+		if !ok {
+			t.Fatalf("should work")
+		}
+		if respObj == nil || len(respObj) != 0 {
+			t.Fatalf("bad: %v", respObj)
+		}
+	})
+
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestACL(t, srv)
 

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -70,6 +70,11 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	if err := s.agent.RPC("Catalog.ListNodes", &args, &out); err != nil {
 		return nil, err
 	}
+
+	// Use empty list instead of nil
+	if out.Nodes == nil {
+		out.Nodes = make(structs.Nodes, 0)
+	}
 	return out.Nodes, nil
 }
 
@@ -116,6 +121,11 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Catalog.ServiceNodes", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.ServiceNodes == nil {
+		out.ServiceNodes = make(structs.ServiceNodes, 0)
 	}
 	return out.ServiceNodes, nil
 }

--- a/command/agent/catalog_endpoint_test.go
+++ b/command/agent/catalog_endpoint_test.go
@@ -351,6 +351,27 @@ func TestCatalogServiceNodes(t *testing.T) {
 
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
+	// Make sure an empty list is returned, not a nil
+	{
+		req, err := http.NewRequest("GET", "/v1/catalog/service/api?tag=a", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		resp := httptest.NewRecorder()
+		obj, err := srv.CatalogServiceNodes(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		assertIndex(t, resp)
+
+		nodes := obj.(structs.ServiceNodes)
+		if nodes == nil || len(nodes) != 0 {
+			t.Fatalf("bad: %v", obj)
+		}
+	}
+
 	// Register node
 	args := &structs.RegisterRequest{
 		Datacenter: "dc1",

--- a/command/agent/coordinate_endpoint.go
+++ b/command/agent/coordinate_endpoint.go
@@ -45,6 +45,18 @@ func (s *HTTPServer) CoordinateDatacenters(resp http.ResponseWriter, req *http.R
 		}
 		return nil, err
 	}
+
+	// Use empty list instead of nil (these aren't really possible because
+	// Serf will give back a default coordinate and there's always one DC,
+	// but it's better to be explicit about what we want here).
+	for i, _ := range out {
+		if out[i].Coordinates == nil {
+			out[i].Coordinates = make(structs.Coordinates, 0)
+		}
+	}
+	if out == nil {
+		out = make([]structs.DatacenterMap, 0)
+	}
 	return out, nil
 }
 
@@ -61,6 +73,11 @@ func (s *HTTPServer) CoordinateNodes(resp http.ResponseWriter, req *http.Request
 	if err := s.agent.RPC("Coordinate.ListNodes", &args, &out); err != nil {
 		sort.Sort(&sorter{out.Coordinates})
 		return nil, err
+	}
+
+	// Use empty list instead of nil.
+	if out.Coordinates == nil {
+		out.Coordinates = make(structs.Coordinates, 0)
 	}
 	return out.Coordinates, nil
 }

--- a/command/agent/coordinate_endpoint_test.go
+++ b/command/agent/coordinate_endpoint_test.go
@@ -48,6 +48,23 @@ func TestCoordinate_Nodes(t *testing.T) {
 
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
+	// Make sure an empty list is non-nil.
+	req, err := http.NewRequest("GET", "/v1/coordinate/nodes?dc=dc1", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := httptest.NewRecorder()
+	obj, err := srv.CoordinateNodes(resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	coordinates := obj.(structs.Coordinates)
+	if coordinates == nil || len(coordinates) != 0 {
+		t.Fatalf("bad: %v", coordinates)
+	}
+
 	// Register the nodes.
 	nodes := []string{"foo", "bar"}
 	for _, node := range nodes {
@@ -85,18 +102,18 @@ func TestCoordinate_Nodes(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Query back and check the nodes are present and sorted correctly.
-	req, err := http.NewRequest("GET", "/v1/coordinate/nodes?dc=dc1", nil)
+	req, err = http.NewRequest("GET", "/v1/coordinate/nodes?dc=dc1", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	resp := httptest.NewRecorder()
-	obj, err := srv.CoordinateNodes(resp, req)
+	resp = httptest.NewRecorder()
+	obj, err = srv.CoordinateNodes(resp, req)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	coordinates := obj.(structs.Coordinates)
+	coordinates = obj.(structs.Coordinates)
 	if len(coordinates) != 2 ||
 		coordinates[0].Node != "bar" ||
 		coordinates[1].Node != "foo" {

--- a/command/agent/health_endpoint.go
+++ b/command/agent/health_endpoint.go
@@ -28,6 +28,11 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	if err := s.agent.RPC("Health.ChecksInState", &args, &out); err != nil {
 		return nil, err
 	}
+
+	// Use empty list instead of nil
+	if out.HealthChecks == nil {
+		out.HealthChecks = make(structs.HealthChecks, 0)
+	}
 	return out.HealthChecks, nil
 }
 
@@ -51,6 +56,11 @@ func (s *HTTPServer) HealthNodeChecks(resp http.ResponseWriter, req *http.Reques
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Health.NodeChecks", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.HealthChecks == nil {
+		out.HealthChecks = make(structs.HealthChecks, 0)
 	}
 	return out.HealthChecks, nil
 }
@@ -76,6 +86,11 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Health.ServiceChecks", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.HealthChecks == nil {
+		out.HealthChecks = make(structs.HealthChecks, 0)
 	}
 	return out.HealthChecks, nil
 }
@@ -113,6 +128,19 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	// Filter to only passing if specified
 	if _, ok := params["passing"]; ok {
 		out.Nodes = filterNonPassing(out.Nodes)
+	}
+
+	// Use empty list instead of nil
+	for i, _ := range out.Nodes {
+		// TODO (slackpad) It's lame that this isn't a slice of pointers
+		// but it's not a well-scoped change to fix this. We should
+		// change this at the next opportunity.
+		if out.Nodes[i].Checks == nil {
+			out.Nodes[i].Checks = make(structs.HealthChecks, 0)
+		}
+	}
+	if out.Nodes == nil {
+		out.Nodes = make(structs.CheckServiceNodes, 0)
 	}
 	return out.Nodes, nil
 }

--- a/command/agent/session_endpoint.go
+++ b/command/agent/session_endpoint.go
@@ -185,6 +185,11 @@ func (s *HTTPServer) SessionGet(resp http.ResponseWriter, req *http.Request) (in
 	if err := s.agent.RPC("Session.Get", &args, &out); err != nil {
 		return nil, err
 	}
+
+	// Use empty list instead of nil
+	if out.Sessions == nil {
+		out.Sessions = make(structs.Sessions, 0)
+	}
 	return out.Sessions, nil
 }
 
@@ -199,6 +204,11 @@ func (s *HTTPServer) SessionList(resp http.ResponseWriter, req *http.Request) (i
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Session.List", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.Sessions == nil {
+		out.Sessions = make(structs.Sessions, 0)
 	}
 	return out.Sessions, nil
 }
@@ -222,6 +232,11 @@ func (s *HTTPServer) SessionsForNode(resp http.ResponseWriter, req *http.Request
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Session.NodeSessions", &args, &out); err != nil {
 		return nil, err
+	}
+
+	// Use empty list instead of nil
+	if out.Sessions == nil {
+		out.Sessions = make(structs.Sessions, 0)
 	}
 	return out.Sessions, nil
 }

--- a/command/agent/session_endpoint_test.go
+++ b/command/agent/session_endpoint_test.go
@@ -350,6 +350,22 @@ func TestSessionTTLRenew(t *testing.T) {
 
 func TestSessionGet(t *testing.T) {
 	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("GET", "/v1/session/info/adf4238a-882b-9ddc-4a9d-5b6758e4159e", nil)
+		resp := httptest.NewRecorder()
+		obj, err := srv.SessionGet(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respObj, ok := obj.(structs.Sessions)
+		if !ok {
+			t.Fatalf("should work")
+		}
+		if respObj == nil || len(respObj) != 0 {
+			t.Fatalf("bad: %v", respObj)
+		}
+	})
+
+	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestSession(t, srv)
 
 		req, err := http.NewRequest("GET",
@@ -370,6 +386,22 @@ func TestSessionGet(t *testing.T) {
 }
 
 func TestSessionList(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("GET", "/v1/session/list", nil)
+		resp := httptest.NewRecorder()
+		obj, err := srv.SessionList(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respObj, ok := obj.(structs.Sessions)
+		if !ok {
+			t.Fatalf("should work")
+		}
+		if respObj == nil || len(respObj) != 0 {
+			t.Fatalf("bad: %v", respObj)
+		}
+	})
+
 	httpTest(t, func(srv *HTTPServer) {
 		var ids []string
 		for i := 0; i < 10; i++ {
@@ -393,6 +425,23 @@ func TestSessionList(t *testing.T) {
 }
 
 func TestSessionsForNode(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		req, err := http.NewRequest("GET",
+			"/v1/session/node/"+srv.agent.config.NodeName, nil)
+		resp := httptest.NewRecorder()
+		obj, err := srv.SessionsForNode(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		respObj, ok := obj.(structs.Sessions)
+		if !ok {
+			t.Fatalf("should work")
+		}
+		if respObj == nil || len(respObj) != 0 {
+			t.Fatalf("bad: %v", respObj)
+		}
+	})
+
 	httpTest(t, func(srv *HTTPServer) {
 		var ids []string
 		for i := 0; i < 10; i++ {

--- a/command/agent/ui_endpoint.go
+++ b/command/agent/ui_endpoint.go
@@ -38,6 +38,19 @@ RPC:
 		}
 		return nil, err
 	}
+
+	// Use empty list instead of nil
+	for _, info := range out.Dump {
+		if info.Services == nil {
+			info.Services = make([]*structs.NodeService, 0)
+		}
+		if info.Checks == nil {
+			info.Checks = make([]*structs.HealthCheck, 0)
+		}
+	}
+	if out.Dump == nil {
+		out.Dump = make(structs.NodeDump, 0)
+	}
 	return out.Dump, nil
 }
 
@@ -73,7 +86,14 @@ RPC:
 
 	// Return only the first entry
 	if len(out.Dump) > 0 {
-		return out.Dump[0], nil
+		info := out.Dump[0]
+		if info.Services == nil {
+			info.Services = make([]*structs.NodeService, 0)
+		}
+		if info.Checks == nil {
+			info.Checks = make([]*structs.HealthCheck, 0)
+		}
+		return info, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
These would manifest in the HTTP output as Javascript nulls instead of empty lists, so we had unintentionally changed the interface while porting to the new state store. We added code to each HTTP endpoint to convert nil slices to empty ones so they JSON-ify properly, and we added tests to catch this in the future.

This should fix #1395 and #1406.