### PR TITLE
rtt. Information about best/worst and average rtt between nodes

### DIFF
--- a/command/rtt.go
+++ b/command/rtt.go
@@ -57,6 +57,12 @@ func (c *RTTCommand) Run(args []string) int {
 	}
 
 	nodes := cmdFlags.Args()
+	if wan && (len(nodes) < 1 || len(nodes) > 2) {
+		c.Ui.Error("One or two node names must be specified")
+		c.Ui.Error("")
+		c.Ui.Error(c.Help())
+		return 1
+	}
 
 	// Create and test the HTTP client.
 	conf := api.DefaultConfig()


### PR DESCRIPTION
Implementation idea from comments #1394.
If ``rtt``` command have no arguments, compute best and worst rtt between agent node and all the rest nodes. If ```rtt``` have one argument, compute between this node and all the rest. Additional, output information about average rtt between all pairs of nodes. Now, support only for LAN.