### PR TITLE
Health checks: add shell configuration

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -944,6 +944,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 				Notify:   &a.state,
 				CheckID:  check.CheckID,
 				Script:   chkType.Script,
+				Shell:    chkType.Shell,
 				Interval: chkType.Interval,
 				Logger:   a.logger,
 			}

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -99,6 +99,7 @@ type CheckMonitor struct {
 	Notify   CheckNotifier
 	CheckID  string
 	Script   string
+	Shell    string
 	Interval time.Duration
 	Logger   *log.Logger
 
@@ -146,8 +147,14 @@ func (c *CheckMonitor) run() {
 
 // check is invoked periodically to perform the script check
 func (c *CheckMonitor) check() {
+	var cmd *exec.Cmd
+	var err error
 	// Create the command
-	cmd, err := ExecScript(c.Script)
+	if c.Shell != "" {
+		cmd, err = ExecScriptShell(c.Script, c.Shell)
+	} else {
+		cmd, err = ExecScript(c.Script)
+	}
 	if err != nil {
 		c.Logger.Printf("[ERR] agent: failed to setup invoke '%s': %s", c.Script, err)
 		c.Notify.UpdateCheck(c.CheckID, structs.HealthCritical, err.Error())

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -50,6 +50,7 @@ type CheckDefinition struct {
 	ServiceID string
 	Token     string
 	Status    string
+	Shell     string
 	CheckType `mapstructure:",squash"`
 }
 
@@ -60,6 +61,7 @@ func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 		Name:      c.Name,
 		Status:    structs.HealthCritical,
 		Notes:     c.Notes,
+		Shell:     c.Shell,
 		ServiceID: c.ServiceID,
 	}
 	if c.Status != "" {

--- a/command/agent/util.go
+++ b/command/agent/util.go
@@ -82,6 +82,18 @@ func ExecScript(script string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
+// ExecScriptShell returns a command to execute a script on specific shell
+func ExecScriptShell(script, shell string) (*exec.Cmd, error) {
+	var flag string
+	if runtime.GOOS == "windows" {
+		flag = "/C"
+	} else {
+		flag = "-c"
+	}
+	cmd := exec.Command(shell, flag, script)
+	return cmd, nil
+}
+
 // generateUUID is used to generate a random UUID
 func generateUUID() string {
 	buf := make([]byte, 16)

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -369,6 +369,7 @@ type HealthCheck struct {
 	Status      string // The current check status
 	Notes       string // Additional notes with the status
 	Output      string // Holds output of script runs
+	Shell       string
 	ServiceID   string // optional associated service
 	ServiceName string // optional service name
 


### PR DESCRIPTION
Related to #1358.
In the check definition, you can specify shell as

```
{
      "id": "fun42",
      "name": "foobar",
      "script": "foobar42",
      "shell": "/bin/zsh",
      "interval": "5s"
},
```
