### PR TITLE
Service deregistration after healthcheck failure #679

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -53,10 +53,12 @@ type AgentServiceRegistration struct {
 
 // AgentCheckRegistration is used to register a new check
 type AgentCheckRegistration struct {
-	ID        string `json:",omitempty"`
-	Name      string `json:",omitempty"`
-	Notes     string `json:",omitempty"`
-	ServiceID string `json:",omitempty"`
+	ID                string `json:",omitempty"`
+	Name              string `json:",omitempty"`
+	Notes             string `json:",omitempty"`
+	ServiceID         string `json:",omitempty"`
+	DeregisterService bool   `json:",omitempty"`
+	FailuresTolerance int    `json:",omitempty"`
 	AgentServiceCheck
 }
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -138,7 +138,7 @@ func (s *HTTPServer) AgentDeregisterCheck(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) AgentCheckPass(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := strings.TrimPrefix(req.URL.Path, "/v1/agent/check/pass/")
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthPassing, note); err != nil {
+	if err := s.agent.UpdateTTLCheck(checkID, structs.HealthPassing, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()
@@ -148,7 +148,7 @@ func (s *HTTPServer) AgentCheckPass(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) AgentCheckWarn(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := strings.TrimPrefix(req.URL.Path, "/v1/agent/check/warn/")
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthWarning, note); err != nil {
+	if err := s.agent.UpdateTTLCheck(checkID, structs.HealthWarning, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()
@@ -158,7 +158,7 @@ func (s *HTTPServer) AgentCheckWarn(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) AgentCheckFail(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := strings.TrimPrefix(req.URL.Path, "/v1/agent/check/fail/")
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthCritical, note); err != nil {
+	if err := s.agent.UpdateTTLCheck(checkID, structs.HealthCritical, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -53,6 +53,9 @@ type CheckType struct {
 	Status string
 
 	Notes string
+
+	DeregisterService bool
+	FailuresTolerance int
 }
 type CheckTypes []*CheckType
 

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -240,6 +240,10 @@ func (l *localState) UpdateCheck(checkID, status, output string) {
 		return
 	}
 
+	// for a check that is set to deregister a service after n-failures
+	// we update its state
+	check.UpdateFailureTolerance(status)
+
 	// Do nothing if update is idempotent
 	if check.Status == status && check.Output == output {
 		return

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -44,23 +44,28 @@ func (s *ServiceDefinition) CheckTypes() (checks CheckTypes) {
 
 // ChecKDefinition is used to JSON decode the Check definitions
 type CheckDefinition struct {
-	ID        string
-	Name      string
-	Notes     string
-	ServiceID string
-	Token     string
-	Status    string
-	CheckType `mapstructure:",squash"`
+	ID                string
+	Name              string
+	Notes             string
+	ServiceID         string
+	Token             string
+	Status            string
+	DeregisterService bool
+	FailuresTolerance int
+	CheckType         `mapstructure:",squash"`
 }
 
 func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 	health := &structs.HealthCheck{
-		Node:      node,
-		CheckID:   c.ID,
-		Name:      c.Name,
-		Status:    structs.HealthCritical,
-		Notes:     c.Notes,
-		ServiceID: c.ServiceID,
+		Node:                node,
+		CheckID:             c.ID,
+		Name:                c.Name,
+		Status:              structs.HealthCritical,
+		Notes:               c.Notes,
+		ServiceID:           c.ServiceID,
+		DeregisterService:   c.DeregisterService,
+		FailuresTolerance:   c.FailuresTolerance,
+		FailuresAllowedLeft: c.FailuresTolerance,
 	}
 	if c.Status != "" {
 		health.Status = c.Status

--- a/consul/structs/structs_test.go
+++ b/consul/structs/structs_test.go
@@ -211,6 +211,41 @@ func TestStructs_HealthCheck_IsSame(t *testing.T) {
 	check(&other.ServiceName)
 }
 
+func TestStructs_HealthCheck_FailureTolerance(t *testing.T) {
+	// Create HealthCheck that has a failure tolerance
+	check := &HealthCheck{
+		Node:                "node1",
+		CheckID:             "check1",
+		Name:                "thecheck",
+		Status:              HealthPassing,
+		Notes:               "it's all good",
+		Output:              "lgtm",
+		ServiceID:           "service1",
+		ServiceName:         "theservice",
+		DeregisterService:   true,
+		FailuresTolerance:   1,
+		FailuresAllowedLeft: 1,
+	}
+
+	if check.NoMoreFailuresAllowed() {
+		t.Fatal("should allow 1 failure")
+	}
+
+	// A failure occurrence
+	check.UpdateFailureTolerance(HealthCritical)
+
+	if !check.NoMoreFailuresAllowed() {
+		t.Fatal("should not allow any more failures")
+	}
+
+	// Reset HealthCheck state to initial
+	check.UpdateFailureTolerance(HealthPassing)
+
+	if check.NoMoreFailuresAllowed() {
+		t.Fatal("should allow a single failure after passing check")
+	}
+}
+
 func TestStructs_CheckServiceNodes_Shuffle(t *testing.T) {
 	// Make a huge list of nodes.
 	var nodes CheckServiceNodes


### PR DESCRIPTION
Hi, this PR is related to #679. 

In short words, it introduces an ability for a service to be automatically deregistered after a check failure (or a specified number of consecutive failures). 
This feature should work on all check types. It's disabled by default and compatible with the current API.

Check definition will have two additional fields:
* `deregisterService: bool` - defaults to `false`, whether the behaviour should be enabled
* `failuresTolerance: int` - (ignored for a TTL check) defaults to `0`, number of acceptable failures before service removal

So, for example, a TTL check definition would look like:
```
{
    "name": "check",
    "ttl": "30s",
    "deregisterService": true
 }
```
and an HTTP check, that will cause the service to be removed after 3rd try:
```
{
    "name": "check",
    "http": "http://localhost:8080",
    "interval": "10s",
    "timeout": "5s",
    "deregisterService": true,
    "failuresTolerance": 2
  }
```

Please, tell me what you think about such solution/implementation.

