### PR TITLE
Added unhealthy_timeout parameter to the healthcheck definition.

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -70,6 +70,7 @@ type AgentServiceCheck struct {
 	Shell             string `json:",omitempty"` // Only supported for Docker.
 	Interval          string `json:",omitempty"`
 	Timeout           string `json:",omitempty"`
+	UnregisterTimeout string `json:",omitempty"` // Only supported for TTL checks.
 	TTL               string `json:",omitempty"`
 	HTTP              string `json:",omitempty"`
 	TCP               string `json:",omitempty"`

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -879,10 +879,15 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 
 			ttl := &CheckTTL{
-				Notify:  &a.state,
-				CheckID: check.CheckID,
-				TTL:     chkType.TTL,
-				Logger:  a.logger,
+				Notify:            &a.state,
+				CheckID:           check.CheckID,
+				TTL:               chkType.TTL,
+				Logger:            a.logger,
+				UnregisterTimeout: chkType.UnregisterTimeout,
+				UnregisterService: func() {
+					a.RemoveCheck(check.CheckID, true)
+					a.state.RemoveService(check.ServiceID)
+				},
 			}
 
 			// Restore persisted state, if any

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -897,7 +897,7 @@ AFTER_FIX:
 }
 
 func FixupCheckType(raw interface{}) error {
-	var ttlKey, intervalKey, timeoutKey string
+	var ttlKey, intervalKey, timeoutKey, unregisterTimeoutKey string
 
 	// Handle decoding of time durations
 	rawMap, ok := raw.(map[string]interface{})
@@ -913,6 +913,8 @@ func FixupCheckType(raw interface{}) error {
 			intervalKey = k
 		case "timeout":
 			timeoutKey = k
+		case "unregistertimeout":
+			unregisterTimeoutKey = k
 		case "service_id":
 			rawMap["serviceid"] = v
 			delete(rawMap, "service_id")
@@ -922,35 +924,15 @@ func FixupCheckType(raw interface{}) error {
 		}
 	}
 
-	if ttl, ok := rawMap[ttlKey]; ok {
-		ttlS, ok := ttl.(string)
-		if ok {
-			if dur, err := time.ParseDuration(ttlS); err != nil {
-				return err
-			} else {
-				rawMap[ttlKey] = dur
-			}
-		}
-	}
-
-	if interval, ok := rawMap[intervalKey]; ok {
-		intervalS, ok := interval.(string)
-		if ok {
-			if dur, err := time.ParseDuration(intervalS); err != nil {
-				return err
-			} else {
-				rawMap[intervalKey] = dur
-			}
-		}
-	}
-
-	if timeout, ok := rawMap[timeoutKey]; ok {
-		timeoutS, ok := timeout.(string)
-		if ok {
-			if dur, err := time.ParseDuration(timeoutS); err != nil {
-				return err
-			} else {
-				rawMap[timeoutKey] = dur
+	for _, key := range []string{ttlKey, unregisterTimeoutKey, intervalKey, timeoutKey} {
+		if value, ok := rawMap[key]; ok {
+			stringValue, ok := value.(string)
+			if ok {
+				if dur, err := time.ParseDuration(stringValue); err != nil {
+					return err
+				} else {
+					rawMap[key] = dur
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Now it works for TTL checks only. If service is unresponsive for the
period defined in timeout it will be deregistered from Consul.
It can be used when you want to cleanup services that were shut down
forever and won't do any healthchecks anymore.

https://github.com/hashicorp/consul/issues/679

Please review.

Update:
Wow, that's a popular enhancement :)
I see another pull request for that feature https://github.com/hashicorp/consul/pull/1432 .
Mine is slightly different, though.