### PR TITLE
Include 'Service'/'Address' field in example

### DIFF
--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -133,6 +133,7 @@ It returns a JSON body like this:
       "ID": "redis",
       "Service": "redis",
       "Tags": null,
+      "Address": "10.1.10.12"
       "Port": 8000
     },
     "Checks": [


### PR DESCRIPTION
Add the `Service`/`Address` field to the example output for the `/v1/health/service/\<service\>` endpoint.

Even though it's an optional value, this is probably the one consumers are looking for (rather than the `Node` address)