### PR TITLE
Switches to curl with certificate checking.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,11 +14,11 @@ ARCH=`uname -m | sed 's|i686|386|' | sed 's|x86_64|amd64|'`
 
 # Install Go
 sudo apt-get update
-sudo apt-get install -y build-essential git-core zip
+sudo apt-get install -y build-essential git-core zip curl
 
 # Install Go
 cd /tmp
-wget --quiet --no-check-certificate https://storage.googleapis.com/golang/go${GOVERSION}.linux-${ARCH}.tar.gz
+curl -s -O https://storage.googleapis.com/golang/go${GOVERSION}.linux-${ARCH}.tar.gz
 tar -xvf go${GOVERSION}.linux-${ARCH}.tar.gz
 sudo mv go $SRCROOT
 sudo chmod 775 $SRCROOT


### PR DESCRIPTION
This came up in https://github.com/hashicorp/consul/commit/8738f9780bd30f628508d4e721df0d77ad0bd3b7#commitcomment-14566231. It looks like it's probably https://github.com/golang/go/issues/8998, but I couldn't find a newer version of `wget` for precise64, and I couldn't find a good newer Ubuntu box with VMWare support, so I switched to `curl` which checks the cert successfully.

/cc @catsby 