### PR TITLE
Removes the GOMAXPROCS warnings which are obsolete for Go 1.5+.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -565,11 +565,6 @@ func (c *Command) Run(args []string) int {
 		return 1
 	}
 
-	// Check GOMAXPROCS
-	if runtime.GOMAXPROCS(0) == 1 {
-		c.Ui.Error("WARNING: It is highly recommended to set GOMAXPROCS higher than 1")
-	}
-
 	// Setup the log outputs
 	logGate, logWriter, logOutput := c.setupLoggers(config)
 	if logWriter == nil {

--- a/command/info.go
+++ b/command/info.go
@@ -48,21 +48,6 @@ func (i *InfoCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check for specific warnings
-	didWarn := false
-	runtime, ok := stats["runtime"]
-	if ok {
-		if maxprocs := runtime["max_procs"]; maxprocs == "1" {
-			i.Ui.Output("WARNING: It is highly recommended to set GOMAXPROCS higher than 1")
-			didWarn = true
-		}
-	}
-
-	// Add a blank line if there are any warnings
-	if didWarn {
-		i.Ui.Output("")
-	}
-
 	// Get the keys in sorted order
 	keys := make([]string, 0, len(stats))
 	for key := range stats {

--- a/website/source/intro/getting-started/agent.html.markdown
+++ b/website/source/intro/getting-started/agent.html.markdown
@@ -28,7 +28,6 @@ For simplicity, we'll run a single Consul agent in server mode:
 $ consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul
 ==> WARNING: BootstrapExpect Mode is specified as 1; this is the same as Bootstrap mode.
 ==> WARNING: Bootstrap mode enabled! Do not enable unless necessary
-==> WARNING: It is highly recommended to set GOMAXPROCS higher than 1
 ==> Starting Consul agent...
 ==> Starting Consul agent RPC...
 ==> Consul agent running!


### PR DESCRIPTION
These warnings no longer make sense for Go 1.5+ since it now defaults to the number of CPUs present. They will fire only on single core machines now and we don't want those people oversubscribing their single-core machines so this is strictly giving bad advice.

/cc @armon 