### PR TITLE
Prevent leak of file descriptors with multiple clients

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -122,12 +122,14 @@ type Config struct {
 	Token string
 }
 
+var defaultHttpClient = cleanhttp.DefaultClient()
+
 // DefaultConfig returns a default configuration for the client
 func DefaultConfig() *Config {
 	config := &Config{
 		Address:    "127.0.0.1:8500",
 		Scheme:     "http",
-		HttpClient: cleanhttp.DefaultClient(),
+		HttpClient: defaultHttpClient,
 	}
 
 	if addr := os.Getenv("CONSUL_HTTP_ADDR"); addr != "" {
@@ -210,6 +212,7 @@ func NewClient(config *Config) (*Client, error) {
 		trans.Dial = func(_, _ string) (net.Conn, error) {
 			return net.Dial("unix", parts[1])
 		}
+		trans.DisableKeepAlives = true
 		config.HttpClient = &http.Client{
 			Transport: trans,
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -178,6 +178,7 @@ func DefaultConfig() *Config {
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},
+				DisableKeepAlives: true,
 			}
 		}
 	}


### PR DESCRIPTION
Each HTTP client keeps alive up to 2 connections, so the number of clients created in the lifetime of an application must be constant to prevent exhaustion of file descriptors.  The options to fix this are:

- keep one global client (in this patch for HTTP)
- do not keep connections open (in this patch for UNIX)
- keep a global pool of clients or transports
- export and document a method to close connections that calls `(*http.Transport).CloseIdleConnections()`
- document that users can only instantiate a small number of clients during the lifetime of an application