### PR TITLE
command/lock: Add -child-exitcode, return 1 on child error

### DIFF
--- a/command/lock_test.go
+++ b/command/lock_test.go
@@ -35,3 +35,35 @@ func TestLockCommandRun(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 }
+
+func TestLockCommandExitCodeZero(t *testing.T) {
+	a1 := testAgent(t)
+	defer a1.Shutdown()
+	waitForLeader(t, a1.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &LockCommand{Ui: ui, childExitCode: true}
+	cmd := fmt.Sprintf("exit 0")
+	args := []string{"-http-addr=" + a1.httpAddr, "-child-exitcode", "test/prefix", cmd}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+}
+
+func TestLockCommandExitCodeOne(t *testing.T) {
+	a1 := testAgent(t)
+	defer a1.Shutdown()
+	waitForLeader(t, a1.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &LockCommand{Ui: ui}
+	cmd := fmt.Sprintf("exit 2")
+	args := []string{"-http-addr=" + a1.httpAddr, "-child-exitcode", "test/prefix", cmd}
+
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+}

--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -62,5 +62,6 @@ The list of available flags are:
 
 * `-pass-stdin` - Pass stdin to child process.
 
-* `-verbose` - Enables verbose output.
+* `-child-exitcode` - Exit 1 if the child process exited with an error.
 
+* `-verbose` - Enables verbose output.


### PR DESCRIPTION
- Exit 1 if -child-exitcode and the child returned with an error.
- There is no platform independent way to check the exact return code of
- the child, so on error always return 1.
- Closes #947
