### PR TITLE
Add the token to /v1/internal/ui/nodes. (issue #1071)

### DIFF
--- a/ui/javascripts/app/routes.js
+++ b/ui/javascripts/app/routes.js
@@ -88,12 +88,14 @@ App.IndexRoute = App.BaseRoute.extend({
 // functioning, as well as the per-dc requests.
 App.DcRoute = App.BaseRoute.extend({
   model: function(params) {
+    var token = App.get('settings.token');
+
     // Return a promise hash to retreieve the
     // dcs and nodes used in the header
     return Ember.RSVP.hash({
       dc: params.dc,
       dcs: Ember.$.getJSON('/v1/catalog/datacenters'),
-      nodes: Ember.$.getJSON(formatUrl('/v1/internal/ui/nodes', params.dc)).then(function(data) {
+      nodes: Ember.$.getJSON(formatUrl('/v1/internal/ui/nodes', params.dc, token)).then(function(data) {
         var objs = [];
 
         // Merge the nodes into a list and create objects out of them


### PR DESCRIPTION
After upgrading to v0.6.0 the UI fails to load with a 403 status.  It appears that internal calls to the HTTP API (/v1/internal/ui/nodes) have no token even though the browser initiating the call does have a token defined.  

There may be further issues related to this, I just fixed the initial load failure and did a quick test clicking through the UI to verify things looked ok.