### PR TITLE
Adds client and transport pooling in the API so we don't leak connections.

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -244,13 +244,16 @@ func TestAPI_UnixSocket(t *testing.T) {
 	})
 	defer s.Stop()
 
-	agent := c.Agent()
-
-	info, err := agent.Self()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if info["Config"]["NodeName"] == "" {
-		t.Fatalf("bad: %v", info)
+	// Run a few iterations to test the path where we use the pooled
+	// connection.
+	for i := 0; i < 3; i++ {
+		agent := c.Agent()
+		info, err := agent.Self()
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if info["Config"]["NodeName"] == "" {
+			t.Fatalf("bad: %v", info)
+		}
 	}
 }


### PR DESCRIPTION
This is a take on #1499 that implements as much pooling as possible, drafting off of @orivej work and suggestions.