### PR TITLE
Builds the insecure SSL transport off the clean default transport.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -172,11 +172,11 @@ func DefaultConfig() *Config {
 		}
 
 		if !doVerify {
-			config.HttpClient.Transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
+			transport := cleanhttp.DefaultTransport()
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
 			}
+			config.HttpClient.Transport = transport
 		}
 	}
 


### PR DESCRIPTION
This is a loose end that came out of #1499 and #1517 - it's better to use cleanhttp's transport (now for cleanup) as well as to get the expected default options.