### PR TITLE
Adds telemetry on number of DNS queries served, per-agent.

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -166,6 +166,7 @@ START:
 func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 	q := req.Question[0]
 	defer func(s time.Time) {
+		metrics.MeasureSince([]string{"consul", "dns", "ptr_query", d.agent.config.NodeName}, s)
 		d.logger.Printf("[DEBUG] dns: request for %v (%v) from client %s (%s)",
 			q, time.Now().Sub(s), resp.RemoteAddr().String(),
 			resp.RemoteAddr().Network())
@@ -222,14 +223,13 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 	if err := resp.WriteMsg(m); err != nil {
 		d.logger.Printf("[WARN] dns: failed to respond: %v", err)
 	}
-
-	metrics.IncrCounter([]string{"consul", "dns", "query", d.agent.config.NodeName}, 1)
 }
 
 // handleQuery is used to handle DNS queries in the configured domain
 func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 	q := req.Question[0]
 	defer func(s time.Time) {
+		metrics.MeasureSince([]string{"consul", "dns", "domain_query", d.agent.config.NodeName}, s)
 		d.logger.Printf("[DEBUG] dns: request for %v (%v) from client %s (%s)",
 			q, time.Now().Sub(s), resp.RemoteAddr().String(),
 			resp.RemoteAddr().Network())
@@ -259,8 +259,6 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 	if err := resp.WriteMsg(m); err != nil {
 		d.logger.Printf("[WARN] dns: failed to respond: %v", err)
 	}
-
-	metrics.IncrCounter([]string{"consul", "dns", "query", d.agent.config.NodeName}, 1)
 }
 
 // addSOA is used to add an SOA record to a message for the given domain

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/miekg/dns"
@@ -221,6 +222,8 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 	if err := resp.WriteMsg(m); err != nil {
 		d.logger.Printf("[WARN] dns: failed to respond: %v", err)
 	}
+
+	metrics.IncrCounter([]string{"consul", "dns", "query", d.agent.config.NodeName}, 1)
 }
 
 // handleQuery is used to handle DNS queries in the configured domain
@@ -256,6 +259,8 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 	if err := resp.WriteMsg(m); err != nil {
 		d.logger.Printf("[WARN] dns: failed to respond: %v", err)
 	}
+
+	metrics.IncrCounter([]string{"consul", "dns", "query", d.agent.config.NodeName}, 1)
 }
 
 // addSOA is used to add an SOA record to a message for the given domain


### PR DESCRIPTION
Adds a counter increment for each successful DNS query (reverse or forward). We had a request to aggregate this per-agent so I suffixed with the node name. We haven't done metrics per node before, though we do a similar thing for services, and Raft metrics roll up per-IP, so there seemed like precedent.