### PR TITLE
Adds child process reaping when Consul is running as PID 1.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -644,11 +644,11 @@ func (c *Command) Run(args []string) int {
 
 	// Enable child process reaping
 	if (config.Reap != nil && *config.Reap) || (config.Reap == nil && os.Getpid() == 1) {
-		logger := c.agent.logger
 		if !reap.IsSupported() {
 			c.Ui.Error("Child process reaping is not supported on this platform (set reap=false)")
 			return 1
 		} else {
+			logger := c.agent.logger
 			logger.Printf("[DEBUG] Automatically reaping child processes")
 
 			pids := make(reap.PidCh, 1)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -643,10 +643,11 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Enable child process reaping
-	if !config.DisableReap && (os.Getpid() == 1) {
+	if (config.Reap != nil && *config.Reap) || (config.Reap == nil && os.Getpid() == 1) {
 		logger := c.agent.logger
 		if !reap.IsSupported() {
-			logger.Printf("[WARN] Running as PID 1 but child process reaping is not supported on this platform, disabling")
+			c.Ui.Error("Child process reaping is not supported on this platform (set reap=false)")
+			return 1
 		} else {
 			logger.Printf("[DEBUG] Automatically reaping child processes")
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -422,6 +422,12 @@ type Config struct {
 	// Minimum Session TTL
 	SessionTTLMin    time.Duration `mapstructure:"-"`
 	SessionTTLMinRaw string        `mapstructure:"session_ttl_min"`
+
+	// DisableReap controls automatic reaping of child processes, useful if
+	// running as PID 1 in a Docker container. This defaults to false, and
+	// reaping will be automatically enabled if this is false and Consul's
+	// PID is 1.
+	DisableReap bool `mapstructure:"disable_reap"`
 }
 
 // UnixSocketPermissions contains information about a unix socket, and
@@ -1139,6 +1145,10 @@ func MergeConfig(a, b *Config) *Config {
 	result.RetryJoinWan = make([]string, 0, len(a.RetryJoinWan)+len(b.RetryJoinWan))
 	result.RetryJoinWan = append(result.RetryJoinWan, a.RetryJoinWan...)
 	result.RetryJoinWan = append(result.RetryJoinWan, b.RetryJoinWan...)
+
+	if b.DisableReap {
+		result.DisableReap = true
+	}
 
 	return &result
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -423,11 +423,11 @@ type Config struct {
 	SessionTTLMin    time.Duration `mapstructure:"-"`
 	SessionTTLMinRaw string        `mapstructure:"session_ttl_min"`
 
-	// DisableReap controls automatic reaping of child processes, useful if
-	// running as PID 1 in a Docker container. This defaults to false, and
-	// reaping will be automatically enabled if this is false and Consul's
-	// PID is 1.
-	DisableReap bool `mapstructure:"disable_reap"`
+	// Reap controls automatic reaping of child processes, useful if running
+	// as PID 1 in a Docker container. This defaults to nil which will make
+	// Consul reap only if it detects it's running as PID 1. If non-nil,
+	// then this will be used to decide if reaping is enabled.
+	Reap *bool `mapstructure:"reap"`
 }
 
 // UnixSocketPermissions contains information about a unix socket, and
@@ -1146,8 +1146,8 @@ func MergeConfig(a, b *Config) *Config {
 	result.RetryJoinWan = append(result.RetryJoinWan, a.RetryJoinWan...)
 	result.RetryJoinWan = append(result.RetryJoinWan, b.RetryJoinWan...)
 
-	if b.DisableReap {
-		result.DisableReap = true
+	if b.Reap != nil {
+		result.Reap = b.Reap
 	}
 
 	return &result

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -430,6 +430,11 @@ type Config struct {
 	Reap *bool `mapstructure:"reap"`
 }
 
+// Bool is used to initialize bool pointers in struct literals.
+func Bool(b bool) *bool {
+	return &b
+}
+
 // UnixSocketPermissions contains information about a unix socket, and
 // implements the FilePermissions interface.
 type UnixSocketPermissions struct {

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -777,6 +777,17 @@ func TestDecodeConfig(t *testing.T) {
 	if config.SessionTTLMin != 5*time.Second {
 		t.Fatalf("bad: %s %#v", config.SessionTTLMin.String(), config)
 	}
+
+	// DisableReap
+	input = `{"disable_reap": true}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.DisableReap != true {
+		t.Fatalf("bad: reap not disabled: %#v", config)
+	}
 }
 
 func TestDecodeConfig_invalidKeys(t *testing.T) {
@@ -1157,6 +1168,7 @@ func TestMergeConfig(t *testing.T) {
 		CheckUpdateIntervalRaw: "8m",
 		RetryIntervalRaw:       "10s",
 		RetryIntervalWanRaw:    "10s",
+		DisableReap:            false,
 	}
 
 	b := &Config{
@@ -1266,6 +1278,7 @@ func TestMergeConfig(t *testing.T) {
 			RPC:        &net.TCPAddr{},
 			RPCRaw:     "127.0.0.5:1233",
 		},
+		DisableReap: true,
 	}
 
 	c := MergeConfig(a, b)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -778,15 +778,25 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %s %#v", config.SessionTTLMin.String(), config)
 	}
 
-	// DisableReap
-	input = `{"disable_reap": true}`
+	// Reap
+	input = `{"reap": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if config.DisableReap != true {
-		t.Fatalf("bad: reap not disabled: %#v", config)
+	if config.Reap == nil || *config.Reap != true {
+		t.Fatalf("bad: reap not enabled: %#v", config)
+	}
+
+	input = `{}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.Reap != nil {
+		t.Fatalf("bad: reap not tri-stated: %#v", config)
 	}
 }
 
@@ -1168,7 +1178,6 @@ func TestMergeConfig(t *testing.T) {
 		CheckUpdateIntervalRaw: "8m",
 		RetryIntervalRaw:       "10s",
 		RetryIntervalWanRaw:    "10s",
-		DisableReap:            false,
 	}
 
 	b := &Config{
@@ -1278,8 +1287,9 @@ func TestMergeConfig(t *testing.T) {
 			RPC:        &net.TCPAddr{},
 			RPCRaw:     "127.0.0.5:1233",
 		},
-		DisableReap: true,
+		Reap: new(bool),
 	}
+	*b.Reap = true
 
 	c := MergeConfig(a, b)
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1287,9 +1287,8 @@ func TestMergeConfig(t *testing.T) {
 			RPC:        &net.TCPAddr{},
 			RPCRaw:     "127.0.0.5:1233",
 		},
-		Reap: new(bool),
+		Reap: Bool(true),
 	}
-	*b.Reap = true
 
 	c := MergeConfig(a, b)
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -407,10 +407,6 @@ definitions support being updated during a reload.
   `disable_anonymous_signature`</a> Disables providing an anonymous signature for de-duplication
   with the update check. See [`disable_update_check`](#disable_update_check).
 
-* <a name="disable_reap"></a><a href="#disable_reap">
-  `disable_reap`</a> will prevent Consul from automatically reaping child processes if it
-  detects it is running as PID 1, such as in a Docker container.
-
 * <a name="disable_remote_exec"></a><a href="#disable_remote_exec">`disable_remote_exec`</a>
   Disables support for remote execution. When set to true, the agent will ignore any incoming
   remote exec requests.
@@ -507,6 +503,11 @@ definitions support being updated during a reload.
 
 * <a name="protocol"></a><a href="#protocol">`protocol`</a> Equivalent to the
   [`-protocol` command-line flag](#_protocol).
+
+* <a name="reap"></a><a href="#reap">`reap`</a> controls Consul's automatic reaping of child processes, which
+  is useful if Consul is running as PID 1 in a Docker container. If this isn't specified, then Consul will
+  automatically reap child processes if it detects it is running as PID 1. If this is specified, then it
+  controls reaping regardless of Consul's PID.
 
 * <a name="recursor"></a><a href="#recursor">`recursor`</a> Provides a single recursor address.
   This has been deprecated, and the value is appended to the [`recursors`](#recursors) list for

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -407,6 +407,10 @@ definitions support being updated during a reload.
   `disable_anonymous_signature`</a> Disables providing an anonymous signature for de-duplication
   with the update check. See [`disable_update_check`](#disable_update_check).
 
+* <a name="disable_reap"></a><a href="#disable_reap">
+  `disable_reap`</a> will prevent Consul from automatically reaping child processes if it
+  detects it is running as PID 1, such as in a Docker container.
+
 * <a name="disable_remote_exec"></a><a href="#disable_remote_exec">`disable_remote_exec`</a>
   Disables support for remote execution. When set to true, the agent will ignore any incoming
   remote exec requests.


### PR DESCRIPTION
Used the same testing methodology as https://github.com/hashicorp/consul-template/pull/479 to make sure this is working (it seems extremely hard to unit test beyond verifying config.

This should fix https://github.com/hashicorp/consul/issues/1183.

The config behavior is slightly different than CT since Consul can't tell whether the user set an item or not. I looked into adding that but it looked like a big effort, and out of scope for this. This should be zero-config for nearly all use cases, anyway.