### PR TITLE
Implement WAN address translation

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -275,6 +275,7 @@ func (a *Agent) consulConfig() *consul.Config {
 	if a.config.AdvertiseAddrs.SerfWan != nil {
 		base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddrs.SerfWan.IP.String()
 		base.SerfWANConfig.MemberlistConfig.AdvertisePort = a.config.AdvertiseAddrs.SerfWan.Port
+		a.config.AdvertiseAddrWan = a.config.AdvertiseAddrs.SerfWan.IP.String()
 	}
 	if a.config.AdvertiseAddrs.RPC != nil {
 		base.RPCAdvertise = a.config.AdvertiseAddrs.RPC

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -168,6 +168,10 @@ func TestAgent_CheckAdvertiseAddrsSettings(t *testing.T) {
 	if rpc != c.AdvertiseAddrs.RPC {
 		t.Fatalf("RPC is not properly set to %v: %s", c.AdvertiseAddrs.RPC, rpc)
 	}
+	advertiseWanAddress := agent.config.AdvertiseAddrWan
+	if serfWanAddr != advertiseWanAddress {
+		t.Fatalf("AdvertiseAddrWan is not properly set to '%s': %s", serfWanAddr, advertiseWanAddress)
+	}
 }
 
 func TestAgent_AddService(t *testing.T) {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -80,6 +80,7 @@ func TestRetryJoin(t *testing.T) {
 		"-server",
 		"-data-dir", tmpDir,
 		"-node", fmt.Sprintf(`"%s"`, conf2.NodeName),
+		"-advertise", agent.config.BindAddr,
 		"-retry-join", serfAddr,
 		"-retry-interval", "1s",
 		"-retry-join-wan", serfWanAddr,

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -158,6 +158,10 @@ type Config struct {
 	// Serf WAN IP. If not specified, the general advertise address is used.
 	AdvertiseAddrWan string `mapstructure:"advertise_addr_wan"`
 
+	// TranslateWanAddrs controls whether or not Consul should prefer
+	// the AdvertiseAddrWan address when doing lookups in remote datacenters.
+	TranslateWanAddrs bool `mapstructure:"translate_wan_addrs"`
+
 	// Port configurations
 	Ports PortConfig
 
@@ -893,6 +897,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.AdvertiseAddrWan != "" {
 		result.AdvertiseAddrWan = b.AdvertiseAddrWan
+	}
+	if b.TranslateWanAddrs == true {
+		result.TranslateWanAddrs = true
 	}
 	if b.AdvertiseAddrs.SerfLan != nil {
 		result.AdvertiseAddrs.SerfLan = b.AdvertiseAddrs.SerfLan

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -251,6 +251,25 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// WAN address translation disabled by default
+	config, err = DecodeConfig(bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.TranslateWanAddrs != false {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	// WAN address translation
+	input = `{"translate_wan_addrs": true}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if config.TranslateWanAddrs != true {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// leave_on_terminate
 	input = `{"leave_on_terminate": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -521,9 +521,15 @@ RPC:
 	// Perform a random shuffle
 	out.Nodes.Shuffle()
 
+	// Determine whether we should use the WAN address or not
+	var useWan bool
+	if d.agent.config.TranslateWanAddrs && datacenter != d.agent.config.Datacenter {
+		useWan = true
+	}
+
 	// Add various responses depending on the request
 	qType := req.Question[0].Qtype
-	d.serviceNodeRecords(out.Nodes, req, resp, ttl)
+	d.serviceNodeRecords(out.Nodes, req, resp, ttl, useWan)
 
 	if qType == dns.TypeSRV {
 		d.serviceSRVRecords(datacenter, out.Nodes, req, resp, ttl)
@@ -617,9 +623,15 @@ RPC:
 		return
 	}
 
+	// Determine whether we should use the WAN address or not
+	var useWan bool
+	if d.agent.config.TranslateWanAddrs && datacenter != d.agent.config.Datacenter {
+		useWan = true
+	}
+
 	// Add various responses depending on the request.
 	qType := req.Question[0].Qtype
-	d.serviceNodeRecords(out.Nodes, req, resp, ttl)
+	d.serviceNodeRecords(out.Nodes, req, resp, ttl, useWan)
 	if qType == dns.TypeSRV {
 		d.serviceSRVRecords(datacenter, out.Nodes, req, resp, ttl)
 	}
@@ -643,18 +655,22 @@ RPC:
 }
 
 // serviceNodeRecords is used to add the node records for a service lookup
-func (d *DNSServer) serviceNodeRecords(nodes structs.CheckServiceNodes, req, resp *dns.Msg, ttl time.Duration) {
+func (d *DNSServer) serviceNodeRecords(nodes structs.CheckServiceNodes, req, resp *dns.Msg, ttl time.Duration, useWan bool) {
 	qName := req.Question[0].Name
 	qType := req.Question[0].Qtype
 	handled := make(map[string]struct{})
 	for _, node := range nodes {
-		// Avoid duplicate entries, possible if a node has
-		// the same service on multiple ports, etc.
+		// Prefer the Service Address or WAN Address over the
+		// Node Address when configured
 		addr := node.Node.Address
 		if node.Service.Address != "" {
 			addr = node.Service.Address
+		} else if useWan == true && node.Node.WanAddress != "" {
+			addr = node.Node.WanAddress
 		}
 
+		// Avoid duplicate entries, possible if a node has
+		// the same service on multiple ports, etc.
 		if _, ok := handled[addr]; ok {
 			continue
 		}

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -402,7 +402,7 @@ RPC:
 	// Determine whether we should use the WAN address or not
 	addr := out.NodeServices.Node.Address
 	if d.agent.config.TranslateWanAddrs && datacenter != d.agent.config.Datacenter {
-		addr = out.NodeServices.Node.WanAddress
+		addr = out.NodeServices.Node.Addresses["wan"]
 	}
 
 	// Add the node record
@@ -671,8 +671,8 @@ func (d *DNSServer) serviceNodeRecords(nodes structs.CheckServiceNodes, req, res
 		addr := node.Node.Address
 		if node.Service.Address != "" {
 			addr = node.Service.Address
-		} else if useWan == true && node.Node.WanAddress != "" {
-			addr = node.Node.WanAddress
+		} else if useWan == true && node.Node.Addresses["wan"] != "" {
+			addr = node.Node.Addresses["wan"]
 		}
 
 		// Avoid duplicate entries, possible if a node has
@@ -721,8 +721,8 @@ func (d *DNSServer) serviceSRVRecords(dc string, nodes structs.CheckServiceNodes
 		addr := node.Node.Address
 		if node.Service.Address != "" {
 			addr = node.Service.Address
-		} else if useWan == true && node.Node.WanAddress != "" {
-			addr = node.Node.WanAddress
+		} else if useWan == true && node.Node.Addresses["wan"] != "" {
+			addr = node.Node.Addresses["wan"]
 		}
 
 		// Add the extra record

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -117,7 +117,9 @@ func TestDNS_NodeLookup(t *testing.T) {
 		Datacenter: "dc1",
 		Node:       "foo",
 		Address:    "127.0.0.1",
-		WanAddress: "127.0.0.2",
+		Addresses: 	map[string]string {
+			"wan": "127.0.0.2",
+		},
 	}
 
 	var out struct{}
@@ -756,7 +758,9 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 			Datacenter: "dc2",
 			Node:       "foo",
 			Address:    "127.0.0.1",
-			WanAddress: "127.0.0.2",
+			Addresses:  map[string]string {
+				"wan": "127.0.0.2",
+			},
 			Service: &structs.NodeService{
 				Service: "db",
 			},

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -117,6 +117,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 		Datacenter: "dc1",
 		Node:       "foo",
 		Address:    "127.0.0.1",
+		WanAddress: "127.0.0.2",
 	}
 
 	var out struct{}
@@ -711,6 +712,136 @@ func TestDNS_ServiceLookup_ServiceAddress(t *testing.T) {
 		}
 		if aRec.Hdr.Ttl != 0 {
 			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+	}
+}
+
+func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
+	dir1, srv1 := makeDNSServerConfig(t,
+		func(c *Config) {
+			c.Datacenter = "dc1"
+			c.TranslateWanAddrs = true
+		}, nil)
+	defer os.RemoveAll(dir1)
+	defer srv1.Shutdown()
+
+	dir2, srv2 := makeDNSServerConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.TranslateWanAddrs = true
+	}, nil)
+	defer os.RemoveAll(dir2)
+	defer srv2.Shutdown()
+
+	testutil.WaitForLeader(t, srv1.agent.RPC, "dc1")
+	testutil.WaitForLeader(t, srv2.agent.RPC, "dc2")
+
+	// Join WAN cluster
+	addr := fmt.Sprintf("127.0.0.1:%d",
+		srv1.agent.config.Ports.SerfWan)
+	if _, err := srv2.agent.JoinWAN([]string{addr}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	testutil.WaitForResult(
+		func() (bool, error) {
+			return len(srv1.agent.WANMembers()) > 1, nil
+		},
+		func(err error) {
+			t.Fatalf("Failed waiting for WAN join: %v", err)
+		})
+
+	// Register a remote node with a service.
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc2",
+			Node:       "foo",
+			Address:    "127.0.0.1",
+			WanAddress: "127.0.0.2",
+			Service: &structs.NodeService{
+				Service: "db",
+			},
+		}
+
+		var out struct{}
+		if err := srv2.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Register an equivalent prepared query.
+	var id string
+	{
+		args := &structs.PreparedQueryRequest{
+			Datacenter: "dc2",
+			Op:         structs.PreparedQueryCreate,
+			Query: &structs.PreparedQuery{
+				Service: structs.ServiceQuery{
+					Service: "db",
+				},
+			},
+		}
+		if err := srv2.agent.RPC("PreparedQuery.Apply", args, &id); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Look up the SRV record via service and prepared query.
+	questions := []string{
+		"db.service.dc2.consul.",
+		id + ".query.dc2.consul.",
+	}
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSRV)
+
+		c := new(dns.Client)
+		addr, _ := srv1.agent.config.ClientListener("", srv1.agent.config.Ports.DNS)
+		in, _, err := c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("Bad: %#v", in)
+		}
+
+		aRec, ok := in.Extra[0].(*dns.A)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.Hdr.Name != "foo.node.dc2.consul." {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.A.String() != "127.0.0.2" {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+	}
+
+	// Also check the A record directly
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeA)
+
+		c := new(dns.Client)
+		addr, _ := srv1.agent.config.ClientListener("", srv1.agent.config.Ports.DNS)
+		in, _, err := c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("Bad: %#v", in)
+		}
+
+		aRec, ok := in.Answer[0].(*dns.A)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+		if aRec.Hdr.Name != question {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+		if aRec.A.String() != "127.0.0.2" {
+			t.Fatalf("Bad: %#v", in.Answer[0])
 		}
 	}
 }

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -525,7 +525,7 @@ func (l *localState) syncService(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
-		WanAddress:   l.config.ConsulConfig.SerfWANConfig.MemberlistConfig.AdvertiseAddr,
+		WanAddress:   l.config.AdvertiseAddrWan,
 		Service:      l.services[id],
 		WriteRequest: structs.WriteRequest{Token: l.serviceToken(id)},
 	}
@@ -583,7 +583,7 @@ func (l *localState) syncCheck(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
-		WanAddress:   l.config.ConsulConfig.SerfWANConfig.MemberlistConfig.AdvertiseAddr,
+		WanAddress:   l.config.AdvertiseAddrWan,
 		Service:      service,
 		Check:        l.checks[id],
 		WriteRequest: structs.WriteRequest{Token: l.checkToken(id)},

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -525,6 +525,7 @@ func (l *localState) syncService(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
+		WanAddress:   l.config.ConsulConfig.SerfWANConfig.MemberlistConfig.AdvertiseAddr,
 		Service:      l.services[id],
 		WriteRequest: structs.WriteRequest{Token: l.serviceToken(id)},
 	}
@@ -582,6 +583,7 @@ func (l *localState) syncCheck(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
+		WanAddress:   l.config.ConsulConfig.SerfWANConfig.MemberlistConfig.AdvertiseAddr,
 		Service:      service,
 		Check:        l.checks[id],
 		WriteRequest: structs.WriteRequest{Token: l.checkToken(id)},

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -525,7 +525,9 @@ func (l *localState) syncService(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
-		WanAddress:   l.config.AdvertiseAddrWan,
+		Addresses:   	map[string]string {
+			"wan": l.config.AdvertiseAddrWan,
+		},
 		Service:      l.services[id],
 		WriteRequest: structs.WriteRequest{Token: l.serviceToken(id)},
 	}
@@ -583,7 +585,9 @@ func (l *localState) syncCheck(id string) error {
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
 		Address:      l.config.AdvertiseAddr,
-		WanAddress:   l.config.AdvertiseAddrWan,
+		Addresses:   	map[string]string {
+			"wan": l.config.AdvertiseAddrWan,
+		},
 		Service:      service,
 		Check:        l.checks[id],
 		WriteRequest: structs.WriteRequest{Token: l.checkToken(id)},

--- a/consul/client.go
+++ b/consul/client.go
@@ -141,7 +141,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.Merge = &lanMergeDelegate{dc: c.config.Datacenter}
 	conf.DisableCoordinates = c.config.DisableCoordinates
 	if wanAddr := c.config.SerfWANConfig.MemberlistConfig.AdvertiseAddr; wanAddr != "" {
-		conf.Tags["WanAddr"] = wanAddr
+		conf.Tags["wan_addr"] = wanAddr
 	}
 	if err := ensurePath(conf.SnapshotPath, false); err != nil {
 		return nil, err

--- a/consul/client.go
+++ b/consul/client.go
@@ -140,6 +140,9 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.RejoinAfterLeave = c.config.RejoinAfterLeave
 	conf.Merge = &lanMergeDelegate{dc: c.config.Datacenter}
 	conf.DisableCoordinates = c.config.DisableCoordinates
+	if wanAddr := c.config.SerfWANConfig.MemberlistConfig.AdvertiseAddr; wanAddr != "" {
+		conf.Tags["WanAddr"] = wanAddr
+	}
 	if err := ensurePath(conf.SnapshotPath, false); err != nil {
 		return nil, err
 	}

--- a/consul/fsm.go
+++ b/consul/fsm.go
@@ -472,8 +472,9 @@ func (s *consulSnapshot) persistNodes(sink raft.SnapshotSink,
 	for node := nodes.Next(); node != nil; node = nodes.Next() {
 		n := node.(*structs.Node)
 		req := structs.RegisterRequest{
-			Node:    n.Node,
-			Address: n.Address,
+			Node:       n.Node,
+			Address:    n.Address,
+			WanAddress: n.WanAddress,
 		}
 
 		// Register the node itself

--- a/consul/fsm.go
+++ b/consul/fsm.go
@@ -474,7 +474,9 @@ func (s *consulSnapshot) persistNodes(sink raft.SnapshotSink,
 		req := structs.RegisterRequest{
 			Node:       n.Node,
 			Address:    n.Address,
-			WanAddress: n.WanAddress,
+			Addresses:  map[string]string {
+				"wan": n.Addresses["wan"],
+			},
 		}
 
 		// Register the node itself

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -418,6 +418,7 @@ AFTER_CHECK:
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
+		WanAddress: member.Tags["WanAddr"],
 		Service:    service,
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
@@ -460,6 +461,7 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
+		WanAddress: member.Tags["WanAddr"],
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
 			CheckID: SerfCheckID,

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -381,7 +381,7 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 	}
 	if node != nil && node.Address == member.Addr.String() {
 		// Check if the WAN address was updated
-		if node.WanAddress != member.Tags["WanAddr"] {
+		if node.WanAddress != member.Tags["wan_addr"] {
 			goto AFTER_CHECK
 		}
 
@@ -423,7 +423,7 @@ AFTER_CHECK:
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
-		WanAddress: member.Tags["WanAddr"],
+		WanAddress: member.Tags["wan_addr"],
 		Service:    service,
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
@@ -466,7 +466,7 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
-		WanAddress: member.Tags["WanAddr"],
+		WanAddress: member.Tags["wan_addr"],
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
 			CheckID: SerfCheckID,

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -381,7 +381,7 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 	}
 	if node != nil && node.Address == member.Addr.String() {
 		// Check if the WAN address was updated
-		if node.WanAddress != member.Tags["wan_addr"] {
+		if node.Addresses["wan"] != member.Tags["wan_addr"] {
 			goto AFTER_CHECK
 		}
 
@@ -423,7 +423,9 @@ AFTER_CHECK:
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
-		WanAddress: member.Tags["wan_addr"],
+		Addresses: 	map[string]string {
+			"wan": member.Tags["wan_addr"],
+		},
 		Service:    service,
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
@@ -466,7 +468,9 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 		Datacenter: s.config.Datacenter,
 		Node:       member.Name,
 		Address:    member.Addr.String(),
-		WanAddress: member.Tags["wan_addr"],
+		Addresses: 	map[string]string {
+			"wan": member.Tags["wan_addr"],
+		},
 		Check: &structs.HealthCheck{
 			Node:    member.Name,
 			CheckID: SerfCheckID,

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -380,6 +380,11 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 		return err
 	}
 	if node != nil && node.Address == member.Addr.String() {
+		// Check if the WAN address was updated
+		if node.WanAddress != member.Tags["WanAddr"] {
+			goto AFTER_CHECK
+		}
+
 		// Check if the associated service is available
 		if service != nil {
 			match := false

--- a/consul/server.go
+++ b/consul/server.go
@@ -298,6 +298,9 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 	if s.config.BootstrapExpect != 0 {
 		conf.Tags["expect"] = fmt.Sprintf("%d", s.config.BootstrapExpect)
 	}
+	if wanAddr := s.config.SerfWANConfig.MemberlistConfig.AdvertiseAddr; wanAddr != "" {
+		conf.Tags["WanAddr"] = wanAddr
+	}
 	conf.MemberlistConfig.LogOutput = s.config.LogOutput
 	conf.LogOutput = s.config.LogOutput
 	conf.EventCh = ch

--- a/consul/server.go
+++ b/consul/server.go
@@ -299,7 +299,7 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 		conf.Tags["expect"] = fmt.Sprintf("%d", s.config.BootstrapExpect)
 	}
 	if wanAddr := s.config.SerfWANConfig.MemberlistConfig.AdvertiseAddr; wanAddr != "" {
-		conf.Tags["WanAddr"] = wanAddr
+		conf.Tags["wan_addr"] = wanAddr
 	}
 	conf.MemberlistConfig.LogOutput = s.config.LogOutput
 	conf.LogOutput = s.config.LogOutput

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -474,7 +474,7 @@ func (s *StateStore) EnsureRegistration(idx uint64, req *structs.RegisterRequest
 func (s *StateStore) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, watches *DumbWatchManager,
 	req *structs.RegisterRequest) error {
 	// Add the node.
-	node := &structs.Node{Node: req.Node, Address: req.Address}
+	node := &structs.Node{Node: req.Node, Address: req.Address, WanAddress: req.WanAddress}
 	if err := s.ensureNodeTxn(tx, idx, watches, node); err != nil {
 		return fmt.Errorf("failed inserting node: %s", err)
 	}
@@ -1373,8 +1373,9 @@ func (s *StateStore) parseNodes(tx *memdb.Txn, idx uint64,
 
 		// Create the wrapped node
 		dump := &structs.NodeInfo{
-			Node:    node.Node,
-			Address: node.Address,
+			Node:       node.Node,
+			Address:    node.Address,
+			WanAddress: node.WanAddress,
 		}
 
 		// Query the node services

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -474,7 +474,7 @@ func (s *StateStore) EnsureRegistration(idx uint64, req *structs.RegisterRequest
 func (s *StateStore) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, watches *DumbWatchManager,
 	req *structs.RegisterRequest) error {
 	// Add the node.
-	node := &structs.Node{Node: req.Node, Address: req.Address, WanAddress: req.WanAddress}
+	node := &structs.Node{Node: req.Node, Address: req.Address, Addresses: req.Addresses}
 	if err := s.ensureNodeTxn(tx, idx, watches, node); err != nil {
 		return fmt.Errorf("failed inserting node: %s", err)
 	}
@@ -1375,7 +1375,7 @@ func (s *StateStore) parseNodes(tx *memdb.Txn, idx uint64,
 		dump := &structs.NodeInfo{
 			Node:       node.Node,
 			Address:    node.Address,
-			WanAddress: node.WanAddress,
+			Addresses:  node.Addresses,
 		}
 
 		// Query the node services

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -162,7 +162,7 @@ type RegisterRequest struct {
 	Datacenter string
 	Node       string
 	Address    string
-	WanAddress string
+	Addresses  map[string]string
 	Service    *NodeService
 	Check      *HealthCheck
 	Checks     HealthChecks
@@ -248,7 +248,7 @@ func (r *ChecksInStateRequest) RequestDatacenter() string {
 type Node struct {
 	Node       string
 	Address    string
-	WanAddress string
+	Addresses  map[string]string
 
 	RaftIndex
 }
@@ -442,7 +442,7 @@ OUTER:
 type NodeInfo struct {
 	Node       string
 	Address    string
-	WanAddress string
+	Addresses  map[string]string
 	Services   []*NodeService
 	Checks     []*HealthCheck
 }

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -162,6 +162,7 @@ type RegisterRequest struct {
 	Datacenter string
 	Node       string
 	Address    string
+	WanAddress string
 	Service    *NodeService
 	Check      *HealthCheck
 	Checks     HealthChecks
@@ -245,8 +246,9 @@ func (r *ChecksInStateRequest) RequestDatacenter() string {
 
 // Used to return information about a node
 type Node struct {
-	Node    string
-	Address string
+	Node       string
+	Address    string
+	WanAddress string
 
 	RaftIndex
 }
@@ -438,10 +440,11 @@ OUTER:
 // a node. This is currently used for the UI only, as it is
 // rather expensive to generate.
 type NodeInfo struct {
-	Node     string
-	Address  string
-	Services []*NodeService
-	Checks   []*HealthCheck
+	Node       string
+	Address    string
+	WanAddress string
+	Services   []*NodeService
+	Checks     []*HealthCheck
 }
 
 // NodeDump is used to dump all the nodes with all their


### PR DESCRIPTION
Often times, it is necessary to discover and communicate with a service in a different datacenter which is behind a NAT. Currently, only Consul servers have the concept of a WAN address. Here, we re-use this knob to enable clients to set their WAN addresses as well, and introduce a new configuration option to instruct Consul to prefer the WAN address (if set) when making cross-DC requests.

@slackpad this feature is a blocker for us. Solves #1386. I have not written much go, so please let me know if anything here is non-idiomatic.