### PR TITLE
.gitignore entries for IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,31 @@ website/vendor
 
 ui/.bundle
 ui/vendor
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties


### PR DESCRIPTION
My preferred IDE, even for Go code, is IntelliJ IDEA. Please accept his minor addition to the .gitignore which helps prevent accidental pollution into commits of project files and other workspace cruft.