### PR TITLE
build the linux_amd64 static binary in a docker container

### DIFF
--- a/scripts/build-with-docker.sh
+++ b/scripts/build-with-docker.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+docker run \
+        --env CGO_ENABLED=0 \
+        --env CONSUL_DEV=1 \
+        --rm \
+        --tty \
+        --volume $(pwd):/go/src/github.com/hashicorp/consul \
+        --workdir /go/src/github.com/hashicorp/consul \
+    golang:1.5 \
+        make


### PR DESCRIPTION
I like to build Go applications inside a container if I can help it as I am (not yet!) a fan of how Go workspaces are organized. This keeps the mess inside a container and dumps the (static!) binary in the normal `$GOPATH/src/github.com/hashicorp/consul/{bin,pkg/linux_amd64}` locations.

```
./scripts/build-with-docker.sh
```
