### PR TITLE
Add complete cluster demo using Vagrant.

### DIFF
--- a/demo/vagrant-cluster-complete/README.md
+++ b/demo/vagrant-cluster-complete/README.md
@@ -1,0 +1,74 @@
+# README #
+
+This demo creates a small Consul cluster using Vagrant and Consul
+configuration files.  The cluster is intended to be equal to that
+given in the [Consul
+documentation](https://www.consul.io/intro/getting-started/join.html).
+
+To get started, you can start the cluster by just doing:
+
+    $ vagrant up
+
+Once it is finished, you should be able to see the following:
+
+    $ vagrant status
+    Current machine states:
+    n1                        running (virtualbox)
+    n2                        running (virtualbox)
+
+At this point the two nodes are running and you can SSH in to play
+with them and run the commands shown in the documentation, e.g.:
+
+    $vagrant ssh n1
+    vagrant@n1:~$ consul members
+    vagrant@n1:~$ dig @127.0.0.1 -p 8600 agent-two.node.consul
+    vagrant@n1:~$ curl http://localhost:8500/v1/health/state/critical
+    ... etc.
+
+The [Key/Value
+Data](https://www.consul.io/intro/getting-started/kv.html)
+demonstration is scripted in key_value.sh.  Run it as follows:
+
+    $vagrant ssh n1
+    vagrant@n1:~$ /vagrant/key_value.sh
+    
+You can also see the Consul UI at http://localhost:8501/ui/#/dc1/services.
+
+To learn more about starting Consul, joining nodes and interacting with the agent,
+checkout the [getting started guide](http://www.consul.io/intro/getting-started/install.html).
+
+
+## Notes
+
+* `Vagrantfile` uses `provision.sh` to provision two nodes, `n1` and `n2`.
+* Files used during configuration of both nodes are in `common`,
+  node-specific files for configuration and health checks are in their
+  subfolders.
+* `consul.conf` is for the consul service running on each machine.
+* `key_value.sh` is a short script to populate the key/values for the cluster.
+
+
+## Differences from the Consul documentation and existing demo.
+
+* This demo uses `hashicorp/precise64` instead of `debian/wheezy64`
+  for the Vagrant box.
+* `provision.sh` uses upstart script instead of `consul agent`.
+  Originally, `provision.sh` used `exec consul agent
+  -config-file=/etc/consul.d/config.json &` to start consul in a
+  background thread so the vagrantfile could run both machines to
+  completion.  This would start consul correctly, but it didn't appear
+  to be stable: the consul nodes would shut down after vagrant ssh'ing
+  into a node, leaving (using either exit or logout), and then vagrant
+  ssh'ing back into the same node.
+* n2/config.json's 0.0.0.0 client_addr, and the forwarded port in
+  Vagrantfile, is to allow the UI to be visible from the host
+  machine's browser as localhost, and also to allow for consul method
+  calls to be made in the n2 vm without specifying the RPC (remote
+  proc call) address "-rpc-addr".
+* Two web services, "healthy" and "unhealthy", are defined for cluster
+  n2.  The
+  [Services](https://www.consul.io/intro/getting-started/services.html)
+  page assumes that a healthy web service is available, while the
+  [Health
+  Checks](https://www.consul.io/intro/getting-started/checks.html)
+  page assumes an unhealthy service is available.

--- a/demo/vagrant-cluster-complete/Vagrantfile
+++ b/demo/vagrant-cluster-complete/Vagrantfile
@@ -1,0 +1,27 @@
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = "hashicorp/precise64"
+
+  config.vm.define :n1 do |n1|
+    n1.vm.hostname = "n1"
+    n1.vm.network "private_network", ip: "172.20.20.10"
+    n1.vm.provision "shell" do |s|
+      s.path = "provision.sh"
+      s.args = ["n1", "N"]
+    end
+  end
+
+  config.vm.define :n2 do |n2|
+    n2.vm.hostname = "n2"
+    n2.vm.network "private_network", ip: "172.20.20.11"
+    n2.vm.network "forwarded_port", guest: 8500, host: 8501
+    n2.vm.provision "shell" do |s|
+      s.path = "provision.sh"
+      s.args = ["n2", "Y"]
+    end
+  end
+
+end

--- a/demo/vagrant-cluster-complete/common/consul.conf
+++ b/demo/vagrant-cluster-complete/common/consul.conf
@@ -1,0 +1,13 @@
+# Upstart script to kick off consul.
+
+description "Consul process"
+
+start on (local-filesystems and net-device-up IFACE=eth0)
+stop on runlevel [!12345]
+
+respawn
+
+# Ref https://www.consul.io/docs/agent/options.html for configuration notes.
+# -config-file is for consul itself
+# -config-dir is to load any checks
+exec consul agent -config-file=/etc/consul.d/config.json -config-dir=/etc/consul.d

--- a/demo/vagrant-cluster-complete/common/motd.txt
+++ b/demo/vagrant-cluster-complete/common/motd.txt
@@ -1,0 +1,14 @@
+Vagrant Consul Demo
+-------------------
+
+Welcome to your Vagrant-built virtual machine.
+Try out the following consul methods:
+
+  $ consul members
+  $ curl localhost:8500/v1/catalog/nodes
+  $ dig @127.0.0.1 -p 8600 agent-two.node.consul
+  $ curl http://localhost:8500/v1/health/state/critical
+  $ dig @127.0.0.1 -p 8600 web.service.consul
+  $ /vagrant/key_value.sh   # run the key_value demo
+  $ curl -v http://localhost:8500/v1/kv/?recurse
+

--- a/demo/vagrant-cluster-complete/key_value.sh
+++ b/demo/vagrant-cluster-complete/key_value.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Consul Key-Value demonstration
+#
+# This script duplicates the actions given at
+# https://www.consul.io/intro/getting-started/kv.html.  Ssh into the
+# virtual box (either one) and run the following:
+#
+#   ./vagrant/key_value.sh
+#
+# To delete all keys, add "delete" as an input arg:
+#
+#   ./vagrant/key_value.sh delete
+
+
+if [ "$1" == "delete" ]; then
+    curl --silent -X DELETE http://localhost:8500/v1/kv/?recurse > /dev/null
+    echo "All keys deleted."
+    exit 0
+fi
+
+
+set -v
+
+# First verify that there are no existing keys in the k/v store:
+curl -v http://localhost:8500/v1/kv/?recurse
+
+# PUT some keys:
+curl -X PUT -d 'test' http://localhost:8500/v1/kv/web/key1
+
+curl -X PUT -d 'test' http://localhost:8500/v1/kv/web/key2?flags=42
+
+curl -X PUT -d 'test' http://localhost:8500/v1/kv/web/sub/key3
+
+
+# Now there are keys returned:
+curl http://localhost:8500/v1/kv/?recurse | python -mjson.tool
+
+# Fetch single key:
+curl http://localhost:8500/v1/kv/web/key1 | python -mjson.tool
+
+# Delete key (here, deleting recursively):
+curl -X DELETE http://localhost:8500/v1/kv/web/sub?recurse
+
+curl http://localhost:8500/v1/kv/?recurse | python -mjson.tool
+
+# Update a key.
+set +v
+# Ref http://www.cambus.net/parsing-json-from-command-line-using-python/
+lastindex=`curl --silent http://localhost:8500/v1/kv/web/key1 | python -c 'import sys, json; print json.load(sys.stdin)[0]["ModifyIndex"]'`
+set -v
+curl -X PUT -d 'new_value' http://localhost:8500/v1/kv/web/key1?cas=${lastindex}
+
+curl -X PUT -d 'rejected_update' http://localhost:8500/v1/kv/web/key1?cas=${lastindex}
+
+set +v
+value=`curl --silent http://localhost:8500/v1/kv/web/key1 | python -c 'import sys, json; print json.load(sys.stdin)[0]["Value"]' | base64 --decode`
+
+echo "New key value: ${value}"
+set -v
+

--- a/demo/vagrant-cluster-complete/n1/config.json
+++ b/demo/vagrant-cluster-complete/n1/config.json
@@ -1,0 +1,11 @@
+{
+    "bootstrap_expect": 1,
+    "server": true,
+    "data_dir": "/tmp/consul",
+    "bind_addr": "172.20.20.10",
+    "node_name": "agent-one",
+
+    "encrypt": "Dt3P9SpKGAR/DIUN1cDirg==",
+    "log_level": "INFO",
+    "enable_syslog": true
+}

--- a/demo/vagrant-cluster-complete/n2/config.json
+++ b/demo/vagrant-cluster-complete/n2/config.json
@@ -1,0 +1,14 @@
+{
+    "bootstrap": false,
+    "server": false,
+    "data_dir": "/tmp/consul",
+    "bind_addr": "172.20.20.11",
+    "client_addr": "0.0.0.0",
+    "node_name": "agent-two",
+    "ui_dir": "/usr/local/bin/dist",
+    "start_join": ["172.20.20.10"],
+    
+    "encrypt": "Dt3P9SpKGAR/DIUN1cDirg==",
+    "log_level": "INFO",
+    "enable_syslog": true
+}

--- a/demo/vagrant-cluster-complete/n2/ping.json
+++ b/demo/vagrant-cluster-complete/n2/ping.json
@@ -1,0 +1,7 @@
+{
+    "check": {
+	"name": "ping",
+	"script": "ping -c1 google.com >/dev/null",
+	"interval": "30s"
+    }
+}

--- a/demo/vagrant-cluster-complete/n2/web.json
+++ b/demo/vagrant-cluster-complete/n2/web.json
@@ -1,0 +1,7 @@
+{
+    "service": {
+	"name": "web",
+	"tags": ["rails"],
+	"port": 80
+    }
+}

--- a/demo/vagrant-cluster-complete/n2/web_unhealthy.json
+++ b/demo/vagrant-cluster-complete/n2/web_unhealthy.json
@@ -1,0 +1,11 @@
+{
+    "service": {
+	"name": "web_unhealthy",
+	"tags": ["rails"],
+	"port": 80,
+	"check": {
+	    "script": "curl localhost >/dev/null 2>&1",
+	    "interval": "10s"
+	}
+    }
+}

--- a/demo/vagrant-cluster-complete/provision.sh
+++ b/demo/vagrant-cluster-complete/provision.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 config_root_dir get_ui_Y_N" >&2
+  exit 1
+fi
+rootdir="$1"
+
+sudo apt-get update
+sudo apt-get install -y unzip
+sudo apt-get install -y curl
+
+CONSUL_VERSION=0.6.0
+CONSUL_URL_BASE=https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}
+
+# Get Consul.
+echo Downloading and installing consul
+cd /tmp
+wget ${CONSUL_URL_BASE}_linux_amd64.zip -O consul.zip
+cd /usr/local/bin/
+mv /tmp/consul.zip .
+sudo unzip consul.zip
+sudo rm consul.zip
+sudo chmod +x /usr/local/bin/consul
+
+# Get UI if needed.
+sudo mkdir -p /usr/local/bin/dist
+if [ "$2" == "Y" ]; then
+    echo Downloading and installing ui
+    cd /tmp
+    wget ${CONSUL_URL_BASE}_web_ui.zip -O ui.zip
+    cd /usr/local/bin/dist
+    mv /tmp/ui.zip .
+    sudo unzip ui.zip
+    sudo rm ui.zip
+fi
+
+# Consul directories and files.
+sudo mkdir -p /etc/consul.d
+sudo chmod a+w /etc/consul.d
+sudo mkdir -p /tmp/consul
+sudo chmod a+w /tmp/consul
+cp /vagrant/${rootdir}/*.* /etc/consul.d/
+sudo chmod a+wrx /etc/consul.d/*.*
+sudo cp /vagrant/common/consul.conf /etc/init/consul.conf
+sudo rm /etc/motd
+sudo cp /vagrant/common/motd.txt /etc/motd
+
+# Start consul.
+sudo start consul

--- a/website/source/intro/getting-started/install.html.markdown
+++ b/website/source/intro/getting-started/install.html.markdown
@@ -14,6 +14,10 @@ Consul cluster. To make installation easy, Consul is distributed as a
 architectures. This page will not cover how to compile Consul from
 source.
 
+~> **Note:** A full Vagrant demo which yields an equivalent setup of the
+two-node Consul cluster explained in this section is provided in the
+[demo section of the Consul repo](https://github.com/hashicorp/consul/tree/master/demo/vagrant-cluster-complete).
+
 ## Installing Consul
 
 To install Consul, find the [appropriate package](/downloads.html) for


### PR DESCRIPTION
This demo builds a cluster approximately equal to that built manually in the Getting Started guide.  See demo/vagrant-cluster-complete/README.md for details.

I wrote this as I was looking to quickly demonstrate consul in a way that complemented the canonical codebase.  Existing vagrant demos (eg, http://www.andyfrench.info/2015/08/setting-up-consul-cluster-for-testing.html) were good, but were independent and didn't reflect the Getting Started guide.

There were a few small gotchas during the implementation, such as the network statements needed for the Consul UI to show up correctly in localhost.  Having a reference implementation for this and configuration files may also be useful.

I made a small edit to the existing documentation pages in the commit.  I couldn't test that out as I didn't know how to build and deploy the site locally.  Let me know if I need to change anything.
