### PR TITLE
Adds "try" and "monitor-retry" options to `consul lock` command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -261,9 +261,16 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 }
 
-// durToMsec converts a duration to a millisecond specified string
+// durToMsec converts a duration to a millisecond specified string. If the
+// user selected a positive value that rounds to 0 ms, then we will use 1 ms
+// so they get a short delay, otherwise Consul will translate the 0 ms into
+// a huge default delay.
 func durToMsec(dur time.Duration) string {
-	return fmt.Sprintf("%dms", dur/time.Millisecond)
+	ms := dur / time.Millisecond
+	if dur > 0 && ms == 0 {
+		ms = 1
+	}
+	return fmt.Sprintf("%dms", ms)
 }
 
 // setWriteOptions is used to annotate the request with

--- a/api/api.go
+++ b/api/api.go
@@ -273,6 +273,21 @@ func durToMsec(dur time.Duration) string {
 	return fmt.Sprintf("%dms", ms)
 }
 
+// serverError is a string we look for to detect 500 errors.
+const serverError = "Unexpected response code: 500"
+
+// IsServerError returns true for 500 errors from the Consul servers, these are
+// usually retryable at a later time.
+func IsServerError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// TODO (slackpad) - Make a real error type here instead of using
+	// a string check.
+	return strings.Contains(err.Error(), serverError)
+}
+
 // setWriteOptions is used to annotate the request with
 // additional write options
 func (r *request) setWriteOptions(q *WriteOptions) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -272,3 +272,17 @@ func TestAPI_durToMsec(t *testing.T) {
 		t.Fatalf("bad: %s", ms)
 	}
 }
+
+func TestAPI_IsServerError(t *testing.T) {
+	if IsServerError(nil) {
+		t.Fatalf("should not be a server error")
+	}
+
+	if IsServerError(fmt.Errorf("not the error you are looking for")) {
+		t.Fatalf("should not be a server error")
+	}
+
+	if !IsServerError(fmt.Errorf(serverError)) {
+		t.Fatalf("should be a server error")
+	}
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -254,3 +254,21 @@ func TestAPI_UnixSocket(t *testing.T) {
 		t.Fatalf("bad: %v", info)
 	}
 }
+
+func TestAPI_durToMsec(t *testing.T) {
+	if ms := durToMsec(0); ms != "0ms" {
+		t.Fatalf("bad: %s", ms)
+	}
+
+	if ms := durToMsec(time.Millisecond); ms != "1ms" {
+		t.Fatalf("bad: %s", ms)
+	}
+
+	if ms := durToMsec(time.Microsecond); ms != "1ms" {
+		t.Fatalf("bad: %s", ms)
+	}
+
+	if ms := durToMsec(5 * time.Millisecond); ms != "5ms" {
+		t.Fatalf("bad: %s", ms)
+	}
+}

--- a/api/lock.go
+++ b/api/lock.go
@@ -29,7 +29,8 @@ const (
 	// DefaultMonitorRetryTime is how long we wait after a failed monitor check
 	// of a lock (500 response code). This allows the monitor to ride out brief
 	// periods of unavailability, subject to the MonitorRetries setting in the
-	// lock options which is by default set to 0, disabling this feature.
+	// lock options which is by default set to 0, disabling this feature. This
+	// affects locks and semaphores.
 	DefaultMonitorRetryTime = 2 * time.Second
 
 	// LockFlagValue is a magic flag we set to indicate a key

--- a/api/lock.go
+++ b/api/lock.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 )
@@ -362,15 +361,11 @@ WAIT:
 RETRY:
 	pair, meta, err := kv.Get(l.opts.Key, opts)
 	if err != nil {
-		// TODO (slackpad) - Make a real error type here instead of using
-		// a string check.
-		const serverError = "Unexpected response code: 500"
-
 		// If configured we can try to ride out a brief Consul unavailability
 		// by doing retries. Note that we have to attempt the retry in a non-
 		// blocking fashion so that we have a clean place to reset the retry
 		// counter if service is restored.
-		if retries > 0 && strings.Contains(err.Error(), serverError) {
+		if retries > 0 && IsServerError(err) {
 			time.Sleep(l.opts.MonitorRetryTime)
 			retries--
 			opts.WaitIndex = 0

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -541,8 +541,9 @@ func TestLock_OneShot(t *testing.T) {
 	if ch != nil {
 		t.Fatalf("should not be leader")
 	}
-	if diff := time.Now().Sub(start); diff > 2*contender.opts.LockWaitTime {
-		t.Fatalf("took too long: %9.6f", diff.Seconds())
+	diff := time.Now().Sub(start)
+	if diff < contender.opts.LockWaitTime || diff > 2*contender.opts.LockWaitTime {
+		t.Fatalf("time out of bounds: %9.6f", diff.Seconds())
 	}
 
 	// Unlock and then make sure the contender can get it.

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -488,3 +488,72 @@ func TestLock_MonitorRetry(t *testing.T) {
 		t.Fatalf("should not be leader")
 	}
 }
+
+func TestLock_OneShot(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	// Set up a lock as a one-shot.
+	opts := &LockOptions{
+		Key:         "test/lock",
+		LockTryOnce: true,
+	}
+	lock, err := c.LockOpts(opts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Make sure the default got set.
+	if lock.opts.LockWaitTime != DefaultLockWaitTime {
+		t.Fatalf("bad: %d", lock.opts.LockWaitTime)
+	}
+
+	// Now set a custom time for the test.
+	opts.LockWaitTime = 250 * time.Millisecond
+	lock, err = c.LockOpts(opts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if lock.opts.LockWaitTime != 250*time.Millisecond {
+		t.Fatalf("bad: %d", lock.opts.LockWaitTime)
+	}
+
+	// Should get the lock.
+	ch, err := lock.Lock(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ch == nil {
+		t.Fatalf("not leader")
+	}
+
+	// Now try with another session.
+	contender, err := c.LockOpts(opts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	start := time.Now()
+	ch, err = contender.Lock(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ch != nil {
+		t.Fatalf("should not be leader")
+	}
+	if diff := time.Now().Sub(start); diff > 2*contender.opts.LockWaitTime {
+		t.Fatalf("took too long: %9.6f", diff.Seconds())
+	}
+
+	// Unlock and then make sure the contender can get it.
+	if err := lock.Unlock(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	ch, err = contender.Lock(nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ch == nil {
+		t.Fatalf("should be leader")
+	}
+}

--- a/api/semaphore.go
+++ b/api/semaphore.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
-	"strings"
 	"sync"
 	"time"
 )
@@ -488,15 +487,11 @@ WAIT:
 RETRY:
 	pairs, meta, err := kv.List(s.opts.Prefix, opts)
 	if err != nil {
-		// TODO (slackpad) - Make a real error type here instead of using
-		// a string check.
-		const serverError = "Unexpected response code: 500"
-
 		// If configured we can try to ride out a brief Consul unavailability
 		// by doing retries. Note that we have to attempt the retry in a non-
 		// blocking fashion so that we have a clean place to reset the retry
 		// counter if service is restored.
-		if retries > 0 && strings.Contains(err.Error(), serverError) {
+		if retries > 0 && IsServerError(err) {
 			time.Sleep(s.opts.MonitorRetryTime)
 			retries--
 			opts.WaitIndex = 0

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -499,8 +499,9 @@ func TestSemaphore_OneShot(t *testing.T) {
 	if ch != nil {
 		t.Fatalf("should not have acquired the semaphore")
 	}
-	if diff := time.Now().Sub(start); diff > 2*contender.opts.SemaphoreWaitTime {
-		t.Fatalf("took too long: %9.6f", diff.Seconds())
+	diff := time.Now().Sub(start)
+	if diff < contender.opts.SemaphoreWaitTime || diff > 2*contender.opts.SemaphoreWaitTime {
+		t.Fatalf("time out of bounds: %9.6f", diff.Seconds())
 	}
 
 	// Give up a slot and make sure the third one can get it.

--- a/command/lock.go
+++ b/command/lock.go
@@ -75,8 +75,8 @@ Options:
   -name=""                   Optional name to associate with lock session.
   -token=""                  ACL token to use. Defaults to that of agent.
   -pass-stdin                Pass stdin to child process.
-  -try=duration              Make a single attempt to acquire the lock, waiting
-                             up to the given duration (eg. "15s").
+  -try=timeout               Attempt to acquire the lock up to the given
+                             timeout (eg. "15s").
   -monitor-retry=n           Retry up to n times if Consul returns a 500 error
                              while monitoring the lock. This allows riding out brief
                              periods of unavailability without causing leader
@@ -145,12 +145,12 @@ func (c *LockCommand) run(args []string, lu **LockUnlock) int {
 		var err error
 		wait, err = time.ParseDuration(try)
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error parsing duration for 'try' option: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error parsing try timeout: %s", err))
 			return 1
 		}
 
-		if wait < 0 {
-			c.Ui.Error("Duration for 'try' option must be positive")
+		if wait <= 0 {
+			c.Ui.Error("Try timeout must be positive")
 			return 1
 		}
 

--- a/command/lock_test.go
+++ b/command/lock_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -13,7 +15,20 @@ func TestLockCommand_implements(t *testing.T) {
 	var _ cli.Command = &LockCommand{}
 }
 
-func TestLockCommandRun(t *testing.T) {
+func TestLockCommand_BadArgs(t *testing.T) {
+	ui := new(cli.MockUi)
+	c := &LockCommand{Ui: ui}
+
+	if code := c.Run([]string{"-try=blah"}); code != 1 {
+		t.Fatalf("expected return code 1, got %d", code)
+	}
+
+	if code := c.Run([]string{"-try=-10s"}); code != 1 {
+		t.Fatalf("expected return code 1, got %d", code)
+	}
+}
+
+func TestLockCommand_Run(t *testing.T) {
 	a1 := testAgent(t)
 	defer a1.Shutdown()
 	waitForLeader(t, a1.httpAddr)
@@ -34,4 +49,70 @@ func TestLockCommandRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+}
+
+func runTry(t *testing.T, n int) {
+	a1 := testAgent(t)
+	defer a1.Shutdown()
+	waitForLeader(t, a1.httpAddr)
+
+	// Define a long-running command.
+	nArg := fmt.Sprintf("-n=%d", n)
+	args := []string{"-http-addr=" + a1.httpAddr, nArg, "-try=250ms", "test/prefix", "sleep 2"}
+
+	// Run several commands at once.
+	var wg sync.WaitGroup
+	locked := make([]bool, n+1)
+	tried := make([]bool, n+1)
+	for i := 0; i < n+1; i++ {
+		wg.Add(1)
+		go func(index int) {
+			ui := new(cli.MockUi)
+			c := &LockCommand{Ui: ui}
+
+			code := c.Run(append([]string{"-try=250ms"}, args...))
+			if code == 0 {
+				locked[index] = true
+			} else {
+				reason := ui.ErrorWriter.String()
+				if !strings.Contains(reason, "Shutdown triggered or timeout during lock acquisition") {
+					t.Fatalf("bad reason: %s", reason)
+				}
+				tried[index] = true
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	// Tally up the outcomes.
+	totalLocked := 0
+	totalTried := 0
+	for i := 0; i < n+1; i++ {
+		if locked[i] == tried[i] {
+			t.Fatalf("command %d didn't lock or try, or did both", i+1)
+		}
+		if locked[i] {
+			totalLocked++
+		}
+		if tried[i] {
+			totalTried++
+		}
+	}
+
+	// We can't check exact counts because sometimes the try attempts may
+	// fail because they get woken up but need to do another try, but we
+	// should get one of each outcome.
+	if totalLocked == 0 || totalTried == 0 {
+		t.Fatalf("unexpected outcome: locked=%d, tried=%d", totalLocked, totalTried)
+	}
+}
+
+func TestLockCommand_Try_Lock(t *testing.T) {
+	runTry(t, 1)
+}
+
+func TestLockCommand_Try_Semaphore(t *testing.T) {
+	runTry(t, 2)
+	runTry(t, 3)
 }

--- a/command/lock_test.go
+++ b/command/lock_test.go
@@ -29,8 +29,9 @@ func argFail(t *testing.T, args []string, expected string) {
 }
 
 func TestLockCommand_BadArgs(t *testing.T) {
-	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "parsing duration")
-	argFail(t, []string{"-try=-10s", "test/prefix", "date"}, "must be positive")
+	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "parsing try timeout")
+	argFail(t, []string{"-try=0s", "test/prefix", "date"}, "timeout must be positive")
+	argFail(t, []string{"-try=-10s", "test/prefix", "date"}, "timeout must be positive")
 	argFail(t, []string{"-monitor-retry=-5", "test/prefix", "date"}, "must be >= 0")
 }
 

--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -62,10 +62,9 @@ The list of available flags are:
 
 * `-pass-stdin` - Pass stdin to child process.
 
-* `-try` - Make a single attempt to acquire the lock, waiting up to the given
-  duration supplied as the argument. The duration is a decimal number, with
-  unit suffix, such as "500ms". Valid time units are "ns", "us" (or "µs"), "ms",
-  "s", "m", "h".
+* `-try` - Attempt to acquire the lock up to the given timeout. The timeout is a
+  positive decimal number, with unit suffix, such as "500ms". Valid time units
+  are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 * `-monitor-retry` - Retry up to this number of times if Consul returns a 500 error
    while monitoring the lock. This allows riding out brief periods of unavailability

--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -67,5 +67,10 @@ The list of available flags are:
   unit suffix, such as "500ms". Valid time units are "ns", "us" (or "µs"), "ms",
   "s", "m", "h".
 
+* `-monitor-retry` - Retry up to this number of times if Consul returns a 500 error
+   while monitoring the lock. This allows riding out brief periods of unavailability
+   without causing leader elections, but increases the amount of time required
+   to detect a lost lock in some cases. Defaults to 0.
+
 * `-verbose` - Enables verbose output.
 

--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -62,5 +62,10 @@ The list of available flags are:
 
 * `-pass-stdin` - Pass stdin to child process.
 
+* `-try` - Make a single attempt to acquire the lock, waiting up to the given
+  duration supplied as the argument. The duration is a decimal number, with
+  unit suffix, such as "500ms". Valid time units are "ns", "us" (or "µs"), "ms",
+  "s", "m", "h".
+
 * `-verbose` - Enables verbose output.
 

--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -70,7 +70,8 @@ The list of available flags are:
 * `-monitor-retry` - Retry up to this number of times if Consul returns a 500 error
    while monitoring the lock. This allows riding out brief periods of unavailability
    without causing leader elections, but increases the amount of time required
-   to detect a lost lock in some cases. Defaults to 0.
+   to detect a lost lock in some cases. Defaults to 3, with a 1s wait between retries.
+   Set to 0 to disable.
 
 * `-verbose` - Enables verbose output.
 


### PR DESCRIPTION
The "try" option should close https://github.com/hashicorp/consul/issues/780 and the "monitor-retry" option should close https://github.com/hashicorp/consul/issues/1162.