### PR TITLE
Allows use of broadcast IP as bind address.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -134,6 +134,9 @@ func Create(config *Config, logOutput io.Writer) (*Agent, error) {
 			return nil, fmt.Errorf("Failed to parse advertise address: %v", config.AdvertiseAddr)
 		}
 	} else if config.BindAddr != "0.0.0.0" && config.BindAddr != "" {
+		if ip := consul.GetSubnetIP(config.BindAddr); ip != nil {
+			config.BindAddr = ip.String()
+		}
 		config.AdvertiseAddr = config.BindAddr
 	} else {
 		ip, err := consul.GetPrivateIP()

--- a/consul/util.go
+++ b/consul/util.go
@@ -201,6 +201,29 @@ func GetPrivateIP() (net.IP, error) {
 	return getPrivateIP(addresses)
 }
 
+// GetSubnetIP is used to return the first matching IP address
+// associated with a given broadcast address
+func GetSubnetIP(ip_str string) net.IP {
+	ip := net.ParseIP(ip_str)
+	if ip.To4() == nil || ip[3] != 0 {
+		return nil
+	}
+
+	// Find matching IPv4 address
+	if addresses, err := net.InterfaceAddrs(); err == nil {
+		for _, addr := range addresses {
+			subnet := addr.(*net.IPNet)
+			if subnet.IP.To4() == nil {
+				continue
+			}
+			if ip.Equal(subnet.IP.Mask(subnet.Mask)) {
+				return subnet.IP
+			}
+		}
+	}
+	return nil
+}
+
 func getPrivateIP(addresses []net.Addr) (net.IP, error) {
 	var candidates []net.IP
 


### PR DESCRIPTION
In consul options, a binding address of 0.0.0.0 is used to resolve a nodes private IP. However if there are multiple private IPs this broadcast address is too wide as I found testing in a Docker container.

This allows the use of a given subnet IP e.g. 10.99.0.0 which will return the first matching IP among the network 10.99.0.0/24 such as 10.99.0.5. It also address a couple issues raised #1110 and #1478. Let me know if this solves the use case and follows idiomatic Go.
