### PR TITLE
Un-pins Go version so we always run CI with the latest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.2
+  - tip
 
 branches:
   only:


### PR DESCRIPTION
If this looks good in CI then we can merge and close #1524.