### PR TITLE
Fix Already Closed Issue #1488 "Unable to find gox"

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -38,7 +38,7 @@ fi
 
 # Build!
 echo "==> Building..."
-gox \
+$GOPATH/bin/gox \
     -os="${XC_OS}" \
     -arch="${XC_ARCH}" \
     -ldflags "-X main.GitCommit ${GIT_COMMIT}${GIT_DIRTY} -X main.GitDescribe ${GIT_DESCRIBE}" \


### PR DESCRIPTION
I encountered this issue myself a few minutes ago, and it only took a few seconds to realize why it might work for some and not for others, and what a convenient universal solution would be.

For anyone who has `$GOPATH/bin` in their `$PATH` this will not be a problem they encounter, for everyone else who follows the Go setup/install guide precisely they will only have `/usr/local/go/bin` in their `$PATH` but `$GOPATH/bin` is required to exist and contain binaries of everything built, in this case, gox.

It was a quick and easy fix and shouldn't be capable of breaking anything. That said, please test.