### PR TITLE
Update hashicorp-ecosystem.html.markdown

### DIFF
--- a/website/source/intro/hashicorp-ecosystem.html.markdown
+++ b/website/source/intro/hashicorp-ecosystem.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Consul & the HashiCorp Ecosystem
 
-HashiCorp is the creator of the open source projects Vagrant, Packer, Terraform, Serf, and Consul, and the commercial product Atlas. Terraform is just one piece of the ecosystem HashiCorp has built to make application delivery a versioned, auditable, repeatable, and collaborative process. To learn more about our beliefs on the qualities of the modern datacenter and responsible application delivery, read [The Atlas Mindset: Version Control for Infrastructure](https://www.hashicorp.com/blog/atlas-mindset.html/?utm_source=consul&utm_campaign=HashicorpEcosystem).
+HashiCorp is the creator of the open source projects Vagrant, Packer, Terraform, Serf, and Consul, and the commercial product Atlas. Terraform is just one piece of the ecosystem HashiCorp has built to make application delivery a versioned, auditable, repeatable, and collaborative process. To learn more about our beliefs on the qualities of the modern datacenter and responsible application delivery, read [The Atlas Mindset: Version Control for Infrastructure](https://www.hashicorp.com/blog/atlas-mindset.html?utm_source=consul&utm_campaign=HashicorpEcosystem).
 
 If you are using Consul for service discovery, it’s likely that you have a system to deploy infrastructure which Consul is then connecting. Terraform is our tool for creating, combining, and modifying infrastructure.
 


### PR DESCRIPTION
Remove slash from link to blog, which was causing 404 error.