### PR TITLE
Don't assume /bin/bash is installed on all OSes

### DIFF
--- a/contrib/zsh-completion/install.sh
+++ b/contrib/zsh-completion/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ZSH_FUNC_DIR="/usr/share/zsh/site-functions"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script builds the application from source for multiple platforms.
 set -e

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Get the version from the command line

--- a/scripts/verify_no_uuid.sh
+++ b/scripts/verify_no_uuid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 grep GenerateUUID consul/state/state_store.go
 RESULT=$?

--- a/website/packer.json
+++ b/website/packer.json
@@ -34,7 +34,7 @@
         "bundle check || bundle install --jobs 7",
         "bundle exec middleman build",
 
-        "/bin/bash ./scripts/deploy.sh"
+        "/usr/bin/env bash ./scripts/deploy.sh"
       ]
     }
   ]

--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 PROJECT="consul"


### PR DESCRIPTION
Use `/usr/bin/env bash` where appropriate.  This is only relevant when doing development and building on non-OS-X and non-Linux OSes.