### PR TITLE
Use the server's address in debug logging, not the c.lastServer

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -413,7 +413,7 @@ func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	connReuseLowWaterMark = clientRPCMinReuseDuration + lib.RandomStagger(clientRPCMinReuseDuration/clientRPCJitterFraction)
 	numLANMembers = len(c.LANMembers())
 	c.connRebalanceTime = now.Add(lib.RateScaledInterval(clusterWideRebalanceConnsPerSec, connReuseLowWaterMark, numLANMembers))
-	c.logger.Printf("[DEBUG] consul: connection to server %s will expire at %v", c.lastServer.Addr, c.connRebalanceTime)
+	c.logger.Printf("[DEBUG] consul: connection to server %s will expire at %v", server.Addr, c.connRebalanceTime)
 
 	// Forward to remote Consul
 TRY_RPC:


### PR DESCRIPTION
Client's `lastServer` may be `nil`.  Leaving #1677 open until we can audit the context of the callers to see if there are callers that have non-serialized access to the `Client` struct.

Hopefully fixes: #1677