### PR TITLE
Fix formatting in exec help

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -623,7 +623,7 @@ Options:
   -http-addr=127.0.0.1:8500  HTTP address of the Consul agent.
   -datacenter=""             Datacenter to dispatch in. Defaults to that of agent.
   -prefix="_rexec"           Prefix in the KV store to use for request data
-  -node=""					 Regular expression to filter on node names
+  -node=""                   Regular expression to filter on node names
   -service=""                Regular expression to filter on service instances
   -tag=""                    Regular expression to filter on service tags. Must be used
                              with -service.


### PR DESCRIPTION
The description for `-node` was separated by tabs instead of spaces, causing it to be incorrectly aligned.

Before:
![image](https://cloud.githubusercontent.com/assets/714287/12868495/c3e012cc-cccd-11e5-847f-efdc2e34ebb4.png)

After:
![image](https://cloud.githubusercontent.com/assets/714287/12868518/e6f03526-cccd-11e5-8207-030aa55d1558.png)