### PR TITLE
Added a reference to Consultant in the Community Tools section.

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -103,6 +103,9 @@ description: |-
         <a href="https://github.com/zeroXten/consul-do">consul-do</a> - Do something, such as run HA cronjobs, based on Consul leadership status
       </li>
       <li>
+        <a href="https://github.com/Magnetme/consultant">Consultant</a> - Library for Java services to self register and deregister, fetching configuration, and subscribing to configuration changes.
+      </li>
+      <li>
         <a href="http://xordataexchange.github.io/crypt/">crypt</a> - Store and retrieve encrypted configuration parameters from etcd or Consul
       </li>
       <li>


### PR DESCRIPTION
This PR adds a reference to our Java library we use at Magnet.me, called Consultant.

Consultant allows our services to self register and deregister from Consul on startup and termination, while also fetching the configuration from Consul's KV store, and subscribing to changes in that configuration.