### PR TITLE
Fix Consul download links

### DIFF
--- a/bench/bench-aws.json
+++ b/bench/bench-aws.json
@@ -53,8 +53,8 @@
             "sudo mkdir /etc/consul.d",
             "sudo apt-get update",
             "sudo apt-get install unzip make",
-            "wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip",
-            "unzip 0.4.1_linux_amd64.zip",
+            "wget https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip",
+            "unzip 0.5.2_linux_amd64.zip",
             "sudo mv consul /usr/local/bin/consul",
             "chmod +x /usr/local/bin/consul"
         ]

--- a/bench/bench.json
+++ b/bench/bench.json
@@ -47,8 +47,8 @@
             "mkdir /etc/consul.d",
             "apt-get update",
             "apt-get install unzip make",
-            "wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip",
-            "unzip 0.4.1_linux_amd64.zip",
+            "wget https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip",
+            "unzip 0.5.2_linux_amd64.zip",
             "mv consul /usr/local/bin/consul",
             "chmod +x /usr/local/bin/consul"
         ]

--- a/terraform/aws/scripts/centos6/install.sh
+++ b/terraform/aws/scripts/centos6/install.sh
@@ -4,13 +4,16 @@ set -e
 # Read the address to join from the file we provisioned
 JOIN_ADDRS=$(cat /tmp/consul-server-addr | tr -d '\n')
 
+# consul version to install
+CONSUL_VERSION=0.5.2
+
 echo "Installing dependencies..."
 yum update -y
 yum install -y unzip wget
 
 echo "Fetching Consul..."
 cd /tmp
-wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -O consul.zip
+wget "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" -O consul.zip
 
 echo "Installing Consul..."
 unzip consul.zip >/dev/null

--- a/terraform/aws/scripts/rhel6/install.sh
+++ b/terraform/aws/scripts/rhel6/install.sh
@@ -4,13 +4,16 @@ set -e
 # Read the address to join from the file we provisioned
 JOIN_ADDRS=$(cat /tmp/consul-server-addr | tr -d '\n')
 
+# consul version to install
+CONSUL_VERSION=0.5.2
+
 echo "Installing dependencies..."
 sudo yum update -y
 sudo yum install -y unzip wget
 
 echo "Fetching Consul..."
 cd /tmp
-wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -O consul.zip
+wget "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" -O consul.zip
 
 echo "Installing Consul..."
 unzip consul.zip >/dev/null
@@ -28,7 +31,7 @@ sudo mv /tmp/consul-join /etc/service/consul-join
 chmod 0644 /etc/service/consul-join
 
 echo "Installing Upstart service..."
-sudo chown root:root /tmp/upstart.conf 
+sudo chown root:root /tmp/upstart.conf
 sudo chown root:root /tmp/upstart-join.conf
 sudo mv /tmp/upstart.conf /etc/init/consul.conf
 sudo mv /tmp/upstart-join.conf /etc/init/consul-join.conf

--- a/terraform/aws/scripts/ubuntu/install.sh
+++ b/terraform/aws/scripts/ubuntu/install.sh
@@ -4,13 +4,16 @@ set -e
 # Read the address to join from the file we provisioned
 JOIN_ADDRS=$(cat /tmp/consul-server-addr | tr -d '\n')
 
+# consul version to install
+CONSUL_VERSION=0.5.2
+
 echo "Installing dependencies..."
 sudo apt-get update -y
 sudo apt-get install -y unzip
 
 echo "Fetching Consul..."
 cd /tmp
-wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -O consul.zip
+wget "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" -O consul.zip
 
 echo "Installing Consul..."
 unzip consul.zip >/dev/null

--- a/terraform/openstack/scripts/install.sh
+++ b/terraform/openstack/scripts/install.sh
@@ -4,6 +4,9 @@ set -e
 # Read the address to join from the file we provisioned
 JOIN_ADDRS=$(cat /tmp/consul-server-addr | tr -d '\n')
 
+# consul version to install
+CONSUL_VERSION=0.5.2
+
 sudo sh -c 'echo "127.0.0.1 consul-node-'$(cat /tmp/consul-server-index)'" >> /etc/hosts'
 
 echo "Installing dependencies..."
@@ -12,7 +15,7 @@ sudo apt-get install -y unzip
 
 echo "Fetching Consul..."
 cd /tmp
-wget https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip -O consul.zip
+wget "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" -O consul.zip
 
 echo "Installing Consul..."
 unzip consul.zip >/dev/null


### PR DESCRIPTION
The download links in the Terraform and benchmark scripts no longer works.
Changed to use the official https://releases.hashicorp.com URLs.

Also added a variable in the Terraform install scripts to make it easier to update the version to be installed.