### PR TITLE
Expose a tunable to adjust the number of DNS responses

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -189,6 +189,11 @@ func (c *Command) readConfig() *Config {
 		}
 	}
 
+	// Verify DNS settings
+	if config.DNSConfig.UDPAnswerLimit < 1 {
+		c.Ui.Error(fmt.Sprintf("dns_config.udp_answer_limit %d too low, must always be greater than zero", config.DNSConfig.UDPAnswerLimit))
+	}
+
 	if config.EncryptKey != "" {
 		if _, err := config.EncryptBytes(); err != nil {
 			c.Ui.Error(fmt.Sprintf("Invalid encryption key: %s", err))

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -81,11 +81,15 @@ type DNSConfig struct {
 	// Records returned in the ANSWER section of a DNS response. This is
 	// not normally useful and will be limited based on the querying
 	// protocol, however systems that implemented §6 Rule 9 in RFC3484
-	// may want to set this to 1 in order to achieve round-robin DNS.
+	// may want to set this to `1` in order to subvert §6 Rule 9 and
+	// re-obtain the effect of randomized resource records (i.e. each
+	// answer contains only one IP, but the IP changes every request).
 	// RFC3484 sorts answers in a deterministic order, which defeats the
-	// purpose of round-robin DNS.  This RFC has been obsoleted by
-	// RFC6724, however a large number of Linux hosts using glibc(3)
-	// implemented §6 Rule 9 (e.g. CentOS 5-6, Debian Squeeze, etc).
+	// purpose of randomized DNS responses.  This RFC has been obsoleted
+	// by RFC6724 and restores the desired behavior of randomized
+	// responses, however a large number of Linux hosts using glibc(3)
+	// implemented §6 Rule 9 and may need this option (e.g. CentOS 5-6,
+	// Debian Squeeze, etc).
 	UDPAnswerLimit int `mapstructure:"udp_answer_limit"`
 
 	// MaxStale is used to bound how stale of a result is

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -77,6 +77,14 @@ type DNSConfig struct {
 	// returned by default for UDP.
 	EnableTruncate bool `mapstructure:"enable_truncate"`
 
+	// EnableSingleton is used to override default behavior
+	// of DNS and return only a single host in a round robin
+	// DNS service request rather than all healthy service
+	// members. This is a work around for systems using
+	// getaddrinfo using rule 9 sorting from RFC3484 which
+	// breaks round robin DNS.
+	EnableSingleton bool `mapstructure:"enable_singleton"`
+
 	// MaxStale is used to bound how stale of a result is
 	// accepted for a DNS lookup. This can be used with
 	// AllowStale to limit how old of a value is served up.
@@ -1129,6 +1137,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.DNSConfig.EnableTruncate {
 		result.DNSConfig.EnableTruncate = true
+	}
+	if b.DNSConfig.EnableSingleton {
+		result.DNSConfig.EnableSingleton = true
 	}
 	if b.DNSConfig.MaxStale != 0 {
 		result.DNSConfig.MaxStale = b.DNSConfig.MaxStale

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1268,7 +1268,7 @@ func TestMergeConfig(t *testing.T) {
 			ServiceTTL: map[string]time.Duration{
 				"api": 10 * time.Second,
 			},
-			UDPAnswerLimit: 3,
+			UDPAnswerLimit: 4,
 		},
 		Domain:           "other",
 		LogLevel:         "info",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -521,19 +521,28 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// DNS node ttl, max stale
-	input = `{"dns_config": {"node_ttl": "5s", "max_stale": "15s", "allow_stale": true}}`
+	input = `{"dns_config": {"allow_stale": true, "enable_truncate": false, "max_stale": "15s", "node_ttl": "5s", "only_passing": true, "udp_answer_limit": 6}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if config.DNSConfig.NodeTTL != 5*time.Second {
+	if !config.DNSConfig.AllowStale {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.DNSConfig.EnableTruncate {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.DNSConfig.MaxStale != 15*time.Second {
 		t.Fatalf("bad: %#v", config)
 	}
-	if !config.DNSConfig.AllowStale {
+	if config.DNSConfig.NodeTTL != 5*time.Second {
+		t.Fatalf("bad: %#v", config)
+	}
+	if !config.DNSConfig.OnlyPassing {
+		t.Fatalf("bad: %#v", config)
+	}
+	if config.DNSConfig.UDPAnswerLimit != 6 {
 		t.Fatalf("bad: %#v", config)
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1252,13 +1252,14 @@ func TestMergeConfig(t *testing.T) {
 		DataDir:         "/tmp/bar",
 		DNSRecursors:    []string{"127.0.0.2:1001"},
 		DNSConfig: DNSConfig{
-			NodeTTL: 10 * time.Second,
+			AllowStale:     false,
+			EnableTruncate: true,
+			MaxStale:       30 * time.Second,
+			NodeTTL:        10 * time.Second,
 			ServiceTTL: map[string]time.Duration{
 				"api": 10 * time.Second,
 			},
-			AllowStale:     true,
-			MaxStale:       30 * time.Second,
-			EnableTruncate: true,
+			UDPAnswerLimit: 3,
 		},
 		Domain:           "other",
 		LogLevel:         "info",

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -12,12 +12,13 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/consul/lib"
 	"github.com/miekg/dns"
 )
 
 const (
-	maxServiceResponses = 3 // For UDP only
-	maxRecurseRecords   = 5
+	maxUDPAnswerLimit = 8 // For UDP only
+	maxRecurseRecords = 5
 )
 
 // DNSServer is used to wrap an Agent and expose various
@@ -599,7 +600,7 @@ func (d *DNSServer) preparedQueryLookup(network, datacenter, query string, req, 
 	// match the previous behavior. We can optimize by pushing more filtering
 	// into the query execution, but for now I think we need to get the full
 	// response. We could also choose a large arbitrary number that will
-	// likely work in practice, like 10*maxServiceResponses which should help
+	// likely work in practice, like 10*maxUDPAnswerLimit which should help
 	// reduce bandwidth if there are thousands of nodes available.
 
 	endpoint := d.agent.getEndpoint(preparedQueryEndpoint)
@@ -682,6 +683,9 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 	qName := req.Question[0].Name
 	qType := req.Question[0].Qtype
 	handled := make(map[string]struct{})
+
+	// Post-shuffle: limit the number of nodes we return to the client
+	effectiveRecordLimit := lib.MinInt(d.config.UDPAnswerLimit, maxUDPAnswerLimit)
 	for _, node := range nodes {
 		// Start with the translated address but use the service address,
 		// if specified.
@@ -702,7 +706,11 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 		if records != nil {
 			resp.Answer = append(resp.Answer, records...)
 		}
-		if d.config.EnableSingleton {
+
+		if len(resp.Answer) >= effectiveRecordLimit {
+			if d.config.EnableTruncate {
+				resp.Truncated = true
+			}
 			break
 		}
 	}

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -509,7 +509,7 @@ func trimUDPAnswers(config *DNSConfig, resp *dns.Msg) (trimmed bool) {
 		resp.Answer = resp.Answer[:len(resp.Answer)-1]
 	}
 
-	return len(resp.Answer) < maxAnswers
+	return len(resp.Answer) < numAnswers
 }
 
 // serviceLookup is used to handle a service query

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -702,6 +702,9 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 		if records != nil {
 			resp.Answer = append(resp.Answer, records...)
 		}
+		if d.config.EnableSingleton {
+			break
+		}
 	}
 }
 

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -689,8 +689,6 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 	qType := req.Question[0].Qtype
 	handled := make(map[string]struct{})
 
-	// Post-shuffle: limit the number of nodes we return to the client
-	effectiveRecordLimit := lib.MinInt(d.config.UDPAnswerLimit, maxUDPAnswerLimit)
 	for _, node := range nodes {
 		// Start with the translated address but use the service address,
 		// if specified.
@@ -710,13 +708,6 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 		records := d.formatNodeRecord(node.Node, addr, qName, qType, ttl)
 		if records != nil {
 			resp.Answer = append(resp.Answer, records...)
-		}
-
-		if len(resp.Answer) >= effectiveRecordLimit {
-			if d.config.EnableTruncate {
-				resp.Truncated = true
-			}
-			break
 		}
 	}
 }

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -2153,28 +2153,6 @@ func TestDNS_ServiceLookup_UDPAnswerLimit(t *testing.T) {
 
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
-	// Register a large number of nodes.
-	for i := 0; i < generateNumNodes; i++ {
-		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
-		if rand.Float64() < pctNodesWithIPv6 {
-			nodeAddress = fmt.Sprintf("fe80::%d", i+1)
-		}
-		args := &structs.RegisterRequest{
-			Datacenter: "dc1",
-			Node:       fmt.Sprintf("foo%d", i),
-			Address:    nodeAddress,
-			Service: &structs.NodeService{
-				Service: "web",
-				Port:    8000,
-			},
-		}
-
-		var out struct{}
-		if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-	}
-
 	for i := 0; i < generateNumNodes; i++ {
 		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
 		if rand.Float64() < pctNodesWithIPv6 {

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/miekg/dns"
 )
 
+const (
+	testUDPAnswerLimit     = 4
+	testMaxUDPDNSResponses = 3
+	testGenerateNumNodes   = 12
+	testUDPTruncateLimit   = 8
+)
+
 func makeDNSServer(t *testing.T) (string, *DNSServer) {
 	return makeDNSServerConfig(t, nil, nil)
 }
@@ -26,7 +33,7 @@ func makeDNSServerConfig(
 	if agentFn != nil {
 		agentFn(agentConf)
 	}
-	dnsConf := &DNSConfig{}
+	dnsConf := &DefaultConfig().DNSConfig
 	if dnsFn != nil {
 		dnsFn(dnsConf)
 	}
@@ -1809,7 +1816,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
 	// Register a large set of nodes.
-	for i := 0; i < 3*maxServiceResponses; i++ {
+	for i := 0; i < 2*testMaxUDPDNSResponses; i++ {
 		args := &structs.RegisterRequest{
 			Datacenter: "dc1",
 			Node:       fmt.Sprintf("foo%d", i),
@@ -1856,7 +1863,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 			m := new(dns.Msg)
 			m.SetQuestion(question, dns.TypeANY)
 
-			c := new(dns.Client)
+			c := &dns.Client{Net: "udp"}
 			in, _, err := c.Exchange(m, addr.String())
 			if err != nil {
 				t.Fatalf("err: %v", err)
@@ -1864,7 +1871,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 
 			// Response length should be truncated and we should get
 			// an A record for each response.
-			if len(in.Answer) != maxServiceResponses {
+			if len(in.Answer) != testMaxUDPDNSResponses {
 				t.Fatalf("Bad: %#v", len(in.Answer))
 			}
 
@@ -1903,7 +1910,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
 	// Register nodes a large number of nodes.
-	for i := 0; i < 3*maxServiceResponses; i++ {
+	for i := 0; i < 2*testUDPTruncateLimit; i++ {
 		args := &structs.RegisterRequest{
 			Datacenter: "dc1",
 			Node:       fmt.Sprintf("foo%d", i),
@@ -2044,16 +2051,18 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_MaxResponses(t *testing.T) {
-	dir, srv := makeDNSServer(t)
+	dir, srv := makeDNSServerConfig(t, nil, func(c *DNSConfig) {
+		c.UDPAnswerLimit = testUDPAnswerLimit
+	})
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
 
 	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
 
 	// Register a large number of nodes.
-	for i := 0; i < 6*maxServiceResponses; i++ {
+	for i := 0; i < testUDPAnswerLimit*testMaxUDPDNSResponses; i++ {
 		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
-		if i > 3 {
+		if i > (testUDPAnswerLimit * testMaxUDPDNSResponses / 2) {
 			nodeAddress = fmt.Sprintf("fe80::%d", i+1)
 		}
 		args := &structs.RegisterRequest{
@@ -2094,7 +2103,7 @@ func TestDNS_ServiceLookup_MaxResponses(t *testing.T) {
 		"web.service.consul.",
 		id + ".query.consul.",
 	}
-	for _, question := range questions {
+	for i, question := range questions {
 		m := new(dns.Msg)
 		m.SetQuestion(question, dns.TypeANY)
 
@@ -2105,8 +2114,8 @@ func TestDNS_ServiceLookup_MaxResponses(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		if len(in.Answer) != 3 {
-			t.Fatalf("should receive 3 answers for ANY")
+		if len(in.Answer) != testUDPAnswerLimit {
+			t.Fatalf("should receive %d answers for ANY, received: %d", testUDPAnswerLimit, len(in.Answer))
 		}
 
 		m.SetQuestion(question, dns.TypeA)
@@ -2115,8 +2124,8 @@ func TestDNS_ServiceLookup_MaxResponses(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		if len(in.Answer) != 3 {
-			t.Fatalf("should receive 3 answers for A")
+		if len(in.Answer) != testUDPAnswerLimit {
+			t.Fatalf("%d: should receive %d answers for A, received: %d", i, testUDPAnswerLimit, len(in.Answer))
 		}
 
 		m.SetQuestion(question, dns.TypeAAAA)
@@ -2125,8 +2134,79 @@ func TestDNS_ServiceLookup_MaxResponses(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		if len(in.Answer) != 3 {
-			t.Fatalf("should receive 3 answers for AAAA")
+		if len(in.Answer) != testUDPAnswerLimit {
+			t.Fatalf("should receive %d answers for AAAA, received: %d", testUDPAnswerLimit, len(in.Answer))
+		}
+	}
+}
+
+func TestDNS_ServiceLookup_UDPAnswerLimit(t *testing.T) {
+	dir, srv := makeDNSServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.agent.Shutdown()
+
+	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
+	// Register a large number of nodes.
+	for i := 0; i < testGenerateNumNodes*testMaxUDPDNSResponses; i++ {
+		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
+		// Mix-in a few IPv6 addresses
+		if i > testGenerateNumNodes/2 {
+			nodeAddress = fmt.Sprintf("fe80::%d", i+1)
+		}
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       fmt.Sprintf("foo%d", i),
+			Address:    nodeAddress,
+			Service: &structs.NodeService{
+				Service: "web",
+				Port:    8000,
+			},
+		}
+
+		var out struct{}
+		if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Look up the service directly and via prepared query.
+	questions := []string{
+		"web.service.consul.",
+	}
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeANY)
+
+		addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
+		c := &dns.Client{Net: "udp"}
+		in, _, err := c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != srv.agent.config.DNSConfig.UDPAnswerLimit {
+			t.Fatalf("%d/%d answers received for ANY", len(in.Answer), srv.agent.config.DNSConfig.UDPAnswerLimit)
+		}
+
+		m.SetQuestion(question, dns.TypeA)
+		in, _, err = c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != srv.agent.config.DNSConfig.UDPAnswerLimit {
+			t.Fatalf("%d/%d answers for A", len(in.Answer), srv.agent.config.DNSConfig.UDPAnswerLimit)
+		}
+
+		m.SetQuestion(question, dns.TypeAAAA)
+		in, _, err = c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != srv.agent.config.DNSConfig.UDPAnswerLimit {
+			t.Fatalf("%d/%d answers for AAAA", len(in.Answer), srv.agent.config.DNSConfig.UDPAnswerLimit)
 		}
 	}
 }

--- a/lib/math.go
+++ b/lib/math.go
@@ -1,0 +1,15 @@
+package lib
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func MinInt(a, b int) int {
+	if a > b {
+		return b
+	}
+	return a
+}

--- a/lib/math_test.go
+++ b/lib/math_test.go
@@ -1,0 +1,27 @@
+package lib
+
+import (
+	"testing"
+)
+
+func TestMathMaxInt(t *testing.T) {
+	tests := [][3]int{{1, 2, 2}, {-1, 1, 1}, {2, 0, 2}}
+	for i, _ := range tests {
+		expected := tests[i][2]
+		actual := MaxInt(tests[i][0], tests[i][1])
+		if expected != actual {
+			t.Fatalf("in iteration %d expected %d, got %d", i, expected, actual)
+		}
+	}
+}
+
+func TestMathMinInt(t *testing.T) {
+	tests := [][3]int{{1, 2, 1}, {-1, 1, -1}, {2, 0, 0}}
+	for i, _ := range tests {
+		expected := tests[i][2]
+		actual := MinInt(tests[i][0], tests[i][1])
+		if expected != actual {
+			t.Fatalf("in iteration %d expected %d, got %d", i, expected, actual)
+		}
+	}
+}

--- a/lib/math_test.go
+++ b/lib/math_test.go
@@ -1,14 +1,16 @@
-package lib
+package lib_test
 
 import (
 	"testing"
+
+	"github.com/hashicorp/consul/lib"
 )
 
 func TestMathMaxInt(t *testing.T) {
 	tests := [][3]int{{1, 2, 2}, {-1, 1, 1}, {2, 0, 2}}
 	for i, _ := range tests {
 		expected := tests[i][2]
-		actual := MaxInt(tests[i][0], tests[i][1])
+		actual := lib.MaxInt(tests[i][0], tests[i][1])
 		if expected != actual {
 			t.Fatalf("in iteration %d expected %d, got %d", i, expected, actual)
 		}
@@ -19,7 +21,7 @@ func TestMathMinInt(t *testing.T) {
 	tests := [][3]int{{1, 2, 1}, {-1, 1, -1}, {2, 0, 0}}
 	for i, _ := range tests {
 		expected := tests[i][2]
-		actual := MinInt(tests[i][0], tests[i][1])
+		actual := lib.MinInt(tests[i][0], tests[i][1])
 		if expected != actual {
 			t.Fatalf("in iteration %d expected %d, got %d", i, expected, actual)
 		}

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -509,15 +509,17 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   * <a name="udp_answer_limit"></a><a
   href="#udp_answer_limit">`udp_answer_limit`</a> - Limit the number of
   resource records contained in the answer section of a UDP-based DNS
-  response.  The default number of resource records returned is `3`.  In
-  environments where
+  response.  When answering a question, Consul will use the complete list of
+  matching hosts, shuffle the list randomly, and then limit the number of
+  answers to `udp_answer_limit` (default `3`).  In environments where
   [RFC 3484 Section 6](https://tools.ietf.org/html/rfc3484#section-6) Rule 9
   is implemented and enforced (i.e. DNS answers are always sorted and
   therefore never random), clients may need to set this value to `1` to
-  preserve round-robin DNS (note: [https://tools.ietf.org/html/rfc3484](RFC
-  3484) has been obsoleted by [RFC 6724](https://tools.ietf.org/html/rfc6724)
-  and as a result it should be increasingly uncommon to need to change this
-  value with modern resolvers).
+  preserve the expected randomized distribution behavior (note:
+  [https://tools.ietf.org/html/rfc3484](RFC 3484) has been obsoleted by
+  [RFC 6724](https://tools.ietf.org/html/rfc6724) and as a result it should
+  be increasingly uncommon to need to change this value with modern
+  resolvers).
 
 * <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the
   [`-domain` command-line flag](#_domain).

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -507,28 +507,18 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
     service addresses regardless of the health of the service.
 
   * <a name="udp_answer_limit"></a><a
-  href="#udp_answer_limit">`udp_answer_limit`</a> - Artificially limit the
-  number of resource records contained in the answer section of a UDP-based
-  DNS response.  The default number of resource records returned is `3`.  In
+  href="#udp_answer_limit">`udp_answer_limit`</a> - Limit the number of
+  resource records contained in the answer section of a UDP-based DNS
+  response.  The default number of resource records returned is `3`.  In
   environments where
   [RFC 3484 Section 6](https://tools.ietf.org/html/rfc3484#section-6) Rule 9
-  is implemented and enforced, clients may need to set this value to `1` to
+  is implemented and enforced (i.e. DNS answers are always sorted and
+  therefore never random), clients may need to set this value to `1` to
   preserve randomized DNS round-robin (note:
   [https://tools.ietf.org/html/rfc3484](RFC 3484) has been obsoleted by
-  [RFC 6724](https://tools.ietf.org/html/rfc6724) so it should be uncommon to
-  need to change this value).
-
-  * <a name="udp_answer_limit"></a><a
-  href="#udp_answer_limit">`udp_answer_limit`</a> - Artificially limit the
-  number of resource records contained in the answer section of a UDP-based
-  DNS response.  The default number of resource records returned is `3`.  In
-  environments where
-  [RFC 3484 Section 6](https://tools.ietf.org/html/rfc3484#section-6) Rule 9
-  is implemented and enforced, clients may need to set this value to `1` to
-  preserve randomized DNS round-robin (note:
-  [https://tools.ietf.org/html/rfc3484](RFC 3484) has been obsoleted by
-  [RFC 6724](https://tools.ietf.org/html/rfc6724) so it should be uncommon to
-  need to change this value).
+  [RFC 6724](https://tools.ietf.org/html/rfc6724) and as a result it should
+  be increasingly uncommon to need to change this value with modern
+  resolvers).
 
 * <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the
   [`-domain` command-line flag](#_domain).

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -506,6 +506,18 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
     critical). Set to false to have the querying agent include all node and
     service addresses regardless of the health of the service.
 
+  * <a name="udp_answer_limit"></a><a
+  href="#udp_answer_limit">`udp_answer_limit`</a> - Artificially limit the
+  number of resource records contained in the answer section of a UDP-based
+  DNS response.  The default number of resource records returned is `3`.  In
+  environments where
+  [RFC 3484 Section 6](https://tools.ietf.org/html/rfc3484#section-6) Rule 9
+  is implemented and enforced, clients may need to set this value to `1` to
+  preserve randomized DNS round-robin (note:
+  [https://tools.ietf.org/html/rfc3484](RFC 3484) has been obsoleted by
+  [RFC 6724](https://tools.ietf.org/html/rfc6724) so it should be uncommon to
+  need to change this value).
+
 * <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the
   [`-domain` command-line flag](#_domain).
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -514,11 +514,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   [RFC 3484 Section 6](https://tools.ietf.org/html/rfc3484#section-6) Rule 9
   is implemented and enforced (i.e. DNS answers are always sorted and
   therefore never random), clients may need to set this value to `1` to
-  preserve randomized DNS round-robin (note:
-  [https://tools.ietf.org/html/rfc3484](RFC 3484) has been obsoleted by
-  [RFC 6724](https://tools.ietf.org/html/rfc6724) and as a result it should
-  be increasingly uncommon to need to change this value with modern
-  resolvers).
+  preserve round-robin DNS (note: [https://tools.ietf.org/html/rfc3484](RFC
+  3484) has been obsoleted by [RFC 6724](https://tools.ietf.org/html/rfc6724)
+  and as a result it should be increasingly uncommon to need to change this
+  value with modern resolvers).
 
 * <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the
   [`-domain` command-line flag](#_domain).

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -499,12 +499,12 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   using TCP to get the full set of records.
 
   * <a name="only_passing"></a><a href="#only_passing">`only_passing`</a>
-    When set to true, the default, the querying agent will only receive node
-    or service addresses for healthy services.  A healthy service is defined
-    as a service with one or more healthchecks and all defined healthchecks
-    for the service are in a passing or warning state (i.e. not
-    critical). Set to false to have the querying agent include all node and
-    service addresses regardless of the health of the service.
+  When set to true, the default, the querying agent will only receive node
+  or service addresses for healthy services.  A healthy service is defined
+  as a service with one or more healthchecks and all defined healthchecks
+  for the service are in a passing or warning state (i.e. not
+  critical). Set to false to have the querying agent include all node and
+  service addresses regardless of the health of the service.
 
   * <a name="udp_answer_limit"></a><a
   href="#udp_answer_limit">`udp_answer_limit`</a> - Limit the number of


### PR DESCRIPTION
Based on work done by @fusiondog in #1583, extend the concept to use an integer instead of a boolean.  This is required to work around RFC3484 Section 6 Rule 9.

Fixes: #1583 && #1481