### PR TITLE
Removes the obsolete deps target from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ branches:
   only:
     - master
 
-install: make deps
+install: make
 script:
   - make test
 


### PR DESCRIPTION
@sean- this is a legit borkage. Let's see if we get that weird error from the CI build for this branch.