### PR TITLE
Adds support for EnableTagOverride to the API client.

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -18,11 +18,12 @@ type AgentCheck struct {
 
 // AgentService represents a service known to the agent
 type AgentService struct {
-	ID      string
-	Service string
-	Tags    []string
-	Port    int
-	Address string
+	ID                string
+	Service           string
+	Tags              []string
+	Port              int
+	Address           string
+	EnableTagOverride bool
 }
 
 // AgentMember represents a cluster member known to the agent
@@ -42,13 +43,14 @@ type AgentMember struct {
 
 // AgentServiceRegistration is used to register a new service
 type AgentServiceRegistration struct {
-	ID      string   `json:",omitempty"`
-	Name    string   `json:",omitempty"`
-	Tags    []string `json:",omitempty"`
-	Port    int      `json:",omitempty"`
-	Address string   `json:",omitempty"`
-	Check   *AgentServiceCheck
-	Checks  AgentServiceChecks
+	ID                string   `json:",omitempty"`
+	Name              string   `json:",omitempty"`
+	Tags              []string `json:",omitempty"`
+	Port              int      `json:",omitempty"`
+	Address           string   `json:",omitempty"`
+	EnableTagOverride bool     `json:",omitempty"`
+	Check             *AgentServiceCheck
+	Checks            AgentServiceChecks
 }
 
 // AgentCheckRegistration is used to register a new check

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -196,6 +196,49 @@ func TestAgent_ServiceAddress(t *testing.T) {
 	}
 }
 
+func TestAgent_EnableTagOverride(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	agent := c.Agent()
+
+	reg1 := &AgentServiceRegistration{
+		Name:              "foo1",
+		Port:              8000,
+		Address:           "192.168.0.42",
+		EnableTagOverride: true,
+	}
+	reg2 := &AgentServiceRegistration{
+		Name: "foo2",
+		Port: 8000,
+	}
+	if err := agent.ServiceRegister(reg1); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if err := agent.ServiceRegister(reg2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	services, err := agent.Services()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if _, ok := services["foo1"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
+	if services["foo1"].EnableTagOverride != true {
+		t.Fatalf("tag override not set on service foo1: %v", services)
+	}
+	if _, ok := services["foo2"]; !ok {
+		t.Fatalf("missing service: %v", services)
+	}
+	if services["foo2"].EnableTagOverride != false {
+		t.Fatalf("tag override set on service foo2: %v", services)
+	}
+}
+
 func TestAgent_Services_MultipleChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -6,13 +6,14 @@ type Node struct {
 }
 
 type CatalogService struct {
-	Node           string
-	Address        string
-	ServiceID      string
-	ServiceName    string
-	ServiceAddress string
-	ServiceTags    []string
-	ServicePort    int
+	Node                     string
+	Address                  string
+	ServiceID                string
+	ServiceName              string
+	ServiceAddress           string
+	ServiceTags              []string
+	ServicePort              int
+	ServiceEnableTagOverride bool
 }
 
 type CatalogNode struct {


### PR DESCRIPTION
Fixes #1709 by adding `EnableTagOverride` to the agent and catalog API structures.