### PR TITLE
Add ubuntu AMIs for eu-west-1 and eu-central-1 to the map.

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -16,6 +16,8 @@ variable "ami" {
     default = {
         us-east-1-ubuntu = "ami-83c525e8"
         us-west-2-ubuntu = "ami-57e8d767"
+        eu-west-1-ubuntu = "ami-47a23a30"
+        eu-central-1-ubuntu = "ami-accff2b1"
         us-east-1-rhel6 = "ami-b0fed2d8"
         us-west-2-rhel6 = "ami-2faa861f"
         us-east-1-centos6 = "ami-c2a818aa"


### PR DESCRIPTION
Used image: ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20150325

I just added two new AMI entries to the map. Due to the inability to pass maps to a module, I think it is, at least for this module, the best idea to extend it with all needed AMIs from around the world.

Cheers!
Mario