### PR TITLE
Takes away Go tip build which is failing for odd reasons.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.6
-  - tip
 
 branches:
   only:


### PR DESCRIPTION
This should cut down on build noise. When we get further with 1.6 we can reintroduce the tip build to help spot issues with the next version of Go.