### PR TITLE
add accept header */* for agent check

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -391,6 +391,7 @@ func (c *CheckHTTP) check() {
 	}
 
 	req.Header.Set("User-Agent", HttpUserAgent)
+	req.Header.Set("Accept", "*/*")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Recent changes in https://github.com/emicklei/go-restful make that package more stringent about the Accept header on requests. (https://github.com/emicklei/go-restful/issues/265)

The consul agent check currently sends an empty Accept header which causes the default behavior of go-restful to return a 406. Sending Accept: */* solves this issue.