### PR TITLE
Adds a PUT-based API for TTL checks and retains output on timeouts.

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -167,6 +167,58 @@ func (s *HTTPServer) AgentCheckFail(resp http.ResponseWriter, req *http.Request)
 	return nil, nil
 }
 
+// checkUpdate is the payload for a PUT to AgentCheckUpdate.
+type checkUpdate struct {
+	// Status us one of the structs.Health* states, "passing", "warning", or
+	// "critical".
+	Status string
+
+	// Output is the information to post to the UI for operators as the
+	// output of the process that decided to hit the TTL check. This is
+	// different from the note field that's associated with the check
+	// itself.
+	Output string
+}
+
+// AgentCheckUpdate is a PUT-based alternative to the GET-based Pass/Warn/Fail
+// APIs.
+func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != "PUT" {
+		resp.WriteHeader(405)
+		return nil, nil
+	}
+
+	var update checkUpdate
+	if err := decodeBody(req, &update, nil); err != nil {
+		resp.WriteHeader(400)
+		resp.Write([]byte(fmt.Sprintf("Request decode failed: %v", err)))
+		return nil, nil
+	}
+
+	switch update.Status {
+	case structs.HealthPassing:
+	case structs.HealthWarning:
+	case structs.HealthCritical:
+	default:
+		resp.WriteHeader(400)
+		resp.Write([]byte(fmt.Sprintf("Invalid check status: '%s'", update.Status)))
+		return nil, nil
+	}
+
+	total := len(update.Output)
+	if total > CheckBufSize {
+		update.Output = fmt.Sprintf("%s\n...\nCaptured %d of %d bytes",
+			update.Output[:CheckBufSize], CheckBufSize, total)
+	}
+
+	checkID := strings.TrimPrefix(req.URL.Path, "/v1/agent/check/update/")
+	if err := s.agent.UpdateCheck(checkID, update.Status, update.Output); err != nil {
+		return nil, err
+	}
+	s.syncChanges()
+	return nil, nil
+}
+
 func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args ServiceDefinition
 	// Fixup the type decode of TTL or Interval if a check if provided

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -207,7 +207,7 @@ func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Reques
 
 	total := len(update.Output)
 	if total > CheckBufSize {
-		update.Output = fmt.Sprintf("%s\n...\nCaptured %d of %d bytes",
+		update.Output = fmt.Sprintf("%s ... (captured %d of %d bytes)",
 			update.Output[:CheckBufSize], CheckBufSize, total)
 	}
 

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -283,10 +283,10 @@ func (c *CheckTTL) getExpiredOutput() string {
 
 	const prefix = "TTL expired"
 	if c.lastOutput == "" {
-		return fmt.Sprintf("%s (no output was available before timeout)", prefix)
+		return prefix
 	}
 
-	return fmt.Sprintf("%s (last output before timeout follows)\n\n%s", prefix, c.lastOutput)
+	return fmt.Sprintf("%s (last output before timeout follows): %s", prefix, c.lastOutput)
 }
 
 // SetStatus is used to update the status of the check,

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -232,6 +232,9 @@ type CheckTTL struct {
 
 	timer *time.Timer
 
+	lastOutput     string
+	lastOutputLock sync.RWMutex
+
 	stop     bool
 	stopCh   chan struct{}
 	stopLock sync.Mutex
@@ -265,12 +268,25 @@ func (c *CheckTTL) run() {
 		case <-c.timer.C:
 			c.Logger.Printf("[WARN] agent: Check '%v' missed TTL, is now critical",
 				c.CheckID)
-			c.Notify.UpdateCheck(c.CheckID, structs.HealthCritical, "TTL expired")
+			c.Notify.UpdateCheck(c.CheckID, structs.HealthCritical, c.getExpiredOutput())
 
 		case <-c.stopCh:
 			return
 		}
 	}
+}
+
+// getExpiredOutput formats the output for the case when the TTL is expired.
+func (c *CheckTTL) getExpiredOutput() string {
+	c.lastOutputLock.RLock()
+	defer c.lastOutputLock.RUnlock()
+
+	const prefix = "TTL expired"
+	if c.lastOutput == "" {
+		return fmt.Sprintf("%s (no output was available before timeout)", prefix)
+	}
+
+	return fmt.Sprintf("%s (last output before timeout follows)\n\n%s", prefix, c.lastOutput)
 }
 
 // SetStatus is used to update the status of the check,
@@ -279,6 +295,12 @@ func (c *CheckTTL) SetStatus(status, output string) {
 	c.Logger.Printf("[DEBUG] agent: Check '%v' status is now %v",
 		c.CheckID, status)
 	c.Notify.UpdateCheck(c.CheckID, status, output)
+
+	// Store the last output so we can retain it if the TTL expires.
+	c.lastOutputLock.Lock()
+	c.lastOutput = output
+	c.lastOutputLock.Unlock()
+
 	c.timer.Reset(c.TTL)
 }
 

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -150,7 +151,7 @@ func TestCheckTTL(t *testing.T) {
 	defer check.Stop()
 
 	time.Sleep(50 * time.Millisecond)
-	check.SetStatus(structs.HealthPassing, "")
+	check.SetStatus(structs.HealthPassing, "test-output")
 
 	if mock.updates["foo"] != 1 {
 		t.Fatalf("should have 1 updates %v", mock.updates)
@@ -175,6 +176,10 @@ func TestCheckTTL(t *testing.T) {
 
 	if mock.state["foo"] != structs.HealthCritical {
 		t.Fatalf("should be critical %v", mock.state)
+	}
+
+	if !strings.Contains(mock.output["foo"], "test-output") {
+		t.Fatalf("should have retained output %v", mock.output)
 	}
 }
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -232,6 +232,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/agent/check/pass/", s.wrap(s.AgentCheckPass))
 	s.mux.HandleFunc("/v1/agent/check/warn/", s.wrap(s.AgentCheckWarn))
 	s.mux.HandleFunc("/v1/agent/check/fail/", s.wrap(s.AgentCheckFail))
+	s.mux.HandleFunc("/v1/agent/check/update/", s.wrap(s.AgentCheckUpdate))
 
 	s.mux.HandleFunc("/v1/agent/service/register", s.wrap(s.AgentRegisterService))
 	s.mux.HandleFunc("/v1/agent/service/deregister/", s.wrap(s.AgentDeregisterService))

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -25,9 +25,10 @@ The following endpoints are supported:
 * [`/v1/agent/force-leave/<node>`](#agent_force_leave)>: Forces removal of a node
 * [`/v1/agent/check/register`](#agent_check_register) : Registers a new local check
 * [`/v1/agent/check/deregister/<checkID>`](#agent_check_deregister) : Deregisters a local check
-* [`/v1/agent/check/pass/<checkID>`](#agent_check_pass) : Marks a local test as passing
-* [`/v1/agent/check/warn/<checkID>`](#agent_check_warn) : Marks a local test as warning
-* [`/v1/agent/check/fail/<checkID>`](#agent_check_fail) : Marks a local test as critical
+* [`/v1/agent/check/pass/<checkID>`](#agent_check_pass) : Marks a local check as passing
+* [`/v1/agent/check/warn/<checkID>`](#agent_check_warn) : Marks a local check as warning
+* [`/v1/agent/check/fail/<checkID>`](#agent_check_fail) : Marks a local check as critical
+* [`/v1/agent/check/update/<checkID>`](#agent_check_update) : Updates a local check
 * [`/v1/agent/service/register`](#agent_service_register) : Registers a new local service
 * [`/v1/agent/service/deregister/<serviceID>`](#agent_service_deregister) : Deregisters a local service
 * [`/v1/agent/service/maintenance/<serviceID>`](#agent_service_maintenance) : Manages service maintenance mode
@@ -310,8 +311,9 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to `passing`
 and the TTL clock is reset.
 
-The optional "?note=" query parameter can be used to associate a human-readable message 
-with the status of the check.
+The optional "?note=" query parameter can be used to associate a human-readable message
+with the status of the check. This will be passed through to the check's `Output` field
+in the check endpoints.
 
 The return code is 200 on success.
 
@@ -321,8 +323,9 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to `warning`,
 and the TTL clock is reset.
 
-The optional "?note=" query parameter can be used to associate a human-readable message 
-with the status of the check.
+The optional "?note=" query parameter can be used to associate a human-readable message
+with the status of the check. This will be passed through to the check's `Output` field
+in the check endpoints.
 
 The return code is 200 on success.
 
@@ -332,8 +335,33 @@ This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.
 When this endpoint is accessed via a GET, the status of the check is set to `critical`,
 and the TTL clock is reset.
 
-The optional "?note=" query parameter can be used to associate a human-readable message 
-with the status of the check.
+The optional "?note=" query parameter can be used to associate a human-readable message
+with the status of the check. This will be passed through to the check's `Output` field
+in the check endpoints.
+
+The return code is 200 on success.
+
+### <a name="agent_check_update"></a> /v1/agent/check/update/\<checkId\>
+
+This endpoint is used with a check that is of the [TTL type](/docs/agent/checks.html).
+When this endpoint is accessed with a PUT, the status and output of the check are
+updated and the TTL clock is reset.
+
+This endpoint expects a JSON request body to be put. The request body must look like:
+
+```javascript
+{
+  "Status": "passing",
+  "Output": "curl reported a failure:\n\n..."
+}
+```
+
+The `Status` field is mandatory, and must be set to "passing", "warning", or "critical".
+
+`Output` is an optional field that will associate a human-readable message with the status
+of the check, such as the output of the checking script or process. This will be truncated
+if it exceeds 4KB in size. This will be passed through to the check's `Output` field in the
+check endpoints.
 
 The return code is 200 on success.
 


### PR DESCRIPTION
This adds a new PUT-based /v1/agent/check/update/<id> API that's easier to pass large output to. While we were in here, we also fixed #1784 so that when the TTL expires, operators can see the last output before the check expired.