### PR TITLE
UDP health checks

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -44,6 +44,7 @@ type CheckType struct {
 	Script            string
 	HTTP              string
 	TCP               string
+	UDP               string
 	Interval          time.Duration
 	DockerContainerID string
 	Shell             string
@@ -59,7 +60,7 @@ type CheckTypes []*CheckType
 
 // Valid checks if the CheckType is valid
 func (c *CheckType) Valid() bool {
-	return c.IsTTL() || c.IsMonitor() || c.IsHTTP() || c.IsTCP() || c.IsDocker()
+	return c.IsTTL() || c.IsMonitor() || c.IsHTTP() || c.IsTCP() || c.IsUDP() || c.IsDocker()
 }
 
 // IsTTL checks if this is a TTL type
@@ -80,6 +81,11 @@ func (c *CheckType) IsHTTP() bool {
 // IsTCP checks if this is a TCP type
 func (c *CheckType) IsTCP() bool {
 	return c.TCP != "" && c.Interval != 0
+}
+
+// IsUDP checks if this is a UDP type
+func (c *CheckType) IsUDP() bool {
+	return c.UDP != "" && c.Interval != 0
 }
 
 func (c *CheckType) IsDocker() bool {
@@ -457,6 +463,7 @@ type CheckTCP struct {
 	Notify   CheckNotifier
 	CheckID  string
 	TCP      string
+	UDP      string
 	Interval time.Duration
 	Timeout  time.Duration
 	Logger   *log.Logger
@@ -506,12 +513,18 @@ func (c *CheckTCP) Stop() {
 func (c *CheckTCP) run() {
 	// Get the randomized initial pause time
 	initialPauseTime := lib.RandomStagger(c.Interval)
-	c.Logger.Printf("[DEBUG] agent: pausing %v before first socket connection of %s", initialPauseTime, c.TCP)
+	addr := c.TCP
+	check := c.check
+	if c.UDP != "" {
+		addr = c.UDP
+		check = c.checkUDP
+	}
+	c.Logger.Printf("[DEBUG] agent: pausing %v before first socket connection of %s", initialPauseTime, addr)
 	next := time.After(initialPauseTime)
 	for {
 		select {
 		case <-next:
-			c.check()
+			check()
 			next = time.After(c.Interval)
 		case <-c.stopCh:
 			return
@@ -530,6 +543,33 @@ func (c *CheckTCP) check() {
 	conn.Close()
 	c.Logger.Printf("[DEBUG] agent: check '%v' is passing", c.CheckID)
 	c.Notify.UpdateCheck(c.CheckID, structs.HealthPassing, fmt.Sprintf("TCP connect %s: Success", c.TCP))
+}
+
+// checkUDP is invoked periodically to perform the UDP check
+func (c *CheckTCP) checkUDP() {
+	conn, err := c.dialer.Dial(`udp`, c.UDP)
+	if err == nil {
+		b := []byte("CONNECTED-MODE SOCKET")
+		err = conn.SetDeadline(time.Now().Add(c.dialer.Timeout))
+		if err == nil {
+			_, err = conn.Write(b)
+			if err == nil {
+				buf := make([]byte, 1024)
+				_, err = conn.Read(buf)
+				if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
+					err = nil
+				}
+			}
+		}
+	}
+	if err != nil {
+		c.Logger.Printf("[WARN] agent: socket connection failed '%s': %s", c.UDP, err)
+		c.Notify.UpdateCheck(c.CheckID, structs.HealthCritical, err.Error())
+		return
+	}
+	conn.Close()
+	c.Logger.Printf("[DEBUG] agent: check '%v' is passing", c.CheckID)
+	c.Notify.UpdateCheck(c.CheckID, structs.HealthPassing, fmt.Sprintf("UDP connect %s: Success", c.UDP))
 }
 
 // A custom interface since go-dockerclient doesn't have one

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -406,6 +406,81 @@ func TestCheckTCPPassing(t *testing.T) {
 	tcpServer.Close()
 }
 
+func mockUDPServer(network string) *net.UDPConn {
+	var (
+		addr string
+	)
+
+	if network == `udp6` {
+		addr = `[::1]:0`
+	} else {
+		addr = `127.0.0.1:0`
+	}
+
+	udpAddr, err := net.ResolveUDPAddr(network, addr)
+	if err != nil {
+		panic(err)
+	}
+	listener, err := net.ListenUDP(network, udpAddr)
+	if err != nil {
+		panic(err)
+	}
+
+	return listener
+}
+
+func expectUDPStatus(t *testing.T, udp string, status string) {
+	mock := &MockNotify{
+		state:   make(map[string]string),
+		updates: make(map[string]int),
+		output:  make(map[string]string),
+	}
+	check := &CheckTCP{
+		Notify:   mock,
+		CheckID:  "foo",
+		UDP:      udp,
+		Interval: 10 * time.Millisecond,
+		Logger:   log.New(os.Stderr, "", log.LstdFlags),
+	}
+	check.Start()
+	defer check.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Should have at least 2 updates
+	if mock.updates["foo"] < 2 {
+		t.Fatalf("should have 2 updates %v", mock.updates)
+	}
+
+	if mock.state["foo"] != status {
+		t.Fatalf("should be %v %v", status, mock.state)
+	}
+}
+
+func TestCheckUDPCritical(t *testing.T) {
+	var (
+		udpServer *net.UDPConn
+	)
+
+	udpServer = mockUDPServer(`udp`)
+	expectUDPStatus(t, `127.0.0.1:0`, "critical")
+	udpServer.Close()
+}
+
+func TestCheckUDPPassing(t *testing.T) {
+	var (
+		udpServer *net.UDPConn
+	)
+
+	udpServer = mockUDPServer(`udp`)
+	expectUDPStatus(t, udpServer.LocalAddr().String(), "passing")
+	udpServer.Close()
+
+	udpServer = mockUDPServer(`udp6`)
+	expectUDPStatus(t, udpServer.LocalAddr().String(), "passing")
+	udpServer.Close()
+}
+
 // A fake docker client to test happy path scenario
 type fakeDockerClientWithNoErrors struct {
 }


### PR DESCRIPTION
New feature: UDP health checks.

UDP health checks are available from [Google Cloud Monitoring](https://cloud.google.com/monitoring/get-started#create_an_uptime_check), [google/seesaw](https://github.com/google/seesaw/blob/e8b39dd873bfb6ef58f40920ecdbe84078ec6805/healthcheck/udp.go), [Fortinet](http://help.fortinet.com/coyotepoint/10-3-2/Content/Health_Checks/TLHC_L4_HC.htm), [Brocade ServerIron](http://community.brocade.com/t5/Application-Delivery-ADX/Health-Checking-101/ta-p/3103), [Nagios](https://www.monitoring-plugins.org/doc/man/check_udp.html) and the feature is [headed for Kubernetes too](https://github.com/kubernetes/kubernetes/pull/14431).

I have modeled this UDP health check on these above implementations, where details were available. 

This check attempts to open a socket to the address and port, and writes to the socket.  A "connection refused" is treated as a failure, but if the connection is accepted and the server simply does not respond, that is treated as a success.  I am open to any improvements to tune this check.

Thanks for your work!
