### PR TITLE
added support for OPTIONS request on KVSEndpoint

### DIFF
--- a/command/agent/kvs_endpoint.go
+++ b/command/agent/kvs_endpoint.go
@@ -37,6 +37,8 @@ func (s *HTTPServer) KVSEndpoint(resp http.ResponseWriter, req *http.Request) (i
 
 	// Switch on the method
 	switch req.Method {
+	case "OPTIONS":
+		return s.KVSOptions(resp, req, &args)
 	case "GET":
 		if keyList {
 			return s.KVSGetKeys(resp, req, &args)
@@ -51,6 +53,10 @@ func (s *HTTPServer) KVSEndpoint(resp http.ResponseWriter, req *http.Request) (i
 		resp.WriteHeader(405)
 		return nil, nil
 	}
+}
+
+func (s *HTTPServer) KVSOptions(resp http.ResponseWriter, req *http.Request, args *structs.KeyRequest) (interface{}, error) {
+	return true, nil
 }
 
 // KVSGet handles a GET request


### PR DESCRIPTION
For CORS this means that preflight request should now return `200` instead of `405`.
