### PR TITLE
Obfuscate token for lookupACL error

### DIFF
--- a/consul/acl.go
+++ b/consul/acl.go
@@ -180,7 +180,14 @@ func (c *aclCache) lookupACL(id, authDC string) (acl.ACL, error) {
 	if strings.Contains(err.Error(), aclNotFound) {
 		return nil, errors.New(aclNotFound)
 	} else {
-		c.logger.Printf("[ERR] consul.acl: Failed to get policy for '%s': %v", id, err)
+		s := id
+		// Print last 3 chars of the token if long enough, otherwise completly hide it
+		if len(s) > 3 {
+			s = fmt.Sprintf("token ending in '%s'", s[len(s)-1:])
+		} else {
+			s = redactedToken
+		}
+		c.logger.Printf("[ERR] consul.acl: Failed to get policy for %s: %v", s, err)
 	}
 
 	// Unable to refresh, apply the down policy

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -183,7 +183,7 @@ func (c *aclCache) lookupACL(id, authDC string) (acl.ACL, error) {
 		s := id
 		// Print last 3 chars of the token if long enough, otherwise completly hide it
 		if len(s) > 3 {
-			s = fmt.Sprintf("token ending in '%s'", s[len(s)-1:])
+			s = fmt.Sprintf("token ending in '%s'", s[len(s)-3:])
 		} else {
 			s = redactedToken
 		}


### PR DESCRIPTION
Attempt to obfuscate the ACL token if it's long enough as the current log message exposes the entire token. Token lookup can be for an ACL with sufficiently open (and therefore dangerous) policy, such as the master ACL token.