### PR TITLE
Clarification for advertise_addrs.rpc

### DIFF
--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -395,7 +395,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   This is a nested setting that allows the following keys:
   * `serf_lan` - The SerfLan address. Accepts values in the form of "host:port" like "10.23.31.101:8301".
   * `serf_wan` - The SerfWan address. Accepts values in the form of "host:port" like "10.23.31.101:8302".
-  * `rpc` - The RPC address. Accepts values in the form of "host:port" like "10.23.31.101:8400".
+  * `rpc` - The server RPC address. Accepts values in the form of "host:port" like "10.23.31.101:8300".
 
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).


### PR DESCRIPTION
Clarification for advertise_addrs.rpc as it sets the server RPC port (default 8300)