### PR TITLE
command: escape the script string provided to lock

### DIFF
--- a/command/lock.go
+++ b/command/lock.go
@@ -131,7 +131,7 @@ func (c *LockCommand) run(args []string, lu **LockUnlock) int {
 	}
 	prefix := extra[0]
 	prefix = strings.TrimPrefix(prefix, "/")
-	script := strings.Join(extra[1:], " ")
+	script := strings.Join(escapeScript(extra[1:]), " ")
 
 	// Calculate a session name if none provided
 	if name == "" {
@@ -438,6 +438,19 @@ func (c *LockCommand) killChild(childDone chan struct{}) error {
 
 func (c *LockCommand) Synopsis() string {
 	return "Execute a command holding a lock"
+}
+
+// escapeScript escapes the given script so it can be safely used afterwards.
+func escapeScript(script []string) []string {
+	for k, v := range script {
+		// If the script argument is itself composed of multiple strings,
+		// escape it with double quotes.
+		parts := strings.SplitN(v, " ", 2)
+		if len(parts) > 1 {
+			script[k] = "\"" + v + "\""
+		}
+	}
+	return script
 }
 
 // LockUnlock is used to abstract over the differences between


### PR DESCRIPTION
This commits deals with executions of the lock command that look like this:

    $ consul lock / mkdir "a b" c

Before this commit, three directories would be created: a, b and c. With this
commit, only two will be created: "a b" and c; which is what the user expects.

I've added a specific test for it and I've also modified the rest of the tests
to simulate better what's actually being passed to the CLI.

Fixes #1621

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>