### PR TITLE
[proposal] command: deprecated the -dc flag in the agent CLI

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -62,6 +62,7 @@ func (c *Command) readConfig() *Config {
 	var retryIntervalWan string
 	var dnsRecursors []string
 	var dev bool
+	var dcDeprecated string
 	cmdFlags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
 
@@ -72,7 +73,8 @@ func (c *Command) readConfig() *Config {
 
 	cmdFlags.StringVar(&cmdConfig.LogLevel, "log-level", "", "log level")
 	cmdFlags.StringVar(&cmdConfig.NodeName, "node", "", "node name")
-	cmdFlags.StringVar(&cmdConfig.Datacenter, "dc", "", "node datacenter")
+	cmdFlags.StringVar(&dcDeprecated, "dc", "", "node datacenter (deprecated: use 'datacenter' instead)")
+	cmdFlags.StringVar(&cmdConfig.Datacenter, "datacenter", "", "node datacenter")
 	cmdFlags.StringVar(&cmdConfig.DataDir, "data-dir", "", "path to the data directory")
 	cmdFlags.BoolVar(&cmdConfig.EnableUi, "ui", false, "enable the built-in web UI")
 	cmdFlags.StringVar(&cmdConfig.UiDir, "ui-dir", "", "path to the web UI directory")
@@ -204,6 +206,14 @@ func (c *Command) readConfig() *Config {
 				c.Ui.Error("WARNING: WAN keyring exists but -encrypt given, using keyring")
 			}
 		}
+	}
+
+	// Output a warning if the 'dc' flag has been used.
+	if dcDeprecated != "" {
+		c.Ui.Error("WARNING: the 'dc' flag has been deprecated. Use 'datacenter' instead")
+
+		// Making sure that we don't break previous versions.
+		config.Datacenter = dcDeprecated
 	}
 
 	// Ensure the datacenter is always lowercased. The DNS endpoints automatically
@@ -980,7 +990,8 @@ Options:
   -data-dir=path           Path to a data directory to store agent state
   -recursor=1.2.3.4        Address of an upstream DNS server.
                            Can be specified multiple times.
-  -dc=east-aws             Datacenter of the agent
+  -dc=east-aws             Datacenter of the agent (deprecated: use 'datacenter' instead).
+  -datacenter=east-aws     Datacenter of the agent.
   -encrypt=key             Provides the gossip encryption key
   -join=1.2.3.4            Address of an agent to join at start time.
                            Can be specified multiple times.

--- a/website/source/docs/agent/basics.html.markdown
+++ b/website/source/docs/agent/basics.html.markdown
@@ -55,8 +55,8 @@ There are several important messages that [`consul agent`](/docs/commands/agent.
 
 * **Datacenter**: This is the datacenter in which the agent is configured to run.
  Consul has first-class support for multiple datacenters; however, to work efficiently,
- each node must be configured to report its datacenter. The [`-dc`](/docs/agent/options.html#_dc) flag
- can be used to set the datacenter. For single-DC configurations, the agent
+ each node must be configured to report its datacenter. The [`-datacenter`](/docs/agent/options.html#_datacenter)
+ flag can be used to set the datacenter. For single-DC configurations, the agent
  will default to "dc1".
 
 * **Server**: This indicates whether the agent is running in server or client mode.

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -134,7 +134,7 @@ The options below are all specified on the command-line.
   prototyping or developing against the API. This mode is **not** intended for
   production use as it does not write any data to disk.
 
-* <a name="_dc"></a><a href="#_dc">`-dc`</a> - This flag controls the datacenter in
+* <a name="_datacenter"></a><a href="#_datacenter">`-datacenter`</a> - This flag controls the datacenter in
   which the agent is running. If not provided,
   it defaults to "dc1". Consul has first-class support for multiple datacenters, but
   it relies on proper configuration. Nodes in the same datacenter should be on a single
@@ -448,7 +448,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   [`-client` command-line flag](#_client).
 
 * <a name="datacenter"></a><a href="#datacenter">`datacenter`</a> Equivalent to the
-  [`-dc` command-line flag](#_dc).
+  [`-datacenter` command-line flag](#_datacenter).
 
 * <a name="data_dir"></a><a href="#data_dir">`data_dir`</a> Equivalent to the
   [`-data-dir` command-line flag](#_data_dir).


### PR DESCRIPTION
The `-dc` flag from the agent CLI command has been deprecated in favor of
`-datacenter`. This is done this way because:

- Other CLI commands used `-datacenter`. See: event, exec and watch.
- The agent configuration file uses `datacenter`.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>