### PR TITLE
Used 'unconvert' to remove unneeded conversions

### DIFF
--- a/command/members.go
+++ b/command/members.go
@@ -108,7 +108,7 @@ func (c *MembersCommand) Run(args []string) int {
 
 	// Generate the columnized version
 	output := columnize.SimpleFormat(result)
-	c.Ui.Output(string(output))
+	c.Ui.Output(output)
 
 	return 0
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -384,7 +384,7 @@ func (s *TestServer) GetKV(key string) []byte {
 		s.t.Fatalf("err: %s", err)
 	}
 
-	return []byte(v)
+	return v
 }
 
 // PopulateKV fills the Consul KV with data from a generic map.


### PR DESCRIPTION
I've removed unneeded conversions by performing the following commands:

    $ go get -u github.com/mdempsky/unconvert
    $ go list ./... | grep -v vendor | xargs unconvert -apply

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>