### PR TITLE
Add leader address to consul stats

### DIFF
--- a/command/members.go
+++ b/command/members.go
@@ -67,11 +67,6 @@ func (c *MembersCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
-	leader, err := client.Stats()
-	if err == nil {
-		c.Ui.Output(fmt.Sprintf("Leader: %s", leader["consul"]["leader_name"]))
-	}
-
 	var members []agent.Member
 	if wan {
 		members, err = client.WANMembers()

--- a/command/members.go
+++ b/command/members.go
@@ -67,6 +67,11 @@ func (c *MembersCommand) Run(args []string) int {
 	}
 	defer client.Close()
 
+	leader, err := client.Stats()
+	if err == nil {
+		c.Ui.Output(fmt.Sprintf("Leader: %s", leader["consul"]["leader_name"]))
+	}
+
 	var members []agent.Member
 	if wan {
 		members, err = client.WANMembers()

--- a/consul/server.go
+++ b/consul/server.go
@@ -733,6 +733,7 @@ func (s *Server) Stats() map[string]map[string]string {
 		"consul": map[string]string{
 			"server":            "true",
 			"leader":            fmt.Sprintf("%v", s.IsLeader()),
+			"leader_name":       s.raft.Leader(),
 			"bootstrap":         fmt.Sprintf("%v", s.config.Bootstrap),
 			"known_datacenters": toString(uint64(len(s.remoteConsuls))),
 		},

--- a/consul/server.go
+++ b/consul/server.go
@@ -733,7 +733,7 @@ func (s *Server) Stats() map[string]map[string]string {
 		"consul": map[string]string{
 			"server":            "true",
 			"leader":            fmt.Sprintf("%v", s.IsLeader()),
-			"leader_name":       s.raft.Leader(),
+			"leader_addr":       s.raft.Leader(),
 			"bootstrap":         fmt.Sprintf("%v", s.config.Bootstrap),
 			"known_datacenters": toString(uint64(len(s.remoteConsuls))),
 		},


### PR DESCRIPTION
Realized that https://github.com/hashicorp/consul/pull/1378 won't work properly on non-server nodes (leader will always be blank) so this takes the stats part of that change, which is still an improvement.