### PR TITLE
Allow [::] as a bind address (binds to first public IPv6 address)

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -142,10 +142,16 @@ func Create(config *Config, logOutput io.Writer) (*Agent, error) {
 		if ip := net.ParseIP(config.AdvertiseAddr); ip == nil {
 			return nil, fmt.Errorf("Failed to parse advertise address: %v", config.AdvertiseAddr)
 		}
-	} else if config.BindAddr != "0.0.0.0" && config.BindAddr != "" {
+	} else if config.BindAddr != "0.0.0.0" && config.BindAddr != "" && config.BindAddr != "[::]" {
 		config.AdvertiseAddr = config.BindAddr
 	} else {
-		ip, err := consul.GetPrivateIP()
+		var err error
+		var ip net.IP
+		if config.BindAddr == "[::]" {
+			ip, err = consul.GetPublicIPv6()
+		} else {
+			ip, err = consul.GetPrivateIP()
+		}
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get advertise address: %v", err)
 		}

--- a/consul/util.go
+++ b/consul/util.go
@@ -264,6 +264,52 @@ func getPrivateIP(addresses []net.Addr) (net.IP, error) {
 
 }
 
+// GetPublicIPv6 is used to return the first public IP address
+// associated with an interface on the machine
+func GetPublicIPv6() (net.IP, error) {
+	addresses, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get interface addresses: %v", err)
+	}
+
+	return getPublicIPv6(addresses)
+}
+
+func getPublicIPv6(addresses []net.Addr) (net.IP, error) {
+	var candidates []net.IP
+
+	// Find public IPv6 address
+	for _, rawAddr := range addresses {
+		var ip net.IP
+		switch addr := rawAddr.(type) {
+		case *net.IPAddr:
+			ip = addr.IP
+		case *net.IPNet:
+			ip = addr.IP
+		default:
+			continue
+		}
+
+		if ip.To4() != nil {
+			continue
+		}
+		// do not bind link-local (fe80::/10) / ULA (fc00::/7) / loopback (::1)
+		if ip[0]|0xf == 0xff || ip[0]|0 == 0 {
+			continue
+		}
+		candidates = append(candidates, ip)
+	}
+	numIps := len(candidates)
+	switch numIps {
+	case 0:
+		return nil, fmt.Errorf("No public IPv6 address found")
+	case 1:
+		return candidates[0], nil
+	default:
+		return nil, fmt.Errorf("Multiple public IPv6 addresses found. Please configure one.")
+	}
+}
+
 // Converts bytes to an integer
 func bytesToUint64(b []byte) uint64 {
 	return binary.BigEndian.Uint64(b)

--- a/consul/util.go
+++ b/consul/util.go
@@ -275,6 +275,10 @@ func GetPublicIPv6() (net.IP, error) {
 	return getPublicIPv6(addresses)
 }
 
+func isUniqueLocalAddress(ip net.IP) bool {
+	return len(ip) == net.IPv6len && ip[0] == 0xfc && ip[1] == 0x00
+}
+
 func getPublicIPv6(addresses []net.Addr) (net.IP, error) {
 	var candidates []net.IP
 
@@ -293,8 +297,8 @@ func getPublicIPv6(addresses []net.Addr) (net.IP, error) {
 		if ip.To4() != nil {
 			continue
 		}
-		// do not bind link-local (fe80::/10) / ULA (fc00::/7) / loopback (::1)
-		if ip[0]|0xf == 0xff || ip[0]|0 == 0 {
+
+		if ip.IsLinkLocalUnicast() || isUniqueLocalAddress(ip) || ip.IsLoopback() {
 			continue
 		}
 		candidates = append(candidates, ip)

--- a/consul/util_test.go
+++ b/consul/util_test.go
@@ -287,6 +287,11 @@ func TestGetPublicIPv6(t *testing.T) {
 		t.Fatalf("failed to parse loopback cidr: %v", err)
 	}
 
+	ip3, _, err := net.ParseCIDR("fc00::1/128")
+	if err != nil {
+		t.Fatalf("failed to parse ULA cidr: %v", err)
+	}
+
 	pubIP, _, err := net.ParseCIDR("2001:0db8:85a3::8a2e:0370:7334/128")
 	if err != nil {
 		t.Fatalf("failed to parse public cidr: %v", err)
@@ -306,6 +311,9 @@ func TestGetPublicIPv6(t *testing.T) {
 					IP: ip2,
 				},
 				&net.IPAddr{
+					IP: ip3,
+				},
+				&net.IPAddr{
 					IP: pubIP,
 				},
 			},
@@ -318,6 +326,9 @@ func TestGetPublicIPv6(t *testing.T) {
 				},
 				&net.IPAddr{
 					IP: ip2,
+				},
+				&net.IPAddr{
+					IP: ip3,
 				},
 			},
 			err: errors.New("No public IPv6 address found"),

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -93,7 +93,8 @@ The options below are all specified on the command-line.
   for internal cluster communications.
   This is an IP address that should be reachable by all other nodes in the cluster.
   By default, this is "0.0.0.0", meaning Consul will use the first available private
-  IP address. Consul uses both TCP and UDP and the same port for both. If you
+  IPv4 address. If you specify "[::]", Consul will use the first available public IPv6 address.
+  Consul uses both TCP and UDP and the same port for both. If you
   have any firewalls, be sure to allow both protocols.
 
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which


### PR DESCRIPTION
Adds one small tweak on top of https://github.com/hashicorp/consul/pull/1219.