### PR TITLE
Increases timeouts for coordinate tests.

### DIFF
--- a/consul/coordinate_endpoint_test.go
+++ b/consul/coordinate_endpoint_test.go
@@ -118,7 +118,7 @@ func TestCoordinate_Update(t *testing.T) {
 	}
 
 	// Wait a while and the updates should get picked up.
-	time.Sleep(2 * s1.config.CoordinateUpdatePeriod)
+	time.Sleep(3 * s1.config.CoordinateUpdatePeriod)
 	c, err = state.CoordinateGetRaw("node1")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -163,7 +163,7 @@ func TestCoordinate_Update(t *testing.T) {
 
 	// Wait a little while for the batch routine to run, then make sure
 	// exactly one of the updates got dropped (we won't know which one).
-	time.Sleep(2 * s1.config.CoordinateUpdatePeriod)
+	time.Sleep(3 * s1.config.CoordinateUpdatePeriod)
 	numDropped := 0
 	for i := 0; i < spamLen; i++ {
 		c, err = state.CoordinateGetRaw(fmt.Sprintf("bogusnode%d", i))
@@ -269,7 +269,7 @@ func TestCoordinate_ListNodes(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &arg3, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	time.Sleep(2 * s1.config.CoordinateUpdatePeriod)
+	time.Sleep(3 * s1.config.CoordinateUpdatePeriod)
 
 	// Now query back for all the nodes.
 	arg := structs.DCSpecificRequest{

--- a/consul/prepared_query_endpoint_test.go
+++ b/consul/prepared_query_endpoint_test.go
@@ -1537,7 +1537,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		if err := msgpackrpc.CallWithCodec(codec1, "Coordinate.Update", &req, &out); err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		time.Sleep(2 * s1.config.CoordinateUpdatePeriod)
+		time.Sleep(3 * s1.config.CoordinateUpdatePeriod)
 	}
 
 	// Try an RTT sort. We don't have any other coordinates in there but


### PR DESCRIPTION
We take the interval and add the random stagger to it, so 2X is cutting it too close and the unit tests are often flaky.