### PR TITLE
Each agent should emit metrics about the services it owns

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -223,6 +223,9 @@ func Create(config *Config, logOutput io.Writer) (*Agent, error) {
 	// Start handling events
 	go agent.handleEvents()
 
+	// Emit metrics for services managed by this node
+	go agent.instrumentServices()
+
 	// Start sending network coordinate to the server.
 	if !config.DisableCoordinates {
 		go agent.sendCoordinate()

--- a/command/agent/instrumentation.go
+++ b/command/agent/instrumentation.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/consul/consul/structs"
+)
+
+var (
+	DefaultAgentIntrumentationInterval = 5 * time.Second
+	AgentIntrumentationInterval        = DefaultAgentIntrumentationInterval
+)
+
+func (a *Agent) instrumentServices() {
+	t := time.NewTicker(AgentIntrumentationInterval)
+
+	// As node checks have an empty ServiceID, the status of the node as a whole
+	// will be listed under the service ""
+	nodeService := ""
+
+	severities := map[string]int{
+		structs.HealthUnknown:  0,
+		structs.HealthPassing:  1,
+		structs.HealthWarning:  2,
+		structs.HealthCritical: 3,
+	}
+
+	for {
+		select {
+		case <-a.shutdownCh:
+			t.Stop()
+			return
+		case <-t.C:
+			statusOfEachService := map[string]string{
+				nodeService: structs.HealthPassing,
+			}
+
+			// We aggregate service name => status => number of instances in this state
+			// as multiple instances of a service could be running on the same node,
+			// in varying states
+			aggregatedServiceStatus := map[string]map[string]float32{}
+
+			// Work out the "worst case" status for each service
+			for _, check := range a.state.Checks() {
+				currentlyKnownServiceStatus := statusOfEachService[check.ServiceID]
+
+				if severities[check.Status] > severities[currentlyKnownServiceStatus] {
+					statusOfEachService[check.ServiceID] = check.Status
+				}
+			}
+
+			for _, service := range a.state.Services() {
+				status := statusOfEachService[service.ID]
+
+				if severities[statusOfEachService[nodeService]] > severities[status] {
+					status = statusOfEachService[nodeService]
+				}
+
+				if _, ok := aggregatedServiceStatus[service.Service]; !ok {
+					aggregatedServiceStatus[service.Service] = map[string]float32{
+						structs.HealthPassing:  0,
+						structs.HealthWarning:  0,
+						structs.HealthCritical: 0,
+					}
+				}
+
+				aggregatedServiceStatus[service.Service][status] += 1
+			}
+
+			for service, instances := range aggregatedServiceStatus {
+				for status, count := range instances {
+					metrics.SetGauge([]string{"services", service, "instances_by_state", status}, count)
+				}
+			}
+		}
+	}
+}

--- a/command/agent/instrumentation_test.go
+++ b/command/agent/instrumentation_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/consul/testutil"
+)
+
+func setupGloablInmemSink() *metrics.InmemSink {
+	inm := metrics.NewInmemSink(10*time.Second, time.Minute)
+	metricsConf := metrics.DefaultConfig("")
+	metricsConf.EnableHostname = false
+	metricsConf.EnableRuntimeMetrics = false
+	metrics.NewGlobal(metricsConf, inm)
+
+	return inm
+}
+
+func TestInstrumentation(t *testing.T) {
+	inm := setupGloablInmemSink()
+	AgentIntrumentationInterval = 1 * time.Second
+	defer func() { AgentIntrumentationInterval = DefaultAgentIntrumentationInterval }()
+
+	conf := nextConfig()
+	dir, agent := makeAgent(t, conf)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	testServices := map[string]map[string]string{
+		"a_multi_instance_service": map[string]string{
+			"a_passing_instance":       "exit 0",
+			"another_passing_instance": "exit 0",
+			"warning_instance":         "exit 1",
+			"failing_instance":         "exit 2",
+		},
+		"a_service_without_checks": map[string]string{
+			"sole_instance": "",
+		},
+	}
+
+	for serviceName, instances := range testServices {
+		for serviceID, script := range instances {
+			checks := CheckTypes{}
+
+			if script != "" {
+				checks = append(checks, &CheckType{Script: script, Interval: 2})
+			}
+
+			err := agent.AddService(
+				&structs.NodeService{
+					ID:      serviceID,
+					Service: serviceName,
+				},
+				checks,
+				false,
+				"",
+			)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+		}
+	}
+
+	verifyGauges(
+		t,
+		inm,
+		map[string]float32{
+			"services.a_multi_instance_service.instances_by_state.passing":  2.0,
+			"services.a_multi_instance_service.instances_by_state.warning":  1.0,
+			"services.a_multi_instance_service.instances_by_state.critical": 1.0,
+			"services.a_service_without_checks.instances_by_state.passing":  1.0,
+			"services.a_service_without_checks.instances_by_state.warning":  0.0,
+			"services.a_service_without_checks.instances_by_state.critical": 0.0,
+		},
+	)
+
+	agent.EnableNodeMaintenance("", "")
+
+	verifyGauges(
+		t,
+		inm,
+		map[string]float32{
+			"services.a_multi_instance_service.instances_by_state.passing":  0.0,
+			"services.a_multi_instance_service.instances_by_state.warning":  0.0,
+			"services.a_multi_instance_service.instances_by_state.critical": 4.0,
+			"services.a_service_without_checks.instances_by_state.passing":  0.0,
+			"services.a_service_without_checks.instances_by_state.warning":  0.0,
+			"services.a_service_without_checks.instances_by_state.critical": 1.0,
+		},
+	)
+
+}
+
+func verifyGauges(t *testing.T, inm *metrics.InmemSink, expectedMetrics map[string]float32) {
+	testutil.WaitForResult(func() (bool, error) {
+		stats := inm.Data()
+		latestInterval := stats[len(stats)-1]
+
+		for metric, expectedValue := range expectedMetrics {
+			val, ok := latestInterval.Gauges[metric]
+
+			if !ok {
+				return false, fmt.Errorf("expected metric %s to be set", metric)
+			}
+
+			if val != expectedValue {
+				return false, fmt.Errorf("expected %s to be %f got %f", metric, expectedValue, val)
+			}
+
+		}
+
+		return true, nil
+
+	}, func(e error) {
+		t.Fatal(e)
+	})
+}


### PR DESCRIPTION
This change causes the agent to emit metrics about how many instances of a service it is responsible for, and what state they're in. The use case behind this is that we need to monitor the number of unsealed/sealed vault servers we have.

Example metrics:

```
services.a_multi_instance_service.instances_by_state.passing:  2.0
services.a_multi_instance_service.instances_by_state.warning:  1.0
services.a_multi_instance_service.instances_by_state.critical: 1.0
```

The metric reporting is done at the agent level (both client and server), as (in our setup) we have a statsite instance per node, which sets the source for metrics to that specific node, and trying to emit metrics that "fake" the correct source from the lead server would get complicated.

The agent uses its local state to determine a service's state. My original intention was to avoid agents sending additional queries to servers, but after diving through the code/looking at some of our other metrics, I'm wondering whether there could be discrepancies between the node's view of the world, and what the servers are telling the rest of the cluster. Do you think this is a valid concern, or is it unlikely to matter in practice?

Also, the metric names are snake cased. There seems to be a mix of snake cased metrics (e.g. `consul.consul.session_ttl.invalidate.p95`, `consul.consul.rpc.raft_handoff`), dash-delimited (e.g. `consul.consul.health.service.query-tag.tabloid.haproxy`), and camel cased (`consul.memberlist.pushPullNode`). Do you have a preference for what this PR should use? I went with snake case as that's what we use in our org.

Semi related to #1822 
