### PR TITLE
Adding ability to skip cert verification on HTTPS checks

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -354,6 +355,11 @@ func (c *CheckHTTP) Start() {
 		// failing checks due to the keepalive interval.
 		trans := cleanhttp.DefaultTransport()
 		trans.DisableKeepAlives = true
+		if os.Getenv("CONSUL_CHECK_HTTP_SSL_SKIP_VERIFY") != "" {
+			trans.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true,
+			}
+		}
 
 		// Create the HTTP client.
 		c.httpClient = &http.Client{


### PR DESCRIPTION
This adds support for a new environment variable
`CONSUL_CHECK_HTTP_SSL_SKIP_VERIFY`, which will cause TLS cert
verification to be skipped when performing HTTPS service checks.

Right now, if I try to do an HTTP check against an
`https://<private_ip>` URL, the check will fail with something like:

```
... x509: cannot validate certificate for x.x.x.x because it doesn't
contain any IP SANs
```

Sometimes it's not possible to use the FQDN that the cert is valid for,
because it may be (for example) fronted by a load-balancer, whereas we
want to check the particular instance of a service.
    
Signed-off-by: Dave Henderson <dhenderson@gmail.com>