### PR TITLE
Node names are not allowed to be empty

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -164,7 +164,13 @@ func (c *Command) readConfig() *Config {
 	if config.NodeName == "" {
 		hostname, err := os.Hostname()
 		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Error determining hostname: %s", err))
+			c.Ui.Error(fmt.Sprintf("Error determining node name: %s", err))
+			return nil
+		}
+
+		hostname = strings.TrimSpace(hostname)
+		if hostname == "" {
+			c.Ui.Error("Node name can not be empty")
 			return nil
 		}
 		config.NodeName = hostname

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -167,13 +167,12 @@ func (c *Command) readConfig() *Config {
 			c.Ui.Error(fmt.Sprintf("Error determining node name: %s", err))
 			return nil
 		}
-
-		hostname = strings.TrimSpace(hostname)
-		if hostname == "" {
-			c.Ui.Error("Node name can not be empty")
-			return nil
-		}
 		config.NodeName = hostname
+	}
+	hostname = strings.TrimSpace(hostname)
+	if hostname == "" {
+		c.Ui.Error("Node name can not be empty")
+		return nil
 	}
 
 	// Ensure we have a data directory


### PR DESCRIPTION
This is easy to run into when setting up Consul in a fresh Vagrant VM.

```
vagrant@:~/go/src/github.com/hashicorp/consul % hostname 

vagrant@:~/go/src/github.com/hashicorp/consul % ./svc/run
==> Node name can not be empty
```