### PR TITLE
Adds metrics and hybrid checks that are handled on agent.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -907,7 +907,6 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 			http.Start()
 			a.checkHTTPs[check.CheckID] = http
-
 		} else if chkType.IsTCP() {
 			if existing, ok := a.checkTCPs[check.CheckID]; ok {
 				existing.Stop()
@@ -953,7 +952,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 			dockerCheck.Start()
 			a.checkDockers[check.CheckID] = dockerCheck
-		} else if chkType.IsMonitor() {
+		} else if chkType.IsMonitor() || chkType.IsMetric() {
 			if existing, ok := a.checkMonitors[check.CheckID]; ok {
 				existing.Stop()
 			}
@@ -964,12 +963,15 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 			}
 
 			monitor := &CheckMonitor{
-				Notify:   &a.state,
-				CheckID:  check.CheckID,
-				Script:   chkType.Script,
-				Interval: chkType.Interval,
-				Logger:   a.logger,
-				ReapLock: &a.reapLock,
+				Notify:          &a.state,
+				CheckID:         check.CheckID,
+				Script:          chkType.Script,
+				Metric:          chkType.Metric,
+				MetricHandler:   chkType.MetricHandler,
+				MetricSeparator: chkType.MetricSeparator,
+				Interval:        chkType.Interval,
+				Logger:          a.logger,
+				ReapLock:        &a.reapLock,
 			}
 			monitor.Start()
 			a.checkMonitors[check.CheckID] = monitor

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -889,6 +889,12 @@ func FixupCheckType(raw interface{}) error {
 		case "docker_container_id":
 			rawMap["DockerContainerID"] = v
 			delete(rawMap, "docker_container_id")
+		case "metric_handler":
+			rawMap["metricHandler"] = v
+			delete(rawMap, "metric_handler")
+		case "metric_separator":
+			rawMap["metricSeparator"] = v
+			delete(rawMap, "metric_separator")
 		}
 	}
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1217,7 +1217,7 @@ func TestDecodeConfig_Service(t *testing.T) {
 
 func TestDecodeConfig_Check(t *testing.T) {
 	// Basics
-	input := `{"check": {"id": "chk1", "name": "mem", "notes": "foobar", "script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "shell": "/bin/bash", "docker_container_id": "redis" }}`
+	input := `{"check": {"id": "chk1", "name": "mem", "notes": "foobar", "script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "shell": "/bin/bash", "docker_container_id": "redis", "metric": "/bin/metrics_redis", "metric_handler": "/bin/metrichandler", "metric_separator":"\n\n" }}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1257,6 +1257,18 @@ func TestDecodeConfig_Check(t *testing.T) {
 	}
 
 	if chk.DockerContainerID != "redis" {
+		t.Fatalf("bad: %v", chk)
+	}
+
+	if chk.Metric != "/bin/metrics_redis" {
+		t.Fatalf("bad: %v", chk)
+	}
+
+	if chk.MetricHandler != "/bin/metrichandler" {
+		t.Fatalf("bad: %v", chk)
+	}
+
+	if chk.MetricSeparator != "\n\n" {
 		t.Fatalf("bad: %v", chk)
 	}
 }

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -242,6 +242,8 @@ body must look like:
   "Name": "Memory utilization",
   "Notes": "Ensure we don't oversubscribe memory",
   "Script": "/usr/local/bin/check_mem.py",
+  "Metrics": "/usr/local/bin/metrics_mem.py",
+  "MetricHandler": "/usr/local/bin/metricshandler.pl",
   "DockerContainerID": "f972c95ebf0e",
   "Shell": "/bin/bash",
   "HTTP": "http://example.com",
@@ -261,6 +263,9 @@ The `Notes` field is not used internally by Consul and is meant to be human-read
 
 If a `Script` is provided, the check type is a script, and Consul will
 evaluate the script every `Interval` to update the status.
+
+If a `Metric` and `MetricHandler` is provided, the check type is a metric and consul
+will evaluate the metric script and pass the output to the handler script every `Interval`.
 
 If a `DockerContainerID` is provided, the check is a Docker check, and Consul will
 evaluate the script every `Interval` in the given container using the specified


### PR DESCRIPTION
This is a starting point for metrics handling in consul.  This follows the suggestions made by Armon in google groups https://groups.google.com/forum/#!topic/consul-tool/g1OkeBgBMOo and handles the metric processing on the agent.   Here is an example config used in testing:

```
consul-client:~# cat /etc/consul/fake-metrics-check.json 
{
 "check": {
   "metric": "/tmp/metricsonly.sh",
   "metric_handler": "grep -v mutate | /tmp/metrichandler.sh",
   "interval": "10s",
   "name": "fake-metric-check"
 }
}
consul-client:~# cat /etc/consul/hybrid-check.json 
{
 "check": {
   "script": "/usr/lib/nagios/plugins/check_load -w 5,5,5 -c 10,10,10 ",
   "metric_handler": "/tmp/metrichandler.sh",
   "interval": "10s",
   "name": "hybrid-check"
 }
}
consul-client:~# cat /tmp/metricsonly.sh 
echo "some.tree.for.graphite 42 "`date +%s`
echo "mutate.key.for.graphite 13 "`date +%s`
consul-client:~# cat /tmp/metrichandler.sh 
while read line
do
 echo $line >> /tmp/metrics.log
done < /dev/stdin
consul-client:~# tail /tmp/metrics.log 
load1=0.040;5.000;10.000;0; load5=0.110;5.000;10.000;0; load15=0.130;5.000;10.000;0;
some.tree.for.graphite 42 1461088134
load1=0.030;5.000;10.000;0; load5=0.110;5.000;10.000;0; load15=0.130;5.000;10.000;0;
some.tree.for.graphite 42 1461088144
load1=0.030;5.000;10.000;0; load5=0.110;5.000;10.000;0; load15=0.130;5.000;10.000;0;
some.tree.for.graphite 42 1461088154
load1=0.020;5.000;10.000;0; load5=0.100;5.000;10.000;0; load15=0.130;5.000;10.000;0;
some.tree.for.graphite 42 1461088164
load1=0.020;5.000;10.000;0; load5=0.100;5.000;10.000;0; load15=0.120;5.000;10.000;0;
some.tree.for.graphite 42 1461088174
```

While this is functional, future features might include global control and some case could be made for collecting metrics to the consul server and centralizing handler config.  Here are some notes on options for central control:
1) have the check config list a metrics channel instead of a handler.  Then separately configure the consul servers with channel configs that listed handlers. 
Pros : Centralized config and script management 
Cons: centralizes metrics transit which could scale to a bottleneck if metrics data is large
2)  have a channel selector set either as a KV entry or internal consul state and agents use that data to select the correct handler to emit with.  Either as a global for all metrics on the agent or through subscriptions in the check configs.
Pros: decentralized metrics emission should scale with agents, centralizes handler selection
Cons: handler channels and scripts must still be distributed to agents first.
3) using the KV option above the scheme could be achieved in the handler using a master handler that reads the KV from the triggering consul instance and makes backend selections from there.
Pros: Same as 2 plus flexibility to use simpler handler config and simpler consul code.
Cons: Same as 2

I prefer option 3 because some people may be content with letting chef manage changes in the metrics handling without wanting the extra overhead that would be required to centralize control of backends in the tool.  Consul still provides the framework to easily build controls around it but otherwise consul remains just a metrics bus.  

Also metric and handler scripts (other than hybrid check scripts which still report status of monitor script) that return with non zero exit codes are ignored. Not sure what action should be taken other than perhaps logging it.  Sensu docs indicate it is ignored in sensu code.  It is an open question what if anything should be done to represent the metric checks differently in the UI.  Currently the metrics only checks note they are processing metrics in the check output, perhaps that is sufficient for most people.
