### PR TITLE
terraform: added support for centos7 to aws

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -8,6 +8,7 @@ variable "user" {
         ubuntu  = "ubuntu"
         rhel6   = "ec2-user"
         centos6 = "centos"
+        centos7 = "centos"
         rhel7   = "ec2-user"
     }
 }
@@ -28,6 +29,8 @@ variable "ami" {
         us-west-2-centos6 = "ami-1255b321"
         us-east-1-rhel7   = "ami-2051294a"
         us-west-2-rhel7   = "ami-775e4f16"
+        us-east-1-centos7 = "ami-6d1c2007"
+        us-west-1-centos7 = "ami-af4333cf"
     }
 }
 
@@ -36,6 +39,7 @@ variable "service_conf" {
     ubuntu  = "debian_upstart.conf"
     rhel6   = "rhel_upstart.conf"
     centos6 = "rhel_upstart.conf"
+    centos7 = "rhel_consul.service"
     rhel7   = "rhel_consul.service"
   }
 }
@@ -44,6 +48,7 @@ variable "service_conf_dest" {
     ubuntu  = "upstart.conf"
     rhel6   = "upstart.conf"
     centos6 = "upstart.conf"
+    centos7 = "consul.service"
     rhel7   = "consul.service"
   }
 }


### PR DESCRIPTION
Updated variables.tf to add support for launching a centos7 based consul cluster in aws.