### PR TITLE
update vagrant demo

### DIFF
--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -8,7 +8,7 @@ sudo apt-get install -y unzip curl
 
 echo Fetching Consul...
 cd /tmp/
-wget https://releases.hashicorp.com/consul/0.6.1/consul_0.6.1_linux_amd64.zip -O consul.zip
+curl https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip -o consul.zip
 
 echo Installing Consul...
 unzip consul.zip


### PR DESCRIPTION
1. Update the version from `0.6.1` to `0.6.4`.
2. Switch `wget` to `curl` because `curl` is installed as a dependency in the script.