### PR TITLE
Fix json for /v1/catalog/node in markdown

### DIFF
--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -195,7 +195,7 @@ It returns a JSON body like this:
 [
   {
     "Node": "baz",
-    "Address": "10.1.10.11"
+    "Address": "10.1.10.11",
     "TaggedAddresses": {
       "wan": "10.1.10.11"
     }


### PR DESCRIPTION
add in a missing comma after the "Address" field