### PR TITLE
Update kvs_endpoint.go

### DIFF
--- a/command/agent/kvs_endpoint.go
+++ b/command/agent/kvs_endpoint.go
@@ -60,6 +60,8 @@ func (s *HTTPServer) KVSGet(resp http.ResponseWriter, req *http.Request, args *s
 	params := req.URL.Query()
 	if _, ok := params["recurse"]; ok {
 		method = "KVS.List"
+	} else if missingKey(resp, args) {
+		return nil, nil
 	}
 	if _, ok := params["searchall"]; ok {
 		method = "KVS.List"


### PR DESCRIPTION
Added a search functionality to search in KV store using existing recurse functionality.
"?searchall=<key>" is the query string.

Found this to be missing. It was hard to remember where a particular key is located. Recurse would give all matching keys in the tree, it would be convenient to have a searchall option.