### PR TITLE
Document `consul lock` shell execution

### DIFF
--- a/website/source/docs/commands/lock.html.markdown
+++ b/website/source/docs/commands/lock.html.markdown
@@ -74,3 +74,11 @@ The list of available flags are:
 
 * `-verbose` - Enables verbose output.
 
+## SHELL
+Consul lock launches its children in a shell. By default, Consul will use the shell
+defined in the environment variable `SHELL`. If `SHELL` is not defined, it will
+default to `/bin/sh`. It should be noted that not all shells terminate child
+processes when they receive `SIGTERM`. Under Ubuntu, `/bin/sh` is linked to `dash`,
+which does **not** terminate its children. In order to ensure that child processes
+are killed when the lock is lost, be sure to set the `SHELL` environment variable
+appropriately.


### PR DESCRIPTION
Consul lock executes children under a shell, which was previously
undocumented. Document it, and warn against cases where this can cause
children to leak when the lock is lost.

I have made this a dedicated section so it can easily be removed
later when we move to exec

https://github.com/hashicorp/consul/issues/1692
https://github.com/hashicorp/consul/issues/2022