### PR TITLE
Compress all DNS responses

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -180,6 +180,7 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 	// Setup the message response
 	m := new(dns.Msg)
 	m.SetReply(req)
+	m.Compress = true
 	m.Authoritative = true
 	m.RecursionAvailable = (len(d.recursors) > 0)
 
@@ -249,6 +250,7 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 	// Setup the message response
 	m := new(dns.Msg)
 	m.SetReply(req)
+	m.Compress = true
 	m.Authoritative = true
 	m.RecursionAvailable = (len(d.recursors) > 0)
 
@@ -776,6 +778,7 @@ func (d *DNSServer) handleRecurse(resp dns.ResponseWriter, req *dns.Msg) {
 	var err error
 	for _, recursor := range d.recursors {
 		r, rtt, err = c.Exchange(req, recursor)
+		r.Compress = true
 		if err == nil {
 			// Forward the response
 			d.logger.Printf("[DEBUG] dns: recurse RTT for %v (%v)", q, rtt)
@@ -792,6 +795,7 @@ func (d *DNSServer) handleRecurse(resp dns.ResponseWriter, req *dns.Msg) {
 		q, resp.RemoteAddr().String(), resp.RemoteAddr().Network())
 	m := &dns.Msg{}
 	m.SetReply(req)
+	m.Compress = true
 	m.RecursionAvailable = true
 	m.SetRcode(req, dns.RcodeServerFailure)
 	resp.WriteMsg(m)

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -778,8 +778,8 @@ func (d *DNSServer) handleRecurse(resp dns.ResponseWriter, req *dns.Msg) {
 	var err error
 	for _, recursor := range d.recursors {
 		r, rtt, err = c.Exchange(req, recursor)
-		r.Compress = true
 		if err == nil {
+			r.Compress = true
 			// Forward the response
 			d.logger.Printf("[DEBUG] dns: recurse RTT for %v (%v)", q, rtt)
 			if err := resp.WriteMsg(r); err != nil {


### PR DESCRIPTION
This is a rebase of [PR 971](https://github.com/hashicorp/consul/pull/971).

Compress all DNS responses as recommended by the [miekg/dns](https://github.com/miekg/dns) library devs.

This fixes an issue where the docker daemon and other Go programs are using consul for DNS resolution as the Golang libraries can't process UDP packets > 512b.