### PR TITLE
Update install.html.markdown OS X Instructions

### DIFF
--- a/website/source/intro/getting-started/install.html.markdown
+++ b/website/source/intro/getting-started/install.html.markdown
@@ -32,13 +32,13 @@ If you are using [homebrew](http://brew.sh/#install) as a package manager,
 you can install consul with:
 
 ```text
-$ brew cask install consul
+$ brew install consul
 ```
 
-if you are missing the [cask plugin](http://caskroom.io/), you can install it with:
-
+You can also see any additional installation options that are available
+through homebrew with:
 ```text
-$ brew install caskroom/cask/brew-cask
+$ brew info consul
 ```
 
 ## Verifying the Installation


### PR DESCRIPTION
Homebrew is phasing out the use of the homebrew-cask add-on, moving it all over to just using `brew install <app>`.

Also, if you type `brew info consul` you can see that you can even automatically install the web-ui through brew as well.