### PR TITLE
Updated Service Definition

### DIFF
--- a/website/source/intro/getting-started/services.html.markdown
+++ b/website/source/intro/getting-started/services.html.markdown
@@ -40,7 +40,7 @@ pretend we have a service named "web" running on port 80. Additionally,
 we'll give it a tag we can use as an additional way to query the service:
 
 ```text
-$ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80}}' \
+$ echo '{"service": {"id": "web", "name": "web", "tags": ["rails"], "port": 80}}' \
     >/etc/consul.d/web.json
 ```
 


### PR DESCRIPTION
On OSX 10.11.5 using Consul 0.6.4 found I needed to add "id" field to service definition to get example to work.