### PR TITLE
Translate Address to tagged WAN address in HTTP API when appropriate.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1066,6 +1066,18 @@ func (a *Agent) UpdateCheck(checkID types.CheckID, status, output string) error 
 	return nil
 }
 
+// TranslateAddr is used to provide the final, translated address for a node,
+// depending on how this agent and the other node are configured.
+func (a *Agent) TranslateAddr(dc string, addr string, taggedAddr map[string]string) string {
+	if a.config.TranslateWanAddrs && (a.config.Datacenter != dc) {
+		wanAddr := taggedAddr["wan"]
+		if wanAddr != "" {
+			addr = wanAddr
+		}
+	}
+	return addr
+}
+
 // persistCheckState is used to record the check status into the data dir.
 // This allows the state to be restored on a later agent start. Currently
 // only useful for TTL based checks.

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -77,6 +77,12 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	if out.Nodes == nil {
 		out.Nodes = make(structs.Nodes, 0)
 	}
+
+	for _, node := range out.Nodes {
+		addr := s.agent.TranslateAddr(args.Datacenter, node.Address, node.TaggedAddresses)
+		node.Address = addr
+	}
+
 	return out.Nodes, nil
 }
 
@@ -129,6 +135,12 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	if out.ServiceNodes == nil {
 		out.ServiceNodes = make(structs.ServiceNodes, 0)
 	}
+
+	for _, serviceNode := range out.ServiceNodes {
+		addr := s.agent.TranslateAddr(args.Datacenter, serviceNode.Address, serviceNode.TaggedAddresses)
+		serviceNode.Address = addr
+	}
+
 	return out.ServiceNodes, nil
 }
 
@@ -153,5 +165,12 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 	if err := s.agent.RPC("Catalog.NodeServices", &args, &out); err != nil {
 		return nil, err
 	}
+
+	if out.NodeServices != nil {
+		node := out.NodeServices.Node
+		addr := s.agent.TranslateAddr(args.Datacenter, node.Address, node.TaggedAddresses)
+		node.Address = addr
+	}
+
 	return out.NodeServices, nil
 }

--- a/command/agent/catalog_endpoint_test.go
+++ b/command/agent/catalog_endpoint_test.go
@@ -145,6 +145,95 @@ func TestCatalogNodes(t *testing.T) {
 	}
 }
 
+func TestCatalogNodes_WanTranslation(t *testing.T) {
+	httpCtx1, httpCtx2 := setupWanHTTPServers(t)
+	defer shutdownHTTPServer(httpCtx1)
+	defer shutdownHTTPServer(httpCtx2)
+	srv1 := httpCtx1.srv
+	srv2 := httpCtx2.srv
+
+	// Register a node with DC2
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc2",
+			Node:       "wan_translation_test",
+			Address:    "127.0.0.1",
+			TaggedAddresses: map[string]string{
+				"wan": "127.0.0.2",
+			},
+			Service: &structs.NodeService{
+				Service: "http_wan_translation_test",
+			},
+		}
+
+		var out struct{}
+		if err := srv2.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	req, err := http.NewRequest("GET", "/v1/catalog/nodes?dc=dc2", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// get nodes for DC2 from DC1
+	resp1 := httptest.NewRecorder()
+	obj1, err1 := srv1.CatalogNodes(resp1, req)
+	if err1 != nil {
+		t.Fatalf("err: %v", err1)
+	}
+
+	// Verify an index is set
+	assertIndex(t, resp1)
+
+	nodes1 := obj1.(structs.Nodes)
+	if len(nodes1) != 2 {
+		t.Fatalf("bad: %v", obj1)
+	}
+
+	var node1 *structs.Node
+
+	for _, node := range nodes1 {
+		if node.Node == "wan_translation_test" {
+			node1 = node
+		}
+	}
+
+	// Expect that DC1 gives us a public address (since the node is in DC2)
+	if node1.Address != "127.0.0.2" {
+		t.Fatalf("bad: %v", node1)
+	}
+
+	// get nodes for DC2 from DC2
+	resp2 := httptest.NewRecorder()
+	obj2, err2 := srv2.CatalogNodes(resp2, req)
+	if err2 != nil {
+		t.Fatalf("err: %v", err2)
+	}
+
+	// Verify an index is set
+	assertIndex(t, resp2)
+
+	nodes2 := obj2.(structs.Nodes)
+	if len(nodes2) != 2 {
+		t.Fatalf("bad: %v", obj2)
+	}
+
+	var node2 *structs.Node
+
+	for _, node := range nodes2 {
+		if node.Node == "wan_translation_test" {
+			node2 = node
+		}
+	}
+
+	// Expect that DC2 gives us a private address (since the node is in DC2)
+	if node2.Address != "127.0.0.1" {
+		t.Fatalf("bad: %v", node2)
+	}
+}
+
 func TestCatalogNodes_Blocking(t *testing.T) {
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
@@ -407,6 +496,81 @@ func TestCatalogServiceNodes(t *testing.T) {
 	}
 }
 
+func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
+	httpCtx1, httpCtx2 := setupWanHTTPServers(t)
+	defer shutdownHTTPServer(httpCtx1)
+	defer shutdownHTTPServer(httpCtx2)
+	srv1 := httpCtx1.srv
+	srv2 := httpCtx2.srv
+
+	// Register a node with DC2
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc2",
+			Node:       "foo",
+			Address:    "127.0.0.1",
+			TaggedAddresses: map[string]string{
+				"wan": "127.0.0.2",
+			},
+			Service: &structs.NodeService{
+				Service: "http_wan_translation_test",
+			},
+		}
+
+		var out struct{}
+		if err := srv2.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	req, err := http.NewRequest("GET", "/v1/catalog/service/http_wan_translation_test?dc=dc2", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Ask HTTP server on DC1 for the node
+	resp1 := httptest.NewRecorder()
+	obj1, err1 := srv1.CatalogServiceNodes(resp1, req)
+	if err1 != nil {
+		t.Fatalf("err: %v", err1)
+	}
+
+	assertIndex(t, resp1)
+
+	nodes1 := obj1.(structs.ServiceNodes)
+	if len(nodes1) != 1 {
+		t.Fatalf("bad: %v", obj1)
+	}
+
+	node1 := nodes1[0]
+
+	// Expect that DC1 gives us a public address (since the node is in DC2)
+	if node1.Address != "127.0.0.2" {
+		t.Fatalf("bad: %v", node1)
+	}
+
+	// Ask HTTP server on DC2 for the node
+	resp2 := httptest.NewRecorder()
+	obj2, err2 := srv2.CatalogServiceNodes(resp2, req)
+	if err2 != nil {
+		t.Fatalf("err: %v", err2)
+	}
+
+	assertIndex(t, resp2)
+
+	nodes2 := obj2.(structs.ServiceNodes)
+	if len(nodes2) != 1 {
+		t.Fatalf("bad: %v", obj2)
+	}
+
+	node2 := nodes2[0]
+
+	// Expect that DC2 gives us a local address (since the node is in DC2)
+	if node2.Address != "127.0.0.1" {
+		t.Fatalf("bad: %v", node2)
+	}
+}
+
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
@@ -548,5 +712,78 @@ func TestCatalogNodeServices(t *testing.T) {
 	services := obj.(*structs.NodeServices)
 	if len(services.Services) != 1 {
 		t.Fatalf("bad: %v", obj)
+	}
+}
+
+func TestCatalogNodeServices_WanTranslation(t *testing.T) {
+	httpCtx1, httpCtx2 := setupWanHTTPServers(t)
+	defer shutdownHTTPServer(httpCtx1)
+	defer shutdownHTTPServer(httpCtx2)
+	srv1 := httpCtx1.srv
+	srv2 := httpCtx2.srv
+
+	// Register a node with DC2
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc2",
+			Node:       "foo",
+			Address:    "127.0.0.1",
+			TaggedAddresses: map[string]string{
+				"wan": "127.0.0.2",
+			},
+			Service: &structs.NodeService{
+				Service: "http_wan_translation_test",
+			},
+		}
+
+		var out struct{}
+		if err := srv2.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	req, err := http.NewRequest("GET", "/v1/catalog/node/foo?dc=dc2", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// ask DC1 for node in DC2
+	resp1 := httptest.NewRecorder()
+	obj1, err1 := srv1.CatalogNodeServices(resp1, req)
+	if err1 != nil {
+		t.Fatalf("err: %v", err1)
+	}
+	assertIndex(t, resp1)
+
+	services1 := obj1.(*structs.NodeServices)
+	if len(services1.Services) != 1 {
+		t.Fatalf("bad: %v", obj1)
+	}
+
+	service1 := services1.Node
+
+	// Expect that DC1 gives us a public address (since the node is in DC2)
+	if service1.Address != "127.0.0.2" {
+		t.Fatalf("bad: %v", service1)
+	}
+
+	// ask DC2 for node in DC2
+	resp2 := httptest.NewRecorder()
+	obj2, err2 := srv2.CatalogNodeServices(resp2, req)
+	if err2 != nil {
+		t.Fatalf("err: %v", err2)
+	}
+	assertIndex(t, resp2)
+
+	services2 := obj2.(*structs.NodeServices)
+	if len(services2.Services) != 1 {
+		t.Fatalf("bad: %v", obj2)
+	}
+
+	service2 := services2.Node
+
+	// Expect that DC2 gives us a private address (since the node is in DC2)
+	if service2.Address != "127.0.0.1" {
+		t.Fatalf("bad: %v", service2)
 	}
 }

--- a/command/agent/health_endpoint.go
+++ b/command/agent/health_endpoint.go
@@ -143,6 +143,13 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	if out.Nodes == nil {
 		out.Nodes = make(structs.CheckServiceNodes, 0)
 	}
+
+	for _, checkServiceNode := range out.Nodes {
+		node := checkServiceNode.Node
+		addr := s.agent.TranslateAddr(args.Datacenter, node.Address, node.TaggedAddresses)
+		node.Address = addr
+	}
+
 	return out.Nodes, nil
 }
 

--- a/command/agent/prepared_query_endpoint.go
+++ b/command/agent/prepared_query_endpoint.go
@@ -122,6 +122,13 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 	if reply.Nodes == nil {
 		reply.Nodes = make(structs.CheckServiceNodes, 0)
 	}
+
+	for _, checkServiceNode := range reply.Nodes {
+		node := checkServiceNode.Node
+		addr := s.agent.TranslateAddr(args.Datacenter, node.Address, node.TaggedAddresses)
+		node.Address = addr
+	}
+
 	return reply, nil
 }
 

--- a/command/agent/prepared_query_endpoint_test.go
+++ b/command/agent/prepared_query_endpoint_test.go
@@ -323,6 +323,52 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		}
 	})
 
+	// testing WAN translation in the response
+	httpTestWithConfig(t, func(srv *HTTPServer) {
+		m := MockPreparedQuery{}
+		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		m.executeFn = func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+			nodesResponse := make(structs.CheckServiceNodes, 1)
+			nodesResponse[0].Node = &structs.Node{Node: "foo", Address: "127.0.0.1",
+				TaggedAddresses: map[string]string{"wan": "127.0.0.2"}}
+			reply.Nodes = nodesResponse
+			return nil
+		}
+
+		body := bytes.NewBuffer(nil)
+		req, err := http.NewRequest("GET", "/v1/query/my-id/execute?dc=dc2", body)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		resp := httptest.NewRecorder()
+		obj, err := srv.PreparedQuerySpecific(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if resp.Code != 200 {
+			t.Fatalf("bad code: %d", resp.Code)
+		}
+		r, ok := obj.(structs.PreparedQueryExecuteResponse)
+		if !ok {
+			t.Fatalf("unexpected: %T", obj)
+		}
+		if r.Nodes == nil || len(r.Nodes) != 1 {
+			t.Fatalf("bad: %v", r)
+		}
+
+		node := r.Nodes[0]
+		if node.Node.Address != "127.0.0.2" {
+			t.Fatalf("bad: %v", node.Node)
+		}
+	}, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.TranslateWanAddrs = true
+	})
+
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("GET", "/v1/query/not-there/execute", body)

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -839,7 +839,9 @@ func (s *StateStore) parseServiceNodes(tx *memdb.Txn, services structs.ServiceNo
 		if err != nil {
 			return nil, fmt.Errorf("failed node lookup: %s", err)
 		}
-		s.Address = n.(*structs.Node).Address
+		node := n.(*structs.Node)
+		s.Address = node.Address
+		s.TaggedAddresses = node.TaggedAddresses
 		results = append(results, s)
 	}
 	return results, nil

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -264,6 +264,7 @@ type Services map[string][]string
 type ServiceNode struct {
 	Node                     string
 	Address                  string
+	TaggedAddresses          map[string]string
 	ServiceID                string
 	ServiceName              string
 	ServiceTags              []string


### PR DESCRIPTION
Likely of interest to @slackpad and @evan2645.

This PR builds on https://github.com/hashicorp/consul/pull/1698. That PR translates a returned IP address to a WAN address when Consul is configured appropriately, but only through the DNS interface.

This PR additionally translates a node's address to the WAN address in the HTTP API. The rationale is:
- the DNS and HTTP APIs should return consistent results
- returning an IP local to DC1 to an HTTP client in DC2 is likely not useful (the client can't do anything with it)

The particular use case that motivated this change is "using the HTTP API in a NAT'd, multi-DC environment, I want to query for all nodes providing service X, and I want to be able to connect to those nodes using the returned `Address`".

The changes that this PR makes are:
- adding `TaggedAddresses` to the `ServiceNode` struct (so that the `catalog_endpoint.go`, in particular, has access to them and co do the WAN translation before returning the result)
- setting `TaggedAddresses` in the `ServiceNode` struct in `state_store.go`
- moving `translateAddr` into `agent.go` and modifying the signature slightly so that it can be used from both HTTP and DNS handlers
- translating node addresses in the following HTTP APIs (tests added for all)
  - `/v1/catalog/nodes`
  - `/v1/catalog/node/<node>`
  - `/v1/catalog/service/<service>`
  - `/v1/health/service/<service>`
  - `/v1/query/<query or name>/execute`

Added tests are passing, but it seems some of the existing tests are somewhat flaky and will occasionally fail. AFAICT, the failures don't have anything to do with this PR's additions.

First time Go user, view the code with suspicion :-).