### PR TITLE
Add embedded-consul to download_tools page

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -141,6 +141,9 @@ description: |-
       <li>
         <a href="http://opennodecloud.com/products/nodefabric.html">NodeFabric</a> - Turnkey CentOS 7 Atomic Host image with integrated Consul, Registrator and HAProxy - enabling rapid MariaDB-Galera and Ceph deployments
       </li>
+      <li>
+        <a href="https://github.com/pszymczyk/embedded-consul">Embedded Consul</a> - Library for JVM based applications, provides easy way to run Consul in integration tests
+      </li>
     </ul>
 
     <p>


### PR DESCRIPTION
Hi

As I mention in email correspondence I would like to to feature my tool in https://www.consul.io/downloads_tools.html. 

Embedded Consul provides easy way to run Consul in integration tests on JVM stack. It’s simillar to another Java embedded tools like:

-embedded mongo https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo
-embedded zookeeper
etc…

It's already successfully adopted in our company. I think it’s very popular to using this kind of stuff in Java world. It would be nice if more developers could hear about it.

regards
Paweł