### PR TITLE
Use stable, monotonically increasing port numbers for tests

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -19,10 +19,24 @@ import (
 	"github.com/hashicorp/consul/testutil"
 )
 
-var offset uint64
+const (
+	basePortNumber = 10000
+
+	portOffsetDNS = iota
+	portOffsetHTTP
+	portOffsetRPC
+	portOffsetSerfLan
+	portOffsetSerfWan
+	portOffsetServer
+
+	// Must be last in list
+	numPortsPerIndex
+)
+
+var offset uint64 = basePortNumber
 
 func nextConfig() *Config {
-	idx := int(atomic.AddUint64(&offset, 1))
+	idx := int(atomic.AddUint64(&offset, numPortsPerIndex))
 	conf := DefaultConfig()
 
 	conf.Version = "a.b"
@@ -32,12 +46,12 @@ func nextConfig() *Config {
 	conf.Datacenter = "dc1"
 	conf.NodeName = fmt.Sprintf("Node %d", idx)
 	conf.BindAddr = "127.0.0.1"
-	conf.Ports.DNS = 19000 + idx
-	conf.Ports.HTTP = 18800 + idx
-	conf.Ports.RPC = 18600 + idx
-	conf.Ports.SerfLan = 18200 + idx
-	conf.Ports.SerfWan = 18400 + idx
-	conf.Ports.Server = 18000 + idx
+	conf.Ports.DNS = basePortNumber + idx + portOffsetDNS
+	conf.Ports.HTTP = basePortNumber + idx + portOffsetHTTP
+	conf.Ports.RPC = basePortNumber + idx + portOffsetRPC
+	conf.Ports.SerfLan = basePortNumber + idx + portOffsetSerfLan
+	conf.Ports.SerfWan = basePortNumber + idx + portOffsetSerfWan
+	conf.Ports.Server = basePortNumber + idx + portOffsetServer
 	conf.Server = true
 	conf.ACLDatacenter = "dc1"
 	conf.ACLMasterToken = "root"


### PR DESCRIPTION
This should fix #1977 and probably a host of other failures associated with failing to listen to an address already in use.