### PR TITLE
Fix deadlock in Consul RTT.

### DIFF
--- a/consul/rtt.go
+++ b/consul/rtt.go
@@ -386,12 +386,11 @@ func getDatacenterMaps(s serfer, dcs []string) []structs.DatacenterMap {
 // other things being equal (or if coordinates are disabled).
 func (s *Server) getDatacentersByDistance() ([]string, error) {
 	s.remoteLock.RLock()
-	defer s.remoteLock.RUnlock()
-
-	var dcs []string
+	dcs := make([]string, 0, len(s.remoteConsuls))
 	for dc := range s.remoteConsuls {
 		dcs = append(dcs, dc)
 	}
+	s.remoteLock.RUnlock()
 
 	// Sort by name first, since the coordinate sort is stable.
 	sort.Strings(dcs)


### PR DESCRIPTION
1. `consul/rtt.go`:388: `getDatacentersByDistance()` == `remoteLock.RLock()`
2. `consul/rtt.go`:341: `sortDatacentersByDistance()` == `RLock()` still held
3. `consul/rtt.go`:282: `getDatacenterDistance()` == `RLock()` still held.
4. `consul/rtt.go`:268: `getNodesForDatacenter()` == Attempt to reacquire `remoteLock.RLock()`, task hangs indefinitely blocking all future readers and writers accessing `remoteConsuls`.