### PR TITLE
If leader response is empty, return HTTP 500 instead of 200

### DIFF
--- a/command/agent/status_endpoint.go
+++ b/command/agent/status_endpoint.go
@@ -9,6 +9,9 @@ func (s *HTTPServer) StatusLeader(resp http.ResponseWriter, req *http.Request) (
 	if err := s.agent.RPC("Status.Leader", struct{}{}, &out); err != nil {
 		return nil, err
 	}
+	if out == "" {
+		resp.WriteHeader(http.StatusInternalServerError) // 500 because there is no leader
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
cc @sean- @slackpad 

A simple change that may make using consul health checks for leader health slightly easier. 