### PR TITLE
Allow for a a more graceful transition from plaintext gossip to encrypted gossip

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -306,6 +306,16 @@ func (a *Agent) consulConfig() *consul.Config {
 	if a.config.ReconnectTimeoutWan != 0 {
 		base.SerfWANConfig.ReconnectTimeout = a.config.ReconnectTimeoutWan
 	}
+	if a.config.AllowInsecureIncomingGossip {
+		fmt.Println("ALLOW INSECURE INCOMING GOSSIP")
+		base.SerfWANConfig.MemberlistConfig.AllowInsecureIncomingGossip = true
+		base.SerfLANConfig.MemberlistConfig.AllowInsecureIncomingGossip = true
+	}
+	if a.config.ProhibitSecureOutgoingGossip {
+		fmt.Println("PROHIBIT SECURE OUTGOING GOSSIP")
+		base.SerfWANConfig.MemberlistConfig.ProhibitSecureOutgoingGossip = true
+		base.SerfLANConfig.MemberlistConfig.ProhibitSecureOutgoingGossip = true
+	}
 	if a.config.AdvertiseAddrs.RPC != nil {
 		base.RPCAdvertise = a.config.AdvertiseAddrs.RPC
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -177,6 +177,10 @@ type Config struct {
 	// Encryption key to use for the Serf communication
 	EncryptKey string `mapstructure:"encrypt" json:"-"`
 
+	// TODO(rboyer):
+	AllowInsecureIncomingGossip  bool `mapstructure:"allow_insecure_incoming_gossip"`
+	ProhibitSecureOutgoingGossip bool `mapstructure:"prohibit_secure_outgoing_gossip"`
+
 	// LogLevel is the level of the logs to putout
 	LogLevel string `mapstructure:"log_level"`
 
@@ -1007,6 +1011,12 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.EncryptKey != "" {
 		result.EncryptKey = b.EncryptKey
+	}
+	if b.ProhibitSecureOutgoingGossip {
+		result.ProhibitSecureOutgoingGossip = true
+	}
+	if b.AllowInsecureIncomingGossip {
+		result.AllowInsecureIncomingGossip = true
 	}
 	if b.LogLevel != "" {
 		result.LogLevel = b.LogLevel

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -112,6 +112,18 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	input = `{"allow_insecure_incoming_gossip":true, "prohibit_secure_outgoing_gossip":true}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if !config.AllowInsecureIncomingGossip {
+		t.Fatalf("bad: %#v", config)
+	}
+	if !config.ProhibitSecureOutgoingGossip {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// DNS setup
 	input = `{"ports": {"dns": 8500}, "recursors": ["8.8.8.8","8.8.4.4"], "recursor":"127.0.0.1", "domain": "foobar"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))

--- a/vendor/github.com/hashicorp/memberlist/config.go
+++ b/vendor/github.com/hashicorp/memberlist/config.go
@@ -147,6 +147,10 @@ type Config struct {
 	// automatically initialized using the SecretKey and SecretKeys values.
 	Keyring *Keyring
 
+	// TODO(rboyer): document
+	AllowInsecureIncomingGossip  bool
+	ProhibitSecureOutgoingGossip bool
+
 	// Delegate and Events are delegates for receiving and providing
 	// data to memberlist via callback mechanisms. For Delegate, see
 	// the Delegate interface. For Events, see the EventDelegate interface.


### PR DESCRIPTION
Currently if you brought up a multi-dc set of wan-joined consul clusters and forgot to enable gossip encryption, the only way to transition to encrypting the gossip causes a temporary rolling gossip split-brain until every server and agent has been bounced.

This patch (which crosses over into `hashicorp/memberlist`, too) adds two new config settings that work in conjunction with `encrypt`:
- `allow_insecure_incoming_gossip` (requires `encryption=true`)
  - This loosens security when attempting to process gossip messages.  It will first try to decrypt the message with the configured keyring, but if that fails it blindly retries assuming it was plaintext.
- `prohibit_secure_outgoing_gossip` (requires `encryption=true`)
  - This disables outbound gossip messages from being encrypted, while still allowing the agent to have a keyring.

The rollout order to avoid a crypto-related gossip split-brain is:
1. everybody has `encrypt="", allow_insecure_incoming_gossip=false, prohibit_secure_outgoing_gossip=false` by default; no encrypted messages
2. incremental switch to: `encrypt="KEY", allow_insecure_incoming_gossip=true, prohibit_secure_outgoing_gossip=true`; no encrypted messages, but everybody COULD decrypt
3. incremental switch to: `encrypt="KEY", allow_insecure_incoming_gossip=true, prohibit_secure_outgoing_gossip=false`; some encrypted messages, and everyone can decrypt
4. incremental switch to: `encrypt="KEY", allow_insecure_incoming_gossip=false, prohibit_secure_outgoing_gossip=false` ; everything is encrypted, no security holes anymore (equivalent to stock encrypted gossip)

This is a pretty edge case need, so I'm fine with this not being merged.  If that's so, it would be terrific if someone could point out any issues with the above as I may need to use this in production as a custom build to transition some clusters regardless of a merge.
