### PR TITLE
Prepared queries: treat empty-string tags as no tags at all

### DIFF
--- a/consul/prepared_query/template.go
+++ b/consul/prepared_query/template.go
@@ -182,5 +182,13 @@ func (ct *CompiledTemplate) Render(name string) (*structs.PreparedQuery, error) 
 		return nil, err
 	}
 
+	tags := []string(nil)
+	for _, tag := range query.Service.Tags {
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	query.Service.Tags = tags
+
 	return query, nil
 }

--- a/consul/prepared_query/template_test.go
+++ b/consul/prepared_query/template_test.go
@@ -244,12 +244,10 @@ func TestTemplate_Render(t *testing.T) {
 			Service: structs.ServiceQuery{
 				Service: "hello- xxx hello-foo-bar-none xxx foo-bar-none",
 				Tags: []string{
-					"",
 					"hello-foo-bar-none",
 					"hello",
 					"foo",
 					"bar-none",
-					"",
 					"42",
 				},
 			},
@@ -274,12 +272,6 @@ func TestTemplate_Render(t *testing.T) {
 			Service: structs.ServiceQuery{
 				Service: "hello- xxx hello-nope xxx nope",
 				Tags: []string{
-					"",
-					"",
-					"",
-					"",
-					"",
-					"",
 					"42",
 				},
 			},

--- a/consul/structs/prepared_query.go
+++ b/consul/structs/prepared_query.go
@@ -57,6 +57,9 @@ type QueryTemplateOptions struct {
 	// used to extract parts of the name and choose a service name, set
 	// tags, etc.
 	Regexp string
+
+	// RemoveEmptyTags, if true, removes empty tags from matched tag list
+	RemoveEmptyTags bool
 }
 
 // PreparedQuery defines a complete prepared query, and is the structure we

--- a/website/source/docs/agent/http/query.html.markdown
+++ b/website/source/docs/agent/http/query.html.markdown
@@ -177,8 +177,7 @@ to static templates, except with some additional fields and features. Here's an 
   "Name": "geo-db",
   "Template": {
     "Type": "name_prefix_match",
-    "Regexp": "^geo-db-(.*?)-([^\\-]+?)$",
-    "RemoveEmptyTags": false
+    "Regexp": "^geo-db-(.*?)-([^\\-]+?)$"
   },
   "Service": {
     "Service": "mysql-${match(1)}",
@@ -193,7 +192,7 @@ to static templates, except with some additional fields and features. Here's an 
 ```
 
 The new `Template` structure configures a prepared query as a template instead of a
-static query. It has three fields:
+static query. It has two fields:
 
 `Type` is the query type, which must be "name_prefix_match". This means that the
 template will apply to any query lookup with a name whose prefix matches the `Name`
@@ -207,10 +206,6 @@ entire name, once this template is selected. In this example, the regular expres
 takes the first item after the "-" as the database name and everything else after as
 a tag. See the [RE2](https://github.com/google/re2/wiki/Syntax) reference for syntax
 of this regular expression.
-
-An optional `RemoveEmptyTags` boolean may be set to true, if the returned tags list
-is to be stripped of empty string elements. `RemoveEmptyTags` defaults to false
-(all tags are being returned, including empty strings).
 
 All other fields of the query have the same meanings as for a static query, except
 that several interpolation variables are available to dynamically populate the query
@@ -475,8 +470,7 @@ a JSON body will be returned like this:
     "Name": "geo-db",
     "Template": {
       "Type": "name_prefix_match",
-      "Regexp": "^geo-db-(.*?)-([^\\-]+?)$",
-      "RemoveEmptyTags": false
+      "Regexp": "^geo-db-(.*?)-([^\\-]+?)$"
     },
     "Service": {
       "Service": "mysql-customer",

--- a/website/source/docs/agent/http/query.html.markdown
+++ b/website/source/docs/agent/http/query.html.markdown
@@ -177,7 +177,8 @@ to static templates, except with some additional fields and features. Here's an 
   "Name": "geo-db",
   "Template": {
     "Type": "name_prefix_match",
-    "Regexp": "^geo-db-(.*?)-([^\\-]+?)$"
+    "Regexp": "^geo-db-(.*?)-([^\\-]+?)$",
+    "RemoveEmptyTags": false
   },
   "Service": {
     "Service": "mysql-${match(1)}",
@@ -192,7 +193,7 @@ to static templates, except with some additional fields and features. Here's an 
 ```
 
 The new `Template` structure configures a prepared query as a template instead of a
-static query. It has two fields:
+static query. It has three fields:
 
 `Type` is the query type, which must be "name_prefix_match". This means that the
 template will apply to any query lookup with a name whose prefix matches the `Name`
@@ -206,6 +207,10 @@ entire name, once this template is selected. In this example, the regular expres
 takes the first item after the "-" as the database name and everything else after as
 a tag. See the [RE2](https://github.com/google/re2/wiki/Syntax) reference for syntax
 of this regular expression.
+
+An optional `RemoveEmptyTags` boolean may be set to true, if the returned tags list
+is to be stripped of empty string elements. `RemoveEmptyTags` defaults to false
+(all tags are being returned, including empty strings).
 
 All other fields of the query have the same meanings as for a static query, except
 that several interpolation variables are available to dynamically populate the query
@@ -470,7 +475,8 @@ a JSON body will be returned like this:
     "Name": "geo-db",
     "Template": {
       "Type": "name_prefix_match",
-      "Regexp": "^geo-db-(.*?)-([^\\-]+?)$"
+      "Regexp": "^geo-db-(.*?)-([^\\-]+?)$",
+      "RemoveEmptyTags": false
     },
     "Service": {
       "Service": "mysql-customer",


### PR DESCRIPTION
Skipping tag filtering in prepared queries might fail as match() produces an empty-string tag.

When using standard DNS interface, it is easy to - optionally - filter by tag, just adding it in front of the service name.
Take the "web" service from the Consul intro as an example:

```
{"service": {"name": "web", "tags": ["rails"], "port": 80}}
```

First, a non-tagged query:

```
$ dig -p 8600 @127.0.0.1 web.service.consul
...
web.service.consul.     0       IN      A       127.0.0.1
...
```

Then, with tag prepended:

```
$ dig -p 8600 @127.0.0.1 rails.web.service.consul
...
rails.web.service.consul. 0     IN      A       127.0.0.1
...
```

A problem arises, if one would like to mimic this behaviour using prepared queries:

```
{
  "Name": "",
  "Template": {
    "Type": "name_prefix_match",
    "Regexp": "^(?:([^\\.]+)\\.)?([^\\.]+)$"
  },
  "Service": {
    "Service": "${match(2)}",
    "Tags": [
      "${match(1)}"
    ]
  }
}
```

This works for queries with a tag specified:

```
$ http 127.0.0.1:8500/v1/query/rails.web/explain | jq .Query.Service
{
  "Service": "web",
  "Failover": {
    "NearestN": 0,
    "Datacenters": null
  },
  "OnlyPassing": false,
  "Tags": [
    "rails"
  ]
}
```

But with the tag ommited - HIL `match()` function returns an empty string, and as such - one ends up with an "empty string" tag:

```
$ http 127.0.0.1:8500/v1/query/web/explain | jq .Query.Service
{
  "Service": "web",
  "Failover": {
    "NearestN": 0,
    "Datacenters": null
  },
  "OnlyPassing": false,
  "Tags": [
    ""
  ]
}
```

This is not equal to no tag filtering at all, and such queries will not return an answer:

```
$ dig -p 8600 @127.0.0.1 rails.web.query.consul
...
rails.web.query.consul. 0       IN      A       127.0.0.1
...

$ dig -p 8600 @127.0.0.1 web.query.consul
...
;; AUTHORITY SECTION:
consul.                 0       IN      SOA     ns.consul.
postmaster.consul. 1467201244 3600 600 86400 0
...
```

As a further confirmation - adding a ""-tag to the service definition would let it match:

```
{"service": {"name": "web", "tags": ["rails", ""], "port": 80}}
```

A potential solution would be to flatten or compact the tags list, omitting empty strings, and returning null instead of a list when no non-empty tags remain:

```
$ http 127.0.0.1:8500/v1/query/web/explain | jq .Query.Service
{
  "Service": "web",
  "Failover": {
    "NearestN": 0,
    "Datacenters": null
  },
  "OnlyPassing": false,
  "Tags": null
}
```

Seems to fix the problem mentioned, hope it does not break other things.
