### PR TITLE
Makes sure version is always displayed consistently.

### DIFF
--- a/command/version.go
+++ b/command/version.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/hashicorp/consul/consul"
 	"github.com/mitchellh/cli"
@@ -9,10 +8,8 @@ import (
 
 // VersionCommand is a Command implementation prints the version.
 type VersionCommand struct {
-	Revision          string
-	Version           string
-	VersionPrerelease string
-	Ui                cli.Ui
+	Version string
+	Ui      cli.Ui
 }
 
 func (c *VersionCommand) Help() string {
@@ -20,19 +17,9 @@ func (c *VersionCommand) Help() string {
 }
 
 func (c *VersionCommand) Run(_ []string) int {
-	var versionString bytes.Buffer
-	fmt.Fprintf(&versionString, "Consul %s", c.Version)
-	if c.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, ".%s", c.VersionPrerelease)
-
-		if c.Revision != "" {
-			fmt.Fprintf(&versionString, " (%s)", c.Revision)
-		}
-	}
-
-	c.Ui.Output(versionString.String())
-	c.Ui.Output(fmt.Sprintf("Consul Protocol: %d (Understands back to: %d)",
-		consul.ProtocolVersionMax, consul.ProtocolVersionMin))
+	c.Ui.Output(fmt.Sprintf("Consul Version: %s", c.Version))
+	c.Ui.Output(fmt.Sprintf("Supported Protocol Version(s): %d to %d",
+		consul.ProtocolVersionMin, consul.ProtocolVersionMax))
 	return 0
 }
 

--- a/commands.go
+++ b/commands.go
@@ -19,11 +19,9 @@ func init() {
 	Commands = map[string]cli.CommandFactory{
 		"agent": func() (cli.Command, error) {
 			return &agent.Command{
-				Revision:          GitCommit,
-				Version:           Version,
-				VersionPrerelease: VersionPrerelease,
-				Ui:                ui,
-				ShutdownCh:        make(chan struct{}),
+				Version:    GetVersion(),
+				Ui:         ui,
+				ShutdownCh: make(chan struct{}),
 			}, nil
 		},
 
@@ -121,20 +119,9 @@ func init() {
 		},
 
 		"version": func() (cli.Command, error) {
-			ver := Version
-			rel := VersionPrerelease
-			if GitDescribe != "" {
-				ver = GitDescribe
-			}
-			if GitDescribe == "" && rel == "" {
-				rel = "dev"
-			}
-
 			return &command.VersionCommand{
-				Revision:          GitCommit,
-				Version:           ver,
-				VersionPrerelease: rel,
-				Ui:                ui,
+				Version: GetVersion(),
+				Ui:      ui,
 			}, nil
 		},
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"fmt"
+	"strings"
+)
+
 // The git commit that was compiled. This will be filled in by the compiler.
 var (
 	GitCommit   string
@@ -13,3 +18,27 @@ const Version = "0.7.0"
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "dev"
+
+// GetVersion returns the full version of Consul.
+func GetVersion() string {
+	version := Version
+	if GitDescribe != "" {
+		version = GitDescribe
+	}
+
+	release := VersionPrerelease
+	if GitDescribe == "" && release == "" {
+		release = "dev"
+	}
+
+	fullVersion := fmt.Sprintf("%s", version)
+	if release != "" {
+		fullVersion += fmt.Sprintf("-%s", release)
+		if GitCommit != "" {
+			fullVersion += fmt.Sprintf(" (%s)", GitCommit)
+		}
+	}
+
+	// Strip off any single quotes added by the git information.
+	return strings.Replace(fullVersion, "'", "", -1)
+}


### PR DESCRIPTION
There were a bunch of different ways we formatted versions so I made one function to rule them all. While in here also cleaned up the protocol version message to be less confusing.