### PR TITLE
Adds version info back into the config.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -38,18 +38,21 @@ var validDatacenter = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
 // ShutdownCh. If two messages are sent on the ShutdownCh it will forcibly
 // exit.
 type Command struct {
-	Version       string
-	Ui            cli.Ui
-	ShutdownCh    <-chan struct{}
-	args          []string
-	logFilter     *logutils.LevelFilter
-	logOutput     io.Writer
-	agent         *Agent
-	rpcServer     *AgentRPC
-	httpServers   []*HTTPServer
-	dnsServer     *DNSServer
-	scadaProvider *scada.Provider
-	scadaHttp     *HTTPServer
+	Revision          string
+	Version           string
+	VersionPrerelease string
+	HumanVersion      string
+	Ui                cli.Ui
+	ShutdownCh        <-chan struct{}
+	args              []string
+	logFilter         *logutils.LevelFilter
+	logOutput         io.Writer
+	agent             *Agent
+	rpcServer         *AgentRPC
+	httpServers       []*HTTPServer
+	dnsServer         *DNSServer
+	scadaProvider     *scada.Provider
+	scadaHttp         *HTTPServer
 }
 
 // readConfig is responsible for setup of our configuration using
@@ -308,6 +311,11 @@ func (c *Command) readConfig() *Config {
 	if config.Bootstrap {
 		c.Ui.Error("WARNING: Bootstrap mode enabled! Do not enable unless necessary")
 	}
+
+	// Set the version info
+	config.Revision = c.Revision
+	config.Version = c.Version
+	config.VersionPrerelease = c.VersionPrerelease
 
 	return config
 }

--- a/command/version.go
+++ b/command/version.go
@@ -8,8 +8,8 @@ import (
 
 // VersionCommand is a Command implementation prints the version.
 type VersionCommand struct {
-	Version string
-	Ui      cli.Ui
+	HumanVersion string
+	Ui           cli.Ui
 }
 
 func (c *VersionCommand) Help() string {
@@ -17,7 +17,7 @@ func (c *VersionCommand) Help() string {
 }
 
 func (c *VersionCommand) Run(_ []string) int {
-	c.Ui.Output(fmt.Sprintf("Consul Version: %s", c.Version))
+	c.Ui.Output(fmt.Sprintf("Consul Version: %s", c.HumanVersion))
 	c.Ui.Output(fmt.Sprintf("Supported Protocol Version(s): %d to %d",
 		consul.ProtocolVersionMin, consul.ProtocolVersionMax))
 	return 0

--- a/commands.go
+++ b/commands.go
@@ -19,9 +19,12 @@ func init() {
 	Commands = map[string]cli.CommandFactory{
 		"agent": func() (cli.Command, error) {
 			return &agent.Command{
-				Version:    GetVersion(),
-				Ui:         ui,
-				ShutdownCh: make(chan struct{}),
+				Revision:          GitCommit,
+				Version:           Version,
+				VersionPrerelease: VersionPrerelease,
+				HumanVersion:      GetHumanVersion(),
+				Ui:                ui,
+				ShutdownCh:        make(chan struct{}),
 			}, nil
 		},
 
@@ -120,8 +123,8 @@ func init() {
 
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
-				Version: GetVersion(),
-				Ui:      ui,
+				HumanVersion: GetHumanVersion(),
+				Ui:           ui,
 			}, nil
 		},
 

--- a/version.go
+++ b/version.go
@@ -19,8 +19,9 @@ const Version = "0.7.0"
 // such as "dev" (in development), "beta", "rc1", etc.
 const VersionPrerelease = "dev"
 
-// GetVersion returns the full version of Consul.
-func GetVersion() string {
+// GetHumanVersion composes the parts of the version in a way that's suitable
+// for displaying to humans.
+func GetHumanVersion() string {
 	version := Version
 	if GitDescribe != "" {
 		version = GitDescribe


### PR DESCRIPTION
In #2191 I accedentally broke SCADA by not populating the agent's version
information into the config structure. This adds it back, and makes the
distinction between the raw parts we send to APIs and the human form of
the version that we display.