### PR TITLE
Fixes #1930 Ability to modify context path of the UI

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -80,6 +80,7 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&cmdConfig.DataDir, "data-dir", "", "path to the data directory")
 	cmdFlags.BoolVar(&cmdConfig.EnableUi, "ui", false, "enable the built-in web UI")
 	cmdFlags.StringVar(&cmdConfig.UiDir, "ui-dir", "", "path to the web UI directory")
+	cmdFlags.StringVar(&cmdConfig.UiPath, "ui-path", "/ui/", "path to the web UI endpoint")
 	cmdFlags.StringVar(&cmdConfig.PidFile, "pid-file", "", "path to file to store PID")
 	cmdFlags.StringVar(&cmdConfig.EncryptKey, "encrypt", "", "gossip encryption key")
 
@@ -1142,6 +1143,7 @@ Options:
   -syslog                  Enables logging to syslog
   -ui                      Enables the built-in static web UI server
   -ui-dir=path             Path to directory containing the Web UI resources
+  -ui-path=/ui-custom/     Custom endpoint/path to web UI server
   -pid-file=path           Path to file to store agent PID
 
  `

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -392,6 +392,10 @@ type Config struct {
 	// If provided, the UI endpoints will be enabled.
 	UiDir string `mapstructure:"ui_dir"`
 
+	// UiPath defines the path where the Web Ui Interface is served
+	// It defaults to /ui/ endpoint
+	UiPath string `mapstructure:"ui_path"`
+
 	// PidFile is the file to store our PID in
 	PidFile string `mapstructure:"pid_file"`
 
@@ -621,6 +625,7 @@ func DefaultConfig() *Config {
 		Telemetry: Telemetry{
 			StatsitePrefix: "consul",
 		},
+		UiPath:              "/ui/",
 		SyslogFacility:      "LOCAL0",
 		Protocol:            consul.ProtocolVersion2Compatible,
 		CheckUpdateInterval: 5 * time.Minute,
@@ -1238,6 +1243,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.UiDir != "" {
 		result.UiDir = b.UiDir
+	}
+	if b.UiPath != "" {
+		result.UiPath = b.UiPath
 	}
 	if b.PidFile != "" {
 		result.PidFile = b.PidFile

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -507,6 +507,13 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// UI Path
+	input = `{"ui_path": "/ui-custom/"}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
 	// Pid File
 	input = `{"pid_file": "/tmp/consul/pid"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -36,6 +36,7 @@ type HTTPServer struct {
 	listener net.Listener
 	logger   *log.Logger
 	uiDir    string
+	uiPath   string
 	addr     string
 }
 
@@ -81,6 +82,7 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 			listener: list,
 			logger:   log.New(logOutput, "", log.LstdFlags),
 			uiDir:    config.UiDir,
+			uiPath:   config.UiPath,
 			addr:     httpAddr.String(),
 		}
 		srv.registerHandlers(config.EnableDebug)
@@ -133,6 +135,7 @@ func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPS
 			listener: list,
 			logger:   log.New(logOutput, "", log.LstdFlags),
 			uiDir:    config.UiDir,
+			uiPath:   config.UiPath,
 			addr:     httpAddr.String(),
 		}
 		srv.registerHandlers(config.EnableDebug)
@@ -280,9 +283,9 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 
 	// Use the custom UI dir if provided.
 	if s.uiDir != "" {
-		s.mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(http.Dir(s.uiDir))))
+		s.mux.Handle(s.uiPath, http.StripPrefix(s.uiPath, http.FileServer(http.Dir(s.uiDir))))
 	} else if s.agent.config.EnableUi {
-		s.mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(assetFS())))
+		s.mux.Handle(s.uiPath, http.StripPrefix(s.uiPath, http.FileServer(assetFS())))
 	}
 
 	// API's are under /internal/ui/ to avoid conflict

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -639,7 +639,7 @@ func TestScadaHTTP(t *testing.T) {
 
 func TestEnableWebUI(t *testing.T) {
 	httpTestWithConfig(t, func(s *HTTPServer) {
-		req, err := http.NewRequest("GET", "/ui/", nil)
+		req, err := http.NewRequest("GET", s.uiPath, nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -654,6 +654,27 @@ func TestEnableWebUI(t *testing.T) {
 		}
 	}, func(c *Config) {
 		c.EnableUi = true
+	})
+}
+
+func TestEnableWebUICustomPath(t *testing.T) {
+	httpTestWithConfig(t, func(s *HTTPServer) {
+		req, err := http.NewRequest("GET", s.uiPath, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// Perform the request
+		resp := httptest.NewRecorder()
+		s.mux.ServeHTTP(resp, req)
+
+		// Check the result
+		if resp.Code != 200 {
+			t.Fatalf("should handle ui")
+		}
+	}, func(c *Config) {
+		c.EnableUi = true
+		c.UiPath = "/ui-custom/"
 	})
 }
 


### PR DESCRIPTION
Adds -ui-path option to agent command && ui_path field to config to allow custom ui path for web UI server; defaults to /ui/

Signed-off-by: Abhinav Dahiya abhinavdtu2012@gmail.com
