### PR TITLE
Remove duplicated environment variables

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,22 @@ const (
 	// HTTPAddrEnvName defines an environment variable name which sets
 	// the HTTP address if there is no -http-addr specified.
 	HTTPAddrEnvName = "CONSUL_HTTP_ADDR"
+
+	// HTTPTokenEnvName defines an environment variable name which sets
+	// the HTTP token.
+	HTTPTokenEnvName = "CONSUL_HTTP_TOKEN"
+
+	// HTTPAuthEnvName defines an environment variable name which sets
+	// the HTTP authentication header.
+	HTTPAuthEnvName = "CONSUL_HTTP_AUTH"
+
+	// HTTPSSLEnvName defines an environment variable name which sets
+	// whether or not to use HTTPS.
+	HTTPSSLEnvName = "CONSUL_HTTP_SSL"
+
+	// HTTPSSLVerifyEnvName defines an environment variable name which sets
+	// whether or not to disable certificate checking.
+	HTTPSSLVerifyEnvName = "CONSUL_HTTP_SSL_VERIFY"
 )
 
 // QueryOptions are used to parameterize a query
@@ -188,11 +204,11 @@ func defaultConfig(transportFn func() *http.Transport) *Config {
 		config.Address = addr
 	}
 
-	if token := os.Getenv("CONSUL_HTTP_TOKEN"); token != "" {
+	if token := os.Getenv(HTTPTokenEnvName); token != "" {
 		config.Token = token
 	}
 
-	if auth := os.Getenv("CONSUL_HTTP_AUTH"); auth != "" {
+	if auth := os.Getenv(HTTPAuthEnvName); auth != "" {
 		var username, password string
 		if strings.Contains(auth, ":") {
 			split := strings.SplitN(auth, ":", 2)
@@ -208,10 +224,10 @@ func defaultConfig(transportFn func() *http.Transport) *Config {
 		}
 	}
 
-	if ssl := os.Getenv("CONSUL_HTTP_SSL"); ssl != "" {
+	if ssl := os.Getenv(HTTPSSLEnvName); ssl != "" {
 		enabled, err := strconv.ParseBool(ssl)
 		if err != nil {
-			log.Printf("[WARN] client: could not parse CONSUL_HTTP_SSL: %s", err)
+			log.Printf("[WARN] client: could not parse %s: %s", HTTPSSLEnvName, err)
 		}
 
 		if enabled {
@@ -219,10 +235,10 @@ func defaultConfig(transportFn func() *http.Transport) *Config {
 		}
 	}
 
-	if verify := os.Getenv("CONSUL_HTTP_SSL_VERIFY"); verify != "" {
+	if verify := os.Getenv(HTTPSSLVerifyEnvName); verify != "" {
 		doVerify, err := strconv.ParseBool(verify)
 		if err != nil {
-			log.Printf("[WARN] client: could not parse CONSUL_HTTP_SSL_VERIFY: %s", err)
+			log.Printf("[WARN] client: could not parse %s: %s", HTTPSSLVerifyEnvName, err)
 		}
 
 		if !doVerify {

--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,12 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+const (
+	// HTTPAddrEnvName defines an environment variable name which sets
+	// the HTTP address if there is no -http-addr specified.
+	HTTPAddrEnvName = "CONSUL_HTTP_ADDR"
+)
+
 // QueryOptions are used to parameterize a query
 type QueryOptions struct {
 	// Providing a datacenter overwrites the DC provided
@@ -178,7 +184,7 @@ func defaultConfig(transportFn func() *http.Transport) *Config {
 		},
 	}
 
-	if addr := os.Getenv("CONSUL_HTTP_ADDR"); addr != "" {
+	if addr := os.Getenv(HTTPAddrEnvName); addr != "" {
 		config.Address = addr
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -78,14 +78,14 @@ func TestDefaultConfig_env(t *testing.T) {
 
 	os.Setenv(HTTPAddrEnvName, addr)
 	defer os.Setenv(HTTPAddrEnvName, "")
-	os.Setenv("CONSUL_HTTP_TOKEN", token)
-	defer os.Setenv("CONSUL_HTTP_TOKEN", "")
-	os.Setenv("CONSUL_HTTP_AUTH", auth)
-	defer os.Setenv("CONSUL_HTTP_AUTH", "")
-	os.Setenv("CONSUL_HTTP_SSL", "1")
-	defer os.Setenv("CONSUL_HTTP_SSL", "")
-	os.Setenv("CONSUL_HTTP_SSL_VERIFY", "0")
-	defer os.Setenv("CONSUL_HTTP_SSL_VERIFY", "")
+	os.Setenv(HTTPTokenEnvName, token)
+	defer os.Setenv(HTTPTokenEnvName, "")
+	os.Setenv(HTTPAuthEnvName, auth)
+	defer os.Setenv(HTTPAuthEnvName, "")
+	os.Setenv(HTTPSSLEnvName, "1")
+	defer os.Setenv(HTTPSSLEnvName, "")
+	os.Setenv(HTTPSSLVerifyEnvName, "0")
+	defer os.Setenv(HTTPSSLVerifyEnvName, "")
 
 	for i, config := range []*Config{DefaultConfig(), DefaultNonPooledConfig()} {
 		if config.Address != addr {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -76,8 +76,8 @@ func TestDefaultConfig_env(t *testing.T) {
 	token := "abcd1234"
 	auth := "username:password"
 
-	os.Setenv("CONSUL_HTTP_ADDR", addr)
-	defer os.Setenv("CONSUL_HTTP_ADDR", "")
+	os.Setenv(HTTPAddrEnvName, addr)
+	defer os.Setenv(HTTPAddrEnvName, "")
 	os.Setenv("CONSUL_HTTP_TOKEN", token)
 	defer os.Setenv("CONSUL_HTTP_TOKEN", "")
 	os.Setenv("CONSUL_HTTP_AUTH", auth)

--- a/command/agent/rpc_client.go
+++ b/command/agent/rpc_client.go
@@ -13,6 +13,12 @@ import (
 	"sync/atomic"
 )
 
+const (
+	// RPCAddrEnvName defines an environment variable name which sets
+	// an RPC address if there is no -rpc-addr specified.
+	RPCAddrEnvName = "CONSUL_RPC_ADDR"
+)
+
 var (
 	clientClosed = fmt.Errorf("client closed")
 )
@@ -84,7 +90,7 @@ func NewRPCClient(addr string) (*RPCClient, error) {
 	var conn net.Conn
 	var err error
 
-	if envAddr := os.Getenv("CONSUL_RPC_ADDR"); envAddr != "" {
+	if envAddr := os.Getenv(RPCAddrEnvName); envAddr != "" {
 		addr = envAddr
 	}
 

--- a/command/rpc.go
+++ b/command/rpc.go
@@ -8,20 +8,10 @@ import (
 	"github.com/hashicorp/consul/command/agent"
 )
 
-const (
-	// RPCAddrEnvName defines an environment variable name which sets
-	// an RPC address if there is no -rpc-addr specified.
-	RPCAddrEnvName = "CONSUL_RPC_ADDR"
-
-	// HTTPAddrEnvName defines an environment variable name which sets
-	// the HTTP address if there is no -http-addr specified.
-	HTTPAddrEnvName = "CONSUL_HTTP_ADDR"
-)
-
 // RPCAddrFlag returns a pointer to a string that will be populated
 // when the given flagset is parsed with the RPC address of the Consul.
 func RPCAddrFlag(f *flag.FlagSet) *string {
-	defaultRPCAddr := os.Getenv(RPCAddrEnvName)
+	defaultRPCAddr := os.Getenv(agent.RPCAddrEnvName)
 	if defaultRPCAddr == "" {
 		defaultRPCAddr = "127.0.0.1:8400"
 	}
@@ -37,7 +27,7 @@ func RPCClient(addr string) (*agent.RPCClient, error) {
 // HTTPAddrFlag returns a pointer to a string that will be populated
 // when the given flagset is parsed with the HTTP address of the Consul.
 func HTTPAddrFlag(f *flag.FlagSet) *string {
-	defaultHTTPAddr := os.Getenv(HTTPAddrEnvName)
+	defaultHTTPAddr := os.Getenv(consulapi.HTTPAddrEnvName)
 	if defaultHTTPAddr == "" {
 		defaultHTTPAddr = "127.0.0.1:8500"
 	}

--- a/command/rpc_test.go
+++ b/command/rpc_test.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"os"
 	"testing"
+
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/agent"
 )
 
 const (
@@ -21,11 +24,11 @@ func getParsedAddr(t *testing.T, addrType, cliVal, envVal string) string {
 	switch addrType {
 	case "rpc":
 		fn = RPCAddrFlag
-		envVar = RPCAddrEnvName
+		envVar = agent.RPCAddrEnvName
 		cliFlag = "-rpc-addr"
 	case "http":
 		fn = HTTPAddrFlag
-		envVar = HTTPAddrEnvName
+		envVar = consulapi.HTTPAddrEnvName
 		cliFlag = "-http-addr"
 	default:
 		t.Fatalf("unknown address type %s", addrType)


### PR DESCRIPTION
`CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR` have been defined as constants in `command/rpc.go`, but they're still hardcoded in `command/agent/rpc_client.go` and `api/api.go`.

This pull request removes these redundancy, and define some more environment variable constants for consistency.
