### PR TITLE
Fix string concatenation in consul.tf

### DIFF
--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "server" {
-    ami = "${lookup(var.ami, concat(var.region, "-", var.platform))}"
+    ami = "${lookup(var.ami, "${var.region}-${var.platform}")}"
     instance_type = "${var.instance_type}"
     key_name = "${var.key_name}"
     count = "${var.servers}"


### PR DESCRIPTION
Since Terraform 0.7 doesn't support the concat() function for string
concatenation, a replacement for concat() needs to be used when
joining strings.

With the current syntax the module doesn't run on Terraform 0.7.