### PR TITLE
Updates Serf to pick up intent queue fix.

### DIFF
--- a/vendor/github.com/hashicorp/serf/serf/config.go
+++ b/vendor/github.com/hashicorp/serf/serf/config.go
@@ -121,12 +121,12 @@ type Config struct {
 	// prevent an unbounded growth of memory utilization
 	MaxQueueDepth int
 
-	// RecentIntentBuffer is used to set the size of recent join and leave intent
-	// messages that will be buffered. This is used to guard against
-	// the case where Serf broadcasts an intent that arrives before the
-	// Memberlist event. It is important that this not be too small to avoid
-	// continuous rebroadcasting of dead events.
-	RecentIntentBuffer int
+	// RecentIntentTimeout is used to determine how long we store recent
+	// join and leave intents. This is used to guard against the case where
+	// Serf broadcasts an intent that arrives before the Memberlist event.
+	// It is important that this not be too short to avoid continuous
+	// rebroadcasting of dead events.
+	RecentIntentTimeout time.Duration
 
 	// EventBuffer is used to control how many events are buffered.
 	// This is used to prevent re-delivery of events to a client. The buffer
@@ -242,7 +242,7 @@ func DefaultConfig() *Config {
 		LogOutput:                    os.Stderr,
 		ProtocolVersion:              ProtocolVersionMax,
 		ReapInterval:                 15 * time.Second,
-		RecentIntentBuffer:           128,
+		RecentIntentTimeout:          5 * time.Minute,
 		ReconnectInterval:            30 * time.Second,
 		ReconnectTimeout:             24 * time.Hour,
 		QueueDepthWarning:            128,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -276,14 +276,18 @@
 			"revision": "84989fd23ad4cc0e7ad44d6a871fd793eb9beb0a"
 		},
 		{
+			"checksumSHA1": "E3Xcanc9ouQwL+CZGOUyA/+giLg=",
 			"comment": "v0.7.0-66-g6c4672d",
 			"path": "github.com/hashicorp/serf/coordinate",
-			"revision": "6c4672d66fc6312ddde18399262943e21175d831"
+			"revision": "114430d8210835d66defdc31cdc176c58e060005",
+			"revisionTime": "2016-08-09T01:42:04Z"
 		},
 		{
+			"checksumSHA1": "vLyudzMEdik8IpRY1H2vRa2PeLU=",
 			"comment": "v0.7.0-66-g6c4672d",
 			"path": "github.com/hashicorp/serf/serf",
-			"revision": "6c4672d66fc6312ddde18399262943e21175d831"
+			"revision": "114430d8210835d66defdc31cdc176c58e060005",
+			"revisionTime": "2016-08-09T01:42:04Z"
 		},
 		{
 			"path": "github.com/hashicorp/yamux",


### PR DESCRIPTION
This fixes #1062 by storing intents per-node instead of in a small, fixed-
size circular buffer.