### PR TITLE
Validates gossip encryption key before made persistent in local.keyring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ BUG FIXES:
   fail to start due to open user-mapped sections. [GH-2203]
 * Fixed an issue where large events affecting many nodes could cause infinite intent
   rebroadcasts, leading to many log messages about intent queue overflows. [GH-1062]
+* Gossip encryption keys are now validated before being made persistent in the
+  keyring, avoiding delayed feedback at runtime. [GH-1299]
 
 OTHER CHANGES:
 

--- a/command/agent/keyring.go
+++ b/command/agent/keyring.go
@@ -22,7 +22,9 @@ const (
 func initKeyring(path, key string) error {
 	var keys []string
 
-	if _, err := base64.StdEncoding.DecodeString(key); err != nil {
+	if keyBytes, err := base64.StdEncoding.DecodeString(key); err != nil {
+		return fmt.Errorf("Invalid key: %s", err)
+	} else if err := memberlist.ValidateKey(keyBytes); err != nil {
 		return fmt.Errorf("Invalid key: %s", err)
 	}
 

--- a/vendor/github.com/hashicorp/memberlist/keyring.go
+++ b/vendor/github.com/hashicorp/memberlist/keyring.go
@@ -58,6 +58,17 @@ func NewKeyring(keys [][]byte, primaryKey []byte) (*Keyring, error) {
 	return keyring, nil
 }
 
+// ValidateKey will check to see if the key is valid and returns an error if not.
+//
+// key should be either 16, 24, or 32 bytes to select AES-128,
+// AES-192, or AES-256.
+func ValidateKey(key []byte) error {
+	if l := len(key); l != 16 && l != 24 && l != 32 {
+		return fmt.Errorf("key size must be 16, 24 or 32 bytes")
+	}
+	return nil
+}
+
 // AddKey will install a new key on the ring. Adding a key to the ring will make
 // it available for use in decryption. If the key already exists on the ring,
 // this function will just return noop.
@@ -65,8 +76,8 @@ func NewKeyring(keys [][]byte, primaryKey []byte) (*Keyring, error) {
 // key should be either 16, 24, or 32 bytes to select AES-128,
 // AES-192, or AES-256.
 func (k *Keyring) AddKey(key []byte) error {
-	if l := len(key); l != 16 && l != 24 && l != 32 {
-		return fmt.Errorf("key size must be 16, 24 or 32 bytes")
+	if err := ValidateKey(key); err != nil {
+		return err
 	}
 
 	// No-op if key is already installed

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -344,10 +344,10 @@
 			"revisionTime": "2015-06-09T07:04:31Z"
 		},
 		{
-			"checksumSHA1": "8ytOx52G+38QMK4G194Kl6g6YGY=",
+			"checksumSHA1": "AY1/cRsuWpoJMG0J821TqFo9nDE=",
 			"path": "github.com/hashicorp/memberlist",
-			"revision": "b2053e314b4a87e5f0d2d47aeafd3e03be13da90",
-			"revisionTime": "2016-06-21T23:59:43Z"
+			"revision": "0c5ba075f8520c65572f001331a1a43b756e01d7",
+			"revisionTime": "2016-08-12T18:27:57Z"
 		},
 		{
 			"checksumSHA1": "qnlqWJYV81ENr61SZk9c65R1mDo=",


### PR DESCRIPTION
This rebases #2148 and updates the vendor metadata.