### PR TITLE
Adds ability to deregister a service based on critical check state longer than a timeout.

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -74,11 +74,11 @@ type AgentServiceCheck struct {
 	TCP               string `json:",omitempty"`
 	Status            string `json:",omitempty"`
 
-	// Checks that are associated with a service may also contain this
-	// optional DeregisterCriticalServiceAfter field, which is a timeout in
-	// the same Go time format as Interval and TTL. If a check is in the
-	// critical state for more than this configured value, then its
-	// associated service (and all of its associated checks) will
+	// In Consul 0.7 and later, checks that are associated with a service
+	// may also contain this optional DeregisterCriticalServiceAfter field,
+	// which is a timeout in the same Go time format as Interval and TTL. If
+	// a check is in the critical state for more than this configured value,
+	// then its associated service (and all of its associated checks) will
 	// automatically be deregistered.
 	DeregisterCriticalServiceAfter string `json:",omitempty"`
 }

--- a/api/agent.go
+++ b/api/agent.go
@@ -62,8 +62,7 @@ type AgentCheckRegistration struct {
 	AgentServiceCheck
 }
 
-// AgentServiceCheck is used to create an associated
-// check for a service
+// AgentServiceCheck is used to define a node or service level check
 type AgentServiceCheck struct {
 	Script            string `json:",omitempty"`
 	DockerContainerID string `json:",omitempty"`
@@ -74,6 +73,14 @@ type AgentServiceCheck struct {
 	HTTP              string `json:",omitempty"`
 	TCP               string `json:",omitempty"`
 	Status            string `json:",omitempty"`
+
+	// Checks that are associated with a service may also contain this
+	// optional DeregisterCriticalServiceAfter field, which is a timeout in
+	// the same Go time format as Interval and TTL. If a check is in the
+	// critical state for more than this configured value, then its
+	// associated service (and all of its associated checks) will
+	// automatically be deregistered.
+	DeregisterCriticalServiceAfter string `json:",omitempty"`
 }
 type AgentServiceChecks []*AgentServiceCheck
 

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -455,6 +455,13 @@ func TestAgent_Checks_serviceBound(t *testing.T) {
 		ServiceID: "redis",
 	}
 	reg.TTL = "15s"
+	reg.DeregisterCriticalServiceAfter = "nope"
+	err := agent.CheckRegister(reg)
+	if err == nil || !strings.Contains(err.Error(), "invalid duration") {
+		t.Fatalf("err: %v", err)
+	}
+
+	reg.DeregisterCriticalServiceAfter = "90m"
 	if err := agent.CheckRegister(reg); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -144,7 +144,7 @@ func (s *HTTPServer) AgentDeregisterCheck(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) AgentCheckPass(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := types.CheckID(strings.TrimPrefix(req.URL.Path, "/v1/agent/check/pass/"))
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthPassing, note); err != nil {
+	if err := s.agent.updateTTLCheck(checkID, structs.HealthPassing, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()
@@ -154,7 +154,7 @@ func (s *HTTPServer) AgentCheckPass(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) AgentCheckWarn(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := types.CheckID(strings.TrimPrefix(req.URL.Path, "/v1/agent/check/warn/"))
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthWarning, note); err != nil {
+	if err := s.agent.updateTTLCheck(checkID, structs.HealthWarning, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()
@@ -164,7 +164,7 @@ func (s *HTTPServer) AgentCheckWarn(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) AgentCheckFail(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	checkID := types.CheckID(strings.TrimPrefix(req.URL.Path, "/v1/agent/check/fail/"))
 	note := req.URL.Query().Get("note")
-	if err := s.agent.UpdateCheck(checkID, structs.HealthCritical, note); err != nil {
+	if err := s.agent.updateTTLCheck(checkID, structs.HealthCritical, note); err != nil {
 		return nil, err
 	}
 	s.syncChanges()
@@ -216,7 +216,7 @@ func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Reques
 	}
 
 	checkID := types.CheckID(strings.TrimPrefix(req.URL.Path, "/v1/agent/check/update/"))
-	if err := s.agent.UpdateCheck(checkID, update.Status, update.Output); err != nil {
+	if err := s.agent.updateTTLCheck(checkID, update.Status, update.Output); err != nil {
 		return nil, err
 	}
 	s.syncChanges()

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -641,7 +641,7 @@ func TestAgent_RemoveCheck(t *testing.T) {
 	}
 }
 
-func TestAgent_UpdateCheck(t *testing.T) {
+func TestAgent_updateTTLCheck(t *testing.T) {
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -655,17 +655,17 @@ func TestAgent_UpdateCheck(t *testing.T) {
 	chk := &CheckType{
 		TTL: 15 * time.Second,
 	}
+
+	// Add check and update it.
 	err := agent.AddCheck(health, chk, false, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	// Remove check
-	if err := agent.UpdateCheck("mem", structs.HealthPassing, "foo"); err != nil {
+	if err := agent.updateTTLCheck("mem", structs.HealthPassing, "foo"); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Ensure we have a check mapping
+	// Ensure we have a check mapping.
 	status := agent.state.Checks()["mem"]
 	if status.Status != structs.HealthPassing {
 		t.Fatalf("bad: %v", status)
@@ -1247,7 +1247,7 @@ func TestAgent_unloadServices(t *testing.T) {
 	}
 }
 
-func TestAgent_ServiceMaintenanceMode(t *testing.T) {
+func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1309,6 +1309,133 @@ func TestAgent_ServiceMaintenanceMode(t *testing.T) {
 	}
 	if check.Notes != defaultServiceMaintReason {
 		t.Fatalf("bad: %#v", check)
+	}
+}
+
+func TestAgent_Service_Reap(t *testing.T) {
+	config := nextConfig()
+	config.CheckReapInterval = time.Millisecond
+	config.CheckDeregisterIntervalMin = 0
+	dir, agent := makeAgent(t, config)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	svc := &structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Tags:    []string{"foo"},
+		Port:    8000,
+	}
+	chkTypes := CheckTypes{
+		&CheckType{
+			Status: structs.HealthPassing,
+			TTL:    10 * time.Millisecond,
+			DeregisterCriticalServiceAfter: 100 * time.Millisecond,
+		},
+	}
+
+	// Register the service.
+	if err := agent.AddService(svc, chkTypes, false, ""); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Make sure it's there and there's no critical check yet.
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) > 0 {
+		t.Fatalf("should not have critical checks")
+	}
+
+	// Wait for the check TTL to fail.
+	time.Sleep(30 * time.Millisecond)
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) != 1 {
+		t.Fatalf("should have a critical check")
+	}
+
+	// Pass the TTL.
+	if err := agent.updateTTLCheck("service:redis", structs.HealthPassing, "foo"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) > 0 {
+		t.Fatalf("should not have critical checks")
+	}
+
+	// Wait for the check TTL to fail again.
+	time.Sleep(30 * time.Millisecond)
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) != 1 {
+		t.Fatalf("should have a critical check")
+	}
+
+	// Wait for the reap.
+	time.Sleep(300 * time.Millisecond)
+	if _, ok := agent.state.Services()["redis"]; ok {
+		t.Fatalf("redis service should have been reaped")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) > 0 {
+		t.Fatalf("should not have critical checks")
+	}
+}
+
+func TestAgent_Service_NoReap(t *testing.T) {
+	config := nextConfig()
+	config.CheckReapInterval = time.Millisecond
+	config.CheckDeregisterIntervalMin = 0
+	dir, agent := makeAgent(t, config)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	svc := &structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Tags:    []string{"foo"},
+		Port:    8000,
+	}
+	chkTypes := CheckTypes{
+		&CheckType{
+			Status: structs.HealthPassing,
+			TTL:    10 * time.Millisecond,
+		},
+	}
+
+	// Register the service.
+	if err := agent.AddService(svc, chkTypes, false, ""); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Make sure it's there and there's no critical check yet.
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) > 0 {
+		t.Fatalf("should not have critical checks")
+	}
+
+	// Wait for the check TTL to fail.
+	time.Sleep(30 * time.Millisecond)
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) != 1 {
+		t.Fatalf("should have a critical check")
+	}
+
+	// Wait a while and make sure it doesn't reap.
+	time.Sleep(300 * time.Millisecond)
+	if _, ok := agent.state.Services()["redis"]; !ok {
+		t.Fatalf("should have redis service")
+	}
+	if checks := agent.state.CriticalChecks(); len(checks) != 1 {
+		t.Fatalf("should have a critical check")
 	}
 }
 

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -35,12 +35,11 @@ const (
 	HttpUserAgent = "Consul Health Check"
 )
 
-// CheckType is used to create either the CheckMonitor
-// or the CheckTTL.
-// Five types are supported: Script, HTTP, TCP, Docker and TTL
-// Script, HTTP, Docker and TCP all require Interval
-// Only one of the types needs to be provided
-// TTL or Script/Interval or HTTP/Interval or TCP/Interval or Docker/Interval
+// CheckType is used to create either the CheckMonitor or the CheckTTL.
+// Five types are supported: Script, HTTP, TCP, Docker and TTL. Script, HTTP,
+// Docker and TCP all require Interval. Only one of the types may to be
+// provided: TTL or Script/Interval or HTTP/Interval or TCP/Interval or
+// Docker/Interval.
 type CheckType struct {
 	Script            string
 	HTTP              string
@@ -51,6 +50,11 @@ type CheckType struct {
 
 	Timeout time.Duration
 	TTL     time.Duration
+
+	// DeregisterCriticalServiceAfter, if >0, will cause the associated
+	// service, if any, to be deregistered if this check is critical for
+	// longer than this duration.
+	DeregisterCriticalServiceAfter time.Duration
 
 	Status string
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1258,7 +1258,7 @@ func TestDecodeConfig_Multiples(t *testing.T) {
 
 func TestDecodeConfig_Service(t *testing.T) {
 	// Basics
-	input := `{"service": {"id": "red1", "name": "redis", "tags": ["master"], "port":8000, "check": {"script": "/bin/check_redis", "interval": "10s", "ttl": "15s" }}}`
+	input := `{"service": {"id": "red1", "name": "redis", "tags": ["master"], "port":8000, "check": {"script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "DeregisterCriticalServiceAfter": "90m" }}}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1296,11 +1296,15 @@ func TestDecodeConfig_Service(t *testing.T) {
 	if serv.Check.TTL != 15*time.Second {
 		t.Fatalf("bad: %v", serv)
 	}
+
+	if serv.Check.DeregisterCriticalServiceAfter != 90*time.Minute {
+		t.Fatalf("bad: %v", serv)
+	}
 }
 
 func TestDecodeConfig_Check(t *testing.T) {
 	// Basics
-	input := `{"check": {"id": "chk1", "name": "mem", "notes": "foobar", "script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "shell": "/bin/bash", "docker_container_id": "redis" }}`
+	input := `{"check": {"id": "chk1", "name": "mem", "notes": "foobar", "script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "shell": "/bin/bash", "docker_container_id": "redis", "deregister_critical_service_after": "90s" }}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1340,6 +1344,10 @@ func TestDecodeConfig_Check(t *testing.T) {
 	}
 
 	if chk.DockerContainerID != "redis" {
+		t.Fatalf("bad: %v", chk)
+	}
+
+	if chk.DeregisterCriticalServiceAfter != 90*time.Second {
 		t.Fatalf("bad: %v", chk)
 	}
 }

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -169,15 +169,15 @@ parsed by Go's `time` package, and has the following
 > optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 > Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-Checks that are associated with a service may also contain an optional
-`deregister_critical_service_after` field, which is a timeout in the same Go time
-format as `interval` and `ttl`. If a check is in the critical state for more than this
-configured value, then its associated service (and all of its associated checks)
-will automatically be deregistered. The minimum timeout is 1 minute, and the
-process that reaps critical services runs every 15 seconds, so a may take slightly
-longer than the configured timeout to trigger the deregistration. This should
-generally be configured with a timeout that's much, much longer than any expected
-recoverable outage for the given service.
+In Consul 0.7 and later, checks that are associated with a service may also contain
+an optional `deregister_critical_service_after` field, which is a timeout in the
+same Go time format as `interval` and `ttl`. If a check is in the critical state
+for more than this configured value, then its associated service (and all of its
+associated checks) will automatically be deregistered. The minimum timeout is 1
+minute, and the process that reaps critical services runs every 15 seconds, so it
+may take slightly longer than the configured timeout to trigger the deregistration.
+This should generally be configured with a timeout that's much, much longer than
+any expected recoverable outage for the given service.
 
 To configure a check, either provide it as a `-config-file` option to the
 agent or place it inside the `-config-dir` of the agent. The file must

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -174,7 +174,7 @@ an optional `deregister_critical_service_after` field, which is a timeout in the
 same Go time format as `interval` and `ttl`. If a check is in the critical state
 for more than this configured value, then its associated service (and all of its
 associated checks) will automatically be deregistered. The minimum timeout is 1
-minute, and the process that reaps critical services runs every 15 seconds, so it
+minute, and the process that reaps critical services runs every 30 seconds, so it
 may take slightly longer than the configured timeout to trigger the deregistration.
 This should generally be configured with a timeout that's much, much longer than
 any expected recoverable outage for the given service.

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -169,6 +169,16 @@ parsed by Go's `time` package, and has the following
 > optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
 > Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
+Checks that are associated with a service may also contain an optional
+`deregister_critical_service_after` field, which is a timeout in the same Go time
+format as `interval` and `ttl`. If a check is in the critical state for more than this
+configured value, then its associated service (and all of its associated checks)
+will automatically be deregistered. The minimum timeout is 1 minute, and the
+process that reaps critical services runs every 15 seconds, so a may take slightly
+longer than the configured timeout to trigger the deregistration. This should
+generally be configured with a timeout that's much, much longer than any expected
+recoverable outage for the given service.
+
 To configure a check, either provide it as a `-config-file` option to the
 agent or place it inside the `-config-dir` of the agent. The file must
 end in the ".json" extension to be loaded by Consul. Check definitions can

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -243,13 +243,14 @@ body must look like:
   "ID": "mem",
   "Name": "Memory utilization",
   "Notes": "Ensure we don't oversubscribe memory",
+  "DeregisterCriticalServiceAfter": "90m"
   "Script": "/usr/local/bin/check_mem.py",
   "DockerContainerID": "f972c95ebf0e",
   "Shell": "/bin/bash",
   "HTTP": "http://example.com",
   "TCP": "example.com:22",
   "Interval": "10s",
-  "TTL": "15s"
+  "TTL": "15s",
 }
 ```
 
@@ -260,6 +261,16 @@ If an `ID` is not provided, it is set to `Name`. You cannot have duplicate
 `ID` entries per agent, so it may be necessary to provide an `ID`.
 
 The `Notes` field is not used internally by Consul and is meant to be human-readable.
+
+Checks that are associated with a service may also contain an optional
+`DeregisterCriticalServiceAfter` field, which is a timeout in the same Go time
+format as `Interval` and `TTL`. If a check is in the critical state for more than this
+configured value, then its associated service (and all of its associated checks)
+will automatically be deregistered. The minimum timeout is 1 minute, and the
+process that reaps critical services runs every 15 seconds, so a may take slightly
+longer than the configured timeout to trigger the deregistration. This should
+generally be configured with a timeout that's much, much longer than any expected
+recoverable outage for the given service.
 
 If a `Script` is provided, the check type is a script, and Consul will
 evaluate the script every `Interval` to update the status.
@@ -389,6 +400,7 @@ body must look like:
   "Port": 8000,
   "EnableTagOverride": false, 
   "Check": {
+    "DeregisterCriticalServiceAfter": "90m",
     "Script": "/usr/local/bin/check_redis.py",
     "HTTP": "http://localhost:5000/health",
     "Interval": "10s",
@@ -413,6 +425,17 @@ information.
 
 If `Check` is provided, only one of `Script`, `HTTP`, `TCP` or `TTL` should be specified.
 `Script` and `HTTP` also require `Interval`. The created check will be named "service:\<ServiceId\>".
+
+Checks that are associated with a service may also contain an optional
+`DeregisterCriticalServiceAfter` field, which is a timeout in the same Go time
+format as `Interval` and `TTL`. If a check is in the critical state for more than this
+configured value, then its associated service (and all of its associated checks)
+will automatically be deregistered. The minimum timeout is 1 minute, and the
+process that reaps critical services runs every 15 seconds, so a may take slightly
+longer than the configured timeout to trigger the deregistration. This should
+generally be configured with a timeout that's much, much longer than any expected
+recoverable outage for the given service.
+
 There is more information about checks [here](/docs/agent/checks.html).
 
 `EnableTagOverride` can optionally be specified to disable the anti-entropy

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -262,12 +262,12 @@ If an `ID` is not provided, it is set to `Name`. You cannot have duplicate
 
 The `Notes` field is not used internally by Consul and is meant to be human-readable.
 
-Checks that are associated with a service may also contain an optional
-`DeregisterCriticalServiceAfter` field, which is a timeout in the same Go time
-format as `Interval` and `TTL`. If a check is in the critical state for more than this
-configured value, then its associated service (and all of its associated checks)
+In Consul 0.7 and later, checks that are associated with a service may also contain
+an optional `DeregisterCriticalServiceAfter` field, which is a timeout in the same Go
+time format as `Interval` and `TTL`. If a check is in the critical state for more than
+this configured value, then its associated service (and all of its associated checks)
 will automatically be deregistered. The minimum timeout is 1 minute, and the
-process that reaps critical services runs every 15 seconds, so a may take slightly
+process that reaps critical services runs every 15 seconds, so it may take slightly
 longer than the configured timeout to trigger the deregistration. This should
 generally be configured with a timeout that's much, much longer than any expected
 recoverable outage for the given service.
@@ -426,12 +426,12 @@ information.
 If `Check` is provided, only one of `Script`, `HTTP`, `TCP` or `TTL` should be specified.
 `Script` and `HTTP` also require `Interval`. The created check will be named "service:\<ServiceId\>".
 
-Checks that are associated with a service may also contain an optional
-`DeregisterCriticalServiceAfter` field, which is a timeout in the same Go time
+In Consul 0.7 and later, checks that are associated with a service may also contain
+an optional `DeregisterCriticalServiceAfter` field, which is a timeout in the same Go time
 format as `Interval` and `TTL`. If a check is in the critical state for more than this
 configured value, then its associated service (and all of its associated checks)
 will automatically be deregistered. The minimum timeout is 1 minute, and the
-process that reaps critical services runs every 15 seconds, so a may take slightly
+process that reaps critical services runs every 15 seconds, so it may take slightly
 longer than the configured timeout to trigger the deregistration. This should
 generally be configured with a timeout that's much, much longer than any expected
 recoverable outage for the given service.

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -267,7 +267,7 @@ an optional `DeregisterCriticalServiceAfter` field, which is a timeout in the sa
 time format as `Interval` and `TTL`. If a check is in the critical state for more than
 this configured value, then its associated service (and all of its associated checks)
 will automatically be deregistered. The minimum timeout is 1 minute, and the
-process that reaps critical services runs every 15 seconds, so it may take slightly
+process that reaps critical services runs every 30 seconds, so it may take slightly
 longer than the configured timeout to trigger the deregistration. This should
 generally be configured with a timeout that's much, much longer than any expected
 recoverable outage for the given service.
@@ -431,7 +431,7 @@ an optional `DeregisterCriticalServiceAfter` field, which is a timeout in the sa
 format as `Interval` and `TTL`. If a check is in the critical state for more than this
 configured value, then its associated service (and all of its associated checks)
 will automatically be deregistered. The minimum timeout is 1 minute, and the
-process that reaps critical services runs every 15 seconds, so it may take slightly
+process that reaps critical services runs every 30 seconds, so it may take slightly
 longer than the configured timeout to trigger the deregistration. This should
 generally be configured with a timeout that's much, much longer than any expected
 recoverable outage for the given service.


### PR DESCRIPTION
Inspired by #1432 and #1433, this adds a new `deregister_critical_service_after` field to a health check definition (all check types are supported) which causes the service associated with that check to get deregistered if the check is critical for longer than the timeout.

Closes #679.