### PR TITLE
Fix typo

### DIFF
--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -306,7 +306,7 @@ definitions support being updated during a reload.
 }
 ```
 
-Note that the use of `port`:
+Note the use of `ports`:
 
 ```javascript
 "ports": {


### PR DESCRIPTION
Refer to `ports` instead of `port` and make the sentence fragment a bit more grokable