### PR TITLE
Changes default DNS allow_stale to true.

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -68,7 +68,7 @@ type DNSConfig struct {
 	// data. This gives horizontal read scalability since
 	// any Consul server can service the query instead of
 	// only the leader.
-	AllowStale bool `mapstructure:"allow_stale"`
+	AllowStale *bool `mapstructure:"allow_stale"`
 
 	// EnableTruncate is used to enable setting the truncate
 	// flag for UDP DNS queries.  This allows unmodified
@@ -644,6 +644,7 @@ func DefaultConfig() *Config {
 			Server:  8300,
 		},
 		DNSConfig: DNSConfig{
+			AllowStale:     Bool(true),
 			UDPAnswerLimit: 3,
 			MaxStale:       5 * time.Second,
 		},
@@ -1335,8 +1336,8 @@ func MergeConfig(a, b *Config) *Config {
 			result.DNSConfig.ServiceTTL[service] = dur
 		}
 	}
-	if b.DNSConfig.AllowStale {
-		result.DNSConfig.AllowStale = true
+	if b.DNSConfig.AllowStale != nil {
+		result.DNSConfig.AllowStale = b.DNSConfig.AllowStale
 	}
 	if b.DNSConfig.UDPAnswerLimit != 0 {
 		result.DNSConfig.UDPAnswerLimit = b.DNSConfig.UDPAnswerLimit

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -544,13 +544,13 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// DNS node ttl, max stale
-	input = `{"dns_config": {"allow_stale": true, "enable_truncate": false, "max_stale": "15s", "node_ttl": "5s", "only_passing": true, "udp_answer_limit": 6}}`
+	input = `{"dns_config": {"allow_stale": false, "enable_truncate": false, "max_stale": "15s", "node_ttl": "5s", "only_passing": true, "udp_answer_limit": 6}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	if !config.DNSConfig.AllowStale {
+	if *config.DNSConfig.AllowStale {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.DNSConfig.EnableTruncate {
@@ -1408,7 +1408,7 @@ func TestMergeConfig(t *testing.T) {
 		DataDir:         "/tmp/bar",
 		DNSRecursors:    []string{"127.0.0.2:1001"},
 		DNSConfig: DNSConfig{
-			AllowStale:         false,
+			AllowStale:         Bool(false),
 			EnableTruncate:     true,
 			DisableCompression: true,
 			MaxStale:           30 * time.Second,

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -198,7 +198,7 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 		Datacenter: datacenter,
 		QueryOptions: structs.QueryOptions{
 			Token:      d.agent.config.ACLToken,
-			AllowStale: d.config.AllowStale,
+			AllowStale: *d.config.AllowStale,
 		},
 	}
 	var out structs.IndexedNodes
@@ -384,7 +384,7 @@ func (d *DNSServer) nodeLookup(network, datacenter, node string, req, resp *dns.
 		Node:       node,
 		QueryOptions: structs.QueryOptions{
 			Token:      d.agent.config.ACLToken,
-			AllowStale: d.config.AllowStale,
+			AllowStale: *d.config.AllowStale,
 		},
 	}
 	var out structs.IndexedNodeServices
@@ -584,7 +584,7 @@ func (d *DNSServer) serviceLookup(network, datacenter, service, tag string, req,
 		TagFilter:   tag != "",
 		QueryOptions: structs.QueryOptions{
 			Token:      d.agent.config.ACLToken,
-			AllowStale: d.config.AllowStale,
+			AllowStale: *d.config.AllowStale,
 		},
 	}
 	var out structs.IndexedCheckServiceNodes
@@ -658,7 +658,7 @@ func (d *DNSServer) preparedQueryLookup(network, datacenter, query string, req, 
 		QueryIDOrName: query,
 		QueryOptions: structs.QueryOptions{
 			Token:      d.agent.config.ACLToken,
-			AllowStale: d.config.AllowStale,
+			AllowStale: *d.config.AllowStale,
 		},
 
 		// Always pass the local agent through. In the DNS interface, there

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -2308,7 +2308,7 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 		c.DNSRecursor = recursor.Addr
 	}, func(c *DNSConfig) {
 		c.NodeTTL = 10 * time.Second
-		c.AllowStale = true
+		*c.AllowStale = true
 		c.MaxStale = time.Second
 	})
 	defer os.RemoveAll(dir)
@@ -2428,7 +2428,7 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 			"db": 10 * time.Second,
 			"*":  5 * time.Second,
 		}
-		c.AllowStale = true
+		*c.AllowStale = true
 		c.MaxStale = time.Second
 	}
 	dir, srv := makeDNSServerConfig(t, nil, confFn)
@@ -2531,7 +2531,7 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 			"db": 10 * time.Second,
 			"*":  5 * time.Second,
 		}
-		c.AllowStale = true
+		*c.AllowStale = true
 		c.MaxStale = time.Second
 	}
 	dir, srv := makeDNSServerConfig(t, nil, confFn)
@@ -3192,7 +3192,7 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	confFn := func(c *DNSConfig) {
-		c.AllowStale = true
+		*c.AllowStale = true
 		c.MaxStale = time.Second
 	}
 	dir, srv := makeDNSServerConfig(t, nil, confFn)

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -485,8 +485,9 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   * <a name="allow_stale"></a><a href="#allow_stale">`allow_stale`</a> - Enables a stale query
   for DNS information. This allows any Consul server, rather than only the leader, to service
   the request. The advantage of this is you get linear read scalability with Consul servers.
-  By default, this is false, meaning all requests are serviced by the leader, providing stronger
-  consistency but less throughput and higher latency.
+  In versions of Consul prior to 0.7, this defaulted to false, meaning all requests are serviced
+  by the leader, providing stronger consistency but less throughput and higher latency. In Consul
+  0.7 and later, this defaults to true for better utilization of available servers.
 
   * <a name="max_stale"></a><a href="#max_stale">`max_stale`</a> When [`allow_stale`](#allow_stale)
   is specified, this is used to limit how

--- a/website/source/docs/upgrade-specific.html.markdown
+++ b/website/source/docs/upgrade-specific.html.markdown
@@ -19,9 +19,22 @@ standard upgrade flow.
 Consul version 0.7 is a very large release with many important changes. Changes
 to be aware of during an upgrade are categorized below.
 
-#### Performance Tuning and New Defaults
+#### Defaults Changed for Better Performance
 
-Consul 0.7 introduced support for tuning Raft performance using a new
+Consul 0.7 now defaults the DNS configuration to allow for stale queries by defaulting
+[`allow_stale`](/docs/agent/options.html#allow_stale) to true for better utilization
+of available servers. If you want to retain the previous behavior, set the following
+configuration:
+
+```javascript
+{
+  "dns_config": {
+    "allow_stale": false
+  }
+}
+```
+
+Consul also 0.7 introduced support for tuning Raft performance using a new
 [performance configuration block](/docs/agent/options.html#performance). Also,
 the default Raft timing is set to a lower-performance mode suitable for
 [minimal Consul servers](/docs/guides/performance.html#minumum).
@@ -40,7 +53,7 @@ to all Consul servers when upgrading:
 
 See the [Server Performance](/docs/guides/performance.html) guide for more details.
 
-#### Default Configuration Changes
+#### Servers No Longer Default to Leave on Interrupt
 
 The default behavior of [`skip_leave_on_interrupt`](/docs/agent/options.html#skip_leave_on_interrupt)
 is now dependent on whether or not the agent is acting as a server or client. When Consul is started as a


### PR DESCRIPTION
This is a much better default for nearly everyone, so we default the DNS `allow_stale` to `true` and make it opt-out for Consul 0.7.