### PR TITLE
Copies the member data instead of referencing by pointer.

### DIFF
--- a/consul/operator_endpoint.go
+++ b/consul/operator_endpoint.go
@@ -38,7 +38,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 	}
 
 	// Index the Consul information about the servers.
-	serverMap := make(map[raft.ServerAddress]*serf.Member)
+	serverMap := make(map[raft.ServerAddress]serf.Member)
 	for _, member := range op.srv.serfLAN.Members() {
 		valid, parts := agent.IsConsulServer(member)
 		if !valid {
@@ -46,7 +46,7 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 		}
 
 		addr := (&net.TCPAddr{IP: member.Addr, Port: parts.Port}).String()
-		serverMap[raft.ServerAddress(addr)] = &member
+		serverMap[raft.ServerAddress(addr)] = member
 	}
 
 	// Fill out the reply.


### PR DESCRIPTION
Without this I was seeing races if there were non-server members in the list. Still looking at the root cause of that.