### PR TITLE
Precise time of the session's life

### DIFF
--- a/api/session.go
+++ b/api/session.go
@@ -29,6 +29,7 @@ type SessionEntry struct {
 	LockDelay   time.Duration
 	Behavior    string
 	TTL         string
+	TimeLeft    string
 }
 
 // Session can be used to query the Session endpoints

--- a/consul/session_endpoint.go
+++ b/consul/session_endpoint.go
@@ -200,6 +200,7 @@ func (s *Session) Renew(args *structs.SessionSpecificRequest,
 	// Reset the session TTL timer
 	reply.Index = index
 	if session != nil {
+		session.Renew()
 		reply.Sessions = structs.Sessions{session}
 		if err := s.srv.resetSessionTimer(args.Session, session); err != nil {
 			s.srv.logger.Printf("[ERR] consul.session: Session renew failed: %v", err)

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -629,10 +629,28 @@ type Session struct {
 	LockDelay time.Duration
 	Behavior  SessionBehavior // What to do when session is invalidated
 	TTL       string
+	TimeLeft  string
 
 	RaftIndex
+
+	lastRenew time.Time
 }
 type Sessions []*Session
+
+func (s *Session) RecalcTimeLeft() error {
+	dur, err := time.ParseDuration(s.TTL)
+	if err != nil {
+		return err
+	}
+
+	s.TimeLeft = (dur*2 - time.Since(s.lastRenew)).String()
+	return nil
+}
+
+func (s *Session) Renew() error {
+	s.lastRenew = time.Now().UTC()
+	return s.RecalcTimeLeft()
+}
 
 type SessionOp string
 


### PR DESCRIPTION
Sadly, it's impossible to precisely find out the time of the session's life.
Because of that I suggest to create a TimeLeft field, so as to not have any problems with backward compatibility (will there even be any?)