### PR TITLE
return an error if no logOutput is provided

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -43,6 +43,10 @@ type HTTPServer struct {
 // NewHTTPServers starts new HTTP servers to provide an interface to
 // the agent.
 func NewHTTPServers(agent *Agent, config *Config, logOutput io.Writer) ([]*HTTPServer, error) {
+	if logOutput == nil {
+		return nil, fmt.Errorf("Please provide a valid logOutput(io.Writer)")
+	}
+
 	var servers []*HTTPServer
 
 	if config.Ports.HTTPS > 0 {


### PR DESCRIPTION
I work on a test scenario to ensure consul integration works as expected. I programmatically start a Consul server. I had no need to log output and provided `nil` to `NewHTTPServers`.
This worked with the last release (`0.6.4`)

Upgrading to `0.7.0` broke my code with a non obvious panic. This PR should make it easier to figure out what's going on.