### PR TITLE
Fixed header level for version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.7.0 (September 14, 2016)
+## 0.7.0 (September 14, 2016)
 
 BREAKING CHANGES:
 


### PR DESCRIPTION
Wrong header level breaks automatic changelog parsing at https://allmychanges.com.

Please, accept this patch.