### PR TITLE
Remove references to the 'unknown' state.

### DIFF
--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -88,9 +88,7 @@ The `CheckID` can be omitted and will default to the value of `Name`. As with `S
 the `CheckID` must be unique on this node. `Notes` is an opaque field that is meant to
 hold human-readable text. If a `ServiceID` is provided that matches the `ID`
 of a service on that node, the check is treated as a service level health
-check, instead of a node level health check. The `Status` must be one of
-`unknown`, `passing`, `warning`, or `critical`. The `unknown` status is used
-to indicate that the initial check has not been performed yet.
+check, instead of a node level health check. The `Status` must be one of `passing`, `warning`, or `critical`.
 
 Multiple checks can be provided by replacing `Check` with `Checks` and sending
 an array of `Check` objects.

--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -179,7 +179,7 @@ the node list in ascending order based on the estimated round trip
 time from that node. Passing "?near=_agent" will use the agent's
 node for the sort.
 
-The supported states are `any`, `unknown`, `passing`, `warning`, or `critical`.
+The supported states are `any`, `passing`, `warning`, or `critical`.
 The `any` state is a wildcard that can be used to return all checks.
 
 It returns a JSON body like this:


### PR DESCRIPTION
- Remove reference to 'unknown' state in catalog endpoint docs
- Remove reference to 'unknown' state in health endpoint docs

The above were the only two references to the *unknown* state still hanging out in the docs.
