### PR TITLE
Terraform AWS Private Key

### DIFF
--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "server" {
 
     connection {
         user = "${lookup(var.user, var.platform)}"
-        key_file = "${var.key_path}"
+        private_key = "${file("${var.key_path}")}"
     }
 
     #Instance tags


### PR DESCRIPTION
`key_file` is [deprecated](https://www.terraform.io/docs/provisioners/connection.html). Switch to `private_key` instead. Add file() function interpolation to get the contents of the private key file. The same as #2313 but for AWS. The [Terraform getting started guide](https://www.terraform.io/intro/getting-started/modules.html) is currently broken and this change brings back the expected functionality. 