### PR TITLE
Docs: Update command to create sample service

### DIFF
--- a/website/source/intro/getting-started/services.html.markdown
+++ b/website/source/intro/getting-started/services.html.markdown
@@ -41,7 +41,7 @@ we'll give it a tag we can use as an additional way to query the service:
 
 ```text
 $ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80}}' \
-    >/etc/consul.d/web.json
+    | sudo tee /etc/consul.d/web.json
 ```
 
 Now, restart the agent, providing the configuration directory:


### PR DESCRIPTION
Since the previous command creates /etc/consul.d with sudo, a regular user won't have permission to echo and redirect a file to the directory. Switch to using tee with sudo to ensure the file gets created.