### PR TITLE
Making CLI flag formatting consistent in the docs

### DIFF
--- a/website/source/docs/agent/encryption.html.markdown
+++ b/website/source/docs/agent/encryption.html.markdown
@@ -34,7 +34,7 @@ the output of [`consul agent`](/docs/commands/agent.html) will include "Encrypte
 $ cat encrypt.json
 {"encrypt": "cg8StVXbQJ0gPvMd9o7yrg=="}
 
-$ consul agent -data-dir=/tmp/consul -config-file encrypt.json
+$ consul agent -data-dir=/tmp/consul -config-file=encrypt.json
 ==> WARNING: LAN keyring exists but -encrypt given, using keyring
 ==> WARNING: WAN keyring exists but -encrypt given, using keyring
 ==> Starting Consul agent...
@@ -93,4 +93,3 @@ also disallow any non-TLS connections. To force clients to use TLS,
 
 TLS is used to secure the RPC calls between agents, but gossip between nodes is done over UDP
 and is secured using a symmetric key. See above for enabling gossip encryption.
-

--- a/website/source/docs/agent/watches.html.markdown
+++ b/website/source/docs/agent/watches.html.markdown
@@ -86,7 +86,7 @@ Here is an example configuration:
 
 Or, using the watch command:
 
-    $ consul watch -type key -key foo/bar/baz /usr/bin/my-key-handler.sh
+    $ consul watch -type=key -key=foo/bar/baz /usr/bin/my-key-handler.sh
 
 An example of the output of this command:
 
@@ -123,7 +123,7 @@ Here is an example configuration:
 
 Or, using the watch command:
 
-    $ consul watch -type keyprefix -prefix foo/ /usr/bin/my-prefix-handler.sh
+    $ consul watch -type=keyprefix -prefix=foo/ /usr/bin/my-prefix-handler.sh
 
 An example of the output of this command:
 
@@ -237,7 +237,7 @@ Here is an example configuration:
 
 Or, using the watch command:
 
-    $ consul watch -type service -service redis /usr/bin/my-service-handler.sh
+    $ consul watch -type=service -service=redis /usr/bin/my-service-handler.sh
 
 An example of the output of this command:
 
@@ -328,7 +328,7 @@ Here is an example configuration:
 
 Or, using the watch command:
 
-    $ consul watch -type event -name web-deploy /usr/bin/my-deploy-handler.sh
+    $ consul watch -type=event -name=web-deploy /usr/bin/my-deploy-handler.sh
 
 An example of the output of this command:
 
@@ -350,4 +350,4 @@ An example of the output of this command:
 
 To fire a new `web-deploy` event the following could be used:
 
-    $ consul event -name web-deploy 1609030
+    $ consul event -name=web-deploy 1609030

--- a/website/source/docs/guides/outage.html.markdown
+++ b/website/source/docs/guides/outage.html.markdown
@@ -24,7 +24,7 @@ add or remove a server, [see this guide](/docs/guides/servers.html).
 If you had only a single server and it has failed, simply restart it.
 Note that a single server configuration requires the
 [`-bootstrap`](/docs/agent/options.html#_bootstrap) or
-[`-bootstrap-expect 1`](/docs/agent/options.html#_bootstrap_expect) flag. If
+[`-bootstrap-expect=1`](/docs/agent/options.html#_bootstrap_expect) flag. If
 the server cannot be recovered, you need to bring up a new server.
 See the [bootstrapping guide](/docs/guides/bootstrapping.html) for more detail.
 

--- a/website/source/intro/getting-started/join.html.markdown
+++ b/website/source/intro/getting-started/join.html.markdown
@@ -78,9 +78,9 @@ All together, these settings yield a
 [`consul agent`](/docs/commands/agent.html) command like this:
 
 ```text
-vagrant@n1:~$ consul agent -server -bootstrap-expect 1 \
-	-data-dir /tmp/consul -node=agent-one -bind=172.20.20.10 \
-	-config-dir /etc/consul.d
+vagrant@n1:~$ consul agent -server -bootstrap-expect=1 \
+	-data-dir=/tmp/consul -node=agent-one -bind=172.20.20.10 \
+	-config-dir=/etc/consul.d
 ...
 ```
 
@@ -100,8 +100,8 @@ All together, these settings yield a
 [`consul agent`](/docs/commands/agent.html) command like this:
 
 ```text
-vagrant@n2:~$ consul agent -data-dir /tmp/consul -node=agent-two \
-	-bind=172.20.20.11 -config-dir /etc/consul.d
+vagrant@n2:~$ consul agent -data-dir=/tmp/consul -node=agent-two \
+	-bind=172.20.20.11 -config-dir=/etc/consul.d
 ...
 ```
 

--- a/website/source/intro/getting-started/services.html.markdown
+++ b/website/source/intro/getting-started/services.html.markdown
@@ -47,7 +47,7 @@ $ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80}}' \
 Now, restart the agent, providing the configuration directory:
 
 ```text
-$ consul agent -dev -config-dir /etc/consul.d
+$ consul agent -dev -config-dir=/etc/consul.d
 ==> Starting Consul agent...
 ...
     [INFO] agent: Synced service 'web'


### PR DESCRIPTION
As per #2350 

I believe that I found every instance of where a space was being used and corrected it to be an equal sign.