### PR TITLE
Adding in us-west-1-ubuntu

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,6 +17,7 @@ variable "ami" {
     description           = "AWS AMI Id, if you change, make sure it is compatible with instance type, not all AMIs allow all instance types "
     default = {
         us-east-1-ubuntu  = "ami-fce3c696"
+        us-west-1-ubuntu  = "ami-a9a8e4c9"
         us-west-2-ubuntu  = "ami-9abea4fb"
         eu-west-1-ubuntu = "ami-47a23a30"
         eu-central-1-ubuntu = "ami-accff2b1"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,7 +17,7 @@ variable "ami" {
     description           = "AWS AMI Id, if you change, make sure it is compatible with instance type, not all AMIs allow all instance types "
     default = {
         us-east-1-ubuntu  = "ami-fce3c696"
-        us-west-1-ubuntu  = "ami-48db9d28"
+        us-west-1-ubuntu  = "ami-a9a8e4c9"
         us-west-2-ubuntu  = "ami-9abea4fb"
         eu-west-1-ubuntu = "ami-47a23a30"
         eu-central-1-ubuntu = "ami-accff2b1"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,7 +17,7 @@ variable "ami" {
     description           = "AWS AMI Id, if you change, make sure it is compatible with instance type, not all AMIs allow all instance types "
     default = {
         us-east-1-ubuntu  = "ami-fce3c696"
-        us-west-1-ubuntu  = "ami-a9a8e4c9"
+        us-west-1-ubuntu  = "ami-48db9d28"
         us-west-2-ubuntu  = "ami-9abea4fb"
         eu-west-1-ubuntu = "ami-47a23a30"
         eu-central-1-ubuntu = "ami-accff2b1"


### PR DESCRIPTION
Going through the Terraform Tutorial but doing it on the us-west-1 region, there isn't a us-west-1 -ubuntu option which causes it to automatically fail by trying to pull ami-fce3c696 (which doesn't exist).
