### PR TITLE
Add info about return values for function Get().

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -92,7 +92,8 @@ func (c *Client) KV() *KV {
 	return &KV{c}
 }
 
-// Get is used to lookup a single key
+// Get is used to lookup a single key. The returned pointer
+// to the KVPair will be nil if the key does not exist.
 func (k *KV) Get(key string, q *QueryOptions) (*KVPair, *QueryMeta, error) {
 	resp, qm, err := k.getInternal(key, nil, q)
 	if err != nil {


### PR DESCRIPTION
The functions documentation should state clearly that the returned pointer to `KVPair` will be nil if the key does not exist.

My assumption was that if the key does not exist `err != nil`. But that is not the case. It might be quite often that people forget that they have to check for both conditions (`err != nil` **and** pointer to KVPair is nil). See e.g. [here](http://techblog.zeomega.com/devops/golang/2015/06/09/consul-kv-api-in-golang.html).