### PR TITLE
Give a valid service address in SRV lookup when it differs from the node's

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -359,7 +359,7 @@ PARSE:
 		d.preparedQueryLookup(network, datacenter, query, req, resp)
 
 	case "addr":
-		if n < 2 {
+		if n != 2 {
 			goto INVALID
 		}
 

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -1039,7 +1039,7 @@ func TestDNS_ServiceLookup_ServiceAddress(t *testing.T) {
 		if srvRec.Port != 12345 {
 			t.Fatalf("Bad: %#v", srvRec)
 		}
-		if srvRec.Target != "foo.node.dc1.consul." {
+		if srvRec.Target != "7f000002.addr.dc1.consul." {
 			t.Fatalf("Bad: %#v", srvRec)
 		}
 		if srvRec.Hdr.Ttl != 0 {
@@ -1050,7 +1050,7 @@ func TestDNS_ServiceLookup_ServiceAddress(t *testing.T) {
 		if !ok {
 			t.Fatalf("Bad: %#v", in.Extra[0])
 		}
-		if aRec.Hdr.Name != "foo.node.dc1.consul." {
+		if aRec.Hdr.Name != "7f000002.addr.dc1.consul." {
 			t.Fatalf("Bad: %#v", in.Extra[0])
 		}
 		if aRec.A.String() != "127.0.0.2" {
@@ -1157,7 +1157,7 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 		if !ok {
 			t.Fatalf("Bad: %#v", in.Extra[0])
 		}
-		if aRec.Hdr.Name != "foo.node.dc2.consul." {
+		if aRec.Hdr.Name != "7f000002.addr.dc2.consul." {
 			t.Fatalf("Bad: %#v", in.Extra[0])
 		}
 		if aRec.A.String() != "127.0.0.2" {
@@ -3193,7 +3193,7 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 	if !ok {
 		t.Fatalf("Bad: %#v", in.Answer[0])
 	}
-	if srv.Target != "foo.node.dc2.consul." {
+	if srv.Target != "7f000002.addr.dc2.consul." {
 		t.Fatalf("Bad: %#v", in.Answer[0])
 	}
 
@@ -3201,7 +3201,7 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 	if !ok {
 		t.Fatalf("Bad: %#v", in.Extra[0])
 	}
-	if a.Hdr.Name != "foo.node.dc2.consul." {
+	if a.Hdr.Name != "7f000002.addr.dc2.consul." {
 		t.Fatalf("Bad: %#v", in.Extra[0])
 	}
 	if a.A.String() != "127.0.0.2" {

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -1062,6 +1062,100 @@ func TestDNS_ServiceLookup_ServiceAddress(t *testing.T) {
 	}
 }
 
+func TestDNS_ServiceLookup_ServiceAddressIPv6(t *testing.T) {
+	dir, srv := makeDNSServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.agent.Shutdown()
+
+	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
+	// Register a node with a service.
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "foo",
+			Address:    "127.0.0.1",
+			Service: &structs.NodeService{
+				Service: "db",
+				Tags:    []string{"master"},
+				Address: "2607:20:4005:808::200e",
+				Port:    12345,
+			},
+		}
+
+		var out struct{}
+		if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Register an equivalent prepared query.
+	var id string
+	{
+		args := &structs.PreparedQueryRequest{
+			Datacenter: "dc1",
+			Op:         structs.PreparedQueryCreate,
+			Query: &structs.PreparedQuery{
+				Service: structs.ServiceQuery{
+					Service: "db",
+				},
+			},
+		}
+		if err := srv.agent.RPC("PreparedQuery.Apply", args, &id); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	// Look up the service directly and via prepared query.
+	questions := []string{
+		"db.service.consul.",
+		id + ".query.consul.",
+	}
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSRV)
+
+		c := new(dns.Client)
+		addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
+		in, _, err := c.Exchange(m, addr.String())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("Bad: %#v", in)
+		}
+
+		srvRec, ok := in.Answer[0].(*dns.SRV)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+		if srvRec.Port != 12345 {
+			t.Fatalf("Bad: %#v", srvRec)
+		}
+		if srvRec.Target != "2607002040050808000000000000200e.addr.dc1.consul." {
+			t.Fatalf("Bad: %#v", srvRec)
+		}
+		if srvRec.Hdr.Ttl != 0 {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+
+		aRec, ok := in.Extra[0].(*dns.AAAA)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.Hdr.Name != "2607002040050808000000000000200e.addr.dc1.consul." {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.AAAA.String() != "2607:20:4005:808::200e" {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.Hdr.Ttl != 0 {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+	}
+}
+
 func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 	dir1, srv1 := makeDNSServerConfig(t,
 		func(c *Config) {


### PR DESCRIPTION
Fixes #832 

Still need to add a 'TestDNS_ServiceLookup_ServiceAddressIPv6' test, I think that's the only thing missing here.