### PR TITLE
More flaky unit test fixes

### DIFF
--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -31,7 +31,6 @@ func TestCatalog_Datacenters(t *testing.T) {
 }
 
 func TestCatalog_Nodes(t *testing.T) {
-	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -52,7 +51,7 @@ func TestCatalog_Nodes(t *testing.T) {
 		}
 
 		if _, ok := nodes[0].TaggedAddresses["wan"]; !ok {
-			return false, fmt.Errorf("Bad: %v", nodes)
+			return false, fmt.Errorf("Bad: %v", nodes[0])
 		}
 
 		return true, nil

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -76,7 +76,6 @@ func TestHealth_Checks(t *testing.T) {
 }
 
 func TestHealth_Service(t *testing.T) {
-	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -95,7 +94,7 @@ func TestHealth_Service(t *testing.T) {
 			return false, fmt.Errorf("Bad: %v", checks)
 		}
 		if _, ok := checks[0].Node.TaggedAddresses["wan"]; !ok {
-			return false, fmt.Errorf("Bad: %v", checks)
+			return false, fmt.Errorf("Bad: %v", checks[0].Node)
 		}
 		return true, nil
 	}, func(err error) {

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -139,7 +139,7 @@ func TestLock_DeleteKey(t *testing.T) {
 			// Should loose leadership
 			select {
 			case <-leaderCh:
-			case <-time.After(time.Second):
+			case <-time.After(10 * time.Second):
 				t.Fatalf("should not be leader")
 			}
 		}()

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -244,21 +244,24 @@ func expectHTTPStatus(t *testing.T, url string, status string) {
 	check.Start()
 	defer check.Stop()
 
-	time.Sleep(50 * time.Millisecond)
+	testutil.WaitForResult(func() (bool, error) {
+		// Should have at least 2 updates
+		if mock.updates["foo"] < 2 {
+			return false, fmt.Errorf("should have 2 updates %v", mock.updates)
+		}
 
-	// Should have at least 2 updates
-	if mock.updates["foo"] < 2 {
-		t.Fatalf("should have 2 updates %v", mock.updates)
-	}
+		if mock.state["foo"] != status {
+			return false, fmt.Errorf("should be %v %v", status, mock.state)
+		}
 
-	if mock.state["foo"] != status {
-		t.Fatalf("should be %v %v", status, mock.state)
-	}
-
-	// Allow slightly more data than CheckBufSize, for the header
-	if n := len(mock.output["foo"]); n > (CheckBufSize + 256) {
-		t.Fatalf("output too long: %d (%d-byte limit)", n, CheckBufSize)
-	}
+		// Allow slightly more data than CheckBufSize, for the header
+		if n := len(mock.output["foo"]); n > (CheckBufSize + 256) {
+			return false, fmt.Errorf("output too long: %d (%d-byte limit)", n, CheckBufSize)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
 }
 
 func TestCheckHTTPCritical(t *testing.T) {
@@ -347,16 +350,19 @@ func TestCheckHTTPTimeout(t *testing.T) {
 	check.Start()
 	defer check.Stop()
 
-	time.Sleep(50 * time.Millisecond)
+	testutil.WaitForResult(func() (bool, error) {
+		// Should have at least 2 updates
+		if mock.updates["bar"] < 2 {
+			return false, fmt.Errorf("should have at least 2 updates %v", mock.updates)
+		}
 
-	// Should have at least 2 updates
-	if mock.updates["bar"] < 2 {
-		t.Fatalf("should have at least 2 updates %v", mock.updates)
-	}
-
-	if mock.state["bar"] != structs.HealthCritical {
-		t.Fatalf("should be critical %v", mock.state)
-	}
+		if mock.state["bar"] != structs.HealthCritical {
+			return false, fmt.Errorf("should be critical %v", mock.state)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
 }
 
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
@@ -410,16 +416,19 @@ func expectTCPStatus(t *testing.T, tcp string, status string) {
 	check.Start()
 	defer check.Stop()
 
-	time.Sleep(50 * time.Millisecond)
+	testutil.WaitForResult(func() (bool, error) {
+		// Should have at least 2 updates
+		if mock.updates["foo"] < 2 {
+			return false, fmt.Errorf("should have 2 updates %v", mock.updates)
+		}
 
-	// Should have at least 2 updates
-	if mock.updates["foo"] < 2 {
-		t.Fatalf("should have 2 updates %v", mock.updates)
-	}
-
-	if mock.state["foo"] != status {
-		t.Fatalf("should be %v %v", status, mock.state)
-	}
+		if mock.state["foo"] != status {
+			return false, fmt.Errorf("should be %v %v", status, mock.state)
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
 }
 
 func TestCheckTCPCritical(t *testing.T) {

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -23,7 +23,7 @@ func TestExecCommandRun(t *testing.T) {
 
 	ui := new(cli.MockUi)
 	c := &ExecCommand{Ui: ui}
-	args := []string{"-http-addr=" + a1.httpAddr, "-wait=400ms", "uptime"}
+	args := []string{"-http-addr=" + a1.httpAddr, "-wait=10s", "uptime"}
 
 	code := c.Run(args)
 	if code != 0 {


### PR DESCRIPTION
Some fixes to the agent tests and tweaks to `TestHealth_Service` and `TestCatalog_Nodes` to hopefully make their Travis failures easier to debug.

For timeouts that seemed like they were just too low for Travis I've been putting them at 10 seconds to match waitForResult.
