### PR TITLE
properly escape session and acl data in UI

### DIFF
--- a/ui/Gemfile.lock
+++ b/ui/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     execjs (2.3.0)
     json (1.8.2)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.15)
     ref (1.0.5)
     sass (3.4.11)
     therubyracer (0.12.1)
@@ -20,3 +20,6 @@ DEPENDENCIES
   sass
   therubyracer
   uglifier
+
+BUNDLED WITH
+   1.12.5

--- a/ui/javascripts/app/helpers.js
+++ b/ui/javascripts/app/helpers.js
@@ -24,19 +24,19 @@ Ember.Handlebars.helper('sessionName', function(session) {
   var name;
 
   if (session.Name === "") {
-    name = '<span>' + session.ID + '</span>';
+    name = '<span>' + Handlebars.Utils.escapeExpression(session.ID) + '</span>';
   } else {
-    name = '<span>' + session.Name + '</span>' + ' <small>' + session.ID + '</small>';
+    name = '<span>' + Handlebars.Utils.escapeExpression(session.Name) + '</span>' + ' <small>' + Handlebars.Utils.escapeExpression(session.ID) + '</small>';
   }
 
   return new Handlebars.SafeString(name);
 });
 
 Ember.Handlebars.helper('sessionMeta', function(session) {
-  var meta = '<div class="metadata">' + session.Behavior + ' behavior</div>';
+  var meta = '<div class="metadata">' + Handlebars.Utils.escapeExpression(session.Behavior) + ' behavior</div>';
 
   if (session.TTL !== "") {
-    meta = meta + '<div class="metadata">, ' + session.TTL + ' TTL</div>';
+    meta = meta + '<div class="metadata">, ' + Handlebars.Utils.escapeExpression(session.TTL) + ' TTL</div>';
   }
 
   return new Handlebars.SafeString(meta);
@@ -46,7 +46,7 @@ Ember.Handlebars.helper('aclName', function(name, id) {
   if (name === "") {
     return id;
   } else {
-    return new Handlebars.SafeString(name + ' <small class="pull-right no-case">' + id + '</small>');
+    return new Handlebars.SafeString(Handlebars.Utils.escapeExpression(name) + ' <small class="pull-right no-case">' + Handlebars.Utils.escapeExpression(id) + '</small>');
   }
 });
 


### PR DESCRIPTION
fixes an XSS vulnerability caused by having the sessionName, sessionMeta, and aclName blindly returning data as Handlebars.SafeStrings