### PR TITLE
Disable -bootstrap-expect flag in dev mode

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -271,6 +271,12 @@ func (c *Command) readConfig() *Config {
 		return nil
 	}
 
+	// Expect can only work when dev mode is off
+	if config.BootstrapExpect > 0 && config.DevMode {
+		c.Ui.Error("Expect mode cannot be enabled when dev mode is enabled")
+		return nil
+	}
+
 	// Expect & Bootstrap are mutually exclusive
 	if config.BootstrapExpect != 0 && config.Bootstrap {
 		c.Ui.Error("Bootstrap cannot be provided with an expected server count")

--- a/consul/serf.go
+++ b/consul/serf.go
@@ -154,7 +154,7 @@ func (s *Server) lanNodeJoin(me serf.MemberEvent) {
 			s.localLock.Unlock()
 		}
 
-		// If we still expecting to bootstrap, may need to handle this.
+		// If we're still expecting to bootstrap, may need to handle this.
 		if s.config.BootstrapExpect != 0 {
 			s.maybeBootstrap()
 		}


### PR DESCRIPTION
Fixes the panic described here https://github.com/hashicorp/consul/issues/2428#issuecomment-257867224 when both -dev and -bootstrap-expect are provided. Expect mode won't do anything in dev mode even with the crash fixed, so it seemed best to just disallow this and provide an error message.