### PR TITLE
Optionally support dated log files in consul.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,6 +2,7 @@ GOTOOLS = \
 	github.com/elazarl/go-bindata-assetfs/... \
 	github.com/jteeuwen/go-bindata/... \
 	github.com/mitchellh/gox \
+	github.com/Symantec/Dominator/lib/logbuf \
 	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/stringer
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Symantec/Dominator/lib/logbuf"
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/circonus"
 	"github.com/armon/go-metrics/datadog"
@@ -137,9 +138,12 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&retryIntervalWan, "retry-interval-wan", "",
 		"interval between join -wan attempts")
 
+	logbuf.UseFlagSet(cmdFlags)
 	if err := cmdFlags.Parse(c.args); err != nil {
 		return nil
 	}
+	// Initialize the log buffer after command flags get parsed
+	logbuf.Get()
 
 	if retryInterval != "" {
 		dur, err := time.ParseDuration(retryInterval)


### PR DESCRIPTION
As an alternative to logging to stderr, we have developed a logging package
that automatically redirects logs to dated log files and optionally removes
old log files when log storage reaches some threshhold. We often run
processes including consul agent as daemons, but from time to time we like
to look at the logs.

With this change, users can run the consul agent the way that always
have writing log messages to stderr or they can redirect those logs to
dated log files. Hope you find this PR useful.