### PR TITLE
Log a better message on trying to deregister a nonexistent service

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -906,7 +906,14 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	// Remove service immediately
-	a.state.RemoveService(serviceID)
+	err := a.state.RemoveService(serviceID)
+
+	// TODO: Return the error instead of just logging here in Consul 0.8
+	// For now, keep the current idempotent behavior on deleting a nonexistent service
+	if err != nil {
+		a.logger.Printf("[WARN] agent: Failed to deregister service %q: %s", serviceID, err)
+		return nil
+	}
 
 	// Remove the service from the data dir
 	if persist {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -935,6 +935,11 @@ func TestAgent_PurgeService(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
+	// Re-add the service
+	if err := agent.AddService(svc, nil, true, ""); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Removed
 	if err := agent.RemoveService(svc.ID, true); err != nil {
 		t.Fatalf("err: %s", err)

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -174,10 +174,14 @@ func (l *localState) RemoveService(serviceID string) {
 	l.Lock()
 	defer l.Unlock()
 
-	delete(l.services, serviceID)
-	delete(l.serviceTokens, serviceID)
-	l.serviceStatus[serviceID] = syncStatus{inSync: false}
-	l.changeMade()
+	if _, ok := l.services[serviceID]; ok {
+		delete(l.services, serviceID)
+		delete(l.serviceTokens, serviceID)
+		l.serviceStatus[serviceID] = syncStatus{inSync: false}
+		l.changeMade()
+	} else {
+		l.logger.Printf("[WARN] agent: Tried to deregister nonexistent service '%s'", serviceID)
+	}
 }
 
 // Services returns the locally registered services that the

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -170,7 +170,7 @@ func (l *localState) AddService(service *structs.NodeService, token string) {
 
 // RemoveService is used to remove a service entry from the local state.
 // The agent will make a best effort to ensure it is deregistered
-func (l *localState) RemoveService(serviceID string) {
+func (l *localState) RemoveService(serviceID string) error {
 	l.Lock()
 	defer l.Unlock()
 
@@ -180,8 +180,10 @@ func (l *localState) RemoveService(serviceID string) {
 		l.serviceStatus[serviceID] = syncStatus{inSync: false}
 		l.changeMade()
 	} else {
-		l.logger.Printf("[WARN] agent: Tried to deregister nonexistent service '%s'", serviceID)
+		return fmt.Errorf("Service does not exist")
 	}
+
+	return nil
 }
 
 // Services returns the locally registered services that the

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -1074,6 +1074,10 @@ func TestAgent_serviceTokens(t *testing.T) {
 	l := new(localState)
 	l.Init(config, nil)
 
+	l.AddService(&structs.NodeService{
+		ID: "redis",
+	}, "")
+
 	// Returns default when no token is set
 	if token := l.ServiceToken("redis"); token != "default" {
 		t.Fatalf("bad: %s", token)


### PR DESCRIPTION
Improve the log message when attempting to deregister a service that doesn't exist, as shown here: https://github.com/hashicorp/consul/issues/1188#issuecomment-153335534