### PR TITLE
UI: remove ACL ID from the left list

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -615,7 +615,7 @@
                 {{#link-to 'acls.show' ID tagName="div" href=false class="list-group-item list-condensed-link" }}
                   <div class="bg-light-gray list-bar-horizontal"></div>
                   <div class="name">
-                    {{ aclName Name ID }}
+                    {{ aclName Name "" }}
                   </div>
                 {{/link-to}}
               {{/collection}}


### PR DESCRIPTION
This patch will remove ACL ID from the left list in the ACL view.

With long ACL names, the list is unusable when ID are present. 