### PR TITLE
Optionally support dated log files in consul.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Symantec/Dominator/lib/logbuf"
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/circonus"
 	"github.com/armon/go-metrics/datadog"
@@ -137,9 +138,12 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&retryIntervalWan, "retry-interval-wan", "",
 		"interval between join -wan attempts")
 
+	logbuf.UseFlagSet(cmdFlags)
 	if err := cmdFlags.Parse(c.args); err != nil {
 		return nil
 	}
+	// Initialize the log buffer after command flags get parsed
+	logbuf.Get()
 
 	if retryInterval != "" {
 		dur, err := time.ParseDuration(retryInterval)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Symantec/Dominator/lib/logbuf"
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/circonus"
 	"github.com/armon/go-metrics/datadog"
@@ -138,12 +137,9 @@ func (c *Command) readConfig() *Config {
 	cmdFlags.StringVar(&retryIntervalWan, "retry-interval-wan", "",
 		"interval between join -wan attempts")
 
-	logbuf.UseFlagSet(cmdFlags)
 	if err := cmdFlags.Parse(c.args); err != nil {
 		return nil
 	}
-	// Initialize the log buffer after command flags get parsed
-	logbuf.Get()
 
 	if retryInterval != "" {
 		dur, err := time.ParseDuration(retryInterval)

--- a/vendor/github.com/Symantec/Dominator/LICENSE
+++ b/vendor/github.com/Symantec/Dominator/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2015 Symantec, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/Symantec/Dominator/lib/logbuf/api.go
+++ b/vendor/github.com/Symantec/Dominator/lib/logbuf/api.go
@@ -1,0 +1,117 @@
+/*
+	Package logbuf provides a circular buffer for writing logs to.
+
+	Package logbuf provides an io.Writer which can be passed to the log.New
+	function to serve as a destination for logs. Logs can be viewed via a HTTP
+	interface and may also be directed to the standard error output.
+*/
+package logbuf
+
+import (
+	"bufio"
+	"container/ring"
+	"flag"
+	"io"
+	"os"
+	"path"
+	"sync"
+	"time"
+)
+
+var (
+	alsoLogToStderr = new(bool)
+	idleMarkTimeout = new(time.Duration)
+	logbufLines     = new(uint)
+	logDir          = new(string)
+	logQuota        = new(uint)
+)
+
+var (
+	kSoleLogBuffer *LogBuffer
+	kOnce          sync.Once
+)
+
+// LogBuffer is a circular buffer suitable for holding logs. It satisfies the
+// io.Writer interface. It is usually passed to the log.New function.
+type LogBuffer struct {
+	rwMutex       sync.RWMutex
+	buffer        *ring.Ring // Always points to next insert position.
+	logDir        string
+	file          *os.File
+	writer        *bufio.Writer
+	usage         uint64
+	quota         uint64
+	writeNotifier chan<- struct{}
+	panicLogfile  *string // Name of last invocation logfile if it has a panic.
+}
+
+// UseFlagSet instructs this package to read its command-line flags from the
+// given flag set instead of from the command line. Caller must pass the
+// flag set to this method before calling Parse on it.
+func UseFlagSet(set *flag.FlagSet) {
+	set.BoolVar(alsoLogToStderr, "alsoLogToStderr", false,
+		"If true, also write logs to stderr")
+	set.DurationVar(idleMarkTimeout, "idleMarkTimeout", 0,
+		"time after last log before a 'MARK' message is written to logfile")
+	set.UintVar(logbufLines, "logbufLines", 1024,
+		"Number of lines to store in the log buffer")
+	set.StringVar(logDir, "logDir", path.Join("/var/log", path.Base(os.Args[0])),
+		"Directory to write log data to. If empty, no logs are written")
+	set.UintVar(logQuota, "logQuota", 10,
+		"Log quota in MiB. If exceeded, old logs are deleted")
+}
+
+// New returns a new *LogBuffer with the specified number of lines of buffer.
+// Only one should be created per application.
+// The behaviour of the LogBuffer is controlled by the following command-line
+// flags (registered with the standard flag pacakge):
+//  -alsoLogToStderr: If true, also write logs to stderr
+//  -logbufLines:     Number of lines to store in the log buffer
+//  -logDir:          Directory to write log data to. If empty, no logs are
+//                    written
+//  -logQuota:        Log quota in MiB. If exceeded, old logs are deleted.
+//                    If zero, the quota will be 16 KiB
+func New() *LogBuffer {
+	quota := uint64(*logQuota) << 20
+	if quota < 16384 {
+		quota = 16384
+	}
+	return newLogBuffer(*logbufLines, *logDir, quota)
+}
+
+// Get works like New except that successive calls to Get return the same
+// instance.
+func Get() *LogBuffer {
+	kOnce.Do(func() {
+		kSoleLogBuffer = New()
+	})
+	return kSoleLogBuffer
+
+}
+
+// Dump will write the contents of the log buffer to w, with a prefix and
+// postfix string written before and after each line. If recentFirst is true,
+// the most recently written contents are dumped first.
+func (lb *LogBuffer) Dump(writer io.Writer, prefix, postfix string,
+	recentFirst bool) error {
+	return lb.dump(writer, prefix, postfix, recentFirst)
+}
+
+// Flush flushes the open log file (if one is open). This should only be called
+// just prior to process termination. The log file is automatically flushed
+// after short periods of inactivity.
+func (lb *LogBuffer) Flush() error {
+	return lb.flush()
+}
+
+// Write will write len(p) bytes from p to the log buffer. It always returns
+// len(p), nil.
+func (lb *LogBuffer) Write(p []byte) (n int, err error) {
+	return lb.write(p)
+}
+
+// WriteHtml will write the contents of the log buffer to w, with appropriate
+// HTML markups.
+func (lb *LogBuffer) WriteHtml(writer io.Writer) {
+	lb.writeHtml(writer)
+}

--- a/vendor/github.com/Symantec/Dominator/lib/logbuf/http.go
+++ b/vendor/github.com/Symantec/Dominator/lib/logbuf/http.go
@@ -1,0 +1,330 @@
+package logbuf
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/Symantec/Dominator/lib/url"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type countingWriter struct {
+	count      uint64
+	writer     io.Writer
+	prefixLine string
+}
+
+func (w *countingWriter) Write(p []byte) (n int, err error) {
+	if w.prefixLine != "" {
+		w.writer.Write([]byte(w.prefixLine))
+		w.prefixLine = ""
+	}
+	n, err = w.writer.Write(p)
+	if n > 0 {
+		w.count += uint64(n)
+	}
+	return
+}
+
+func (lb *LogBuffer) addHttpHandlers() {
+	http.HandleFunc("/logs", lb.httpListHandler)
+	http.HandleFunc("/logs/dump", lb.httpDumpHandler)
+	http.HandleFunc("/logs/showLast", lb.httpShowLastHandler)
+	http.HandleFunc("/logs/showPreviousPanic", lb.httpShowPreviousPanicHandler)
+}
+
+func (lb *LogBuffer) httpListHandler(w http.ResponseWriter, req *http.Request) {
+	if lb.logDir == "" {
+		return
+	}
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	parsedQuery := url.ParseQuery(req.URL)
+	_, recentFirst := parsedQuery.Flags["recentFirst"]
+	names, panicMap, err := lb.list(recentFirst)
+	if err != nil {
+		fmt.Fprintln(writer, err)
+		return
+	}
+	recentFirstString := ""
+	if recentFirst {
+		recentFirstString = "&recentFirst"
+	}
+	if parsedQuery.OutputType() == url.OutputTypeText {
+		for _, name := range names {
+			fmt.Fprintln(writer, name)
+		}
+		return
+	}
+	fmt.Fprintln(writer, "<body>")
+	fmt.Fprint(writer, "Logs: ")
+	if recentFirst {
+		fmt.Fprintf(writer, "showing recent first ")
+		fmt.Fprintln(writer, `<a href="logs">show recent last</a><br>`)
+	} else {
+		fmt.Fprintf(writer, "showing recent last ")
+		fmt.Fprintln(writer,
+			`<a href="logs?recentFirst">show recent first</a><br>`)
+	}
+	showRecentLinks(writer, recentFirstString)
+	fmt.Fprintln(writer, "<p>")
+	currentName := ""
+	lb.rwMutex.Lock()
+	if lb.file != nil {
+		currentName = path.Base(lb.file.Name())
+	}
+	lb.rwMutex.Unlock()
+	if recentFirst {
+		fmt.Fprintf(writer,
+			"<a href=\"logs/dump?name=latest%s\">current</a><br>\n",
+			recentFirstString)
+	}
+	for _, name := range names {
+		if name == currentName {
+			fmt.Fprintf(writer,
+				"<a href=\"logs/dump?name=%s%s\">%s</a> (current)<br>\n",
+				name, recentFirstString, name)
+		} else {
+			hasPanic := ""
+			if _, ok := panicMap[name]; ok {
+				hasPanic = " (has panic log)"
+			}
+			fmt.Fprintf(writer,
+				"<a href=\"logs/dump?name=%s%s\">%s</a>%s<br>\n",
+				name, recentFirstString, name, hasPanic)
+		}
+	}
+	if !recentFirst {
+		fmt.Fprintf(writer,
+			"<a href=\"logs/dump?name=latest%s\">current</a><br>\n",
+			recentFirstString)
+	}
+	fmt.Fprintln(writer, "</body>")
+}
+
+func showRecentLinks(w io.Writer, recentFirstString string) {
+	fmt.Fprintf(w, "Show last: <a href=\"logs/showLast?1m%s\">minute</a>\n",
+		recentFirstString)
+	fmt.Fprintf(w, "           <a href=\"logs/showLast?10m%s\">10 min</a>\n",
+		recentFirstString)
+	fmt.Fprintf(w, "           <a href=\"logs/showLast?1h%s\">hour</a>\n",
+		recentFirstString)
+	fmt.Fprintf(w, "           <a href=\"logs/showLast?1d%s\">day</a>\n",
+		recentFirstString)
+	fmt.Fprintf(w, "           <a href=\"logs/showLast?1w%s\">week</a>\n",
+		recentFirstString)
+}
+
+func (lb *LogBuffer) httpDumpHandler(w http.ResponseWriter, req *http.Request) {
+	parsedQuery := url.ParseQuery(req.URL)
+	name, ok := parsedQuery.Table["name"]
+	if !ok {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	_, recentFirst := parsedQuery.Flags["recentFirst"]
+	if name == "latest" {
+		lbFilename := ""
+		lb.rwMutex.Lock()
+		if lb.file != nil {
+			lbFilename = lb.file.Name()
+		}
+		lb.rwMutex.Unlock()
+		if lbFilename == "" {
+			writer := bufio.NewWriter(w)
+			defer writer.Flush()
+			lb.Dump(writer, "", "", recentFirst)
+			return
+		}
+		name = path.Base(lbFilename)
+	}
+	file, err := os.Open(path.Join(lb.logDir, path.Base(path.Clean(name))))
+	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	defer file.Close()
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	if recentFirst {
+		scanner := bufio.NewScanner(file)
+		lines := make([]string, 0)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if len(line) < 1 {
+				continue
+			}
+			lines = append(lines, line)
+		}
+		if err = scanner.Err(); err == nil {
+			reverseStrings(lines)
+			for _, line := range lines {
+				fmt.Fprintln(writer, line)
+			}
+		}
+	} else {
+		_, err = io.Copy(writer, bufio.NewReader(file))
+	}
+	if err != nil {
+		fmt.Fprintln(writer, err)
+	}
+}
+
+func (lb *LogBuffer) httpShowLastHandler(w http.ResponseWriter,
+	req *http.Request) {
+	parsedQuery := url.ParseQuery(req.URL)
+	_, recentFirst := parsedQuery.Flags["recentFirst"]
+	for flag := range parsedQuery.Flags {
+		length := len(flag)
+		if length < 2 {
+			continue
+		}
+		unitChar := flag[length-1]
+		var unit time.Duration
+		switch unitChar {
+		case 's':
+			unit = time.Second
+		case 'm':
+			unit = time.Minute
+		case 'h':
+			unit = time.Hour
+		case 'd':
+			unit = time.Hour * 24
+		case 'w':
+			unit = time.Hour * 24 * 7
+		default:
+			continue
+		}
+		if val, err := strconv.ParseUint(flag[:length-1], 10, 64); err != nil {
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		} else {
+			lb.showRecent(w, time.Duration(val)*unit, recentFirst)
+			return
+		}
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+}
+
+func (lb *LogBuffer) showRecent(w io.Writer, duration time.Duration,
+	recentFirst bool) {
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	names, _, err := lb.list(true)
+	if err != nil {
+		fmt.Fprintln(writer, err)
+		return
+	}
+	earliestTime := time.Now().Add(-duration)
+	// Get a list of names which may be recent enough.
+	tmpNames := make([]string, 0, len(names))
+	for _, name := range names {
+		startTime, err := time.ParseInLocation(timeLayout, name, time.Local)
+		if err != nil {
+			continue
+		}
+		tmpNames = append(tmpNames, name)
+		if startTime.Before(earliestTime) {
+			break
+		}
+	}
+	names = tmpNames
+	if !recentFirst {
+		reverseStrings(names)
+	}
+	fmt.Fprintln(writer, "<body>")
+	fmt.Fprintln(writer,
+		`<font size=2 style="font-family:'Courier New', monospace">`)
+	cWriter := &countingWriter{writer: writer}
+	lb.flush()
+	for _, name := range names {
+		cWriter.count = 0
+		lb.dumpSince(cWriter, name, earliestTime, "", "<br>\n", recentFirst)
+		if cWriter.count > 0 {
+			cWriter.prefixLine = "<hr>\n"
+		}
+	}
+	fmt.Fprintln(writer, "</body>")
+}
+
+func (lb *LogBuffer) list(recentFirst bool) (
+	[]string, map[string]struct{}, error) {
+	file, err := os.Open(lb.logDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	fileInfos, err := file.Readdir(-1)
+	file.Close()
+	if err != nil {
+		return nil, nil, err
+	}
+	panicMap := make(map[string]struct{})
+	names := make([]string, 0, len(fileInfos))
+	for _, fi := range fileInfos {
+		if strings.Count(fi.Name(), ":") == 3 {
+			names = append(names, fi.Name())
+			if fi.Mode()&os.ModeSticky != 0 {
+				panicMap[fi.Name()] = struct{}{}
+			}
+		}
+	}
+	sort.Strings(names)
+	if recentFirst {
+		reverseStrings(names)
+	}
+	return names, panicMap, nil
+}
+
+func (lb *LogBuffer) httpShowPreviousPanicHandler(w http.ResponseWriter,
+	req *http.Request) {
+	writer := bufio.NewWriter(w)
+	defer writer.Flush()
+	panicLogfile := lb.panicLogfile
+	if panicLogfile == nil {
+		fmt.Fprintln(writer, "Last invocation did not panic!")
+		return
+	}
+	if *panicLogfile == "" {
+		fmt.Fprintln(writer, "Logfile for previous invocation has expired")
+		return
+	}
+	file, err := os.Open(path.Join(lb.logDir, *panicLogfile))
+	if err != nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	defer file.Close()
+	_, err = io.Copy(writer, bufio.NewReader(file))
+	if err != nil {
+		fmt.Fprintln(writer, err)
+	}
+}
+
+func (lb *LogBuffer) writeHtml(writer io.Writer) {
+	fmt.Fprintln(writer, `<a href="logs">Logs:</a><br>`)
+	panicLogfile := lb.panicLogfile
+	if panicLogfile != nil {
+		fmt.Fprint(writer,
+			"<font color=\"red\">Last invocation paniced</font>, ")
+		if *panicLogfile == "" {
+			fmt.Fprintln(writer, "logfile no longer available<br>")
+		} else {
+			fmt.Fprintln(writer,
+				"<a href=\"logs/showPreviousPanic\">logfile</a><br>")
+		}
+	}
+	fmt.Fprintln(writer, "<pre>")
+	lb.Dump(writer, "", "", false)
+	fmt.Fprintln(writer, "</pre>")
+}

--- a/vendor/github.com/Symantec/Dominator/lib/logbuf/impl.go
+++ b/vendor/github.com/Symantec/Dominator/lib/logbuf/impl.go
@@ -1,0 +1,324 @@
+package logbuf
+
+import (
+	"bufio"
+	"container/ring"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	dirPerms  = syscall.S_IRWXU | syscall.S_IRGRP | syscall.S_IXGRP
+	filePerms = syscall.S_IRUSR | syscall.S_IWUSR | syscall.S_IRGRP
+
+	timeLayout = "2006-01-02:15:04:05.999"
+)
+
+func newLogBuffer(length uint, dirname string, quota uint64) *LogBuffer {
+	logBuffer := &LogBuffer{
+		buffer: ring.New(int(length)),
+		logDir: dirname,
+		quota:  quota}
+	if err := logBuffer.setupFileLogging(); err != nil {
+		fmt.Fprintln(logBuffer, err)
+	}
+	logBuffer.addHttpHandlers()
+	return logBuffer
+}
+
+func (lb *LogBuffer) setupFileLogging() error {
+	if lb.logDir == "" {
+		return nil
+	}
+	if err := lb.createLogDirectory(); err != nil {
+		return err
+	}
+	writeNotifier := make(chan struct{}, 1)
+	lb.writeNotifier = writeNotifier
+	go lb.flushWhenIdle(writeNotifier)
+	return nil
+}
+
+func (lb *LogBuffer) createLogDirectory() error {
+	if fi, err := os.Stat(lb.logDir); err != nil {
+		if err := os.Mkdir(lb.logDir, dirPerms); err != nil {
+			return fmt.Errorf("error creating: %s: %s", lb.logDir, err)
+		}
+		fi, err = os.Stat(lb.logDir)
+	} else if !fi.IsDir() {
+		return errors.New(lb.logDir + ": is not a directory")
+	}
+	lb.scanPreviousForPanic()
+	return lb.enforceQuota()
+}
+
+func (lb *LogBuffer) scanPreviousForPanic() {
+	target, err := os.Readlink(path.Join(lb.logDir, "latest"))
+	if err != nil {
+		return
+	}
+	targetPath := path.Join(lb.logDir, target)
+	file, err := os.Open(targetPath)
+	if err != nil {
+		return
+	}
+	go func() {
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "panic: ") {
+				lb.rwMutex.Lock()
+				lb.panicLogfile = &target
+				lb.rwMutex.Unlock()
+				if fi, err := os.Stat(targetPath); err != nil {
+					return
+				} else {
+					os.Chmod(targetPath, fi.Mode()|os.ModeSticky)
+				}
+				return
+			}
+		}
+	}()
+}
+
+func (lb *LogBuffer) dump(writer io.Writer, prefix, postfix string,
+	recentFirst bool) error {
+	entries := lb.getEntries()
+	if recentFirst {
+		reverseEntries(entries)
+	}
+	for _, entry := range entries {
+		writer.Write([]byte(prefix))
+		writer.Write(entry)
+		writer.Write([]byte(postfix))
+	}
+	return nil
+}
+
+func (lb *LogBuffer) flush() error {
+	lb.rwMutex.Lock()
+	defer lb.rwMutex.Unlock()
+	if lb.writer != nil {
+		return lb.writer.Flush()
+	}
+	return nil
+}
+
+func (lb *LogBuffer) write(p []byte) (n int, err error) {
+	if *alsoLogToStderr {
+		os.Stderr.Write(p)
+	}
+	val := make([]byte, len(p))
+	copy(val, p)
+	lb.rwMutex.Lock()
+	sendNotify := lb.writeToLogFile(p)
+	lb.buffer.Value = val
+	lb.buffer = lb.buffer.Next()
+	lb.rwMutex.Unlock()
+	if sendNotify {
+		lb.writeNotifier <- struct{}{}
+	}
+	return len(p), nil
+}
+
+// This should be called with the lock held.
+func (lb *LogBuffer) writeToLogFile(p []byte) bool {
+	if lb.writer == nil {
+		return false
+	}
+	lb.writer.Write(p)
+	lb.usage += uint64(len(p))
+	if lb.usage <= lb.quota {
+		return true
+	}
+	lb.enforceQuota()
+	return true
+}
+
+// This should be called with the lock held.
+func (lb *LogBuffer) enforceQuota() error {
+	file, err := os.Open(lb.logDir)
+	if err != nil {
+		return err
+	}
+	names, err := file.Readdirnames(-1)
+	file.Close()
+	if err != nil {
+		return err
+	}
+	sort.Strings(names)
+	var usage uint64
+	deletedLatestFile := false
+	deleteRemainingFiles := false
+	latestFile := true
+	for index := len(names) - 1; index >= 0; index-- {
+		filename := path.Join(lb.logDir, names[index])
+		fi, err := os.Lstat(filename)
+		if err == os.ErrNotExist {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if fi.Mode().IsRegular() {
+			size := uint64(fi.Size())
+			if size < lb.quota>>10 {
+				size = lb.quota >> 10 // Limit number of files to 1024.
+			}
+			if size+usage > lb.quota || deleteRemainingFiles {
+				os.Remove(filename)
+				deleteRemainingFiles = true
+				if latestFile {
+					deletedLatestFile = true
+				}
+			} else {
+				usage += size
+			}
+			latestFile = false
+		}
+	}
+	lb.usage = usage
+	if deletedLatestFile && lb.file != nil {
+		lb.writer.Flush()
+		lb.writer = nil
+		lb.file.Close()
+		lb.file = nil
+	}
+	if lb.file == nil {
+		filename := time.Now().Format(timeLayout)
+		file, err := os.OpenFile(path.Join(lb.logDir, filename),
+			os.O_CREATE|os.O_WRONLY, filePerms)
+		if err != nil {
+			return err
+		}
+		if !*alsoLogToStderr {
+			syscall.Dup2(int(file.Fd()), int(os.Stdout.Fd()))
+			syscall.Dup2(int(file.Fd()), int(os.Stderr.Fd()))
+		}
+		lb.file = file
+		lb.writer = bufio.NewWriter(file)
+		symlink := path.Join(lb.logDir, "latest")
+		tmpSymlink := symlink + "~"
+		os.Remove(tmpSymlink)
+		os.Symlink(filename, tmpSymlink)
+		os.Rename(tmpSymlink, symlink)
+	}
+	return nil
+}
+
+func (lb *LogBuffer) flushWhenIdle(writeNotifier <-chan struct{}) {
+	flushTimer := time.NewTimer(time.Second)
+	idleMarkDuration := *idleMarkTimeout
+	if idleMarkDuration < 1 {
+		idleMarkDuration = time.Hour * 24 * 365 * 280 // Far in the future.
+	}
+	idleMarkTimer := time.NewTimer(idleMarkDuration)
+	for {
+		select {
+		case <-writeNotifier:
+			flushTimer.Reset(time.Second)
+			idleMarkTimer.Reset(idleMarkDuration)
+		case <-flushTimer.C:
+			lb.flush()
+		case <-idleMarkTimer.C:
+			lb.writeMark()
+			flushTimer.Reset(time.Second)
+			idleMarkTimer.Reset(idleMarkDuration)
+		}
+	}
+}
+
+func (lb *LogBuffer) getEntries() [][]byte {
+	lb.rwMutex.RLock()
+	defer lb.rwMutex.RUnlock()
+	entries := make([][]byte, 0, lb.buffer.Len())
+	lb.buffer.Do(func(p interface{}) {
+		if p != nil {
+			entries = append(entries, p.([]byte))
+		}
+	})
+	return entries
+}
+
+func (lb *LogBuffer) dumpSince(writer io.Writer, name string,
+	earliestTime time.Time, prefix, postfix string, recentFirst bool) error {
+	file, err := os.Open(path.Join(lb.logDir, path.Base(path.Clean(name))))
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	lines := make([]string, 0)
+	timeFormat := "2006/01/02 15:04:05"
+	minLength := len(timeFormat) + 2
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) >= minLength {
+			timeString := line[:minLength-2]
+			timeStamp, err := time.ParseInLocation(timeFormat, timeString,
+				time.Local)
+			if err == nil && timeStamp.Before(earliestTime) {
+				continue
+			}
+		}
+		if recentFirst {
+			lines = append(lines, line)
+		} else {
+			writer.Write([]byte(prefix))
+			writer.Write([]byte(line))
+			writer.Write([]byte(postfix))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if recentFirst {
+		reverseStrings(lines)
+		for _, line := range lines {
+			writer.Write([]byte(prefix))
+			writer.Write([]byte(line))
+			writer.Write([]byte(postfix))
+		}
+	}
+	return nil
+}
+
+func (lb *LogBuffer) writeMark() {
+	now := time.Now()
+	year, month, day := now.Date()
+	hour, minute, second := now.Clock()
+	str := fmt.Sprintf("%d/%02d/%02d %02d:%02d:%02d MARK\n",
+		year, month, day, hour, minute, second)
+	lb.rwMutex.Lock()
+	defer lb.rwMutex.Unlock()
+	lb.writeToLogFile([]byte(str))
+}
+
+func reverseEntries(entries [][]byte) {
+	length := len(entries)
+	for index := 0; index < length/2; index++ {
+		entries[index], entries[length-1-index] =
+			entries[length-1-index], entries[index]
+	}
+}
+
+func reverseStrings(strings []string) {
+	length := len(strings)
+	for index := 0; index < length/2; index++ {
+		strings[index], strings[length-1-index] =
+			strings[length-1-index], strings[index]
+	}
+}
+
+func init() {
+	UseFlagSet(flag.CommandLine)
+}

--- a/vendor/github.com/Symantec/Dominator/lib/url/api.go
+++ b/vendor/github.com/Symantec/Dominator/lib/url/api.go
@@ -1,0 +1,29 @@
+package url
+
+import (
+	"net/url"
+	"time"
+)
+
+const (
+	OutputTypeHtml = iota
+	OutputTypeText
+	OutputTypeJson
+)
+
+type ParsedQuery struct {
+	Flags map[string]struct{}
+	Table map[string]string
+}
+
+func ParseQuery(URL *url.URL) ParsedQuery {
+	return parseQuery(URL)
+}
+
+func (pq ParsedQuery) Last() (time.Duration, error) {
+	return pq.last()
+}
+
+func (pq ParsedQuery) OutputType() uint {
+	return pq.outputType()
+}

--- a/vendor/github.com/Symantec/Dominator/lib/url/last.go
+++ b/vendor/github.com/Symantec/Dominator/lib/url/last.go
@@ -1,0 +1,41 @@
+package url
+
+import (
+	"errors"
+	"strconv"
+	"time"
+)
+
+func (pq ParsedQuery) last() (time.Duration, error) {
+	query, ok := pq.Table["last"]
+	if !ok {
+		return 0, errors.New("bad query")
+	}
+	length := len(query)
+	if length < 2 {
+		return 0, errors.New("bad query")
+	}
+	var unit time.Duration
+	unitString := query[length-1]
+	query = query[:length-1]
+	switch unitString {
+	case 's':
+		unit = time.Second
+	case 'm':
+		unit = time.Minute
+	case 'h':
+		unit = time.Hour
+	case 'd':
+		unit = time.Hour * 24
+	case 'w':
+		unit = time.Hour * 24 * 7
+	default:
+		return 0, errors.New("unknown unit in query")
+	}
+	if val, err := strconv.ParseUint(query, 10, 64); err != nil {
+		return 0, err
+	} else {
+		duration := time.Duration(val) * unit
+		return duration, nil
+	}
+}

--- a/vendor/github.com/Symantec/Dominator/lib/url/parseQuery.go
+++ b/vendor/github.com/Symantec/Dominator/lib/url/parseQuery.go
@@ -1,0 +1,22 @@
+package url
+
+import (
+	"net/url"
+	"strings"
+)
+
+func parseQuery(URL *url.URL) ParsedQuery {
+	var parsedQuery ParsedQuery
+	parsedQuery.Flags = make(map[string]struct{})
+	parsedQuery.Table = make(map[string]string)
+	for _, pair := range strings.Split(URL.RawQuery, "&") {
+		splitPair := strings.Split(pair, "=")
+		if len(splitPair) == 1 {
+			parsedQuery.Flags[splitPair[0]] = struct{}{}
+		}
+		if len(splitPair) == 2 {
+			parsedQuery.Table[splitPair[0]] = splitPair[1]
+		}
+	}
+	return parsedQuery
+}

--- a/vendor/github.com/Symantec/Dominator/lib/url/parsedQuery.go
+++ b/vendor/github.com/Symantec/Dominator/lib/url/parsedQuery.go
@@ -1,0 +1,13 @@
+package url
+
+func (pq ParsedQuery) outputType() uint {
+	if value, ok := pq.Table["output"]; ok {
+		switch value {
+		case "json":
+			return OutputTypeJson
+		case "text":
+			return OutputTypeText
+		}
+	}
+	return OutputTypeHtml
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,6 +15,18 @@
 			"revisionTime": "2016-07-16T02:56:31Z"
 		},
 		{
+			"checksumSHA1": "BDMwtKr4z8gDY44D357JR/btBC0=",
+			"path": "github.com/Symantec/Dominator/lib/logbuf",
+			"revision": "8f706d9dbbb82321e51d4c16df190af7d8a9f2b8",
+			"revisionTime": "2016-11-16T18:35:26Z"
+		},
+		{
+			"checksumSHA1": "4byZ4HZxj1dUysDIvlec6yjXPEQ=",
+			"path": "github.com/Symantec/Dominator/lib/url",
+			"revision": "8f706d9dbbb82321e51d4c16df190af7d8a9f2b8",
+			"revisionTime": "2016-11-16T18:35:26Z"
+		},
+		{
 			"checksumSHA1": "l0iFqayYAaEip6Olaq3/LCOa/Sg=",
 			"path": "github.com/armon/circbuf",
 			"revision": "bbbad097214e2918d8543d5201d12bfd7bca254d",


### PR DESCRIPTION
As an alternative to logging to stderr, we have developed a logging package
that automatically redirects logs to dated log files and optionally removes
old log files when log storage reaches some threshhold. We often run
processes including consul agent as daemons, but from time to time we like
to look at the logs.

With this change, users can run the consul agent the way that always
have writing log messages to stderr or they can redirect those logs to
dated log files. Hope you find this PR useful.