### PR TITLE
adapt to server's checker field TLSSkipVerify type

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -74,7 +74,7 @@ type AgentServiceCheck struct {
 	TCP               string `json:",omitempty"`
 	Status            string `json:",omitempty"`
 	Notes             string `json:",omitempty"`
-	TLSSkipVerify     string `json:",omitempty"`
+	TLSSkipVerify     bool   `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service
 	// may also contain this optional DeregisterCriticalServiceAfter field,


### PR DESCRIPTION
the TLSSkipVerify Type in api.AgentServiceCheck struct different from server's type