### PR TITLE
Fix for KV put command

### DIFF
--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -229,8 +229,12 @@ func (c *KVPutCommand) dataFromArgs(args []string) (string, string, error) {
 		return key, string(data), nil
 	case '-':
 		var b bytes.Buffer
-		if _, err := io.Copy(&b, stdin); err != nil {
-			return "", "", fmt.Errorf("Failed to read stdin: %s", err)
+		if len(data) > 1 {
+			return key, data, nil
+		} else {
+			if _, err := io.Copy(&b, stdin); err != nil {
+				return "", "", fmt.Errorf("Failed to read stdin: %s", err)
+			}
 		}
 		return key, b.String(), nil
 	default:

--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -228,15 +228,15 @@ func (c *KVPutCommand) dataFromArgs(args []string) (string, string, error) {
 		}
 		return key, string(data), nil
 	case '-':
-		var b bytes.Buffer
 		if len(data) > 1 {
 			return key, data, nil
 		} else {
+			var b bytes.Buffer
 			if _, err := io.Copy(&b, stdin); err != nil {
 				return "", "", fmt.Errorf("Failed to read stdin: %s", err)
 			}
+			return key, b.String(), nil
 		}
-		return key, b.String(), nil
 	default:
 		return key, data, nil
 	}

--- a/command/kv_put_test.go
+++ b/command/kv_put_test.go
@@ -194,6 +194,34 @@ func TestKVPutCommand_Stdin(t *testing.T) {
 	}
 }
 
+func TestKVPutCommand_NegativeVal(t *testing.T) {
+	srv, client := testAgentWithAPIClient(t)
+	defer srv.Shutdown()
+	waitForLeader(t, srv.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &KVPutCommand{Ui: ui}
+
+	args := []string{
+		"-http-addr=" + srv.httpAddr,
+		"foo", "-2",
+	}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	data, _, err := client.KV().Get("foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data.Value, []byte("-2")) {
+		t.Errorf("bad: %#v", data.Value)
+	}
+}
+
 func TestKVPutCommand_Flags(t *testing.T) {
 	srv, client := testAgentWithAPIClient(t)
 	defer srv.Shutdown()


### PR DESCRIPTION
Fix for #2526 

Added a simple check to differentiate between stdin flag or value that contains a '-' when using the `consul kv put` command. 