### PR TITLE
[website]: Clojure client to SDK section

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -60,6 +60,9 @@ description: |-
         <a href="https://github.com/dcarbone/php-consul-api">php-consul-api</a> - GO-like PHP Client for the Consul HTTP API
       </li>
       <li>
+        <a href="https://github.com/tolitius/envoy">envoy</a> - Consul Clojure client with watchers and other goodies
+      </li>
+      <li>
         <a href="https://github.com/codacy/scala-consul">scala-consul</a> - Scala client for the Consul HTTP API
       </li>
       <li>
@@ -161,9 +164,6 @@ description: |-
       </li>
       <li>
         <a href="https://github.com/pszymczyk/embedded-consul">Embedded Consul</a> - Library for JVM based applications, provides easy way to run Consul in integration tests
-      </li>
-      <li>
-        <a href="https://github.com/tolitius/envoy">envoy</a> - Consul Clojure client with watchers and other goodies
       </li>
     </ul>
 


### PR DESCRIPTION
Consul Clojure client is misplaced in the "[Download Consul Tools](https://www.consul.io/downloads_tools.html)" list. It is currently under the `tools` section, but according to other language bindings should be under the `SDK` section.