### PR TITLE
Use ErrorWriter in cli so that errors get written to stderr

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -15,7 +15,7 @@ import (
 var Commands map[string]cli.CommandFactory
 
 func init() {
-	ui := &cli.BasicUi{Writer: os.Stdout}
+	ui := &cli.BasicUi{Writer: os.Stdout, ErrorWriter: os.Stderr}
 
 	Commands = map[string]cli.CommandFactory{
 		"agent": func() (cli.Command, error) {


### PR DESCRIPTION
A fix for #2527 - initialize the ErrorWriter in the cli's BasicUi so that errors and warns get written to stderr