### PR TITLE
Add regexp to list services from catalog

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -74,6 +74,10 @@ type QueryOptions struct {
 	// that node. Setting this to "_agent" will use the agent's node
 	// for the sort.
 	Near string
+
+	// Regexp is used to filter results when querying the services in a DC.
+	// All returned service names match the given regexp.
+	Regexp string
 }
 
 // WriteOptions are used to parameterize a write
@@ -385,6 +389,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Near != "" {
 		r.params.Set("near", q.Near)
+	}
+	if q.Regexp != "" {
+		r.params.Set("regexp", q.Regexp)
 	}
 }
 

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -570,6 +570,17 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	*token = s.agent.config.ACLToken
 }
 
+// parseRegexp is used to parse the ?regexp query param
+func (s *HTTPServer) parseRegexp(req *http.Request, regexp *string) {
+	if other := req.URL.Query().Get("regexp"); other != "" {
+		*regexp = other
+		return
+	}
+
+	// Set the default regexp
+	*regexp = ""
+}
+
 // parseSource is used to parse the ?near=<node> query parameter, used for
 // sorting by RTT based on a source node. We set the source's DC to the target
 // DC in the request, if given, or else the agent's DC.
@@ -589,6 +600,7 @@ func (s *HTTPServer) parseSource(req *http.Request, source *structs.QuerySource)
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions) bool {
 	s.parseDC(req, dc)
 	s.parseToken(req, &b.Token)
+	s.parseRegexp(req, &b.Regexp)
 	if parseConsistency(resp, req, b) {
 		return true
 	}

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -192,6 +193,16 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 			index, services, err := state.Services()
 			if err != nil {
 				return err
+			}
+
+			if args.QueryOptions.Regexp != "" {
+				var filteredServices = make(structs.Services)
+				for service, tags := range services {
+					if match, _ := regexp.MatchString(args.QueryOptions.Regexp, service); match {
+						filteredServices[service] = tags
+					}
+				}
+				services = filteredServices
 			}
 
 			reply.Index, reply.Services = index, services

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -116,6 +116,9 @@ type QueryOptions struct {
 	// If set, the leader must verify leadership prior to
 	// servicing the request. Prevents a stale read.
 	RequireConsistent bool
+
+	// If set, when querying catalog, all returned service names match the given regexp.
+	Regexp string
 }
 
 // QueryOption only applies to reads, so always true


### PR DESCRIPTION
When there is a lot of registered services, it may be very usefull
to query the catalog using a regexp. This avoid returning all registered services,
but list only the ones that match the given regexp.