### PR TITLE
Doc Fix: The Near key is out of place

### DIFF
--- a/website/source/docs/agent/http/query.html.markdown
+++ b/website/source/docs/agent/http/query.html.markdown
@@ -70,13 +70,13 @@ query, like this example:
   "Name": "my-query",
   "Session": "adf4238a-882b-9ddc-4a9d-5b6758e4159e",
   "Token": "",
-  "Near": "node1",
   "Service": {
     "Service": "redis",
     "Failover": {
       "NearestN": 3,
       "Datacenters": ["dc1", "dc2"]
     },
+    "Near": "node1",
     "OnlyPassing": false,
     "Tags": ["primary", "!experimental"]
   },


### PR DESCRIPTION
This took me a bit to find due to this error. The `Near` needs to go int he service block. It took me looking at the list of all the queries to figure it out. 