### PR TITLE
Prevent panic errors in tombstone GC

### DIFF
--- a/consul/state/tombstone_gc.go
+++ b/consul/state/tombstone_gc.go
@@ -142,8 +142,13 @@ func (t *TombstoneGC) expireTime(expires time.Time) {
 	// Get the maximum index and clear the entry
 	t.lock.Lock()
 	exp := t.expires[expires]
+	enabled := t.enabled
 	delete(t.expires, expires)
 	t.lock.Unlock()
+
+	if !enabled {
+		return
+	}
 
 	// Notify the expires channel
 	t.expireCh <- exp.maxIndex


### PR DESCRIPTION
This patch fixes the race condition caused by concurrent call to the ```SetEnabled``` method and call of the timer handler. If the ```SetEnabled``` will acquire the lock earlier, it will erase the content of the ```expires``` map.

So when the timer handler will acquire the lock, it will access to the non-existing interval (which is evaluated to nil), thus cause the panic.

I added a check, that ensures the tombstone GC is enabled before sending anything to expire channel.

fixes #2087