### PR TITLE
Change raft snapshot interval to 5 seconds

### DIFF
--- a/consul/config.go
+++ b/consul/config.go
@@ -350,6 +350,9 @@ func DefaultConfig() *Config {
 	// Disable shutdown on removal
 	conf.RaftConfig.ShutdownOnRemove = false
 
+	// Check every 5 seconds to see if there are enough new entries for a snapshot
+	conf.RaftConfig.SnapshotInterval = 5 * time.Second
+
 	return conf
 }
 


### PR DESCRIPTION
Check for snapshots more frequently to keep the raft file smaller and avoid doing a huge truncation when writing lots of keys very quickly. Should help with #866.