### PR TITLE
Adds complete ACL coverage for nodes and sessions.

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -19,6 +19,7 @@ type Policy struct {
 	Keys            []*KeyPolicy           `hcl:"key,expand"`
 	Nodes           []*NodePolicy          `hcl:"node,expand"`
 	Services        []*ServicePolicy       `hcl:"service,expand"`
+	Sessions        []*SessionPolicy       `hcl:"session,expand"`
 	Events          []*EventPolicy         `hcl:"event,expand"`
 	PreparedQueries []*PreparedQueryPolicy `hcl:"query,expand"`
 	Keyring         string                 `hcl:"keyring"`
@@ -52,6 +53,17 @@ type ServicePolicy struct {
 }
 
 func (s *ServicePolicy) GoString() string {
+	return fmt.Sprintf("%#v", *s)
+}
+
+// SessionPolicy represents a policy for making sessions tied to specific node
+// name prefixes.
+type SessionPolicy struct {
+	Node   string `hcl:",key"`
+	Policy string
+}
+
+func (s *SessionPolicy) GoString() string {
 	return fmt.Sprintf("%#v", *s)
 }
 
@@ -122,6 +134,13 @@ func Parse(rules string) (*Policy, error) {
 	for _, sp := range p.Services {
 		if !isPolicyValid(sp.Policy) {
 			return nil, fmt.Errorf("Invalid service policy: %#v", sp)
+		}
+	}
+
+	// Validate the session policies
+	for _, sp := range p.Sessions {
+		if !isPolicyValid(sp.Policy) {
+			return nil, fmt.Errorf("Invalid session policy: %#v", sp)
 		}
 	}
 

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -46,6 +46,12 @@ service "" {
 service "foo" {
 	policy = "read"
 }
+session "foo" {
+	policy = "write"
+}
+session "bar" {
+	policy = "deny"
+}
 query "" {
 	policy = "read"
 }
@@ -129,6 +135,16 @@ query "bar" {
 				Policy: PolicyRead,
 			},
 		},
+		Sessions: []*SessionPolicy{
+			&SessionPolicy{
+				Node:   "foo",
+				Policy: PolicyWrite,
+			},
+			&SessionPolicy{
+				Node:   "bar",
+				Policy: PolicyDeny,
+			},
+		},
 	}
 
 	out, err := Parse(inp)
@@ -198,6 +214,14 @@ func TestACLPolicy_Parse_JSON(t *testing.T) {
 		},
 		"foo": {
 			"policy": "read"
+		}
+	},
+	"session": {
+		"foo": {
+			"policy": "write"
+		},
+		"bar": {
+			"policy": "deny"
 		}
 	}
 }`
@@ -274,6 +298,16 @@ func TestACLPolicy_Parse_JSON(t *testing.T) {
 				Policy: PolicyRead,
 			},
 		},
+		Sessions: []*SessionPolicy{
+			&SessionPolicy{
+				Node:   "foo",
+				Policy: PolicyWrite,
+			},
+			&SessionPolicy{
+				Node:   "bar",
+				Policy: PolicyDeny,
+			},
+		},
 	}
 
 	out, err := Parse(inp)
@@ -331,6 +365,7 @@ func TestACLPolicy_Bad_Policy(t *testing.T) {
 		`operator = "nope"`,
 		`query "" { policy = "nope" }`,
 		`service "" { policy = "nope" }`,
+		`session "" { policy = "nope" }`,
 	}
 	for _, c := range cases {
 		_, err := Parse(c)

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -45,6 +45,7 @@ func TestPreparedQuery(t *testing.T) {
 
 	// Create a simple prepared query.
 	def := &PreparedQueryDefinition{
+		Name: "test",
 		Service: ServiceQuery{
 			Service: "redis",
 		},

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -818,14 +818,11 @@ func (a *Agent) sendCoordinate() {
 				continue
 			}
 
-			// TODO - Consider adding a distance check so we don't send
-			// an update if the position hasn't changed by more than a
-			// threshold.
 			req := structs.CoordinateUpdateRequest{
 				Datacenter:   a.config.Datacenter,
 				Node:         a.config.NodeName,
 				Coord:        c,
-				WriteRequest: structs.WriteRequest{Token: a.config.ACLToken},
+				WriteRequest: structs.WriteRequest{Token: a.config.GetTokenForAgent()},
 			}
 			var reply struct{}
 			if err := a.RPC("Coordinate.Update", &req, &reply); err != nil {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -227,8 +227,8 @@ func Create(config *Config, logOutput io.Writer, logWriter *logger.LogWriter,
 			Port:    agent.config.Ports.Server,
 			Tags:    []string{},
 		}
-		// TODO (slackpad) - Plumb the "acl_agent_token" into here.
-		agent.state.AddService(&consulService, "")
+
+		agent.state.AddService(&consulService, agent.config.GetTokenForAgent())
 	} else {
 		err = agent.setupClient()
 		agent.state.SetIface(agent.client)
@@ -363,6 +363,9 @@ func (a *Agent) consulConfig() *consul.Config {
 	}
 	if a.config.ACLToken != "" {
 		base.ACLToken = a.config.ACLToken
+	}
+	if a.config.ACLAgentToken != "" {
+		base.ACLAgentToken = a.config.ACLAgentToken
 	}
 	if a.config.ACLMasterToken != "" {
 		base.ACLMasterToken = a.config.ACLMasterToken

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -488,6 +488,11 @@ type Config struct {
 	// token is not provided. If not configured the 'anonymous' token is used.
 	ACLToken string `mapstructure:"acl_token" json:"-"`
 
+	// ACLAgentToken is the default token used to make requests for the agent
+	// itself, such as for registering itself with the catalog. If not
+	// configured, the 'acl_token' will be used.
+	ACLAgentToken string `mapstructure:"acl_agent_token" json:"-"`
+
 	// ACLMasterToken is used to bootstrap the ACL system. It should be specified
 	// on the servers in the ACLDatacenter. When the leader comes online, it ensures
 	// that the Master token is available. This provides the initial token.
@@ -754,6 +759,18 @@ func (c *Config) ClientListener(override string, port int) (net.Addr, error) {
 		return nil, fmt.Errorf("Failed to parse IP: %v", addr)
 	}
 	return &net.TCPAddr{IP: ip, Port: port}, nil
+}
+
+// GetTokenForAgent returns the token the agent should use for its own internal
+// operations, such as registering itself with the catalog.
+func (c *Config) GetTokenForAgent() string {
+	if c.ACLAgentToken != "" {
+		return c.ACLAgentToken
+	} else if c.ACLToken != "" {
+		return c.ACLToken
+	} else {
+		return ""
+	}
 }
 
 // DecodeConfig reads the configuration from the given reader in JSON
@@ -1465,6 +1482,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.ACLToken != "" {
 		result.ACLToken = b.ACLToken
+	}
+	if b.ACLAgentToken != "" {
+		result.ACLAgentToken = b.ACLAgentToken
 	}
 	if b.ACLMasterToken != "" {
 		result.ACLMasterToken = b.ACLMasterToken

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -569,6 +569,7 @@ func TestDNS_ServiceLookup(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -1021,6 +1022,7 @@ func TestDNS_ServiceLookup_ServiceAddress(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -1115,6 +1117,7 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -1236,6 +1239,7 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 			Datacenter: "dc2",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -1641,6 +1645,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -1745,6 +1750,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -2040,6 +2046,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -2163,6 +2170,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},
@@ -2283,6 +2291,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service:     "db",
 					OnlyPassing: true,
@@ -2356,6 +2365,7 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "web",
 				},
@@ -2450,6 +2460,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "web",
 				},
@@ -2770,6 +2781,7 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "search",
 				},
@@ -4342,6 +4354,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 			Datacenter: "dc1",
 			Op:         structs.PreparedQueryCreate,
 			Query: &structs.PreparedQuery{
+				Name: "test",
 				Service: structs.ServiceQuery{
 					Service: "db",
 				},

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -400,7 +400,7 @@ func (l *localState) setSyncState() error {
 	req := structs.NodeSpecificRequest{
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
-		QueryOptions: structs.QueryOptions{Token: l.config.ACLToken},
+		QueryOptions: structs.QueryOptions{Token: l.config.GetTokenForAgent()},
 	}
 	var out1 structs.IndexedNodeServices
 	var out2 structs.IndexedHealthChecks
@@ -709,7 +709,7 @@ func (l *localState) syncNodeInfo() error {
 		Node:            l.config.NodeName,
 		Address:         l.config.AdvertiseAddr,
 		TaggedAddresses: l.config.TaggedAddresses,
-		WriteRequest:    structs.WriteRequest{Token: l.config.ACLToken},
+		WriteRequest:    structs.WriteRequest{Token: l.config.GetTokenForAgent()},
 	}
 	var out struct{}
 	err := l.iface.RPC("Catalog.Register", &req, &out)

--- a/command/agent/session_endpoint.go
+++ b/command/agent/session_endpoint.go
@@ -46,6 +46,7 @@ func (s *HTTPServer) SessionCreate(resp http.ResponseWriter, req *http.Request) 
 		},
 	}
 	s.parseDC(req, &args.Datacenter)
+	s.parseToken(req, &args.Token)
 
 	// Handle optional request body
 	if req.ContentLength > 0 {
@@ -117,6 +118,7 @@ func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request)
 		Op: structs.SessionDestroy,
 	}
 	s.parseDC(req, &args.Datacenter)
+	s.parseToken(req, &args.Token)
 
 	// Pull out the session id
 	args.Session.ID = strings.TrimPrefix(req.URL.Path, "/v1/session/destroy/")

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -350,7 +350,7 @@ func (f *aclFilter) filterHealthChecks(checks *structs.HealthChecks) {
 	hc := *checks
 	for i := 0; i < len(hc); i++ {
 		check := hc[i]
-		if f.allowService(check.ServiceName) {
+		if f.allowNode(check.Node) && f.allowService(check.ServiceName) {
 			continue
 		}
 		f.logger.Printf("[DEBUG] consul: dropping check %q from result due to ACLs", check.CheckID)
@@ -403,7 +403,7 @@ func (f *aclFilter) filterCheckServiceNodes(nodes *structs.CheckServiceNodes) {
 	csn := *nodes
 	for i := 0; i < len(csn); i++ {
 		node := csn[i]
-		if f.allowService(node.Service.Service) {
+		if f.allowNode(node.Node.Node) && f.allowService(node.Service.Service) {
 			continue
 		}
 		f.logger.Printf("[DEBUG] consul: dropping node %q from result due to ACLs", node.Node.Node)

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -1012,6 +1012,41 @@ func TestACL_filterCheckServiceNodes(t *testing.T) {
 	}
 }
 
+func TestACL_filterCoordinates(t *testing.T) {
+	// Create some coordinates.
+	coords := structs.Coordinates{
+		&structs.Coordinate{
+			Node:  "node1",
+			Coord: generateRandomCoordinate(),
+		},
+		&structs.Coordinate{
+			Node:  "node2",
+			Coord: generateRandomCoordinate(),
+		},
+	}
+
+	// Try permissive filtering.
+	filt := newAclFilter(acl.AllowAll(), nil, false)
+	filt.filterCoordinates(&coords)
+	if len(coords) != 2 {
+		t.Fatalf("bad: %#v", coords)
+	}
+
+	// Try restrictive filtering without version 8 ACL enforcement.
+	filt = newAclFilter(acl.DenyAll(), nil, false)
+	filt.filterCoordinates(&coords)
+	if len(coords) != 2 {
+		t.Fatalf("bad: %#v", coords)
+	}
+
+	// Try restrictive filtering with version 8 ACL enforcement.
+	filt = newAclFilter(acl.DenyAll(), nil, true)
+	filt.filterCoordinates(&coords)
+	if len(coords) != 0 {
+		t.Fatalf("bad: %#v", coords)
+	}
+}
+
 func TestACL_filterNodeDump(t *testing.T) {
 	// Create a node dump
 	dump := structs.NodeDump{

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -1261,6 +1261,39 @@ func TestACL_filterCoordinates(t *testing.T) {
 	}
 }
 
+func TestACL_filterSessions(t *testing.T) {
+	// Create a session list.
+	sessions := structs.Sessions{
+		&structs.Session{
+			Node: "foo",
+		},
+		&structs.Session{
+			Node: "bar",
+		},
+	}
+
+	// Try permissive filtering.
+	filt := newAclFilter(acl.AllowAll(), nil, true)
+	filt.filterSessions(&sessions)
+	if len(sessions) != 2 {
+		t.Fatalf("bad: %#v", sessions)
+	}
+
+	// Try restrictive filtering but with version 8 enforcement turned off.
+	filt = newAclFilter(acl.DenyAll(), nil, false)
+	filt.filterSessions(&sessions)
+	if len(sessions) != 2 {
+		t.Fatalf("bad: %#v", sessions)
+	}
+
+	// Try restrictive filtering with version 8 enforcement turned on.
+	filt = newAclFilter(acl.DenyAll(), nil, true)
+	filt.filterSessions(&sessions)
+	if len(sessions) != 0 {
+		t.Fatalf("bad: %#v", sessions)
+	}
+}
+
 func TestACL_filterNodeDump(t *testing.T) {
 	// Create a node dump.
 	fill := func() structs.NodeDump {

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -271,20 +271,6 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 				return err
 			}
 
-			// Node read access is required with version 8 ACLs. We
-			// just return the same response as if the node doesn't
-			// exist, which is consistent with how the rest of the
-			// catalog filtering works and doesn't disclose the node.
-			acl, err := c.srv.resolveToken(args.Token)
-			if err != nil {
-				return err
-			}
-			if acl != nil && c.srv.config.ACLEnforceVersion8 {
-				if !acl.NodeRead(args.Node) {
-					return permissionDeniedErr
-				}
-			}
-
 			reply.Index, reply.NodeServices = index, services
 			return c.srv.filterACL(args.Token, reply)
 		})

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -1537,9 +1537,11 @@ func TestCatalog_NodeServices_ACLDeny(t *testing.T) {
 
 	// Now turn on version 8 enforcement and try again.
 	s1.config.ACLEnforceVersion8 = true
-	err := msgpackrpc.CallWithCodec(codec, "Catalog.NodeServices", &args, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if err := msgpackrpc.CallWithCodec(codec, "Catalog.NodeServices", &args, &reply); err != nil {
 		t.Fatalf("err: %v", err)
+	}
+	if reply.NodeServices != nil {
+		t.Fatalf("should not nil")
 	}
 
 	// Create an ACL that can read the node.
@@ -1569,6 +1571,15 @@ node "%s" {
 	}
 	if reply.NodeServices == nil {
 		t.Fatalf("should not be nil")
+	}
+
+	// Make sure an unknown node doesn't cause trouble.
+	args.Node = "nope"
+	if err := msgpackrpc.CallWithCodec(codec, "Catalog.NodeServices", &args, &reply); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if reply.NodeServices != nil {
+		t.Fatalf("should not nil")
 	}
 }
 

--- a/consul/config.go
+++ b/consul/config.go
@@ -155,6 +155,11 @@ type Config struct {
 	// backwards compatibility as well.
 	ACLToken string
 
+	// ACLAgentToken is the default token used to make requests for the agent
+	// itself, such as for registering itself with the catalog. If not
+	// configured, the ACLToken will be used.
+	ACLAgentToken string
+
 	// ACLMasterToken is used to bootstrap the ACL system. It should be specified
 	// on the servers in the ACLDatacenter. When the leader comes online, it ensures
 	// that the Master token is available. This provides the initial token.
@@ -370,6 +375,7 @@ func (c *Config) ScaleRaft(raftMultRaw uint) {
 	c.RaftConfig.LeaderLeaseTimeout = raftMult * def.LeaderLeaseTimeout
 }
 
+// tlsConfig maps this config into a tlsutil config.
 func (c *Config) tlsConfig() *tlsutil.Config {
 	tlsConf := &tlsutil.Config{
 		VerifyIncoming:       c.VerifyIncoming,
@@ -383,4 +389,16 @@ func (c *Config) tlsConfig() *tlsutil.Config {
 		Domain:               c.Domain,
 	}
 	return tlsConf
+}
+
+// GetTokenForAgent returns the token the agent should use for its own internal
+// operations, such as registering itself with the catalog.
+func (c *Config) GetTokenForAgent() string {
+	if c.ACLAgentToken != "" {
+		return c.ACLAgentToken
+	} else if c.ACLToken != "" {
+		return c.ACLToken
+	} else {
+		return ""
+	}
 }

--- a/consul/config_test.go
+++ b/consul/config_test.go
@@ -1,0 +1,20 @@
+package consul
+
+import (
+	"testing"
+)
+
+func TestConfig_GetTokenForAgent(t *testing.T) {
+	config := DefaultConfig()
+	if token := config.GetTokenForAgent(); token != "" {
+		t.Fatalf("bad: %s", token)
+	}
+	config.ACLToken = "hello"
+	if token := config.GetTokenForAgent(); token != "hello" {
+		t.Fatalf("bad: %s", token)
+	}
+	config.ACLAgentToken = "world"
+	if token := config.GetTokenForAgent(); token != "world" {
+		t.Fatalf("bad: %s", token)
+	}
+}

--- a/consul/health_endpoint_test.go
+++ b/consul/health_endpoint_test.go
@@ -507,6 +507,12 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 	if !found {
 		t.Fatalf("bad: %#v", reply.HealthChecks)
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }
 
 func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
@@ -543,6 +549,12 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 	if len(reply.HealthChecks) != 0 {
 		t.Fatalf("bad: %#v", reply.HealthChecks)
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }
 
 func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
@@ -572,6 +584,12 @@ func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
 	if len(reply.Nodes) != 0 {
 		t.Fatalf("bad: %#v", reply.Nodes)
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }
 
 func TestHealth_ChecksInState_FilterACL(t *testing.T) {
@@ -602,4 +620,10 @@ func TestHealth_ChecksInState_FilterACL(t *testing.T) {
 	if !found {
 		t.Fatalf("missing service 'foo': %#v", reply.HealthChecks)
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }

--- a/consul/internal_endpoint_test.go
+++ b/consul/internal_endpoint_test.go
@@ -284,6 +284,12 @@ func TestInternal_NodeInfo_FilterACL(t *testing.T) {
 			t.Fatalf("bad: %#v", info.Services)
 		}
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }
 
 func TestInternal_NodeDump_FilterACL(t *testing.T) {
@@ -327,6 +333,12 @@ func TestInternal_NodeDump_FilterACL(t *testing.T) {
 			t.Fatalf("bad: %#v", info.Services)
 		}
 	}
+
+	// We've already proven that we call the ACL filtering function so we
+	// test node filtering down in acl.go for node cases. This also proves
+	// that we respect the version 8 ACL flag, since the test server sets
+	// that to false (the regression value of *not* changing this is better
+	// for now until we change the sense of the version 8 ACL flag).
 }
 
 func TestInternal_EventFire_Token(t *testing.T) {

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -428,7 +428,7 @@ AFTER_CHECK:
 			Status:  structs.HealthPassing,
 			Output:  SerfCheckAliveOutput,
 		},
-		WriteRequest: structs.WriteRequest{Token: s.config.ACLToken},
+		WriteRequest: structs.WriteRequest{Token: s.config.GetTokenForAgent()},
 	}
 	var out struct{}
 	return s.endpoints.Catalog.Register(&req, &out)
@@ -469,7 +469,7 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 			Status:  structs.HealthCritical,
 			Output:  SerfCheckFailedOutput,
 		},
-		WriteRequest: structs.WriteRequest{Token: s.config.ACLToken},
+		WriteRequest: structs.WriteRequest{Token: s.config.GetTokenForAgent()},
 	}
 	var out struct{}
 	return s.endpoints.Catalog.Register(&req, &out)
@@ -612,7 +612,7 @@ func (s *Server) reapTombstones(index uint64) {
 		Datacenter:   s.config.Datacenter,
 		Op:           structs.TombstoneReap,
 		ReapIndex:    index,
-		WriteRequest: structs.WriteRequest{Token: s.config.ACLToken},
+		WriteRequest: structs.WriteRequest{Token: s.config.GetTokenForAgent()},
 	}
 	_, err := s.raftApply(structs.TombstoneRequestType, &req)
 	if err != nil {

--- a/consul/session_endpoint_test.go
+++ b/consul/session_endpoint_test.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 )
 
-func TestSessionEndpoint_Apply(t *testing.T) {
+func TestSession_Apply(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -70,7 +71,7 @@ func TestSessionEndpoint_Apply(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_DeleteApply(t *testing.T) {
+func TestSession_DeleteApply(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -133,7 +134,101 @@ func TestSessionEndpoint_DeleteApply(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_Get(t *testing.T) {
+func TestSession_Apply_ACLDeny(t *testing.T) {
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLMasterToken = "root"
+		c.ACLDefaultPolicy = "deny"
+		c.ACLEnforceVersion8 = false
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testutil.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Create the ACL.
+	req := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name: "User token",
+			Type: structs.ACLTypeClient,
+			Rules: `
+session "foo" {
+	policy = "write"
+}
+`,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+
+	var token string
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.Apply", &req, &token); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Just add a node.
+	s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"})
+
+	// Try to create without a token, which will go through since version 8
+	// enforcement isn't enabled.
+	arg := structs.SessionRequest{
+		Datacenter: "dc1",
+		Op:         structs.SessionCreate,
+		Session: structs.Session{
+			Node: "foo",
+			Name: "my-session",
+		},
+	}
+	var id1 string
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &id1); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Now turn on version 8 enforcement and try again, it should be denied.
+	var id2 string
+	s1.config.ACLEnforceVersion8 = true
+	err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &id2)
+	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Now set a token and try again. This should go through.
+	arg.Token = token
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &id2); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Do a delete on the first session with version 8 enforcement off and
+	// no token. This should go through.
+	var out string
+	s1.config.ACLEnforceVersion8 = false
+	arg.Op = structs.SessionDestroy
+	arg.Token = ""
+	arg.Session.ID = id1
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Turn on version 8 enforcement and make sure the delete of the second
+	// session fails.
+	s1.config.ACLEnforceVersion8 = true
+	arg.Session.ID = id2
+	err = msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out)
+	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Now set a token and try again. This should go through.
+	arg.Token = token
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestSession_Get(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -176,7 +271,7 @@ func TestSessionEndpoint_Get(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_List(t *testing.T) {
+func TestSession_List(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -227,7 +322,175 @@ func TestSessionEndpoint_List(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_ApplyTimers(t *testing.T) {
+func TestSession_Get_List_NodeSessions_ACLFilter(t *testing.T) {
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLMasterToken = "root"
+		c.ACLDefaultPolicy = "deny"
+		c.ACLEnforceVersion8 = false
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testutil.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Create the ACL.
+	req := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name: "User token",
+			Type: structs.ACLTypeClient,
+			Rules: `
+session "foo" {
+	policy = "read"
+}
+`,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+
+	var token string
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.Apply", &req, &token); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Create a node and a session.
+	s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"})
+	arg := structs.SessionRequest{
+		Datacenter: "dc1",
+		Op:         structs.SessionCreate,
+		Session: structs.Session{
+			Node: "foo",
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+	var out string
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Perform all the read operations, which should go through since version
+	// 8 ACL enforcement isn't enabled.
+	getR := structs.SessionSpecificRequest{
+		Datacenter: "dc1",
+		Session:    out,
+	}
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.Get", &getR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	listR := structs.DCSpecificRequest{
+		Datacenter: "dc1",
+	}
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.List", &listR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	nodeR := structs.NodeSpecificRequest{
+		Datacenter: "dc1",
+		Node:       "foo",
+	}
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.NodeSessions", &nodeR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+
+	// Now turn on version 8 enforcement and make sure everything is empty.
+	s1.config.ACLEnforceVersion8 = true
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.Get", &getR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 0 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	{
+		var sessions structs.IndexedSessions
+
+		if err := msgpackrpc.CallWithCodec(codec, "Session.List", &listR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 0 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.NodeSessions", &nodeR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 0 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+
+	// Finally, supply the token and make sure the reads are allowed.
+	getR.Token = token
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.Get", &getR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	listR.Token = token
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.List", &listR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+	nodeR.Token = token
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.NodeSessions", &nodeR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 1 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+
+	// Try to get a session that doesn't exist to make sure that's handled
+	// correctly by the filter (it will get passed a nil slice).
+	getR.Session = "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+	{
+		var sessions structs.IndexedSessions
+		if err := msgpackrpc.CallWithCodec(codec, "Session.Get", &getR, &sessions); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(sessions.Sessions) != 0 {
+			t.Fatalf("bad: %v", sessions.Sessions)
+		}
+	}
+}
+
+func TestSession_ApplyTimers(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -268,7 +531,7 @@ func TestSessionEndpoint_ApplyTimers(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_Renew(t *testing.T) {
+func TestSession_Renew(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -428,7 +691,85 @@ func TestSessionEndpoint_Renew(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_NodeSessions(t *testing.T) {
+func TestSession_Renew_ACLDeny(t *testing.T) {
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLMasterToken = "root"
+		c.ACLDefaultPolicy = "deny"
+		c.ACLEnforceVersion8 = false
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testutil.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Create the ACL.
+	req := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name: "User token",
+			Type: structs.ACLTypeClient,
+			Rules: `
+session "foo" {
+	policy = "write"
+}
+`,
+		},
+		WriteRequest: structs.WriteRequest{Token: "root"},
+	}
+
+	var token string
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.Apply", &req, &token); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Just add a node.
+	s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"})
+
+	// Create a session. The token won't matter here since we don't have
+	// version 8 ACL enforcement on yet.
+	arg := structs.SessionRequest{
+		Datacenter: "dc1",
+		Op:         structs.SessionCreate,
+		Session: structs.Session{
+			Node: "foo",
+			Name: "my-session",
+		},
+	}
+	var id string
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &id); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Renew without a token should go through without version 8 ACL
+	// enforcement.
+	renewR := structs.SessionSpecificRequest{
+		Datacenter: "dc1",
+		Session:    id,
+	}
+	var session structs.IndexedSessions
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Renew", &renewR, &session); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Now turn on version 8 enforcement and the renew should be rejected.
+	s1.config.ACLEnforceVersion8 = true
+	err := msgpackrpc.CallWithCodec(codec, "Session.Renew", &renewR, &session)
+	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Set the token and it should go through.
+	renewR.Token = token
+	if err := msgpackrpc.CallWithCodec(codec, "Session.Renew", &renewR, &session); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestSession_NodeSessions(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -486,7 +827,7 @@ func TestSessionEndpoint_NodeSessions(t *testing.T) {
 	}
 }
 
-func TestSessionEndpoint_Apply_BadTTL(t *testing.T) {
+func TestSession_Apply_BadTTL(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -377,6 +377,14 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   all operations, and "extend-cache" allows any cached ACLs to be used, ignoring their TTL
   values. If a non-cached ACL is used, "extend-cache" acts like "deny".
 
+* <a name"acl_agent_token"></a><a href="#acl_agent_token">`acl_agent_token`</a> - Used for clients
+  and servers to perform internal operations to the service catalog. If this isn't specified, then
+  the <a href="#acl_token">`acl_token`</a> will be used. This was added in Consul 0.7.2.
+  <br><br>
+  For clients, this token must at least have write access to the node name it will register as. For
+  servers, this must have write access to all nodes that are expected to join the cluster, as well
+  as write access to the "consul" service, which will be registered automatically on its behalf.
+
 * <a name="acl_enforce_version_8"></a><a href="#acl_enforce_version_8">`acl_enforce_version_8`</a> -
   Used for clients and servers to determine if enforcement should occur for new ACL policies being
   previewed before Consul 0.8. Added in Consul 0.7.2, this will default to false in versions of


### PR DESCRIPTION
This is a follow on to #2590 and adds more ACL coverage. There should be one more PR to follow to cover all the agent endpoints.