### PR TITLE
fix fmt.Errorf usage bug

### DIFF
--- a/consul/session_endpoint.go
+++ b/consul/session_endpoint.go
@@ -53,7 +53,7 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 			}
 
 		default:
-			return fmt.Errorf("Invalid session operation %q, args.Op")
+			return fmt.Errorf("Invalid session operation %q", args.Op)
 		}
 	}
 


### PR DESCRIPTION
error detail :  missing argument for Errorf("%q"): format reads arg 1, have only 0 args