### PR TITLE
Systemd unit to use default KillSignal of SIGTERM

### DIFF
--- a/terraform/shared/scripts/rhel_consul.service
+++ b/terraform/shared/scripts/rhel_consul.service
@@ -8,7 +8,6 @@ EnvironmentFile=-/etc/sysconfig/consul
 Restart=on-failure
 ExecStart=/usr/local/bin/consul agent $CONSUL_FLAGS -config-dir=/etc/systemd/system/consul.d
 ExecReload=/bin/kill -HUP $MAINPID
-KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Following up on [a conversation](https://github.com/solarkennedy/puppet-consul/issues/282#issuecomment-268246692) I had with @armon, it may be worth setting the example here as well, not to send SIGINT to server-mode agents, because they might unintentionally change the Raft consensus pool.

From the commit message:

> Since Consul 0.7, client-mode agents are shutting down gracefully by
> default, so no need to send them a SIGINT specially. The default for
> server-mode agents is still not to leave gracefully on SIGTERM, but it
> was left this way for a reason. To override this, it is better to set
> the leave_on_terminate option, rather than changing the KillSignal.