### PR TITLE
update `/v1/agent/service/register` endpoint doc

### DIFF
--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -477,7 +477,8 @@ information.
 
 If `Check` is provided, only one of `Script`, `HTTP`, `TCP` or `TTL`
 should be specified. `Script` and `HTTP` also require `Interval`. The
-created check will be named `service:<ServiceId>`.
+created check will be named `service:<ServiceId>`. The `Status` field 
+can be provided to specify the initial state of the health check.
 
 In Consul 0.7 and later, checks that are associated with a service may
 also contain an optional `DeregisterCriticalServiceAfter` field, which


### PR DESCRIPTION
According to the [source code](https://github.com/hashicorp/consul/blob/a67d308175e683ad5f9284e16cc426a76e9f66c6/command/agent/agent_endpoint.go#L443) `Status` field is also permitted