### PR TITLE
Add Seoul region to the map for ubuntu

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -22,6 +22,7 @@ variable "ami" {
         eu-west-1-ubuntu = "ami-47a23a30"
         eu-central-1-ubuntu = "ami-accff2b1"
         ap-northeast-1-ubuntu = "ami-90815290"
+        ap-northeast-2-ubuntu = "ami-58af6136"
         ap-southeast-1-ubuntu = "ami-0accf458"
         ap-southeast-2-ubuntu = "ami-1dc8b127"
         us-east-1-rhel6   = "ami-0d28fe66"


### PR DESCRIPTION
Going through the Terraform Tutorial but doing it on the `ap-northeast-2 region` (Seoul, 🇰🇷 ), there isn't a `ap-northeast-2-ubuntu` item on `ami` map. So Terraform failed to find that variable.

<img width="756" alt="2016-12-30 3 16 06" src="https://cloud.githubusercontent.com/assets/2101743/21552075/5b7ee132-ce42-11e6-8005-57e778744321.png">

