### PR TITLE
reset watch's lastIndex on error

### DIFF
--- a/watch/plan.go
+++ b/watch/plan.go
@@ -57,6 +57,7 @@ OUTER:
 		if err != nil {
 			// Perform an exponential backoff
 			failures++
+			p.lastIndex = 1
 			retry := retryInterval * time.Duration(failures*failures)
 			if retry > maxBackoffTime {
 				retry = maxBackoffTime

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -86,6 +86,9 @@ OUTER:
 		if oldIndex != 0 && reflect.DeepEqual(p.lastResult, result) {
 			continue
 		}
+		if p.lastIndex < oldIndex {
+			p.lastIndex = 0
+		}
 
 		// Handle the updated result
 		p.lastResult = result

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -57,7 +57,7 @@ OUTER:
 		if err != nil {
 			// Perform an exponential backoff
 			failures++
-			p.lastIndex = 1
+			p.lastIndex = 0
 			retry := retryInterval * time.Duration(failures*failures)
 			if retry > maxBackoffTime {
 				retry = maxBackoffTime


### PR DESCRIPTION
Watch()ing a agent in `-dev` mode misses changes when the agent restarts.

When a -dev agent is restarted it'll have a clean state, including a
reset index. A watch() will reconnect after a restart of the agent, but it won't
notice that the index counter has reset and it will keep waiting until
the server reached the old index again, which is wrong. Resetting the index 
prevents that and makes watch() work for -dev agents over restarts.