### PR TITLE
Add consul-announcer to Community Tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -112,6 +112,9 @@ description: |-
         <a href="https://github.com/kelseyhightower/confd">confd</a> - Manage local application configuration files using templates and data from etcd or Consul
       </li>
       <li>
+        <a href="https://github.com/ncbi/consul-announcer">consul-announcer</a> - Command line wrapper for registering services in Consul
+      </li>
+      <li>
         <a href="https://github.com/myENA/consul-backinator">consul-backinator</a> - Command line Consul KV backup and restoration utility
       </li>
       <li>


### PR DESCRIPTION
Utility wraps given process (as `time` does), registers service(s) & healthceck(s) according to given config (in native to Consul format) and takes care of de-registering service on shut-down.