### PR TITLE
cli: Add -base64 option to `consul kv get`

### DIFF
--- a/command/kv_get_test.go
+++ b/command/kv_get_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -248,5 +249,93 @@ func TestKVGetCommand_Recurse(t *testing.T) {
 		if !strings.Contains(output, key+":"+value) {
 			t.Fatalf("bad %#v missing %q", output, key)
 		}
+	}
+}
+
+func TestKVGetCommand_RecurseBase64(t *testing.T) {
+	srv, client := testAgentWithAPIClient(t)
+	defer srv.Shutdown()
+	waitForLeader(t, srv.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &KVGetCommand{Ui: ui}
+
+	keys := map[string]string{
+		"foo/a": "Hello World 1",
+		"foo/b": "Hello World 2",
+		"foo/c": "Hello World 3",
+	}
+	for k, v := range keys {
+		pair := &api.KVPair{Key: k, Value: []byte(v)}
+		if _, err := client.KV().Put(pair, nil); err != nil {
+			t.Fatalf("err: %#v", err)
+		}
+	}
+
+	args := []string{
+		"-http-addr=" + srv.httpAddr,
+		"-recurse",
+		"-base64",
+		"foo",
+	}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	output := ui.OutputWriter.String()
+	for key, value := range keys {
+		if !strings.Contains(output, key+":"+base64.StdEncoding.EncodeToString([]byte(value))) {
+			t.Fatalf("bad %#v missing %q", output, key)
+		}
+	}
+}
+
+func TestKVGetCommand_DetailedBase64(t *testing.T) {
+	srv, client := testAgentWithAPIClient(t)
+	defer srv.Shutdown()
+	waitForLeader(t, srv.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &KVGetCommand{Ui: ui}
+
+	pair := &api.KVPair{
+		Key:   "foo",
+		Value: []byte("bar"),
+	}
+	_, err := client.KV().Put(pair, nil)
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+
+	args := []string{
+		"-http-addr=" + srv.httpAddr,
+		"-detailed",
+		"-base64",
+		"foo",
+	}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	output := ui.OutputWriter.String()
+	for _, key := range []string{
+		"CreateIndex",
+		"LockIndex",
+		"ModifyIndex",
+		"Flags",
+		"Session",
+		"Value",
+	} {
+		if !strings.Contains(output, key) {
+			t.Fatalf("bad %#v, missing %q", output, key)
+		}
+	}
+
+	if !strings.Contains(output, base64.StdEncoding.EncodeToString([]byte("bar"))) {
+		t.Fatalf("bad %#v, value is not base64 encoded", output)
 	}
 }

--- a/website/source/docs/commands/kv/get.html.markdown.erb
+++ b/website/source/docs/commands/kv/get.html.markdown.erb
@@ -24,6 +24,8 @@ Usage: `consul kv get [options] [KEY_OR_PREFIX]`
 
 #### KV Get Options
 
+* `-base64` - Base 64 encode the value. The default value is false.
+
 * `-detailed` - Provide additional metadata about the key in addition to the
   value such as the ModifyIndex and any flags that may have been set on the key.
   The default value is false.


### PR DESCRIPTION
This commit adds a `-base64` option to the `consul kv get` command, which base 64 encodes the output such that it can be processed by terminal tools in the event that the data is binary. The flag defaults to false.