### PR TITLE
cli: Fix panic on empty data argument to `kv put`

### DIFF
--- a/command/kv_put.go
+++ b/command/kv_put.go
@@ -236,6 +236,11 @@ func (c *KVPutCommand) dataFromArgs(args []string) (string, string, error) {
 	key := args[0]
 	data := args[1]
 
+	// Handle empty quoted shell parameters
+	if len(data) == 0 {
+		return key, "", nil
+	}
+
 	switch data[0] {
 	case '@':
 		data, err := ioutil.ReadFile(data[1:])

--- a/command/kv_put_test.go
+++ b/command/kv_put_test.go
@@ -101,6 +101,34 @@ func TestKVPutCommand_Run(t *testing.T) {
 	}
 }
 
+func TestKVPutCommand_RunEmptyDataQuoted(t *testing.T) {
+	srv, client := testAgentWithAPIClient(t)
+	defer srv.Shutdown()
+	waitForLeader(t, srv.httpAddr)
+
+	ui := new(cli.MockUi)
+	c := &KVPutCommand{Ui: ui}
+
+	args := []string{
+		"-http-addr=" + srv.httpAddr,
+		"foo", "",
+	}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	data, _, err := client.KV().Get("foo", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if data.Value != nil {
+		t.Errorf("bad: %#v", data.Value)
+	}
+}
+
 func TestKVPutCommand_RunBase64(t *testing.T) {
 	srv, client := testAgentWithAPIClient(t)
 	defer srv.Shutdown()


### PR DESCRIPTION
Passing in an empty quoted argument from the shell currently panics as we never check the length being greater than 0 prior to indexing into the first rune, as illustrated in the test in this commit.

We also fix the panic, treating an empty string for data as equivalent to not having passed it in the first place.