### PR TITLE
UI: add notification for disabled JavaScript

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -19,6 +19,13 @@
 </head>
 <body>
 
+  <noscript>
+    <center>
+      <h2>JavaScript Required</h2>
+      <p>Please enable JavaScript in your web browser to use Consul UI.</p>
+    </center>
+  </noscript>
+
   <div class="wrapper">
     <div class="container">
       <div class="col-md-12">


### PR DESCRIPTION
This adds a helpful message for users who attempt to access the Consul UI with JS disabled in their browser.
