### PR TITLE
Standardize the case of all check log messages

### DIFF
--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -197,7 +197,7 @@ func (c *CheckMonitor) check() {
 			output.Size(), output.TotalWritten(), outputStr)
 	}
 
-	c.Logger.Printf("[DEBUG] agent: check '%s' script '%s' output: %s",
+	c.Logger.Printf("[DEBUG] agent: Check '%s' script '%s' output: %s",
 		c.CheckID, c.Script, outputStr)
 
 	// Check if the check passed
@@ -441,7 +441,7 @@ func (c *CheckHTTP) check() {
 	// Read the response into a circular buffer to limit the size
 	output, _ := circbuf.NewBuffer(CheckBufSize)
 	if _, err := io.Copy(output, resp.Body); err != nil {
-		c.Logger.Printf("[WARN] agent: check '%v': Get error while reading body: %s", c.CheckID, err)
+		c.Logger.Printf("[WARN] agent: Check '%v': Get error while reading body: %s", c.CheckID, err)
 	}
 
 	// Format the response body
@@ -449,19 +449,19 @@ func (c *CheckHTTP) check() {
 
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 		// PASSING (2xx)
-		c.Logger.Printf("[DEBUG] agent: check '%v' is passing", c.CheckID)
+		c.Logger.Printf("[DEBUG] agent: Check '%v' is passing", c.CheckID)
 		c.Notify.UpdateCheck(c.CheckID, structs.HealthPassing, result)
 
 	} else if resp.StatusCode == 429 {
 		// WARNING
 		// 429 Too Many Requests (RFC 6585)
 		// The user has sent too many requests in a given amount of time.
-		c.Logger.Printf("[WARN] agent: check '%v' is now warning", c.CheckID)
+		c.Logger.Printf("[WARN] agent: Check '%v' is now warning", c.CheckID)
 		c.Notify.UpdateCheck(c.CheckID, structs.HealthWarning, result)
 
 	} else {
 		// CRITICAL
-		c.Logger.Printf("[WARN] agent: check '%v' is now critical", c.CheckID)
+		c.Logger.Printf("[WARN] agent: Check '%v' is now critical", c.CheckID)
 		c.Notify.UpdateCheck(c.CheckID, structs.HealthCritical, result)
 	}
 }
@@ -545,7 +545,7 @@ func (c *CheckTCP) check() {
 		return
 	}
 	conn.Close()
-	c.Logger.Printf("[DEBUG] agent: check '%v' is passing", c.CheckID)
+	c.Logger.Printf("[DEBUG] agent: Check '%v' is passing", c.CheckID)
 	c.Notify.UpdateCheck(c.CheckID, structs.HealthPassing, fmt.Sprintf("TCP connect %s: Success", c.TCP))
 }
 
@@ -671,7 +671,7 @@ func (c *CheckDocker) check() {
 			output.Size(), output.TotalWritten(), outputStr)
 	}
 
-	c.Logger.Printf("[DEBUG] agent: check '%s' script '%s' output: %s",
+	c.Logger.Printf("[DEBUG] agent: Check '%s' script '%s' output: %s",
 		c.CheckID, c.Script, outputStr)
 
 	execInfo, err := c.dockerClient.InspectExec(exec.ID)


### PR DESCRIPTION
Hi,

I don't know if it was intentional or not - but it was bugging me that the log messages for `checks` were mixed case.

Cheers
James