### PR TITLE
Local Agent DNS Lookup

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -610,6 +610,13 @@ PARSE:
 		node := strings.Join(labels[:n-1], ".")
 		d.nodeLookup(cfg, network, datacenter, node, req, resp, maxRecursionLevel)
 
+	case "agent":
+		if n != 1 {
+			goto INVALID
+		}
+		node := d.agent.config.NodeName
+		d.nodeLookup(network, datacenter, node, req, resp)
+
 	case "query":
 		if n == 1 {
 			goto INVALID
@@ -642,7 +649,7 @@ PARSE:
 				},
 				A: ip,
 			})
-		// IPv6
+			// IPv6
 		case 16:
 			ip, err := hex.DecodeString(labels[0])
 			if err != nil {
@@ -1540,13 +1547,13 @@ func (d *DNSServer) serviceSRVRecords(cfg *dnsConfig, dc string, nodes structs.C
 					record.Hdr.Name = srvRec.Target
 					resp.Extra = append(resp.Extra, record)
 
-				// IPv6
+					// IPv6
 				case *dns.AAAA:
 					srvRec.Target = fmt.Sprintf("%s.addr.%s.%s", hex.EncodeToString(record.AAAA), dc, d.domain)
 					record.Hdr.Name = srvRec.Target
 					resp.Extra = append(resp.Extra, record)
 
-				// Something else (probably a CNAME; just add the records).
+					// Something else (probably a CNAME; just add the records).
 				default:
 					resp.Extra = append(resp.Extra, records...)
 				}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -615,7 +615,7 @@ PARSE:
 			goto INVALID
 		}
 		node := d.agent.config.NodeName
-		d.nodeLookup(network, datacenter, node, req, resp)
+		d.nodeLookup(cfg, network, datacenter, node, req, resp, maxRecursionLevel)
 
 	case "query":
 		if n == 1 {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -256,6 +256,53 @@ func TestDNS_NodeLookup(t *testing.T) {
 	txt, ok = in.Answer[1].(*dns.TXT)
 	require.True(t, ok, "Second answer is not a TXT record")
 
+	// lookup agent.consul
+	m = new(dns.Msg)
+	m.SetQuestion("agent.consul.", dns.TypeANY)
+
+	c = new(dns.Client)
+	addr, _ = srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
+	in, _, err = c.Exchange(m, addr.String())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(in.Answer) != 1 {
+		t.Fatalf("Bad: %#v", in)
+	}
+
+	aRec, ok = in.Answer[0].(*dns.A)
+	if !ok {
+		t.Fatalf("Bad: %#v", in.Answer[0])
+	}
+	if aRec.A.String() != "127.0.0.1" {
+		t.Fatalf("Bad: %#v", in.Answer[0])
+	}
+	if aRec.Hdr.Ttl != 0 {
+		t.Fatalf("Bad: %#v", in.Answer[0])
+	}
+	// lookup foo.agent.consul, we should get an SOA
+	m = new(dns.Msg)
+	m.SetQuestion("this.agent.consul.", dns.TypeANY)
+
+	c = new(dns.Client)
+	in, _, err = c.Exchange(m, addr.String())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(in.Ns) != 1 {
+		t.Fatalf("Bad: %#v %#v", in, len(in.Answer))
+	}
+
+	soaRec, ok := in.Ns[0].(*dns.SOA)
+	if !ok {
+		t.Fatalf("Bad: %#v", in.Ns[0])
+	}
+	if soaRec.Hdr.Ttl != 0 {
+		t.Fatalf("Bad: %#v", in.Ns[0])
+	}
+
 	// lookup a non-existing node, we should receive a SOA
 	m = new(dns.Msg)
 	m.SetQuestion("nofoo.node.dc1.consul.", dns.TypeANY)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -261,8 +261,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 	m.SetQuestion("agent.consul.", dns.TypeANY)
 
 	c = new(dns.Client)
-	addr, _ = srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
-	in, _, err = c.Exchange(m, addr.String())
+	in, _, err = c.Exchange(m, a.DNSAddr())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -286,7 +285,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 	m.SetQuestion("this.agent.consul.", dns.TypeANY)
 
 	c = new(dns.Client)
-	in, _, err = c.Exchange(m, addr.String())
+	in, _, err = c.Exchange(m, a.DNSAddr())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -286,21 +286,12 @@ func TestDNS_NodeLookup(t *testing.T) {
 
 	c = new(dns.Client)
 	in, _, err = c.Exchange(m, a.DNSAddr())
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if len(in.Ns) != 1 {
-		t.Fatalf("Bad: %#v %#v", in, len(in.Answer))
-	}
+	require.NoError(t, err)
+	require.Len(t, in.Ns, 1)
 
 	soaRec, ok := in.Ns[0].(*dns.SOA)
-	if !ok {
-		t.Fatalf("Bad: %#v", in.Ns[0])
-	}
-	if soaRec.Hdr.Ttl != 0 {
-		t.Fatalf("Bad: %#v", in.Ns[0])
-	}
+	require.True(t, ok, "NS RR is not a SOA record")
+	require.Equal(t, uint32(0), soaRec.Hdr.Ttl)
 
 	// lookup a non-existing node, we should receive a SOA
 	m = new(dns.Msg)
@@ -310,7 +301,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 	in, _, err = c.Exchange(m, a.DNSAddr())
 	require.NoError(t, err)
 	require.Len(t, in.Ns, 1)
-	soaRec, ok := in.Ns[0].(*dns.SOA)
+	soaRec, ok = in.Ns[0].(*dns.SOA)
 	require.True(t, ok, "NS RR is not a SOA record")
 	require.Equal(t, uint32(0), soaRec.Hdr.Ttl)
 }

--- a/website/source/docs/agent/dns.html.md
+++ b/website/source/docs/agent/dns.html.md
@@ -200,7 +200,7 @@ rabbitmq.node1.dc1.consul.	0	IN	A	10.1.11.20
 
 Again, note that the SRV record returns the port of the service as well as its IP.
 
-### Prepared Query Lookups
+## Prepared Query Lookups
 
 The format of a prepared query lookup is:
 
@@ -243,6 +243,16 @@ This endpoint currently only finds services within the same datacenter
 and doesn't support tags. This DNS interface will be expanded over time.
 If you need more complex behavior, please use the
 [catalog API](/api/catalog.html).
+
+### Agent Query Lookup
+
+The agent query is designed to return IP information about the local Consul 
+agent. The IP information returned is the DNS answer for the local node name.
+This does in fact send a DNS query from the local instance to the Consul Server
+Quorum. The result is the IP information that any other service would receive
+for the local Consul agent (this is most commonly the IPv4 bind address). The 
+only valid agent lookup is `agent.consul`. If anything other than that is 
+received an SOA record is returned.
 
 ### UDP Based DNS Queries
 


### PR DESCRIPTION
Not ready to merge, but continuing the discussion on #2300

I created an agent namespace. When you query agent.consul, the behavior is simply to retrieve the NodeName from config and query that name. This returns effectively the bind address, however I think if a user has overridden this with `advertise_addr` config it will return that. I'm not sure @slackpad if this is what you intended or if this interface needs to be more intelligent. @ryansch or @far-blue is this meeting your need or did I misunderstand the use case?