### PR TITLE
Node metadata

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -74,6 +74,11 @@ type QueryOptions struct {
 	// that node. Setting this to "_agent" will use the agent's node
 	// for the sort.
 	Near string
+
+	// NodeMeta is used to filter results by nodes with the given
+	// metadata key/value pairs. Currently, only one key/value pair can
+	// be provided for filtering.
+	NodeMeta map[string]string
 }
 
 // WriteOptions are used to parameterize a write
@@ -385,6 +390,11 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Near != "" {
 		r.params.Set("near", q.Near)
+	}
+	if len(q.NodeMeta) > 0 {
+		for key, value := range q.NodeMeta {
+			r.params.Add("node-meta", key+":"+value)
+		}
 	}
 }
 

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -4,12 +4,14 @@ type Node struct {
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
+	Meta            map[string]string
 }
 
 type CatalogService struct {
 	Node                     string
 	Address                  string
 	TaggedAddresses          map[string]string
+	NodeMeta                 map[string]string
 	ServiceID                string
 	ServiceName              string
 	ServiceAddress           string
@@ -29,6 +31,7 @@ type CatalogRegistration struct {
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
+	NodeMeta        map[string]string
 	Datacenter      string
 	Service         *AgentService
 	Check           *AgentCheck

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -60,6 +60,64 @@ func TestCatalog_Nodes(t *testing.T) {
 	})
 }
 
+func TestCatalog_Nodes_MetaFilter(t *testing.T) {
+	meta := map[string]string{"somekey": "somevalue"}
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeMeta = meta
+	})
+	defer s.Stop()
+
+	catalog := c.Catalog()
+
+	// Make sure we get the node back when filtering by its metadata
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: meta})
+		if err != nil {
+			return false, err
+		}
+
+		if meta.LastIndex == 0 {
+			return false, fmt.Errorf("Bad: %v", meta)
+		}
+
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("Bad: %v", nodes)
+		}
+
+		if _, ok := nodes[0].TaggedAddresses["wan"]; !ok {
+			return false, fmt.Errorf("Bad: %v", nodes[0])
+		}
+
+		if v, ok := nodes[0].Meta["somekey"]; !ok || v != "somevalue" {
+			return false, fmt.Errorf("Bad: %v", nodes[0].Meta)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	// Get nothing back when we use an invalid filter
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: map[string]string{"nope":"nope"}})
+		if err != nil {
+			return false, err
+		}
+
+		if meta.LastIndex == 0 {
+			return false, fmt.Errorf("Bad: %v", meta)
+		}
+
+		if len(nodes) != 0 {
+			return false, fmt.Errorf("Bad: %v", nodes)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+}
+
 func TestCatalog_Services(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
@@ -78,6 +136,56 @@ func TestCatalog_Services(t *testing.T) {
 		}
 
 		if len(services) == 0 {
+			return false, fmt.Errorf("Bad: %v", services)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+}
+
+func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
+	meta := map[string]string{"somekey": "somevalue"}
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeMeta = meta
+	})
+	defer s.Stop()
+
+	catalog := c.Catalog()
+
+	// Make sure we get the service back when filtering by the node's metadata
+	testutil.WaitForResult(func() (bool, error) {
+		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: meta})
+		if err != nil {
+			return false, err
+		}
+
+		if meta.LastIndex == 0 {
+			return false, fmt.Errorf("Bad: %v", meta)
+		}
+
+		if len(services) == 0 {
+			return false, fmt.Errorf("Bad: %v", services)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	// Get nothing back when using an invalid filter
+	testutil.WaitForResult(func() (bool, error) {
+		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: map[string]string{"nope":"nope"}})
+		if err != nil {
+			return false, err
+		}
+
+		if meta.LastIndex == 0 {
+			return false, fmt.Errorf("Bad: %v", meta)
+		}
+
+		if len(services) != 0 {
 			return false, fmt.Errorf("Bad: %v", services)
 		}
 
@@ -173,6 +281,7 @@ func TestCatalog_Registration(t *testing.T) {
 		Datacenter: "dc1",
 		Node:       "foobar",
 		Address:    "192.168.10.10",
+		NodeMeta:   map[string]string{"somekey": "somevalue"},
 		Service:    service,
 		Check:      check,
 	}
@@ -198,6 +307,10 @@ func TestCatalog_Registration(t *testing.T) {
 
 		if health[0].CheckID != "service:redis1" {
 			return false, fmt.Errorf("missing checkid service:redis1")
+		}
+
+		if v, ok := node.Node.Meta["somekey"]; !ok || v != "somevalue" {
+			return false, fmt.Errorf("missing node meta pair somekey:somevalue")
 		}
 
 		return true, nil

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1687,6 +1687,9 @@ func (a *Agent) loadMetadata(conf *Config) error {
 	defer a.state.Unlock()
 
 	for key, value := range conf.Meta {
+		if key == "" {
+			return fmt.Errorf("Key name cannot be blank")
+		}
 		if strings.Contains(key, ":") {
 			return fmt.Errorf("Key name cannot contain ':' character: %s", key)
 		}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -47,13 +47,13 @@ const (
 	metaKeyReservedPrefix = "consul-"
 
 	// The maximum number of metadata key pairs allowed to be registered
-	metaMaxKeyPairs       = 64
+	metaMaxKeyPairs = 64
 
 	// The maximum allowed length of a metadata key
-	metaKeyMaxLength      = 128
+	metaKeyMaxLength = 128
 
 	// The maximum allowed length of a metadata value
-	metaValueMaxLength    = 512
+	metaValueMaxLength = 512
 )
 
 var (
@@ -1727,9 +1727,6 @@ func validateMetaPair(key, value string) error {
 	}
 	if len(key) > metaKeyMaxLength {
 		return fmt.Errorf("Key is longer than %d chars", metaKeyMaxLength)
-	}
-	if strings.Contains(key, ":") {
-		return fmt.Errorf("Key contains ':' character")
 	}
 	if strings.HasPrefix(key, metaKeyReservedPrefix) {
 		return fmt.Errorf("Key prefix '%s' is reserved for internal use", metaKeyReservedPrefix)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1710,6 +1710,16 @@ func (a *Agent) loadMetadata(conf *Config) error {
 	return nil
 }
 
+// parseMetaPair parses a key/value pair of the form key:value
+func parseMetaPair(raw string) (string, string) {
+	pair := strings.SplitN(raw, ":", 2)
+	if len(pair) == 2 {
+		return pair[0], pair[1]
+	} else {
+		return pair[0], ""
+	}
+}
+
 // validateMeta validates a set of key/value pairs from the agent config
 func validateMetadata(meta map[string]string) error {
 	if len(meta) > metaMaxKeyPairs {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -20,6 +20,7 @@ type AgentSelf struct {
 	Coord  *coordinate.Coordinate
 	Member serf.Member
 	Stats  map[string]map[string]string
+	Meta   map[string]string
 }
 
 func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -47,6 +48,7 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 		Coord:  c,
 		Member: s.agent.LocalMember(),
 		Stats:  s.agent.Stats(),
+		Meta:   s.agent.state.Metadata(),
 	}, nil
 }
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -201,7 +201,12 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Self(t *testing.T) {
-	dir, srv := makeHTTPServer(t)
+	meta := map[string]string{
+		"somekey": "somevalue",
+	}
+	dir, srv := makeHTTPServerWithConfig(t, func(conf *Config) {
+		conf.Meta = meta
+	})
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
 	defer srv.agent.Shutdown()
@@ -231,6 +236,9 @@ func TestAgent_Self(t *testing.T) {
 	}
 	if !reflect.DeepEqual(c, val.Coord) {
 		t.Fatalf("coordinates are not equal: %v != %v", c, val.Coord)
+	}
+	if !reflect.DeepEqual(meta, val.Meta) {
+		t.Fatalf("meta fields are not equal: %v != %v", meta, val.Meta)
 	}
 
 	srv.agent.config.DisableCoordinates = true

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/raft"
+	"strings"
 )
 
 const (
@@ -1852,69 +1853,64 @@ func TestAgent_purgeCheckState(t *testing.T) {
 }
 
 func TestAgent_metadata(t *testing.T) {
-	config := nextConfig()
-	dir, agent := makeAgent(t, config)
-	defer os.RemoveAll(dir)
-	defer agent.Shutdown()
-
 	// Load a valid set of key/value pairs
-	config.Meta = map[string]string{
+	meta := map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}
 	// Should succeed
-	if err := agent.loadMetadata(config); err != nil {
+	if err := validateMetadata(meta); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	agent.unloadMetadata()
 
 	// Should get error
-	config.Meta = map[string]string{
+	meta = map[string]string{
 		"": "value1",
 	}
-	if err := agent.loadMetadata(config); err == nil {
+	if err := validateMetadata(meta); !strings.Contains(err.Error(), "Couldn't load metadata pair") {
 		t.Fatalf("should have failed")
 	}
-	agent.unloadMetadata()
 
 	// Should get error
-	tooManyKeys := make(map[string]string)
+	meta = make(map[string]string)
 	for i := 0; i < metaMaxKeyPairs+1; i++ {
-		tooManyKeys[string(i)] = "value"
+		meta[string(i)] = "value"
 	}
-	if err := agent.loadMetadata(config); err == nil {
+	if err := validateMetadata(meta); !strings.Contains(err.Error(), "cannot contain more than") {
 		t.Fatalf("should have failed")
 	}
 }
 
 func TestAgent_validateMetaPair(t *testing.T) {
-	longKey := fmt.Sprintf(fmt.Sprintf("%%%ds", metaKeyMaxLength+1), "")
-	longValue := fmt.Sprintf(fmt.Sprintf("%%%ds", metaValueMaxLength+1), "")
+	longKey := strings.Repeat("a", metaKeyMaxLength+1)
+	longValue := strings.Repeat("b", metaValueMaxLength+1)
 	pairs := []struct {
-		Key     string
-		Value   string
-		Success bool
+		Key   string
+		Value string
+		Error string
 	}{
 		// valid pair
-		{"key", "value", true},
+		{"key", "value", ""},
 		// invalid, blank key
-		{"", "value", false},
+		{"", "value", "cannot be blank"},
 		// allowed special chars in key name
-		{"k_e-y", "value", true},
+		{"k_e-y", "value", ""},
 		// disallowed special chars in key name
-		{"(%key&)", "value", false},
+		{"(%key&)", "value", "invalid characters"},
 		// key too long
-		{longKey, "value", false},
+		{longKey, "value", "Key is too long"},
 		// reserved prefix
-		{metaKeyReservedPrefix + "key", "value", false},
+		{metaKeyReservedPrefix + "key", "value", "reserved for internal use"},
 		// value too long
-		{"key", longValue, false},
+		{"key", longValue, "Value is too long"},
 	}
 
 	for _, pair := range pairs {
 		err := validateMetaPair(pair.Key, pair.Value)
-		if pair.Success != (err == nil) {
-			t.Fatalf("bad: %v, %v", pair, err)
+		if pair.Error == "" && err != nil {
+			t.Fatalf("should have succeeded: %v, %v", pair, err)
+		} else if pair.Error != "" && !strings.Contains(err.Error(), pair.Error) {
+			t.Fatalf("should have failed: %v, %v", pair, err)
 		}
 	}
 }

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1901,8 +1901,6 @@ func TestAgent_validateMetaPair(t *testing.T) {
 		{"", "value", false},
 		// allowed special chars in key name
 		{"k_e-y", "value", true},
-		// ':' in key name
-		{"k:ey", "value", false},
 		// disallowed special chars in key name
 		{"(%key&)", "value", false},
 		// key too long

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -64,16 +64,9 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	// Setup the request
 	args := structs.DCSpecificRequest{}
 	s.parseSource(req, &args.Source)
+	s.parseMetaFilter(req, &args.NodeMetaKey, &args.NodeMetaValue)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
-	}
-	// Try to parse node metadata filter params
-	if filter, ok := req.URL.Query()["node-meta"]; ok && len(filter) > 0 {
-		pair := strings.SplitN(filter[0], ":", 2)
-		args.NodeMetaKey = pair[0]
-		if len(pair) == 2 {
-			args.NodeMetaValue = pair[1]
-		}
 	}
 
 	var out structs.IndexedNodes
@@ -93,6 +86,7 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Set default DC
 	args := structs.DCSpecificRequest{}
+	s.parseMetaFilter(req, &args.NodeMetaKey, &args.NodeMetaValue)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -67,6 +67,14 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
+	// Try to parse node metadata filter params
+	if filter, ok := req.URL.Query()["node-meta"]; ok && len(filter) > 0 {
+		pair := strings.SplitN(filter[0], ":", 2)
+		args.NodeMetaKey = pair[0]
+		if len(pair) == 2 {
+			args.NodeMetaValue = pair[1]
+		}
+	}
 
 	var out structs.IndexedNodes
 	defer setMeta(resp, &out.QueryMeta)

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -64,7 +64,7 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	// Setup the request
 	args := structs.DCSpecificRequest{}
 	s.parseSource(req, &args.Source)
-	s.parseMetaFilter(req, &args.NodeMetaKey, &args.NodeMetaValue)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
@@ -86,7 +86,7 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Set default DC
 	args := structs.DCSpecificRequest{}
-	s.parseMetaFilter(req, &args.NodeMetaKey, &args.NodeMetaValue)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -364,6 +364,12 @@ func (c *Command) readConfig() *Config {
 		}
 	}
 
+	// Verify the node metadata entries are valid
+	if err := validateMetadata(config.Meta); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to parse node metadata: %v", err))
+		return nil
+	}
+
 	// Set the version info
 	config.Revision = c.Revision
 	config.Version = c.Version
@@ -1081,10 +1087,7 @@ func (c *Command) handleReload(config *Config) (*Config, error) {
 		errs = multierror.Append(errs, fmt.Errorf("Failed unloading checks: %s", err))
 		return nil, errs
 	}
-	if err := c.agent.unloadMetadata(); err != nil {
-		errs = multierror.Append(errs, fmt.Errorf("Failed unloading metadata: %s", err))
-		return nil, errs
-	}
+	c.agent.unloadMetadata()
 
 	// Reload service/check definitions and metadata.
 	if err := c.agent.loadServices(newConf); err != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -342,6 +342,9 @@ type Config struct {
 	// they are configured with TranslateWanAddrs set to true.
 	TaggedAddresses map[string]string
 
+	// Node metadata
+	Meta map[string]string `mapstructure:"node_meta" json:"-"`
+
 	// LeaveOnTerm controls if Serf does a graceful leave when receiving
 	// the TERM signal. Defaults true on clients, false on servers. This can
 	// be changed on reload.
@@ -1575,6 +1578,14 @@ func MergeConfig(a, b *Config) *Config {
 		}
 		for field, value := range b.HTTPAPIResponseHeaders {
 			result.HTTPAPIResponseHeaders[field] = value
+		}
+	}
+	if len(b.Meta) != 0 {
+		if result.Meta == nil {
+			result.Meta = make(map[string]string)
+		}
+		for field, value := range b.Meta {
+			result.Meta[field] = value
 		}
 	}
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -342,7 +342,9 @@ type Config struct {
 	// they are configured with TranslateWanAddrs set to true.
 	TaggedAddresses map[string]string
 
-	// Node metadata
+	// Node metadata key/value pairs. These are excluded from JSON output
+	// because they can be reloaded and might be stale when shown from the
+	// config instead of the local state.
 	Meta map[string]string `mapstructure:"node_meta" json:"-"`
 
 	// LeaveOnTerm controls if Serf does a graceful leave when receiving

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -713,6 +713,7 @@ func DefaultConfig() *Config {
 		Telemetry: Telemetry{
 			StatsitePrefix: "consul",
 		},
+		Meta:                       make(map[string]string),
 		SyslogFacility:             "LOCAL0",
 		Protocol:                   consul.ProtocolVersion2Compatible,
 		CheckUpdateInterval:        5 * time.Minute,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -281,6 +281,19 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Node metadata fields
+	input = `{"node_meta": {"thing1": "1", "thing2": "2"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if v, ok := config.Meta["thing1"]; !ok || v != "1" {
+		t.Fatalf("bad: %#v", config)
+	}
+	if v, ok := config.Meta["thing2"]; !ok || v != "2" {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// leave_on_terminate
 	input = `{"leave_on_terminate": true}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1519,6 +1532,9 @@ func TestMergeConfig(t *testing.T) {
 			DogStatsdAddr:   "nope",
 			DogStatsdTags:   []string{"nope"},
 		},
+		Meta: map[string]string{
+			"key": "value1",
+		},
 	}
 
 	b := &Config{
@@ -1619,6 +1635,9 @@ func TestMergeConfig(t *testing.T) {
 			DisableHostname: true,
 			DogStatsdAddr:   "127.0.0.1:7254",
 			DogStatsdTags:   []string{"tag_1:val_1", "tag_2:val_2"},
+		},
+		Meta: map[string]string{
+			"key": "value2",
 		},
 		DisableUpdateCheck:        true,
 		DisableAnonymousSignature: true,

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -586,14 +586,20 @@ func (s *HTTPServer) parseSource(req *http.Request, source *structs.QuerySource)
 
 // parseMetaFilter is used to parse the ?node-meta=key:value query parameter, used for
 // filtering results to nodes with the given metadata key/value
-func (s *HTTPServer) parseMetaFilter(req *http.Request, key *string, value *string) {
-	if filter, ok := req.URL.Query()["node-meta"]; ok && len(filter) > 0 {
-		pair := strings.SplitN(filter[0], ":", 2)
-		*key = pair[0]
-		if len(pair) == 2 {
-			*value = pair[1]
+func (s *HTTPServer) parseMetaFilter(req *http.Request) map[string]string {
+	if filterList, ok := req.URL.Query()["node-meta"]; ok {
+		filters := make(map[string]string)
+		for _, filter := range filterList {
+			pair := strings.SplitN(filter, ":", 2)
+			if len(pair) == 2 {
+				filters[pair[0]] = pair[1]
+			} else {
+				filters[pair[0]] = ""
+			}
 		}
+		return filters
 	}
+	return nil
 }
 
 // parse is a convenience method for endpoints that need

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -590,12 +590,8 @@ func (s *HTTPServer) parseMetaFilter(req *http.Request) map[string]string {
 	if filterList, ok := req.URL.Query()["node-meta"]; ok {
 		filters := make(map[string]string)
 		for _, filter := range filterList {
-			pair := strings.SplitN(filter, ":", 2)
-			if len(pair) == 2 {
-				filters[pair[0]] = pair[1]
-			} else {
-				filters[pair[0]] = ""
-			}
+			key, value := parseMetaPair(filter)
+			filters[key] = value
 		}
 		return filters
 	}

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -584,6 +584,18 @@ func (s *HTTPServer) parseSource(req *http.Request, source *structs.QuerySource)
 	}
 }
 
+// parseMetaFilter is used to parse the ?node-meta=key:value query parameter, used for
+// filtering results to nodes with the given metadata key/value
+func (s *HTTPServer) parseMetaFilter(req *http.Request, key *string, value *string) {
+	if filter, ok := req.URL.Query()["node-meta"]; ok && len(filter) > 0 {
+		pair := strings.SplitN(filter[0], ":", 2)
+		*key = pair[0]
+		if len(pair) == 2 {
+			*value = pair[1]
+		}
+	}
+}
+
 // parse is a convenience method for endpoints that need
 // to use both parseWait and parseDC.
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions) bool {

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -985,6 +985,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 
 func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	conf := nextConfig()
+	conf.Meta["somekey"] = "somevalue"
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -1020,7 +1021,8 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		// Make sure we synced our node info - this should have ridden on the
 		// "consul" service sync
 		addrs := services.NodeServices.Node.TaggedAddresses
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) {
+		meta := services.NodeServices.Node.Meta
+		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) || !reflect.DeepEqual(meta, conf.Meta) {
 			return false, fmt.Errorf("bad: %v", addrs)
 		}
 
@@ -1044,7 +1046,8 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 			return false, fmt.Errorf("err: %v", err)
 		}
 		addrs := services.NodeServices.Node.TaggedAddresses
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) {
+		meta := services.NodeServices.Node.Meta
+		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) || !reflect.DeepEqual(meta, conf.Meta) {
 			return false, fmt.Errorf("bad: %v", addrs)
 		}
 

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -156,6 +156,14 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		return err
 	}
 
+	var metaFilter []interface{}
+	if args.NodeMetaKey != "" {
+		metaFilter = append(metaFilter, args.NodeMetaKey)
+		if args.NodeMetaValue != "" {
+			metaFilter = append(metaFilter, args.NodeMetaValue)
+		}
+	}
+
 	// Get the list of nodes.
 	state := c.srv.fsm.State()
 	return c.srv.blockingRPC(
@@ -163,7 +171,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 		&reply.QueryMeta,
 		state.GetQueryWatch("Nodes"),
 		func() error {
-			index, nodes, err := state.Nodes()
+			index, nodes, err := state.Nodes(metaFilter...)
 			if err != nil {
 				return err
 			}

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -196,7 +196,14 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 		&reply.QueryMeta,
 		state.GetQueryWatch("Services"),
 		func() error {
-			index, services, err := state.Services()
+			var index uint64
+			var services structs.Services
+			var err error
+			if args.NodeMetaKey != "" {
+				index, services, err = state.ServicesByNodeMeta(args.NodeMetaKey, args.NodeMetaValue)
+			} else {
+				index, services, err = state.Services()
+			}
 			if err != nil {
 				return err
 			}

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -166,8 +166,8 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 			var index uint64
 			var nodes structs.Nodes
 			var err error
-			if args.NodeMetaKey != "" {
-				index, nodes, err = state.NodesByMeta(args.NodeMetaKey, args.NodeMetaValue)
+			if len(args.NodeMetaFilters) > 0 {
+				index, nodes, err = state.NodesByMeta(args.NodeMetaFilters)
 			} else {
 				index, nodes, err = state.Nodes()
 			}
@@ -199,8 +199,8 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 			var index uint64
 			var services structs.Services
 			var err error
-			if args.NodeMetaKey != "" {
-				index, services, err = state.ServicesByNodeMeta(args.NodeMetaKey, args.NodeMetaValue)
+			if len(args.NodeMetaFilters) > 0 {
+				index, services, err = state.ServicesByNodeMeta(args.NodeMetaFilters)
 			} else {
 				index, services, err = state.Services()
 			}

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -599,18 +599,6 @@ func TestCatalog_ListNodes_MetaFilter(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	// Filter by a specific meta k/v pair
-	args := structs.DCSpecificRequest{
-		Datacenter:    "dc1",
-		NodeMetaKey:   "somekey",
-		NodeMetaValue: "somevalue",
-	}
-	var out structs.IndexedNodes
-	err := msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
 	testutil.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Add a new node with the right meta k/v pair
@@ -618,6 +606,15 @@ func TestCatalog_ListNodes_MetaFilter(t *testing.T) {
 	if err := s1.fsm.State().EnsureNode(1, node); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+
+	// Filter by a specific meta k/v pair
+	args := structs.DCSpecificRequest{
+		Datacenter: "dc1",
+		NodeMetaFilters: map[string]string{
+			"somekey": "somevalue",
+		},
+	}
+	var out structs.IndexedNodes
 
 	testutil.WaitForResult(func() (bool, error) {
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
@@ -639,12 +636,13 @@ func TestCatalog_ListNodes_MetaFilter(t *testing.T) {
 
 	// Now filter on a nonexistent meta k/v pair
 	args = structs.DCSpecificRequest{
-		Datacenter:    "dc1",
-		NodeMetaKey:   "somekey",
-		NodeMetaValue: "invalid",
+		Datacenter: "dc1",
+		NodeMetaFilters: map[string]string{
+			"somekey": "invalid",
+		},
 	}
 	out = structs.IndexedNodes{}
-	err = msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
+	err := msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1069,18 +1067,6 @@ func TestCatalog_ListServices_MetaFilter(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	// Filter by a specific meta k/v pair
-	args := structs.DCSpecificRequest{
-		Datacenter:    "dc1",
-		NodeMetaKey:   "somekey",
-		NodeMetaValue: "somevalue",
-	}
-	var out structs.IndexedServices
-	err := msgpackrpc.CallWithCodec(codec, "Catalog.ListServices", &args, &out)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
 	testutil.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Add a new node with the right meta k/v pair
@@ -1093,6 +1079,14 @@ func TestCatalog_ListServices_MetaFilter(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Filter by a specific meta k/v pair
+	args := structs.DCSpecificRequest{
+		Datacenter: "dc1",
+		NodeMetaFilters: map[string]string{
+			"somekey": "somevalue",
+		},
+	}
+	var out structs.IndexedServices
 	if err := msgpackrpc.CallWithCodec(codec, "Catalog.ListServices", &args, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1112,12 +1106,13 @@ func TestCatalog_ListServices_MetaFilter(t *testing.T) {
 
 	// Now filter on a nonexistent meta k/v pair
 	args = structs.DCSpecificRequest{
-		Datacenter:    "dc1",
-		NodeMetaKey:   "somekey",
-		NodeMetaValue: "invalid",
+		Datacenter: "dc1",
+		NodeMetaFilters: map[string]string{
+			"somekey": "invalid",
+		},
 	}
 	out = structs.IndexedServices{}
-	err = msgpackrpc.CallWithCodec(codec, "Catalog.ListServices", &args, &out)
+	err := msgpackrpc.CallWithCodec(codec, "Catalog.ListServices", &args, &out)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/consul/state/schema.go
+++ b/consul/state/schema.go
@@ -78,6 +78,15 @@ func nodesTableSchema() *memdb.TableSchema {
 					Lowercase: true,
 				},
 			},
+			"meta": &memdb.IndexSchema{
+				Name:         "meta",
+				AllowMissing: true,
+				Unique:       false,
+				Indexer: &memdb.StringMapFieldIndex{
+					Field:     "Meta",
+					Lowercase: false,
+				},
+			},
 		},
 	}
 }

--- a/consul/state/state_store_test.go
+++ b/consul/state/state_store_test.go
@@ -759,7 +759,7 @@ func TestStateStore_GetNodesByMeta(t *testing.T) {
 	s := testStateStore(t)
 
 	// Listing with no results returns nil
-	idx, res, err := s.NodesByMeta("somekey", "somevalue")
+	idx, res, err := s.NodesByMeta(map[string]string{"somekey": "somevalue"})
 	if idx != 0 || res != nil || err != nil {
 		t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, res, err)
 	}
@@ -775,7 +775,7 @@ func TestStateStore_GetNodesByMeta(t *testing.T) {
 	}
 
 	// Retrieve the node with role=client
-	idx, nodes, err := s.NodesByMeta("role", "client")
+	idx, nodes, err := s.NodesByMeta(map[string]string{"role": "client"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -800,7 +800,7 @@ func TestStateStore_GetNodesByMeta(t *testing.T) {
 	}
 
 	// Retrieve both nodes via their common meta field
-	idx, nodes, err = s.NodesByMeta("common", "1")
+	idx, nodes, err = s.NodesByMeta(map[string]string{"common": "1"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1160,7 +1160,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	s := testStateStore(t)
 
 	// Listing with no results returns nil
-	idx, res, err := s.ServicesByNodeMeta("somekey", "somevalue")
+	idx, res, err := s.ServicesByNodeMeta(map[string]string{"somekey": "somevalue"})
 	if idx != 0 || len(res) != 0 || err != nil {
 		t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, res, err)
 	}
@@ -1196,7 +1196,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	}
 
 	// Filter the services by the first node's meta value
-	idx, res, err = s.ServicesByNodeMeta("role", "client")
+	idx, res, err = s.ServicesByNodeMeta(map[string]string{"role": "client"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1211,7 +1211,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	}
 
 	// Get all services using the common meta value
-	idx, res, err = s.ServicesByNodeMeta("common", "1")
+	idx, res, err = s.ServicesByNodeMeta(map[string]string{"common": "1"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -287,12 +287,6 @@ type Node struct {
 }
 type Nodes []*Node
 
-// Used for filtering nodes by metadata key/value pairs
-type NodeMetaFilter struct {
-	Key   string
-	Value string
-}
-
 // Used to return information about a provided services.
 // Maps service name to available tags
 type Services map[string][]string

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -173,6 +173,7 @@ type RegisterRequest struct {
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
+	NodeMeta        map[string]string
 	Service         *NodeService
 	Check           *HealthCheck
 	Checks          HealthChecks
@@ -195,7 +196,8 @@ func (r *RegisterRequest) ChangesNode(node *Node) bool {
 	// Check if any of the node-level fields are being changed.
 	if r.Node != node.Node ||
 		r.Address != node.Address ||
-		!reflect.DeepEqual(r.TaggedAddresses, node.TaggedAddresses) {
+		!reflect.DeepEqual(r.TaggedAddresses, node.TaggedAddresses) ||
+		!reflect.DeepEqual(r.NodeMeta, node.Meta) {
 		return true
 	}
 
@@ -227,8 +229,10 @@ type QuerySource struct {
 
 // DCSpecificRequest is used to query about a specific DC
 type DCSpecificRequest struct {
-	Datacenter string
-	Source     QuerySource
+	Datacenter    string
+	NodeMetaKey   string
+	NodeMetaValue string
+	Source        QuerySource
 	QueryOptions
 }
 
@@ -278,6 +282,7 @@ type Node struct {
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
+	Meta            map[string]string
 
 	RaftIndex
 }
@@ -296,6 +301,7 @@ type ServiceNode struct {
 	Node                     string
 	Address                  string
 	TaggedAddresses          map[string]string
+	NodeMeta                 map[string]string
 	ServiceID                string
 	ServiceName              string
 	ServiceTags              []string
@@ -488,6 +494,7 @@ type NodeInfo struct {
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
+	Meta            map[string]string
 	Services        []*NodeService
 	Checks          HealthChecks
 }

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -229,10 +229,9 @@ type QuerySource struct {
 
 // DCSpecificRequest is used to query about a specific DC
 type DCSpecificRequest struct {
-	Datacenter    string
-	NodeMetaKey   string
-	NodeMetaValue string
-	Source        QuerySource
+	Datacenter      string
+	NodeMetaFilters map[string]string
+	Source          QuerySource
 	QueryOptions
 }
 
@@ -287,6 +286,12 @@ type Node struct {
 	RaftIndex
 }
 type Nodes []*Node
+
+// Used for filtering nodes by metadata key/value pairs
+type NodeMetaFilter struct {
+	Key   string
+	Value string
+}
 
 // Used to return information about a provided services.
 // Maps service name to available tags

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -292,8 +292,8 @@ type Nodes []*Node
 // Maps service name to available tags
 type Services map[string][]string
 
-// ServiceNode represents a node that is part of a service. Address and
-// TaggedAddresses are node-related fields that are always empty in the state
+// ServiceNode represents a node that is part of a service. Address, TaggedAddresses,
+// and NodeMeta are node-related fields that are always empty in the state
 // store and are filled in on the way out by parseServiceNodes(). This is also
 // why PartialClone() skips them, because we know they are blank already so it
 // would be a waste of time to copy them.

--- a/consul/structs/structs_test.go
+++ b/consul/structs/structs_test.go
@@ -110,12 +110,18 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 		Node:            "test",
 		Address:         "127.0.0.1",
 		TaggedAddresses: make(map[string]string),
+		NodeMeta: map[string]string{
+			"role": "server",
+		},
 	}
 
 	node := &Node{
 		Node:            "test",
 		Address:         "127.0.0.1",
 		TaggedAddresses: make(map[string]string),
+		Meta: map[string]string{
+			"role": "server",
+		},
 	}
 
 	check := func(twiddle, restore func()) {
@@ -137,6 +143,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 	check(func() { req.Node = "nope" }, func() { req.Node = "test" })
 	check(func() { req.Address = "127.0.0.2" }, func() { req.Address = "127.0.0.1" })
 	check(func() { req.TaggedAddresses["wan"] = "nope" }, func() { delete(req.TaggedAddresses, "wan") })
+	check(func() { req.NodeMeta["invalid"] = "nope" }, func() { delete(req.NodeMeta, "invalid")})
 
 	if !req.ChangesNode(nil) {
 		t.Fatalf("should change")

--- a/consul/structs/structs_test.go
+++ b/consul/structs/structs_test.go
@@ -151,6 +151,9 @@ func testServiceNode() *ServiceNode {
 		TaggedAddresses: map[string]string{
 			"hello": "world",
 		},
+		NodeMeta: map[string]string{
+			"tag": "value",
+		},
 		ServiceID:                "service1",
 		ServiceName:              "dogs",
 		ServiceTags:              []string{"prod", "v1"},
@@ -172,12 +175,13 @@ func TestStructs_ServiceNode_PartialClone(t *testing.T) {
 	// Make sure the parts that weren't supposed to be cloned didn't get
 	// copied over, then zero-value them out so we can do a DeepEqual() on
 	// the rest of the contents.
-	if clone.Address != "" || len(clone.TaggedAddresses) != 0 {
+	if clone.Address != "" || len(clone.TaggedAddresses) != 0 || len(clone.NodeMeta) != 0 {
 		t.Fatalf("bad: %v", clone)
 	}
 
 	sn.Address = ""
 	sn.TaggedAddresses = nil
+	sn.NodeMeta = nil
 	if !reflect.DeepEqual(sn, clone) {
 		t.Fatalf("bad: %v", clone)
 	}
@@ -197,6 +201,7 @@ func TestStructs_ServiceNode_Conversions(t *testing.T) {
 	// them out before we do the compare.
 	sn.Address = ""
 	sn.TaggedAddresses = nil
+	sn.NodeMeta = nil
 	if !reflect.DeepEqual(sn, sn2) {
 		t.Fatalf("bad: %v", sn2)
 	}

--- a/consul/structs/structs_test.go
+++ b/consul/structs/structs_test.go
@@ -143,7 +143,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 	check(func() { req.Node = "nope" }, func() { req.Node = "test" })
 	check(func() { req.Address = "127.0.0.2" }, func() { req.Address = "127.0.0.1" })
 	check(func() { req.TaggedAddresses["wan"] = "nope" }, func() { delete(req.TaggedAddresses, "wan") })
-	check(func() { req.NodeMeta["invalid"] = "nope" }, func() { delete(req.NodeMeta, "invalid")})
+	check(func() { req.NodeMeta["invalid"] = "nope" }, func() { delete(req.NodeMeta, "invalid") })
 
 	if !req.ChangesNode(nil) {
 		t.Fatalf("should change")

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -53,6 +53,7 @@ type TestAddressConfig struct {
 // TestServerConfig is the main server configuration struct.
 type TestServerConfig struct {
 	NodeName          string                 `json:"node_name"`
+	NodeMeta          map[string]string      `json:"node_meta"`
 	Performance       *TestPerformanceConfig `json:"performance,omitempty"`
 	Bootstrap         bool                   `json:"bootstrap,omitempty"`
 	Server            bool                   `json:"server,omitempty"`

--- a/vendor/github.com/hashicorp/go-memdb/README.md
+++ b/vendor/github.com/hashicorp/go-memdb/README.md
@@ -19,7 +19,7 @@ The database provides the following:
 
 * Rich Indexing - Tables can support any number of indexes, which can be simple like
   a single field index, or more advanced compound field indexes. Certain types like
-  UUID can be efficiently compressed from strings into byte indexes for reduces
+  UUID can be efficiently compressed from strings into byte indexes for reduced
   storage requirements.
 
 For the underlying immutable radix trees, see [go-immutable-radix](https://github.com/hashicorp/go-immutable-radix).

--- a/vendor/github.com/hashicorp/go-memdb/index.go
+++ b/vendor/github.com/hashicorp/go-memdb/index.go
@@ -9,13 +9,25 @@ import (
 
 // Indexer is an interface used for defining indexes
 type Indexer interface {
-	// FromObject is used to extract an index value from an
-	// object or to indicate that the index value is missing.
-	FromObject(raw interface{}) (bool, []byte, error)
-
 	// ExactFromArgs is used to build an exact index lookup
 	// based on arguments
 	FromArgs(args ...interface{}) ([]byte, error)
+}
+
+// SingleIndexer is an interface used for defining indexes
+// generating a single entry per object
+type SingleIndexer interface {
+	// FromObject is used to extract an index value from an
+	// object or to indicate that the index value is missing.
+	FromObject(raw interface{}) (bool, []byte, error)
+}
+
+// MultiIndexer is an interface used for defining indexes
+// generating multiple entries per object
+type MultiIndexer interface {
+	// FromObject is used to extract index values from an
+	// object or to indicate that the index value is missing.
+	FromObject(raw interface{}) (bool, [][]byte, error)
 }
 
 // PrefixIndexer can optionally be implemented for any
@@ -86,6 +98,155 @@ func (s *StringFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
 		return val[:n-1], nil
 	}
 	return val, nil
+}
+
+// StringSliceFieldIndex is used to extract a field from an object
+// using reflection and builds an index on that field.
+type StringSliceFieldIndex struct {
+	Field     string
+	Lowercase bool
+}
+
+func (s *StringSliceFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(s.Field)
+	if !fv.IsValid() {
+		return false, nil,
+			fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+	}
+
+	if fv.Kind() != reflect.Slice || fv.Type().Elem().Kind() != reflect.String {
+		return false, nil, fmt.Errorf("field '%s' is not a string slice", s.Field)
+	}
+
+	length := fv.Len()
+	vals := make([][]byte, 0, length)
+	for i := 0; i < fv.Len(); i++ {
+		val := fv.Index(i).String()
+		if val == "" {
+			continue
+		}
+
+		if s.Lowercase {
+			val = strings.ToLower(val)
+		}
+
+		// Add the null character as a terminator
+		val += "\x00"
+		vals = append(vals, []byte(val))
+	}
+	if len(vals) == 0 {
+		return false, nil, nil
+	}
+	return true, vals, nil
+}
+
+func (s *StringSliceFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	arg, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a string: %#v", args[0])
+	}
+	if s.Lowercase {
+		arg = strings.ToLower(arg)
+	}
+	// Add the null character as a terminator
+	arg += "\x00"
+	return []byte(arg), nil
+}
+
+func (s *StringSliceFieldIndex) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	val, err := s.FromArgs(args...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Strip the null terminator, the rest is a prefix
+	n := len(val)
+	if n > 0 {
+		return val[:n-1], nil
+	}
+	return val, nil
+}
+
+// StringMapFieldIndex is used to extract a field of type map[string]string
+// from an object using reflection and builds an index on that field.
+type StringMapFieldIndex struct {
+	Field     string
+	Lowercase bool
+}
+
+var MapType = reflect.MapOf(reflect.TypeOf(""), reflect.TypeOf("")).Kind()
+
+func (s *StringMapFieldIndex) FromObject(obj interface{}) (bool, [][]byte, error) {
+	v := reflect.ValueOf(obj)
+	v = reflect.Indirect(v) // Dereference the pointer if any
+
+	fv := v.FieldByName(s.Field)
+	if !fv.IsValid() {
+		return false, nil, fmt.Errorf("field '%s' for %#v is invalid", s.Field, obj)
+	}
+
+	if fv.Kind() != MapType {
+		return false, nil, fmt.Errorf("field '%s' is not a map[string]string", s.Field)
+	}
+
+	length := fv.Len()
+	vals := make([][]byte, 0, length)
+	for _, key := range fv.MapKeys() {
+		k := key.String()
+		if k == "" {
+			continue
+		}
+		val := fv.MapIndex(key).String()
+
+		if s.Lowercase {
+			k = strings.ToLower(k)
+			val = strings.ToLower(val)
+		}
+
+		// Add the null character as a terminator
+		k += "\x00" + val + "\x00"
+
+		vals = append(vals, []byte(k))
+	}
+	if len(vals) == 0 {
+		return false, nil, nil
+	}
+	return true, vals, nil
+}
+
+func (s *StringMapFieldIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) > 2 || len(args) == 0 {
+		return nil, fmt.Errorf("must provide one or two arguments")
+	}
+	key, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a string: %#v", args[0])
+	}
+	if s.Lowercase {
+		key = strings.ToLower(key)
+	}
+	// Add the null character as a terminator
+	key += "\x00"
+
+	if len(args) == 2 {
+		val, ok := args[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("argument must be a string: %#v", args[1])
+		}
+		if s.Lowercase {
+			val = strings.ToLower(val)
+		}
+		// Add the null character as a terminator
+		key += val + "\x00"
+	}
+
+	return []byte(key), nil
 }
 
 // UUIDFieldIndex is used to extract a field from an object
@@ -270,7 +431,11 @@ type CompoundIndex struct {
 
 func (c *CompoundIndex) FromObject(raw interface{}) (bool, []byte, error) {
 	var out []byte
-	for i, idx := range c.Indexes {
+	for i, idxRaw := range c.Indexes {
+		idx, ok := idxRaw.(SingleIndexer)
+		if !ok {
+			return false, nil, fmt.Errorf("sub-index %d error: %s", i, "sub-index must be a SingleIndexer")
+		}
 		ok, val, err := idx.FromObject(raw)
 		if err != nil {
 			return false, nil, fmt.Errorf("sub-index %d error: %v", i, err)

--- a/vendor/github.com/hashicorp/go-memdb/schema.go
+++ b/vendor/github.com/hashicorp/go-memdb/schema.go
@@ -46,6 +46,9 @@ func (s *TableSchema) Validate() error {
 	if !s.Indexes["id"].Unique {
 		return fmt.Errorf("id index must be unique")
 	}
+	if _, ok := s.Indexes["id"].Indexer.(SingleIndexer); !ok {
+		return fmt.Errorf("id index must be a SingleIndexer")
+	}
 	for name, index := range s.Indexes {
 		if name != index.Name {
 			return fmt.Errorf("index name mis-match for '%s'", name)
@@ -71,6 +74,12 @@ func (s *IndexSchema) Validate() error {
 	}
 	if s.Indexer == nil {
 		return fmt.Errorf("missing index function for '%s'", s.Name)
+	}
+	switch s.Indexer.(type) {
+	case SingleIndexer:
+	case MultiIndexer:
+	default:
+		return fmt.Errorf("indexer for '%s' must be a SingleIndexer or MultiIndexer", s.Name)
 	}
 	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -396,10 +396,10 @@
 			"revisionTime": "2016-06-09T02:05:29Z"
 		},
 		{
-			"checksumSHA1": "/V57CyN7x2NUlHoOzVL5GgGXX84=",
+			"checksumSHA1": "ZpTDFeRvXFwIvSHRD8eDYHxaj4Y=",
 			"path": "github.com/hashicorp/go-memdb",
-			"revision": "98f52f52d7a476958fa9da671354d270c50661a7",
-			"revisionTime": "2016-03-01T23:01:42Z"
+			"revision": "d2d2b77acab85aa635614ac17ea865969f56009e",
+			"revisionTime": "2017-01-07T16:22:14Z"
 		},
 		{
 			"checksumSHA1": "TNlVzNR1OaajcNi3CbQ3bGbaLGU=",

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -128,6 +128,8 @@ This endpoint is used to return the configuration and member information of the 
 
 Consul 0.7.0 and later also includes a snapshot of various operating statistics under the `Stats` key. These statistics are intended to help human operators for debugging and may change over time, so this part of the interface should not be consumed programmatically.
 
+Consul 0.7.3 and later also includes a block of user-defined node metadata values under the `Meta` key. These are arbitrary key/value pairs defined in the [node meta](/docs/agent/options.html#_node_meta) section of the agent configuration.
+
 It returns a JSON body like this:
 
 ```javascript
@@ -194,6 +196,10 @@ It returns a JSON body like this:
     "DelegateMin": 2,
     "DelegateMax": 4,
     "DelegateCur": 4
+  },
+  "Meta": {
+    "instance_type": "i2.xlarge",
+    "os_version": "ubuntu_16.04",
   }
 }
 ```

--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -191,6 +191,10 @@ the node list in ascending order based on the estimated round trip
 time from that node. Passing `?near=_agent` will use the agent's
 node for the sort.
 
+Adding the optional `?node-meta=` parameter with a desired node
+metadata key/value pair of the form `key:value` will filter the
+results to nodes with that pair present.
+
 It returns a JSON body like this:
 
 ```javascript
@@ -221,6 +225,10 @@ This endpoint supports blocking queries and all consistency modes.
 This endpoint is hit with a `GET` and returns the services registered
 in a given DC. By default, the datacenter of the agent is queried;
 however, the `dc` can be provided using the `?dc=` query parameter.
+
+Adding the optional `?node-meta=` parameter with a desired node
+metadata key/value pair of the form `key:value` will filter the
+results to services with that pair present.
 
 It returns a JSON body like this:
 

--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -44,6 +44,9 @@ body must look something like:
     "lan": "192.168.10.10",
     "wan": "10.0.10.10"
   },
+  "NodeMeta": {
+    "somekey": "somevalue"
+  },
   "Service": {
     "ID": "redis1",
     "Service": "redis",
@@ -72,6 +75,10 @@ the node with the catalog. `TaggedAddresses` can be used in conjunction with the
 [`translate_wan_addrs`](/docs/agent/options.html#translate_wan_addrs) configuration
 option and the `wan` address. The `lan` address was added in Consul 0.7 to help find
 the LAN address if address translation is enabled.
+
+The `Meta` block was added in Consul 0.7.3 to enable associating arbitrary metadata
+key/value pairs with a node for filtering purposes. For more information on node metadata,
+see the [node meta](/docs/agent/options.html#_node_meta) section of the configuration page.
 
 If the `Service` key is provided, the service will also be registered. If
 `ID` is not provided, it will be defaulted to the value of the `Service.Service` property.
@@ -191,9 +198,9 @@ the node list in ascending order based on the estimated round trip
 time from that node. Passing `?near=_agent` will use the agent's
 node for the sort.
 
-Adding the optional `?node-meta=` parameter with a desired node
-metadata key/value pair of the form `key:value` will filter the
-results to nodes with that pair present.
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This will filter the results to nodes with that pair present.
 
 It returns a JSON body like this:
 
@@ -205,6 +212,9 @@ It returns a JSON body like this:
     "TaggedAddresses": {
       "lan": "10.1.10.11",
       "wan": "10.1.10.11"
+    },
+    "Meta": {
+      "instance_type": "t2.medium"
     }
   },
   {
@@ -213,6 +223,9 @@ It returns a JSON body like this:
     "TaggedAddresses": {
       "lan": "10.1.10.11",
       "wan": "10.1.10.12"
+    },
+    "Meta": {
+      "instance_type": "t2.large"
     }
   }
 ]
@@ -226,9 +239,9 @@ This endpoint is hit with a `GET` and returns the services registered
 in a given DC. By default, the datacenter of the agent is queried;
 however, the `dc` can be provided using the `?dc=` query parameter.
 
-Adding the optional `?node-meta=` parameter with a desired node
-metadata key/value pair of the form `key:value` will filter the
-results to services with that pair present.
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This will filter the results to services with that pair present.
 
 It returns a JSON body like this:
 
@@ -273,6 +286,9 @@ It returns a JSON body like this:
       "lan": "192.168.10.10",
       "wan": "10.0.10.10"
     },
+    "Meta": {
+      "instance_type": "t2.medium"
+    }
     "CreateIndex": 51,
     "ModifyIndex": 51,
     "Node": "foobar",
@@ -294,6 +310,7 @@ The returned fields are as follows:
 
 - `Address`: IP address of the Consul node on which the service is registered
 - `TaggedAddresses`: List of explicit LAN and WAN IP addresses for the agent
+- `Meta`: Added in Consul 0.7.3, a list of user-defined metadata key/value pairs for the node
 - `CreateIndex`: Internal index value representing when the service was created
 - `ModifyIndex`: Last index that modified the service
 - `Node`: Node name of the Consul node on which the service is registered
@@ -321,6 +338,9 @@ It returns a JSON body like this:
     "TaggedAddresses": {
       "lan": "10.1.10.12",
       "wan": "10.1.10.12"
+    },
+    "Meta": {
+      "instance_type": "t2.medium"
     }
   },
   "Services": {

--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -131,6 +131,9 @@ It returns a JSON body like this:
       "TaggedAddresses": {
         "lan": "10.1.10.12",
         "wan": "10.1.10.12"
+      },
+      "Meta": {
+        "instance_type": "t2.medium"
       }
     },
     "Service": {

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -251,6 +251,15 @@ will exit with an error at startup.
 * <a name="_node"></a><a href="#_node">`-node`</a> - The name of this node in the cluster.
   This must be unique within the cluster. By default this is the hostname of the machine.
 
+* <a name="_node_meta"></a><a href="#_node_meta">`-node-meta`</a> - An arbitrary metadata key/value pair
+  to associate with the node, of the form `key:value`. This can be specified multiple times. Node metadata
+  pairs have the following restrictions:
+  - A maximum of 64 key/value pairs can be registered per node.
+  - Metadata keys must be between 1 and 128 characters (inclusive) in length
+  - Metadata keys must contain only alphanumeric, `-`, and `_` characters.
+  - Metadata keys must not begin with the `consul-` prefix; that is reserved for internal use by Consul.
+  - Metadata values must be between 0 and 512 (inclusive) characters in length.
+
 * <a name="_pid_file"></a><a href="#_pid_file">`-pid-file`</a> - This flag provides the file
   path for the agent to store its PID. This is useful for sending signals (for example, `SIGINT`
   to close the agent or `SIGHUP` to update check definite
@@ -657,6 +666,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="node_name"></a><a href="#node_name">`node_name`</a> Equivalent to the
   [`-node` command-line flag](#_node).
+
+* <a name="node_meta"></a><a href="#node_meta">`node_meta`</a> This object allows associating arbitrary
+  metadata key/value pairs with the local node, which can then be used for filtering results from certain
+  catalog endpoints. See the [`-node-meta` command-line flag](#_node_meta) for more information.
 
 * <a name="performance"></a><a href="#performance">`performance`</a> Available in Consul 0.7 and
   later, this is a nested object that allows tuning the performance of different subsystems in

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -251,9 +251,9 @@ will exit with an error at startup.
 * <a name="_node"></a><a href="#_node">`-node`</a> - The name of this node in the cluster.
   This must be unique within the cluster. By default this is the hostname of the machine.
 
-* <a name="_node_meta"></a><a href="#_node_meta">`-node-meta`</a> - An arbitrary metadata key/value pair
-  to associate with the node, of the form `key:value`. This can be specified multiple times. Node metadata
-  pairs have the following restrictions:
+* <a name="_node_meta"></a><a href="#_node_meta">`-node-meta`</a> - Available in Consul 0.7.3 and later,
+  this specifies an arbitrary metadata key/value pair to associate with the node, of the form `key:value`.
+  This can be specified multiple times. Node metadata pairs have the following restrictions:
   - A maximum of 64 key/value pairs can be registered per node.
   - Metadata keys must be between 1 and 128 characters (inclusive) in length
   - Metadata keys must contain only alphanumeric, `-`, and `_` characters.
@@ -667,9 +667,18 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 * <a name="node_name"></a><a href="#node_name">`node_name`</a> Equivalent to the
   [`-node` command-line flag](#_node).
 
-* <a name="node_meta"></a><a href="#node_meta">`node_meta`</a> This object allows associating arbitrary
-  metadata key/value pairs with the local node, which can then be used for filtering results from certain
-  catalog endpoints. See the [`-node-meta` command-line flag](#_node_meta) for more information.
+* <a name="node_meta"></a><a href="#node_meta">`node_meta`</a> Available in Consul 0.7.3 and later,
+  This object allows associating arbitrary metadata key/value pairs with the local node, which can
+  then be used for filtering results from certain catalog endpoints. See the
+  [`-node-meta` command-line flag](#_node_meta) for more information.
+
+    ```javascript
+      {
+        "node_meta": {
+            "instance_type": "t2.medium"
+        }
+      }
+    ```
 
 * <a name="performance"></a><a href="#performance">`performance`</a> Available in Consul 0.7 and
   later, this is a nested object that allows tuning the performance of different subsystems in


### PR DESCRIPTION
Still missing documentation, but this covers the initial stuff with filtering on /catalog/nodes and /catalog/services.

Closes #154.