### PR TITLE
Add support for multiple address binds to dns and http servers

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -467,6 +467,23 @@ func parseSingleIPTemplate(ipTmpl string) (string, error) {
 	}
 }
 
+// parseMultipleIPTemplate is used as a helper function to parse out multiple IP
+// address from a config parameter where multiple addresses can be used (HTTP, DNS)
+func parseMultipleIPTemplate(ipTmpl string) (string, error) {
+	out, err := template.Parse(ipTmpl)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse address template %q: %v", ipTmpl, err)
+	}
+
+	ips := strings.Split(out, " ")
+	switch len(ips) {
+	case 0:
+		return "", errors.New("No addresses found, please configure one.")
+	default:
+		return out, nil
+	}
+}
+
 // resolveTmplAddrs iterates over the myriad of addresses in the agent's config
 // and performs go-sockaddr/template Parse on each known address in case the
 // user specified a template config for any of their values.
@@ -480,7 +497,7 @@ func (a *Agent) resolveTmplAddrs() error {
 	}
 
 	if a.config.Addresses.DNS != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.DNS)
+		ipStr, err := parseMultipleIPTemplate(a.config.Addresses.DNS)
 		if err != nil {
 			return fmt.Errorf("DNS address resolution failed: %v", err)
 		}
@@ -488,7 +505,7 @@ func (a *Agent) resolveTmplAddrs() error {
 	}
 
 	if a.config.Addresses.HTTP != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.HTTP)
+		ipStr, err := parseMultipleIPTemplate(a.config.Addresses.HTTP)
 		if err != nil {
 			return fmt.Errorf("HTTP address resolution failed: %v", err)
 		}
@@ -496,7 +513,7 @@ func (a *Agent) resolveTmplAddrs() error {
 	}
 
 	if a.config.Addresses.HTTPS != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.HTTPS)
+		ipStr, err := parseMultipleIPTemplate(a.config.Addresses.HTTPS)
 		if err != nil {
 			return fmt.Errorf("HTTPS address resolution failed: %v", err)
 		}

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -343,6 +343,7 @@ func TestAgent_Reload(t *testing.T) {
 	args := []string{
 		"-server",
 		"-data-dir", tmpDir,
+		"-bind", "127.0.0.1",
 		"-http-port", fmt.Sprintf("%d", conf.Ports.HTTP),
 		"-config-file", tmpFile.Name(),
 	}

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -498,14 +498,20 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   will attempt to clear the file and create the domain socket in its place. The
   permissions of the socket file are tunable via the [`unix_sockets` config construct](#unix_sockets).
   <br><br>
+  For both the 'http' and 'dns' service, there is support for multiple IP addresses and unix sockets
+  if you want the http interface bound to more than a single, or all (0.0.0.0), interfaces.
+  The format is unique addresses separated by a space. e.g. "127.0.0.1 192.168.0.100". One can also
+  use the template language to list interfaces. See github.com/hashicorp/go-sockaddr/template for
+  details.
+  <br><br>
   When running Consul agent commands against Unix socket interfaces, use the
   `-rpc-addr` or `-http-addr` arguments to specify the path to the socket. You
   can also place the desired values in `CONSUL_RPC_ADDR` and `CONSUL_HTTP_ADDR`
   environment variables.
   <br><br>
-  For TCP addresses, the variable values should be an IP address with the port. For
-  example: `10.0.0.1:8500` and not `10.0.0.1`. However, ports are set separately in the
-  <a href="#ports">`ports`</a> structure when defining them in a configuration file.
+  For TCP addresses, the variable values should be an IP address without a port. For
+  Ports are set separately in the <a href="#ports">`ports`</a> structure when defining
+  them in a configuration file.
   <br><br>
   The following keys are valid:
   * `dns` - The DNS server. Defaults to `client_addr`


### PR DESCRIPTION
First pass at implementing DNS/HTTP servers that allow multiple binds. This works on every manual test, and I put in some tests for the HTTP and DNS listeners. On my mac, the test harness was doing weird things with the dns bind, and I couldn't figure out if it was something on my mac and it's vpn/firewall stuff, or something else. All tests pass in travis-ci though, so I'm hoping it's just my dev environment. This would possibly resolve, or at least help, both #2217 and #473.