### PR TITLE
Add node metadata filtering to remaining endpoints

### DIFF
--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -222,6 +222,36 @@ func TestCatalog_Service(t *testing.T) {
 	})
 }
 
+func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
+	meta := map[string]string{"somekey": "somevalue"}
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeMeta = meta
+	})
+	defer s.Stop()
+
+	catalog := c.Catalog()
+
+	testutil.WaitForResult(func() (bool, error) {
+		services, meta, err := catalog.Service("consul", "", &QueryOptions{NodeMeta: meta})
+		if err != nil {
+			return false, err
+		}
+
+		if meta.LastIndex == 0 {
+			return false, fmt.Errorf("Bad: %v", meta)
+		}
+
+		if len(services) == 0 {
+			return false, fmt.Errorf("Bad: %v", services)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+}
+
 func TestCatalog_Node(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)

--- a/command/agent/catalog_endpoint.go
+++ b/command/agent/catalog_endpoint.go
@@ -103,6 +103,7 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	// Set default DC
 	args := structs.ServiceSpecificRequest{}
 	s.parseSource(req, &args.Source)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}

--- a/command/agent/health_endpoint.go
+++ b/command/agent/health_endpoint.go
@@ -11,6 +11,7 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	// Set default DC
 	args := structs.ChecksInStateRequest{}
 	s.parseSource(req, &args.Source)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
@@ -70,6 +71,7 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 	// Set default DC
 	args := structs.ServiceSpecificRequest{}
 	s.parseSource(req, &args.Source)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
@@ -100,6 +102,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	// Set default DC
 	args := structs.ServiceSpecificRequest{}
 	s.parseSource(req, &args.Source)
+	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}

--- a/command/agent/health_endpoint_test.go
+++ b/command/agent/health_endpoint_test.go
@@ -65,6 +65,49 @@ func TestHealthChecksInState(t *testing.T) {
 	})
 }
 
+func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
+	httpTest(t, func(srv *HTTPServer) {
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "bar",
+			Address:    "127.0.0.1",
+			NodeMeta:   map[string]string{"somekey": "somevalue"},
+			Check: &structs.HealthCheck{
+				Node:   "bar",
+				Name:   "node check",
+				Status: structs.HealthCritical,
+			},
+		}
+		var out struct{}
+		if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		req, err := http.NewRequest("GET", "/v1/health/state/critical?node-meta=somekey:somevalue", nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		testutil.WaitForResult(func() (bool, error) {
+			resp := httptest.NewRecorder()
+			obj, err := srv.HealthChecksInState(resp, req)
+			if err != nil {
+				return false, err
+			}
+			if err := checkIndex(resp); err != nil {
+				return false, err
+			}
+
+			// Should be 1 health check for the server
+			nodes := obj.(structs.HealthChecks)
+			if len(nodes) != 1 {
+				return false, fmt.Errorf("bad: %v", obj)
+			}
+			return true, nil
+		}, func(err error) { t.Fatalf("err: %v", err) })
+	})
+}
+
 func TestHealthChecksInState_DistanceSort(t *testing.T) {
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
@@ -258,6 +301,69 @@ func TestHealthServiceChecks(t *testing.T) {
 	}
 }
 
+func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
+	dir, srv := makeHTTPServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
+	req, err := http.NewRequest("GET", "/v1/health/checks/consul?dc=dc1&node-meta=somekey:somevalue", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := httptest.NewRecorder()
+	obj, err := srv.HealthServiceChecks(resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assertIndex(t, resp)
+
+	// Should be a non-nil empty list
+	nodes := obj.(structs.HealthChecks)
+	if nodes == nil || len(nodes) != 0 {
+		t.Fatalf("bad: %v", obj)
+	}
+
+	// Create a service check
+	args := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       srv.agent.config.NodeName,
+		Address:    "127.0.0.1",
+		NodeMeta:   map[string]string{"somekey": "somevalue"},
+		Check: &structs.HealthCheck{
+			Node:      srv.agent.config.NodeName,
+			Name:      "consul check",
+			ServiceID: "consul",
+		},
+	}
+
+	var out struct{}
+	if err = srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req, err = http.NewRequest("GET", "/v1/health/checks/consul?dc=dc1&node-meta=somekey:somevalue", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp = httptest.NewRecorder()
+	obj, err = srv.HealthServiceChecks(resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assertIndex(t, resp)
+
+	// Should be 1 health check for consul
+	nodes = obj.(structs.HealthChecks)
+	if len(nodes) != 1 {
+		t.Fatalf("bad: %v", obj)
+	}
+}
+
 func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
@@ -410,6 +516,69 @@ func TestHealthServiceNodes(t *testing.T) {
 	}
 
 	req, err = http.NewRequest("GET", "/v1/health/service/test?dc=dc1", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp = httptest.NewRecorder()
+	obj, err = srv.HealthServiceNodes(resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	assertIndex(t, resp)
+
+	// Should be a non-nil empty list for checks
+	nodes = obj.(structs.CheckServiceNodes)
+	if len(nodes) != 1 || nodes[0].Checks == nil || len(nodes[0].Checks) != 0 {
+		t.Fatalf("bad: %v", obj)
+	}
+}
+
+func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
+	dir, srv := makeHTTPServer(t)
+	defer os.RemoveAll(dir)
+	defer srv.Shutdown()
+	defer srv.agent.Shutdown()
+
+	testutil.WaitForLeader(t, srv.agent.RPC, "dc1")
+
+	req, err := http.NewRequest("GET", "/v1/health/service/consul?dc=dc1&node-meta=somekey:somevalue", nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	resp := httptest.NewRecorder()
+	obj, err := srv.HealthServiceNodes(resp, req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	assertIndex(t, resp)
+
+	// Should be a non-nil empty list
+	nodes := obj.(structs.CheckServiceNodes)
+	if nodes == nil || len(nodes) != 0 {
+		t.Fatalf("bad: %v", obj)
+	}
+
+	args := &structs.RegisterRequest{
+		Datacenter: "dc1",
+		Node:       "bar",
+		Address:    "127.0.0.1",
+		NodeMeta:   map[string]string{"somekey": "somevalue"},
+		Service: &structs.NodeService{
+			ID:      "test",
+			Service: "test",
+		},
+	}
+
+	var out struct{}
+	if err := srv.agent.RPC("Catalog.Register", args, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	req, err = http.NewRequest("GET", "/v1/health/service/test?dc=dc1&node-meta=somekey:somevalue", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -243,6 +243,15 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 				return err
 			}
 			reply.Index, reply.ServiceNodes = index, services
+			if len(args.NodeMetaFilters) > 0 {
+				var filtered structs.ServiceNodes
+				for _, service := range services {
+					if structs.SatisfiesMetaFilters(service.NodeMeta, args.NodeMetaFilters) {
+						filtered = append(filtered, service)
+					}
+				}
+				reply.ServiceNodes = filtered
+			}
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}

--- a/consul/state/catalog_test.go
+++ b/consul/state/catalog_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/types"
 )
 
 func TestStateStore_EnsureRegistration(t *testing.T) {
@@ -1546,6 +1547,63 @@ func TestStateStore_ServiceChecks(t *testing.T) {
 	}
 }
 
+func TestStateStore_ServiceChecksByNodeMeta(t *testing.T) {
+	s := testStateStore(t)
+
+	// Create the first node and service with some checks
+	testRegisterNodeWithMeta(t, s, 0, "node1", map[string]string{"somekey": "somevalue", "common": "1"})
+	testRegisterService(t, s, 1, "node1", "service1")
+	testRegisterCheck(t, s, 2, "node1", "service1", "check1", structs.HealthPassing)
+	testRegisterCheck(t, s, 3, "node1", "service1", "check2", structs.HealthPassing)
+
+	// Create a second node/service with a different set of checks
+	testRegisterNodeWithMeta(t, s, 4, "node2", map[string]string{"common": "1"})
+	testRegisterService(t, s, 5, "node2", "service1")
+	testRegisterCheck(t, s, 6, "node2", "service1", "check3", structs.HealthPassing)
+
+	cases := []struct {
+		filters map[string]string
+		checks  []string
+	}{
+		// Basic meta filter
+		{
+			filters: map[string]string{"somekey": "somevalue"},
+			checks:  []string{"check1", "check2"},
+		},
+		// Common meta field
+		{
+			filters: map[string]string{"common": "1"},
+			checks:  []string{"check1", "check2", "check3"},
+		},
+		// Invalid meta filter
+		{
+			filters: map[string]string{"invalid": "nope"},
+			checks:  []string{},
+		},
+		// Multiple filters
+		{
+			filters: map[string]string{"somekey": "somevalue", "common": "1"},
+			checks:  []string{"check1", "check2"},
+		},
+	}
+
+	// Try querying for all checks associated with service1
+	for _, tc := range cases {
+		_, checks, err := s.ServiceChecksByNodeMeta("service1", tc.filters)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if len(checks) != len(tc.checks) {
+			t.Fatalf("bad checks: %#v", checks)
+		}
+		for i, check := range checks {
+			if check.CheckID != types.CheckID(tc.checks[i]) {
+				t.Fatalf("bad checks: %#v", checks)
+			}
+		}
+	}
+}
+
 func TestStateStore_ChecksInState(t *testing.T) {
 	s := testStateStore(t)
 
@@ -1582,6 +1640,88 @@ func TestStateStore_ChecksInState(t *testing.T) {
 	}
 	if n := len(checks); n != 3 {
 		t.Fatalf("expected 3 checks, got: %d", n)
+	}
+}
+
+func TestStateStore_ChecksInStateByNodeMeta(t *testing.T) {
+	s := testStateStore(t)
+
+	// Querying with no results returns nil
+	idx, res, err := s.ChecksInStateByNodeMeta(structs.HealthPassing, nil)
+	if idx != 0 || res != nil || err != nil {
+		t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, res, err)
+	}
+
+	// Register a node with checks in varied states
+	testRegisterNodeWithMeta(t, s, 0, "node1", map[string]string{"somekey": "somevalue", "common": "1"})
+	testRegisterCheck(t, s, 1, "node1", "", "check1", structs.HealthPassing)
+	testRegisterCheck(t, s, 2, "node1", "", "check2", structs.HealthCritical)
+
+	testRegisterNodeWithMeta(t, s, 3, "node2", map[string]string{"common": "1"})
+	testRegisterCheck(t, s, 4, "node2", "", "check3", structs.HealthPassing)
+
+	cases := []struct {
+		filters map[string]string
+		state   string
+		checks  []string
+	}{
+		// Basic meta filter, any status
+		{
+			filters: map[string]string{"somekey": "somevalue"},
+			state:   structs.HealthAny,
+			checks:  []string{"check2", "check1"},
+		},
+		// Basic meta filter, only passing
+		{
+			filters: map[string]string{"somekey": "somevalue"},
+			state:   structs.HealthPassing,
+			checks:  []string{"check1"},
+		},
+		// Common meta filter, any status
+		{
+			filters: map[string]string{"common": "1"},
+			state:   structs.HealthAny,
+			checks:  []string{"check2", "check1", "check3"},
+		},
+		// Common meta filter, only passing
+		{
+			filters: map[string]string{"common": "1"},
+			state:   structs.HealthPassing,
+			checks:  []string{"check1", "check3"},
+		},
+		// Invalid meta filter
+		{
+			filters: map[string]string{"invalid": "nope"},
+			checks:  []string{},
+		},
+		// Multiple filters, any status
+		{
+			filters: map[string]string{"somekey": "somevalue", "common": "1"},
+			state:   structs.HealthAny,
+			checks:  []string{"check2", "check1"},
+		},
+		// Multiple filters, only passing
+		{
+			filters: map[string]string{"somekey": "somevalue", "common": "1"},
+			state:   structs.HealthPassing,
+			checks:  []string{"check1"},
+		},
+	}
+
+	// Try querying for all checks associated with service1
+	for _, tc := range cases {
+		_, checks, err := s.ChecksInStateByNodeMeta(tc.state, tc.filters)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if len(checks) != len(tc.checks) {
+			t.Fatalf("bad checks: %#v", checks)
+		}
+		for i, check := range checks {
+			if check.CheckID != types.CheckID(tc.checks[i]) {
+				t.Fatalf("bad checks: %#v, %v", checks, tc.checks)
+			}
+		}
 	}
 }
 

--- a/consul/state/state_store.go
+++ b/consul/state/state_store.go
@@ -222,6 +222,8 @@ func (s *StateStore) getWatchTables(method string) []string {
 		return []string{"nodes", "services"}
 	case "NodeCheck", "NodeChecks", "ServiceChecks", "ChecksInState":
 		return []string{"checks"}
+	case "ChecksInStateByNodeMeta", "ServiceChecksByNodeMeta":
+		return []string{"nodes", "checks"}
 	case "CheckServiceNodes", "NodeInfo", "NodeDump":
 		return []string{"nodes", "services", "checks"}
 	case "SessionGet", "SessionList", "NodeSessions":

--- a/consul/state/state_store_test.go
+++ b/consul/state/state_store_test.go
@@ -35,7 +35,11 @@ func testStateStore(t *testing.T) *StateStore {
 }
 
 func testRegisterNode(t *testing.T, s *StateStore, idx uint64, nodeID string) {
-	node := &structs.Node{Node: nodeID}
+	testRegisterNodeWithMeta(t, s, idx, nodeID, nil)
+}
+
+func testRegisterNodeWithMeta(t *testing.T, s *StateStore, idx uint64, nodeID string, meta map[string]string) {
+	node := &structs.Node{Node: nodeID, Meta: meta}
 	if err := s.EnsureNode(idx, node); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -241,11 +241,12 @@ func (r *DCSpecificRequest) RequestDatacenter() string {
 
 // ServiceSpecificRequest is used to query about a specific service
 type ServiceSpecificRequest struct {
-	Datacenter  string
-	ServiceName string
-	ServiceTag  string
-	TagFilter   bool // Controls tag filtering
-	Source      QuerySource
+	Datacenter      string
+	NodeMetaFilters map[string]string
+	ServiceName     string
+	ServiceTag      string
+	TagFilter       bool // Controls tag filtering
+	Source          QuerySource
 	QueryOptions
 }
 
@@ -266,9 +267,10 @@ func (r *NodeSpecificRequest) RequestDatacenter() string {
 
 // ChecksInStateRequest is used to query for nodes in a state
 type ChecksInStateRequest struct {
-	Datacenter string
-	State      string
-	Source     QuerySource
+	Datacenter      string
+	NodeMetaFilters map[string]string
+	State           string
+	Source          QuerySource
 	QueryOptions
 }
 
@@ -286,6 +288,15 @@ type Node struct {
 	RaftIndex
 }
 type Nodes []*Node
+
+func SatisfiesMetaFilters(meta map[string]string, filters map[string]string) bool {
+	for key, value := range filters {
+		if v, ok := meta[key]; !ok || v != value {
+			return false
+		}
+	}
+	return true
+}
 
 // Used to return information about a provided services.
 // Maps service name to available tags

--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -200,7 +200,8 @@ node for the sort.
 
 In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
 provided with a desired node metadata key/value pair of the form `key:value`.
-This will filter the results to nodes with that pair present.
+This parameter can be specified multiple times, and will filter the results to
+nodes with the specified key/value pair(s).
 
 It returns a JSON body like this:
 
@@ -241,7 +242,8 @@ however, the `dc` can be provided using the `?dc=` query parameter.
 
 In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
 provided with a desired node metadata key/value pair of the form `key:value`.
-This will filter the results to services with that pair present.
+This parameter can be specified multiple times, and will filter the results to
+services on nodes with the specified key/value pair(s).
 
 It returns a JSON body like this:
 

--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -276,6 +276,11 @@ the node list in ascending order based on the estimated round trip
 time from that node. Passing `?near=_agent` will use the agent's
 node for the sort.
 
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This parameter can be specified multiple times, and will filter the results to
+service entries on nodes with the specified key/value pair(s).
+
 It returns a JSON body like this:
 
 ```javascript

--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -75,6 +75,11 @@ the node list in ascending order based on the estimated round trip
 time from that node. Passing `?near=_agent` will use the agent's
 node for the sort.
 
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This parameter can be specified multiple times, and will filter the results to
+health checks on nodes with the specified key/value pair(s).
+
 It returns a JSON body like this:
 
 ```javascript
@@ -111,6 +116,11 @@ by tag using the "?tag=" query parameter.
 Providing the `?passing` query parameter, added in Consul 0.2, will
 filter results to only nodes with all checks in the `passing` state.
 This can be used to avoid extra filtering logic on the client side.
+
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This parameter can be specified multiple times, and will filter the results to
+nodes with the specified key/value pair(s).
 
 This endpoint is very similar to the `/v1/catalog/service` endpoint; however, this
 endpoint automatically returns the status of the associated health check
@@ -181,6 +191,11 @@ Adding the optional `?near=` parameter with a node name will sort
 the node list in ascending order based on the estimated round trip
 time from that node. Passing `?near=_agent` will use the agent's
 node for the sort.
+
+In Consul 0.7.3 and later, the optional `?node-meta=` parameter can be
+provided with a desired node metadata key/value pair of the form `key:value`.
+This parameter can be specified multiple times, and will filter the results to
+health checks on nodes with the specified key/value pair(s).
 
 The supported states are `any`, `passing`, `warning`, or `critical`.
 The `any` state is a wildcard that can be used to return all checks.


### PR DESCRIPTION
This adds support for filtering by node metadata values to the following endpoints:
```
/v1/catalog/service/<service>
/v1/health/state/<state>
/v1/health/checks/<service>
/v1/health/service/<service>
```

It also updates /v1/catalog/nodes and /v1/catalog/services to support multiple metadata filters.