### PR TITLE
Support Host header in HTTP health checks

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -75,6 +75,7 @@ type AgentServiceCheck struct {
 	TCP               string `json:",omitempty"`
 	Status            string `json:",omitempty"`
 	Notes             string `json:",omitempty"`
+	HostHeader        string `json:",omitempty"`
 	TLSSkipVerify     bool   `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1175,6 +1175,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist
 				Interval:      chkType.Interval,
 				Timeout:       chkType.Timeout,
 				Logger:        a.logger,
+				HostHeader:    chkType.HostHeader,
 				TLSSkipVerify: chkType.TLSSkipVerify,
 			}
 			http.Start()

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -48,6 +48,7 @@ type CheckType struct {
 	Interval          time.Duration
 	DockerContainerID string
 	Shell             string
+	HostHeader        string
 	TLSSkipVerify     bool
 
 	Timeout time.Duration
@@ -341,6 +342,7 @@ type CheckHTTP struct {
 	Interval      time.Duration
 	Timeout       time.Duration
 	Logger        *log.Logger
+	HostHeader    string
 	TLSSkipVerify bool
 
 	httpClient *http.Client
@@ -429,6 +431,9 @@ func (c *CheckHTTP) check() {
 
 	req.Header.Set("User-Agent", HttpUserAgent)
 	req.Header.Set("Accept", "text/plain, text/*, */*")
+	if c.HostHeader != "" {
+		req.Host = c.HostHeader
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1159,6 +1159,9 @@ func FixupCheckType(raw interface{}) error {
 		case "docker_container_id":
 			rawMap["DockerContainerID"] = v
 			delete(rawMap, k)
+		case "host_header":
+			rawMap["HostHeader"] = v
+			delete(rawMap, k)
 		case "tls_skip_verify":
 			rawMap["TLSSkipVerify"] = v
 			delete(rawMap, k)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1136,6 +1136,7 @@ func TestDecodeConfig_Services(t *testing.T) {
 				"port": 9200,
 				"check": {
 					"HTTP": "http://localhost:9200/_cluster_health",
+					"host_header": "test.example",
 					"interval": "10s",
 					"timeout": "100ms"
 				}
@@ -1189,9 +1190,10 @@ func TestDecodeConfig_Services(t *testing.T) {
 			},
 			&ServiceDefinition{
 				Check: CheckType{
-					HTTP:     "http://localhost:9200/_cluster_health",
-					Interval: 10 * time.Second,
-					Timeout:  100 * time.Millisecond,
+					HTTP:       "http://localhost:9200/_cluster_health",
+					HostHeader: "test.example",
+					Interval:   10 * time.Second,
+					Timeout:    100 * time.Millisecond,
 				},
 				ID:   "es0",
 				Name: "elasticsearch",
@@ -1287,6 +1289,14 @@ func TestDecodeConfig_Checks(t *testing.T) {
 				"timeout": "100ms",
 				"service_id": "insecure-sslservice",
 				"tls_skip_verify": true
+			},
+			{
+				"id": "chk7",
+				"name": "service:behind-reverseproxy",
+				"HTTP": "http://localhost/status",
+				"host_header": "proxy.example",
+				"interval": "10s",
+				"service_id": "behind-reverseproxy"
 			}
 		]
 	}`
@@ -1353,6 +1363,16 @@ func TestDecodeConfig_Checks(t *testing.T) {
 					Interval:      10 * time.Second,
 					Timeout:       100 * time.Millisecond,
 					TLSSkipVerify: true,
+				},
+			},
+			&CheckDefinition{
+				ID:        "chk7",
+				Name:      "service:behind-reverseproxy",
+				ServiceID: "behind-reverseproxy",
+				CheckType: CheckType{
+					HTTP:          "http://localhost/status",
+					HostHeader:    "proxy.example",
+					Interval:      10 * time.Second,
 				},
 			},
 		},

--- a/website/source/docs/agent/checks.html.markdown
+++ b/website/source/docs/agent/checks.html.markdown
@@ -37,7 +37,8 @@ There are five different kinds of checks:
   limited to roughly 4K. Responses larger than this will be truncated. HTTP checks
   also support SSL. By default, a valid SSL certificate is expected. Certificate
   verification can be turned off by setting the `tls_skip_verify` field to `true`
-  in the check definition.
+  in the check definition. HTTP `Host` header can be set using the `HostHeader` field
+  for checks that are perfomed through a reverse proxy.
 
 * TCP + Interval - These checks make an TCP connection attempt every Interval
   (e.g. every 30 seconds) to the specified IP/hostname and port. If no hostname

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -297,6 +297,7 @@ body must look like:
   "TCP": "example.com:22",
   "Interval": "10s",
   "TTL": "15s",
+  "HostHeader": "test.example",
   "TLSSkipVerify": true
 }
 ```
@@ -336,6 +337,10 @@ expected. Certificate verification can be controlled using the
 
 If `TLSSkipVerify` is set to `true`, certificate verification will be
 disabled. By default, certificate verification is enabled.
+
+`HostHeader` can be used to perform checks through reverse proxy so that
+Consul will check the end-user interface (avoid to consider the service as healthy
+if the reverse proxy has an issue).
 
 A `TCP` check will perform an TCP connection attempt against the value of `TCP`
 (expected to be an IP or hostname plus port combination) every `Interval`. If the


### PR DESCRIPTION
This commit introduce support for passing Host HTTP Header in HTTP health
checks.
Such check pattern is very common (for ex. when using a reverse-proxy) and
you usually want to check the user facing port/API rather than the
internal service exposed to 127.0.0.1.

Fix #1184