### PR TITLE
Do not skip tests when Consul is missing

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -165,7 +165,8 @@ func NewTestServer(t TestingT) *TestServer {
 // an optional callback function to modify the configuration.
 func NewTestServerConfig(t TestingT, cb ServerConfigCallback) *TestServer {
 	if path, err := exec.LookPath("consul"); err != nil || path == "" {
-		t.Skip("consul not found on $PATH, skipping")
+		t.Fatal("consul not found on $PATH - download and install " + 
+				"consul or skip this test")
 	}
 
 	dataDir, err := ioutil.TempDir("", "consul")


### PR DESCRIPTION
This bit me on CI. The current behavior of the testutil server is to skip if consul isn't present. When lots of output is scrolling by, you're likely to miss the message that the test was skipped. Instead, I propose that we hard fatal if consul doesn't exist, and upstream consumers can skip the tests if they want.