### PR TITLE
Adds basic support for node IDs.

### DIFF
--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -657,7 +657,7 @@ func TestAgent_Monitor(t *testing.T) {
 	// Wait for the first log message and validate it
 	select {
 	case log := <-logCh:
-		if !strings.Contains(log, "[INFO] raft: Initial configuration") {
+		if !strings.Contains(log, "[INFO]") {
 			t.Fatalf("bad: %q", log)
 		}
 	case <-time.After(10 * time.Second):

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -1,6 +1,7 @@
 package api
 
 type Node struct {
+	ID              string
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
@@ -8,6 +9,7 @@ type Node struct {
 }
 
 type CatalogService struct {
+	ID                       string
 	Node                     string
 	Address                  string
 	TaggedAddresses          map[string]string
@@ -28,6 +30,7 @@ type CatalogNode struct {
 }
 
 type CatalogRegistration struct {
+	ID              string
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
@@ -39,7 +42,7 @@ type CatalogRegistration struct {
 
 type CatalogDeregistration struct {
 	Node       string
-	Address    string
+	Address    string // Obsolete.
 	Datacenter string
 	ServiceID  string
 	CheckID    string

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/types"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/raft"
 	"strings"
 )
@@ -306,6 +308,62 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 			t.Fatalf("bad: %s", wan.String())
 		}
 	}()
+}
+
+func TestAgent_NodeID(t *testing.T) {
+	c := nextConfig()
+	dir, agent := makeAgent(t, c)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	// The auto-assigned ID should be valid.
+	id := agent.consulConfig().NodeID
+	if _, err := uuid.ParseUUID(string(id)); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Set an invalid ID via config.
+	c.NodeID = types.NodeID("nope")
+	err := agent.setupNodeID(c)
+	if err == nil || !strings.Contains(err.Error(), "uuid string is wrong length") {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Set a valid ID via config.
+	newID, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c.NodeID = types.NodeID(newID)
+	if err := agent.setupNodeID(c); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if id := agent.consulConfig().NodeID; string(id) != newID {
+		t.Fatalf("bad: %q vs. %q", id, newID)
+	}
+
+	// Set an invalid ID via the file.
+	fileID := filepath.Join(c.DataDir, "node-id")
+	if err := ioutil.WriteFile(fileID, []byte("adf4238a!882b!9ddc!4a9d!5b6758e4159e"), 0600); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c.NodeID = ""
+	err = agent.setupNodeID(c)
+	if err == nil || !strings.Contains(err.Error(), "uuid is improperly formatted") {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Set a valid ID via the file.
+	if err := ioutil.WriteFile(fileID, []byte("adf4238a-882b-9ddc-4a9d-5b6758e4159e"), 0600); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	c.NodeID = ""
+	if err := agent.setupNodeID(c); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if id := agent.consulConfig().NodeID; string(id) != "adf4238a-882b-9ddc-4a9d-5b6758e4159e" {
+		t.Fatalf("bad: %q vs. %q", id, newID)
+	}
 }
 
 func TestAgent_AddService(t *testing.T) {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -322,6 +322,15 @@ func TestAgent_NodeID(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	// Running again should get the same ID (persisted in the file).
+	c.NodeID = ""
+	if err := agent.setupNodeID(c); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if newID := agent.consulConfig().NodeID; id != newID {
+		t.Fatalf("bad: %q vs %q", id, newID)
+	}
+
 	// Set an invalid ID via config.
 	c.NodeID = types.NodeID("nope")
 	err := agent.setupNodeID(c)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -92,6 +92,7 @@ func (c *Command) readConfig() *Config {
 
 	cmdFlags.StringVar(&cmdConfig.LogLevel, "log-level", "", "log level")
 	cmdFlags.StringVar(&cmdConfig.NodeName, "node", "", "node name")
+	cmdFlags.StringVar((*string)(&cmdConfig.NodeID), "node-id", "", "node ID")
 	cmdFlags.StringVar(&dcDeprecated, "dc", "", "node datacenter (deprecated: use 'datacenter' instead)")
 	cmdFlags.StringVar(&cmdConfig.Datacenter, "datacenter", "", "node datacenter")
 	cmdFlags.StringVar(&cmdConfig.DataDir, "data-dir", "", "path to the data directory")
@@ -1115,6 +1116,7 @@ func (c *Command) Run(args []string) int {
 
 	c.Ui.Output("Consul agent running!")
 	c.Ui.Info(fmt.Sprintf("       Version: '%s'", c.HumanVersion))
+	c.Ui.Info(fmt.Sprintf("       Node ID: '%s'", config.NodeID))
 	c.Ui.Info(fmt.Sprintf("     Node name: '%s'", config.NodeName))
 	c.Ui.Info(fmt.Sprintf("    Datacenter: '%s'", config.Datacenter))
 	c.Ui.Info(fmt.Sprintf("        Server: %v (bootstrap: %v)", config.Server, config.Bootstrap))

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/watch"
 	"github.com/mitchellh/mapstructure"
 )
@@ -311,6 +312,10 @@ type Config struct {
 
 	// LogLevel is the level of the logs to putout
 	LogLevel string `mapstructure:"log_level"`
+
+	// Node ID is a unique ID for this node across space and time. Defaults
+	// to a randomly-generated ID that persists in the data-dir.
+	NodeID types.NodeID `mapstructure:"node_id"`
 
 	// Node name is the name we use to advertise. Defaults to hostname.
 	NodeName string `mapstructure:"node_name"`
@@ -1272,6 +1277,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.Protocol > 0 {
 		result.Protocol = b.Protocol
+	}
+	if b.NodeID != "" {
+		result.NodeID = b.NodeID
 	}
 	if b.NodeName != "" {
 		result.NodeName = b.NodeName

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -60,13 +60,17 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// Without a protocol
-	input = `{"node_name": "foo", "datacenter": "dc2"}`
+	input = `{"node_id": "bar", "node_name": "foo", "datacenter": "dc2"}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	if config.NodeName != "foo" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	if config.NodeID != "bar" {
 		t.Fatalf("bad: %#v", config)
 	}
 
@@ -1532,6 +1536,7 @@ func TestMergeConfig(t *testing.T) {
 		DataDir:                "/tmp/foo",
 		Domain:                 "basic",
 		LogLevel:               "debug",
+		NodeID:                 "bar",
 		NodeName:               "foo",
 		ClientAddr:             "127.0.0.1",
 		BindAddr:               "127.0.0.1",
@@ -1586,6 +1591,7 @@ func TestMergeConfig(t *testing.T) {
 		},
 		Domain:           "other",
 		LogLevel:         "info",
+		NodeID:           "bar",
 		NodeName:         "baz",
 		ClientAddr:       "127.0.0.2",
 		BindAddr:         "127.0.0.2",

--- a/command/agent/local.go
+++ b/command/agent/local.go
@@ -44,7 +44,7 @@ type localState struct {
 	iface consul.Interface
 
 	// nodeInfoInSync tracks whether the server has our correct top-level
-	// node information in sync (currently only used for tagged addresses)
+	// node information in sync
 	nodeInfoInSync bool
 
 	// Services tracks the local services
@@ -431,6 +431,7 @@ func (l *localState) setSyncState() error {
 
 	// Check the node info
 	if out1.NodeServices == nil || out1.NodeServices.Node == nil ||
+		out1.NodeServices.Node.ID != l.config.NodeID ||
 		!reflect.DeepEqual(out1.NodeServices.Node.TaggedAddresses, l.config.TaggedAddresses) ||
 		!reflect.DeepEqual(out1.NodeServices.Node.Meta, l.metadata) {
 		l.nodeInfoInSync = false
@@ -633,6 +634,7 @@ func (l *localState) deleteCheck(id types.CheckID) error {
 func (l *localState) syncService(id string) error {
 	req := structs.RegisterRequest{
 		Datacenter:      l.config.Datacenter,
+		ID:              l.config.NodeID,
 		Node:            l.config.NodeName,
 		Address:         l.config.AdvertiseAddr,
 		TaggedAddresses: l.config.TaggedAddresses,
@@ -695,6 +697,7 @@ func (l *localState) syncCheck(id types.CheckID) error {
 
 	req := structs.RegisterRequest{
 		Datacenter:      l.config.Datacenter,
+		ID:              l.config.NodeID,
 		Node:            l.config.NodeName,
 		Address:         l.config.AdvertiseAddr,
 		TaggedAddresses: l.config.TaggedAddresses,
@@ -722,6 +725,7 @@ func (l *localState) syncCheck(id types.CheckID) error {
 func (l *localState) syncNodeInfo() error {
 	req := structs.RegisterRequest{
 		Datacenter:      l.config.Datacenter,
+		ID:              l.config.NodeID,
 		Node:            l.config.NodeName,
 		Address:         l.config.AdvertiseAddr,
 		TaggedAddresses: l.config.TaggedAddresses,

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -121,10 +121,14 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 			return false, fmt.Errorf("err: %v", err)
 		}
 
-		// Make sure we sent along our tagged addresses when we synced.
+		// Make sure we sent along our node info when we synced.
+		id := services.NodeServices.Node.ID
 		addrs := services.NodeServices.Node.TaggedAddresses
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) {
-			return false, fmt.Errorf("bad: %v", addrs)
+		meta := services.NodeServices.Node.Meta
+		if id != conf.NodeID ||
+			!reflect.DeepEqual(addrs, conf.TaggedAddresses) ||
+			!reflect.DeepEqual(meta, conf.Meta) {
+			return false, fmt.Errorf("bad: %v", services.NodeServices.Node)
 		}
 
 		// We should have 6 services (consul included)
@@ -717,7 +721,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		}
 	}
 
-	// Make sure we sent along our tagged addresses when we synced.
+	// Make sure we sent along our node info addresses when we synced.
 	{
 		req := structs.NodeSpecificRequest{
 			Datacenter: "dc1",
@@ -728,9 +732,13 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
+		id := services.NodeServices.Node.ID
 		addrs := services.NodeServices.Node.TaggedAddresses
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) {
-			t.Fatalf("bad: %v", addrs)
+		meta := services.NodeServices.Node.Meta
+		if id != conf.NodeID ||
+			!reflect.DeepEqual(addrs, conf.TaggedAddresses) ||
+			!reflect.DeepEqual(meta, conf.Meta) {
+			t.Fatalf("bad: %v", services.NodeServices.Node)
 		}
 	}
 
@@ -985,6 +993,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 
 func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	conf := nextConfig()
+	conf.NodeID = types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5")
 	conf.Meta["somekey"] = "somevalue"
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -1020,12 +1029,14 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 
 		// Make sure we synced our node info - this should have ridden on the
 		// "consul" service sync
+		id := services.NodeServices.Node.ID
 		addrs := services.NodeServices.Node.TaggedAddresses
 		meta := services.NodeServices.Node.Meta
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) || !reflect.DeepEqual(meta, conf.Meta) {
-			return false, fmt.Errorf("bad: %v", addrs)
+		if id != conf.NodeID ||
+			!reflect.DeepEqual(addrs, conf.TaggedAddresses) ||
+			!reflect.DeepEqual(meta, conf.Meta) {
+			return false, fmt.Errorf("bad: %v", services.NodeServices.Node)
 		}
-
 		return true, nil
 	}, func(err error) {
 		t.Fatalf("err: %s", err)
@@ -1045,12 +1056,15 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
 			return false, fmt.Errorf("err: %v", err)
 		}
+
+		id := services.NodeServices.Node.ID
 		addrs := services.NodeServices.Node.TaggedAddresses
 		meta := services.NodeServices.Node.Meta
-		if len(addrs) == 0 || !reflect.DeepEqual(addrs, conf.TaggedAddresses) || !reflect.DeepEqual(meta, conf.Meta) {
-			return false, fmt.Errorf("bad: %v", addrs)
+		if id != conf.NodeID ||
+			!reflect.DeepEqual(addrs, conf.TaggedAddresses) ||
+			!reflect.DeepEqual(meta, conf.Meta) {
+			return false, fmt.Errorf("bad: %v", services.NodeServices.Node)
 		}
-
 		return true, nil
 	}, func(err error) {
 		t.Fatalf("err: %s", err)

--- a/consul/catalog_endpoint.go
+++ b/consul/catalog_endpoint.go
@@ -7,6 +7,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/types"
+	"github.com/hashicorp/go-uuid"
 )
 
 // Catalog endpoint is used to manipulate the service catalog
@@ -24,6 +25,11 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 	// Verify the args.
 	if args.Node == "" || args.Address == "" {
 		return fmt.Errorf("Must provide node and address")
+	}
+	if args.ID != "" {
+		if _, err := uuid.ParseUUID(string(args.ID)); err != nil {
+			return fmt.Errorf("Bad node ID: %v", err)
+		}
 	}
 
 	// Fetch the ACL token, if any.

--- a/consul/client.go
+++ b/consul/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/consul/agent"
 	"github.com/hashicorp/consul/consul/servers"
 	"github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
 )
@@ -144,6 +145,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.NodeName = c.config.NodeName
 	conf.Tags["role"] = "node"
 	conf.Tags["dc"] = c.config.Datacenter
+	conf.Tags["id"] = string(c.config.NodeID)
 	conf.Tags["vsn"] = fmt.Sprintf("%d", c.config.ProtocolVersion)
 	conf.Tags["vsn_min"] = fmt.Sprintf("%d", ProtocolVersionMin)
 	conf.Tags["vsn_max"] = fmt.Sprintf("%d", ProtocolVersionMax)
@@ -156,7 +158,7 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 	conf.RejoinAfterLeave = c.config.RejoinAfterLeave
 	conf.Merge = &lanMergeDelegate{dc: c.config.Datacenter}
 	conf.DisableCoordinates = c.config.DisableCoordinates
-	if err := ensurePath(conf.SnapshotPath, false); err != nil {
+	if err := lib.EnsurePath(conf.SnapshotPath, false); err != nil {
 		return nil, err
 	}
 	return serf.Create(conf)

--- a/consul/config.go
+++ b/consul/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
@@ -65,6 +66,9 @@ type Config struct {
 
 	// DevMode is used to enable a development server mode.
 	DevMode bool
+
+	// NodeID is a unique identifier for this node across space and time.
+	NodeID types.NodeID
 
 	// Node name is the name we use to advertise. Defaults to hostname.
 	NodeName string

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -418,6 +418,7 @@ AFTER_CHECK:
 	// Register with the catalog
 	req := structs.RegisterRequest{
 		Datacenter: s.config.Datacenter,
+		ID:         types.NodeID(member.Tags["id"]),
 		Node:       member.Name,
 		Address:    member.Addr.String(),
 		Service:    service,

--- a/consul/server.go
+++ b/consul/server.go
@@ -284,6 +284,10 @@ func NewServer(config *Config) (*Server, error) {
 	}
 	go s.wanEventHandler()
 
+	// Start monitoring leadership. This must happen after Serf is set up
+	// since it can fire events when leadership is obtained.
+	go s.monitorLeadership()
+
 	// Start ACL replication.
 	if s.IsACLReplicationEnabled() {
 		go s.runACLReplication()
@@ -491,9 +495,6 @@ func (s *Server) setupRaft() error {
 	if err != nil {
 		return err
 	}
-
-	// Start monitoring leadership.
-	go s.monitorLeadership()
 	return nil
 }
 

--- a/consul/server.go
+++ b/consul/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/consul/consul/agent"
 	"github.com/hashicorp/consul/consul/state"
 	"github.com/hashicorp/consul/consul/structs"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/raft-boltdb"
@@ -308,6 +309,7 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 	}
 	conf.Tags["role"] = "consul"
 	conf.Tags["dc"] = s.config.Datacenter
+	conf.Tags["id"] = string(s.config.NodeID)
 	conf.Tags["vsn"] = fmt.Sprintf("%d", s.config.ProtocolVersion)
 	conf.Tags["vsn_min"] = fmt.Sprintf("%d", ProtocolVersionMin)
 	conf.Tags["vsn_max"] = fmt.Sprintf("%d", ProtocolVersionMax)
@@ -337,7 +339,7 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 	// When enabled, the Serf gossip may just turn off if we are the minority
 	// node which is rather unexpected.
 	conf.EnableNameConflictResolution = false
-	if err := ensurePath(conf.SnapshotPath, false); err != nil {
+	if err := lib.EnsurePath(conf.SnapshotPath, false); err != nil {
 		return nil, err
 	}
 
@@ -390,7 +392,7 @@ func (s *Server) setupRaft() error {
 	} else {
 		// Create the base raft path.
 		path := filepath.Join(s.config.DataDir, raftState)
-		if err := ensurePath(path, true); err != nil {
+		if err := lib.EnsurePath(path, true); err != nil {
 			return err
 		}
 

--- a/consul/state/catalog_test.go
+++ b/consul/state/catalog_test.go
@@ -16,6 +16,7 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 
 	// Start with just a node.
 	req := &structs.RegisterRequest{
+		ID:      types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5"),
 		Node:    "node1",
 		Address: "1.2.3.4",
 		TaggedAddresses: map[string]string{
@@ -35,7 +36,8 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		if out.Node != "node1" || out.Address != "1.2.3.4" ||
+		if out.ID != types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5") ||
+			out.Node != "node1" || out.Address != "1.2.3.4" ||
 			len(out.TaggedAddresses) != 1 ||
 			out.TaggedAddresses["hello"] != "world" ||
 			out.Meta["somekey"] != "somevalue" ||

--- a/consul/structs/structs.go
+++ b/consul/structs/structs.go
@@ -170,6 +170,7 @@ type QueryMeta struct {
 // is provided, the node is registered.
 type RegisterRequest struct {
 	Datacenter      string
+	ID              types.NodeID
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
@@ -194,7 +195,8 @@ func (r *RegisterRequest) ChangesNode(node *Node) bool {
 	}
 
 	// Check if any of the node-level fields are being changed.
-	if r.Node != node.Node ||
+	if r.ID != node.ID ||
+		r.Node != node.Node ||
 		r.Address != node.Address ||
 		!reflect.DeepEqual(r.TaggedAddresses, node.TaggedAddresses) ||
 		!reflect.DeepEqual(r.NodeMeta, node.Meta) {
@@ -280,6 +282,7 @@ func (r *ChecksInStateRequest) RequestDatacenter() string {
 
 // Used to return information about a node
 type Node struct {
+	ID              types.NodeID
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string
@@ -302,12 +305,13 @@ func SatisfiesMetaFilters(meta map[string]string, filters map[string]string) boo
 // Maps service name to available tags
 type Services map[string][]string
 
-// ServiceNode represents a node that is part of a service. Address, TaggedAddresses,
-// and NodeMeta are node-related fields that are always empty in the state
-// store and are filled in on the way out by parseServiceNodes(). This is also
-// why PartialClone() skips them, because we know they are blank already so it
-// would be a waste of time to copy them.
+// ServiceNode represents a node that is part of a service. ID, Address,
+// TaggedAddresses, and NodeMeta are node-related fields that are always empty
+// in the state store and are filled in on the way out by parseServiceNodes().
+// This is also why PartialClone() skips them, because we know they are blank
+// already so it would be a waste of time to copy them.
 type ServiceNode struct {
+	ID                       types.NodeID
 	Node                     string
 	Address                  string
 	TaggedAddresses          map[string]string
@@ -329,6 +333,7 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 	copy(tags, s.ServiceTags)
 
 	return &ServiceNode{
+		// Skip ID, see above.
 		Node: s.Node,
 		// Skip Address, see above.
 		// Skip TaggedAddresses, see above.
@@ -395,6 +400,7 @@ func (s *NodeService) IsSame(other *NodeService) bool {
 // ToServiceNode converts the given node service to a service node.
 func (s *NodeService) ToServiceNode(node string) *ServiceNode {
 	return &ServiceNode{
+		// Skip ID, see ServiceNode definition.
 		Node: node,
 		// Skip Address, see ServiceNode definition.
 		// Skip TaggedAddresses, see ServiceNode definition.
@@ -501,6 +507,7 @@ OUTER:
 // a node. This is currently used for the UI only, as it is
 // rather expensive to generate.
 type NodeInfo struct {
+	ID              types.NodeID
 	Node            string
 	Address         string
 	TaggedAddresses map[string]string

--- a/consul/structs/structs_test.go
+++ b/consul/structs/structs_test.go
@@ -107,6 +107,7 @@ func TestStructs_ACL_IsSame(t *testing.T) {
 
 func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 	req := &RegisterRequest{
+		ID:              types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5"),
 		Node:            "test",
 		Address:         "127.0.0.1",
 		TaggedAddresses: make(map[string]string),
@@ -116,6 +117,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 	}
 
 	node := &Node{
+		ID:              types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5"),
 		Node:            "test",
 		Address:         "127.0.0.1",
 		TaggedAddresses: make(map[string]string),
@@ -140,6 +142,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 		}
 	}
 
+	check(func() { req.ID = "nope" }, func() { req.ID = types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5") })
 	check(func() { req.Node = "nope" }, func() { req.Node = "test" })
 	check(func() { req.Address = "127.0.0.2" }, func() { req.Address = "127.0.0.1" })
 	check(func() { req.TaggedAddresses["wan"] = "nope" }, func() { delete(req.TaggedAddresses, "wan") })
@@ -153,6 +156,7 @@ func TestStructs_RegisterRequest_ChangesNode(t *testing.T) {
 // testServiceNode gives a fully filled out ServiceNode instance.
 func testServiceNode() *ServiceNode {
 	return &ServiceNode{
+		ID:      types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5"),
 		Node:    "node1",
 		Address: "127.0.0.1",
 		TaggedAddresses: map[string]string{
@@ -182,10 +186,14 @@ func TestStructs_ServiceNode_PartialClone(t *testing.T) {
 	// Make sure the parts that weren't supposed to be cloned didn't get
 	// copied over, then zero-value them out so we can do a DeepEqual() on
 	// the rest of the contents.
-	if clone.Address != "" || len(clone.TaggedAddresses) != 0 || len(clone.NodeMeta) != 0 {
+	if clone.ID != "" ||
+		clone.Address != "" ||
+		len(clone.TaggedAddresses) != 0 ||
+		len(clone.NodeMeta) != 0 {
 		t.Fatalf("bad: %v", clone)
 	}
 
+	sn.ID = ""
 	sn.Address = ""
 	sn.TaggedAddresses = nil
 	sn.NodeMeta = nil
@@ -206,6 +214,7 @@ func TestStructs_ServiceNode_Conversions(t *testing.T) {
 
 	// These two fields get lost in the conversion, so we have to zero-value
 	// them out before we do the compare.
+	sn.ID = ""
 	sn.Address = ""
 	sn.TaggedAddresses = nil
 	sn.NodeMeta = nil

--- a/consul/util.go
+++ b/consul/util.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strconv"
 
@@ -62,14 +60,6 @@ func init() {
 		panic(fmt.Sprintf("Bad cidr. Got %v", err))
 	}
 	privateBlocks[5] = block
-}
-
-// ensurePath is used to make sure a path exists
-func ensurePath(path string, dir bool) error {
-	if !dir {
-		path = filepath.Dir(path)
-	}
-	return os.MkdirAll(path, 0755)
 }
 
 // CanServersUnderstandProtocol checks to see if all the servers in the given

--- a/lib/path.go
+++ b/lib/path.go
@@ -1,0 +1,14 @@
+package lib
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// EnsurePath is used to make sure a path exists
+func EnsurePath(path string, dir bool) error {
+	if !dir {
+		path = filepath.Dir(path)
+	}
+	return os.MkdirAll(path, 0755)
+}

--- a/types/node_id.go
+++ b/types/node_id.go
@@ -1,0 +1,4 @@
+package types
+
+// NodeID is a unique identifier for a node across space and time.
+type NodeID string

--- a/website/source/docs/agent/http/agent.html.markdown
+++ b/website/source/docs/agent/http/agent.html.markdown
@@ -143,6 +143,7 @@ It returns a JSON body like this:
     "DNSRecursors": [],
     "Domain": "consul.",
     "LogLevel": "INFO",
+    "NodeID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "NodeName": "foobar",
     "ClientAddr": "127.0.0.1",
     "BindAddr": "0.0.0.0",
@@ -183,6 +184,7 @@ It returns a JSON body like this:
     "Tags": {
       "bootstrap": "1",
       "dc": "dc1",
+      "id": "40e4a748-2192-161a-0510-9bf59fe950b5",
       "port": "8300",
       "role": "consul",
       "vsn": "1",

--- a/website/source/docs/agent/http/catalog.html.markdown
+++ b/website/source/docs/agent/http/catalog.html.markdown
@@ -38,6 +38,7 @@ body must look something like:
 ```javascript
 {
   "Datacenter": "dc1",
+  "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
   "Node": "foobar",
   "Address": "192.168.10.10",
   "TaggedAddresses": {
@@ -74,7 +75,10 @@ to match that of the agent. If only those are provided, the endpoint will regist
 the node with the catalog. `TaggedAddresses` can be used in conjunction with the
 [`translate_wan_addrs`](/docs/agent/options.html#translate_wan_addrs) configuration
 option and the `wan` address. The `lan` address was added in Consul 0.7 to help find
-the LAN address if address translation is enabled.
+the LAN address if address translation is enabled. The `ID` field was added in Consul
+0.7.3 and is optional, but if supplied must be in the form of a hex string, 36
+characters long. This is a unique identifier for this node across all time, even if
+the node name or address changes.
 
 The `Meta` block was added in Consul 0.7.3 to enable associating arbitrary metadata
 key/value pairs with a node for filtering purposes. For more information on node metadata,
@@ -208,6 +212,7 @@ It returns a JSON body like this:
 ```javascript
 [
   {
+    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "Node": "baz",
     "Address": "10.1.10.11",
     "TaggedAddresses": {
@@ -219,6 +224,7 @@ It returns a JSON body like this:
     }
   },
   {
+    "ID": "8f246b77-f3e1-ff88-5b48-8ec93abf3e05",
     "Node": "foobar",
     "Address": "10.1.10.12",
     "TaggedAddresses": {
@@ -288,6 +294,8 @@ It returns a JSON body like this:
 ```javascript
 [
   {
+    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
+    "Node": "foobar",
     "Address": "192.168.10.10",
     "TaggedAddresses": {
       "lan": "192.168.10.10",
@@ -298,7 +306,6 @@ It returns a JSON body like this:
     }
     "CreateIndex": 51,
     "ModifyIndex": 51,
-    "Node": "foobar",
     "ServiceAddress": "172.17.0.3",
     "ServiceEnableTagOverride": false,
     "ServiceID": "32a2a47f7992:nodea:5000",
@@ -340,6 +347,7 @@ It returns a JSON body like this:
 ```javascript
 {
   "Node": {
+    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "Node": "foobar",
     "Address": "10.1.10.12",
     "TaggedAddresses": {

--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -33,6 +33,8 @@ It returns a JSON body like this:
 ```javascript
 [
   {
+    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
+    "Node": "foobar",
     "Node": "foobar",
     "CheckID": "serfHealth",
     "Name": "Serf Health Status",
@@ -43,6 +45,7 @@ It returns a JSON body like this:
     "ServiceName": ""
   },
   {
+    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "Node": "foobar",
     "CheckID": "service:redis",
     "Name": "Service 'redis' check",
@@ -136,6 +139,7 @@ It returns a JSON body like this:
 [
   {
     "Node": {
+      "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
       "Node": "foobar",
       "Address": "10.1.10.12",
       "TaggedAddresses": {

--- a/website/source/docs/agent/http/health.html.markdown
+++ b/website/source/docs/agent/http/health.html.markdown
@@ -35,7 +35,6 @@ It returns a JSON body like this:
   {
     "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "Node": "foobar",
-    "Node": "foobar",
     "CheckID": "serfHealth",
     "Name": "Serf Health Status",
     "Status": "passing",

--- a/website/source/docs/agent/http/query.html.markdown
+++ b/website/source/docs/agent/http/query.html.markdown
@@ -402,6 +402,7 @@ a JSON body will be returned like this:
   "Nodes": [
     {
       "Node": {
+        "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
         "Node": "foobar",
         "Address": "10.1.10.12",
         "TaggedAddresses": {

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -287,8 +287,10 @@ will exit with an error at startup.
   changes. This must be in the form of a hex string, 36 characters long, such as
   `adf4238a-882b-9ddc-4a9d-5b6758e4159e`. If this isn't supplied, which is the most common case, then
   the agent will generate an identifier at startup and persist it in the <a href="#_data_dir">data directory</a>
-  so that it will remain the same across agent restarts. This is currently only exposed via the agent's
-  <a href="/docs/agent/http/agent.html#agent_self">/v1/agent/self</a> endpoint, but future versions of
+  so that it will remain the same across agent restarts. This is currently only exposed via
+  <a href="/docs/agent/http/agent.html#agent_self">/v1/agent/self</a>,
+  <a href="/docs/agent/http/catalog.html">/v1/catalog</a>, and
+  <a href="/docs/agent/http/health.html">/v1/health</a> endpoints, but future versions of
   Consul will use this to better manage cluster changes, especially for Consul servers.
 
 * <a name="_node_meta"></a><a href="#_node_meta">`-node-meta`</a> - Available in Consul 0.7.3 and later,

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -282,6 +282,15 @@ will exit with an error at startup.
 * <a name="_node"></a><a href="#_node">`-node`</a> - The name of this node in the cluster.
   This must be unique within the cluster. By default this is the hostname of the machine.
 
+* <a name="_node_id"></a><a href="#_node_id">`-node-id`</a> - Available in Consul 0.7.3 and later, this
+  is a unique identifier for this node across all time, even if the name of the node or address
+  changes. This must be in the form of a hex string, 36 characters long, such as
+  `adf4238a-882b-9ddc-4a9d-5b6758e4159e`. If this isn't supplied, which is the most common case, then
+  the agent will generate an identifier at startup and persist it in the <a href="#_data_dir">data directory</a>
+  so that it will remain the same across agent restarts. This is currently only exposed via the agent's
+  <a href="/docs/agent/http/agent.html#agent_self">/v1/agent/self</a> endpoint, but future versions of
+  Consul will use this to better manage cluster changes, especially for Consul servers.
+
 * <a name="_node_meta"></a><a href="#_node_meta">`-node-meta`</a> - Available in Consul 0.7.3 and later,
   this specifies an arbitrary metadata key/value pair to associate with the node, of the form `key:value`.
   This can be specified multiple times. Node metadata pairs have the following restrictions:
@@ -694,6 +703,9 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="log_level"></a><a href="#log_level">`log_level`</a> Equivalent to the
   [`-log-level` command-line flag](#_log_level).
+
+* <a name="node_id"></a><a href="#node_id">`node_id`</a> Equivalent to the
+  [`-node-id` command-line flag](#_node_id).
 
 * <a name="node_name"></a><a href="#node_name">`node_name`</a> Equivalent to the
   [`-node` command-line flag](#_node).


### PR DESCRIPTION
This puts in some basic support for a node ID by having agents make on up at startup and include it in their Serf tags, which is the minimum required for Raft server management with the V2 library.

We had originally intended to add it to the catalog as part of this change, but it's not that useful there unless we also expose it via DNS, etc. so we will hold off on that for now.