### PR TITLE
Fix consul kv example with flag separator

### DIFF
--- a/website/source/docs/commands/kv/get.html.markdown.erb
+++ b/website/source/docs/commands/kv/get.html.markdown.erb
@@ -129,7 +129,7 @@ recurse beyond that separator. You can choose a different separator by setting
 `-separator="<string>"`.
 
 ```
-$ consul kv get -keys -separator="s" redis
+$ consul kv get -keys -separator="c" redis
 redis/c
 ```
 


### PR DESCRIPTION
Previously, the example for consul kv is as follow.
```bash
$ consul kv get -keys -separator="s" redis
redis/c
```

Actually, this is not correct. Correct it as follow.
```bash
$ consul kv get -keys -separator="c" redis
redis/c
```