### PR TITLE
Robustifies unit tests.

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -310,7 +310,6 @@ func (s *TestServer) waitForLeader() {
 
 		// Ensure we have a leader and a node registration.
 		if leader := resp.Header.Get("X-Consul-KnownLeader"); leader != "true" {
-			fmt.Println(leader)
 			return false, fmt.Errorf("Consul leader status: %#v", leader)
 		}
 		index, err = strconv.ParseInt(resp.Header.Get("X-Consul-Index"), 10, 64)

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/consul/consul/structs"
@@ -292,11 +293,13 @@ func (s *TestServer) waitForAPI() {
 // waitForLeader waits for the Consul server's HTTP API to become
 // available, and then waits for a known leader and an index of
 // 1 or more to be observed to confirm leader election is done.
-// It then waits to ensure the anti-entropy checks have completed.
+// It then waits to ensure the anti-entropy sync has completed.
 func (s *TestServer) waitForLeader() {
+	var index int64
 	WaitForResult(func() (bool, error) {
-		// Query the API and check the status code
-		resp, err := s.HttpClient.Get(s.url("/v1/catalog/nodes"))
+		// Query the API and check the status code.
+		url := s.url(fmt.Sprintf("/v1/catalog/nodes?index=%d&wait=10s", index))
+		resp, err := s.HttpClient.Get(url)
 		if err != nil {
 			return false, err
 		}
@@ -305,25 +308,28 @@ func (s *TestServer) waitForLeader() {
 			return false, err
 		}
 
-		// Ensure we have a leader and a node registration
+		// Ensure we have a leader and a node registration.
 		if leader := resp.Header.Get("X-Consul-KnownLeader"); leader != "true" {
 			fmt.Println(leader)
 			return false, fmt.Errorf("Consul leader status: %#v", leader)
 		}
-		if resp.Header.Get("X-Consul-Index") == "0" {
+		index, err = strconv.ParseInt(resp.Header.Get("X-Consul-Index"), 10, 64)
+		if err != nil {
+			return false, fmt.Errorf("Consul index was bad: %v", err)
+		}
+		if index == 0 {
 			return false, fmt.Errorf("Consul index is 0")
 		}
 
+		// Watch for the anti-entropy sync to finish.
 		var parsed []map[string]interface{}
 		dec := json.NewDecoder(resp.Body)
 		if err := dec.Decode(&parsed); err != nil {
 			return false, err
 		}
-
 		if len(parsed) < 1 {
 			return false, fmt.Errorf("No nodes")
 		}
-
 		taggedAddresses, ok := parsed[0]["TaggedAddresses"].(map[string]interface{})
 		if !ok {
 			return false, fmt.Errorf("Missing tagged addresses")

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -11,11 +11,8 @@ type testFn func() (bool, error)
 type errorFn func(error)
 
 func WaitForResult(test testFn, error errorFn) {
-	retries := 400
-
-	for retries > 0 {
+	for retries := 100; retries > 0; retries-- {
 		time.Sleep(100 * time.Millisecond)
-		retries--
 
 		success, err := test()
 		if success {


### PR DESCRIPTION
This makes the leader wait in the common path use blocking queries so it's a lot less CPU hungry. It also drops the standard wait back down, runs the test before the initial wait, and exponentially increases the wait. This helps speed the tests along but stays robust and prevents the FD exhaustion we were trying to fix before.