### PR TITLE
Fixes up ACL timing issues with unit tests.

### DIFF
--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -610,7 +611,9 @@ func TestAgent_Leave(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := c2.Agent().Leave(); err != nil {
+	// We sometimes see an EOF response to this one, depending on timing.
+	err := c2.Agent().Leave()
+	if err != nil && err != io.EOF {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -336,7 +336,6 @@ func (s *TestServer) waitForLeader() {
 		if _, ok := taggedAddresses["lan"]; !ok {
 			return false, fmt.Errorf("No lan tagged addresses")
 		}
-
 		return true, nil
 	}, func(err error) {
 		defer s.Stop()


### PR DESCRIPTION
The change in https://github.com/hashicorp/consul/pull/2683 has uncovered some "permission denied" errors, presumably since we made things more aggressive without an initial delay. Since there's a separate setup for tests that actually want to exercise ACLs, this disables ACLs for other cases so things don't get blocked if the ACL DC isn't setup yet in the WAN.