### PR TITLE
Docs: add consul kv import/export links to sidebar

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -105,8 +105,14 @@
 						<li<%= sidebar_current("docs-commands-kv-delete") %>>
 							<a href="/docs/commands/kv/delete.html">delete</a>
 						</li>
+						<li<%= sidebar_current("docs-commands-kv-export") %>>
+							<a href="/docs/commands/kv/export.html">export</a>
+						</li>
 						<li<%= sidebar_current("docs-commands-kv-get") %>>
 							<a href="/docs/commands/kv/get.html">get</a>
+						</li>
+						<li<%= sidebar_current("docs-commands-kv-import") %>>
+							<a href="/docs/commands/kv/import.html">import</a>
 						</li>
 						<li<%= sidebar_current("docs-commands-kv-put") %>>
 							<a href="/docs/commands/kv/put.html">put</a>


### PR DESCRIPTION
I read this line in `consul kv` CLI [documentation](https://www.consul.io/docs/commands/kv.html):

>For more information, examples, and usage about a subcommand, click on the name of the subcommand in the sidebar or one of the links below:

but glanced at the sidebar and not ever subcommand was there! Oh noes!

This PR adds them, and they show up like this:

![image](https://cloud.githubusercontent.com/assets/985061/22524408/1cec6200-e891-11e6-8adc-5f750a8cd65b.png)