### PR TITLE
DNS lookup by Consul node ID

### DIFF
--- a/consul/state/catalog.go
+++ b/consul/state/catalog.go
@@ -725,11 +725,12 @@ func (s *StateStore) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint6
 	}
 
 	node := n.(*structs.Node)
+	nodeName := node.Node
 
 	// Read all of the services
-	services, err := tx.Get("services", "node", nodeNameOrID)
+	services, err := tx.Get("services", "node", nodeName)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed querying services for node %q: %s", nodeNameOrID, err)
+		return 0, nil, fmt.Errorf("failed querying services for node %q: %s", nodeName, err)
 	}
 	ws.Add(services.WatchCh())
 

--- a/consul/state/catalog.go
+++ b/consul/state/catalog.go
@@ -702,10 +702,13 @@ func (s *StateStore) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint6
 			return 0, nil, nil
 		}
 
-		// Attempt to lookup the node by it's node ID
+		// Attempt to lookup the node by its node ID
 		iter, err := tx.Get("nodes", "uuid_prefix", nodeNameOrID)
 		if err != nil {
-			return 0, nil, fmt.Errorf("node ID lookup failed: %s", err)
+			ws.Add(watchCh)
+			// TODO(sean@): We could/should log an error re: the uuid_prefix lookup
+			// failing once a logger has been introduced to the catalog.
+			return 0, nil, nil
 		}
 		n = iter.Next()
 		if n == nil {

--- a/consul/state/catalog.go
+++ b/consul/state/catalog.go
@@ -710,16 +710,18 @@ func (s *StateStore) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint6
 			// failing once a logger has been introduced to the catalog.
 			return 0, nil, nil
 		}
+
 		n = iter.Next()
 		if n == nil {
+			// No nodes matched, even with the Node ID: add a watch on the node name.
 			ws.Add(watchCh)
 			return 0, nil, nil
 		}
 
 		idWatchCh := iter.WatchCh()
 		if iter.Next() != nil {
-			// Watch on the channel that did a node name lookup if we don't find
-			// anything when searching by Node ID.
+			// More than one match present: Watch on the node name channel and return
+			// an empty result (node lookups can not be ambiguous).
 			ws.Add(watchCh)
 			return 0, nil, nil
 		}

--- a/consul/state/catalog_test.go
+++ b/consul/state/catalog_test.go
@@ -204,6 +204,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 		Node:    "node1",
 		Address: "1.2.3.4",
 	}
+	nodeID := string(req.ID)
+	nodeName := string(req.Node)
 	restore := s.Restore()
 	if err := restore.Registration(1, req); err != nil {
 		t.Fatalf("err: %s", err)
@@ -211,17 +213,26 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	restore.Commit()
 
 	// Retrieve the node and verify its contents.
-	verifyNode := func() {
-		_, out, err := s.GetNode("node1")
+	verifyNode := func(nodeLookup string) {
+		_, out, err := s.GetNode(nodeLookup)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		if out.Node != "node1" || out.Address != "1.2.3.4" ||
+		if out == nil {
+			_, out, err = s.GetNodeID(types.NodeID(nodeLookup))
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+		}
+
+		if out == nil || out.Address != "1.2.3.4" ||
+			!(out.Node == nodeLookup || string(out.ID) == nodeLookup) ||
 			out.CreateIndex != 1 || out.ModifyIndex != 1 {
 			t.Fatalf("bad node returned: %#v", out)
 		}
 	}
-	verifyNode()
+	verifyNode(nodeID)
+	verifyNode(nodeName)
 
 	// Add in a service definition.
 	req.Service = &structs.NodeService{
@@ -237,8 +248,8 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	restore.Commit()
 
 	// Verify that the service got registered.
-	verifyService := func() {
-		idx, out, err := s.NodeServices(nil, "node1")
+	verifyService := func(nodeLookup string) {
+		idx, out, err := s.NodeServices(nil, nodeLookup)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -258,7 +269,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 
 	// Add in a top-level check.
 	req.Check = &structs.HealthCheck{
-		Node:    "node1",
+		Node:    nodeName,
 		CheckID: "check1",
 		Name:    "check",
 	}
@@ -270,7 +281,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 
 	// Verify that the check got registered.
 	verifyCheck := func() {
-		idx, out, err := s.NodeChecks(nil, "node1")
+		idx, out, err := s.NodeChecks(nil, nodeName)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -281,19 +292,21 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			t.Fatalf("bad: %#v", out)
 		}
 		c := out[0]
-		if c.Node != "node1" || c.CheckID != "check1" || c.Name != "check" ||
+		if c.Node != nodeName || c.CheckID != "check1" || c.Name != "check" ||
 			c.CreateIndex != 3 || c.ModifyIndex != 3 {
 			t.Fatalf("bad check returned: %#v", c)
 		}
 	}
-	verifyNode()
-	verifyService()
+	verifyNode(nodeID)
+	verifyNode(nodeName)
+	verifyService(nodeID)
+	verifyService(nodeName)
 	verifyCheck()
 
 	// Add in another check via the slice.
 	req.Checks = structs.HealthChecks{
 		&structs.HealthCheck{
-			Node:    "node1",
+			Node:    nodeName,
 			CheckID: "check2",
 			Name:    "check",
 		},
@@ -305,10 +318,12 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	restore.Commit()
 
 	// Verify that the additional check got registered.
-	verifyNode()
-	verifyService()
+	verifyNode(nodeID)
+	verifyNode(nodeName)
+	verifyService(nodeID)
+	verifyService(nodeName)
 	func() {
-		idx, out, err := s.NodeChecks(nil, "node1")
+		idx, out, err := s.NodeChecks(nil, nodeName)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -319,13 +334,13 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			t.Fatalf("bad: %#v", out)
 		}
 		c1 := out[0]
-		if c1.Node != "node1" || c1.CheckID != "check1" || c1.Name != "check" ||
+		if c1.Node != nodeName || c1.CheckID != "check1" || c1.Name != "check" ||
 			c1.CreateIndex != 3 || c1.ModifyIndex != 4 {
 			t.Fatalf("bad check returned: %#v", c1)
 		}
 
 		c2 := out[1]
-		if c2.Node != "node1" || c2.CheckID != "check2" || c2.Name != "check" ||
+		if c2.Node != nodeName || c2.CheckID != "check2" || c2.Name != "check" ||
 			c2.CreateIndex != 4 || c2.ModifyIndex != 4 {
 			t.Fatalf("bad check returned: %#v", c2)
 		}

--- a/consul/state/prepared_query.go
+++ b/consul/state/prepared_query.go
@@ -14,6 +14,11 @@ var validUUID = regexp.MustCompile(`(?i)^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f
 
 // isUUID returns true if the given string is a valid UUID.
 func isUUID(str string) bool {
+	const uuidLen = 36
+	if len(str) != uuidLen {
+		return false
+	}
+
 	return validUUID.MatchString(str)
 }
 

--- a/consul/state/schema.go
+++ b/consul/state/schema.go
@@ -80,7 +80,7 @@ func nodesTableSchema() *memdb.TableSchema {
 			},
 			"uuid": &memdb.IndexSchema{
 				Name:         "uuid",
-				AllowMissing: false,
+				AllowMissing: true,
 				Unique:       true,
 				Indexer: &memdb.UUIDFieldIndex{
 					Field: "ID",

--- a/consul/state/schema.go
+++ b/consul/state/schema.go
@@ -78,6 +78,14 @@ func nodesTableSchema() *memdb.TableSchema {
 					Lowercase: true,
 				},
 			},
+			"uuid": &memdb.IndexSchema{
+				Name:         "uuid",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.UUIDFieldIndex{
+					Field: "ID",
+				},
+			},
 			"meta": &memdb.IndexSchema{
 				Name:         "meta",
 				AllowMissing: true,


### PR DESCRIPTION
Assuming the following output from a consul agent:

```
==> Consul agent running!
           Version: 'v0.7.3-43-gc5e140c-dev (c5e140c+CHANGES)'
           Node ID: '40e4a748-2192-161a-0510-9bf59fe950b5'
         Node name: 'myhost'
```

it is now possible to lookup nodes by their Node Name or Node ID, or a
prefix match of the Node ID, with the following caveats re: the prefix
match:

1) first eight digits of the Node ID are a required minimum (eight was
   chosen as an arbitrary number)
2) the length of the Node ID must be an even number or no result will be
   returned.

```
% dig @127.0.0.1 -p 8600 myhost.node.dc1.consul.
myhost.node.dc1.consul.	0	IN	A	127.0.0.1
% dig @127.0.0.1 -p 8600 40e4a748-2192-161a-0510-9bf59fe950b5.node.dc1.consul.
40e4a748-2192-161a-0510-9bf59fe950b5.node.dc1.consul. 0	IN A 127.0.0.1
% dig @127.0.0.1 -p 8600 40e4a748.node.dc1.consul.
40e4a748.node.dc1.consul. 0	IN	A	127.0.0.1
% dig @127.0.0.1 -p 8600 40e4a74821.node.dc1.consul.
40e4a74821.node.dc1.consul. 0	IN	A	127.0.0.1
% dig @127.0.0.1 -p 8600 40e4a748-21.node.dc1.consul.
40e4a748-21.node.dc1.consul. 0	IN	A	127.0.0.1
```