### PR TITLE
Support custom client configuration in WatchPlan.Run()

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1092,7 +1092,7 @@ func (c *Command) Run(args []string) int {
 		go func(wp *watch.WatchPlan) {
 			wp.Handler = makeWatchHandler(logOutput, wp.Exempt["handler"])
 			wp.LogOutput = c.logOutput
-			if err := wp.Run(httpAddr.String()); err != nil {
+			if err := wp.Run(httpAddr.String(), nil); err != nil {
 				c.Ui.Error(fmt.Sprintf("Error running watch: %v", err))
 			}
 		}(wp)
@@ -1305,7 +1305,7 @@ func (c *Command) handleReload(config *Config) (*Config, error) {
 		go func(wp *watch.WatchPlan) {
 			wp.Handler = makeWatchHandler(c.logOutput, wp.Exempt["handler"])
 			wp.LogOutput = c.logOutput
-			if err := wp.Run(httpAddr.String()); err != nil {
+			if err := wp.Run(httpAddr.String(), nil); err != nil {
 				errs = multierror.Append(errs, fmt.Errorf("Error running watch: %v", err))
 			}
 		}(wp)

--- a/command/watch.go
+++ b/command/watch.go
@@ -213,7 +213,7 @@ func (c *WatchCommand) Run(args []string) int {
 	}()
 
 	// Run the watch
-	if err := wp.Run(*httpAddr); err != nil {
+	if err := wp.Run(*httpAddr, nil); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error querying Consul agent: %s", err))
 		return 1
 	}

--- a/watch/funcs_test.go
+++ b/watch/funcs_test.go
@@ -59,7 +59,7 @@ func TestKeyWatch(t *testing.T) {
 		}
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestKeyPrefixWatch(t *testing.T) {
 		}
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestServicesWatch(t *testing.T) {
 		agent.ServiceDeregister("foo")
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestNodesWatch(t *testing.T) {
 		catalog.Deregister(dereg, nil)
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -256,7 +256,7 @@ func TestServiceWatch(t *testing.T) {
 		agent.ServiceDeregister("foo")
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -316,7 +316,7 @@ func TestChecksWatch_State(t *testing.T) {
 		catalog.Deregister(dereg, nil)
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestChecksWatch_Service(t *testing.T) {
 		catalog.Deregister(dereg, nil)
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestEventWatch(t *testing.T) {
 		}
 	}()
 
-	err := plan.Run(consulAddr)
+	err := plan.Run(consulAddr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -20,13 +20,15 @@ const (
 )
 
 // Run is used to run a watch plan
-func (p *WatchPlan) Run(address string) error {
+func (p *WatchPlan) Run(address string, conf *consulapi.Config) error {
 	// Setup the client
-	p.address = address
-	conf := consulapi.DefaultConfig()
-	conf.Address = address
-	conf.Datacenter = p.Datacenter
-	conf.Token = p.Token
+	if conf == nil {
+		conf = consulapi.DefaultConfig()
+		conf.Address = address
+		conf.Datacenter = p.Datacenter
+		conf.Token = p.Token
+	}
+	p.address = conf.Address
 	client, err := consulapi.NewClient(conf)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to agent: %v", err)

--- a/watch/plan_test.go
+++ b/watch/plan_test.go
@@ -3,6 +3,8 @@ package watch
 import (
 	"testing"
 	"time"
+
+	consulapi "github.com/hashicorp/consul/api"
 )
 
 func init() {
@@ -43,12 +45,32 @@ func TestRun_Stop(t *testing.T) {
 		plan.Stop()
 	})
 
-	err := plan.Run("127.0.0.1:8500")
+	err := plan.Run("127.0.0.1:8500", nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	if expect == 1 {
 		t.Fatalf("Bad: %d", expect)
+	}
+}
+
+func TestRun_Config(t *testing.T) {
+	plan := mustParse(t, `{"type":"noop"}`)
+
+	conf := consulapi.DefaultConfig()
+	conf.Address = "127.0.0.1:8500"
+
+	time.AfterFunc(10*time.Millisecond, func() {
+		plan.Stop()
+	})
+
+	err := plan.Run("", conf)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if plan.address != conf.Address {
+		t.Fatalf("Bad: %s", plan.address)
 	}
 }


### PR DESCRIPTION
While using WatchPlan to watch service checks, I needed custom configuration to connect SSL enabled Consul. Specifically, I wanted to supply CA path, client certificate and key, as far as I observed, they cannot be inferred from environment variables like HTTPS is inferred from `CONSUL_HTTP_SSL`.

I intended to not to touch many places, therefore with this implementation the arguments to `Run()` are rather redundant, since `address` can already be supplied using `conf` parameter. However I'm open to all suggestions regarding how we can supply the custom configuration.

Thanks!