### PR TITLE
Drop testutil wait to 2 seconds.

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -298,7 +298,7 @@ func (s *TestServer) waitForLeader() {
 	var index int64
 	WaitForResult(func() (bool, error) {
 		// Query the API and check the status code.
-		url := s.url(fmt.Sprintf("/v1/catalog/nodes?index=%d&wait=10s", index))
+		url := s.url(fmt.Sprintf("/v1/catalog/nodes?index=%d&wait=2s", index))
 		resp, err := s.HttpClient.Get(url)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
There's likely a race (related to https://github.com/hashicorp/consul/issues/2644) where the catalog update might be in but the leader tracking doesn't report a leader, so this blocks forever and then times out. As a workaround we can lower the query wait time to always allow for a few retries.