### PR TITLE
Update `shirou/gopsutil/313` to pull in lowercased `HostID`s.

### DIFF
--- a/vendor/github.com/shirou/gopsutil/host/host_darwin.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_darwin.go
@@ -59,7 +59,7 @@ func Info() (*InfoStat, error) {
 
 	values, err := common.DoSysctrl("kern.uuid")
 	if err == nil && len(values) == 1 && values[0] != "" {
-		ret.HostID = values[0]
+		ret.HostID = strings.ToLower(values[0])
 	}
 
 	return ret, nil

--- a/vendor/github.com/shirou/gopsutil/host/host_freebsd.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_freebsd.go
@@ -62,7 +62,7 @@ func Info() (*InfoStat, error) {
 
 	values, err := common.DoSysctrl("kern.hostuuid")
 	if err == nil && len(values) == 1 && values[0] != "" {
-		ret.HostID = values[0]
+		ret.HostID = strings.ToLower(values[0])
 	}
 
 	return ret, nil

--- a/vendor/github.com/shirou/gopsutil/host/host_linux.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_linux.go
@@ -70,14 +70,14 @@ func Info() (*InfoStat, error) {
 	case common.PathExists(sysProductUUID):
 		lines, err := common.ReadLines(sysProductUUID)
 		if err == nil && len(lines) > 0 && lines[0] != "" {
-			ret.HostID = lines[0]
+			ret.HostID = strings.ToLower(lines[0])
 			break
 		}
 		fallthrough
 	default:
 		values, err := common.DoSysctrl("kernel.random.boot_id")
 		if err == nil && len(values) == 1 && values[0] != "" {
-			ret.HostID = values[0]
+			ret.HostID = strings.ToLower(values[0])
 		}
 	}
 

--- a/vendor/github.com/shirou/gopsutil/host/host_windows.go
+++ b/vendor/github.com/shirou/gopsutil/host/host_windows.go
@@ -64,7 +64,7 @@ func Info() (*InfoStat, error) {
 	{
 		hostID, err := getMachineGuid()
 		if err == nil {
-			ret.HostID = hostID
+			ret.HostID = strings.ToLower(hostID)
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -705,10 +705,10 @@
 			"revisionTime": "2017-02-04T05:36:48Z"
 		},
 		{
-			"checksumSHA1": "j5cGmi4mFeXmsLpSTiakU/k7aOc=",
+			"checksumSHA1": "GsqEEmGv6sj8DreS2SYXRkoZ9NI=",
 			"path": "github.com/shirou/gopsutil/host",
-			"revision": "32b6636de04b303274daac3ca2b10d3b0e4afc35",
-			"revisionTime": "2017-02-04T05:36:48Z"
+			"revision": "36f5033d9787f85e97cc259fcb33bd699f3dbe0f",
+			"revisionTime": "2017-02-07T00:10:46Z"
 		},
 		{
 			"checksumSHA1": "hz9RxkaV3Tnju2eiHBWO/Yv7n5c=",


### PR DESCRIPTION
Consul already did a `strings.ToLower()` on its node IDs so this should have little to no impact, but chasing the vendor update anyway to keep parity with hashicorp/nomad#2288.