### PR TITLE
Centralize command-line parsing part 2

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -79,6 +79,11 @@ type QueryOptions struct {
 	// metadata key/value pairs. Currently, only one key/value pair can
 	// be provided for filtering.
 	NodeMeta map[string]string
+
+	// RelayFactor is used in keyring operations to cause reponses to be
+	// relayed back to the sender through N other random nodes. Must be
+	// a value from 0 to 5 (inclusive).
+	RelayFactor uint8
 }
 
 // WriteOptions are used to parameterize a write
@@ -90,6 +95,11 @@ type WriteOptions struct {
 	// Token is used to provide a per-request ACL token
 	// which overrides the agent's default token.
 	Token string
+
+	// RelayFactor is used in keyring operations to cause reponses to be
+	// relayed back to the sender through N other random nodes. Must be
+	// a value from 0 to 5 (inclusive).
+	RelayFactor uint8
 }
 
 // QueryMeta is used to return meta data about a query
@@ -396,6 +406,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 			r.params.Add("node-meta", key+":"+value)
 		}
 	}
+	if q.RelayFactor != 0 {
+		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
+	}
 }
 
 // durToMsec converts a duration to a millisecond specified string. If the
@@ -436,6 +449,9 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 	}
 	if q.Token != "" {
 		r.header.Set("X-Consul-Token", q.Token)
+	}
+	if q.RelayFactor != 0 {
+		r.header.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -451,7 +451,7 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 		r.header.Set("X-Consul-Token", q.Token)
 	}
 	if q.RelayFactor != 0 {
-		r.header.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
+		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
 }
 

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -154,7 +154,14 @@ func keyringErrorsOrNil(responses []*structs.KeyringResponse) error {
 	var errs error
 	for _, response := range responses {
 		if response.Error != "" {
-			errs = multierror.Append(errs, fmt.Errorf(response.Error))
+			pool := response.Datacenter + " (LAN)"
+			if response.WAN {
+				pool = "WAN"
+			}
+			errs = multierror.Append(errs, fmt.Errorf("%s error: %s", pool, response.Error))
+			for key, message := range response.Messages {
+				errs = multierror.Append(errs, fmt.Errorf("%s: %s", key, message))
+			}
 		}
 	}
 	return errs

--- a/command/base/command.go
+++ b/command/base/command.go
@@ -58,6 +58,10 @@ func (c *Command) HTTPClient() (*api.Client, error) {
 	return api.NewClient(config)
 }
 
+func (c *Command) HTTPDatacenter() string {
+	return c.datacenter.String()
+}
+
 // httpFlagsClient is the list of flags that apply to HTTP connections.
 func (c *Command) httpFlagsClient(f *flag.FlagSet) *flag.FlagSet {
 	if f == nil {
@@ -198,6 +202,10 @@ func printTitle(w io.Writer, s string) {
 func printFlag(w io.Writer, f *flag.Flag) {
 	example, _ := flag.UnquoteUsage(f)
 	if example != "" {
+		// Change 'value' to 'string' for consistency
+		if example == "value" {
+			example = "string"
+		}
 		fmt.Fprintf(w, "  -%s=<%s>\n", f.Name, example)
 	} else {
 		fmt.Fprintf(w, "  -%s\n", f.Name)

--- a/command/base/command.go
+++ b/command/base/command.go
@@ -62,6 +62,12 @@ func (c *Command) HTTPDatacenter() string {
 	return c.datacenter.String()
 }
 
+func (c *Command) HTTPStale() bool {
+	var stale bool
+	c.stale.Merge(&stale)
+	return stale
+}
+
 // httpFlagsClient is the list of flags that apply to HTTP connections.
 func (c *Command) httpFlagsClient(f *flag.FlagSet) *flag.FlagSet {
 	if f == nil {
@@ -134,6 +140,9 @@ func (c *Command) Parse(args []string) error {
 
 // Help returns the help for this flagSet.
 func (c *Command) Help() string {
+	if c.flagSet == nil {
+		return ""
+	}
 	return c.helpFlagsFor(c.flagSet)
 }
 

--- a/command/base/command.go
+++ b/command/base/command.go
@@ -75,7 +75,7 @@ func (c *Command) httpFlagsClient(f *flag.FlagSet) *flag.FlagSet {
 	}
 
 	f.Var(&c.httpAddr, "http-addr",
-		"Address and port to the Consul HTTP agent. The value can be an IP "+
+		"The `address` and port of the Consul HTTP agent. The value can be an IP "+
 			"address or DNS address, but it must also include the port. This can "+
 			"also be specified via the CONSUL_HTTP_ADDR environment variable. The "+
 			"default value is 127.0.0.1:8500.")
@@ -140,6 +140,8 @@ func (c *Command) Parse(args []string) error {
 
 // Help returns the help for this flagSet.
 func (c *Command) Help() string {
+	// Some commands with subcommands (kv/snapshot) call this without initializing
+	// any flags first, so exit early to avoid a panic
 	if c.flagSet == nil {
 		return ""
 	}
@@ -211,10 +213,6 @@ func printTitle(w io.Writer, s string) {
 func printFlag(w io.Writer, f *flag.Flag) {
 	example, _ := flag.UnquoteUsage(f)
 	if example != "" {
-		// Change 'value' to 'string' for consistency
-		if example == "value" {
-			example = "string"
-		}
 		fmt.Fprintf(w, "  -%s=<%s>\n", f.Name, example)
 	} else {
 		fmt.Fprintf(w, "  -%s\n", f.Name)

--- a/command/event.go
+++ b/command/event.go
@@ -37,7 +37,7 @@ func (c *EventCommand) Run(args []string) int {
 	f.StringVar(&node, "node", "",
 		"Regular expression to filter on node names.")
 	f.StringVar(&service, "service", "",
-		"Regular expression to filter on service instances")
+		"Regular expression to filter on service instances.")
 	f.StringVar(&tag, "tag", "",
 		"Regular expression to filter on service tags. Must be used with -service.")
 

--- a/command/event_test.go
+++ b/command/event_test.go
@@ -1,13 +1,14 @@
 package command
 
 import (
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 	"strings"
 	"testing"
 )
 
 func TestEventCommand_implements(t *testing.T) {
-	var _ cli.Command = &WatchCommand{}
+	var _ cli.Command = &EventCommand{}
 }
 
 func TestEventCommandRun(t *testing.T) {
@@ -15,7 +16,12 @@ func TestEventCommandRun(t *testing.T) {
 	defer a1.Shutdown()
 
 	ui := new(cli.MockUi)
-	c := &EventCommand{Ui: ui}
+	c := &EventCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetClientHTTP,
+		},
+	}
 	args := []string{"-http-addr=" + a1.httpAddr, "-name=cmd"}
 
 	code := c.Run(args)

--- a/command/exec.go
+++ b/command/exec.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"unicode"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
 
@@ -53,9 +53,7 @@ const (
 
 // rExecConf is used to pass around configuration
 type rExecConf struct {
-	datacenter string
-	prefix     string
-	token      string
+	prefix string
 
 	foreignDC bool
 	localDC   string
@@ -118,8 +116,9 @@ type rExecExit struct {
 // ExecCommand is a Command implementation that is used to
 // do remote execution of commands
 type ExecCommand struct {
+	base.Command
+
 	ShutdownCh <-chan struct{}
-	Ui         cli.Ui
 	conf       rExecConf
 	client     *consulapi.Client
 	sessionID  string
@@ -127,24 +126,29 @@ type ExecCommand struct {
 }
 
 func (c *ExecCommand) Run(args []string) int {
-	cmdFlags := flag.NewFlagSet("exec", flag.ContinueOnError)
-	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
-	cmdFlags.StringVar(&c.conf.datacenter, "datacenter", "", "")
-	cmdFlags.StringVar(&c.conf.node, "node", "", "")
-	cmdFlags.StringVar(&c.conf.service, "service", "", "")
-	cmdFlags.StringVar(&c.conf.tag, "tag", "", "")
-	cmdFlags.StringVar(&c.conf.prefix, "prefix", rExecPrefix, "")
-	cmdFlags.DurationVar(&c.conf.replWait, "wait-repl", rExecReplicationWait, "")
-	cmdFlags.DurationVar(&c.conf.wait, "wait", rExecQuietWait, "")
-	cmdFlags.BoolVar(&c.conf.verbose, "verbose", false, "")
-	cmdFlags.StringVar(&c.conf.token, "token", "", "")
-	httpAddr := HTTPAddrFlag(cmdFlags)
-	if err := cmdFlags.Parse(args); err != nil {
+	f := c.Command.NewFlagSet(c)
+	f.StringVar(&c.conf.node, "node", "",
+		"Regular expression to filter on node names.")
+	f.StringVar(&c.conf.service, "service", "",
+		"Regular expression to filter on service instances.")
+	f.StringVar(&c.conf.tag, "tag", "",
+		"Regular expression to filter on service tags. Must be used with -service.")
+	f.StringVar(&c.conf.prefix, "prefix", rExecPrefix,
+		"Prefix in the KV store to use for request data.")
+	f.DurationVar(&c.conf.wait, "wait", rExecQuietWait,
+		"Period to wait with no responses before terminating execution.")
+	f.DurationVar(&c.conf.replWait, "wait-repl", rExecReplicationWait,
+		"Period to wait for replication before firing event. This is an "+
+			"optimization to allow stale reads to be performed.")
+	f.BoolVar(&c.conf.verbose, "verbose", false,
+		"Enables verbose output.")
+
+	if err := c.Command.Parse(args); err != nil {
 		return 1
 	}
 
 	// Join the commands to execute
-	c.conf.cmd = strings.Join(cmdFlags.Args(), " ")
+	c.conf.cmd = strings.Join(f.Args(), " ")
 
 	// If there is no command, read stdin for a script input
 	if c.conf.cmd == "-" {
@@ -175,11 +179,7 @@ func (c *ExecCommand) Run(args []string) int {
 	}
 
 	// Create and test the HTTP client
-	client, err := HTTPClientConfig(func(clientConf *consulapi.Config) {
-		clientConf.Address = *httpAddr
-		clientConf.Datacenter = c.conf.datacenter
-		clientConf.Token = c.conf.token
-	})
+	client, err := c.Command.HTTPClient()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
@@ -192,7 +192,7 @@ func (c *ExecCommand) Run(args []string) int {
 	c.client = client
 
 	// Check if this is a foreign datacenter
-	if c.conf.datacenter != "" && c.conf.datacenter != info["Config"]["Datacenter"] {
+	if c.Command.HTTPDatacenter() != "" && c.Command.HTTPDatacenter() != info["Config"]["Datacenter"] {
 		if c.conf.verbose {
 			c.Ui.Info("Remote exec in foreign datacenter, using Session TTL")
 		}
@@ -489,7 +489,7 @@ func (c *ExecCommand) createSessionForeign() (string, error) {
 	node := services[0].Node.Node
 	if c.conf.verbose {
 		c.Ui.Info(fmt.Sprintf("Binding session to remote node %s@%s",
-			node, c.conf.datacenter))
+			node, c.Command.HTTPDatacenter()))
 	}
 
 	session := c.client.Session()
@@ -618,22 +618,8 @@ Usage: consul exec [options] [-|command...]
   definitions. If a command is '-', stdin will be read until EOF
   and used as a script input.
 
-Options:
+` + c.Command.Help()
 
-  -http-addr=127.0.0.1:8500  HTTP address of the Consul agent.
-  -datacenter=""             Datacenter to dispatch in. Defaults to that of agent.
-  -prefix="_rexec"           Prefix in the KV store to use for request data
-  -node=""                   Regular expression to filter on node names
-  -service=""                Regular expression to filter on service instances
-  -tag=""                    Regular expression to filter on service tags. Must be used
-                             with -service.
-  -wait=2s                   Period to wait with no responses before terminating execution.
-  -wait-repl=200ms           Period to wait for replication before firing event. This is an
-                             optimization to allow stale reads to be performed.
-  -verbose                   Enables verbose output
-  -token=""                  ACL token to use during requests. Defaults to that
-                             of the agent.
-`
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -8,9 +8,20 @@ import (
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/agent"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
+
+func testExecCommand(t *testing.T) (*cli.MockUi, *ExecCommand) {
+	ui := new(cli.MockUi)
+	return ui, &ExecCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
+	}
+}
 
 func TestExecCommand_implements(t *testing.T) {
 	var _ cli.Command = &ExecCommand{}
@@ -21,8 +32,7 @@ func TestExecCommandRun(t *testing.T) {
 	defer a1.Shutdown()
 	waitForLeader(t, a1.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{Ui: ui}
+	ui, c := testExecCommand(t)
 	args := []string{"-http-addr=" + a1.httpAddr, "-wait=10s", "uptime"}
 
 	code := c.Run(args)
@@ -57,8 +67,7 @@ func TestExecCommandRun_CrossDC(t *testing.T) {
 	waitForLeader(t, a1.httpAddr)
 	waitForLeader(t, a2.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{Ui: ui}
+	ui, c := testExecCommand(t)
 	args := []string{"-http-addr=" + a1.httpAddr,
 		"-wait=400ms", "-datacenter=dc2", "uptime"}
 
@@ -130,11 +139,8 @@ func TestExecCommand_Sessions(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{
-		Ui:     ui,
-		client: client,
-	}
+	_, c := testExecCommand(t)
+	c.client = client
 
 	id, err := c.createSession()
 	if err != nil {
@@ -174,11 +180,8 @@ func TestExecCommand_Sessions_Foreign(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{
-		Ui:     ui,
-		client: client,
-	}
+	_, c := testExecCommand(t)
+	c.client = client
 
 	c.conf.foreignDC = true
 	c.conf.localDC = "dc1"
@@ -228,11 +231,8 @@ func TestExecCommand_UploadDestroy(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{
-		Ui:     ui,
-		client: client,
-	}
+	_, c := testExecCommand(t)
+	c.client = client
 
 	id, err := c.createSession()
 	if err != nil {
@@ -288,11 +288,8 @@ func TestExecCommand_StreamResults(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	ui := new(cli.MockUi)
-	c := &ExecCommand{
-		Ui:     ui,
-		client: client,
-	}
+	_, c := testExecCommand(t)
+	c.client = client
 	c.conf.prefix = "_rexec"
 
 	id, err := c.createSession()

--- a/command/info.go
+++ b/command/info.go
@@ -1,9 +1,8 @@
 package command
 
 import (
-	"flag"
 	"fmt"
-	"github.com/mitchellh/cli"
+	"github.com/hashicorp/consul/command/base"
 	"sort"
 	"strings"
 )
@@ -11,7 +10,7 @@ import (
 // InfoCommand is a Command implementation that queries a running
 // Consul agent for various debugging statistics for operators
 type InfoCommand struct {
-	Ui cli.Ui
+	base.Command
 }
 
 func (i *InfoCommand) Help() string {
@@ -20,31 +19,32 @@ Usage: consul info [options]
 
 	Provides debugging information for operators
 
-Options:
+` + i.Command.Help()
 
-  -rpc-addr=127.0.0.1:8400  RPC address of the Consul agent.
-`
 	return strings.TrimSpace(helpText)
 }
 
 func (i *InfoCommand) Run(args []string) int {
-	cmdFlags := flag.NewFlagSet("info", flag.ContinueOnError)
-	cmdFlags.Usage = func() { i.Ui.Output(i.Help()) }
-	rpcAddr := RPCAddrFlag(cmdFlags)
-	if err := cmdFlags.Parse(args); err != nil {
+	i.Command.NewFlagSet(i)
+
+	if err := i.Command.Parse(args); err != nil {
 		return 1
 	}
 
-	client, err := RPCClient(*rpcAddr)
+	client, err := i.Command.HTTPClient()
 	if err != nil {
 		i.Ui.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
-	defer client.Close()
 
-	stats, err := client.Stats()
+	self, err := client.Agent().Self()
 	if err != nil {
 		i.Ui.Error(fmt.Sprintf("Error querying agent: %s", err))
+		return 1
+	}
+	stats, ok := self["Stats"]
+	if !ok {
+		i.Ui.Error(fmt.Sprintf("Agent response did not contain 'Stats' key: %v", self))
 		return 1
 	}
 
@@ -60,7 +60,11 @@ func (i *InfoCommand) Run(args []string) int {
 		i.Ui.Output(key + ":")
 
 		// Sort the sub-keys
-		subvals := stats[key]
+		subvals, ok := stats[key].(map[string]interface{})
+		if !ok {
+			i.Ui.Error(fmt.Sprintf("Got invalid subkey in stats: %v", subvals))
+			return 1
+		}
 		subkeys := make([]string, 0, len(subvals))
 		for k := range subvals {
 			subkeys = append(subkeys, k)
@@ -77,5 +81,5 @@ func (i *InfoCommand) Run(args []string) int {
 }
 
 func (i *InfoCommand) Synopsis() string {
-	return "Provides debugging information for operators"
+	return "Provides debugging information for operators."
 }

--- a/command/info_test.go
+++ b/command/info_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 	"strings"
 	"testing"
@@ -15,8 +16,13 @@ func TestInfoCommandRun(t *testing.T) {
 	defer a1.Shutdown()
 
 	ui := new(cli.MockUi)
-	c := &InfoCommand{Ui: ui}
-	args := []string{"-rpc-addr=" + a1.addr}
+	c := &InfoCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetClientHTTP,
+		},
+	}
+	args := []string{"-http-addr=" + a1.httpAddr}
 
 	code := c.Run(args)
 	if code != 0 {

--- a/command/join.go
+++ b/command/join.go
@@ -57,6 +57,11 @@ func (c *JoinCommand) Run(args []string) int {
 		}
 	}
 
+	if joins == 0 {
+		c.Ui.Error("Failed to join any nodes.")
+		return 1
+	}
+
 	c.Ui.Output(fmt.Sprintf(
 		"Successfully joined cluster by contacting %d nodes.", joins))
 	return 0

--- a/command/join.go
+++ b/command/join.go
@@ -1,16 +1,15 @@
 package command
 
 import (
-	"flag"
 	"fmt"
-	"github.com/mitchellh/cli"
+	"github.com/hashicorp/consul/command/base"
 	"strings"
 )
 
 // JoinCommand is a Command implementation that tells a running Consul
 // agent to join another.
 type JoinCommand struct {
-	Ui cli.Ui
+	base.Command
 }
 
 func (c *JoinCommand) Help() string {
@@ -20,26 +19,21 @@ Usage: consul join [options] address ...
   Tells a running Consul agent (with "consul agent") to join the cluster
   by specifying at least one existing member.
 
-Options:
+` + c.Command.Help()
 
-  -rpc-addr=127.0.0.1:8400  RPC address of the Consul agent.
-  -wan                      Joins a server to another server in the WAN pool
-`
 	return strings.TrimSpace(helpText)
 }
 
 func (c *JoinCommand) Run(args []string) int {
 	var wan bool
 
-	cmdFlags := flag.NewFlagSet("join", flag.ContinueOnError)
-	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
-	cmdFlags.BoolVar(&wan, "wan", false, "wan")
-	rpcAddr := RPCAddrFlag(cmdFlags)
-	if err := cmdFlags.Parse(args); err != nil {
+	f := c.Command.NewFlagSet(c)
+	f.BoolVar(&wan, "wan", false, "Joins a server to another server in the WAN pool.")
+	if err := c.Command.Parse(args); err != nil {
 		return 1
 	}
 
-	addrs := cmdFlags.Args()
+	addrs := f.Args()
 	if len(addrs) == 0 {
 		c.Ui.Error("At least one address to join must be specified.")
 		c.Ui.Error("")
@@ -47,21 +41,24 @@ func (c *JoinCommand) Run(args []string) int {
 		return 1
 	}
 
-	client, err := RPCClient(*rpcAddr)
+	client, err := c.Command.HTTPClient()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
-	defer client.Close()
 
-	n, err := client.Join(addrs, wan)
-	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error joining the cluster: %s", err))
-		return 1
+	joins := 0
+	for _, addr := range addrs {
+		err := client.Agent().Join(addr, wan)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error joining address '%s': %s", addr, err))
+		} else {
+			joins++
+		}
 	}
 
 	c.Ui.Output(fmt.Sprintf(
-		"Successfully joined cluster by contacting %d nodes.", n))
+		"Successfully joined cluster by contacting %d nodes.", joins))
 	return 0
 }
 

--- a/command/join_test.go
+++ b/command/join_test.go
@@ -2,10 +2,21 @@ package command
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 	"strings"
 	"testing"
 )
+
+func testJoinCommand(t *testing.T) (*cli.MockUi, *JoinCommand) {
+	ui := new(cli.MockUi)
+	return ui, &JoinCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetClientHTTP,
+		},
+	}
+}
 
 func TestJoinCommand_implements(t *testing.T) {
 	var _ cli.Command = &JoinCommand{}
@@ -17,10 +28,9 @@ func TestJoinCommandRun(t *testing.T) {
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 
-	ui := new(cli.MockUi)
-	c := &JoinCommand{Ui: ui}
+	ui, c := testJoinCommand(t)
 	args := []string{
-		"-rpc-addr=" + a1.addr,
+		"-http-addr=" + a1.httpAddr,
 		fmt.Sprintf("127.0.0.1:%d", a2.config.Ports.SerfLan),
 	}
 
@@ -40,10 +50,9 @@ func TestJoinCommandRun_wan(t *testing.T) {
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 
-	ui := new(cli.MockUi)
-	c := &JoinCommand{Ui: ui}
+	ui, c := testJoinCommand(t)
 	args := []string{
-		"-rpc-addr=" + a1.addr,
+		"-http-addr=" + a1.httpAddr,
 		"-wan",
 		fmt.Sprintf("127.0.0.1:%d", a2.config.Ports.SerfWan),
 	}
@@ -59,9 +68,8 @@ func TestJoinCommandRun_wan(t *testing.T) {
 }
 
 func TestJoinCommandRun_noAddrs(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &JoinCommand{Ui: ui}
-	args := []string{"-rpc-addr=foo"}
+	ui, c := testJoinCommand(t)
+	args := []string{"-http-addr=foo"}
 
 	code := c.Run(args)
 	if code != 1 {

--- a/command/keygen.go
+++ b/command/keygen.go
@@ -6,16 +6,21 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/cli"
+	"github.com/hashicorp/consul/command/base"
 )
 
 // KeygenCommand is a Command implementation that generates an encryption
 // key for use in `consul agent`.
 type KeygenCommand struct {
-	Ui cli.Ui
+	base.Command
 }
 
-func (c *KeygenCommand) Run(_ []string) int {
+func (c *KeygenCommand) Run(args []string) int {
+	c.Command.NewFlagSet(c)
+	if err := c.Command.Parse(args); err != nil {
+		return 1
+	}
+
 	key := make([]byte, 16)
 	n, err := rand.Reader.Read(key)
 	if err != nil {
@@ -42,6 +47,8 @@ Usage: consul keygen
   Generates a new encryption key that can be used to configure the
   agent to encrypt traffic. The output of this command is already
   in the proper format that the agent expects.
-`
+
+` + c.Command.Help()
+
 	return strings.TrimSpace(helpText)
 }

--- a/command/keygen_test.go
+++ b/command/keygen_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/base64"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 	"testing"
 )
@@ -12,7 +13,12 @@ func TestKeygenCommand_implements(t *testing.T) {
 
 func TestKeygenCommand(t *testing.T) {
 	ui := new(cli.MockUi)
-	c := &KeygenCommand{Ui: ui}
+	c := &KeygenCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetNone,
+		},
+	}
 	code := c.Run(nil)
 	if code != 0 {
 		t.Fatalf("bad: %d", code)

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -36,9 +36,9 @@ func (c *KeyringCommand) Run(args []string) int {
 	f.BoolVar(&listKeys, "list", false,
 		"List all keys currently in use within the cluster.")
 	f.IntVar(&relay, "relay-factor", 0,
-		"Added in Consul 0.7.4, setting this to a non-zero value will cause nodes "+
-			"to relay their response to the operation through this many randomly-chosen "+
-			"other nodes in the cluster. The maximum allowed value is 5.")
+		"Setting this to a non-zero value will cause nodes to relay their response "+
+			"to the operation through this many randomly-chosen other nodes in the "+
+			"cluster. The maximum allowed value is 5.")
 
 	if err := c.Command.Parse(args); err != nil {
 		return 1

--- a/command/keyring.go
+++ b/command/keyring.go
@@ -1,37 +1,46 @@
 package command
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
+	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/agent"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
 
 // KeyringCommand is a Command implementation that handles querying, installing,
 // and removing gossip encryption keys from a keyring.
 type KeyringCommand struct {
-	Ui cli.Ui
+	base.Command
 }
 
 func (c *KeyringCommand) Run(args []string) int {
-	var installKey, useKey, removeKey, token string
+	var installKey, useKey, removeKey string
 	var listKeys bool
 	var relay int
 
-	cmdFlags := flag.NewFlagSet("keys", flag.ContinueOnError)
-	cmdFlags.Usage = func() { c.Ui.Output(c.Help()) }
+	f := c.Command.NewFlagSet(c)
 
-	cmdFlags.StringVar(&installKey, "install", "", "install key")
-	cmdFlags.StringVar(&useKey, "use", "", "use key")
-	cmdFlags.StringVar(&removeKey, "remove", "", "remove key")
-	cmdFlags.BoolVar(&listKeys, "list", false, "list keys")
-	cmdFlags.StringVar(&token, "token", "", "acl token")
-	cmdFlags.IntVar(&relay, "relay-factor", 0, "relay factor")
+	f.StringVar(&installKey, "install", "",
+		"Install a new encryption key. This will broadcast the new key to "+
+			"all members in the cluster.")
+	f.StringVar(&useKey, "use", "",
+		"Change the primary encryption key, which is used to encrypt "+
+			"messages. The key must already be installed before this operation "+
+			"can succeed.")
+	f.StringVar(&removeKey, "remove", "",
+		"Remove the given key from the cluster. This operation may only be "+
+			"performed on keys which are not currently the primary key.")
+	f.BoolVar(&listKeys, "list", false,
+		"List all keys currently in use within the cluster.")
+	f.IntVar(&relay, "relay-factor", 0,
+		"Added in Consul 0.7.4, setting this to a non-zero value will cause nodes "+
+			"to relay their response to the operation through this many randomly-chosen "+
+			"other nodes in the cluster. The maximum allowed value is 5.")
 
-	rpcAddr := RPCAddrFlag(cmdFlags)
-	if err := cmdFlags.Parse(args); err != nil {
+	if err := c.Command.Parse(args); err != nil {
 		return 1
 	}
 
@@ -66,124 +75,69 @@ func (c *KeyringCommand) Run(args []string) int {
 	}
 
 	// All other operations will require a client connection
-	client, err := RPCClient(*rpcAddr)
+	client, err := c.Command.HTTPClient()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
 		return 1
 	}
-	defer client.Close()
 
 	if listKeys {
 		c.Ui.Info("Gathering installed encryption keys...")
-		r, err := client.ListKeys(token, relayFactor)
+		responses, err := client.Operator().KeyringList(&consulapi.QueryOptions{RelayFactor: relayFactor})
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
 		}
-		if rval := c.handleResponse(r.Info, r.Messages); rval != 0 {
-			return rval
-		}
-		c.handleList(r.Info, r.Keys)
+		c.handleList(responses)
 		return 0
 	}
 
+	opts := &consulapi.WriteOptions{RelayFactor: relayFactor}
 	if installKey != "" {
 		c.Ui.Info("Installing new gossip encryption key...")
-		r, err := client.InstallKey(installKey, token, relayFactor)
+		err := client.Operator().KeyringInstall(installKey, opts)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
 		}
-		return c.handleResponse(r.Info, r.Messages)
+		return 0
 	}
 
 	if useKey != "" {
 		c.Ui.Info("Changing primary gossip encryption key...")
-		r, err := client.UseKey(useKey, token, relayFactor)
+		err := client.Operator().KeyringUse(useKey, opts)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
 		}
-		return c.handleResponse(r.Info, r.Messages)
+		return 0
 	}
 
 	if removeKey != "" {
 		c.Ui.Info("Removing gossip encryption key...")
-		r, err := client.RemoveKey(removeKey, token, relayFactor)
+		err := client.Operator().KeyringRemove(removeKey, opts)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("error: %s", err))
 			return 1
 		}
-		return c.handleResponse(r.Info, r.Messages)
+		return 0
 	}
 
 	// Should never make it here
 	return 0
 }
 
-func (c *KeyringCommand) handleResponse(
-	info []agent.KeyringInfo,
-	messages []agent.KeyringMessage) int {
-
-	var rval int
-
-	for _, i := range info {
-		if i.Error != "" {
-			pool := i.Pool
-			if pool != "WAN" {
-				pool = i.Datacenter + " (LAN)"
-			}
-
-			c.Ui.Error("")
-			c.Ui.Error(fmt.Sprintf("%s error: %s", pool, i.Error))
-
-			for _, msg := range messages {
-				if msg.Datacenter != i.Datacenter || msg.Pool != i.Pool {
-					continue
-				}
-				c.Ui.Error(fmt.Sprintf("  %s: %s", msg.Node, msg.Message))
-			}
-			rval = 1
-		}
-	}
-
-	if rval == 0 {
-		c.Ui.Info("Done!")
-	}
-
-	return rval
-}
-
-func (c *KeyringCommand) handleList(
-	info []agent.KeyringInfo,
-	keys []agent.KeyringEntry) {
-
-	installed := make(map[string]map[string][]int)
-	for _, key := range keys {
-		var nodes int
-		for _, i := range info {
-			if i.Datacenter == key.Datacenter && i.Pool == key.Pool {
-				nodes = i.NumNodes
-			}
+func (c *KeyringCommand) handleList(responses []*consulapi.KeyringResponse) {
+	for _, response := range responses {
+		pool := response.Datacenter + " (LAN)"
+		if response.WAN {
+			pool = "WAN"
 		}
 
-		pool := key.Pool
-		if pool != "WAN" {
-			pool = key.Datacenter + " (LAN)"
-		}
-
-		if _, ok := installed[pool]; !ok {
-			installed[pool] = map[string][]int{key.Key: []int{key.Count, nodes}}
-		} else {
-			installed[pool][key.Key] = []int{key.Count, nodes}
-		}
-	}
-
-	for pool, keys := range installed {
 		c.Ui.Output("")
 		c.Ui.Output(pool + ":")
-		for key, num := range keys {
-			c.Ui.Output(fmt.Sprintf("  %s [%d/%d]", key, num[0], num[1]))
+		for key, num := range response.Keys {
+			c.Ui.Output(fmt.Sprintf("  %s [%d/%d]", key, num, response.NumNodes))
 		}
 	}
 }
@@ -205,26 +159,8 @@ Usage: consul keyring [options]
   are no errors. If any node fails to reply or reports failure, the exit code
   will be 1.
 
-Options:
+` + c.Command.Help()
 
-  -install=<key>            Install a new encryption key. This will broadcast
-                            the new key to all members in the cluster.
-  -list                     List all keys currently in use within the cluster.
-  -remove=<key>             Remove the given key from the cluster. This
-                            operation may only be performed on keys which are
-                            not currently the primary key.
-  -token=""                 ACL token to use during requests. Defaults to that
-                            of the agent.
-  -relay-factor             Added in Consul 0.7.4, setting this to a non-zero
-                            value will cause nodes to relay their response to
-                            the operation through this many randomly-chosen
-                            other nodes in the cluster. The maximum allowed
-                            value is 5.
-  -use=<key>                Change the primary encryption key, which is used to
-                            encrypt messages. The key must already be installed
-                            before this operation can succeed.
-  -rpc-addr=127.0.0.1:8400  RPC address of the Consul agent.
-`
 	return strings.TrimSpace(helpText)
 }
 

--- a/command/keyring_test.go
+++ b/command/keyring_test.go
@@ -5,8 +5,19 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/command/agent"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
+
+func testKeyringCommand(t *testing.T) (*cli.MockUi, *KeyringCommand) {
+	ui := new(cli.MockUi)
+	return ui, &KeyringCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetClientHTTP,
+		},
+	}
+}
 
 func TestKeyringCommand_implements(t *testing.T) {
 	var _ cli.Command = &KeyringCommand{}
@@ -23,7 +34,7 @@ func TestKeyringCommandRun(t *testing.T) {
 	defer a1.Shutdown()
 
 	// The LAN and WAN keyrings were initialized with key1
-	out := listKeys(t, a1.addr)
+	out := listKeys(t, a1.httpAddr)
 	if !strings.Contains(out, "dc1 (LAN):\n  "+key1) {
 		t.Fatalf("bad: %#v", out)
 	}
@@ -35,10 +46,10 @@ func TestKeyringCommandRun(t *testing.T) {
 	}
 
 	// Install the second key onto the keyring
-	installKey(t, a1.addr, key2)
+	installKey(t, a1.httpAddr, key2)
 
 	// Both keys should be present
-	out = listKeys(t, a1.addr)
+	out = listKeys(t, a1.httpAddr)
 	for _, key := range []string{key1, key2} {
 		if !strings.Contains(out, key) {
 			t.Fatalf("bad: %#v", out)
@@ -46,11 +57,11 @@ func TestKeyringCommandRun(t *testing.T) {
 	}
 
 	// Rotate to key2, remove key1
-	useKey(t, a1.addr, key2)
-	removeKey(t, a1.addr, key1)
+	useKey(t, a1.httpAddr, key2)
+	removeKey(t, a1.httpAddr, key1)
 
 	// Only key2 is present now
-	out = listKeys(t, a1.addr)
+	out = listKeys(t, a1.httpAddr)
 	if !strings.Contains(out, "dc1 (LAN):\n  "+key2) {
 		t.Fatalf("bad: %#v", out)
 	}
@@ -63,8 +74,7 @@ func TestKeyringCommandRun(t *testing.T) {
 }
 
 func TestKeyringCommandRun_help(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 	code := c.Run(nil)
 	if code != 1 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
@@ -77,9 +87,8 @@ func TestKeyringCommandRun_help(t *testing.T) {
 }
 
 func TestKeyringCommandRun_failedConnection(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
-	args := []string{"-list", "-rpc-addr=127.0.0.1:0"}
+	ui, c := testKeyringCommand(t)
+	args := []string{"-list", "-http-addr=127.0.0.1:0"}
 	code := c.Run(args)
 	if code != 1 {
 		t.Fatalf("bad: %d, %#v", code, ui.ErrorWriter.String())
@@ -90,8 +99,7 @@ func TestKeyringCommandRun_failedConnection(t *testing.T) {
 }
 
 func TestKeyringCommandRun_invalidRelayFactor(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 
 	args := []string{"-list", "-relay-factor=6"}
 	code := c.Run(args)
@@ -101,10 +109,9 @@ func TestKeyringCommandRun_invalidRelayFactor(t *testing.T) {
 }
 
 func listKeys(t *testing.T, addr string) string {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 
-	args := []string{"-list", "-rpc-addr=" + addr}
+	args := []string{"-list", "-http-addr=" + addr}
 	code := c.Run(args)
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
@@ -114,10 +121,9 @@ func listKeys(t *testing.T, addr string) string {
 }
 
 func installKey(t *testing.T, addr string, key string) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 
-	args := []string{"-install=" + key, "-rpc-addr=" + addr}
+	args := []string{"-install=" + key, "-http-addr=" + addr}
 	code := c.Run(args)
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
@@ -125,10 +131,9 @@ func installKey(t *testing.T, addr string, key string) {
 }
 
 func useKey(t *testing.T, addr string, key string) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 
-	args := []string{"-use=" + key, "-rpc-addr=" + addr}
+	args := []string{"-use=" + key, "-http-addr=" + addr}
 	code := c.Run(args)
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
@@ -136,10 +141,9 @@ func useKey(t *testing.T, addr string, key string) {
 }
 
 func removeKey(t *testing.T, addr string, key string) {
-	ui := new(cli.MockUi)
-	c := &KeyringCommand{Ui: ui}
+	ui, c := testKeyringCommand(t)
 
-	args := []string{"-remove=" + key, "-rpc-addr=" + addr}
+	args := []string{"-remove=" + key, "-http-addr=" + addr}
 	code := c.Run(args)
 	if code != 0 {
 		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())

--- a/command/kv_command.go
+++ b/command/kv_command.go
@@ -3,13 +3,14 @@ package command
 import (
 	"strings"
 
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
 
 // KVCommand is a Command implementation that just shows help for
 // the subcommands nested below it.
 type KVCommand struct {
-	Ui cli.Ui
+	base.Command
 }
 
 func (c *KVCommand) Run(args []string) int {

--- a/command/kv_delete_test.go
+++ b/command/kv_delete_test.go
@@ -6,8 +6,19 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
+
+func testKVDeleteCommand(t *testing.T) (*cli.MockUi, *KVDeleteCommand) {
+	ui := new(cli.MockUi)
+	return ui, &KVDeleteCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
+	}
+}
 
 func TestKVDeleteCommand_implements(t *testing.T) {
 	var _ cli.Command = &KVDeleteCommand{}
@@ -18,8 +29,7 @@ func TestKVDeleteCommand_noTabs(t *testing.T) {
 }
 
 func TestKVDeleteCommand_Validation(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KVDeleteCommand{Ui: ui}
+	ui, c := testKVDeleteCommand(t)
 
 	cases := map[string]struct {
 		args   []string
@@ -73,8 +83,7 @@ func TestKVDeleteCommand_Run(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVDeleteCommand{Ui: ui}
+	ui, c := testKVDeleteCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "foo",
@@ -109,8 +118,7 @@ func TestKVDeleteCommand_Recurse(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVDeleteCommand{Ui: ui}
+	ui, c := testKVDeleteCommand(t)
 
 	keys := []string{"foo/a", "foo/b", "food"}
 
@@ -152,8 +160,7 @@ func TestKVDeleteCommand_CAS(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVDeleteCommand{Ui: ui}
+	ui, c := testKVDeleteCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "foo",

--- a/command/kv_export_test.go
+++ b/command/kv_export_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
 
@@ -15,7 +16,12 @@ func TestKVExportCommand_Run(t *testing.T) {
 	waitForLeader(t, srv.httpAddr)
 
 	ui := new(cli.MockUi)
-	c := &KVExportCommand{Ui: ui}
+	c := KVExportCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
+	}
 
 	keys := map[string]string{
 		"foo/a": "a",

--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -57,6 +57,8 @@ Usage: consul kv get [options] [KEY_OR_PREFIX]
 
 func (c *KVGetCommand) Run(args []string) int {
 	f := c.Command.NewFlagSet(c)
+	base64encode := f.Bool("base64", false,
+		"Base64 encode the value. The default value is false.")
 	detailed := f.Bool("detailed", false,
 		"Provide additional metadata about the key in addition to the value such "+
 			"as the ModifyIndex and any flags that may have been set on the key. "+
@@ -66,8 +68,6 @@ func (c *KVGetCommand) Run(args []string) int {
 			"This is especially useful if you only need the key names themselves. "+
 			"This option is commonly combined with the -separator option. The default "+
 			"value is false.")
-	base64encode := f.Bool("base64", false,
-		"Base64 encode the value. The default value is false.")
 	recurse := f.Bool("recurse", false,
 		"Recursively look at all keys prefixed with the given path. The default "+
 			"value is false.")

--- a/command/kv_get_test.go
+++ b/command/kv_get_test.go
@@ -6,8 +6,19 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
+
+func testKVGetCommand(t *testing.T) (*cli.MockUi, *KVGetCommand) {
+	ui := new(cli.MockUi)
+	return ui, &KVGetCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
+	}
+}
 
 func TestKVGetCommand_implements(t *testing.T) {
 	var _ cli.Command = &KVGetCommand{}
@@ -18,8 +29,7 @@ func TestKVGetCommand_noTabs(t *testing.T) {
 }
 
 func TestKVGetCommand_Validation(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	cases := map[string]struct {
 		args   []string
@@ -61,8 +71,7 @@ func TestKVGetCommand_Run(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "foo",
@@ -94,8 +103,7 @@ func TestKVGetCommand_Missing(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	_, c := testKVGetCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,
@@ -113,8 +121,7 @@ func TestKVGetCommand_Empty(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "empty",
@@ -141,8 +148,7 @@ func TestKVGetCommand_Detailed(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "foo",
@@ -184,8 +190,7 @@ func TestKVGetCommand_Keys(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	keys := []string{"foo/bar", "foo/baz", "foo/zip"}
 	for _, key := range keys {
@@ -218,8 +223,7 @@ func TestKVGetCommand_Recurse(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	keys := map[string]string{
 		"foo/a": "a",
@@ -257,8 +261,7 @@ func TestKVGetCommand_RecurseBase64(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	keys := map[string]string{
 		"foo/a": "Hello World 1",
@@ -297,8 +300,7 @@ func TestKVGetCommand_DetailedBase64(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVGetCommand{Ui: ui}
+	ui, c := testKVGetCommand(t)
 
 	pair := &api.KVPair{
 		Key:   "foo",

--- a/command/kv_import_test.go
+++ b/command/kv_import_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
 
@@ -27,7 +28,10 @@ func TestKVImportCommand_Run(t *testing.T) {
 
 	ui := new(cli.MockUi)
 	c := &KVImportCommand{
-		Ui:        ui,
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
 		testStdin: strings.NewReader(json),
 	}
 

--- a/command/kv_put_test.go
+++ b/command/kv_put_test.go
@@ -11,20 +11,30 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
 )
+
+func testKVPutCommand(t *testing.T) (*cli.MockUi, *KVPutCommand) {
+	ui := new(cli.MockUi)
+	return ui, &KVPutCommand{
+		Command: base.Command{
+			Ui:    ui,
+			Flags: base.FlagSetHTTP,
+		},
+	}
+}
 
 func TestKVPutCommand_implements(t *testing.T) {
 	var _ cli.Command = &KVPutCommand{}
 }
 
 func TestKVPutCommand_noTabs(t *testing.T) {
-	assertNoTabs(t, new(KVPutCommand))
+	assertNoTabs(t, new(KVDeleteCommand))
 }
 
 func TestKVPutCommand_Validation(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	cases := map[string]struct {
 		args   []string
@@ -78,8 +88,7 @@ func TestKVPutCommand_Run(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,
@@ -106,8 +115,7 @@ func TestKVPutCommand_RunEmptyDataQuoted(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,
@@ -134,8 +142,7 @@ func TestKVPutCommand_RunBase64(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	const encodedString = "aGVsbG8gd29ybGQK"
 
@@ -170,8 +177,7 @@ func TestKVPutCommand_File(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	f, err := ioutil.TempFile("", "kv-put-command-file")
 	if err != nil {
@@ -203,8 +209,7 @@ func TestKVPutCommand_File(t *testing.T) {
 }
 
 func TestKVPutCommand_FileNoExist(t *testing.T) {
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"foo", "@/nope/definitely/not-a-real-file.txt",
@@ -228,11 +233,8 @@ func TestKVPutCommand_Stdin(t *testing.T) {
 
 	stdinR, stdinW := io.Pipe()
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{
-		Ui:        ui,
-		testStdin: stdinR,
-	}
+	ui, c := testKVPutCommand(t)
+	c.testStdin = stdinR
 
 	go func() {
 		stdinW.Write([]byte("bar"))
@@ -264,8 +266,7 @@ func TestKVPutCommand_NegativeVal(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,
@@ -292,8 +293,7 @@ func TestKVPutCommand_Flags(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,
@@ -330,8 +330,7 @@ func TestKVPutCommand_CAS(t *testing.T) {
 		t.Fatalf("err: %#v", err)
 	}
 
-	ui := new(cli.MockUi)
-	c := &KVPutCommand{Ui: ui}
+	ui, c := testKVPutCommand(t)
 
 	args := []string{
 		"-http-addr=" + srv.httpAddr,

--- a/commands.go
+++ b/commands.go
@@ -41,14 +41,20 @@ func init() {
 
 		"event": func() (cli.Command, error) {
 			return &command.EventCommand{
-				Ui: ui,
+				Command: base.Command{
+					Flags: base.FlagSetHTTP,
+					Ui:    ui,
+				},
 			}, nil
 		},
 
 		"exec": func() (cli.Command, error) {
 			return &command.ExecCommand{
 				ShutdownCh: makeShutdownCh(),
-				Ui:         ui,
+				Command: base.Command{
+					Flags: base.FlagSetHTTP,
+					Ui:    ui,
+				},
 			}, nil
 		},
 
@@ -57,6 +63,15 @@ func init() {
 				Command: base.Command{
 					Flags: base.FlagSetClientHTTP,
 					Ui:    ui,
+				},
+			}, nil
+		},
+
+		"info": func() (cli.Command, error) {
+			return &command.InfoCommand{
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetClientHTTP,
 				},
 			}, nil
 		},
@@ -152,12 +167,6 @@ func init() {
 
 		"operator": func() (cli.Command, error) {
 			return &command.OperatorCommand{
-				Ui: ui,
-			}, nil
-		},
-
-		"info": func() (cli.Command, error) {
-			return &command.InfoCommand{
 				Ui: ui,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -85,6 +85,15 @@ func init() {
 			}, nil
 		},
 
+		"keygen": func() (cli.Command, error) {
+			return &command.KeygenCommand{
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetNone,
+				},
+			}, nil
+		},
+
 		"kv": func() (cli.Command, error) {
 			return &command.KVCommand{
 				Ui: ui,
@@ -117,12 +126,6 @@ func init() {
 
 		"kv import": func() (cli.Command, error) {
 			return &command.KVImportCommand{
-				Ui: ui,
-			}, nil
-		},
-
-		"keygen": func() (cli.Command, error) {
-			return &command.KeygenCommand{
 				Ui: ui,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -94,6 +94,15 @@ func init() {
 			}, nil
 		},
 
+		"keyring": func() (cli.Command, error) {
+			return &command.KeyringCommand{
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetClientHTTP,
+				},
+			}, nil
+		},
+
 		"kv": func() (cli.Command, error) {
 			return &command.KVCommand{
 				Ui: ui,
@@ -126,12 +135,6 @@ func init() {
 
 		"kv import": func() (cli.Command, error) {
 			return &command.KVImportCommand{
-				Ui: ui,
-			}, nil
-		},
-
-		"keyring": func() (cli.Command, error) {
-			return &command.KeyringCommand{
 				Ui: ui,
 			}, nil
 		},

--- a/commands.go
+++ b/commands.go
@@ -105,37 +105,55 @@ func init() {
 
 		"kv": func() (cli.Command, error) {
 			return &command.KVCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetNone,
+				},
 			}, nil
 		},
 
 		"kv delete": func() (cli.Command, error) {
 			return &command.KVDeleteCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetHTTP,
+				},
 			}, nil
 		},
 
 		"kv get": func() (cli.Command, error) {
 			return &command.KVGetCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetHTTP,
+				},
 			}, nil
 		},
 
 		"kv put": func() (cli.Command, error) {
 			return &command.KVPutCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetHTTP,
+				},
 			}, nil
 		},
 
 		"kv export": func() (cli.Command, error) {
 			return &command.KVExportCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetHTTP,
+				},
 			}, nil
 		},
 
 		"kv import": func() (cli.Command, error) {
 			return &command.KVImportCommand{
-				Ui: ui,
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetHTTP,
+				},
 			}, nil
 		},
 

--- a/commands.go
+++ b/commands.go
@@ -76,6 +76,15 @@ func init() {
 			}, nil
 		},
 
+		"join": func() (cli.Command, error) {
+			return &command.JoinCommand{
+				Command: base.Command{
+					Ui:    ui,
+					Flags: base.FlagSetClientHTTP,
+				},
+			}, nil
+		},
+
 		"kv": func() (cli.Command, error) {
 			return &command.KVCommand{
 				Ui: ui,
@@ -108,12 +117,6 @@ func init() {
 
 		"kv import": func() (cli.Command, error) {
 			return &command.KVImportCommand{
-				Ui: ui,
-			}, nil
-		},
-
-		"join": func() (cli.Command, error) {
-			return &command.JoinCommand{
 				Ui: ui,
 			}, nil
 		},

--- a/website/source/docs/commands/event.html.markdown.erb
+++ b/website/source/docs/commands/event.html.markdown.erb
@@ -39,13 +39,12 @@ Usage: `consul event [options] [payload]`
 The only required option is `-name` which specifies the event name. An optional
 payload can be provided as the final argument.
 
-The list of available flags are:
+#### API Options
 
-* `-http-addr` - Address to the HTTP server of the agent you want to contact
-  to send this command. If this isn't specified, the command will contact
-  `127.0.0.1:8500` which is the default HTTP address of a Consul agent.
+<%= partial "docs/commands/http_api_options_client" %>
+<%= partial "docs/commands/http_api_options_server" %>
 
-* `-datacenter` - Datacenter to query. Defaults to that of agent.
+#### Command Options
 
 * `-name` - The name of the event.
 
@@ -57,5 +56,3 @@ The list of available flags are:
   a matching tag. This must be used with `-service`. As an example, you may
   do `-service mysql -tag secondary`.
 
-* `-token` - The ACL token to use when firing the event. This token must have
-  write-level privileges for the event specified. Defaults to that of the agent.

--- a/website/source/docs/commands/exec.html.markdown.erb
+++ b/website/source/docs/commands/exec.html.markdown.erb
@@ -37,14 +37,12 @@ The only required option is a command to execute. This is either given
 as trailing arguments, or by specifying `-`; STDIN will be read to
 completion as a script to evaluate.
 
-The list of available flags are:
+#### API Options
 
-* `-http-addr` - Address to the HTTP server of the agent you want to contact
-  to send this command. If this isn't specified, the command will contact
-  `127.0.0.1:8500` which is the default HTTP address of a Consul agent.
+<%= partial "docs/commands/http_api_options_client" %>
+<%= partial "docs/commands/http_api_options_server" %>
 
-* `-datacenter` - Datacenter to query. Defaults to that of agent. In version
-  0.4, that is the only supported value.
+#### Command Options
 
 * `-prefix` - Key prefix in the KV store to use for storing request data.
   Defaults to `_rexec`.
@@ -67,7 +65,3 @@ The list of available flags are:
   to 200 msec.
 
 * `-verbose` - Enables verbose output.
-
-* `-token` - The ACL token to use during requests. This token must have access
-  to the prefix in the KV store as well as exec "write" access for the `_rexec`
-  event. Defaults to that of the agent.

--- a/website/source/docs/commands/info.html.markdown.erb
+++ b/website/source/docs/commands/info.html.markdown.erb
@@ -72,10 +72,6 @@ serf_wan:
 
 Usage: `consul info`
 
-The command-line flags are all optional. The list of available flags are:
+#### API Options
 
-* `-rpc-addr` - Address to the RPC server of the agent you want to contact
-  to send this command. If this isn't specified, the command checks the
-  CONSUL_RPC_ADDR env variable. If this isn't set, the default RPC 
-  address will be set to "127.0.0.1:8400". 
-
+<%= partial "docs/commands/http_api_options_client" %>

--- a/website/source/docs/commands/join.html.markdown.erb
+++ b/website/source/docs/commands/join.html.markdown.erb
@@ -31,14 +31,14 @@ You may call join with multiple addresses if you want to try to join
 multiple clusters. Consul will attempt to join all addresses, and the join
 command will fail only if Consul was unable to join with any.
 
-The command-line flags are all optional. The list of available flags are:
+#### API Options
+
+<%= partial "docs/commands/http_api_options_client" %>
+
+#### Command Options
 
 * `-wan` - For agents running in server mode, the agent will attempt to join
   other servers gossiping in a WAN cluster. This is used to form a bridge between
   multiple datacenters.
 
-* `-rpc-addr` - Address to the RPC server of the agent you want to contact
-  to send this command. If this isn't specified, the command checks the
-  CONSUL_RPC_ADDR env variable. If this isn't set, the default RPC 
-  address will be set to "127.0.0.1:8400". 
 

--- a/website/source/docs/commands/keyring.html.markdown.erb
+++ b/website/source/docs/commands/keyring.html.markdown.erb
@@ -33,7 +33,11 @@ Usage: `consul keyring [options]`
 Only one actionable argument may be specified per run, including `-list`,
 `-install`, `-remove`, and `-use`.
 
-The list of available flags are:
+#### API Options
+
+<%= partial "docs/commands/http_api_options_client" %>
+
+#### Command Options
 
 * `-list` - List all keys currently in use within the cluster.
 
@@ -46,15 +50,9 @@ The list of available flags are:
 * `-remove` - Remove the given key from the cluster. This operation may only be
   performed on keys which are not currently the primary key.
 
-* `-token=""` - ACL token to use during requests. Defaults to that of the agent.
-
 * `-relay-factor` - Added in Consul 0.7.4, setting this to a non-zero value will
   cause nodes to relay their response to the operation through this many
   randomly-chosen other nodes in the cluster. The maximum allowed value is 5.
-
-* `-rpc-addr` - Address to the RPC server of the agent you want to contact
-  to send this command. If this isn't specified, the command will contact
-  "127.0.0.1:8400" which is the default RPC address of a Consul agent.
 
 ## Output
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -88,8 +88,8 @@
 					</li>
 
 					<li<%= sidebar_current("docs-commands-info") %>>
-                    <a href="/docs/commands/info.html">info</a>
-                    </li>
+					<a href="/docs/commands/info.html">info</a>
+					</li>
 
 					<li<%= sidebar_current("docs-commands-join") %>>
 					<a href="/docs/commands/join.html">join</a>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -87,6 +87,10 @@
 					<a href="/docs/commands/force-leave.html">force-leave</a>
 					</li>
 
+					<li<%= sidebar_current("docs-commands-info") %>>
+                    <a href="/docs/commands/info.html">info</a>
+                    </li>
+
 					<li<%= sidebar_current("docs-commands-join") %>>
 					<a href="/docs/commands/join.html">join</a>
 					</li>
@@ -141,10 +145,6 @@
 
 					<li<%= sidebar_current("docs-commands-operator") %>>
 					<a href="/docs/commands/operator.html">operator</a>
-					</li>
-
-					<li<%= sidebar_current("docs-commands-info") %>>
-					<a href="/docs/commands/info.html">info</a>
 					</li>
 
 					<li<%= sidebar_current("docs-commands-reload") %>>


### PR DESCRIPTION
This converts the commands up through `kv` to use the base.Command structure for parsing.

Fixes #2566 