### PR TITLE
Clean up http-addr parsing for https and unix sockets

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -348,9 +348,11 @@ func NewClient(config *Config) (*Client, error) {
 
 	parts := strings.SplitN(config.Address, "://", 2)
 	if len(parts) == 2 {
-		if parts[0] == "https" {
+		switch parts[0] {
+		case "http":
+		case "https":
 			config.Scheme = "https"
-		} else if parts[0] == "unix" {
+		case "unix":
 			trans := cleanhttp.DefaultTransport()
 			trans.Dial = func(_, _ string) (net.Conn, error) {
 				return net.Dial("unix", parts[1])
@@ -358,6 +360,8 @@ func NewClient(config *Config) (*Client, error) {
 			config.HttpClient = &http.Client{
 				Transport: trans,
 			}
+		default:
+			return nil, fmt.Errorf("Unknown protocol scheme: %s", parts[0])
 		}
 		config.Address = parts[1]
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -346,13 +346,18 @@ func NewClient(config *Config) (*Client, error) {
 		config.HttpClient = defConfig.HttpClient
 	}
 
-	if parts := strings.SplitN(config.Address, "unix://", 2); len(parts) == 2 {
-		trans := cleanhttp.DefaultTransport()
-		trans.Dial = func(_, _ string) (net.Conn, error) {
-			return net.Dial("unix", parts[1])
-		}
-		config.HttpClient = &http.Client{
-			Transport: trans,
+	parts := strings.SplitN(config.Address, "://", 2)
+	if len(parts) == 2 {
+		if parts[0] == "https" {
+			config.Scheme = "https"
+		} else if parts[0] == "unix" {
+			trans := cleanhttp.DefaultTransport()
+			trans.Dial = func(_, _ string) (net.Conn, error) {
+				return net.Dial("unix", parts[1])
+			}
+			config.HttpClient = &http.Client{
+				Transport: trans,
+			}
 		}
 		config.Address = parts[1]
 	}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1082,7 +1082,13 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Get the new client http listener addr
-	httpAddr, err := config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
+	var httpAddr net.Addr
+	var err error
+	if config.Ports.HTTP != -1 {
+		httpAddr, err = config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
+	} else {
+		httpAddr, err = config.ClientListener(config.Addresses.HTTPS, config.Ports.HTTPS)
+	}
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to determine HTTP address: %v", err))
 	}
@@ -1092,7 +1098,12 @@ func (c *Command) Run(args []string) int {
 		go func(wp *watch.WatchPlan) {
 			wp.Handler = makeWatchHandler(logOutput, wp.Exempt["handler"])
 			wp.LogOutput = c.logOutput
-			if err := wp.Run(httpAddr.String()); err != nil {
+			addr := httpAddr.String()
+			// If it's a unix socket, prefix with unix:// so the client initializes correctly
+			if httpAddr.Network() == "unix" {
+				addr = "unix://" + addr
+			}
+			if err := wp.Run(addr); err != nil {
 				c.Ui.Error(fmt.Sprintf("Error running watch: %v", err))
 			}
 		}(wp)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1086,8 +1086,11 @@ func (c *Command) Run(args []string) int {
 	var err error
 	if config.Ports.HTTP != -1 {
 		httpAddr, err = config.ClientListener(config.Addresses.HTTP, config.Ports.HTTP)
-	} else {
+	} else if config.Ports.HTTPS != -1 {
 		httpAddr, err = config.ClientListener(config.Addresses.HTTPS, config.Ports.HTTPS)
+	} else if len(config.WatchPlans) > 0 {
+		c.Ui.Error("Error: cannot use watches if both HTTP and HTTPS are disabled")
+		return 1
 	}
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to determine HTTP address: %v", err))

--- a/command/base/command.go
+++ b/command/base/command.go
@@ -86,7 +86,8 @@ func (c *Command) httpFlagsClient(f *flag.FlagSet) *flag.FlagSet {
 		"The `address` and port of the Consul HTTP agent. The value can be an IP "+
 			"address or DNS address, but it must also include the port. This can "+
 			"also be specified via the CONSUL_HTTP_ADDR environment variable. The "+
-			"default value is 127.0.0.1:8500.")
+			"default value is http://127.0.0.1:8500. The scheme can also be set to "+
+			"HTTPS by setting the environment variable CONSUL_HTTP_SSL=true.")
 	f.Var(&c.token, "token",
 		"ACL token to use in the request. This can also be specified via the "+
 			"CONSUL_HTTP_TOKEN environment variable. If unspecified, the query will "+

--- a/website/source/docs/commands/_http_api_options_client.html.markdown
+++ b/website/source/docs/commands/_http_api_options_client.html.markdown
@@ -1,7 +1,9 @@
 * `-http-addr=<addr>` - Address of the Consul agent with the port. This can be
   an IP address or DNS address, but it must include the port. This can also be
-  specified via the `CONSUL_HTTP_ADDR` environment variable. The default value is
-  127.0.0.1:8500.
+  specified via the `CONSUL_HTTP_ADDR` environment variable. In Consul 0.8 and
+  later, the default value is http://127.0.0.1:8500, and https can optionally
+  be used instead. The scheme can also be set to HTTPS by setting the
+  environment variable `CONSUL_HTTP_SSL=true`.
 
 * `-token=<value>` - ACL token to use in the request. This can also be specified
   via the `CONSUL_HTTP_TOKEN` environment variable. If unspecified, the query


### PR DESCRIPTION
This allows passing an `-http-addr` prefixed with `http://` or `https://` to set the scheme. Also fixes an issue where internal watches would fail when using a unix socket or when only HTTPS was enabled.

Fixes #1962 
Fixes #2365 
Fixes #2385 