### PR TITLE
Updates hashicorp/go-immutable-radix to pick up leaf panic fixes.

### DIFF
--- a/vendor/github.com/hashicorp/go-immutable-radix/node.go
+++ b/vendor/github.com/hashicorp/go-immutable-radix/node.go
@@ -91,24 +91,6 @@ func (n *Node) delEdge(label byte) {
 	}
 }
 
-func (n *Node) mergeChild() {
-	e := n.edges[0]
-	child := e.node
-	n.prefix = concat(n.prefix, child.prefix)
-	if child.leaf != nil {
-		n.leaf = new(leafNode)
-		*n.leaf = *child.leaf
-	} else {
-		n.leaf = nil
-	}
-	if len(child.edges) != 0 {
-		n.edges = make([]edge, len(child.edges))
-		copy(n.edges, child.edges)
-	} else {
-		n.edges = nil
-	}
-}
-
 func (n *Node) GetWatch(k []byte) (<-chan struct{}, interface{}, bool) {
 	search := k
 	watch := n.mutateCh

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -444,10 +444,10 @@
 			"revisionTime": "2017-02-11T01:34:15Z"
 		},
 		{
-			"checksumSHA1": "jPxyofQxI1PRPq6LPc6VlcRn5fI=",
+			"checksumSHA1": "zvmksNyW6g+Fd/bywd4vcn8rp+M=",
 			"path": "github.com/hashicorp/go-immutable-radix",
-			"revision": "76b5f4e390910df355bfb9b16b41899538594a05",
-			"revisionTime": "2017-01-13T02:29:29Z"
+			"revision": "d0852f9e7b91ec9633735052bdab00bf802b353c",
+			"revisionTime": "2017-02-14T00:45:45Z"
 		},
 		{
 			"checksumSHA1": "K8Fsgt1llTXP0EwqdBzvSGdKOKc=",


### PR DESCRIPTION
This fixes #2724 by properly tracking leaf updates during very large delete transactions.