### PR TITLE
Return more informations on error

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -174,8 +174,13 @@ func (k *KV) getInternal(key string, params map[string]string, q *QueryOptions) 
 		resp.Body.Close()
 		return nil, qm, nil
 	} else if resp.StatusCode != 200 {
+		errMsg := fmt.Sprintf("Unexpected response code: %d", resp.StatusCode)
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, resp.Body); err == nil {
+			errMsg = fmt.Sprintf("%s: %s", errMsg, buf.String())
+		}
 		resp.Body.Close()
-		return nil, nil, fmt.Errorf("Unexpected response code: %d", resp.StatusCode)
+		return nil, nil, fmt.Errorf(errMsg)
 	}
 	return resp, qm, nil
 }


### PR DESCRIPTION
* This makes it possible to distinguish errors like:
  403: Permission denied
  403: ACL not found