### PR TITLE
Demo: install latest version by default

### DIFF
--- a/demo/vagrant-cluster/README.md
+++ b/demo/vagrant-cluster/README.md
@@ -2,7 +2,8 @@
 
 This demo provides a very simple `Vagrantfile` that creates two Consul
 server nodes, one at *172.20.20.10* and another at *172.20.20.11*. Both are
-running a standard Debian * distribution, and Consul is pre-installed.
+running a standard Debian * distribution, and *the latest version* of Consul
+is pre-installed.
 
 To get started, you can start the nodes by just doing:
 
@@ -29,7 +30,7 @@ At this point the two nodes are running and you can SSH in to play with them:
 ```
 vagrant ssh n1
 consul version
-Consul v0.7.2
+Consul v0.7.5
 Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
 exit
 ```
@@ -39,14 +40,15 @@ and
 ```
 vagrant ssh n2
 consul version
-Consul v0.7.2
+Consul v0.7.5
 Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
 exit
 ```
 
-> NOTE: This demo will install the latest Consul release version by default,
-> but if you prefer a different version, you can set the `CONSUL_DEMO_VERSION`
-> environment variable before starting `vagrant` like this: 
+> NOTE: This demo will query the HashiCorp Checkpoint service to determine
+> the the latest Consul release version and install that version by default,
+> but if you need a different Consul version, set the `CONSUL_DEMO_VERSION`
+> environment variable before `vagrant up` like this:
 > `CONSUL_DEMO_VERSION=0.6.4 vagrant up`
 
 ## Where to Next?

--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -5,7 +5,13 @@ $script = <<SCRIPT
 
 echo "Installing dependencies ..."
 sudo apt-get update
-sudo apt-get install -y unzip curl
+sudo apt-get install -y unzip curl jq
+
+echo "Determining Consul version to install ..."
+CHECKPOINT_URL="https://checkpoint-api.hashicorp.com/v1/check"
+if [ -z "$CONSUL_DEMO_VERSION" ]; then
+    CONSUL_DEMO_VERSION=$(curl -s "${CHECKPOINT_URL}"/consul | jq .current_version | tr -d '"')
+fi
 
 echo "Fetching Consul version ${CONSUL_DEMO_VERSION} ..."
 cd /tmp/
@@ -22,7 +28,7 @@ sudo chmod a+w /etc/consul.d
 SCRIPT
 
 # Specify a Consul version
-CONSUL_DEMO_VERSION = ENV['CONSUL_DEMO_VERSION'] || "0.7.2"
+CONSUL_DEMO_VERSION = ENV['CONSUL_DEMO_VERSION']
 
 # Specify a custom Vagrant box for the demo
 DEMO_BOX_NAME = ENV['DEMO_BOX_NAME'] || "debian/jessie64"


### PR DESCRIPTION
Updates Vagrant demo to make it automagically install latest available version:

- Query Checkpoint to determine latest Consul version and install that
  (can override installed version with CONSUL_DEMO_VERSION variable)
- Update README
