### PR TITLE
Change `ClientAddr` to default to `BindAddr` when not present.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -264,6 +264,12 @@ func (c *Command) readConfig() *Config {
 		}
 	}
 
+	// If the client address is empty, default to using the value specified by the
+	// bind address.
+	if config.ClientAddr == "" {
+		config.ClientAddr = config.BindAddr
+	}
+
 	// Ensure all endpoints are unique
 	if err := config.verifyUniqueListeners(); err != nil {
 		c.Ui.Error(fmt.Sprintf("All listening endpoints must be unique: %s", err))

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -742,7 +742,6 @@ func DefaultConfig() *Config {
 		Datacenter:      consul.DefaultDC,
 		Domain:          "consul.",
 		LogLevel:        "INFO",
-		ClientAddr:      "127.0.0.1",
 		BindAddr:        "0.0.0.0",
 		Ports: PortConfig{
 			DNS:     8600,

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -116,8 +116,8 @@ will exit with an error at startup.
 
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which
   Consul will bind client interfaces, including the HTTP and DNS servers. When
-  not specified, the default value is the same as
-  the [`_bind` command-line flag](#_bind) address.
+  not specified, the default value is the same as the [`_bind` command-line
+  flag](#_bind) address (prior to 0.8 the default value was `127.0.0.1`).
 
 * <a name="_config_file"></a><a href="#_config_file">`-config-file`</a> - A configuration file
   to load. For more information on
@@ -589,10 +589,11 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="client_addr"></a><a href="#client_addr">`client_addr`</a> Equivalent
   to the [`-client` command-line flag](#_client).  When not specified, the
-  default value is the same as the [`bind_addr`](#bind_addr) address.  It is not
-  normally necessary to specify this value, however, may be necessary in more
-  complex setups where agents are NATed or when an agent is running in client
-  and server mode (common in development).
+  default value is the same as the [`bind_addr`](#bind_addr) address (prior to
+  `0.8` the default value was `127.0.0.1`).  It is not normally necessary to
+  specify this value, however, may be necessary in more complex setups where
+  agents are NATed or when an agent is running in client and server mode (common
+  in development).
 
 * <a name="datacenter"></a><a href="#datacenter">`datacenter`</a> Equivalent to the
   [`-datacenter` command-line flag](#_datacenter).

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -115,8 +115,9 @@ will exit with an error at startup.
   [`-bind` command-line flag](#_bind), and if this is not specified, the `-bind` option is used. This is available in Consul 0.7.1 and later.
 
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which
-  Consul will bind client interfaces, including the HTTP and DNS servers. By default,
-  this is "127.0.0.1", allowing only loopback connections.
+  Consul will bind client interfaces, including the HTTP and DNS servers. When
+  not specified, the default value is the same as
+  the [`_bind` command-line flag](#_bind) address.
 
 * <a name="_config_file"></a><a href="#_config_file">`-config-file`</a> - A configuration file
   to load. For more information on
@@ -586,8 +587,12 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   reduce write pressure. If a check ever changes state, the new state and associated
   output is synchronized immediately. To disable this behavior, set the value to "0s".
 
-* <a name="client_addr"></a><a href="#client_addr">`client_addr`</a> Equivalent to the
-  [`-client` command-line flag](#_client).
+* <a name="client_addr"></a><a href="#client_addr">`client_addr`</a> Equivalent
+  to the [`-client` command-line flag](#_client).  When not specified, the
+  default value is the same as the [`bind_addr`](#bind_addr) address.  It is not
+  normally necessary to specify this value, however, may be necessary in more
+  complex setups where agents are NATed or when an agent is running in client
+  and server mode (common in development).
 
 * <a name="datacenter"></a><a href="#datacenter">`datacenter`</a> Equivalent to the
   [`-datacenter` command-line flag](#_datacenter).


### PR DESCRIPTION
With this change, it is now possible to only specify the `-bind` or
`bind_addr` attributes and get a functioning consul agent.

There are two possible paths from this PR:

1. Set `BindAddr`'s default to `{{ GetPrivateIP }}`, which will return an empty string and fail downstream if a private IP isn't available.
2. Leave things as the status quo for the time being until we move to something that's 100% backwards compatible.

I researched option #2 but put a pin in that because it brought a pile of additional work.  The rough sketch of what I had in mind to satisfy option #2 would be to:

* introduce a `-listen` flag and config option which would contain one or more IP addresses that would be used for all services.
* introduce similar `-listen-http`, `-listen-serf` that would be the more granular per-service overrides, but similar to `-listen`, also zero or more.
* deprecate `-advertise-addr` and `-advertise-addr-wan` and tagged addresses
* introduce a mapping scheme that would allow for NAT'ing Consul's various addresses before values are either queried or leaked into Consul/Serf.  This was the biggest lift, but it simplifies the UX considerably.

The thought experiment went like this (JSON5 used in this example for comments-sake):

```json
{
  // or simply "nat"
  "nat_rules": {
    "dc": {
      // Like _agent in prepared queries, _dc would be an alias for the current datacenter.  In this case, any query for the http or https services would be static NAT'ed to the following two endpoints.
      "_dc": {
        "http": "1.2.3.4:8600",
        "https": "6.7.8.9:8600"
      }
    }
    "agent": {
      "node1": { /* node1's override */ },
      "*._dc": { /* I contemplated a glob and removing the agent nesting... */ },
    },
  }
}
```

But again, that was a big lift potentially and it was easier to just set two defaults.  It'd be nice to clean this all up in a unified manner, however, and a thrust in this direction seemed like a reasonable approach.

Regarding the PR, I considered a fallback to `127.0.0.1`, but that never seemed like a good idea in a normal production environment.  If someone wants `127.0.0.1`, they should explicitly set it.  Merge or discard as you see fit.