### PR TITLE
Revert "Change `ClientAddr` to default to `BindAddr` when not present."

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -264,12 +264,6 @@ func (c *Command) readConfig() *Config {
 		}
 	}
 
-	// If the client address is empty, default to using the value specified by the
-	// bind address.
-	if config.ClientAddr == "" {
-		config.ClientAddr = config.BindAddr
-	}
-
 	// Ensure all endpoints are unique
 	if err := config.verifyUniqueListeners(); err != nil {
 		c.Ui.Error(fmt.Sprintf("All listening endpoints must be unique: %s", err))

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -742,6 +742,7 @@ func DefaultConfig() *Config {
 		Datacenter:      consul.DefaultDC,
 		Domain:          "consul.",
 		LogLevel:        "INFO",
+		ClientAddr:      "127.0.0.1",
 		BindAddr:        "0.0.0.0",
 		Ports: PortConfig{
 			DNS:     8600,

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -115,9 +115,8 @@ will exit with an error at startup.
   [`-bind` command-line flag](#_bind), and if this is not specified, the `-bind` option is used. This is available in Consul 0.7.1 and later.
 
 * <a name="_client"></a><a href="#_client">`-client`</a> - The address to which
-  Consul will bind client interfaces, including the HTTP and DNS servers. When
-  not specified, the default value is the same as the [`_bind` command-line
-  flag](#_bind) address (prior to 0.8 the default value was `127.0.0.1`).
+  Consul will bind client interfaces, including the HTTP and DNS servers. By default,
+  this is "127.0.0.1", allowing only loopback connections.
 
 * <a name="_config_file"></a><a href="#_config_file">`-config-file`</a> - A configuration file
   to load. For more information on
@@ -587,13 +586,8 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   reduce write pressure. If a check ever changes state, the new state and associated
   output is synchronized immediately. To disable this behavior, set the value to "0s".
 
-* <a name="client_addr"></a><a href="#client_addr">`client_addr`</a> Equivalent
-  to the [`-client` command-line flag](#_client).  When not specified, the
-  default value is the same as the [`bind_addr`](#bind_addr) address (prior to
-  `0.8` the default value was `127.0.0.1`).  It is not normally necessary to
-  specify this value, however, may be necessary in more complex setups where
-  agents are NATed or when an agent is running in client and server mode (common
-  in development).
+* <a name="client_addr"></a><a href="#client_addr">`client_addr`</a> Equivalent to the
+  [`-client` command-line flag](#_client).
 
 * <a name="datacenter"></a><a href="#datacenter">`datacenter`</a> Equivalent to the
   [`-datacenter` command-line flag](#_datacenter).


### PR DESCRIPTION
Reverts hashicorp/consul#2786

This is breaking some assumptions in testing.  The code looks right, but the tests are brittle in a few places and need to be worked on.  Backing out for now but will re-merge later when I have time to dig into this.