### PR TITLE
Website add meganav

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.12"
+gem "middleman-hashicorp", "0.3.13"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/hashicorp/middleman-hashicorp.git
-  revision: 8a95c5854a4497fdb81ebf9f82103010691a1fa2
+  revision: 3ef8214c5650d2fede0f45a8a0f103d70ca9c9c3
   specs:
-    middleman-hashicorp (0.3.10)
+    middleman-hashicorp (0.3.11)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/hashicorp/middleman-hashicorp.git
-  revision: 3ef8214c5650d2fede0f45a8a0f103d70ca9c9c3
-  specs:
-    middleman-hashicorp (0.3.11)
-      bootstrap-sass (~> 3.3)
-      builder (~> 3.2)
-      middleman (~> 3.4)
-      middleman-livereload (~> 3.4)
-      middleman-syntax (~> 3.0)
-      redcarpet (~> 3.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -89,7 +77,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.12)
+    middleman-hashicorp (0.3.13)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -163,7 +151,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.12)
+  middleman-hashicorp (= 0.3.13)
 
 BUNDLED WITH
    1.14.6

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/hashicorp/middleman-hashicorp.git
+  revision: 8a95c5854a4497fdb81ebf9f82103010691a1fa2
+  specs:
+    middleman-hashicorp (0.3.10)
+      bootstrap-sass (~> 3.3)
+      builder (~> 3.2)
+      middleman (~> 3.4)
+      middleman-livereload (~> 3.4)
+      middleman-syntax (~> 3.0)
+      redcarpet (~> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.12"
+VERSION?="0.3.13"
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/packer.json
+++ b/website/packer.json
@@ -8,7 +8,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "hashicorp/middleman-hashicorp:0.3.12",
+      "image": "hashicorp/middleman-hashicorp:0.3.13",
       "discard": "true",
       "run_command": ["-d", "-i", "-t", "{{ .Image }}", "/bin/sh"]
     }

--- a/website/source/assets/javascripts/application.coffee
+++ b/website/source/assets/javascripts/application.coffee
@@ -9,3 +9,5 @@
 #= require _app/app
 #= require _app/homepage
 #= require _app/util
+
+#= require hashicorp/mega-nav

--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -10,6 +10,7 @@ text-rendering: optimizeLegibility;
 body {
   font-size: 15px;
   color: $black;
+  font-family: $font-family-open-sans;
   font-weight: 300;
 }
 
@@ -32,7 +33,7 @@ h3{
 }
 
 p, a, input, .alert {
-  font-family: $font-family-open-sans;
+
 }
 
 //an alternative color for buttons in the doc body

--- a/website/source/assets/stylesheets/_jumbotron.scss
+++ b/website/source/assets/stylesheets/_jumbotron.scss
@@ -47,7 +47,7 @@
     -webkit-backface-visibility:hidden;
 
     .jumbo-logo-wrap{
-      margin-top: 135px;
+      margin-top: 155px;
 
       .jumbo-logo{
         width: 318px;

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
 @import "bootstrap";
 
 // Remote fonts
-@import url("//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Open+Sans:300,400,600");
+@import url("//fonts.googleapis.com/css?family=Open+Sans:300,400,600");
 
 // Core variables and mixins
 @import "_variables";

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -5,6 +5,9 @@
 // Remote fonts
 @import url("//fonts.googleapis.com/css?family=Open+Sans:300,400,600");
 
+// Mega Nav
+@import 'hashicorp/mega-nav';
+
 // Core variables and mixins
 @import "_variables";
 

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -24,7 +24,6 @@
 @import 'hashicorp-shared/_hashicorp-sidebar';
 
 // Components
-@import '_announcement-bnr';
 @import "_header";
 @import '_footer';
 @import "_jumbotron";

--- a/website/source/layouts/_header.erb
+++ b/website/source/layouts/_header.erb
@@ -44,7 +44,6 @@
 
     <div id="header" class="navigation <%= current_page.data.page_title == "home" ? "" : "navbar-static-top" %>">
       <%= mega_nav :consul %>
-      <!-- <%= partial "layouts/announcement-bnr" %> -->
       <div class="container">
     		<div class="row">
     			<div class="col-xs-12">

--- a/website/source/layouts/_header.erb
+++ b/website/source/layouts/_header.erb
@@ -43,7 +43,8 @@
     <!-- End Google Tag Manager (noscript) -->
 
     <div id="header" class="navigation <%= current_page.data.page_title == "home" ? "" : "navbar-static-top" %>">
-      <%= partial "layouts/announcement-bnr" %>
+      <%= mega_nav :consul %>
+      <!-- <%= partial "layouts/announcement-bnr" %> -->
       <div class="container">
     		<div class="row">
     			<div class="col-xs-12">

--- a/website/source/layouts/_header.erb
+++ b/website/source/layouts/_header.erb
@@ -50,7 +50,6 @@
     				<div class="navbar-header">
     					<div class="navbar-brand">
     						<a class="logo" href="/">Consul</a>
-    						<a class="by-hashicorp white" href="https://www.hashicorp.com/"><span class="svg-wrap">by</span><%= partial "layouts/svg/svg-by-hashicorp" %><%= partial "layouts/svg/svg-hashicorp-logo" %>Hashicorp</a>
     					</div>
     					<button class="navbar-toggle white" type="button">
     						<span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
🚧 WIP. Don't merge until final approval from @pearkes

HashiCorp is adding a high-level element to provide navigation and visibility to OSS project sites. We like to call it Mega Nav :zap:. Mega Nav is pulled in from [middleman-hashicorp](https://github.com/hashicorp/middleman-hashicorp) and is positioned above the local nav in the site. It looks like this: 

### Desktop Inactive
<img width="1430" alt="screen shot 2017-03-08 at 9 29 53 am" src="https://cloud.githubusercontent.com/assets/416727/23715979/6b303488-03e3-11e7-81d2-d043b4f11667.png">

### Desktop Active
<img width="1423" alt="screen shot 2017-03-08 at 9 30 04 am" src="https://cloud.githubusercontent.com/assets/416727/23715989/72f0ecda-03e3-11e7-8894-5019ac436af9.png">

### Mobile Inactive
<img width="402" alt="screen shot 2017-03-08 at 9 30 40 am" src="https://cloud.githubusercontent.com/assets/416727/23716013/846abb8a-03e3-11e7-87ee-ee23cdbff89a.png">

### Mobile Active
<img width="400" alt="screen shot 2017-03-08 at 9 30 49 am" src="https://cloud.githubusercontent.com/assets/416727/23716033/92b6a9ba-03e3-11e7-801e-7b94598fbb8d.png">

cc @hashicorp/design 