### PR TITLE
Updated documentation to add information that bootstrap overrides ser…

### DIFF
--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -91,6 +91,7 @@ The options below are all specified on the command-line.
   the cluster. When provided, Consul waits until the specified number of servers are
   available and then bootstraps the cluster. This allows an initial leader to be elected
   automatically. This cannot be used in conjunction with the legacy [`-bootstrap`](#_bootstrap) flag.
+  This flag implies server mode.
 
 * <a name="_bind"></a><a href="#_bind">`-bind`</a> - The address that should be bound to
   for internal cluster communications.


### PR DESCRIPTION
There is an edge case that consul will fail to start in client mode when **-bootstrap-expect** is set and **-server** is set to false.  This is an edge case and was discovered by using the same terraform config with a template to create both servers and workstations.

Added a simple one line change to the options documentation.