### PR TITLE
Adds a stats fetcher to make sure we don't block the autopilot loop.

### DIFF
--- a/consul/agent/server.go
+++ b/consul/agent/server.go
@@ -34,6 +34,7 @@ type Server struct {
 	Version     int
 	RaftVersion int
 	Addr        net.Addr
+	Status      serf.MemberStatus
 }
 
 // Key returns the corresponding Key
@@ -104,6 +105,7 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		Addr:        addr,
 		Version:     vsn,
 		RaftVersion: raft_vsn,
+		Status:      m.Status,
 	}
 	return true, parts
 }

--- a/consul/agent/server_test.go
+++ b/consul/agent/server_test.go
@@ -62,6 +62,7 @@ func TestIsConsulServer(t *testing.T) {
 			"vsn":      "1",
 			"raft_vsn": "3",
 		},
+		Status: serf.StatusLeft,
 	}
 	ok, parts := agent.IsConsulServer(m)
 	if !ok || parts.Datacenter != "east-aws" || parts.Port != 10000 {
@@ -81,6 +82,9 @@ func TestIsConsulServer(t *testing.T) {
 	}
 	if parts.RaftVersion != 3 {
 		t.Fatalf("bad: %v", parts.RaftVersion)
+	}
+	if parts.Status != serf.StatusLeft {
+		t.Fatalf("bad: %v", parts.Status)
 	}
 	m.Tags["bootstrap"] = "1"
 	m.Tags["disabled"] = "1"

--- a/consul/server.go
+++ b/consul/server.go
@@ -260,7 +260,7 @@ func NewServer(config *Config) (*Server, error) {
 	s.autopilotPolicy = &BasicAutopilot{s}
 
 	// Initialize the stats fetcher that autopilot will use.
-	s.statsFetcher = NewStatsFetcher(s.shutdownCh, s.connPool, s.config.Datacenter)
+	s.statsFetcher = NewStatsFetcher(logger, s.connPool, s.config.Datacenter)
 
 	// Initialize the authoritative ACL cache.
 	s.aclAuthCache, err = acl.NewCache(aclCacheSize, s.aclLocalFault)

--- a/consul/server.go
+++ b/consul/server.go
@@ -161,6 +161,10 @@ type Server struct {
 	sessionTimers     map[string]*time.Timer
 	sessionTimersLock sync.Mutex
 
+	// statsFetcher is used by autopilot to check the status of the other
+	// Consul servers.
+	statsFetcher *StatsFetcher
+
 	// tombstoneGC is used to track the pending GC invocations
 	// for the KV tombstones
 	tombstoneGC *state.TombstoneGC
@@ -254,6 +258,9 @@ func NewServer(config *Config) (*Server, error) {
 		shutdownCh:            make(chan struct{}),
 	}
 	s.autopilotPolicy = &BasicAutopilot{s}
+
+	// Initialize the stats fetcher that autopilot will use.
+	s.statsFetcher = NewStatsFetcher(s.shutdownCh, s.connPool, s.config.Datacenter)
 
 	// Initialize the authoritative ACL cache.
 	s.aclAuthCache, err = acl.NewCache(aclCacheSize, s.aclLocalFault)

--- a/consul/stats_fetcher.go
+++ b/consul/stats_fetcher.go
@@ -43,7 +43,8 @@ func (f *StatsFetcher) fetch(server *agent.Server, replyCh chan *structs.ServerS
 	var reply structs.ServerStats
 	err := f.pool.RPC(f.datacenter, server.Addr, server.Version, "Status.RaftStats", &args, &reply)
 	if err != nil {
-		f.logger.Printf("[WARN] consul: error getting server health from %q: %v", server.Name, err)
+		f.logger.Printf("[WARN] consul: error getting server health from %q: %v",
+			server.Name, err)
 	} else {
 		replyCh <- &reply
 	}
@@ -65,7 +66,8 @@ func (f *StatsFetcher) Fetch(ctx context.Context, servers []*agent.Server) map[s
 	f.inflightLock.Lock()
 	for _, server := range servers {
 		if _, ok := f.inflight[server.ID]; ok {
-			f.logger.Printf("[WARN] consul: error getting server health from %q: last request still outstanding", server.Name)
+			f.logger.Printf("[WARN] consul: error getting server health from %q: last request still outstanding",
+				server.Name)
 		} else {
 			workItem := &workItem{
 				server:  server,
@@ -87,7 +89,8 @@ func (f *StatsFetcher) Fetch(ctx context.Context, servers []*agent.Server) map[s
 			replies[workItem.server.ID] = reply
 
 		case <-ctx.Done():
-			// Give up on this and any remaining outstanding RPCs.
+			f.logger.Printf("[WARN] consul: error getting server health from %q: %v",
+				workItem.server.Name, ctx.Err())
 		}
 	}
 	return replies

--- a/consul/stats_fetcher.go
+++ b/consul/stats_fetcher.go
@@ -1,0 +1,74 @@
+package consul
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul/consul/agent"
+	"github.com/hashicorp/consul/consul/structs"
+)
+
+// StatsFetcher makes sure there's only one in-flight request for stats at any
+// given time, and allows us to have a timeout so the autopilot loop doesn't get
+// blocked if there's a slow server.
+type StatsFetcher struct {
+	shutdownCh   <-chan struct{}
+	pool         *ConnPool
+	datacenter   string
+	inflight     map[string]struct{}
+	inflightLock sync.Mutex
+}
+
+// NewStatsFetcher returns a stats fetcher.
+func NewStatsFetcher(shutdownCh <-chan struct{}, pool *ConnPool, datacenter string) *StatsFetcher {
+	return &StatsFetcher{
+		shutdownCh: shutdownCh,
+		pool:       pool,
+		datacenter: datacenter,
+		inflight:   make(map[string]struct{}),
+	}
+}
+
+// Fetch will attempt to get the server health for up to the timeout, and will
+// also return an error immediately if there is a request still outstanding. We
+// throw away results from any outstanding requests since we don't want to
+// ingest stale health data.
+func (f *StatsFetcher) Fetch(server *agent.Server, timeout time.Duration) (*structs.ServerStats, error) {
+	// Don't allow another request if there's another one outstanding.
+	f.inflightLock.Lock()
+	if _, ok := f.inflight[server.ID]; ok {
+		f.inflightLock.Unlock()
+		return nil, fmt.Errorf("stats request already outstanding")
+	}
+	f.inflight[server.ID] = struct{}{}
+	f.inflightLock.Unlock()
+
+	// Make the request in a goroutine.
+	errCh := make(chan error, 1)
+	var reply structs.ServerStats
+	go func() {
+		var args struct{}
+		errCh <- f.pool.RPC(f.datacenter, server.Addr, server.Version, "Status.RaftStats", &args, &reply)
+
+		f.inflightLock.Lock()
+		delete(f.inflight, server.ID)
+		f.inflightLock.Unlock()
+	}()
+
+	// Wait for something to happen.
+	select {
+	case <-f.shutdownCh:
+		return nil, fmt.Errorf("shutdown")
+
+	case err := <-errCh:
+		if err == nil {
+			return &reply, nil
+		} else {
+			return nil, err
+		}
+
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("timeout")
+	}
+}

--- a/consul/stats_fetcher_test.go
+++ b/consul/stats_fetcher_test.go
@@ -1,0 +1,109 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/consul/agent"
+	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/types"
+)
+
+func TestStatsFetcher(t *testing.T) {
+	dir1, s1 := testServerDCExpect(t, "dc1", 3)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	dir2, s2 := testServerDCExpect(t, "dc1", 3)
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+
+	dir3, s3 := testServerDCExpect(t, "dc1", 3)
+	defer os.RemoveAll(dir3)
+	defer s3.Shutdown()
+
+	addr := fmt.Sprintf("127.0.0.1:%d",
+		s1.config.SerfLANConfig.MemberlistConfig.BindPort)
+	if _, err := s2.JoinLAN([]string{addr}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, err := s3.JoinLAN([]string{addr}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	testutil.WaitForLeader(t, s1.RPC, "dc1")
+
+	members := s1.serfLAN.Members()
+	if len(members) != 3 {
+		t.Fatalf("bad len: %d", len(members))
+	}
+
+	var servers []*agent.Server
+	for _, member := range members {
+		ok, server := agent.IsConsulServer(member)
+		if !ok {
+			t.Fatalf("bad: %#v", member)
+		}
+		servers = append(servers, server)
+	}
+
+	// Do a normal fetch and make sure we get three responses.
+	func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		stats := s1.statsFetcher.Fetch(ctx, servers)
+		if len(stats) != 3 {
+			t.Fatalf("bad: %#v", stats)
+		}
+		for id, stat := range stats {
+			switch types.NodeID(id) {
+			case s1.config.NodeID, s2.config.NodeID, s3.config.NodeID:
+				// OK
+			default:
+				t.Fatalf("bad: %s", id)
+			}
+
+			if stat == nil || stat.LastTerm == 0 {
+				t.Fatalf("bad: %#v", stat)
+			}
+		}
+	}()
+
+	// Fake an in-flight request to server 3 and make sure we don't fetch
+	// from it.
+	func() {
+		s1.statsFetcher.inflight[string(s3.config.NodeID)] = struct{}{}
+		defer delete(s1.statsFetcher.inflight, string(s3.config.NodeID))
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		stats := s1.statsFetcher.Fetch(ctx, servers)
+		if len(stats) != 2 {
+			t.Fatalf("bad: %#v", stats)
+		}
+		for id, stat := range stats {
+			switch types.NodeID(id) {
+			case s1.config.NodeID, s2.config.NodeID:
+				// OK
+			case s3.config.NodeID:
+				t.Fatalf("bad")
+			default:
+				t.Fatalf("bad: %s", id)
+			}
+
+			if stat == nil || stat.LastTerm == 0 {
+				t.Fatalf("bad: %#v", stat)
+			}
+		}
+	}()
+
+	// Do a fetch with a canceled context and make sure we bail right away.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	cancel()
+	stats := s1.statsFetcher.Fetch(ctx, servers)
+	if len(stats) != 0 {
+		t.Fatalf("bad: %#v", stats)
+	}
+}

--- a/consul/structs/operator.go
+++ b/consul/structs/operator.go
@@ -139,7 +139,7 @@ type ServerHealth struct {
 
 // IsHealthy determines whether this ServerHealth is considered healthy
 // based on the given Autopilot config
-func (h *ServerHealth) IsHealthy(lastTerm uint64, lastIndex uint64, autopilotConf *AutopilotConfig) bool {
+func (h *ServerHealth) IsHealthy(lastTerm uint64, leaderLastIndex uint64, autopilotConf *AutopilotConfig) bool {
 	if h.SerfStatus != serf.StatusAlive {
 		return false
 	}
@@ -152,7 +152,7 @@ func (h *ServerHealth) IsHealthy(lastTerm uint64, lastIndex uint64, autopilotCon
 		return false
 	}
 
-	if lastIndex > autopilotConf.MaxTrailingLogs && h.LastIndex < lastIndex-autopilotConf.MaxTrailingLogs {
+	if leaderLastIndex > autopilotConf.MaxTrailingLogs && h.LastIndex < leaderLastIndex-autopilotConf.MaxTrailingLogs {
 		return false
 	}
 


### PR DESCRIPTION
This changes the autopilot health checker to snap the last index at the same time it requests stats from all its peers and to do all the fetches in parallel. We used `context` so that we can also move on if we don't hear from some of the servers so we don't block the health loop.