### PR TITLE
Dns check query type for addr request

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -374,9 +374,14 @@ PARSE:
 			goto INVALID
 		}
 
+		qType := req.Question[0].Qtype
+
 		switch len(labels[0]) / 2 {
 		// IPv4
 		case 4:
+			if qType != dns.TypeANY && qType != dns.TypeA {
+				return
+			}
 			ip, err := hex.DecodeString(labels[0])
 			if err != nil {
 				goto INVALID
@@ -393,6 +398,9 @@ PARSE:
 			})
 		// IPv6
 		case 16:
+			if qType != dns.TypeANY && qType != dns.TypeAAAA {
+				return
+			}
 			ip, err := hex.DecodeString(labels[0])
 			if err != nil {
 				goto INVALID

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -3687,7 +3687,7 @@ func TestDNS_AddressLookup(t *testing.T) {
 	}
 	for question, answer := range cases {
 		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+		m.SetQuestion(question, dns.TypeA)
 
 		c := new(dns.Client)
 		addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)
@@ -3727,7 +3727,7 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 	}
 	for question, answer := range cases {
 		m := new(dns.Msg)
-		m.SetQuestion(question, dns.TypeSRV)
+		m.SetQuestion(question, dns.TypeAAAA)
 
 		c := new(dns.Client)
 		addr, _ := srv.agent.config.ClientListener("", srv.agent.config.Ports.DNS)


### PR DESCRIPTION
Without query type check, consul may return A, AAAA record when client asking for SRV record explicitly.