### PR TITLE
UI Improvement: Add sticky scroll to side panel

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -285,7 +285,7 @@
         <hr>
       </div>
 
-      <div class="col-md-6 col-lg-7 border-left">
+      <div class="col-md-6 col-lg-7 border-left sticky-scroll">
         <div class="padded-border">
 
           <div class="panel">

--- a/ui/styles/_buttons.scss
+++ b/ui/styles/_buttons.scss
@@ -12,6 +12,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    -webkit-transform: translateZ(0);
 
     &:hover {
         color: darken($gray, 10%);

--- a/ui/styles/_forms.scss
+++ b/ui/styles/_forms.scss
@@ -23,4 +23,5 @@
 
 textarea.form-control {
     height: 130px;
+    -webkit-transform: translateZ(0);
 }

--- a/ui/styles/base.scss
+++ b/ui/styles/base.scss
@@ -71,6 +71,13 @@ a {
     margin-top: 200px;
 }
 
+.sticky-scroll {
+    top: 15px;
+    position: sticky;
+    position: -webkit-sticky;
+    overflow: scroll;
+}
+
 .row {
     &.colored {
         background-color: $light-purple;


### PR DESCRIPTION
So that when there are long lists of key/values, you don't have to keep scrolling back up to the top when clicking between them.

![consul_sticky_scroll mov](https://cloud.githubusercontent.com/assets/7771981/24165776/b9bff32c-0e47-11e7-943d-34e89438f950.gif)
