### PR TITLE
Re-add RPC parsing

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -29,6 +29,10 @@ type PortConfig struct {
 	SerfLan int `mapstructure:"serf_lan"` // LAN gossip (Client + Server)
 	SerfWan int `mapstructure:"serf_wan"` // WAN gossip (Server only)
 	Server  int // Server internal RPC
+
+	// RPC is deprecated and is no longer used. It will be removed in a future
+	// version.
+	RPC int // CLI RPC
 }
 
 // AddressConfig is used to provide address overrides
@@ -38,6 +42,10 @@ type AddressConfig struct {
 	DNS   string // DNS Query interface
 	HTTP  string // HTTP API
 	HTTPS string // HTTPS API
+
+	// RPC is deprecated and is no longer used. It will be removed in a future
+	// version.
+	RPC string // CLI RPC
 }
 
 type AdvertiseAddrsConfig struct {
@@ -967,6 +975,16 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 
+	// Check for deprecations
+	if result.Ports.RPC != 0 {
+		fmt.Fprintln(os.Stderr, "==> DEPRECATION: ports.rpc is deprecated and is "+
+			"no longer used. Please remove it from your configuration.")
+	}
+	if result.Addresses.RPC != "" {
+		fmt.Fprintln(os.Stderr, "==> DEPRECATION: addresses.rpc is deprecated and "+
+			"is no longer used. Please remove it from your configuration.")
+	}
+
 	// Check unused fields and verify that no bad configuration options were
 	// passed to Consul. There are a few additional fields which don't directly
 	// use mapstructure decoding, so we need to account for those as well. These
@@ -1517,6 +1535,9 @@ func MergeConfig(a, b *Config) *Config {
 	if b.Ports.HTTPS != 0 {
 		result.Ports.HTTPS = b.Ports.HTTPS
 	}
+	if b.Ports.RPC != 0 {
+		result.Ports.RPC = b.Ports.RPC
+	}
 	if b.Ports.SerfLan != 0 {
 		result.Ports.SerfLan = b.Ports.SerfLan
 	}
@@ -1534,6 +1555,9 @@ func MergeConfig(a, b *Config) *Config {
 	}
 	if b.Addresses.HTTPS != "" {
 		result.Addresses.HTTPS = b.Addresses.HTTPS
+	}
+	if b.Addresses.RPC != "" {
+		result.Addresses.RPC = b.Addresses.RPC
 	}
 	if b.EnableUi {
 		result.EnableUi = true

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -163,6 +163,17 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 
+	// Deprecated RPC configs - TODO: remove this in a future release
+	input = `{"ports": {"rpc": 1234}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.Ports.RPC != 1234 {
+		t.Fatalf("bad: %#v", config)
+	}
+
 	// Serf configs
 	input = `{"ports": {"serf_lan": 1000, "serf_wan": 2000}}`
 	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
@@ -920,6 +931,17 @@ func TestDecodeConfig(t *testing.T) {
 		t.Fatalf("bad: %#v", config)
 	}
 	if config.Addresses.HTTPS != "127.0.0.1" {
+		t.Fatalf("bad: %#v", config)
+	}
+
+	// RPC Addresses - TODO: remove in a future release
+	input = `{"addresses": {"rpc": "1.2.3.4"}}`
+	config, err = DecodeConfig(bytes.NewReader([]byte(input)))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if config.Addresses.RPC != "1.2.3.4" {
 		t.Fatalf("bad: %#v", config)
 	}
 


### PR DESCRIPTION
This makes the upgrade path a bit nicer, since people will likely have older configurations. This prints out a warning instead of just failing if the old rpc addr or ports definition is in the config.