### PR TITLE
Add IPv6 private address ranges

### DIFF
--- a/consul/util.go
+++ b/consul/util.go
@@ -23,7 +23,7 @@ var privateBlocks []*net.IPNet
 
 func init() {
 	// Add each private block
-	privateBlocks = make([]*net.IPNet, 6)
+	privateBlocks = make([]*net.IPNet, 10)
 
 	_, block, err := net.ParseCIDR("10.0.0.0/8")
 	if err != nil {
@@ -60,6 +60,30 @@ func init() {
 		panic(fmt.Sprintf("Bad cidr. Got %v", err))
 	}
 	privateBlocks[5] = block
+
+	_, block, err = net.ParseCIDR("fc00::/7") /* RFC 4193: unique local addresses */
+	if err != nil {
+		panic(fmt.Sprintf("Bad cidr. Got %v", err))
+	}
+	privateBlocks[6] = block
+
+	_, block, err = net.ParseCIDR("fec0::/10") /* RFC 1884: site-local addresses */
+	if err != nil {
+		panic(fmt.Sprintf("Bad cidr. Got %v", err))
+	}
+	privateBlocks[7] = block
+
+	_, block, err = net.ParseCIDR("fe80::/10") /* RFC 4291: link-local addresses */
+	if err != nil {
+		panic(fmt.Sprintf("Bad cidr. Got %v", err))
+	}
+	privateBlocks[8] = block
+
+	_, block, err = net.ParseCIDR("::1/128") /* RFC 1884: loopback address */
+	if err != nil {
+		panic(fmt.Sprintf("Bad cidr. Got %v", err))
+	}
+	privateBlocks[9] = block
 }
 
 // CanServersUnderstandProtocol checks to see if all the servers in the given

--- a/consul/util_test.go
+++ b/consul/util_test.go
@@ -97,6 +97,21 @@ func TestIsPrivateIP(t *testing.T) {
 	if !isPrivateIP("127.0.0.1") {
 		t.Fatalf("bad")
 	}
+	if isPrivateIP("6666:6666::1") {
+		t.Fatalf("bad")
+	}
+	if !isPrivateIP("fec0:0f::1") {
+		t.Fatalf("bad")
+	}
+	if !isPrivateIP("fd12:34::1") {
+		t.Fatalf("bad")
+	}
+	if !isPrivateIP("fe80::12") {
+		t.Fatalf("bad")
+	}
+	if !isPrivateIP("::1") {
+		t.Fatalf("bad")
+	}
 }
 
 func TestUtil_CanServersUnderstandProtocol(t *testing.T) {


### PR DESCRIPTION
Presently, Consul is only aware of IPv4 private address ranges; for IPv6, it isn't aware of any of:

- The loopback address
- Link-local address ranges (though other work is needed before Consul can successfully use these).
- Site-local address ranges
- Unique local addresses (modern replacement for site-local addresses, which were inadequately defined).

This patch adds these four categories.