### PR TITLE
Switches version 8 ACLs to opt-out, and fixes a few issues.

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1192,11 +1192,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	// Remove service immediately
-	err := a.state.RemoveService(serviceID)
-
-	// TODO: Return the error instead of just logging here in Consul 0.8
-	// For now, keep the current idempotent behavior on deleting a nonexistent service
-	if err != nil {
+	if err := a.state.RemoveService(serviceID); err != nil {
 		a.logger.Printf("[WARN] agent: Failed to deregister service %q: %s", serviceID, err)
 		return nil
 	}

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -312,7 +312,7 @@ func TestAgent_Reload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	_, err = tmpFile.WriteString(`{"service":{"name":"redis"}}`)
+	_, err = tmpFile.WriteString(`{"acl_enforce_version_8": false, "service":{"name":"redis"}}`)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -356,7 +356,7 @@ func TestAgent_Reload(t *testing.T) {
 		t.Fatalf("missing redis service")
 	}
 
-	err = ioutil.WriteFile(tmpFile.Name(), []byte(`{"service":{"name":"redis-reloaded"}}`), 0644)
+	err = ioutil.WriteFile(tmpFile.Name(), []byte(`{"acl_enforce_version_8": false, "service":{"name":"redis-reloaded"}}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -827,7 +827,7 @@ func DefaultConfig() *Config {
 		ACLDownPolicy:      "extend-cache",
 		ACLDefaultPolicy:   "allow",
 		ACLDisabledTTL:     120 * time.Second,
-		ACLEnforceVersion8: Bool(false),
+		ACLEnforceVersion8: Bool(true),
 		RetryInterval:      30 * time.Second,
 		RetryIntervalWan:   30 * time.Second,
 

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -747,9 +747,9 @@ func TestDecodeConfig(t *testing.T) {
 	}
 
 	// ACL flag for Consul version 0.8 features (broken out since we will
-	// eventually remove this). We first verify this is opt-out.
+	// eventually remove this).
 	config = DefaultConfig()
-	if *config.ACLEnforceVersion8 != false {
+	if *config.ACLEnforceVersion8 != true {
 		t.Fatalf("bad: %#v", config)
 	}
 

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -519,11 +519,6 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Update the agent ACL token, resume sync
-	conf.ACLAgentToken = token
-	agent.StartSync()
-	time.Sleep(200 * time.Millisecond)
-
 	// Create service (disallowed)
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
@@ -647,6 +642,11 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 				t.Fatalf("should be in sync: %v %v", name, status)
 			}
 		}
+	}
+
+	// Make sure the token got cleaned up.
+	if token := agent.state.ServiceToken("api"); token != "" {
+		t.Fatalf("bad: %s", token)
 	}
 }
 
@@ -900,11 +900,6 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Update the agent ACL token, resume sync
-	conf.ACLAgentToken = token
-	agent.StartSync()
-	time.Sleep(200 * time.Millisecond)
-
 	// Create services using the root token
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
@@ -1110,6 +1105,11 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		if !status.inSync {
 			t.Fatalf("should be in sync: %v %v", name, status)
 		}
+	}
+
+	// Make sure the token got cleaned up.
+	if token := agent.state.CheckToken("api-check"); token != "" {
+		t.Fatalf("bad: %s", token)
 	}
 }
 
@@ -1419,9 +1419,9 @@ func TestAgent_serviceTokens(t *testing.T) {
 		t.Fatalf("bad: %s", token)
 	}
 
-	// Removes token
+	// Keeps token around for the delete
 	l.RemoveService("redis")
-	if token := l.ServiceToken("redis"); token != "default" {
+	if token := l.ServiceToken("redis"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
 }
@@ -1443,9 +1443,9 @@ func TestAgent_checkTokens(t *testing.T) {
 		t.Fatalf("bad: %s", token)
 	}
 
-	// Removes token
+	// Keeps token around for the delete
 	l.RemoveCheck("mem")
-	if token := l.CheckToken("mem"); token != "default" {
+	if token := l.CheckToken("mem"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
 }

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -476,7 +476,15 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 }
 
 var testRegisterRules = `
+node "" {
+	policy = "write"
+}
+
 service "api" {
+	policy = "write"
+}
+
+service "consul" {
 	policy = "write"
 }
 `
@@ -486,6 +494,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 	conf.ACLDatacenter = "dc1"
 	conf.ACLMasterToken = "root"
 	conf.ACLDefaultPolicy = "deny"
+	conf.ACLEnforceVersion8 = Bool(true)
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -501,81 +510,142 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 			Type:  structs.ACLTypeClient,
 			Rules: testRegisterRules,
 		},
-		WriteRequest: structs.WriteRequest{Token: "root"},
+		WriteRequest: structs.WriteRequest{
+			Token: "root",
+		},
 	}
-	var out string
-	if err := agent.RPC("ACL.Apply", &arg, &out); err != nil {
+	var token string
+	if err := agent.RPC("ACL.Apply", &arg, &token); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	// Update the agent ACL token, resume sync
-	conf.ACLToken = out
+	conf.ACLAgentToken = token
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
 
-	// Create service (Allowed)
+	// Create service (disallowed)
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
 		Service: "mysql",
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	agent.state.AddService(srv1, "")
+	agent.state.AddService(srv1, token)
 
-	// Create service (Disallowed)
+	// Create service (allowed)
 	srv2 := &structs.NodeService{
 		ID:      "api",
 		Service: "api",
 		Tags:    []string{"foo"},
 		Port:    5001,
 	}
-	agent.state.AddService(srv2, "")
+	agent.state.AddService(srv2, token)
 
 	// Trigger anti-entropy run and wait
 	agent.StartSync()
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify that we are in sync
-	req := structs.NodeSpecificRequest{
-		Datacenter:   "dc1",
-		Node:         agent.config.NodeName,
-		QueryOptions: structs.QueryOptions{Token: out},
-	}
-	var services structs.IndexedNodeServices
-	if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	{
+		req := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       agent.config.NodeName,
+			QueryOptions: structs.QueryOptions{
+				Token: "root",
+			},
+		}
+		var services structs.IndexedNodeServices
+		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
+			t.Fatalf("err: %v", err)
+		}
 
-	// We should have 2 services (consul included)
-	if len(services.NodeServices.Services) != 2 {
-		t.Fatalf("bad: %v", services.NodeServices.Services)
-	}
+		// We should have 2 services (consul included)
+		if len(services.NodeServices.Services) != 2 {
+			t.Fatalf("bad: %v", services.NodeServices.Services)
+		}
 
-	// All the services should match
-	for id, serv := range services.NodeServices.Services {
-		serv.CreateIndex, serv.ModifyIndex = 0, 0
-		switch id {
-		case "mysql":
-			t.Fatalf("should not be permitted")
-		case "api":
-			if !reflect.DeepEqual(serv, srv2) {
-				t.Fatalf("bad: %#v %#v", serv, srv2)
+		// All the services should match
+		for id, serv := range services.NodeServices.Services {
+			serv.CreateIndex, serv.ModifyIndex = 0, 0
+			switch id {
+			case "mysql":
+				t.Fatalf("should not be permitted")
+			case "api":
+				if !reflect.DeepEqual(serv, srv2) {
+					t.Fatalf("bad: %#v %#v", serv, srv2)
+				}
+			case "consul":
+				// ignore
+			default:
+				t.Fatalf("unexpected service: %v", id)
 			}
-		case "consul":
-			// ignore
-		default:
-			t.Fatalf("unexpected service: %v", id)
+		}
+
+		// Check the local state
+		if len(agent.state.services) != 3 {
+			t.Fatalf("bad: %v", agent.state.services)
+		}
+		if len(agent.state.serviceStatus) != 3 {
+			t.Fatalf("bad: %v", agent.state.serviceStatus)
+		}
+		for name, status := range agent.state.serviceStatus {
+			if !status.inSync {
+				t.Fatalf("should be in sync: %v %v", name, status)
+			}
 		}
 	}
 
-	// Check the local state
-	if len(agent.state.services) != 3 {
-		t.Fatalf("bad: %v", agent.state.services)
-	}
-	if len(agent.state.serviceStatus) != 3 {
-		t.Fatalf("bad: %v", agent.state.serviceStatus)
-	}
-	for name, status := range agent.state.serviceStatus {
-		if !status.inSync {
-			t.Fatalf("should be in sync: %v %v", name, status)
+	// Now remove the service and re-sync
+	agent.state.RemoveService("api")
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that we are in sync
+	{
+		req := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       agent.config.NodeName,
+			QueryOptions: structs.QueryOptions{
+				Token: "root",
+			},
+		}
+		var services structs.IndexedNodeServices
+		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// We should have 1 service (just consul)
+		if len(services.NodeServices.Services) != 1 {
+			t.Fatalf("bad: %v", services.NodeServices.Services)
+		}
+
+		// All the services should match
+		for id, serv := range services.NodeServices.Services {
+			serv.CreateIndex, serv.ModifyIndex = 0, 0
+			switch id {
+			case "mysql":
+				t.Fatalf("should not be permitted")
+			case "api":
+				t.Fatalf("should be deleted")
+			case "consul":
+				// ignore
+			default:
+				t.Fatalf("unexpected service: %v", id)
+			}
+		}
+
+		// Check the local state
+		if len(agent.state.services) != 2 {
+			t.Fatalf("bad: %v", agent.state.services)
+		}
+		if len(agent.state.serviceStatus) != 2 {
+			t.Fatalf("bad: %v", agent.state.serviceStatus)
+		}
+		for name, status := range agent.state.serviceStatus {
+			if !status.inSync {
+				t.Fatalf("should be in sync: %v %v", name, status)
+			}
 		}
 	}
 }
@@ -791,6 +861,249 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		t.Fatalf("bad: %v", agent.state.checks)
 	}
 	if len(agent.state.checkStatus) != 3 {
+		t.Fatalf("bad: %v", agent.state.checkStatus)
+	}
+	for name, status := range agent.state.checkStatus {
+		if !status.inSync {
+			t.Fatalf("should be in sync: %v %v", name, status)
+		}
+	}
+}
+
+func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
+	conf := nextConfig()
+	conf.ACLDatacenter = "dc1"
+	conf.ACLMasterToken = "root"
+	conf.ACLDefaultPolicy = "deny"
+	conf.ACLEnforceVersion8 = Bool(true)
+	dir, agent := makeAgent(t, conf)
+	defer os.RemoveAll(dir)
+	defer agent.Shutdown()
+
+	testutil.WaitForLeader(t, agent.RPC, "dc1")
+
+	// Create the ACL
+	arg := structs.ACLRequest{
+		Datacenter: "dc1",
+		Op:         structs.ACLSet,
+		ACL: structs.ACL{
+			Name:  "User token",
+			Type:  structs.ACLTypeClient,
+			Rules: testRegisterRules,
+		},
+		WriteRequest: structs.WriteRequest{
+			Token: "root",
+		},
+	}
+	var token string
+	if err := agent.RPC("ACL.Apply", &arg, &token); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Update the agent ACL token, resume sync
+	conf.ACLAgentToken = token
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
+
+	// Create services using the root token
+	srv1 := &structs.NodeService{
+		ID:      "mysql",
+		Service: "mysql",
+		Tags:    []string{"master"},
+		Port:    5000,
+	}
+	agent.state.AddService(srv1, "root")
+	srv2 := &structs.NodeService{
+		ID:      "api",
+		Service: "api",
+		Tags:    []string{"foo"},
+		Port:    5001,
+	}
+	agent.state.AddService(srv2, "root")
+
+	// Trigger anti-entropy run and wait
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that we are in sync
+	{
+		req := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       agent.config.NodeName,
+			QueryOptions: structs.QueryOptions{
+				Token: "root",
+			},
+		}
+		var services structs.IndexedNodeServices
+		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// We should have 3 services (consul included)
+		if len(services.NodeServices.Services) != 3 {
+			t.Fatalf("bad: %v", services.NodeServices.Services)
+		}
+
+		// All the services should match
+		for id, serv := range services.NodeServices.Services {
+			serv.CreateIndex, serv.ModifyIndex = 0, 0
+			switch id {
+			case "mysql":
+				if !reflect.DeepEqual(serv, srv1) {
+					t.Fatalf("bad: %#v %#v", serv, srv1)
+				}
+			case "api":
+				if !reflect.DeepEqual(serv, srv2) {
+					t.Fatalf("bad: %#v %#v", serv, srv2)
+				}
+			case "consul":
+				// ignore
+			default:
+				t.Fatalf("unexpected service: %v", id)
+			}
+		}
+
+		// Check the local state
+		if len(agent.state.services) != 3 {
+			t.Fatalf("bad: %v", agent.state.services)
+		}
+		if len(agent.state.serviceStatus) != 3 {
+			t.Fatalf("bad: %v", agent.state.serviceStatus)
+		}
+		for name, status := range agent.state.serviceStatus {
+			if !status.inSync {
+				t.Fatalf("should be in sync: %v %v", name, status)
+			}
+		}
+	}
+
+	// This check won't be allowed.
+	chk1 := &structs.HealthCheck{
+		Node:        agent.config.NodeName,
+		ServiceID:   "mysql",
+		ServiceName: "mysql",
+		CheckID:     "mysql-check",
+		Name:        "mysql",
+		Status:      structs.HealthPassing,
+	}
+	agent.state.AddCheck(chk1, token)
+
+	// This one will be allowed.
+	chk2 := &structs.HealthCheck{
+		Node:        agent.config.NodeName,
+		ServiceID:   "api",
+		ServiceName: "api",
+		CheckID:     "api-check",
+		Name:        "api",
+		Status:      structs.HealthPassing,
+	}
+	agent.state.AddCheck(chk2, token)
+
+	// Trigger anti-entropy run and wait.
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that we are in sync
+	if err := testutil.WaitForResult(func() (bool, error) {
+		req := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       agent.config.NodeName,
+			QueryOptions: structs.QueryOptions{
+				Token: "root",
+			},
+		}
+		var checks structs.IndexedHealthChecks
+		if err := agent.RPC("Health.NodeChecks", &req, &checks); err != nil {
+			return false, fmt.Errorf("err: %v", err)
+		}
+
+		// We should have 2 checks (serf included)
+		if len(checks.HealthChecks) != 2 {
+			return false, fmt.Errorf("bad: %v", checks)
+		}
+
+		// All the checks should match
+		for _, chk := range checks.HealthChecks {
+			chk.CreateIndex, chk.ModifyIndex = 0, 0
+			switch chk.CheckID {
+			case "mysql-check":
+				t.Fatalf("should not be permitted")
+			case "api-check":
+				if !reflect.DeepEqual(chk, chk2) {
+					return false, fmt.Errorf("bad: %v %v", chk, chk2)
+				}
+			case "serfHealth":
+				// ignore
+			default:
+				return false, fmt.Errorf("unexpected check: %v", chk)
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the local state.
+	if len(agent.state.checks) != 2 {
+		t.Fatalf("bad: %v", agent.state.checks)
+	}
+	if len(agent.state.checkStatus) != 2 {
+		t.Fatalf("bad: %v", agent.state.checkStatus)
+	}
+	for name, status := range agent.state.checkStatus {
+		if !status.inSync {
+			t.Fatalf("should be in sync: %v %v", name, status)
+		}
+	}
+
+	// Now delete the check and wait for sync.
+	agent.state.RemoveCheck("api-check")
+	agent.StartSync()
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify that we are in sync
+	if err := testutil.WaitForResult(func() (bool, error) {
+		req := structs.NodeSpecificRequest{
+			Datacenter: "dc1",
+			Node:       agent.config.NodeName,
+			QueryOptions: structs.QueryOptions{
+				Token: "root",
+			},
+		}
+		var checks structs.IndexedHealthChecks
+		if err := agent.RPC("Health.NodeChecks", &req, &checks); err != nil {
+			return false, fmt.Errorf("err: %v", err)
+		}
+
+		// We should have 1 check (just serf)
+		if len(checks.HealthChecks) != 1 {
+			return false, fmt.Errorf("bad: %v", checks)
+		}
+
+		// All the checks should match
+		for _, chk := range checks.HealthChecks {
+			chk.CreateIndex, chk.ModifyIndex = 0, 0
+			switch chk.CheckID {
+			case "mysql-check":
+				t.Fatalf("should not be permitted")
+			case "api-check":
+				t.Fatalf("should be deleted")
+			case "serfHealth":
+				// ignore
+			default:
+				return false, fmt.Errorf("unexpected check: %v", chk)
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the local state.
+	if len(agent.state.checks) != 1 {
+		t.Fatalf("bad: %v", agent.state.checks)
+	}
+	if len(agent.state.checkStatus) != 1 {
 		t.Fatalf("bad: %v", agent.state.checkStatus)
 	}
 	for name, status := range agent.state.checkStatus {

--- a/consul/acl.go
+++ b/consul/acl.go
@@ -341,9 +341,14 @@ func (f *aclFilter) allowNode(node string) bool {
 
 // allowService is used to determine if a service is accessible for an ACL.
 func (f *aclFilter) allowService(service string) bool {
-	if service == "" || service == ConsulServiceID {
+	if service == "" {
 		return true
 	}
+
+	if !f.enforceVersion8 && service == ConsulServiceID {
+		return true
+	}
+
 	return f.acl.ServiceRead(service)
 }
 

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -903,17 +903,28 @@ func TestACL_filterServices(t *testing.T) {
 	services := structs.Services{
 		"service1": []string{},
 		"service2": []string{},
+		"consul":   []string{},
 	}
 
-	// Try permissive filtering
+	// Try permissive filtering.
 	filt := newAclFilter(acl.AllowAll(), nil, false)
 	filt.filterServices(services)
-	if len(services) != 2 {
+	if len(services) != 3 {
 		t.Fatalf("bad: %#v", services)
 	}
 
-	// Try restrictive filtering
+	// Try restrictive filtering.
 	filt = newAclFilter(acl.DenyAll(), nil, false)
+	filt.filterServices(services)
+	if len(services) != 1 {
+		t.Fatalf("bad: %#v", services)
+	}
+	if _, ok := services["consul"]; !ok {
+		t.Fatalf("bad: %#v", services)
+	}
+
+	// Try restrictive filtering with version 8 enforcement.
+	filt = newAclFilter(acl.DenyAll(), nil, true)
 	filt.filterServices(services)
 	if len(services) != 0 {
 		t.Fatalf("bad: %#v", services)

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -54,25 +54,26 @@ type TestAddressConfig struct {
 
 // TestServerConfig is the main server configuration struct.
 type TestServerConfig struct {
-	NodeName          string                 `json:"node_name"`
-	NodeMeta          map[string]string      `json:"node_meta,omitempty"`
-	Performance       *TestPerformanceConfig `json:"performance,omitempty"`
-	Bootstrap         bool                   `json:"bootstrap,omitempty"`
-	Server            bool                   `json:"server,omitempty"`
-	DataDir           string                 `json:"data_dir,omitempty"`
-	Datacenter        string                 `json:"datacenter,omitempty"`
-	DisableCheckpoint bool                   `json:"disable_update_check"`
-	LogLevel          string                 `json:"log_level,omitempty"`
-	Bind              string                 `json:"bind_addr,omitempty"`
-	Addresses         *TestAddressConfig     `json:"addresses,omitempty"`
-	Ports             *TestPortConfig        `json:"ports,omitempty"`
-	RaftProtocol      int                    `json:"raft_protocol,omitempty"`
-	ACLMasterToken    string                 `json:"acl_master_token,omitempty"`
-	ACLDatacenter     string                 `json:"acl_datacenter,omitempty"`
-	ACLDefaultPolicy  string                 `json:"acl_default_policy,omitempty"`
-	Encrypt           string                 `json:"encrypt,omitempty"`
-	Stdout, Stderr    io.Writer              `json:"-"`
-	Args              []string               `json:"-"`
+	NodeName           string                 `json:"node_name"`
+	NodeMeta           map[string]string      `json:"node_meta,omitempty"`
+	Performance        *TestPerformanceConfig `json:"performance,omitempty"`
+	Bootstrap          bool                   `json:"bootstrap,omitempty"`
+	Server             bool                   `json:"server,omitempty"`
+	DataDir            string                 `json:"data_dir,omitempty"`
+	Datacenter         string                 `json:"datacenter,omitempty"`
+	DisableCheckpoint  bool                   `json:"disable_update_check"`
+	LogLevel           string                 `json:"log_level,omitempty"`
+	Bind               string                 `json:"bind_addr,omitempty"`
+	Addresses          *TestAddressConfig     `json:"addresses,omitempty"`
+	Ports              *TestPortConfig        `json:"ports,omitempty"`
+	RaftProtocol       int                    `json:"raft_protocol,omitempty"`
+	ACLMasterToken     string                 `json:"acl_master_token,omitempty"`
+	ACLDatacenter      string                 `json:"acl_datacenter,omitempty"`
+	ACLDefaultPolicy   string                 `json:"acl_default_policy,omitempty"`
+	ACLEnforceVersion8 bool                   `json:"acl_enforce_version_8"`
+	Encrypt            string                 `json:"encrypt,omitempty"`
+	Stdout, Stderr     io.Writer              `json:"-"`
+	Args               []string               `json:"-"`
 }
 
 // ServerConfigCallback is a function interface which can be


### PR DESCRIPTION
This PR switches version 8 ACLs to opt-out for the upcoming 0.8 release. We also fixed a few issues with version 8 ACLs:

1. Removes an exception for the `consul` service. Closes #2816.
2. Fixes an issue where services and checks can't AE sync back deletes. Closes #2818.
3. Ensures that check registrations don't ride along with service registrations where the tokens are different.