### PR TITLE
Supress signal logging on SIGPIPE. Should address #2768

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1167,12 +1167,13 @@ WAIT:
 		// Agent is already shutdown!
 		return 0
 	}
-	c.Ui.Output(fmt.Sprintf("Caught signal: %v", sig))
 
-	// Skip SIGPIPE signals
+	// Skip SIGPIPE signals and skip logging whenever such signal is received as well
 	if sig == syscall.SIGPIPE {
 		goto WAIT
 	}
+
+	c.Ui.Output(fmt.Sprintf("Caught signal: %v", sig))
 
 	// Check if this is a SIGHUP
 	if sig == syscall.SIGHUP {


### PR DESCRIPTION
When consul-template is communicating with consul and the job is done, consul thread receives SIGPIPE.

This cause the logs to be filled "Caught signal: broken pipe" and they does not bring any usefull info with them.

Skipping those.