### PR TITLE
Disables agent-level enforcement on Consul agents unless acl_datacenter is set.

### DIFF
--- a/command/agent/acl.go
+++ b/command/agent/acl.go
@@ -170,7 +170,7 @@ func (m *aclManager) lookupACL(agent *Agent, id string) (acl.ACL, error) {
 	// At this point we might have a stale cached ACL, or none at all, so
 	// try to contact the servers.
 	args := structs.ACLPolicyRequest{
-		Datacenter: agent.config.Datacenter,
+		Datacenter: agent.config.ACLDatacenter,
 		ACL:        id,
 	}
 	if cached != nil {
@@ -239,6 +239,12 @@ func (m *aclManager) lookupACL(agent *Agent, id string) (acl.ACL, error) {
 func (a *Agent) resolveToken(id string) (acl.ACL, error) {
 	// Disable ACLs if version 8 enforcement isn't enabled.
 	if !(*a.config.ACLEnforceVersion8) {
+		return nil, nil
+	}
+
+	// Bail if there's no ACL datacenter configured. This means that agent
+	// enforcement isn't on.
+	if a.config.ACLDatacenter == "" {
 		return nil, nil
 	}
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -422,13 +422,12 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 #### Configuration Key Reference
 
-* <a name="acl_datacenter"></a><a href="#acl_datacenter">`acl_datacenter`</a> - Only
-  used by servers. This designates the datacenter which
-  is authoritative for ACL information. It must be provided to enable ACLs.
-  All servers and datacenters must agree on the ACL datacenter. Setting it on
-  the servers is all you need for enforcement, but for the APIs to forward properly
-  from the clients, it must be set on them too. Future changes may move
-  enforcement to the edges, so it's best to just set `acl_datacenter` on all nodes.
+* <a name="acl_datacenter"></a><a href="#acl_datacenter">`acl_datacenter`</a> - This designates
+  the datacenter which is authoritative for ACL information. It must be provided to enable ACLs.
+  All servers and datacenters must agree on the ACL datacenter. Setting it on the servers is all
+  you need for cluster-level enforcement, but for the APIs to forward properly from the clients,
+  it must be set on them too. In Consul 0.8 and later, this also enables agent-level enforcement
+  of ACLs. Please see the [ACL internals guide](/docs/internals/acl.html) for more details.
 
 * <a name="acl_default_policy"></a><a href="#acl_default_policy">`acl_default_policy`</a> - Either
   "allow" or "deny"; defaults to "allow". The default policy controls the behavior of a token when

--- a/website/source/docs/internals/acl.html.markdown
+++ b/website/source/docs/internals/acl.html.markdown
@@ -579,11 +579,18 @@ Since clients now resolve ACLs locally, the [`acl_down_policy`](/docs/agent/opti
 now applies to Consul clients as well as Consul servers. This will determine what the
 client will do in the event that the servers are down.
 
-Consul clients *do not* need to have the [`acl_master_token`](/docs/agent/options.html#acl_agent_master_token)
-or the [`acl_datacenter`](/docs/agent/options.html#acl_datacenter) configured. They will
-contact the Consul servers to determine if ACLs are enabled. If they detect that ACLs are
-not enabled, they will check at most every 2 minutes to see if they have become enabled, and
-will start enforcing ACLs automatically.
+Consul clients must have [`acl_datacenter`](/docs/agent/options.html#acl_datacenter) configured
+in order to enable agent-level ACL features. If this is set, the agents will contact the Consul
+servers to determine if ACLs are enabled at the cluster level. If they detect that ACLs are not
+enabled, they will check at most every 2 minutes to see if they have become enabled, and will
+start enforcing ACLs automatically. If an agent has an `acl_datacenter` defined, operators will
+need to use the [`acl_agent_master_token`](/docs/agent/options.html#acl_agent_master_token) to
+perform agent-level operations if the Consul servers aren't present (such as for a manual join
+to the cluster), unless the [`acl_down_policy`](/docs/agent/options.html#acl_down_policy) on the
+agent is set to "allow".
+
+Non-server agents do not need to have the [`acl_master_token`](/docs/agent/options.html#acl_agent_master_token)
+configured; it is not used by agents in any way.
 
 #### New ACL Policies
 


### PR DESCRIPTION
This makes it clearer that operators want ACLs enabled on the agents, otherwise if no servers are around agent-level operations will fail, even if ACLs are completely disabled. We also corrected the RPC call to use the `acl_datacenter`.