### PR TITLE
Bans check updates for nodes other than top-level reg. updates.

### DIFF
--- a/consul/autopilot_test.go
+++ b/consul/autopilot_test.go
@@ -194,7 +194,7 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 	// Add s4 to peers directly
 	s4addr := fmt.Sprintf("127.0.0.1:%d",
 		s4.config.SerfLANConfig.MemberlistConfig.BindPort)
-	s1.raft.AddVoter(raft.ServerID(s4.config.NodeID), raft.ServerAddress(s4addr),0, 0)
+	s1.raft.AddVoter(raft.ServerID(s4.config.NodeID), raft.ServerAddress(s4addr), 0, 0)
 
 	// Verify we have 4 peers
 	peers, err := s1.numPeers()

--- a/consul/state/catalog.go
+++ b/consul/state/catalog.go
@@ -126,19 +126,21 @@ func (s *StateStore) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *struc
 		}
 	}
 
-	// TODO (slackpad) In Consul 0.8 ban checks that don't have the same
-	// node as the top-level registration. This is just weird to be able to
-	// update unrelated nodes' checks from in here. In 0.7.2 we banned this
-	// up in the ACL check since that's guarded behind an opt-in flag until
-	// Consul 0.8.
-
 	// Add the checks, if any.
 	if req.Check != nil {
+		if req.Check.Node != req.Node {
+			return fmt.Errorf("check node %q does not match node %q",
+				req.Check.Node, req.Node)
+		}
 		if err := s.ensureCheckTxn(tx, idx, req.Check); err != nil {
 			return fmt.Errorf("failed inserting check: %s", err)
 		}
 	}
 	for _, check := range req.Checks {
+		if check.Node != req.Node {
+			return fmt.Errorf("check node %q does not match node %q",
+				check.Node, req.Node)
+		}
 		if err := s.ensureCheckTxn(tx, idx, check); err != nil {
 			return fmt.Errorf("failed inserting check: %s", err)
 		}


### PR DESCRIPTION
There's a random `go fmt` update as part of this change.