### PR TITLE
Add --quiet option to wget to prevent crashing when running remote-exec

### DIFF
--- a/terraform/shared/scripts/install.sh
+++ b/terraform/shared/scripts/install.sh
@@ -14,7 +14,7 @@ fi
 echo "Fetching Consul..."
 CONSUL=0.7.0
 cd /tmp
-wget https://releases.hashicorp.com/consul/${CONSUL}/consul_${CONSUL}_linux_amd64.zip -O consul.zip
+wget https://releases.hashicorp.com/consul/${CONSUL}/consul_${CONSUL}_linux_amd64.zip -O consul.zip --quiet
 
 echo "Installing Consul..."
 unzip consul.zip >/dev/null


### PR DESCRIPTION
Resolves #2848 