### PR TITLE
api: Add config flag to ensure HTTP connections are closed.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -163,6 +163,10 @@ type Config struct {
 	// Token is used to provide a per-request ACL token
 	// which overrides the agent's default token.
 	Token string
+
+	// CloseConnections instructs the client to ensure connections to the API
+	// are closed by setting the Connection HTTP header.
+	CloseConnections bool
 }
 
 // TLSConfig is used to generate a TLSClientConfig that's useful for talking to
@@ -511,6 +515,7 @@ func (c *Client) newRequest(method, path string) *request {
 		params: make(map[string][]string),
 		header: make(http.Header),
 	}
+
 	if c.config.Datacenter != "" {
 		r.params.Set("dc", c.config.Datacenter)
 	}
@@ -519,6 +524,9 @@ func (c *Client) newRequest(method, path string) *request {
 	}
 	if c.config.Token != "" {
 		r.header.Set("X-Consul-Token", r.config.Token)
+	}
+	if c.config.CloseConnections {
+		r.header.Set("Connection", "close")
 	}
 	return r
 }


### PR DESCRIPTION
Closes #2852.

In HTTP/1 and later, persistent connections are the default behavior of any HTTP connection. This change introduces a boolean configuration flag to the `Config` struct that allows users to instruct the Consul client to close HTTP connections by setting the `Connection` header in the request to `close`.

When hitting the Consul API using the Golang client, the established TCP connection is never closed. This can lead to exponentially increasing the number of connections left in an ESTABLISHED state, exhausting open file handles and potentially crashing the application making the API calls.

This fix does not change the default behavior of the client, however, if the core maintainers agree, we should either:
- Modify this PR to ensure the default value of CloseConnections is true, thus ensuring connections are closed by default.
- Modify the server-side code to set the Connection header to ensure connections are closed by default.

Big thanks to @jrasell for finding and testing the issue. 