### PR TITLE
clarify when acl_default_policy takes effect

### DIFF
--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -281,7 +281,8 @@ definitions support being updated during a reload.
   "allow" or "deny"; defaults to "allow". The default policy controls the behavior of a token when
   there is no matching rule. In "allow" mode, ACLs are a blacklist: any operation not specifically
   prohibited is allowed. In "deny" mode, ACLs are a whitelist: any operation not
-  specifically allowed is blocked.
+  specifically allowed is blocked. *Note*: this will not take effect until you've set `acl_datacenter` 
+  to enable ACL support.
 
 * <a name="acl_down_policy"></a><a href="#acl_down_policy">`acl_down_policy`</a> - Either
   "allow", "deny" or "extend-cache"; "extend-cache" is the default. In the case that the


### PR DESCRIPTION
clarify that setting `acl_default_policy` won't have any effect unless ACL support is also enabled by setting `acl_datacenter`