### PR TITLE
Raft Protocol vs Consul Protocol Doc Clarification

### DIFF
--- a/website/source/docs/compatibility.html.markdown
+++ b/website/source/docs/compatibility.html.markdown
@@ -36,18 +36,9 @@ For more details on the specifics of upgrading, see the [upgrading page](/docs/u
     <th>Protocol Compatibility</th>
   </tr>
   <tr>
-    <td>0.1</td>
+    <td>0.1 - 0.3</td>
     <td>1</td>
   </tr>
-  <tr>
-    <td>0.2</td>
-    <td>1</td>
-  </tr>
-  <tr>
-    <td>0.3</td>
-    <td>1, 2</td>
-  </tr>
-  <tr>
     <td>0.4</td>
     <td>1, 2</td>
   </tr>
@@ -60,7 +51,10 @@ For more details on the specifics of upgrading, see the [upgrading page](/docs/u
     <td>1, 2, 3</td>
   </tr>
   <tr>
-    <td>0.7</td>
+    <td>0.7 - 0.8</td>
     <td>2, 3. Will automatically use protocol > 2 when speaking to compatible agents</td>
   </tr>
 </table>
+
+-> **Note:** Raft Protocol is versioned separately, but maintains compatibility with at least one prior version. See [here](https://www.consul.io/docs/upgrade-specific.html#raft-protocol-version-compatibility) for details.
+

--- a/website/source/docs/upgrade-specific.html.markdown
+++ b/website/source/docs/upgrade-specific.html.markdown
@@ -49,7 +49,7 @@ When upgrading to Consul 0.8.0 from a version lower than 0.7.0, users will need 
 set the [`-raft-protocol`](/docs/agent/options.html#_raft_protocol) option to 1 in
 order to maintain backwards compatibility with the old servers during the upgrade.
 After the servers have been migrated to version 0.8.0, `-raft-protocol` can be moved
-up to 3 and the servers restarted to match the default.
+up to 2 and the servers restarted to match the default.
 
 The Raft protocol must be stepped up in this way; only adjacent version numbers are
 compatible (for example, version 1 cannot talk to version 3). Here is a table of the

--- a/website/source/docs/upgrade-specific.html.markdown
+++ b/website/source/docs/upgrade-specific.html.markdown
@@ -49,7 +49,7 @@ When upgrading to Consul 0.8.0 from a version lower than 0.7.0, users will need 
 set the [`-raft-protocol`](/docs/agent/options.html#_raft_protocol) option to 1 in
 order to maintain backwards compatibility with the old servers during the upgrade.
 After the servers have been migrated to version 0.8.0, `-raft-protocol` can be moved
-up to 2 and the servers restarted to match the default.
+up to 3 and the servers restarted to match the default.
 
 The Raft protocol must be stepped up in this way; only adjacent version numbers are
 compatible (for example, version 1 cannot talk to version 3). Here is a table of the


### PR DESCRIPTION
I do not know if I have this correct. I am unclear if `protocol` version and `raft` version are the same. Based on the info in `Specific Version Details` and `Compatibility Section` it's a little confusing. I'll do the editing if somebody can give a little clarification.