### PR TITLE
Fix ipv6 join failure on upgrade 0.7.2 to 0.8

### DIFF
--- a/consul/servers/serf_flooder.go
+++ b/consul/servers/serf_flooder.go
@@ -69,6 +69,17 @@ func FloodJoins(logger *log.Logger, portFn FloodPortFn,
 		// leave it blank to behave as if we just supplied an address.
 		if port, ok := portFn(server); ok {
 			addr = net.JoinHostPort(addr, fmt.Sprintf("%d", port))
+		} else {
+			// globalSerf.Join expects bracketed ipv6 addresses
+			ip := net.ParseIP(addr)
+			if ip == nil {
+				// should never happen
+				logger.Printf("[DEBUG] consul: Failed to parse IP %s", addr)
+			}
+			// If we have an IPv6 address, we should add brackets
+			if ip.To4() == nil {
+				addr = fmt.Sprintf("[%s]", addr)
+			}
 		}
 
 		// Do the join!


### PR DESCRIPTION
We're running an IPv6-only cluster.

With upgrade from 0.7.2 to 0.8 we got ```dial tcp: too many colons in address``` on startup

This PR fixes this by adding brackets in serf_flooder when the address is an IPv6 address (and no port has been added by net.JoinHostPort (which adds the brackets correctly))

This way, the ```hasPort``` function  (see https://github.com/hashicorp/consul/blob/master/vendor/github.com/hashicorp/memberlist/util.go#L220-L232) works correctly when called by ```resolveAddr``` (https://github.com/hashicorp/consul/blob/master/vendor/github.com/hashicorp/memberlist/memberlist.go#L277)
