### PR TITLE
Replace scala-consul by helm in libraries and SDKs

### DIFF
--- a/website/source/api/libraries-and-sdks.html.md
+++ b/website/source/api/libraries-and-sdks.html.md
@@ -40,7 +40,7 @@ the community.
     <a href="https://github.com/hadielmougy/clj-consul-catalog">clj-consul-catalog</a> - Clojure discovery client for the Consul HTTP API
   </li>
   <li>
-    <a href="https://github.com/codacy/scala-consul">scala-consul</a> - Scala client for the Consul HTTP API
+    <a href="https://github.com/Verizon/helm">helm</a> - A native Scala client for interacting with Consul
   </li>
   <li>
     <a href="https://github.com/OrbitzWorldwide/consul-client">consul-client</a> - Java client for the Consul HTTP API


### PR DESCRIPTION
scala-consul isn't maintained anymore:

from [the readme](https://github.com/codacy/scala-consul/blob/master/README.md):
> Codacy is not using consul at the moment and for that reason we are not developing this library any more. If you want to be a maintainer of this library create an issue so we can take that into consideration. Also, feel free to fork this and keep your own code.