### PR TITLE
Fixed spelling for consul kv get command --help comments.

### DIFF
--- a/command/kv_get.go
+++ b/command/kv_get.go
@@ -43,7 +43,7 @@ Usage: consul kv get [options] [KEY_OR_PREFIX]
 
       $ consul kv get -recurse foo
 
-  This will return all key-vlaue pairs. To just list the keys which start with
+  This will return all key-value pairs. To just list the keys which start with
   the specified prefix, use the "-keys" option instead:
 
       $ consul kv get -keys foo


### PR DESCRIPTION
### No code/logic/functionality/test changes.  Fixes purely a misspelling in doc comments.

I happened to notice that the `consul kv get` subcommand documentation had a misspelling for one of the get commands.