### PR TITLE
Ensure to exit with a non-zero status code when a timeout and all jobs are not completed.

### DIFF
--- a/command/exec.go
+++ b/command/exec.go
@@ -312,6 +312,9 @@ OUTER:
 				c.Ui.Info(fmt.Sprintf("Completed in %0.2f seconds",
 					float64(time.Now().Sub(start))/float64(time.Second)))
 			}
+			if exitCount < ackCount {
+				badExit++
+			}
 			break OUTER
 
 		case <-errCh:


### PR DESCRIPTION
- [x] Introduces a simple if check branch during the select on the timeout chan.
- [x] Increments local var `badExit` so when the the break to the `OUTER` loop occurs a non-zero exit is emitted.

Closes #2757