### PR TITLE
Ensure that EnableUI and UIDir are mutually exclusive.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -423,6 +423,11 @@ func (c *Command) readConfig() *Config {
 		return nil
 	}
 
+	if config.EnableUi && config.UiDir != "" {
+		c.Ui.Error("you must specify either EnableUi or UiDir but not both options.")
+		return nil
+	}
+
 	// Set the version info
 	config.Revision = c.Revision
 	config.Version = c.Version

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -351,11 +351,11 @@ will exit with an error at startup.
 
 * <a name="_ui"></a><a href="#_ui">`-ui`</a> - Enables the built-in web UI
   server and the required HTTP routes. This eliminates the need to maintain the
-  Consul web UI files separately from the binary.
+  Consul web UI files separately from the binary. This flag should not be used in conjunction with the -ui-dir flag.
 
 * <a name="_ui_dir"></a><a href="#_ui_dir">`-ui-dir`</a> - This flag provides the directory containing
   the Web UI resources for Consul. This will automatically enable the Web UI. The directory must be
-  readable to the agent. Starting with Consul version 0.7.0 and later, the Web UI assets are included in the binary so this flag is no longer necessary; specifying only the `-ui` flag is enough to enable the Web UI.
+  readable to the agent. Starting with Consul version 0.7.0 and later, the Web UI assets are included in the binary so this flag is no longer necessary; specifying only the `-ui` flag is enough to enable the Web UI. This flag should not be used in conjunction with the -ui flag.
 
 ## <a name="configuration_files"></a>Configuration Files
 


### PR DESCRIPTION
- [x] - Adds an additional constraint on the `config.EnableUi` and `config.UiDir` to ensure only one value is specified.
- [x] - find out where to update the docs to reflect this.
- [ ] - Get sign off on wording around documentation update: https://github.com/hashicorp/consul/pull/2903/commits/35249e600beb62d49c8a9f6e08f5707490f79c04

Closes #2576 