### PR TITLE
Updated autopilot guide to correct synax issue with example config

### DIFF
--- a/website/source/docs/guides/autopilot.html.markdown
+++ b/website/source/docs/guides/autopilot.html.markdown
@@ -30,7 +30,7 @@ bootstrapping the cluster:
     "cleanup_dead_servers": true,
     "last_contact_threshold": "200ms",
     "max_trailing_logs": 250,
-    "server_stabilization_time": 10s,
+    "server_stabilization_time": "10s",
     "redundancy_zone_tag": "az",
     "disable_upgrade_migration": false
 }


### PR DESCRIPTION
Small issue with missing " around the server_stabalisation_time config example, no big change, just in case someone copies and pastes from the guide.