### PR TITLE
add txn check not exists

### DIFF
--- a/api/kv.go
+++ b/api/kv.go
@@ -49,17 +49,18 @@ type KVPairs []*KVPair
 type KVOp string
 
 const (
-	KVSet          KVOp = "set"
-	KVDelete       KVOp = "delete"
-	KVDeleteCAS    KVOp = "delete-cas"
-	KVDeleteTree   KVOp = "delete-tree"
-	KVCAS          KVOp = "cas"
-	KVLock         KVOp = "lock"
-	KVUnlock       KVOp = "unlock"
-	KVGet          KVOp = "get"
-	KVGetTree      KVOp = "get-tree"
-	KVCheckSession KVOp = "check-session"
-	KVCheckIndex   KVOp = "check-index"
+	KVSet            KVOp = "set"
+	KVDelete         KVOp = "delete"
+	KVDeleteCAS      KVOp = "delete-cas"
+	KVDeleteTree     KVOp = "delete-tree"
+	KVCAS            KVOp = "cas"
+	KVLock           KVOp = "lock"
+	KVUnlock         KVOp = "unlock"
+	KVGet            KVOp = "get"
+	KVGetTree        KVOp = "get-tree"
+	KVCheckSession   KVOp = "check-session"
+	KVCheckIndex     KVOp = "check-index"
+	KVCheckNotExists KVOp = "check-not-exists"
 )
 
 // KVTxnOp defines a single operation inside a transaction.

--- a/consul/state/txn.go
+++ b/consul/state/txn.go
@@ -79,6 +79,12 @@ func (s *StateStore) txnKVS(tx *memdb.Txn, idx uint64, op *structs.TxnKVOp) (str
 	case api.KVCheckIndex:
 		entry, err = s.kvsCheckIndexTxn(tx, op.DirEnt.Key, op.DirEnt.ModifyIndex)
 
+	case api.KVCheckNotExists:
+		_, entry, err = s.kvsGetTxn(tx, nil, op.DirEnt.Key)
+		if entry != nil && err == nil {
+			err = fmt.Errorf("key %q exists", op.DirEnt.Key)
+		}
+
 	default:
 		err = fmt.Errorf("unknown KV verb %q", op.Verb)
 	}

--- a/consul/txn_endpoint_test.go
+++ b/consul/txn_endpoint_test.go
@@ -285,6 +285,14 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 					},
 				},
 			},
+			&structs.TxnOp{
+				KV: &structs.TxnKVOp{
+					Verb: api.KVCheckNotExists,
+					DirEnt: structs.DirEntry{
+						Key: "nope",
+					},
+				},
+			},
 		},
 		WriteRequest: structs.WriteRequest{
 			Token: id,

--- a/website/source/api/txn.markdown
+++ b/website/source/api/txn.markdown
@@ -149,16 +149,17 @@ look like this:
 The following table summarizes the available verbs and the fields that apply to
 that operation ("X" means a field is required and "O" means it is optional):
 
-| Verb            | Operation                                    | Key  | Value | Flags | Index | Session |
-| --------------- | -------------------------------------------- | :--: | :---: | :---: | :---: | :-----: |
-| `set`           | Sets the `Key` to the given `Value`          | `x`  | `x`   | `o`   |       |         |  
-| `cas`           | Sets, but with CAS semantics                 | `x`  | `x`   | `o`   | `x`   |         |  
-| `lock`          | Lock with the given `Session`                | `x`  | `x`   | `o`   |       | `x`     |  
-| `unlock`        | Unlock with the given `Session`              | `x`  | `x`   | `o`   |       | `x`     |  
-| `get`           | Get the key, fails if it does not exist      | `x`  |       |       |       |         |  
-| `get-tree`      | Gets all keys with the prefix                | `x`  |       |       |       |         |  
-| `check-index`   | Fail if modify index != index                | `x`  |       |       | `x`   |         |  
-| `check-session` | Fail if not locked by session                | `x`  |       |       |       | `x`     |  
-| `delete`        | Delete the key                               | `x`  |       |       |       |         |  
-| `delete-tree`   | Delete all keys with a prefix                | `x`  |       |       |       |         |  
-| `delete-cas`    | Delete, but with CAS semantics               | `x`  |       |       | `x`   |         |  
+| Verb               | Operation                                    | Key  | Value | Flags | Index | Session |
+| ------------------ | -------------------------------------------- | :--: | :---: | :---: | :---: | :-----: |
+| `set`              | Sets the `Key` to the given `Value`          | `x`  | `x`   | `o`   |       |         |  
+| `cas`              | Sets, but with CAS semantics                 | `x`  | `x`   | `o`   | `x`   |         |  
+| `lock`             | Lock with the given `Session`                | `x`  | `x`   | `o`   |       | `x`     |  
+| `unlock`           | Unlock with the given `Session`              | `x`  | `x`   | `o`   |       | `x`     |  
+| `get`              | Get the key, fails if it does not exist      | `x`  |       |       |       |         |  
+| `get-tree`         | Gets all keys with the prefix                | `x`  |       |       |       |         |  
+| `check-index`      | Fail if modify index != index                | `x`  |       |       | `x`   |         |  
+| `check-session`    | Fail if not locked by session                | `x`  |       |       |       | `x`     |  
+| `check-not-exists` | Fail if key exists                           | `x`  |       |       |       |         |  
+| `delete`           | Delete the key                               | `x`  |       |       |       |         |  
+| `delete-tree`      | Delete all keys with a prefix                | `x`  |       |       |       |         |  
+| `delete-cas`       | Delete, but with CAS semantics               | `x`  |       |       | `x`   |         |  


### PR DESCRIPTION
This patch is split into two parts:

1. refactor
   * refactor the code to use the `api.KVOp` type and its constants everywhere instead of `structs.KVSOp` internally and `api.KVOp` externally
   * refactor the code to use `api.HealthXXX` constants everywhere instead of the `structs.HealthXXX` constants internally and the `api.HealthXXX` constants externally

2. add support for `check-not-exists` on the TXN endpoint