### PR TITLE
FEATURE: use go-sockaddr to resolve recursors

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -578,6 +578,14 @@ func (a *Agent) resolveTmplAddrs() error {
 		a.config.TaggedAddresses[k] = ipStr
 	}
 
+	for i, v := range a.config.DNSRecursors {
+		ipStr, err := parseSingleIPTemplate(v)
+		if err != nil {
+			return fmt.Errorf("DNS recursor address resolution failed: %v", err)
+		}
+		a.config.DNSRecursors[i] = ipStr
+	}
+
 	return nil
 }
 

--- a/vendor/github.com/hashicorp/go-sockaddr/README.md
+++ b/vendor/github.com/hashicorp/go-sockaddr/README.md
@@ -24,7 +24,7 @@ For example, with this library it is possible to find an IP address that:
 
 * is attached to a default route
   ([`GetDefaultInterfaces()`](https://godoc.org/github.com/hashicorp/go-sockaddr#GetDefaultInterfaces))
-* is contained within a CIDR block (['IfByNetwork()'](https://godoc.org/github.com/hashicorp/go-sockaddr#IfByNetwork))
+* is contained within a CIDR block ([`IfByNetwork()`](https://godoc.org/github.com/hashicorp/go-sockaddr#IfByNetwork))
 * is an RFC1918 address
   ([`IfByRFC("1918")`](https://godoc.org/github.com/hashicorp/go-sockaddr#IfByRFC))
 * is ordered

--- a/vendor/github.com/hashicorp/go-sockaddr/ipv4addr.go
+++ b/vendor/github.com/hashicorp/go-sockaddr/ipv4addr.go
@@ -499,6 +499,7 @@ func ipv4AddrInit() {
 		"size", // Same position as in IPv6 for output consistency
 		"broadcast",
 		"uint32",
+		"aws_dns",
 	}
 
 	ipv4AddrAttrMap = map[AttrName]func(ipv4 IPv4Addr) string{
@@ -510,6 +511,15 @@ func ipv4AddrInit() {
 		},
 		"uint32": func(ipv4 IPv4Addr) string {
 			return fmt.Sprintf("%d", uint32(ipv4.Address))
+		},
+		"aws_dns": func(ipv4 IPv4Addr) string {
+			addr := ipv4.NetworkAddress()
+			if ipv4.Maskbits() < 31 {
+				addr += 2
+			}
+			x := make(net.IP, IPv4len)
+			binary.BigEndian.PutUint32(x, uint32(addr))
+			return x.String()
 		},
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -486,10 +486,10 @@
 			"revisionTime": "2016-05-03T14:34:40Z"
 		},
 		{
-			"checksumSHA1": "BGODc7juQbdG3vNXHZG07kt+lKI=",
+			"checksumSHA1": "wzYP3Wl6YQpNnibnl3kNWSN2lcg=",
 			"path": "github.com/hashicorp/go-sockaddr",
-			"revision": "f910dd83c2052566cad78352c33af714358d1372",
-			"revisionTime": "2017-02-08T07:30:35Z"
+			"revision": "dd2f3a465ed5eb0a401073b6b595898a3bb62284",
+			"revisionTime": "2017-04-20T00:41:28Z"
 		},
 		{
 			"checksumSHA1": "lPzwetgfMBtpHqdTPolgejMctVQ=",


### PR DESCRIPTION
This allows AmazonProvidedDNS to be one of the consul DNS recursors, and
at the same time make the AMI immutable.