### PR TITLE
Remove references to the deprecated Consul/Atlas integration

### DIFF
--- a/website/source/docs/agent/basics.html.markdown
+++ b/website/source/docs/agent/basics.html.markdown
@@ -38,7 +38,6 @@ $ consul agent -data-dir=/tmp/consul
           Server: false (bootstrap: false)
      Client Addr: 127.0.0.1 (HTTP: 8500, DNS: 8600)
     Cluster Addr: 192.168.1.43 (LAN: 8301, WAN: 8302)
-           Atlas: (Infrastructure: 'hashicorp/test' Join: true)
 
 ==> Log data will now stream in as it occurs:
 
@@ -74,11 +73,6 @@ There are several important messages that [`consul agent`](/docs/commands/agent.
 * **Cluster Addr**: This is the address and set of ports used for communication between
   Consul agents in a cluster. Not all Consul agents in a cluster have to
   use the same port, but this address **MUST** be reachable by all other nodes.
-
-* **Atlas**: This shows the [Atlas infrastructure](https://atlas.hashicorp.com)
-  with which the node is registered. It also indicates if auto-join is enabled.
-  The Atlas infrastructure is set using [`-atlas`](/docs/agent/options.html#_atlas)
-  and auto-join is enabled by setting [`-atlas-join`](/docs/agent/options.html#_atlas_join).
 
 ## Stopping an Agent
 

--- a/website/source/docs/agent/encryption.html.markdown
+++ b/website/source/docs/agent/encryption.html.markdown
@@ -46,7 +46,6 @@ $ consul agent -data-dir=/tmp/consul -config-file=encrypt.json
        Client Addr: 127.0.0.1 (HTTP: 8500, HTTPS: -1, DNS: 8600, RPC: 8400)
       Cluster Addr: 10.1.10.12 (LAN: 8301, WAN: 8302)
     Gossip encrypt: true, RPC-TLS: false, TLS-Incoming: false
-             Atlas: <disabled>
 ...
 ```
 

--- a/website/source/docs/agent/options.html.markdown
+++ b/website/source/docs/agent/options.html.markdown
@@ -59,31 +59,6 @@ The options below are all specified on the command-line.
   address when being accessed from a remote datacenter if the remote datacenter is configured
   with <a href="#translate_wan_addrs">`translate_wan_addrs`</a>.
 
-~> **Notice:** The hosted version of Consul Enterprise was deprecated on
-  March 7th, 2017. For details, see https://atlas.hashicorp.com/help/consul/alternatives.
-
-* <a name="_atlas"></a><a href="#_atlas">`-atlas`</a> - This flag
-  enables [Atlas](https://atlas.hashicorp.com) integration.
-  It is used to provide the Atlas infrastructure name and the SCADA connection. The format of
-  this is `username/environment`. This enables Atlas features such as the Monitoring UI
-  and node auto joining.
-
-* <a name="_atlas_join"></a><a href="#_atlas_join">`-atlas-join`</a> - When set, enables auto-join
-  via Atlas. Atlas will track the most
-  recent members to join the infrastructure named by [`-atlas`](#_atlas) and automatically
-  join them on start. For servers, the LAN and WAN pool are both joined.
-
-* <a name="_atlas_token"></a><a href="#_atlas_token">`-atlas-token`</a> - Provides the Atlas
-  API authentication token. This can also be provided
-  using the `ATLAS_TOKEN` environment variable. Required for use with Atlas.
-
-* <a name="_atlas_endpoint"></a><a href="#_atlas_endpoint">`-atlas-endpoint`</a> - The endpoint
-  address used for Atlas integration. Used only if the `-atlas` and
-  `-atlas-token` options are specified. This is optional, and defaults to the
-  public Atlas endpoints. This can also be specified using the `SCADA_ENDPOINT`
-  environment variable. The CLI option takes precedence, followed by the
-  configuration file directive, and lastly, the environment variable.
-
 * <a name="_bootstrap"></a><a href="#_bootstrap">`-bootstrap`</a> - This flag is used to control if a
   server is in "bootstrap" mode. It is important that
   no more than one server *per* datacenter be running in this mode. Technically, a server in bootstrap mode
@@ -552,23 +527,6 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).
-
-* <a name="atlas_acl_token"></a><a href="#atlas_acl_token">`atlas_acl_token`</a> When provided,
-  any requests made by Atlas will use this ACL token unless explicitly overridden. When not provided
-  the [`acl_token`](#acl_token) is used. This can be set to 'anonymous' to reduce permission below
-  that of [`acl_token`](#acl_token).
-
-* <a name="atlas_infrastructure"></a><a href="#atlas_infrastructure">`atlas_infrastructure`</a>
-  Equivalent to the [`-atlas` command-line flag](#_atlas).
-
-* <a name="atlas_join"></a><a href="#atlas_join">`atlas_join`</a> Equivalent to the
-  [`-atlas-join` command-line flag](#_atlas_join).
-
-* <a name="atlas_token"></a><a href="#atlas_token">`atlas_token`</a> Equivalent to the
-  [`-atlas-token` command-line flag](#_atlas_token).
-
-* <a name="atlas_endpoint"></a><a href="#atlas_endpoint">`atlas_endpoint`</a> Equivalent to the
-  [`-atlas-endpoint` command-line flag](#_atlas_endpoint).
 
 * <a name="autopilot"></a><a href="#autopilot">`autopilot`</a> Added in Consul 0.8, this object
   allows a number of sub-keys to be set which can configure operator-friendly settings for Consul servers.
@@ -1133,10 +1091,6 @@ port.
 
 * DNS Interface (Default 8600). Used to resolve DNS queries. TCP and UDP.
 
-Consul will also make an outgoing connection to HashiCorp's servers for
-Atlas-related features and to check for the availability of newer versions
-of Consul. This will be a TLS-secured TCP connection to `scada.hashicorp.com:7223`.
-
 ## <a id="reloadable-configuration"></a>Reloadable Configuration
 
 Reloading configuration does not reload all configuration items. The
@@ -1148,6 +1102,3 @@ items which are reloaded include:
 * Watches
 * HTTP Client Address
 * <a href="#node_meta">Node Metadata</a>
-* Atlas Token
-* Atlas Infrastructure
-* Atlas Endpoint

--- a/website/source/docs/guides/atlas.html.markdown
+++ b/website/source/docs/guides/atlas.html.markdown
@@ -8,53 +8,6 @@ description: |-
 
 # Atlas Integration
 
-~> **Notice:** The hosted version of Consul Enterprise will be deprecated on
+~> **Notice:** The hosted version of Consul Enterprise was deprecated on
 March 7th, 2017. For details, see https://atlas.hashicorp.com/help/consul/alternatives
 
-[Atlas](https://atlas.hashicorp.com?utm_source=oss&utm_medium=guide-atlas&utm_campaign=consul) is a service provided by HashiCorp to deploy applications and manage infrastructure.
-Starting with Consul 0.5, it is possible to integrate Consul with Atlas. Atlas is able to display the state of the Consul cluster in its dashboard and set up alerts based on health checks. Additionally, nodes can use Atlas to auto-join a Consul cluster without hardcoding any configuration.
-
-Atlas is able to securely retrieve data from nodes as Consul maintains a long-running connection to the
-[SCADA](http://scada.hashicorp.com) service.
-
-## Enabling Atlas Integration
-
-To enable Atlas integration, you must specify the name of the Atlas infrastructure and the Atlas authentication
-token in your Consul configuration. The Atlas infrastructure name can be set either with the [`-atlas` CLI flag](/docs/agent/options.html#_atlas) or with the [`atlas_infrastructure` configuration option](/docs/agent/options.html#atlas_infrastructure). The Atlas token is set with the [`-atlas-token` CLI flag](/docs/agent/options.html#_atlas_token),
-[`atlas_token` configuration option](/docs/agent/options.html#atlas_token), or `ATLAS_TOKEN` environment variable.
-
-To get an Atlas username and token, [create an account here](https://atlas.hashicorp.com/account/new?utm_source=oss&utm_medium=guide-atlas&utm_campaign=consul) and replace the respective values in your Consul configuration with your credentials.
-
-To verify the integration, either run the agent with `debug`-level logging or use `consul monitor -log-level=debug`
-and look for a line like:
-
-    [DEBUG] scada-client: assigned session '406ca55d-1801-f964-2942-45f5f9df3995'
-
-This shows that the Consul agent was successfully able to register with the SCADA service.
-
-## Using Auto-Join
-
-Once integrated with Atlas, the auto-join feature can be used to have nodes automatically join other
-peers in their datacenter. Server nodes will automatically join peer LAN nodes and other WAN nodes.
-Client nodes will only join other LAN nodes in their datacenter.
-
-Auto-join is enabled with the [`-atlas-join` CLI flag](/docs/agent/options.html#_atlas_join) or the
-[`atlas_join` configuration option](/docs/agent/options.html#atlas_join).
-
-## Securing Atlas
-
-The connection to Atlas does not have elevated privileges. API requests made by Atlas
-are served in the same way any other HTTP request is handled. If ACLs are enabled, it is possible, via
-the [`atlas_acl_token`](/docs/agent/options.html#atlas_acl_token) configuration option, to force an
-Atlas ACL token to be used instead of the agent's default token.
-
-The resolution order for ACL tokens is:
-
-1. Request-specific token provided by `?token=`. These tokens are set in the Atlas UI.
-2. The agent's [`atlas_acl_token`](/docs/agent/options.html#atlas_acl_token), if configured.
-3. The agent's [`acl_token`](/docs/agent/options.html#acl_token), if configured.
-4. The `anonymous` token.
-
-Because the [`acl_token`](/docs/agent/options.html#acl_token) typically has elevated permissions
-compared to the `anonymous` token, the [`atlas_acl_token`](/docs/agent/options.html#atlas_acl_token)
-can be set to `anonymous` to drop privileges that would otherwise be inherited from the agent.

--- a/website/source/docs/guides/atlas.html.markdown
+++ b/website/source/docs/guides/atlas.html.markdown
@@ -8,6 +8,6 @@ description: |-
 
 # Atlas Integration
 
-~> **Notice:** The hosted version of Consul Enterprise was deprecated on
+~> **Notice:** The hosted version of [Consul Enterprise](https://www.hashicorp.com/products/consul) was deprecated on
 March 7th, 2017. For details, see https://atlas.hashicorp.com/help/consul/alternatives
 


### PR DESCRIPTION
Atlas references were removed from the relevant agent-related pages. All content was removed from the Atlas guide itself, with the exception of the deprecation notice at the top. The reference in the FAQ was also intentionally left in.