### PR TITLE
Fix failing tests

### DIFF
--- a/command/agent/acl_endpoint_test.go
+++ b/command/agent/acl_endpoint_test.go
@@ -34,7 +34,6 @@ func makeTestACL(t *testing.T, srv *HTTPServer) string {
 }
 
 func TestACLUpdate(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestACL(t, srv)
 
@@ -65,7 +64,6 @@ func TestACLUpdate(t *testing.T) {
 }
 
 func TestACLUpdate_Upsert(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		enc := json.NewEncoder(body)
@@ -94,7 +92,6 @@ func TestACLUpdate_Upsert(t *testing.T) {
 }
 
 func TestACLDestroy(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestACL(t, srv)
 		req, err := http.NewRequest("PUT", "/v1/acl/destroy/"+id+"?token=root", nil)
@@ -125,7 +122,6 @@ func TestACLDestroy(t *testing.T) {
 }
 
 func TestACLClone(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestACL(t, srv)
 
@@ -162,7 +158,6 @@ func TestACLClone(t *testing.T) {
 }
 
 func TestACLGet(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET", "/v1/acl/info/nope", nil)
 		resp := httptest.NewRecorder()
@@ -200,7 +195,6 @@ func TestACLGet(t *testing.T) {
 }
 
 func TestACLList(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		var ids []string
 		for i := 0; i < 10; i++ {
@@ -226,7 +220,6 @@ func TestACLList(t *testing.T) {
 }
 
 func TestACLReplicationStatus(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET", "/v1/acl/replication", nil)
 		resp := httptest.NewRecorder()

--- a/command/agent/acl_test.go
+++ b/command/agent/acl_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestACL_Bad_Config(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDownPolicy = "nope"
 
@@ -46,7 +45,6 @@ func (m *MockServer) GetPolicy(args *structs.ACLPolicyRequest, reply *structs.AC
 }
 
 func TestACL_Version8(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(false)
 
@@ -72,7 +70,6 @@ func TestACL_Version8(t *testing.T) {
 }
 
 func TestACL_Disabled(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDisabledTTL = 10 * time.Millisecond
 	config.ACLEnforceVersion8 = Bool(true)
@@ -129,7 +126,6 @@ func TestACL_Disabled(t *testing.T) {
 }
 
 func TestACL_Special_IDs(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 	config.ACLAgentMasterToken = "towel"
@@ -185,7 +181,6 @@ func TestACL_Special_IDs(t *testing.T) {
 }
 
 func TestACL_Down_Deny(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDownPolicy = "deny"
 	config.ACLEnforceVersion8 = Bool(true)
@@ -218,7 +213,6 @@ func TestACL_Down_Deny(t *testing.T) {
 }
 
 func TestACL_Down_Allow(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDownPolicy = "allow"
 	config.ACLEnforceVersion8 = Bool(true)
@@ -251,7 +245,6 @@ func TestACL_Down_Allow(t *testing.T) {
 }
 
 func TestACL_Down_Extend(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDownPolicy = "extend-cache"
 	config.ACLEnforceVersion8 = Bool(true)
@@ -332,7 +325,6 @@ func TestACL_Down_Extend(t *testing.T) {
 }
 
 func TestACL_Cache(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -517,7 +509,6 @@ func catalogPolicy(req *structs.ACLPolicyRequest, reply *structs.ACLPolicy) erro
 }
 
 func TestACL_vetServiceRegister(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -566,7 +557,6 @@ func TestACL_vetServiceRegister(t *testing.T) {
 }
 
 func TestACL_vetServiceUpdate(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -605,7 +595,6 @@ func TestACL_vetServiceUpdate(t *testing.T) {
 }
 
 func TestACL_vetCheckRegister(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -691,7 +680,6 @@ func TestACL_vetCheckRegister(t *testing.T) {
 }
 
 func TestACL_vetCheckUpdate(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -750,7 +738,6 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 }
 
 func TestACL_filterMembers(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -789,7 +776,6 @@ func TestACL_filterMembers(t *testing.T) {
 }
 
 func TestACL_filterServices(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 
@@ -823,7 +809,6 @@ func TestACL_filterServices(t *testing.T) {
 }
 
 func TestACL_filterChecks(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLEnforceVersion8 = Bool(true)
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -49,7 +49,6 @@ func makeReadOnlyAgentACL(t *testing.T, srv *HTTPServer) string {
 }
 
 func TestAgent_Services(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -82,7 +81,6 @@ func TestAgent_Services(t *testing.T) {
 }
 
 func TestAgent_Services_ACLFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -124,7 +122,6 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Checks(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -157,7 +154,6 @@ func TestAgent_Checks(t *testing.T) {
 }
 
 func TestAgent_Checks_ACLFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -207,7 +203,6 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Self(t *testing.T) {
-	t.Parallel()
 	meta := map[string]string{
 		"somekey": "somevalue",
 	}
@@ -259,7 +254,6 @@ func TestAgent_Self(t *testing.T) {
 }
 
 func TestAgent_Self_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -307,7 +301,6 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Reload(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
@@ -386,7 +379,6 @@ func TestAgent_Reload(t *testing.T) {
 }
 
 func TestAgent_Reload_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -426,7 +418,6 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Members(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -452,7 +443,6 @@ func TestAgent_Members(t *testing.T) {
 }
 
 func TestAgent_Members_WAN(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -478,7 +468,6 @@ func TestAgent_Members_WAN(t *testing.T) {
 }
 
 func TestAgent_Members_ACLFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -520,7 +509,6 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 }
 
 func TestAgent_Join(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -556,7 +544,6 @@ func TestAgent_Join(t *testing.T) {
 }
 
 func TestAgent_Join_WAN(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -592,7 +579,6 @@ func TestAgent_Join_WAN(t *testing.T) {
 }
 
 func TestAgent_Join_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -645,7 +631,6 @@ func TestAgent_Join_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_Leave(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -689,7 +674,6 @@ func TestAgent_Leave(t *testing.T) {
 }
 
 func TestAgent_Leave_ACLDeny(t *testing.T) {
-	t.Parallel()
 	// Try without a token.
 	func() {
 		dir, srv := makeHTTPServerWithACLs(t)
@@ -747,7 +731,6 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_ForceLeave(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -790,7 +773,6 @@ func TestAgent_ForceLeave(t *testing.T) {
 }
 
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -838,7 +820,6 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -888,7 +869,6 @@ func TestAgent_RegisterCheck(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_Passing(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -933,7 +913,6 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -963,7 +942,6 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -999,7 +977,6 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_DeregisterCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1031,7 +1008,6 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 }
 
 func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1064,7 +1040,6 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 }
 
 func TestAgent_PassCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1097,7 +1072,6 @@ func TestAgent_PassCheck(t *testing.T) {
 }
 
 func TestAgent_PassCheck_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1131,7 +1105,6 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_WarnCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1164,7 +1137,6 @@ func TestAgent_WarnCheck(t *testing.T) {
 }
 
 func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1198,7 +1170,6 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_FailCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1231,7 +1202,6 @@ func TestAgent_FailCheck(t *testing.T) {
 }
 
 func TestAgent_FailCheck_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1265,7 +1235,6 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_UpdateCheck(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1394,7 +1363,6 @@ func TestAgent_UpdateCheck(t *testing.T) {
 }
 
 func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1430,7 +1398,6 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_RegisterService(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1488,7 +1455,6 @@ func TestAgent_RegisterService(t *testing.T) {
 }
 
 func TestAgent_RegisterService_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1535,7 +1501,6 @@ func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_DeregisterService(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1573,7 +1538,6 @@ func TestAgent_DeregisterService(t *testing.T) {
 }
 
 func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1609,7 +1573,6 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1657,7 +1620,6 @@ func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1701,7 +1663,6 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1739,7 +1700,6 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 }
 
 func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1776,7 +1736,6 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1804,7 +1763,6 @@ func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_Enable(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1839,7 +1797,6 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_Disable(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1865,7 +1822,6 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1895,7 +1851,6 @@ func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 }
 
 func TestAgent_RegisterCheck_Service(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1953,7 +1908,6 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 }
 
 func TestAgent_Monitor(t *testing.T) {
-	t.Parallel()
 	logWriter := logger.NewLogWriter(512)
 	logger := io.MultiWriter(os.Stdout, logWriter)
 
@@ -2021,7 +1975,6 @@ func (r *closableRecorder) CloseNotify() <-chan bool {
 }
 
 func TestAgent_Monitor_ACLDeny(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -154,7 +154,6 @@ func externalIP() (string, error) {
 }
 
 func TestAgentStartStop(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -174,7 +173,6 @@ func TestAgentStartStop(t *testing.T) {
 }
 
 func TestAgent_RPCPing(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -186,7 +184,6 @@ func TestAgent_RPCPing(t *testing.T) {
 }
 
 func TestAgent_CheckSerfBindAddrsSettings(t *testing.T) {
-	t.Parallel()
 	c := nextConfig()
 	ip, err := externalIP()
 	if err != nil {
@@ -209,7 +206,6 @@ func TestAgent_CheckSerfBindAddrsSettings(t *testing.T) {
 	}
 }
 func TestAgent_CheckAdvertiseAddrsSettings(t *testing.T) {
-	t.Parallel()
 	c := nextConfig()
 	c.AdvertiseAddrs.SerfLan, _ = net.ResolveTCPAddr("tcp", "127.0.0.42:1233")
 	c.AdvertiseAddrs.SerfWan, _ = net.ResolveTCPAddr("tcp", "127.0.0.43:1234")
@@ -248,7 +244,6 @@ func TestAgent_CheckAdvertiseAddrsSettings(t *testing.T) {
 }
 
 func TestAgent_CheckPerformanceSettings(t *testing.T) {
-	t.Parallel()
 	// Try a default config.
 	{
 		c := nextConfig()
@@ -287,7 +282,6 @@ func TestAgent_CheckPerformanceSettings(t *testing.T) {
 }
 
 func TestAgent_ReconnectConfigSettings(t *testing.T) {
-	t.Parallel()
 	c := nextConfig()
 	func() {
 		dir, agent := makeAgent(t, c)
@@ -326,7 +320,6 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 }
 
 func TestAgent_setupNodeID(t *testing.T) {
-	t.Parallel()
 	c := nextConfig()
 	c.NodeID = ""
 	dir, agent := makeAgent(t, c)
@@ -393,7 +386,6 @@ func TestAgent_setupNodeID(t *testing.T) {
 }
 
 func TestAgent_makeNodeID(t *testing.T) {
-	t.Parallel()
 	c := nextConfig()
 	c.NodeID = ""
 	dir, agent := makeAgent(t, c)
@@ -430,7 +422,6 @@ func TestAgent_makeNodeID(t *testing.T) {
 }
 
 func TestAgent_AddService(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -529,7 +520,6 @@ func TestAgent_AddService(t *testing.T) {
 }
 
 func TestAgent_RemoveService(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -629,7 +619,6 @@ func TestAgent_RemoveService(t *testing.T) {
 }
 
 func TestAgent_AddCheck(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -667,7 +656,6 @@ func TestAgent_AddCheck(t *testing.T) {
 }
 
 func TestAgent_AddCheck_StartPassing(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -705,7 +693,6 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 }
 
 func TestAgent_AddCheck_MinInterval(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -739,7 +726,6 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 }
 
 func TestAgent_AddCheck_MissingService(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -761,7 +747,6 @@ func TestAgent_AddCheck_MissingService(t *testing.T) {
 }
 
 func TestAgent_AddCheck_RestoreState(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -805,7 +790,6 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 }
 
 func TestAgent_RemoveCheck(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -852,7 +836,6 @@ func TestAgent_RemoveCheck(t *testing.T) {
 }
 
 func TestAgent_updateTTLCheck(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -887,7 +870,6 @@ func TestAgent_updateTTLCheck(t *testing.T) {
 }
 
 func TestAgent_ConsulService(t *testing.T) {
-	t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -912,7 +894,6 @@ func TestAgent_ConsulService(t *testing.T) {
 }
 
 func TestAgent_PersistService(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Server = false
 	dir, agent := makeAgent(t, config)
@@ -999,7 +980,6 @@ func TestAgent_PersistService(t *testing.T) {
 }
 
 func TestAgent_persistedService_compat(t *testing.T) {
-	t.Parallel()
 	// Tests backwards compatibility of persisted services from pre-0.5.1
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
@@ -1046,7 +1026,6 @@ func TestAgent_persistedService_compat(t *testing.T) {
 }
 
 func TestAgent_PurgeService(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1087,7 +1066,6 @@ func TestAgent_PurgeService(t *testing.T) {
 }
 
 func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Server = false
 	dir, agent := makeAgent(t, config)
@@ -1137,7 +1115,6 @@ func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
 }
 
 func TestAgent_PersistCheck(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Server = false
 	dir, agent := makeAgent(t, config)
@@ -1238,7 +1215,6 @@ func TestAgent_PersistCheck(t *testing.T) {
 }
 
 func TestAgent_PurgeCheck(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1274,7 +1250,6 @@ func TestAgent_PurgeCheck(t *testing.T) {
 }
 
 func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Server = false
 	dir, agent := makeAgent(t, config)
@@ -1327,7 +1302,6 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 }
 
 func TestAgent_loadChecks_token(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Checks = append(config.Checks, &CheckDefinition{
 		ID:    "rabbitmq",
@@ -1351,7 +1325,6 @@ func TestAgent_loadChecks_token(t *testing.T) {
 }
 
 func TestAgent_unloadChecks(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1405,7 +1378,6 @@ func TestAgent_unloadChecks(t *testing.T) {
 }
 
 func TestAgent_loadServices_token(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.Services = append(config.Services, &ServiceDefinition{
 		ID:    "rabbitmq",
@@ -1427,7 +1399,6 @@ func TestAgent_loadServices_token(t *testing.T) {
 }
 
 func TestAgent_unloadServices(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1476,7 +1447,6 @@ func TestAgent_unloadServices(t *testing.T) {
 }
 
 func TestAgent_Service_MaintenanceMode(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1542,7 +1512,6 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 }
 
 func TestAgent_Service_Reap(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.CheckReapInterval = time.Millisecond
 	config.CheckDeregisterIntervalMin = 0
@@ -1617,7 +1586,6 @@ func TestAgent_Service_Reap(t *testing.T) {
 }
 
 func TestAgent_Service_NoReap(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.CheckReapInterval = time.Millisecond
 	config.CheckDeregisterIntervalMin = 0
@@ -1671,7 +1639,6 @@ func TestAgent_Service_NoReap(t *testing.T) {
 }
 
 func TestAgent_addCheck_restoresSnapshot(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1716,7 +1683,6 @@ func TestAgent_addCheck_restoresSnapshot(t *testing.T) {
 }
 
 func TestAgent_NodeMaintenanceMode(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1763,7 +1729,6 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 }
 
 func TestAgent_checkStateSnapshot(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1822,7 +1787,6 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 }
 
 func TestAgent_loadChecks_checkFails(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1859,7 +1823,6 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 }
 
 func TestAgent_persistCheckState(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1908,7 +1871,6 @@ func TestAgent_persistCheckState(t *testing.T) {
 }
 
 func TestAgent_loadCheckState(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -1971,7 +1933,6 @@ func TestAgent_loadCheckState(t *testing.T) {
 }
 
 func TestAgent_purgeCheckState(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	dir, agent := makeAgent(t, config)
 	defer os.RemoveAll(dir)
@@ -2005,7 +1966,6 @@ func TestAgent_purgeCheckState(t *testing.T) {
 }
 
 func TestAgent_GetCoordinate(t *testing.T) {
-	t.Parallel()
 	check := func(server bool) {
 		config := nextConfig()
 		config.Server = server

--- a/command/agent/catalog_endpoint_test.go
+++ b/command/agent/catalog_endpoint_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestCatalogRegister(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -56,7 +55,6 @@ func TestCatalogRegister(t *testing.T) {
 }
 
 func TestCatalogDeregister(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -86,7 +84,6 @@ func TestCatalogDeregister(t *testing.T) {
 }
 
 func TestCatalogDatacenters(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -109,7 +106,6 @@ func TestCatalogDatacenters(t *testing.T) {
 }
 
 func TestCatalogNodes(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -150,7 +146,6 @@ func TestCatalogNodes(t *testing.T) {
 }
 
 func TestCatalogNodes_MetaFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -198,7 +193,6 @@ func TestCatalogNodes_MetaFilter(t *testing.T) {
 }
 
 func TestCatalogNodes_WanTranslation(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeHTTPServerWithConfig(t,
 		func(c *Config) {
 			c.Datacenter = "dc1"
@@ -303,7 +297,6 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 }
 
 func TestCatalogNodes_Blocking(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -365,7 +358,6 @@ func TestCatalogNodes_Blocking(t *testing.T) {
 }
 
 func TestCatalogNodes_DistanceSort(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -461,7 +453,6 @@ func TestCatalogNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalogServices(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -504,7 +495,6 @@ func TestCatalogServices(t *testing.T) {
 }
 
 func TestCatalogServices_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -553,7 +543,6 @@ func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalogServiceNodes(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -618,7 +607,6 @@ func TestCatalogServiceNodes(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -685,7 +673,6 @@ func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeHTTPServerWithConfig(t,
 		func(c *Config) {
 			c.Datacenter = "dc1"
@@ -781,7 +768,6 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 }
 
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -884,7 +870,6 @@ func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalogNodeServices(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -927,7 +912,6 @@ func TestCatalogNodeServices(t *testing.T) {
 }
 
 func TestCatalogNodeServices_WanTranslation(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeHTTPServerWithConfig(t,
 		func(c *Config) {
 			c.Datacenter = "dc1"

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -96,27 +96,22 @@ func expectStatus(t *testing.T, script, status string) {
 }
 
 func TestCheckMonitor_Passing(t *testing.T) {
-	t.Parallel()
 	expectStatus(t, "exit 0", api.HealthPassing)
 }
 
 func TestCheckMonitor_Warning(t *testing.T) {
-	t.Parallel()
 	expectStatus(t, "exit 1", api.HealthWarning)
 }
 
 func TestCheckMonitor_Critical(t *testing.T) {
-	t.Parallel()
 	expectStatus(t, "exit 2", api.HealthCritical)
 }
 
 func TestCheckMonitor_BadCmd(t *testing.T) {
-	t.Parallel()
 	expectStatus(t, "foobarbaz", api.HealthCritical)
 }
 
 func TestCheckMonitor_Timeout(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),
@@ -146,7 +141,6 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 }
 
 func TestCheckMonitor_RandomStagger(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),
@@ -175,7 +169,6 @@ func TestCheckMonitor_RandomStagger(t *testing.T) {
 }
 
 func TestCheckMonitor_LimitOutput(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),
@@ -200,7 +193,6 @@ func TestCheckMonitor_LimitOutput(t *testing.T) {
 }
 
 func TestCheckTTL(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),
@@ -311,7 +303,6 @@ func expectHTTPStatus(t *testing.T, url string, status string) {
 }
 
 func TestCheckHTTPCritical(t *testing.T) {
-	t.Parallel()
 	// var server *httptest.Server
 
 	server := mockHTTPServer(150)
@@ -339,7 +330,6 @@ func TestCheckHTTPCritical(t *testing.T) {
 }
 
 func TestCheckHTTPPassing(t *testing.T) {
-	t.Parallel()
 	var server *httptest.Server
 
 	server = mockHTTPServer(200)
@@ -360,7 +350,6 @@ func TestCheckHTTPPassing(t *testing.T) {
 }
 
 func TestCheckHTTPWarning(t *testing.T) {
-	t.Parallel()
 	server := mockHTTPServer(429)
 	expectHTTPStatus(t, server.URL, api.HealthWarning)
 	server.Close()
@@ -378,7 +367,6 @@ func mockSlowHTTPServer(responseCode int, sleep time.Duration) *httptest.Server 
 }
 
 func TestCheckHTTPTimeout(t *testing.T) {
-	t.Parallel()
 	server := mockSlowHTTPServer(200, 10*time.Millisecond)
 	defer server.Close()
 
@@ -416,7 +404,6 @@ func TestCheckHTTPTimeout(t *testing.T) {
 }
 
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
-	t.Parallel()
 	check := &CheckHTTP{
 		CheckID:  types.CheckID("foo"),
 		HTTP:     "http://foo.bar/baz",
@@ -433,7 +420,6 @@ func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
 }
 
 func TestCheckHTTP_TLSSkipVerify_defaultFalse(t *testing.T) {
-	t.Parallel()
 	check := &CheckHTTP{
 		CheckID:  "foo",
 		HTTP:     "https://foo.bar/baz",
@@ -450,7 +436,6 @@ func TestCheckHTTP_TLSSkipVerify_defaultFalse(t *testing.T) {
 }
 
 func TestCheckHTTP_TLSSkipVerify_true_pass(t *testing.T) {
-	t.Parallel()
 	server := mockTLSHTTPServer(200)
 	defer server.Close()
 
@@ -487,7 +472,6 @@ func TestCheckHTTP_TLSSkipVerify_true_pass(t *testing.T) {
 }
 
 func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
-	t.Parallel()
 	server := mockTLSHTTPServer(500)
 	defer server.Close()
 
@@ -523,7 +507,6 @@ func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
 }
 
 func TestCheckHTTP_TLSSkipVerify_false(t *testing.T) {
-	t.Parallel()
 	server := mockTLSHTTPServer(200)
 	defer server.Close()
 
@@ -615,7 +598,6 @@ func expectTCPStatus(t *testing.T, tcp string, status string) {
 }
 
 func TestCheckTCPCritical(t *testing.T) {
-	t.Parallel()
 	var (
 		tcpServer net.Listener
 	)
@@ -626,7 +608,6 @@ func TestCheckTCPCritical(t *testing.T) {
 }
 
 func TestCheckTCPPassing(t *testing.T) {
-	t.Parallel()
 	var (
 		tcpServer net.Listener
 	)
@@ -804,37 +785,30 @@ func expectDockerCheckStatus(t *testing.T, dockerClient DockerClient, status str
 }
 
 func TestDockerCheckWhenExecReturnsSuccessExitCode(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithNoErrors{}, api.HealthPassing, "output")
 }
 
 func TestDockerCheckWhenExecCreationFails(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithCreateExecFailure{}, api.HealthCritical, "Unable to create Exec, error: Exec Creation Failed")
 }
 
 func TestDockerCheckWhenExitCodeIsNonZero(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithExecNonZeroExitCode{}, api.HealthCritical, "")
 }
 
 func TestDockerCheckWhenExitCodeIsone(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithExecExitCodeOne{}, api.HealthWarning, "output")
 }
 
 func TestDockerCheckWhenExecStartFails(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithStartExecFailure{}, api.HealthCritical, "Unable to start Exec: Couldn't Start Exec")
 }
 
 func TestDockerCheckWhenExecInfoFails(t *testing.T) {
-	t.Parallel()
 	expectDockerCheckStatus(t, &fakeDockerClientWithExecInfoErrors{}, api.HealthCritical, "Unable to inspect Exec: Unable to query exec info")
 }
 
 func TestDockerCheckDefaultToSh(t *testing.T) {
-	t.Parallel()
 	os.Setenv("SHELL", "")
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
@@ -860,7 +834,6 @@ func TestDockerCheckDefaultToSh(t *testing.T) {
 }
 
 func TestDockerCheckUseShellFromEnv(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),
@@ -887,7 +860,6 @@ func TestDockerCheckUseShellFromEnv(t *testing.T) {
 }
 
 func TestDockerCheckTruncateOutput(t *testing.T) {
-	t.Parallel()
 	mock := &MockNotify{
 		state:   make(map[types.CheckID]string),
 		updates: make(map[types.CheckID]int),

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -53,7 +53,7 @@ func TestValidDatacenter(t *testing.T) {
 }
 
 func TestRetryJoin(t *testing.T) {
-	t.Parallel()
+	// do not t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -123,7 +123,7 @@ func TestRetryJoin(t *testing.T) {
 }
 
 func TestReadCliConfig(t *testing.T) {
-	t.Parallel()
+	// do not t.Parallel()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -255,7 +255,7 @@ func TestReadCliConfig(t *testing.T) {
 }
 
 func TestRetryJoinFail(t *testing.T) {
-	t.Parallel()
+	// do not t.Parallel()
 	conf := nextConfig()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
@@ -286,7 +286,7 @@ func TestRetryJoinFail(t *testing.T) {
 }
 
 func TestRetryJoinWanFail(t *testing.T) {
-	t.Parallel()
+	// do not t.Parallel()
 	conf := nextConfig()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -24,12 +24,10 @@ func baseCommand(ui *cli.MockUi) base.Command {
 }
 
 func TestCommand_implements(t *testing.T) {
-	t.Parallel()
 	var _ cli.Command = new(Command)
 }
 
 func TestValidDatacenter(t *testing.T) {
-	t.Parallel()
 	shouldMatch := []string{
 		"dc1",
 		"east-aws-001",
@@ -53,7 +51,6 @@ func TestValidDatacenter(t *testing.T) {
 }
 
 func TestRetryJoin(t *testing.T) {
-	// do not t.Parallel()
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
@@ -123,7 +120,6 @@ func TestRetryJoin(t *testing.T) {
 }
 
 func TestReadCliConfig(t *testing.T) {
-	// do not t.Parallel()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -255,7 +251,6 @@ func TestReadCliConfig(t *testing.T) {
 }
 
 func TestRetryJoinFail(t *testing.T) {
-	// do not t.Parallel()
 	conf := nextConfig()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
@@ -286,7 +281,6 @@ func TestRetryJoinFail(t *testing.T) {
 }
 
 func TestRetryJoinWanFail(t *testing.T) {
-	// do not t.Parallel()
 	conf := nextConfig()
 	tmpDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
@@ -318,7 +312,6 @@ func TestRetryJoinWanFail(t *testing.T) {
 }
 
 func TestDiscoverEC2Hosts(t *testing.T) {
-	t.Parallel()
 	if os.Getenv("AWS_REGION") == "" {
 		t.Skip("AWS_REGION not set, skipping")
 	}
@@ -349,7 +342,6 @@ func TestDiscoverEC2Hosts(t *testing.T) {
 }
 
 func TestDiscoverGCEHosts(t *testing.T) {
-	t.Parallel()
 	if os.Getenv("GCE_PROJECT") == "" {
 		t.Skip("GCE_PROJECT not set, skipping")
 	}
@@ -377,7 +369,6 @@ func TestDiscoverGCEHosts(t *testing.T) {
 }
 
 func TestSetupScadaConn(t *testing.T) {
-	t.Parallel()
 	// Create a config and assign an infra name
 	conf1 := nextConfig()
 	conf1.AtlasInfrastructure = "hashicorp/test1"
@@ -422,7 +413,6 @@ func TestSetupScadaConn(t *testing.T) {
 }
 
 func TestProtectDataDir(t *testing.T) {
-	t.Parallel()
 	dir, err := ioutil.TempDir("", "consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -459,7 +449,6 @@ func TestProtectDataDir(t *testing.T) {
 }
 
 func TestBadDataDirPermissions(t *testing.T) {
-	t.Parallel()
 	dir, err := ioutil.TempDir("", "consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestConfigEncryptBytes(t *testing.T) {
-	t.Parallel()
 	// Test with some input
 	src := []byte("abc")
 	c := &Config{
@@ -46,7 +45,6 @@ func TestConfigEncryptBytes(t *testing.T) {
 }
 
 func TestDecodeConfig(t *testing.T) {
-	t.Parallel()
 	// Basics
 	input := `{"data_dir": "/tmp/", "log_level": "debug"}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1068,7 +1066,6 @@ func TestDecodeConfig(t *testing.T) {
 }
 
 func TestDecodeConfig_invalidKeys(t *testing.T) {
-	t.Parallel()
 	input := `{"bad": "no way jose"}`
 	_, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err == nil || !strings.Contains(err.Error(), "invalid keys") {
@@ -1077,7 +1074,6 @@ func TestDecodeConfig_invalidKeys(t *testing.T) {
 }
 
 func TestRetryJoinEC2(t *testing.T) {
-	t.Parallel()
 	input := `{"retry_join_ec2": {
 	  "region": "us-east-1",
 		"tag_key": "ConsulRole",
@@ -1108,7 +1104,6 @@ func TestRetryJoinEC2(t *testing.T) {
 }
 
 func TestRetryJoinGCE(t *testing.T) {
-	t.Parallel()
 	input := `{"retry_join_gce": {
 	  "project_name": "test-project",
 		"zone_pattern": "us-west1-a",
@@ -1135,7 +1130,6 @@ func TestRetryJoinGCE(t *testing.T) {
 }
 
 func TestDecodeConfig_Performance(t *testing.T) {
-	t.Parallel()
 	input := `{"performance": { "raft_multiplier": 3 }}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
 	if err != nil {
@@ -1153,7 +1147,6 @@ func TestDecodeConfig_Performance(t *testing.T) {
 }
 
 func TestDecodeConfig_Autopilot(t *testing.T) {
-	t.Parallel()
 	input := `{"autopilot": {
 	  "cleanup_dead_servers": true,
 	  "last_contact_threshold": "100ms",
@@ -1187,7 +1180,6 @@ func TestDecodeConfig_Autopilot(t *testing.T) {
 }
 
 func TestDecodeConfig_Services(t *testing.T) {
-	t.Parallel()
 	input := `{
 		"services": [
 			{
@@ -1303,7 +1295,6 @@ func TestDecodeConfig_Services(t *testing.T) {
 }
 
 func TestDecodeConfig_verifyUniqueListeners(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name string
 		cfg  string
@@ -1335,7 +1326,6 @@ func TestDecodeConfig_verifyUniqueListeners(t *testing.T) {
 }
 
 func TestDecodeConfig_Checks(t *testing.T) {
-	t.Parallel()
 	input := `{
 		"checks": [
 			{
@@ -1458,7 +1448,6 @@ func TestDecodeConfig_Checks(t *testing.T) {
 }
 
 func TestDecodeConfig_Multiples(t *testing.T) {
-	t.Parallel()
 	input := `{
 		"services": [
 			{
@@ -1524,7 +1513,6 @@ func TestDecodeConfig_Multiples(t *testing.T) {
 }
 
 func TestDecodeConfig_Service(t *testing.T) {
-	t.Parallel()
 	// Basics
 	input := `{"service": {"id": "red1", "name": "redis", "tags": ["master"], "port":8000, "check": {"script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "DeregisterCriticalServiceAfter": "90m" }}}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1571,7 +1559,6 @@ func TestDecodeConfig_Service(t *testing.T) {
 }
 
 func TestDecodeConfig_Check(t *testing.T) {
-	t.Parallel()
 	// Basics
 	input := `{"check": {"id": "chk1", "name": "mem", "notes": "foobar", "script": "/bin/check_redis", "interval": "10s", "ttl": "15s", "shell": "/bin/bash", "docker_container_id": "redis", "deregister_critical_service_after": "90s" }}`
 	config, err := DecodeConfig(bytes.NewReader([]byte(input)))
@@ -1622,7 +1609,6 @@ func TestDecodeConfig_Check(t *testing.T) {
 }
 
 func TestMergeConfig(t *testing.T) {
-	t.Parallel()
 	a := &Config{
 		Bootstrap:              false,
 		BootstrapExpect:        0,
@@ -1815,7 +1801,6 @@ func TestMergeConfig(t *testing.T) {
 }
 
 func TestReadConfigPaths_badPath(t *testing.T) {
-	t.Parallel()
 	_, err := ReadConfigPaths([]string{"/i/shouldnt/exist/ever/rainbows"})
 	if err == nil {
 		t.Fatal("should have err")
@@ -1823,7 +1808,6 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 }
 
 func TestReadConfigPaths_file(t *testing.T) {
-	t.Parallel()
 	tf, err := ioutil.TempFile("", "consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1843,7 +1827,6 @@ func TestReadConfigPaths_file(t *testing.T) {
 }
 
 func TestReadConfigPaths_dir(t *testing.T) {
-	t.Parallel()
 	td, err := ioutil.TempDir("", "consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -1887,7 +1870,6 @@ func TestReadConfigPaths_dir(t *testing.T) {
 }
 
 func TestUnixSockets(t *testing.T) {
-	t.Parallel()
 	path1, ok := unixSocketAddr("unix:///path/to/socket")
 	if !ok || path1 != "/path/to/socket" {
 		t.Fatalf("bad: %v %v", ok, path1)

--- a/command/agent/coordinate_endpoint_test.go
+++ b/command/agent/coordinate_endpoint_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCoordinate_Datacenters(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -42,7 +41,6 @@ func TestCoordinate_Datacenters(t *testing.T) {
 }
 
 func TestCoordinate_Nodes(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -131,7 +131,6 @@ func dnsA(src, dest string) *dns.A {
 }
 
 func TestRecursorAddr(t *testing.T) {
-	t.Parallel()
 	addr, err := recursorAddr("8.8.8.8")
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -142,7 +141,6 @@ func TestRecursorAddr(t *testing.T) {
 }
 
 func TestDNS_NodeLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -238,7 +236,6 @@ func TestDNS_NodeLookup(t *testing.T) {
 }
 
 func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -273,7 +270,6 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -316,7 +312,6 @@ func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_AAAA(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -362,7 +357,6 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_CNAME(t *testing.T) {
-	t.Parallel()
 	recursor := makeRecursor(t, []dns.RR{
 		dnsCNAME("www.google.com", "google.com"),
 		dnsA("google.com", "1.2.3.4"),
@@ -417,7 +411,6 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -460,7 +453,6 @@ func TestDNS_ReverseLookup(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -504,7 +496,6 @@ func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 }
 
 func TestDNS_ReverseLookup_IPV6(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -547,7 +538,6 @@ func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -671,7 +661,6 @@ func TestDNS_ServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -746,7 +735,6 @@ func TestDNS_ExternalServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServerConfig(t, func(c *Config) {
 		c.Domain = "CONSUL."
 	}, nil)
@@ -860,7 +848,6 @@ func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 }
 
 func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1003,7 +990,6 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1099,7 +1085,6 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1195,7 +1180,6 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1291,7 +1275,6 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeDNSServerConfig(t,
 		func(c *Config) {
 			c.Datacenter = "dc1"
@@ -1479,7 +1462,6 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 }
 
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1553,7 +1535,6 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1615,7 +1596,6 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1697,7 +1677,6 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1803,7 +1782,6 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -1937,7 +1915,6 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 }
 
 func TestDNS_Recurse(t *testing.T) {
-	t.Parallel()
 	recursor := makeRecursor(t, []dns.RR{dnsA("apple.com", "1.2.3.4")})
 	defer recursor.Shutdown()
 
@@ -1966,7 +1943,6 @@ func TestDNS_Recurse(t *testing.T) {
 }
 
 func TestDNS_Recurse_Truncation(t *testing.T) {
-	t.Parallel()
 	answerMessage := dns.Msg{
 		MsgHdr: dns.MsgHdr{Truncated: true},
 		Answer: []dns.RR{dnsA("apple.com", "1.2.3.4")},
@@ -2002,7 +1978,6 @@ func TestDNS_Recurse_Truncation(t *testing.T) {
 }
 
 func TestDNS_RecursorTimeout(t *testing.T) {
-	t.Parallel()
 	serverClientTimeout := 3 * time.Second
 	testClientTimeout := serverClientTimeout + 5*time.Second
 
@@ -2055,7 +2030,6 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -2214,7 +2188,6 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -2330,7 +2303,6 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServerConfig(t, nil, func(c *DNSConfig) {
 		c.OnlyPassing = true
 	})
@@ -2456,7 +2428,6 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -2550,7 +2521,6 @@ func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_Truncate(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServerConfig(t, nil, func(c *DNSConfig) {
 		c.EnableTruncate = true
 	})
@@ -2620,7 +2590,6 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServerConfig(t, nil, func(c *DNSConfig) {
 		c.EnableTruncate = true
 	})
@@ -2812,7 +2781,6 @@ func testDNS_ServiceLookup_responseLimits(t *testing.T, answerLimit int, qType u
 }
 
 func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
-	t.Parallel()
 	// Build a matrix of config parameters (udpAnswerLimit), and the
 	// length of the response per query type and question.  Negative
 	// values imply the test must return at least the abs(value) number
@@ -2868,7 +2836,6 @@ func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_CNAME(t *testing.T) {
-	t.Parallel()
 	recursor := makeRecursor(t, []dns.RR{
 		dnsCNAME("www.google.com", "google.com"),
 		dnsA("google.com", "1.2.3.4"),
@@ -2966,7 +2933,6 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TTL(t *testing.T) {
-	t.Parallel()
 	recursor := makeRecursor(t, []dns.RR{
 		dnsCNAME("www.google.com", "google.com"),
 		dnsA("google.com", "1.2.3.4"),
@@ -3092,7 +3058,6 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_TTL(t *testing.T) {
-	t.Parallel()
 	confFn := func(c *DNSConfig) {
 		c.ServiceTTL = map[string]time.Duration{
 			"db": 10 * time.Second,
@@ -3196,7 +3161,6 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_TTL(t *testing.T) {
-	t.Parallel()
 	confFn := func(c *DNSConfig) {
 		c.ServiceTTL = map[string]time.Duration{
 			"db": 10 * time.Second,
@@ -3388,7 +3352,6 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_Failover(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeDNSServerConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.TranslateWanAddrs = true
@@ -3499,7 +3462,6 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3577,7 +3539,6 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3655,7 +3616,6 @@ func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
-	t.Parallel()
 	confFn := func(c *Config) {
 		c.ACLMasterToken = "root"
 		c.ACLDatacenter = "dc1"
@@ -3712,7 +3672,6 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 }
 
 func TestDNS_AddressLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3752,7 +3711,6 @@ func TestDNS_AddressLookup(t *testing.T) {
 }
 
 func TestDNS_AddressLookupIPV6(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3793,7 +3751,6 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 }
 
 func TestDNS_NonExistingLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3824,7 +3781,6 @@ func TestDNS_NonExistingLookup(t *testing.T) {
 }
 
 func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -3967,7 +3923,6 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
-	t.Parallel()
 	confFn := func(c *DNSConfig) {
 		*c.AllowStale = true
 		c.MaxStale = time.Second
@@ -4017,7 +3972,6 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 }
 
 func TestDNS_InvalidQueries(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -4058,7 +4012,6 @@ func TestDNS_InvalidQueries(t *testing.T) {
 }
 
 func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -4093,7 +4046,6 @@ func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_NoTrim(t *testing.T) {
-	t.Parallel()
 	resp := &dns.Msg{
 		Answer: []dns.RR{
 			&dns.SRV{
@@ -4150,7 +4102,6 @@ func TestDNS_trimUDPResponse_NoTrim(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimLimit(t *testing.T) {
-	t.Parallel()
 	config := &DefaultConfig().DNSConfig
 
 	resp, expected := &dns.Msg{}, &dns.Msg{}
@@ -4190,7 +4141,6 @@ func TestDNS_trimUDPResponse_TrimLimit(t *testing.T) {
 }
 
 func TestDNS_trimUDPResponse_TrimSize(t *testing.T) {
-	t.Parallel()
 	config := &DefaultConfig().DNSConfig
 
 	resp := &dns.Msg{}
@@ -4243,7 +4193,6 @@ func TestDNS_trimUDPResponse_TrimSize(t *testing.T) {
 }
 
 func TestDNS_syncExtra(t *testing.T) {
-	t.Parallel()
 	resp := &dns.Msg{
 		Answer: []dns.RR{
 			// These two are on the same host so the redundant extra
@@ -4467,7 +4416,6 @@ func TestDNS_syncExtra(t *testing.T) {
 }
 
 func TestDNS_Compression_trimUDPResponse(t *testing.T) {
-	t.Parallel()
 	config := &DefaultConfig().DNSConfig
 
 	m := dns.Msg{}
@@ -4486,7 +4434,6 @@ func TestDNS_Compression_trimUDPResponse(t *testing.T) {
 }
 
 func TestDNS_Compression_Query(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -4576,7 +4523,6 @@ func TestDNS_Compression_Query(t *testing.T) {
 }
 
 func TestDNS_Compression_ReverseLookup(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeDNSServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.agent.Shutdown()
@@ -4631,7 +4577,6 @@ func TestDNS_Compression_ReverseLookup(t *testing.T) {
 }
 
 func TestDNS_Compression_Recurse(t *testing.T) {
-	t.Parallel()
 	recursor := makeRecursor(t, []dns.RR{dnsA("apple.com", "1.2.3.4")})
 	defer recursor.Shutdown()
 

--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestEventFire(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer([]byte("test"))
 		url := "/v1/event/fire/test?node=Node&service=foo&tag=bar"
@@ -56,7 +55,6 @@ func TestEventFire(t *testing.T) {
 }
 
 func TestEventFire_token(t *testing.T) {
-	t.Parallel()
 	httpTestWithConfig(t, func(srv *HTTPServer) {
 		// Create an ACL token
 		args := structs.ACLRequest{
@@ -119,7 +117,6 @@ func TestEventFire_token(t *testing.T) {
 }
 
 func TestEventList(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		p := &UserEvent{Name: "test"}
 		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
@@ -156,7 +153,6 @@ func TestEventList(t *testing.T) {
 }
 
 func TestEventList_Filter(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		p := &UserEvent{Name: "test"}
 		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
@@ -198,7 +194,6 @@ func TestEventList_Filter(t *testing.T) {
 }
 
 func TestEventList_ACLFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServerWithACLs(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -264,7 +259,6 @@ func TestEventList_ACLFilter(t *testing.T) {
 }
 
 func TestEventList_Blocking(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		p := &UserEvent{Name: "test"}
 		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
@@ -327,7 +321,6 @@ func TestEventList_Blocking(t *testing.T) {
 }
 
 func TestEventList_EventBufOrder(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Fire some events in a non-sequential order
 		expected := &UserEvent{Name: "foo"}
@@ -372,7 +365,6 @@ func TestEventList_EventBufOrder(t *testing.T) {
 }
 
 func TestUUIDToUint64(t *testing.T) {
-	t.Parallel()
 	inp := "cb9a81ad-fff6-52ac-92a7-5f70687805ec"
 
 	// Output value was computed using python

--- a/command/agent/flag_slice_value_test.go
+++ b/command/agent/flag_slice_value_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestAppendSliceValue_implements(t *testing.T) {
-	t.Parallel()
 	var raw interface{}
 	raw = new(AppendSliceValue)
 	if _, ok := raw.(flag.Value); !ok {
@@ -16,7 +15,6 @@ func TestAppendSliceValue_implements(t *testing.T) {
 }
 
 func TestAppendSliceValueSet(t *testing.T) {
-	t.Parallel()
 	sv := new(AppendSliceValue)
 	err := sv.Set("foo")
 	if err != nil {

--- a/command/agent/health_endpoint_test.go
+++ b/command/agent/health_endpoint_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestHealthChecksInState(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET", "/v1/health/state/warning?dc=dc1", nil)
 		if err != nil {
@@ -72,7 +71,6 @@ func TestHealthChecksInState(t *testing.T) {
 }
 
 func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		args := &structs.RegisterRequest{
 			Datacenter: "dc1",
@@ -118,7 +116,6 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthChecksInState_DistanceSort(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -204,7 +201,6 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 }
 
 func TestHealthNodeChecks(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -251,7 +247,6 @@ func TestHealthNodeChecks(t *testing.T) {
 }
 
 func TestHealthServiceChecks(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -314,7 +309,6 @@ func TestHealthServiceChecks(t *testing.T) {
 }
 
 func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -378,7 +372,6 @@ func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthServiceChecks_DistanceSort(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -469,7 +462,6 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 }
 
 func TestHealthServiceNodes(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -551,7 +543,6 @@ func TestHealthServiceNodes(t *testing.T) {
 }
 
 func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -615,7 +606,6 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealthServiceNodes_DistanceSort(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -706,7 +696,6 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -753,7 +742,6 @@ func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 }
 
 func TestHealthServiceNodes_WanTranslation(t *testing.T) {
-	t.Parallel()
 	dir1, srv1 := makeHTTPServerWithConfig(t,
 		func(c *Config) {
 			c.Datacenter = "dc1"
@@ -848,7 +836,6 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 }
 
 func TestFilterNonPassing(t *testing.T) {
-	t.Parallel()
 	nodes := structs.CheckServiceNodes{
 		structs.CheckServiceNode{
 			Checks: structs.HealthChecks{

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -80,7 +80,6 @@ func encodeReq(obj interface{}) io.ReadCloser {
 }
 
 func TestHTTPServer_UnixSocket(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
@@ -143,7 +142,6 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 }
 
 func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
@@ -189,7 +187,6 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 }
 
 func TestSetIndex(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	setIndex(resp, 1000)
 	header := resp.Header().Get("X-Consul-Index")
@@ -203,7 +200,6 @@ func TestSetIndex(t *testing.T) {
 }
 
 func TestSetKnownLeader(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	setKnownLeader(resp, true)
 	header := resp.Header().Get("X-Consul-KnownLeader")
@@ -219,7 +215,6 @@ func TestSetKnownLeader(t *testing.T) {
 }
 
 func TestSetLastContact(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	setLastContact(resp, 123456*time.Microsecond)
 	header := resp.Header().Get("X-Consul-LastContact")
@@ -229,7 +224,6 @@ func TestSetLastContact(t *testing.T) {
 }
 
 func TestSetMeta(t *testing.T) {
-	t.Parallel()
 	meta := structs.QueryMeta{
 		Index:       1000,
 		KnownLeader: true,
@@ -252,7 +246,6 @@ func TestSetMeta(t *testing.T) {
 }
 
 func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
-	t.Parallel()
 	// Header should not be present if address translation is off.
 	{
 		dir, srv := makeHTTPServer(t)
@@ -298,7 +291,6 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 }
 
 func TestHTTPAPIResponseHeaders(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	srv.agent.config.HTTPAPIResponseHeaders = map[string]string{
 		"Access-Control-Allow-Origin": "*",
@@ -330,7 +322,6 @@ func TestHTTPAPIResponseHeaders(t *testing.T) {
 }
 
 func TestContentTypeIsJSON(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 
 	defer os.RemoveAll(dir)
@@ -355,7 +346,6 @@ func TestContentTypeIsJSON(t *testing.T) {
 }
 
 func TestHTTP_wrap_obfuscateLog(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -380,12 +370,10 @@ func TestHTTP_wrap_obfuscateLog(t *testing.T) {
 }
 
 func TestPrettyPrint(t *testing.T) {
-	t.Parallel()
 	testPrettyPrint("pretty=1", t)
 }
 
 func TestPrettyPrintBare(t *testing.T) {
-	t.Parallel()
 	testPrettyPrint("pretty", t)
 }
 
@@ -419,7 +407,6 @@ func testPrettyPrint(pretty string, t *testing.T) {
 }
 
 func TestParseSource(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -477,7 +464,6 @@ func TestParseSource(t *testing.T) {
 }
 
 func TestParseWait(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
@@ -500,7 +486,6 @@ func TestParseWait(t *testing.T) {
 }
 
 func TestParseWait_InvalidTime(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
@@ -520,7 +505,6 @@ func TestParseWait_InvalidTime(t *testing.T) {
 }
 
 func TestParseWait_InvalidIndex(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
@@ -540,7 +524,6 @@ func TestParseWait_InvalidIndex(t *testing.T) {
 }
 
 func TestParseConsistency(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
@@ -581,7 +564,6 @@ func TestParseConsistency(t *testing.T) {
 }
 
 func TestParseConsistency_Invalid(t *testing.T) {
-	t.Parallel()
 	resp := httptest.NewRecorder()
 	var b structs.QueryOptions
 
@@ -602,7 +584,6 @@ func TestParseConsistency_Invalid(t *testing.T) {
 
 // Test ACL token is resolved in correct order
 func TestACLResolution(t *testing.T) {
-	t.Parallel()
 	var token string
 	// Request without token
 	req, err := http.NewRequest("GET",
@@ -691,7 +672,6 @@ func TestACLResolution(t *testing.T) {
 }
 
 func TestScadaHTTP(t *testing.T) {
-	t.Parallel()
 	// Create the agent
 	dir, agent := makeAgent(t, nextConfig())
 	defer os.RemoveAll(dir)
@@ -725,7 +705,6 @@ func TestScadaHTTP(t *testing.T) {
 }
 
 func TestEnableWebUI(t *testing.T) {
-	t.Parallel()
 	httpTestWithConfig(t, func(s *HTTPServer) {
 		req, err := http.NewRequest("GET", "/ui/", nil)
 		if err != nil {

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAgent_LoadKeyrings(t *testing.T) {
-	t.Parallel()
 	key := "tbLJg26ZJyJ9pK3qhc9jig=="
 
 	// Should be no configured keyring file by default
@@ -78,7 +77,6 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 }
 
 func TestAgent_InitKeyring(t *testing.T) {
-	t.Parallel()
 	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 	expected := fmt.Sprintf(`["%s"]`, key1)
@@ -120,7 +118,6 @@ func TestAgent_InitKeyring(t *testing.T) {
 }
 
 func TestAgentKeyring_ACL(t *testing.T) {
-	t.Parallel()
 	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 

--- a/command/agent/kvs_endpoint_test.go
+++ b/command/agent/kvs_endpoint_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -90,7 +89,6 @@ func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 }
 
 func TestKVSEndpoint_Recurse(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -187,7 +185,6 @@ func TestKVSEndpoint_Recurse(t *testing.T) {
 }
 
 func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -275,7 +272,6 @@ func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 }
 
 func TestKVSEndpoint_CAS(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -373,7 +369,6 @@ func TestKVSEndpoint_CAS(t *testing.T) {
 }
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -434,7 +429,6 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 }
 
 func TestKVSEndpoint_AcquireRelease(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Acquire the lock
 		id := makeTestSession(t, srv)
@@ -505,7 +499,6 @@ func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 }
 
 func TestKVSEndpoint_GET_Raw(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		buf := bytes.NewBuffer([]byte("test"))
 		req, err := http.NewRequest("PUT", "/v1/kv/test", buf)
@@ -540,7 +533,6 @@ func TestKVSEndpoint_GET_Raw(t *testing.T) {
 }
 
 func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("PUT", "/v1/kv/test?cas=0&acquire=xxx", nil)
 		if err != nil {
@@ -562,7 +554,6 @@ func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 }
 
 func TestKVSEndpoint_DELETE_ConflictingFlags(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("DELETE", "/v1/kv/test?recurse&cas=0", nil)
 		if err != nil {

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -254,7 +253,6 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -359,7 +357,6 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -494,7 +491,6 @@ service "consul" {
 `
 
 func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	conf.ACLDatacenter = "dc1"
 	conf.ACLMasterToken = "root"
@@ -656,7 +652,6 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -877,7 +872,6 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	conf.ACLDatacenter = "dc1"
 	conf.ACLMasterToken = "root"
@@ -1121,7 +1115,6 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	conf.CheckUpdateInterval = 500 * time.Millisecond
 	dir, agent := makeAgent(t, conf)
@@ -1313,7 +1306,6 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	conf.NodeID = types.NodeID("40e4a748-2192-161a-0510-9bf59fe950b5")
 	conf.Meta["somekey"] = "somevalue"
@@ -1394,7 +1386,6 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_deleteService_fails(t *testing.T) {
-	t.Parallel()
 	l := new(localState)
 	if err := l.deleteService(""); err == nil {
 		t.Fatalf("should have failed")
@@ -1402,7 +1393,6 @@ func TestAgentAntiEntropy_deleteService_fails(t *testing.T) {
 }
 
 func TestAgentAntiEntropy_deleteCheck_fails(t *testing.T) {
-	t.Parallel()
 	l := new(localState)
 	if err := l.deleteCheck(""); err == nil {
 		t.Fatalf("should have errored")
@@ -1410,7 +1400,6 @@ func TestAgentAntiEntropy_deleteCheck_fails(t *testing.T) {
 }
 
 func TestAgent_serviceTokens(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLToken = "default"
 	l := new(localState)
@@ -1439,7 +1428,6 @@ func TestAgent_serviceTokens(t *testing.T) {
 }
 
 func TestAgent_checkTokens(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLToken = "default"
 	l := new(localState)
@@ -1464,7 +1452,6 @@ func TestAgent_checkTokens(t *testing.T) {
 }
 
 func TestAgent_checkCriticalTime(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	l := new(localState)
 	l.Init(config, nil)
@@ -1525,7 +1512,6 @@ func TestAgent_checkCriticalTime(t *testing.T) {
 }
 
 func TestAgent_nestedPauseResume(t *testing.T) {
-	t.Parallel()
 	l := new(localState)
 	if l.isPaused() != false {
 		t.Fatal("localState should be unPaused after init")
@@ -1558,7 +1544,6 @@ func TestAgent_nestedPauseResume(t *testing.T) {
 }
 
 func TestAgent_sendCoordinate(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	conf.SyncCoordinateRateTarget = 10.0 // updates/sec
 	conf.SyncCoordinateIntervalMin = 1 * time.Millisecond

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestOperator_RaftConfiguration(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("GET", "/v1/operator/raft/configuration", body)
@@ -44,7 +43,6 @@ func TestOperator_RaftConfiguration(t *testing.T) {
 }
 
 func TestOperator_RaftPeer(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("DELETE", "/v1/operator/raft/peer?address=nope", body)
@@ -81,7 +79,6 @@ func TestOperator_RaftPeer(t *testing.T) {
 }
 
 func TestOperator_KeyringInstall(t *testing.T) {
-	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
 	configFunc := func(c *Config) {
@@ -121,7 +118,6 @@ func TestOperator_KeyringInstall(t *testing.T) {
 }
 
 func TestOperator_KeyringList(t *testing.T) {
-	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	configFunc := func(c *Config) {
 		c.EncryptKey = key
@@ -173,7 +169,6 @@ func TestOperator_KeyringList(t *testing.T) {
 }
 
 func TestOperator_KeyringRemove(t *testing.T) {
-	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	tempKey := "z90lFx3sZZLtTOkutXcwYg=="
 	configFunc := func(c *Config) {
@@ -236,7 +231,6 @@ func TestOperator_KeyringRemove(t *testing.T) {
 }
 
 func TestOperator_KeyringUse(t *testing.T) {
-	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
 	configFunc := func(c *Config) {
@@ -284,7 +278,6 @@ func TestOperator_KeyringUse(t *testing.T) {
 }
 
 func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
-	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	configFunc := func(c *Config) {
 		c.EncryptKey = key
@@ -314,7 +307,6 @@ func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 }
 
 func TestOperator_AutopilotGetConfiguration(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("GET", "/v1/operator/autopilot/configuration", body)
@@ -341,7 +333,6 @@ func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 }
 
 func TestOperator_AutopilotSetConfiguration(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
 		req, err := http.NewRequest("PUT", "/v1/operator/autopilot/configuration", body)
@@ -372,7 +363,6 @@ func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 }
 
 func TestOperator_AutopilotCASConfiguration(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
 		req, err := http.NewRequest("PUT", "/v1/operator/autopilot/configuration", body)
@@ -452,7 +442,6 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 }
 
 func TestOperator_ServerHealth(t *testing.T) {
-	t.Parallel()
 	cb := func(c *Config) {
 		c.RaftProtocol = 3
 	}
@@ -493,7 +482,6 @@ func TestOperator_ServerHealth(t *testing.T) {
 }
 
 func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
-	t.Parallel()
 	threshold := time.Duration(-1)
 	cb := func(c *Config) {
 		c.RaftProtocol = 3

--- a/command/agent/prepared_query_endpoint_test.go
+++ b/command/agent/prepared_query_endpoint_test.go
@@ -69,7 +69,6 @@ func (m *MockPreparedQuery) Explain(args *structs.PreparedQueryExecuteRequest,
 }
 
 func TestPreparedQuery_Create(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -156,7 +155,6 @@ func TestPreparedQuery_Create(t *testing.T) {
 }
 
 func TestPreparedQuery_List(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -241,7 +239,6 @@ func TestPreparedQuery_List(t *testing.T) {
 }
 
 func TestPreparedQuery_Execute(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -485,7 +482,6 @@ func TestPreparedQuery_Execute(t *testing.T) {
 }
 
 func TestPreparedQuery_Explain(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -561,7 +557,6 @@ func TestPreparedQuery_Explain(t *testing.T) {
 }
 
 func TestPreparedQuery_Get(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -630,7 +625,6 @@ func TestPreparedQuery_Get(t *testing.T) {
 }
 
 func TestPreparedQuery_Update(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -712,7 +706,6 @@ func TestPreparedQuery_Update(t *testing.T) {
 }
 
 func TestPreparedQuery_Delete(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		m := MockPreparedQuery{}
 		if err := srv.agent.InjectEndpoint("PreparedQuery", &m); err != nil {
@@ -764,7 +757,6 @@ func TestPreparedQuery_Delete(t *testing.T) {
 }
 
 func TestPreparedQuery_BadMethods(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("DELETE", "/v1/query", body)
@@ -801,7 +793,6 @@ func TestPreparedQuery_BadMethods(t *testing.T) {
 }
 
 func TestPreparedQuery_parseLimit(t *testing.T) {
-	t.Parallel()
 	body := bytes.NewBuffer(nil)
 	req, err := http.NewRequest("GET", "/v1/query", body)
 	if err != nil {
@@ -840,7 +831,6 @@ func TestPreparedQuery_parseLimit(t *testing.T) {
 // this is just a basic end-to-end sanity check to make sure things are wired
 // correctly when calling through to the real endpoints.
 func TestPreparedQuery_Integration(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Register a node and a service.
 		{

--- a/command/agent/remote_exec_test.go
+++ b/command/agent/remote_exec_test.go
@@ -24,7 +24,6 @@ func generateUUID() (ret string) {
 }
 
 func TestRexecWriter(t *testing.T) {
-	t.Parallel()
 	writer := &rexecWriter{
 		BufCh:    make(chan []byte, 16),
 		BufSize:  16,
@@ -96,13 +95,11 @@ func TestRexecWriter(t *testing.T) {
 }
 
 func TestRemoteExecGetSpec(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	testRemoteExecGetSpec(t, config)
 }
 
 func TestRemoteExecGetSpec_ACLToken(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDatacenter = "dc1"
 	config.ACLToken = "root"
@@ -144,13 +141,11 @@ func testRemoteExecGetSpec(t *testing.T, c *Config) {
 }
 
 func TestRemoteExecWrites(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	testRemoteExecWrites(t, config)
 }
 
 func TestRemoteExecWrites_ACLToken(t *testing.T) {
-	t.Parallel()
 	config := nextConfig()
 	config.ACLDatacenter = "dc1"
 	config.ACLToken = "root"
@@ -271,12 +266,10 @@ func testHandleRemoteExec(t *testing.T, command string, expectedSubstring string
 }
 
 func TestHandleRemoteExec(t *testing.T) {
-	t.Parallel()
 	testHandleRemoteExec(t, "uptime", "load", "0")
 }
 
 func TestHandleRemoteExecFailed(t *testing.T) {
-	t.Parallel()
 	testHandleRemoteExec(t, "echo failing;exit 2", "failing", "2")
 }
 

--- a/command/agent/session_endpoint_test.go
+++ b/command/agent/session_endpoint_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestSessionCreate(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Create a health check
 		args := &structs.RegisterRequest{
@@ -64,7 +63,6 @@ func TestSessionCreate(t *testing.T) {
 }
 
 func TestSessionCreateDelete(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Create a health check
 		args := &structs.RegisterRequest{
@@ -114,7 +112,6 @@ func TestSessionCreateDelete(t *testing.T) {
 }
 
 func TestFixupLockDelay(t *testing.T) {
-	t.Parallel()
 	inp := map[string]interface{}{
 		"lockdelay": float64(15),
 	}
@@ -205,7 +202,6 @@ func makeTestSessionTTL(t *testing.T, srv *HTTPServer, ttl string) string {
 }
 
 func TestSessionDestroy(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestSession(t, srv)
 
@@ -222,7 +218,6 @@ func TestSessionDestroy(t *testing.T) {
 }
 
 func TestSessionCustomTTL(t *testing.T) {
-	t.Parallel()
 	ttl := 250 * time.Millisecond
 	testSessionTTL(t, ttl, customTTL(ttl))
 }
@@ -275,7 +270,6 @@ func testSessionTTL(t *testing.T, ttl time.Duration, cb func(c *Config)) {
 }
 
 func TestSessionTTLRenew(t *testing.T) {
-	t.Parallel()
 	ttl := 250 * time.Millisecond
 	TTL := ttl.String()
 	httpTestWithConfig(t, func(srv *HTTPServer) {
@@ -356,7 +350,6 @@ func TestSessionTTLRenew(t *testing.T) {
 }
 
 func TestSessionGet(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET", "/v1/session/info/adf4238a-882b-9ddc-4a9d-5b6758e4159e", nil)
 		resp := httptest.NewRecorder()
@@ -394,7 +387,6 @@ func TestSessionGet(t *testing.T) {
 }
 
 func TestSessionList(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET", "/v1/session/list", nil)
 		resp := httptest.NewRecorder()
@@ -434,7 +426,6 @@ func TestSessionList(t *testing.T) {
 }
 
 func TestSessionsForNode(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		req, err := http.NewRequest("GET",
 			"/v1/session/node/"+srv.agent.config.NodeName, nil)
@@ -476,7 +467,6 @@ func TestSessionsForNode(t *testing.T) {
 }
 
 func TestSessionDeleteDestroy(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		id := makeTestSessionDelete(t, srv)
 

--- a/command/agent/snapshot_endpoint_test.go
+++ b/command/agent/snapshot_endpoint_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
-	t.Parallel()
 	var snap io.Reader
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
@@ -55,7 +54,6 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestSnapshot_Options(t *testing.T) {
-	t.Parallel()
 	for _, method := range []string{"GET", "PUT"} {
 		httpTest(t, func(srv *HTTPServer) {
 			body := bytes.NewBuffer(nil)
@@ -108,7 +106,6 @@ func TestSnapshot_Options(t *testing.T) {
 }
 
 func TestSnapshot_BadMethods(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		body := bytes.NewBuffer(nil)
 		req, err := http.NewRequest("POST", "/v1/snapshot", body)

--- a/command/agent/status_endpoint_test.go
+++ b/command/agent/status_endpoint_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestStatusLeader(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -27,7 +26,6 @@ func TestStatusLeader(t *testing.T) {
 }
 
 func TestStatusPeers(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/command/agent/structs_test.go
+++ b/command/agent/structs_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestAgentStructs_HealthCheck(t *testing.T) {
-	t.Parallel()
 	def := CheckDefinition{}
 	check := def.HealthCheck("node1")
 
@@ -19,7 +18,6 @@ func TestAgentStructs_HealthCheck(t *testing.T) {
 }
 
 func TestAgentStructs_CheckTypes(t *testing.T) {
-	t.Parallel()
 	svc := new(ServiceDefinition)
 
 	// Singular Check field works

--- a/command/agent/txn_endpoint_test.go
+++ b/command/agent/txn_endpoint_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		buf := bytes.NewBuffer([]byte("{"))
 		req, err := http.NewRequest("PUT", "/v1/txn", buf)
@@ -35,7 +34,6 @@ func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 }
 
 func TestTxnEndpoint_Bad_Method(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		buf := bytes.NewBuffer([]byte("{}"))
 		req, err := http.NewRequest("GET", "/v1/txn", buf)
@@ -54,7 +52,6 @@ func TestTxnEndpoint_Bad_Method(t *testing.T) {
 }
 
 func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
 [
@@ -83,7 +80,6 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 }
 
 func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		value := strings.Repeat("X", maxKVSize/2)
 		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -127,7 +123,6 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 }
 
 func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
 [
@@ -157,7 +152,6 @@ func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 }
 
 func TestTxnEndpoint_KV_Actions(t *testing.T) {
-	t.Parallel()
 	httpTest(t, func(srv *HTTPServer) {
 		// Make sure all incoming fields get converted properly to the internal
 		// RPC format.

--- a/command/agent/ui_endpoint_test.go
+++ b/command/agent/ui_endpoint_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestUiIndex(t *testing.T) {
-	t.Parallel()
 	// Make a test dir to serve UI files
 	uiDir, err := ioutil.TempDir("", "consul")
 	if err != nil {
@@ -70,7 +69,6 @@ func TestUiIndex(t *testing.T) {
 }
 
 func TestUiNodes(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -115,7 +113,6 @@ func TestUiNodes(t *testing.T) {
 }
 
 func TestUiNodeInfo(t *testing.T) {
-	t.Parallel()
 	dir, srv := makeHTTPServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -177,7 +174,6 @@ func TestUiNodeInfo(t *testing.T) {
 }
 
 func TestSummarizeServices(t *testing.T) {
-	t.Parallel()
 	dump := structs.NodeDump{
 		&structs.NodeInfo{
 			Node:    "foo",

--- a/command/agent/user_event_test.go
+++ b/command/agent/user_event_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestValidateUserEventParams(t *testing.T) {
-	t.Parallel()
 	p := &UserEvent{}
 	err := validateUserEventParams(p)
 	if err == nil || err.Error() != "User event missing name" {
@@ -47,7 +46,6 @@ func TestValidateUserEventParams(t *testing.T) {
 }
 
 func TestShouldProcessUserEvent(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -118,7 +116,6 @@ func TestShouldProcessUserEvent(t *testing.T) {
 }
 
 func TestIngestUserEvent(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -151,7 +148,6 @@ func TestIngestUserEvent(t *testing.T) {
 }
 
 func TestFireReceiveEvent(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 	dir, agent := makeAgent(t, conf)
 	defer os.RemoveAll(dir)
@@ -192,7 +188,6 @@ func TestFireReceiveEvent(t *testing.T) {
 }
 
 func TestUserEventToken(t *testing.T) {
-	t.Parallel()
 	conf := nextConfig()
 
 	// Set the default policies to deny

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestAEScale(t *testing.T) {
-	t.Parallel()
 	intv := time.Minute
 	if v := aeScale(intv, 100); v != intv {
 		t.Fatalf("Bad: %v", v)
@@ -26,7 +25,6 @@ func TestAEScale(t *testing.T) {
 }
 
 func TestStringHash(t *testing.T) {
-	t.Parallel()
 	in := "hello world"
 	expected := "5eb63bbbe01eeed093cb22bb8f5acdc3"
 
@@ -36,7 +34,6 @@ func TestStringHash(t *testing.T) {
 }
 
 func TestSetFilePermissions(t *testing.T) {
-	t.Parallel()
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}

--- a/command/agent/watch_handler_test.go
+++ b/command/agent/watch_handler_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestVerifyWatchHandler(t *testing.T) {
-	t.Parallel()
 	if err := verifyWatchHandler(nil); err == nil {
 		t.Fatalf("should err")
 	}
@@ -23,7 +22,6 @@ func TestVerifyWatchHandler(t *testing.T) {
 }
 
 func TestMakeWatchHandler(t *testing.T) {
-	t.Parallel()
 	defer os.Remove("handler_out")
 	defer os.Remove("handler_index_out")
 	script := "echo $CONSUL_INDEX >> handler_index_out && cat >> handler_out"


### PR DESCRIPTION
* `--- FAIL: TestRetryJoin (5.06s)
	command_test.go:121: timeout: bad: []serf.Member{serf.Member{Name:"Node 11350", Addr:net.IP{0x7f, 0x0, 0x0, 0x1}, Port:0x5369, Tags:map[string]string{"bootstrap":"1", "vsn":"2", "raft_vsn":"2", "wan_join_port":"21354", "vsn_min":"2", "vsn_max":"3", "build":"0.8.0c.d:", "dc":"dc1", "id":"e8295b53-26d1-74b2-33b0-fb99eba4fd30", "port":"21355", "role":"consul"}, Status:1, ProtocolMin:0x1, ProtocolMax:0x5, ProtocolCur:0x2, DelegateMin:0x2, DelegateMax:0x5, DelegateCur:0x4}}`