### PR TITLE
test: add a new retry framework

### DIFF
--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -75,37 +75,29 @@ func TestCatalog_Nodes_MetaFilter(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
-	for r :=
-
-		// Make sure we get the node back when filtering by its metadata
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Make sure we get the node back when filtering by its metadata
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: meta})
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(nodes) == 0 {
 			t.Logf("Bad: %v", nodes)
 			continue
 		}
-
 		if _, ok := nodes[0].TaggedAddresses["wan"]; !ok {
 			t.Logf("Bad: %v", nodes[0])
 			continue
 		}
-
 		if v, ok := nodes[0].Meta["somekey"]; !ok || v != "somevalue" {
 			t.Logf("Bad: %v", nodes[0].Meta)
 			continue
 		}
-
 		if nodes[0].Datacenter != "dc1" {
 			t.Logf("Bad datacenter: %v", nodes[0])
 			continue
@@ -113,27 +105,22 @@ func TestCatalog_Nodes_MetaFilter(t *testing.T) {
 		break
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Get nothing back when we use an invalid filter
-
 		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: map[string]string{"nope": "nope"}})
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(nodes) != 0 {
 			t.Logf("Bad: %v", nodes)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_Services(t *testing.T) {
@@ -143,18 +130,15 @@ func TestCatalog_Services(t *testing.T) {
 
 	catalog := c.Catalog()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		services, meta, err := catalog.Services(nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(services) == 0 {
 			t.Logf("Bad: %v", services)
 			continue
@@ -172,50 +156,41 @@ func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
-	for r :=
-
-		// Make sure we get the service back when filtering by the node's metadata
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Make sure we get the service back when filtering by the node's metadata
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: meta})
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(services) == 0 {
 			t.Logf("Bad: %v", services)
 			continue
 		}
 		break
 	}
+
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Get nothing back when using an invalid filter
-
 		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: map[string]string{"nope": "nope"}})
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(services) != 0 {
 			t.Logf("Bad: %v", services)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_Service(t *testing.T) {
@@ -225,30 +200,25 @@ func TestCatalog_Service(t *testing.T) {
 
 	catalog := c.Catalog()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		services, meta, err := catalog.Service("consul", "", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(services) == 0 {
 			t.Logf("Bad: %v", services)
 			continue
 		}
-
 		if services[0].Datacenter != "dc1" {
 			t.Logf("Bad datacenter: %v", services[0])
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
@@ -261,30 +231,25 @@ func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
 
 	catalog := c.Catalog()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		services, meta, err := catalog.Service("consul", "", &QueryOptions{NodeMeta: meta})
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(services) == 0 {
 			t.Logf("Bad: %v", services)
 			continue
 		}
-
 		if services[0].Datacenter != "dc1" {
 			t.Logf("Bad datacenter: %v", services[0])
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_Node(t *testing.T) {
@@ -295,35 +260,29 @@ func TestCatalog_Node(t *testing.T) {
 	catalog := c.Catalog()
 	name, _ := c.Agent().NodeName()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		info, meta, err := catalog.Node(name, nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if meta.LastIndex == 0 {
 			t.Logf("Bad: %v", meta)
 			continue
 		}
-
 		if len(info.Services) == 0 {
 			t.Logf("Bad: %v", info)
 			continue
 		}
-
 		if _, ok := info.Node.TaggedAddresses["wan"]; !ok {
 			t.Logf("Bad: %v", info)
 			continue
 		}
-
 		if info.Node.Datacenter != "dc1" {
 			t.Logf("Bad datacenter: %v", info)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_Registration(t *testing.T) {
@@ -357,35 +316,30 @@ func TestCatalog_Registration(t *testing.T) {
 		Service:    service,
 		Check:      check,
 	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		if _, err := catalog.Register(reg, nil); err != nil {
 			t.Log(err)
 			continue
 		}
-
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if _, ok := node.Services["redis1"]; !ok {
 			t.Log("missing service: redis1")
 			continue
 		}
-
 		health, _, err := c.Health().Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if health[0].CheckID != "service:redis1" {
 			t.Log("missing checkid service:redis1")
 			continue
 		}
-
 		if v, ok := node.Node.Meta["somekey"]; !ok || v != "somevalue" {
 			t.Log("missing node meta pair somekey:somevalue")
 			continue
@@ -404,14 +358,13 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if _, ok := node.Services["redis1"]; ok {
 			t.Log("ServiceID:redis1 is not deregistered")
 			continue
@@ -430,14 +383,13 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		health, _, err := c.Health().Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if len(health) != 0 {
 			t.Log("CheckID:service:redis1 is not deregistered")
 			continue
@@ -455,21 +407,19 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if node != nil {
 			t.Logf("node is not deregistered: %v", node)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCatalog_EnableTagOverride(t *testing.T) {
@@ -492,19 +442,17 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 		Address:    "192.168.10.10",
 		Service:    service,
 	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		if _, err := catalog.Register(reg, nil); err != nil {
 			t.Log(err)
 			continue
 		}
-
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if _, ok := node.Services["redis1"]; !ok {
 			t.Log("missing service: redis1")
 			continue
@@ -513,13 +461,11 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 			t.Log("tag override set")
 			continue
 		}
-
 		services, _, err := catalog.Service("redis", "", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if len(services) < 1 || services[0].ServiceName != "redis" {
 			t.Log("missing service: redis")
 			continue
@@ -533,18 +479,15 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 
 	service.EnableTagOverride = true
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		if _, err := catalog.Register(reg, nil); err != nil {
 			t.Log(err)
 			continue
 		}
-
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if _, ok := node.Services["redis1"]; !ok {
 			t.Log("missing service: redis1")
 			continue
@@ -553,13 +496,11 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 			t.Log("tag override not set")
 			continue
 		}
-
 		services, _, err := catalog.Service("redis", "", nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if len(services) < 1 || services[0].ServiceName != "redis" {
 			t.Log("missing service: redis")
 			continue
@@ -570,5 +511,4 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 		}
 		break
 	}
-
 }

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/consul/testutil"
@@ -76,58 +75,65 @@ func TestCatalog_Nodes_MetaFilter(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
+	for r :=
 
-	// Make sure we get the node back when filtering by its metadata
-	if err := testutil.WaitForResult(func() (bool, error) {
+		// Make sure we get the node back when filtering by its metadata
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: meta})
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(nodes) == 0 {
-			return false, fmt.Errorf("Bad: %v", nodes)
+			t.Logf("Bad: %v", nodes)
+			continue
 		}
 
 		if _, ok := nodes[0].TaggedAddresses["wan"]; !ok {
-			return false, fmt.Errorf("Bad: %v", nodes[0])
+			t.Logf("Bad: %v", nodes[0])
+			continue
 		}
 
 		if v, ok := nodes[0].Meta["somekey"]; !ok || v != "somevalue" {
-			return false, fmt.Errorf("Bad: %v", nodes[0].Meta)
+			t.Logf("Bad: %v", nodes[0].Meta)
+			continue
 		}
 
 		if nodes[0].Datacenter != "dc1" {
-			return false, fmt.Errorf("Bad datacenter: %v", nodes[0])
+			t.Logf("Bad datacenter: %v", nodes[0])
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	// Get nothing back when we use an invalid filter
-	if err := testutil.WaitForResult(func() (bool, error) {
+		// Get nothing back when we use an invalid filter
+
 		nodes, meta, err := catalog.Nodes(&QueryOptions{NodeMeta: map[string]string{"nope": "nope"}})
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(nodes) != 0 {
-			return false, fmt.Errorf("Bad: %v", nodes)
+			t.Logf("Bad: %v", nodes)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Services(t *testing.T) {
@@ -136,25 +142,26 @@ func TestCatalog_Services(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		services, meta, err := catalog.Services(nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(services) == 0 {
-			return false, fmt.Errorf("Bad: %v", services)
+			t.Logf("Bad: %v", services)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
@@ -165,46 +172,50 @@ func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
+	for r :=
 
-	// Make sure we get the service back when filtering by the node's metadata
-	if err := testutil.WaitForResult(func() (bool, error) {
+		// Make sure we get the service back when filtering by the node's metadata
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: meta})
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(services) == 0 {
-			return false, fmt.Errorf("Bad: %v", services)
+			t.Logf("Bad: %v", services)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	// Get nothing back when using an invalid filter
-	if err := testutil.WaitForResult(func() (bool, error) {
+		// Get nothing back when using an invalid filter
+
 		services, meta, err := catalog.Services(&QueryOptions{NodeMeta: map[string]string{"nope": "nope"}})
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(services) != 0 {
-			return false, fmt.Errorf("Bad: %v", services)
+			t.Logf("Bad: %v", services)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Service(t *testing.T) {
@@ -213,29 +224,31 @@ func TestCatalog_Service(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		services, meta, err := catalog.Service("consul", "", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(services) == 0 {
-			return false, fmt.Errorf("Bad: %v", services)
+			t.Logf("Bad: %v", services)
+			continue
 		}
 
 		if services[0].Datacenter != "dc1" {
-			return false, fmt.Errorf("Bad datacenter: %v", services[0])
+			t.Logf("Bad datacenter: %v", services[0])
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
@@ -247,29 +260,31 @@ func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
 	defer s.Stop()
 
 	catalog := c.Catalog()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		services, meta, err := catalog.Service("consul", "", &QueryOptions{NodeMeta: meta})
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(services) == 0 {
-			return false, fmt.Errorf("Bad: %v", services)
+			t.Logf("Bad: %v", services)
+			continue
 		}
 
 		if services[0].Datacenter != "dc1" {
-			return false, fmt.Errorf("Bad datacenter: %v", services[0])
+			t.Logf("Bad datacenter: %v", services[0])
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Node(t *testing.T) {
@@ -279,33 +294,36 @@ func TestCatalog_Node(t *testing.T) {
 
 	catalog := c.Catalog()
 	name, _ := c.Agent().NodeName()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		info, meta, err := catalog.Node(name, nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if meta.LastIndex == 0 {
-			return false, fmt.Errorf("Bad: %v", meta)
+			t.Logf("Bad: %v", meta)
+			continue
 		}
 
 		if len(info.Services) == 0 {
-			return false, fmt.Errorf("Bad: %v", info)
+			t.Logf("Bad: %v", info)
+			continue
 		}
 
 		if _, ok := info.Node.TaggedAddresses["wan"]; !ok {
-			return false, fmt.Errorf("Bad: %v", info)
+			t.Logf("Bad: %v", info)
+			continue
 		}
 
 		if info.Node.Datacenter != "dc1" {
-			return false, fmt.Errorf("Bad datacenter: %v", info)
+			t.Logf("Bad datacenter: %v", info)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_Registration(t *testing.T) {
@@ -339,37 +357,40 @@ func TestCatalog_Registration(t *testing.T) {
 		Service:    service,
 		Check:      check,
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		if _, err := catalog.Register(reg, nil); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if _, ok := node.Services["redis1"]; !ok {
-			return false, fmt.Errorf("missing service: redis1")
+			t.Log("missing service: redis1")
+			continue
 		}
 
 		health, _, err := c.Health().Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if health[0].CheckID != "service:redis1" {
-			return false, fmt.Errorf("missing checkid service:redis1")
+			t.Log("missing checkid service:redis1")
+			continue
 		}
 
 		if v, ok := node.Node.Meta["somekey"]; !ok || v != "somevalue" {
-			return false, fmt.Errorf("missing node meta pair somekey:somevalue")
+			t.Log("missing node meta pair somekey:somevalue")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Test catalog deregistration of the previously registered service
@@ -383,20 +404,19 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if _, ok := node.Services["redis1"]; ok {
-			return false, fmt.Errorf("ServiceID:redis1 is not deregistered")
+			t.Log("ServiceID:redis1 is not deregistered")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Test deregistration of the previously registered check
@@ -410,20 +430,19 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		health, _, err := c.Health().Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if len(health) != 0 {
-			return false, fmt.Errorf("CheckID:service:redis1 is not deregistered")
+			t.Log("CheckID:service:redis1 is not deregistered")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Test node deregistration of the previously registered node
@@ -436,21 +455,21 @@ func TestCatalog_Registration(t *testing.T) {
 	if _, err := catalog.Deregister(dereg, nil); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if node != nil {
-			return false, fmt.Errorf("node is not deregistered: %v", node)
+			t.Logf("node is not deregistered: %v", node)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCatalog_EnableTagOverride(t *testing.T) {
@@ -473,73 +492,83 @@ func TestCatalog_EnableTagOverride(t *testing.T) {
 		Address:    "192.168.10.10",
 		Service:    service,
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		if _, err := catalog.Register(reg, nil); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if _, ok := node.Services["redis1"]; !ok {
-			return false, fmt.Errorf("missing service: redis1")
+			t.Log("missing service: redis1")
+			continue
 		}
 		if node.Services["redis1"].EnableTagOverride != false {
-			return false, fmt.Errorf("tag override set")
+			t.Log("tag override set")
+			continue
 		}
 
 		services, _, err := catalog.Service("redis", "", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if len(services) < 1 || services[0].ServiceName != "redis" {
-			return false, fmt.Errorf("missing service: redis")
+			t.Log("missing service: redis")
+			continue
 		}
 		if services[0].ServiceEnableTagOverride != false {
-			return false, fmt.Errorf("tag override set")
+			t.Log("tag override set")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	service.EnableTagOverride = true
-	if err := testutil.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		if _, err := catalog.Register(reg, nil); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		node, _, err := catalog.Node("foobar", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if _, ok := node.Services["redis1"]; !ok {
-			return false, fmt.Errorf("missing service: redis1")
+			t.Log("missing service: redis1")
+			continue
 		}
 		if node.Services["redis1"].EnableTagOverride != true {
-			return false, fmt.Errorf("tag override not set")
+			t.Log("tag override not set")
+			continue
 		}
 
 		services, _, err := catalog.Service("redis", "", nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if len(services) < 1 || services[0].ServiceName != "redis" {
-			return false, fmt.Errorf("missing service: redis")
+			t.Log("missing service: redis")
+			continue
 		}
 		if services[0].ServiceEnableTagOverride != true {
-			return false, fmt.Errorf("tag override not set")
+			t.Log("tag override not set")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }

--- a/api/coordinate_test.go
+++ b/api/coordinate_test.go
@@ -1,10 +1,9 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestCoordinate_Datacenters(t *testing.T) {
@@ -13,21 +12,21 @@ func TestCoordinate_Datacenters(t *testing.T) {
 	defer s.Stop()
 
 	coordinate := c.Coordinate()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		datacenters, err := coordinate.Datacenters()
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if len(datacenters) == 0 {
-			return false, fmt.Errorf("Bad: %v", datacenters)
+			t.Logf("Bad: %v", datacenters)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCoordinate_Nodes(t *testing.T) {
@@ -36,19 +35,19 @@ func TestCoordinate_Nodes(t *testing.T) {
 	defer s.Stop()
 
 	coordinate := c.Coordinate()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		_, _, err := coordinate.Nodes(nil)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
+		break
 
 		// There's not a good way to populate coordinates without
 		// waiting for them to calculate and update, so the best
 		// we can do is call the endpoint and make sure we don't
 		// get an error.
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
 	}
+
 }

--- a/api/coordinate_test.go
+++ b/api/coordinate_test.go
@@ -13,20 +13,17 @@ func TestCoordinate_Datacenters(t *testing.T) {
 
 	coordinate := c.Coordinate()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		datacenters, err := coordinate.Datacenters()
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if len(datacenters) == 0 {
 			t.Logf("Bad: %v", datacenters)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCoordinate_Nodes(t *testing.T) {
@@ -36,7 +33,6 @@ func TestCoordinate_Nodes(t *testing.T) {
 
 	coordinate := c.Coordinate()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		_, _, err := coordinate.Nodes(nil)
 		if err != nil {
 			t.Log(err)
@@ -49,5 +45,4 @@ func TestCoordinate_Nodes(t *testing.T) {
 		// we can do is call the endpoint and make sure we don't
 		// get an error.
 	}
-
 }

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestEvent_FireList(t *testing.T) {
@@ -29,14 +29,16 @@ func TestEvent_FireList(t *testing.T) {
 
 	var events []*UserEvent
 	var qm *QueryMeta
-	if err := testutil.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		events, qm, err = event.List("", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		return len(events) > 0, err
-	}); err != nil {
-		t.Fatal(err)
+		if len(events) > 0 {
+			break
+		}
+		t.Log(err)
 	}
 
 	if events[len(events)-1].ID != id {

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -30,15 +30,15 @@ func TestEvent_FireList(t *testing.T) {
 	var events []*UserEvent
 	var qm *QueryMeta
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		events, qm, err = event.List("", nil)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if len(events) > 0 {
-			break
+		if len(events) == 0 {
+			t.Log("no events")
+			continue
 		}
-		t.Log(err)
+		break
 	}
 
 	if events[len(events)-1].ID != id {

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -23,7 +23,6 @@ func TestHealth_Node(t *testing.T) {
 	}
 	name := info["Config"]["NodeName"].(string)
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		checks, meta, err := health.Node(name, nil)
 		if err != nil {
 			t.Log(err)
@@ -39,7 +38,6 @@ func TestHealth_Node(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealthChecks_AggregatedStatus(t *testing.T) {
@@ -198,7 +196,6 @@ func TestHealth_Checks(t *testing.T) {
 	}
 	defer agent.ServiceDeregister("foo")
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		checks := HealthChecks{
 			&HealthCheck{
 				Node:        "node123",
@@ -210,7 +207,6 @@ func TestHealth_Checks(t *testing.T) {
 				ServiceTags: []string{"bar"},
 			},
 		}
-
 		out, meta, err := health.Checks("foo", nil)
 		if err != nil {
 			t.Log(err)
@@ -226,7 +222,6 @@ func TestHealth_Checks(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealth_Checks_NodeMetaFilter(t *testing.T) {
@@ -252,7 +247,6 @@ func TestHealth_Checks_NodeMetaFilter(t *testing.T) {
 	}
 	defer agent.ServiceDeregister("foo")
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		checks, meta, err := health.Checks("foo", &QueryOptions{NodeMeta: meta})
 		if err != nil {
 			t.Log(err)
@@ -268,7 +262,6 @@ func TestHealth_Checks_NodeMetaFilter(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealth_Service(t *testing.T) {
@@ -277,7 +270,6 @@ func TestHealth_Service(t *testing.T) {
 
 	health := c.Health()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// consul service should always exist...
 		checks, meta, err := health.Service("consul", "", true, nil)
 		if err != nil {
@@ -302,7 +294,6 @@ func TestHealth_Service(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealth_Service_NodeMetaFilter(t *testing.T) {
@@ -314,7 +305,6 @@ func TestHealth_Service_NodeMetaFilter(t *testing.T) {
 
 	health := c.Health()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// consul service should always exist...
 		checks, meta, err := health.Service("consul", "", true, &QueryOptions{NodeMeta: meta})
 		if err != nil {
@@ -339,7 +329,6 @@ func TestHealth_Service_NodeMetaFilter(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealth_State(t *testing.T) {
@@ -349,7 +338,6 @@ func TestHealth_State(t *testing.T) {
 
 	health := c.Health()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		checks, meta, err := health.State("any", nil)
 		if err != nil {
 			t.Log(err)
@@ -365,7 +353,6 @@ func TestHealth_State(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealth_State_NodeMetaFilter(t *testing.T) {
@@ -378,7 +365,6 @@ func TestHealth_State_NodeMetaFilter(t *testing.T) {
 
 	health := c.Health()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		checks, meta, err := health.State("any", &QueryOptions{NodeMeta: meta})
 		if err != nil {
 			t.Log(err)
@@ -394,5 +380,4 @@ func TestHealth_State_NodeMetaFilter(t *testing.T) {
 		}
 		break
 	}
-
 }

--- a/api/operator_autopilot_test.go
+++ b/api/operator_autopilot_test.go
@@ -90,19 +90,23 @@ func TestOperator_AutopilotServerHealth(t *testing.T) {
 
 	operator := c.Operator()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		out, err := operator.AutopilotServerHealth(nil)
 		if err != nil {
 			t.Logf("err: %v", err)
 			continue
 		}
-		if len(out.Servers) != 1 ||
-			!out.Servers[0].Healthy ||
-			out.Servers[0].Name != s.Config.NodeName {
-			t.Logf("bad: %v", out)
+		if got, want := len(out.Servers), 1; got != want {
+			t.Logf("got %d servers want %d", got, want)
+			continue
+		}
+		if got, want := out.Servers[0].Healthy, true; got != want {
+			t.Logf("got healthy %s want %s", got, want)
+			continue
+		}
+		if got, want := out.Servers[0].Name, s.Config.NodeName; got != want {
+			t.Logf("got name %q want %q", got, want)
 			continue
 		}
 		break
 	}
-
 }

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestPreparedQuery(t *testing.T) {
@@ -30,18 +30,18 @@ func TestPreparedQuery(t *testing.T) {
 	}
 
 	catalog := c.Catalog()
-	if err := testutil.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		if _, err := catalog.Register(reg, nil); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		if _, _, err := catalog.Node("foobar", nil); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Create a simple prepared query.

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -31,12 +31,10 @@ func TestPreparedQuery(t *testing.T) {
 
 	catalog := c.Catalog()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		if _, err := catalog.Register(reg, nil); err != nil {
 			t.Log(err)
 			continue
 		}
-
 		if _, _, err := catalog.Node("foobar", nil); err != nil {
 			t.Log(err)
 			continue

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -19,7 +18,7 @@ import (
 	"github.com/hashicorp/consul/command/base"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/logger"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/serf/serf"
 	"github.com/mitchellh/cli"
@@ -346,11 +345,10 @@ func TestAgent_Reload(t *testing.T) {
 		cmd.Run(args)
 		close(doneCh)
 	}()
-
-	if err := testutil.WaitForResult(func() (bool, error) {
-		return len(cmd.httpServers) == 1, nil
-	}); err != nil {
-		t.Fatalf("should have an http server")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(cmd.httpServers) == 1 {
+			break
+		}
 	}
 
 	if _, ok := cmd.agent.state.services["redis"]; !ok {
@@ -535,12 +533,12 @@ func TestAgent_Join(t *testing.T) {
 	if len(srv.agent.LANMembers()) != 2 {
 		t.Fatalf("should have 2 members")
 	}
-
-	if err := testutil.WaitForResult(func() (bool, error) {
-		return len(a2.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("should have 2 members")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(a2.LANMembers()) == 2 {
+			break
+		}
 	}
+
 }
 
 func TestAgent_Join_WAN(t *testing.T) {
@@ -570,12 +568,12 @@ func TestAgent_Join_WAN(t *testing.T) {
 	if len(srv.agent.WANMembers()) != 2 {
 		t.Fatalf("should have 2 members")
 	}
-
-	if err := testutil.WaitForResult(func() (bool, error) {
-		return len(a2.WANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("should have 2 members")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(a2.WANMembers()) == 2 {
+			break
+		}
 	}
+
 }
 
 func TestAgent_Join_ACLDeny(t *testing.T) {
@@ -663,14 +661,13 @@ func TestAgent_Leave(t *testing.T) {
 	if obj != nil {
 		t.Fatalf("Err: %v", obj)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		m := srv.agent.LANMembers()
 		success := m[1].Status == serf.StatusLeft
-		return success, errors.New(m[1].Status.String())
-	}); err != nil {
-		t.Fatalf("member status is %v, should be left", err)
+		continue
 	}
+
 }
 
 func TestAgent_Leave_ACLDeny(t *testing.T) {
@@ -762,14 +759,13 @@ func TestAgent_ForceLeave(t *testing.T) {
 	if obj != nil {
 		t.Fatalf("Err: %v", obj)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		m := srv.agent.LANMembers()
 		success := m[1].Status == serf.StatusLeft
-		return success, errors.New(m[1].Status.String())
-	}); err != nil {
-		t.Fatalf("member status is %v, should be left", err)
+		continue
 	}
+
 }
 
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
@@ -1932,7 +1928,8 @@ func TestAgent_Monitor(t *testing.T) {
 
 	// Try to stream logs until we see the expected log line
 	expected := []byte("raft: Initial configuration (index=1)")
-	if err := testutil.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		req, _ = http.NewRequest("GET", "/v1/agent/monitor?loglevel=debug", nil)
 		resp = newClosableRecorder()
 		done := make(chan struct{})
@@ -1947,12 +1944,12 @@ func TestAgent_Monitor(t *testing.T) {
 		<-done
 
 		if bytes.Contains(resp.Body.Bytes(), expected) {
-			return true, nil
+			t.Log(nil)
+			break
 		}
-		return false, fmt.Errorf("didn't see expected")
-	}); err != nil {
-		t.Fatalf("err: %v", err)
+		continue
 	}
+
 }
 
 type closableRecorder struct {

--- a/command/agent/catalog_endpoint_test.go
+++ b/command/agent/catalog_endpoint_test.go
@@ -90,13 +90,11 @@ func TestCatalogDatacenters(t *testing.T) {
 	defer srv.Shutdown()
 	defer srv.agent.Shutdown()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		obj, err := srv.CatalogDatacenters(nil, nil)
 		if err != nil {
 			t.Log(err)
 			continue
 		}
-
 		dcs := obj.([]string)
 		if len(dcs) != 1 {
 			t.Logf("missing dc: %v", dcs)
@@ -104,7 +102,6 @@ func TestCatalogDatacenters(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestCatalogNodes(t *testing.T) {
@@ -222,9 +219,11 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a node with DC2.
@@ -702,9 +701,11 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a node with DC2.
@@ -941,9 +942,11 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a node with DC2.

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -17,7 +17,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 )
 
@@ -78,21 +78,21 @@ func expectStatus(t *testing.T, script, status string) {
 	}
 	check.Start()
 	defer check.Stop()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
-			return false, fmt.Errorf("should have 2 updates %v", mock.updates)
+			t.Logf("should have 2 updates %v", mock.updates)
+			continue
 		}
 
 		if mock.State("foo") != status {
-			return false, fmt.Errorf("should be %v %v", status, mock.state)
+			t.Logf("should be %v %v", status, mock.state)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckMonitor_Passing(t *testing.T) {
@@ -281,25 +281,27 @@ func expectHTTPStatus(t *testing.T, url string, status string) {
 	}
 	check.Start()
 	defer check.Stop()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
-			return false, fmt.Errorf("should have 2 updates %v", mock.updates)
+			t.Logf("should have 2 updates %v", mock.updates)
+			continue
 		}
 
 		if mock.State("foo") != status {
-			return false, fmt.Errorf("should be %v %v", status, mock.state)
+			t.Logf("should be %v %v", status, mock.state)
+			continue
 		}
 
 		// Allow slightly more data than CheckBufSize, for the header
 		if n := len(mock.Output("foo")); n > (CheckBufSize + 256) {
-			return false, fmt.Errorf("output too long: %d (%d-byte limit)", n, CheckBufSize)
+			t.Logf("output too long: %d (%d-byte limit)", n, CheckBufSize)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckHTTPCritical(t *testing.T) {
@@ -387,20 +389,21 @@ func TestCheckHTTPTimeout(t *testing.T) {
 
 	check.Start()
 	defer check.Stop()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		// Should have at least 2 updates
 		if mock.updates["bar"] < 2 {
-			return false, fmt.Errorf("should have at least 2 updates %v", mock.updates)
+			t.Logf("should have at least 2 updates %v", mock.updates)
+			continue
 		}
 
 		if mock.state["bar"] != api.HealthCritical {
-			return false, fmt.Errorf("should be critical %v", mock.state)
+			t.Logf("should be critical %v", mock.state)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
@@ -460,15 +463,15 @@ func TestCheckHTTP_TLSSkipVerify_true_pass(t *testing.T) {
 	if !check.httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("should be true")
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		if mock.state["skipverify_true"] != api.HealthPassing {
-			return false, fmt.Errorf("should be passing %v", mock.state)
+			t.Logf("should be passing %v", mock.state)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
@@ -495,15 +498,15 @@ func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
 	if !check.httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("should be true")
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		if mock.state["skipverify_true"] != api.HealthCritical {
-			return false, fmt.Errorf("should be critical %v", mock.state)
+			t.Logf("should be critical %v", mock.state)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckHTTP_TLSSkipVerify_false(t *testing.T) {
@@ -531,20 +534,21 @@ func TestCheckHTTP_TLSSkipVerify_false(t *testing.T) {
 	if check.httpClient.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("should be false")
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		// This should fail due to an invalid SSL cert
 		if mock.state["skipverify_false"] != api.HealthCritical {
-			return false, fmt.Errorf("should be critical %v", mock.state)
+			t.Logf("should be critical %v", mock.state)
+			continue
 		}
 
 		if !strings.Contains(mock.output["skipverify_false"], "certificate signed by unknown authority") {
-			return false, fmt.Errorf("should fail with certificate error %v", mock.output)
+			t.Logf("should fail with certificate error %v", mock.output)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func mockTCPServer(network string) net.Listener {
@@ -581,20 +585,21 @@ func expectTCPStatus(t *testing.T, tcp string, status string) {
 	}
 	check.Start()
 	defer check.Stop()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
-			return false, fmt.Errorf("should have 2 updates %v", mock.updates)
+			t.Logf("should have 2 updates %v", mock.updates)
+			continue
 		}
 
 		if mock.State("foo") != status {
-			return false, fmt.Errorf("should be %v %v", status, mock.state)
+			t.Logf("should be %v %v", status, mock.state)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestCheckTCPCritical(t *testing.T) {

--- a/command/agent/check_test.go
+++ b/command/agent/check_test.go
@@ -79,20 +79,17 @@ func expectStatus(t *testing.T, script, status string) {
 	check.Start()
 	defer check.Stop()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
 			t.Logf("should have 2 updates %v", mock.updates)
 			continue
 		}
-
 		if mock.State("foo") != status {
 			t.Logf("should be %v %v", status, mock.state)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCheckMonitor_Passing(t *testing.T) {
@@ -282,18 +279,15 @@ func expectHTTPStatus(t *testing.T, url string, status string) {
 	check.Start()
 	defer check.Stop()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
 			t.Logf("should have 2 updates %v", mock.updates)
 			continue
 		}
-
 		if mock.State("foo") != status {
 			t.Logf("should be %v %v", status, mock.state)
 			continue
 		}
-
 		// Allow slightly more data than CheckBufSize, for the header
 		if n := len(mock.Output("foo")); n > (CheckBufSize + 256) {
 			t.Logf("output too long: %d (%d-byte limit)", n, CheckBufSize)
@@ -301,7 +295,6 @@ func expectHTTPStatus(t *testing.T, url string, status string) {
 		}
 		break
 	}
-
 }
 
 func TestCheckHTTPCritical(t *testing.T) {
@@ -390,20 +383,17 @@ func TestCheckHTTPTimeout(t *testing.T) {
 	check.Start()
 	defer check.Stop()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Should have at least 2 updates
 		if mock.updates["bar"] < 2 {
 			t.Logf("should have at least 2 updates %v", mock.updates)
 			continue
 		}
-
 		if mock.state["bar"] != api.HealthCritical {
 			t.Logf("should be critical %v", mock.state)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
@@ -464,14 +454,12 @@ func TestCheckHTTP_TLSSkipVerify_true_pass(t *testing.T) {
 		t.Fatalf("should be true")
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		if mock.state["skipverify_true"] != api.HealthPassing {
 			t.Logf("should be passing %v", mock.state)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
@@ -499,14 +487,12 @@ func TestCheckHTTP_TLSSkipVerify_true_fail(t *testing.T) {
 		t.Fatalf("should be true")
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		if mock.state["skipverify_true"] != api.HealthCritical {
 			t.Logf("should be critical %v", mock.state)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestCheckHTTP_TLSSkipVerify_false(t *testing.T) {
@@ -535,20 +521,17 @@ func TestCheckHTTP_TLSSkipVerify_false(t *testing.T) {
 		t.Fatalf("should be false")
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// This should fail due to an invalid SSL cert
 		if mock.state["skipverify_false"] != api.HealthCritical {
 			t.Logf("should be critical %v", mock.state)
 			continue
 		}
-
 		if !strings.Contains(mock.output["skipverify_false"], "certificate signed by unknown authority") {
 			t.Logf("should fail with certificate error %v", mock.output)
 			continue
 		}
 		break
 	}
-
 }
 
 func mockTCPServer(network string) net.Listener {
@@ -586,13 +569,11 @@ func expectTCPStatus(t *testing.T, tcp string, status string) {
 	check.Start()
 	defer check.Stop()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		// Should have at least 2 updates
 		if mock.Updates("foo") < 2 {
 			t.Logf("should have 2 updates %v", mock.updates)
 			continue
 		}
-
 		if mock.State("foo") != status {
 			t.Logf("should be %v %v", status, mock.state)
 			continue

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -104,20 +104,16 @@ func TestRetryJoin(t *testing.T) {
 		close(doneCh)
 	}()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		mem := agent.LANMembers()
-		if len(mem) != 2 {
-			t.Logf("bad: %#v", mem)
+		if got, want := len(agent.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
 			continue
 		}
-		mem = agent.WANMembers()
-		if len(mem) != 2 {
-			t.Logf("bad (wan): %#v", mem)
+		if got, want := len(agent.WANMembers()), 2; got != want {
+			t.Logf("got %d WAN members want %d", got, want)
 			continue
 		}
 		break
 	}
-
 }
 
 func TestReadCliConfig(t *testing.T) {

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/miekg/dns"
 )
 
@@ -1299,11 +1300,10 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 	if _, err := srv2.agent.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(srv1.agent.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatalf("Failed waiting for WAN join: %v", err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(srv1.agent.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Register a remote node with a service.
@@ -3375,10 +3375,10 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 	if _, err := srv2.agent.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(srv1.agent.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatalf("Failed waiting for WAN join: %v", err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(srv1.agent.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Register a remote node with a service.

--- a/command/agent/dns_test.go
+++ b/command/agent/dns_test.go
@@ -1301,9 +1301,11 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a remote node with a service.
@@ -3376,9 +3378,11 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a remote node with a service.

--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/consul/structs"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestEventFire(t *testing.T) {
@@ -122,33 +122,37 @@ func TestEventList(t *testing.T) {
 		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testutil.WaitForResult(func() (bool, error) {
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 1 || list[0].Name != "test" {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
 			header := resp.Header().Get("X-Consul-Index")
 			if header == "" || header == "0" {
-				return false, fmt.Errorf("bad: %#v", header)
+				t.Logf("bad: %#v", header)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 
@@ -163,33 +167,37 @@ func TestEventList_Filter(t *testing.T) {
 		if err := srv.agent.UserEvent("dc1", "root", p); err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testutil.WaitForResult(func() (bool, error) {
 			req, err := http.NewRequest("GET", "/v1/event/list?name=foo", nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 1 || list[0].Name != "foo" {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
 			header := resp.Header().Get("X-Consul-Index")
 			if header == "" || header == "0" {
-				return false, fmt.Errorf("bad: %#v", header)
+				t.Logf("bad: %#v", header)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 
@@ -207,54 +215,62 @@ func TestEventList_ACLFilter(t *testing.T) {
 
 	// Try no token.
 	{
-		if err := testutil.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 0 {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	}
 
 	// Try the root token.
 	{
-		if err := testutil.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			req, err := http.NewRequest("GET", "/v1/event/list?token=root", nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 1 || list[0].Name != "foo" {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	}
 }
 
@@ -266,24 +282,26 @@ func TestEventList_Blocking(t *testing.T) {
 		}
 
 		var index string
-		if err := testutil.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			_, err = srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			header := resp.Header().Get("X-Consul-Index")
 			if header == "" || header == "0" {
-				return false, fmt.Errorf("bad: %#v", header)
+				t.Logf("bad: %#v", header)
+				continue
 			}
 			index = header
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
 
 		go func() {
@@ -293,30 +311,33 @@ func TestEventList_Blocking(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 		}()
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testutil.WaitForResult(func() (bool, error) {
 			url := "/v1/event/list?index=" + index
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 2 || list[1].Name != "second" {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 
@@ -336,31 +357,36 @@ func TestEventList_EventBufOrder(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 		}
+		for r :=
 
-		// Test that the event order is preserved when name
-		// filtering on a list of > 1 matching event.
-		if err := testutil.WaitForResult(func() (bool, error) {
+			// Test that the event order is preserved when name
+			// filtering on a list of > 1 matching event.
+			retry.OneSec(); r.NextOr(t.FailNow); {
+
 			url := "/v1/event/list?name=foo"
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			resp := httptest.NewRecorder()
 			obj, err := srv.EventList(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			list, ok := obj.([]*UserEvent)
 			if !ok {
-				return false, fmt.Errorf("bad: %#v", obj)
+				t.Logf("bad: %#v", obj)
+				continue
 			}
 			if len(list) != 3 || list[2].ID != expected.ID {
-				return false, fmt.Errorf("bad: %#v", list)
+				t.Logf("bad: %#v", list)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 

--- a/command/agent/event_endpoint_test.go
+++ b/command/agent/event_endpoint_test.go
@@ -123,7 +123,6 @@ func TestEventList(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
 				t.Log(err)
@@ -135,7 +134,6 @@ func TestEventList(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			list, ok := obj.([]*UserEvent)
 			if !ok {
 				t.Logf("bad: %#v", obj)
@@ -152,7 +150,6 @@ func TestEventList(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 
@@ -168,7 +165,6 @@ func TestEventList_Filter(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			req, err := http.NewRequest("GET", "/v1/event/list?name=foo", nil)
 			if err != nil {
 				t.Log(err)
@@ -180,7 +176,6 @@ func TestEventList_Filter(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			list, ok := obj.([]*UserEvent)
 			if !ok {
 				t.Logf("bad: %#v", obj)
@@ -197,7 +192,6 @@ func TestEventList_Filter(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 
@@ -216,7 +210,6 @@ func TestEventList_ACLFilter(t *testing.T) {
 	// Try no token.
 	{
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
 				t.Log(err)
@@ -228,7 +221,6 @@ func TestEventList_ACLFilter(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			list, ok := obj.([]*UserEvent)
 			if !ok {
 				t.Logf("bad: %#v", obj)
@@ -240,13 +232,11 @@ func TestEventList_ACLFilter(t *testing.T) {
 			}
 			break
 		}
-
 	}
 
 	// Try the root token.
 	{
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			req, err := http.NewRequest("GET", "/v1/event/list?token=root", nil)
 			if err != nil {
 				t.Log(err)
@@ -258,7 +248,6 @@ func TestEventList_ACLFilter(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			list, ok := obj.([]*UserEvent)
 			if !ok {
 				t.Logf("bad: %#v", obj)
@@ -270,7 +259,6 @@ func TestEventList_ACLFilter(t *testing.T) {
 			}
 			break
 		}
-
 	}
 }
 
@@ -283,7 +271,6 @@ func TestEventList_Blocking(t *testing.T) {
 
 		var index string
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			req, err := http.NewRequest("GET", "/v1/event/list", nil)
 			if err != nil {
 				t.Log(err)
@@ -312,7 +299,6 @@ func TestEventList_Blocking(t *testing.T) {
 			}
 		}()
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			url := "/v1/event/list?index=" + index
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
@@ -325,7 +311,6 @@ func TestEventList_Blocking(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			list, ok := obj.([]*UserEvent)
 			if !ok {
 				t.Logf("bad: %#v", obj)
@@ -337,7 +322,6 @@ func TestEventList_Blocking(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 
@@ -357,12 +341,10 @@ func TestEventList_EventBufOrder(t *testing.T) {
 				t.Fatalf("err: %v", err)
 			}
 		}
-		for r :=
 
-			// Test that the event order is preserved when name
-			// filtering on a list of > 1 matching event.
-			retry.OneSec(); r.NextOr(t.FailNow); {
-
+		// Test that the event order is preserved when name
+		// filtering on a list of > 1 matching event.
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 			url := "/v1/event/list?name=foo"
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
@@ -386,7 +368,6 @@ func TestEventList_EventBufOrder(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 

--- a/command/agent/health_endpoint_test.go
+++ b/command/agent/health_endpoint_test.go
@@ -22,7 +22,6 @@ func TestHealthChecksInState(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
@@ -33,7 +32,6 @@ func TestHealthChecksInState(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			// Should be a non-nil empty list
 			nodes := obj.(structs.HealthChecks)
 			if nodes == nil || len(nodes) != 0 {
@@ -42,7 +40,6 @@ func TestHealthChecksInState(t *testing.T) {
 			}
 			break
 		}
-
 	})
 
 	httpTest(t, func(srv *HTTPServer) {
@@ -51,7 +48,6 @@ func TestHealthChecksInState(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
@@ -62,7 +58,6 @@ func TestHealthChecksInState(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			// Should be 1 health check for the server
 			nodes := obj.(structs.HealthChecks)
 			if len(nodes) != 1 {
@@ -71,7 +66,6 @@ func TestHealthChecksInState(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 
@@ -98,7 +92,6 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
@@ -109,7 +102,6 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 				t.Log(err)
 				continue
 			}
-
 			// Should be 1 health check for the server
 			nodes := obj.(structs.HealthChecks)
 			if len(nodes) != 1 {
@@ -118,7 +110,6 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 			}
 			break
 		}
-
 	})
 }
 
@@ -182,11 +173,8 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Retry until foo moves to the front of the line.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Retry until foo moves to the front of the line.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthChecksInState(resp, req)
 		if err != nil {
@@ -209,7 +197,6 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealthNodeChecks(t *testing.T) {
@@ -448,11 +435,8 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Retry until foo has moved to the front of the line.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Retry until foo has moved to the front of the line.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthServiceChecks(resp, req)
 		if err != nil {
@@ -475,7 +459,6 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealthServiceNodes(t *testing.T) {
@@ -687,11 +670,8 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Retry until foo has moved to the front of the line.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Retry until foo has moved to the front of the line.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthServiceNodes(resp, req)
 		if err != nil {
@@ -714,7 +694,6 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 		}
 		break
 	}
-
 }
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
@@ -791,9 +770,11 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(srv1.agent.WANMembers()) > 1 {
-			break
+		if got, want := len(srv1.agent.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Register a node with DC2.

--- a/command/agent/health_endpoint_test.go
+++ b/command/agent/health_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/serf/coordinate"
 )
 
@@ -20,26 +21,28 @@ func TestHealthChecksInState(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testrpc.WaitForResult(func() (bool, error) {
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			if err := checkIndex(resp); err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			// Should be a non-nil empty list
 			nodes := obj.(structs.HealthChecks)
 			if nodes == nil || len(nodes) != 0 {
-				return false, fmt.Errorf("bad: %v", obj)
+				t.Logf("bad: %v", obj)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 
 	httpTest(t, func(srv *HTTPServer) {
@@ -47,26 +50,28 @@ func TestHealthChecksInState(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testrpc.WaitForResult(func() (bool, error) {
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			if err := checkIndex(resp); err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			// Should be 1 health check for the server
 			nodes := obj.(structs.HealthChecks)
 			if len(nodes) != 1 {
-				return false, fmt.Errorf("bad: %v", obj)
+				t.Logf("bad: %v", obj)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 
@@ -92,26 +97,28 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-		if err := testrpc.WaitForResult(func() (bool, error) {
 			resp := httptest.NewRecorder()
 			obj, err := srv.HealthChecksInState(resp, req)
 			if err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 			if err := checkIndex(resp); err != nil {
-				return false, err
+				t.Log(err)
+				continue
 			}
 
 			// Should be 1 health check for the server
 			nodes := obj.(structs.HealthChecks)
 			if len(nodes) != 1 {
-				return false, fmt.Errorf("bad: %v", obj)
+				t.Logf("bad: %v", obj)
+				continue
 			}
-			return true, nil
-		}); err != nil {
-			t.Fatal(err)
+			break
 		}
+
 	})
 }
 
@@ -175,29 +182,34 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Retry until foo moves to the front of the line.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Retry until foo moves to the front of the line.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthChecksInState(resp, req)
 		if err != nil {
-			return false, fmt.Errorf("err: %v", err)
+			t.Logf("err: %v", err)
+			continue
 		}
 		assertIndex(t, resp)
 		nodes = obj.(structs.HealthChecks)
 		if len(nodes) != 2 {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
 		if nodes[0].Node != "foo" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
 		if nodes[1].Node != "bar" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestHealthNodeChecks(t *testing.T) {
@@ -436,29 +448,34 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Retry until foo has moved to the front of the line.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Retry until foo has moved to the front of the line.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthServiceChecks(resp, req)
 		if err != nil {
-			return false, fmt.Errorf("err: %v", err)
+			t.Logf("err: %v", err)
+			continue
 		}
 		assertIndex(t, resp)
 		nodes = obj.(structs.HealthChecks)
 		if len(nodes) != 2 {
-			return false, fmt.Errorf("bad: %v", obj)
+			t.Logf("bad: %v", obj)
+			continue
 		}
 		if nodes[0].Node != "foo" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
 		if nodes[1].Node != "bar" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestHealthServiceNodes(t *testing.T) {
@@ -670,29 +687,34 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 	if err := srv.agent.RPC("Coordinate.Update", &arg, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Retry until foo has moved to the front of the line.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Retry until foo has moved to the front of the line.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		resp = httptest.NewRecorder()
 		obj, err = srv.HealthServiceNodes(resp, req)
 		if err != nil {
-			return false, fmt.Errorf("err: %v", err)
+			t.Logf("err: %v", err)
+			continue
 		}
 		assertIndex(t, resp)
 		nodes = obj.(structs.CheckServiceNodes)
 		if len(nodes) != 2 {
-			return false, fmt.Errorf("bad: %v", obj)
+			t.Logf("bad: %v", obj)
+			continue
 		}
 		if nodes[0].Node.Node != "foo" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
 		if nodes[1].Node.Node != "bar" {
-			return false, fmt.Errorf("bad: %v", nodes)
+			t.Logf("bad: %v", nodes)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
@@ -768,10 +790,10 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	if _, err := srv2.agent.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(srv1.agent.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatal(err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(srv1.agent.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Register a node with DC2.

--- a/command/agent/local_test.go
+++ b/command/agent/local_test.go
@@ -117,7 +117,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Node:       agent.config.NodeName,
 	}
 
-	verifyServices := func() (bool, error) {
+	if err := testrpc.WaitForResult(func() (bool, error) {
 		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
 			return false, fmt.Errorf("err: %v", err)
 		}
@@ -182,9 +182,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		}
 
 		return true, nil
-	}
-
-	if err := testrpc.WaitForResult(verifyServices); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -194,7 +192,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 	// Trigger anti-entropy run and wait
 	agent.StartSync()
 
-	verifyServicesAfterRemove := func() (bool, error) {
+	if err := testrpc.WaitForResult(func() (bool, error) {
 		if err := agent.RPC("Catalog.NodeServices", &req, &services); err != nil {
 			return false, fmt.Errorf("err: %v", err)
 		}
@@ -245,9 +243,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		}
 
 		return true, nil
-	}
-
-	if err := testrpc.WaitForResult(verifyServicesAfterRemove); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -451,8 +451,8 @@ func TestOperator_ServerHealth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
+		r := retry.Timer{Timeout: 3 * time.Second, Wait: 200 * time.Millisecond}
+		for r.NextOr(t.FailNow) {
 			resp := httptest.NewRecorder()
 			obj, err := srv.OperatorServerHealth(resp, req)
 			if err != nil {
@@ -494,8 +494,8 @@ func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
+		r := retry.Timer{Timeout: 3 * time.Second, Wait: 200 * time.Millisecond}
+		for r.NextOr(t.FailNow) {
 			resp := httptest.NewRecorder()
 			obj, err := srv.OperatorServerHealth(resp, req)
 			if err != nil {
@@ -519,6 +519,5 @@ func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 			}
 			break
 		}
-
 	}, cb)
 }

--- a/command/agent/user_event_test.go
+++ b/command/agent/user_event_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestValidateUserEventParams(t *testing.T) {
@@ -174,11 +175,10 @@ func TestFireReceiveEvent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(agent.UserEvents()) == 1, nil
-	}); err != nil {
-		t.Fatal(err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(agent.UserEvents()) == 1 {
+			break
+		}
 	}
 
 	last := agent.LastUserEvent()

--- a/command/force_leave_test.go
+++ b/command/force_leave_test.go
@@ -56,12 +56,13 @@ func TestForceLeaveCommandRun(t *testing.T) {
 		t.Fatalf("should have 2 members: %#v", m)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		m = a1.agent.LANMembers()
-		success := m[1].Status == serf.StatusLeft
-		continue
+		m := a1.agent.LANMembers()
+		if got, want := m[1].Status, serf.StatusLeft; got != want {
+			t.Logf("got serf status %q want %q", got, want)
+			continue
+		}
+		break
 	}
-
 }
 
 func TestForceLeaveCommandRun_noAddrs(t *testing.T) {

--- a/command/force_leave_test.go
+++ b/command/force_leave_test.go
@@ -1,13 +1,12 @@
 package command
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/serf/serf"
 	"github.com/mitchellh/cli"
 )
@@ -56,14 +55,13 @@ func TestForceLeaveCommandRun(t *testing.T) {
 	if len(m) != 2 {
 		t.Fatalf("should have 2 members: %#v", m)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testutil.WaitForResult(func() (bool, error) {
 		m = a1.agent.LANMembers()
 		success := m[1].Status == serf.StatusLeft
-		return success, errors.New(m[1].Status.String())
-	}); err != nil {
-		t.Fatalf("member status is %v, should be left", err)
+		continue
 	}
+
 }
 
 func TestForceLeaveCommandRun_noAddrs(t *testing.T) {

--- a/command/rtt_test.go
+++ b/command/rtt_test.go
@@ -106,11 +106,8 @@ func TestRTTCommand_Run_LAN(t *testing.T) {
 		a.config.NodeName,
 		"dogs",
 	}
-	for r :=
-
-		// Wait for the updates to get flushed to the data store.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Wait for the updates to get flushed to the data store.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		code := c.Run(args)
 		if code != 0 {
 			t.Logf("bad: %d: %#v", code, ui.ErrorWriter.String())

--- a/command/rtt_test.go
+++ b/command/rtt_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul/command/agent"
 	"github.com/hashicorp/consul/command/base"
 	"github.com/hashicorp/consul/consul/structs"
-	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/mitchellh/cli"
 )
@@ -106,23 +106,24 @@ func TestRTTCommand_Run_LAN(t *testing.T) {
 		a.config.NodeName,
 		"dogs",
 	}
+	for r :=
 
-	// Wait for the updates to get flushed to the data store.
-	if err := testutil.WaitForResult(func() (bool, error) {
+		// Wait for the updates to get flushed to the data store.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		code := c.Run(args)
 		if code != 0 {
-			return false, fmt.Errorf("bad: %d: %#v", code, ui.ErrorWriter.String())
+			t.Logf("bad: %d: %#v", code, ui.ErrorWriter.String())
+			continue
 		}
 
 		// Make sure the proper RTT was reported in the output.
 		expected := fmt.Sprintf("rtt: %s", dist_str)
 		if !strings.Contains(ui.OutputWriter.String(), expected) {
-			return false, fmt.Errorf("bad: %#v", ui.OutputWriter.String())
+			t.Logf("bad: %#v", ui.OutputWriter.String())
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Default to the agent's node.

--- a/consul/acl_replication_test.go
+++ b/consul/acl_replication_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestACLReplication_Sorter(t *testing.T) {
@@ -393,10 +394,15 @@ func TestACLReplication(t *testing.T) {
 
 		return true, nil
 	}
+	for r :=
 
-	// Wait for the replica to converge.
-	if err := testrpc.WaitForResult(checkSame); err != nil {
-		t.Fatalf("ACLs didn't converge")
+		// Wait for the replica to converge.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if err := checkSame(); err != nil {
+			t.Log(err)
+			continue
+		}
+		break
 	}
 
 	// Create more new tokens.
@@ -416,10 +422,15 @@ func TestACLReplication(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 	}
+	for r :=
 
-	// Wait for the replica to converge.
-	if err := testrpc.WaitForResult(checkSame); err != nil {
-		t.Fatalf("ACLs didn't converge")
+		// Wait for the replica to converge.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if err := checkSame(); err != nil {
+			t.Log(err)
+			continue
+		}
+		break
 	}
 
 	// Delete a token.
@@ -435,9 +446,15 @@ func TestACLReplication(t *testing.T) {
 	if err := s1.RPC("ACL.Apply", &arg, &dontCare); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Wait for the replica to converge.
-	if err := testrpc.WaitForResult(checkSame); err != nil {
-		t.Fatalf("ACLs didn't converge")
+		// Wait for the replica to converge.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if err := checkSame(); err != nil {
+			t.Log(err)
+			continue
+		}
+		break
 	}
+
 }

--- a/consul/acl_replication_test.go
+++ b/consul/acl_replication_test.go
@@ -364,21 +364,21 @@ func TestACLReplication(t *testing.T) {
 		}
 	}
 
-	checkSame := func() (bool, error) {
+	checkSame := func() error {
 		index, remote, err := s1.fsm.State().ACLList(nil)
 		if err != nil {
-			return false, err
+			return err
 		}
 		_, local, err := s2.fsm.State().ACLList(nil)
 		if err != nil {
-			return false, err
+			return err
 		}
-		if len(remote) != len(local) {
-			return false, nil
+		if got, want := len(remote), len(local); got != want {
+			return fmt.Errorf("got %d remote ACLs want %d", got, want)
 		}
 		for i, acl := range remote {
-			if !acl.IsSame(local[i]) {
-				return false, nil
+			if got, want := acl, local[i]; !got.IsSame(want) {
+				return fmt.Errorf("got ACL %v want %v", got, want)
 			}
 		}
 
@@ -389,15 +389,13 @@ func TestACLReplication(t *testing.T) {
 		if !status.Enabled || !status.Running ||
 			status.ReplicatedIndex != index ||
 			status.SourceDatacenter != "dc1" {
-			return false, nil
+			return fmt.Errorf("ACL replication status differs")
 		}
 
-		return true, nil
+		return nil
 	}
-	for r :=
-
-		// Wait for the replica to converge.
-		retry.OneSec(); r.NextOr(t.FailNow); {
+	// Wait for the replica to converge.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		if err := checkSame(); err != nil {
 			t.Log(err)
 			continue
@@ -422,10 +420,8 @@ func TestACLReplication(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 	}
-	for r :=
-
-		// Wait for the replica to converge.
-		retry.OneSec(); r.NextOr(t.FailNow); {
+	// Wait for the replica to converge.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		if err := checkSame(); err != nil {
 			t.Log(err)
 			continue
@@ -446,10 +442,8 @@ func TestACLReplication(t *testing.T) {
 	if err := s1.RPC("ACL.Apply", &arg, &dontCare); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Wait for the replica to converge.
-		retry.OneSec(); r.NextOr(t.FailNow); {
+	// Wait for the replica to converge.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		if err := checkSame(); err != nil {
 			t.Log(err)
 			continue

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -232,12 +232,12 @@ func TestACL_NonAuthority_NotFound(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	client := rpcClient(t, s1)
@@ -285,12 +285,12 @@ func TestACL_NonAuthority_Found(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -363,12 +363,12 @@ func TestACL_NonAuthority_Management(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -422,12 +422,12 @@ func TestACL_DownPolicy_Deny(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -498,12 +498,12 @@ func TestACL_DownPolicy_Allow(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -576,12 +576,12 @@ func TestACL_DownPolicy_ExtendCache(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		p1, _ := s1.numPeers()
-		if p1 == 2 {
-			break
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -696,11 +696,8 @@ func TestACL_Replication(t *testing.T) {
 	if err := s1.RPC("ACL.Apply", &arg, &id); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Wait for replication to occur.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Wait for replication to occur.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		_, acl, err := s2.fsm.State().ACLGet(nil, id)
 		if err != nil {
 			t.Log(err)

--- a/consul/acl_test.go
+++ b/consul/acl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 var testACLPolicy = `
@@ -230,12 +231,13 @@ func TestACL_NonAuthority_NotFound(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
 
 	client := rpcClient(t, s1)
@@ -282,13 +284,15 @@ func TestACL_NonAuthority_Found(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Create a new token
@@ -358,13 +362,15 @@ func TestACL_NonAuthority_Management(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// find the non-authoritative server
@@ -415,13 +421,15 @@ func TestACL_DownPolicy_Deny(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Create a new token
@@ -489,13 +497,15 @@ func TestACL_DownPolicy_Allow(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Create a new token
@@ -565,13 +575,15 @@ func TestACL_DownPolicy_ExtendCache(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ := s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatal(err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Create a new token
@@ -684,26 +696,30 @@ func TestACL_Replication(t *testing.T) {
 	if err := s1.RPC("ACL.Apply", &arg, &id); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Wait for replication to occur.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Wait for replication to occur.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		_, acl, err := s2.fsm.State().ACLGet(nil, id)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 		if acl == nil {
-			return false, nil
+			t.Log(nil)
+			continue
 		}
 		_, acl, err = s3.fsm.State().ACLGet(nil, id)
 		if err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 		if acl == nil {
-			return false, nil
+			t.Log(nil)
+			continue
 		}
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Kill the ACL datacenter.

--- a/consul/autopilot_test.go
+++ b/consul/autopilot_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 )
@@ -49,12 +50,14 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 	}
 
 	for _, s := range servers {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 3, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 3 {
+				break
+			}
 		}
+
 	}
 
 	// Bring up a new server
@@ -64,17 +67,17 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 
 	// Kill a non-leader server
 	s3.Shutdown()
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		alive := 0
 		for _, m := range s1.LANMembers() {
 			if m.Status == serf.StatusAlive {
 				alive++
 			}
 		}
-		return alive == 2, nil
-	}); err != nil {
-		t.Fatal(err)
+		if alive == 2 {
+			break
+		}
 	}
 
 	// Join the new server
@@ -85,12 +88,14 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 
 	// Make sure the dead server is removed and we're back to 3 total peers
 	for _, s := range servers {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 3, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 3 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -131,12 +136,14 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 	}
 
 	for _, s := range servers {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 4, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 4 {
+				break
+			}
 		}
+
 	}
 
 	// Kill a non-leader server
@@ -144,12 +151,14 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 
 	// Should be removed from the peers automatically
 	for _, s := range []*Server{s1, s2, s3} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 3, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 3 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -183,12 +192,14 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 	}
 
 	for _, s := range servers {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 3, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 3 {
+				break
+			}
 		}
+
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -209,12 +220,14 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 
 	// Wait for s4 to be removed
 	for _, s := range []*Server{s1, s2, s3} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			peers, _ := s.numPeers()
-			return peers == 3, nil
-		}); err != nil {
-			t.Fatal(err)
+			if peers == 3 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -246,38 +259,43 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	for r :=
 
-	// Wait for the new server to be added as a non-voter, but make sure
-	// it doesn't get promoted to a voter even after ServerStabilizationTime,
-	// because that would result in an even-numbered quorum count.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Wait for the new server to be added as a non-voter, but make sure
+		// it doesn't get promoted to a voter even after ServerStabilizationTime,
+		// because that would result in an even-numbered quorum count.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		future := s1.raft.GetConfiguration()
 		if err := future.Error(); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		servers := future.Configuration().Servers
 
 		if len(servers) != 2 {
-			return false, fmt.Errorf("bad: %v", servers)
+			t.Logf("bad: %v", servers)
+			continue
 		}
 		if servers[1].Suffrage != raft.Nonvoter {
-			return false, fmt.Errorf("bad: %v", servers)
+			t.Logf("bad: %v", servers)
+			continue
 		}
 		health := s1.getServerHealth(string(servers[1].ID))
 		if health == nil {
-			return false, fmt.Errorf("nil health")
+			t.Log("nil health")
+			continue
 		}
 		if !health.Healthy {
-			return false, fmt.Errorf("bad: %v", health)
+			t.Logf("bad: %v", health)
+			continue
 		}
 		if time.Now().Sub(health.StableSince) < s1.config.AutopilotConfig.ServerStabilizationTime {
-			return false, fmt.Errorf("stable period not elapsed")
+			t.Log("stable period not elapsed")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
 
 	// Now add another server and make sure they both get promoted to voters after stabilization
@@ -291,27 +309,29 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 	if _, err := s3.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		future := s1.raft.GetConfiguration()
 		if err := future.Error(); err != nil {
-			return false, err
+			t.Log(err)
+			continue
 		}
 
 		servers := future.Configuration().Servers
 
 		if len(servers) != 3 {
-			return false, fmt.Errorf("bad: %v", servers)
+			t.Logf("bad: %v", servers)
+			continue
 		}
 		if servers[1].Suffrage != raft.Voter {
-			return false, fmt.Errorf("bad: %v", servers)
+			t.Logf("bad: %v", servers)
+			continue
 		}
 		if servers[2].Suffrage != raft.Voter {
-			return false, fmt.Errorf("bad: %v", servers)
+			t.Logf("bad: %v", servers)
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }

--- a/consul/autopilot_test.go
+++ b/consul/autopilot_test.go
@@ -51,13 +51,13 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 
 	for _, s := range servers {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 3 {
-				break
+			if got, want := peers, 3; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 
 	// Bring up a new server
@@ -68,16 +68,17 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 	// Kill a non-leader server
 	s3.Shutdown()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		alive := 0
 		for _, m := range s1.LANMembers() {
 			if m.Status == serf.StatusAlive {
 				alive++
 			}
 		}
-		if alive == 2 {
-			break
+		if got, want := alive, 2; got != want {
+			t.Logf("got %d alive servers want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Join the new server
@@ -89,13 +90,13 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 	// Make sure the dead server is removed and we're back to 3 total peers
 	for _, s := range servers {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 3 {
-				break
+			if got, want := peers, 3; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 }
 
@@ -137,13 +138,13 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 
 	for _, s := range servers {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 4 {
-				break
+			if got, want := peers, 4; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 
 	// Kill a non-leader server
@@ -152,13 +153,13 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 	// Should be removed from the peers automatically
 	for _, s := range []*Server{s1, s2, s3} {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 3 {
-				break
+			if got, want := peers, 3; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 }
 
@@ -193,13 +194,13 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 
 	for _, s := range servers {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 3 {
-				break
+			if got, want := peers, 3; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
@@ -221,13 +222,13 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 	// Wait for s4 to be removed
 	for _, s := range []*Server{s1, s2, s3} {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 			peers, _ := s.numPeers()
-			if peers == 3 {
-				break
+			if got, want := peers, 3; got != want {
+				t.Logf("got %d peers want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 }
 
@@ -259,13 +260,11 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 	}
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	for r :=
 
-		// Wait for the new server to be added as a non-voter, but make sure
-		// it doesn't get promoted to a voter even after ServerStabilizationTime,
-		// because that would result in an even-numbered quorum count.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Wait for the new server to be added as a non-voter, but make sure
+	// it doesn't get promoted to a voter even after ServerStabilizationTime,
+	// because that would result in an even-numbered quorum count.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		future := s1.raft.GetConfiguration()
 		if err := future.Error(); err != nil {
 			t.Log(err)
@@ -273,7 +272,6 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 		}
 
 		servers := future.Configuration().Servers
-
 		if len(servers) != 2 {
 			t.Logf("bad: %v", servers)
 			continue
@@ -310,7 +308,6 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		future := s1.raft.GetConfiguration()
 		if err := future.Error(); err != nil {
 			t.Log(err)
@@ -318,7 +315,6 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 		}
 
 		servers := future.Configuration().Servers
-
 		if len(servers) != 3 {
 			t.Logf("bad: %v", servers)
 			continue
@@ -333,5 +329,4 @@ func TestAutopilot_PromoteNonVoter(t *testing.T) {
 		}
 		break
 	}
-
 }

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 )
@@ -603,12 +604,12 @@ func TestCatalog_ListNodes(t *testing.T) {
 	if err := s1.fsm.State().EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		return len(out.Nodes) == 2, nil
-	}); err != nil {
-		t.Fatal(err)
+		if len(out.Nodes) == 2 {
+			break
+		}
 	}
 
 	// Server node is auto added from Serf
@@ -646,12 +647,12 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 		},
 	}
 	var out structs.IndexedNodes
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		return len(out.Nodes) == 1, nil
-	}); err != nil {
-		t.Fatal(err)
+		if len(out.Nodes) == 1 {
+			break
+		}
 	}
 
 	// Verify that only the correct node was returned
@@ -677,14 +678,17 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Should get an empty list of nodes back
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Should get an empty list of nodes back
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		return len(out.Nodes) == 0, nil
-	}); err != nil {
-		t.Fatal(err)
+		if len(out.Nodes) == 0 {
+			break
+		}
 	}
+
 }
 
 func TestCatalog_ListNodes_StaleRaad(t *testing.T) {
@@ -890,12 +894,14 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 		Datacenter: "dc1",
 	}
 	var out structs.IndexedNodes
-	if err := testrpc.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		return len(out.Nodes) == 5, nil
-	}); err != nil {
-		t.Fatal(err)
+		if len(out.Nodes) == 5 {
+			break
+		}
 	}
+
 	if out.Nodes[0].Node != "aaa" {
 		t.Fatalf("bad: %v", out)
 	}
@@ -918,12 +924,14 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 		Datacenter: "dc1",
 		Source:     structs.QuerySource{Datacenter: "dc1", Node: "foo"},
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		return len(out.Nodes) == 5, nil
-	}); err != nil {
-		t.Fatal(err)
+		if len(out.Nodes) == 5 {
+			break
+		}
 	}
+
 	if out.Nodes[0].Node != "foo" {
 		t.Fatalf("bad: %v", out)
 	}

--- a/consul/catalog_endpoint_test.go
+++ b/consul/catalog_endpoint_test.go
@@ -605,11 +605,12 @@ func TestCatalog_ListNodes(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		if len(out.Nodes) == 2 {
-			break
+		if got, want := len(out.Nodes), 2; got != want {
+			t.Logf("got %d nodes want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Server node is auto added from Serf
@@ -648,11 +649,12 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 	}
 	var out structs.IndexedNodes
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		if len(out.Nodes) == 1 {
-			break
+		if got, want := len(out.Nodes), 1; got != want {
+			t.Logf("got %d nodes want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Verify that only the correct node was returned
@@ -678,17 +680,14 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Should get an empty list of nodes back
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		if len(out.Nodes) == 0 {
-			break
+		if got, want := len(out.Nodes), 0; got != want {
+			t.Logf("got %d nodes want %d", got, want)
+			continue
 		}
+		break
 	}
-
 }
 
 func TestCatalog_ListNodes_StaleRaad(t *testing.T) {
@@ -895,11 +894,12 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 	}
 	var out structs.IndexedNodes
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		if len(out.Nodes) == 5 {
-			break
+		if got, want := len(out.Nodes), 5; got != want {
+			t.Logf("got %d nodes want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	if out.Nodes[0].Node != "aaa" {
@@ -925,11 +925,12 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 		Source:     structs.QuerySource{Datacenter: "dc1", Node: "foo"},
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
-		if len(out.Nodes) == 5 {
-			break
+		if got, want := len(out.Nodes), 5; got != want {
+			t.Logf("got %d nodes want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	if out.Nodes[0].Node != "foo" {

--- a/consul/client_test.go
+++ b/consul/client_test.go
@@ -86,30 +86,32 @@ func TestClient_JoinLAN(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if c1.servers.NumServers() == 1 {
-			break
+		if got, want := c1.servers.NumServers(), 1; got != want {
+			t.Logf("got %d servers want %d", got, want)
+			continue
 		}
+		break
 	}
+	// Check the members
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		// Check the members
-
-		server_check := len(s1.LANMembers()) == 2
-		client_check := len(c1.LANMembers()) == 2
-		if server_check && client_check {
-			break
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
 		}
+		if got, want := len(c1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
+		}
+		break
 	}
+	// Check we have a new consul
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if
-
-		// Check we have a new consul
-
-		c1.servers.NumServers() == 1 {
-			break
+		if got, want := c1.servers.NumServers(), 1; got != want {
+			t.Logf("got %d servers want %d", got, want)
+			continue
 		}
+		break
 	}
-
 }
 
 func TestClient_JoinLAN_Invalid(t *testing.T) {
@@ -192,18 +194,14 @@ func TestClient_RPC(t *testing.T) {
 	if len(c1.LANMembers()) != 2 {
 		t.Fatalf("bad len")
 	}
-	for r :=
-
-		// RPC should succeed
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		err := c1.RPC("Status.Ping", struct{}{}, &out)
-		if err == nil {
-			break
+		if err != nil {
+			t.Log(err)
+			continue
 		}
-		t.Log(err)
+		break
 	}
-
 }
 
 func TestClient_RPC_Pool(t *testing.T) {
@@ -221,13 +219,17 @@ func TestClient_RPC_Pool(t *testing.T) {
 	if _, err := c1.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Wait for both agents to finish joining
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.LANMembers()) == 2 && len(c1.LANMembers()) == 2 {
-			break
+	// Wait for both agents to finish joining
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
 		}
+		if got, want := len(c1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Blast out a bunch of RPC requests at the same time to try to get
@@ -235,22 +237,19 @@ func TestClient_RPC_Pool(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 150; i++ {
 		wg.Add(1)
-
 		go func() {
 			defer wg.Done()
 			var out struct{}
 			for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 				err := c1.RPC("Status.Ping", struct{}{}, &out)
-				if err == nil {
-					break
+				if err != nil {
+					t.Log(err)
+					continue
 				}
-				t.Log(err)
+				break
 			}
-
 		}()
 	}
-
 	wg.Wait()
 }
 
@@ -355,28 +354,23 @@ func TestClient_RPC_TLS(t *testing.T) {
 	if _, err := c1.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Wait for joins to finish/RPC to succeed
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
-		if len(s1.LANMembers()) != 2 {
-			t.Logf("bad len: %v", len(s1.LANMembers()))
+	// Wait for joins to finish/RPC to succeed
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
 			continue
 		}
-
-		if len(c1.LANMembers()) != 2 {
-			t.Logf("bad len: %v", len(c1.LANMembers()))
+		if got, want := len(c1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
 			continue
 		}
-
 		err := c1.RPC("Status.Ping", struct{}{}, &out)
-		if err == nil {
-			break
+		if err != nil {
+			t.Log(err)
+			continue
 		}
-		t.Log(err)
+		break
 	}
-
 }
 
 func TestClient_SnapshotRPC(t *testing.T) {
@@ -400,13 +394,13 @@ func TestClient_SnapshotRPC(t *testing.T) {
 	if len(s1.LANMembers()) != 2 || len(c1.LANMembers()) != 2 {
 		t.Fatalf("Server has %v of %v expected members; Client has %v of %v expected members.", len(s1.LANMembers()), 2, len(c1.LANMembers()), 2)
 	}
-	for r :=
-
-		// Wait until we've got a healthy server.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if c1.servers.NumServers() == 1 {
-			break
+	// Wait until we've got a healthy server.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if got, want := c1.servers.NumServers(), 1; got != want {
+			t.Logf("got %d servers want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Take a snapshot.
@@ -460,13 +454,13 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	if len(s1.LANMembers()) != 2 || len(c1.LANMembers()) != 2 {
 		t.Fatalf("Server has %v of %v expected members; Client has %v of %v expected members.", len(s1.LANMembers()), 2, len(c1.LANMembers()), 2)
 	}
-	for r :=
-
-		// Wait until we've got a healthy server.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if c1.servers.NumServers() == 1 {
-			break
+	// Wait until we've got a healthy server.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if got, want := c1.servers.NumServers(), 1; got != want {
+			t.Logf("got %d servers want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Take a snapshot.
@@ -514,13 +508,16 @@ func TestClientServer_UserEvent(t *testing.T) {
 
 	// Wait for the leader
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	for r :=
-
-		// Check the members
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(c1.LANMembers()) == 2 && len(s1.LANMembers()) == 2 {
-			break
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
 		}
+		if got, want := len(c1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Fire the user event

--- a/consul/coordinate_endpoint_test.go
+++ b/consul/coordinate_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/coordinate"
 )
@@ -349,9 +350,11 @@ func TestCoordinate_ListNodes(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &arg3, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Now query back for all the nodes.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Now query back for all the nodes.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		arg := structs.DCSpecificRequest{
 			Datacenter: "dc1",
 		}
@@ -363,15 +366,15 @@ func TestCoordinate_ListNodes(t *testing.T) {
 			resp.Coordinates[0].Node != "bar" ||
 			resp.Coordinates[1].Node != "baz" ||
 			resp.Coordinates[2].Node != "foo" {
-			return false, fmt.Errorf("bad: %v", resp.Coordinates)
+			t.Logf("bad: %v", resp.Coordinates)
+			continue
 		}
 		verifyCoordinatesEqual(t, resp.Coordinates[0].Coord, arg2.Coord) // bar
 		verifyCoordinatesEqual(t, resp.Coordinates[1].Coord, arg3.Coord) // baz
-		verifyCoordinatesEqual(t, resp.Coordinates[2].Coord, arg1.Coord) // foo
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		verifyCoordinatesEqual(t, resp.Coordinates[2].Coord, arg1.Coord)
+		break // foo
 	}
+
 }
 
 func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
@@ -442,11 +445,13 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &arg3, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Wait for all the coordinate updates to apply. Since we aren't
-	// enforcing version 8 ACLs, this should also allow us to read
-	// everything back without a token.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Wait for all the coordinate updates to apply. Since we aren't
+		// enforcing version 8 ACLs, this should also allow us to read
+		// everything back without a token.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		arg := structs.DCSpecificRequest{
 			Datacenter: "dc1",
 		}
@@ -455,11 +460,10 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 		if len(resp.Coordinates) == 3 {
-			return true, nil
+			t.Log(nil)
+			break
 		}
-		return false, fmt.Errorf("bad: %v", resp.Coordinates)
-	}); err != nil {
-		t.Fatal(err)
+		continue
 	}
 
 	// Now that we've waited for the batch processing to ingest the

--- a/consul/coordinate_endpoint_test.go
+++ b/consul/coordinate_endpoint_test.go
@@ -350,11 +350,8 @@ func TestCoordinate_ListNodes(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &arg3, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Now query back for all the nodes.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Now query back for all the nodes.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		arg := structs.DCSpecificRequest{
 			Datacenter: "dc1",
 		}
@@ -371,10 +368,9 @@ func TestCoordinate_ListNodes(t *testing.T) {
 		}
 		verifyCoordinatesEqual(t, resp.Coordinates[0].Coord, arg2.Coord) // bar
 		verifyCoordinatesEqual(t, resp.Coordinates[1].Coord, arg3.Coord) // baz
-		verifyCoordinatesEqual(t, resp.Coordinates[2].Coord, arg1.Coord)
-		break // foo
+		verifyCoordinatesEqual(t, resp.Coordinates[2].Coord, arg1.Coord) // foo
+		break
 	}
-
 }
 
 func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
@@ -445,13 +441,10 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &arg3, &out); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Wait for all the coordinate updates to apply. Since we aren't
-		// enforcing version 8 ACLs, this should also allow us to read
-		// everything back without a token.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Wait for all the coordinate updates to apply. Since we aren't
+	// enforcing version 8 ACLs, this should also allow us to read
+	// everything back without a token.
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		arg := structs.DCSpecificRequest{
 			Datacenter: "dc1",
 		}
@@ -459,11 +452,11 @@ func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
 		if err := msgpackrpc.CallWithCodec(codec, "Coordinate.ListNodes", &arg, &resp); err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if len(resp.Coordinates) == 3 {
-			t.Log(nil)
-			break
+		if got, want := len(resp.Coordinates), 3; got != want {
+			t.Logf("got %d coordinates want %d", got, want)
+			continue
 		}
-		continue
+		break
 	}
 
 	// Now that we've waited for the batch processing to ingest the

--- a/consul/prepared_query_endpoint_test.go
+++ b/consul/prepared_query_endpoint_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/coordinate"
 )
@@ -1454,10 +1455,10 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	if _, err := s2.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatalf("Failed waiting for WAN join: %v", err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Create an ACL with read permission to the service.
@@ -2703,10 +2704,10 @@ func TestPreparedQuery_Wrapper(t *testing.T) {
 	if _, err := s2.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatalf("Failed waiting for WAN join: %v", err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Try all the operations on a real server via the wrapper.

--- a/consul/prepared_query_endpoint_test.go
+++ b/consul/prepared_query_endpoint_test.go
@@ -1456,9 +1456,11 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.WANMembers()) > 1 {
-			break
+		if got, want := len(s1.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Create an ACL with read permission to the service.
@@ -2705,9 +2707,11 @@ func TestPreparedQuery_Wrapper(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.WANMembers()) > 1 {
-			break
+		if got, want := len(s1.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Try all the operations on a real server via the wrapper.

--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-uuid"
 )
@@ -155,19 +156,20 @@ func TestServer_JoinLAN(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Check the members
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the members
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.LANMembers()) == 2 {
+			break
+		}
+	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s2.LANMembers()) == 2 {
+			break
+		}
 	}
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
-	}
 }
 
 func TestServer_JoinWAN(t *testing.T) {
@@ -185,30 +187,30 @@ func TestServer_JoinWAN(t *testing.T) {
 	if _, err := s2.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Check the members
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.WANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the members
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.WANMembers()) == 2 {
+			break
+		}
 	}
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.WANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s2.WANMembers()) == 2 {
+			break
+		}
 	}
 
 	// Check the router has both
 	if len(s1.router.GetDatacenters()) != 2 {
 		t.Fatalf("remote consul missing")
 	}
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.router.GetDatacenters()) == 2, nil
-	}); err != nil {
-		t.Fatal("remote consul missing")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s2.router.GetDatacenters()) == 2 {
+			break
+		}
 	}
+
 }
 
 func TestServer_JoinWAN_Flood(t *testing.T) {
@@ -228,11 +230,12 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 	}
 
 	for i, s := range []*Server{s1, s2} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
-			return len(s.WANMembers()) == 2, nil
-		}); err != nil {
-			t.Fatalf("bad len for server %d", i)
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+			if len(s.WANMembers()) == 2 {
+				break
+			}
 		}
+
 	}
 
 	dir3, s3 := testServer(t)
@@ -248,11 +251,12 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 	}
 
 	for i, s := range []*Server{s1, s2, s3} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
-			return len(s.WANMembers()) == 3, nil
-		}); err != nil {
-			t.Fatalf("bad len for server %d", i)
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+			if len(s.WANMembers()) == 3 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -290,33 +294,40 @@ func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
 	if _, err := s3.JoinLAN([]string{addrs2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Check the WAN members on s1
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.WANMembers()) == 3, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the WAN members on s1
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.WANMembers()) == 3 {
+			break
+		}
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if
 
-	// Check the WAN members on s2
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.WANMembers()) == 3, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the WAN members on s2
+
+		len(s2.WANMembers()) == 3 {
+			break
+		}
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if
 
-	// Check the LAN members on s2
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the LAN members on s2
+
+		len(s2.LANMembers()) == 2 {
+			break
+		}
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if
 
-	// Check the LAN members on s3
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s3.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the LAN members on s3
+
+		len(s3.LANMembers()) == 2 {
+			break
+		}
 	}
 
 	// Check the router has both
@@ -374,19 +385,21 @@ func TestServer_LeaveLeader(t *testing.T) {
 
 	var p1 int
 	var p2 int
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ = s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 2 peers %s", err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 2 peers %s", err)
+		if p2 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
 
 	// Issue a leave to the leader
@@ -401,12 +414,14 @@ func TestServer_LeaveLeader(t *testing.T) {
 
 	// Should lose a peer
 	for _, s := range []*Server{s1, s2} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			p1, _ = s.numPeers()
-			return p1 == 1, nil
-		}); err != nil {
-			t.Fatalf("should have 1 peer %s", err)
+			if p1 == 1 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -429,19 +444,21 @@ func TestServer_Leave(t *testing.T) {
 
 	var p1 int
 	var p2 int
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p1, _ = s1.numPeers()
-		return p1 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 2 peers %s", err)
+		if p1 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 2, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 2 peers %s", err)
+		if p2 == 2 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
 
 	// Issue a leave to the non-leader
@@ -456,12 +473,14 @@ func TestServer_Leave(t *testing.T) {
 
 	// Should lose a peer
 	for _, s := range []*Server{s1, s2} {
-		if err := testrpc.WaitForResult(func() (bool, error) {
+		for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 			p1, _ = s.numPeers()
-			return p1 == 1, nil
-		}); err != nil {
-			t.Fatalf("should have 1 peer %s", err)
+			if p1 == 1 {
+				break
+			}
 		}
+
 	}
 }
 
@@ -506,34 +525,36 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r :=
 
-	// Check the members
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+		// Check the members
+		retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.LANMembers()) == 2 {
+			break
+		}
 	}
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s2.LANMembers()) == 2, nil
-	}); err != nil {
-		t.Fatal("bad len")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s2.LANMembers()) == 2 {
+			break
+		}
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	// Verify Raft has established a peer
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Verify Raft has established a peer
+
 		peers, _ := s1.numPeers()
-		return peers == 2, nil
-	}); err != nil {
-		t.Fatalf("no peers")
+		if peers == 2 {
+			break
+		}
+	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
+		peers, _ := s2.numPeers()
+		if peers == 2 {
+			break
+		}
 	}
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		peers, _ := s2.numPeers()
-		return peers == 2, nil
-	}); err != nil {
-		t.Fatalf("no peers")
-	}
 }
 
 func TestServer_Expect(t *testing.T) {
@@ -565,20 +586,24 @@ func TestServer_Expect(t *testing.T) {
 
 	var p1 int
 	var p2 int
+	for r :=
 
-	// Should have no peers yet since the bootstrap didn't occur.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Should have no peers yet since the bootstrap didn't occur.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		p1, _ = s1.numPeers()
-		return p1 == 0, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p1 == 0 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 0, fmt.Errorf("%d", p2)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p2 == 0 {
+			break
+		}
+		t.Logf("%d", p2)
 	}
 
 	// Join the third node.
@@ -587,27 +612,32 @@ func TestServer_Expect(t *testing.T) {
 	}
 
 	var p3 int
+	for r :=
 
-	// Now we have three servers so we should bootstrap.
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Now we have three servers so we should bootstrap.
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		p1, _ = s1.numPeers()
-		return p1 == 3, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 3 peers %s", err)
+		if p1 == 3 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 3, fmt.Errorf("%d", p2)
-	}); err != nil {
-		t.Fatalf("should have 3 peers %s", err)
+		if p2 == 3 {
+			break
+		}
+		t.Logf("%d", p2)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p3, _ = s3.numPeers()
-		return p3 == 3, fmt.Errorf("%d", p3)
-	}); err != nil {
-		t.Fatalf("should have 3 peers %s", err)
+		if p3 == 3 {
+			break
+		}
+		t.Logf("%d", p3)
 	}
 
 	// Make sure a leader is elected, grab the current term and then add in
@@ -620,11 +650,13 @@ func TestServer_Expect(t *testing.T) {
 
 	// Wait for the new server to see itself added to the cluster.
 	var p4 int
-	if err := testrpc.WaitForResult(func() (bool, error) {
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
 		p4, _ = s4.numPeers()
-		return p4 == 4, fmt.Errorf("%d", p4)
-	}); err != nil {
-		t.Fatalf("should have 4 peers %s", err)
+		if p4 == 4 {
+			break
+		}
+		t.Logf("%d", p4)
 	}
 
 	// Make sure there's still a leader and that the term didn't change,
@@ -661,20 +693,24 @@ func TestServer_BadExpect(t *testing.T) {
 
 	var p1 int
 	var p2 int
+	for r :=
 
-	// should have no peers yet
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// should have no peers yet
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		p1, _ = s1.numPeers()
-		return p1 == 0, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p1 == 0 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 0, fmt.Errorf("%d", p2)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p2 == 0 {
+			break
+		}
+		t.Logf("%d", p2)
 	}
 
 	// join the third node
@@ -683,28 +719,34 @@ func TestServer_BadExpect(t *testing.T) {
 	}
 
 	var p3 int
+	for r :=
 
-	// should still have no peers (because s2 is in expect=2 mode)
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// should still have no peers (because s2 is in expect=2 mode)
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		p1, _ = s1.numPeers()
-		return p1 == 0, fmt.Errorf("%d", p1)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p1 == 0 {
+			break
+		}
+		t.Logf("%d", p1)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		p2, _ = s2.numPeers()
-		return p2 == 0, fmt.Errorf("%d", p2)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
+		if p2 == 0 {
+			break
+		}
+		t.Logf("%d", p2)
+	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+
+		p3, _ = s3.numPeers()
+		if p3 == 0 {
+			break
+		}
+		t.Logf("%d", p3)
 	}
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		p3, _ = s3.numPeers()
-		return p3 == 0, fmt.Errorf("%d", p3)
-	}); err != nil {
-		t.Fatalf("should have 0 peers %s", err)
-	}
 }
 
 type fakeGlobalResp struct{}
@@ -721,11 +763,10 @@ func TestServer_globalRPCErrors(t *testing.T) {
 	dir1, s1 := testServerDC(t, "dc1")
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
-
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.router.GetDatacenters()) == 1, nil
-	}); err != nil {
-		t.Fatalf("did not join WAN")
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.router.GetDatacenters()) == 1 {
+			break
+		}
 	}
 
 	// Check that an error from a remote DC is returned

--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -156,20 +156,18 @@ func TestServer_JoinLAN(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Check the members
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.LANMembers()) == 2 {
-			break
-		}
-	}
+	// Check the members
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s2.LANMembers()) == 2 {
-			break
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s1 want %d", got, want)
+			continue
 		}
+		if got, want := len(s2.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
-
 }
 
 func TestServer_JoinWAN(t *testing.T) {
@@ -187,18 +185,17 @@ func TestServer_JoinWAN(t *testing.T) {
 	if _, err := s2.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Check the members
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.WANMembers()) == 2 {
-			break
-		}
-	}
+	// Check the members
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s2.WANMembers()) == 2 {
-			break
+		if got, want := len(s1.WANMembers()), 2; got != want {
+			t.Logf("got %d WAN members for s1 want %d", got, want)
+			continue
 		}
+		if got, want := len(s2.WANMembers()), 2; got != want {
+			t.Logf("got %d WAN members for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Check the router has both
@@ -206,11 +203,12 @@ func TestServer_JoinWAN(t *testing.T) {
 		t.Fatalf("remote consul missing")
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s2.router.GetDatacenters()) == 2 {
-			break
+		if got, want := len(s2.router.GetDatacenters()), 2; got != want {
+			t.Logf("got %d datacenters want %d", got, want)
+			continue
 		}
+		break
 	}
-
 }
 
 func TestServer_JoinWAN_Flood(t *testing.T) {
@@ -229,13 +227,14 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	for i, s := range []*Server{s1, s2} {
+	for _, s := range []*Server{s1, s2} {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-			if len(s.WANMembers()) == 2 {
-				break
+			if got, want := len(s.WANMembers()), 2; got != want {
+				t.Logf("got %d WAN members want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 
 	dir3, s3 := testServer(t)
@@ -250,13 +249,14 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	for i, s := range []*Server{s1, s2, s3} {
+	for _, s := range []*Server{s1, s2, s3} {
 		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-			if len(s.WANMembers()) == 3 {
-				break
+			if got, want := len(s.WANMembers()), 3; got != want {
+				t.Logf("got %d WAN members want %d", got, want)
+				continue
 			}
+			break
 		}
-
 	}
 }
 
@@ -294,40 +294,24 @@ func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
 	if _, err := s3.JoinLAN([]string{addrs2}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Check the WAN members on s1
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.WANMembers()) == 3 {
-			break
-		}
-	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if
-
-		// Check the WAN members on s2
-
-		len(s2.WANMembers()) == 3 {
-			break
+		if got, want := len(s1.WANMembers()), 3; got != want {
+			t.Logf("got %d WAN members for s1 want %d", got, want)
+			continue
 		}
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if
-
-		// Check the LAN members on s2
-
-		len(s2.LANMembers()) == 2 {
-			break
+		if got, want := len(s2.WANMembers()), 3; got != want {
+			t.Logf("got %d WAN members for s2 want %d", got, want)
+			continue
 		}
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if
-
-		// Check the LAN members on s3
-
-		len(s3.LANMembers()) == 2 {
-			break
+		if got, want := len(s2.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s2 want %d", got, want)
+			continue
 		}
+		if got, want := len(s3.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s3 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Check the router has both
@@ -383,23 +367,18 @@ func TestServer_LeaveLeader(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p1 int
-	var p2 int
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 2 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 2 {
-			break
+		p2, _ := s2.numPeers()
+		if got, want := p2, 2; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	// Issue a leave to the leader
@@ -413,15 +392,18 @@ func TestServer_LeaveLeader(t *testing.T) {
 	}
 
 	// Should lose a peer
-	for _, s := range []*Server{s1, s2} {
-		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-			p1, _ = s.numPeers()
-			if p1 == 1 {
-				break
-			}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		p1, _ := s1.numPeers()
+		if got, want := p1, 1; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-
+		p2, _ := s2.numPeers()
+		if got, want := p2, 1; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
 }
 
@@ -442,23 +424,18 @@ func TestServer_Leave(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p1 int
-	var p2 int
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 2 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 2 {
-			break
+		p2, _ := s2.numPeers()
+		if got, want := p2, 2; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p1)
+		break
 	}
 
 	// Issue a leave to the non-leader
@@ -472,15 +449,18 @@ func TestServer_Leave(t *testing.T) {
 	}
 
 	// Should lose a peer
-	for _, s := range []*Server{s1, s2} {
-		for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-			p1, _ = s.numPeers()
-			if p1 == 1 {
-				break
-			}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		p1, _ := s1.numPeers()
+		if got, want := p1, 1; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-
+		p2, _ := s2.numPeers()
+		if got, want := p2, 1; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
 }
 
@@ -525,36 +505,27 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 	if _, err := s2.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	for r :=
-
-		// Check the members
-		retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.LANMembers()) == 2 {
-			break
-		}
-	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s2.LANMembers()) == 2 {
-			break
+		if got, want := len(s1.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s1 want %d", got, want)
+			continue
 		}
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		// Verify Raft has established a peer
-
-		peers, _ := s1.numPeers()
-		if peers == 2 {
-			break
+		if got, want := len(s2.LANMembers()), 2; got != want {
+			t.Logf("got %d LAN members for s2 want %d", got, want)
+			continue
 		}
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		peers, _ := s2.numPeers()
-		if peers == 2 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 2; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
+		p2, _ := s2.numPeers()
+		if got, want := p2, 2; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
-
 }
 
 func TestServer_Expect(t *testing.T) {
@@ -584,26 +555,19 @@ func TestServer_Expect(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p1 int
-	var p2 int
-	for r :=
-
-		// Should have no peers yet since the bootstrap didn't occur.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 0 {
-			break
-		}
-		t.Logf("%d", p1)
-	}
+	// Should have no peers yet since the bootstrap didn't occur.
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 0 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 0; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p2)
+		p2, _ := s2.numPeers()
+		if got, want := p2, 0; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Join the third node.
@@ -611,33 +575,23 @@ func TestServer_Expect(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p3 int
-	for r :=
-
-		// Now we have three servers so we should bootstrap.
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 3 {
-			break
-		}
-		t.Logf("%d", p1)
-	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 3 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 3; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p2)
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p3, _ = s3.numPeers()
-		if p3 == 3 {
-			break
+		p2, _ := s2.numPeers()
+		if got, want := p2, 3; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p3)
+		p3, _ := s3.numPeers()
+		if got, want := p3, 3; got != want {
+			t.Logf("got %d peers for s3 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Make sure a leader is elected, grab the current term and then add in
@@ -649,14 +603,28 @@ func TestServer_Expect(t *testing.T) {
 	}
 
 	// Wait for the new server to see itself added to the cluster.
-	var p4 int
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p4, _ = s4.numPeers()
-		if p4 == 4 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 4; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p4)
+		p2, _ := s2.numPeers()
+		if got, want := p2, 4; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		p3, _ := s3.numPeers()
+		if got, want := p3, 4; got != want {
+			t.Logf("got %d peers for s3 want %d", got, want)
+			continue
+		}
+		p4, _ := s4.numPeers()
+		if got, want := p4, 4; got != want {
+			t.Logf("got %d peers for s4 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// Make sure there's still a leader and that the term didn't change,
@@ -691,26 +659,18 @@ func TestServer_BadExpect(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p1 int
-	var p2 int
-	for r :=
-
-		// should have no peers yet
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 0 {
-			break
-		}
-		t.Logf("%d", p1)
-	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 0 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 0; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p2)
+		p2, _ := s2.numPeers()
+		if got, want := p2, 0; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
+		}
+		break
 	}
 
 	// join the third node
@@ -718,35 +678,25 @@ func TestServer_BadExpect(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var p3 int
-	for r :=
-
-		// should still have no peers (because s2 is in expect=2 mode)
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p1, _ = s1.numPeers()
-		if p1 == 0 {
-			break
-		}
-		t.Logf("%d", p1)
-	}
+	// should still have no peers (because s2 is in expect=2 mode)
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p2, _ = s2.numPeers()
-		if p2 == 0 {
-			break
+		p1, _ := s1.numPeers()
+		if got, want := p1, 0; got != want {
+			t.Logf("got %d peers for s1 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p2)
-	}
-	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
-		p3, _ = s3.numPeers()
-		if p3 == 0 {
-			break
+		p2, _ := s2.numPeers()
+		if got, want := p2, 0; got != want {
+			t.Logf("got %d peers for s2 want %d", got, want)
+			continue
 		}
-		t.Logf("%d", p3)
+		p3, _ := s3.numPeers()
+		if got, want := p3, 0; got != want {
+			t.Logf("got %d peers for s3 want %d", got, want)
+			continue
+		}
+		break
 	}
-
 }
 
 type fakeGlobalResp struct{}
@@ -764,9 +714,11 @@ func TestServer_globalRPCErrors(t *testing.T) {
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.router.GetDatacenters()) == 1 {
-			break
+		if got, want := len(s1.router.GetDatacenters()), 1; got != want {
+			t.Logf("got %d datacenters want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Check that an error from a remote DC is returned

--- a/consul/session_ttl_test.go
+++ b/consul/session_ttl_test.go
@@ -299,11 +299,12 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-
 		peers, _ := s1.numPeers()
-		if peers == 3 {
-			break
+		if got, want := peers, 3; got != want {
+			t.Logf("got %d peers want %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Find the leader
@@ -362,11 +363,8 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 	if len(leader.sessionTimers) != 0 {
 		t.Fatalf("session timers should be empty on the shutdown leader")
 	}
-	for r :=
-
-		// Find the new leader
-		retry.OneSec(); r.NextOr(t.FailNow); {
-
+	// Find the new leader
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 		leader = nil
 		for _, s := range servers {
 			if s.IsLeader() {
@@ -377,7 +375,6 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 			t.Log("Should have a new leader")
 			continue
 		}
-
 		// Ensure session timer is restored
 		if _, ok := leader.sessionTimers[id1]; !ok {
 			t.Log("missing session timer")
@@ -385,5 +382,4 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 		}
 		break
 	}
-
 }

--- a/consul/session_ttl_test.go
+++ b/consul/session_ttl_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 )
 
@@ -297,12 +298,12 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 	if _, err := s3.JoinLAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
 
-	if err := testrpc.WaitForResult(func() (bool, error) {
 		peers, _ := s1.numPeers()
-		return peers == 3, nil
-	}); err != nil {
-		t.Fatalf("should have 3 peers %s", err)
+		if peers == 3 {
+			break
+		}
 	}
 
 	// Find the leader
@@ -361,9 +362,11 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 	if len(leader.sessionTimers) != 0 {
 		t.Fatalf("session timers should be empty on the shutdown leader")
 	}
+	for r :=
 
-	// Find the new leader
-	if err := testrpc.WaitForResult(func() (bool, error) {
+		// Find the new leader
+		retry.OneSec(); r.NextOr(t.FailNow); {
+
 		leader = nil
 		for _, s := range servers {
 			if s.IsLeader() {
@@ -371,16 +374,16 @@ func TestServer_SessionTTL_Failover(t *testing.T) {
 			}
 		}
 		if leader == nil {
-			return false, fmt.Errorf("Should have a new leader")
+			t.Log("Should have a new leader")
+			continue
 		}
 
 		// Ensure session timer is restored
 		if _, ok := leader.sessionTimers[id1]; !ok {
-			return false, fmt.Errorf("missing session timer")
+			t.Log("missing session timer")
+			continue
 		}
-
-		return true, nil
-	}); err != nil {
-		t.Fatal(err)
+		break
 	}
+
 }

--- a/consul/snapshot_endpoint_test.go
+++ b/consul/snapshot_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 )
 
@@ -330,10 +331,10 @@ func TestSnapshot_Forward_Datacenter(t *testing.T) {
 	if _, err := s2.JoinWAN([]string{addr}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := testrpc.WaitForResult(func() (bool, error) {
-		return len(s1.WANMembers()) > 1, nil
-	}); err != nil {
-		t.Fatalf("failed to join WAN: %s", err)
+	for r := retry.OneSec(); r.NextOr(t.FailNow); {
+		if len(s1.WANMembers()) > 1 {
+			break
+		}
 	}
 
 	// Run a snapshot from each server locally and remotely to ensure we

--- a/consul/snapshot_endpoint_test.go
+++ b/consul/snapshot_endpoint_test.go
@@ -332,9 +332,11 @@ func TestSnapshot_Forward_Datacenter(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	for r := retry.OneSec(); r.NextOr(t.FailNow); {
-		if len(s1.WANMembers()) > 1 {
-			break
+		if got, want := len(s1.WANMembers()), 2; got < want {
+			t.Logf("got %d WAN members want at least %d", got, want)
+			continue
 		}
+		break
 	}
 
 	// Run a snapshot from each server locally and remotely to ensure we

--- a/testutil/retry/retry.go
+++ b/testutil/retry/retry.go
@@ -1,0 +1,92 @@
+// Package retry provides support for repeating operations in tests.
+//
+// A sample retry operation looks like this:
+//
+//   func TestX(t *testing.T) {
+//       for r := retry.OneSec(); r.NextOr(t.FailNow); {
+//           if err := foo(); err != nil {
+//               t.Log("f: ", err)
+//               continue
+//           }
+//           break
+//       }
+//   }
+//
+// A sample retry operation which exits a test with a message
+// looks like this:
+//
+//   func TestX(t *testing.T) {
+//       for r := retry.OneSec(); r.NextOr(func(){ t.Fatal("foo failed") }); {
+//           if err := foo(); err != nil {
+//               t.Log("f: ", err)
+//               continue
+//           }
+//           break
+//       }
+//   }
+package retry
+
+import "time"
+
+// OneSec repeats an operation for one second and waits 25ms in between.
+func OneSec() *Timer {
+	return &Timer{Timeout: time.Second, Wait: 25 * time.Millisecond}
+}
+
+// ThreeTimes repeats an operation three times and waits 25ms in between.
+func ThreeTimes() *Counter {
+	return &Counter{Count: 3, Wait: 25 * time.Millisecond}
+}
+
+// Retryer provides an interface for repeating operations
+// until they succeed or an exit condition is met.
+type Retryer interface {
+	// NextOr returns true if the operation should be repeated.
+	// Otherwise, it calls fail and returns false.
+	NextOr(fail func()) bool
+}
+
+// Counter repeats an operation a given number of
+// times and waits between subsequent operations.
+type Counter struct {
+	Count int
+	Wait  time.Duration
+
+	count int
+}
+
+func (r *Counter) NextOr(fail func()) bool {
+	if r.count == r.Count {
+		fail()
+		return false
+	}
+	if r.count > 0 {
+		time.Sleep(r.Wait)
+	}
+	r.count++
+	return true
+}
+
+// Timer repeats an operation for a given amount
+// of time and waits between subsequent operations.
+type Timer struct {
+	Timeout time.Duration
+	Wait    time.Duration
+
+	// stop is the timeout deadline.
+	// Set on the first invocation of Next().
+	stop time.Time
+}
+
+func (r *Timer) NextOr(fail func()) bool {
+	if r.stop.IsZero() {
+		r.stop = time.Now().Add(r.Timeout)
+		return true
+	}
+	if time.Now().After(r.stop) {
+		fail()
+		return false
+	}
+	time.Sleep(r.Wait)
+	return true
+}

--- a/testutil/retry/retry_test.go
+++ b/testutil/retry/retry_test.go
@@ -1,0 +1,43 @@
+package retry
+
+import (
+	"testing"
+	"time"
+)
+
+// delta defines the time band a test run should complete in.
+var delta = 5 * time.Millisecond
+
+func TestRetryer(t *testing.T) {
+	tests := []struct {
+		desc string
+		r    Retryer
+	}{
+		{"counter", &Counter{Count: 3, Wait: 10 * time.Millisecond}},
+		{"timer", &Timer{Timeout: 20 * time.Millisecond, Wait: 10 * time.Millisecond}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var iters, fails int
+			fail := func() { fails++ }
+			start := time.Now()
+			for tt.r.NextOr(fail) {
+				iters++
+			}
+			dur := time.Since(start)
+			if got, want := iters, 3; got != want {
+				t.Fatalf("got %d retries want %d", got, want)
+			}
+			if got, want := fails, 1; got != want {
+				t.Fatalf("got %d FailNow calls want %d", got, want)
+			}
+			// since the first iteration happens immediately
+			// the retryer waits only twice for three iterations.
+			// order of events: (true, (wait) true, (wait) true, false)
+			if got, want := dur, 20*time.Millisecond; got < (want-delta) || got > (want+delta) {
+				t.Fatalf("loop took %v want %v (+/- %v)", got, want, delta)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current retry framework in testutil/testprc.WaitForResult uses
callbacks to execute a function until it succeeds. It accepts a boolean
parameter as ok/nok and captures the error if any. At the end the test
is failed with Fatal and the last error.

This skews the line numbers in the error messages and makes the test
functions more complex than they need to be since both the bool value
and the error can indicate whether the operation succeeded or not.
Therefore, one of them is redundant.

The new retry framework uses a simple for-loop without callbacks to
retain the correct callstack since the Go testing lib does not offer an
option to specify the callstack depth for correct line numbers.

Since this requires refactoring the test functions in general this patch
also shows the use of the github.com/pascaldekloe/goe/verify library
which provides a good mechanism for comparing nested data structures.
Instead of just converting the tests from testutil.WaitForResult to
retry the tests that performing a nested comparison of data structures
are converted to the verify library at the same time.