### PR TITLE
Fix the build on Illumos.

### DIFF
--- a/vendor/github.com/docker/docker/LICENSE
+++ b/vendor/github.com/docker/docker/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2013-2016 Docker, Inc.
+   Copyright 2013-2017 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/docker/docker/NOTICE
+++ b/vendor/github.com/docker/docker/NOTICE
@@ -1,5 +1,5 @@
 Docker
-Copyright 2012-2016 Docker, Inc.
+Copyright 2012-2017 Docker, Inc.
 
 This product includes software developed at Docker, Inc. (https://www.docker.com).
 

--- a/vendor/github.com/docker/docker/pkg/system/events_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/events_windows.go
@@ -6,6 +6,8 @@ package system
 import (
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -67,7 +69,7 @@ func PulseEvent(handle syscall.Handle) (err error) {
 	return setResetPulse(handle, procPulseEvent)
 }
 
-func setResetPulse(handle syscall.Handle, proc *syscall.LazyProc) (err error) {
+func setResetPulse(handle syscall.Handle, proc *windows.LazyProc) (err error) {
 	r0, _, _ := proc.Call(uintptr(handle))
 	if r0 != 0 {
 		err = syscall.Errno(r0)

--- a/vendor/github.com/docker/docker/pkg/system/exitcode.go
+++ b/vendor/github.com/docker/docker/pkg/system/exitcode.go
@@ -1,0 +1,33 @@
+package system
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// GetExitCode returns the ExitStatus of the specified error if its type is
+// exec.ExitError, returns 0 and an error otherwise.
+func GetExitCode(err error) (int, error) {
+	exitCode := 0
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return procExit.ExitStatus(), nil
+		}
+	}
+	return exitCode, fmt.Errorf("failed to get exit code")
+}
+
+// ProcessExitCode process the specified error and returns the exit status code
+// if the error was of type exec.ExitError, returns nothing otherwise.
+func ProcessExitCode(err error) (exitCode int) {
+	if err != nil {
+		var exiterr error
+		if exitCode, exiterr = GetExitCode(err); exiterr != nil {
+			// TODO: Fix this so we check the error's text.
+			// we've failed to retrieve exit code, so we set it to 127
+			exitCode = 127
+		}
+	}
+	return
+}

--- a/vendor/github.com/docker/docker/pkg/system/filesys.go
+++ b/vendor/github.com/docker/docker/pkg/system/filesys.go
@@ -3,9 +3,16 @@
 package system
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
+
+// MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
+// ACL'd for Builtin Administrators and Local System.
+func MkdirAllWithACL(path string, perm os.FileMode) error {
+	return MkdirAll(path, perm)
+}
 
 // MkdirAll creates a directory named path along with any necessary parents,
 // with permission specified by attribute perm for all dir created.
@@ -16,4 +23,46 @@ func MkdirAll(path string, perm os.FileMode) error {
 // IsAbs is a platform-specific wrapper for filepath.IsAbs.
 func IsAbs(path string) bool {
 	return filepath.IsAbs(path)
+}
+
+// The functions below here are wrappers for the equivalents in the os and ioutils packages.
+// They are passthrough on Unix platforms, and only relevant on Windows.
+
+// CreateSequential creates the named file with mode 0666 (before umask), truncating
+// it if it already exists. If successful, methods on the returned
+// File can be used for I/O; the associated file descriptor has mode
+// O_RDWR.
+// If there is an error, it will be of type *PathError.
+func CreateSequential(name string) (*os.File, error) {
+	return os.Create(name)
+}
+
+// OpenSequential opens the named file for reading. If successful, methods on
+// the returned file can be used for reading; the associated file
+// descriptor has mode O_RDONLY.
+// If there is an error, it will be of type *PathError.
+func OpenSequential(name string) (*os.File, error) {
+	return os.Open(name)
+}
+
+// OpenFileSequential is the generalized open call; most users will use Open
+// or Create instead. It opens the named file with specified flag
+// (O_RDONLY etc.) and perm, (0666 etc.) if applicable. If successful,
+// methods on the returned File can be used for I/O.
+// If there is an error, it will be of type *PathError.
+func OpenFileSequential(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+// TempFileSequential creates a new temporary file in the directory dir
+// with a name beginning with prefix, opens the file for reading
+// and writing, and returns the resulting *os.File.
+// If dir is the empty string, TempFile uses the default directory
+// for temporary files (see os.TempDir).
+// Multiple programs calling TempFile simultaneously
+// will not choose the same file. The caller can use f.Name()
+// to find the pathname of the file. It is the caller's responsibility
+// to remove the file when no longer needed.
+func TempFileSequential(dir, prefix string) (f *os.File, err error) {
+	return ioutil.TempFile(dir, prefix)
 }

--- a/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/filesys_windows.go
@@ -6,17 +6,36 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
+	"unsafe"
+
+	winio "github.com/Microsoft/go-winio"
 )
 
+// MkdirAllWithACL is a wrapper for MkdirAll that creates a directory
+// ACL'd for Builtin Administrators and Local System.
+func MkdirAllWithACL(path string, perm os.FileMode) error {
+	return mkdirall(path, true)
+}
+
 // MkdirAll implementation that is volume path aware for Windows.
-func MkdirAll(path string, perm os.FileMode) error {
+func MkdirAll(path string, _ os.FileMode) error {
+	return mkdirall(path, false)
+}
+
+// mkdirall is a custom version of os.MkdirAll modified for use on Windows
+// so that it is both volume path aware, and can create a directory with
+// a DACL.
+func mkdirall(path string, adminAndLocalSystem bool) error {
 	if re := regexp.MustCompile(`^\\\\\?\\Volume{[a-z0-9-]+}$`); re.MatchString(path) {
 		return nil
 	}
 
-	// The rest of this method is copied from os.MkdirAll and should be kept
+	// The rest of this method is largely copied from os.MkdirAll and should be kept
 	// as-is to ensure compatibility.
 
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
@@ -45,14 +64,19 @@ func MkdirAll(path string, perm os.FileMode) error {
 
 	if j > 1 {
 		// Create parent
-		err = MkdirAll(path[0:j-1], perm)
+		err = mkdirall(path[0:j-1], false)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Parent now exists; invoke Mkdir and use its result.
-	err = os.Mkdir(path, perm)
+	// Parent now exists; invoke os.Mkdir or mkdirWithACL and use its result.
+	if adminAndLocalSystem {
+		err = mkdirWithACL(path)
+	} else {
+		err = os.Mkdir(path, 0)
+	}
+
 	if err != nil {
 		// Handle arguments like "foo/." by
 		// double-checking that directory doesn't exist.
@@ -61,6 +85,36 @@ func MkdirAll(path string, perm os.FileMode) error {
 			return nil
 		}
 		return err
+	}
+	return nil
+}
+
+// mkdirWithACL creates a new directory. If there is an error, it will be of
+// type *PathError. .
+//
+// This is a modified and combined version of os.Mkdir and syscall.Mkdir
+// in golang to cater for creating a directory am ACL permitting full
+// access, with inheritance, to any subfolder/file for Built-in Administrators
+// and Local System.
+func mkdirWithACL(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: e}
 	}
 	return nil
 }
@@ -79,4 +133,159 @@ func IsAbs(path string) bool {
 		}
 	}
 	return true
+}
+
+// The origin of the functions below here are the golang OS and syscall packages,
+// slightly modified to only cope with files, not directories due to the
+// specific use case.
+//
+// The alteration is to allow a file on Windows to be opened with
+// FILE_FLAG_SEQUENTIAL_SCAN (particular for docker load), to avoid eating
+// the standby list, particularly when accessing large files such as layer.tar.
+
+// CreateSequential creates the named file with mode 0666 (before umask), truncating
+// it if it already exists. If successful, methods on the returned
+// File can be used for I/O; the associated file descriptor has mode
+// O_RDWR.
+// If there is an error, it will be of type *PathError.
+func CreateSequential(name string) (*os.File, error) {
+	return OpenFileSequential(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0)
+}
+
+// OpenSequential opens the named file for reading. If successful, methods on
+// the returned file can be used for reading; the associated file
+// descriptor has mode O_RDONLY.
+// If there is an error, it will be of type *PathError.
+func OpenSequential(name string) (*os.File, error) {
+	return OpenFileSequential(name, os.O_RDONLY, 0)
+}
+
+// OpenFileSequential is the generalized open call; most users will use Open
+// or Create instead.
+// If there is an error, it will be of type *PathError.
+func OpenFileSequential(name string, flag int, _ os.FileMode) (*os.File, error) {
+	if name == "" {
+		return nil, &os.PathError{Op: "open", Path: name, Err: syscall.ENOENT}
+	}
+	r, errf := syscallOpenFileSequential(name, flag, 0)
+	if errf == nil {
+		return r, nil
+	}
+	return nil, &os.PathError{Op: "open", Path: name, Err: errf}
+}
+
+func syscallOpenFileSequential(name string, flag int, _ os.FileMode) (file *os.File, err error) {
+	r, e := syscallOpenSequential(name, flag|syscall.O_CLOEXEC, 0)
+	if e != nil {
+		return nil, e
+	}
+	return os.NewFile(uintptr(r), name), nil
+}
+
+func makeInheritSa() *syscall.SecurityAttributes {
+	var sa syscall.SecurityAttributes
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	return &sa
+}
+
+func syscallOpenSequential(path string, mode int, _ uint32) (fd syscall.Handle, err error) {
+	if len(path) == 0 {
+		return syscall.InvalidHandle, syscall.ERROR_FILE_NOT_FOUND
+	}
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return syscall.InvalidHandle, err
+	}
+	var access uint32
+	switch mode & (syscall.O_RDONLY | syscall.O_WRONLY | syscall.O_RDWR) {
+	case syscall.O_RDONLY:
+		access = syscall.GENERIC_READ
+	case syscall.O_WRONLY:
+		access = syscall.GENERIC_WRITE
+	case syscall.O_RDWR:
+		access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+	}
+	if mode&syscall.O_CREAT != 0 {
+		access |= syscall.GENERIC_WRITE
+	}
+	if mode&syscall.O_APPEND != 0 {
+		access &^= syscall.GENERIC_WRITE
+		access |= syscall.FILE_APPEND_DATA
+	}
+	sharemode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE)
+	var sa *syscall.SecurityAttributes
+	if mode&syscall.O_CLOEXEC == 0 {
+		sa = makeInheritSa()
+	}
+	var createmode uint32
+	switch {
+	case mode&(syscall.O_CREAT|syscall.O_EXCL) == (syscall.O_CREAT | syscall.O_EXCL):
+		createmode = syscall.CREATE_NEW
+	case mode&(syscall.O_CREAT|syscall.O_TRUNC) == (syscall.O_CREAT | syscall.O_TRUNC):
+		createmode = syscall.CREATE_ALWAYS
+	case mode&syscall.O_CREAT == syscall.O_CREAT:
+		createmode = syscall.OPEN_ALWAYS
+	case mode&syscall.O_TRUNC == syscall.O_TRUNC:
+		createmode = syscall.TRUNCATE_EXISTING
+	default:
+		createmode = syscall.OPEN_EXISTING
+	}
+	// Use FILE_FLAG_SEQUENTIAL_SCAN rather than FILE_ATTRIBUTE_NORMAL as implemented in golang.
+	//https://msdn.microsoft.com/en-us/library/windows/desktop/aa363858(v=vs.85).aspx
+	const fileFlagSequentialScan = 0x08000000 // FILE_FLAG_SEQUENTIAL_SCAN
+	h, e := syscall.CreateFile(pathp, access, sharemode, sa, createmode, fileFlagSequentialScan, 0)
+	return h, e
+}
+
+// Helpers for TempFileSequential
+var rand uint32
+var randmu sync.Mutex
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+func nextSuffix() string {
+	randmu.Lock()
+	r := rand
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	rand = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+// TempFileSequential is a copy of ioutil.TempFile, modified to use sequential
+// file access. Below is the original comment from golang:
+// TempFile creates a new temporary file in the directory dir
+// with a name beginning with prefix, opens the file for reading
+// and writing, and returns the resulting *os.File.
+// If dir is the empty string, TempFile uses the default directory
+// for temporary files (see os.TempDir).
+// Multiple programs calling TempFile simultaneously
+// will not choose the same file. The caller can use f.Name()
+// to find the pathname of the file. It is the caller's responsibility
+// to remove the file when no longer needed.
+func TempFileSequential(dir, prefix string) (f *os.File, err error) {
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	nconflict := 0
+	for i := 0; i < 10000; i++ {
+		name := filepath.Join(dir, prefix+nextSuffix())
+		f, err = OpenFileSequential(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		if os.IsExist(err) {
+			if nconflict++; nconflict > 10 {
+				randmu.Lock()
+				rand = reseed()
+				randmu.Unlock()
+			}
+			continue
+		}
+		break
+	}
+	return
 }

--- a/vendor/github.com/docker/docker/pkg/system/lstat_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/lstat_unix.go
@@ -2,9 +2,7 @@
 
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
 // Lstat takes a path to a file and returns
 // a system.StatT type pertaining to that file.

--- a/vendor/github.com/docker/docker/pkg/system/lstat_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/lstat_windows.go
@@ -1,25 +1,14 @@
-// +build windows
-
 package system
 
-import (
-	"os"
-)
+import "os"
 
 // Lstat calls os.Lstat to get a fileinfo interface back.
 // This is then copied into our own locally defined structure.
-// Note the Linux version uses fromStatT to do the copy back,
-// but that not strictly necessary when already in an OS specific module.
 func Lstat(path string) (*StatT, error) {
 	fi, err := os.Lstat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return &StatT{
-		name:    fi.Name(),
-		size:    fi.Size(),
-		mode:    fi.Mode(),
-		modTime: fi.ModTime(),
-		isDir:   fi.IsDir()}, nil
+	return fromStatT(&fi)
 }

--- a/vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go
+++ b/vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 )
 
+// #cgo CFLAGS: -std=c99
 // #cgo LDFLAGS: -lkstat
 // #include <unistd.h>
 // #include <stdlib.h>
@@ -89,7 +90,7 @@ func ReadMemInfo() (*MemInfo, error) {
 
 	if ppKernel < 0 || MemTotal < 0 || MemFree < 0 || SwapTotal < 0 ||
 		SwapFree < 0 {
-		return nil, fmt.Errorf("Error getting system memory info %v\n", err)
+		return nil, fmt.Errorf("error getting system memory info %v\n", err)
 	}
 
 	meminfo := &MemInfo{}

--- a/vendor/github.com/docker/docker/pkg/system/meminfo_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/meminfo_windows.go
@@ -1,12 +1,13 @@
 package system
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
-	modkernel32 = syscall.NewLazyDLL("kernel32.dll")
+	modkernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
 	procGlobalMemoryStatusEx = modkernel32.NewProc("GlobalMemoryStatusEx")
 )

--- a/vendor/github.com/docker/docker/pkg/system/process_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/process_unix.go
@@ -1,0 +1,22 @@
+// +build linux freebsd solaris darwin
+
+package system
+
+import (
+	"syscall"
+)
+
+// IsProcessAlive returns true if process with a given pid is running.
+func IsProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, syscall.Signal(0))
+	if err == nil || err == syscall.EPERM {
+		return true
+	}
+
+	return false
+}
+
+// KillProcess force-stops a process.
+func KillProcess(pid int) {
+	syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/vendor/github.com/docker/docker/pkg/system/stat_darwin.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_darwin.go
@@ -1,12 +1,8 @@
-// +build !linux,!windows,!freebsd,!solaris,!openbsd
-
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
-// fromStatT creates a system.StatT type from a syscall.Stat_t type
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return &StatT{size: s.Size,
 		mode: uint32(s.Mode),

--- a/vendor/github.com/docker/docker/pkg/system/stat_freebsd.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_freebsd.go
@@ -1,8 +1,6 @@
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
 // fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
@@ -12,16 +10,4 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
 		mtim: s.Mtimespec}, nil
-}
-
-// Stat takes a path to a file and returns
-// a system.Stat_t type pertaining to that file.
-//
-// Throws an error if the file does not exist
-func Stat(path string) (*StatT, error) {
-	s := &syscall.Stat_t{}
-	if err := syscall.Stat(path, s); err != nil {
-		return nil, err
-	}
-	return fromStatT(s)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_linux.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_linux.go
@@ -1,33 +1,19 @@
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
 // fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return &StatT{size: s.Size,
-		mode: s.Mode,
+		mode: uint32(s.Mode),
 		uid:  s.Uid,
 		gid:  s.Gid,
-		rdev: s.Rdev,
+		rdev: uint64(s.Rdev),
 		mtim: s.Mtim}, nil
 }
 
-// FromStatT exists only on linux, and loads a system.StatT from a
-// syscal.Stat_t.
+// FromStatT converts a syscall.Stat_t type to a system.Stat_t type
+// This is exposed on Linux as pkg/archive/changes uses it.
 func FromStatT(s *syscall.Stat_t) (*StatT, error) {
-	return fromStatT(s)
-}
-
-// Stat takes a path to a file and returns
-// a system.StatT type pertaining to that file.
-//
-// Throws an error if the file does not exist
-func Stat(path string) (*StatT, error) {
-	s := &syscall.Stat_t{}
-	if err := syscall.Stat(path, s); err != nil {
-		return nil, err
-	}
 	return fromStatT(s)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_openbsd.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_openbsd.go
@@ -1,10 +1,8 @@
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
-// fromStatT creates a system.StatT type from a syscall.Stat_t type
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return &StatT{size: s.Size,
 		mode: uint32(s.Mode),

--- a/vendor/github.com/docker/docker/pkg/system/stat_solaris.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_solaris.go
@@ -1,12 +1,8 @@
-// +build solaris
-
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
-// fromStatT creates a system.StatT type from a syscall.Stat_t type
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 	return &StatT{size: s.Size,
 		mode: uint32(s.Mode),
@@ -14,21 +10,4 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
 		mtim: s.Mtim}, nil
-}
-
-// FromStatT loads a system.StatT from a syscal.Stat_t.
-func FromStatT(s *syscall.Stat_t) (*StatT, error) {
-	return fromStatT(s)
-}
-
-// Stat takes a path to a file and returns
-// a system.StatT type pertaining to that file.
-//
-// Throws an error if the file does not exist
-func Stat(path string) (*StatT, error) {
-	s := &syscall.Stat_t{}
-	if err := syscall.Stat(path, s); err != nil {
-		return nil, err
-	}
-	return fromStatT(s)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_unix.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_unix.go
@@ -2,9 +2,7 @@
 
 package system
 
-import (
-	"syscall"
-)
+import "syscall"
 
 // StatT type contains status of a file. It contains metadata
 // like permission, owner, group, size, etc about a file.
@@ -47,7 +45,14 @@ func (s StatT) Mtim() syscall.Timespec {
 	return s.mtim
 }
 
-// GetLastModification returns file's last modification time.
-func (s StatT) GetLastModification() syscall.Timespec {
-	return s.Mtim()
+// Stat takes a path to a file and returns
+// a system.StatT type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*StatT, error) {
+	s := &syscall.Stat_t{}
+	if err := syscall.Stat(path, s); err != nil {
+		return nil, err
+	}
+	return fromStatT(s)
 }

--- a/vendor/github.com/docker/docker/pkg/system/stat_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/stat_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package system
 
 import (
@@ -8,18 +6,11 @@ import (
 )
 
 // StatT type contains status of a file. It contains metadata
-// like name, permission, size, etc about a file.
+// like permission, size, etc about a file.
 type StatT struct {
-	name    string
-	size    int64
-	mode    os.FileMode
-	modTime time.Time
-	isDir   bool
-}
-
-// Name returns file's name.
-func (s StatT) Name() string {
-	return s.name
+	mode os.FileMode
+	size int64
+	mtim time.Time
 }
 
 // Size returns file's size.
@@ -29,15 +20,30 @@ func (s StatT) Size() int64 {
 
 // Mode returns file's permission mode.
 func (s StatT) Mode() os.FileMode {
-	return s.mode
+	return os.FileMode(s.mode)
 }
 
-// ModTime returns file's last modification time.
-func (s StatT) ModTime() time.Time {
-	return s.modTime
+// Mtim returns file's last modification time.
+func (s StatT) Mtim() time.Time {
+	return time.Time(s.mtim)
 }
 
-// IsDir returns whether file is actually a directory.
-func (s StatT) IsDir() bool {
-	return s.isDir
+// Stat takes a path to a file and returns
+// a system.StatT type pertaining to that file.
+//
+// Throws an error if the file does not exist
+func Stat(path string) (*StatT, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	return fromStatT(&fi)
+}
+
+// fromStatT converts a os.FileInfo type to a system.StatT type
+func fromStatT(fi *os.FileInfo) (*StatT, error) {
+	return &StatT{
+		size: (*fi).Size(),
+		mode: (*fi).Mode(),
+		mtim: (*fi).ModTime()}, nil
 }

--- a/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
+++ b/vendor/github.com/docker/docker/pkg/system/syscall_windows.go
@@ -53,6 +53,8 @@ func GetOSVersion() OSVersion {
 }
 
 // IsWindowsClient returns true if the SKU is client
+// @engine maintainers - this function should not be removed or modified as it
+// is used to enforce licensing restrictions on Windows.
 func IsWindowsClient() bool {
 	osviex := &osVersionInfoEx{OSVersionInfoSize: 284}
 	r1, _, err := procGetVersionExW.Call(uintptr(unsafe.Pointer(osviex)))

--- a/vendor/github.com/docker/docker/pkg/system/utimes_darwin.go
+++ b/vendor/github.com/docker/docker/pkg/system/utimes_darwin.go
@@ -1,8 +1,0 @@
-package system
-
-import "syscall"
-
-// LUtimesNano is not supported by darwin platform.
-func LUtimesNano(path string, ts []syscall.Timespec) error {
-	return ErrNotSupportedPlatform
-}

--- a/vendor/github.com/docker/docker/pkg/system/utimes_unsupported.go
+++ b/vendor/github.com/docker/docker/pkg/system/utimes_unsupported.go
@@ -1,10 +1,10 @@
-// +build !linux,!freebsd,!darwin
+// +build !linux,!freebsd
 
 package system
 
 import "syscall"
 
-// LUtimesNano is not supported on platforms other than linux, freebsd and darwin.
+// LUtimesNano is only supported on linux and freebsd.
 func LUtimesNano(path string, ts []syscall.Timespec) error {
 	return ErrNotSupportedPlatform
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -360,10 +360,10 @@
 			"revisionTime": "2016-08-09T18:56:09Z"
 		},
 		{
-			"checksumSHA1": "Eh3iu/9RzHzNY4vHHPKaZISAgBo=",
+			"checksumSHA1": "SXjPQfi84j+BFZi4Fl1c/OC/f7M=",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "eb28dde01f165849bf372e18200e83042c76f26c",
-			"revisionTime": "2016-08-09T18:56:09Z"
+			"revision": "f1571e8b67b4014189e356d20d4f388f0e9e88d3",
+			"revisionTime": "2017-04-28T23:08:38Z"
 		},
 		{
 			"checksumSHA1": "hZV62Xzt/i0e/WBKWww3rpkRAR4=",


### PR DESCRIPTION
Update `github.com/docker/docker/pkg/system`.

The only actual fix requird is `vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go` but I updated the entire package since it was chalk full of portability fixes.

Without this fix it is not possible to build `consul` on Illumos:

```
# github.com/hashicorp/consul/vendor/github.com/docker/docker/pkg/system
vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go: In function 'allocSwaptable':
vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go:22:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
 // for (int i = 0; i < num; i++,swapent++) {
  ^
vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go:22:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go: In function 'freeSwaptable':
vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go:30:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
 // for (int i = 0; i < st->swt_n; i++,swapent++) {
  ^
```