### PR TITLE
Add `AddAccessibleService` to testutil

### DIFF
--- a/testutil/README.md
+++ b/testutil/README.md
@@ -58,6 +58,9 @@ func TestFoo_bar(t *testing.T) {
 	// Create a service
 	srv1.AddService(t, "redis", structs.HealthPassing, []string{"master"})
 
+	// Create a service that will be accessed in target source code
+	srv1.AddAccessibleService("redis", structs.HealthPassing, "127.0.0.1", 6379, []string{"master"})
+
 	// Create a service check
 	srv1.AddCheck(t, "service:redis", "redis", structs.HealthPassing)
 

--- a/testutil/server_methods.go
+++ b/testutil/server_methods.go
@@ -109,9 +109,20 @@ func (s *TestServer) ListKV(t *testing.T, prefix string) []string {
 // automatically adds a health check with the given status, which
 // can be one of "passing", "warning", or "critical".
 func (s *TestServer) AddService(t *testing.T, name, status string, tags []string) {
+	s.AddAddressableService(t, name, status, "", 0, tags) // set empty address and 0 as port for non-accessible service
+}
+
+// AddAddressableService adds a new service to the Consul instance by
+// passing "address" and "port". It is helpful when you need to prepare a fakeService
+// that maybe accessed with in target source code.
+// It also automatically adds a health check with the given status, which
+// can be one of "passing", "warning", or "critical", just like `AddService` does.
+func (s *TestServer) AddAddressableService(t *testing.T, name, status, address string, port int, tags []string) {
 	svc := &TestService{
-		Name: name,
-		Tags: tags,
+		Name:    name,
+		Tags:    tags,
+		Address: address,
+		Port:    port,
 	}
 	payload, err := s.encodePayload(svc)
 	if err != nil {

--- a/testutil/server_wrapper.go
+++ b/testutil/server_wrapper.go
@@ -56,6 +56,10 @@ func (w *WrappedServer) AddService(name, status string, tags []string) {
 	w.s.AddService(w.t, name, status, tags)
 }
 
+func (w *WrappedServer) AddAddressableService(name, status, address string, port int, tags []string) {
+	w.s.AddAddressableService(w.t, name, status, address, port, tags)
+}
+
 func (w *WrappedServer) AddCheck(name, serviceID, status string) {
 	w.s.AddCheck(w.t, name, serviceID, status)
 }


### PR DESCRIPTION
`AddAccessibleService` works just like `AddService` but also passing
"address" and "port". It is helpfu when you need to prepare a
fakeService that will be accessed later in target source code.

This is a rebase. Closes #2375 