### PR TITLE
Use bind address as source for outgoing connections (#2822)

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -290,11 +290,9 @@ func Create(config *Config, logOutput io.Writer, logWriter *logger.LogWriter,
 // consulConfig is used to return a consul configuration
 func (a *Agent) consulConfig() *consul.Config {
 	// Start with the provided config or default config
-	var base *consul.Config
+	base := consul.DefaultConfig()
 	if a.config.ConsulConfig != nil {
 		base = a.config.ConsulConfig
-	} else {
-		base = consul.DefaultConfig()
 	}
 
 	// This is set when the agent starts up
@@ -346,10 +344,9 @@ func (a *Agent) consulConfig() *consul.Config {
 	}
 	if a.config.AdvertiseAddr != "" {
 		base.SerfLANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddr
+		base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddr
 		if a.config.AdvertiseAddrWan != "" {
 			base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddrWan
-		} else {
-			base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.AdvertiseAddr
 		}
 		base.RPCAdvertise = &net.TCPAddr{
 			IP:   net.ParseIP(a.config.AdvertiseAddr),
@@ -445,8 +442,7 @@ func (a *Agent) consulConfig() *consul.Config {
 	if len(revision) > 8 {
 		revision = revision[:8]
 	}
-	base.Build = fmt.Sprintf("%s%s:%s",
-		a.config.Version, a.config.VersionPrerelease, revision)
+	base.Build = fmt.Sprintf("%s%s:%s", a.config.Version, a.config.VersionPrerelease, revision)
 
 	// Copy the TLS configuration
 	base.VerifyIncoming = a.config.VerifyIncoming || a.config.VerifyIncomingRPC

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -439,6 +439,11 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.RPCAdvertise = base.RPCAddr
 	}
 
+	// set the src address for outgoing rpc connections
+	// to RPCAdvertise with port 0 so that outgoing
+	// connections use a random port.
+	base.RPCSrcAddr = &net.TCPAddr{IP: base.RPCAdvertise.IP}
+
 	// Format the build string
 	revision := a.config.Revision
 	if len(revision) > 8 {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -437,6 +437,11 @@ func (a *Agent) consulConfig() *consul.Config {
 		base.AutopilotConfig.DisableUpgradeMigration = *a.config.Autopilot.DisableUpgradeMigration
 	}
 
+	// make sure the advertise address is always set
+	if base.RPCAdvertise == nil {
+		base.RPCAdvertise = base.RPCAddr
+	}
+
 	// Format the build string
 	revision := a.config.Revision
 	if len(revision) > 8 {

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -337,6 +337,7 @@ func TestAgent_Reload(t *testing.T) {
 
 	args := []string{
 		"-server",
+		"-advertise", "127.0.0.1",
 		"-data-dir", tmpDir,
 		"-http-port", fmt.Sprintf("%d", conf.Ports.HTTP),
 		"-config-file", tmpFile.Name(),

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -195,12 +195,12 @@ func TestAgent_CheckSerfBindAddrsSettings(t *testing.T) {
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
 
-	serfWanBind := agent.consulConfig().SerfWANConfig.MemberlistConfig.BindAddr
+	serfWanBind := consulConfig(agent).SerfWANConfig.MemberlistConfig.BindAddr
 	if serfWanBind != ip {
 		t.Fatalf("SerfWanBindAddr is should be a non-loopback IP not %s", serfWanBind)
 	}
 
-	serfLanBind := agent.consulConfig().SerfLANConfig.MemberlistConfig.BindAddr
+	serfLanBind := consulConfig(agent).SerfLANConfig.MemberlistConfig.BindAddr
 	if serfLanBind != ip {
 		t.Fatalf("SerfLanBindAddr is should be a non-loopback IP not %s", serfWanBind)
 	}
@@ -214,23 +214,23 @@ func TestAgent_CheckAdvertiseAddrsSettings(t *testing.T) {
 	defer os.RemoveAll(dir)
 	defer agent.Shutdown()
 
-	serfLanAddr := agent.consulConfig().SerfLANConfig.MemberlistConfig.AdvertiseAddr
+	serfLanAddr := consulConfig(agent).SerfLANConfig.MemberlistConfig.AdvertiseAddr
 	if serfLanAddr != "127.0.0.42" {
 		t.Fatalf("SerfLan is not properly set to '127.0.0.42': %s", serfLanAddr)
 	}
-	serfLanPort := agent.consulConfig().SerfLANConfig.MemberlistConfig.AdvertisePort
+	serfLanPort := consulConfig(agent).SerfLANConfig.MemberlistConfig.AdvertisePort
 	if serfLanPort != 1233 {
 		t.Fatalf("SerfLan is not properly set to '1233': %d", serfLanPort)
 	}
-	serfWanAddr := agent.consulConfig().SerfWANConfig.MemberlistConfig.AdvertiseAddr
+	serfWanAddr := consulConfig(agent).SerfWANConfig.MemberlistConfig.AdvertiseAddr
 	if serfWanAddr != "127.0.0.43" {
 		t.Fatalf("SerfWan is not properly set to '127.0.0.43': %s", serfWanAddr)
 	}
-	serfWanPort := agent.consulConfig().SerfWANConfig.MemberlistConfig.AdvertisePort
+	serfWanPort := consulConfig(agent).SerfWANConfig.MemberlistConfig.AdvertisePort
 	if serfWanPort != 1234 {
 		t.Fatalf("SerfWan is not properly set to '1234': %d", serfWanPort)
 	}
-	rpc := agent.consulConfig().RPCAdvertise
+	rpc := consulConfig(agent).RPCAdvertise
 	if rpc != c.AdvertiseAddrs.RPC {
 		t.Fatalf("RPC is not properly set to %v: %s", c.AdvertiseAddrs.RPC, rpc)
 	}
@@ -253,7 +253,7 @@ func TestAgent_CheckPerformanceSettings(t *testing.T) {
 		defer agent.Shutdown()
 
 		raftMult := time.Duration(consul.DefaultRaftMultiplier)
-		r := agent.consulConfig().RaftConfig
+		r := consulConfig(agent).RaftConfig
 		def := raft.DefaultConfig()
 		if r.HeartbeatTimeout != raftMult*def.HeartbeatTimeout ||
 			r.ElectionTimeout != raftMult*def.ElectionTimeout ||
@@ -271,7 +271,7 @@ func TestAgent_CheckPerformanceSettings(t *testing.T) {
 		defer agent.Shutdown()
 
 		const raftMult time.Duration = 99
-		r := agent.consulConfig().RaftConfig
+		r := consulConfig(agent).RaftConfig
 		def := raft.DefaultConfig()
 		if r.HeartbeatTimeout != raftMult*def.HeartbeatTimeout ||
 			r.ElectionTimeout != raftMult*def.ElectionTimeout ||
@@ -288,12 +288,12 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 		defer os.RemoveAll(dir)
 		defer agent.Shutdown()
 
-		lan := agent.consulConfig().SerfLANConfig.ReconnectTimeout
+		lan := consulConfig(agent).SerfLANConfig.ReconnectTimeout
 		if lan != 3*24*time.Hour {
 			t.Fatalf("bad: %s", lan.String())
 		}
 
-		wan := agent.consulConfig().SerfWANConfig.ReconnectTimeout
+		wan := consulConfig(agent).SerfWANConfig.ReconnectTimeout
 		if wan != 3*24*time.Hour {
 			t.Fatalf("bad: %s", wan.String())
 		}
@@ -307,12 +307,12 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 		defer os.RemoveAll(dir)
 		defer agent.Shutdown()
 
-		lan := agent.consulConfig().SerfLANConfig.ReconnectTimeout
+		lan := consulConfig(agent).SerfLANConfig.ReconnectTimeout
 		if lan != 24*time.Hour {
 			t.Fatalf("bad: %s", lan.String())
 		}
 
-		wan := agent.consulConfig().SerfWANConfig.ReconnectTimeout
+		wan := consulConfig(agent).SerfWANConfig.ReconnectTimeout
 		if wan != 36*time.Hour {
 			t.Fatalf("bad: %s", wan.String())
 		}
@@ -327,7 +327,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 	defer agent.Shutdown()
 
 	// The auto-assigned ID should be valid.
-	id := agent.consulConfig().NodeID
+	id := consulConfig(agent).NodeID
 	if _, err := uuid.ParseUUID(string(id)); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 	if err := agent.setupNodeID(c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if newID := agent.consulConfig().NodeID; id != newID {
+	if newID := consulConfig(agent).NodeID; id != newID {
 		t.Fatalf("bad: %q vs %q", id, newID)
 	}
 
@@ -357,7 +357,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 	if err := agent.setupNodeID(c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if id := agent.consulConfig().NodeID; string(id) != newID {
+	if id := consulConfig(agent).NodeID; string(id) != newID {
 		t.Fatalf("bad: %q vs. %q", id, newID)
 	}
 
@@ -380,7 +380,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 	if err := agent.setupNodeID(c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if id := agent.consulConfig().NodeID; string(id) != "adf4238a-882b-9ddc-4a9d-5b6758e4159e" {
+	if id := consulConfig(agent).NodeID; string(id) != "adf4238a-882b-9ddc-4a9d-5b6758e4159e" {
 		t.Fatalf("bad: %q vs. %q", id, newID)
 	}
 }
@@ -1984,4 +1984,12 @@ func TestAgent_GetCoordinate(t *testing.T) {
 
 	check(true)
 	check(false)
+}
+
+func consulConfig(a *Agent) *consul.Config {
+	c, err := a.consulConfig()
+	if err != nil {
+		panic(err)
+	}
+	return c
 }

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1,13 +1,9 @@
 package agent
 
 import (
-	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"log"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -30,9 +26,6 @@ import (
 	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/scada-client/scada"
 	"github.com/mitchellh/cli"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
-	compute "google.golang.org/api/compute/v1"
 )
 
 // gracefulTimeout controls how long we wait before forcefully terminating
@@ -434,150 +427,6 @@ func (c *Command) readConfig() *Config {
 	config.VersionPrerelease = c.VersionPrerelease
 
 	return config
-}
-
-// of instance ips that match the tags given in GCETags.
-func (c *Config) discoverGCEHosts(logger *log.Logger) ([]string, error) {
-	config := c.RetryJoinGCE
-	ctx := oauth2.NoContext
-	var client *http.Client
-	var err error
-
-	logger.Printf("[INFO] agent: Initializing GCE client")
-	if config.CredentialsFile != "" {
-		logger.Printf("[INFO] agent: Loading credentials from %s", config.CredentialsFile)
-		key, err := ioutil.ReadFile(config.CredentialsFile)
-		if err != nil {
-			return nil, err
-		}
-		jwtConfig, err := google.JWTConfigFromJSON(key, compute.ComputeScope)
-		if err != nil {
-			return nil, err
-		}
-		client = jwtConfig.Client(ctx)
-	} else {
-		logger.Printf("[INFO] agent: Using default credential chain")
-		client, err = google.DefaultClient(ctx, compute.ComputeScope)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	computeService, err := compute.New(client)
-	if err != nil {
-		return nil, err
-	}
-
-	if config.ProjectName == "" {
-		logger.Printf("[INFO] agent: No GCE project provided, will discover from metadata.")
-		config.ProjectName, err = gceProjectIDFromMetadata(logger)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		logger.Printf("[INFO] agent: Using pre-defined GCE project name: %s", config.ProjectName)
-	}
-
-	zones, err := gceDiscoverZones(ctx, logger, computeService, config.ProjectName, config.ZonePattern)
-	if err != nil {
-		return nil, err
-	}
-
-	logger.Printf("[INFO] agent: Discovering GCE hosts with tag %s in zones: %s", config.TagValue, strings.Join(zones, ", "))
-
-	var servers []string
-	for _, zone := range zones {
-		addresses, err := gceInstancesAddressesForZone(ctx, logger, computeService, config.ProjectName, zone, config.TagValue)
-		if err != nil {
-			return nil, err
-		}
-		if len(addresses) > 0 {
-			logger.Printf("[INFO] agent: Discovered %d instances in %s/%s: %v", len(addresses), config.ProjectName, zone, addresses)
-		}
-		servers = append(servers, addresses...)
-	}
-
-	return servers, nil
-}
-
-// gceProjectIDFromMetadata queries the metadata service on GCE to get the
-// project ID (name) of an instance.
-func gceProjectIDFromMetadata(logger *log.Logger) (string, error) {
-	logger.Printf("[INFO] agent: Attempting to discover GCE project from metadata.")
-	client := &http.Client{}
-
-	req, err := http.NewRequest("GET", "http://metadata.google.internal/computeMetadata/v1/project/project-id", nil)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Add("Metadata-Flavor", "Google")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	defer resp.Body.Close()
-
-	project, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	logger.Printf("[INFO] agent: GCE project discovered as: %s", project)
-	return string(project), nil
-}
-
-// gceDiscoverZones discovers a list of zones from a supplied zone pattern, or
-// all of the zones available to a project.
-func gceDiscoverZones(ctx context.Context, logger *log.Logger, computeService *compute.Service, project, pattern string) ([]string, error) {
-	var zones []string
-
-	if pattern != "" {
-		logger.Printf("[INFO] agent: Discovering zones for project %s matching pattern: %s", project, pattern)
-	} else {
-		logger.Printf("[INFO] agent: Discovering all zones available to project: %s", project)
-	}
-
-	call := computeService.Zones.List(project)
-	if pattern != "" {
-		call = call.Filter(fmt.Sprintf("name eq %s", pattern))
-	}
-
-	if err := call.Pages(ctx, func(page *compute.ZoneList) error {
-		for _, v := range page.Items {
-			zones = append(zones, v.Name)
-		}
-		return nil
-	}); err != nil {
-		return zones, err
-	}
-
-	logger.Printf("[INFO] agent: Discovered GCE zones: %s", strings.Join(zones, ", "))
-	return zones, nil
-}
-
-// gceInstancesAddressesForZone locates all instances within a specific project
-// and zone, matching the supplied tag. Only the private IP addresses are
-// returned, but ID is also logged.
-func gceInstancesAddressesForZone(ctx context.Context, logger *log.Logger, computeService *compute.Service, project, zone, tag string) ([]string, error) {
-	var addresses []string
-	call := computeService.Instances.List(project, zone)
-	if err := call.Pages(ctx, func(page *compute.InstanceList) error {
-		for _, v := range page.Items {
-			for _, t := range v.Tags.Items {
-				if t == tag && len(v.NetworkInterfaces) > 0 && v.NetworkInterfaces[0].NetworkIP != "" {
-					addresses = append(addresses, v.NetworkInterfaces[0].NetworkIP)
-				}
-			}
-		}
-		return nil
-	}); err != nil {
-		return addresses, err
-	}
-
-	return addresses, nil
 }
 
 // setupAgent is used to start the agent and various interfaces

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -20,12 +20,6 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/armon/go-metrics/circonus"
 	"github.com/armon/go-metrics/datadog"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/defaults"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/consul/command/base"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/lib"
@@ -442,67 +436,6 @@ func (c *Command) readConfig() *Config {
 	return config
 }
 
-// where EC2TagKey = EC2TagValue
-func (c *Config) discoverEc2Hosts(logger *log.Logger) ([]string, error) {
-	config := c.RetryJoinEC2
-
-	ec2meta := ec2metadata.New(session.New())
-	if config.Region == "" {
-		logger.Printf("[INFO] agent: No EC2 region provided, querying instance metadata endpoint...")
-		identity, err := ec2meta.GetInstanceIdentityDocument()
-		if err != nil {
-			return nil, err
-		}
-		config.Region = identity.Region
-	}
-
-	awsConfig := &aws.Config{
-		Region: &config.Region,
-		Credentials: credentials.NewChainCredentials(
-			[]credentials.Provider{
-				&credentials.StaticProvider{
-					Value: credentials.Value{
-						AccessKeyID:     config.AccessKeyID,
-						SecretAccessKey: config.SecretAccessKey,
-					},
-				},
-				&credentials.EnvProvider{},
-				&credentials.SharedCredentialsProvider{},
-				defaults.RemoteCredProvider(*(defaults.Config()), defaults.Handlers()),
-			}),
-	}
-
-	svc := ec2.New(session.New(), awsConfig)
-
-	resp, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("tag:" + config.TagKey),
-				Values: []*string{
-					aws.String(config.TagValue),
-				},
-			},
-		},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	var servers []string
-	for i := range resp.Reservations {
-		for _, instance := range resp.Reservations[i].Instances {
-			// Terminated instances don't have the PrivateIpAddress field
-			if instance.PrivateIpAddress != nil {
-				servers = append(servers, *instance.PrivateIpAddress)
-			}
-		}
-	}
-
-	return servers, nil
-}
-
-// discoverGCEHosts searches a Google Compute Engine region, returning a list
 // of instance ips that match the tags given in GCETags.
 func (c *Config) discoverGCEHosts(logger *log.Logger) ([]string, error) {
 	config := c.RetryJoinGCE

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -442,50 +442,6 @@ func (c *Command) readConfig() *Config {
 	return config
 }
 
-// verifyUniqueListeners checks to see if an address was used more than once in
-// the config
-func (c *Config) verifyUniqueListeners() error {
-	listeners := []struct {
-		host  string
-		port  int
-		descr string
-	}{
-		{c.Addresses.DNS, c.Ports.DNS, "DNS"},
-		{c.Addresses.HTTP, c.Ports.HTTP, "HTTP"},
-		{c.Addresses.HTTPS, c.Ports.HTTPS, "HTTPS"},
-		{c.AdvertiseAddr, c.Ports.Server, "Server RPC"},
-		{c.AdvertiseAddr, c.Ports.SerfLan, "Serf LAN"},
-		{c.AdvertiseAddr, c.Ports.SerfWan, "Serf WAN"},
-	}
-
-	type key struct {
-		host string
-		port int
-	}
-	m := make(map[key]string, len(listeners))
-
-	for _, l := range listeners {
-		if l.host == "" {
-			l.host = "0.0.0.0"
-		} else if strings.HasPrefix(l.host, "unix") {
-			// Don't compare ports on unix sockets
-			l.port = 0
-		}
-		if l.host == "0.0.0.0" && l.port <= 0 {
-			continue
-		}
-
-		k := key{l.host, l.port}
-		v, ok := m[k]
-		if ok {
-			return fmt.Errorf("%s address already configured for %s", l.descr, v)
-		}
-		m[k] = l.descr
-	}
-	return nil
-}
-
-// discoverEc2Hosts searches an AWS region, returning a list of instance ips
 // where EC2TagKey = EC2TagValue
 func (c *Config) discoverEc2Hosts(logger *log.Logger) ([]string, error) {
 	config := c.RetryJoinEC2

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -924,24 +924,23 @@ func (c *Config) ClientListener(override string, port int) (net.Addr, error) {
 func (c *Config) GetTokenForAgent() string {
 	if c.ACLAgentToken != "" {
 		return c.ACLAgentToken
-	} else if c.ACLToken != "" {
-		return c.ACLToken
-	} else {
-		return ""
 	}
+	if c.ACLToken != "" {
+		return c.ACLToken
+	}
+	return ""
 }
 
 // DecodeConfig reads the configuration from the given reader in JSON
 // format and decodes it into a proper Config structure.
 func DecodeConfig(r io.Reader) (*Config, error) {
 	var raw interface{}
-	var result Config
-	dec := json.NewDecoder(r)
-	if err := dec.Decode(&raw); err != nil {
+	if err := json.NewDecoder(r).Decode(&raw); err != nil {
 		return nil, err
 	}
 
 	// Check the result type
+	var result Config
 	if obj, ok := raw.(map[string]interface{}); ok {
 		// Check for a "services", "service" or "check" key, meaning
 		// this is actually a definition entry

--- a/command/agent/config_aws.go
+++ b/command/agent/config_aws.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+// discoverEc2Hosts searches an AWS region, returning a list of instance ips
+// where EC2TagKey = EC2TagValue
+func (c *Config) discoverEc2Hosts(logger *log.Logger) ([]string, error) {
+	config := c.RetryJoinEC2
+
+	ec2meta := ec2metadata.New(session.New())
+	if config.Region == "" {
+		logger.Printf("[INFO] agent: No EC2 region provided, querying instance metadata endpoint...")
+		identity, err := ec2meta.GetInstanceIdentityDocument()
+		if err != nil {
+			return nil, err
+		}
+		config.Region = identity.Region
+	}
+
+	awsConfig := &aws.Config{
+		Region: &config.Region,
+		Credentials: credentials.NewChainCredentials(
+			[]credentials.Provider{
+				&credentials.StaticProvider{
+					Value: credentials.Value{
+						AccessKeyID:     config.AccessKeyID,
+						SecretAccessKey: config.SecretAccessKey,
+					},
+				},
+				&credentials.EnvProvider{},
+				&credentials.SharedCredentialsProvider{},
+				defaults.RemoteCredProvider(*(defaults.Config()), defaults.Handlers()),
+			}),
+	}
+
+	svc := ec2.New(session.New(), awsConfig)
+
+	resp, err := svc.DescribeInstances(&ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:" + config.TagKey),
+				Values: []*string{
+					aws.String(config.TagValue),
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var servers []string
+	for i := range resp.Reservations {
+		for _, instance := range resp.Reservations[i].Instances {
+			// Terminated instances don't have the PrivateIpAddress field
+			if instance.PrivateIpAddress != nil {
+				servers = append(servers, *instance.PrivateIpAddress)
+			}
+		}
+	}
+
+	return servers, nil
+}

--- a/command/agent/config_gce.go
+++ b/command/agent/config_gce.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	compute "google.golang.org/api/compute/v1"
+)
+
+// discoverGCEHosts searches a Google Compute Engine region, returning a list
+// of instance ips that match the tags given in GCETags.
+func (c *Config) discoverGCEHosts(logger *log.Logger) ([]string, error) {
+	config := c.RetryJoinGCE
+	ctx := oauth2.NoContext
+	var client *http.Client
+	var err error
+
+	logger.Printf("[INFO] agent: Initializing GCE client")
+	if config.CredentialsFile != "" {
+		logger.Printf("[INFO] agent: Loading credentials from %s", config.CredentialsFile)
+		key, err := ioutil.ReadFile(config.CredentialsFile)
+		if err != nil {
+			return nil, err
+		}
+		jwtConfig, err := google.JWTConfigFromJSON(key, compute.ComputeScope)
+		if err != nil {
+			return nil, err
+		}
+		client = jwtConfig.Client(ctx)
+	} else {
+		logger.Printf("[INFO] agent: Using default credential chain")
+		client, err = google.DefaultClient(ctx, compute.ComputeScope)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	computeService, err := compute.New(client)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.ProjectName == "" {
+		logger.Printf("[INFO] agent: No GCE project provided, will discover from metadata.")
+		config.ProjectName, err = gceProjectIDFromMetadata(logger)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		logger.Printf("[INFO] agent: Using pre-defined GCE project name: %s", config.ProjectName)
+	}
+
+	zones, err := gceDiscoverZones(ctx, logger, computeService, config.ProjectName, config.ZonePattern)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Printf("[INFO] agent: Discovering GCE hosts with tag %s in zones: %s", config.TagValue, strings.Join(zones, ", "))
+
+	var servers []string
+	for _, zone := range zones {
+		addresses, err := gceInstancesAddressesForZone(ctx, logger, computeService, config.ProjectName, zone, config.TagValue)
+		if err != nil {
+			return nil, err
+		}
+		if len(addresses) > 0 {
+			logger.Printf("[INFO] agent: Discovered %d instances in %s/%s: %v", len(addresses), config.ProjectName, zone, addresses)
+		}
+		servers = append(servers, addresses...)
+	}
+
+	return servers, nil
+}
+
+// gceProjectIDFromMetadata queries the metadata service on GCE to get the
+// project ID (name) of an instance.
+func gceProjectIDFromMetadata(logger *log.Logger) (string, error) {
+	logger.Printf("[INFO] agent: Attempting to discover GCE project from metadata.")
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", "http://metadata.google.internal/computeMetadata/v1/project/project-id", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+
+	project, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	logger.Printf("[INFO] agent: GCE project discovered as: %s", project)
+	return string(project), nil
+}
+
+// gceDiscoverZones discovers a list of zones from a supplied zone pattern, or
+// all of the zones available to a project.
+func gceDiscoverZones(ctx context.Context, logger *log.Logger, computeService *compute.Service, project, pattern string) ([]string, error) {
+	var zones []string
+
+	if pattern != "" {
+		logger.Printf("[INFO] agent: Discovering zones for project %s matching pattern: %s", project, pattern)
+	} else {
+		logger.Printf("[INFO] agent: Discovering all zones available to project: %s", project)
+	}
+
+	call := computeService.Zones.List(project)
+	if pattern != "" {
+		call = call.Filter(fmt.Sprintf("name eq %s", pattern))
+	}
+
+	if err := call.Pages(ctx, func(page *compute.ZoneList) error {
+		for _, v := range page.Items {
+			zones = append(zones, v.Name)
+		}
+		return nil
+	}); err != nil {
+		return zones, err
+	}
+
+	logger.Printf("[INFO] agent: Discovered GCE zones: %s", strings.Join(zones, ", "))
+	return zones, nil
+}
+
+// gceInstancesAddressesForZone locates all instances within a specific project
+// and zone, matching the supplied tag. Only the private IP addresses are
+// returned, but ID is also logged.
+func gceInstancesAddressesForZone(ctx context.Context, logger *log.Logger, computeService *compute.Service, project, zone, tag string) ([]string, error) {
+	var addresses []string
+	call := computeService.Instances.List(project, zone)
+	if err := call.Pages(ctx, func(page *compute.InstanceList) error {
+		for _, v := range page.Items {
+			for _, t := range v.Tags.Items {
+				if t == tag && len(v.NetworkInterfaces) > 0 && v.NetworkInterfaces[0].NetworkIP != "" {
+					addresses = append(addresses, v.NetworkInterfaces[0].NetworkIP)
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return addresses, err
+	}
+
+	return addresses, nil
+}

--- a/consul/client.go
+++ b/consul/client.go
@@ -84,7 +84,7 @@ type Client struct {
 // configuration, potentially returning an error
 func NewClient(config *Config) (*Client, error) {
 	// Check the protocol version
-	if err := config.CheckVersion(); err != nil {
+	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
 	}
 

--- a/consul/client.go
+++ b/consul/client.go
@@ -115,7 +115,7 @@ func NewClient(config *Config) (*Client, error) {
 	// Create server
 	c := &Client{
 		config:     config,
-		connPool:   NewPool(config.LogOutput, clientRPCConnMaxIdle, clientMaxStreams, tlsWrap),
+		connPool:   NewPool(config.RPCSrcAddr, config.LogOutput, clientRPCConnMaxIdle, clientMaxStreams, tlsWrap),
 		eventCh:    make(chan serf.Event, serfEventBacklog),
 		logger:     logger,
 		shutdownCh: make(chan struct{}),

--- a/consul/config.go
+++ b/consul/config.go
@@ -95,6 +95,10 @@ type Config struct {
 	// reachable
 	RPCAdvertise *net.TCPAddr
 
+	// RPCSrcAddr is the source address for outgoing RPC connections.
+	// It is RPCAdvertise with the port set to zero.
+	RPCSrcAddr *net.TCPAddr
+
 	// SerfLANConfig is the configuration for the intra-dc serf
 	SerfLANConfig *serf.Config
 

--- a/consul/config.go
+++ b/consul/config.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	DefaultDC          = "dc1"
+	DefaultRPCPort     = 8300
 	DefaultLANSerfPort = 8301
 	DefaultWANSerfPort = 8302
 
@@ -31,13 +32,13 @@ const (
 )
 
 var (
-	DefaultRPCAddr = &net.TCPAddr{IP: net.ParseIP("0.0.0.0"), Port: 8300}
-)
+	DefaultRPCAddr = &net.TCPAddr{IP: net.ParseIP("0.0.0.0"), Port: DefaultRPCPort}
 
-// ProtocolVersionMap is the mapping of Consul protocol versions
-// to Serf protocol versions. We mask the Serf protocols using
-// our own protocol version.
-var protocolVersionMap map[uint8]uint8
+	// ProtocolVersionMap is the mapping of Consul protocol versions
+	// to Serf protocol versions. We mask the Serf protocols using
+	// our own protocol version.
+	protocolVersionMap map[uint8]uint8
+)
 
 func init() {
 	protocolVersionMap = map[uint8]uint8{
@@ -307,19 +308,18 @@ type Config struct {
 	AutopilotInterval time.Duration
 }
 
-// CheckVersion is used to check if the ProtocolVersion is valid
-func (c *Config) CheckVersion() error {
+// CheckProtocolVersion validates the protocol version.
+func (c *Config) CheckProtocolVersion() error {
 	if c.ProtocolVersion < ProtocolVersionMin {
-		return fmt.Errorf("Protocol version '%d' too low. Must be in range: [%d, %d]",
-			c.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
-	} else if c.ProtocolVersion > ProtocolVersionMax {
-		return fmt.Errorf("Protocol version '%d' too high. Must be in range: [%d, %d]",
-			c.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
+		return fmt.Errorf("Protocol version '%d' too low. Must be in range: [%d, %d]", c.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
+	}
+	if c.ProtocolVersion > ProtocolVersionMax {
+		return fmt.Errorf("Protocol version '%d' too high. Must be in range: [%d, %d]", c.ProtocolVersion, ProtocolVersionMin, ProtocolVersionMax)
 	}
 	return nil
 }
 
-// CheckACL is used to sanity check the ACL configuration
+// CheckACL validates the ACL configuration.
 func (c *Config) CheckACL() error {
 	switch c.ACLDefaultPolicy {
 	case "allow":
@@ -337,7 +337,7 @@ func (c *Config) CheckACL() error {
 	return nil
 }
 
-// DefaultConfig is used to return a sane default configuration
+// DefaultConfig returns a sane default configuration.
 func DefaultConfig() *Config {
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -453,9 +453,9 @@ func (c *Config) tlsConfig() *tlsutil.Config {
 func (c *Config) GetTokenForAgent() string {
 	if c.ACLAgentToken != "" {
 		return c.ACLAgentToken
-	} else if c.ACLToken != "" {
-		return c.ACLToken
-	} else {
-		return ""
 	}
+	if c.ACLToken != "" {
+		return c.ACLToken
+	}
+	return ""
 }

--- a/consul/server.go
+++ b/consul/server.go
@@ -257,7 +257,7 @@ func NewServer(config *Config) (*Server, error) {
 		autopilotRemoveDeadCh: make(chan struct{}),
 		autopilotShutdownCh:   make(chan struct{}),
 		config:                config,
-		connPool:              NewPool(config.LogOutput, serverRPCCache, serverMaxStreams, tlsWrap),
+		connPool:              NewPool(config.RPCSrcAddr, config.LogOutput, serverRPCCache, serverMaxStreams, tlsWrap),
 		eventChLAN:            make(chan serf.Event, 256),
 		eventChWAN:            make(chan serf.Event, 256),
 		localConsuls:          make(map[raft.ServerAddress]*agent.Server),
@@ -613,7 +613,7 @@ func (s *Server) setupRPC(tlsWrap tlsutil.DCWrapper) error {
 	// Provide a DC specific wrapper. Raft replication is only
 	// ever done in the same datacenter, so we can provide it as a constant.
 	wrapper := tlsutil.SpecificDC(s.config.Datacenter, tlsWrap)
-	s.raftLayer = NewRaftLayer(s.config.RPCAdvertise, wrapper)
+	s.raftLayer = NewRaftLayer(s.config.RPCSrcAddr, s.config.RPCAdvertise, wrapper)
 	return nil
 }
 

--- a/consul/server.go
+++ b/consul/server.go
@@ -210,7 +210,7 @@ type endpoints struct {
 // configuration, potentially returning an error
 func NewServer(config *Config) (*Server, error) {
 	// Check the protocol version.
-	if err := config.CheckVersion(); err != nil {
+	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
 	}
 

--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -47,6 +47,7 @@ func testServerConfig(t *testing.T, NodeName string) (string, *Config) {
 		IP:   []byte{127, 0, 0, 1},
 		Port: getPort(),
 	}
+	config.RPCAdvertise = config.RPCAddr
 	nodeID, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This patch configures consul to use the bind address as the
source address for outgoing RPC connections.

Fixes #2822