### PR TITLE
Fixes panic in leader loop on step down w/o step up

### DIFF
--- a/consul/leader.go
+++ b/consul/leader.go
@@ -65,9 +65,6 @@ func (s *Server) monitorLeadership() {
 // leaderLoop runs as long as we are the leader to run various
 // maintenance activities
 func (s *Server) leaderLoop(stopCh chan struct{}) {
-	// Ensure we revoke leadership on stepdown
-	defer s.revokeLeadership()
-
 	// Fire a user event indicating a new leader
 	payload := []byte(s.config.NodeName)
 	if err := s.serfLAN.UserEvent(newLeaderEvent, payload, false); err != nil {
@@ -101,6 +98,7 @@ RECONCILE:
 			goto WAIT
 		}
 		establishedLeader = true
+		defer s.revokeLeadership()
 	}
 
 	// Reconcile any missing data

--- a/consul/leader.go
+++ b/consul/leader.go
@@ -124,6 +124,17 @@ WAIT:
 			goto RECONCILE
 		case member := <-reconcileCh:
 			s.reconcileMember(member)
+		case <-s.reassertLeaderCh:
+			if establishedLeader {
+				if err := s.revokeLeadership(); err != nil {
+					s.logger.Printf("[ERR] consul: failed to revoke leadership: %v", err)
+					goto WAIT
+				}
+				if err := s.establishLeadership(); err != nil {
+					s.logger.Printf("[ERR] consul: failed to re-establish leadership: %v", err)
+					goto WAIT
+				}
+			}
 		case index := <-s.tombstoneGC.ExpireCh():
 			go s.reapTombstones(index)
 		}

--- a/consul/server.go
+++ b/consul/server.go
@@ -174,6 +174,10 @@ type Server struct {
 	// Consul servers.
 	statsFetcher *StatsFetcher
 
+	// reassertLeaderCh is used to signal the leader loop should re-run
+	// leadership actions after a snapshot restore.
+	reassertLeaderCh chan struct{}
+
 	// tombstoneGC is used to track the pending GC invocations
 	// for the KV tombstones
 	tombstoneGC *state.TombstoneGC
@@ -266,6 +270,7 @@ func NewServer(config *Config) (*Server, error) {
 		router:                servers.NewRouter(logger, shutdownCh, config.Datacenter),
 		rpcServer:             rpc.NewServer(),
 		rpcTLS:                incomingTLS,
+		reassertLeaderCh:      make(chan struct{}),
 		tombstoneGC:           gc,
 		shutdownCh:            make(chan struct{}),
 	}

--- a/consul/snapshot_endpoint.go
+++ b/consul/snapshot_endpoint.go
@@ -100,12 +100,10 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 		if err := barrier.Error(); err != nil {
 			return nil, err
 		}
-		if err := s.revokeLeadership(); err != nil {
-			return nil, err
-		}
-		if err := s.establishLeadership(); err != nil {
-			return nil, err
-		}
+
+		// Tell the leader loop to reassert leader actions since we just
+		// replaced the state store contents.
+		s.reassertLeaderCh <- struct{}{}
 
 		// Give the caller back an empty reader since there's nothing to
 		// stream back.


### PR DESCRIPTION
Fixes #2980.

If the leader loop wasn't able to fully step up, it would still `defer` a step down which would lead to the panic seen in #2980. This change only `defer`s the step down once the step up completes. We also identified an unsafe call of the step up/step down actions from the snapshot endpoint, so we put those inside the leader loop for safety.