### PR TITLE
UI: open docs links in new tab

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -89,7 +89,7 @@
         <div class="text-center vertical-center">
           <p class="bold">ACLs Disabled</p>
           <p>ACLs are disabled in this Consul cluster. This is the default behavior, as you have to explicitly enable them.</p>
-          </p>Learn more in the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation</a>.</p>
+          </p>Learn more in the <a href="https://www.consul.io/docs/guides/acl.html" target="_blank">ACL documentation</a>.</p>
         </div>
       </div>
     </div>
@@ -672,7 +672,7 @@
                     <div class="form-group">
                       <label>Rules</label>
                       {{ textarea value=newAcl.Rules class="form-control" }}
-                      <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation.</a></span>
+                      <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/guides/acl.html" target="_blank">ACL documentation.</a></span>
                     </div>
 
                     <button {{ action "createAcl"}} {{ bind-attr class=":btn :btn-success" }}>Create</button>
@@ -718,7 +718,7 @@
                 <div class="form-group">
                   <label>Rules</label>
                   {{ textarea value=model.Rules class="form-control" }}
-                  <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation.</a></span>
+                  <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/guides/acl.html" target="_blank">ACL documentation.</a></span>
                 </div>
 
                 <button {{ action "updateAcl"}} {{ bind-attr class=":btn :btn-success" }}>Update</button>

--- a/ui/index.html
+++ b/ui/index.html
@@ -77,7 +77,7 @@
           <p>The default agent token does not
           have the appropriate permissions to perform the expected action.</p>
           {{/if}}
-          <p>Learn more in the <a href="https://www.consul.io/docs/guides/acl.html">ACL documentation</a>.</p>
+          <p>Learn more in the <a href="https://www.consul.io/docs/guides/acl.html" target="_blank">ACL documentation</a>.</p>
         </div>
       </div>
     </div>
@@ -89,7 +89,7 @@
         <div class="text-center vertical-center">
           <p class="bold">ACLs Disabled</p>
           <p>ACLs are disabled in this Consul cluster. This is the default behavior, as you have to explicitly enable them.</p>
-          </p>Learn more in the <a href="https://www.consul.io/docs/internals/acl.html">ACL documentation</a>.</p>
+          </p>Learn more in the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation</a>.</p>
         </div>
       </div>
     </div>
@@ -672,7 +672,7 @@
                     <div class="form-group">
                       <label>Rules</label>
                       {{ textarea value=newAcl.Rules class="form-control" }}
-                      <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html">ACL documentation.</a></span>
+                      <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation.</a></span>
                     </div>
 
                     <button {{ action "createAcl"}} {{ bind-attr class=":btn :btn-success" }}>Create</button>
@@ -718,7 +718,7 @@
                 <div class="form-group">
                   <label>Rules</label>
                   {{ textarea value=model.Rules class="form-control" }}
-                  <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html">ACL documentation.</a></span>
+                  <span class="help-block">For more information on rules, visit the <a href="https://www.consul.io/docs/internals/acl.html" target="_blank">ACL documentation.</a></span>
                 </div>
 
                 <button {{ action "updateAcl"}} {{ bind-attr class=":btn :btn-success" }}>Update</button>


### PR DESCRIPTION
- set `target="_blank"` on all docs URLs linked from within UI

This is helpful because if a user clicks the docs link from UI and has already entered any details into a form, say when creating a new ACL, they will be brought to the docs in the same window as the UI, and will lose everything they've entered into the form when clicking the back button:

<img width="1172" alt="consul_by_hashicorp" src="https://cloud.githubusercontent.com/assets/77563/25752451/55c7cd06-3186-11e7-9cb8-fcbd0e088cbf.png">

This can be a frustrating thing from a UX perspective, so this change mitigates that by opening all docs links from the UI in a new tab/window.
