### PR TITLE
Add the minimal fix to restore being able to compile on Illumos.

### DIFF
--- a/vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go
+++ b/vendor/github.com/docker/docker/pkg/system/meminfo_solaris.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 )
 
+// #cgo CFLAGS: -std=c99
 // #cgo LDFLAGS: -lkstat
 // #include <unistd.h>
 // #include <stdlib.h>


### PR DESCRIPTION
This brings in the necessary fix to satisfy #2989 without dragging along
additional vendor updates reverted in #3019.

Pointy Hat: @sean- for not testing a release build w/ a clean `GOPATH`