### PR TITLE
Bumps up the leader timeout.

### DIFF
--- a/testutil/server.go
+++ b/testutil/server.go
@@ -122,7 +122,7 @@ func defaultServerConfig() *TestServerConfig {
 			Server:  randomPort(),
 			RPC:     randomPort(),
 		},
-		ReadyTimeout: 3 * time.Second,
+		ReadyTimeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
This should only increase the time to detect failures, but this isn't a common thing to fail, other than for spurious reasons, so moving this up will hopefully make the tests more stable on weak CI build machines.