### PR TITLE
agent: use bind over advertise for src

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -305,7 +305,7 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		}
 		a.config.AdvertiseAddr = ipStr
 
-	case a.config.BindAddr != "0.0.0.0" && a.config.BindAddr != "" && a.config.BindAddr != "[::]":
+	case a.config.BindAddr != "" && !isAddrANY(a.config.BindAddr):
 		a.config.AdvertiseAddr = a.config.BindAddr
 
 	default:

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -440,9 +440,10 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	}
 
 	// set the src address for outgoing rpc connections
-	// to RPCAdvertise with port 0 so that outgoing
-	// connections use a random port.
-	base.RPCSrcAddr = &net.TCPAddr{IP: base.RPCAdvertise.IP}
+	// Use port 0 so that outgoing connections use a random port.
+	if !isAddrANY(base.RPCAddr.IP) {
+		base.RPCSrcAddr = &net.TCPAddr{IP: base.RPCAddr.IP}
+	}
 
 	// Format the build string
 	revision := a.config.Revision

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -361,12 +361,12 @@ func (c *Command) readConfig() *Config {
 		return nil
 	}
 
-	if config.AdvertiseAddr == "0.0.0.0" || config.AdvertiseAddr == "::" || config.AdvertiseAddr == "[::]" {
+	if isAddrANY(config.AdvertiseAddr) {
 		c.UI.Error("Advertise address cannot be " + config.AdvertiseAddr)
 		return nil
 	}
 
-	if config.AdvertiseAddrWan == "0.0.0.0" || config.AdvertiseAddrWan == "::" || config.AdvertiseAddrWan == "[::]" {
+	if isAddrANY(config.AdvertiseAddrWan) {
 		c.UI.Error("Advertise WAN address cannot be " + config.AdvertiseAddrWan)
 		return nil
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1976,3 +1976,23 @@ func (d dirEnts) Less(i, j int) bool {
 func (d dirEnts) Swap(i, j int) {
 	d[i], d[j] = d[j], d[i]
 }
+
+// isAddrANY checks if the given ip address is an IPv4 or IPv6 ANY address. ip
+// can be either a *net.IP or a string. It panics on another type.
+func isAddrANY(ip interface{}) bool {
+	if ip == nil {
+		return false
+	}
+	var ips string
+	switch x := ip.(type) {
+	case net.IP:
+		ips = x.String()
+	case *net.IP:
+		ips = x.String()
+	case string:
+		ips = x
+	default:
+		panic(fmt.Sprintf("invalid type: %T", ip))
+	}
+	return ips == "0.0.0.0" || ips == "::" || ips == "[::]"
+}


### PR DESCRIPTION
This is a follow-up of #2822 which uses the bind address as source and not the advertise address since that won't work in NAT environments. 