### PR TITLE
test: improvements

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ cov:
 
 test: dev
 	go test -tags "$(GOTAGS)" -i -run '^$$' ./...
-	( set -o pipefail ; go test -tags "$(GOTAGS)" -v $(GOFILES) | tee test.log )
+	( set -o pipefail ; go test -tags "$(GOTAGS)" -v ./... | tee test.log )
 
 cover:
 	go test $(GOFILES) --cover

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -32,7 +32,7 @@ func TestAgent_Reload(t *testing.T) {
 	t.Parallel()
 
 	// Create our initial empty config file, to be overwritten later
-	configFile, err := ioutil.TempFile("", "reload")
+	configFile, err := ioutil.TempFile("", t.Name()+"-reload")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -32,10 +32,7 @@ func TestAgent_Reload(t *testing.T) {
 	t.Parallel()
 
 	// Create our initial empty config file, to be overwritten later
-	configFile, err := ioutil.TempFile("", t.Name()+"-reload")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	configFile := testutil.TempFile(t, "reload")
 	if _, err := configFile.Write([]byte("{}")); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -50,7 +47,7 @@ func TestAgent_Reload(t *testing.T) {
 
 	// Update the config file with a service definition
 	config := `{"service":{"name":"redis", "port":1234}}`
-	err = ioutil.WriteFile(configFile.Name(), []byte(config), 0644)
+	err := ioutil.WriteFile(configFile.Name(), []byte(config), 0644)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,7 +44,7 @@ func makeClientWithConfig(
 		cb1(conf)
 	}
 	// Create server
-	server, err := testutil.NewTestServerConfig(cb2)
+	server, err := testutil.NewTestServerConfig(t.Name(), cb2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestAPI_UnixSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", "consul")
+	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -4,7 +4,6 @@ import (
 	crand "crypto/rand"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func makeClientWithConfig(
 		cb1(conf)
 	}
 	// Create server
-	server, err := testutil.NewTestServerConfig(t.Name(), cb2)
+	server, err := testutil.NewTestServerConfigT(t, cb2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,10 +480,7 @@ func TestAPI_UnixSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tempDir)
 	socket := filepath.Join(tempDir, "test.sock")
 

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -500,7 +500,7 @@ func TestSemaphore_OneShot(t *testing.T) {
 		t.Fatalf("should not have acquired the semaphore")
 	}
 	diff := time.Now().Sub(start)
-	if diff < contender.opts.SemaphoreWaitTime || diff > 2*contender.opts.SemaphoreWaitTime {
+	if diff < contender.opts.SemaphoreWaitTime {
 		t.Fatalf("time out of bounds: %9.6f", diff.Seconds())
 	}
 

--- a/command/agent/acl_test.go
+++ b/command/agent/acl_test.go
@@ -21,7 +21,7 @@ func TestACL_Bad_Config(t *testing.T) {
 	config.ACLDownPolicy = "nope"
 
 	var err error
-	config.DataDir, err = ioutil.TempDir("", "agent")
+	config.DataDir, err = ioutil.TempDir("", t.Name()+"-agent")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/acl_test.go
+++ b/command/agent/acl_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	rawacl "github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/serf/serf"
 )
@@ -21,10 +21,7 @@ func TestACL_Bad_Config(t *testing.T) {
 	config.ACLDownPolicy = "nope"
 
 	var err error
-	config.DataDir, err = ioutil.TempDir("", t.Name()+"-agent")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	config.DataDir = testutil.TempDir(t, "agent")
 	defer os.RemoveAll(config.DataDir)
 
 	_, err = Create(config, nil, nil, nil)

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul/command/base"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/logger"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/serf/serf"
@@ -243,18 +244,12 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 func TestAgent_Reload(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tmpDir)
 
 	// Write initial config, to be reloaded later
-	tmpFile, err := ioutil.TempFile(tmpDir, "config")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	_, err = tmpFile.WriteString(`{"acl_enforce_version_8": false, "service":{"name":"redis"}}`)
+	tmpFile := testutil.TempFile(t, "config")
+	_, err := tmpFile.WriteString(`{"acl_enforce_version_8": false, "service":{"name":"redis"}}`)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -278,7 +278,7 @@ func TestAgent_Reload(t *testing.T) {
 
 	args := []string{
 		"-server",
-		"-advertise", "127.0.0.1",
+		"-bind", "127.0.0.1",
 		"-data-dir", tmpDir,
 		"-http-port", fmt.Sprintf("%d", conf.Ports.HTTP),
 		"-config-file", tmpFile.Name(),

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -243,7 +243,7 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 func TestAgent_Reload(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", "consul")
+	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -185,6 +186,10 @@ func TestAgent_RPCPing(t *testing.T) {
 }
 
 func TestAgent_CheckSerfBindAddrsSettings(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("skip test on macOS to avoid firewall warning dialog")
+	}
+
 	c := nextConfig()
 	ip, err := externalIP()
 	if err != nil {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -95,7 +95,7 @@ func nextConfig() *Config {
 }
 
 func makeAgentLog(t *testing.T, conf *Config, l io.Writer, writer *logger.LogWriter) (string, *Agent) {
-	dir, err := ioutil.TempDir("", "agent")
+	dir, err := ioutil.TempDir("", t.Name()+"-agent")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("err: %v", err))
 	}
@@ -111,7 +111,7 @@ func makeAgentLog(t *testing.T, conf *Config, l io.Writer, writer *logger.LogWri
 }
 
 func makeAgentKeyring(t *testing.T, conf *Config, key string) (string, *Agent) {
-	dir, err := ioutil.TempDir("", "agent")
+	dir, err := ioutil.TempDir("", t.Name()+"-agent")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/version"
 	"github.com/hashicorp/go-uuid"
@@ -96,10 +97,7 @@ func nextConfig() *Config {
 }
 
 func makeAgentLog(t *testing.T, conf *Config, l io.Writer, writer *logger.LogWriter) (string, *Agent) {
-	dir, err := ioutil.TempDir("", t.Name()+"-agent")
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("err: %v", err))
-	}
+	dir := testutil.TempDir(t, "agent")
 
 	conf.DataDir = dir
 	agent, err := Create(conf, l, writer, nil)
@@ -112,10 +110,7 @@ func makeAgentLog(t *testing.T, conf *Config, l io.Writer, writer *logger.LogWri
 }
 
 func makeAgentKeyring(t *testing.T, conf *Config, key string) (string, *Agent) {
-	dir, err := ioutil.TempDir("", t.Name()+"-agent")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "agent")
 
 	conf.DataDir = dir
 

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -135,6 +135,7 @@ func TestRetryJoin(t *testing.T) {
 
 	args := []string{
 		"-server",
+		"-bind", agent.config.BindAddr,
 		"-data-dir", tmpDir,
 		"-node", fmt.Sprintf(`"%s"`, conf2.NodeName),
 		"-advertise", agent.config.BindAddr,
@@ -310,6 +311,7 @@ func TestRetryJoinFail(t *testing.T) {
 	serfAddr := fmt.Sprintf("%s:%d", conf.BindAddr, conf.Ports.SerfLan)
 
 	args := []string{
+		"-bind", conf.BindAddr,
 		"-data-dir", tmpDir,
 		"-retry-join", serfAddr,
 		"-retry-max", "1",
@@ -341,6 +343,7 @@ func TestRetryJoinWanFail(t *testing.T) {
 
 	args := []string{
 		"-server",
+		"-bind", conf.BindAddr,
 		"-data-dir", tmpDir,
 		"-retry-join-wan", serfAddr,
 		"-retry-max-wan", "1",

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -103,7 +103,7 @@ func TestRetryJoin(t *testing.T) {
 	defer agent.Shutdown()
 
 	conf2 := nextConfig()
-	tmpDir, err := ioutil.TempDir("", "consul")
+	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -161,7 +161,7 @@ func TestRetryJoin(t *testing.T) {
 }
 
 func TestReadCliConfig(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "consul")
+	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -293,7 +293,7 @@ func TestReadCliConfig(t *testing.T) {
 
 func TestRetryJoinFail(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", "consul")
+	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -323,7 +323,7 @@ func TestRetryJoinFail(t *testing.T) {
 
 func TestRetryJoinWanFail(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", "consul")
+	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -410,7 +410,7 @@ func TestDiscoverGCEHosts(t *testing.T) {
 }
 
 func TestProtectDataDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "consul")
+	dir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestProtectDataDir(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	cfgFile, err := ioutil.TempFile("", "consul")
+	cfgFile, err := ioutil.TempFile("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestProtectDataDir(t *testing.T) {
 }
 
 func TestBadDataDirPermissions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "consul")
+	dir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -12,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/version"
 	"github.com/mitchellh/cli"
@@ -103,10 +103,7 @@ func TestRetryJoin(t *testing.T) {
 	defer agent.Shutdown()
 
 	conf2 := nextConfig()
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tmpDir)
 
 	doneCh := make(chan struct{})
@@ -162,10 +159,7 @@ func TestRetryJoin(t *testing.T) {
 }
 
 func TestReadCliConfig(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tmpDir)
 
 	shutdownCh := make(chan struct{})
@@ -294,10 +288,7 @@ func TestReadCliConfig(t *testing.T) {
 
 func TestRetryJoinFail(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tmpDir)
 
 	shutdownCh := make(chan struct{})
@@ -325,10 +316,7 @@ func TestRetryJoinFail(t *testing.T) {
 
 func TestRetryJoinWanFail(t *testing.T) {
 	conf := nextConfig()
-	tmpDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tmpDir)
 
 	shutdownCh := make(chan struct{})
@@ -413,24 +401,18 @@ func TestDiscoverGCEHosts(t *testing.T) {
 }
 
 func TestProtectDataDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(dir)
 
 	if err := os.MkdirAll(filepath.Join(dir, "mdb"), 0700); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	cfgFile, err := ioutil.TempFile("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	cfgFile := testutil.TempFile(t, "consul")
 	defer os.Remove(cfgFile.Name())
 
 	content := fmt.Sprintf(`{"server": true, "data_dir": "%s"}`, dir)
-	_, err = cfgFile.Write([]byte(content))
+	_, err := cfgFile.Write([]byte(content))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -449,10 +431,7 @@ func TestProtectDataDir(t *testing.T) {
 }
 
 func TestBadDataDirPermissions(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(dir)
 
 	dataDir := filepath.Join(dir, "mdb")

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1797,7 +1797,7 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 }
 
 func TestReadConfigPaths_file(t *testing.T) {
-	tf, err := ioutil.TempFile("", "consul")
+	tf, err := ioutil.TempFile("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1816,7 +1816,7 @@ func TestReadConfigPaths_file(t *testing.T) {
 }
 
 func TestReadConfigPaths_dir(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/testutil"
 )
 
 func TestConfigEncryptBytes(t *testing.T) {
@@ -1797,10 +1798,7 @@ func TestReadConfigPaths_badPath(t *testing.T) {
 }
 
 func TestReadConfigPaths_file(t *testing.T) {
-	tf, err := ioutil.TempFile("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tf := testutil.TempFile(t, "consul")
 	tf.Write([]byte(`{"node_name":"bar"}`))
 	tf.Close()
 	defer os.Remove(tf.Name())
@@ -1816,13 +1814,10 @@ func TestReadConfigPaths_file(t *testing.T) {
 }
 
 func TestReadConfigPaths_dir(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "a.json"),
+	err := ioutil.WriteFile(filepath.Join(td, "a.json"),
 		[]byte(`{"node_name": "bar"}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/go-cleanhttp"
 )
 
@@ -77,12 +78,9 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tempDir)
-	socket := filepath.Join(tempDir, t.Name()+".sock")
+	socket := filepath.Join(tempDir, "test.sock")
 
 	dir, srv := makeHTTPServerWithConfig(t, func(c *Config) {
 		c.Addresses.HTTP = "unix://" + socket
@@ -139,12 +137,9 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(tempDir)
-	socket := filepath.Join(tempDir, t.Name()+".sock")
+	socket := filepath.Join(tempDir, "test.sock")
 
 	// Create a regular file at the socket path
 	if err := ioutil.WriteFile(socket, []byte("hello world"), 0644); err != nil {

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -77,12 +77,12 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", "consul")
+	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
-	socket := filepath.Join(tempDir, "test.sock")
+	socket := filepath.Join(tempDir, t.Name()+".sock")
 
 	dir, srv := makeHTTPServerWithConfig(t, func(c *Config) {
 		c.Addresses.HTTP = "unix://" + socket
@@ -139,12 +139,12 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 		t.SkipNow()
 	}
 
-	tempDir, err := ioutil.TempDir("", "consul")
+	tempDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 	defer os.RemoveAll(tempDir)
-	socket := filepath.Join(tempDir, "test.sock")
+	socket := filepath.Join(tempDir, t.Name()+".sock")
 
 	// Create a regular file at the socket path
 	if err := ioutil.WriteFile(socket, []byte("hello world"), 0644); err != nil {

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -81,7 +81,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 	expected := fmt.Sprintf(`["%s"]`, key1)
 
-	dir, err := ioutil.TempDir("", "consul")
+	dir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/keyring_test.go
+++ b/command/agent/keyring_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 )
 
 func TestAgent_LoadKeyrings(t *testing.T) {
@@ -81,10 +82,7 @@ func TestAgent_InitKeyring(t *testing.T) {
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 	expected := fmt.Sprintf(`["%s"]`, key1)
 
-	dir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	dir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "keyring")

--- a/command/agent/ui_endpoint_test.go
+++ b/command/agent/ui_endpoint_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestUiIndex(t *testing.T) {
 	// Make a test dir to serve UI files
-	uiDir, err := ioutil.TempDir("", "consul")
+	uiDir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/ui_endpoint_test.go
+++ b/command/agent/ui_endpoint_test.go
@@ -15,15 +15,13 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/go-cleanhttp"
 )
 
 func TestUiIndex(t *testing.T) {
 	// Make a test dir to serve UI files
-	uiDir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	uiDir := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(uiDir)
 
 	// Make the server

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -37,7 +37,7 @@ func TestSetFilePermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	tempFile, err := ioutil.TempFile("", "consul")
+	tempFile, err := ioutil.TempFile("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/agent/util_test.go
+++ b/command/agent/util_test.go
@@ -1,11 +1,12 @@
 package agent
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/testutil"
 )
 
 func TestAEScale(t *testing.T) {
@@ -37,10 +38,7 @@ func TestSetFilePermissions(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.SkipNow()
 	}
-	tempFile, err := ioutil.TempFile("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempFile := testutil.TempFile(t, "consul")
 	path := tempFile.Name()
 	defer os.Remove(path)
 

--- a/command/configtest_test.go
+++ b/command/configtest_test.go
@@ -25,7 +25,7 @@ func TestConfigTestCommand_implements(t *testing.T) {
 }
 
 func TestConfigTestCommandFailOnEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "consul")
+	tmpFile, err := ioutil.TempFile("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -43,7 +43,7 @@ func TestConfigTestCommandFailOnEmptyFile(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnEmptyDir(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -61,7 +61,7 @@ func TestConfigTestCommandSucceedOnEmptyDir(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnMinimalConfigFile(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -85,7 +85,7 @@ func TestConfigTestCommandSucceedOnMinimalConfigFile(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnMinimalConfigDir(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -108,7 +108,7 @@ func TestConfigTestCommandSucceedOnMinimalConfigDir(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/configtest_test.go
+++ b/command/configtest_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -25,10 +26,7 @@ func TestConfigTestCommand_implements(t *testing.T) {
 }
 
 func TestConfigTestCommandFailOnEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpFile := testutil.TempFile(t, "consul")
 	defer os.RemoveAll(tmpFile.Name())
 
 	_, cmd := testConfigTestCommand(t)
@@ -43,10 +41,7 @@ func TestConfigTestCommandFailOnEmptyFile(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnEmptyDir(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
 	ui, cmd := testConfigTestCommand(t)
@@ -61,14 +56,11 @@ func TestConfigTestCommandSucceedOnEmptyDir(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnMinimalConfigFile(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "config.json")
-	err = ioutil.WriteFile(fp, []byte(`{}`), 0644)
+	err := ioutil.WriteFile(fp, []byte(`{}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -85,13 +77,10 @@ func TestConfigTestCommandSucceedOnMinimalConfigFile(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnMinimalConfigDir(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{}`), 0644)
+	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -108,13 +97,10 @@ func TestConfigTestCommandSucceedOnMinimalConfigDir(t *testing.T) {
 }
 
 func TestConfigTestCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "config.json"), []byte{}, 0644)
+	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte{}, 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/exec_test.go
+++ b/command/exec_test.go
@@ -35,7 +35,7 @@ func TestExecCommandRun(t *testing.T) {
 	waitForLeader(t, a1.httpAddr)
 
 	ui, c := testExecCommand(t)
-	args := []string{"-http-addr=" + a1.httpAddr, "-wait=10s", "uptime"}
+	args := []string{"-http-addr=" + a1.httpAddr, "-wait=500ms", "uptime"}
 
 	code := c.Run(args)
 	if code != 0 {
@@ -73,8 +73,7 @@ func TestExecCommandRun_CrossDC(t *testing.T) {
 	waitForLeader(t, a2.httpAddr)
 
 	ui, c := testExecCommand(t)
-	args := []string{"-http-addr=" + a1.httpAddr,
-		"-wait=400ms", "-datacenter=dc2", "uptime"}
+	args := []string{"-http-addr=" + a1.httpAddr, "-wait=500ms", "-datacenter=dc2", "uptime"}
 
 	code := c.Run(args)
 	if code != 0 {

--- a/command/keygen_test.go
+++ b/command/keygen_test.go
@@ -2,9 +2,10 @@ package command
 
 import (
 	"encoding/base64"
+	"testing"
+
 	"github.com/hashicorp/consul/command/base"
 	"github.com/mitchellh/cli"
-	"testing"
 )
 
 func TestKeygenCommand_implements(t *testing.T) {

--- a/command/kv_put_test.go
+++ b/command/kv_put_test.go
@@ -179,7 +179,7 @@ func TestKVPutCommand_File(t *testing.T) {
 
 	ui, c := testKVPutCommand(t)
 
-	f, err := ioutil.TempFile("", "kv-put-command-file")
+	f, err := ioutil.TempFile("", t.Name()+"-kv-put-command-file")
 	if err != nil {
 		t.Fatalf("err: %#v", err)
 	}

--- a/command/kv_put_test.go
+++ b/command/kv_put_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -179,10 +179,7 @@ func TestKVPutCommand_File(t *testing.T) {
 
 	ui, c := testKVPutCommand(t)
 
-	f, err := ioutil.TempFile("", t.Name()+"-kv-put-command-file")
-	if err != nil {
-		t.Fatalf("err: %#v", err)
-	}
+	f := testutil.TempFile(t, "kv-put-command-file")
 	defer os.Remove(f.Name())
 	if _, err := f.WriteString("bar"); err != nil {
 		t.Fatalf("err: %#v", err)

--- a/command/members_test.go
+++ b/command/members_test.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"fmt"
-	"github.com/hashicorp/consul/command/base"
-	"github.com/mitchellh/cli"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/command/base"
+	"github.com/mitchellh/cli"
 )
 
 func testMembersCommand(t *testing.T) (*cli.MockUi, *MembersCommand) {

--- a/command/snapshot_inspect_test.go
+++ b/command/snapshot_inspect_test.go
@@ -2,13 +2,13 @@ package command
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -73,10 +73,7 @@ func TestSnapshotInspectCommand_Run(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "snapshot")
 	defer os.RemoveAll(dir)
 
 	file := path.Join(dir, "backup.tgz")

--- a/command/snapshot_inspect_test.go
+++ b/command/snapshot_inspect_test.go
@@ -73,7 +73,7 @@ func TestSnapshotInspectCommand_Run(t *testing.T) {
 	defer srv.Shutdown()
 	waitForLeader(t, srv.httpAddr)
 
-	dir, err := ioutil.TempDir("", "snapshot")
+	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/snapshot_restore_test.go
+++ b/command/snapshot_restore_test.go
@@ -2,13 +2,13 @@ package command
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -75,10 +75,7 @@ func TestSnapshotRestoreCommand_Run(t *testing.T) {
 
 	ui, c := testSnapshotRestoreCommand(t)
 
-	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "snapshot")
 	defer os.RemoveAll(dir)
 
 	file := path.Join(dir, "backup.tgz")

--- a/command/snapshot_restore_test.go
+++ b/command/snapshot_restore_test.go
@@ -75,7 +75,7 @@ func TestSnapshotRestoreCommand_Run(t *testing.T) {
 
 	ui, c := testSnapshotRestoreCommand(t)
 
-	dir, err := ioutil.TempDir("", "snapshot")
+	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/snapshot_save_test.go
+++ b/command/snapshot_save_test.go
@@ -1,13 +1,13 @@
 package command
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -74,10 +74,7 @@ func TestSnapshotSaveCommand_Run(t *testing.T) {
 
 	ui, c := testSnapshotSaveCommand(t)
 
-	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "snapshot")
 	defer os.RemoveAll(dir)
 
 	file := path.Join(dir, "backup.tgz")

--- a/command/snapshot_save_test.go
+++ b/command/snapshot_save_test.go
@@ -74,7 +74,7 @@ func TestSnapshotSaveCommand_Run(t *testing.T) {
 
 	ui, c := testSnapshotSaveCommand(t)
 
-	dir, err := ioutil.TempDir("", "snapshot")
+	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -67,7 +67,7 @@ func testAgentWithConfigReload(t *testing.T, cb func(c *agent.Config), reloadCh 
 		cb(conf)
 	}
 
-	dir, err := ioutil.TempDir("", "agent")
+	dir, err := ioutil.TempDir("", t.Name()+"-agent")
 	if err != nil {
 		t.Fatalf(fmt.Sprintf("err: %v", err))
 	}

--- a/command/util_test.go
+++ b/command/util_test.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/consul/command/agent"
 	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/logger"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/version"
 	"github.com/hashicorp/go-uuid"
@@ -67,10 +67,7 @@ func testAgentWithConfigReload(t *testing.T, cb func(c *agent.Config), reloadCh 
 		cb(conf)
 	}
 
-	dir, err := ioutil.TempDir("", t.Name()+"-agent")
-	if err != nil {
-		t.Fatalf(fmt.Sprintf("err: %v", err))
-	}
+	dir := testutil.TempDir(t, "agent")
 	conf.DataDir = dir
 
 	a, err := agent.Create(conf, lw, nil, reloadCh)

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/command/base"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/mitchellh/cli"
 )
 
@@ -25,10 +26,7 @@ func TestValidateCommand_implements(t *testing.T) {
 }
 
 func TestValidateCommandFailOnEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tmpFile := testutil.TempFile(t, "consul")
 	defer os.RemoveAll(tmpFile.Name())
 
 	_, cmd := testValidateCommand(t)
@@ -41,10 +39,7 @@ func TestValidateCommandFailOnEmptyFile(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnEmptyDir(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
 	ui, cmd := testValidateCommand(t)
@@ -57,14 +52,11 @@ func TestValidateCommandSucceedOnEmptyDir(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnMinimalConfigFile(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "config.json")
-	err = ioutil.WriteFile(fp, []byte(`{}`), 0644)
+	err := ioutil.WriteFile(fp, []byte(`{}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -79,13 +71,10 @@ func TestValidateCommandSucceedOnMinimalConfigFile(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnMinimalConfigDir(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{}`), 0644)
+	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{}`), 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -100,13 +89,10 @@ func TestValidateCommandSucceedOnMinimalConfigDir(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
-	err = ioutil.WriteFile(filepath.Join(td, "config.json"), []byte{}, 0644)
+	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte{}, 0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -121,10 +107,7 @@ func TestValidateCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
 }
 
 func TestValidateCommandQuiet(t *testing.T) {
-	td, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
 
 	ui, cmd := testValidateCommand(t)

--- a/command/validate_test.go
+++ b/command/validate_test.go
@@ -25,7 +25,7 @@ func TestValidateCommand_implements(t *testing.T) {
 }
 
 func TestValidateCommandFailOnEmptyFile(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "consul")
+	tmpFile, err := ioutil.TempFile("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -41,7 +41,7 @@ func TestValidateCommandFailOnEmptyFile(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnEmptyDir(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -57,7 +57,7 @@ func TestValidateCommandSucceedOnEmptyDir(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnMinimalConfigFile(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -79,7 +79,7 @@ func TestValidateCommandSucceedOnMinimalConfigFile(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnMinimalConfigDir(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -100,7 +100,7 @@ func TestValidateCommandSucceedOnMinimalConfigDir(t *testing.T) {
 }
 
 func TestValidateCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -121,7 +121,7 @@ func TestValidateCommandSucceedOnConfigDirWithEmptyFile(t *testing.T) {
 }
 
 func TestValidateCommandQuiet(t *testing.T) {
-	td, err := ioutil.TempDir("", "consul")
+	td, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/consul/client_test.go
+++ b/consul/client_test.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/serf"
 )
 
 func testClientConfig(t *testing.T, NodeName string) (string, *Config) {
-	dir := tmpDir(t)
+	dir := testutil.TempDir(t, "consul")
 	config := DefaultConfig()
 	config.Datacenter = "dc1"
 	config.DataDir = dir

--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/consul/agent"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-uuid"
@@ -23,14 +23,6 @@ func getPort() int {
 	return int(atomic.AddInt32(&nextPort, 1))
 }
 
-func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", t.Name()+"-consul")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return dir
-}
-
 func configureTLS(config *Config) {
 	config.CAFile = "../test/ca/root.cer"
 	config.CertFile = "../test/key/ourdomain.cer"
@@ -38,7 +30,7 @@ func configureTLS(config *Config) {
 }
 
 func testServerConfig(t *testing.T, NodeName string) (string, *Config) {
-	dir := tmpDir(t)
+	dir := testutil.TempDir(t, "consul")
 	config := DefaultConfig()
 
 	config.NodeName = NodeName

--- a/consul/server_test.go
+++ b/consul/server_test.go
@@ -24,7 +24,7 @@ func getPort() int {
 }
 
 func tmpDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", "consul")
+	dir, err := ioutil.TempDir("", t.Name()+"-consul")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -126,7 +126,7 @@ func makeRaft(t *testing.T, dir string) (*raft.Raft, *MockFSM) {
 }
 
 func TestSnapshot(t *testing.T) {
-	dir, err := ioutil.TempDir("", "snapshot")
+	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestSnapshot_BadVerify(t *testing.T) {
 }
 
 func TestSnapshot_BadRestore(t *testing.T) {
-	dir, err := ioutil.TempDir("", "snapshot")
+	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -14,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
 )
@@ -126,10 +126,7 @@ func makeRaft(t *testing.T, dir string) (*raft.Raft, *MockFSM) {
 }
 
 func TestSnapshot(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "snapshot")
 	defer os.RemoveAll(dir)
 
 	// Make a Raft and populate it with some data. We tee everything we
@@ -238,10 +235,7 @@ func TestSnapshot_BadVerify(t *testing.T) {
 }
 
 func TestSnapshot_BadRestore(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name()+"-snapshot")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	dir := testutil.TempDir(t, "snapshot")
 	defer os.RemoveAll(dir)
 
 	// Make a Raft and populate it with some data.

--- a/testutil/io.go
+++ b/testutil/io.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// tmpdir is the base directory for all temporary directories
+// and files created with TempDir and TempFile. This could be
+// achieved by setting a system environment variable but then
+// the test execution would depend on whether or not the
+// environment variable is set.
+//
+// On macOS the temp base directory is quite long and that
+// triggers a problem with some tests that bind to UNIX sockets
+// where the filename seems to be too long. Using a shorter name
+// fixes this and makes the paths more readable.
+//
+// It also provides a single base directory for cleanup.
+var tmpdir = "/tmp/consul-test"
+
+func init() {
+	if err := os.MkdirAll(tmpdir, 0755); err != nil {
+		fmt.Println("Cannot create %s. Reverting to /tmp", tmpdir)
+		tmpdir = "/tmp"
+	}
+}
+
+// TempDir creates a temporary directory within tmpdir
+// with the name 'testname-name'. If the directory cannot
+// be created t.Fatal is called.
+func TempDir(t *testing.T, name string) string {
+	if t != nil && t.Name() != "" {
+		name = t.Name() + "-" + name
+	}
+	d, err := ioutil.TempDir(tmpdir, name)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	return d
+}
+
+// TempFile creates a temporary file within tmpdir
+// with the name 'testname-name'. If the file cannot
+// be created t.Fatal is called. If a temporary directory
+// has been created before consider storing the file
+// inside this directory to avoid double cleanup.
+func TempFile(t *testing.T, name string) *os.File {
+	if t != nil && t.Name() != "" {
+		name = t.Name() + "-" + name
+	}
+	f, err := ioutil.TempFile(tmpdir, name)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	return f
+}

--- a/testutil/io.go
+++ b/testutil/io.go
@@ -23,7 +23,7 @@ var tmpdir = "/tmp/consul-test"
 
 func init() {
 	if err := os.MkdirAll(tmpdir, 0755); err != nil {
-		fmt.Println("Cannot create %s. Reverting to /tmp", tmpdir)
+		fmt.Printf("Cannot create %s. Reverting to /tmp\n", tmpdir)
 		tmpdir = "/tmp"
 	}
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -173,26 +173,26 @@ type TestServer struct {
 
 // NewTestServer is an easy helper method to create a new Consul
 // test server with the most basic configuration.
-func NewTestServer() (*TestServer, error) {
-	return NewTestServerConfig(nil)
+func NewTestServer(name string) (*TestServer, error) {
+	return NewTestServerConfig(name, nil)
 }
 
 // NewTestServerConfig creates a new TestServer, and makes a call to an optional
 // callback function to modify the configuration. If there is an error
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
-func NewTestServerConfig(cb ServerConfigCallback) (*TestServer, error) {
+func NewTestServerConfig(name string, cb ServerConfigCallback) (*TestServer, error) {
 	if path, err := exec.LookPath("consul"); err != nil || path == "" {
 		return nil, fmt.Errorf("consul not found on $PATH - download and install " +
 			"consul or skip this test")
 	}
 
-	dataDir, err := ioutil.TempDir("", "consul")
+	dataDir, err := ioutil.TempDir("", name+"-consul")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating tempdir")
 	}
 
-	configFile, err := ioutil.TempFile(dataDir, "config")
+	configFile, err := ioutil.TempFile(dataDir, name+"-config")
 	if err != nil {
 		defer os.RemoveAll(dataDir)
 		return nil, errors.Wrap(err, "failed creating temp config")

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -124,7 +124,7 @@ func defaultServerConfig() *TestServerConfig {
 			Server:  randomPort(),
 			RPC:     randomPort(),
 		},
-		ReadyTimeout: 3 * time.Second,
+		ReadyTimeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
* While investigating hanging tests I thought it to be useful if the temp files/dirs contain the test name.

* There was a flurry of macOS firewall warnings when binding to a non-loopback address in the code that I was working on which was a good indication for a bug. After fixing it I've tracked down all tests that generate such a warning and changed them so that they bind to `127.0.0.1`. One test requires an external ip address so this will trigger a warning. I've disabled this test for `darwin` since it is only one test and the CI will catch it. Having no warnings as the default seems like the better choice.

* The `ExecCommandRun` test had a wait time of `10s` which I've lowered to `500ms`.

* I've simplified the `make test` target to use `./...` again. I forgot why I switched to the individual packages in the first place.

* I've added a helper for `ioutil.Temp(Dir|File)` which handles the prefixing and also uses a shorter path `/tmp/consul-test` for temporary files since the long system temp base dir seems to break the UNIX socket tests.

In a subsequent step most or all calls to `TempFile` should most likely be removed and the temp files should be placed into the temp dirs which are usually created as well. This avoids a lot of garbage that some tests create in the temp dir.