### PR TITLE
agent: Replace client/server with delegate interface

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -28,7 +28,7 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 	var c *coordinate.Coordinate
 	if !s.agent.config.DisableCoordinates {
 		var err error
-		if c, err = s.agent.GetCoordinate(); err != nil {
+		if c, err = s.agent.GetLANCoordinate(); err != nil {
 			return nil, err
 		}
 	}

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -192,7 +192,7 @@ func TestAgent_Self(t *testing.T) {
 		t.Fatalf("incorrect port: %v", obj)
 	}
 
-	c, err := srv.agent.server.GetLANCoordinate()
+	c, err := srv.agent.GetLANCoordinate()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -1978,7 +1978,7 @@ func TestAgent_GetCoordinate(t *testing.T) {
 		// sure that the agent chooses the correct Serf instance,
 		// depending on how it's configured as a client or a server.
 		// If it chooses the wrong one, this will crash.
-		if _, err := agent.GetCoordinate(); err != nil {
+		if _, err := agent.GetLANCoordinate(); err != nil {
 			t.Fatalf("err: %s", err)
 		}
 	}

--- a/command/agent/keyring.go
+++ b/command/agent/keyring.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/consul/consul"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/serf/serf"
@@ -111,7 +112,8 @@ func loadKeyringFile(c *serf.Config) error {
 // performing various operations on the encryption keyring.
 func (a *Agent) keyringProcess(args *structs.KeyringRequest) (*structs.KeyringResponses, error) {
 	var reply structs.KeyringResponses
-	if a.server == nil {
+
+	if _, ok := a.delegate.(*consul.Server); !ok {
 		return nil, fmt.Errorf("keyring operations must run against a server node")
 	}
 	if err := a.RPC("Internal.KeyringOperation", args, &reply); err != nil {

--- a/consul/client.go
+++ b/consul/client.go
@@ -407,8 +407,8 @@ func (c *Client) Stats() map[string]map[string]string {
 	return stats
 }
 
-// GetCoordinate returns the network coordinate of the current node, as
+// GetLANCoordinate returns the network coordinate of the current node, as
 // maintained by Serf.
-func (c *Client) GetCoordinate() (*coordinate.Coordinate, error) {
+func (c *Client) GetLANCoordinate() (*coordinate.Coordinate, error) {
 	return c.serf.GetCoordinate()
 }


### PR DESCRIPTION
This patch adds a new internal interface `clientServer` which defines the common methods of `consul.Client` and `consul.Server`. This allows to replace the following code

```go
    if a.server != nil {
        a.server.do()
    } else {
        a.client.do()
    }
```

with

```go
    a.delegate.do()
```

When a specific type is required a type check can be performed:

```go
    if srv, ok := a.delegate.(*consul.Server); ok {
        srv.doSrv()
    }
```