### PR TITLE
agent: support custom check id and name

### DIFF
--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -258,7 +258,7 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 	health := args.HealthCheck(s.agent.config.NodeName)
 
 	// Verify the check type.
-	chkType := &args.CheckType
+	chkType := args.CheckType()
 	if !chkType.Valid() {
 		resp.WriteHeader(400)
 		fmt.Fprint(resp, invalidCheckMessage)

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -650,9 +650,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 	// Register node
 	args := &CheckDefinition{
 		Name: "test",
-		CheckType: CheckType{
-			TTL: 15 * time.Second,
-		},
+		TTL:  15 * time.Second,
 	}
 	req, _ := http.NewRequest("GET", "/v1/agent/check/register?token=abc123", jsonReader(args))
 	obj, err := srv.AgentRegisterCheck(nil, req)
@@ -693,10 +691,8 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 
 	// Register node
 	args := &CheckDefinition{
-		Name: "test",
-		CheckType: CheckType{
-			TTL: 15 * time.Second,
-		},
+		Name:   "test",
+		TTL:    15 * time.Second,
 		Status: api.HealthPassing,
 	}
 	req, _ := http.NewRequest("GET", "/v1/agent/check/register", jsonReader(args))
@@ -732,10 +728,8 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 
 	// Register node
 	args := &CheckDefinition{
-		Name: "test",
-		CheckType: CheckType{
-			TTL: 15 * time.Second,
-		},
+		Name:   "test",
+		TTL:    15 * time.Second,
 		Status: "fluffy",
 	}
 	req, _ := http.NewRequest("GET", "/v1/agent/check/register", jsonReader(args))
@@ -756,9 +750,7 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	args := &CheckDefinition{
 		Name: "test",
-		CheckType: CheckType{
-			TTL: 15 * time.Second,
-		},
+		TTL:  15 * time.Second,
 	}
 
 	t.Run("no token", func(t *testing.T) {
@@ -1596,9 +1588,7 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 	checkArgs := &CheckDefinition{
 		Name:      "memcache_check2",
 		ServiceID: "memcache",
-		CheckType: CheckType{
-			TTL: 15 * time.Second,
-		},
+		TTL:       15 * time.Second,
 	}
 	req, _ = http.NewRequest("GET", "/v1/agent/check/register", jsonReader(checkArgs))
 	if _, err := srv.AgentRegisterCheck(nil, req); err != nil {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -697,16 +697,12 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// check that both checks are there
-	if got, want := agent.state.Checks()["chk1"], hchk1; !verify.Values(t, "chk1", got, want) {
+	if got, want := agent.state.Checks()["chk1"], hchk1; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
-	if got, want := agent.state.Checks()["chk2"], hchk2; !verify.Values(t, "chk1", got, want) {
+	if got, want := agent.state.Checks()["chk2"], hchk2; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
-
-	// check that chk1 is "dangling", i.e. that it isn't
-	// returned as the list of checks for the service.
-	// todo(fs): how do I do this properly?
 
 	// Remove service
 	if err := agent.RemoveService("redis", false); err != nil {

--- a/command/agent/check.go
+++ b/command/agent/check.go
@@ -44,6 +44,17 @@ const (
 // provided: TTL or Script/Interval or HTTP/Interval or TCP/Interval or
 // Docker/Interval.
 type CheckType struct {
+	// fields already embedded in CheckDefinition
+	// Note: CheckType.CheckID == CheckDefinition.ID
+
+	CheckID types.CheckID
+	Name    string
+	Status  string
+	Notes   string
+
+	// fields copied to CheckDefinition
+	// Update CheckDefinition when adding fields here
+
 	Script            string
 	HTTP              string
 	TCP               string
@@ -51,18 +62,13 @@ type CheckType struct {
 	DockerContainerID string
 	Shell             string
 	TLSSkipVerify     bool
-
-	Timeout time.Duration
-	TTL     time.Duration
+	Timeout           time.Duration
+	TTL               time.Duration
 
 	// DeregisterCriticalServiceAfter, if >0, will cause the associated
 	// service, if any, to be deregistered if this check is critical for
 	// longer than this duration.
 	DeregisterCriticalServiceAfter time.Duration
-
-	Status string
-
-	Notes string
 }
 type CheckTypes []*CheckType
 

--- a/command/agent/structs.go
+++ b/command/agent/structs.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"time"
+
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/types"
@@ -52,7 +54,22 @@ type CheckDefinition struct {
 	ServiceID string
 	Token     string
 	Status    string
-	CheckType `mapstructure:",squash"`
+
+	// Copied fields from CheckType without the fields
+	// already present in CheckDefinition:
+	//
+	//   ID (CheckID), Name, Status, Notes
+	//
+	Script                         string
+	HTTP                           string
+	TCP                            string
+	Interval                       time.Duration
+	DockerContainerID              string
+	Shell                          string
+	TLSSkipVerify                  bool
+	Timeout                        time.Duration
+	TTL                            time.Duration
+	DeregisterCriticalServiceAfter time.Duration
 }
 
 func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
@@ -71,6 +88,25 @@ func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
 		health.CheckID = types.CheckID(health.Name)
 	}
 	return health
+}
+
+func (c *CheckDefinition) CheckType() *CheckType {
+	return &CheckType{
+		CheckID:           c.ID,
+		Name:              c.Name,
+		Script:            c.Script,
+		HTTP:              c.HTTP,
+		TCP:               c.TCP,
+		Interval:          c.Interval,
+		DockerContainerID: c.DockerContainerID,
+		Shell:             c.Shell,
+		TLSSkipVerify:     c.TLSSkipVerify,
+		Timeout:           c.Timeout,
+		TTL:               c.TTL,
+		DeregisterCriticalServiceAfter: c.DeregisterCriticalServiceAfter,
+		Status: c.Status,
+		Notes:  c.Notes,
+	}
 }
 
 // persistedService is used to wrap a service definition and bundle it

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -98,7 +98,9 @@ The table below shows this endpoint's support for
 
 - `Check` `(Check: nil)` - Specifies a check. Please see the
   [check documentation](/api/agent/check.html) for more information about the
-  accepted fields.
+  accepted fields. If you don't provide a name or id for the check then they
+  will be generated. To provide a custom id and/or name set the `CheckID`
+  and/or `Name` field.
 
 - `EnableTagOverride` `(bool: false)` - Specifies to disable the anti-entropy
   feature for this service's tags. If `EnableTagOverride` is set to `true` then

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -100,9 +100,16 @@ The table below shows this endpoint's support for
   [check documentation](/api/agent/check.html) for more information about the
   accepted fields. If you don't provide a name or id for the check then they
   will be generated. To provide a custom id and/or name set the `CheckID`
-  and/or `Name` field. Even though the behavior is deterministic, it
-  is recommended for all checks to either let consul set the `CheckID`
-  by leaving the field empty/omitting it or to provide a unique value.
+  and/or `Name` field.
+  
+- `Checks` `(array<Check>: nil`) - Specifies a list of checks. Please see the
+  [check documentation](/api/agent/check.html) for more information about the
+  accepted fields. If you don't provide a name or id for the check then they
+  will be generated. To provide a custom id and/or name set the `CheckID`
+  and/or `Name` field. The automatically generated `Name` and `CheckID` depend
+  on the position of the check within the array, so even though the behavior is
+  determinsitic, it is recommended for all checks to either let consul set the
+  `CheckID` by leaving the field empty/omitting it or to provide a unique value.
 
 - `EnableTagOverride` `(bool: false)` - Specifies to disable the anti-entropy
   feature for this service's tags. If `EnableTagOverride` is set to `true` then

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -100,7 +100,9 @@ The table below shows this endpoint's support for
   [check documentation](/api/agent/check.html) for more information about the
   accepted fields. If you don't provide a name or id for the check then they
   will be generated. To provide a custom id and/or name set the `CheckID`
-  and/or `Name` field.
+  and/or `Name` field. Even though the behavior is deterministic, it
+  is recommended for all checks to either let consul set the `CheckID`
+  by leaving the field empty/omitting it or to provide a unique value.
 
 - `EnableTagOverride` `(bool: false)` - Specifies to disable the anti-entropy
   feature for this service's tags. If `EnableTagOverride` is set to `true` then


### PR DESCRIPTION
This patch adds support for a custom check id and name when
registering a service.

This is achieved by adding a CheckID and a Name field to the
CheckType structure which is used to register checks with a
service and when returning health check definitions.

CheckDefinition is a superset of CheckType which duplicates
some of the fields of CheckType. This patch decouples these
two structures by removing the embedding of CheckType in
CheckDefinition.

Fixes #3047