### PR TITLE
Please check this suggested enhancement

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -345,10 +345,18 @@ PARSE:
 			tag := ""
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
+				svc = labels[n-2]
+				for i, s := range strings {
+					if "tags" == s {
+						// [tag.[tag.[...]]].tags.com.acme.orders.service.consul
+						tag = strings.Join(labels[:i-1], ".")
+						svc = strings.Join(labels[i+1:n-2], ".")
+					}
+				}
 			}
 
 			// tag[.tag].name.service.consul
-			d.serviceLookup(network, datacenter, labels[n-2], tag, req, resp)
+			d.serviceLookup(network, datacenter, svc, tag, req, resp)
 		}
 
 	case "node":

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -343,6 +343,7 @@ PARSE:
 
 			// Support "." in the label, re-join all the parts
 			tag := ""
+			svc := ""
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
 				svc = labels[n-2]


### PR DESCRIPTION
The enhancement suggested by this pull request allows searching services whose names contain dots ('.') and filter the results by tags, all on the DNS interface.