### PR TITLE
Makes test target fail based on return code from go test.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,10 +48,10 @@ cov:
 
 test: dev
 	go test -tags "$(GOTAGS)" -i -run '^$$' ./...
-	go test -tags "$(GOTAGS)" -v $$(go list ./... | egrep -v '(consul/consul|vendor)') > test.log 2>&1 || true
-	go test -tags "$(GOTAGS)" -v github.com/hashicorp/consul/consul >> test.log 2>&1 || true
+	go test -tags "$(GOTAGS)" -v $$(go list ./... | egrep -v '(consul/consul|vendor)') > test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
+	go test -tags "$(GOTAGS)" -v $$(go list ./... | egrep '(consul/consul)') >> test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
 	@if [ "$$TRAVIS" == "true" ] ; then cat test.log ; fi
-	@if grep -q 'FAIL:' test.log ; then grep 'FAIL:' test.log ; exit 1 ; else echo 'PASS' ; fi
+	@if grep -q 'FAIL_TOKEN' test.log ; then grep 'FAIL:' test.log ; exit 1 ; else echo 'PASS' ; fi
 
 test-race: dev
 	go test -tags "$(GOTAGS)" -i -run '^$$' ./...


### PR DESCRIPTION
/cc @magiconair I noticed a case where the tests panic-ed but the make run said "PASS" so I changed this to work off of the return code. Also tweaked the test split to be more symmetrical with `go list` for each pass.