### PR TITLE
Full DNS support for service names containing dots ('.')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 FEATURES:
 
+* agent: Added `encrypt_verify_incoming` and `encrypt_verify_outgoing` options to use for upshifting to encrypted gossip on an existing cluster.
+
 IMPROVEMENTS:
 
 * agent: Added a check which prevents advertising or setting a service to a zero address (`0.0.0.0`, `[::]`, `::`). [GH-2961]

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -345,12 +345,12 @@ PARSE:
 			tag := ""
 			svc := labels[n-2]
 			if n >= 3 {
-				tag = strings.Join(labels[:n-2], ".")
+				tag = strings.Join(labels[:n-1], ".")
 				for i, s := range labels {
 					if "tags" == s {
-						// [tag.[tag.[...]]].tags.com.acme.orders.service.consul
-						tag = strings.Join(labels[:i-1], ".")
-						svc = strings.Join(labels[i+1:n-2], ".")
+						// [tag.[tag.[...]]]tags.com.acme.orders.service.consul
+						tag = strings.Join(labels[:i], ".")
+						svc = strings.Join(labels[i+1:n-1], ".")
 					}
 				}
 			}

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -347,7 +347,7 @@ PARSE:
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
 				svc = labels[n-2]
-				for i, s := range strings {
+				for i, s := range labels {
 					if "tags" == s {
 						// [tag.[tag.[...]]].tags.com.acme.orders.service.consul
 						tag = strings.Join(labels[:i-1], ".")

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -345,10 +345,18 @@ PARSE:
 			tag := ""
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
+				svc = labels[n-2]
+				for i, s := range strings {
+					if "tags" == s {
+						// [tag.[tag.[...]]].tags.com.acme.orders.service.consul
+						tag = strings.Join(labels[:i-1], ".")
+						svc = strings.Join(labels[i+1:n-2], ".")
+					}
+				}
 			}
 
 			// tag[.tag].name.service.consul
-			d.serviceLookup(network, datacenter, labels[n-2], tag, req, resp)
+			d.serviceLookup(network, datacenter, svc, tag, req, resp)
 		}
 
 	case "node":

--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -343,6 +343,7 @@ PARSE:
 
 			// Support "." in the label, re-join all the parts
 			tag := ""
+			svc := ""
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
 				svc = labels[n-2]


### PR DESCRIPTION
Using the DNS interface, you cannot search services whose names contain dots (e.g. 'com.acme.sales.service.consul'), since the code will interpret 'sales' as the service name and 'com', 'acme' as tags the service returned must contain.
This commit proposes an extended FQDN syntax for service searches: '[tag.[tag.[...]]]]tags.svc.name.with.dots.service.consul'. The code behaves identically to latest main branch code if 'tags' is not present in the FQDN, but if it is it parses the FQDN according to the extended FQDN syntax.

'make test' throws many errors in my machine but none seems to be related to this change.