### PR TITLE
agent: increase graceful shutdown timeout

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -813,7 +813,7 @@ func (cmd *Command) Run(args []string) int {
 				close(gracefulCh)
 			}()
 
-			gracefulTimeout := 5 * time.Second
+			gracefulTimeout := 15 * time.Second
 			select {
 			case <-signalCh:
 				return 1


### PR DESCRIPTION
When triggering a leave through an INT/TERM signal the hard-coded
timeout of 5 seconds is too short to complete the leave successfully.
Therefore, the agent always times out.

This value should probably configurable.