### PR TITLE
Fix incorrect action description

### DIFF
--- a/website/source/api/acl.html.md
+++ b/website/source/api/acl.html.md
@@ -208,7 +208,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `uuid` `(string: <required>)` - Specifies the UUID of the ACL token to
-  destroy. This is required and is specified as part of the URL path.
+  be cloned. This is required and is specified as part of the URL path.
 
 ### Sample Request
 


### PR DESCRIPTION
It looks like the description for the uuid in the "clone" request was probably originally copied from the "delete" request. Cloning doesn't delete anything.