### PR TITLE
Bug fix for stale reads on server startup, take #2

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -183,6 +183,9 @@ func (s *Server) establishLeadership() error {
 
 	s.startAutopilot()
 
+	// Set consistent read readiness state
+	s.setConsistentReadReady()
+
 	return nil
 }
 
@@ -198,6 +201,9 @@ func (s *Server) revokeLeadership() error {
 		s.logger.Printf("[ERR] consul: Clearing session timers failed: %v", err)
 		return err
 	}
+
+	// Clear state about readiness to serve consistent reads
+	s.resetConsistentReadReady()
 
 	s.stopAutopilot()
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -183,7 +183,6 @@ func (s *Server) establishLeadership() error {
 
 	s.startAutopilot()
 
-	// Set consistent read readiness state
 	s.setConsistentReadReady()
 
 	return nil
@@ -202,7 +201,6 @@ func (s *Server) revokeLeadership() error {
 		return err
 	}
 
-	// Clear state about readiness to serve consistent reads
 	s.resetConsistentReadReady()
 
 	s.stopAutopilot()

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -32,6 +32,10 @@ func TestLeader_RegisterMember(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
+	if !s1.isReadyForConsistentReads() {
+		t.Fatalf("Expected server to be ready for consistent reads ")
+	}
+
 	// Client should be registered
 	state := s1.fsm.State()
 	retry.Run(t, func(r *retry.R) {
@@ -493,6 +497,9 @@ func TestLeader_LeftLeader(t *testing.T) {
 		t.Fatalf("Should have a leader")
 	}
 	leader.Leave()
+	if leader.isReadyForConsistentReads() {
+		t.Fatalf("Expectected consistent read state to be false ")
+	}
 	leader.Shutdown()
 	time.Sleep(100 * time.Millisecond)
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -32,10 +32,6 @@ func TestLeader_RegisterMember(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
-	if !s1.isReadyForConsistentReads() {
-		t.Fatalf("Expected server to be ready for consistent reads ")
-	}
-
 	// Client should be registered
 	state := s1.fsm.State()
 	retry.Run(t, func(r *retry.R) {
@@ -496,9 +492,12 @@ func TestLeader_LeftLeader(t *testing.T) {
 	if leader == nil {
 		t.Fatalf("Should have a leader")
 	}
+	if !leader.isReadyForConsistentReads() {
+		t.Fatalf("Expected leader to be ready for consistent reads ")
+	}
 	leader.Leave()
 	if leader.isReadyForConsistentReads() {
-		t.Fatalf("Expectected consistent read state to be false ")
+		t.Fatalf("Expected consistent read state to be false ")
 	}
 	leader.Shutdown()
 	time.Sleep(100 * time.Millisecond)

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -434,8 +434,7 @@ func (s *Server) setQueryMeta(m *structs.QueryMeta) {
 func (s *Server) consistentRead() error {
 	defer metrics.MeasureSince([]string{"consul", "rpc", "consistentRead"}, time.Now())
 	future := s.raft.VerifyLeader()
-	err := future.Error()
-	if err != nil {
+	if err := future.Error(); err != nil {
 		return err //fail fast if leader verification fails
 	}
 	// poll consistent read readiness, wait for up to RPCHoldTimeout milliseconds
@@ -443,9 +442,9 @@ func (s *Server) consistentRead() error {
 		return nil
 	}
 	jitter := lib.RandomStagger(s.config.RPCHoldTimeout / jitterFraction)
-	deadline := time.Now().Add(jitter)
+	deadline := time.Now().Add(s.config.RPCHoldTimeout)
 
-	for time.Now().After(deadline) {
+	for time.Now().Before(deadline) {
 
 		select {
 		case <-time.After(jitter):

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -179,12 +179,8 @@ func TestReadyForConsistentReads(t *testing.T) {
 
 	s.resetConsistentReadReady()
 
-	if err := s.consistentRead(); err.Error() != "Not ready to serve consistent reads" {
-		t.Fatal("Server should NOT be ready for consistent reads")
-	}
-
 	setConsistentFunc := func() {
-		time.Sleep(2 * time.Millisecond)
+		time.Sleep(3 * time.Millisecond)
 		s.setConsistentReadReady()
 	}
 
@@ -193,12 +189,15 @@ func TestReadyForConsistentReads(t *testing.T) {
 	//set some time to wait for the goroutine above to finish
 	waitUntil := time.Now().Add(time.Millisecond * 5)
 	err := s.consistentRead()
+	if err.Error() != "Not ready to serve consistent reads" {
+		t.Fatal("Server should NOT be ready for consistent reads")
+	}
 	for time.Now().Before(waitUntil) && err != nil {
 		err = s.consistentRead()
 	}
 
 	if err != nil {
-		t.Fatal("Expected server to be ready for consistent reads ")
+		t.Fatalf("Expected server to be ready for consistent reads, got error %v", err)
 	}
 
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"sync/atomic"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/agent"
 	"github.com/hashicorp/consul/agent/consul/servers"
@@ -140,6 +142,9 @@ type Server struct {
 	// into the leader manager, so that the strong state can be
 	// updated
 	reconcileCh chan serf.Member
+
+	// used to track when the server is ready to serve consistent reads
+	readyForConsistentReads uint32
 
 	// router is used to map out Consul servers in the WAN and in Consul
 	// Enterprise user-defined areas.
@@ -1000,6 +1005,21 @@ func (s *Server) GetLANCoordinate() (*coordinate.Coordinate, error) {
 // GetWANCoordinate returns the coordinate of the server in the WAN gossip pool.
 func (s *Server) GetWANCoordinate() (*coordinate.Coordinate, error) {
 	return s.serfWAN.GetCoordinate()
+}
+
+// Atomically sets a readiness state flag when leadership is obtained, to indicate that server is past its barrier write
+func (s *Server) setConsistentReadReady() {
+	atomic.StoreUint32(&s.readyForConsistentReads, 1)
+}
+
+// Atomically reset readiness state flag on leadership revoke
+func (s *Server) resetConsistentReadReady() {
+	atomic.StoreUint32(&s.readyForConsistentReads, 0)
+}
+
+// Returns true if this server is ready to serve consistent reads
+func (s *Server) isReadyForConsistentReads() bool {
+	return atomic.LoadUint32(&s.readyForConsistentReads) > 0
 }
 
 // peersInfoContent is used to help operators understand what happened to the

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1018,7 +1018,7 @@ func (s *Server) resetConsistentReadReady() {
 
 // Returns true if this server is ready to serve consistent reads
 func (s *Server) isReadyForConsistentReads() bool {
-	return atomic.LoadInt32(&s.readyForConsistentReads) > 0
+	return atomic.LoadInt32(&s.readyForConsistentReads) == 1
 }
 
 // peersInfoContent is used to help operators understand what happened to the

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -14,9 +14,8 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
-	"time"
-
 	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/agent"
@@ -143,8 +142,8 @@ type Server struct {
 	// updated
 	reconcileCh chan serf.Member
 
-	// used to track when the server is ready to serve consistent reads
-	readyForConsistentReads uint32
+	// used to track when the server is ready to serve consistent reads, updated atomically
+	readyForConsistentReads int32
 
 	// router is used to map out Consul servers in the WAN and in Consul
 	// Enterprise user-defined areas.
@@ -1009,17 +1008,17 @@ func (s *Server) GetWANCoordinate() (*coordinate.Coordinate, error) {
 
 // Atomically sets a readiness state flag when leadership is obtained, to indicate that server is past its barrier write
 func (s *Server) setConsistentReadReady() {
-	atomic.StoreUint32(&s.readyForConsistentReads, 1)
+	atomic.StoreInt32(&s.readyForConsistentReads, 1)
 }
 
 // Atomically reset readiness state flag on leadership revoke
 func (s *Server) resetConsistentReadReady() {
-	atomic.StoreUint32(&s.readyForConsistentReads, 0)
+	atomic.StoreInt32(&s.readyForConsistentReads, 0)
 }
 
 // Returns true if this server is ready to serve consistent reads
 func (s *Server) isReadyForConsistentReads() bool {
-	return atomic.LoadUint32(&s.readyForConsistentReads) > 0
+	return atomic.LoadInt32(&s.readyForConsistentReads) > 0
 }
 
 // peersInfoContent is used to help operators understand what happened to the

--- a/agent/consul/structs/structs.go
+++ b/agent/consul/structs/structs.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	ErrNoLeader  = fmt.Errorf("No cluster leader")
-	ErrNoDCPath  = fmt.Errorf("No path to datacenter")
-	ErrNoServers = fmt.Errorf("No known Consul servers")
+	ErrNoLeader                   = fmt.Errorf("No cluster leader")
+	ErrNoDCPath                   = fmt.Errorf("No path to datacenter")
+	ErrNoServers                  = fmt.Errorf("No known Consul servers")
+	ErrNotReadyForConsistentReads = fmt.Errorf("Not ready to serve consistent reads")
 )
 
 type MessageType uint8

--- a/website/source/docs/internals/consensus.html.md
+++ b/website/source/docs/internals/consensus.html.md
@@ -75,7 +75,9 @@ is an opaque binary blob). The leader then writes the entry to durable storage a
 attempts to replicate to a quorum of followers. Once the log entry is considered
 *committed*, it can be *applied* to a finite state machine. The finite state machine
 is application specific; in Consul's case, we use
-[BoltDB](https://github.com/boltdb/bolt) to maintain cluster state.
+[MemDB](https://github.com/hashicorp/go-memdb) to maintain cluster state. Consul's writes
+block until it is both _committed_ and _applied_. This achieves read after write semantics
+when used with the [consistent](/api/index.html#consistent) mode for queries.
 
 Obviously, it would be undesirable to allow a replicated log to grow in an unbounded
 fashion. Raft provides a mechanism by which the current state is snapshotted and the


### PR DESCRIPTION
Uses an atomic integer to track when leader is ready to serve consistent reads, and uses RPCHoldTime to wait for ready state.