### PR TITLE
Pkg refactor cleanup

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -174,7 +174,7 @@ func (m *aclManager) lookupACL(a *Agent, id string) (acl.ACL, error) {
 		args.ETag = cached.ETag
 	}
 	var reply structs.ACLPolicy
-	err := a.RPC(a.getEndpoint("ACL")+".GetPolicy", &args, &reply)
+	err := a.RPC("ACL.GetPolicy", &args, &reply)
 	if err != nil {
 		if strings.Contains(err.Error(), aclDisabled) {
 			a.logger.Printf("[DEBUG] agent: ACLs disabled on servers, will check again after %s", a.config.ACLDisabledTTL)

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -47,7 +47,7 @@ func TestACL_Version8(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestACL_Disabled(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -123,7 +123,7 @@ func TestACL_Special_IDs(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestACL_Down_Deny(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -206,7 +206,7 @@ func TestACL_Down_Allow(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -236,7 +236,7 @@ func TestACL_Down_Extend(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -313,7 +313,7 @@ func TestACL_Cache(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -495,7 +495,7 @@ func TestACL_vetServiceRegister(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -541,7 +541,7 @@ func TestACL_vetServiceUpdate(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -577,7 +577,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -660,7 +660,7 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -716,7 +716,7 @@ func TestACL_filterMembers(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -752,7 +752,7 @@ func TestACL_filterServices(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -783,7 +783,7 @@ func TestACL_filterChecks(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.RegisterEndpoint("ACL", &m); err != nil {
+	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -47,7 +47,7 @@ func TestACL_Version8(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestACL_Disabled(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -123,7 +123,7 @@ func TestACL_Special_IDs(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestACL_Down_Deny(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -206,7 +206,7 @@ func TestACL_Down_Allow(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -236,7 +236,7 @@ func TestACL_Down_Extend(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -313,7 +313,7 @@ func TestACL_Cache(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -495,7 +495,7 @@ func TestACL_vetServiceRegister(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -541,7 +541,7 @@ func TestACL_vetServiceUpdate(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -577,7 +577,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -660,7 +660,7 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -716,7 +716,7 @@ func TestACL_filterMembers(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -752,7 +752,7 @@ func TestACL_filterServices(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -783,7 +783,7 @@ func TestACL_filterChecks(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockServer{catalogPolicy}
-	if err := a.InjectEndpoint("ACL", &m); err != nil {
+	if err := a.RegisterEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,9 +57,9 @@ const (
 // dnsNameRe checks if a name or tag is dns-compatible.
 var dnsNameRe = regexp.MustCompile(`^[a-zA-Z0-9\-]+$`)
 
-// clientServer defines the interface shared by both
+// delegate defines the interface shared by both
 // consul.Client and consul.Server.
-type clientServer interface {
+type delegate interface {
 	Encrypted() bool
 	GetLANCoordinate() (*coordinate.Coordinate, error)
 	Leave() error
@@ -94,7 +94,7 @@ type Agent struct {
 
 	// delegate is either a *consul.Server or *consul.Client
 	// depending on the configuration
-	delegate clientServer
+	delegate delegate
 
 	// acls is an object that helps manage local ACL enforcement.
 	acls *aclManager

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1342,6 +1342,13 @@ func (a *Agent) reapServices() {
 
 }
 
+// persistedService is used to wrap a service definition and bundle it
+// with an ACL token so we can restore both at a later agent start.
+type persistedService struct {
+	Token   string
+	Service *structs.NodeService
+}
+
 // persistService saves a service definition to a JSON file in the data dir
 func (a *Agent) persistService(service *structs.NodeService) error {
 	svcPath := filepath.Join(a.config.DataDir, servicesDir, stringHash(service.ID))
@@ -1368,7 +1375,7 @@ func (a *Agent) purgeService(serviceID string) error {
 }
 
 // persistCheck saves a check definition to the local agent's state directory
-func (a *Agent) persistCheck(check *structs.HealthCheck, chkType *CheckType) error {
+func (a *Agent) persistCheck(check *structs.HealthCheck, chkType *structs.CheckType) error {
 	checkPath := filepath.Join(a.config.DataDir, checksDir, checkIDHash(check.CheckID))
 
 	// Create the persisted check
@@ -1426,7 +1433,7 @@ func writeFileAtomic(path string, contents []byte) error {
 // AddService is used to add a service entry.
 // This entry is persistent and the agent will make a best effort to
 // ensure it is registered
-func (a *Agent) AddService(service *structs.NodeService, chkTypes CheckTypes, persist bool, token string) error {
+func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string) error {
 	if service.Service == "" {
 		return fmt.Errorf("Service name missing")
 	}
@@ -1552,7 +1559,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 // This entry is persistent and the agent will make a best effort to
 // ensure it is registered. The Check may include a CheckType which
 // is used to automatically update the check status
-func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *CheckType, persist bool, token string) error {
+func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType, persist bool, token string) error {
 	if check.CheckID == "" {
 		return fmt.Errorf("CheckID missing")
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1067,11 +1067,11 @@ LOAD:
 	return nil
 }
 
-// RegisterEndpoint registers a handler for the consul RPC server
+// registerEndpoint registers a handler for the consul RPC server
 // under a unique name while making it accessible under the provided
 // name. This allows overwriting handlers for the golang net/rpc
 // service which does not allow this.
-func (a *Agent) RegisterEndpoint(name string, handler interface{}) error {
+func (a *Agent) registerEndpoint(name string, handler interface{}) error {
 	srv, ok := a.delegate.(*consul.Server)
 	if !ok {
 		panic("agent must be a server")

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -68,7 +68,7 @@ type delegate interface {
 	JoinLAN(addrs []string) (n int, err error)
 	RemoveFailedNode(node string) error
 	RPC(method string, args interface{}, reply interface{}) error
-	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn consul.SnapshotReplyFn) error
+	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error
 	Stats() map[string]map[string]string
 }
@@ -1080,7 +1080,7 @@ func (a *Agent) RPC(method string, args interface{}, reply interface{}) error {
 // payload, and the response message will determine the error status, and any
 // return payload will be written to out.
 func (a *Agent) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer,
-	replyFn consul.SnapshotReplyFn) error {
+	replyFn structs.SnapshotReplyFn) error {
 	return a.delegate.SnapshotRPC(args, in, out, replyFn)
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/consul"
-	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/consul/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/ipaddr"
@@ -135,7 +134,7 @@ type Agent struct {
 	eventBuf    []*UserEvent
 	eventIndex  int
 	eventLock   sync.RWMutex
-	eventNotify state.NotifyGroup
+	eventNotify NotifyGroup
 
 	reloadCh chan chan error
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -230,9 +230,6 @@ func (a *Agent) Start() error {
 		return fmt.Errorf("Failed to setup node ID: %v", err)
 	}
 
-	// Initialize the local state.
-	a.state.Init(c, a.logger)
-
 	// Setup either the client or the server.
 	if c.Server {
 		server, err := a.makeServer()
@@ -241,7 +238,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = server
-		a.state.SetIface(server)
+		a.state.Init(c, a.logger, server)
 
 		// Automatically register the "consul" service on server nodes
 		consulService := structs.NodeService{
@@ -259,7 +256,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = client
-		a.state.SetIface(client)
+		a.state.Init(c, a.logger, client)
 	}
 
 	// Load checks/services/metadata.

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -230,7 +230,7 @@ func (s *HTTPServer) syncChanges() {
 const invalidCheckMessage = "Must provide TTL or Script/DockerContainerID/HTTP/TCP and Interval"
 
 func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	var args CheckDefinition
+	var args structs.CheckDefinition
 	// Fixup the type decode of TTL or Interval.
 	decodeCB := func(raw interface{}) error {
 		return FixupCheckType(raw)
@@ -412,7 +412,7 @@ func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Reques
 }
 
 func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	var args ServiceDefinition
+	var args structs.ServiceDefinition
 	// Fixup the type decode of TTL or Interval if a check if provided.
 	decodeCB := func(raw interface{}) error {
 		rawMap, ok := raw.(map[string]interface{})

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -234,8 +234,8 @@ func TestAgent_Reload(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
 	cfg.ACLEnforceVersion8 = Bool(false)
-	cfg.Services = []*ServiceDefinition{
-		&ServiceDefinition{Name: "redis"},
+	cfg.Services = []*structs.ServiceDefinition{
+		&structs.ServiceDefinition{Name: "redis"},
 	}
 	a := NewTestAgent(t.Name(), cfg)
 	defer a.Shutdown()
@@ -246,8 +246,8 @@ func TestAgent_Reload(t *testing.T) {
 
 	cfg2 := TestConfig()
 	cfg2.ACLEnforceVersion8 = Bool(false)
-	cfg2.Services = []*ServiceDefinition{
-		&ServiceDefinition{Name: "redis-reloaded"},
+	cfg2.Services = []*structs.ServiceDefinition{
+		&structs.ServiceDefinition{Name: "redis-reloaded"},
 	}
 
 	ok, err := a.ReloadConfig(cfg2)
@@ -580,7 +580,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register node
-	args := &CheckDefinition{
+	args := &structs.CheckDefinition{
 		Name: "test",
 		TTL:  15 * time.Second,
 	}
@@ -621,7 +621,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register node
-	args := &CheckDefinition{
+	args := &structs.CheckDefinition{
 		Name:   "test",
 		TTL:    15 * time.Second,
 		Status: api.HealthPassing,
@@ -657,7 +657,7 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 	defer a.Shutdown()
 
 	// Register node
-	args := &CheckDefinition{
+	args := &structs.CheckDefinition{
 		Name:   "test",
 		TTL:    15 * time.Second,
 		Status: "fluffy",
@@ -677,7 +677,7 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 	a := NewTestAgent(t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
-	args := &CheckDefinition{
+	args := &structs.CheckDefinition{
 		Name: "test",
 		TTL:  15 * time.Second,
 	}
@@ -754,7 +754,7 @@ func TestAgent_PassCheck(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -781,7 +781,7 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -807,7 +807,7 @@ func TestAgent_WarnCheck(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -834,7 +834,7 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -860,7 +860,7 @@ func TestAgent_FailCheck(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -887,7 +887,7 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -913,7 +913,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1012,7 +1012,7 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 	defer a.Shutdown()
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
-	chkType := &CheckType{TTL: 15 * time.Second}
+	chkType := &structs.CheckType{TTL: 15 * time.Second}
 	if err := a.AddCheck(chk, chkType, false, ""); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1039,18 +1039,18 @@ func TestAgent_RegisterService(t *testing.T) {
 	a := NewTestAgent(t.Name(), nil)
 	defer a.Shutdown()
 
-	args := &ServiceDefinition{
+	args := &structs.ServiceDefinition{
 		Name: "test",
 		Tags: []string{"master"},
 		Port: 8000,
-		Check: CheckType{
+		Check: structs.CheckType{
 			TTL: 15 * time.Second,
 		},
-		Checks: CheckTypes{
-			&CheckType{
+		Checks: []*structs.CheckType{
+			&structs.CheckType{
 				TTL: 20 * time.Second,
 			},
-			&CheckType{
+			&structs.CheckType{
 				TTL: 30 * time.Second,
 			},
 		},
@@ -1091,18 +1091,18 @@ func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 	a := NewTestAgent(t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
-	args := &ServiceDefinition{
+	args := &structs.ServiceDefinition{
 		Name: "test",
 		Tags: []string{"master"},
 		Port: 8000,
-		Check: CheckType{
+		Check: structs.CheckType{
 			TTL: 15 * time.Second,
 		},
-		Checks: CheckTypes{
-			&CheckType{
+		Checks: []*structs.CheckType{
+			&structs.CheckType{
 				TTL: 20 * time.Second,
 			},
-			&CheckType{
+			&structs.CheckType{
 				TTL: 30 * time.Second,
 			},
 		},
@@ -1130,7 +1130,7 @@ func TestAgent_RegisterService_InvalidAddress(t *testing.T) {
 
 	for _, addr := range []string{"0.0.0.0", "::", "[::]"} {
 		t.Run("addr "+addr, func(t *testing.T) {
-			args := &ServiceDefinition{
+			args := &structs.ServiceDefinition{
 				Name:    "test",
 				Address: addr,
 				Port:    8000,
@@ -1475,10 +1475,10 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 	a := NewTestAgent(t.Name(), nil)
 	defer a.Shutdown()
 
-	args := &ServiceDefinition{
+	args := &structs.ServiceDefinition{
 		Name: "memcache",
 		Port: 8000,
-		Check: CheckType{
+		Check: structs.CheckType{
 			TTL: 15 * time.Second,
 		},
 	}
@@ -1490,7 +1490,7 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 	}
 
 	// Now register an additional check
-	checkArgs := &CheckDefinition{
+	checkArgs := &structs.CheckDefinition{
 		Name:      "memcache_check2",
 		ServiceID: "memcache",
 		TTL:       15 * time.Second,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -336,7 +336,7 @@ func TestAgent_AddService(t *testing.T) {
 	tests := []struct {
 		desc       string
 		srv        *structs.NodeService
-		chkTypes   CheckTypes
+		chkTypes   []*structs.CheckType
 		healthChks map[string]*structs.HealthCheck
 	}{
 		{
@@ -347,8 +347,8 @@ func TestAgent_AddService(t *testing.T) {
 				Tags:    []string{"tag1"},
 				Port:    8100,
 			},
-			CheckTypes{
-				&CheckType{
+			[]*structs.CheckType{
+				&structs.CheckType{
 					CheckID: "check1",
 					Name:    "name1",
 					TTL:     time.Minute,
@@ -375,22 +375,22 @@ func TestAgent_AddService(t *testing.T) {
 				Tags:    []string{"tag2"},
 				Port:    8200,
 			},
-			CheckTypes{
-				&CheckType{
+			[]*structs.CheckType{
+				&structs.CheckType{
 					CheckID: "check1",
 					Name:    "name1",
 					TTL:     time.Minute,
 					Notes:   "note1",
 				},
-				&CheckType{
+				&structs.CheckType{
 					CheckID: "check-noname",
 					TTL:     time.Minute,
 				},
-				&CheckType{
+				&structs.CheckType{
 					Name: "check-noid",
 					TTL:  time.Minute,
 				},
-				&CheckType{
+				&structs.CheckType{
 					TTL: time.Minute,
 				},
 			},
@@ -499,14 +499,14 @@ func TestAgent_RemoveService(t *testing.T) {
 			Service: "memcache",
 			Port:    8000,
 		}
-		chkTypes := CheckTypes{&CheckType{TTL: time.Minute}}
+		chkTypes := []*structs.CheckType{&structs.CheckType{TTL: time.Minute}}
 
 		if err := a.AddService(srv, chkTypes, false, ""); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
 		// Add a check after the fact with a specific check ID
-		check := &CheckDefinition{
+		check := &structs.CheckDefinition{
 			ID:        "check2",
 			Name:      "check2",
 			ServiceID: "memcache",
@@ -535,9 +535,9 @@ func TestAgent_RemoveService(t *testing.T) {
 			Service: "redis",
 			Port:    8000,
 		}
-		chkTypes := CheckTypes{
-			&CheckType{TTL: time.Minute},
-			&CheckType{TTL: 30 * time.Second},
+		chkTypes := []*structs.CheckType{
+			&structs.CheckType{TTL: time.Minute},
+			&structs.CheckType{TTL: 30 * time.Second},
 		}
 		if err := a.AddService(srv, chkTypes, false, ""); err != nil {
 			t.Fatalf("err: %v", err)
@@ -579,13 +579,13 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{ID: "redis", Service: "redis", Port: 8000}
-	chk1 := &CheckType{CheckID: "chk1", Name: "chk1", TTL: time.Minute}
-	chk2 := &CheckType{CheckID: "chk2", Name: "chk2", TTL: 2 * time.Minute}
+	chk1 := &structs.CheckType{CheckID: "chk1", Name: "chk1", TTL: time.Minute}
+	chk2 := &structs.CheckType{CheckID: "chk2", Name: "chk2", TTL: 2 * time.Minute}
 	hchk1 := &structs.HealthCheck{Node: "node1", CheckID: "chk1", Name: "chk1", Status: "critical", ServiceID: "redis", ServiceName: "redis"}
 	hchk2 := &structs.HealthCheck{Node: "node1", CheckID: "chk2", Name: "chk2", Status: "critical", ServiceID: "redis", ServiceName: "redis"}
 
 	// register service with chk1
-	if err := a.AddService(svc, CheckTypes{chk1}, false, ""); err != nil {
+	if err := a.AddService(svc, []*structs.CheckType{chk1}, false, ""); err != nil {
 		t.Fatal("Failed to register service", err)
 	}
 
@@ -595,7 +595,7 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// update the service with chk2
-	if err := a.AddService(svc, CheckTypes{chk2}, false, ""); err != nil {
+	if err := a.AddService(svc, []*structs.CheckType{chk2}, false, ""); err != nil {
 		t.Fatal("Failed to update service", err)
 	}
 
@@ -632,7 +632,7 @@ func TestAgent_AddCheck(t *testing.T) {
 		Name:    "memory util",
 		Status:  api.HealthCritical,
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		Script:   "exit 0",
 		Interval: 15 * time.Second,
 	}
@@ -669,7 +669,7 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 		Name:    "memory util",
 		Status:  api.HealthPassing,
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		Script:   "exit 0",
 		Interval: 15 * time.Second,
 	}
@@ -706,7 +706,7 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 		Name:    "memory util",
 		Status:  api.HealthCritical,
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		Script:   "exit 0",
 		Interval: time.Microsecond,
 	}
@@ -739,7 +739,7 @@ func TestAgent_AddCheck_MissingService(t *testing.T) {
 		Name:      "baz check 1",
 		ServiceID: "baz",
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		Script:   "exit 0",
 		Interval: time.Microsecond,
 	}
@@ -770,7 +770,7 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 		CheckID: "baz",
 		Name:    "baz check 1",
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		TTL: time.Minute,
 	}
 	err = a.AddCheck(health, chk, false, "")
@@ -813,7 +813,7 @@ func TestAgent_RemoveCheck(t *testing.T) {
 		Name:    "memory util",
 		Status:  api.HealthCritical,
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		Script:   "exit 0",
 		Interval: 15 * time.Second,
 	}
@@ -849,7 +849,7 @@ func TestAgent_updateTTLCheck(t *testing.T) {
 		Name:    "memory util",
 		Status:  api.HealthCritical,
 	}
-	chk := &CheckType{
+	chk := &structs.CheckType{
 		TTL: 15 * time.Second,
 	}
 
@@ -1085,14 +1085,14 @@ func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
 
 	// Try bringing the agent back up with the service already
 	// existing in the config
-	svc2 := &ServiceDefinition{
+	svc2 := &structs.ServiceDefinition{
 		ID:   "redis",
 		Name: "redis",
 		Tags: []string{"bar"},
 		Port: 9000,
 	}
 
-	cfg.Services = []*ServiceDefinition{svc2}
+	cfg.Services = []*structs.ServiceDefinition{svc2}
 	a2 := NewTestAgent(t.Name()+"-a2", cfg)
 	defer a2.Shutdown()
 
@@ -1124,7 +1124,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 		Name:    "memory check",
 		Status:  api.HealthPassing,
 	}
-	chkType := &CheckType{
+	chkType := &structs.CheckType{
 		Script:   "/bin/true",
 		Interval: 10 * time.Second,
 	}
@@ -1265,7 +1265,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	a.Shutdown()
 
 	// Start again with the check registered in config
-	check2 := &CheckDefinition{
+	check2 := &structs.CheckDefinition{
 		ID:       "mem",
 		Name:     "memory check",
 		Notes:    "my cool notes",
@@ -1273,7 +1273,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 		Interval: 30 * time.Second,
 	}
 
-	cfg.Checks = []*CheckDefinition{check2}
+	cfg.Checks = []*structs.CheckDefinition{check2}
 	a2 := NewTestAgent(t.Name()+"-a2", cfg)
 	defer a2.Shutdown()
 
@@ -1294,7 +1294,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 func TestAgent_loadChecks_token(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
-	cfg.Checks = append(cfg.Checks, &CheckDefinition{
+	cfg.Checks = append(cfg.Checks, &structs.CheckDefinition{
 		ID:    "rabbitmq",
 		Name:  "rabbitmq",
 		Token: "abc123",
@@ -1367,7 +1367,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 func TestAgent_loadServices_token(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
-	cfg.Services = append(cfg.Services, &ServiceDefinition{
+	cfg.Services = append(cfg.Services, &structs.ServiceDefinition{
 		ID:    "rabbitmq",
 		Name:  "rabbitmq",
 		Port:  5672,
@@ -1510,8 +1510,8 @@ func TestAgent_Service_Reap(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	chkTypes := CheckTypes{
-		&CheckType{
+	chkTypes := []*structs.CheckType{
+		&structs.CheckType{
 			Status: api.HealthPassing,
 			TTL:    10 * time.Millisecond,
 			DeregisterCriticalServiceAfter: 100 * time.Millisecond,
@@ -1584,8 +1584,8 @@ func TestAgent_Service_NoReap(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    8000,
 	}
-	chkTypes := CheckTypes{
-		&CheckType{
+	chkTypes := []*structs.CheckType{
+		&structs.CheckType{
 			Status: api.HealthPassing,
 			TTL:    10 * time.Millisecond,
 		},
@@ -1653,7 +1653,7 @@ func TestAgent_addCheck_restoresSnapshot(t *testing.T) {
 	}
 
 	// Re-registering the service preserves the state of the check
-	chkTypes := CheckTypes{&CheckType{TTL: 30 * time.Second}}
+	chkTypes := []*structs.CheckType{&structs.CheckType{TTL: 30 * time.Second}}
 	if err := a.AddService(svc, chkTypes, false, ""); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/check.go
+++ b/agent/check.go
@@ -38,72 +38,6 @@ const (
 	UserAgent = "Consul Health Check"
 )
 
-// CheckType is used to create either the CheckMonitor or the CheckTTL.
-// Five types are supported: Script, HTTP, TCP, Docker and TTL. Script, HTTP,
-// Docker and TCP all require Interval. Only one of the types may to be
-// provided: TTL or Script/Interval or HTTP/Interval or TCP/Interval or
-// Docker/Interval.
-type CheckType struct {
-	// fields already embedded in CheckDefinition
-	// Note: CheckType.CheckID == CheckDefinition.ID
-
-	CheckID types.CheckID
-	Name    string
-	Status  string
-	Notes   string
-
-	// fields copied to CheckDefinition
-	// Update CheckDefinition when adding fields here
-
-	Script            string
-	HTTP              string
-	Header            map[string][]string
-	Method            string
-	TCP               string
-	Interval          time.Duration
-	DockerContainerID string
-	Shell             string
-	TLSSkipVerify     bool
-	Timeout           time.Duration
-	TTL               time.Duration
-
-	// DeregisterCriticalServiceAfter, if >0, will cause the associated
-	// service, if any, to be deregistered if this check is critical for
-	// longer than this duration.
-	DeregisterCriticalServiceAfter time.Duration
-}
-type CheckTypes []*CheckType
-
-// Valid checks if the CheckType is valid
-func (c *CheckType) Valid() bool {
-	return c.IsTTL() || c.IsMonitor() || c.IsHTTP() || c.IsTCP() || c.IsDocker()
-}
-
-// IsTTL checks if this is a TTL type
-func (c *CheckType) IsTTL() bool {
-	return c.TTL != 0
-}
-
-// IsMonitor checks if this is a Monitor type
-func (c *CheckType) IsMonitor() bool {
-	return c.Script != "" && c.DockerContainerID == "" && c.Interval != 0
-}
-
-// IsHTTP checks if this is a HTTP type
-func (c *CheckType) IsHTTP() bool {
-	return c.HTTP != "" && c.Interval != 0
-}
-
-// IsTCP checks if this is a TCP type
-func (c *CheckType) IsTCP() bool {
-	return c.TCP != "" && c.Interval != 0
-}
-
-// IsDocker returns true when checking a docker container.
-func (c *CheckType) IsDocker() bool {
-	return c.DockerContainerID != "" && c.Script != "" && c.Interval != 0
-}
-
 // CheckNotifier interface is used by the CheckMonitor
 // to notify when a check has a status update. The update
 // should take care to be idempotent.
@@ -324,7 +258,7 @@ func (c *CheckTTL) SetStatus(status, output string) {
 // so that it may be restored later on.
 type persistedCheck struct {
 	Check   *structs.HealthCheck
-	ChkType *CheckType
+	ChkType *structs.CheckType
 	Token   string
 }
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/consul"
+	"github.com/hashicorp/consul/agent/consul/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
@@ -729,10 +730,10 @@ type Config struct {
 	SyncCoordinateIntervalMin time.Duration `mapstructure:"-" json:"-"`
 
 	// Checks holds the provided check definitions
-	Checks []*CheckDefinition `mapstructure:"-" json:"-"`
+	Checks []*structs.CheckDefinition `mapstructure:"-" json:"-"`
 
 	// Services holds the provided service definitions
-	Services []*ServiceDefinition `mapstructure:"-" json:"-"`
+	Services []*structs.ServiceDefinition `mapstructure:"-" json:"-"`
 
 	// ConsulConfig can either be provided or a default one created
 	ConsulConfig *consul.Config `mapstructure:"-" json:"-"`
@@ -1371,7 +1372,7 @@ func DecodeConfig(r io.Reader) (*Config, error) {
 }
 
 // DecodeServiceDefinition is used to decode a service definition
-func DecodeServiceDefinition(raw interface{}) (*ServiceDefinition, error) {
+func DecodeServiceDefinition(raw interface{}) (*structs.ServiceDefinition, error) {
 	rawMap, ok := raw.(map[string]interface{})
 	if !ok {
 		goto AFTER_FIX
@@ -1404,7 +1405,7 @@ func DecodeServiceDefinition(raw interface{}) (*ServiceDefinition, error) {
 	}
 AFTER_FIX:
 	var md mapstructure.Metadata
-	var result ServiceDefinition
+	var result structs.ServiceDefinition
 	msdec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Metadata: &md,
 		Result:   &result,
@@ -1511,12 +1512,12 @@ func FixupCheckType(raw interface{}) error {
 }
 
 // DecodeCheckDefinition is used to decode a check definition
-func DecodeCheckDefinition(raw interface{}) (*CheckDefinition, error) {
+func DecodeCheckDefinition(raw interface{}) (*structs.CheckDefinition, error) {
 	if err := FixupCheckType(raw); err != nil {
 		return nil, err
 	}
 	var md mapstructure.Metadata
-	var result CheckDefinition
+	var result structs.CheckDefinition
 	msdec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Metadata: &md,
 		Result:   &result,

--- a/agent/config_test.go
+++ b/agent/config_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/consul/structs"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/pascaldekloe/goe/verify"
 )
@@ -742,8 +743,8 @@ func TestDecodeConfig(t *testing.T) {
 					}
 				}`,
 			c: &Config{
-				Services: []*ServiceDefinition{
-					&ServiceDefinition{
+				Services: []*structs.ServiceDefinition{
+					&structs.ServiceDefinition{
 						ID:                "a",
 						Name:              "b",
 						Tags:              []string{"c", "d"},
@@ -751,7 +752,7 @@ func TestDecodeConfig(t *testing.T) {
 						Port:              123,
 						Token:             "f",
 						EnableTagOverride: true,
-						Check: CheckType{
+						Check: structs.CheckType{
 							CheckID:           "g",
 							Name:              "h",
 							Status:            "i",
@@ -825,8 +826,8 @@ func TestDecodeConfig(t *testing.T) {
 					}
 				}`,
 			c: &Config{
-				Services: []*ServiceDefinition{
-					&ServiceDefinition{
+				Services: []*structs.ServiceDefinition{
+					&structs.ServiceDefinition{
 						ID:                "a",
 						Name:              "b",
 						Tags:              []string{"c", "d"},
@@ -834,7 +835,7 @@ func TestDecodeConfig(t *testing.T) {
 						Port:              123,
 						Token:             "f",
 						EnableTagOverride: true,
-						Checks: CheckTypes{
+						Checks: []*structs.CheckType{
 							{
 								CheckID:           "g",
 								Name:              "h",
@@ -937,8 +938,8 @@ func TestDecodeConfig(t *testing.T) {
 					]
 				}`,
 			c: &Config{
-				Services: []*ServiceDefinition{
-					&ServiceDefinition{
+				Services: []*structs.ServiceDefinition{
+					&structs.ServiceDefinition{
 						ID:                "a",
 						Name:              "b",
 						Tags:              []string{"c", "d"},
@@ -946,7 +947,7 @@ func TestDecodeConfig(t *testing.T) {
 						Port:              123,
 						Token:             "f",
 						EnableTagOverride: true,
-						Check: CheckType{
+						Check: structs.CheckType{
 							CheckID:           "g",
 							Name:              "h",
 							Status:            "i",
@@ -965,7 +966,7 @@ func TestDecodeConfig(t *testing.T) {
 							DeregisterCriticalServiceAfter: 5 * time.Second,
 						},
 					},
-					&ServiceDefinition{
+					&structs.ServiceDefinition{
 						ID:                "aa",
 						Name:              "bb",
 						Tags:              []string{"cc", "dd"},
@@ -973,7 +974,7 @@ func TestDecodeConfig(t *testing.T) {
 						Port:              246,
 						Token:             "ff",
 						EnableTagOverride: false,
-						Check: CheckType{
+						Check: structs.CheckType{
 							CheckID:           "gg",
 							Name:              "hh",
 							Status:            "ii",
@@ -1021,8 +1022,8 @@ func TestDecodeConfig(t *testing.T) {
 					}
 				}`,
 			c: &Config{
-				Checks: []*CheckDefinition{
-					&CheckDefinition{
+				Checks: []*structs.CheckDefinition{
+					&structs.CheckDefinition{
 						ID:                "a",
 						Name:              "b",
 						Notes:             "c",
@@ -1092,8 +1093,8 @@ func TestDecodeConfig(t *testing.T) {
 					]
 				}`,
 			c: &Config{
-				Checks: []*CheckDefinition{
-					&CheckDefinition{
+				Checks: []*structs.CheckDefinition{
+					&structs.CheckDefinition{
 						ID:                "a",
 						Name:              "b",
 						Notes:             "c",
@@ -1113,7 +1114,7 @@ func TestDecodeConfig(t *testing.T) {
 						TTL:               4 * time.Second,
 						DeregisterCriticalServiceAfter: 5 * time.Second,
 					},
-					&CheckDefinition{
+					&structs.CheckDefinition{
 						ID:                "aa",
 						Name:              "bb",
 						Notes:             "cc",
@@ -1336,8 +1337,8 @@ func TestMergeConfig(t *testing.T) {
 		CertFile:               "test/cert.pem",
 		KeyFile:                "test/key.pem",
 		TLSMinVersion:          "tls12",
-		Checks:                 []*CheckDefinition{nil},
-		Services:               []*ServiceDefinition{nil},
+		Checks:                 []*structs.CheckDefinition{nil},
+		Services:               []*structs.ServiceDefinition{nil},
 		StartJoin:              []string{"1.1.1.1"},
 		StartJoinWan:           []string{"1.1.1.1"},
 		EnableUI:               true,
@@ -1502,7 +1503,7 @@ func TestUnixSockets(t *testing.T) {
 
 func TestCheckDefinitionToCheckType(t *testing.T) {
 	t.Parallel()
-	got := &CheckDefinition{
+	got := &structs.CheckDefinition{
 		ID:     "id",
 		Name:   "name",
 		Status: "green",
@@ -1521,7 +1522,7 @@ func TestCheckDefinitionToCheckType(t *testing.T) {
 		TTL:               3 * time.Second,
 		DeregisterCriticalServiceAfter: 4 * time.Second,
 	}
-	want := &CheckType{
+	want := &structs.CheckType{
 		CheckID: "id",
 		Name:    "name",
 		Status:  "green",

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -341,15 +341,11 @@ func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	return nil
 }
 
-// SnapshotReplyFn gets a peek at the reply before the snapshot streams, which
-// is useful for setting headers.
-type SnapshotReplyFn func(reply *structs.SnapshotResponse) error
-
 // SnapshotRPC sends the snapshot request to one of the servers, reading from
 // the streaming input and writing to the streaming output depending on the
 // operation.
 func (c *Client) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer,
-	replyFn SnapshotReplyFn) error {
+	replyFn structs.SnapshotReplyFn) error {
 
 	// Locate a server to make the request to.
 	server := c.servers.FindServer()

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -43,15 +43,6 @@ const (
 	serfEventBacklogWarning = 200
 )
 
-// Interface is used to provide either a Client or Server,
-// both of which can be used to perform certain common
-// Consul methods
-type Interface interface {
-	RPC(method string, args interface{}, reply interface{}) error
-	LANMembers() []serf.Member
-	LocalMember() serf.Member
-}
-
 // Client is Consul client which uses RPC to communicate with the
 // services for service discovery, health checking, and DC forwarding.
 type Client struct {

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -265,7 +265,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 	for range servers {
 		time.Sleep(100 * time.Millisecond)
 		s := c.servers.FindServer()
-		ok, err := c.connPool.PingConsulServer(s)
+		ok, err := c.connPool.Ping(s.Datacenter, s.Addr, s.Version, s.UseTLS)
 		if !ok {
 			t.Errorf("Unable to ping server %v: %s", s.String(), err)
 		}

--- a/agent/consul/raft_rpc.go
+++ b/agent/consul/raft_rpc.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/raft"
 )
@@ -100,7 +101,7 @@ func (l *RaftLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net
 	// Check for tls mode
 	if l.tlsFunc(address) && l.tlsWrap != nil {
 		// Switch the connection into TLS mode
-		if _, err := conn.Write([]byte{byte(rpcTLS)}); err != nil {
+		if _, err := conn.Write([]byte{byte(pool.RPCTLS)}); err != nil {
 			conn.Close()
 			return nil, err
 		}
@@ -113,7 +114,7 @@ func (l *RaftLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net
 	}
 
 	// Write the Raft byte to set the mode
-	_, err = conn.Write([]byte{byte(rpcRaft)})
+	_, err = conn.Write([]byte{byte(pool.RPCRaft)})
 	if err != nil {
 		conn.Close()
 		return nil, err

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -12,23 +12,12 @@ import (
 	"github.com/hashicorp/consul/agent/consul/agent"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/consul/structs"
+	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/yamux"
-)
-
-type RPCType byte
-
-const (
-	rpcConsul RPCType = iota
-	rpcRaft
-	rpcMultiplex // Old Muxado byte, no longer supported.
-	rpcTLS
-	rpcMultiplexV2
-	rpcSnapshot
-	rpcGossip
 )
 
 const (
@@ -92,24 +81,25 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 		conn.Close()
 		return
 	}
+	typ := pool.RPCType(buf[0])
 
 	// Enforce TLS if VerifyIncoming is set
-	if s.config.VerifyIncoming && !isTLS && RPCType(buf[0]) != rpcTLS {
+	if s.config.VerifyIncoming && !isTLS && typ != pool.RPCTLS {
 		s.logger.Printf("[WARN] consul.rpc: Non-TLS connection attempted with VerifyIncoming set %s", logConn(conn))
 		conn.Close()
 		return
 	}
 
 	// Switch on the byte
-	switch RPCType(buf[0]) {
-	case rpcConsul:
+	switch typ {
+	case pool.RPCConsul:
 		s.handleConsulConn(conn)
 
-	case rpcRaft:
+	case pool.RPCRaft:
 		metrics.IncrCounter([]string{"consul", "rpc", "raft_handoff"}, 1)
 		s.raftLayer.Handoff(conn)
 
-	case rpcTLS:
+	case pool.RPCTLS:
 		if s.rpcTLS == nil {
 			s.logger.Printf("[WARN] consul.rpc: TLS connection attempted, server not configured for TLS %s", logConn(conn))
 			conn.Close()
@@ -118,14 +108,14 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 		conn = tls.Server(conn, s.rpcTLS)
 		s.handleConn(conn, true)
 
-	case rpcMultiplexV2:
+	case pool.RPCMultiplexV2:
 		s.handleMultiplexV2(conn)
 
-	case rpcSnapshot:
+	case pool.RPCSnapshot:
 		s.handleSnapshotConn(conn)
 
 	default:
-		s.logger.Printf("[ERR] consul.rpc: unrecognized RPC byte: %v %s", buf[0], logConn(conn))
+		s.logger.Printf("[ERR] consul.rpc: unrecognized RPC byte: %v %s", typ, logConn(conn))
 		conn.Close()
 		return
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -977,10 +977,10 @@ func (s *Server) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io
 	return nil
 }
 
-// InjectEndpoint is used to substitute an endpoint for testing.
-func (s *Server) InjectEndpoint(endpoint interface{}) error {
+// RegisterEndpoint is used to substitute an endpoint for testing.
+func (s *Server) RegisterEndpoint(name string, handler interface{}) error {
 	s.logger.Printf("[WARN] consul: endpoint injected; this should only be used for testing")
-	return s.rpcServer.Register(endpoint)
+	return s.rpcServer.RegisterName(name, handler)
 }
 
 // Stats is used to return statistics for debugging and insight

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -937,7 +937,7 @@ func (s *Server) RPC(method string, args interface{}, reply interface{}) error {
 // SnapshotRPC dispatches the given snapshot request, reading from the streaming
 // input and writing to the streaming output depending on the operation.
 func (s *Server) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer,
-	replyFn SnapshotReplyFn) error {
+	replyFn structs.SnapshotReplyFn) error {
 
 	// Perform the operation.
 	var reply structs.SnapshotResponse

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -593,7 +593,7 @@ func testVerifyRPC(s1, s2 *Server, t *testing.T) (bool, error) {
 	if leader == nil {
 		t.Fatal("no leader")
 	}
-	return s2.connPool.PingConsulServer(leader)
+	return s2.connPool.Ping(leader.Datacenter, leader.Addr, leader.Version, leader.UseTLS)
 }
 
 func TestServer_TLSToNoTLS(t *testing.T) {

--- a/agent/consul/servers/manager_internal_test.go
+++ b/agent/consul/servers/manager_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -31,7 +32,7 @@ type fauxConnPool struct {
 	failPct float64
 }
 
-func (cp *fauxConnPool) PingConsulServer(server *agent.Server) (bool, error) {
+func (cp *fauxConnPool) Ping(string, net.Addr, int, bool) (bool, error) {
 	var success bool
 	successProb := rand.Float64()
 	if successProb > cp.failPct {
@@ -179,7 +180,7 @@ func test_reconcileServerList(maxServers int) (bool, error) {
 			// failPct of the servers for the reconcile.  This
 			// allows for the selected server to no longer be
 			// healthy for the reconcile below.
-			if ok, _ := m.connPoolPinger.PingConsulServer(node); ok {
+			if ok, _ := m.connPoolPinger.Ping(node.Datacenter, node.Addr, node.Version, node.UseTLS); ok {
 				// Will still be present
 				healthyServers = append(healthyServers, node)
 			} else {

--- a/agent/consul/servers/manager_test.go
+++ b/agent/consul/servers/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"strings"
 	"testing"
@@ -17,7 +18,7 @@ type fauxConnPool struct {
 	failPct float64
 }
 
-func (cp *fauxConnPool) PingConsulServer(server *agent.Server) (bool, error) {
+func (cp *fauxConnPool) Ping(string, net.Addr, int, bool) (bool, error) {
 	var success bool
 	successProb := rand.Float64()
 	if successProb > cp.failPct {

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/consul/structs"
+	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/snapshot"
 	"github.com/hashicorp/go-msgpack/codec"
 )
@@ -187,10 +188,10 @@ RESPOND:
 // the streaming output (for a snapshot). If the reply contains an error, this
 // will always return an error as well, so you don't need to check the error
 // inside the filled-in reply.
-func SnapshotRPC(pool *ConnPool, dc string, addr net.Addr, useTLS bool,
+func SnapshotRPC(connPool *pool.ConnPool, dc string, addr net.Addr, useTLS bool,
 	args *structs.SnapshotRequest, in io.Reader, reply *structs.SnapshotResponse) (io.ReadCloser, error) {
 
-	conn, hc, err := pool.DialTimeout(dc, addr, 10*time.Second, useTLS)
+	conn, hc, err := connPool.DialTimeout(dc, addr, 10*time.Second, useTLS)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +207,7 @@ func SnapshotRPC(pool *ConnPool, dc string, addr net.Addr, useTLS bool,
 
 	// Write the snapshot RPC byte to set the mode, then perform the
 	// request.
-	if _, err := conn.Write([]byte{byte(rpcSnapshot)}); err != nil {
+	if _, err := conn.Write([]byte{byte(pool.RPCSnapshot)}); err != nil {
 		return nil, fmt.Errorf("failed to write stream type: %v", err)
 	}
 

--- a/agent/consul/stats_fetcher.go
+++ b/agent/consul/stats_fetcher.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul/agent"
 	"github.com/hashicorp/consul/agent/consul/structs"
+	"github.com/hashicorp/consul/agent/pool"
 )
 
 // StatsFetcher has two functions for autopilot. First, lets us fetch all the
@@ -18,14 +19,14 @@ import (
 // as we run the health check fairly frequently.
 type StatsFetcher struct {
 	logger       *log.Logger
-	pool         *ConnPool
+	pool         *pool.ConnPool
 	datacenter   string
 	inflight     map[string]struct{}
 	inflightLock sync.Mutex
 }
 
 // NewStatsFetcher returns a stats fetcher.
-func NewStatsFetcher(logger *log.Logger, pool *ConnPool, datacenter string) *StatsFetcher {
+func NewStatsFetcher(logger *log.Logger, pool *pool.ConnPool, datacenter string) *StatsFetcher {
 	return &StatsFetcher{
 		logger:     logger,
 		pool:       pool,

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 )
@@ -19,7 +20,7 @@ func rpcClient(t *testing.T, s *Server) rpc.ClientCodec {
 	}
 
 	// Write the Consul RPC byte to set the mode
-	conn.Write([]byte{byte(rpcConsul)})
+	conn.Write([]byte{byte(pool.RPCConsul)})
 	return msgpackrpc.NewClientCodec(conn)
 }
 

--- a/agent/consul/structs/check_defintion.go
+++ b/agent/consul/structs/check_defintion.go
@@ -1,50 +1,11 @@
-package agent
+package structs
 
 import (
 	"time"
 
-	"github.com/hashicorp/consul/agent/consul/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/types"
 )
-
-// ServiceDefinition is used to JSON decode the Service definitions
-type ServiceDefinition struct {
-	ID                string
-	Name              string
-	Tags              []string
-	Address           string
-	Port              int
-	Check             CheckType
-	Checks            CheckTypes
-	Token             string
-	EnableTagOverride bool
-}
-
-func (s *ServiceDefinition) NodeService() *structs.NodeService {
-	ns := &structs.NodeService{
-		ID:                s.ID,
-		Service:           s.Name,
-		Tags:              s.Tags,
-		Address:           s.Address,
-		Port:              s.Port,
-		EnableTagOverride: s.EnableTagOverride,
-	}
-	if ns.ID == "" && ns.Service != "" {
-		ns.ID = ns.Service
-	}
-	return ns
-}
-
-func (s *ServiceDefinition) CheckTypes() (checks CheckTypes) {
-	s.Checks = append(s.Checks, &s.Check)
-	for _, check := range s.Checks {
-		if check.Valid() {
-			checks = append(checks, check)
-		}
-	}
-	return
-}
 
 // CheckDefinition is used to JSON decode the Check definitions
 type CheckDefinition struct {
@@ -74,8 +35,8 @@ type CheckDefinition struct {
 	DeregisterCriticalServiceAfter time.Duration
 }
 
-func (c *CheckDefinition) HealthCheck(node string) *structs.HealthCheck {
-	health := &structs.HealthCheck{
+func (c *CheckDefinition) HealthCheck(node string) *HealthCheck {
+	health := &HealthCheck{
 		Node:      node,
 		CheckID:   c.ID,
 		Name:      c.Name,
@@ -109,11 +70,4 @@ func (c *CheckDefinition) CheckType() *CheckType {
 		Status: c.Status,
 		Notes:  c.Notes,
 	}
-}
-
-// persistedService is used to wrap a service definition and bundle it
-// with an ACL token so we can restore both at a later agent start.
-type persistedService struct {
-	Token   string
-	Service *structs.NodeService
 }

--- a/agent/consul/structs/check_defintion_test.go
+++ b/agent/consul/structs/check_defintion_test.go
@@ -1,0 +1,18 @@
+package structs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+)
+
+func TestAgentStructs_HealthCheck(t *testing.T) {
+	t.Parallel()
+	def := CheckDefinition{}
+	check := def.HealthCheck("node1")
+
+	// Health checks default to critical state
+	if check.Status != api.HealthCritical {
+		t.Fatalf("bad: %v", check.Status)
+	}
+}

--- a/agent/consul/structs/check_type.go
+++ b/agent/consul/structs/check_type.go
@@ -1,0 +1,73 @@
+package structs
+
+import (
+	"time"
+
+	"github.com/hashicorp/consul/types"
+)
+
+// CheckType is used to create either the CheckMonitor or the CheckTTL.
+// Five types are supported: Script, HTTP, TCP, Docker and TTL. Script, HTTP,
+// Docker and TCP all require Interval. Only one of the types may to be
+// provided: TTL or Script/Interval or HTTP/Interval or TCP/Interval or
+// Docker/Interval.
+type CheckType struct {
+	// fields already embedded in CheckDefinition
+	// Note: CheckType.CheckID == CheckDefinition.ID
+
+	CheckID types.CheckID
+	Name    string
+	Status  string
+	Notes   string
+
+	// fields copied to CheckDefinition
+	// Update CheckDefinition when adding fields here
+
+	Script            string
+	HTTP              string
+	Header            map[string][]string
+	Method            string
+	TCP               string
+	Interval          time.Duration
+	DockerContainerID string
+	Shell             string
+	TLSSkipVerify     bool
+	Timeout           time.Duration
+	TTL               time.Duration
+
+	// DeregisterCriticalServiceAfter, if >0, will cause the associated
+	// service, if any, to be deregistered if this check is critical for
+	// longer than this duration.
+	DeregisterCriticalServiceAfter time.Duration
+}
+type CheckTypes []*CheckType
+
+// Valid checks if the CheckType is valid
+func (c *CheckType) Valid() bool {
+	return c.IsTTL() || c.IsMonitor() || c.IsHTTP() || c.IsTCP() || c.IsDocker()
+}
+
+// IsTTL checks if this is a TTL type
+func (c *CheckType) IsTTL() bool {
+	return c.TTL != 0
+}
+
+// IsMonitor checks if this is a Monitor type
+func (c *CheckType) IsMonitor() bool {
+	return c.Script != "" && c.DockerContainerID == "" && c.Interval != 0
+}
+
+// IsHTTP checks if this is a HTTP type
+func (c *CheckType) IsHTTP() bool {
+	return c.HTTP != "" && c.Interval != 0
+}
+
+// IsTCP checks if this is a TCP type
+func (c *CheckType) IsTCP() bool {
+	return c.TCP != "" && c.Interval != 0
+}
+
+// IsDocker returns true when checking a docker container.
+func (c *CheckType) IsDocker() bool {
+	return c.DockerContainerID != "" && c.Script != "" && c.Interval != 0
+}

--- a/agent/consul/structs/service_definition.go
+++ b/agent/consul/structs/service_definition.go
@@ -1,0 +1,39 @@
+package structs
+
+// ServiceDefinition is used to JSON decode the Service definitions
+type ServiceDefinition struct {
+	ID                string
+	Name              string
+	Tags              []string
+	Address           string
+	Port              int
+	Check             CheckType
+	Checks            CheckTypes
+	Token             string
+	EnableTagOverride bool
+}
+
+func (s *ServiceDefinition) NodeService() *NodeService {
+	ns := &NodeService{
+		ID:                s.ID,
+		Service:           s.Name,
+		Tags:              s.Tags,
+		Address:           s.Address,
+		Port:              s.Port,
+		EnableTagOverride: s.EnableTagOverride,
+	}
+	if ns.ID == "" && ns.Service != "" {
+		ns.ID = ns.Service
+	}
+	return ns
+}
+
+func (s *ServiceDefinition) CheckTypes() (checks CheckTypes) {
+	s.Checks = append(s.Checks, &s.Check)
+	for _, check := range s.Checks {
+		if check.Valid() {
+			checks = append(checks, check)
+		}
+	}
+	return
+}

--- a/agent/consul/structs/service_definition_test.go
+++ b/agent/consul/structs/service_definition_test.go
@@ -1,22 +1,9 @@
-package agent
+package structs
 
 import (
 	"testing"
 	"time"
-
-	"github.com/hashicorp/consul/api"
 )
-
-func TestAgentStructs_HealthCheck(t *testing.T) {
-	t.Parallel()
-	def := CheckDefinition{}
-	check := def.HealthCheck("node1")
-
-	// Health checks default to critical state
-	if check.Status != api.HealthCritical {
-		t.Fatalf("bad: %v", check.Status)
-	}
-}
 
 func TestAgentStructs_CheckTypes(t *testing.T) {
 	t.Parallel()

--- a/agent/consul/structs/snapshot.go
+++ b/agent/consul/structs/snapshot.go
@@ -7,6 +7,10 @@ const (
 	SnapshotRestore
 )
 
+// SnapshotReplyFn gets a peek at the reply before the snapshot streams, which
+// is useful for setting headers.
+type SnapshotReplyFn func(reply *SnapshotResponse) error
+
 // SnapshotRequest is used as a header for a snapshot RPC request. This will
 // precede any streaming data that's part of the request and is JSON-encoded on
 // the wire.

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -695,10 +695,9 @@ func (d *DNSServer) preparedQueryLookup(network, datacenter, query string, req, 
 	// likely work in practice, like 10*maxUDPAnswerLimit which should help
 	// reduce bandwidth if there are thousands of nodes available.
 
-	endpoint := d.agent.getEndpoint(preparedQueryEndpoint)
 	var out structs.PreparedQueryExecuteResponse
 RPC:
-	if err := d.agent.RPC(endpoint+".Execute", &args, &out); err != nil {
+	if err := d.agent.RPC("PreparedQuery.Execute", &args, &out); err != nil {
 		// If they give a bogus query name, treat that as a name error,
 		// not a full on server error. We have to use a string compare
 		// here since the RPC layer loses the type information.

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3932,7 +3932,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4013,7 +4013,7 @@ func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3932,7 +3932,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -4013,7 +4013,7 @@ func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -1338,7 +1338,7 @@ func TestAgent_serviceTokens(t *testing.T) {
 	cfg := TestConfig()
 	cfg.ACLToken = "default"
 	l := new(localState)
-	l.Init(cfg, nil)
+	l.Init(cfg, nil, nil)
 
 	l.AddService(&structs.NodeService{
 		ID: "redis",
@@ -1367,7 +1367,7 @@ func TestAgent_checkTokens(t *testing.T) {
 	cfg := TestConfig()
 	cfg.ACLToken = "default"
 	l := new(localState)
-	l.Init(cfg, nil)
+	l.Init(cfg, nil, nil)
 
 	// Returns default when no token is set
 	if token := l.CheckToken("mem"); token != "default" {
@@ -1391,7 +1391,7 @@ func TestAgent_checkCriticalTime(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
 	l := new(localState)
-	l.Init(cfg, nil)
+	l.Init(cfg, nil, nil)
 
 	// Add a passing check and make sure it's not critical.
 	checkID := types.CheckID("redis:1")

--- a/agent/notify.go
+++ b/agent/notify.go
@@ -1,4 +1,4 @@
-package state
+package agent
 
 import (
 	"sync"

--- a/agent/notify_test.go
+++ b/agent/notify_test.go
@@ -1,4 +1,4 @@
-package state
+package agent
 
 import (
 	"testing"

--- a/agent/pool/conn.go
+++ b/agent/pool/conn.go
@@ -1,0 +1,15 @@
+package pool
+
+type RPCType byte
+
+const (
+	// keep numbers unique.
+	// iota depends on order
+	RPCConsul      RPCType = 0
+	RPCRaft                = 1
+	RPCMultiplex           = 2 // Old Muxado byte, no longer supported.
+	RPCTLS                 = 3
+	RPCMultiplexV2         = 4
+	RPCSnapshot            = 5
+	RPCGossip              = 6
+)

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -37,8 +37,7 @@ func (s *HTTPServer) preparedQueryCreate(resp http.ResponseWriter, req *http.Req
 	}
 
 	var reply string
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Apply", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Apply", &args, &reply); err != nil {
 		return nil, err
 	}
 	return preparedQueryCreateResponse{reply}, nil
@@ -52,8 +51,7 @@ func (s *HTTPServer) preparedQueryList(resp http.ResponseWriter, req *http.Reque
 	}
 
 	var reply structs.IndexedPreparedQueries
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".List", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.List", &args, &reply); err != nil {
 		return nil, err
 	}
 
@@ -110,8 +108,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 	}
 
 	var reply structs.PreparedQueryExecuteResponse
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Execute", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Execute", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
@@ -155,8 +152,7 @@ func (s *HTTPServer) preparedQueryExplain(id string, resp http.ResponseWriter, r
 	}
 
 	var reply structs.PreparedQueryExplainResponse
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Explain", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Explain", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
@@ -179,8 +175,7 @@ func (s *HTTPServer) preparedQueryGet(id string, resp http.ResponseWriter, req *
 	}
 
 	var reply structs.IndexedPreparedQueries
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Get", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Get", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
@@ -212,8 +207,7 @@ func (s *HTTPServer) preparedQueryUpdate(id string, resp http.ResponseWriter, re
 	args.Query.ID = id
 
 	var reply string
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Apply", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Apply", &args, &reply); err != nil {
 		return nil, err
 	}
 	return nil, nil
@@ -231,8 +225,7 @@ func (s *HTTPServer) preparedQueryDelete(id string, resp http.ResponseWriter, re
 	s.parseToken(req, &args.Token)
 
 	var reply string
-	endpoint := s.agent.getEndpoint(preparedQueryEndpoint)
-	if err := s.agent.RPC(endpoint+".Apply", &args, &reply); err != nil {
+	if err := s.agent.RPC("PreparedQuery.Apply", &args, &reply); err != nil {
 		return nil, err
 	}
 	return nil, nil

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	preparedQueryEndpoint      = "PreparedQuery"
 	preparedQueryExecuteSuffix = "/execute"
 	preparedQueryExplainSuffix = "/explain"
 )

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -74,7 +74,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -159,7 +159,7 @@ func TestPreparedQuery_List(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -192,7 +192,7 @@ func TestPreparedQuery_List(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -242,7 +242,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -275,7 +275,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -331,7 +331,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -365,7 +365,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -415,7 +415,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -479,7 +479,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -552,7 +552,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -617,7 +617,7 @@ func TestPreparedQuery_Update(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -695,7 +695,7 @@ func TestPreparedQuery_Delete(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.InjectEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -74,7 +74,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -159,7 +159,7 @@ func TestPreparedQuery_List(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -192,7 +192,7 @@ func TestPreparedQuery_List(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -242,7 +242,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -275,7 +275,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -331,7 +331,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -365,7 +365,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -415,7 +415,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -479,7 +479,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -552,7 +552,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{}
-		if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 
@@ -617,7 +617,7 @@ func TestPreparedQuery_Update(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -695,7 +695,7 @@ func TestPreparedQuery_Delete(t *testing.T) {
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{}
-	if err := a.RegisterEndpoint("PreparedQuery", &m); err != nil {
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 


### PR DESCRIPTION
This is a prequel to 

* splitting runtime config from user config
* decouple DNS and HTTP server from agent
* move `consul` to `rpc` and both DNS and HTTP server into their own packages under `agent`
* multiple bind addresses