### PR TITLE
agent: fix 'consul leave' shutdown race (#2880)

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -199,7 +199,7 @@ func (s *HTTPServer) AgentLeave(resp http.ResponseWriter, req *http.Request) (in
 	if err := s.agent.Leave(); err != nil {
 		return nil, err
 	}
-	return nil, s.agent.Shutdown()
+	return nil, s.agent.ShutdownAgent()
 }
 
 func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -156,7 +156,8 @@ func (a *TestAgent) Start() *TestAgent {
 			fmt.Println(id, a.Name, "Error starting agent:", err)
 			runtime.Goexit()
 		} else {
-			agent.Shutdown()
+			agent.ShutdownAgent()
+			agent.ShutdownEndpoints()
 			wait := time.Duration(rand.Int31n(2000)) * time.Millisecond
 			fmt.Println(id, a.Name, "retrying in", wait)
 			time.Sleep(wait)
@@ -221,7 +222,10 @@ func (a *TestAgent) Shutdown() error {
 			os.RemoveAll(a.DataDir)
 		}
 	}()
-	return a.Agent.Shutdown()
+
+	// shutdown agent before endpoints
+	defer a.Agent.ShutdownEndpoints()
+	return a.Agent.ShutdownAgent()
 }
 
 func (a *TestAgent) HTTPAddr() string {

--- a/command/agent.go
+++ b/command/agent.go
@@ -691,7 +691,10 @@ func (cmd *AgentCommand) run(args []string) int {
 		cmd.UI.Error(fmt.Sprintf("Error starting agent: %s", err))
 		return 1
 	}
-	defer agent.Shutdown()
+
+	// shutdown agent before endpoints
+	defer agent.ShutdownEndpoints()
+	defer agent.ShutdownAgent()
 
 	if !config.DisableUpdateCheck {
 		cmd.startupUpdateCheck(config)


### PR DESCRIPTION
When the agent is triggered to shutdown via an external 'consul leave'
command delivered via the HTTP API then the client expects to receive a
response when the agent is down. This creates a race on when to shutdown
the agent itself like the RPC server, the checks and the state and the
external endpoints like DNS and HTTP.

This patch splits the shutdown process into two parts:

 * shutdown the agent
 * shutdown the endpoints (http and dns)

They can be executed multiple times, concurrently and in any order but
should be executed first agent, then endpoints to provide consistent
behavior across all use cases. Both calls have to be executed for a
proper shutdown.

This could be partially hidden in a single function but would introduce
some magic that happens behind the scenes which one has to know of but
isn't obvious.

Fixes #2880