### PR TITLE
agent: notify systemd after JoinLAN (#2121)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1227,7 +1227,9 @@ func (a *Agent) JoinLAN(addrs []string) (n int, err error) {
 	n, err = a.delegate.JoinLAN(addrs)
 	a.logger.Printf("[INFO] agent: (LAN) joined: %d Err: %v", n, err)
 	if err == nil && a.joinLANNotifier != nil {
-		a.joinLANNotifier.Notify("READY=1")
+		if notifErr := a.joinLANNotifier.Notify(systemd.Ready); notifErr != nil {
+			a.logger.Printf("[DEBUG] agent: systemd notify failed: ", notifErr)
+		}
 	}
 	return
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/consul/structs"
+	"github.com/hashicorp/consul/agent/systemd"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
@@ -69,6 +70,11 @@ type delegate interface {
 	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error
 	Stats() map[string]map[string]string
+}
+
+// notifier is called after a successful JoinLAN.
+type notifier interface {
+	Notify(string) error
 }
 
 // The agent is the long running process that is run on every machine.
@@ -141,6 +147,9 @@ type Agent struct {
 	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
 
+	// joinLANNotifier is called after a successful JoinLAN.
+	joinLANNotifier notifier
+
 	// retryJoinCh transports errors from the retry join
 	// attempts.
 	retryJoinCh chan error
@@ -188,22 +197,23 @@ func New(c *Config) (*Agent, error) {
 	}
 
 	a := &Agent{
-		config:         c,
-		acls:           acls,
-		checkReapAfter: make(map[types.CheckID]time.Duration),
-		checkMonitors:  make(map[types.CheckID]*CheckMonitor),
-		checkTTLs:      make(map[types.CheckID]*CheckTTL),
-		checkHTTPs:     make(map[types.CheckID]*CheckHTTP),
-		checkTCPs:      make(map[types.CheckID]*CheckTCP),
-		checkDockers:   make(map[types.CheckID]*CheckDocker),
-		eventCh:        make(chan serf.UserEvent, 1024),
-		eventBuf:       make([]*UserEvent, 256),
-		reloadCh:       make(chan chan error),
-		retryJoinCh:    make(chan error),
-		shutdownCh:     make(chan struct{}),
-		endpoints:      make(map[string]string),
-		dnsAddrs:       dnsAddrs,
-		httpAddrs:      httpAddrs,
+		config:          c,
+		acls:            acls,
+		checkReapAfter:  make(map[types.CheckID]time.Duration),
+		checkMonitors:   make(map[types.CheckID]*CheckMonitor),
+		checkTTLs:       make(map[types.CheckID]*CheckTTL),
+		checkHTTPs:      make(map[types.CheckID]*CheckHTTP),
+		checkTCPs:       make(map[types.CheckID]*CheckTCP),
+		checkDockers:    make(map[types.CheckID]*CheckDocker),
+		eventCh:         make(chan serf.UserEvent, 1024),
+		eventBuf:        make([]*UserEvent, 256),
+		joinLANNotifier: &systemd.Notifier{},
+		reloadCh:        make(chan chan error),
+		retryJoinCh:     make(chan error),
+		shutdownCh:      make(chan struct{}),
+		endpoints:       make(map[string]string),
+		dnsAddrs:        dnsAddrs,
+		httpAddrs:       httpAddrs,
 	}
 	if err := a.resolveTmplAddrs(); err != nil {
 		return nil, err
@@ -1216,6 +1226,9 @@ func (a *Agent) JoinLAN(addrs []string) (n int, err error) {
 	a.logger.Printf("[INFO] agent: (LAN) joining: %v", addrs)
 	n, err = a.delegate.JoinLAN(addrs)
 	a.logger.Printf("[INFO] agent: (LAN) joined: %d Err: %v", n, err)
+	if err == nil && a.joinLANNotifier != nil {
+		a.joinLANNotifier.Notify("READY=1")
+	}
 	return
 }
 

--- a/agent/systemd/notify.go
+++ b/agent/systemd/notify.go
@@ -1,0 +1,33 @@
+package systemd
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+var NotifyNoSocket = errors.New("No socket")
+
+// Notifier provides a method to send a message to systemd.
+type Notifier struct{}
+
+// Notify sends a message to the init daemon. It is common to ignore the error.
+func (n *Notifier) Notify(state string) error {
+	addr := &net.UnixAddr{
+		Name: os.Getenv("NOTIFY_SOCKET"),
+		Net:  "unixgram",
+	}
+
+	if addr.Name == "" {
+		return NotifyNoSocket
+	}
+
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(state))
+	return err
+}

--- a/agent/systemd/notify.go
+++ b/agent/systemd/notify.go
@@ -6,6 +6,15 @@ import (
 	"os"
 )
 
+const (
+	// magic values for systemd
+	// from https://www.freedesktop.org/software/systemd/man/sd_notify.html#Description
+
+	Ready     = "READY=1"
+	Reloading = "RELOADING=1"
+	Stopping  = "STOPPING=1"
+)
+
 var NotifyNoSocket = errors.New("No socket")
 
 // Notifier provides a method to send a message to systemd.

--- a/website/source/docs/agent/basics.html.md
+++ b/website/source/docs/agent/basics.html.md
@@ -74,6 +74,11 @@ There are several important messages that [`consul agent`](/docs/commands/agent.
   Consul agents in a cluster. Not all Consul agents in a cluster have to
   use the same port, but this address **MUST** be reachable by all other nodes.
 
+When running under systemd on Linux consul notifies systemd by sending
+`READY=1` to the `$NOTIFY_SOCKET` when a LAN join has completed. For
+this either the `join` or `retry_join` option has to be set and the
+service definition file has to have `Type=notify` set.
+
 ## Stopping an Agent
 
 An agent can be stopped in two ways: gracefully or forcefully. To gracefully

--- a/website/source/docs/agent/basics.html.md
+++ b/website/source/docs/agent/basics.html.md
@@ -74,7 +74,7 @@ There are several important messages that [`consul agent`](/docs/commands/agent.
   Consul agents in a cluster. Not all Consul agents in a cluster have to
   use the same port, but this address **MUST** be reachable by all other nodes.
 
-When running under systemd on Linux consul notifies systemd by sending
+When running under `systemd` on Linux, Consul notifies systemd by sending
 `READY=1` to the `$NOTIFY_SOCKET` when a LAN join has completed. For
 this either the `join` or `retry_join` option has to be set and the
 service definition file has to have `Type=notify` set.


### PR DESCRIPTION
This patch adds support for notifying systemd via the
NOTIFY_SOCKET by sending 'READY=1' to the socket after
a successful JoinLAN.

Fixes #2121