### PR TITLE
agent: fix watch registration and logging (#3177)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -517,7 +517,7 @@ func (a *Agent) registerWatches() error {
 				addr = "unix://" + addr
 			}
 			if err := wp.Run(addr); err != nil {
-				a.logger.Println("[ERR] Failed to run watch: %v", err)
+				a.logger.Printf("[ERR] Failed to run watch: %v", err)
 			}
 		}(wp)
 	}

--- a/agent/config.go
+++ b/agent/config.go
@@ -803,7 +803,7 @@ type ProtoAddr struct {
 }
 
 func (p ProtoAddr) String() string {
-	return p.Proto + "+" + p.Net + "://" + p.Addr
+	return p.Proto + "://" + p.Addr
 }
 
 func (c *Config) DNSAddrs() ([]ProtoAddr, error) {


### PR DESCRIPTION
This patch fixes watch registration through the config file
and a broken log line when the watch registration fails.

Fixes #3177