### PR TITLE
Fix bug with watch handlers not being closed upon consul reload

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -517,7 +517,7 @@ func (a *Agent) registerWatches() error {
 				addr = "unix://" + addr
 			}
 			if err := wp.Run(addr); err != nil {
-				a.logger.Println("[ERR] Failed to run watch: %v", err)
+				a.logger.Printf("[ERR] Failed to run watch: %v", err)
 			}
 		}(wp)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2340,7 +2340,7 @@ func (a *Agent) ReloadConfig(newCfg *Config, prevConfig *Config) (bool, error) {
 	}
 
 	// Get the new client listener addr
-	httpAddr, err := newCfg.ClientListener(prevConfig.Addresses.HTTP, prevConfig.Ports.HTTP)
+	httpAddr, err := newCfg.ClientListener(newCfg.Addresses.HTTP, newCfg.Ports.HTTP)
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("Failed to determine HTTP address: %v", err))
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2302,7 +2302,7 @@ func (a *Agent) DisableNodeMaintenance() {
 	a.logger.Printf("[INFO] agent: Node left maintenance mode")
 }
 
-func (a *Agent) ReloadConfig(newCfg *Config) (bool, error) {
+func (a *Agent) ReloadConfig(newCfg *Config, prevConfig *Config) (bool, error) {
 	var errs error
 
 	// Bulk update the services and checks
@@ -2340,13 +2340,13 @@ func (a *Agent) ReloadConfig(newCfg *Config) (bool, error) {
 	}
 
 	// Get the new client listener addr
-	httpAddr, err := newCfg.ClientListener(a.config.Addresses.HTTP, a.config.Ports.HTTP)
+	httpAddr, err := newCfg.ClientListener(prevConfig.Addresses.HTTP, prevConfig.Ports.HTTP)
 	if err != nil {
 		errs = multierror.Append(errs, fmt.Errorf("Failed to determine HTTP address: %v", err))
 	}
 
 	// Deregister the old watches
-	for _, wp := range a.config.WatchPlans {
+	for _, wp := range prevConfig.WatchPlans {
 		wp.Stop()
 	}
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -803,7 +803,7 @@ type ProtoAddr struct {
 }
 
 func (p ProtoAddr) String() string {
-	return p.Proto + "+" + p.Net + "://" + p.Addr
+	return p.Proto + "://" + p.Addr
 }
 
 func (c *Config) DNSAddrs() ([]ProtoAddr, error) {

--- a/command/agent.go
+++ b/command/agent.go
@@ -841,7 +841,7 @@ func (cmd *AgentCommand) handleReload(agent *agent.Agent, cfg *agent.Config) (*a
 		newCfg.LogLevel = cfg.LogLevel
 	}
 
-	ok, errs := agent.ReloadConfig(newCfg)
+	ok, errs := agent.ReloadConfig(newCfg, cfg)
 	if ok {
 		return newCfg, errs
 	}

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -118,3 +118,7 @@ func (p *Plan) shouldStop() bool {
 		return false
 	}
 }
+
+func (p *Plan) IsStopped() bool {
+	return p.stop
+}


### PR DESCRIPTION
Prior to 0.8.4, when "consul reload" was executed, any existing watch handlers were stopped via the Stop method. When things moved around, this broke in a way that only the first "consul reload" would do the right thing. Subsequent "consul reloads" would never find the new watch handlers because the reference to agent.config is always the first one. 

My fix is the smallest possible change that works, because I want to get this in for the Tuesday release. I am still in favor of separating watch behavior from watch configuration so that this sort of stuff doesn't have to hang off agent.Config. 