### PR TITLE
catch cross compilation error on user lookup

### DIFF
--- a/agent/util.go
+++ b/agent/util.go
@@ -116,9 +116,14 @@ func setFilePermissions(path string, p FilePermissions) error {
 		if u, err := user.Lookup(p.User()); err == nil {
 			uid, _ = strconv.Atoi(u.Uid)
 			goto GROUP
+		} else {
+			switch err.Error() {
+			case "user: Lookup requires cgo":
+				return fmt.Errorf("compilation issue: %v", err)
+			default:
+				return fmt.Errorf("invalid user specified: %v", p.User())
+			}
 		}
-
-		return fmt.Errorf("invalid user specified: %v", p.User())
 	}
 
 GROUP:


### PR DESCRIPTION
Re: https://github.com/hashicorp/consul/issues/3184
When using unix sockets, user lookups fail if consul was compiled on a different architecture (due to use of cgo). The current error incorrectly suggests the user doesn't exist when the user lookup itself is failing.
This PR is to return a useful error when this scenario occurs. 