### PR TITLE
rpc: fix failing tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,8 +7,7 @@ GOTOOLS = \
 	golang.org/x/tools/cmd/stringer \
 	github.com/axw/gocov/gocov \
 	gopkg.in/matm/v1/gocov-html
-	
-GOTAGS ?= consul
+
 GOFILES ?= $(shell go list ./... | grep -v /vendor/)
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
@@ -27,37 +26,37 @@ all: bin
 
 bin: tools
 	@mkdir -p bin/
-	@GOTAGS='$(GOTAGS)' sh -c "'$(CURDIR)/scripts/build.sh'"
+	@sh -c "'$(CURDIR)/scripts/build.sh'"
 
 # dev creates binaries for testing locally - these are put into ./bin and $GOPATH
 dev:
 	mkdir -p pkg/$(GOOS)_$(GOARCH)/ bin/
-	go install -ldflags '$(GOLDFLAGS)' -tags '$(GOTAGS)'
+	go install -ldflags '$(GOLDFLAGS)'
 	cp $(GOPATH)/bin/consul bin/
 	cp $(GOPATH)/bin/consul pkg/$(GOOS)_$(GOARCH)
 
 # linux builds a linux package independent of the source platform
 linux:
 	mkdir -p pkg/linux_amd64/
-	GOOS=linux GOARCH=amd64 go build -ldflags '$(GOLDFLAGS)' -tags '$(GOTAGS)' -o pkg/linux_amd64/consul
+	GOOS=linux GOARCH=amd64 go build -ldflags '$(GOLDFLAGS)' -o pkg/linux_amd64/consul
 
 # dist builds binaries for all platforms and packages them for distribution
 dist:
-	@GOTAGS='$(GOTAGS)' sh -c "'$(CURDIR)/scripts/dist.sh'"
+	@sh -c "'$(CURDIR)/scripts/dist.sh'"
 
 cov:
 	gocov test $(GOFILES) | gocov-html > /tmp/coverage.html
 	open /tmp/coverage.html
 
 test: dev
-	go test -tags "$(GOTAGS)" -i ./...
-	go test -tags "$(GOTAGS)" -v ./... > test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
+	go test -i ./...
+	go test -v ./... > test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
 	@if [ "$$TRAVIS" == "true" ] ; then cat test.log ; fi
 	@if grep -q 'FAIL_TOKEN' test.log ; then grep 'FAIL:' test.log ; exit 1 ; else echo 'PASS' ; fi
 
 test-race: dev
-	go test -tags "$(GOTAGS)" -i -run '^$$' ./...
-	( set -o pipefail ; go test -race -tags "$(GOTAGS)" -v ./... 2>&1 | tee test-race.log )
+	go test -i -run '^$$' ./...
+	( set -o pipefail ; go test -race -v ./... 2>&1 | tee test-race.log )
 
 cover:
 	go test $(GOFILES) --cover

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,9 +51,7 @@ cov:
 
 test: dev
 	go test -tags "$(GOTAGS)" -i ./...
-	go test -tags "$(GOTAGS)" -run '^$$' ./... > /dev/null
-	go test -tags "$(GOTAGS)" -v $$(go list ./... | egrep -v '(agent/consul|vendor)') > test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
-	go test -tags "$(GOTAGS)" -v $$(go list ./... | egrep '(agent/consul)') >> test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
+	go test -tags "$(GOTAGS)" -v ./... > test.log 2>&1 || echo 'FAIL_TOKEN' >> test.log
 	@if [ "$$TRAVIS" == "true" ] ; then cat test.log ; fi
 	@if grep -q 'FAIL_TOKEN' test.log ; then grep 'FAIL:' test.log ; exit 1 ; else echo 'PASS' ; fi
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -104,7 +104,7 @@ type Agent struct {
 
 	// state stores a local representation of the node,
 	// services and checks. Used for anti-entropy.
-	state localState
+	state *localState
 
 	// checkReapAfter maps the check ID to a timeout after which we should
 	// reap its associated service
@@ -241,15 +241,27 @@ func (a *Agent) Start() error {
 		return fmt.Errorf("Failed to setup node ID: %v", err)
 	}
 
+	// create the local state
+	a.state = NewLocalState(c, a.logger)
+
+	// create the config for the rpc server/client
+	consulCfg, err := a.consulConfig()
+	if err != nil {
+		return err
+	}
+
+	// link consul client/server with the state
+	consulCfg.ServerUp = a.state.ConsulServerUp
+
 	// Setup either the client or the server.
 	if c.Server {
-		server, err := a.makeServer()
+		server, err := consul.NewServerLogger(consulCfg, a.logger)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to start Consul server: %v", err)
 		}
 
 		a.delegate = server
-		a.state.Init(c, a.logger, server)
+		a.state.delegate = server
 
 		// Automatically register the "consul" service on server nodes
 		consulService := structs.NodeService{
@@ -261,13 +273,13 @@ func (a *Agent) Start() error {
 
 		a.state.AddService(&consulService, c.GetTokenForAgent())
 	} else {
-		client, err := a.makeClient()
+		client, err := consul.NewClientLogger(consulCfg, a.logger)
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to start Consul client: %v", err)
 		}
 
 		a.delegate = client
-		a.state.Init(c, a.logger, client)
+		a.state.delegate = client
 	}
 
 	// Load checks/services/metadata.
@@ -774,9 +786,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.TLSCipherSuites = a.config.TLSCipherSuites
 	base.TLSPreferServerCipherSuites = a.config.TLSPreferServerCipherSuites
 
-	// Setup the ServerUp callback
-	base.ServerUp = a.state.ConsulServerUp
-
 	// Setup the user event callback
 	base.UserEventHandler = func(e serf.UserEvent) {
 		select {
@@ -787,6 +796,13 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 
 	// Setup the loggers
 	base.LogOutput = a.LogOutput
+
+	if !a.config.DisableKeyringFile {
+		if err := a.setupKeyrings(base); err != nil {
+			return nil, fmt.Errorf("Failed to configure keyring: %v", err)
+		}
+	}
+
 	return base, nil
 }
 
@@ -895,42 +911,6 @@ func (a *Agent) resolveTmplAddrs() error {
 	}
 
 	return nil
-}
-
-// makeServer creates a new consul server.
-func (a *Agent) makeServer() (*consul.Server, error) {
-	config, err := a.consulConfig()
-	if err != nil {
-		return nil, err
-	}
-	if !a.config.DisableKeyringFile {
-		if err := a.setupKeyrings(config); err != nil {
-			return nil, fmt.Errorf("Failed to configure keyring: %v", err)
-		}
-	}
-	server, err := consul.NewServerLogger(config, a.logger)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to start Consul server: %v", err)
-	}
-	return server, nil
-}
-
-// makeClient creates a new consul client.
-func (a *Agent) makeClient() (*consul.Client, error) {
-	config, err := a.consulConfig()
-	if err != nil {
-		return nil, err
-	}
-	if !a.config.DisableKeyringFile {
-		if err := a.setupKeyrings(config); err != nil {
-			return nil, fmt.Errorf("Failed to configure keyring: %v", err)
-		}
-	}
-	client, err := consul.NewClientLogger(config, a.logger)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to start Consul client: %v", err)
-	}
-	return client, nil
 }
 
 // makeRandomID will generate a random UUID for a node.
@@ -1644,7 +1624,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			ttl := &CheckTTL{
-				Notify:  &a.state,
+				Notify:  a.state,
 				CheckID: check.CheckID,
 				TTL:     chkType.TTL,
 				Logger:  a.logger,
@@ -1670,7 +1650,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			http := &CheckHTTP{
-				Notify:        &a.state,
+				Notify:        a.state,
 				CheckID:       check.CheckID,
 				HTTP:          chkType.HTTP,
 				Header:        chkType.Header,
@@ -1694,7 +1674,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			tcp := &CheckTCP{
-				Notify:   &a.state,
+				Notify:   a.state,
 				CheckID:  check.CheckID,
 				TCP:      chkType.TCP,
 				Interval: chkType.Interval,
@@ -1715,7 +1695,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			dockerCheck := &CheckDocker{
-				Notify:            &a.state,
+				Notify:            a.state,
 				CheckID:           check.CheckID,
 				DockerContainerID: chkType.DockerContainerID,
 				Shell:             chkType.Shell,
@@ -1739,7 +1719,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			monitor := &CheckMonitor{
-				Notify:   &a.state,
+				Notify:   a.state,
 				CheckID:  check.CheckID,
 				Script:   chkType.Script,
 				Interval: chkType.Interval,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -551,8 +551,13 @@ func (a *Agent) reloadWatches(cfg *Config) error {
 func (a *Agent) consulConfig() (*consul.Config, error) {
 	// Start with the provided config or default config
 	base := consul.DefaultConfig()
+
+	// a.config.ConsulConfig, if set, is a partial configuration for the
+	// consul server or client. Therefore, clone and augment it but
+	// don't use it as base directly.
 	if a.config.ConsulConfig != nil {
-		base = a.config.ConsulConfig
+		base = new(consul.Config)
+		*base = *a.config.ConsulConfig
 	}
 
 	// This is set when the agent starts up

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -893,10 +893,16 @@ func TestAgent_ConsulService(t *testing.T) {
 		t.Fatalf("%s service should be registered", consul.ConsulServiceID)
 	}
 
-	// Perform anti-entropy on consul service
-	if err := a.state.syncService(consul.ConsulServiceID); err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	// todo(fs): data race
+	func() {
+		a.state.Lock()
+		defer a.state.Unlock()
+
+		// Perform anti-entropy on consul service
+		if err := a.state.syncService(consul.ConsulServiceID); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}()
 
 	// Consul service should be in sync
 	if !a.state.serviceStatus[consul.ConsulServiceID].inSync {

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -74,7 +74,7 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	if err := s.agent.RPC("Catalog.ListNodes", &args, &out); err != nil {
 		return nil, err
 	}
-	translateAddresses(s.agent.config, args.Datacenter, out.Nodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {
@@ -134,7 +134,7 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	if err := s.agent.RPC("Catalog.ServiceNodes", &args, &out); err != nil {
 		return nil, err
 	}
-	translateAddresses(s.agent.config, args.Datacenter, out.ServiceNodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes)
 
 	// Use empty list instead of nil
 	if out.ServiceNodes == nil {
@@ -170,7 +170,7 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 		return nil, err
 	}
 	if out.NodeServices != nil && out.NodeServices.Node != nil {
-		translateAddresses(s.agent.config, args.Datacenter, out.NodeServices.Node)
+		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices.Node)
 	}
 
 	// Use empty list instead of nil

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -33,16 +33,22 @@ func TestCatalogRegister(t *testing.T) {
 		t.Fatalf("bad: %v", res)
 	}
 
-	// Service should be in sync
-	if err := a.state.syncService("foo"); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if _, ok := a.state.serviceStatus["foo"]; !ok {
-		t.Fatalf("bad: %#v", a.state.serviceStatus)
-	}
-	if !a.state.serviceStatus["foo"].inSync {
-		t.Fatalf("should be in sync")
-	}
+	// todo(fs): data race
+	func() {
+		a.state.Lock()
+		defer a.state.Unlock()
+
+		// Service should be in sync
+		if err := a.state.syncService("foo"); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		if _, ok := a.state.serviceStatus["foo"]; !ok {
+			t.Fatalf("bad: %#v", a.state.serviceStatus)
+		}
+		if !a.state.serviceStatus["foo"].inSync {
+			t.Fatalf("should be in sync")
+		}
+	}()
 }
 
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {

--- a/agent/config_files.go
+++ b/agent/config_files.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+type fileInfo struct {
+	// path is the full path to the file.
+	path string
+
+	// b is the content of the file. nil if there was an error.
+	b []byte
+
+	// err is set if the file could not be read.
+	err error
+}
+
+// readPaths reads the contents of the paths according to the rules of
+// readPath.
+func readPaths(paths, exts []string, level int) []fileInfo {
+	var fis []fileInfo
+	for _, path := range paths {
+		fis = append(fis, readPath(path, exts, level)...)
+	}
+	return fis
+}
+
+// readPath reads the contents of all files with extensions listed in
+// exts recursively up to the given level starting from root. Files and
+// directories are processed in lexicographical order. The function
+// returns a fileInfo struct for every file that was not skipped.
+func readPath(root string, exts []string, level int) []fileInfo {
+	if level <= 0 {
+		return nil
+	}
+
+	var fis []fileInfo
+	err := filepath.Walk(root, func(fpath string, info os.FileInfo, err error) error {
+		// fmt.Println("walk: path=", fpath)
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			fis = append(fis, readPath(fpath, exts, level-1)...)
+			return nil
+		}
+
+		// skip non-config file
+		if !strSliceContains(exts, path.Ext(fpath)) {
+			return nil
+		}
+
+		// read config file
+		b, err := ioutil.ReadFile(fpath)
+		if err != nil {
+			fis = append(fis, fileInfo{path: fpath, err: err})
+			return nil
+		}
+		fis = append(fis, fileInfo{path: fpath, b: b})
+		return nil
+	})
+	if err != nil {
+		fis = append(fis, fileInfo{path: root, err: err})
+	}
+	return fis
+}
+
+func strSliceContains(s []string, val string) bool {
+	for _, v := range s {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -318,7 +318,7 @@ type aclFilter struct {
 // newACLFilter constructs a new aclFilter.
 func newACLFilter(acl acl.ACL, logger *log.Logger, enforceVersion8 bool) *aclFilter {
 	if logger == nil {
-		logger = log.New(os.Stdout, "", log.LstdFlags)
+		logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
 	return &aclFilter{
 		acl:             acl,

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestACLEndpoint_Apply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -74,6 +75,7 @@ func TestACLEndpoint_Apply(t *testing.T) {
 }
 
 func TestACLEndpoint_Update_PurgeCache(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -152,6 +154,7 @@ func TestACLEndpoint_Update_PurgeCache(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_CustomID(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -199,6 +202,7 @@ func TestACLEndpoint_Apply_CustomID(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_Denied(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 	})
@@ -225,6 +229,7 @@ func TestACLEndpoint_Apply_Denied(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_DeleteAnon(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -254,6 +259,7 @@ func TestACLEndpoint_Apply_DeleteAnon(t *testing.T) {
 }
 
 func TestACLEndpoint_Apply_RootChange(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -283,6 +289,7 @@ func TestACLEndpoint_Apply_RootChange(t *testing.T) {
 }
 
 func TestACLEndpoint_Get(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -330,6 +337,7 @@ func TestACLEndpoint_Get(t *testing.T) {
 }
 
 func TestACLEndpoint_GetPolicy(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -387,6 +395,7 @@ func TestACLEndpoint_GetPolicy(t *testing.T) {
 }
 
 func TestACLEndpoint_List(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -448,6 +457,7 @@ func TestACLEndpoint_List(t *testing.T) {
 }
 
 func TestACLEndpoint_List_Denied(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 	})
@@ -469,6 +479,7 @@ func TestACLEndpoint_List_Denied(t *testing.T) {
 }
 
 func TestACLEndpoint_ReplicationStatus(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc2"
 		c.ACLReplicationToken = "secret"

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -224,6 +224,7 @@ func TestACLReplication_reconcileACLs(t *testing.T) {
 }
 
 func TestACLReplication_updateLocalACLs_RateLimit(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc2"
 		c.ACLDatacenter = "dc1"
@@ -273,6 +274,7 @@ func TestACLReplication_updateLocalACLs_RateLimit(t *testing.T) {
 }
 
 func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
+	t.Parallel()
 	// ACLs not enabled.
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = ""
@@ -321,6 +323,7 @@ func TestACLReplication_IsACLReplicationEnabled(t *testing.T) {
 }
 
 func TestACLReplication(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -23,6 +23,7 @@ key "foo/" {
 `
 
 func TestACL_Disabled(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -41,6 +42,7 @@ func TestACL_Disabled(t *testing.T) {
 }
 
 func TestACL_ResolveRootACL(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 	})
@@ -65,6 +67,7 @@ func TestACL_ResolveRootACL(t *testing.T) {
 }
 
 func TestACL_Authority_NotFound(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 	})
@@ -85,6 +88,7 @@ func TestACL_Authority_NotFound(t *testing.T) {
 }
 
 func TestACL_Authority_Found(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 		c.ACLMasterToken = "root"
@@ -131,6 +135,7 @@ func TestACL_Authority_Found(t *testing.T) {
 }
 
 func TestACL_Authority_Anonymous_Found(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 	})
@@ -157,6 +162,7 @@ func TestACL_Authority_Anonymous_Found(t *testing.T) {
 }
 
 func TestACL_Authority_Master_Found(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 		c.ACLMasterToken = "foobar"
@@ -184,6 +190,7 @@ func TestACL_Authority_Master_Found(t *testing.T) {
 }
 
 func TestACL_Authority_Management(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 		c.ACLMasterToken = "foobar"
@@ -212,6 +219,7 @@ func TestACL_Authority_Management(t *testing.T) {
 }
 
 func TestACL_NonAuthority_NotFound(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 	})
@@ -251,6 +259,7 @@ func TestACL_NonAuthority_NotFound(t *testing.T) {
 }
 
 func TestACL_NonAuthority_Found(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -316,6 +325,7 @@ func TestACL_NonAuthority_Found(t *testing.T) {
 }
 
 func TestACL_NonAuthority_Management(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1" // Enable ACLs!
 		c.ACLMasterToken = "foobar"
@@ -364,6 +374,7 @@ func TestACL_NonAuthority_Management(t *testing.T) {
 }
 
 func TestACL_DownPolicy_Deny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLDownPolicy = "deny"
@@ -429,6 +440,7 @@ func TestACL_DownPolicy_Deny(t *testing.T) {
 }
 
 func TestACL_DownPolicy_Allow(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLDownPolicy = "allow"
@@ -494,6 +506,7 @@ func TestACL_DownPolicy_Allow(t *testing.T) {
 }
 
 func TestACL_DownPolicy_ExtendCache(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLTTL = 0
@@ -570,6 +583,7 @@ func TestACL_DownPolicy_ExtendCache(t *testing.T) {
 }
 
 func TestACL_Replication(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -682,6 +696,7 @@ func TestACL_Replication(t *testing.T) {
 }
 
 func TestACL_MultiDC_Found(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/consul/autopilot_test.go
+++ b/agent/consul/autopilot_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAutopilot_CleanupDeadServer(t *testing.T) {
+	t.Parallel()
 	for i := 1; i <= 3; i++ {
 		testCleanupDeadServer(t, i)
 	}
@@ -76,6 +77,7 @@ func testCleanupDeadServer(t *testing.T, raftVersion int) {
 }
 
 func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = true
@@ -120,6 +122,7 @@ func TestAutopilot_CleanupDeadServerPeriodic(t *testing.T) {
 }
 
 func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerDCBootstrap(t, "dc1", true)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -168,6 +171,7 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 }
 
 func TestAutopilot_PromoteNonVoter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = true

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestCatalog_Register(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -47,6 +48,7 @@ func TestCatalog_Register(t *testing.T) {
 }
 
 func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -76,6 +78,7 @@ func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {
 }
 
 func TestCatalog_Register_NodeID(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -111,6 +114,7 @@ func TestCatalog_Register_NodeID(t *testing.T) {
 }
 
 func TestCatalog_Register_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -212,6 +216,7 @@ service "foo" {
 }
 
 func TestCatalog_Register_ForwardLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -255,6 +260,7 @@ func TestCatalog_Register_ForwardLeader(t *testing.T) {
 }
 
 func TestCatalog_Register_ForwardDC(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -287,6 +293,7 @@ func TestCatalog_Register_ForwardDC(t *testing.T) {
 }
 
 func TestCatalog_Deregister(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -312,6 +319,7 @@ func TestCatalog_Deregister(t *testing.T) {
 }
 
 func TestCatalog_Deregister_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -523,6 +531,7 @@ service "service" {
 }
 
 func TestCatalog_ListDatacenters(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -556,6 +565,7 @@ func TestCatalog_ListDatacenters(t *testing.T) {
 }
 
 func TestCatalog_ListDatacenters_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -594,6 +604,7 @@ func TestCatalog_ListDatacenters_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_ListNodes(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -635,6 +646,7 @@ func TestCatalog_ListNodes(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -697,6 +709,7 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_StaleRead(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -761,6 +774,7 @@ func TestCatalog_ListNodes_StaleRead(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ConsistentRead_Fail(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -807,6 +821,7 @@ func TestCatalog_ListNodes_ConsistentRead_Fail(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ConsistentRead(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -851,6 +866,7 @@ func TestCatalog_ListNodes_ConsistentRead(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -941,6 +957,7 @@ func TestCatalog_ListNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_ListNodes_ACLFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -1041,6 +1058,7 @@ func Benchmark_Catalog_ListNodes(t *testing.B) {
 }
 
 func TestCatalog_ListServices(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1091,6 +1109,7 @@ func TestCatalog_ListServices(t *testing.T) {
 }
 
 func TestCatalog_ListServices_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1154,6 +1173,7 @@ func TestCatalog_ListServices_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Blocking(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1212,6 +1232,7 @@ func TestCatalog_ListServices_Blocking(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Timeout(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1253,6 +1274,7 @@ func TestCatalog_ListServices_Timeout(t *testing.T) {
 }
 
 func TestCatalog_ListServices_Stale(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1290,6 +1312,7 @@ func TestCatalog_ListServices_Stale(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1339,6 +1362,7 @@ func TestCatalog_ListServiceNodes(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1439,6 +1463,7 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestCatalog_ListServiceNodes_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1526,6 +1551,7 @@ func TestCatalog_ListServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestCatalog_NodeServices(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1576,6 +1602,7 @@ func TestCatalog_NodeServices(t *testing.T) {
 
 // Used to check for a regression against a known bug
 func TestCatalog_Register_FailedCase1(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -1695,6 +1722,7 @@ service "foo" {
 }
 
 func TestCatalog_ListServices_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1717,6 +1745,7 @@ func TestCatalog_ListServices_FilterACL(t *testing.T) {
 }
 
 func TestCatalog_ServiceNodes_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -1766,6 +1795,7 @@ func TestCatalog_ServiceNodes_FilterACL(t *testing.T) {
 }
 
 func TestCatalog_NodeServices_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -1841,6 +1871,7 @@ node "%s" {
 }
 
 func TestCatalog_NodeServices_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -696,7 +696,7 @@ func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestCatalog_ListNodes_StaleRaad(t *testing.T) {
+func TestCatalog_ListNodes_StaleRead(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -62,6 +62,7 @@ func testClientWithConfig(t *testing.T, cb func(c *Config)) (string, *Client) {
 }
 
 func TestClient_StartStop(t *testing.T) {
+	t.Parallel()
 	dir, client := testClient(t)
 	defer os.RemoveAll(dir)
 
@@ -71,6 +72,7 @@ func TestClient_StartStop(t *testing.T) {
 }
 
 func TestClient_JoinLAN(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -95,6 +97,7 @@ func TestClient_JoinLAN(t *testing.T) {
 }
 
 func TestClient_JoinLAN_Invalid(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -118,6 +121,7 @@ func TestClient_JoinLAN_Invalid(t *testing.T) {
 }
 
 func TestClient_JoinWAN_Invalid(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -141,6 +145,7 @@ func TestClient_JoinWAN_Invalid(t *testing.T) {
 }
 
 func TestClient_RPC(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -176,6 +181,7 @@ func TestClient_RPC(t *testing.T) {
 }
 
 func TestClient_RPC_Pool(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -218,6 +224,7 @@ func TestClient_RPC_Pool(t *testing.T) {
 }
 
 func TestClient_RPC_ConsulServerPing(t *testing.T) {
+	t.Parallel()
 	var servers []*Server
 	var serverDirs []string
 	const numServers = 5
@@ -281,6 +288,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 }
 
 func TestClient_RPC_TLS(t *testing.T) {
+	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
@@ -326,6 +334,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 }
 
 func TestClient_SnapshotRPC(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -368,6 +377,7 @@ func TestClient_SnapshotRPC(t *testing.T) {
 }
 
 func TestClient_SnapshotRPC_TLS(t *testing.T) {
+	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
@@ -423,6 +433,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 }
 
 func TestClientServer_UserEvent(t *testing.T) {
+	t.Parallel()
 	clientOut := make(chan serf.UserEvent, 2)
 	dir1, c1 := testClientWithConfig(t, func(conf *Config) {
 		conf.UserEventHandler = func(e serf.UserEvent) {
@@ -499,6 +510,7 @@ func TestClientServer_UserEvent(t *testing.T) {
 }
 
 func TestClient_Encrypted(t *testing.T) {
+	t.Parallel()
 	dir1, c1 := testClient(t)
 	defer os.RemoveAll(dir1)
 	defer c1.Shutdown()

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -85,6 +85,11 @@ type Config struct {
 	// as a voting member of the Raft cluster.
 	NonVoter bool
 
+	// NotifyListen is called after the RPC listener has been configured.
+	// RPCAdvertise will be set to the listener address if it hasn't been
+	// configured at this point.
+	NotifyListen func()
+
 	// RPCAddr is the RPC address used by Consul. This should be reachable
 	// by the WAN and LAN
 	RPCAddr *net.TCPAddr
@@ -92,7 +97,8 @@ type Config struct {
 	// RPCAdvertise is the address that is advertised to other nodes for
 	// the RPC endpoint. This can differ from the RPC address, if for example
 	// the RPCAddr is unspecified "0.0.0.0:8300", but this address must be
-	// reachable
+	// reachable. If RPCAdvertise is nil then it will be set to the Listener
+	// address after the listening socket is configured.
 	RPCAdvertise *net.TCPAddr
 
 	// RPCSrcAddr is the source address for outgoing RPC connections.

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -42,8 +42,7 @@ func verifyCoordinatesEqual(t *testing.T, a, b *coordinate.Coordinate) {
 }
 
 func TestCoordinate_Update(t *testing.T) {
-	name := fmt.Sprintf("Node %d", getPort())
-	dir1, config1 := testServerConfig(t, name)
+	dir1, config1 := testServerConfig(t)
 	defer os.RemoveAll(dir1)
 
 	config1.CoordinateUpdatePeriod = 500 * time.Millisecond

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -42,16 +42,13 @@ func verifyCoordinatesEqual(t *testing.T, a, b *coordinate.Coordinate) {
 }
 
 func TestCoordinate_Update(t *testing.T) {
-	dir1, config1 := testServerConfig(t)
+	t.Parallel()
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.CoordinateUpdatePeriod = 500 * time.Millisecond
+		c.CoordinateUpdateBatchSize = 5
+		c.CoordinateUpdateMaxBatches = 2
+	})
 	defer os.RemoveAll(dir1)
-
-	config1.CoordinateUpdatePeriod = 500 * time.Millisecond
-	config1.CoordinateUpdateBatchSize = 5
-	config1.CoordinateUpdateMaxBatches = 2
-	s1, err := NewServer(config1)
-	if err != nil {
-		t.Fatal(err)
-	}
 	defer s1.Shutdown()
 
 	codec := rpcClient(t, s1)
@@ -197,6 +194,7 @@ func TestCoordinate_Update(t *testing.T) {
 }
 
 func TestCoordinate_Update_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -278,6 +276,7 @@ node "node1" {
 }
 
 func TestCoordinate_ListDatacenters(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -308,6 +307,7 @@ func TestCoordinate_ListDatacenters(t *testing.T) {
 }
 
 func TestCoordinate_ListNodes(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -380,6 +380,7 @@ func TestCoordinate_ListNodes(t *testing.T) {
 }
 
 func TestCoordinate_ListNodes_ACLFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestHealth_ChecksInState(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -59,6 +60,7 @@ func TestHealth_ChecksInState(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -154,6 +156,7 @@ func TestHealth_ChecksInState_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -231,6 +234,7 @@ func TestHealth_ChecksInState_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_NodeChecks(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -272,6 +276,7 @@ func TestHealth_NodeChecks(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -318,6 +323,7 @@ func TestHealth_ServiceChecks(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -423,6 +429,7 @@ func TestHealth_ServiceChecks_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -511,6 +518,7 @@ func TestHealth_ServiceChecks_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -594,6 +602,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -724,6 +733,7 @@ func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -812,6 +822,7 @@ func TestHealth_ServiceNodes_DistanceSort(t *testing.T) {
 }
 
 func TestHealth_NodeChecks_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -847,6 +858,7 @@ func TestHealth_NodeChecks_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -889,6 +901,7 @@ func TestHealth_ServiceChecks_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -924,6 +937,7 @@ func TestHealth_ServiceNodes_FilterACL(t *testing.T) {
 }
 
 func TestHealth_ChecksInState_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestInternal_NodeInfo(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -66,6 +67,7 @@ func TestInternal_NodeInfo(t *testing.T) {
 }
 
 func TestInternal_NodeDump(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -157,6 +159,7 @@ func TestInternal_NodeDump(t *testing.T) {
 }
 
 func TestInternal_KeyringOperation(t *testing.T) {
+	t.Parallel()
 	key1 := "H1dfkSZOVnP/JUnaBfTzXg=="
 	keyBytes1, err := base64.StdEncoding.DecodeString(key1)
 	if err != nil {
@@ -239,6 +242,7 @@ func TestInternal_KeyringOperation(t *testing.T) {
 }
 
 func TestInternal_NodeInfo_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -289,6 +293,7 @@ func TestInternal_NodeInfo_FilterACL(t *testing.T) {
 }
 
 func TestInternal_NodeDump_FilterACL(t *testing.T) {
+	t.Parallel()
 	dir, token, srv, codec := testACLFilterServer(t)
 	defer os.RemoveAll(dir)
 	defer srv.Shutdown()
@@ -338,6 +343,7 @@ func TestInternal_NodeDump_FilterACL(t *testing.T) {
 }
 
 func TestInternal_EventFire_Token(t *testing.T) {
+	t.Parallel()
 	dir, srv := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestKVS_Apply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -69,6 +70,7 @@ func TestKVS_Apply(t *testing.T) {
 }
 
 func TestKVS_Apply_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -131,6 +133,7 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestKVS_Get(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -178,6 +181,7 @@ func TestKVS_Get(t *testing.T) {
 }
 
 func TestKVS_Get_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -223,6 +227,7 @@ func TestKVS_Get_ACLDeny(t *testing.T) {
 }
 
 func TestKVSEndpoint_List(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -294,6 +299,7 @@ func TestKVSEndpoint_List(t *testing.T) {
 }
 
 func TestKVSEndpoint_List_Blocking(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -389,6 +395,7 @@ func TestKVSEndpoint_List_Blocking(t *testing.T) {
 }
 
 func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -473,6 +480,7 @@ func TestKVSEndpoint_List_ACLDeny(t *testing.T) {
 }
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -542,6 +550,7 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 }
 
 func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -620,6 +629,7 @@ func TestKVSEndpoint_ListKeys_ACLDeny(t *testing.T) {
 }
 
 func TestKVS_Apply_LockDelay(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -689,6 +699,7 @@ func TestKVS_Apply_LockDelay(t *testing.T) {
 }
 
 func TestKVS_Issue_1626(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestLeader_RegisterMember(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -82,6 +83,7 @@ func TestLeader_RegisterMember(t *testing.T) {
 }
 
 func TestLeader_FailedMember(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -142,6 +144,7 @@ func TestLeader_FailedMember(t *testing.T) {
 }
 
 func TestLeader_LeftMember(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -187,6 +190,7 @@ func TestLeader_LeftMember(t *testing.T) {
 	})
 }
 func TestLeader_ReapMember(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -247,6 +251,7 @@ func TestLeader_ReapMember(t *testing.T) {
 }
 
 func TestLeader_Reconcile_ReapMember(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -295,6 +300,7 @@ func TestLeader_Reconcile_ReapMember(t *testing.T) {
 }
 
 func TestLeader_Reconcile(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -334,6 +340,7 @@ func TestLeader_Reconcile(t *testing.T) {
 }
 
 func TestLeader_Reconcile_Races(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -423,6 +430,7 @@ func TestLeader_Reconcile_Races(t *testing.T) {
 }
 
 func TestLeader_LeftServer(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -460,6 +468,7 @@ func TestLeader_LeftServer(t *testing.T) {
 }
 
 func TestLeader_LeftLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -525,6 +534,7 @@ func TestLeader_LeftLeader(t *testing.T) {
 }
 
 func TestLeader_MultiBootstrap(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -556,6 +566,7 @@ func TestLeader_MultiBootstrap(t *testing.T) {
 }
 
 func TestLeader_TombstoneGC_Reset(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -617,6 +628,7 @@ func TestLeader_TombstoneGC_Reset(t *testing.T) {
 }
 
 func TestLeader_ReapTombstones(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -686,6 +698,7 @@ func TestLeader_ReapTombstones(t *testing.T) {
 }
 
 func TestLeader_RollRaftServer(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = true
 		c.Datacenter = "dc1"
@@ -768,6 +781,7 @@ func TestLeader_RollRaftServer(t *testing.T) {
 }
 
 func TestLeader_ChangeServerID(t *testing.T) {
+	t.Parallel()
 	conf := func(c *Config) {
 		c.Bootstrap = false
 		c.BootstrapExpect = 3

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -465,6 +465,7 @@ func TestLeader_LeftServer(t *testing.T) {
 	for _, s := range servers[1:] {
 		retry.Run(t, func(r *retry.R) { r.Check(wantPeers(s, 2)) })
 	}
+	s1.Shutdown()
 }
 
 func TestLeader_LeftLeader(t *testing.T) {

--- a/agent/consul/operator_autopilot_endpoint_test.go
+++ b/agent/consul/operator_autopilot_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestOperator_Autopilot_GetConfiguration(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.AutopilotConfig.CleanupDeadServers = false
 	})
@@ -38,6 +39,7 @@ func TestOperator_Autopilot_GetConfiguration(t *testing.T) {
 }
 
 func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -95,6 +97,7 @@ func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_Autopilot_SetConfiguration(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.AutopilotConfig.CleanupDeadServers = false
 	})
@@ -130,6 +133,7 @@ func TestOperator_Autopilot_SetConfiguration(t *testing.T) {
 }
 
 func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -197,6 +201,7 @@ func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_ServerHealth(t *testing.T) {
+	t.Parallel()
 	conf := func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = false
@@ -254,6 +259,7 @@ func TestOperator_ServerHealth(t *testing.T) {
 }
 
 func TestOperator_ServerHealth_UnsupportedRaftVersion(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = true

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestOperator_RaftGetConfiguration(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -56,6 +57,7 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 }
 
 func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -132,6 +134,7 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -190,6 +193,7 @@ func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -245,6 +249,7 @@ func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByID(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
 	})
@@ -305,6 +310,7 @@ func TestOperator_RaftRemovePeerByID(t *testing.T) {
 }
 
 func TestOperator_RaftRemovePeerByID_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestPreparedQuery_Apply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -181,6 +182,7 @@ func TestPreparedQuery_Apply(t *testing.T) {
 }
 
 func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -462,6 +464,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestPreparedQuery_Apply_ForwardLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = false
 	})
@@ -529,6 +532,7 @@ func TestPreparedQuery_Apply_ForwardLeader(t *testing.T) {
 }
 
 func TestPreparedQuery_parseQuery(t *testing.T) {
+	t.Parallel()
 	query := &structs.PreparedQuery{}
 
 	err := parseQuery(query, true)
@@ -617,6 +621,7 @@ func TestPreparedQuery_parseQuery(t *testing.T) {
 }
 
 func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -830,6 +835,7 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 }
 
 func TestPreparedQuery_Get(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -1081,6 +1087,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 }
 
 func TestPreparedQuery_List(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -1287,6 +1294,7 @@ func TestPreparedQuery_List(t *testing.T) {
 }
 
 func TestPreparedQuery_Explain(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -1422,6 +1430,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 // walk through the different cases once we have it up. This is broken into
 // sections so it's still pretty easy to read.
 func TestPreparedQuery_Execute(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -2443,6 +2452,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 }
 
 func TestPreparedQuery_Execute_ForwardLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -2571,6 +2581,7 @@ func TestPreparedQuery_Execute_ForwardLeader(t *testing.T) {
 }
 
 func TestPreparedQuery_tagFilter(t *testing.T) {
+	t.Parallel()
 	testNodes := func() structs.CheckServiceNodes {
 		return structs.CheckServiceNodes{
 			structs.CheckServiceNode{
@@ -2662,6 +2673,7 @@ func TestPreparedQuery_tagFilter(t *testing.T) {
 }
 
 func TestPreparedQuery_Wrapper(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -2748,6 +2760,7 @@ func (m *mockQueryServer) ForwardDC(method, dc string, args interface{}, reply i
 }
 
 func TestPreparedQuery_queryFailover(t *testing.T) {
+	t.Parallel()
 	query := &structs.PreparedQuery{
 		Name: "test",
 		Service: structs.ServiceQuery{

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -49,7 +49,7 @@ const (
 func (s *Server) listen() {
 	for {
 		// Accept a connection
-		conn, err := s.rpcListener.Accept()
+		conn, err := s.Listener.Accept()
 		if err != nil {
 			if s.shutdown {
 				return

--- a/agent/consul/rpc_test.go
+++ b/agent/consul/rpc_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestRPC_NoLeader_Fail(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 1 * time.Millisecond
 	})
@@ -46,6 +47,7 @@ func TestRPC_NoLeader_Fail(t *testing.T) {
 }
 
 func TestRPC_NoLeader_Retry(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.RPCHoldTimeout = 10 * time.Second
 	})
@@ -76,6 +78,7 @@ func TestRPC_NoLeader_Retry(t *testing.T) {
 }
 
 func TestRPC_blockingQuery(t *testing.T) {
+	t.Parallel()
 	dir, s := testServer(t)
 	defer os.RemoveAll(dir)
 	defer s.Shutdown()

--- a/agent/consul/rtt_test.go
+++ b/agent/consul/rtt_test.go
@@ -131,6 +131,7 @@ func seedCoordinates(t *testing.T, codec rpc.ClientCodec, server *Server) {
 }
 
 func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
+	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
 	defer server.Shutdown()
@@ -183,6 +184,7 @@ func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
+	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
 	defer server.Shutdown()
@@ -232,6 +234,7 @@ func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_ServiceNodes(t *testing.T) {
+	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
 	defer server.Shutdown()
@@ -281,6 +284,7 @@ func TestRTT_sortNodesByDistanceFrom_ServiceNodes(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_HealthChecks(t *testing.T) {
+	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
 	defer server.Shutdown()
@@ -330,6 +334,7 @@ func TestRTT_sortNodesByDistanceFrom_HealthChecks(t *testing.T) {
 }
 
 func TestRTT_sortNodesByDistanceFrom_CheckServiceNodes(t *testing.T) {
+	t.Parallel()
 	dir, server := testServer(t)
 	defer os.RemoveAll(dir)
 	defer server.Shutdown()

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -172,8 +172,7 @@ type Server struct {
 	// sessionTimers track the expiration time of each Session that has
 	// a TTL. On expiration, a SessionDestroy event will occur, and
 	// destroy the session via standard session destroy processing
-	sessionTimers     map[string]*time.Timer
-	sessionTimersLock sync.Mutex
+	sessionTimers *SessionTimers
 
 	// statsFetcher is used by autopilot to check the status of the other
 	// Consul servers.
@@ -296,6 +295,7 @@ func NewServerLogger(config *Config, logger *log.Logger) (*Server, error) {
 		rpcServer:             rpc.NewServer(),
 		rpcTLS:                incomingTLS,
 		reassertLeaderCh:      make(chan chan error),
+		sessionTimers:         NewSessionTimers(),
 		tombstoneGC:           gc,
 		shutdownCh:            shutdownCh,
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -627,8 +627,9 @@ func testVerifyRPC(s1, s2 *Server, t *testing.T) (bool, error) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Check the members
+	// make sure both servers know about each other
 	retry.Run(t, func(r *retry.R) { r.Check(wantPeers(s1, 2)) })
+	retry.Run(t, func(r *retry.R) { r.Check(wantPeers(s2, 2)) })
 
 	// Have s2 make an RPC call to s1
 	s2.localLock.RLock()

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -236,11 +236,11 @@ func TestServer_JoinWAN(t *testing.T) {
 
 func TestServer_JoinWAN_Flood(t *testing.T) {
 	// Set up two servers in a WAN.
-	dir1, s1 := testServer(t)
+	dir1, s1 := testServerDCBootstrap(t, "dc1", true)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
-	dir2, s2 := testServerDC(t, "dc2")
+	dir2, s2 := testServerDCBootstrap(t, "dc2", true)
 	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()
 
@@ -254,7 +254,7 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 		})
 	}
 
-	dir3, s3 := testServer(t)
+	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
 	defer os.RemoveAll(dir3)
 	defer s3.Shutdown()
 
@@ -265,7 +265,7 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 	for _, s := range []*Server{s1, s2, s3} {
 		retry.Run(t, func(r *retry.R) {
 			if got, want := len(s.WANMembers()), 3; got != want {
-				r.Fatalf("got %d WAN members want %d", got, want)
+				r.Fatalf("got %d WAN members for %s want %d", got, s.config.NodeName, want)
 			}
 		})
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -76,36 +76,32 @@ func testServerConfig(t *testing.T, NodeName string) (string, *Config) {
 }
 
 func testServer(t *testing.T) (string, *Server) {
-	return testServerDC(t, "dc1")
+	return testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+	})
 }
 
 func testServerDC(t *testing.T, dc string) (string, *Server) {
-	return testServerDCBootstrap(t, dc, true)
+	return testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = dc
+		c.Bootstrap = true
+	})
 }
 
 func testServerDCBootstrap(t *testing.T, dc string, bootstrap bool) (string, *Server) {
-	name := fmt.Sprintf("Node %d", getPort())
-	dir, config := testServerConfig(t, name)
-	config.Datacenter = dc
-	config.Bootstrap = bootstrap
-	server, err := NewServer(config)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return dir, server
+	return testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = dc
+		c.Bootstrap = bootstrap
+	})
 }
 
 func testServerDCExpect(t *testing.T, dc string, expect int) (string, *Server) {
-	name := fmt.Sprintf("Node %d", getPort())
-	dir, config := testServerConfig(t, name)
-	config.Datacenter = dc
-	config.Bootstrap = false
-	config.BootstrapExpect = expect
-	server, err := NewServer(config)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	return dir, server
+	return testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = dc
+		c.Bootstrap = false
+		c.BootstrapExpect = expect
+	})
 }
 
 func testServerWithConfig(t *testing.T, cb func(c *Config)) (string, *Server) {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -72,11 +72,11 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.SerfWANConfig.MemberlistConfig.ProbeInterval = 100 * time.Millisecond
 	config.SerfWANConfig.MemberlistConfig.GossipInterval = 100 * time.Millisecond
 
-	config.RaftConfig.LeaderLeaseTimeout = 20 * time.Millisecond
-	config.RaftConfig.HeartbeatTimeout = 40 * time.Millisecond
-	config.RaftConfig.ElectionTimeout = 40 * time.Millisecond
+	config.RaftConfig.LeaderLeaseTimeout = 100 * time.Millisecond
+	config.RaftConfig.HeartbeatTimeout = 200 * time.Millisecond
+	config.RaftConfig.ElectionTimeout = 200 * time.Millisecond
 
-	config.ReconcileInterval = 100 * time.Millisecond
+	config.ReconcileInterval = 300 * time.Millisecond
 
 	config.AutopilotConfig.ServerStabilizationTime = 100 * time.Millisecond
 	config.ServerHealthInterval = 50 * time.Millisecond

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -169,6 +169,7 @@ func newServer(c *Config) (*Server, error) {
 }
 
 func TestServer_StartStop(t *testing.T) {
+	t.Parallel()
 	// Start up a server and then stop it.
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -183,6 +184,7 @@ func TestServer_StartStop(t *testing.T) {
 }
 
 func TestServer_JoinLAN(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -204,6 +206,7 @@ func TestServer_JoinLAN(t *testing.T) {
 }
 
 func TestServer_JoinWAN(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -235,6 +238,7 @@ func TestServer_JoinWAN(t *testing.T) {
 }
 
 func TestServer_JoinWAN_Flood(t *testing.T) {
+	t.Parallel()
 	// Set up two servers in a WAN.
 	dir1, s1 := testServerDCBootstrap(t, "dc1", true)
 	defer os.RemoveAll(dir1)
@@ -272,6 +276,7 @@ func TestServer_JoinWAN_Flood(t *testing.T) {
 }
 
 func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -349,6 +354,7 @@ func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
 }
 
 func TestServer_LeaveLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -386,6 +392,7 @@ func TestServer_LeaveLeader(t *testing.T) {
 }
 
 func TestServer_Leave(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -423,6 +430,7 @@ func TestServer_Leave(t *testing.T) {
 }
 
 func TestServer_RPC(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -434,6 +442,7 @@ func TestServer_RPC(t *testing.T) {
 }
 
 func TestServer_JoinLAN_TLS(t *testing.T) {
+	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
@@ -475,6 +484,7 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 }
 
 func TestServer_Expect(t *testing.T) {
+	t.Parallel()
 	// All test servers should be in expect=3 mode, except for the 3rd one,
 	// but one with expect=0 can cause a bootstrap to occur from the other
 	// servers as currently implemented.
@@ -537,6 +547,7 @@ func TestServer_Expect(t *testing.T) {
 }
 
 func TestServer_BadExpect(t *testing.T) {
+	t.Parallel()
 	// this one is in expect=3 mode
 	dir1, s1 := testServerDCExpect(t, "dc1", 3)
 	defer os.RemoveAll(dir1)
@@ -583,6 +594,7 @@ func (r *fakeGlobalResp) New() interface{} {
 }
 
 func TestServer_globalRPCErrors(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerDC(t, "dc1")
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -603,6 +615,7 @@ func TestServer_globalRPCErrors(t *testing.T) {
 }
 
 func TestServer_Encrypted(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -651,6 +664,7 @@ func testVerifyRPC(s1, s2 *Server, t *testing.T) (bool, error) {
 }
 
 func TestServer_TLSToNoTLS(t *testing.T) {
+	t.Parallel()
 	// Set up a server with no TLS configured
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -678,6 +692,7 @@ func TestServer_TLSToNoTLS(t *testing.T) {
 }
 
 func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
+	t.Parallel()
 	// Set up a server with no TLS configured
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
@@ -703,6 +718,7 @@ func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
 }
 
 func TestServer_TLSToFullVerify(t *testing.T) {
+	t.Parallel()
 	// Set up a server with TLS and VerifyIncoming set
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.CAFile = "../../test/client_certs/rootca.crt"

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -326,7 +326,7 @@ func TestServer_JoinSeparateLanAndWanAddresses(t *testing.T) {
 			r.Fatalf("got %d s2 LAN members want %d", got, want)
 		}
 		if got, want := len(s3.LANMembers()), 2; got != want {
-			r.Fatalf("got %d s3 WAN members want %d", got, want)
+			r.Fatalf("got %d s3 LAN members want %d", got, want)
 		}
 	})
 

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestSession_Apply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -72,6 +73,7 @@ func TestSession_Apply(t *testing.T) {
 }
 
 func TestSession_DeleteApply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -135,6 +137,7 @@ func TestSession_DeleteApply(t *testing.T) {
 }
 
 func TestSession_Apply_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -229,6 +232,7 @@ session "foo" {
 }
 
 func TestSession_Get(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -272,6 +276,7 @@ func TestSession_Get(t *testing.T) {
 }
 
 func TestSession_List(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -323,6 +328,7 @@ func TestSession_List(t *testing.T) {
 }
 
 func TestSession_Get_List_NodeSessions_ACLFilter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -491,6 +497,7 @@ session "foo" {
 }
 
 func TestSession_ApplyTimers(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -532,6 +539,7 @@ func TestSession_ApplyTimers(t *testing.T) {
 }
 
 func TestSession_Renew(t *testing.T) {
+	t.Parallel()
 	ttl := time.Second
 	TTL := ttl.String()
 
@@ -695,6 +703,7 @@ func TestSession_Renew(t *testing.T) {
 }
 
 func TestSession_Renew_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -773,6 +782,7 @@ session "foo" {
 }
 
 func TestSession_NodeSessions(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -831,6 +841,7 @@ func TestSession_NodeSessions(t *testing.T) {
 }
 
 func TestSession_Apply_BadTTL(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -532,7 +532,7 @@ func TestSession_ApplyTimers(t *testing.T) {
 }
 
 func TestSession_Renew(t *testing.T) {
-	ttl := 250 * time.Millisecond
+	ttl := time.Second
 	TTL := ttl.String()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -514,7 +514,7 @@ func TestSession_ApplyTimers(t *testing.T) {
 	}
 
 	// Check the session map
-	if _, ok := s1.sessionTimers[out]; !ok {
+	if s1.sessionTimers.Get(out) == nil {
 		t.Fatalf("missing session timer")
 	}
 
@@ -526,7 +526,7 @@ func TestSession_ApplyTimers(t *testing.T) {
 	}
 
 	// Check the session map
-	if _, ok := s1.sessionTimers[out]; ok {
+	if s1.sessionTimers.Get(out) != nil {
 		t.Fatalf("session timer exists")
 	}
 }
@@ -564,7 +564,7 @@ func TestSession_Renew(t *testing.T) {
 	}
 
 	// Verify the timer map is setup
-	if len(s1.sessionTimers) != 5 {
+	if s1.sessionTimers.Len() != 5 {
 		t.Fatalf("missing session timers")
 	}
 

--- a/agent/consul/session_timers.go
+++ b/agent/consul/session_timers.go
@@ -1,0 +1,82 @@
+package consul
+
+import (
+	"sync"
+	"time"
+)
+
+// SessionTimers provides a map of named timers which
+// is safe for concurrent use.
+type SessionTimers struct {
+	sync.RWMutex
+	m map[string]*time.Timer
+}
+
+func NewSessionTimers() *SessionTimers {
+	return &SessionTimers{m: make(map[string]*time.Timer)}
+}
+
+// Get returns the timer with the given id or nil.
+func (t *SessionTimers) Get(id string) *time.Timer {
+	t.RLock()
+	defer t.RUnlock()
+	return t.m[id]
+}
+
+// Set stores the timer under given id. If tm is nil the timer
+// witht the given id is removed.
+func (t *SessionTimers) Set(id string, tm *time.Timer) {
+	t.Lock()
+	defer t.Unlock()
+	if tm == nil {
+		// todo(fs): shouldn't we call Stop() here?
+		delete(t.m, id)
+	} else {
+		t.m[id] = tm
+	}
+}
+
+// Del removes the timer with the given id.
+func (t *SessionTimers) Del(id string) {
+	t.Set(id, nil)
+}
+
+// Len returns the number of registered timers.
+func (t *SessionTimers) Len() int {
+	t.RLock()
+	defer t.RUnlock()
+	return len(t.m)
+}
+
+// ResetOrCreate sets the ttl of the timer with the given id or creates a new
+// one if it does not exist.
+func (t *SessionTimers) ResetOrCreate(id string, ttl time.Duration, afterFunc func()) {
+	t.Lock()
+	defer t.Unlock()
+
+	if tm := t.m[id]; tm != nil {
+		tm.Reset(ttl)
+		return
+	}
+	t.m[id] = time.AfterFunc(ttl, afterFunc)
+}
+
+// Stop stops the timer with the given id and removes it.
+func (t *SessionTimers) Stop(id string) {
+	t.Lock()
+	defer t.Unlock()
+	if tm := t.m[id]; tm != nil {
+		tm.Stop()
+		delete(t.m, id)
+	}
+}
+
+// StopAll stops and removes all registered timers.
+func (t *SessionTimers) StopAll() {
+	t.Lock()
+	defer t.Unlock()
+	for _, tm := range t.m {
+		tm.Stop()
+	}
+	t.m = make(map[string]*time.Timer)
+}

--- a/agent/consul/session_timers_test.go
+++ b/agent/consul/session_timers_test.go
@@ -1,0 +1,105 @@
+package consul
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSessionTimers(t *testing.T) {
+	m := NewSessionTimers()
+	ch := make(chan int)
+	newTm := func(d time.Duration) *time.Timer {
+		return time.AfterFunc(d, func() { ch <- 1 })
+	}
+
+	waitForTimer := func() {
+		select {
+		case <-ch:
+			return
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timer did not fire")
+		}
+	}
+
+	// check that non-existent id returns nil
+	if got, want := m.Get("foo"), (*time.Timer)(nil); got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+
+	// add a timer and look it up and delete via Set(id, nil)
+	tm := newTm(time.Millisecond)
+	m.Set("foo", tm)
+	if got, want := m.Len(), 1; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+	if got, want := m.Get("foo"), tm; got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	m.Set("foo", nil)
+	if got, want := m.Get("foo"), (*time.Timer)(nil); got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	waitForTimer()
+
+	// same thing via Del(id)
+	tm = newTm(time.Millisecond)
+	m.Set("foo", tm)
+	if got, want := m.Get("foo"), tm; got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	m.Del("foo")
+	if got, want := m.Len(), 0; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+	waitForTimer()
+
+	// create timer via ResetOrCreate
+	m.ResetOrCreate("foo", time.Millisecond, func() { ch <- 1 })
+	if got, want := m.Len(), 1; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+	waitForTimer()
+
+	// timer is still there
+	if got, want := m.Len(), 1; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+
+	// reset the timer and check that it fires again
+	m.ResetOrCreate("foo", time.Millisecond, nil)
+	waitForTimer()
+
+	// reset the timer with a long ttl and then stop it
+	m.ResetOrCreate("foo", 20*time.Millisecond, func() { ch <- 1 })
+	m.Stop("foo")
+	select {
+	case <-ch:
+		t.Fatal("timer fired although it shouldn't")
+	case <-time.After(100 * time.Millisecond):
+		// want
+	}
+
+	// stopping a stopped timer should not break
+	m.Stop("foo")
+
+	// stop should also remove the timer
+	if got, want := m.Len(), 0; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+
+	// create two timers and stop and then stop all
+	m.ResetOrCreate("foo1", 20*time.Millisecond, func() { ch <- 1 })
+	m.ResetOrCreate("foo2", 30*time.Millisecond, func() { ch <- 2 })
+	m.StopAll()
+	select {
+	case x := <-ch:
+		t.Fatalf("timer %d fired although it shouldn't", x)
+	case <-time.After(100 * time.Millisecond):
+		// want
+	}
+
+	// stopall should remove all timers
+	if got, want := m.Len(), 0; got != want {
+		t.Fatalf("got len %d want %d", got, want)
+	}
+}

--- a/agent/consul/session_ttl.go
+++ b/agent/consul/session_ttl.go
@@ -94,7 +94,7 @@ func (s *Server) resetSessionTimerLocked(id string, ttl time.Duration) {
 		return
 	}
 
-	// Create a new timer to track expiration of thi ssession
+	// Create a new timer to track expiration of this ssession
 	timer := time.AfterFunc(ttl, func() {
 		s.invalidateSession(id)
 	})

--- a/agent/consul/session_ttl_test.go
+++ b/agent/consul/session_ttl_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestInitializeSessionTimers(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -45,6 +46,7 @@ func TestInitializeSessionTimers(t *testing.T) {
 }
 
 func TestResetSessionTimer_Fault(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -84,6 +86,7 @@ func TestResetSessionTimer_Fault(t *testing.T) {
 }
 
 func TestResetSessionTimer_NoTTL(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -117,6 +120,7 @@ func TestResetSessionTimer_NoTTL(t *testing.T) {
 }
 
 func TestResetSessionTimer_InvalidTTL(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -136,6 +140,7 @@ func TestResetSessionTimer_InvalidTTL(t *testing.T) {
 }
 
 func TestResetSessionTimerLocked(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -154,6 +159,7 @@ func TestResetSessionTimerLocked(t *testing.T) {
 }
 
 func TestResetSessionTimerLocked_Renew(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -201,6 +207,7 @@ func TestResetSessionTimerLocked_Renew(t *testing.T) {
 }
 
 func TestInvalidateSession(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -235,6 +242,7 @@ func TestInvalidateSession(t *testing.T) {
 }
 
 func TestClearSessionTimer(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -252,6 +260,7 @@ func TestClearSessionTimer(t *testing.T) {
 }
 
 func TestClearAllSessionTimers(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -272,6 +281,7 @@ func TestClearAllSessionTimers(t *testing.T) {
 }
 
 func TestServer_SessionTTL_Failover(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -147,6 +147,7 @@ func verifySnapshot(t *testing.T, s *Server, dc, token string) {
 }
 
 func TestSnapshot(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -156,6 +157,7 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestSnapshot_LeaderState(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -238,6 +240,7 @@ func TestSnapshot_LeaderState(t *testing.T) {
 }
 
 func TestSnapshot_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -283,6 +286,7 @@ func TestSnapshot_ACLDeny(t *testing.T) {
 }
 
 func TestSnapshot_Forward_Leader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = true
 	})
@@ -309,6 +313,7 @@ func TestSnapshot_Forward_Leader(t *testing.T) {
 }
 
 func TestSnapshot_Forward_Datacenter(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerDC(t, "dc1")
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -337,6 +342,7 @@ func TestSnapshot_Forward_Datacenter(t *testing.T) {
 }
 
 func TestSnapshot_AllowStale(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Bootstrap = false
 	})

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -211,10 +211,10 @@ func TestSnapshot_LeaderState(t *testing.T) {
 	}
 
 	// Make sure the leader has timers setup.
-	if _, ok := s1.sessionTimers[before]; !ok {
+	if s1.sessionTimers.Get(before) == nil {
 		t.Fatalf("missing session timer")
 	}
-	if _, ok := s1.sessionTimers[after]; !ok {
+	if s1.sessionTimers.Get(after) == nil {
 		t.Fatalf("missing session timer")
 	}
 
@@ -229,10 +229,10 @@ func TestSnapshot_LeaderState(t *testing.T) {
 
 	// Make sure the before time is still there, and that the after timer
 	// got reverted. This proves we fully cycled the leader state.
-	if _, ok := s1.sessionTimers[before]; !ok {
+	if s1.sessionTimers.Get(before) == nil {
 		t.Fatalf("missing session timer")
 	}
-	if _, ok := s1.sessionTimers[after]; ok {
+	if s1.sessionTimers.Get(after) != nil {
 		t.Fatalf("unexpected session timer")
 	}
 }

--- a/agent/consul/stats_fetcher_test.go
+++ b/agent/consul/stats_fetcher_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestStatsFetcher(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerDCExpect(t, "dc1", 3)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func rpcClient(t *testing.T, s *Server) rpc.ClientCodec {
-	addr := s.config.RPCAddr
+	addr := s.config.RPCAdvertise
 	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/agent/consul/status_endpoint_test.go
+++ b/agent/consul/status_endpoint_test.go
@@ -25,6 +25,7 @@ func rpcClient(t *testing.T, s *Server) rpc.ClientCodec {
 }
 
 func TestStatusLeader(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -51,6 +52,7 @@ func TestStatusLeader(t *testing.T) {
 }
 
 func TestStatusPeers(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTxn_CheckNotExists(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -66,6 +67,7 @@ func TestTxn_CheckNotExists(t *testing.T) {
 }
 
 func TestTxn_Apply(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -152,6 +154,7 @@ func TestTxn_Apply(t *testing.T) {
 }
 
 func TestTxn_Apply_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"
@@ -323,6 +326,7 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 }
 
 func TestTxn_Apply_LockDelay(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -408,6 +412,7 @@ func TestTxn_Apply_LockDelay(t *testing.T) {
 }
 
 func TestTxn_Read(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -473,6 +478,7 @@ func TestTxn_Read(t *testing.T) {
 }
 
 func TestTxn_Read_ACLDeny(t *testing.T) {
+	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLMasterToken = "root"

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -414,7 +414,7 @@ RPC:
 	// Add the node record
 	n := out.NodeServices.Node
 	edns := req.IsEdns0() != nil
-	addr := translateAddress(d.agent.config, datacenter, n.Address, n.TaggedAddresses)
+	addr := d.agent.TranslateAddress(datacenter, n.Address, n.TaggedAddresses)
 	records := d.formatNodeRecord(out.NodeServices.Node, addr,
 		req.Question[0].Name, qType, d.config.NodeTTL, edns)
 	if records != nil {
@@ -784,7 +784,7 @@ func (d *DNSServer) serviceNodeRecords(dc string, nodes structs.CheckServiceNode
 	for _, node := range nodes {
 		// Start with the translated address but use the service address,
 		// if specified.
-		addr := translateAddress(d.agent.config, dc, node.Node.Address, node.Node.TaggedAddresses)
+		addr := d.agent.TranslateAddress(dc, node.Node.Address, node.Node.TaggedAddresses)
 		if node.Service.Address != "" {
 			addr = node.Service.Address
 		}
@@ -841,7 +841,7 @@ func (d *DNSServer) serviceSRVRecords(dc string, nodes structs.CheckServiceNodes
 
 		// Start with the translated address but use the service address,
 		// if specified.
-		addr := translateAddress(d.agent.config, dc, node.Node.Address, node.Node.TaggedAddresses)
+		addr := d.agent.TranslateAddress(dc, node.Node.Address, node.Node.TaggedAddresses)
 		if node.Service.Address != "" {
 			addr = node.Service.Address
 		}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -4558,7 +4558,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Do a manual exchange with compression on (the default).
-		a.dns.config.DisableCompression = false
+		a.DNSDisableCompression(false)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -4569,7 +4569,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Disable compression and try again.
-		a.dns.config.DisableCompression = true
+		a.DNSDisableCompression(true)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -4623,7 +4623,7 @@ func TestDNS_Compression_ReverseLookup(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.dns.config.DisableCompression = true
+	a.DNSDisableCompression(true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -4671,7 +4671,7 @@ func TestDNS_Compression_Recurse(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.dns.config.DisableCompression = true
+	a.DNSDisableCompression(true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3919,15 +3919,16 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	a := NewTestAgent(t.Name(), cfg)
 	defer a.Shutdown()
 
-	m := MockPreparedQuery{}
-	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
-		t.Fatalf("err: %v", err)
+	m := MockPreparedQuery{
+		executeFn: func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+			// Return a response that's perpetually too stale.
+			reply.LastContact = 2 * time.Second
+			return nil
+		},
 	}
 
-	m.executeFn = func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
-		// Return a response that's perpetually too stale.
-		reply.LastContact = 2 * time.Second
-		return nil
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
+		t.Fatalf("err: %v", err)
 	}
 
 	// Make sure that the lookup terminates and results in an SOA since
@@ -4000,19 +4001,20 @@ func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	a := NewTestAgent(t.Name(), nil)
 	defer a.Shutdown()
 
-	m := MockPreparedQuery{}
-	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
-		t.Fatalf("err: %v", err)
+	m := MockPreparedQuery{
+		executeFn: func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+			// Check that the agent inserted its self-name and datacenter to
+			// the RPC request body.
+			if args.Agent.Datacenter != a.Config.Datacenter ||
+				args.Agent.Node != a.Config.NodeName {
+				t.Fatalf("bad: %#v", args.Agent)
+			}
+			return nil
+		},
 	}
 
-	m.executeFn = func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
-		// Check that the agent inserted its self-name and datacenter to
-		// the RPC request body.
-		if args.Agent.Datacenter != a.Config.Datacenter ||
-			args.Agent.Node != a.Config.NodeName {
-			t.Fatalf("bad: %#v", args.Agent)
-		}
-		return nil
+	if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
+		t.Fatalf("err: %v", err)
 	}
 
 	{

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -171,7 +171,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	}
 
 	// Translate addresses after filtering so we don't waste effort.
-	translateAddresses(s.agent.config, args.Datacenter, out.Nodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {

--- a/agent/local.go
+++ b/agent/local.go
@@ -74,22 +74,23 @@ type localState struct {
 	triggerCh chan struct{}
 }
 
-// Init is used to initialize the local state
-func (l *localState) Init(c *Config, lg *log.Logger, d delegate) {
-	l.config = c
-	l.delegate = d
-	l.logger = lg
-	l.services = make(map[string]*structs.NodeService)
-	l.serviceStatus = make(map[string]syncStatus)
-	l.serviceTokens = make(map[string]string)
-	l.checks = make(map[types.CheckID]*structs.HealthCheck)
-	l.checkStatus = make(map[types.CheckID]syncStatus)
-	l.checkTokens = make(map[types.CheckID]string)
-	l.checkCriticalTime = make(map[types.CheckID]time.Time)
-	l.deferCheck = make(map[types.CheckID]*time.Timer)
-	l.metadata = make(map[string]string)
-	l.consulCh = make(chan struct{}, 1)
-	l.triggerCh = make(chan struct{}, 1)
+// NewLocalState creates a  is used to initialize the local state
+func NewLocalState(c *Config, lg *log.Logger) *localState {
+	return &localState{
+		config:            c,
+		logger:            lg,
+		services:          make(map[string]*structs.NodeService),
+		serviceStatus:     make(map[string]syncStatus),
+		serviceTokens:     make(map[string]string),
+		checks:            make(map[types.CheckID]*structs.HealthCheck),
+		checkStatus:       make(map[types.CheckID]syncStatus),
+		checkTokens:       make(map[types.CheckID]string),
+		checkCriticalTime: make(map[types.CheckID]time.Time),
+		deferCheck:        make(map[types.CheckID]*time.Timer),
+		metadata:          make(map[string]string),
+		consulCh:          make(chan struct{}, 1),
+		triggerCh:         make(chan struct{}, 1),
+	}
 }
 
 // changeMade is used to trigger an anti-entropy run

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -312,6 +312,9 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 			r.Fatalf("err: %v", err)
 		}
 
+		a.state.RLock()
+		defer a.state.RUnlock()
+
 		// All the services should match
 		for id, serv := range services.NodeServices.Services {
 			serv.CreateIndex, serv.ModifyIndex = 0, 0

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -1419,8 +1419,7 @@ func TestAgent_serviceTokens(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
 	cfg.ACLToken = "default"
-	l := new(localState)
-	l.Init(cfg, nil, nil)
+	l := NewLocalState(cfg, nil)
 
 	l.AddService(&structs.NodeService{
 		ID: "redis",
@@ -1448,8 +1447,7 @@ func TestAgent_checkTokens(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
 	cfg.ACLToken = "default"
-	l := new(localState)
-	l.Init(cfg, nil, nil)
+	l := NewLocalState(cfg, nil)
 
 	// Returns default when no token is set
 	if token := l.CheckToken("mem"); token != "default" {
@@ -1472,8 +1470,7 @@ func TestAgent_checkTokens(t *testing.T) {
 func TestAgent_checkCriticalTime(t *testing.T) {
 	t.Parallel()
 	cfg := TestConfig()
-	l := new(localState)
-	l.Init(cfg, nil, nil)
+	l := NewLocalState(cfg, nil)
 
 	// Add a passing check and make sure it's not critical.
 	checkID := types.CheckID("redis:1")

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -122,7 +122,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 	// a query can fail over to a different DC than where the execute request
 	// was sent to. That's why we use the reply's DC and not the one from
 	// the args.
-	translateAddresses(s.agent.config, reply.Datacenter, reply.Nodes)
+	s.agent.TranslateAddresses(reply.Datacenter, reply.Nodes)
 
 	// Use empty list instead of nil.
 	if reply.Nodes == nil {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -245,6 +245,13 @@ func (a *TestAgent) Client() *api.Client {
 	return c
 }
 
+// DNSDisableCompression disables compression for all started DNS servers.
+func (a *TestAgent) DNSDisableCompression(b bool) {
+	for _, srv := range a.dnsServers {
+		srv.disableCompression.Store(b)
+	}
+}
+
 func (a *TestAgent) consulConfig() *consul.Config {
 	c, err := a.Agent.consulConfig()
 	if err != nil {

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestAPI_ACL_CreateDestroy(t *testing.T) {
+func TestAPI_ACLCreateDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -49,7 +49,7 @@ func TestAPI_ACL_CreateDestroy(t *testing.T) {
 	}
 }
 
-func TestAPI_ACL_CloneDestroy(t *testing.T) {
+func TestAPI_ACLCloneDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -79,7 +79,7 @@ func TestAPI_ACL_CloneDestroy(t *testing.T) {
 	}
 }
 
-func TestAPI_ACL_Info(t *testing.T) {
+func TestAPI_ACLInfo(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -103,7 +103,7 @@ func TestAPI_ACL_Info(t *testing.T) {
 	}
 }
 
-func TestAPI_ACL_List(t *testing.T) {
+func TestAPI_ACLList(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -127,7 +127,7 @@ func TestAPI_ACL_List(t *testing.T) {
 	}
 }
 
-func TestAPI_ACL_Replication(t *testing.T) {
+func TestAPI_ACLReplication(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestACL_CreateDestroy(t *testing.T) {
+func TestAPI_ACL_CreateDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -49,7 +49,7 @@ func TestACL_CreateDestroy(t *testing.T) {
 	}
 }
 
-func TestACL_CloneDestroy(t *testing.T) {
+func TestAPI_ACL_CloneDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -79,7 +79,7 @@ func TestACL_CloneDestroy(t *testing.T) {
 	}
 }
 
-func TestACL_Info(t *testing.T) {
+func TestAPI_ACL_Info(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -103,7 +103,7 @@ func TestACL_Info(t *testing.T) {
 	}
 }
 
-func TestACL_List(t *testing.T) {
+func TestAPI_ACL_List(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()
@@ -127,7 +127,7 @@ func TestACL_List(t *testing.T) {
 	}
 }
 
-func TestACL_Replication(t *testing.T) {
+func TestAPI_ACL_Replication(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 )
 
-func TestAPI_Agent_Self(t *testing.T) {
+func TestAPI_AgentSelf(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -28,7 +28,7 @@ func TestAPI_Agent_Self(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Reload(t *testing.T) {
+func TestAPI_AgentReload(t *testing.T) {
 	t.Parallel()
 
 	// Create our initial empty config file, to be overwritten later
@@ -70,7 +70,7 @@ func TestAPI_Agent_Reload(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Members(t *testing.T) {
+func TestAPI_AgentMembers(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -87,7 +87,7 @@ func TestAPI_Agent_Members(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Services(t *testing.T) {
+func TestAPI_AgentServices(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -132,7 +132,7 @@ func TestAPI_Agent_Services(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Services_CheckPassing(t *testing.T) {
+func TestAPI_AgentServices_CheckPassing(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -176,7 +176,7 @@ func TestAPI_Agent_Services_CheckPassing(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Services_CheckBadStatus(t *testing.T) {
+func TestAPI_AgentServices_CheckBadStatus(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -196,7 +196,7 @@ func TestAPI_Agent_Services_CheckBadStatus(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_ServiceAddress(t *testing.T) {
+func TestAPI_AgentServiceAddress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -243,7 +243,7 @@ func TestAPI_Agent_ServiceAddress(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_EnableTagOverride(t *testing.T) {
+func TestAPI_AgentEnableTagOverride(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -286,7 +286,7 @@ func TestAPI_Agent_EnableTagOverride(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Services_MultipleChecks(t *testing.T) {
+func TestAPI_AgentServices_MultipleChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -330,7 +330,7 @@ func TestAPI_Agent_Services_MultipleChecks(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_SetTTLStatus(t *testing.T) {
+func TestAPI_AgentSetTTLStatus(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -414,7 +414,7 @@ func TestAPI_Agent_SetTTLStatus(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Checks(t *testing.T) {
+func TestAPI_AgentChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -446,7 +446,7 @@ func TestAPI_Agent_Checks(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_CheckStartPassing(t *testing.T) {
+func TestAPI_AgentCheckStartPassing(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -481,7 +481,7 @@ func TestAPI_Agent_CheckStartPassing(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Checks_serviceBound(t *testing.T) {
+func TestAPI_AgentChecks_serviceBound(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -527,7 +527,7 @@ func TestAPI_Agent_Checks_serviceBound(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Checks_Docker(t *testing.T) {
+func TestAPI_AgentChecks_Docker(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -571,7 +571,7 @@ func TestAPI_Agent_Checks_Docker(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Join(t *testing.T) {
+func TestAPI_AgentJoin(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -591,7 +591,7 @@ func TestAPI_Agent_Join(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Leave(t *testing.T) {
+func TestAPI_AgentLeave(t *testing.T) {
 	t.Parallel()
 	c1, s1 := makeClient(t)
 	defer s1.Stop()
@@ -626,7 +626,7 @@ func TestAPI_Agent_Leave(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_ForceLeave(t *testing.T) {
+func TestAPI_AgentForceLeave(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -640,7 +640,7 @@ func TestAPI_Agent_ForceLeave(t *testing.T) {
 	}
 }
 
-func TestAPI_Agent_Monitor(t *testing.T) {
+func TestAPI_AgentMonitor(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/serf/serf"
 )
 
-func TestAgent_Self(t *testing.T) {
+func TestAPI_Agent_Self(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -28,7 +28,7 @@ func TestAgent_Self(t *testing.T) {
 	}
 }
 
-func TestAgent_Reload(t *testing.T) {
+func TestAPI_Agent_Reload(t *testing.T) {
 	t.Parallel()
 
 	// Create our initial empty config file, to be overwritten later
@@ -70,7 +70,7 @@ func TestAgent_Reload(t *testing.T) {
 	}
 }
 
-func TestAgent_Members(t *testing.T) {
+func TestAPI_Agent_Members(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -87,7 +87,7 @@ func TestAgent_Members(t *testing.T) {
 	}
 }
 
-func TestAgent_Services(t *testing.T) {
+func TestAPI_Agent_Services(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -132,7 +132,7 @@ func TestAgent_Services(t *testing.T) {
 	}
 }
 
-func TestAgent_Services_CheckPassing(t *testing.T) {
+func TestAPI_Agent_Services_CheckPassing(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -176,7 +176,7 @@ func TestAgent_Services_CheckPassing(t *testing.T) {
 	}
 }
 
-func TestAgent_Services_CheckBadStatus(t *testing.T) {
+func TestAPI_Agent_Services_CheckBadStatus(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -196,7 +196,7 @@ func TestAgent_Services_CheckBadStatus(t *testing.T) {
 	}
 }
 
-func TestAgent_ServiceAddress(t *testing.T) {
+func TestAPI_Agent_ServiceAddress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -243,7 +243,7 @@ func TestAgent_ServiceAddress(t *testing.T) {
 	}
 }
 
-func TestAgent_EnableTagOverride(t *testing.T) {
+func TestAPI_Agent_EnableTagOverride(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -286,7 +286,7 @@ func TestAgent_EnableTagOverride(t *testing.T) {
 	}
 }
 
-func TestAgent_Services_MultipleChecks(t *testing.T) {
+func TestAPI_Agent_Services_MultipleChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -330,7 +330,7 @@ func TestAgent_Services_MultipleChecks(t *testing.T) {
 	}
 }
 
-func TestAgent_SetTTLStatus(t *testing.T) {
+func TestAPI_Agent_SetTTLStatus(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -414,7 +414,7 @@ func TestAgent_SetTTLStatus(t *testing.T) {
 	}
 }
 
-func TestAgent_Checks(t *testing.T) {
+func TestAPI_Agent_Checks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -446,7 +446,7 @@ func TestAgent_Checks(t *testing.T) {
 	}
 }
 
-func TestAgent_CheckStartPassing(t *testing.T) {
+func TestAPI_Agent_CheckStartPassing(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -481,7 +481,7 @@ func TestAgent_CheckStartPassing(t *testing.T) {
 	}
 }
 
-func TestAgent_Checks_serviceBound(t *testing.T) {
+func TestAPI_Agent_Checks_serviceBound(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -527,7 +527,7 @@ func TestAgent_Checks_serviceBound(t *testing.T) {
 	}
 }
 
-func TestAgent_Checks_Docker(t *testing.T) {
+func TestAPI_Agent_Checks_Docker(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -571,7 +571,7 @@ func TestAgent_Checks_Docker(t *testing.T) {
 	}
 }
 
-func TestAgent_Join(t *testing.T) {
+func TestAPI_Agent_Join(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -591,7 +591,7 @@ func TestAgent_Join(t *testing.T) {
 	}
 }
 
-func TestAgent_Leave(t *testing.T) {
+func TestAPI_Agent_Leave(t *testing.T) {
 	t.Parallel()
 	c1, s1 := makeClient(t)
 	defer s1.Stop()
@@ -626,7 +626,7 @@ func TestAgent_Leave(t *testing.T) {
 	}
 }
 
-func TestAgent_ForceLeave(t *testing.T) {
+func TestAPI_Agent_ForceLeave(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -640,7 +640,7 @@ func TestAgent_ForceLeave(t *testing.T) {
 	}
 }
 
-func TestAgent_Monitor(t *testing.T) {
+func TestAPI_Agent_Monitor(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -663,7 +663,7 @@ func TestAgent_Monitor(t *testing.T) {
 	}
 }
 
-func TestServiceMaintenance(t *testing.T) {
+func TestAPI_ServiceMaintenance(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -718,7 +718,7 @@ func TestServiceMaintenance(t *testing.T) {
 	}
 }
 
-func TestNodeMaintenance(t *testing.T) {
+func TestAPI_NodeMaintenance(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -72,7 +72,7 @@ func testKey() string {
 		buf[10:16])
 }
 
-func TestDefaultConfig_env(t *testing.T) {
+func TestAPI_DefaultConfig_env(t *testing.T) {
 	t.Parallel()
 	addr := "1.2.3.4:5678"
 	token := "abcd1234"
@@ -150,7 +150,7 @@ func TestDefaultConfig_env(t *testing.T) {
 	}
 }
 
-func TestSetupTLSConfig(t *testing.T) {
+func TestAPI_SetupTLSConfig(t *testing.T) {
 	// A default config should result in a clean default client config.
 	tlsConfig := &TLSConfig{}
 	cc, err := SetupTLSConfig(tlsConfig)
@@ -253,7 +253,7 @@ func TestSetupTLSConfig(t *testing.T) {
 	}
 }
 
-func TestClientTLSOptions(t *testing.T) {
+func TestAPI_ClientTLSOptions(t *testing.T) {
 	t.Parallel()
 	// Start a server that verifies incoming HTTPS connections
 	_, srvVerify := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
@@ -362,7 +362,7 @@ func TestClientTLSOptions(t *testing.T) {
 	})
 }
 
-func TestSetQueryOptions(t *testing.T) {
+func TestAPI_SetQueryOptions(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -402,7 +402,7 @@ func TestSetQueryOptions(t *testing.T) {
 	}
 }
 
-func TestSetWriteOptions(t *testing.T) {
+func TestAPI_SetWriteOptions(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -422,7 +422,7 @@ func TestSetWriteOptions(t *testing.T) {
 	}
 }
 
-func TestRequestToHTTP(t *testing.T) {
+func TestAPI_RequestToHTTP(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -445,7 +445,7 @@ func TestRequestToHTTP(t *testing.T) {
 	}
 }
 
-func TestParseQueryMeta(t *testing.T) {
+func TestAPI_ParseQueryMeta(t *testing.T) {
 	t.Parallel()
 	resp := &http.Response{
 		Header: make(map[string][]string),

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -49,7 +49,7 @@ func TestAPI_CatalogNodes(t *testing.T) {
 					"wan": "127.0.0.1",
 				},
 				Meta:        map[string]string{},
-				CreateIndex: meta.LastIndex,
+				CreateIndex: meta.LastIndex - 1,
 				ModifyIndex: meta.LastIndex,
 			},
 		}

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func TestAPI_Catalog_Datacenters(t *testing.T) {
+func TestAPI_CatalogDatacenters(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -25,7 +25,7 @@ func TestAPI_Catalog_Datacenters(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Nodes(t *testing.T) {
+func TestAPI_CatalogNodes(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -59,7 +59,7 @@ func TestAPI_Catalog_Nodes(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Nodes_MetaFilter(t *testing.T) {
+func TestAPI_CatalogNodes_MetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -112,7 +112,7 @@ func TestAPI_Catalog_Nodes_MetaFilter(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Services(t *testing.T) {
+func TestAPI_CatalogServices(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -134,7 +134,7 @@ func TestAPI_Catalog_Services(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Services_NodeMetaFilter(t *testing.T) {
+func TestAPI_CatalogServices_NodeMetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -175,7 +175,7 @@ func TestAPI_Catalog_Services_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Service(t *testing.T) {
+func TestAPI_CatalogService(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -201,7 +201,7 @@ func TestAPI_Catalog_Service(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Service_NodeMetaFilter(t *testing.T) {
+func TestAPI_CatalogService_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
@@ -230,7 +230,7 @@ func TestAPI_Catalog_Service_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Node(t *testing.T) {
+func TestAPI_CatalogNode(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -261,7 +261,7 @@ func TestAPI_Catalog_Node(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_Registration(t *testing.T) {
+func TestAPI_CatalogRegistration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -389,7 +389,7 @@ func TestAPI_Catalog_Registration(t *testing.T) {
 	})
 }
 
-func TestAPI_Catalog_EnableTagOverride(t *testing.T) {
+func TestAPI_CatalogEnableTagOverride(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func TestCatalog_Datacenters(t *testing.T) {
+func TestAPI_Catalog_Datacenters(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -25,7 +25,7 @@ func TestCatalog_Datacenters(t *testing.T) {
 	})
 }
 
-func TestCatalog_Nodes(t *testing.T) {
+func TestAPI_Catalog_Nodes(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -59,7 +59,7 @@ func TestCatalog_Nodes(t *testing.T) {
 	})
 }
 
-func TestCatalog_Nodes_MetaFilter(t *testing.T) {
+func TestAPI_Catalog_Nodes_MetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -112,7 +112,7 @@ func TestCatalog_Nodes_MetaFilter(t *testing.T) {
 	})
 }
 
-func TestCatalog_Services(t *testing.T) {
+func TestAPI_Catalog_Services(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -134,7 +134,7 @@ func TestCatalog_Services(t *testing.T) {
 	})
 }
 
-func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
+func TestAPI_Catalog_Services_NodeMetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -175,7 +175,7 @@ func TestCatalog_Services_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestCatalog_Service(t *testing.T) {
+func TestAPI_Catalog_Service(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -201,7 +201,7 @@ func TestCatalog_Service(t *testing.T) {
 	})
 }
 
-func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
+func TestAPI_Catalog_Service_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
@@ -230,7 +230,7 @@ func TestCatalog_Service_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestCatalog_Node(t *testing.T) {
+func TestAPI_Catalog_Node(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -261,7 +261,7 @@ func TestCatalog_Node(t *testing.T) {
 	})
 }
 
-func TestCatalog_Registration(t *testing.T) {
+func TestAPI_Catalog_Registration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -389,7 +389,7 @@ func TestCatalog_Registration(t *testing.T) {
 	})
 }
 
-func TestCatalog_EnableTagOverride(t *testing.T) {
+func TestAPI_Catalog_EnableTagOverride(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -49,7 +49,7 @@ func TestCatalog_Nodes(t *testing.T) {
 					"wan": "127.0.0.1",
 				},
 				Meta:        map[string]string{},
-				CreateIndex: meta.LastIndex - 1,
+				CreateIndex: meta.LastIndex,
 				ModifyIndex: meta.LastIndex,
 			},
 		}

--- a/api/coordinate_test.go
+++ b/api/coordinate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestCoordinate_Datacenters(t *testing.T) {
+func TestAPI_Coordinate_Datacenters(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -24,7 +24,7 @@ func TestCoordinate_Datacenters(t *testing.T) {
 	})
 }
 
-func TestCoordinate_Nodes(t *testing.T) {
+func TestAPI_Coordinate_Nodes(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/coordinate_test.go
+++ b/api/coordinate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestAPI_Coordinate_Datacenters(t *testing.T) {
+func TestAPI_CoordinateDatacenters(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -24,7 +24,7 @@ func TestAPI_Coordinate_Datacenters(t *testing.T) {
 	})
 }
 
-func TestAPI_Coordinate_Nodes(t *testing.T) {
+func TestAPI_CoordinateNodes(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestEvent_FireList(t *testing.T) {
+func TestAPI_Event_FireList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/event_test.go
+++ b/api/event_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestAPI_Event_FireList(t *testing.T) {
+func TestAPI_EventFireList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func TestHealth_Node(t *testing.T) {
+func TestAPI_Health_Node(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -36,7 +36,7 @@ func TestHealth_Node(t *testing.T) {
 	})
 }
 
-func TestHealthChecks_AggregatedStatus(t *testing.T) {
+func TestAPI_HealthChecks_AggregatedStatus(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -169,7 +169,7 @@ func TestHealthChecks_AggregatedStatus(t *testing.T) {
 	}
 }
 
-func TestHealth_Checks(t *testing.T) {
+func TestAPI_Health_Checks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeName = "node123"
@@ -218,7 +218,7 @@ func TestHealth_Checks(t *testing.T) {
 	})
 }
 
-func TestHealth_Checks_NodeMetaFilter(t *testing.T) {
+func TestAPI_Health_Checks_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
@@ -255,7 +255,7 @@ func TestHealth_Checks_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestHealth_Service(t *testing.T) {
+func TestAPI_Health_Service(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -281,7 +281,7 @@ func TestHealth_Service(t *testing.T) {
 	})
 }
 
-func TestHealth_Service_NodeMetaFilter(t *testing.T) {
+func TestAPI_Health_Service_NodeMetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -310,7 +310,7 @@ func TestHealth_Service_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestHealth_State(t *testing.T) {
+func TestAPI_Health_State(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -330,7 +330,7 @@ func TestHealth_State(t *testing.T) {
 	})
 }
 
-func TestHealth_State_NodeMetaFilter(t *testing.T) {
+func TestAPI_Health_State_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func TestAPI_Health_Node(t *testing.T) {
+func TestAPI_HealthNode(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -169,7 +169,7 @@ func TestAPI_HealthChecks_AggregatedStatus(t *testing.T) {
 	}
 }
 
-func TestAPI_Health_Checks(t *testing.T) {
+func TestAPI_HealthChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeName = "node123"
@@ -218,7 +218,7 @@ func TestAPI_Health_Checks(t *testing.T) {
 	})
 }
 
-func TestAPI_Health_Checks_NodeMetaFilter(t *testing.T) {
+func TestAPI_HealthChecks_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
@@ -255,7 +255,7 @@ func TestAPI_Health_Checks_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestAPI_Health_Service(t *testing.T) {
+func TestAPI_HealthService(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
@@ -281,7 +281,7 @@ func TestAPI_Health_Service(t *testing.T) {
 	})
 }
 
-func TestAPI_Health_Service_NodeMetaFilter(t *testing.T) {
+func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
 		conf.NodeMeta = meta
@@ -310,7 +310,7 @@ func TestAPI_Health_Service_NodeMetaFilter(t *testing.T) {
 	})
 }
 
-func TestAPI_Health_State(t *testing.T) {
+func TestAPI_HealthState(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -330,7 +330,7 @@ func TestAPI_Health_State(t *testing.T) {
 	})
 }
 
-func TestAPI_Health_State_NodeMetaFilter(t *testing.T) {
+func TestAPI_HealthState_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	meta := map[string]string{"somekey": "somevalue"}
 	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestClientPutGetDelete(t *testing.T) {
+func TestAPI_ClientPutGetDelete(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -73,7 +73,7 @@ func TestClientPutGetDelete(t *testing.T) {
 	}
 }
 
-func TestClient_List_DeleteRecurse(t *testing.T) {
+func TestAPI_Client_List_DeleteRecurse(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -128,7 +128,7 @@ func TestClient_List_DeleteRecurse(t *testing.T) {
 	}
 }
 
-func TestClient_DeleteCAS(t *testing.T) {
+func TestAPI_Client_DeleteCAS(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -174,7 +174,7 @@ func TestClient_DeleteCAS(t *testing.T) {
 	}
 }
 
-func TestClient_CAS(t *testing.T) {
+func TestAPI_Client_CAS(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -222,7 +222,7 @@ func TestClient_CAS(t *testing.T) {
 	}
 }
 
-func TestClient_WatchGet(t *testing.T) {
+func TestAPI_Client_WatchGet(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -279,7 +279,7 @@ func TestClient_WatchGet(t *testing.T) {
 	<-doneCh
 }
 
-func TestClient_WatchList(t *testing.T) {
+func TestAPI_Client_WatchList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -337,7 +337,7 @@ func TestClient_WatchList(t *testing.T) {
 	<-doneCh
 }
 
-func TestClient_Keys_DeleteRecurse(t *testing.T) {
+func TestAPI_Client_Keys_DeleteRecurse(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -387,7 +387,7 @@ func TestClient_Keys_DeleteRecurse(t *testing.T) {
 	}
 }
 
-func TestClient_AcquireRelease(t *testing.T) {
+func TestAPI_Client_AcquireRelease(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -456,7 +456,7 @@ func TestClient_AcquireRelease(t *testing.T) {
 	}
 }
 
-func TestClient_Txn(t *testing.T) {
+func TestAPI_Client_Txn(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -73,7 +73,7 @@ func TestAPI_ClientPutGetDelete(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_List_DeleteRecurse(t *testing.T) {
+func TestAPI_ClientList_DeleteRecurse(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -128,7 +128,7 @@ func TestAPI_Client_List_DeleteRecurse(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_DeleteCAS(t *testing.T) {
+func TestAPI_ClientDeleteCAS(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -174,7 +174,7 @@ func TestAPI_Client_DeleteCAS(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_CAS(t *testing.T) {
+func TestAPI_ClientCAS(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -222,7 +222,7 @@ func TestAPI_Client_CAS(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_WatchGet(t *testing.T) {
+func TestAPI_ClientWatchGet(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -279,7 +279,7 @@ func TestAPI_Client_WatchGet(t *testing.T) {
 	<-doneCh
 }
 
-func TestAPI_Client_WatchList(t *testing.T) {
+func TestAPI_ClientWatchList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -337,7 +337,7 @@ func TestAPI_Client_WatchList(t *testing.T) {
 	<-doneCh
 }
 
-func TestAPI_Client_Keys_DeleteRecurse(t *testing.T) {
+func TestAPI_ClientKeys_DeleteRecurse(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -387,7 +387,7 @@ func TestAPI_Client_Keys_DeleteRecurse(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_AcquireRelease(t *testing.T) {
+func TestAPI_ClientAcquireRelease(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -456,7 +456,7 @@ func TestAPI_Client_AcquireRelease(t *testing.T) {
 	}
 }
 
-func TestAPI_Client_Txn(t *testing.T) {
+func TestAPI_ClientTxn(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestLock_LockUnlock(t *testing.T) {
+func TestAPI_Lock_LockUnlock(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -69,7 +69,7 @@ func TestLock_LockUnlock(t *testing.T) {
 	}
 }
 
-func TestLock_ForceInvalidate(t *testing.T) {
+func TestAPI_Lock_ForceInvalidate(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -104,7 +104,7 @@ func TestLock_ForceInvalidate(t *testing.T) {
 	}
 }
 
-func TestLock_DeleteKey(t *testing.T) {
+func TestAPI_Lock_DeleteKey(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -146,7 +146,7 @@ func TestLock_DeleteKey(t *testing.T) {
 	}
 }
 
-func TestLock_Contend(t *testing.T) {
+func TestAPI_Lock_Contend(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -199,7 +199,7 @@ func TestLock_Contend(t *testing.T) {
 	}
 }
 
-func TestLock_Destroy(t *testing.T) {
+func TestAPI_Lock_Destroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -268,7 +268,7 @@ func TestLock_Destroy(t *testing.T) {
 	}
 }
 
-func TestLock_Conflict(t *testing.T) {
+func TestAPI_Lock_Conflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -306,7 +306,7 @@ func TestLock_Conflict(t *testing.T) {
 	}
 }
 
-func TestLock_ReclaimLock(t *testing.T) {
+func TestAPI_Lock_ReclaimLock(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -374,7 +374,7 @@ func TestLock_ReclaimLock(t *testing.T) {
 	}
 }
 
-func TestLock_MonitorRetry(t *testing.T) {
+func TestAPI_Lock_MonitorRetry(t *testing.T) {
 	t.Parallel()
 	raw, s := makeClient(t)
 	defer s.Stop()
@@ -489,7 +489,7 @@ func TestLock_MonitorRetry(t *testing.T) {
 	}
 }
 
-func TestLock_OneShot(t *testing.T) {
+func TestAPI_Lock_OneShot(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestAPI_Lock_LockUnlock(t *testing.T) {
+func TestAPI_LockLockUnlock(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -69,7 +69,7 @@ func TestAPI_Lock_LockUnlock(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_ForceInvalidate(t *testing.T) {
+func TestAPI_LockForceInvalidate(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -104,7 +104,7 @@ func TestAPI_Lock_ForceInvalidate(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_DeleteKey(t *testing.T) {
+func TestAPI_LockDeleteKey(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -146,7 +146,7 @@ func TestAPI_Lock_DeleteKey(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_Contend(t *testing.T) {
+func TestAPI_LockContend(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -199,7 +199,7 @@ func TestAPI_Lock_Contend(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_Destroy(t *testing.T) {
+func TestAPI_LockDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -268,7 +268,7 @@ func TestAPI_Lock_Destroy(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_Conflict(t *testing.T) {
+func TestAPI_LockConflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -306,7 +306,7 @@ func TestAPI_Lock_Conflict(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_ReclaimLock(t *testing.T) {
+func TestAPI_LockReclaimLock(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -374,7 +374,7 @@ func TestAPI_Lock_ReclaimLock(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_MonitorRetry(t *testing.T) {
+func TestAPI_LockMonitorRetry(t *testing.T) {
 	t.Parallel()
 	raw, s := makeClient(t)
 	defer s.Stop()
@@ -489,7 +489,7 @@ func TestAPI_Lock_MonitorRetry(t *testing.T) {
 	}
 }
 
-func TestAPI_Lock_OneShot(t *testing.T) {
+func TestAPI_LockOneShot(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/operator_autopilot_test.go
+++ b/api/operator_autopilot_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestAPI_Operator_AutopilotGetSetConfiguration(t *testing.T) {
+func TestAPI_OperatorAutopilotGetSetConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -36,7 +36,7 @@ func TestAPI_Operator_AutopilotGetSetConfiguration(t *testing.T) {
 	}
 }
 
-func TestAPI_Operator_AutopilotCASConfiguration(t *testing.T) {
+func TestAPI_OperatorAutopilotCASConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -81,7 +81,7 @@ func TestAPI_Operator_AutopilotCASConfiguration(t *testing.T) {
 	}
 }
 
-func TestAPI_Operator_AutopilotServerHealth(t *testing.T) {
+func TestAPI_OperatorAutopilotServerHealth(t *testing.T) {
 	t.Parallel()
 	c, s := makeClientWithConfig(t, nil, func(c *testutil.TestServerConfig) {
 		c.RaftProtocol = 3

--- a/api/operator_autopilot_test.go
+++ b/api/operator_autopilot_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestOperator_AutopilotGetSetConfiguration(t *testing.T) {
+func TestAPI_Operator_AutopilotGetSetConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -36,7 +36,7 @@ func TestOperator_AutopilotGetSetConfiguration(t *testing.T) {
 	}
 }
 
-func TestOperator_AutopilotCASConfiguration(t *testing.T) {
+func TestAPI_Operator_AutopilotCASConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -81,7 +81,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 	}
 }
 
-func TestOperator_AutopilotServerHealth(t *testing.T) {
+func TestAPI_Operator_AutopilotServerHealth(t *testing.T) {
 	t.Parallel()
 	c, s := makeClientWithConfig(t, nil, func(c *testutil.TestServerConfig) {
 		c.RaftProtocol = 3

--- a/api/operator_keyring_test.go
+++ b/api/operator_keyring_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil"
 )
 
-func TestOperator_KeyringInstallListPutRemove(t *testing.T) {
+func TestAPI_Operator_KeyringInstallListPutRemove(t *testing.T) {
 	oldKey := "d8wu8CSUrqgtjVsvcBPmhQ=="
 	newKey := "qxycTi/SsePj/TZzCBmNXw=="
 	t.Parallel()

--- a/api/operator_keyring_test.go
+++ b/api/operator_keyring_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/consul/testutil"
 )
 
-func TestAPI_Operator_KeyringInstallListPutRemove(t *testing.T) {
+func TestAPI_OperatorKeyringInstallListPutRemove(t *testing.T) {
 	oldKey := "d8wu8CSUrqgtjVsvcBPmhQ=="
 	newKey := "qxycTi/SsePj/TZzCBmNXw=="
 	t.Parallel()

--- a/api/operator_raft_test.go
+++ b/api/operator_raft_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestAPI_Operator_RaftGetConfiguration(t *testing.T) {
+func TestAPI_OperatorRaftGetConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -22,7 +22,7 @@ func TestAPI_Operator_RaftGetConfiguration(t *testing.T) {
 	}
 }
 
-func TestAPI_Operator_RaftRemovePeerByAddress(t *testing.T) {
+func TestAPI_OperatorRaftRemovePeerByAddress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/operator_raft_test.go
+++ b/api/operator_raft_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestOperator_RaftGetConfiguration(t *testing.T) {
+func TestAPI_Operator_RaftGetConfiguration(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -22,7 +22,7 @@ func TestOperator_RaftGetConfiguration(t *testing.T) {
 	}
 }
 
-func TestOperator_RaftRemovePeerByAddress(t *testing.T) {
+func TestAPI_Operator_RaftRemovePeerByAddress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 )
 
-func TestPreparedQuery(t *testing.T) {
+func TestAPI_PreparedQuery(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestAPI_Semaphore_AcquireRelease(t *testing.T) {
+func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -69,7 +69,7 @@ func TestAPI_Semaphore_AcquireRelease(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_ForceInvalidate(t *testing.T) {
+func TestAPI_SemaphoreForceInvalidate(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -104,7 +104,7 @@ func TestAPI_Semaphore_ForceInvalidate(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_DeleteKey(t *testing.T) {
+func TestAPI_SemaphoreDeleteKey(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -138,7 +138,7 @@ func TestAPI_Semaphore_DeleteKey(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_Contend(t *testing.T) {
+func TestAPI_SemaphoreContend(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -191,7 +191,7 @@ func TestAPI_Semaphore_Contend(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_BadLimit(t *testing.T) {
+func TestAPI_SemaphoreBadLimit(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -222,7 +222,7 @@ func TestAPI_Semaphore_BadLimit(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_Destroy(t *testing.T) {
+func TestAPI_SemaphoreDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -278,7 +278,7 @@ func TestAPI_Semaphore_Destroy(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_Conflict(t *testing.T) {
+func TestAPI_SemaphoreConflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -316,7 +316,7 @@ func TestAPI_Semaphore_Conflict(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_MonitorRetry(t *testing.T) {
+func TestAPI_SemaphoreMonitorRetry(t *testing.T) {
 	t.Parallel()
 	raw, s := makeClient(t)
 	defer s.Stop()
@@ -433,7 +433,7 @@ func TestAPI_Semaphore_MonitorRetry(t *testing.T) {
 	}
 }
 
-func TestAPI_Semaphore_OneShot(t *testing.T) {
+func TestAPI_SemaphoreOneShot(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestSemaphore_AcquireRelease(t *testing.T) {
+func TestAPI_Semaphore_AcquireRelease(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -69,7 +69,7 @@ func TestSemaphore_AcquireRelease(t *testing.T) {
 	}
 }
 
-func TestSemaphore_ForceInvalidate(t *testing.T) {
+func TestAPI_Semaphore_ForceInvalidate(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -104,7 +104,7 @@ func TestSemaphore_ForceInvalidate(t *testing.T) {
 	}
 }
 
-func TestSemaphore_DeleteKey(t *testing.T) {
+func TestAPI_Semaphore_DeleteKey(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -138,7 +138,7 @@ func TestSemaphore_DeleteKey(t *testing.T) {
 	}
 }
 
-func TestSemaphore_Contend(t *testing.T) {
+func TestAPI_Semaphore_Contend(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -191,7 +191,7 @@ func TestSemaphore_Contend(t *testing.T) {
 	}
 }
 
-func TestSemaphore_BadLimit(t *testing.T) {
+func TestAPI_Semaphore_BadLimit(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -222,7 +222,7 @@ func TestSemaphore_BadLimit(t *testing.T) {
 	}
 }
 
-func TestSemaphore_Destroy(t *testing.T) {
+func TestAPI_Semaphore_Destroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -278,7 +278,7 @@ func TestSemaphore_Destroy(t *testing.T) {
 	}
 }
 
-func TestSemaphore_Conflict(t *testing.T) {
+func TestAPI_Semaphore_Conflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -316,7 +316,7 @@ func TestSemaphore_Conflict(t *testing.T) {
 	}
 }
 
-func TestSemaphore_MonitorRetry(t *testing.T) {
+func TestAPI_Semaphore_MonitorRetry(t *testing.T) {
 	t.Parallel()
 	raw, s := makeClient(t)
 	defer s.Stop()
@@ -433,7 +433,7 @@ func TestSemaphore_MonitorRetry(t *testing.T) {
 	}
 }
 
-func TestSemaphore_OneShot(t *testing.T) {
+func TestAPI_Semaphore_OneShot(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestAPI_Session_CreateDestroy(t *testing.T) {
+func TestAPI_SessionCreateDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -35,7 +35,7 @@ func TestAPI_Session_CreateDestroy(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_CreateRenewDestroy(t *testing.T) {
+func TestAPI_SessionCreateRenewDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -86,7 +86,7 @@ func TestAPI_Session_CreateRenewDestroy(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_CreateRenewDestroyRenew(t *testing.T) {
+func TestAPI_SessionCreateRenewDestroyRenew(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -140,7 +140,7 @@ func TestAPI_Session_CreateRenewDestroyRenew(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_CreateDestroyRenewPeriodic(t *testing.T) {
+func TestAPI_SessionCreateDestroyRenewPeriodic(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -194,7 +194,7 @@ func TestAPI_Session_CreateDestroyRenewPeriodic(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_Info(t *testing.T) {
+func TestAPI_SessionInfo(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -248,7 +248,7 @@ func TestAPI_Session_Info(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_Node(t *testing.T) {
+func TestAPI_SessionNode(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -283,7 +283,7 @@ func TestAPI_Session_Node(t *testing.T) {
 	}
 }
 
-func TestAPI_Session_List(t *testing.T) {
+func TestAPI_SessionList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestSession_CreateDestroy(t *testing.T) {
+func TestAPI_Session_CreateDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -35,7 +35,7 @@ func TestSession_CreateDestroy(t *testing.T) {
 	}
 }
 
-func TestSession_CreateRenewDestroy(t *testing.T) {
+func TestAPI_Session_CreateRenewDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -86,7 +86,7 @@ func TestSession_CreateRenewDestroy(t *testing.T) {
 	}
 }
 
-func TestSession_CreateRenewDestroyRenew(t *testing.T) {
+func TestAPI_Session_CreateRenewDestroyRenew(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -140,7 +140,7 @@ func TestSession_CreateRenewDestroyRenew(t *testing.T) {
 	}
 }
 
-func TestSession_CreateDestroyRenewPeriodic(t *testing.T) {
+func TestAPI_Session_CreateDestroyRenewPeriodic(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -194,7 +194,7 @@ func TestSession_CreateDestroyRenewPeriodic(t *testing.T) {
 	}
 }
 
-func TestSession_Info(t *testing.T) {
+func TestAPI_Session_Info(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -248,7 +248,7 @@ func TestSession_Info(t *testing.T) {
 	}
 }
 
-func TestSession_Node(t *testing.T) {
+func TestAPI_Session_Node(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -283,7 +283,7 @@ func TestSession_Node(t *testing.T) {
 	}
 }
 
-func TestSession_List(t *testing.T) {
+func TestAPI_Session_List(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/api/snapshot_test.go
+++ b/api/snapshot_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSnapshot(t *testing.T) {
+func TestAPI_Snapshot(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -80,7 +80,7 @@ func TestSnapshot(t *testing.T) {
 	}
 }
 
-func TestSnapshot_Options(t *testing.T) {
+func TestAPI_Snapshot_Options(t *testing.T) {
 	t.Parallel()
 	c, s := makeACLClient(t)
 	defer s.Stop()

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestStatusLeader(t *testing.T) {
+func TestAPI_StatusLeader(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -20,7 +20,7 @@ func TestStatusLeader(t *testing.T) {
 	}
 }
 
-func TestStatusPeers(t *testing.T) {
+func TestAPI_StatusPeers(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()

--- a/testutil/retry/retry_test.go
+++ b/testutil/retry/retry_test.go
@@ -6,15 +6,15 @@ import (
 )
 
 // delta defines the time band a test run should complete in.
-var delta = 10 * time.Millisecond
+var delta = 25 * time.Millisecond
 
 func TestRetryer(t *testing.T) {
 	tests := []struct {
 		desc string
 		r    Retryer
 	}{
-		{"counter", &Counter{Count: 3, Wait: 10 * time.Millisecond}},
-		{"timer", &Timer{Timeout: 20 * time.Millisecond, Wait: 10 * time.Millisecond}},
+		{"counter", &Counter{Count: 3, Wait: 100 * time.Millisecond}},
+		{"timer", &Timer{Timeout: 200 * time.Millisecond, Wait: 100 * time.Millisecond}},
 	}
 
 	for _, tt := range tests {
@@ -35,7 +35,7 @@ func TestRetryer(t *testing.T) {
 			// since the first iteration happens immediately
 			// the retryer waits only twice for three iterations.
 			// order of events: (true, (wait) true, (wait) true, false)
-			if got, want := dur, 20*time.Millisecond; got < (want-delta) || got > (want+delta) {
+			if got, want := dur, 200*time.Millisecond; got < (want-delta) || got > (want+delta) {
 				t.Fatalf("loop took %v want %v (+/- %v)", got, want, delta)
 			}
 		})

--- a/vendor/github.com/hashicorp/serf/serf/delegate.go
+++ b/vendor/github.com/hashicorp/serf/serf/delegate.go
@@ -251,7 +251,8 @@ func (d *delegate) MergeRemoteState(buf []byte, isJoin bool) {
 	// If we are doing a join, and eventJoinIgnore is set
 	// then we set the eventMinTime to the EventLTime. This
 	// prevents any of the incoming events from being processed
-	if isJoin && d.serf.eventJoinIgnore {
+	eventJoinIgnore := d.serf.eventJoinIgnore.Load().(bool)
+	if isJoin && eventJoinIgnore {
 		d.serf.eventLock.Lock()
 		if pp.EventLTime > d.serf.eventMinTime {
 			d.serf.eventMinTime = pp.EventLTime

--- a/version/version_base.go
+++ b/version/version_base.go
@@ -1,5 +1,3 @@
-// +build consul
-
 package version
 
 // NOTE we rely on other "version_*.go" files to be lexically after


### PR DESCRIPTION
This is a PR to address the failing tests in the RPC server which is in the `agent/consul` package. It is still work in progress tackling one failing test at a time until they all repeatedly pass under high concurrent load. However, it is useful to have a place to discuss approach and potential solutions. 

The PR is focussed on making reviews as simple as possible. Therefore, changes are often force-pushed and commits are split-up and rearranged to support the review process.

The PR consists of several parts:

1. unify the test server setup to use only one function
1. bind all network servers to port 0 to get a random address from the kernel
1. address issues in failing tests
1. parallelize all tests in the `agent/consul` package to help finding the failing tests.

To identify failing tests run in the `agent/consul` package

```shell
go test -parallel 96 -timeout 20s github.com/hashicorp/consul/agent/consul | tee test.log | egrep '(PASS|FAIL|panic: test timed out)' ; echo "***"
```

Then let this run for a while, take the output and sort to find the tests which are failing most.