### PR TITLE
Fix socket file handle leaks from old blocking queries upon consul re…

### DIFF
--- a/watch/funcs.go
+++ b/watch/funcs.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"context"
 	"fmt"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -41,7 +42,9 @@ func keyWatch(params map[string]interface{}) (WatcherFunc, error) {
 	}
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		kv := p.client.KV()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		pair, meta, err := kv.Get(key, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -70,7 +73,9 @@ func keyPrefixWatch(params map[string]interface{}) (WatcherFunc, error) {
 	}
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		kv := p.client.KV()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		pairs, meta, err := kv.List(prefix, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -89,7 +94,9 @@ func servicesWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		catalog := p.client.Catalog()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		services, meta, err := catalog.Services(&opts)
 		if err != nil {
 			return 0, nil, err
@@ -108,7 +115,9 @@ func nodesWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		catalog := p.client.Catalog()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		nodes, meta, err := catalog.Nodes(&opts)
 		if err != nil {
 			return 0, nil, err
@@ -144,7 +153,9 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		health := p.client.Health()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		nodes, meta, err := health.Service(service, tag, passingOnly, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -177,7 +188,9 @@ func checksWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		health := p.client.Health()
-		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
 		var checks []*consulapi.HealthCheck
 		var meta *consulapi.QueryMeta
 		var err error
@@ -205,7 +218,9 @@ func eventWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		event := p.client.Event()
-		opts := consulapi.QueryOptions{WaitIndex: p.lastIndex}
+		ctx, cancel := context.WithCancel(context.Background())
+		p.cancelFunc = cancel
+		opts := consulapi.QueryOptions{WaitIndex: p.lastIndex, Context: ctx}
 		events, meta, err := event.List(name, &opts)
 		if err != nil {
 			return 0, nil, err

--- a/watch/funcs.go
+++ b/watch/funcs.go
@@ -43,6 +43,7 @@ func keyWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		kv := p.client.KV()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		pair, meta, err := kv.Get(key, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -72,6 +73,7 @@ func keyPrefixWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		kv := p.client.KV()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		pairs, meta, err := kv.List(prefix, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -91,6 +93,7 @@ func servicesWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		catalog := p.client.Catalog()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		services, meta, err := catalog.Services(&opts)
 		if err != nil {
 			return 0, nil, err
@@ -110,6 +113,7 @@ func nodesWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		catalog := p.client.Catalog()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		nodes, meta, err := catalog.Nodes(&opts)
 		if err != nil {
 			return 0, nil, err
@@ -146,6 +150,7 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		health := p.client.Health()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		nodes, meta, err := health.Service(service, tag, passingOnly, &opts)
 		if err != nil {
 			return 0, nil, err
@@ -179,6 +184,7 @@ func checksWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		health := p.client.Health()
 		opts := makeQueryOptionsWithContext(p, stale)
+		defer p.cancelFunc()
 		var checks []*consulapi.HealthCheck
 		var meta *consulapi.QueryMeta
 		var err error
@@ -207,6 +213,7 @@ func eventWatch(params map[string]interface{}) (WatcherFunc, error) {
 	fn := func(p *Plan) (uint64, interface{}, error) {
 		event := p.client.Event()
 		opts := makeQueryOptionsWithContext(p, false)
+		defer p.cancelFunc()
 		events, meta, err := event.List(name, &opts)
 		if err != nil {
 			return 0, nil, err

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -107,6 +107,9 @@ func (p *Plan) Stop() {
 		return
 	}
 	p.stop = true
+	if p.cancelFunc != nil {
+		p.cancelFunc()
+	}
 	close(p.stopCh)
 }
 

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sync"
 
+	"context"
+
 	consulapi "github.com/hashicorp/consul/api"
 )
 
@@ -27,9 +29,10 @@ type Plan struct {
 	lastIndex  uint64
 	lastResult interface{}
 
-	stop     bool
-	stopCh   chan struct{}
-	stopLock sync.Mutex
+	stop       bool
+	stopCh     chan struct{}
+	stopLock   sync.Mutex
+	cancelFunc context.CancelFunc
 }
 
 // WatcherFunc is used to watch for a diff

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,11 +1,10 @@
 package watch
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sync"
-
-	"context"
 
 	consulapi "github.com/hashicorp/consul/api"
 )


### PR DESCRIPTION
…load. This fixes issue #3018 

Wired up a context to pass through via QueryOptions to the underlying http request. When the watch plan is stopped, it calls cancelFunc on that context. 