### PR TITLE
Correctly forward Host header in healthcheck

### DIFF
--- a/agent/check.go
+++ b/agent/check.go
@@ -386,6 +386,10 @@ func (c *CheckHTTP) check() {
 		req.Header = make(http.Header)
 	}
 
+	if host := req.Header.Get("Host"); host != "" {
+		req.Host = host
+	}
+
 	if req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", UserAgent)
 	}

--- a/agent/check_test.go
+++ b/agent/check_test.go
@@ -213,6 +213,7 @@ func TestCheckHTTP(t *testing.T) {
 
 		// custom header
 		{desc: "custom header", code: 200, header: http.Header{"A": []string{"b", "c"}}, status: api.HealthPassing},
+		{desc: "host header", code: 200, header: http.Header{"Host": []string{"a"}}, status: api.HealthPassing},
 	}
 
 	for _, tt := range tests {
@@ -236,6 +237,15 @@ func TestCheckHTTP(t *testing.T) {
 				for k, v := range tt.header {
 					expectedHeader[k] = v
 				}
+
+				// the Host header is in r.Host and not in the headers
+				host := expectedHeader.Get("Host")
+				if host != "" && host != r.Host {
+					w.WriteHeader(999)
+					return
+				}
+				expectedHeader.Del("Host")
+
 				if !reflect.DeepEqual(expectedHeader, r.Header) {
 					w.WriteHeader(999)
 					return


### PR DESCRIPTION
Host header must be set explicitely on http requests

I'll write test a bit later