### PR TITLE
accept recv-only channels for all cancellations

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -442,7 +442,7 @@ func (a *Agent) DisableNodeMaintenance() error {
 // Monitor returns a channel which will receive streaming logs from the agent
 // Providing a non-nil stopCh can be used to close the connection and stop the
 // log stream
-func (a *Agent) Monitor(loglevel string, stopCh chan struct{}, q *QueryOptions) (chan string, error) {
+func (a *Agent) Monitor(loglevel string, stopCh <-chan struct{}, q *QueryOptions) (chan string, error) {
 	r := a.c.newRequest("GET", "/v1/agent/monitor")
 	r.setQueryOptions(q)
 	if loglevel != "" {

--- a/api/session.go
+++ b/api/session.go
@@ -145,7 +145,7 @@ func (s *Session) Renew(id string, q *WriteOptions) (*SessionEntry, *WriteMeta, 
 // RenewPeriodic is used to periodically invoke Session.Renew on a
 // session until a doneCh is closed. This is meant to be used in a long running
 // goroutine to ensure a session stays valid.
-func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, doneCh chan struct{}) error {
+func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, doneCh <-chan struct{}) error {
 	ttl, err := time.ParseDuration(initialTTL)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cancellation channels are often derived from a Context, which
returns a directional `<-chan struct{}` from Done(). In order to use
this with parts of the consul API, one is required to create a new channel
and dispatch a separate goroutine to watch for context cancellation and
close the new channel.

Changing the signature for the methods that take cancellation channels
will allow easier integration with existing uses of Context. Since the
cancellation pattern only reads from these channels, there should be no
backwards incompatibility with existing codebases, and most of the
methods already accept only the correct type.