### PR TITLE
Expands and rework context support in the API client.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -106,14 +106,14 @@ type QueryOptions struct {
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
 
-	// context is an optional context pass through to the underlying HTTP
+	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
-	context context.Context
+	ctx context.Context
 }
 
 func (o *QueryOptions) Context() context.Context {
-	if o != nil && o.context != nil {
-		return o.context
+	if o != nil && o.ctx != nil {
+		return o.ctx
 	}
 	return context.Background()
 }
@@ -123,7 +123,7 @@ func (o *QueryOptions) WithContext(ctx context.Context) *QueryOptions {
 	if o != nil {
 		*o2 = *o
 	}
-	o2.context = ctx
+	o2.ctx = ctx
 	return o2
 }
 
@@ -142,14 +142,14 @@ type WriteOptions struct {
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
 
-	// context is an optional context pass through to the underlying HTTP
+	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
-	context context.Context
+	ctx context.Context
 }
 
 func (o *WriteOptions) Context() context.Context {
-	if o != nil && o.context != nil {
-		return o.context
+	if o != nil && o.ctx != nil {
+		return o.ctx
 	}
 	return context.Background()
 }
@@ -159,7 +159,7 @@ func (o *WriteOptions) WithContext(ctx context.Context) *WriteOptions {
 	if o != nil {
 		*o2 = *o
 	}
-	o2.context = ctx
+	o2.ctx = ctx
 	return o2
 }
 
@@ -535,7 +535,7 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	if q.RelayFactor != 0 {
 		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
-	r.ctx = q.context
+	r.ctx = q.ctx
 }
 
 // durToMsec converts a duration to a millisecond specified string. If the
@@ -580,7 +580,7 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 	if q.RelayFactor != 0 {
 		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
-	r.ctx = q.context
+	r.ctx = q.ctx
 }
 
 // toHTTP converts the request to an HTTP request

--- a/api/api.go
+++ b/api/api.go
@@ -106,9 +106,23 @@ type QueryOptions struct {
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
 
-	// Context (optional) is passed through to the underlying http request layer, can be used
-	// to set timeouts and deadlines as well as to cancel requests
-	Context context.Context
+	context context.Context
+}
+
+func (o *QueryOptions) Context() context.Context {
+	if o.context != nil {
+		return o.context
+	}
+	return context.Background()
+}
+
+func (o *QueryOptions) WithContext(ctx context.Context) *QueryOptions {
+	o2 := new(QueryOptions)
+	if o != nil {
+		*o2 = *o
+	}
+	o2.context = ctx
+	return o2
 }
 
 // WriteOptions are used to parameterize a write
@@ -125,6 +139,24 @@ type WriteOptions struct {
 	// relayed back to the sender through N other random nodes. Must be
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
+
+	context context.Context
+}
+
+func (o *WriteOptions) Context() context.Context {
+	if o.context != nil {
+		return o.context
+	}
+	return context.Background()
+}
+
+func (o *WriteOptions) WithContext(ctx context.Context) *WriteOptions {
+	o2 := new(WriteOptions)
+	if o != nil {
+		*o2 = *o
+	}
+	o2.context = ctx
+	return o2
 }
 
 // QueryMeta is used to return meta data about a query
@@ -499,7 +531,7 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	if q.RelayFactor != 0 {
 		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
-	r.ctx = q.Context
+	r.ctx = q.context
 }
 
 // durToMsec converts a duration to a millisecond specified string. If the
@@ -544,6 +576,7 @@ func (r *request) setWriteOptions(q *WriteOptions) {
 	if q.RelayFactor != 0 {
 		r.params.Set("relay-factor", strconv.Itoa(int(q.RelayFactor)))
 	}
+	r.ctx = q.context
 }
 
 // toHTTP converts the request to an HTTP request

--- a/api/api.go
+++ b/api/api.go
@@ -106,11 +106,13 @@ type QueryOptions struct {
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
 
+	// context is an optional context pass through to the underlying HTTP
+	// request layer. Use Context() and WithContext() to manage this.
 	context context.Context
 }
 
 func (o *QueryOptions) Context() context.Context {
-	if o.context != nil {
+	if o != nil && o.context != nil {
 		return o.context
 	}
 	return context.Background()
@@ -140,11 +142,13 @@ type WriteOptions struct {
 	// a value from 0 to 5 (inclusive).
 	RelayFactor uint8
 
+	// context is an optional context pass through to the underlying HTTP
+	// request layer. Use Context() and WithContext() to manage this.
 	context context.Context
 }
 
 func (o *WriteOptions) Context() context.Context {
-	if o.context != nil {
+	if o != nil && o.context != nil {
 		return o.context
 	}
 	return context.Background()

--- a/api/session.go
+++ b/api/session.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -184,11 +183,8 @@ func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, d
 			return nil
 
 		case <-ctx.Done():
-			// Attempt a session destroy, we can't use the canceled
-			// context to attempt the destroy so we do a short
-			// timeout for best effort.
-			timeout, _ := context.WithTimeout(context.Background(), 1*time.Second)
-			s.Destroy(id, q.WithContext(timeout))
+			// Bail immediately since attempting the destroy would
+			// use the canceled context in q, which would just bail.
 			return ctx.Err()
 		}
 	}

--- a/api/session.go
+++ b/api/session.go
@@ -146,6 +146,8 @@ func (s *Session) Renew(id string, q *WriteOptions) (*SessionEntry, *WriteMeta, 
 // session until a doneCh is closed. This is meant to be used in a long running
 // goroutine to ensure a session stays valid.
 func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, doneCh <-chan struct{}) error {
+	ctx := q.Context()
+
 	ttl, err := time.ParseDuration(initialTTL)
 	if err != nil {
 		return err
@@ -179,6 +181,8 @@ func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, d
 			// Attempt a session destroy
 			s.Destroy(id, q)
 			return nil
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/api/session.go
+++ b/api/session.go
@@ -182,6 +182,8 @@ func (s *Session) RenewPeriodic(initialTTL string, id string, q *WriteOptions, d
 			s.Destroy(id, q)
 			return nil
 		case <-ctx.Done():
+			// Attempt a session destroy
+			s.Destroy(id, q)
 			return ctx.Err()
 		}
 	}

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestAPI_SessionCreateDestroy(t *testing.T) {
@@ -230,15 +228,13 @@ func TestAPI_SessionRenewPeriodic_Cancel(t *testing.T) {
 			}
 		}
 
-		retry.Run(t, func(r *retry.R) {
-			sess, _, err := session.Info(id, nil)
-			if err != nil {
-				r.Fatalf("err: %v", err)
-			}
-			if sess != nil {
-				r.Fatalf("session was not expired")
-			}
-		})
+		sess, _, err := session.Info(id, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if sess != nil {
+			t.Fatalf("session was not expired")
+		}
 	})
 
 	t.Run("context", func(t *testing.T) {
@@ -264,15 +260,15 @@ func TestAPI_SessionRenewPeriodic_Cancel(t *testing.T) {
 			}
 		}
 
-		retry.Run(t, func(r *retry.R) {
-			sess, _, err := session.Info(id, nil)
-			if err != nil {
-				r.Fatalf("err: %v", err)
-			}
-			if sess != nil {
-				r.Fatalf("session was not expired")
-			}
-		})
+		// See comment in session.go for why the session isn't removed
+		// in this case.
+		sess, _, err := session.Info(id, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if sess == nil {
+			t.Fatalf("session should not be expired")
+		}
 	})
 }
 

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/testutil/retry"
 )
 
 func TestAPI_SessionCreateDestroy(t *testing.T) {
@@ -192,6 +196,84 @@ func TestAPI_SessionCreateDestroyRenewPeriodic(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 	}
+}
+
+func TestAPI_SessionRenewPeriodic_Cancel(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	session := c.Session()
+	entry := &SessionEntry{
+		Behavior: SessionBehaviorDelete,
+		TTL:      "500s", // disable ttl
+	}
+
+	t.Run("done channel", func(t *testing.T) {
+		id, _, err := session.Create(entry, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		errCh := make(chan error, 1)
+		doneCh := make(chan struct{})
+		go func() { errCh <- session.RenewPeriodic("1s", id, nil, doneCh) }()
+
+		close(doneCh)
+
+		select {
+		case <-time.After(1 * time.Second):
+			t.Fatal("renewal loop didn't terminate")
+		case err = <-errCh:
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+		}
+
+		retry.Run(t, func(r *retry.R) {
+			sess, _, err := session.Info(id, nil)
+			if err != nil {
+				r.Fatalf("err: %v", err)
+			}
+			if sess != nil {
+				r.Fatalf("session was not expired")
+			}
+		})
+	})
+
+	t.Run("context", func(t *testing.T) {
+		id, _, err := session.Create(entry, nil)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wo := new(WriteOptions).WithContext(ctx)
+
+		errCh := make(chan error, 1)
+		go func() { errCh <- session.RenewPeriodic("1s", id, wo, nil) }()
+
+		cancel()
+
+		select {
+		case <-time.After(1 * time.Second):
+			t.Fatal("renewal loop didn't terminate")
+		case err = <-errCh:
+			if err == nil || !strings.Contains(err.Error(), "context canceled") {
+				t.Fatalf("err: %v", err)
+			}
+		}
+
+		retry.Run(t, func(r *retry.R) {
+			sess, _, err := session.Info(id, nil)
+			if err != nil {
+				r.Fatalf("err: %v", err)
+			}
+			if sess != nil {
+				r.Fatalf("session was not expired")
+			}
+		})
+	})
 }
 
 func TestAPI_SessionInfo(t *testing.T) {

--- a/watch/funcs.go
+++ b/watch/funcs.go
@@ -234,6 +234,6 @@ func eventWatch(params map[string]interface{}) (WatcherFunc, error) {
 func makeQueryOptionsWithContext(p *Plan, stale bool) consulapi.QueryOptions {
 	ctx, cancel := context.WithCancel(context.Background())
 	p.cancelFunc = cancel
-	opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex, Context: ctx}
-	return opts
+	opts := consulapi.QueryOptions{AllowStale: stale, WaitIndex: p.lastIndex}
+	return *opts.WithContext(ctx)
 }


### PR DESCRIPTION
This adds a little bit of refactoring and tests on top of #3221.

Closes #3221.