### PR TITLE
Add network area TLS setting to docs

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -371,7 +371,7 @@ func NewServerLogger(config *Config, logger *log.Logger) (*Server, error) {
 	go s.lanEventHandler()
 
 	// Add a "static route" to the WAN Serf and hook it up to Serf events.
-	if err := s.router.AddArea(types.AreaWAN, s.serfWAN, s.connPool); err != nil {
+	if err := s.router.AddArea(types.AreaWAN, s.serfWAN, s.connPool, s.config.VerifyOutgoing); err != nil {
 		s.Shutdown()
 		return nil, fmt.Errorf("Failed to add WAN serf route: %v", err)
 	}

--- a/agent/consul/servers/router_test.go
+++ b/agent/consul/servers/router_test.go
@@ -105,7 +105,7 @@ func TestRouter_Shutdown(t *testing.T) {
 	// Create a WAN-looking area.
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestRouter_Shutdown(t *testing.T) {
 	otherID := types.AreaID("other")
 	other := newMockCluster(self)
 	other.AddMember("dcY", "node1", nil)
-	if err := r.AddArea(otherID, other, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(otherID, other, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	_, _, ok := r.FindRoute("dcY")
@@ -129,7 +129,7 @@ func TestRouter_Shutdown(t *testing.T) {
 	}
 
 	// You can't add areas once the router is shut down.
-	err := r.AddArea(otherID, other, &fauxConnPool{})
+	err := r.AddArea(otherID, other, &fauxConnPool{}, false)
 	if err == nil || !strings.Contains(err.Error(), "router is shut down") {
 		t.Fatalf("err: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestRouter_Routing(t *testing.T) {
 	// Create a WAN-looking area.
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -170,7 +170,7 @@ func TestRouter_Routing(t *testing.T) {
 	other.AddMember("dc0", "node0", nil)
 	other.AddMember("dc1", "node1", nil)
 	other.AddMember("dcY", "node1", nil)
-	if err := r.AddArea(otherID, other, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(otherID, other, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -275,7 +275,7 @@ func TestRouter_Routing_Offline(t *testing.T) {
 	// Create a WAN-looking area.
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{1.0}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{1.0}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -329,7 +329,7 @@ func TestRouter_Routing_Offline(t *testing.T) {
 	other := newMockCluster(self)
 	other.AddMember("dc0", "node0", nil)
 	other.AddMember("dc1", "node1", nil)
-	if err := r.AddArea(otherID, other, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(otherID, other, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -354,7 +354,7 @@ func TestRouter_GetDatacenters(t *testing.T) {
 
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -386,7 +386,7 @@ func TestRouter_GetDatacentersByDistance(t *testing.T) {
 	// Start with just the WAN area described in the diagram above.
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -404,7 +404,7 @@ func TestRouter_GetDatacentersByDistance(t *testing.T) {
 	other := newMockCluster(self)
 	other.AddMember("dc0", "node0", lib.GenerateCoordinate(20*time.Millisecond))
 	other.AddMember("dc1", "node1", lib.GenerateCoordinate(21*time.Millisecond))
-	if err := r.AddArea(otherID, other, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(otherID, other, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -423,7 +423,7 @@ func TestRouter_GetDatacenterMaps(t *testing.T) {
 
 	self := "node0.dc0"
 	wan := testCluster(self)
-	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}); err != nil {
+	if err := r.AddArea(types.AreaWAN, wan, &fauxConnPool{}, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/website/source/api/operator/area.html.md
+++ b/website/source/api/operator/area.html.md
@@ -64,12 +64,16 @@ The table below shows this endpoint's support for
   If this list is not supplied, joining can be done with a call to the
   [join endpoint](#area-join) once the network area is created.
 
+- `UseTLS` `(bool: <optional>)` - Specifies whether gossip over this area should be
+  encrypted with TLS if possible.
+
 ### Sample Payload
 
 ```json
 {
   "PeerDatacenter": "dc2",
-  "RetryJoin": [ "10.1.2.3", "10.1.2.4", "10.1.2.5" ]
+  "RetryJoin": [ "10.1.2.3", "10.1.2.4", "10.1.2.5" ],
+  "UseTLS": false
 }
 ```
 
@@ -130,6 +134,49 @@ $ curl \
     "RetryJoin": ["10.1.2.3", "10.1.2.4", "10.1.2.5"]
   }
 ]
+```
+
+## Update Network Area
+
+This endpoint updates a network area to the given configuration.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/operator/area/:uuid`       | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | ACL Required     |
+| ---------------- | ----------------- | ---------------- |
+| `NO`             | `none`            | `operator:write` |
+
+### Parameters
+
+- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
+  the datacenter of the agent being queried. This is specified as a URL query
+  parameter.
+
+- `UseTLS` `(bool: <optional>)` - Specifies whether gossip over this area should be
+  encrypted with TLS if possible.
+
+### Sample Payload
+
+```json
+{
+  "UseTLS": true
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## List Specific Network Area

--- a/website/source/docs/agent/encryption.html.md
+++ b/website/source/docs/agent/encryption.html.md
@@ -123,8 +123,11 @@ options are set to `false`. HTTPS for the API can be enabled at this point by
 setting the [`https`](/docs/agent/options.html#http_port) port.
 2. Perform a rolling restart of each agent in the cluster. After this step, TLS should be enabled
 everywhere but the agents will not yet be enforcing TLS.
-3. Change the `verify_incoming` and `verify_outgoing` settings (as well as `verify_server_hostname`
+3. (Optional, Enterprise-only) If applicable, set the `UseTLS` setting in any network areas to `true`.
+This can be done either through the [`consul operator area update`](/docs/commands/operator/area.html)
+command or the [Operator API](api/operator/area.html).
+4. Change the `verify_incoming` and `verify_outgoing` settings (as well as `verify_server_hostname`
 if applicable) to `true`.
-4. Perform another rolling restart of each agent in the cluster.
+5. Perform another rolling restart of each agent in the cluster.
 
 At this point, full TLS encryption for RPC communication should be enabled.

--- a/website/source/docs/commands/operator/area.html.markdown.erb
+++ b/website/source/docs/commands/operator/area.html.markdown.erb
@@ -42,6 +42,7 @@ Subcommands:
     join       Join Consul servers into an existing network area
     list       List network areas
     members    Display Consul server members present in network areas
+    update     Update the configuration of a network area
 ```
 
 If ACLs are enabled, the client will need to supply an ACL Token with `operator`
@@ -66,6 +67,9 @@ where the area was created, and the peer datacenter. This is required.
 
 * `-retry-join=<value>` Specifies the address of a Consul server to join to, such as an IP
 or hostname with an optional port number. This is optional and can be specified multiple times.
+
+* `-use-tls=<value>` Specifies whether gossip over this area should be encrypted with
+TLS if possible. Must be either `true` or `false`.
 
 The output looks like this, displaying the ID of the newly-created network area:
 
@@ -214,5 +218,36 @@ spoken by the node.
 `RTT` is an estimated network round trip time from the server answering the query
 to the given server, in a human-readable format. This is computed using
 [network coordinates](/docs/internals/coordinates.html).
+
+The return code will indicate success or failure.
+
+## update
+
+This command updates the configuration of network area.
+
+Usage: `consul operator area update [options]`
+
+#### API Options
+
+<%= partial "docs/commands/http_api_options_client" %>
+<%= partial "docs/commands/http_api_options_server" %>
+
+#### Command Options
+
+* `-id=<value>` - Looks up the area to operate on by its ID. This can be given
+instead of a peer datacenter.
+
+* `-peer-datacenter=<value>` - Declares the peer Consul datacenter that will make up the other
+side of this network area. Network areas always involve a pair of datacenters: the datacenter
+where the area was created, and the peer datacenter. This is required.
+
+* `-use-tls=<value>` Specifies whether gossip over this area should be encrypted with
+TLS if possible. Must be either `true` or `false`.
+
+The output looks like this:
+
+```
+Updated area "d2872ec5-68ea-b862-b75d-0bee99aca100"
+```
 
 The return code will indicate success or failure.


### PR DESCRIPTION
Also tweaks `router.AddArea` to keep parity with enterprise.