### PR TITLE
Changes ACL clone response to 403 if not authorized, or if token doesn't exist.

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -128,11 +128,10 @@ func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (inte
 		return nil, err
 	}
 
-	// Bail if the ACL is not found
+	// Bail if the ACL is not found, this could be a 404 or a 403, so
+	// always just return a 403.
 	if len(out.ACLs) == 0 {
-		resp.WriteHeader(404)
-		fmt.Fprint(resp, "Target ACL not found")
-		return nil, nil
+		return nil, errPermissionDenied
 	}
 
 	// Create a new ACL

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -124,8 +124,15 @@ func TestACL_Clone(t *testing.T) {
 
 	id := makeTestACL(t, a.srv)
 
-	req, _ := http.NewRequest("PUT", "/v1/acl/clone/"+id+"?token=root", nil)
+	req, _ := http.NewRequest("PUT", "/v1/acl/clone/"+id, nil)
 	resp := httptest.NewRecorder()
+	_, err := a.srv.ACLClone(resp, req)
+	if !isPermissionDenied(err) {
+		t.Fatalf("err: %v", err)
+	}
+
+	req, _ = http.NewRequest("PUT", "/v1/acl/clone/"+id+"?token=root", nil)
+	resp = httptest.NewRecorder()
 	obj, err := a.srv.ACLClone(resp, req)
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
Fixes #1113