### PR TITLE
Changes remote exec KV read to call GetTokenForAgent().

### DIFF
--- a/agent/remote_exec.go
+++ b/agent/remote_exec.go
@@ -243,7 +243,7 @@ func (a *Agent) remoteExecGetSpec(event *remoteExecEvent, spec *remoteExecSpec) 
 			AllowStale: true, // Stale read for scale! Retry on failure.
 		},
 	}
-	get.Token = a.config.ACLToken
+	get.Token = a.config.GetTokenForAgent()
 	var out structs.IndexedDirEntries
 QUERY:
 	if err := a.RPC("KVS.Get", &get, &out); err != nil {
@@ -310,7 +310,7 @@ func (a *Agent) remoteExecWriteKey(event *remoteExecEvent, suffix string, val []
 			Session: event.Session,
 		},
 	}
-	write.Token = a.config.ACLToken
+	write.Token = a.config.GetTokenForAgent()
 	var success bool
 	if err := a.RPC("KVS.Apply", &write, &success); err != nil {
 		return err

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -107,6 +107,15 @@ func TestRemoteExecGetSpec_ACLToken(t *testing.T) {
 	testRemoteExecGetSpec(t, cfg)
 }
 
+func TestRemoteExecGetSpec_ACLAgentToken(t *testing.T) {
+	t.Parallel()
+	cfg := TestConfig()
+	cfg.ACLDatacenter = "dc1"
+	cfg.ACLAgentToken = "root"
+	cfg.ACLDefaultPolicy = "deny"
+	testRemoteExecGetSpec(t, cfg)
+}
+
 func testRemoteExecGetSpec(t *testing.T, c *Config) {
 	a := NewTestAgent(t.Name(), nil)
 	defer a.Shutdown()

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -459,11 +459,13 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   <a href="#acl_enforce_version_8">`acl_enforce_version_8`</a> is set to true.
 
 * <a name="acl_agent_token"></a><a href="#acl_agent_token">`acl_agent_token`</a> - Used for clients
-  and servers to perform internal operations to the service catalog. If this isn't specified, then
-  the <a href="#acl_token">`acl_token`</a> will be used. This was added in Consul 0.7.2.
+  and servers to perform internal operations. If this isn't specified, then the
+  <a href="#acl_token">`acl_token`</a> will be used. This was added in Consul 0.7.2.
   <br><br>
   This token must at least have write access to the node name it will register as in order to set any
-  of the node-level information in the catalog such as metadata, or the node's tagged addresses.
+  of the node-level information in the catalog such as metadata, or the node's tagged addresses. There
+  are other places this token is used, please see [ACL Agent Token](/docs/guides/acl.html#acl-agent-token)
+  for more details.
 
 * <a name="acl_enforce_version_8"></a><a href="#acl_enforce_version_8">`acl_enforce_version_8`</a> -
   Used for clients and servers to determine if enforcement should occur for new ACL policies being


### PR DESCRIPTION
This lets it use the `acl_agent_token` instead of just the `acl_token`. Docs were also updated accordingly.

Fixes #3160.