### PR TITLE
Fix UpgradeVersionTag field not being passed correctly

### DIFF
--- a/agent/operator_endpoint.go
+++ b/agent/operator_endpoint.go
@@ -210,6 +210,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 			ServerStabilizationTime: api.NewReadableDuration(reply.ServerStabilizationTime),
 			RedundancyZoneTag:       reply.RedundancyZoneTag,
 			DisableUpgradeMigration: reply.DisableUpgradeMigration,
+			UpgradeVersionTag:       reply.UpgradeVersionTag,
 			CreateIndex:             reply.CreateIndex,
 			ModifyIndex:             reply.ModifyIndex,
 		}
@@ -235,6 +236,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 			ServerStabilizationTime: conf.ServerStabilizationTime.Duration(),
 			RedundancyZoneTag:       conf.RedundancyZoneTag,
 			DisableUpgradeMigration: conf.DisableUpgradeMigration,
+			UpgradeVersionTag:       conf.UpgradeVersionTag,
 		}
 
 		// Check for cas value


### PR DESCRIPTION
This field wasn't being copied correctly, so updating the value through the CLI/HTTP endpoint didn't work (only the value in the config was being used).