### PR TITLE
Update consul to version 0.9.0

### DIFF
--- a/terraform/shared/scripts/install.sh
+++ b/terraform/shared/scripts/install.sh
@@ -12,7 +12,7 @@ fi
 
 
 echo "Fetching Consul..."
-CONSUL=0.8.3
+CONSUL=0.9.0
 cd /tmp
 wget https://releases.hashicorp.com/consul/${CONSUL}/consul_${CONSUL}_linux_amd64.zip -O consul.zip --quiet
 


### PR DESCRIPTION
Just updating the terraform install.sh script to use the latest version.

Might be nice to have a release at https://releases.hashicorp/consul/latest/consul_latest_linux_amd64.zip just so updates like this aren't necessary anymore.