### PR TITLE
command/lock: Add -child-exitcode, return 2 on child error

### DIFF
--- a/command/lock_test.go
+++ b/command/lock_test.go
@@ -257,3 +257,33 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 		t.Fatalf("bad: %#v", opts)
 	}
 }
+
+func TestLockCommand_ChildExitCode(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), nil)
+	defer a.Shutdown()
+
+	t.Run("clean exit", func(t *testing.T) {
+		_, c := testLockCommand(t)
+		args := []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "exit 0"}
+		if got, want := c.Run(args), 0; got != want {
+			t.Fatalf("got %d want %d", got, want)
+		}
+	})
+
+	t.Run("error exit", func(t *testing.T) {
+		_, c := testLockCommand(t)
+		args := []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "exit 1"}
+		if got, want := c.Run(args), 2; got != want {
+			t.Fatalf("got %d want %d", got, want)
+		}
+	})
+
+	t.Run("not propagated", func(t *testing.T) {
+		_, c := testLockCommand(t)
+		args := []string{"-http-addr=" + a.HTTPAddr(), "test/prefix", "exit 1"}
+		if got, want := c.Run(args), 0; got != want {
+			t.Fatalf("got %d want %d", got, want)
+		}
+	})
+}

--- a/website/source/docs/commands/lock.html.markdown.erb
+++ b/website/source/docs/commands/lock.html.markdown.erb
@@ -52,6 +52,10 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 #### Command Options
 
+* `-child-exit-code` - Exit 2 if the child process exited with an error
+  if this is true, otherwise this doesn't propagate an error from the
+  child. The default value is false.
+
 * `-monitor-retry` - Retry up to this number of times if Consul returns a 500 error
    while monitoring the lock. This allows riding out brief periods of unavailability
    without causing leader elections, but increases the amount of time required
@@ -66,6 +70,9 @@ Windows has no POSIX compatible notion for `SIGTERM`.
   If not provided, one is generated based on the child command.
 
 * `-pass-stdin` - Pass stdin to child process.
+
+* `timeout` - Maximum amount of time to wait to acquire the lock, specified
+   as a duration like `1s` or `3h`. The default value is 0.
 
 * `-try` - Attempt to acquire the lock up to the given timeout. The timeout is a
   positive decimal number, with unit suffix, such as "500ms". Valid time units


### PR DESCRIPTION
* Exit 2 if -child-exit-code and the child returned with an error.
* There is no platform independent way to check the exact return code of
* the child, so on error always return 2.
* Closes #947
* Closes #1503