### PR TITLE
Move go-socketaddr template parsing into config package to make it ha…

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -228,21 +228,9 @@ func New(c *Config) (*Agent, error) {
 		httpAddrs:       httpAddrs,
 		tokens:          new(token.Store),
 	}
-	if err := a.resolveTmplAddrs(); err != nil {
-		return nil, err
-	}
 
 	// Try to get an advertise address
 	switch {
-	case a.config.AdvertiseAddr != "":
-		ipStr, err := parseSingleIPTemplate(a.config.AdvertiseAddr)
-		if err != nil {
-			return nil, fmt.Errorf("Advertise address resolution failed: %v", err)
-		}
-		if net.ParseIP(ipStr) == nil {
-			return nil, fmt.Errorf("Failed to parse advertise address: %v", ipStr)
-		}
-		a.config.AdvertiseAddr = ipStr
 
 	case a.config.BindAddr != "" && !ipaddr.IsAny(a.config.BindAddr):
 		a.config.AdvertiseAddr = a.config.BindAddr
@@ -259,16 +247,7 @@ func New(c *Config) (*Agent, error) {
 	}
 
 	// Try to get an advertise address for the wan
-	if a.config.AdvertiseAddrWan != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.AdvertiseAddrWan)
-		if err != nil {
-			return nil, fmt.Errorf("Advertise WAN address resolution failed: %v", err)
-		}
-		if net.ParseIP(ipStr) == nil {
-			return nil, fmt.Errorf("Failed to parse advertise address for WAN: %v", ipStr)
-		}
-		a.config.AdvertiseAddrWan = ipStr
-	} else {
+	if a.config.AdvertiseAddrWan == "" {
 		a.config.AdvertiseAddrWan = a.config.AdvertiseAddr
 	}
 
@@ -837,94 +816,6 @@ func parseSingleIPTemplate(ipTmpl string) (string, error) {
 	default:
 		return "", fmt.Errorf("Multiple addresses found (%q), please configure one.", out)
 	}
-}
-
-// resolveTmplAddrs iterates over the myriad of addresses in the agent's config
-// and performs go-sockaddr/template Parse on each known address in case the
-// user specified a template config for any of their values.
-func (a *Agent) resolveTmplAddrs() error {
-	if a.config.AdvertiseAddr != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.AdvertiseAddr)
-		if err != nil {
-			return fmt.Errorf("Advertise address resolution failed: %v", err)
-		}
-		a.config.AdvertiseAddr = ipStr
-	}
-
-	if a.config.Addresses.DNS != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.DNS)
-		if err != nil {
-			return fmt.Errorf("DNS address resolution failed: %v", err)
-		}
-		a.config.Addresses.DNS = ipStr
-	}
-
-	if a.config.Addresses.HTTP != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.HTTP)
-		if err != nil {
-			return fmt.Errorf("HTTP address resolution failed: %v", err)
-		}
-		a.config.Addresses.HTTP = ipStr
-	}
-
-	if a.config.Addresses.HTTPS != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.Addresses.HTTPS)
-		if err != nil {
-			return fmt.Errorf("HTTPS address resolution failed: %v", err)
-		}
-		a.config.Addresses.HTTPS = ipStr
-	}
-
-	if a.config.AdvertiseAddrWan != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.AdvertiseAddrWan)
-		if err != nil {
-			return fmt.Errorf("Advertise WAN address resolution failed: %v", err)
-		}
-		a.config.AdvertiseAddrWan = ipStr
-	}
-
-	if a.config.BindAddr != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.BindAddr)
-		if err != nil {
-			return fmt.Errorf("Bind address resolution failed: %v", err)
-		}
-		a.config.BindAddr = ipStr
-	}
-
-	if a.config.ClientAddr != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.ClientAddr)
-		if err != nil {
-			return fmt.Errorf("Client address resolution failed: %v", err)
-		}
-		a.config.ClientAddr = ipStr
-	}
-
-	if a.config.SerfLanBindAddr != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.SerfLanBindAddr)
-		if err != nil {
-			return fmt.Errorf("Serf LAN Address resolution failed: %v", err)
-		}
-		a.config.SerfLanBindAddr = ipStr
-	}
-
-	if a.config.SerfWanBindAddr != "" {
-		ipStr, err := parseSingleIPTemplate(a.config.SerfWanBindAddr)
-		if err != nil {
-			return fmt.Errorf("Serf WAN Address resolution failed: %v", err)
-		}
-		a.config.SerfWanBindAddr = ipStr
-	}
-
-	// Parse all tagged addresses
-	for k, v := range a.config.TaggedAddresses {
-		ipStr, err := parseSingleIPTemplate(v)
-		if err != nil {
-			return fmt.Errorf("%s address resolution failed: %v", k, err)
-		}
-		a.config.TaggedAddresses[k] = ipStr
-	}
-
-	return nil
 }
 
 // makeRandomID will generate a random UUID for a node.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -117,6 +117,7 @@ func TestAgent_CheckAdvertiseAddrsSettings(t *testing.T) {
 	cfg.AdvertiseAddrs.SerfLan, _ = net.ResolveTCPAddr("tcp", "127.0.0.42:1233")
 	cfg.AdvertiseAddrs.SerfWan, _ = net.ResolveTCPAddr("tcp", "127.0.0.43:1234")
 	cfg.AdvertiseAddrs.RPC, _ = net.ResolveTCPAddr("tcp", "127.0.0.44:1235")
+	cfg.SetupTaggedAndAdvertiseAddrs()
 	a := NewTestAgent(t.Name(), cfg)
 	defer a.Shutdown()
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -2127,7 +2127,7 @@ func ReadConfigPaths(paths []string) (*Config, error) {
 // and performs go-sockaddr/template Parse on each known address in case the
 // user specified a template config for any of their values.
 func (c *Config) ResolveTmplAddrs() (err error) {
-	parse := func(addr *string, name string) {
+	parse := func(addr *string, validateIP bool, name string) {
 		if *addr == "" || err != nil {
 			return
 		}
@@ -2137,11 +2137,8 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 			err = fmt.Errorf("Resolution of %s failed: %v", name, err)
 			return
 		}
-		if strings.HasPrefix(ip, "unix://") {
-			*addr = ip
-			return
-		}
-		if net.ParseIP(ip) == nil {
+
+		if validateIP && net.ParseIP(ip) == nil {
 			err = fmt.Errorf("Failed to parse %s: %v", name, ip)
 			return
 		}
@@ -2151,15 +2148,15 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 	if c == nil {
 		return
 	}
-	parse(&c.Addresses.DNS, "DNS address")
-	parse(&c.Addresses.HTTP, "HTTP address")
-	parse(&c.Addresses.HTTPS, "HTTPS address")
-	parse(&c.AdvertiseAddr, "Advertise address")
-	parse(&c.AdvertiseAddrWan, "Advertise WAN address")
-	parse(&c.BindAddr, "Bind address")
-	parse(&c.ClientAddr, "Client address")
-	parse(&c.SerfLanBindAddr, "Serf LAN address")
-	parse(&c.SerfWanBindAddr, "Serf WAN address")
+	parse(&c.Addresses.DNS, false, "DNS address")
+	parse(&c.Addresses.HTTP, false, "HTTP address")
+	parse(&c.Addresses.HTTPS, false, "HTTPS address")
+	parse(&c.AdvertiseAddr, true, "Advertise address")
+	parse(&c.AdvertiseAddrWan, true, "Advertise WAN address")
+	parse(&c.BindAddr, false, "Bind address")
+	parse(&c.ClientAddr, false, "Client address")
+	parse(&c.SerfLanBindAddr, true, "Serf LAN address")
+	parse(&c.SerfWanBindAddr, true, "Serf WAN address")
 
 	return
 }

--- a/agent/config.go
+++ b/agent/config.go
@@ -2121,6 +2121,100 @@ func ReadConfigPaths(paths []string) (*Config, error) {
 	return result, nil
 }
 
+// ResolveTmplAddrs iterates over the myriad of addresses in the agent's config
+// and performs go-sockaddr/template Parse on each known address in case the
+// user specified a template config for any of their values.
+func (c *Config) ResolveTmplAddrs() error {
+	if c.AdvertiseAddr != "" {
+		ipStr, err := parseSingleIPTemplate(c.AdvertiseAddr)
+		if err != nil {
+			return fmt.Errorf("Advertise address resolution failed: %v", err)
+		}
+		if net.ParseIP(ipStr) == nil {
+			return fmt.Errorf("Failed to parse advertise address: %v", ipStr)
+		}
+		c.AdvertiseAddr = ipStr
+	}
+
+	if c.Addresses.DNS != "" {
+		ipStr, err := parseSingleIPTemplate(c.Addresses.DNS)
+		if err != nil {
+			return fmt.Errorf("DNS address resolution failed: %v", err)
+		}
+		c.Addresses.DNS = ipStr
+	}
+
+	if c.Addresses.HTTP != "" {
+		ipStr, err := parseSingleIPTemplate(c.Addresses.HTTP)
+		if err != nil {
+			return fmt.Errorf("HTTP address resolution failed: %v", err)
+		}
+		c.Addresses.HTTP = ipStr
+	}
+
+	if c.Addresses.HTTPS != "" {
+		ipStr, err := parseSingleIPTemplate(c.Addresses.HTTPS)
+		if err != nil {
+			return fmt.Errorf("HTTPS address resolution failed: %v", err)
+		}
+		c.Addresses.HTTPS = ipStr
+	}
+
+	if c.AdvertiseAddrWan != "" {
+		ipStr, err := parseSingleIPTemplate(c.AdvertiseAddrWan)
+		if err != nil {
+			return fmt.Errorf("Advertise WAN address resolution failed: %v", err)
+		}
+		if net.ParseIP(ipStr) == nil {
+			return fmt.Errorf("Failed to parse Advertise WAN address: %v", ipStr)
+		}
+		c.AdvertiseAddrWan = ipStr
+	}
+
+	if c.BindAddr != "" {
+		ipStr, err := parseSingleIPTemplate(c.BindAddr)
+		if err != nil {
+			return fmt.Errorf("Bind address resolution failed: %v", err)
+		}
+		c.BindAddr = ipStr
+	}
+
+	if c.ClientAddr != "" {
+		ipStr, err := parseSingleIPTemplate(c.ClientAddr)
+		if err != nil {
+			return fmt.Errorf("Client address resolution failed: %v", err)
+		}
+		c.ClientAddr = ipStr
+	}
+
+	if c.SerfLanBindAddr != "" {
+		ipStr, err := parseSingleIPTemplate(c.SerfLanBindAddr)
+		if err != nil {
+			return fmt.Errorf("Serf LAN Address resolution failed: %v", err)
+		}
+		c.SerfLanBindAddr = ipStr
+	}
+
+	if c.SerfWanBindAddr != "" {
+		ipStr, err := parseSingleIPTemplate(c.SerfWanBindAddr)
+		if err != nil {
+			return fmt.Errorf("Serf WAN Address resolution failed: %v", err)
+		}
+		c.SerfWanBindAddr = ipStr
+	}
+
+	// Parse all tagged addresses
+	for k, v := range c.TaggedAddresses {
+		ipStr, err := parseSingleIPTemplate(v)
+		if err != nil {
+			return fmt.Errorf("%s address resolution failed: %v", k, err)
+		}
+		c.TaggedAddresses[k] = ipStr
+	}
+
+	return nil
+}
+
 // Implement the sort interface for dirEnts
 func (d dirEnts) Len() int {
 	return len(d)

--- a/agent/config.go
+++ b/agent/config.go
@@ -2148,6 +2148,9 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 		*addr = ip
 	}
 
+	if c == nil {
+		return
+	}
 	parse(&c.Addresses.DNS, "DNS address")
 	parse(&c.Addresses.HTTP, "HTTP address")
 	parse(&c.Addresses.HTTPS, "HTTPS address")

--- a/agent/config.go
+++ b/agent/config.go
@@ -2143,7 +2143,7 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 			return
 		}
 		if socketAllowed && socketPath(ip) == "" && ipAddr == nil {
-			err = fmt.Errorf("Failed to parse %s, is not a valid IP address or socket: %v", name, ip)
+			err = fmt.Errorf("Failed to parse %s, %q is not a valid IP address or socket", name, ip)
 			return
 		}
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -2137,6 +2137,10 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 			err = fmt.Errorf("Resolution of %s failed: %v", name, err)
 			return
 		}
+		if strings.HasPrefix(ip, "unix://") {
+			*addr = ip
+			return
+		}
 		if net.ParseIP(ip) == nil {
 			err = fmt.Errorf("Failed to parse %s: %v", name, ip)
 			return

--- a/agent/config.go
+++ b/agent/config.go
@@ -2164,7 +2164,7 @@ func (c *Config) ResolveTmplAddrs() (err error) {
 	return
 }
 
-// Additional post processing of the configs to set tagged and advertise addresses
+// SetupTaggedAndAdvertiseAddrs configures advertise addresses and sets up a map of tagged addresses
 func (cfg *Config) SetupTaggedAndAdvertiseAddrs() error {
 	if cfg.AdvertiseAddr == "" {
 		switch {

--- a/agent/config_test.go
+++ b/agent/config_test.go
@@ -103,28 +103,56 @@ func TestDecodeConfig(t *testing.T) {
 			c:  &Config{ACLTTL: 2 * time.Second, ACLTTLRaw: "2s"},
 		},
 		{
-			in: `{"addresses":{"dns":"a"}}`,
-			c:  &Config{Addresses: AddressConfig{DNS: "a"}},
+			in: `{"addresses":{"dns":"1.2.3.4"}}`,
+			c:  &Config{Addresses: AddressConfig{DNS: "1.2.3.4"}},
 		},
 		{
-			in: `{"addresses":{"http":"a"}}`,
-			c:  &Config{Addresses: AddressConfig{HTTP: "a"}},
+			in: `{"addresses":{"dns":"{{\"1.2.3.4\"}}"}}`,
+			c:  &Config{Addresses: AddressConfig{DNS: "1.2.3.4"}},
 		},
 		{
-			in: `{"addresses":{"https":"a"}}`,
-			c:  &Config{Addresses: AddressConfig{HTTPS: "a"}},
+			in: `{"addresses":{"http":"1.2.3.4"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTP: "1.2.3.4"}},
+		},
+		{
+			in: `{"addresses":{"http":"unix:///var/foo/bar"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTP: "unix:///var/foo/bar"}},
+		},
+		{
+			in: `{"addresses":{"http":"{{\"1.2.3.4\"}}"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTP: "1.2.3.4"}},
+		},
+		{
+			in: `{"addresses":{"https":"1.2.3.4"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTPS: "1.2.3.4"}},
+		},
+		{
+			in: `{"addresses":{"https":"unix:///var/foo/bar"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTPS: "unix:///var/foo/bar"}},
+		},
+		{
+			in: `{"addresses":{"https":"{{\"1.2.3.4\"}}"}}`,
+			c:  &Config{Addresses: AddressConfig{HTTPS: "1.2.3.4"}},
 		},
 		{
 			in: `{"addresses":{"rpc":"a"}}`,
 			c:  &Config{Addresses: AddressConfig{RPC: "a"}},
 		},
 		{
-			in: `{"advertise_addr":"a"}`,
-			c:  &Config{AdvertiseAddr: "a"},
+			in: `{"advertise_addr":"1.2.3.4"}`,
+			c:  &Config{AdvertiseAddr: "1.2.3.4"},
 		},
 		{
-			in: `{"advertise_addr_wan":"a"}`,
-			c:  &Config{AdvertiseAddrWan: "a"},
+			in: `{"advertise_addr":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{AdvertiseAddr: "1.2.3.4"},
+		},
+		{
+			in: `{"advertise_addr_wan":"1.2.3.4"}`,
+			c:  &Config{AdvertiseAddrWan: "1.2.3.4"},
+		},
+		{
+			in: `{"advertise_addr_wan":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{AdvertiseAddrWan: "1.2.3.4"},
 		},
 		{
 			in: `{"advertise_addrs":{"rpc":"1.2.3.4:5678"}}`,
@@ -202,8 +230,12 @@ func TestDecodeConfig(t *testing.T) {
 			c:  &Config{Autopilot: Autopilot{CleanupDeadServers: Bool(true)}},
 		},
 		{
-			in: `{"bind_addr":"a"}`,
-			c:  &Config{BindAddr: "a"},
+			in: `{"bind_addr":"1.2.3.4"}`,
+			c:  &Config{BindAddr: "1.2.3.4"},
+		},
+		{
+			in: `{"bind_addr":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{BindAddr: "1.2.3.4"},
 		},
 		{
 			in: `{"bootstrap":true}`,
@@ -230,8 +262,12 @@ func TestDecodeConfig(t *testing.T) {
 			c:  &Config{CertFile: "a"},
 		},
 		{
-			in: `{"client_addr":"a"}`,
-			c:  &Config{ClientAddr: "a"},
+			in: `{"client_addr":"1.2.3.4"}`,
+			c:  &Config{ClientAddr: "1.2.3.4"},
+		},
+		{
+			in: `{"client_addr":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{ClientAddr: "1.2.3.4"},
 		},
 		{
 			in: `{"data_dir":"a"}`,
@@ -531,12 +567,28 @@ func TestDecodeConfig(t *testing.T) {
 			c:  &Config{RetryMaxAttemptsWan: 123},
 		},
 		{
-			in: `{"serf_lan_bind":"a"}`,
-			c:  &Config{SerfLanBindAddr: "a"},
+			in: `{"serf_lan_bind":"1.2.3.4"}`,
+			c:  &Config{SerfLanBindAddr: "1.2.3.4"},
 		},
 		{
-			in: `{"serf_wan_bind":"a"}`,
-			c:  &Config{SerfWanBindAddr: "a"},
+			in: `{"serf_lan_bind":"unix:///var/foo/bar"}`,
+			c:  &Config{SerfLanBindAddr: "unix:///var/foo/bar"},
+		},
+		{
+			in: `{"serf_lan_bind":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{SerfLanBindAddr: "1.2.3.4"},
+		},
+		{
+			in: `{"serf_wan_bind":"1.2.3.4"}`,
+			c:  &Config{SerfWanBindAddr: "1.2.3.4"},
+		},
+		{
+			in: `{"serf_wan_bind":"unix:///var/foo/bar"}`,
+			c:  &Config{SerfWanBindAddr: "unix:///var/foo/bar"},
+		},
+		{
+			in: `{"serf_wan_bind":"{{\"1.2.3.4\"}}"}`,
+			c:  &Config{SerfWanBindAddr: "1.2.3.4"},
 		},
 		{
 			in: `{"server":true}`,
@@ -1164,6 +1216,9 @@ func TestDecodeConfig(t *testing.T) {
 			c, err := DecodeConfig(strings.NewReader(tt.in))
 			if got, want := err, tt.err; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got error %v want %v", got, want)
+			}
+			if err := c.ResolveTmplAddrs(); err != nil {
+				t.Fatalf("got error %v on ResolveTmplAddrs", err)
 			}
 			got, want := c, tt.c
 			verify.Values(t, "", got, want)

--- a/agent/config_test.go
+++ b/agent/config_test.go
@@ -71,6 +71,12 @@ func TestDecodeConfig(t *testing.T) {
 			parseTemplateErr: errors.New("Failed to parse Advertise WAN address: unix:///path/to/file"),
 			c:                &Config{AdvertiseAddrWan: "unix:///path/to/file"},
 		},
+		{
+			in:               `{"addresses":{"http":"notunix://blah"}}`,
+			parseTemplateErr: errors.New("Failed to parse HTTP address, is not a valid IP address or socket: notunix://blah"),
+			c:                &Config{Addresses: AddressConfig{HTTP: "notunix://blah"}},
+		},
+
 		// happy flows in alphabetical order
 		{
 			in: `{"acl_agent_master_token":"a"}`,

--- a/agent/config_test.go
+++ b/agent/config_test.go
@@ -73,7 +73,7 @@ func TestDecodeConfig(t *testing.T) {
 		},
 		{
 			in:               `{"addresses":{"http":"notunix://blah"}}`,
-			parseTemplateErr: errors.New("Failed to parse HTTP address, is not a valid IP address or socket: notunix://blah"),
+			parseTemplateErr: errors.New("Failed to parse HTTP address, \"notunix://blah\" is not a valid IP address or socket"),
 			c:                &Config{Addresses: AddressConfig{HTTP: "notunix://blah"}},
 		},
 

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -15,7 +15,6 @@ import (
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
 	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
-
 	a.Start()
 	defer a.Shutdown()
 
@@ -673,7 +672,6 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
 	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
 	a.Start()
-
 	defer a.Shutdown()
 
 	// Register info

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
+	cfg := TestConfig()
+	a := &TestAgent{Name: t.Name(), NoInitialSync: true, Config: cfg}
+
 	a.Start()
 	defer a.Shutdown()
 
@@ -670,8 +672,10 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
+	cfg := TestConfig()
+	a := &TestAgent{Name: t.Name(), NoInitialSync: true, Config: cfg}
 	a.Start()
+
 	defer a.Shutdown()
 
 	// Register info

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -14,8 +14,7 @@ import (
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
-	cfg := TestConfig()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true, Config: cfg}
+	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
 
 	a.Start()
 	defer a.Shutdown()
@@ -672,8 +671,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
-	cfg := TestConfig()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true, Config: cfg}
+	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
 	a.Start()
 
 	defer a.Shutdown()

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -334,6 +334,7 @@ func TestConfig() *Config {
 
 	ccfg.CoordinateUpdatePeriod = 100 * time.Millisecond
 	ccfg.ServerHealthInterval = 10 * time.Millisecond
+	cfg.SetupTaggedAndAdvertiseAddrs()
 	return cfg
 }
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -462,6 +462,10 @@ func (cmd *AgentCommand) readConfig() *agent.Config {
 	cfg.Version = cmd.Version
 	cfg.VersionPrerelease = cmd.VersionPrerelease
 
+	if err := cfg.ResolveTmplAddrs(); err != nil {
+		cmd.UI.Error(fmt.Sprintf("Failed to parse config: %v", err))
+		return nil
+	}
 	return cfg
 }
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -466,6 +466,13 @@ func (cmd *AgentCommand) readConfig() *agent.Config {
 		cmd.UI.Error(fmt.Sprintf("Failed to parse config: %v", err))
 		return nil
 	}
+	// More post processing of the config
+	if err := cfg.SetupTaggedAndAdvertiseAddrs(); err != nil {
+		cmd.UI.Error(fmt.Sprintf("Failed to set up tagged and advertise addresses: %v", err))
+		return nil
+	}
+	// Try to get an advertise address if not set
+
 	return cfg
 }
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -466,12 +466,11 @@ func (cmd *AgentCommand) readConfig() *agent.Config {
 		cmd.UI.Error(fmt.Sprintf("Failed to parse config: %v", err))
 		return nil
 	}
-	// More post processing of the config
+
 	if err := cfg.SetupTaggedAndAdvertiseAddrs(); err != nil {
 		cmd.UI.Error(fmt.Sprintf("Failed to set up tagged and advertise addresses: %v", err))
 		return nil
 	}
-	// Try to get an advertise address if not set
 
 	return cfg
 }

--- a/command/agent_test.go
+++ b/command/agent_test.go
@@ -176,6 +176,7 @@ func TestReadCliConfig(t *testing.T) {
 			args: []string{
 				"-data-dir", tmpDir,
 				"-node", `"a"`,
+				"-bind", "1.2.3.4",
 				"-advertise-wan", "1.2.3.4",
 				"-serf-wan-bind", "4.3.2.1",
 				"-serf-lan-bind", "4.3.2.2",
@@ -207,6 +208,7 @@ func TestReadCliConfig(t *testing.T) {
 				"-data-dir", tmpDir,
 				"-node-meta", "somekey:somevalue",
 				"-node-meta", "otherkey:othervalue",
+				"-bind", "1.2.3.4",
 			},
 			ShutdownCh:  shutdownCh,
 			BaseCommand: baseCommand(cli.NewMockUi()),
@@ -229,6 +231,7 @@ func TestReadCliConfig(t *testing.T) {
 				"-node", `"server1"`,
 				"-server",
 				"-data-dir", tmpDir,
+				"-bind", "1.2.3.4",
 			},
 			ShutdownCh:  shutdownCh,
 			BaseCommand: baseCommand(ui),
@@ -256,6 +259,7 @@ func TestReadCliConfig(t *testing.T) {
 			args: []string{
 				"-data-dir", tmpDir,
 				"-node", `"client"`,
+				"-bind", "1.2.3.4",
 			},
 			ShutdownCh:  shutdownCh,
 			BaseCommand: baseCommand(ui),
@@ -301,6 +305,7 @@ func TestAgent_HostBasedIDs(t *testing.T) {
 		cmd := &AgentCommand{
 			args: []string{
 				"-data-dir", tmpDir,
+				"-bind", "127.0.0.1",
 			},
 			BaseCommand: baseCommand(cli.NewMockUi()),
 		}
@@ -317,6 +322,7 @@ func TestAgent_HostBasedIDs(t *testing.T) {
 			args: []string{
 				"-data-dir", tmpDir,
 				"-disable-host-node-id=false",
+				"-bind", "127.0.0.1",
 			},
 			BaseCommand: baseCommand(cli.NewMockUi()),
 		}


### PR DESCRIPTION
…ppen before creating a new agent. Also removed redundant parsetemplate calls from agent.go.