### PR TITLE
Adds a Guides link to the nav.

### DIFF
--- a/website/source/layouts/_sidebar.erb
+++ b/website/source/layouts/_sidebar.erb
@@ -7,6 +7,7 @@
 
   <ul class="nav sidebar-nav">
     <li><a href="/intro/index.html">Intro</a></li>
+    <li><a href="/docs/guides/index.html">Guides</a></li>
     <li><a href="/docs/index.html">Docs</a></li>
     <li><a href="/api/index.html">API</a></li>
     <li><a href="/community.html">Community</a></li>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -73,6 +73,7 @@
               <nav class="navigation-links" role="navigation">
                 <ul class="main-links nav navbar-nav navbar-right">
                   <li><a href="/intro/index.html">Intro</a></li>
+                  <li><a href="/docs/guides/index.html">Guides</a></li>
                   <li><a href="/docs/index.html">Docs</a></li>
                   <li><a href="/api/index.html">API</a></li>
                   <li><a href="/community.html">Community</a></li>
@@ -105,6 +106,7 @@
           <div class="col-xs-12">
             <ul class="footer-links nav navbar-nav">
               <li><a href="/intro/index.html">Intro</a></li>
+              <li><a href="/docs/guides/index.html">Guides</a></li>
               <li><a href="/docs/index.html">Docs</a></li>
               <li><a href="/api/index.html">API</a></li>
               <li><a href="/community.html">Community</a></li>


### PR DESCRIPTION
This is a quick fix, but I'll /cc @sethvargo for any tips on how to re-root guides as a top level thing. We definitely would want to set up some redirects if we do this. This PR just links to the Guides section within the existing Docs section.