### PR TITLE
Register Entity Meta -> NodeMeta

### DIFF
--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -48,7 +48,7 @@ The table below shows this endpoint's support for
 - `TaggedAddresses` `(map<string|string>: nil)` - Specifies the tagged
   addresses.
 
-- `Meta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata
+- `NodeMeta` `(map<string|string>: nil)` - Specifies arbitrary KV metadata
   pairs for filtering purposes.
 
 - `Service` `(Service: nil)` - Specifies to register a service. If `ID` is not


### PR DESCRIPTION
Corrects a typo in the description of parameters for the Register Entity API endpoint.

(*This caused me a headache.*)