### PR TITLE
wrap titles in list and panel

### DIFF
--- a/ui/styles/_lists.scss
+++ b/ui/styles/_lists.scss
@@ -50,7 +50,7 @@
         margin-bottom: 4px;
         margin-top: 4px;
 
-        height: 40px;
+        min-height: 40px;
 
         &.double-line {
             height: 54px;
@@ -60,7 +60,8 @@
 
         .name {
             font-size: 15px;
-            padding-top: 6px;
+            padding: 6px 6px 6px 30px;
+            word-break: break-all;
 
             span {
                 white-space: nowrap;
@@ -110,6 +111,7 @@
         float: left;
         height: 100%;
         margin-right: 10px;
+        position: absolute;
     }
 
 

--- a/ui/styles/_panels.scss
+++ b/ui/styles/_panels.scss
@@ -17,6 +17,7 @@
         color: $gray-darker;
         border-radius: 3px;
         opacity: 0.8;
+        word-break: break-all;
 
         small {
             font-size: 14px;


### PR DESCRIPTION
Currently when you have a long title in the UI, it doesn't get wrapped and can be lost in lists and extend beyond the boundaries of panels. Here is an example.

![before](https://user-images.githubusercontent.com/1075622/28831988-4f0fb9ca-76a9-11e7-8ca4-dc8a2785d051.png)

To fix this, I've wrapped the text in both lists and panels. I also setup the list item height to expand as needed. 

![after](https://user-images.githubusercontent.com/1075622/28832083-8809abb4-76a9-11e7-95af-cec3b356f6f3.png)

If there is anything that needs to be changed or there are questions, let me know. After we have everything good to go I can package the UI into the bindata file and commit that.