### PR TITLE
Remove people from community section

### DIFF
--- a/website/packer.json
+++ b/website/packer.json
@@ -10,15 +10,12 @@
       "type": "docker",
       "image": "hashicorp/middleman-hashicorp:0.3.28",
       "discard": "true",
-      "run_command": ["-d", "-i", "-t", "{{ .Image }}", "/bin/sh"]
+      "volumes": {
+        "{{ pwd }}": "/website"
+      }
     }
   ],
   "provisioners": [
-    {
-      "type": "file",
-      "source": ".",
-      "destination": "/website"
-    },
     {
       "type": "shell",
       "environment_vars": [
@@ -30,7 +27,7 @@
       "inline": [
         "bundle check || bundle install",
         "bundle exec middleman build",
-        "/bin/sh ./scripts/deploy.sh"
+        "/bin/bash ./scripts/deploy.sh"
       ]
     }
   ]

--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -1,0 +1,40 @@
+#
+# REDIRECTS FILE
+#
+# This is a sample redirect file. Redirects allow individual projects to add
+# their own redirect rules in a declarative manner using Fastly edge
+# dictionaries.
+#
+# FORMAT
+#
+# Redirects are in the format. There must be at least one space between the
+# original path and the new path, and there must be exactly two entries per
+# line.
+#
+#     /original-path    /new-path
+#
+# GLOB MATCHING
+#
+# Because of the way lookup tables work, there is no support for glob matching.
+# Fastly does not provide a way to iterate through the lookup table, so it is
+# not possible to run through the table and find anything that matches. As such
+# URLs must match directly.
+#
+# More complex redirects are possible, but must be added directly to the
+# configuration. Please contact the release engineering team for assistance.
+#
+# DELETING
+#
+# Deleting items is not supported at this time. To delete an item, contact the
+# release engineering team and they will delete the dictionary item.
+#
+# MISC
+#
+# - Blank lines are ignored
+# - Comments are hash-style
+# - URLs are limited to 256 characters
+# - Items are case-sensitive (please use all lowercase)
+#
+
+/api.html                 /api/index.html
+/docs/agent/http.html     /api/index.html

--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -1,9 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 PROJECT="consul"
 PROJECT_URL="www.consul.io"
 FASTLY_SERVICE_ID="7GrxRJP3PVBuqQbyxYQ0MV"
+FASTLY_DICTIONARY_ID="7d0yAgSHAQ2efWKeUC3kqW"
 
 # Ensure the proper AWS environment variables are set
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
@@ -93,6 +94,75 @@ if [ -z "$NO_UPLOAD" ]; then
     modify "s3://hc-sites/$PROJECT/latest/"
 fi
 
+# Add redirects if they exist
+if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./redirects.txt" ]; then
+  echo "Adding redirects..."
+  fields=()
+  while read -r line; do
+    [[ "$line" =~ ^#.* ]] && continue
+    [[ -z "$line" ]] && continue
+
+    # Read fields
+    IFS=" " read -ra parts <<<"$line"
+    fields+=("${parts[@]}")
+  done < "./redirects.txt"
+
+  # Check we have pairs
+  if [ $((${#fields[@]} % 2)) -ne 0 ]; then
+    echo "Bad redirects (not an even number)!"
+    exit 1
+  fi
+
+  # Check we don't have more than 1000 entries (yes, it says 2000 below, but that
+  # is because we've split into multiple lines).
+  if [ "${#fields}" -gt 2000 ]; then
+    echo "More than 1000 entries!"
+    exit 1
+  fi
+
+  # Validations
+  for field in "${fields[@]}"; do
+    if [ "${#field}" -gt 256 ]; then
+      echo "'$field' is > 256 characters!"
+      exit 1
+    fi
+
+    if [ "${field:0:1}" != "/" ]; then
+      echo "'$field' does not start with /!"
+      exit 1
+    fi
+  done
+
+  # Build the payload for single-request updates.
+  jq_args=()
+  jq_query="."
+  for (( i=0; i<${#fields[@]}; i+=2 )); do
+    original="${fields[i]}"
+    redirect="${fields[i+1]}"
+    echo "Redirecting ${original} -> ${redirect}"
+    jq_args+=(--arg "key$((i/2))" "${original}")
+    jq_args+=(--arg "value$((i/2))" "${redirect}")
+    jq_query+="| .items |= (. + [{op: \"upsert\", item_key: \$key$((i/2)), item_value: \$value$((i/2))}])"
+  done
+
+  # Do not post empty items (the API gets sad)
+  if [ "${#jq_args[@]}" -ne 0 ]; then
+    json="$(jq "${jq_args[@]}" "${jq_query}" <<<'{"items": []}')"
+
+    # Post the JSON body
+    curl \
+      --fail \
+      --silent \
+      --output /dev/null \
+      --request "PATCH" \
+      --header "Fastly-Key: $FASTLY_API_KEY" \
+      --header "Content-type: application/json" \
+      --header "Accept: application/json" \
+      --data "$json"\
+      "https://api.fastly.com/service/$FASTLY_SERVICE_ID/dictionary/$FASTLY_DICTIONARY_ID/items"
+  fi
+fi
+
 # Perform a purge of the surrogate key.
 if [ -z "$NO_PURGE" ]; then
   echo "Purging Fastly cache..."
@@ -118,8 +188,13 @@ if [ -z "$NO_WARM" ]; then
   echo "wget --recursive --delete-after https://$PROJECT_URL/"
   echo ""
   wget \
-    --recursive \
     --delete-after \
-    --quiet \
+    --level inf \
+    --no-directories \
+    --no-host-directories \
+    --no-verbose \
+    --page-requisites \
+    --recursive \
+    --spider \
     "https://$PROJECT_URL/"
 fi

--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -2,28 +2,28 @@
 layout: "inner"
 page_title: "Community"
 description: |-
-  Consul is a new project with a growing community. Despite this, there are active, dedicated users willing to help you through various mediums.
+  Consul is a new project with a growing community. Despite this, there are
+  active, dedicated users willing to help you through various mediums.
 ---
 
 <h1>Community</h1>
 
 <p>
-Consul is a new project with a growing community. Despite this,
-there are active, dedicated users willing to help you through various
-mediums.
+  Consul is a new project with a growing community. Despite this, there are
+  active, dedicated users willing to help you through various mediums.
 </p>
 <p>
   <strong>Chat:</strong> <a href="https://gitter.im/hashicorp-consul/Lobby">Consul on Gitter</a>
 </p>
 <p>
-<strong>Mailing list:</strong>
-<a href="https://groups.google.com/group/consul-tool">Consul Google Group</a>
+  <strong>Mailing list:</strong>
+  <a href="https://groups.google.com/group/consul-tool">Consul Google Group</a>
 </p>
 <p>
-<strong>Bug Tracker:</strong>
-<a href="https://github.com/hashicorp/consul/issues">Issue tracker
+  <strong>Bug Tracker:</strong>
+  <a href="https://github.com/hashicorp/consul/issues">Issue tracker
   on GitHub</a>. Please only use this for reporting bugs. Do not ask
-for general help here. Use IRC or the mailing list for that.
+  for general help here. Use IRC or the mailing list for that.
 </p>
 <p>
   <strong>Community Tools:</strong>
@@ -36,129 +36,3 @@ for general help here. Use IRC or the mailing list for that.
   Paid <a href="https://www.hashicorp.com/training.html">HashiCorp training courses</a>
   are also available in a city near you. Private training courses are also available.
 </p>
-
-<h1>People</h1>
-<p>
-The following people are some of the faces behind Consul. They each
-contribute to Consul in some core way. Over time, faces may appear and
-disappear from this list as contributors come and go.
-</p>
-<div class="people">
-  <div class="person">
-    <img class="pull-left" src="//www.gravatar.com/avatar/11ba9630c9136eef9a70d26473d355d5.png?s=125">
-    <div class="bio">
-      <h3>Armon Dadgar (<a href="https://github.com/armon">@armon</a>)</h3>
-      <p>
-      Armon Dadgar is the creator of Consul. He researched and developed
-      most of the internals of how Consul works, including the
-      gossip layer, leader election, etc. Armon is also the creator of
-      <a href="https://www.serf.io">Serf</a>,
-      <a href="https://github.com/armon/statsite">Statsite</a>, and
-      <a href="https://github.com/armon/bloomd">Bloomd</a>.
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//www.gravatar.com/avatar/54079122b67de9677c1f93933ce8b63a.png?s=125">
-    <div class="bio">
-      <h3>Mitchell Hashimoto (<a href="https://github.com/mitchellh">@mitchellh</a>)</h3>
-      <p>
-      Mitchell Hashimoto is a co-creator of Consul. He primarily took
-      a management role in the creation of Consul, guiding product
-      and user experience decisions on top of Armon's technical decisions.
-      Mitchell Hashimoto is also the creator of
-      <a href="https://www.vagrantup.com">Vagrant</a>,
-      <a href="https://www.packer.io">Packer</a>, and
-      <a href="https://www.serf.io">Serf</a>.
-      </p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//www.gravatar.com/avatar/2acc31dd6370a54b18f6755cd0710ce6.png?s=125">
-    <div class="bio">
-      <h3>Jack Pearkes (<a href="https://github.com/pearkes">@pearkes</a>)</h3>
-      <p>
-      Jack Pearkes created and maintains the Consul web UI.
-      He is also a core committer to
-      <a href="https://www.packer.io">Packer</a> and maintains
-      many successful
-      <a href="https://github.com/pearkes">open source projects</a>
-      while also being an employee of
-      <a href="https://www.hashicorp.com">HashiCorp</a>.
-      </p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//avatars0.githubusercontent.com/u/1642288?v=3&amp;s=125">
-    <div class="bio">
-      <h3>Ryan Uber (<a href="https://github.com/ryanuber">@ryanuber</a>)</h3>
-      <p>
-      Ryan Uber is a core contributor to Consul where he works on all
-      facets of Consul. He is also a core committer to
-      <a href="https://www.serf.io">Serf</a>,
-      <a href="https://www.nomadproject.io">Nomad</a>, and
-      the Consul tools ecosystem, all while being an employee at
-      <a href="https://www.hashicorp.com">HashiCorp</a>.
-      </p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//avatars3.githubusercontent.com/u/673509?v=3&amp;s=125">
-    <div class="bio">
-      <h3>James Phillips (<a href="https://github.com/slackpad">@slackpad</a>)</h3>
-      <p>
-      James Phillips is a core contributor to Consul where he works on all
-      facets of Consul, including network tomography and prepared
-      queries. He is also a core committer to
-      <a href="https://www.serf.io">Serf</a> and
-      the Consul tools ecosystem, all while being an employee at
-      <a href="https://www.hashicorp.com">HashiCorp</a>.
-      </p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//avatars1.githubusercontent.com/u/408570?v=3&amp;s=125">
-    <div class="bio">
-      <h3>Seth Vargo (<a href="https://github.com/sethvargo">@sethvargo</a>)</h3>
-      <p>
-      Seth Vargo is a contributor to Consul, but his main focus is the
-      <a href="https://www.consul.io/downloads_tools.html">Consul tools ecosystem</a>.
-      He is also a core committer to
-      <a href="https://www.vagrantup.com">Vagrant</a>,
-      <a href="https://www.packer.io">Packer</a>, and
-      <a href="https://www.vaultproject.io">Vault</a>, and many more
-      open source projects, all while being an employee at
-      <a href="https://www.hashicorp.com">HashiCorp</a>.
-      </p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//www.gravatar.com/avatar/1e87e6016a7c4f4ecbd2517d84058467.png?s=125">
-    <div class="bio">
-      <h3>William Tisäter (<a href="https://github.com/tiwilliam">@tiwilliam</a>)</h3>
-      <p>William Tisäter is a Consul core committer. He is also the maintainer of
-      <a href="https://pypi.python.org/pypi/pygeoip">pygeoip</a> and builds things daily at
-      <a href="https://tictail.com">Tictail</a>.</p>
-    </div>
-  </div>
-
-  <div class="person">
-    <img class="pull-left" src="//www.gravatar.com/avatar/f6790b57128862abbfb6768264ea8824.png?s=125">
-    <div class="bio">
-      <h3>Ryan Breen (<a href="https://github.com/ryanbreen">@ryanbreen</a>)</h3>
-      <p>
-      Ryan Breen is a Consul committer. He is also the maintainer of
-      <a href="https://github.com/Cimpress-MCP/git2consul">git2consul</a>,
-      <a href="https://github.com/Cimpress-MCP/fsconsul">fsconsul</a>, and
-      <a href="https://github.com/Cimpress-MCP/gosecret">gosecret</a>.
-      Ryan works at <a href="http://www.cimpress.com">Cimpress</a>
-      building infrastructure for mass customization of consumer goods.
-      </p>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
Remove people from community section This is going to be replaced with dynamic content from our CMS in the future, but we agreed to remove it in the interim. 

This also updates the deploy process and brings project-side redirects (if you did not have them already).