### PR TITLE
Respect udp_answer_limit parameter even if UDP payload size is not 512

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -567,7 +567,7 @@ func trimUDPResponse(config *DNSConfig, req, resp *dns.Msg) (trimmed bool) {
 
 	// This cuts UDP responses to a useful but limited number of responses.
 	maxAnswers := lib.MinInt(maxUDPAnswerLimit, config.UDPAnswerLimit)
-	if maxSize == defaultMaxUDPSize && numAnswers > maxAnswers {
+	if numAnswers > maxAnswers {
 		resp.Answer = resp.Answer[:maxAnswers]
 		if hasExtra {
 			syncExtra(index, resp)


### PR DESCRIPTION
Fix #3355

Signed-off-by: Grégoire Seux <g.seux@criteo.com>