### PR TITLE
Fix rtt wan nodename check

### DIFF
--- a/command/lock/lock.go
+++ b/command/lock/lock.go
@@ -84,7 +84,7 @@ func (c *cmd) init() {
 			"required to detect a lost lock in some cases. The default value is 3, "+
 			"with a 1s wait between retries. Set this value to 0 to disable retires.")
 	c.flags.StringVar(&c.name, "name", "",
-		"Optional name to associate with the lock session. It not provided, one "+
+		"Optional name to associate with the lock session. If not provided, one "+
 			"is generated based on the provided child command.")
 	c.flags.BoolVar(&c.passStdin, "pass-stdin", false,
 		"Pass stdin to the child process.")

--- a/command/rtt/rtt.go
+++ b/command/rtt/rtt.go
@@ -78,14 +78,14 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		// Parse the input nodes.
-		parts1 := strings.Split(nodes[0], ".")
-		parts2 := strings.Split(nodes[1], ".")
-		if len(parts1) != 2 || len(parts2) != 2 {
+		node0index := strings.LastIndex(nodes[0], ".")
+		node1index := strings.LastIndex(nodes[1], ".")
+		if node0index == -1 || node1index == -1 {
 			c.UI.Error("Node names must be specified as <node name>.<datacenter> with -wan")
 			return 1
 		}
-		node1, dc1 := parts1[0], parts1[1]
-		node2, dc2 := parts2[0], parts2[1]
+		node1, dc1 := nodes[0][:node0index], nodes[0][node0index+1:]
+		node2, dc2 := nodes[1][:node1index], nodes[1][node1index+1:]
 
 		// Pull all the WAN coordinates.
 		dcs, err := coordClient.Datacenters()


### PR DESCRIPTION
with `nodename = foo.com` and `dc = dc1`  
```bash
> consul rtt foo.com.dc1
Could not find a coordinate for node "foo.com.dc1"
```

I didn't find a limit or state on nodename's format, so maybe a looser check policy is preferred ?