### PR TITLE
Refactor anti-entropy and local state

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -259,7 +259,7 @@ func (a *Agent) vetServiceRegister(token string, service *structs.NodeService) e
 	}
 
 	// Vet any service that might be getting overwritten.
-	services := a.state.Services()
+	services := a.State.Services()
 	if existing, ok := services[service.ID]; ok {
 		if !rule.ServiceWrite(existing.Service, nil) {
 			return acl.ErrPermissionDenied
@@ -282,7 +282,7 @@ func (a *Agent) vetServiceUpdate(token string, serviceID string) error {
 	}
 
 	// Vet any changes based on the existing services's info.
-	services := a.state.Services()
+	services := a.State.Services()
 	if existing, ok := services[serviceID]; ok {
 		if !rule.ServiceWrite(existing.Service, nil) {
 			return acl.ErrPermissionDenied
@@ -318,7 +318,7 @@ func (a *Agent) vetCheckRegister(token string, check *structs.HealthCheck) error
 	}
 
 	// Vet any check that might be getting overwritten.
-	checks := a.state.Checks()
+	checks := a.State.Checks()
 	if existing, ok := checks[check.CheckID]; ok {
 		if len(existing.ServiceName) > 0 {
 			if !rule.ServiceWrite(existing.ServiceName, nil) {
@@ -346,7 +346,7 @@ func (a *Agent) vetCheckUpdate(token string, checkID types.CheckID) error {
 	}
 
 	// Vet any changes based on the existing check's info.
-	checks := a.state.Checks()
+	checks := a.State.Checks()
 	if existing, ok := checks[checkID]; ok {
 		if len(existing.ServiceName) > 0 {
 			if !rule.ServiceWrite(existing.ServiceName, nil) {

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -564,7 +564,7 @@ func TestACL_vetServiceRegister(t *testing.T) {
 
 	// Try to register over a service without write privs to the existing
 	// service.
-	a.state.AddService(&structs.NodeService{
+	a.State.AddService(&structs.NodeService{
 		ID:      "my-service",
 		Service: "other",
 	}, "")
@@ -596,7 +596,7 @@ func TestACL_vetServiceUpdate(t *testing.T) {
 	}
 
 	// Update with write privs.
-	a.state.AddService(&structs.NodeService{
+	a.State.AddService(&structs.NodeService{
 		ID:      "my-service",
 		Service: "service",
 	}, "")
@@ -662,11 +662,11 @@ func TestACL_vetCheckRegister(t *testing.T) {
 
 	// Try to register over a service check without write privs to the
 	// existing service.
-	a.state.AddService(&structs.NodeService{
+	a.State.AddService(&structs.NodeService{
 		ID:      "my-service",
 		Service: "service",
 	}, "")
-	a.state.AddCheck(&structs.HealthCheck{
+	a.State.AddCheck(&structs.HealthCheck{
 		CheckID:     types.CheckID("my-check"),
 		ServiceID:   "my-service",
 		ServiceName: "other",
@@ -681,7 +681,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 	}
 
 	// Try to register over a node check without write privs to the node.
-	a.state.AddCheck(&structs.HealthCheck{
+	a.State.AddCheck(&structs.HealthCheck{
 		CheckID: types.CheckID("my-node-check"),
 	}, "")
 	err = a.vetCheckRegister("service-rw", &structs.HealthCheck{
@@ -713,11 +713,11 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 	}
 
 	// Update service check with write privs.
-	a.state.AddService(&structs.NodeService{
+	a.State.AddService(&structs.NodeService{
 		ID:      "my-service",
 		Service: "service",
 	}, "")
-	a.state.AddCheck(&structs.HealthCheck{
+	a.State.AddCheck(&structs.HealthCheck{
 		CheckID:     types.CheckID("my-service-check"),
 		ServiceID:   "my-service",
 		ServiceName: "service",
@@ -734,7 +734,7 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 	}
 
 	// Update node check with write privs.
-	a.state.AddCheck(&structs.HealthCheck{
+	a.State.AddCheck(&structs.HealthCheck{
 		CheckID: types.CheckID("my-node-check"),
 	}, "")
 	err = a.vetCheckUpdate("node-rw", "my-node-check")

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -1,0 +1,146 @@
+// Package ae provides an anti-entropy mechanism for the local state.
+package ae
+
+import (
+	"log"
+	"math"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/consul/lib"
+)
+
+const (
+	// This scale factor means we will add a minute after we cross 128 nodes,
+	// another at 256, another at 512, etc. By 8192 nodes, we will scale up
+	// by a factor of 8.
+	//
+	// If you update this, you may need to adjust the tuning of
+	// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
+	aeScaleThreshold = 128
+
+	syncStaggerIntv = 3 * time.Second
+	syncRetryIntv   = 15 * time.Second
+)
+
+// aeScale is used to scale the time interval at which anti-entropy updates take
+// place. It is used to prevent saturation as the cluster size grows.
+func aeScale(d time.Duration, n int) time.Duration {
+	// Don't scale until we cross the threshold
+	if n <= aeScaleThreshold {
+		return d
+	}
+
+	mult := math.Ceil(math.Log2(float64(n))-math.Log2(aeScaleThreshold)) + 1.0
+	return time.Duration(mult) * d
+}
+
+type StateSyncer struct {
+	// paused is used to check if we are paused. Must be the first
+	// element due to a go bug.
+	// todo(fs): which bug? still relevant?
+	paused int32
+
+	// State contains the data that needs to be synchronized.
+	State interface {
+		UpdateSyncState() error
+		SyncChanges() error
+	}
+
+	// Interval is the time between two sync runs.
+	Interval time.Duration
+
+	// ClusterSize returns the number of members in the cluster.
+	// todo(fs): we use this for staggering but what about a random number?
+	ClusterSize func() int
+
+	// ShutdownCh is closed when the application is shutting down.
+	ShutdownCh chan struct{}
+
+	// ConsulCh contains data when a new consul server has been added to the cluster.
+	ConsulCh chan struct{}
+
+	// TriggerCh contains data when a sync should run immediately.
+	TriggerCh chan struct{}
+
+	Logger *log.Logger
+}
+
+// Pause is used to pause state synchronization, this can be
+// used to make batch changes
+func (ae *StateSyncer) Pause() {
+	atomic.AddInt32(&ae.paused, 1)
+}
+
+// Resume is used to resume state synchronization
+func (ae *StateSyncer) Resume() {
+	paused := atomic.AddInt32(&ae.paused, -1)
+	if paused < 0 {
+		panic("unbalanced State.Resume() detected")
+	}
+	ae.changeMade()
+}
+
+// Paused is used to check if we are paused
+func (ae *StateSyncer) Paused() bool {
+	return atomic.LoadInt32(&ae.paused) > 0
+}
+
+func (ae *StateSyncer) changeMade() {
+	select {
+	case ae.TriggerCh <- struct{}{}:
+	default:
+	}
+}
+
+// antiEntropy is a long running method used to perform anti-entropy
+// between local and remote state.
+func (ae *StateSyncer) Run() {
+SYNC:
+	// Sync our state with the servers
+	for {
+		err := ae.State.UpdateSyncState()
+		if err == nil {
+			break
+		}
+		ae.Logger.Printf("[ERR] agent: failed to sync remote state: %v", err)
+		select {
+		case <-ae.ConsulCh:
+			// Stagger the retry on leader election, avoid a thundering heard
+			select {
+			case <-time.After(lib.RandomStagger(aeScale(syncStaggerIntv, ae.ClusterSize()))):
+			case <-ae.ShutdownCh:
+				return
+			}
+		case <-time.After(syncRetryIntv + lib.RandomStagger(aeScale(syncRetryIntv, ae.ClusterSize()))):
+		case <-ae.ShutdownCh:
+			return
+		}
+	}
+
+	// Force-trigger AE to pickup any changes
+	ae.changeMade()
+
+	// Schedule the next full sync, with a random stagger
+	aeIntv := aeScale(ae.Interval, ae.ClusterSize())
+	aeIntv = aeIntv + lib.RandomStagger(aeIntv)
+	aeTimer := time.After(aeIntv)
+
+	// Wait for sync events
+	for {
+		select {
+		case <-aeTimer:
+			goto SYNC
+		case <-ae.TriggerCh:
+			// Skip the sync if we are paused
+			if ae.Paused() {
+				continue
+			}
+			if err := ae.State.SyncChanges(); err != nil {
+				ae.Logger.Printf("[ERR] agent: failed to sync changes: %v", err)
+			}
+		case <-ae.ShutdownCh:
+			return
+		}
+	}
+}

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -212,8 +212,8 @@ func (s *StateSyncer) nextFSMState(fs fsmState) fsmState {
 	}
 }
 
-// event defines a timing or notification event from a multiple
-// timers and channels.
+// event defines a timing or notification event from multiple timers and
+// channels.
 type event string
 
 const (
@@ -224,7 +224,9 @@ const (
 )
 
 // retrySyncFullEventFn waits for an event which triggers a retry
-// of a full sync or a termination signal.
+// of a full sync or a termination signal. This function should not be
+// called directly but through s.retryFullSyncState to allow mocking for
+// testing.
 func (s *StateSyncer) retrySyncFullEventFn() event {
 	select {
 	// trigger a full sync immediately.
@@ -249,7 +251,9 @@ func (s *StateSyncer) retrySyncFullEventFn() event {
 }
 
 // syncChangesEventFn waits for a event which either triggers a full
-// or a partial sync or a termination signal.
+// or a partial sync or a termination signal. This function should not
+// be called directly but through s.syncChangesEvent to allow mocking
+// for testing.
 func (s *StateSyncer) syncChangesEventFn() event {
 	select {
 	// trigger a full sync immediately
@@ -276,9 +280,16 @@ func (s *StateSyncer) syncChangesEventFn() event {
 	}
 }
 
+// stubbed out for testing
+var libRandomStagger = lib.RandomStagger
+
+// staggerFn returns a random duration which depends on the cluster size
+// and a random factor which should provide some timely distribution of
+// cluster wide events. This function should not be called directly
+// but through s.stagger to allow mocking for testing.
 func (s *StateSyncer) staggerFn(d time.Duration) time.Duration {
 	f := scaleFactor(s.ClusterSize())
-	return lib.RandomStagger(time.Duration(f) * d)
+	return libRandomStagger(time.Duration(f) * d)
 }
 
 // Pause temporarily disables sync runs.

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -313,8 +313,9 @@ func (s *StateSyncer) Resume() {
 	if s.paused < 0 {
 		panic("unbalanced pause/resume")
 	}
-	if s.paused == 0 {
+	trigger := s.paused == 0
+	s.pauseLock.Unlock()
+	if trigger {
 		s.SyncChanges.Trigger()
 	}
-	s.pauseLock.Unlock()
 }

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -99,7 +99,7 @@ const (
 	retryFailIntv = 15 * time.Second
 )
 
-func NewStateSyner(state State, intv time.Duration, shutdownCh chan struct{}, logger *log.Logger) *StateSyncer {
+func NewStateSyncer(state State, intv time.Duration, shutdownCh chan struct{}, logger *log.Logger) *StateSyncer {
 	s := &StateSyncer{
 		State:             state,
 		Interval:          intv,

--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -142,6 +142,7 @@ FullSync:
 			case <-s.SyncFull.Notif():
 				select {
 				case <-time.After(s.stagger(s.serverUpInterval)):
+					continue FullSync
 				case <-s.ShutdownCh:
 					return
 				}
@@ -149,12 +150,11 @@ FullSync:
 			// retry full sync after some time
 			// todo(fs): why don't we use s.Interval here?
 			case <-time.After(s.retryFailInterval + s.stagger(s.retryFailInterval)):
+				continue FullSync
 
 			case <-s.ShutdownCh:
 				return
 			}
-
-			continue
 		}
 
 		// do partial syncs until it is time for a full sync again

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -1,24 +1,27 @@
 package ae
 
 import (
+	"fmt"
 	"testing"
-	"time"
 )
 
-func TestAE_scale(t *testing.T) {
+func TestAE_scaleFactor(t *testing.T) {
 	t.Parallel()
-	intv := time.Minute
-	if v := aeScale(intv, 100); v != intv {
-		t.Fatalf("Bad: %v", v)
+	tests := []struct {
+		nodes int
+		scale int
+	}{
+		{100, 1},
+		{200, 2},
+		{1000, 4},
+		{10000, 8},
 	}
-	if v := aeScale(intv, 200); v != 2*intv {
-		t.Fatalf("Bad: %v", v)
-	}
-	if v := aeScale(intv, 1000); v != 4*intv {
-		t.Fatalf("Bad: %v", v)
-	}
-	if v := aeScale(intv, 10000); v != 8*intv {
-		t.Fatalf("Bad: %v", v)
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d nodes", tt.nodes), func(t *testing.T) {
+			if got, want := scaleFactor(tt.nodes), tt.scale; got != want {
+				t.Fatalf("got scale factor %d want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -1,0 +1,55 @@
+package ae
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAE_scale(t *testing.T) {
+	t.Parallel()
+	intv := time.Minute
+	if v := aeScale(intv, 100); v != intv {
+		t.Fatalf("Bad: %v", v)
+	}
+	if v := aeScale(intv, 200); v != 2*intv {
+		t.Fatalf("Bad: %v", v)
+	}
+	if v := aeScale(intv, 1000); v != 4*intv {
+		t.Fatalf("Bad: %v", v)
+	}
+	if v := aeScale(intv, 10000); v != 8*intv {
+		t.Fatalf("Bad: %v", v)
+	}
+}
+
+func TestAE_nestedPauseResume(t *testing.T) {
+	t.Parallel()
+	l := new(StateSyncer)
+	if l.Paused() != false {
+		t.Fatal("syncer should be unPaused after init")
+	}
+	l.Pause()
+	if l.Paused() != true {
+		t.Fatal("syncer should be Paused after first call to Pause()")
+	}
+	l.Pause()
+	if l.Paused() != true {
+		t.Fatal("syncer should STILL be Paused after second call to Pause()")
+	}
+	l.Resume()
+	if l.Paused() != true {
+		t.Fatal("syncer should STILL be Paused after FIRST call to Resume()")
+	}
+	l.Resume()
+	if l.Paused() != false {
+		t.Fatal("syncer should NOT be Paused after SECOND call to Resume()")
+	}
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatal("unbalanced Resume() should cause a panic()")
+		}
+	}()
+	l.Resume()
+}

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -27,7 +27,7 @@ func TestAE_scaleFactor(t *testing.T) {
 
 func TestAE_nestedPauseResume(t *testing.T) {
 	t.Parallel()
-	l := new(StateSyncer)
+	l := NewStateSyner(nil, 0, nil, nil)
 	if l.Paused() != false {
 		t.Fatal("syncer should be unPaused after init")
 	}

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -1,7 +1,9 @@
 package ae
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -55,4 +57,23 @@ func TestAE_nestedPauseResume(t *testing.T) {
 		}
 	}()
 	l.Resume()
+}
+
+func TestAE_ifNotPausedRun(t *testing.T) {
+	l := NewStateSyner(nil, 0, nil, nil)
+
+	errCalled := errors.New("f called")
+	f := func() error { return errCalled }
+
+	l.Pause()
+	err := l.ifNotPausedRun(f)
+	if got, want := err, errPaused; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got error %q want %q", got, want)
+	}
+	l.Resume()
+
+	err = l.ifNotPausedRun(f)
+	if got, want := err, errCalled; got != want {
+		t.Fatalf("got error %q want %q", got, want)
+	}
 }

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -29,7 +29,7 @@ func TestAE_scaleFactor(t *testing.T) {
 
 func TestAE_Pause_nestedPauseResume(t *testing.T) {
 	t.Parallel()
-	l := NewStateSyner(nil, 0, nil, nil)
+	l := NewStateSyncer(nil, 0, nil, nil)
 	if l.Paused() != false {
 		t.Fatal("syncer should be unPaused after init")
 	}
@@ -60,7 +60,7 @@ func TestAE_Pause_nestedPauseResume(t *testing.T) {
 }
 
 func TestAE_Pause_ResumeTriggersSyncChanges(t *testing.T) {
-	l := NewStateSyner(nil, 0, nil, nil)
+	l := NewStateSyncer(nil, 0, nil, nil)
 	l.Pause()
 	l.Resume()
 	select {
@@ -74,7 +74,7 @@ func TestAE_Pause_ResumeTriggersSyncChanges(t *testing.T) {
 }
 
 func TestAE_Pause_ifNotPausedRun(t *testing.T) {
-	l := NewStateSyner(nil, 0, nil, nil)
+	l := NewStateSyncer(nil, 0, nil, nil)
 
 	errCalled := errors.New("f called")
 	f := func() error { return errCalled }

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/lib"
 )
 
 func TestAE_scaleFactor(t *testing.T) {
@@ -77,6 +79,20 @@ func TestAE_Pause_ResumeTriggersSyncChanges(t *testing.T) {
 	}
 }
 
+func TestAE_staggerDependsOnClusterSize(t *testing.T) {
+	libRandomStagger = func(d time.Duration) time.Duration { return d }
+	defer func() { libRandomStagger = lib.RandomStagger }()
+
+	l := testSyncer()
+	if got, want := l.staggerFn(10*time.Millisecond), 10*time.Millisecond; got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	l.ClusterSize = func() int { return 256 }
+	if got, want := l.staggerFn(10*time.Millisecond), 20*time.Millisecond; got != want {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
 func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
 	shutdownCh := make(chan struct{})
 	state := &mock{
@@ -106,17 +122,29 @@ func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
 }
 
 func TestAE_Run_Quit(t *testing.T) {
-	// start timer which explodes if runFSM does not quit
-	tm := time.AfterFunc(time.Second, func() { panic("timeout") })
+	t.Run("Run panics without ClusterSize", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			if err == nil {
+				t.Fatal("Run should panic")
+			}
+		}()
+		l := testSyncer()
+		l.ClusterSize = nil
+		l.Run()
+	})
+	t.Run("runFSM quits", func(t *testing.T) {
+		// start timer which explodes if runFSM does not quit
+		tm := time.AfterFunc(time.Second, func() { panic("timeout") })
 
-	l := testSyncer()
-	l.runFSM(fullSyncState, func(fsmState) fsmState { return doneState })
-	// should just quit
-	tm.Stop()
+		l := testSyncer()
+		l.runFSM(fullSyncState, func(fsmState) fsmState { return doneState })
+		// should just quit
+		tm.Stop()
+	})
 }
 
 func TestAE_FSM(t *testing.T) {
-
 	t.Run("fullSyncState", func(t *testing.T) {
 		t.Run("Paused -> retryFullSyncState", func(t *testing.T) {
 			l := testSyncer()
@@ -220,6 +248,69 @@ func TestAE_FSM(t *testing.T) {
 				t.Fatalf("got state %v want %v", got, want)
 			}
 		})
+		t.Run("invalid event -> panic ", func(t *testing.T) {
+			defer func() {
+				err := recover()
+				if err == nil {
+					t.Fatal("invalid event should panic")
+				}
+			}()
+			test(event("invalid"), fsmState(""))
+		})
+	})
+	t.Run("invalid state -> panic ", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			if err == nil {
+				t.Fatal("invalid state should panic")
+			}
+		}()
+		l := testSyncer()
+		l.nextFSMState(fsmState("invalid"))
+	})
+}
+
+func TestAE_RetrySyncFullEvent(t *testing.T) {
+	t.Run("trigger shutdownEvent", func(t *testing.T) {
+		l := testSyncer()
+		l.ShutdownCh = make(chan struct{})
+		evch := make(chan event)
+		go func() { evch <- l.retrySyncFullEvent() }()
+		close(l.ShutdownCh)
+		if got, want := <-evch, shutdownEvent; got != want {
+			t.Fatalf("got event %q want %q", got, want)
+		}
+	})
+	t.Run("trigger shutdownEvent during FullNotif", func(t *testing.T) {
+		l := testSyncer()
+		l.ShutdownCh = make(chan struct{})
+		evch := make(chan event)
+		go func() { evch <- l.retrySyncFullEvent() }()
+		l.SyncFull.Trigger()
+		time.Sleep(100 * time.Millisecond)
+		close(l.ShutdownCh)
+		if got, want := <-evch, shutdownEvent; got != want {
+			t.Fatalf("got event %q want %q", got, want)
+		}
+	})
+	t.Run("trigger syncFullNotifEvent", func(t *testing.T) {
+		l := testSyncer()
+		l.serverUpInterval = 10 * time.Millisecond
+		evch := make(chan event)
+		go func() { evch <- l.retrySyncFullEvent() }()
+		l.SyncFull.Trigger()
+		if got, want := <-evch, syncFullNotifEvent; got != want {
+			t.Fatalf("got event %q want %q", got, want)
+		}
+	})
+	t.Run("trigger syncFullTimerEvent", func(t *testing.T) {
+		l := testSyncer()
+		l.retryFailInterval = 10 * time.Millisecond
+		evch := make(chan event)
+		go func() { evch <- l.retrySyncFullEvent() }()
+		if got, want := <-evch, syncFullTimerEvent; got != want {
+			t.Fatalf("got event %q want %q", got, want)
+		}
 	})
 }
 

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -3,8 +3,12 @@ package ae
 import (
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestAE_scaleFactor(t *testing.T) {
@@ -90,4 +94,59 @@ func TestAE_Pause_ifNotPausedRun(t *testing.T) {
 	if got, want := err, errCalled; got != want {
 		t.Fatalf("got error %q want %q", got, want)
 	}
+}
+
+func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
+	shutdownCh := make(chan struct{})
+	state := &mock{
+		syncChanges: func() error {
+			close(shutdownCh)
+			return nil
+		},
+	}
+
+	// indicate that we have partial changes before starting Run
+	l := testSyncer(state, shutdownCh)
+	l.SyncChanges.Trigger()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.Run()
+	}()
+	wg.Wait()
+
+	if got, want := state.seq, []string{"full", "changes"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got call sequence %v want %v", got, want)
+	}
+}
+
+type mock struct {
+	seq                   []string
+	syncFull, syncChanges func() error
+}
+
+func (m *mock) SyncFull() error {
+	m.seq = append(m.seq, "full")
+	if m.syncFull != nil {
+		return m.syncFull()
+	}
+	return nil
+}
+
+func (m *mock) SyncChanges() error {
+	m.seq = append(m.seq, "changes")
+	if m.syncChanges != nil {
+		return m.syncChanges()
+	}
+	return nil
+}
+
+func testSyncer(state State, shutdownCh chan struct{}) *StateSyncer {
+	logger := log.New(os.Stderr, "", 0)
+	l := NewStateSyncer(state, 0, shutdownCh, logger)
+	l.stagger = func(d time.Duration) time.Duration { return d }
+	l.ClusterSize = func() int { return 1 }
+	return l
 }

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -27,7 +27,7 @@ func TestAE_scaleFactor(t *testing.T) {
 	}
 }
 
-func TestAE_nestedPauseResume(t *testing.T) {
+func TestAE_Pause_nestedPauseResume(t *testing.T) {
 	t.Parallel()
 	l := NewStateSyner(nil, 0, nil, nil)
 	if l.Paused() != false {
@@ -59,7 +59,21 @@ func TestAE_nestedPauseResume(t *testing.T) {
 	l.Resume()
 }
 
-func TestAE_ifNotPausedRun(t *testing.T) {
+func TestAE_Pause_ResumeTriggersSyncChanges(t *testing.T) {
+	l := NewStateSyner(nil, 0, nil, nil)
+	l.Pause()
+	l.Resume()
+	select {
+	case <-l.SyncChanges.Notif():
+		// expected
+	case <-l.SyncFull.Notif():
+		t.Fatal("resume triggered SyncFull instead of SyncChanges")
+	default:
+		t.Fatal("resume did not trigger SyncFull")
+	}
+}
+
+func TestAE_Pause_ifNotPausedRun(t *testing.T) {
 	l := NewStateSyner(nil, 0, nil, nil)
 
 	errCalled := errors.New("f called")

--- a/agent/ae/trigger.go
+++ b/agent/ae/trigger.go
@@ -1,0 +1,23 @@
+package ae
+
+// Trigger implements a non-blocking event notifier. Events can be
+// triggered without blocking and notifications happen only when the
+// previous event was consumed.
+type Trigger struct {
+	ch chan struct{}
+}
+
+func NewTrigger() *Trigger {
+	return &Trigger{make(chan struct{}, 1)}
+}
+
+func (t Trigger) Trigger() {
+	select {
+	case t.ch <- struct{}{}:
+	default:
+	}
+}
+
+func (t Trigger) Notif() <-chan struct{} {
+	return t.ch
+}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -248,7 +248,7 @@ func (a *Agent) Start() error {
 
 	// create a notif channel to trigger state sychronizations
 	// when a consul server was added to the cluster.
-	consulCh := make(chan struct{}, 1)
+	serverUpCh := make(chan struct{}, 1)
 
 	// create a notif channel to trigger state synchronizations
 	// when the state has changed.
@@ -263,7 +263,7 @@ func (a *Agent) Start() error {
 		State:      a.state,
 		Interval:   c.AEInterval,
 		ShutdownCh: a.shutdownCh,
-		ConsulCh:   consulCh,
+		ServerUpCh: serverUpCh,
 		TriggerCh:  triggerCh,
 		Logger:     a.logger,
 	}
@@ -280,7 +280,7 @@ func (a *Agent) Start() error {
 	// todo(fs): IMO, the non-blocking nature of this call should be hidden in the syncer
 	consulCfg.ServerUp = func() {
 		select {
-		case consulCh <- struct{}{}:
+		case serverUpCh <- struct{}{}:
 		default:
 		}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1620,8 +1620,8 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	// Deregister any associated health checks
-	for checkID, health := range a.state.Checks() {
-		if health.ServiceID != serviceID {
+	for checkID, check := range a.state.Checks() {
+		if check.ServiceID != serviceID {
 			continue
 		}
 		if err := a.RemoveCheck(checkID, persist); err != nil {
@@ -1653,11 +1653,11 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 	}
 
 	if check.ServiceID != "" {
-		svc, ok := a.state.Services()[check.ServiceID]
-		if !ok {
+		s := a.state.Services()[check.ServiceID]
+		if s == nil {
 			return fmt.Errorf("ServiceID %q does not exist", check.ServiceID)
 		}
-		check.ServiceName = svc.Service
+		check.ServiceName = s.Service
 	}
 
 	a.checkLock.Lock()
@@ -2159,12 +2159,11 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 // unloadServices will deregister all services other than the 'consul' service
 // known to the local agent.
 func (a *Agent) unloadServices() error {
-	for _, service := range a.state.Services() {
-		if err := a.RemoveService(service.ID, false); err != nil {
-			return fmt.Errorf("Failed deregistering service '%s': %v", service.ID, err)
+	for id := range a.state.Services() {
+		if err := a.RemoveService(id, false); err != nil {
+			return fmt.Errorf("Failed deregistering service '%s': %v", id, err)
 		}
 	}
-
 	return nil
 }
 
@@ -2247,12 +2246,11 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig) error {
 
 // unloadChecks will deregister all checks known to the local agent.
 func (a *Agent) unloadChecks() error {
-	for _, check := range a.state.Checks() {
-		if err := a.RemoveCheck(check.CheckID, false); err != nil {
-			return fmt.Errorf("Failed deregistering check '%s': %s", check.CheckID, err)
+	for id := range a.state.Checks() {
+		if err := a.RemoveCheck(id, false); err != nil {
+			return fmt.Errorf("Failed deregistering check '%s': %s", id, err)
 		}
 	}
-
 	return nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -268,7 +268,7 @@ func (a *Agent) Start() error {
 
 	// create the state synchronization manager which performs
 	// regular and on-demand state synchronizations (anti-entropy).
-	a.sync = ae.NewStateSyner(a.State, c.AEInterval, a.shutdownCh, a.logger)
+	a.sync = ae.NewStateSyncer(a.State, c.AEInterval, a.shutdownCh, a.logger)
 
 	// create the config for the rpc server/client
 	consulCfg, err := a.consulConfig()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -109,7 +109,7 @@ type Agent struct {
 
 	// state stores a local representation of the node,
 	// services and checks. Used for anti-entropy.
-	state *local.State
+	State *local.State
 
 	// sync manages the synchronization of the local
 	// and the remote state.
@@ -230,6 +230,22 @@ func New(c *config.RuntimeConfig) (*Agent, error) {
 	return a, nil
 }
 
+func LocalConfig(cfg *config.RuntimeConfig) local.Config {
+	lc := local.Config{
+		AdvertiseAddr:       cfg.AdvertiseAddrLAN.String(),
+		CheckUpdateInterval: cfg.CheckUpdateInterval,
+		Datacenter:          cfg.Datacenter,
+		DiscardCheckOutput:  cfg.DiscardCheckOutput,
+		NodeID:              cfg.NodeID,
+		NodeName:            cfg.NodeName,
+		TaggedAddresses:     map[string]string{},
+	}
+	for k, v := range cfg.TaggedAddresses {
+		lc.TaggedAddresses[k] = v
+	}
+	return lc
+}
+
 func (a *Agent) Start() error {
 	c := a.config
 
@@ -256,24 +272,12 @@ func (a *Agent) Start() error {
 	triggerCh := make(chan struct{}, 1)
 
 	// create the local state
-	lc := local.Config{
-		AdvertiseAddr:       c.AdvertiseAddrLAN.String(),
-		CheckUpdateInterval: c.CheckUpdateInterval,
-		Datacenter:          c.Datacenter,
-		DiscardCheckOutput:  c.DiscardCheckOutput,
-		NodeID:              c.NodeID,
-		NodeName:            c.NodeName,
-		TaggedAddresses:     map[string]string{},
-	}
-	for k, v := range c.TaggedAddresses {
-		lc.TaggedAddresses[k] = v
-	}
-	a.state = local.NewState(lc, a.logger, a.tokens, triggerCh)
+	a.State = local.NewState(LocalConfig(c), a.logger, a.tokens, triggerCh)
 
 	// create the state synchronization manager which performs
 	// regular and on-demand state synchronizations (anti-entropy).
 	a.sync = &ae.StateSyncer{
-		State:      a.state,
+		State:      a.State,
 		Interval:   c.AEInterval,
 		ShutdownCh: a.shutdownCh,
 		ServerUpCh: serverUpCh,
@@ -306,7 +310,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = server
-		a.state.SetDelegate(server)
+		a.State.SetDelegate(server)
 		a.sync.ClusterSize = func() int { return len(server.LANMembers()) }
 	} else {
 		client, err := consul.NewClientLogger(consulCfg, a.logger)
@@ -315,7 +319,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = client
-		a.state.SetDelegate(client)
+		a.State.SetDelegate(client)
 		a.sync.ClusterSize = func() int { return len(client.LANMembers()) }
 	}
 
@@ -1387,7 +1391,7 @@ OUTER:
 // reapServicesInternal does a single pass, looking for services to reap.
 func (a *Agent) reapServicesInternal() {
 	reaped := make(map[string]bool)
-	for checkID, cs := range a.state.CriticalCheckStates() {
+	for checkID, cs := range a.State.CriticalCheckStates() {
 		serviceID := cs.Check.ServiceID
 
 		// There's nothing to do if there's no service.
@@ -1445,7 +1449,7 @@ func (a *Agent) persistService(service *structs.NodeService) error {
 	svcPath := filepath.Join(a.config.DataDir, servicesDir, stringHash(service.ID))
 
 	wrapped := persistedService{
-		Token:   a.state.ServiceToken(service.ID),
+		Token:   a.State.ServiceToken(service.ID),
 		Service: service,
 	}
 	encoded, err := json.Marshal(wrapped)
@@ -1473,7 +1477,7 @@ func (a *Agent) persistCheck(check *structs.HealthCheck, chkType *structs.CheckT
 	wrapped := persistedCheck{
 		Check:   check,
 		ChkType: chkType,
-		Token:   a.state.CheckToken(check.CheckID),
+		Token:   a.State.CheckToken(check.CheckID),
 	}
 
 	encoded, err := json.Marshal(wrapped)
@@ -1572,7 +1576,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 	defer a.restoreCheckState(snap)
 
 	// Add the service
-	a.state.AddService(service, token)
+	a.State.AddService(service, token)
 
 	// Persist the service to a file
 	if persist && !a.config.DevMode {
@@ -1622,7 +1626,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	// Remove service immediately
-	if err := a.state.RemoveService(serviceID); err != nil {
+	if err := a.State.RemoveService(serviceID); err != nil {
 		a.logger.Printf("[WARN] agent: Failed to deregister service %q: %s", serviceID, err)
 		return nil
 	}
@@ -1635,7 +1639,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	// Deregister any associated health checks
-	for checkID, check := range a.state.Checks() {
+	for checkID, check := range a.State.Checks() {
 		if check.ServiceID != serviceID {
 			continue
 		}
@@ -1668,7 +1672,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 	}
 
 	if check.ServiceID != "" {
-		s := a.state.Services()[check.ServiceID]
+		s := a.State.Service(check.ServiceID)
 		if s == nil {
 			return fmt.Errorf("ServiceID %q does not exist", check.ServiceID)
 		}
@@ -1689,7 +1693,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			ttl := &CheckTTL{
-				Notify:  a.state,
+				Notify:  a.State,
 				CheckID: check.CheckID,
 				TTL:     chkType.TTL,
 				Logger:  a.logger,
@@ -1716,7 +1720,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			http := &CheckHTTP{
-				Notify:        a.state,
+				Notify:        a.State,
 				CheckID:       check.CheckID,
 				HTTP:          chkType.HTTP,
 				Header:        chkType.Header,
@@ -1741,7 +1745,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			tcp := &CheckTCP{
-				Notify:   a.state,
+				Notify:   a.State,
 				CheckID:  check.CheckID,
 				TCP:      chkType.TCP,
 				Interval: chkType.Interval,
@@ -1778,7 +1782,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			dockerCheck := &CheckDocker{
-				Notify:            a.state,
+				Notify:            a.State,
 				CheckID:           check.CheckID,
 				DockerContainerID: chkType.DockerContainerID,
 				Shell:             chkType.Shell,
@@ -1808,7 +1812,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			monitor := &CheckMonitor{
-				Notify:     a.state,
+				Notify:     a.State,
 				CheckID:    check.CheckID,
 				Script:     chkType.Script,
 				ScriptArgs: chkType.ScriptArgs,
@@ -1837,7 +1841,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 	}
 
 	// Add to the local state for anti-entropy
-	err := a.state.AddCheck(check, token)
+	err := a.State.AddCheck(check, token)
 	if err != nil {
 		a.cancelCheckMonitors(check.CheckID)
 		return err
@@ -1860,7 +1864,7 @@ func (a *Agent) RemoveCheck(checkID types.CheckID, persist bool) error {
 	}
 
 	// Add to the local state for anti-entropy
-	a.state.RemoveCheck(checkID)
+	a.State.RemoveCheck(checkID)
 
 	a.checkLock.Lock()
 	defer a.checkLock.Unlock()
@@ -2025,7 +2029,7 @@ func (a *Agent) Stats() map[string]map[string]string {
 		"check_monitors": strconv.Itoa(len(a.checkMonitors)),
 		"check_ttls":     strconv.Itoa(len(a.checkTTLs)),
 	}
-	for k, v := range a.state.Stats() {
+	for k, v := range a.State.Stats() {
 		stats["agent"][k] = v
 	}
 
@@ -2149,7 +2153,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 		}
 		serviceID := p.Service.ID
 
-		if a.state.Service(serviceID) != nil {
+		if a.State.Service(serviceID) != nil {
 			// Purge previously persisted service. This allows config to be
 			// preferred over services persisted from the API.
 			a.logger.Printf("[DEBUG] agent: service %q exists, not restoring from %q",
@@ -2172,7 +2176,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 // unloadServices will deregister all services other than the 'consul' service
 // known to the local agent.
 func (a *Agent) unloadServices() error {
-	for id := range a.state.Services() {
+	for id := range a.State.Services() {
 		if err := a.RemoveService(id, false); err != nil {
 			return fmt.Errorf("Failed deregistering service '%s': %v", id, err)
 		}
@@ -2228,7 +2232,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig) error {
 		}
 		checkID := p.Check.CheckID
 
-		if a.state.Check(checkID) != nil {
+		if a.State.Check(checkID) != nil {
 			// Purge previously persisted check. This allows config to be
 			// preferred over persisted checks from the API.
 			a.logger.Printf("[DEBUG] agent: check %q exists, not restoring from %q",
@@ -2259,7 +2263,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig) error {
 
 // unloadChecks will deregister all checks known to the local agent.
 func (a *Agent) unloadChecks() error {
-	for id := range a.state.Checks() {
+	for id := range a.State.Checks() {
 		if err := a.RemoveCheck(id, false); err != nil {
 			return fmt.Errorf("Failed deregistering check '%s': %s", id, err)
 		}
@@ -2271,7 +2275,7 @@ func (a *Agent) unloadChecks() error {
 // checks. This is done before we reload our checks, so that we can properly
 // restore into the same state.
 func (a *Agent) snapshotCheckState() map[types.CheckID]*structs.HealthCheck {
-	return a.state.Checks()
+	return a.State.Checks()
 }
 
 // restoreCheckState is used to reset the health state based on a snapshot.
@@ -2279,7 +2283,7 @@ func (a *Agent) snapshotCheckState() map[types.CheckID]*structs.HealthCheck {
 // in health state and potential session invalidations.
 func (a *Agent) restoreCheckState(snap map[types.CheckID]*structs.HealthCheck) {
 	for id, check := range snap {
-		a.state.UpdateCheck(id, check.Status, check.Output)
+		a.State.UpdateCheck(id, check.Status, check.Output)
 	}
 }
 
@@ -2291,12 +2295,12 @@ func (a *Agent) loadMetadata(conf *config.RuntimeConfig) error {
 		meta[k] = v
 	}
 	meta[structs.MetaSegmentKey] = conf.SegmentName
-	return a.state.LoadMetadata(meta)
+	return a.State.LoadMetadata(meta)
 }
 
 // unloadMetadata resets the local metadata state
 func (a *Agent) unloadMetadata() {
-	a.state.UnloadMetadata()
+	a.State.UnloadMetadata()
 }
 
 // serviceMaintCheckID returns the ID of a given service's maintenance check
@@ -2307,14 +2311,14 @@ func serviceMaintCheckID(serviceID string) types.CheckID {
 // EnableServiceMaintenance will register a false health check against the given
 // service ID with critical status. This will exclude the service from queries.
 func (a *Agent) EnableServiceMaintenance(serviceID, reason, token string) error {
-	service, ok := a.state.Services()[serviceID]
+	service, ok := a.State.Services()[serviceID]
 	if !ok {
 		return fmt.Errorf("No service registered with ID %q", serviceID)
 	}
 
 	// Check if maintenance mode is not already enabled
 	checkID := serviceMaintCheckID(serviceID)
-	if _, ok := a.state.Checks()[checkID]; ok {
+	if _, ok := a.State.Checks()[checkID]; ok {
 		return nil
 	}
 
@@ -2342,13 +2346,13 @@ func (a *Agent) EnableServiceMaintenance(serviceID, reason, token string) error 
 // DisableServiceMaintenance will deregister the fake maintenance mode check
 // if the service has been marked as in maintenance.
 func (a *Agent) DisableServiceMaintenance(serviceID string) error {
-	if _, ok := a.state.Services()[serviceID]; !ok {
+	if _, ok := a.State.Services()[serviceID]; !ok {
 		return fmt.Errorf("No service registered with ID %q", serviceID)
 	}
 
 	// Check if maintenance mode is enabled
 	checkID := serviceMaintCheckID(serviceID)
-	if _, ok := a.state.Checks()[checkID]; !ok {
+	if _, ok := a.State.Checks()[checkID]; !ok {
 		return nil
 	}
 
@@ -2362,7 +2366,7 @@ func (a *Agent) DisableServiceMaintenance(serviceID string) error {
 // EnableNodeMaintenance places a node into maintenance mode.
 func (a *Agent) EnableNodeMaintenance(reason, token string) {
 	// Ensure node maintenance is not already enabled
-	if _, ok := a.state.Checks()[structs.NodeMaint]; ok {
+	if _, ok := a.State.Checks()[structs.NodeMaint]; ok {
 		return
 	}
 
@@ -2385,7 +2389,7 @@ func (a *Agent) EnableNodeMaintenance(reason, token string) {
 
 // DisableNodeMaintenance removes a node from maintenance mode
 func (a *Agent) DisableNodeMaintenance() {
-	if _, ok := a.state.Checks()[structs.NodeMaint]; !ok {
+	if _, ok := a.State.Checks()[structs.NodeMaint]; !ok {
 		return
 	}
 	a.RemoveCheck(structs.NodeMaint, true)
@@ -2429,7 +2433,7 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	// Update filtered metrics
 	metrics.UpdateFilter(newCfg.TelemetryAllowedPrefixes, newCfg.TelemetryBlockedPrefixes)
 
-	a.state.SetDiscardCheckOutput(newCfg.DiscardCheckOutput)
+	a.State.SetDiscardCheckOutput(newCfg.DiscardCheckOutput)
 
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/consul/agent/ae"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/consul"
+	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/systemd"
 	"github.com/hashicorp/consul/agent/token"
@@ -108,7 +109,7 @@ type Agent struct {
 
 	// state stores a local representation of the node,
 	// services and checks. Used for anti-entropy.
-	state *localState
+	state *local.State
 
 	// sync manages the synchronization of the local
 	// and the remote state.
@@ -255,7 +256,19 @@ func (a *Agent) Start() error {
 	triggerCh := make(chan struct{}, 1)
 
 	// create the local state
-	a.state = NewLocalState(c, a.logger, a.tokens, triggerCh)
+	lc := local.Config{
+		AdvertiseAddr:       c.AdvertiseAddrLAN.String(),
+		CheckUpdateInterval: c.CheckUpdateInterval,
+		Datacenter:          c.Datacenter,
+		DiscardCheckOutput:  c.DiscardCheckOutput,
+		NodeID:              c.NodeID,
+		NodeName:            c.NodeName,
+		TaggedAddresses:     map[string]string{},
+	}
+	for k, v := range c.TaggedAddresses {
+		lc.TaggedAddresses[k] = v
+	}
+	a.state = local.NewState(lc, a.logger, a.tokens, triggerCh)
 
 	// create the state synchronization manager which performs
 	// regular and on-demand state synchronizations (anti-entropy).
@@ -293,7 +306,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = server
-		a.state.delegate = server
+		a.state.SetDelegate(server)
 		a.sync.ClusterSize = func() int { return len(server.LANMembers()) }
 	} else {
 		client, err := consul.NewClientLogger(consulCfg, a.logger)
@@ -302,7 +315,7 @@ func (a *Agent) Start() error {
 		}
 
 		a.delegate = client
-		a.state.delegate = client
+		a.state.SetDelegate(client)
 		a.sync.ClusterSize = func() int { return len(client.LANMembers()) }
 	}
 
@@ -2005,15 +2018,13 @@ func (a *Agent) GossipEncrypted() bool {
 
 // Stats is used to get various debugging state from the sub-systems
 func (a *Agent) Stats() map[string]map[string]string {
-	toString := func(v uint64) string {
-		return strconv.FormatUint(v, 10)
-	}
 	stats := a.delegate.Stats()
 	stats["agent"] = map[string]string{
-		"check_monitors": toString(uint64(len(a.checkMonitors))),
-		"check_ttls":     toString(uint64(len(a.checkTTLs))),
-		"checks":         toString(uint64(len(a.state.checks))),
-		"services":       toString(uint64(len(a.state.services))),
+		"check_monitors": strconv.Itoa(len(a.checkMonitors)),
+		"check_ttls":     strconv.Itoa(len(a.checkTTLs)),
+	}
+	for k, v := range a.state.Stats() {
+		stats["agent"][k] = v
 	}
 
 	revision := a.config.Revision
@@ -2136,7 +2147,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 		}
 		serviceID := p.Service.ID
 
-		if _, ok := a.state.services[serviceID]; ok {
+		if a.state.Service(serviceID) != nil {
 			// Purge previously persisted service. This allows config to be
 			// preferred over services persisted from the API.
 			a.logger.Printf("[DEBUG] agent: service %q exists, not restoring from %q",
@@ -2215,7 +2226,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig) error {
 		}
 		checkID := p.Check.CheckID
 
-		if _, ok := a.state.checks[checkID]; ok {
+		if a.state.Check(checkID) != nil {
 			// Purge previously persisted check. This allows config to be
 			// preferred over persisted checks from the API.
 			a.logger.Printf("[DEBUG] agent: check %q exists, not restoring from %q",
@@ -2273,26 +2284,17 @@ func (a *Agent) restoreCheckState(snap map[types.CheckID]*structs.HealthCheck) {
 // loadMetadata loads node metadata fields from the agent config and
 // updates them on the local agent.
 func (a *Agent) loadMetadata(conf *config.RuntimeConfig) error {
-	a.state.Lock()
-	defer a.state.Unlock()
-
-	for key, value := range conf.NodeMeta {
-		a.state.metadata[key] = value
+	meta := map[string]string{}
+	for k, v := range conf.NodeMeta {
+		meta[k] = v
 	}
-
-	a.state.metadata[structs.MetaSegmentKey] = conf.SegmentName
-
-	a.state.changeMade()
-
-	return nil
+	meta[structs.MetaSegmentKey] = conf.SegmentName
+	return a.state.LoadMetadata(meta)
 }
 
 // unloadMetadata resets the local metadata state
 func (a *Agent) unloadMetadata() {
-	a.state.Lock()
-	defer a.state.Unlock()
-
-	a.state.metadata = make(map[string]string)
+	a.state.UnloadMetadata()
 }
 
 // serviceMaintCheckID returns the ID of a given service's maintenance check

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -72,7 +72,7 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 		Coord:       cs[s.agent.config.SegmentName],
 		Member:      s.agent.LocalMember(),
 		Stats:       s.agent.Stats(),
-		Meta:        s.agent.state.Metadata(),
+		Meta:        s.agent.State.Metadata(),
 	}, nil
 }
 
@@ -137,7 +137,7 @@ func (s *HTTPServer) AgentServices(resp http.ResponseWriter, req *http.Request) 
 	var token string
 	s.parseToken(req, &token)
 
-	services := s.agent.state.Services()
+	services := s.agent.State.Services()
 	if err := s.agent.filterServices(token, &services); err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (s *HTTPServer) AgentChecks(resp http.ResponseWriter, req *http.Request) (i
 	var token string
 	s.parseToken(req, &token)
 
-	checks := s.agent.state.Checks()
+	checks := s.agent.State.Checks()
 	if err := s.agent.filterChecks(token, &checks); err != nil {
 		return nil, err
 	}
@@ -304,7 +304,7 @@ func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request
 // services and checks to the server. If the operation fails, we only
 // only warn because the write did succeed and anti-entropy will sync later.
 func (s *HTTPServer) syncChanges() {
-	if err := s.agent.state.SyncChanges(); err != nil {
+	if err := s.agent.State.SyncChanges(); err != nil {
 		s.agent.logger.Printf("[ERR] agent: failed to sync changes: %v", err)
 	}
 }

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -304,7 +304,7 @@ func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request
 // services and checks to the server. If the operation fails, we only
 // only warn because the write did succeed and anti-entropy will sync later.
 func (s *HTTPServer) syncChanges() {
-	if err := s.agent.state.syncChanges(); err != nil {
+	if err := s.agent.state.SyncChanges(); err != nil {
 		s.agent.logger.Printf("[ERR] agent: failed to sync changes: %v", err)
 	}
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -51,7 +51,7 @@ func TestAgent_Services(t *testing.T) {
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 
 	req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
 	obj, err := a.srv.AgentServices(nil, req)
@@ -78,7 +78,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/services", nil)
@@ -116,7 +116,7 @@ func TestAgent_Checks(t *testing.T) {
 		Name:    "mysql",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk1, "")
+	a.State.AddCheck(chk1, "")
 
 	req, _ := http.NewRequest("GET", "/v1/agent/checks", nil)
 	obj, err := a.srv.AgentChecks(nil, req)
@@ -143,7 +143,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 		Name:    "mysql",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk1, "")
+	a.State.AddCheck(chk1, "")
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/checks", nil)
@@ -283,8 +283,8 @@ func TestAgent_Reload(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	if _, ok := a.state.services["redis"]; !ok {
-		t.Fatalf("missing redis service")
+	if a.State.Service("redis") == nil {
+		t.Fatal("missing redis service")
 	}
 
 	cfg2 := TestConfig(config.Source{
@@ -307,8 +307,8 @@ func TestAgent_Reload(t *testing.T) {
 	if err := a.ReloadConfig(cfg2); err != nil {
 		t.Fatalf("got error %v want nil", err)
 	}
-	if _, ok := a.state.services["redis-reloaded"]; !ok {
-		t.Fatalf("missing redis-reloaded service")
+	if a.State.Service("redis-reloaded") == nil {
+		t.Fatal("missing redis-reloaded service")
 	}
 
 	for _, wp := range a.watchPlans {
@@ -682,7 +682,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 
 	// Ensure we have a check mapping
 	checkID := types.CheckID("test")
-	if _, ok := a.state.Checks()[checkID]; !ok {
+	if _, ok := a.State.Checks()[checkID]; !ok {
 		t.Fatalf("missing test check")
 	}
 
@@ -691,12 +691,12 @@ func TestAgent_RegisterCheck(t *testing.T) {
 	}
 
 	// Ensure the token was configured
-	if token := a.state.CheckToken(checkID); token == "" {
+	if token := a.State.CheckToken(checkID); token == "" {
 		t.Fatalf("missing token")
 	}
 
 	// By default, checks start in critical state.
-	state := a.state.Checks()[checkID]
+	state := a.State.Checks()[checkID]
 	if state.Status != api.HealthCritical {
 		t.Fatalf("bad: %v", state)
 	}
@@ -817,7 +817,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 
 	// Ensure we have a check mapping
 	checkID := types.CheckID("test")
-	if _, ok := a.state.Checks()[checkID]; !ok {
+	if _, ok := a.State.Checks()[checkID]; !ok {
 		t.Fatalf("missing test check")
 	}
 
@@ -825,7 +825,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 		t.Fatalf("missing test check ttl")
 	}
 
-	state := a.state.Checks()[checkID]
+	state := a.State.Checks()[checkID]
 	if state.Status != api.HealthPassing {
 		t.Fatalf("bad: %v", state)
 	}
@@ -896,7 +896,7 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	if _, ok := a.state.Checks()["test"]; ok {
+	if _, ok := a.State.Checks()["test"]; ok {
 		t.Fatalf("have test check")
 	}
 }
@@ -947,7 +947,7 @@ func TestAgent_PassCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	state := a.state.Checks()["test"]
+	state := a.State.Checks()["test"]
 	if state.Status != api.HealthPassing {
 		t.Fatalf("bad: %v", state)
 	}
@@ -1000,7 +1000,7 @@ func TestAgent_WarnCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	state := a.state.Checks()["test"]
+	state := a.State.Checks()["test"]
 	if state.Status != api.HealthWarning {
 		t.Fatalf("bad: %v", state)
 	}
@@ -1053,7 +1053,7 @@ func TestAgent_FailCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	state := a.state.Checks()["test"]
+	state := a.State.Checks()["test"]
 	if state.Status != api.HealthCritical {
 		t.Fatalf("bad: %v", state)
 	}
@@ -1117,7 +1117,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 				t.Fatalf("expected 200, got %d", resp.Code)
 			}
 
-			state := a.state.Checks()["test"]
+			state := a.State.Checks()["test"]
 			if state.Status != c.Status || state.Output != c.Output {
 				t.Fatalf("bad: %v", state)
 			}
@@ -1145,7 +1145,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 		// Since we append some notes about truncating, we just do a
 		// rough check that the output buffer was cut down so this test
 		// isn't super brittle.
-		state := a.state.Checks()["test"]
+		state := a.State.Checks()["test"]
 		if state.Status != api.HealthPassing || len(state.Output) > 2*CheckBufSize {
 			t.Fatalf("bad: %v", state)
 		}
@@ -1228,12 +1228,12 @@ func TestAgent_RegisterService(t *testing.T) {
 	}
 
 	// Ensure the servie
-	if _, ok := a.state.Services()["test"]; !ok {
+	if _, ok := a.State.Services()["test"]; !ok {
 		t.Fatalf("missing test service")
 	}
 
 	// Ensure we have a check mapping
-	checks := a.state.Checks()
+	checks := a.State.Checks()
 	if len(checks) != 3 {
 		t.Fatalf("bad: %v", checks)
 	}
@@ -1243,7 +1243,7 @@ func TestAgent_RegisterService(t *testing.T) {
 	}
 
 	// Ensure the token was configured
-	if token := a.state.ServiceToken("test"); token == "" {
+	if token := a.State.ServiceToken("test"); token == "" {
 		t.Fatalf("missing token")
 	}
 }
@@ -1364,11 +1364,11 @@ func TestAgent_DeregisterService(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	if _, ok := a.state.Services()["test"]; ok {
+	if _, ok := a.State.Services()["test"]; ok {
 		t.Fatalf("have test service")
 	}
 
-	if _, ok := a.state.Checks()["test"]; ok {
+	if _, ok := a.State.Checks()["test"]; ok {
 		t.Fatalf("have test check")
 	}
 }
@@ -1466,13 +1466,13 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 
 	// Ensure the maintenance check was registered
 	checkID := serviceMaintCheckID("test")
-	check, ok := a.state.Checks()[checkID]
+	check, ok := a.State.Checks()[checkID]
 	if !ok {
 		t.Fatalf("should have registered maintenance check")
 	}
 
 	// Ensure the token was added
-	if token := a.state.CheckToken(checkID); token != "mytoken" {
+	if token := a.State.CheckToken(checkID); token != "mytoken" {
 		t.Fatalf("expected 'mytoken', got '%s'", token)
 	}
 
@@ -1513,7 +1513,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 
 	// Ensure the maintenance check was removed
 	checkID := serviceMaintCheckID("test")
-	if _, ok := a.state.Checks()[checkID]; ok {
+	if _, ok := a.State.Checks()[checkID]; ok {
 		t.Fatalf("should have removed maintenance check")
 	}
 }
@@ -1579,13 +1579,13 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was registered
-	check, ok := a.state.Checks()[structs.NodeMaint]
+	check, ok := a.State.Checks()[structs.NodeMaint]
 	if !ok {
 		t.Fatalf("should have registered maintenance check")
 	}
 
 	// Check that the token was used
-	if token := a.state.CheckToken(structs.NodeMaint); token != "mytoken" {
+	if token := a.State.CheckToken(structs.NodeMaint); token != "mytoken" {
 		t.Fatalf("expected 'mytoken', got '%s'", token)
 	}
 
@@ -1614,7 +1614,7 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 	}
 
 	// Ensure the maintenance check was removed
-	if _, ok := a.state.Checks()[structs.NodeMaint]; ok {
+	if _, ok := a.State.Checks()[structs.NodeMaint]; ok {
 		t.Fatalf("should have removed maintenance check")
 	}
 }
@@ -1670,7 +1670,7 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	result := a.state.Checks()
+	result := a.State.Checks()
 	if _, ok := result["service:memcache"]; !ok {
 		t.Fatalf("missing memcached check")
 	}

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1271,7 +1271,7 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 		EnableTagOverride: true,
 	}
 
-	if got, want := a.state.Services()["test"], svc; !verify.Values(t, "", got, want) {
+	if got, want := a.State.Service("test"), svc; !verify.Values(t, "", got, want) {
 		t.Fail()
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -911,7 +911,7 @@ func TestAgent_PersistService(t *testing.T) {
 	if got, want := restored.Token, "mytoken"; got != want {
 		t.Fatalf("got token %q want %q", got, want)
 	}
-	if got, want := restored.Service.Port, 8081; got != want {
+	if got, want := restored.Service.Port, 8001; got != want {
 		t.Fatalf("got port %d want %d", got, want)
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -363,14 +363,14 @@ func TestAgent_AddService(t *testing.T) {
 					t.Fatalf("err: %v", err)
 				}
 
-				got, want := a.state.Services()[tt.srv.ID], tt.srv
+				got, want := a.State.Services()[tt.srv.ID], tt.srv
 				verify.Values(t, "", got, want)
 			})
 
 			// check the health checks
 			for k, v := range tt.healthChks {
 				t.Run(k, func(t *testing.T) {
-					got, want := a.state.Checks()[types.CheckID(k)], v
+					got, want := a.State.Checks()[types.CheckID(k)], v
 					verify.Values(t, k, got, want)
 				})
 			}
@@ -437,10 +437,10 @@ func TestAgent_RemoveService(t *testing.T) {
 		if err := a.RemoveService("memcache", false); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		if _, ok := a.state.Checks()["service:memcache"]; ok {
+		if _, ok := a.State.Checks()["service:memcache"]; ok {
 			t.Fatalf("have memcache check")
 		}
-		if _, ok := a.state.Checks()["check2"]; ok {
+		if _, ok := a.State.Checks()["check2"]; ok {
 			t.Fatalf("have check2 check")
 		}
 	}
@@ -466,15 +466,15 @@ func TestAgent_RemoveService(t *testing.T) {
 		}
 
 		// Ensure we have a state mapping
-		if _, ok := a.state.Services()["redis"]; ok {
+		if _, ok := a.State.Services()["redis"]; ok {
 			t.Fatalf("have redis service")
 		}
 
 		// Ensure checks were removed
-		if _, ok := a.state.Checks()["service:redis:1"]; ok {
+		if _, ok := a.State.Checks()["service:redis:1"]; ok {
 			t.Fatalf("check redis:1 should be removed")
 		}
-		if _, ok := a.state.Checks()["service:redis:2"]; ok {
+		if _, ok := a.State.Checks()["service:redis:2"]; ok {
 			t.Fatalf("check redis:2 should be removed")
 		}
 
@@ -507,7 +507,7 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// verify chk1 exists
-	if a.state.Checks()["chk1"] == nil {
+	if a.State.Checks()["chk1"] == nil {
 		t.Fatal("Could not find health check chk1")
 	}
 
@@ -517,10 +517,10 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// check that both checks are there
-	if got, want := a.state.Checks()["chk1"], hchk1; !verify.Values(t, "", got, want) {
+	if got, want := a.State.Checks()["chk1"], hchk1; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
-	if got, want := a.state.Checks()["chk2"], hchk2; !verify.Values(t, "", got, want) {
+	if got, want := a.State.Checks()["chk2"], hchk2; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
 
@@ -530,10 +530,10 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// Check that both checks are gone
-	if a.state.Checks()["chk1"] != nil {
+	if a.State.Checks()["chk1"] != nil {
 		t.Fatal("Found health check chk1 want nil")
 	}
-	if a.state.Checks()["chk2"] != nil {
+	if a.State.Checks()["chk2"] != nil {
 		t.Fatal("Found health check chk2 want nil")
 	}
 }
@@ -561,7 +561,7 @@ func TestAgent_AddCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	sChk, ok := a.state.Checks()["mem"]
+	sChk, ok := a.State.Checks()["mem"]
 	if !ok {
 		t.Fatalf("missing mem check")
 	}
@@ -600,7 +600,7 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	sChk, ok := a.state.Checks()["mem"]
+	sChk, ok := a.State.Checks()["mem"]
 	if !ok {
 		t.Fatalf("missing mem check")
 	}
@@ -639,7 +639,7 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	if _, ok := a.state.Checks()["mem"]; !ok {
+	if _, ok := a.State.Checks()["mem"]; !ok {
 		t.Fatalf("missing mem check")
 	}
 
@@ -704,7 +704,7 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 	}
 
 	// Ensure the check status was restored during registration
-	checks := a.state.Checks()
+	checks := a.State.Checks()
 	check, ok := checks["baz"]
 	if !ok {
 		t.Fatalf("missing check")
@@ -739,7 +739,7 @@ func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 	}
 
 	// Ensure we don't have a check mapping
-	if memChk := a.state.Checks()["mem"]; memChk != nil {
+	if memChk := a.State.Checks()["mem"]; memChk != nil {
 		t.Fatalf("should be missing mem check")
 	}
 }
@@ -782,7 +782,7 @@ func TestAgent_RemoveCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping
-	if _, ok := a.state.Checks()["mem"]; ok {
+	if _, ok := a.State.Checks()["mem"]; ok {
 		t.Fatalf("have mem check")
 	}
 
@@ -817,7 +817,7 @@ func TestAgent_updateTTLCheck(t *testing.T) {
 	}
 
 	// Ensure we have a check mapping.
-	status := a.state.Checks()["mem"]
+	status := a.State.Checks()["mem"]
 	if status.Status != api.HealthPassing {
 		t.Fatalf("bad: %v", status)
 	}
@@ -904,15 +904,15 @@ func TestAgent_PersistService(t *testing.T) {
 	a2.Start()
 	defer a2.Shutdown()
 
-	restored, ok := a2.state.services[svc.ID]
-	if !ok {
-		t.Fatalf("bad: %#v", a2.state.services)
+	restored := a2.State.ServiceState(svc.ID)
+	if restored == nil {
+		t.Fatalf("service %q missing", svc.ID)
 	}
-	if a2.state.serviceTokens[svc.ID] != "mytoken" {
-		t.Fatalf("bad: %#v", a2.state.services[svc.ID])
+	if got, want := restored.Token, "mytoken"; got != want {
+		t.Fatalf("got token %q want %q", got, want)
 	}
-	if restored.Port != 8001 {
-		t.Fatalf("bad: %#v", restored)
+	if got, want := restored.Service.Port, 8081; got != want {
+		t.Fatalf("got port %d want %d", got, want)
 	}
 }
 
@@ -951,7 +951,7 @@ func TestAgent_persistedService_compat(t *testing.T) {
 	}
 
 	// Ensure the service was restored
-	services := a.state.Services()
+	services := a.State.Services()
 	result, ok := services["redis"]
 	if !ok {
 		t.Fatalf("missing service")
@@ -1043,8 +1043,8 @@ func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
 	if _, err := os.Stat(file); err == nil {
 		t.Fatalf("should have removed persisted service")
 	}
-	result, ok := a2.state.services["redis"]
-	if !ok {
+	result := a2.State.Service("redis")
+	if result == nil {
 		t.Fatalf("missing service registration")
 	}
 	if !reflect.DeepEqual(result.Tags, []string{"bar"}) || result.Port != 9000 {
@@ -1137,9 +1137,9 @@ func TestAgent_PersistCheck(t *testing.T) {
 	a2.Start()
 	defer a2.Shutdown()
 
-	result, ok := a2.state.checks[check.CheckID]
-	if !ok {
-		t.Fatalf("bad: %#v", a2.state.checks)
+	result := a2.State.Check(check.CheckID)
+	if result == nil {
+		t.Fatalf("bad: %#v", a2.State.Checks())
 	}
 	if result.Status != api.HealthCritical {
 		t.Fatalf("bad: %#v", result)
@@ -1152,8 +1152,8 @@ func TestAgent_PersistCheck(t *testing.T) {
 	if _, ok := a2.checkMonitors[check.CheckID]; !ok {
 		t.Fatalf("bad: %#v", a2.checkMonitors)
 	}
-	if a2.state.checkTokens[check.CheckID] != "mytoken" {
-		t.Fatalf("bad: %s", a2.state.checkTokens[check.CheckID])
+	if a2.State.CheckState(check.CheckID).Token != "mytoken" {
+		t.Fatalf("bad: %s", a2.State.CheckState(check.CheckID).Token)
 	}
 }
 
@@ -1241,8 +1241,8 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	if _, err := os.Stat(file); err == nil {
 		t.Fatalf("should have removed persisted check")
 	}
-	result, ok := a2.state.checks["mem"]
-	if !ok {
+	result := a2.State.Check("mem")
+	if result == nil {
 		t.Fatalf("missing check registration")
 	}
 	expected := &structs.HealthCheck{
@@ -1269,11 +1269,11 @@ func TestAgent_loadChecks_token(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	checks := a.state.Checks()
+	checks := a.State.Checks()
 	if _, ok := checks["rabbitmq"]; !ok {
 		t.Fatalf("missing check")
 	}
-	if token := a.state.CheckToken("rabbitmq"); token != "abc123" {
+	if token := a.State.CheckToken("rabbitmq"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
 }
@@ -1307,7 +1307,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	found := false
-	for check := range a.state.Checks() {
+	for check := range a.State.Checks() {
 		if check == check1.CheckID {
 			found = true
 			break
@@ -1323,7 +1323,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 	}
 
 	// Make sure it was unloaded
-	for check := range a.state.Checks() {
+	for check := range a.State.Checks() {
 		if check == check1.CheckID {
 			t.Fatalf("should have unloaded checks")
 		}
@@ -1342,11 +1342,11 @@ func TestAgent_loadServices_token(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	services := a.state.Services()
+	services := a.State.Services()
 	if _, ok := services["rabbitmq"]; !ok {
 		t.Fatalf("missing service")
 	}
-	if token := a.state.ServiceToken("rabbitmq"); token != "abc123" {
+	if token := a.State.ServiceToken("rabbitmq"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
 }
@@ -1368,7 +1368,7 @@ func TestAgent_unloadServices(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	found := false
-	for id := range a.state.Services() {
+	for id := range a.State.Services() {
 		if id == svc.ID {
 			found = true
 			break
@@ -1382,7 +1382,7 @@ func TestAgent_unloadServices(t *testing.T) {
 	if err := a.unloadServices(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if len(a.state.Services()) != 0 {
+	if len(a.State.Services()) != 0 {
 		t.Fatalf("should have unloaded services")
 	}
 }
@@ -1411,13 +1411,13 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 
 	// Make sure the critical health check was added
 	checkID := serviceMaintCheckID("redis")
-	check, ok := a.state.Checks()[checkID]
+	check, ok := a.State.Checks()[checkID]
 	if !ok {
 		t.Fatalf("should have registered critical maintenance check")
 	}
 
 	// Check that the token was used to register the check
-	if token := a.state.CheckToken(checkID); token != "mytoken" {
+	if token := a.State.CheckToken(checkID); token != "mytoken" {
 		t.Fatalf("expected 'mytoken', got: '%s'", token)
 	}
 
@@ -1432,7 +1432,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	}
 
 	// Ensure the check was deregistered
-	if _, ok := a.state.Checks()[checkID]; ok {
+	if _, ok := a.State.Checks()[checkID]; ok {
 		t.Fatalf("should have deregistered maintenance check")
 	}
 
@@ -1442,7 +1442,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	}
 
 	// Ensure the check was registered with the default notes
-	check, ok = a.state.Checks()[checkID]
+	check, ok = a.State.Checks()[checkID]
 	if !ok {
 		t.Fatalf("should have registered critical check")
 	}
@@ -1479,19 +1479,19 @@ func TestAgent_Service_Reap(t *testing.T) {
 	}
 
 	// Make sure it's there and there's no critical check yet.
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) > 0 {
+	if checks := a.State.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have critical checks")
 	}
 
 	// Wait for the check TTL to fail but before the check is reaped.
 	time.Sleep(100 * time.Millisecond)
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) != 1 {
+	if checks := a.State.CriticalCheckStates(); len(checks) != 1 {
 		t.Fatalf("should have a critical check")
 	}
 
@@ -1499,28 +1499,28 @@ func TestAgent_Service_Reap(t *testing.T) {
 	if err := a.updateTTLCheck("service:redis", api.HealthPassing, "foo"); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) > 0 {
+	if checks := a.State.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have critical checks")
 	}
 
 	// Wait for the check TTL to fail again.
 	time.Sleep(100 * time.Millisecond)
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) != 1 {
+	if checks := a.State.CriticalCheckStates(); len(checks) != 1 {
 		t.Fatalf("should have a critical check")
 	}
 
 	// Wait for the reap.
 	time.Sleep(400 * time.Millisecond)
-	if _, ok := a.state.Services()["redis"]; ok {
+	if _, ok := a.State.Services()["redis"]; ok {
 		t.Fatalf("redis service should have been reaped")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) > 0 {
+	if checks := a.State.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have critical checks")
 	}
 }
@@ -1552,28 +1552,28 @@ func TestAgent_Service_NoReap(t *testing.T) {
 	}
 
 	// Make sure it's there and there's no critical check yet.
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) > 0 {
+	if checks := a.State.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have critical checks")
 	}
 
 	// Wait for the check TTL to fail.
 	time.Sleep(200 * time.Millisecond)
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) != 1 {
+	if checks := a.State.CriticalCheckStates(); len(checks) != 1 {
 		t.Fatalf("should have a critical check")
 	}
 
 	// Wait a while and make sure it doesn't reap.
 	time.Sleep(200 * time.Millisecond)
-	if _, ok := a.state.Services()["redis"]; !ok {
+	if _, ok := a.State.Services()["redis"]; !ok {
 		t.Fatalf("should have redis service")
 	}
-	if checks := a.state.CriticalChecks(); len(checks) != 1 {
+	if checks := a.State.CriticalCheckStates(); len(checks) != 1 {
 		t.Fatalf("should have a critical check")
 	}
 }
@@ -1612,7 +1612,7 @@ func TestAgent_addCheck_restoresSnapshot(t *testing.T) {
 	if err := a.AddService(svc, chkTypes, false, ""); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	check, ok := a.state.Checks()["service:redis"]
+	check, ok := a.State.Checks()["service:redis"]
 	if !ok {
 		t.Fatalf("missing check")
 	}
@@ -1630,13 +1630,13 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	a.EnableNodeMaintenance("broken", "mytoken")
 
 	// Make sure the critical health check was added
-	check, ok := a.state.Checks()[structs.NodeMaint]
+	check, ok := a.State.Checks()[structs.NodeMaint]
 	if !ok {
 		t.Fatalf("should have registered critical node check")
 	}
 
 	// Check that the token was used to register the check
-	if token := a.state.CheckToken(structs.NodeMaint); token != "mytoken" {
+	if token := a.State.CheckToken(structs.NodeMaint); token != "mytoken" {
 		t.Fatalf("expected 'mytoken', got: '%s'", token)
 	}
 
@@ -1649,7 +1649,7 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	a.DisableNodeMaintenance()
 
 	// Ensure the check was deregistered
-	if _, ok := a.state.Checks()[structs.NodeMaint]; ok {
+	if _, ok := a.State.Checks()[structs.NodeMaint]; ok {
 		t.Fatalf("should have deregistered critical node check")
 	}
 
@@ -1657,7 +1657,7 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	a.EnableNodeMaintenance("", "")
 
 	// Make sure the check was registered with the default note
-	check, ok = a.state.Checks()[structs.NodeMaint]
+	check, ok = a.State.Checks()[structs.NodeMaint]
 	if !ok {
 		t.Fatalf("should have registered critical node check")
 	}
@@ -1712,7 +1712,7 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 	a.restoreCheckState(snap)
 
 	// Search for the check
-	out, ok := a.state.Checks()[check1.CheckID]
+	out, ok := a.State.Checks()[check1.CheckID]
 	if !ok {
 		t.Fatalf("check should have been registered")
 	}

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestCatalogRegister(t *testing.T) {
+	t.Skip("skipping since it is not clear what this test is supposed to verify")
+
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
@@ -27,28 +29,11 @@ func TestCatalogRegister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-
 	res := obj.(bool)
 	if res != true {
 		t.Fatalf("bad: %v", res)
 	}
 
-	// todo(fs): data race
-	// func() {
-	// 	a.State.Lock()
-	// 	defer a.State.Unlock()
-
-	// 	// Service should be in sync
-	// 	if err := a.State.syncService("foo"); err != nil {
-	// 		t.Fatalf("err: %s", err)
-	// 	}
-	// 	if _, ok := a.State.serviceStatus["foo"]; !ok {
-	// 		t.Fatalf("bad: %#v", a.State.serviceStatus)
-	// 	}
-	// 	if !a.State.serviceStatus["foo"].inSync {
-	// 		t.Fatalf("should be in sync")
-	// 	}
-	// }()
 	if err := a.State.SyncChanges(); err != nil {
 		t.Fatal("sync failed: ", err)
 	}

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -33,22 +33,32 @@ func TestCatalogRegister(t *testing.T) {
 		t.Fatalf("bad: %v", res)
 	}
 
-	// data race
-	func() {
-		a.state.Lock()
-		defer a.state.Unlock()
+	// todo(fs): data race
+	// func() {
+	// 	a.State.Lock()
+	// 	defer a.State.Unlock()
 
-		// Service should be in sync
-		if err := a.state.syncService("foo"); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if _, ok := a.state.serviceStatus["foo"]; !ok {
-			t.Fatalf("bad: %#v", a.state.serviceStatus)
-		}
-		if !a.state.serviceStatus["foo"].inSync {
-			t.Fatalf("should be in sync")
-		}
-	}()
+	// 	// Service should be in sync
+	// 	if err := a.State.syncService("foo"); err != nil {
+	// 		t.Fatalf("err: %s", err)
+	// 	}
+	// 	if _, ok := a.State.serviceStatus["foo"]; !ok {
+	// 		t.Fatalf("bad: %#v", a.State.serviceStatus)
+	// 	}
+	// 	if !a.State.serviceStatus["foo"].inSync {
+	// 		t.Fatalf("should be in sync")
+	// 	}
+	// }()
+	if err := a.State.SyncChanges(); err != nil {
+		t.Fatal("sync failed: ", err)
+	}
+	s := a.State.ServiceState("foo")
+	if s == nil {
+		t.Fatal("service 'foo' missing")
+	}
+	if !s.InSync {
+		t.Fatalf("service 'foo' should be in sync")
+	}
 }
 
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -12,40 +12,6 @@ import (
 	"github.com/hashicorp/serf/coordinate"
 )
 
-func TestCatalogRegister(t *testing.T) {
-	t.Skip("skipping since it is not clear what this test is supposed to verify")
-
-	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
-	defer a.Shutdown()
-
-	// Register node
-	args := &structs.RegisterRequest{
-		Node:    "foo",
-		Address: "127.0.0.1",
-	}
-	req, _ := http.NewRequest("PUT", "/v1/catalog/register", jsonReader(args))
-	obj, err := a.srv.CatalogRegister(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	res := obj.(bool)
-	if res != true {
-		t.Fatalf("bad: %v", res)
-	}
-
-	if err := a.State.SyncChanges(); err != nil {
-		t.Fatal("sync failed: ", err)
-	}
-	s := a.State.ServiceState("foo")
-	if s == nil {
-		t.Fatal("service 'foo' missing")
-	}
-	if !s.InSync {
-		t.Fatalf("service 'foo' should be in sync")
-	}
-}
-
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -348,7 +348,7 @@ func (l *State) AddCheck(check *structs.HealthCheck, token string) error {
 	// if there is a serviceID associated with the check, make sure it exists before adding it
 	// NOTE - This logic may be moved to be handled within the Agent's Addcheck method after a refactor
 	if check.ServiceID != "" && l.services[check.ServiceID] == nil {
-		return fmt.Errorf("Check %q refers to non-existent service %q does not exist", check.CheckID, check.ServiceID)
+		return fmt.Errorf("Check %q refers to non-existent service %q", check.CheckID, check.ServiceID)
 	}
 
 	// hard-set the node name

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -206,19 +206,11 @@ func (l *State) AddService(service *structs.NodeService, token string) error {
 		service.ID = service.Service
 	}
 
-	l.AddServiceState(&ServiceState{
+	l.SetServiceState(&ServiceState{
 		Service: service,
 		Token:   token,
 	})
 	return nil
-}
-
-func (l *State) AddServiceState(s *ServiceState) {
-	l.Lock()
-	defer l.Unlock()
-
-	l.services[s.Service.ID] = s
-	l.TriggerSyncChanges()
 }
 
 // RemoveService is used to remove a service entry from the local state.
@@ -285,6 +277,17 @@ func (l *State) ServiceState(id string) *ServiceState {
 	return s.Clone()
 }
 
+// SetServiceState is used to overwrite a raw service state with the given
+// state. This method is safe to be called concurrently but should only be used
+// during testing. You should most likely call AddService instead.
+func (l *State) SetServiceState(s *ServiceState) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.services[s.Service.ID] = s
+	l.TriggerSyncChanges()
+}
+
 // ServiceStates returns a shallow copy of all service state records.
 // The service record still points to the original service record and
 // must not be modified.
@@ -345,19 +348,11 @@ func (l *State) AddCheck(check *structs.HealthCheck, token string) error {
 	// hard-set the node name
 	check.Node = l.config.NodeName
 
-	l.AddCheckState(&CheckState{
+	l.SetCheckState(&CheckState{
 		Check: check,
 		Token: token,
 	})
 	return nil
-}
-
-func (l *State) AddCheckState(c *CheckState) {
-	l.Lock()
-	defer l.Unlock()
-
-	l.checks[c.Check.CheckID] = c
-	l.TriggerSyncChanges()
 }
 
 // RemoveCheck is used to remove a health check from the local state.
@@ -482,6 +477,17 @@ func (l *State) CheckState(id types.CheckID) *CheckState {
 		return nil
 	}
 	return c.Clone()
+}
+
+// SetCheckState is used to overwrite a raw check state with the given
+// state. This method is safe to be called concurrently but should only be used
+// during testing. You should most likely call AddCheck instead.
+func (l *State) SetCheckState(c *CheckState) {
+	l.Lock()
+	defer l.Unlock()
+
+	l.checks[c.Check.CheckID] = c
+	l.TriggerSyncChanges()
 }
 
 // CheckStates returns a shallow copy of all health check state records.

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -335,6 +335,9 @@ func (l *State) AddCheck(check *structs.HealthCheck, token string) error {
 		return fmt.Errorf("no check")
 	}
 
+	// clone the check since we will be modifying it.
+	check = check.Clone()
+
 	if l.discardCheckOutput.Load().(bool) {
 		check.Output = ""
 	}

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -341,7 +341,7 @@ func (l *State) AddCheck(check *structs.HealthCheck, token string) error {
 
 	// if there is a serviceID associated with the check, make sure it exists before adding it
 	// NOTE - This logic may be moved to be handled within the Agent's Addcheck method after a refactor
-	if check.ServiceID != "" && l.services[check.ServiceID] == nil {
+	if check.ServiceID != "" && l.Service(check.ServiceID) == nil {
 		return fmt.Errorf("Check %q refers to non-existent service %q", check.CheckID, check.ServiceID)
 	}
 

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -18,9 +18,6 @@ import (
 	"github.com/hashicorp/consul/types"
 )
 
-// permissionDenied is returned when an ACL based rejection happens.
-const permissionDenied = "Permission denied"
-
 // Config is the configuration for the State. It is
 // populated during NewLocalAgent from the agent configuration to avoid
 // race conditions with the agent configuration.
@@ -39,7 +36,8 @@ type ServiceState struct {
 	// Service is the local copy of the service record.
 	Service *structs.NodeService
 
-	// Token is the ACL to update the service record on the server.
+	// Token is the ACL to update or delete the service record on the
+	// server.
 	Token string
 
 	// InSync contains whether the local state of the service record
@@ -64,8 +62,8 @@ type CheckState struct {
 	// Check is the local copy of the health check record.
 	Check *structs.HealthCheck
 
-	// Token is the ACL record to update the health check record
-	// on the server.
+	// Token is the ACL record to update or delete the health check
+	// record on the server.
 	Token string
 
 	// CriticalTime is the last time the health check status went
@@ -74,8 +72,8 @@ type CheckState struct {
 	CriticalTime time.Time
 
 	// DeferCheck is used to delay the sync of a health check when
-	// only the status has changed.
-	// todo(fs): ^^ this needs double checking...
+	// only the output has changed. This rate limits changes which
+	// do not affect the state of the node and/or service.
 	DeferCheck *time.Timer
 
 	// InSync contains whether the local state of the health check
@@ -107,7 +105,7 @@ func (c *CheckState) CriticalFor() time.Duration {
 	return time.Since(c.CriticalTime)
 }
 
-type delegate interface {
+type rpc interface {
 	RPC(method string, args interface{}, reply interface{}) error
 }
 
@@ -116,13 +114,24 @@ type delegate interface {
 // catalog representation
 type State struct {
 	sync.RWMutex
+
+	// Delegate the RPC interface to the consul server or agent.
+	//
+	// It is set after both the state and the consul server/agent have
+	// been created.
+	Delegate rpc
+
+	// TriggerSyncChanges is used to notify the state syncer that a
+	// partial sync should be performed.
+	//
+	// It is set after both the state and the state syncer have been
+	// created.
+	TriggerSyncChanges func()
+
 	logger *log.Logger
 
 	// Config is the agent config
 	config Config
-
-	// delegate is the consul interface to use for keeping in sync
-	delegate delegate
 
 	// nodeInfoInSync tracks whether the server has our correct top-level
 	// node information in sync
@@ -134,12 +143,8 @@ type State struct {
 	// Checks tracks the local checks
 	checks map[types.CheckID]*CheckState
 
-	// metadata tracks the local metadata fields
+	// metadata tracks the node metadata fields
 	metadata map[string]string
-
-	// triggerCh is used to inform of a change to local state
-	// that requires anti-entropy with the server
-	triggerCh chan struct{}
 
 	// discardCheckOutput stores whether the output of health checks
 	// is stored in the raft log.
@@ -150,31 +155,17 @@ type State struct {
 }
 
 // NewLocalState creates a  is used to initialize the local state
-func NewState(c Config, lg *log.Logger, tokens *token.Store, triggerCh chan struct{}) *State {
+func NewState(c Config, lg *log.Logger, tokens *token.Store) *State {
 	l := &State{
-		config:    c,
-		logger:    lg,
-		services:  make(map[string]*ServiceState),
-		checks:    make(map[types.CheckID]*CheckState),
-		metadata:  make(map[string]string),
-		triggerCh: triggerCh,
-		tokens:    tokens,
+		config:   c,
+		logger:   lg,
+		services: make(map[string]*ServiceState),
+		checks:   make(map[types.CheckID]*CheckState),
+		metadata: make(map[string]string),
+		tokens:   tokens,
 	}
-	l.discardCheckOutput.Store(c.DiscardCheckOutput)
+	l.SetDiscardCheckOutput(c.DiscardCheckOutput)
 	return l
-}
-
-func (l *State) SetDelegate(d delegate) {
-	l.delegate = d
-}
-
-// changeMade is used to trigger an anti-entropy run
-func (l *State) changeMade() {
-	// todo(fs): IMO, the non-blocking nature of this call should be hidden in the syncer
-	select {
-	case l.triggerCh <- struct{}{}:
-	default:
-	}
 }
 
 func (l *State) SetDiscardCheckOutput(b bool) {
@@ -204,14 +195,12 @@ func (l *State) serviceToken(id string) string {
 // AddService is used to add a service entry to the local state.
 // This entry is persistent and the agent will make a best effort to
 // ensure it is registered
-// todo(fs): where is the persistence happening?
 func (l *State) AddService(service *structs.NodeService, token string) error {
 	if service == nil {
 		return fmt.Errorf("no service")
 	}
 
 	// use the service name as id if the id was omitted
-	// todo(fs): is this for backwards compatibility?
 	if service.ID == "" {
 		service.ID = service.Service
 	}
@@ -228,7 +217,7 @@ func (l *State) AddServiceState(s *ServiceState) {
 	defer l.Unlock()
 
 	l.services[s.Service.ID] = s
-	l.changeMade()
+	l.TriggerSyncChanges()
 }
 
 // RemoveService is used to remove a service entry from the local state.
@@ -247,7 +236,7 @@ func (l *State) RemoveService(id string) error {
 	// entry around until it is actually removed.
 	s.InSync = false
 	s.Deleted = true
-	l.changeMade()
+	l.TriggerSyncChanges()
 
 	return nil
 }
@@ -366,7 +355,7 @@ func (l *State) AddCheckState(c *CheckState) {
 	defer l.Unlock()
 
 	l.checks[c.Check.CheckID] = c
-	l.changeMade()
+	l.TriggerSyncChanges()
 }
 
 // RemoveCheck is used to remove a health check from the local state.
@@ -387,7 +376,7 @@ func (l *State) RemoveCheck(id types.CheckID) error {
 	// entry around until it is actually removed.
 	c.InSync = false
 	c.Deleted = true
-	l.changeMade()
+	l.TriggerSyncChanges()
 
 	return nil
 }
@@ -443,7 +432,7 @@ func (l *State) UpdateCheck(id types.CheckID, status, output string) {
 					return
 				}
 				c.InSync = false
-				l.changeMade()
+				l.TriggerSyncChanges()
 			})
 		}
 		return
@@ -453,7 +442,7 @@ func (l *State) UpdateCheck(id types.CheckID, status, output string) {
 	c.Check.Status = status
 	c.Check.Output = output
 	c.InSync = false
-	l.changeMade()
+	l.TriggerSyncChanges()
 }
 
 // Check returns the locally registered check that the
@@ -549,12 +538,12 @@ func (l *State) updateSyncState() error {
 	}
 
 	var out1 structs.IndexedNodeServices
-	if err := l.delegate.RPC("Catalog.NodeServices", &req, &out1); err != nil {
+	if err := l.Delegate.RPC("Catalog.NodeServices", &req, &out1); err != nil {
 		return err
 	}
 
 	var out2 structs.IndexedHealthChecks
-	if err := l.delegate.RPC("Health.NodeChecks", &req, &out2); err != nil {
+	if err := l.Delegate.RPC("Health.NodeChecks", &req, &out2); err != nil {
 		return err
 	}
 
@@ -605,8 +594,7 @@ func (l *State) updateSyncState() error {
 			continue
 		}
 
-		// If the service is scheduled for removal skip it.
-		// todo(fs): is this correct?
+		// If the service is already scheduled for removal skip it
 		if ls.Deleted {
 			continue
 		}
@@ -646,8 +634,7 @@ func (l *State) updateSyncState() error {
 			continue
 		}
 
-		// If the check is scheduled for removal skip it.
-		// todo(fs): is this correct?
+		// If the check is already scheduled for removal skip it.
 		if lc.Deleted {
 			continue
 		}
@@ -687,10 +674,13 @@ func (l *State) updateSyncState() error {
 func (l *State) SyncFull() error {
 	// note that we do not acquire the lock here since the methods
 	// we are calling will do that themself.
+	//
+	// Also note that we don't hold the lock for the entire operation
+	// but release it between the two calls. This is not an issue since
+	// the algorithm is best-effort to achieve eventual consistency.
+	// SyncChanges will sync whatever updateSyncState() has determined
+	// needs updating.
 
-	// todo(fs): is it an issue that we do not hold the lock for the entire time?
-	// todo(fs): IMO, this doesn't matter since SyncChanges will sync whatever
-	// todo(fs): was determined in the update step.
 	if err := l.updateSyncState(); err != nil {
 		return err
 	}
@@ -764,7 +754,7 @@ func (l *State) LoadMetadata(data map[string]string) error {
 	for k, v := range data {
 		l.metadata[k] = v
 	}
-	l.changeMade()
+	l.TriggerSyncChanges()
 	return nil
 }
 
@@ -815,19 +805,24 @@ func (l *State) deleteService(id string) error {
 		WriteRequest: structs.WriteRequest{Token: l.serviceToken(id)},
 	}
 	var out struct{}
-	err := l.delegate.RPC("Catalog.Deregister", &req, &out)
-	if err == nil || strings.Contains(err.Error(), "Unknown service") {
+	err := l.Delegate.RPC("Catalog.Deregister", &req, &out)
+	switch {
+	case err == nil || strings.Contains(err.Error(), "Unknown service"):
 		delete(l.services, id)
-		l.logger.Printf("[INFO] agent: Deregistered service '%s'", id)
+		l.logger.Printf("[INFO] agent: Deregistered service %q", id)
 		return nil
-	}
-	if acl.IsErrPermissionDenied(err) {
-		// todo(fs): why is the service in sync here?
+
+	case acl.IsErrPermissionDenied(err):
+		// todo(fs): mark the service to be in sync to prevent excessive retrying before next full sync
+		// todo(fs): some backoff strategy might be a better solution
 		l.services[id].InSync = true
-		l.logger.Printf("[WARN] agent: Service '%s' deregistration blocked by ACLs", id)
+		l.logger.Printf("[WARN] agent: Service %q deregistration blocked by ACLs", id)
 		return nil
+
+	default:
+		l.logger.Printf("[WARN] agent: Deregistering service %q failed. %s", id, err)
+		return err
 	}
-	return err
 }
 
 // deleteCheck is used to delete a check from the server
@@ -843,20 +838,28 @@ func (l *State) deleteCheck(id types.CheckID) error {
 		WriteRequest: structs.WriteRequest{Token: l.checkToken(id)},
 	}
 	var out struct{}
-	err := l.delegate.RPC("Catalog.Deregister", &req, &out)
-	if err == nil || strings.Contains(err.Error(), "Unknown check") {
-		// todo(fs): do we need to stop the deferCheck timer here?
+	err := l.Delegate.RPC("Catalog.Deregister", &req, &out)
+	switch {
+	case err == nil || strings.Contains(err.Error(), "Unknown check"):
+		c := l.checks[id]
+		if c != nil && c.DeferCheck != nil {
+			c.DeferCheck.Stop()
+		}
 		delete(l.checks, id)
-		l.logger.Printf("[INFO] agent: Deregistered check '%s'", id)
+		l.logger.Printf("[INFO] agent: Deregistered check %q", id)
 		return nil
-	}
-	if acl.IsErrPermissionDenied(err) {
-		// todo(fs): why is the check in sync here?
+
+	case acl.IsErrPermissionDenied(err):
+		// todo(fs): mark the check to be in sync to prevent excessive retrying before next full sync
+		// todo(fs): some backoff strategy might be a better solution
 		l.checks[id].InSync = true
-		l.logger.Printf("[WARN] agent: Check '%s' deregistration blocked by ACLs", id)
+		l.logger.Printf("[WARN] agent: Check %q deregistration blocked by ACLs", id)
 		return nil
+
+	default:
+		l.logger.Printf("[WARN] agent: Deregistering check %q failed. %s", id, err)
+		return err
 	}
-	return err
 }
 
 // syncService is used to sync a service to the server
@@ -900,8 +903,9 @@ func (l *State) syncService(id string) error {
 	}
 
 	var out struct{}
-	err := l.delegate.RPC("Catalog.Register", &req, &out)
-	if err == nil {
+	err := l.Delegate.RPC("Catalog.Register", &req, &out)
+	switch {
+	case err == nil:
 		l.services[id].InSync = true
 		// Given how the register API works, this info is also updated
 		// every time we sync a service.
@@ -909,20 +913,23 @@ func (l *State) syncService(id string) error {
 		for _, check := range checks {
 			l.checks[check.CheckID].InSync = true
 		}
-		l.logger.Printf("[INFO] agent: Synced service '%s'", id)
+		l.logger.Printf("[INFO] agent: Synced service %q", id)
 		return nil
-	}
-	if acl.IsErrPermissionDenied(err) {
-		// todo(fs): why are the service and the checks in sync here?
-		// todo(fs): why is the node info not in sync here?
+
+	case acl.IsErrPermissionDenied(err):
+		// todo(fs): mark the service and the checks to be in sync to prevent excessive retrying before next full sync
+		// todo(fs): some backoff strategy might be a better solution
 		l.services[id].InSync = true
 		for _, check := range checks {
 			l.checks[check.CheckID].InSync = true
 		}
-		l.logger.Printf("[WARN] agent: Service '%s' registration blocked by ACLs", id)
+		l.logger.Printf("[WARN] agent: Service %q registration blocked by ACLs", id)
 		return nil
+
+	default:
+		l.logger.Printf("[WARN] agent: Syncing service %q failed. %s", id, err)
+		return err
 	}
-	return err
 }
 
 // syncCheck is used to sync a check to the server
@@ -947,22 +954,27 @@ func (l *State) syncCheck(id types.CheckID) error {
 	}
 
 	var out struct{}
-	err := l.delegate.RPC("Catalog.Register", &req, &out)
-	if err == nil {
+	err := l.Delegate.RPC("Catalog.Register", &req, &out)
+	switch {
+	case err == nil:
 		l.checks[id].InSync = true
 		// Given how the register API works, this info is also updated
 		// every time we sync a check.
 		l.nodeInfoInSync = true
-		l.logger.Printf("[INFO] agent: Synced check '%s'", id)
+		l.logger.Printf("[INFO] agent: Synced check %q", id)
 		return nil
-	}
-	if acl.IsErrPermissionDenied(err) {
-		// todo(fs): why is the check in sync here?
+
+	case acl.IsErrPermissionDenied(err):
+		// todo(fs): mark the check to be in sync to prevent excessive retrying before next full sync
+		// todo(fs): some backoff strategy might be a better solution
 		l.checks[id].InSync = true
-		l.logger.Printf("[WARN] agent: Check '%s' registration blocked by ACLs", id)
+		l.logger.Printf("[WARN] agent: Check %q registration blocked by ACLs", id)
 		return nil
+
+	default:
+		l.logger.Printf("[WARN] agent: Syncing check %q failed. %s", id, err)
+		return err
 	}
-	return err
 }
 
 func (l *State) syncNodeInfo() error {
@@ -976,17 +988,22 @@ func (l *State) syncNodeInfo() error {
 		WriteRequest:    structs.WriteRequest{Token: l.tokens.AgentToken()},
 	}
 	var out struct{}
-	err := l.delegate.RPC("Catalog.Register", &req, &out)
-	if err == nil {
+	err := l.Delegate.RPC("Catalog.Register", &req, &out)
+	switch {
+	case err == nil:
 		l.nodeInfoInSync = true
 		l.logger.Printf("[INFO] agent: Synced node info")
 		return nil
-	}
-	if acl.IsErrPermissionDenied(err) {
-		// todo(fs): why is the node info in sync here?
+
+	case acl.IsErrPermissionDenied(err):
+		// todo(fs): mark the node info to be in sync to prevent excessive retrying before next full sync
+		// todo(fs): some backoff strategy might be a better solution
 		l.nodeInfoInSync = true
 		l.logger.Printf("[WARN] agent: Node info update blocked by ACLs")
 		return nil
+
+	default:
+		l.logger.Printf("[WARN] agent: Syncing node info failed. %s", err)
+		return err
 	}
-	return err
 }

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -525,6 +525,7 @@ func (l *State) CriticalCheckStates() map[types.CheckID]*CheckState {
 func (l *State) Metadata() map[string]string {
 	l.RLock()
 	defer l.RUnlock()
+
 	m := make(map[string]string)
 	for k, v := range l.metadata {
 		m[k] = v
@@ -535,7 +536,7 @@ func (l *State) Metadata() map[string]string {
 // updateSyncState does a read of the server state, and updates
 // the local sync status as appropriate
 func (l *State) updateSyncState() error {
-	// 1. get all checks and services from the master
+	// Get all checks and services from the master
 	req := structs.NodeSpecificRequest{
 		Datacenter:   l.config.Datacenter,
 		Node:         l.config.NodeName,
@@ -552,7 +553,7 @@ func (l *State) updateSyncState() error {
 		return err
 	}
 
-	// 2. create useful data structures for traversal
+	// Create useful data structures for traversal
 	remoteServices := make(map[string]*structs.NodeService)
 	if out1.NodeServices != nil {
 		remoteServices = out1.NodeServices.Services
@@ -563,12 +564,13 @@ func (l *State) updateSyncState() error {
 		remoteChecks[rc.CheckID] = rc
 	}
 
-	// 3. perform sync
+	// Traverse all checks, services and the node info to determine
+	// which entries need to be updated on or removed from the server
 
 	l.Lock()
 	defer l.Unlock()
 
-	// sync node info
+	// Check if node info needs syncing
 	if out1.NodeServices == nil || out1.NodeServices.Node == nil ||
 		out1.NodeServices.Node.ID != l.config.NodeID ||
 		!reflect.DeepEqual(out1.NodeServices.Node.TaggedAddresses, l.config.TaggedAddresses) ||
@@ -576,25 +578,30 @@ func (l *State) updateSyncState() error {
 		l.nodeInfoInSync = false
 	}
 
-	// sync services
+	// Check which services need syncing
 
-	// sync local services that do not exist remotely
+	// Look for local services that do not exist remotely and mark them for
+	// syncing so that they will be pushed to the server later
 	for id, s := range l.services {
 		if remoteServices[id] == nil {
 			s.InSync = false
 		}
 	}
 
+	// Traverse the list of services from the server.
+	// Remote services which do not exist locally have been deregistered.
+	// Otherwise, check whether the two definitions are still in sync.
 	for id, rs := range remoteServices {
-		// If we don't have the service locally, deregister it
 		ls := l.services[id]
 		if ls == nil {
-			// The consul service is created automatically and does
-			// not need to be deregistered.
+			// The consul service is managed automatically and does
+			// not need to be deregistered
 			if id == structs.ConsulServiceID {
 				continue
 			}
 
+			// Mark a remote service that does not exist locally as deleted so
+			// that it will be removed on the server later.
 			l.services[id] = &ServiceState{Deleted: true}
 			continue
 		}
@@ -614,19 +621,22 @@ func (l *State) updateSyncState() error {
 		ls.InSync = ls.Service.IsSame(rs)
 	}
 
-	// sync checks
+	// Check which checks need syncing
 
-	// sync local checks which do not exist remotely
+	// Look for local checks that do not exist remotely and mark them for
+	// syncing so that they will be pushed to the server later
 	for id, c := range l.checks {
 		if remoteChecks[id] == nil {
 			c.InSync = false
 		}
 	}
 
+	// Traverse the list of checks from the server.
+	// Remote checks which do not exist locally have been deregistered.
+	// Otherwise, check whether the two definitions are still in sync.
 	for id, rc := range remoteChecks {
 		lc := l.checks[id]
 
-		// If we don't have the check locally, deregister it
 		if lc == nil {
 			// The Serf check is created automatically and does not
 			// need to be deregistered.
@@ -635,6 +645,8 @@ func (l *State) updateSyncState() error {
 				continue
 			}
 
+			// Mark a remote check that does not exist locally as deleted so
+			// that it will be removed on the server later.
 			l.checks[id] = &CheckState{Deleted: true}
 			continue
 		}
@@ -692,8 +704,8 @@ func (l *State) SyncFull() error {
 	return l.SyncChanges()
 }
 
-// SyncChanges is used to scan the status our local services and checks
-// and update any that are out of sync with the server
+// SyncChanges pushes checks, services and node info data which has been
+// marked out of sync or deleted to the server.
 func (l *State) SyncChanges() error {
 	l.Lock()
 	defer l.Unlock()
@@ -703,6 +715,7 @@ func (l *State) SyncChanges() error {
 	// API works.
 
 	// Sync the services
+	// (logging happens in the helper methods)
 	for id, s := range l.services {
 		var err error
 		switch {
@@ -711,13 +724,15 @@ func (l *State) SyncChanges() error {
 		case !s.InSync:
 			err = l.syncService(id)
 		default:
-			l.logger.Printf("[DEBUG] agent: Service '%s' in sync", id)
+			l.logger.Printf("[DEBUG] agent: Service %q in sync", id)
 		}
 		if err != nil {
 			return err
 		}
 	}
 
+	// Sync the checks
+	// (logging happens in the helper methods)
 	for id, c := range l.checks {
 		var err error
 		switch {
@@ -730,7 +745,7 @@ func (l *State) SyncChanges() error {
 			}
 			err = l.syncCheck(id)
 		default:
-			l.logger.Printf("[DEBUG] agent: Check '%s' in sync", id)
+			l.logger.Printf("[DEBUG] agent: Check %q in sync", id)
 		}
 		if err != nil {
 			return err
@@ -739,15 +754,11 @@ func (l *State) SyncChanges() error {
 
 	// Now sync the node level info if we need to, and didn't do any of
 	// the other sync operations.
-	if !l.nodeInfoInSync {
-		if err := l.syncNodeInfo(); err != nil {
-			return err
-		}
-	} else {
+	if l.nodeInfoInSync {
 		l.logger.Printf("[DEBUG] agent: Node info in sync")
+		return nil
 	}
-
-	return nil
+	return l.syncNodeInfo()
 }
 
 // LoadMetadata loads node metadata fields from the agent config and

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1,11 +1,14 @@
-package local
+package local_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
@@ -16,7 +19,7 @@ import (
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
 	a.Start()
 	defer a.Shutdown()
 
@@ -35,7 +38,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 	args.Service = srv1
 	if err := a.RPC("Catalog.Register", args, &out); err != nil {
 		t.Fatalf("err: %v", err)
@@ -48,7 +51,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Tags:    []string{},
 		Port:    8000,
 	}
-	a.state.AddService(srv2, "")
+	a.State.AddService(srv2, "")
 
 	srv2_mod := new(structs.NodeService)
 	*srv2_mod = *srv2
@@ -65,7 +68,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Tags:    []string{},
 		Port:    80,
 	}
-	a.state.AddService(srv3, "")
+	a.State.AddService(srv3, "")
 
 	// Exists remote (delete)
 	srv4 := &structs.NodeService{
@@ -87,7 +90,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Address: "127.0.0.10",
 		Port:    8000,
 	}
-	a.state.AddService(srv5, "")
+	a.State.AddService(srv5, "")
 
 	srv5_mod := new(structs.NodeService)
 	*srv5_mod = *srv5
@@ -104,12 +107,10 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Tags:    []string{},
 		Port:    11211,
 	}
-	a.state.AddService(srv6, "")
-
-	// todo(fs): data race
-	a.state.Lock()
-	a.state.serviceStatus["cache"] = syncStatus{inSync: true}
-	a.state.Unlock()
+	a.State.AddServiceState(&local.ServiceState{
+		Service: srv6,
+		InSync:  true,
+	})
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -170,26 +171,13 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state
-		if len(a.state.services) != 5 {
-			r.Fatalf("bad: %v", a.state.services)
-		}
-		if len(a.state.serviceStatus) != 5 {
-			r.Fatalf("bad: %v", a.state.serviceStatus)
-		}
-		for name, status := range a.state.serviceStatus {
-			if !status.inSync {
-				r.Fatalf("should be in sync: %v %v", name, status)
-			}
+		if err := servicesInSync(a.State, 5); err != nil {
+			r.Fatal(err)
 		}
 	})
 
 	// Remove one of the services
-	a.state.RemoveService("api")
+	a.State.RemoveService("api")
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -231,28 +219,15 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state
-		if len(a.state.services) != 4 {
-			r.Fatalf("bad: %v", a.state.services)
-		}
-		if len(a.state.serviceStatus) != 4 {
-			r.Fatalf("bad: %v", a.state.serviceStatus)
-		}
-		for name, status := range a.state.serviceStatus {
-			if !status.inSync {
-				r.Fatalf("should be in sync: %v %v", name, status)
-			}
+		if err := servicesInSync(a.State, 4); err != nil {
+			r.Fatal(err)
 		}
 	})
 }
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
 	a.Start()
 	defer a.Shutdown()
 
@@ -271,7 +246,7 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 		Port:              6100,
 		EnableTagOverride: true,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 	srv1_mod := new(structs.NodeService)
 	*srv1_mod = *srv1
 	srv1_mod.Port = 7100
@@ -289,7 +264,7 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 		Port:              6200,
 		EnableTagOverride: false,
 	}
-	a.state.AddService(srv2, "")
+	a.State.AddService(srv2, "")
 	srv2_mod := new(structs.NodeService)
 	*srv2_mod = *srv2
 	srv2_mod.Port = 7200
@@ -314,8 +289,8 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 			r.Fatalf("err: %v", err)
 		}
 
-		a.state.RLock()
-		defer a.state.RUnlock()
+		a.State.RLock()
+		defer a.State.RUnlock()
 
 		// All the services should match
 		for id, serv := range services.NodeServices.Services {
@@ -342,21 +317,15 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		for name, status := range a.state.serviceStatus {
-			if !status.inSync {
-				r.Fatalf("should be in sync: %v %v", name, status)
-			}
+		if err := servicesInSync(a.State, 2); err != nil {
+			r.Fatal(err)
 		}
 	})
 }
 
 func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
 	{
@@ -367,7 +336,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 			Tags:    []string{"master"},
 			Port:    5000,
 		}
-		a.state.AddService(srv, "")
+		a.State.AddService(srv, "")
 
 		chk := &structs.HealthCheck{
 			Node:      a.Config.NodeName,
@@ -376,18 +345,22 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 			ServiceID: "mysql",
 			Status:    api.HealthPassing,
 		}
-		a.state.AddCheck(chk, "")
+		a.State.AddCheck(chk, "")
 
 		// todo(fs): data race
-		func() {
-			a.state.RLock()
-			defer a.state.RUnlock()
+		// func() {
+		// 	a.State.RLock()
+		// 	defer a.State.RUnlock()
 
-			// Sync the service once
-			if err := a.state.syncService("mysql"); err != nil {
-				t.Fatalf("err: %s", err)
-			}
-		}()
+		// 	// Sync the service once
+		// 	if err := a.State.syncService("mysql"); err != nil {
+		// 		t.Fatalf("err: %s", err)
+		// 	}
+		// }()
+		// todo(fs): is this correct?
+		if err := a.State.SyncChanges(); err != nil {
+			t.Fatal("sync failed: ", err)
+		}
 
 		// We should have 2 services (consul included)
 		svcReq := structs.NodeSpecificRequest{
@@ -424,7 +397,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 			Tags:    []string{"master"},
 			Port:    5000,
 		}
-		a.state.AddService(srv, "")
+		a.State.AddService(srv, "")
 
 		chk1 := &structs.HealthCheck{
 			Node:      a.Config.NodeName,
@@ -433,7 +406,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 			ServiceID: "redis",
 			Status:    api.HealthPassing,
 		}
-		a.state.AddCheck(chk1, "")
+		a.State.AddCheck(chk1, "")
 
 		chk2 := &structs.HealthCheck{
 			Node:      a.Config.NodeName,
@@ -442,18 +415,22 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 			ServiceID: "redis",
 			Status:    api.HealthPassing,
 		}
-		a.state.AddCheck(chk2, "")
+		a.State.AddCheck(chk2, "")
 
 		// todo(fs): data race
-		func() {
-			a.state.RLock()
-			defer a.state.RUnlock()
+		// func() {
+		// 	a.State.RLock()
+		// 	defer a.State.RUnlock()
 
-			// Sync the service once
-			if err := a.state.syncService("redis"); err != nil {
-				t.Fatalf("err: %s", err)
-			}
-		}()
+		// 	// Sync the service once
+		// 	if err := a.State.syncService("redis"); err != nil {
+		// 		t.Fatalf("err: %s", err)
+		// 	}
+		// }()
+		// todo(fs): is this correct?
+		if err := a.State.SyncChanges(); err != nil {
+			t.Fatal("sync failed: ", err)
+		}
 
 		// We should have 3 services (consul included)
 		svcReq := structs.NodeSpecificRequest{
@@ -499,7 +476,7 @@ var testRegisterRules = `
 
 func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), HCL: `
+	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
@@ -533,7 +510,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, token)
+	a.State.AddService(srv1, token)
 
 	// Create service (allowed)
 	srv2 := &structs.NodeService{
@@ -542,7 +519,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 		Tags:    []string{"foo"},
 		Port:    5001,
 	}
-	a.state.AddService(srv2, token)
+	a.State.AddService(srv2, token)
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -584,28 +561,13 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		func() {
-			a.state.RLock()
-			defer a.state.RUnlock()
-
-			// Check the local state
-			if len(a.state.services) != 2 {
-				t.Fatalf("bad: %v", a.state.services)
-			}
-			if len(a.state.serviceStatus) != 2 {
-				t.Fatalf("bad: %v", a.state.serviceStatus)
-			}
-			for name, status := range a.state.serviceStatus {
-				if !status.inSync {
-					t.Fatalf("should be in sync: %v %v", name, status)
-				}
-			}
-		}()
+		if err := servicesInSync(a.State, 2); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Now remove the service and re-sync
-	a.state.RemoveService("api")
+	a.State.RemoveService("api")
 	a.StartSync()
 	time.Sleep(200 * time.Millisecond)
 
@@ -643,35 +605,20 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		func() {
-			a.state.RLock()
-			defer a.state.RUnlock()
-
-			// Check the local state
-			if len(a.state.services) != 1 {
-				t.Fatalf("bad: %v", a.state.services)
-			}
-			if len(a.state.serviceStatus) != 1 {
-				t.Fatalf("bad: %v", a.state.serviceStatus)
-			}
-			for name, status := range a.state.serviceStatus {
-				if !status.inSync {
-					t.Fatalf("should be in sync: %v %v", name, status)
-				}
-			}
-		}()
+		if err := servicesInSync(a.State, 1); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// Make sure the token got cleaned up.
-	if token := a.state.ServiceToken("api"); token != "" {
+	if token := a.State.ServiceToken("api"); token != "" {
 		t.Fatalf("bad: %s", token)
 	}
 }
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
 	a.Start()
 	defer a.Shutdown()
 
@@ -690,7 +637,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		Name:    "mysql",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk1, "")
+	a.State.AddCheck(chk1, "")
 	args.Check = chk1
 	if err := a.RPC("Catalog.Register", args, &out); err != nil {
 		t.Fatalf("err: %v", err)
@@ -703,7 +650,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		Name:    "redis",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk2, "")
+	a.State.AddCheck(chk2, "")
 
 	chk2_mod := new(structs.HealthCheck)
 	*chk2_mod = *chk2
@@ -720,7 +667,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		Name:    "web",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk3, "")
+	a.State.AddCheck(chk3, "")
 
 	// Exists remote (delete)
 	chk4 := &structs.HealthCheck{
@@ -741,12 +688,10 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		Name:    "cache",
 		Status:  api.HealthPassing,
 	}
-	a.state.AddCheck(chk5, "")
-
-	// todo(fs): data race
-	a.state.Lock()
-	a.state.checkStatus["cache"] = syncStatus{inSync: true}
-	a.state.Unlock()
+	a.State.AddCheckState(&local.CheckState{
+		Check:  chk5,
+		InSync: true,
+	})
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -796,24 +741,9 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		}
 	})
 
-	// todo(fs): data race
-	func() {
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state
-		if len(a.state.checks) != 4 {
-			t.Fatalf("bad: %v", a.state.checks)
-		}
-		if len(a.state.checkStatus) != 4 {
-			t.Fatalf("bad: %v", a.state.checkStatus)
-		}
-		for name, status := range a.state.checkStatus {
-			if !status.inSync {
-				t.Fatalf("should be in sync: %v %v", name, status)
-			}
-		}
-	}()
+	if err := checksInSync(a.State, 4); err != nil {
+		t.Fatal(err)
+	}
 
 	// Make sure we sent along our node info addresses when we synced.
 	{
@@ -836,7 +766,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	}
 
 	// Remove one of the checks
-	a.state.RemoveCheck("redis")
+	a.State.RemoveCheck("redis")
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -876,29 +806,14 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		}
 	})
 
-	// todo(fs): data race
-	func() {
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state
-		if len(a.state.checks) != 3 {
-			t.Fatalf("bad: %v", a.state.checks)
-		}
-		if len(a.state.checkStatus) != 3 {
-			t.Fatalf("bad: %v", a.state.checkStatus)
-		}
-		for name, status := range a.state.checkStatus {
-			if !status.inSync {
-				t.Fatalf("should be in sync: %v %v", name, status)
-			}
-		}
-	}()
+	if err := checksInSync(a.State, 3); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), HCL: `
+	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
@@ -932,14 +847,14 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		Tags:    []string{"master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "root")
+	a.State.AddService(srv1, "root")
 	srv2 := &structs.NodeService{
 		ID:      "api",
 		Service: "api",
 		Tags:    []string{"foo"},
 		Port:    5001,
 	}
-	a.state.AddService(srv2, "root")
+	a.State.AddService(srv2, "root")
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -983,24 +898,9 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 			}
 		}
 
-		// todo(fs): data race
-		func() {
-			a.state.RLock()
-			defer a.state.RUnlock()
-
-			// Check the local state
-			if len(a.state.services) != 2 {
-				t.Fatalf("bad: %v", a.state.services)
-			}
-			if len(a.state.serviceStatus) != 2 {
-				t.Fatalf("bad: %v", a.state.serviceStatus)
-			}
-			for name, status := range a.state.serviceStatus {
-				if !status.inSync {
-					t.Fatalf("should be in sync: %v %v", name, status)
-				}
-			}
-		}()
+		if err := servicesInSync(a.State, 2); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	// This check won't be allowed.
@@ -1013,7 +913,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		Name:        "mysql",
 		Status:      api.HealthPassing,
 	}
-	a.state.AddCheck(chk1, token)
+	a.State.AddCheck(chk1, token)
 
 	// This one will be allowed.
 	chk2 := &structs.HealthCheck{
@@ -1025,7 +925,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		Name:        "api",
 		Status:      api.HealthPassing,
 	}
-	a.state.AddCheck(chk2, token)
+	a.State.AddCheck(chk2, token)
 
 	// Trigger anti-entropy run and wait.
 	a.StartSync()
@@ -1068,27 +968,12 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		}
 	})
 
-	// todo(fs): data race
-	func() {
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state.
-		if len(a.state.checks) != 2 {
-			t.Fatalf("bad: %v", a.state.checks)
-		}
-		if len(a.state.checkStatus) != 2 {
-			t.Fatalf("bad: %v", a.state.checkStatus)
-		}
-		for name, status := range a.state.checkStatus {
-			if !status.inSync {
-				t.Fatalf("should be in sync: %v %v", name, status)
-			}
-		}
-	}()
+	if err := checksInSync(a.State, 2); err != nil {
+		t.Fatal(err)
+	}
 
 	// Now delete the check and wait for sync.
-	a.state.RemoveCheck("api-check")
+	a.State.RemoveCheck("api-check")
 	a.StartSync()
 	time.Sleep(200 * time.Millisecond)
 	// Verify that we are in sync
@@ -1126,27 +1011,12 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		}
 	})
 
-	// todo(fs): data race
-	func() {
-		a.state.RLock()
-		defer a.state.RUnlock()
-
-		// Check the local state.
-		if len(a.state.checks) != 1 {
-			t.Fatalf("bad: %v", a.state.checks)
-		}
-		if len(a.state.checkStatus) != 1 {
-			t.Fatalf("bad: %v", a.state.checkStatus)
-		}
-		for name, status := range a.state.checkStatus {
-			if !status.inSync {
-				t.Fatalf("should be in sync: %v %v", name, status)
-			}
-		}
-	}()
+	if err := checksInSync(a.State, 1); err != nil {
+		t.Fatal(err)
+	}
 
 	// Make sure the token got cleaned up.
-	if token := a.state.CheckToken("api-check"); token != "" {
+	if token := a.State.CheckToken("api-check"); token != "" {
 		t.Fatalf("bad: %s", token)
 	}
 }
@@ -1203,7 +1073,7 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 
 func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	t.Parallel()
-	a := &TestAgent{Name: t.Name(), HCL: `
+	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		check_update_interval = "500ms"
 	`, NoInitialSync: true}
 	a.Start()
@@ -1217,7 +1087,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 		Status:  api.HealthPassing,
 		Output:  "",
 	}
-	a.state.AddCheck(check, "")
+	a.State.AddCheck(check, "")
 
 	// Trigger anti-entropy run and wait
 	a.StartSync()
@@ -1238,7 +1108,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	})
 
 	// Update the check output! Should be deferred
-	a.state.UpdateCheck("web", api.HealthPassing, "output")
+	a.State.UpdateCheck("web", api.HealthPassing, "output")
 
 	// Should not update for 500 milliseconds
 	time.Sleep(250 * time.Millisecond)
@@ -1337,7 +1207,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	}
 
 	// Now make an update that should be deferred.
-	a.state.UpdateCheck("web", api.HealthPassing, "deferred")
+	a.State.UpdateCheck("web", api.HealthPassing, "deferred")
 
 	// Trigger anti-entropy run and wait.
 	a.StartSync()
@@ -1381,7 +1251,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	nodeMeta := map[string]string{
 		"somekey": "somevalue",
 	}
-	a := &TestAgent{Name: t.Name(), HCL: `
+	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		node_id = "40e4a748-2192-161a-0510-9bf59fe950b5"
 		node_meta {
 			somekey = "somevalue"
@@ -1453,40 +1323,15 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	})
 }
 
-func TestAgentAntiEntropy_deleteService_fails(t *testing.T) {
-	t.Parallel()
-	l := new(localState)
-
-	// todo(fs): data race
-	l.Lock()
-	defer l.Unlock()
-	if err := l.deleteService(""); err == nil {
-		t.Fatalf("should have failed")
-	}
-}
-
-func TestAgentAntiEntropy_deleteCheck_fails(t *testing.T) {
-	t.Parallel()
-	l := new(localState)
-
-	// todo(fs): data race
-	l.Lock()
-	defer l.Unlock()
-	if err := l.deleteCheck(""); err == nil {
-		t.Fatalf("should have errored")
-	}
-}
-
 func TestAgent_serviceTokens(t *testing.T) {
 	t.Parallel()
 
+	cfg := agent.TestConfig()
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
+	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
 
-	l.AddService(&structs.NodeService{
-		ID: "redis",
-	}, "")
+	l.AddService(&structs.NodeService{ID: "redis"}, "")
 
 	// Returns default when no token is set
 	if token := l.ServiceToken("redis"); token != "default" {
@@ -1494,7 +1339,7 @@ func TestAgent_serviceTokens(t *testing.T) {
 	}
 
 	// Returns configured token
-	l.serviceTokens["redis"] = "abc123"
+	l.AddService(&structs.NodeService{ID: "redis"}, "abc123")
 	if token := l.ServiceToken("redis"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
@@ -1509,17 +1354,19 @@ func TestAgent_serviceTokens(t *testing.T) {
 func TestAgent_checkTokens(t *testing.T) {
 	t.Parallel()
 
+	cfg := agent.TestConfig()
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
+	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
 
 	// Returns default when no token is set
+	l.AddCheck(&structs.HealthCheck{CheckID: types.CheckID("mem")}, "")
 	if token := l.CheckToken("mem"); token != "default" {
 		t.Fatalf("bad: %s", token)
 	}
 
 	// Returns configured token
-	l.checkTokens["mem"] = "abc123"
+	l.AddCheck(&structs.HealthCheck{CheckID: types.CheckID("mem")}, "abc123")
 	if token := l.CheckToken("mem"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
@@ -1533,7 +1380,7 @@ func TestAgent_checkTokens(t *testing.T) {
 
 func TestAgent_checkCriticalTime(t *testing.T) {
 	t.Parallel()
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
+	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
 
 	svc := &structs.NodeService{ID: "redis", Service: "redis", Port: 8000}
 	l.AddService(svc, "")
@@ -1548,54 +1395,54 @@ func TestAgent_checkCriticalTime(t *testing.T) {
 		Status:    api.HealthPassing,
 	}
 	l.AddCheck(chk, "")
-	if checks := l.CriticalChecks(); len(checks) > 0 {
+	if checks := l.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have any critical checks")
 	}
 
 	// Set it to warning and make sure that doesn't show up as critical.
 	l.UpdateCheck(checkID, api.HealthWarning, "")
-	if checks := l.CriticalChecks(); len(checks) > 0 {
+	if checks := l.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have any critical checks")
 	}
 
 	// Fail the check and make sure the time looks reasonable.
 	l.UpdateCheck(checkID, api.HealthCritical, "")
-	if crit, ok := l.CriticalChecks()[checkID]; !ok {
+	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
-	} else if crit.CriticalFor > time.Millisecond {
-		t.Fatalf("bad: %#v", crit)
+	} else if c.CriticalFor() > time.Millisecond {
+		t.Fatalf("bad: %#v", c)
 	}
 
 	// Wait a while, then fail it again and make sure the time keeps track
 	// of the initial failure, and doesn't reset here.
 	time.Sleep(50 * time.Millisecond)
 	l.UpdateCheck(chk.CheckID, api.HealthCritical, "")
-	if crit, ok := l.CriticalChecks()[checkID]; !ok {
+	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
-	} else if crit.CriticalFor < 25*time.Millisecond ||
-		crit.CriticalFor > 75*time.Millisecond {
-		t.Fatalf("bad: %#v", crit)
+	} else if c.CriticalFor() < 25*time.Millisecond ||
+		c.CriticalFor() > 75*time.Millisecond {
+		t.Fatalf("bad: %#v", c)
 	}
 
 	// Set it passing again.
 	l.UpdateCheck(checkID, api.HealthPassing, "")
-	if checks := l.CriticalChecks(); len(checks) > 0 {
+	if checks := l.CriticalCheckStates(); len(checks) > 0 {
 		t.Fatalf("should not have any critical checks")
 	}
 
 	// Fail the check and make sure the time looks like it started again
 	// from the latest failure, not the original one.
 	l.UpdateCheck(checkID, api.HealthCritical, "")
-	if crit, ok := l.CriticalChecks()[checkID]; !ok {
+	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
-	} else if crit.CriticalFor > time.Millisecond {
-		t.Fatalf("bad: %#v", crit)
+	} else if c.CriticalFor() > time.Millisecond {
+		t.Fatalf("bad: %#v", c)
 	}
 }
 
 func TestAgent_AddCheckFailure(t *testing.T) {
 	t.Parallel()
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
+	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
 
 	// Add a check for a service that does not exist and verify that it fails
 	checkID := types.CheckID("redis:1")
@@ -1615,7 +1462,7 @@ func TestAgent_AddCheckFailure(t *testing.T) {
 
 func TestAgent_sendCoordinate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t.Name(), `
 		sync_coordinate_interval_min = "1ms"
 		sync_coordinate_rate_target = 10.0
 		consul = {
@@ -1648,4 +1495,30 @@ func TestAgent_sendCoordinate(t *testing.T) {
 			r.Fatalf("bad: %v", coord)
 		}
 	})
+}
+
+func servicesInSync(state *local.State, wantServices int) error {
+	services := state.ServiceStates()
+	if got, want := len(services), wantServices; got != want {
+		return fmt.Errorf("got %d services want %d", got, want)
+	}
+	for id, s := range services {
+		if !s.InSync {
+			return fmt.Errorf("service %q should be in sync", id)
+		}
+	}
+	return nil
+}
+
+func checksInSync(state *local.State, wantChecks int) error {
+	checks := state.CheckStates()
+	if got, want := len(checks), wantChecks; got != want {
+		return fmt.Errorf("got %d checks want %d", got, want)
+	}
+	for id, c := range checks {
+		if !c.InSync {
+			return fmt.Errorf("check %q should be in sync", id)
+		}
+	}
+	return nil
 }

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
@@ -20,7 +20,7 @@ import (
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
-	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
 
@@ -113,8 +113,9 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		InSync:  true,
 	})
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	var services structs.IndexedNodeServices
 	req := structs.NodeSpecificRequest{
@@ -180,8 +181,9 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 	// Remove one of the services
 	a.State.RemoveService("api")
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	retry.Run(t, func(r *retry.R) {
 		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
@@ -228,7 +230,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	t.Parallel()
-	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
 
@@ -275,8 +277,9 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	req := structs.NodeSpecificRequest{
 		Datacenter: "dc1",
@@ -348,18 +351,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 		}
 		a.State.AddCheck(chk, "")
 
-		// todo(fs): data race
-		// func() {
-		// 	a.State.RLock()
-		// 	defer a.State.RUnlock()
-
-		// 	// Sync the service once
-		// 	if err := a.State.syncService("mysql"); err != nil {
-		// 		t.Fatalf("err: %s", err)
-		// 	}
-		// }()
-		// todo(fs): is this correct?
-		if err := a.State.SyncChanges(); err != nil {
+		if err := a.State.SyncFull(); err != nil {
 			t.Fatal("sync failed: ", err)
 		}
 
@@ -418,18 +410,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 		}
 		a.State.AddCheck(chk2, "")
 
-		// todo(fs): data race
-		// func() {
-		// 	a.State.RLock()
-		// 	defer a.State.RUnlock()
-
-		// 	// Sync the service once
-		// 	if err := a.State.syncService("redis"); err != nil {
-		// 		t.Fatalf("err: %s", err)
-		// 	}
-		// }()
-		// todo(fs): is this correct?
-		if err := a.State.SyncChanges(); err != nil {
+		if err := a.State.SyncFull(); err != nil {
 			t.Fatal("sync failed: ", err)
 		}
 
@@ -522,9 +503,9 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 	}
 	a.State.AddService(srv2, token)
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	{
@@ -569,8 +550,9 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 	// Now remove the service and re-sync
 	a.State.RemoveService("api")
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	{
@@ -619,7 +601,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
-	a := &agent.TestAgent{Name: t.Name(), NoInitialSync: true}
+	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
 
@@ -694,8 +676,9 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		InSync: true,
 	})
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	req := structs.NodeSpecificRequest{
 		Datacenter: "dc1",
@@ -769,8 +752,9 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	// Remove one of the checks
 	a.State.RemoveCheck("redis")
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	retry.Run(t, func(r *retry.R) {
@@ -857,9 +841,9 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	}
 	a.State.AddService(srv2, "root")
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	{
@@ -928,9 +912,9 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	}
 	a.State.AddCheck(chk2, token)
 
-	// Trigger anti-entropy run and wait.
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	retry.Run(t, func(r *retry.R) {
@@ -975,8 +959,10 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 
 	// Now delete the check and wait for sync.
 	a.State.RemoveCheck("api-check")
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Verify that we are in sync
 	retry.Run(t, func(r *retry.R) {
 		req := structs.NodeSpecificRequest{
@@ -1090,8 +1076,9 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	}
 	a.State.AddCheck(check, "")
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that we are in sync
 	req := structs.NodeSpecificRequest{
@@ -1172,9 +1159,9 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 		}
 	}
 
-	// Trigger anti-entropy run and wait.
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that the output was synced back to the agent's value.
 	if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
@@ -1210,9 +1197,9 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	// Now make an update that should be deferred.
 	a.State.UpdateCheck("web", api.HealthPassing, "deferred")
 
-	// Trigger anti-entropy run and wait.
-	a.StartSync()
-	time.Sleep(200 * time.Millisecond)
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	// Verify that the output is still out of sync since there's a deferred
 	// update pending.
@@ -1272,8 +1259,9 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
 	req := structs.NodeSpecificRequest{
 		Datacenter: "dc1",
@@ -1304,8 +1292,10 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Trigger anti-entropy run and wait
-	a.StartSync()
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
 	// Wait for the sync - this should have been a sync of just the node info
 	retry.Run(t, func(r *retry.R) {
 		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1298,7 +1298,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	}
 }
 
-func TestAgent_serviceTokens(t *testing.T) {
+func TestAgent_ServiceTokens(t *testing.T) {
 	t.Parallel()
 
 	tokens := new(token.Store)
@@ -1326,7 +1326,7 @@ func TestAgent_serviceTokens(t *testing.T) {
 	}
 }
 
-func TestAgent_checkTokens(t *testing.T) {
+func TestAgent_CheckTokens(t *testing.T) {
 	t.Parallel()
 
 	tokens := new(token.Store)
@@ -1353,7 +1353,7 @@ func TestAgent_checkTokens(t *testing.T) {
 	}
 }
 
-func TestAgent_checkCriticalTime(t *testing.T) {
+func TestAgent_CheckCriticalTime(t *testing.T) {
 	t.Parallel()
 	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
 	l := local.NewState(lcfg, nil, new(token.Store), make(chan struct{}, 1))

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1,4 +1,4 @@
-package agent
+package local
 
 import (
 	"reflect"

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -123,60 +123,58 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Node:       a.Config.NodeName,
 	}
 
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// Make sure we sent along our node info when we synced.
-		id := services.NodeServices.Node.ID
-		addrs := services.NodeServices.Node.TaggedAddresses
-		meta := services.NodeServices.Node.Meta
-		delete(meta, structs.MetaSegmentKey) // Added later, not in config.
-		verify.Values(r, "node id", id, a.config.NodeID)
-		verify.Values(r, "tagged addrs", addrs, a.config.TaggedAddresses)
-		verify.Values(r, "node meta", meta, a.config.NodeMeta)
+	// Make sure we sent along our node info when we synced.
+	id := services.NodeServices.Node.ID
+	addrs := services.NodeServices.Node.TaggedAddresses
+	meta := services.NodeServices.Node.Meta
+	delete(meta, structs.MetaSegmentKey) // Added later, not in config.
+	verify.Values(t, "node id", id, a.Config.NodeID)
+	verify.Values(t, "tagged addrs", addrs, a.Config.TaggedAddresses)
+	verify.Values(t, "node meta", meta, a.Config.NodeMeta)
 
-		// We should have 6 services (consul included)
-		if len(services.NodeServices.Services) != 6 {
-			r.Fatalf("bad: %v", services.NodeServices.Services)
-		}
+	// We should have 6 services (consul included)
+	if len(services.NodeServices.Services) != 6 {
+		t.Fatalf("bad: %v", services.NodeServices.Services)
+	}
 
-		// All the services should match
-		for id, serv := range services.NodeServices.Services {
-			serv.CreateIndex, serv.ModifyIndex = 0, 0
-			switch id {
-			case "mysql":
-				if !reflect.DeepEqual(serv, srv1) {
-					r.Fatalf("bad: %v %v", serv, srv1)
-				}
-			case "redis":
-				if !reflect.DeepEqual(serv, srv2) {
-					r.Fatalf("bad: %#v %#v", serv, srv2)
-				}
-			case "web":
-				if !reflect.DeepEqual(serv, srv3) {
-					r.Fatalf("bad: %v %v", serv, srv3)
-				}
-			case "api":
-				if !reflect.DeepEqual(serv, srv5) {
-					r.Fatalf("bad: %v %v", serv, srv5)
-				}
-			case "cache":
-				if !reflect.DeepEqual(serv, srv6) {
-					r.Fatalf("bad: %v %v", serv, srv6)
-				}
-			case structs.ConsulServiceID:
-				// ignore
-			default:
-				r.Fatalf("unexpected service: %v", id)
+	// All the services should match
+	for id, serv := range services.NodeServices.Services {
+		serv.CreateIndex, serv.ModifyIndex = 0, 0
+		switch id {
+		case "mysql":
+			if !reflect.DeepEqual(serv, srv1) {
+				t.Fatalf("bad: %v %v", serv, srv1)
 			}
+		case "redis":
+			if !reflect.DeepEqual(serv, srv2) {
+				t.Fatalf("bad: %#v %#v", serv, srv2)
+			}
+		case "web":
+			if !reflect.DeepEqual(serv, srv3) {
+				t.Fatalf("bad: %v %v", serv, srv3)
+			}
+		case "api":
+			if !reflect.DeepEqual(serv, srv5) {
+				t.Fatalf("bad: %v %v", serv, srv5)
+			}
+		case "cache":
+			if !reflect.DeepEqual(serv, srv6) {
+				t.Fatalf("bad: %v %v", serv, srv6)
+			}
+		case structs.ConsulServiceID:
+			// ignore
+		default:
+			t.Fatalf("unexpected service: %v", id)
 		}
+	}
 
-		if err := servicesInSync(a.State, 5); err != nil {
-			r.Fatal(err)
-		}
-	})
+	if err := servicesInSync(a.State, 5); err != nil {
+		t.Fatal(err)
+	}
 
 	// Remove one of the services
 	a.State.RemoveService("api")
@@ -185,47 +183,45 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// We should have 5 services (consul included)
-		if len(services.NodeServices.Services) != 5 {
-			r.Fatalf("bad: %v", services.NodeServices.Services)
-		}
+	// We should have 5 services (consul included)
+	if len(services.NodeServices.Services) != 5 {
+		t.Fatalf("bad: %v", services.NodeServices.Services)
+	}
 
-		// All the services should match
-		for id, serv := range services.NodeServices.Services {
-			serv.CreateIndex, serv.ModifyIndex = 0, 0
-			switch id {
-			case "mysql":
-				if !reflect.DeepEqual(serv, srv1) {
-					r.Fatalf("bad: %v %v", serv, srv1)
-				}
-			case "redis":
-				if !reflect.DeepEqual(serv, srv2) {
-					r.Fatalf("bad: %#v %#v", serv, srv2)
-				}
-			case "web":
-				if !reflect.DeepEqual(serv, srv3) {
-					r.Fatalf("bad: %v %v", serv, srv3)
-				}
-			case "cache":
-				if !reflect.DeepEqual(serv, srv6) {
-					r.Fatalf("bad: %v %v", serv, srv6)
-				}
-			case structs.ConsulServiceID:
-				// ignore
-			default:
-				r.Fatalf("unexpected service: %v", id)
+	// All the services should match
+	for id, serv := range services.NodeServices.Services {
+		serv.CreateIndex, serv.ModifyIndex = 0, 0
+		switch id {
+		case "mysql":
+			if !reflect.DeepEqual(serv, srv1) {
+				t.Fatalf("bad: %v %v", serv, srv1)
 			}
+		case "redis":
+			if !reflect.DeepEqual(serv, srv2) {
+				t.Fatalf("bad: %#v %#v", serv, srv2)
+			}
+		case "web":
+			if !reflect.DeepEqual(serv, srv3) {
+				t.Fatalf("bad: %v %v", serv, srv3)
+			}
+		case "cache":
+			if !reflect.DeepEqual(serv, srv6) {
+				t.Fatalf("bad: %v %v", serv, srv6)
+			}
+		case structs.ConsulServiceID:
+			// ignore
+		default:
+			t.Fatalf("unexpected service: %v", id)
 		}
+	}
 
-		if err := servicesInSync(a.State, 4); err != nil {
-			r.Fatal(err)
-		}
-	})
+	if err := servicesInSync(a.State, 4); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
@@ -462,8 +458,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
-		acl_enforce_version_8 = true
-	`, NoInitialSync: true}
+		acl_enforce_version_8 = true`}
 	a.Start()
 	defer a.Shutdown()
 
@@ -687,43 +682,41 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	var checks structs.IndexedHealthChecks
 
 	// Verify that we are in sync
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// We should have 5 checks (serf included)
-		if len(checks.HealthChecks) != 5 {
-			r.Fatalf("bad: %v", checks)
-		}
+	// We should have 5 checks (serf included)
+	if len(checks.HealthChecks) != 5 {
+		t.Fatalf("bad: %v", checks)
+	}
 
-		// All the checks should match
-		for _, chk := range checks.HealthChecks {
-			chk.CreateIndex, chk.ModifyIndex = 0, 0
-			switch chk.CheckID {
-			case "mysql":
-				if !reflect.DeepEqual(chk, chk1) {
-					r.Fatalf("bad: %v %v", chk, chk1)
-				}
-			case "redis":
-				if !reflect.DeepEqual(chk, chk2) {
-					r.Fatalf("bad: %v %v", chk, chk2)
-				}
-			case "web":
-				if !reflect.DeepEqual(chk, chk3) {
-					r.Fatalf("bad: %v %v", chk, chk3)
-				}
-			case "cache":
-				if !reflect.DeepEqual(chk, chk5) {
-					r.Fatalf("bad: %v %v", chk, chk5)
-				}
-			case "serfHealth":
-				// ignore
-			default:
-				r.Fatalf("unexpected check: %v", chk)
+	// All the checks should match
+	for _, chk := range checks.HealthChecks {
+		chk.CreateIndex, chk.ModifyIndex = 0, 0
+		switch chk.CheckID {
+		case "mysql":
+			if !reflect.DeepEqual(chk, chk1) {
+				t.Fatalf("bad: %v %v", chk, chk1)
 			}
+		case "redis":
+			if !reflect.DeepEqual(chk, chk2) {
+				t.Fatalf("bad: %v %v", chk, chk2)
+			}
+		case "web":
+			if !reflect.DeepEqual(chk, chk3) {
+				t.Fatalf("bad: %v %v", chk, chk3)
+			}
+		case "cache":
+			if !reflect.DeepEqual(chk, chk5) {
+				t.Fatalf("bad: %v %v", chk, chk5)
+			}
+		case "serfHealth":
+			// ignore
+		default:
+			t.Fatalf("unexpected check: %v", chk)
 		}
-	})
+	}
 
 	if err := checksInSync(a.State, 4); err != nil {
 		t.Fatal(err)
@@ -744,9 +737,9 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		addrs := services.NodeServices.Node.TaggedAddresses
 		meta := services.NodeServices.Node.Meta
 		delete(meta, structs.MetaSegmentKey) // Added later, not in config.
-		verify.Values(t, "node id", id, a.config.NodeID)
-		verify.Values(t, "tagged addrs", addrs, a.config.TaggedAddresses)
-		verify.Values(t, "node meta", meta, a.config.NodeMeta)
+		verify.Values(t, "node id", id, a.Config.NodeID)
+		verify.Values(t, "tagged addrs", addrs, a.Config.TaggedAddresses)
+		verify.Values(t, "node meta", meta, a.Config.NodeMeta)
 	}
 
 	// Remove one of the checks
@@ -757,39 +750,37 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	}
 
 	// Verify that we are in sync
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// We should have 5 checks (serf included)
-		if len(checks.HealthChecks) != 4 {
-			r.Fatalf("bad: %v", checks)
-		}
+	// We should have 5 checks (serf included)
+	if len(checks.HealthChecks) != 4 {
+		t.Fatalf("bad: %v", checks)
+	}
 
-		// All the checks should match
-		for _, chk := range checks.HealthChecks {
-			chk.CreateIndex, chk.ModifyIndex = 0, 0
-			switch chk.CheckID {
-			case "mysql":
-				if !reflect.DeepEqual(chk, chk1) {
-					r.Fatalf("bad: %v %v", chk, chk1)
-				}
-			case "web":
-				if !reflect.DeepEqual(chk, chk3) {
-					r.Fatalf("bad: %v %v", chk, chk3)
-				}
-			case "cache":
-				if !reflect.DeepEqual(chk, chk5) {
-					r.Fatalf("bad: %v %v", chk, chk5)
-				}
-			case "serfHealth":
-				// ignore
-			default:
-				r.Fatalf("unexpected check: %v", chk)
+	// All the checks should match
+	for _, chk := range checks.HealthChecks {
+		chk.CreateIndex, chk.ModifyIndex = 0, 0
+		switch chk.CheckID {
+		case "mysql":
+			if !reflect.DeepEqual(chk, chk1) {
+				t.Fatalf("bad: %v %v", chk, chk1)
 			}
+		case "web":
+			if !reflect.DeepEqual(chk, chk3) {
+				t.Fatalf("bad: %v %v", chk, chk3)
+			}
+		case "cache":
+			if !reflect.DeepEqual(chk, chk5) {
+				t.Fatalf("bad: %v %v", chk, chk5)
+			}
+		case "serfHealth":
+			// ignore
+		default:
+			t.Fatalf("unexpected check: %v", chk)
 		}
-	})
+	}
 
 	if err := checksInSync(a.State, 3); err != nil {
 		t.Fatal(err)
@@ -802,8 +793,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
-		acl_enforce_version_8 = true
-	`, NoInitialSync: true}
+		acl_enforce_version_8 = true`}
 	a.Start()
 	defer a.Shutdown()
 
@@ -917,41 +907,39 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	}
 
 	// Verify that we are in sync
-	retry.Run(t, func(r *retry.R) {
-		req := structs.NodeSpecificRequest{
-			Datacenter: "dc1",
-			Node:       a.Config.NodeName,
-			QueryOptions: structs.QueryOptions{
-				Token: "root",
-			},
-		}
-		var checks structs.IndexedHealthChecks
-		if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	req := structs.NodeSpecificRequest{
+		Datacenter: "dc1",
+		Node:       a.Config.NodeName,
+		QueryOptions: structs.QueryOptions{
+			Token: "root",
+		},
+	}
+	var checks structs.IndexedHealthChecks
+	if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// We should have 2 checks (serf included)
-		if len(checks.HealthChecks) != 2 {
-			r.Fatalf("bad: %v", checks)
-		}
+	// We should have 2 checks (serf included)
+	if len(checks.HealthChecks) != 2 {
+		t.Fatalf("bad: %v", checks)
+	}
 
-		// All the checks should match
-		for _, chk := range checks.HealthChecks {
-			chk.CreateIndex, chk.ModifyIndex = 0, 0
-			switch chk.CheckID {
-			case "mysql-check":
-				t.Fatalf("should not be permitted")
-			case "api-check":
-				if !reflect.DeepEqual(chk, chk2) {
-					r.Fatalf("bad: %v %v", chk, chk2)
-				}
-			case "serfHealth":
-				// ignore
-			default:
-				r.Fatalf("unexpected check: %v", chk)
+	// All the checks should match
+	for _, chk := range checks.HealthChecks {
+		chk.CreateIndex, chk.ModifyIndex = 0, 0
+		switch chk.CheckID {
+		case "mysql-check":
+			t.Fatalf("should not be permitted")
+		case "api-check":
+			if !reflect.DeepEqual(chk, chk2) {
+				t.Fatalf("bad: %v %v", chk, chk2)
 			}
+		case "serfHealth":
+			// ignore
+		default:
+			t.Fatalf("unexpected check: %v", chk)
 		}
-	})
+	}
 
 	if err := checksInSync(a.State, 2); err != nil {
 		t.Fatal(err)
@@ -964,7 +952,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 	}
 
 	// Verify that we are in sync
-	retry.Run(t, func(r *retry.R) {
+	{
 		req := structs.NodeSpecificRequest{
 			Datacenter: "dc1",
 			Node:       a.Config.NodeName,
@@ -974,12 +962,12 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		}
 		var checks structs.IndexedHealthChecks
 		if err := a.RPC("Health.NodeChecks", &req, &checks); err != nil {
-			r.Fatalf("err: %v", err)
+			t.Fatalf("err: %v", err)
 		}
 
 		// We should have 1 check (just serf)
 		if len(checks.HealthChecks) != 1 {
-			r.Fatalf("bad: %v", checks)
+			t.Fatalf("bad: %v", checks)
 		}
 
 		// All the checks should match
@@ -987,16 +975,16 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 			chk.CreateIndex, chk.ModifyIndex = 0, 0
 			switch chk.CheckID {
 			case "mysql-check":
-				r.Fatalf("should not be permitted")
+				t.Fatalf("should not be permitted")
 			case "api-check":
-				r.Fatalf("should be deleted")
+				t.Fatalf("should be deleted")
 			case "serfHealth":
 				// ignore
 			default:
-				r.Fatalf("unexpected check: %v", chk)
+				t.Fatalf("unexpected check: %v", chk)
 			}
 		}
-	})
+	}
 
 	if err := checksInSync(a.State, 1); err != nil {
 		t.Fatal(err)
@@ -1062,7 +1050,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		check_update_interval = "500ms"
-	`, NoInitialSync: true}
+	`}
 	a.Start()
 	defer a.Shutdown()
 
@@ -1243,8 +1231,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		node_id = "40e4a748-2192-161a-0510-9bf59fe950b5"
 		node_meta {
 			somekey = "somevalue"
-		}
-	`, NoInitialSync: true}
+		}`}
 	a.Start()
 	defer a.Shutdown()
 
@@ -1268,24 +1255,21 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		Node:       a.Config.NodeName,
 	}
 	var services structs.IndexedNodeServices
-	// Wait for the sync
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
-		// Make sure we synced our node info - this should have ridden on the
-		// "consul" service sync
-		id := services.NodeServices.Node.ID
-		addrs := services.NodeServices.Node.TaggedAddresses
-		meta := services.NodeServices.Node.Meta
-		delete(meta, structs.MetaSegmentKey) // Added later, not in config.
-		if id != nodeID ||
-			!reflect.DeepEqual(addrs, a.config.TaggedAddresses) ||
-			!reflect.DeepEqual(meta, nodeMeta) {
-			r.Fatalf("bad: %v", services.NodeServices.Node)
-		}
-	})
+	// Make sure we synced our node info - this should have ridden on the
+	// "consul" service sync
+	id := services.NodeServices.Node.ID
+	addrs := services.NodeServices.Node.TaggedAddresses
+	meta := services.NodeServices.Node.Meta
+	delete(meta, structs.MetaSegmentKey) // Added later, not in config.
+	if id != a.Config.NodeID ||
+		!reflect.DeepEqual(addrs, a.Config.TaggedAddresses) ||
+		!reflect.DeepEqual(meta, a.Config.NodeMeta) {
+		t.Fatalf("bad: %v", services.NodeServices.Node)
+	}
 
 	// Blow away the catalog version of the node info
 	if err := a.RPC("Catalog.Register", args, &out); err != nil {
@@ -1297,30 +1281,30 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 	}
 
 	// Wait for the sync - this should have been a sync of just the node info
-	retry.Run(t, func(r *retry.R) {
-		if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
-			r.Fatalf("err: %v", err)
-		}
+	if err := a.RPC("Catalog.NodeServices", &req, &services); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 
+	{
 		id := services.NodeServices.Node.ID
 		addrs := services.NodeServices.Node.TaggedAddresses
 		meta := services.NodeServices.Node.Meta
 		delete(meta, structs.MetaSegmentKey) // Added later, not in config.
 		if id != nodeID ||
-			!reflect.DeepEqual(addrs, a.config.TaggedAddresses) ||
+			!reflect.DeepEqual(addrs, a.Config.TaggedAddresses) ||
 			!reflect.DeepEqual(meta, nodeMeta) {
-			r.Fatalf("bad: %v", services.NodeServices.Node)
+			t.Fatalf("bad: %v", services.NodeServices.Node)
 		}
-	})
+	}
 }
 
 func TestAgent_serviceTokens(t *testing.T) {
 	t.Parallel()
 
-	cfg := agent.TestConfig()
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
+	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
+	l := local.NewState(lcfg, nil, tokens, make(chan struct{}, 1))
 
 	l.AddService(&structs.NodeService{ID: "redis"}, "")
 
@@ -1345,10 +1329,10 @@ func TestAgent_serviceTokens(t *testing.T) {
 func TestAgent_checkTokens(t *testing.T) {
 	t.Parallel()
 
-	cfg := agent.TestConfig()
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
+	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
+	l := local.NewState(lcfg, nil, tokens, make(chan struct{}, 1))
 
 	// Returns default when no token is set
 	l.AddCheck(&structs.HealthCheck{CheckID: types.CheckID("mem")}, "")
@@ -1371,7 +1355,8 @@ func TestAgent_checkTokens(t *testing.T) {
 
 func TestAgent_checkCriticalTime(t *testing.T) {
 	t.Parallel()
-	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
+	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
+	l := local.NewState(lcfg, nil, new(token.Store), make(chan struct{}, 1))
 
 	svc := &structs.NodeService{ID: "redis", Service: "redis", Port: 8000}
 	l.AddService(svc, "")
@@ -1433,7 +1418,8 @@ func TestAgent_checkCriticalTime(t *testing.T) {
 
 func TestAgent_AddCheckFailure(t *testing.T) {
 	t.Parallel()
-	l := local.NewState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
+	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
+	l := local.NewState(lcfg, nil, new(token.Store), make(chan struct{}, 1))
 
 	// Add a check for a service that does not exist and verify that it fails
 	checkID := types.CheckID("redis:1")
@@ -1465,8 +1451,10 @@ func TestAgent_sendCoordinate(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	t.Logf("%d %d %s", a.consulConfig().CoordinateUpdateBatchSize, a.consulConfig().CoordinateUpdateMaxBatches,
-		a.consulConfig().CoordinateUpdatePeriod.String())
+	t.Logf("%d %d %s",
+		a.Config.ConsulCoordinateUpdateBatchSize,
+		a.Config.ConsulCoordinateUpdateMaxBatches,
+		a.Config.ConsulCoordinateUpdatePeriod.String())
 
 	// Make sure the coordinate is present.
 	req := structs.DCSpecificRequest{

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1011,16 +1011,18 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 
 func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t.Name(), `
 		discard_check_output = true
 		check_update_interval = "0s" # set to "0s" since otherwise output checks are deferred
 	`)
 	defer a.Shutdown()
 
 	inSync := func(id string) bool {
-		a.state.Lock()
-		defer a.state.Unlock()
-		return a.state.checkStatus[types.CheckID(id)].inSync
+		s := a.State.CheckState(types.CheckID(id))
+		if s == nil {
+			return false
+		}
+		return s.InSync
 	}
 
 	// register a check
@@ -1031,7 +1033,7 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 		Status:  api.HealthPassing,
 		Output:  "first output",
 	}
-	if err := a.state.AddCheck(check, ""); err != nil {
+	if err := a.State.AddCheck(check, ""); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
 
@@ -1045,15 +1047,15 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 
 	// update the check with the same status but different output
 	// and the check should still be in sync.
-	a.state.UpdateCheck(check.CheckID, api.HealthPassing, "second output")
+	a.State.UpdateCheck(check.CheckID, api.HealthPassing, "second output")
 	if !inSync("web") {
 		t.Fatal("check should be in sync")
 	}
 
 	// disable discarding of check output and update the check again with different
 	// output. Then the check should be out of sync.
-	a.state.SetDiscardCheckOutput(false)
-	a.state.UpdateCheck(check.CheckID, api.HealthPassing, "third output")
+	a.State.SetDiscardCheckOutput(false)
+	a.State.UpdateCheck(check.CheckID, api.HealthPassing, "third output")
 	if inSync("web") {
 		t.Fatal("check should be out of sync")
 	}
@@ -1316,8 +1318,9 @@ func TestAgent_ServiceTokens(t *testing.T) {
 
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
-	l := local.NewState(lcfg, nil, tokens, make(chan struct{}, 1))
+	cfg := config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`)
+	l := local.NewState(agent.LocalConfig(cfg), nil, tokens)
+	l.TriggerSyncChanges = func() {}
 
 	l.AddService(&structs.NodeService{ID: "redis"}, "")
 
@@ -1344,8 +1347,9 @@ func TestAgent_CheckTokens(t *testing.T) {
 
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
-	l := local.NewState(lcfg, nil, tokens, make(chan struct{}, 1))
+	cfg := config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`)
+	l := local.NewState(agent.LocalConfig(cfg), nil, tokens)
+	l.TriggerSyncChanges = func() {}
 
 	// Returns default when no token is set
 	l.AddCheck(&structs.HealthCheck{CheckID: types.CheckID("mem")}, "")
@@ -1368,8 +1372,9 @@ func TestAgent_CheckTokens(t *testing.T) {
 
 func TestAgent_CheckCriticalTime(t *testing.T) {
 	t.Parallel()
-	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
-	l := local.NewState(lcfg, nil, new(token.Store), make(chan struct{}, 1))
+	cfg := config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`)
+	l := local.NewState(agent.LocalConfig(cfg), nil, new(token.Store))
+	l.TriggerSyncChanges = func() {}
 
 	svc := &structs.NodeService{ID: "redis", Service: "redis", Port: 8000}
 	l.AddService(svc, "")
@@ -1431,8 +1436,9 @@ func TestAgent_CheckCriticalTime(t *testing.T) {
 
 func TestAgent_AddCheckFailure(t *testing.T) {
 	t.Parallel()
-	lcfg := agent.LocalConfig(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`))
-	l := local.NewState(lcfg, nil, new(token.Store), make(chan struct{}, 1))
+	cfg := config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`)
+	l := local.NewState(agent.LocalConfig(cfg), nil, new(token.Store))
+	l.TriggerSyncChanges = func() {}
 
 	// Add a check for a service that does not exist and verify that it fails
 	checkID := types.CheckID("redis:1")

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1,6 +1,7 @@
 package local_test
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -1453,11 +1454,10 @@ func TestAgent_AddCheckFailure(t *testing.T) {
 		ServiceID: "redis",
 		Status:    api.HealthPassing,
 	}
-	expectedErr := "ServiceID \"redis\" does not exist"
-	if err := l.AddCheck(chk, ""); err == nil || expectedErr != err.Error() {
-		t.Fatalf("Expected error when adding a check for a non-existent service but got %v", err)
+	wantErr := errors.New(`Check "redis:1" refers to non-existent service "redis"`)
+	if got, want := l.AddCheck(chk, ""), wantErr; !reflect.DeepEqual(got, want) {
+		t.Fatalf("got error %q want %q", got, want)
 	}
-
 }
 
 func TestAgent_sendCoordinate(t *testing.T) {

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -246,6 +246,9 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 		EnableTagOverride: true,
 	}
 	a.State.AddService(srv1, "")
+	if err := a.State.SyncChanges(); err != nil {
+		t.Fatalf("err: %v", err)
+	}
 	srv1_mod := new(structs.NodeService)
 	*srv1_mod = *srv1
 	srv1_mod.Port = 7100

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1272,8 +1272,6 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Make sure we synced our node info - this should have ridden on the
-	// "consul" service sync
 	id := services.NodeServices.Node.ID
 	addrs := services.NodeServices.Node.TaggedAddresses
 	meta := services.NodeServices.Node.Meta

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -108,7 +108,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 		Tags:    []string{},
 		Port:    11211,
 	}
-	a.State.AddServiceState(&local.ServiceState{
+	a.State.SetServiceState(&local.ServiceState{
 		Service: srv6,
 		InSync:  true,
 	})
@@ -679,7 +679,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 		Name:    "cache",
 		Status:  api.HealthPassing,
 	}
-	a.State.AddCheckState(&local.CheckState{
+	a.State.SetCheckState(&local.CheckState{
 		Check:  chk5,
 		InSync: true,
 	})

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1036,14 +1036,12 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 	if err := a.State.AddCheck(check, ""); err != nil {
 		t.Fatalf("bad: %s", err)
 	}
-
-	// wait until the check is in sync
-	retry.Run(t, func(r *retry.R) {
-		if inSync("web") {
-			return
-		}
-		r.FailNow()
-	})
+	if err := a.State.SyncFull(); err != nil {
+		t.Fatal("bad: %s", err)
+	}
+	if !inSync("web") {
+		t.Fatal("check should be in sync")
+	}
 
 	// update the check with the same status but different output
 	// and the check should still be in sync.

--- a/agent/local_test.go
+++ b/agent/local_test.go
@@ -1482,7 +1482,7 @@ func TestAgent_serviceTokens(t *testing.T) {
 
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens)
+	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
 
 	l.AddService(&structs.NodeService{
 		ID: "redis",
@@ -1511,7 +1511,7 @@ func TestAgent_checkTokens(t *testing.T) {
 
 	tokens := new(token.Store)
 	tokens.UpdateUserToken("default")
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens)
+	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, tokens, make(chan struct{}, 1))
 
 	// Returns default when no token is set
 	if token := l.CheckToken("mem"); token != "default" {
@@ -1533,7 +1533,7 @@ func TestAgent_checkTokens(t *testing.T) {
 
 func TestAgent_checkCriticalTime(t *testing.T) {
 	t.Parallel()
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store))
+	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
 
 	svc := &structs.NodeService{ID: "redis", Service: "redis", Port: 8000}
 	l.AddService(svc, "")
@@ -1595,7 +1595,7 @@ func TestAgent_checkCriticalTime(t *testing.T) {
 
 func TestAgent_AddCheckFailure(t *testing.T) {
 	t.Parallel()
-	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store))
+	l := NewLocalState(config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`), nil, new(token.Store), make(chan struct{}, 1))
 
 	// Add a check for a service that does not exist and verify that it fails
 	checkID := types.CheckID("redis:1")
@@ -1611,38 +1611,6 @@ func TestAgent_AddCheckFailure(t *testing.T) {
 		t.Fatalf("Expected error when adding a check for a non-existent service but got %v", err)
 	}
 
-}
-
-func TestAgent_nestedPauseResume(t *testing.T) {
-	t.Parallel()
-	l := new(localState)
-	if l.isPaused() != false {
-		t.Fatal("localState should be unPaused after init")
-	}
-	l.Pause()
-	if l.isPaused() != true {
-		t.Fatal("localState should be Paused after first call to Pause()")
-	}
-	l.Pause()
-	if l.isPaused() != true {
-		t.Fatal("localState should STILL be Paused after second call to Pause()")
-	}
-	l.Resume()
-	if l.isPaused() != true {
-		t.Fatal("localState should STILL be Paused after FIRST call to Resume()")
-	}
-	l.Resume()
-	if l.isPaused() != false {
-		t.Fatal("localState should NOT be Paused after SECOND call to Resume()")
-	}
-
-	defer func() {
-		err := recover()
-		if err == nil {
-			t.Fatal("unbalanced Resume() should cause a panic()")
-		}
-	}()
-	l.Resume()
 }
 
 func TestAgent_sendCoordinate(t *testing.T) {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -65,10 +65,6 @@ type TestAgent struct {
 	// Key is the optional encryption key for the LAN and WAN keyring.
 	Key string
 
-	// NoInitialSync determines whether an anti-entropy run
-	// will be scheduled after the agent started.
-	NoInitialSync bool
-
 	// dns is a reference to the first started DNS endpoint.
 	// It is valid after Start().
 	dns *DNSServer
@@ -175,9 +171,9 @@ func (a *TestAgent) Start() *TestAgent {
 			}
 		}
 	}
-	if !a.NoInitialSync {
-		a.Agent.StartSync()
-	}
+
+	// Start the anti-entropy syncer
+	a.Agent.StartSync()
 
 	var out structs.IndexedNodes
 	retry.Run(&panicFailer{}, func(r *retry.R) {
@@ -200,7 +196,7 @@ func (a *TestAgent) Start() *TestAgent {
 				r.Fatal(a.Name, "No leader")
 			}
 			if out.Index == 0 {
-				r.Fatal(a.Name, "Consul index is 0")
+				r.Fatal(a.Name, ": Consul index is 0")
 			}
 		} else {
 			req, _ := http.NewRequest("GET", "/v1/agent/self", nil)

--- a/agent/user_event.go
+++ b/agent/user_event.go
@@ -173,7 +173,7 @@ func (a *Agent) shouldProcessUserEvent(msg *UserEvent) bool {
 		}
 
 		// Scan for a match
-		services := a.state.Services()
+		services := a.State.Services()
 		found := false
 	OUTER:
 		for name, info := range services {

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -57,7 +57,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 		Tags:    []string{"test", "foo", "bar", "master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 
 	p := &UserEvent{}
 	if !a.shouldProcessUserEvent(p) {
@@ -157,7 +157,7 @@ func TestFireReceiveEvent(t *testing.T) {
 		Tags:    []string{"test", "foo", "bar", "master"},
 		Port:    5000,
 	}
-	a.state.AddService(srv1, "")
+	a.State.AddService(srv1, "")
 
 	p1 := &UserEvent{Name: "deploy", ServiceFilter: "web"}
 	err := a.UserEvent("dc1", "root", p1)

--- a/agent/util.go
+++ b/agent/util.go
@@ -4,26 +4,14 @@ import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
-	"math"
 	"os"
 	"os/exec"
 	"os/signal"
 	osuser "os/user"
 	"strconv"
-	"time"
 
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-msgpack/codec"
-)
-
-const (
-	// This scale factor means we will add a minute after we cross 128 nodes,
-	// another at 256, another at 512, etc. By 8192 nodes, we will scale up
-	// by a factor of 8.
-	//
-	// If you update this, you may need to adjust the tuning of
-	// CoordinateUpdatePeriod and CoordinateUpdateMaxBatchSize.
-	aeScaleThreshold = 128
 )
 
 // msgpackHandle is a shared handle for encoding/decoding of
@@ -31,18 +19,6 @@ const (
 var msgpackHandle = &codec.MsgpackHandle{
 	RawToString: true,
 	WriteExt:    true,
-}
-
-// aeScale is used to scale the time interval at which anti-entropy updates take
-// place. It is used to prevent saturation as the cluster size grows.
-func aeScale(interval time.Duration, n int) time.Duration {
-	// Don't scale until we cross the threshold
-	if n <= aeScaleThreshold {
-		return interval
-	}
-
-	multiplier := math.Ceil(math.Log2(float64(n))-math.Log2(aeScaleThreshold)) + 1.0
-	return time.Duration(multiplier) * interval
 }
 
 // decodeMsgPack is used to decode a MsgPack encoded object

--- a/agent/util_test.go
+++ b/agent/util_test.go
@@ -4,27 +4,9 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/consul/testutil"
 )
-
-func TestAEScale(t *testing.T) {
-	t.Parallel()
-	intv := time.Minute
-	if v := aeScale(intv, 100); v != intv {
-		t.Fatalf("Bad: %v", v)
-	}
-	if v := aeScale(intv, 200); v != 2*intv {
-		t.Fatalf("Bad: %v", v)
-	}
-	if v := aeScale(intv, 1000); v != 4*intv {
-		t.Fatalf("Bad: %v", v)
-	}
-	if v := aeScale(intv, 10000); v != 8*intv {
-		t.Fatalf("Bad: %v", v)
-	}
-}
 
 func TestStringHash(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This patch decouples the local state and the anti-entropy code from the agent and from each other to have cleaner separation of concerns and to ensure that data structures are properly locked.