### PR TITLE
Fix bug with unused (replaced with "") CONSUL_HTTP_AUTH in some places

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -462,6 +462,10 @@ func NewClient(config *Config) (*Client, error) {
 		config.Address = parts[1]
 	}
 
+	if config.Token == "" {
+		config.Token = defConfig.Token
+	}
+	
 	client := &Client{
 		config: *config,
 	}


### PR DESCRIPTION
example: https://github.com/hashicorp/consul/blob/master/watch/plan.go#L26

	conf := consulapi.DefaultConfig()
	conf.Address = address
	conf.Datacenter = p.Datacenter
	conf.Token = p.Token                             # <-- replace Token from DefaultConfig/CONSUL_HTTP_AUTH with "" if no "-token"
	client, err := consulapi.NewClient(conf)

how to reproduce bug:
0. consul -> localhost:8500 with more than 0 service checks
1. deny all for anonymous token
2. create appropriate acl <token> for watch checks (agent:read + node:read,service:read)
3. bash:
CONSUL_HTTP_AUTH=<token> consul watch -http-addr=localhost:8500 -type=checks # --> return []
consul watch -http-addr=localhost:8500 -type=checks -token=<token> # -> return { .... right json result .... }