### PR TITLE
acl: consolidate error handling

### DIFF
--- a/acl/errors.go
+++ b/acl/errors.go
@@ -1,0 +1,67 @@
+package acl
+
+import (
+	"errors"
+	"strings"
+)
+
+// These error constants define the standard ACL error types. The values
+// must not be changed since the error values are sent via RPC calls
+// from older clients and may not have the correct type.
+const (
+	errNotFound         = "ACL not found"
+	errRootDenied       = "Cannot resolve root ACL"
+	errDisabled         = "ACL support disabled"
+	errPermissionDenied = "Permission denied"
+)
+
+var (
+	// ErrNotFound indicates there is no matching ACL.
+	ErrNotFound = errors.New(errNotFound)
+
+	// ErrRootDenied is returned when attempting to resolve a root ACL.
+	ErrRootDenied = errors.New(errRootDenied)
+
+	// ErrDisabled is returned when ACL changes are not permitted since
+	// they are disabled.
+	ErrDisabled = errors.New(errDisabled)
+
+	// ErrPermissionDenied is returned when an ACL based rejection
+	// happens.
+	ErrPermissionDenied = PermissionDeniedError{}
+)
+
+// IsErrNotFound checks if the given error message is comparable to
+// ErrNotFound.
+func IsErrNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errNotFound)
+}
+
+// IsErrRootDenied checks if the given error messge is comparable to
+// ErrRootDenied.
+func IsErrRootDenied(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errRootDenied)
+}
+
+// IsErrDisabled checks if the given error message is comparable to
+// ErrDisabled.
+func IsErrDisabled(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errDisabled)
+}
+
+// IsErrPermissionDenied checks if the given error message is comparable
+// to ErrPermissionDenied.
+func IsErrPermissionDenied(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errPermissionDenied)
+}
+
+type PermissionDeniedError struct {
+	Cause string
+}
+
+func (e PermissionDeniedError) Error() string {
+	if e.Cause != "" {
+		return errPermissionDenied + ": " + e.Cause
+	}
+	return errPermissionDenied
+}

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -1,9 +1,7 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,20 +18,7 @@ import (
 // consul/acl.go. We may refactor some of the caching logic in the future,
 // but for now we are developing this separately to see how things shake out.
 
-// These must be kept in sync with the constants in consul/acl.go.
 const (
-	// aclNotFound indicates there is no matching ACL.
-	aclNotFound = "ACL not found"
-
-	// rootDenied is returned when attempting to resolve a root ACL.
-	rootDenied = "Cannot resolve root ACL"
-
-	// permissionDenied is returned when an ACL based rejection happens.
-	permissionDenied = "Permission denied"
-
-	// aclDisabled is returned when ACL changes are not permitted since they
-	// are disabled.
-	aclDisabled = "ACL support disabled"
 
 	// anonymousToken is the token ID we re-write to if there is no token ID
 	// provided.
@@ -42,8 +27,6 @@ const (
 	// Maximum number of cached ACL entries.
 	aclCacheSize = 10 * 1024
 )
-
-var errPermissionDenied = errors.New(permissionDenied)
 
 // aclCacheEntry is used to cache ACL tokens.
 type aclCacheEntry struct {
@@ -148,7 +131,7 @@ func (m *aclManager) lookupACL(a *Agent, id string) (acl.ACL, error) {
 	if len(id) == 0 {
 		id = anonymousToken
 	} else if acl.RootACL(id) != nil {
-		return nil, errors.New(rootDenied)
+		return nil, acl.ErrRootDenied
 	} else if a.tokens.IsAgentMasterToken(id) {
 		return m.master, nil
 	}
@@ -176,14 +159,14 @@ func (m *aclManager) lookupACL(a *Agent, id string) (acl.ACL, error) {
 	var reply structs.ACLPolicy
 	err := a.RPC("ACL.GetPolicy", &args, &reply)
 	if err != nil {
-		if strings.Contains(err.Error(), aclDisabled) {
+		if acl.IsErrDisabled(err) {
 			a.logger.Printf("[DEBUG] agent: ACLs disabled on servers, will check again after %s", a.config.ACLDisabledTTL)
 			m.disabledLock.Lock()
 			m.disabled = time.Now().Add(a.config.ACLDisabledTTL)
 			m.disabledLock.Unlock()
 			return nil, nil
-		} else if strings.Contains(err.Error(), aclNotFound) {
-			return nil, errors.New(aclNotFound)
+		} else if acl.IsErrNotFound(err) {
+			return nil, acl.ErrNotFound
 		} else {
 			a.logger.Printf("[DEBUG] agent: Failed to get policy for ACL from servers: %v", err)
 			if m.down != nil {
@@ -259,24 +242,24 @@ func (a *Agent) resolveToken(id string) (acl.ACL, error) {
 // the given token.
 func (a *Agent) vetServiceRegister(token string, service *structs.NodeService) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
 	// Vet the service itself.
-	if !acl.ServiceWrite(service.Service) {
-		return errPermissionDenied
+	if !rule.ServiceWrite(service.Service) {
+		return acl.ErrPermissionDenied
 	}
 
 	// Vet any service that might be getting overwritten.
 	services := a.state.Services()
 	if existing, ok := services[service.ID]; ok {
-		if !acl.ServiceWrite(existing.Service) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(existing.Service) {
+			return acl.ErrPermissionDenied
 		}
 	}
 
@@ -287,19 +270,19 @@ func (a *Agent) vetServiceRegister(token string, service *structs.NodeService) e
 // token.
 func (a *Agent) vetServiceUpdate(token string, serviceID string) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
 	// Vet any changes based on the existing services's info.
 	services := a.state.Services()
 	if existing, ok := services[serviceID]; ok {
-		if !acl.ServiceWrite(existing.Service) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(existing.Service) {
+			return acl.ErrPermissionDenied
 		}
 	} else {
 		return fmt.Errorf("Unknown service %q", serviceID)
@@ -312,22 +295,22 @@ func (a *Agent) vetServiceUpdate(token string, serviceID string) error {
 // given token.
 func (a *Agent) vetCheckRegister(token string, check *structs.HealthCheck) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
 	// Vet the check itself.
 	if len(check.ServiceName) > 0 {
-		if !acl.ServiceWrite(check.ServiceName) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(check.ServiceName) {
+			return acl.ErrPermissionDenied
 		}
 	} else {
-		if !acl.NodeWrite(a.config.NodeName) {
-			return errPermissionDenied
+		if !rule.NodeWrite(a.config.NodeName) {
+			return acl.ErrPermissionDenied
 		}
 	}
 
@@ -335,12 +318,12 @@ func (a *Agent) vetCheckRegister(token string, check *structs.HealthCheck) error
 	checks := a.state.Checks()
 	if existing, ok := checks[check.CheckID]; ok {
 		if len(existing.ServiceName) > 0 {
-			if !acl.ServiceWrite(existing.ServiceName) {
-				return errPermissionDenied
+			if !rule.ServiceWrite(existing.ServiceName) {
+				return acl.ErrPermissionDenied
 			}
 		} else {
-			if !acl.NodeWrite(a.config.NodeName) {
-				return errPermissionDenied
+			if !rule.NodeWrite(a.config.NodeName) {
+				return acl.ErrPermissionDenied
 			}
 		}
 	}
@@ -351,11 +334,11 @@ func (a *Agent) vetCheckRegister(token string, check *structs.HealthCheck) error
 // vetCheckUpdate makes sure that a check update is allowed by the given token.
 func (a *Agent) vetCheckUpdate(token string, checkID types.CheckID) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
@@ -363,12 +346,12 @@ func (a *Agent) vetCheckUpdate(token string, checkID types.CheckID) error {
 	checks := a.state.Checks()
 	if existing, ok := checks[checkID]; ok {
 		if len(existing.ServiceName) > 0 {
-			if !acl.ServiceWrite(existing.ServiceName) {
-				return errPermissionDenied
+			if !rule.ServiceWrite(existing.ServiceName) {
+				return acl.ErrPermissionDenied
 			}
 		} else {
-			if !acl.NodeWrite(a.config.NodeName) {
-				return errPermissionDenied
+			if !rule.NodeWrite(a.config.NodeName) {
+				return acl.ErrPermissionDenied
 			}
 		}
 	} else {
@@ -381,11 +364,11 @@ func (a *Agent) vetCheckUpdate(token string, checkID types.CheckID) error {
 // filterMembers redacts members that the token doesn't have access to.
 func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
@@ -393,7 +376,7 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 	m := *members
 	for i := 0; i < len(m); i++ {
 		node := m[i].Name
-		if acl.NodeRead(node) {
+		if rule.NodeRead(node) {
 			continue
 		}
 		a.logger.Printf("[DEBUG] agent: dropping node %q from result due to ACLs", node)
@@ -407,17 +390,17 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 // filterServices redacts services that the token doesn't have access to.
 func (a *Agent) filterServices(token string, services *map[string]*structs.NodeService) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
 	// Filter out services based on the service policy.
 	for id, service := range *services {
-		if acl.ServiceRead(service.Service) {
+		if rule.ServiceRead(service.Service) {
 			continue
 		}
 		a.logger.Printf("[DEBUG] agent: dropping service %q from result due to ACLs", id)
@@ -429,22 +412,22 @@ func (a *Agent) filterServices(token string, services *map[string]*structs.NodeS
 // filterChecks redacts checks that the token doesn't have access to.
 func (a *Agent) filterChecks(token string, checks *map[types.CheckID]*structs.HealthCheck) error {
 	// Resolve the token and bail if ACLs aren't enabled.
-	acl, err := a.resolveToken(token)
+	rule, err := a.resolveToken(token)
 	if err != nil {
 		return err
 	}
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
 	// Filter out checks based on the node or service policy.
 	for id, check := range *checks {
 		if len(check.ServiceName) > 0 {
-			if acl.ServiceRead(check.ServiceName) {
+			if rule.ServiceRead(check.ServiceName) {
 				continue
 			}
 		} else {
-			if acl.NodeRead(a.config.NodeName) {
+			if rule.NodeRead(a.config.NodeName) {
 				continue
 			}
 		}

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -37,7 +38,9 @@ func (s *HTTPServer) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (
 	if err != nil {
 		if strings.Contains(err.Error(), structs.ACLBootstrapNotAllowedErr.Error()) {
 			resp.WriteHeader(http.StatusForbidden)
-			fmt.Fprintf(resp, "Permission denied: %v", err)
+			// todo(fs): my guess is that "Permission denied" is a magic value therefore we should use the error type
+			// fmt.Fprintf(resp, "Permission denied: %v", err)
+			fmt.Fprint(resp, acl.PermissionDeniedError{Cause: err.Error()}.Error())
 			return nil, nil
 		} else {
 			return nil, err
@@ -158,7 +161,7 @@ func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (inte
 	// Bail if the ACL is not found, this could be a 404 or a 403, so
 	// always just return a 403.
 	if len(out.ACLs) == 0 {
-		return nil, errPermissionDenied
+		return nil, acl.ErrPermissionDenied
 	}
 
 	// Create a new ACL

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -38,8 +38,6 @@ func (s *HTTPServer) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (
 	if err != nil {
 		if strings.Contains(err.Error(), structs.ACLBootstrapNotAllowedErr.Error()) {
 			resp.WriteHeader(http.StatusForbidden)
-			// todo(fs): my guess is that "Permission denied" is a magic value therefore we should use the error type
-			// fmt.Fprintf(resp, "Permission denied: %v", err)
 			fmt.Fprint(resp, acl.PermissionDeniedError{Cause: err.Error()}.Error())
 			return nil, nil
 		} else {

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -173,7 +174,7 @@ func TestACL_Clone(t *testing.T) {
 	req, _ := http.NewRequest("PUT", "/v1/acl/clone/"+id, nil)
 	resp := httptest.NewRecorder()
 	_, err := a.srv.ACLClone(resp, req)
-	if !isPermissionDenied(err) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -73,7 +72,7 @@ func TestACL_Disabled(t *testing.T) {
 	m := MockServer{
 		// Fetch a token without ACLs enabled and make sure the manager sees it.
 		getPolicyFn: func(*structs.ACLPolicyRequest, *structs.ACLPolicy) error {
-			return errors.New(aclDisabled)
+			return rawacl.ErrDisabled
 		},
 	}
 	if err := a.registerEndpoint("ACL", &m); err != nil {
@@ -93,7 +92,7 @@ func TestACL_Disabled(t *testing.T) {
 	// Now turn on ACLs and check right away, it should still think ACLs are
 	// disabled since we don't check again right away.
 	m.getPolicyFn = func(*structs.ACLPolicyRequest, *structs.ACLPolicy) error {
-		return errors.New(aclNotFound)
+		return rawacl.ErrNotFound
 	}
 	if token, err := a.resolveToken("nope"); token != nil || err != nil {
 		t.Fatalf("bad: %v err: %v", token, err)
@@ -107,7 +106,7 @@ func TestACL_Disabled(t *testing.T) {
 	time.Sleep(2 * cfg.ACLDisabledTTL)
 	for i := 0; i < 10; i++ {
 		_, err := a.resolveToken("nope")
-		if err == nil || !strings.Contains(err.Error(), aclNotFound) {
+		if !rawacl.IsErrNotFound(err) {
 			t.Fatalf("err: %v", err)
 		}
 		if a.acls.isDisabled() {
@@ -130,14 +129,14 @@ func TestACL_Special_IDs(t *testing.T) {
 			if req.ACL != "anonymous" {
 				t.Fatalf("bad: %#v", *req)
 			}
-			return errors.New(aclNotFound)
+			return rawacl.ErrNotFound
 		},
 	}
 	if err := a.registerEndpoint("ACL", &m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	_, err := a.resolveToken("")
-	if err == nil || !strings.Contains(err.Error(), aclNotFound) {
+	if !rawacl.IsErrNotFound(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -147,7 +146,7 @@ func TestACL_Special_IDs(t *testing.T) {
 		return nil
 	}
 	_, err = a.resolveToken("deny")
-	if err == nil || !strings.Contains(err.Error(), rootDenied) {
+	if !rawacl.IsErrRootDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -346,20 +345,20 @@ func TestACL_Cache(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	acl, err := a.resolveToken("yep")
+	rule, err := a.resolveToken("yep")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if acl == nil {
+	if rule == nil {
 		t.Fatalf("should not be nil")
 	}
-	if !acl.AgentRead(cfg.NodeName) {
+	if !rule.AgentRead(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if acl.AgentWrite(cfg.NodeName) {
+	if rule.AgentWrite(cfg.NodeName) {
 		t.Fatalf("should deny")
 	}
-	if acl.NodeRead("nope") {
+	if rule.NodeRead("nope") {
 		t.Fatalf("should deny")
 	}
 
@@ -368,20 +367,20 @@ func TestACL_Cache(t *testing.T) {
 		t.Fatalf("should not have called to server")
 		return nil
 	}
-	acl, err = a.resolveToken("yep")
+	rule, err = a.resolveToken("yep")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if acl == nil {
+	if rule == nil {
 		t.Fatalf("should not be nil")
 	}
-	if !acl.AgentRead(cfg.NodeName) {
+	if !rule.AgentRead(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if acl.AgentWrite(cfg.NodeName) {
+	if rule.AgentWrite(cfg.NodeName) {
 		t.Fatalf("should deny")
 	}
-	if acl.NodeRead("nope") {
+	if rule.NodeRead("nope") {
 		t.Fatalf("should deny")
 	}
 
@@ -389,10 +388,10 @@ func TestACL_Cache(t *testing.T) {
 	// gone.
 	time.Sleep(20 * time.Millisecond)
 	m.getPolicyFn = func(req *structs.ACLPolicyRequest, reply *structs.ACLPolicy) error {
-		return errors.New(aclNotFound)
+		return rawacl.ErrNotFound
 	}
 	_, err = a.resolveToken("yep")
-	if err == nil || !strings.Contains(err.Error(), aclNotFound) {
+	if !rawacl.IsErrNotFound(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -413,20 +412,20 @@ func TestACL_Cache(t *testing.T) {
 		}
 		return nil
 	}
-	acl, err = a.resolveToken("yep")
+	rule, err = a.resolveToken("yep")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if acl == nil {
+	if rule == nil {
 		t.Fatalf("should not be nil")
 	}
-	if !acl.AgentRead(cfg.NodeName) {
+	if !rule.AgentRead(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if !acl.AgentWrite(cfg.NodeName) {
+	if !rule.AgentWrite(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if acl.NodeRead("nope") {
+	if rule.NodeRead("nope") {
 		t.Fatalf("should deny")
 	}
 
@@ -443,20 +442,20 @@ func TestACL_Cache(t *testing.T) {
 		didRefresh = true
 		return nil
 	}
-	acl, err = a.resolveToken("yep")
+	rule, err = a.resolveToken("yep")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if acl == nil {
+	if rule == nil {
 		t.Fatalf("should not be nil")
 	}
-	if !acl.AgentRead(cfg.NodeName) {
+	if !rule.AgentRead(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if !acl.AgentWrite(cfg.NodeName) {
+	if !rule.AgentWrite(cfg.NodeName) {
 		t.Fatalf("should allow")
 	}
-	if acl.NodeRead("nope") {
+	if rule.NodeRead("nope") {
 		t.Fatalf("should deny")
 	}
 	if !didRefresh {
@@ -525,7 +524,7 @@ func TestACL_vetServiceRegister(t *testing.T) {
 		ID:      "my-service",
 		Service: "service",
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -539,7 +538,7 @@ func TestACL_vetServiceRegister(t *testing.T) {
 		ID:      "my-service",
 		Service: "service",
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -575,7 +574,7 @@ func TestACL_vetServiceUpdate(t *testing.T) {
 
 	// Update without write privs.
 	err = a.vetServiceUpdate("service-ro", "my-service")
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -609,7 +608,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 		ServiceID:   "my-service",
 		ServiceName: "service",
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -625,7 +624,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 	err = a.vetCheckRegister("node-ro", &structs.HealthCheck{
 		CheckID: types.CheckID("my-check"),
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -645,7 +644,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 		ServiceID:   "my-service",
 		ServiceName: "service",
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -658,7 +657,7 @@ func TestACL_vetCheckRegister(t *testing.T) {
 		ServiceID:   "my-service",
 		ServiceName: "service",
 	})
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -699,7 +698,7 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 
 	// Update service check without write privs.
 	err = a.vetCheckUpdate("service-ro", "my-service-check")
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -714,7 +713,7 @@ func TestACL_vetCheckUpdate(t *testing.T) {
 
 	// Update without write privs.
 	err = a.vetCheckUpdate("node-ro", "my-node-check")
-	if !isPermissionDenied(err) {
+	if !rawacl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/systemd"
@@ -1195,7 +1196,7 @@ func (a *Agent) sendCoordinate() {
 			}
 			var reply struct{}
 			if err := a.RPC("Coordinate.Update", &req, &reply); err != nil {
-				if strings.Contains(err.Error(), permissionDenied) {
+				if acl.IsErrPermissionDenied(err) {
 					a.logger.Printf("[WARN] agent: Coordinate update blocked by ACLs")
 				} else {
 					a.logger.Printf("[ERR] agent: Coordinate update error: %v", err)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/logger"
@@ -218,7 +219,7 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
-		if _, err := a.srv.AgentSelf(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentSelf(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -246,7 +247,7 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/metrics", nil)
-		if _, err := a.srv.AgentSelf(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentSelf(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -321,7 +322,7 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/reload", nil)
-		if _, err := a.srv.AgentReload(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentReload(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -329,7 +330,7 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 	t.Run("read-only token", func(t *testing.T) {
 		ro := makeReadOnlyAgentACL(t, a.srv)
 		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/reload?token=%s", ro), nil)
-		if _, err := a.srv.AgentReload(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentReload(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -477,7 +478,7 @@ func TestAgent_Join_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/join/%s", addr), nil)
-		if _, err := a1.srv.AgentJoin(nil, req); !isPermissionDenied(err) {
+		if _, err := a1.srv.AgentJoin(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -493,7 +494,7 @@ func TestAgent_Join_ACLDeny(t *testing.T) {
 	t.Run("read-only token", func(t *testing.T) {
 		ro := makeReadOnlyAgentACL(t, a1.srv)
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/join/%s?token=%s", addr, ro), nil)
-		if _, err := a1.srv.AgentJoin(nil, req); !isPermissionDenied(err) {
+		if _, err := a1.srv.AgentJoin(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -573,7 +574,7 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/leave", nil)
-		if _, err := a.srv.AgentLeave(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentLeave(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -581,7 +582,7 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 	t.Run("read-only token", func(t *testing.T) {
 		ro := makeReadOnlyAgentACL(t, a.srv)
 		req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/leave?token=%s", ro), nil)
-		if _, err := a.srv.AgentLeave(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentLeave(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -637,7 +638,7 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/force-leave/nope", nil)
-		if _, err := a.srv.AgentForceLeave(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentForceLeave(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -652,7 +653,7 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 	t.Run("read-only token", func(t *testing.T) {
 		ro := makeReadOnlyAgentACL(t, a.srv)
 		req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/agent/force-leave/nope?token=%s", ro), nil)
-		if _, err := a.srv.AgentForceLeave(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentForceLeave(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -768,7 +769,7 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/check/register", jsonReader(args))
-		if _, err := a.srv.AgentRegisterCheck(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentRegisterCheck(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -819,7 +820,7 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/check/deregister/test", nil)
-		if _, err := a.srv.AgentDeregisterCheck(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentDeregisterCheck(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -872,7 +873,7 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/check/pass/test", nil)
-		if _, err := a.srv.AgentCheckPass(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentCheckPass(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -925,7 +926,7 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/check/warn/test", nil)
-		if _, err := a.srv.AgentCheckWarn(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentCheckWarn(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -978,7 +979,7 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/check/fail/test", nil)
-		if _, err := a.srv.AgentCheckFail(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentCheckFail(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1104,7 +1105,7 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 	t.Run("no token", func(t *testing.T) {
 		args := checkUpdate{api.HealthPassing, "hello-passing"}
 		req, _ := http.NewRequest("PUT", "/v1/agent/check/update/test", jsonReader(args))
-		if _, err := a.srv.AgentCheckUpdate(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentCheckUpdate(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1194,7 +1195,7 @@ func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/service/register", jsonReader(args))
-		if _, err := a.srv.AgentRegisterService(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentRegisterService(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1282,7 +1283,7 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/v1/agent/service/deregister/test", nil)
-		if _, err := a.srv.AgentDeregisterService(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentDeregisterService(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1439,7 +1440,7 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/maintenance/test?enable=true&reason=broken", nil)
-		if _, err := a.srv.AgentServiceMaintenance(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentServiceMaintenance(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1541,7 +1542,7 @@ func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 
 	t.Run("no token", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/self/maintenance?enable=true&reason=broken", nil)
-		if _, err := a.srv.AgentNodeMaintenance(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentNodeMaintenance(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	})
@@ -1673,7 +1674,7 @@ func TestAgent_Monitor_ACLDeny(t *testing.T) {
 
 	// Try without a token.
 	req, _ := http.NewRequest("GET", "/v1/agent/monitor", nil)
-	if _, err := a.srv.AgentMonitor(nil, req); !isPermissionDenied(err) {
+	if _, err := a.srv.AgentMonitor(nil, req); !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -1836,7 +1837,7 @@ func TestAgent_Token(t *testing.T) {
 	t.Run("permission denied", func(t *testing.T) {
 		resetTokens(tokens{})
 		req, _ := http.NewRequest("PUT", "/v1/agent/token/acl_token", body("X"))
-		if _, err := a.srv.AgentToken(nil, req); !isPermissionDenied(err) {
+		if _, err := a.srv.AgentToken(nil, req); !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 		if got, want := a.tokens.UserToken(), ""; got != want {

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1,11 +1,9 @@
 package consul
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -16,19 +14,6 @@ import (
 
 // These must be kept in sync with the constants in command/agent/acl.go.
 const (
-	// aclNotFound indicates there is no matching ACL.
-	aclNotFound = "ACL not found"
-
-	// rootDenied is returned when attempting to resolve a root ACL.
-	rootDenied = "Cannot resolve root ACL"
-
-	// permissionDenied is returned when an ACL based rejection happens.
-	permissionDenied = "Permission denied"
-
-	// aclDisabled is returned when ACL changes are not permitted since they
-	// are disabled.
-	aclDisabled = "ACL support disabled"
-
 	// anonymousToken is the token ID we re-write to if there is no token ID
 	// provided.
 	anonymousToken = "anonymous"
@@ -40,8 +25,6 @@ const (
 	// Maximum number of cached ACL entries.
 	aclCacheSize = 10 * 1024
 )
-
-var errPermissionDenied = errors.New(permissionDenied)
 
 // aclCacheEntry is used to cache non-authoritative ACLs
 // If non-authoritative, then we must respect a TTL
@@ -60,22 +43,22 @@ func (s *Server) aclLocalFault(id string) (string, string, error) {
 
 	// Query the state store.
 	state := s.fsm.State()
-	_, acl, err := state.ACLGet(nil, id)
+	_, rule, err := state.ACLGet(nil, id)
 	if err != nil {
 		return "", "", err
 	}
-	if acl == nil {
-		return "", "", errors.New(aclNotFound)
+	if rule == nil {
+		return "", "", acl.ErrNotFound
 	}
 
 	// Management tokens have no policy and inherit from the 'manage' root
 	// policy.
-	if acl.Type == structs.ACLTypeManagement {
+	if rule.Type == structs.ACLTypeManagement {
 		return "manage", "", nil
 	}
 
 	// Otherwise use the default policy.
-	return s.config.ACLDefaultPolicy, acl.Rules, nil
+	return s.config.ACLDefaultPolicy, rule.Rules, nil
 }
 
 // resolveToken is the primary interface used by ACL-checkers (such as an
@@ -95,7 +78,7 @@ func (s *Server) resolveToken(id string) (acl.ACL, error) {
 	if len(id) == 0 {
 		id = anonymousToken
 	} else if acl.RootACL(id) != nil {
-		return nil, errors.New(rootDenied)
+		return nil, acl.ErrRootDenied
 	}
 
 	// Check if we are the ACL datacenter and the leader, use the
@@ -189,8 +172,8 @@ func (c *aclCache) lookupACL(id, authDC string) (acl.ACL, error) {
 
 	// Check for not-found, which will cause us to bail immediately. For any
 	// other error we report it in the logs but can continue.
-	if strings.Contains(err.Error(), aclNotFound) {
-		return nil, errors.New(aclNotFound)
+	if acl.IsErrNotFound(err) {
+		return nil, acl.ErrNotFound
 	}
 	c.logger.Printf("[ERR] consul.acl: Failed to get policy from ACL datacenter: %v", err)
 
@@ -656,10 +639,10 @@ func (s *Server) filterACL(token string, subj interface{}) error {
 // address this race better (even then it would be super rare, and would at
 // worst let a service update revert a recent node update, so it doesn't open up
 // too much abuse).
-func vetRegisterWithACL(acl acl.ACL, subj *structs.RegisterRequest,
+func vetRegisterWithACL(rule acl.ACL, subj *structs.RegisterRequest,
 	ns *structs.NodeServices) error {
 	// Fast path if ACLs are not enabled.
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
@@ -667,22 +650,22 @@ func vetRegisterWithACL(acl acl.ACL, subj *structs.RegisterRequest,
 	// node info for each request without having to have node "write"
 	// privileges.
 	needsNode := ns == nil || subj.ChangesNode(ns.Node)
-	if needsNode && !acl.NodeWrite(subj.Node) {
-		return errPermissionDenied
+	if needsNode && !rule.NodeWrite(subj.Node) {
+		return acl.ErrPermissionDenied
 	}
 
 	// Vet the service change. This includes making sure they can register
 	// the given service, and that we can write to any existing service that
 	// is being modified by id (if any).
 	if subj.Service != nil {
-		if !acl.ServiceWrite(subj.Service.Service) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(subj.Service.Service) {
+			return acl.ErrPermissionDenied
 		}
 
 		if ns != nil {
 			other, ok := ns.Services[subj.Service.ID]
-			if ok && !acl.ServiceWrite(other.Service) {
-				return errPermissionDenied
+			if ok && !rule.ServiceWrite(other.Service) {
+				return acl.ErrPermissionDenied
 			}
 		}
 	}
@@ -710,8 +693,8 @@ func vetRegisterWithACL(acl acl.ACL, subj *structs.RegisterRequest,
 
 		// Node-level check.
 		if check.ServiceID == "" {
-			if !acl.NodeWrite(subj.Node) {
-				return errPermissionDenied
+			if !rule.NodeWrite(subj.Node) {
+				return acl.ErrPermissionDenied
 			}
 			continue
 		}
@@ -735,8 +718,8 @@ func vetRegisterWithACL(acl acl.ACL, subj *structs.RegisterRequest,
 			return fmt.Errorf("Unknown service '%s' for check '%s'", check.ServiceID, check.CheckID)
 		}
 
-		if !acl.ServiceWrite(other.Service) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(other.Service) {
+			return acl.ErrPermissionDenied
 		}
 	}
 
@@ -748,10 +731,10 @@ func vetRegisterWithACL(acl acl.ACL, subj *structs.RegisterRequest,
 // dynamic, this is a pretty complex algorithm and was worth breaking out of the
 // endpoint. The NodeService for the referenced service must be supplied, and can
 // be nil; similar for the HealthCheck for the referenced health check.
-func vetDeregisterWithACL(acl acl.ACL, subj *structs.DeregisterRequest,
+func vetDeregisterWithACL(rule acl.ACL, subj *structs.DeregisterRequest,
 	ns *structs.NodeService, nc *structs.HealthCheck) error {
 	// Fast path if ACLs are not enabled.
-	if acl == nil {
+	if rule == nil {
 		return nil
 	}
 
@@ -762,25 +745,25 @@ func vetDeregisterWithACL(acl acl.ACL, subj *structs.DeregisterRequest,
 		if ns == nil {
 			return fmt.Errorf("Unknown service '%s'", subj.ServiceID)
 		}
-		if !acl.ServiceWrite(ns.Service) {
-			return errPermissionDenied
+		if !rule.ServiceWrite(ns.Service) {
+			return acl.ErrPermissionDenied
 		}
 	} else if subj.CheckID != "" {
 		if nc == nil {
 			return fmt.Errorf("Unknown check '%s'", subj.CheckID)
 		}
 		if nc.ServiceID != "" {
-			if !acl.ServiceWrite(nc.ServiceName) {
-				return errPermissionDenied
+			if !rule.ServiceWrite(nc.ServiceName) {
+				return acl.ErrPermissionDenied
 			}
 		} else {
-			if !acl.NodeWrite(subj.Node) {
-				return errPermissionDenied
+			if !rule.NodeWrite(subj.Node) {
+				return acl.ErrPermissionDenied
 			}
 		}
 	} else {
-		if !acl.NodeWrite(subj.Node) {
-			return errPermissionDenied
+		if !rule.NodeWrite(subj.Node) {
+			return acl.ErrPermissionDenied
 		}
 	}
 

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -26,7 +26,7 @@ func (a *ACL) Bootstrap(args *structs.DCSpecificRequest, reply *structs.ACL) err
 
 	// Verify we are allowed to serve this request
 	if a.srv.config.ACLDatacenter != a.srv.config.Datacenter {
-		return fmt.Errorf(aclDisabled)
+		return acl.ErrDisabled
 	}
 
 	// By doing some pre-checks we can head off later bootstrap attempts
@@ -103,7 +103,7 @@ func aclApplyInternal(srv *Server, args *structs.ACLRequest, reply *string) erro
 
 		// Verify this is not a root ACL
 		if acl.RootACL(args.ACL.ID) != nil {
-			return fmt.Errorf("%s: Cannot modify root ACL", permissionDenied)
+			return acl.PermissionDeniedError{Cause: "Cannot modify root ACL"}
 		}
 
 		// Validate the rules compile
@@ -114,7 +114,7 @@ func aclApplyInternal(srv *Server, args *structs.ACLRequest, reply *string) erro
 
 	case structs.ACLDelete:
 		if args.ACL.ID == anonymousToken {
-			return fmt.Errorf("%s: Cannot delete anonymous token", permissionDenied)
+			return acl.PermissionDeniedError{Cause: "Cannot delete anonymous token"}
 		}
 
 	default:
@@ -149,14 +149,14 @@ func (a *ACL) Apply(args *structs.ACLRequest, reply *string) error {
 
 	// Verify we are allowed to serve this request
 	if a.srv.config.ACLDatacenter != a.srv.config.Datacenter {
-		return fmt.Errorf(aclDisabled)
+		return acl.ErrDisabled
 	}
 
 	// Verify token is permitted to modify ACLs
-	if acl, err := a.srv.resolveToken(args.Token); err != nil {
+	if rule, err := a.srv.resolveToken(args.Token); err != nil {
 		return err
-	} else if acl == nil || !acl.ACLModify() {
-		return errPermissionDenied
+	} else if rule == nil || !rule.ACLModify() {
+		return acl.ErrPermissionDenied
 	}
 
 	// If no ID is provided, generate a new ID. This must be done prior to
@@ -206,7 +206,7 @@ func (a *ACL) Get(args *structs.ACLSpecificRequest,
 
 	// Verify we are allowed to serve this request
 	if a.srv.config.ACLDatacenter != a.srv.config.Datacenter {
-		return fmt.Errorf(aclDisabled)
+		return acl.ErrDisabled
 	}
 
 	return a.srv.blockingQuery(&args.QueryOptions,
@@ -241,7 +241,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicyRequest, reply *structs.ACLPolicy
 
 	// Verify we are allowed to serve this request
 	if a.srv.config.ACLDatacenter != a.srv.config.Datacenter {
-		return fmt.Errorf(aclDisabled)
+		return acl.ErrDisabled
 	}
 
 	// Get the policy via the cache
@@ -276,14 +276,14 @@ func (a *ACL) List(args *structs.DCSpecificRequest,
 
 	// Verify we are allowed to serve this request
 	if a.srv.config.ACLDatacenter != a.srv.config.Datacenter {
-		return fmt.Errorf(aclDisabled)
+		return acl.ErrDisabled
 	}
 
 	// Verify token is permitted to list ACLs
-	if acl, err := a.srv.resolveToken(args.Token); err != nil {
+	if rule, err := a.srv.resolveToken(args.Token); err != nil {
 		return err
-	} else if acl == nil || !acl.ACLList() {
-		return errPermissionDenied
+	} else if rule == nil || !rule.ACLList() {
+		return acl.ErrPermissionDenied
 	}
 
 	return a.srv.blockingQuery(&args.QueryOptions,

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testrpc"
@@ -198,7 +199,7 @@ func TestACLEndpoint_Update_PurgeCache(t *testing.T) {
 
 	// Resolve again
 	acl3, err := s1.resolveToken(id)
-	if err == nil || err.Error() != aclNotFound {
+	if !acl.IsErrNotFound(err) {
 		t.Fatalf("err: %v", err)
 	}
 	if acl3 != nil {
@@ -276,7 +277,7 @@ func TestACLEndpoint_Apply_Denied(t *testing.T) {
 	}
 	var out string
 	err := msgpackrpc.CallWithCodec(codec, "ACL.Apply", &arg, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -526,7 +527,7 @@ func TestACLEndpoint_List_Denied(t *testing.T) {
 	}
 	var acls structs.IndexedACLs
 	err := msgpackrpc.CallWithCodec(codec, "ACL.List", &getR, &acls)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -49,20 +49,20 @@ func TestACL_ResolveRootACL(t *testing.T) {
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
-	acl, err := s1.resolveToken("allow")
-	if err == nil || err.Error() != rootDenied {
+	rule, err := s1.resolveToken("allow")
+	if !acl.IsErrRootDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
-	if acl != nil {
-		t.Fatalf("bad: %v", acl)
+	if rule != nil {
+		t.Fatalf("bad: %v", rule)
 	}
 
-	acl, err = s1.resolveToken("deny")
-	if err == nil || err.Error() != rootDenied {
+	rule, err = s1.resolveToken("deny")
+	if !acl.IsErrRootDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
-	if acl != nil {
-		t.Fatalf("bad: %v", acl)
+	if rule != nil {
+		t.Fatalf("bad: %v", rule)
 	}
 }
 
@@ -78,11 +78,11 @@ func TestACL_Authority_NotFound(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
-	acl, err := s1.resolveToken("does not exist")
-	if err == nil || err.Error() != aclNotFound {
+	rule, err := s1.resolveToken("does not exist")
+	if !acl.IsErrNotFound(err) {
 		t.Fatalf("err: %v", err)
 	}
-	if acl != nil {
+	if rule != nil {
 		t.Fatalf("got acl")
 	}
 }
@@ -249,11 +249,11 @@ func TestACL_NonAuthority_NotFound(t *testing.T) {
 		nonAuth = s2
 	}
 
-	acl, err := nonAuth.resolveToken("does not exist")
-	if err == nil || err.Error() != aclNotFound {
+	rule, err := nonAuth.resolveToken("does not exist")
+	if !acl.IsErrNotFound(err) {
 		t.Fatalf("err: %v", err)
 	}
-	if acl != nil {
+	if rule != nil {
 		t.Fatalf("got acl")
 	}
 }
@@ -1574,7 +1574,7 @@ node "node" {
 
 	// With that policy, the update should now be blocked for node reasons.
 	err = vetRegisterWithACL(perms, args, nil)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1599,7 +1599,7 @@ node "node" {
 		ID:      "my-id",
 	}
 	err = vetRegisterWithACL(perms, args, ns)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1629,7 +1629,7 @@ service "service" {
 		ID:      "my-id",
 	}
 	err = vetRegisterWithACL(perms, args, ns)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1723,7 +1723,7 @@ service "other" {
 
 	// This should get rejected.
 	err = vetRegisterWithACL(perms, args, ns)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1753,7 +1753,7 @@ node "node" {
 
 	// This should get rejected because there's a node-level check in here.
 	err = vetRegisterWithACL(perms, args, ns)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1768,7 +1768,7 @@ node "node" {
 	// that gets rejected since they no longer have permissions.
 	args.Address = "127.0.0.2"
 	err = vetRegisterWithACL(perms, args, ns)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 }
@@ -1803,7 +1803,7 @@ service "service" {
 
 	// With that policy, the update should now be blocked for node reasons.
 	err = vetDeregisterWithACL(perms, args, nil, nil)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1828,7 +1828,7 @@ service "service" {
 		ServiceName: "nope",
 	}
 	err = vetDeregisterWithACL(perms, args, nil, nc)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1844,7 +1844,7 @@ service "service" {
 	nc.ServiceID = ""
 	nc.ServiceName = ""
 	err = vetDeregisterWithACL(perms, args, nil, nc)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -1868,7 +1868,7 @@ service "service" {
 		Service: "nope",
 	}
 	err = vetDeregisterWithACL(perms, args, ns, nil)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -164,7 +165,7 @@ service "foo" {
 	// This should fail since we are writing to the "db" service, which isn't
 	// allowed.
 	err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &argR, &outR)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -187,7 +188,7 @@ service "foo" {
 	// enforcement.
 	s1.config.ACLEnforceVersion8 = true
 	err = msgpackrpc.CallWithCodec(codec, "Catalog.Register", &argR, &outR)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -210,7 +211,7 @@ service "foo" {
 	argR.Service.ID = "my-id"
 	argR.Token = id
 	err = msgpackrpc.CallWithCodec(codec, "Catalog.Register", &argR, &outR)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }
@@ -433,7 +434,7 @@ service "service" {
 			Datacenter: "dc1",
 			Node:       "node",
 			CheckID:    "service-check"}, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 	err = msgpackrpc.CallWithCodec(codec, "Catalog.Deregister",
@@ -441,7 +442,7 @@ service "service" {
 			Datacenter: "dc1",
 			Node:       "node",
 			CheckID:    "node-check"}, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 	err = msgpackrpc.CallWithCodec(codec, "Catalog.Deregister",
@@ -449,14 +450,14 @@ service "service" {
 			Datacenter: "dc1",
 			Node:       "node",
 			ServiceID:  "service"}, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 	err = msgpackrpc.CallWithCodec(codec, "Catalog.Deregister",
 		&structs.DeregisterRequest{
 			Datacenter: "dc1",
 			Node:       "node"}, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/consul/coordinate_endpoint.go
+++ b/agent/consul/coordinate_endpoint.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
@@ -128,13 +129,13 @@ func (c *Coordinate) Update(args *structs.CoordinateUpdateRequest, reply *struct
 	}
 
 	// Fetch the ACL token, if any, and enforce the node policy if enabled.
-	acl, err := c.srv.resolveToken(args.Token)
+	rule, err := c.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && c.srv.config.ACLEnforceVersion8 {
-		if !acl.NodeWrite(args.Node) {
-			return errPermissionDenied
+	if rule != nil && c.srv.config.ACLEnforceVersion8 {
+		if !rule.NodeWrite(args.Node) {
+			return acl.ErrPermissionDenied
 		}
 	}
 

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/testutil/retry"
@@ -237,7 +238,7 @@ func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	// Now turn on version 8 enforcement and try again.
 	s1.config.ACLEnforceVersion8 = true
 	err := msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &req, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -270,7 +271,7 @@ node "node1" {
 	// But it should be blocked for the other node.
 	req.Node = "node2"
 	err = msgpackrpc.CallWithCodec(codec, "Coordinate.Update", &req, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
@@ -365,7 +366,7 @@ func TestInternal_EventFire_Token(t *testing.T) {
 		Payload:    []byte("nope"),
 	}
 	err := msgpackrpc.CallWithCodec(codec, "Internal.EventFire", &event, nil)
-	if err == nil || err.Error() != permissionDenied {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %s", err)
 	}
 

--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -20,18 +20,18 @@ type KVS struct {
 // preApply does all the verification of a KVS update that is performed BEFORE
 // we submit as a Raft log entry. This includes enforcing the lock delay which
 // must only be done on the leader.
-func kvsPreApply(srv *Server, acl acl.ACL, op api.KVOp, dirEnt *structs.DirEntry) (bool, error) {
+func kvsPreApply(srv *Server, rule acl.ACL, op api.KVOp, dirEnt *structs.DirEntry) (bool, error) {
 	// Verify the entry.
 	if dirEnt.Key == "" && op != api.KVDeleteTree {
 		return false, fmt.Errorf("Must provide key")
 	}
 
 	// Apply the ACL policy if any.
-	if acl != nil {
+	if rule != nil {
 		switch op {
 		case api.KVDeleteTree:
-			if !acl.KeyWritePrefix(dirEnt.Key) {
-				return false, errPermissionDenied
+			if !rule.KeyWritePrefix(dirEnt.Key) {
+				return false, acl.ErrPermissionDenied
 			}
 
 		case api.KVGet, api.KVGetTree:
@@ -41,13 +41,13 @@ func kvsPreApply(srv *Server, acl acl.ACL, op api.KVOp, dirEnt *structs.DirEntry
 			// These could reveal information based on the outcome
 			// of the transaction, and they operate on individual
 			// keys so we check them here.
-			if !acl.KeyRead(dirEnt.Key) {
-				return false, errPermissionDenied
+			if !rule.KeyRead(dirEnt.Key) {
+				return false, acl.ErrPermissionDenied
 			}
 
 		default:
-			if !acl.KeyWrite(dirEnt.Key) {
-				return false, errPermissionDenied
+			if !rule.KeyWrite(dirEnt.Key) {
+				return false, acl.ErrPermissionDenied
 			}
 		}
 	}

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -2,10 +2,10 @@ package consul
 
 import (
 	"os"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
@@ -113,7 +113,7 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 	}
 	var outR bool
 	err := msgpackrpc.CallWithCodec(codec, "KVS.Apply", &argR, &outR)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestKVS_Apply_ACLDeny(t *testing.T) {
 		WriteRequest: structs.WriteRequest{Token: id},
 	}
 	err = msgpackrpc.CallWithCodec(codec, "KVS.Apply", &argR, &outR)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 }

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -427,10 +427,9 @@ func (s *Server) reconcileMember(member serf.Member) error {
 			member, err)
 
 		// Permission denied should not bubble up
-		if strings.Contains(err.Error(), permissionDenied) {
+		if acl.IsErrPermissionDenied(err) {
 			return nil
 		}
-		return err
 	}
 	return nil
 }

--- a/agent/consul/operator_autopilot_endpoint.go
+++ b/agent/consul/operator_autopilot_endpoint.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -13,12 +14,12 @@ func (op *Operator) AutopilotGetConfiguration(args *structs.DCSpecificRequest, r
 	}
 
 	// This action requires operator read access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorRead() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorRead() {
+		return acl.ErrPermissionDenied
 	}
 
 	state := op.srv.fsm.State()
@@ -42,12 +43,12 @@ func (op *Operator) AutopilotSetConfiguration(args *structs.AutopilotSetConfigRe
 	}
 
 	// This action requires operator write access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorWrite() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorWrite() {
+		return acl.ErrPermissionDenied
 	}
 
 	// Apply the update
@@ -78,12 +79,12 @@ func (op *Operator) ServerHealth(args *structs.DCSpecificRequest, reply *structs
 	}
 
 	// This action requires operator read access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorRead() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorRead() {
+		return acl.ErrPermissionDenied
 	}
 
 	// Exit early if the min Raft version is too low

--- a/agent/consul/operator_autopilot_endpoint_test.go
+++ b/agent/consul/operator_autopilot_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/testutil/retry"
@@ -59,7 +60,7 @@ func TestOperator_Autopilot_GetConfiguration_ACLDeny(t *testing.T) {
 	}
 	var reply structs.AutopilotConfig
 	err := msgpackrpc.CallWithCodec(codec, "Operator.AutopilotGetConfiguration", &arg, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -156,7 +157,7 @@ func TestOperator_Autopilot_SetConfiguration_ACLDeny(t *testing.T) {
 	}
 	var reply *bool
 	err := msgpackrpc.CallWithCodec(codec, "Operator.AutopilotSetConfiguration", &arg, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/consul/operator_raft_endpoint.go
+++ b/agent/consul/operator_raft_endpoint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/raft"
@@ -17,12 +18,12 @@ func (op *Operator) RaftGetConfiguration(args *structs.DCSpecificRequest, reply 
 	}
 
 	// This action requires operator read access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorRead() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorRead() {
+		return acl.ErrPermissionDenied
 	}
 
 	// We can't fetch the leader and the configuration atomically with
@@ -76,12 +77,12 @@ func (op *Operator) RaftRemovePeerByAddress(args *structs.RaftRemovePeerRequest,
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorWrite() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorWrite() {
+		return acl.ErrPermissionDenied
 	}
 
 	// Since this is an operation designed for humans to use, we will return
@@ -143,12 +144,12 @@ func (op *Operator) RaftRemovePeerByID(args *structs.RaftRemovePeerRequest, repl
 
 	// This is a super dangerous operation that requires operator write
 	// access.
-	acl, err := op.srv.resolveToken(args.Token)
+	rule, err := op.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && !acl.OperatorWrite() {
-		return errPermissionDenied
+	if rule != nil && !rule.OperatorWrite() {
+		return acl.ErrPermissionDenied
 	}
 
 	// Since this is an operation designed for humans to use, we will return

--- a/agent/consul/operator_raft_endpoint_test.go
+++ b/agent/consul/operator_raft_endpoint_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
@@ -76,7 +77,7 @@ func TestOperator_RaftGetConfiguration_ACLDeny(t *testing.T) {
 	}
 	var reply structs.RaftConfigurationResponse
 	err := msgpackrpc.CallWithCodec(codec, "Operator.RaftGetConfiguration", &arg, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -213,7 +214,7 @@ func TestOperator_RaftRemovePeerByAddress_ACLDeny(t *testing.T) {
 	}
 	var reply struct{}
 	err := msgpackrpc.CallWithCodec(codec, "Operator.RaftRemovePeerByAddress", &arg, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -331,7 +332,7 @@ func TestOperator_RaftRemovePeerByID_ACLDeny(t *testing.T) {
 	}
 	var reply struct{}
 	err := msgpackrpc.CallWithCodec(codec, "Operator.RaftRemovePeerByID", &arg, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
@@ -235,7 +236,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 	// Creating without a token should fail since the default policy is to
 	// deny.
 	err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -278,7 +279,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 	query.Op = structs.PreparedQueryUpdate
 	query.WriteRequest.Token = ""
 	err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -292,7 +293,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 	query.Op = structs.PreparedQueryDelete
 	query.WriteRequest.Token = ""
 	err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -458,7 +459,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 	query.Query.Name = "redis"
 	query.WriteRequest.Token = token
 	err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 }
@@ -678,7 +679,7 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 	// Creating without a token should fail since the default policy is to
 	// deny.
 	err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Apply", &query, &reply)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("bad: %v", err)
 	}
 
@@ -725,7 +726,7 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("bad: %v", err)
 		}
 
@@ -784,7 +785,7 @@ func TestPreparedQuery_ACLDeny_Catchall_Template(t *testing.T) {
 		}
 		var resp structs.PreparedQueryExplainResponse
 		err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Explain", req, &resp)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("bad: %v", err)
 		}
 	}
@@ -924,7 +925,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("bad: %v", err)
 		}
 
@@ -1405,7 +1406,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 		}
 		var resp structs.PreparedQueryExplainResponse
 		err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Explain", req, &resp)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("bad: %v", err)
 		}
 	}

--- a/agent/consul/session_endpoint.go
+++ b/agent/consul/session_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
@@ -33,11 +34,11 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 	}
 
 	// Fetch the ACL token, if any, and apply the policy.
-	acl, err := s.srv.resolveToken(args.Token)
+	rule, err := s.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && s.srv.config.ACLEnforceVersion8 {
+	if rule != nil && s.srv.config.ACLEnforceVersion8 {
 		switch args.Op {
 		case structs.SessionDestroy:
 			state := s.srv.fsm.State()
@@ -48,13 +49,13 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 			if existing == nil {
 				return fmt.Errorf("Unknown session %q", args.Session.ID)
 			}
-			if !acl.SessionWrite(existing.Node) {
-				return errPermissionDenied
+			if !rule.SessionWrite(existing.Node) {
+				return acl.ErrPermissionDenied
 			}
 
 		case structs.SessionCreate:
-			if !acl.SessionWrite(args.Session.Node) {
-				return errPermissionDenied
+			if !rule.SessionWrite(args.Session.Node) {
+				return acl.ErrPermissionDenied
 			}
 
 		default:
@@ -235,13 +236,13 @@ func (s *Session) Renew(args *structs.SessionSpecificRequest,
 	}
 
 	// Fetch the ACL token, if any, and apply the policy.
-	acl, err := s.srv.resolveToken(args.Token)
+	rule, err := s.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
 	}
-	if acl != nil && s.srv.config.ACLEnforceVersion8 {
-		if !acl.SessionWrite(session.Node) {
-			return errPermissionDenied
+	if rule != nil && s.srv.config.ACLEnforceVersion8 {
+		if !rule.SessionWrite(session.Node) {
+			return acl.ErrPermissionDenied
 		}
 	}
 

--- a/agent/consul/session_endpoint_test.go
+++ b/agent/consul/session_endpoint_test.go
@@ -2,10 +2,10 @@ package consul
 
 import (
 	"os"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testrpc"
@@ -194,7 +194,7 @@ session "foo" {
 	var id2 string
 	s1.config.ACLEnforceVersion8 = true
 	err := msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &id2)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -220,7 +220,7 @@ session "foo" {
 	s1.config.ACLEnforceVersion8 = true
 	arg.Session.ID = id2
 	err = msgpackrpc.CallWithCodec(codec, "Session.Apply", &arg, &out)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 
@@ -770,7 +770,7 @@ session "foo" {
 	// Now turn on version 8 enforcement and the renew should be rejected.
 	s1.config.ACLEnforceVersion8 = true
 	err := msgpackrpc.CallWithCodec(codec, "Session.Renew", &renewR, &session)
-	if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+	if !acl.IsErrPermissionDenied(err) {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/consul/snapshot_endpoint.go
+++ b/agent/consul/snapshot_endpoint.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/snapshot"
@@ -58,10 +59,10 @@ func (s *Server) dispatchSnapshotRequest(args *structs.SnapshotRequest, in io.Re
 	// Verify token is allowed to operate on snapshots. There's only a
 	// single ACL sense here (not read and write) since reading gets you
 	// all the ACLs and you could escalate from there.
-	if acl, err := s.resolveToken(args.Token); err != nil {
+	if rule, err := s.resolveToken(args.Token); err != nil {
 		return nil, err
-	} else if acl != nil && !acl.Snapshot() {
-		return nil, errPermissionDenied
+	} else if rule != nil && !rule.Snapshot() {
+		return nil, acl.ErrPermissionDenied
 	}
 
 	// Dispatch the operation.

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
@@ -262,7 +263,7 @@ func TestSnapshot_ACLDeny(t *testing.T) {
 		var reply structs.SnapshotResponse
 		_, err := SnapshotRPC(s1.connPool, s1.config.Datacenter, s1.config.RPCAddr, false,
 			&args, bytes.NewReader([]byte("")), &reply)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	}()
@@ -276,7 +277,7 @@ func TestSnapshot_ACLDeny(t *testing.T) {
 		var reply structs.SnapshotResponse
 		_, err := SnapshotRPC(s1.connPool, s1.config.Datacenter, s1.config.RPCAddr, false,
 			&args, bytes.NewReader([]byte("")), &reply)
-		if err == nil || !strings.Contains(err.Error(), permissionDenied) {
+		if !acl.IsErrPermissionDenied(err) {
 			t.Fatalf("err: %v", err)
 		}
 	}()

--- a/agent/consul/txn_endpoint_test.go
+++ b/agent/consul/txn_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testrpc"
@@ -314,7 +315,7 @@ func TestTxn_Apply_ACLDeny(t *testing.T) {
 		default:
 			expected.Errors = append(expected.Errors, &structs.TxnError{
 				OpIndex: i,
-				What:    errPermissionDenied.Error(),
+				What:    acl.ErrPermissionDenied.Error(),
 			})
 		}
 	}
@@ -578,7 +579,7 @@ func TestTxn_Read_ACLDeny(t *testing.T) {
 		default:
 			expected.Errors = append(expected.Errors, &structs.TxnError{
 				OpIndex: i,
-				What:    errPermissionDenied.Error(),
+				What:    acl.ErrPermissionDenied.Error(),
 			})
 		}
 	}

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -63,9 +64,8 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
-		if strings.Contains(err.Error(), permissionDenied) {
-			resp.WriteHeader(403)
-			fmt.Fprint(resp, permissionDenied)
+		if acl.IsErrPermissionDenied(err) {
+			http.Error(resp, acl.ErrPermissionDenied.Error(), 403)
 			return nil, nil
 		}
 		resp.WriteHeader(500)

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -65,7 +65,8 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
 		if acl.IsErrPermissionDenied(err) {
-			http.Error(resp, acl.ErrPermissionDenied.Error(), 403)
+			resp.WriteHeader(403)
+			fmt.Fprint(resp, acl.ErrPermissionDenied.Error())
 			return nil, nil
 		}
 		resp.WriteHeader(500)

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -2,13 +2,14 @@ package agent
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testutil/retry"
 )
@@ -96,14 +97,14 @@ func TestEventFire_token(t *testing.T) {
 		// Check the result
 		body := resp.Body.String()
 		if c.allowed {
-			if strings.Contains(body, permissionDenied) {
+			if acl.IsErrPermissionDenied(errors.New(body)) {
 				t.Fatalf("bad: %s", body)
 			}
 			if resp.Code != 200 {
 				t.Fatalf("bad: %d", resp.Code)
 			}
 		} else {
-			if !strings.Contains(body, permissionDenied) {
+			if !acl.IsErrPermissionDenied(errors.New(body)) {
 				t.Fatalf("bad: %s", body)
 			}
 			if resp.Code != 403 {

--- a/agent/http.go
+++ b/agent/http.go
@@ -234,9 +234,11 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			s.agent.logger.Printf("[ERR] http: Request %s %v, error: %v from=%s", req.Method, logURL, err, req.RemoteAddr)
 			switch {
 			case acl.IsErrPermissionDenied(err) || acl.IsErrNotFound(err):
-				http.Error(resp, err.Error(), http.StatusForbidden) // 403
+				resp.WriteHeader(http.StatusForbidden) // 403
+				fmt.Fprint(resp, err.Error())
 			default:
-				http.Error(resp, err.Error(), http.StatusInternalServerError) // 500
+				resp.WriteHeader(http.StatusInternalServerError) // 500
+				fmt.Fprint(resp, err.Error())
 			}
 		}
 

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -646,10 +646,6 @@ func getIndex(t *testing.T, resp *httptest.ResponseRecorder) uint64 {
 	return uint64(val)
 }
 
-func isPermissionDenied(err error) bool {
-	return err != nil && strings.Contains(err.Error(), errPermissionDenied.Error())
-}
-
 func jsonReader(v interface{}) io.Reader {
 	if v == nil {
 		return nil

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/acl"
 )
 
 func TestSnapshot(t *testing.T) {
@@ -61,7 +63,7 @@ func TestSnapshot_Options(t *testing.T) {
 			req, _ := http.NewRequest(method, "/v1/snapshot?token=anonymous", body)
 			resp := httptest.NewRecorder()
 			_, err := a.srv.Snapshot(resp, req)
-			if err == nil || !strings.Contains(err.Error(), "Permission denied") {
+			if !acl.IsErrPermissionDenied(err) {
 				t.Fatalf("err: %v", err)
 			}
 		})

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testutil/retry"
 )
@@ -217,10 +218,7 @@ func TestUserEventToken(t *testing.T) {
 	for _, c := range cases {
 		event := &UserEvent{Name: c.name}
 		err := a.UserEvent("dc1", token, event)
-		allowed := false
-		if err == nil || err.Error() != permissionDenied {
-			allowed = true
-		}
+		allowed := !acl.IsErrPermissionDenied(err)
 		if allowed != c.expect {
 			t.Fatalf("bad: %#v result: %v", c, allowed)
 		}


### PR DESCRIPTION
The error handling of the ACL code relies on the presence of certain
magic error messages. Since the error values are sent via RPC between
older and newer consul agents we cannot just replace the magic values
with typed errors and switch to type checks since this would break
compatibility with older clients.

Therefore, this patch moves all magic ACL error messages into the acl
package and provides default error values and helper functions which
determine the type of error.