### PR TITLE
Introduce a new ReadPrefix method to check for ACL violations before …

### DIFF
--- a/agent/consul/kvs_endpoint.go
+++ b/agent/consul/kvs_endpoint.go
@@ -129,7 +129,7 @@ func (k *KVS) Get(args *structs.KeyRequest, reply *structs.IndexedDirEntries) er
 				return err
 			}
 			if acl != nil && !acl.KeyRead(args.Key) {
-				ent = nil
+				return errPermissionDenied
 			}
 			if ent == nil {
 				// Must provide non-zero index to prevent blocking
@@ -157,6 +157,10 @@ func (k *KVS) List(args *structs.KeyRequest, reply *structs.IndexedDirEntries) e
 	acl, err := k.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
+	}
+
+	if acl != nil && !acl.KeyReadPrefix(args.Key) {
+		return errPermissionDenied
 	}
 
 	return k.srv.blockingQuery(
@@ -197,6 +201,10 @@ func (k *KVS) ListKeys(args *structs.KeyListRequest, reply *structs.IndexedKeyLi
 	acl, err := k.srv.resolveToken(args.Token)
 	if err != nil {
 		return err
+	}
+
+	if acl != nil && !acl.KeyReadPrefix(args.Prefix) {
+		return errPermissionDenied
 	}
 
 	return k.srv.blockingQuery(

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -214,16 +214,10 @@ func TestKVS_Get_ACLDeny(t *testing.T) {
 		Key:        "zip",
 	}
 	var dirent structs.IndexedDirEntries
-	if err := msgpackrpc.CallWithCodec(codec, "KVS.Get", &getR, &dirent); err != nil {
+	if err := msgpackrpc.CallWithCodec(codec, "KVS.Get", &getR, &dirent); err.Error() != errPermissionDenied.Error() {
 		t.Fatalf("err: %v", err)
 	}
 
-	if dirent.Index == 0 {
-		t.Fatalf("Bad: %v", dirent)
-	}
-	if len(dirent.Entries) != 0 {
-		t.Fatalf("Bad: %v", dirent)
-	}
 }
 
 func TestKVSEndpoint_List(t *testing.T) {


### PR DESCRIPTION
…reading key values from the state store. This causes 403s when an ACL without read permissions tries to read or recurse through a key space, rather than a 404.