### PR TITLE
Added configuration instructions for forwarding DNS queries from Unbound

### DIFF
--- a/website/source/docs/guides/forwarding.html.md
+++ b/website/source/docs/guides/forwarding.html.md
@@ -15,12 +15,12 @@ running on an unprivileged port, from another DNS server or port redirect.
 
 In this guide, we will demonstrate forwarding from
 [BIND](https://www.isc.org/downloads/bind/) as well as
-[dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) and
-[iptables](http://www.netfilter.org/). For the sake of simplicity, BIND
-and Consul are running on the same machine in this example. For iptables
-the rules must be set on the same host as the Consul instance and relay
-hosts should not be on the same host or the redirects will intercept the
-traffic.
+[dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html),
+[Unbound](https://www.unbound.net/), and [iptables](http://www.netfilter.org/).
+For the sake of simplicity, BIND and Consul are running on the same machine in 
+this example. For iptables the rules must be set on the same host as the Consul
+instance and relay hosts should not be on the same host or the redirects will 
+intercept the traffic.
 
 It is worth mentioning that, by default, Consul does not resolve DNS
 records outside the `.consul.` zone unless the
@@ -128,6 +128,31 @@ for additional details):
 # Set the size of dnsmasq's cache. The default is 150 names. Setting the
 # cache size to zero disables caching.
 #cache-size=65536
+```
+
+### Unbound Setup
+
+Unbound is typically configured via a `unbound.conf` or a series of files in
+the `/etc/unbound/unbound.conf.d` directory. In an Unbound configuration file
+(e.g. `/etc/unbound/unbound.conf.d/consul.conf`), add the following:
+
+```text
+#Allow insecure queries to local resolvers
+server:
+  do-not-query-localhost: no
+  domain-insecure: "consul"
+
+#Add consul as a stub-zone
+stub-zone:
+  name: "consul"
+  stub-addr: 127.0.0.1@8600
+```
+
+You may have to add the following line to the bottom of your 
+`/etc/unbound/unbound.conf` file for the new configuration to be included:
+
+```text
+include: "/etc/unbound/unbound.conf.d/*.conf"
 ```
 
 ### iptables Setup


### PR DESCRIPTION
Spent a few hours trying to configure unbound to forward to consul. While the config looks simple, there is fairly poor and varying documentation available on how to make this work. Figured I would try to make the information more widely available.