### PR TITLE
dns: fix panic when querying NS or SOA records on agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -62,7 +62,6 @@ type delegate interface {
 	JoinLAN(addrs []string) (n int, err error)
 	RemoveFailedNode(node string) error
 	RPC(method string, args interface{}, reply interface{}) error
-	ServerAddrs() map[string]string
 	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error
 	Stats() map[string]map[string]string

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -411,10 +411,6 @@ func (c *Client) Stats() map[string]map[string]string {
 	return stats
 }
 
-func (c *Client) ServerAddrs() map[string]string {
-	return c.routers.GetServerAddrs()
-}
-
 // GetLANCoordinate returns the network coordinate of the current node, as
 // maintained by Serf.
 func (c *Client) GetLANCoordinate() (*coordinate.Coordinate, error) {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1047,15 +1047,6 @@ func (s *Server) GetWANCoordinate() (*coordinate.Coordinate, error) {
 	return s.serfWAN.GetCoordinate()
 }
 
-func (s *Server) ServerAddrs() map[string]string {
-	ret, err := s.router.FindServerAddrs(s.config.Datacenter)
-	if err != nil {
-		s.logger.Printf("[WARN] Unexpected state, no server addresses for datacenter %v, got error: %v", s.config.Datacenter, err)
-		return nil
-	}
-	return ret
-}
-
 // Atomically sets a readiness state flag when leadership is obtained, to indicate that server is past its barrier write
 func (s *Server) setConsistentReadReady() {
 	atomic.StoreInt32(&s.readyForConsistentReads, 1)

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -711,16 +711,6 @@ RPC:
 		}
 	}
 
-	// Determine the TTL
-	var ttl time.Duration
-	if d.config.ServiceTTL != nil {
-		var ok bool
-		ttl, ok = d.config.ServiceTTL[service]
-		if !ok {
-			ttl = d.config.ServiceTTL["*"]
-		}
-	}
-
 	// Filter out any service nodes due to health checks
 	out.Nodes = out.Nodes.Filter(d.config.OnlyPassing)
 
@@ -733,6 +723,16 @@ RPC:
 
 	// Perform a random shuffle
 	out.Nodes.Shuffle()
+
+	// Determine the TTL
+	var ttl time.Duration
+	if d.config.ServiceTTL != nil {
+		var ok bool
+		ttl, ok = d.config.ServiceTTL[service]
+		if !ok {
+			ttl = d.config.ServiceTTL["*"]
+		}
+	}
 
 	// Add various responses depending on the request
 	qType := req.Question[0].Qtype

--- a/agent/router/manager.go
+++ b/agent/router/manager.go
@@ -223,15 +223,6 @@ func (m *Manager) getServerList() serverList {
 	return m.listValue.Load().(serverList)
 }
 
-// GetServerAddrs returns a map from node name to address for all servers
-func (m *Manager) GetServerAddrs() map[string]string {
-	ret := make(map[string]string)
-	for _, server := range m.getServerList().servers {
-		ret[server.Name] = server.Addr.String()
-	}
-	return ret
-}
-
 // saveServerList is a convenience method which hides the locking semantics
 // of atomic.Value from the caller.
 func (m *Manager) saveServerList(l serverList) {

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -489,26 +489,3 @@ func (r *Router) GetDatacenterMaps() ([]structs.DatacenterMap, error) {
 	}
 	return maps, nil
 }
-
-func (r *Router) FindServerAddrs(datacenter string) (map[string]string, error) {
-	r.RLock()
-	defer r.RUnlock()
-
-	// Get the list of managers for this datacenter. This will usually just
-	// have one entry, but it's possible to have a user-defined area + WAN.
-	managers, ok := r.managers[datacenter]
-	if !ok {
-		return nil, fmt.Errorf("datacenter %v not found", datacenter)
-	}
-
-	ret := make(map[string]string)
-	for _, manager := range managers {
-		if manager.IsOffline() {
-			continue
-		}
-		for name, addr := range manager.GetServerAddrs() {
-			ret[name] = addr
-		}
-	}
-	return ret, nil
-}


### PR DESCRIPTION
This patch replaces the implementation of #3353 with one that has consistent behavior on both server and agent. By making an RPC call to get the list of consul service instances to determine the services it uses the raft log as the source of truth instead of keeping track of serf messages which can generate a different view per agent. 

Fixes #3407 