### PR TITLE
agent: normalize http status code usage

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -51,7 +51,7 @@ func (s *HTTPServer) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (
 func (s *HTTPServer) ACLDestroy(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -87,7 +87,7 @@ func (s *HTTPServer) ACLUpdate(resp http.ResponseWriter, req *http.Request) (int
 func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update bool) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -130,7 +130,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -16,7 +16,7 @@ type aclCreateResponse struct {
 
 // ACLDisabled handles if ACL datacenter is not configured
 func ACLDisabled(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	resp.WriteHeader(401)
+	resp.WriteHeader(http.StatusUnauthorized) // 401
 	fmt.Fprint(resp, "ACL support disabled")
 	return nil, nil
 }

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -64,7 +64,7 @@ func (s *HTTPServer) ACLDestroy(resp http.ResponseWriter, req *http.Request) (in
 	// Pull out the acl id
 	args.ACL.ID = strings.TrimPrefix(req.URL.Path, "/v1/acl/destroy/")
 	if args.ACL.ID == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}
@@ -103,7 +103,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 	// Handle optional request body
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.ACL, nil); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -112,7 +112,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 	// Ensure there is an ID set for update. ID is optional for
 	// create, as one will be generated if not provided.
 	if update && args.ACL.ID == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "ACL ID must be set")
 		return nil, nil
 	}
@@ -145,7 +145,7 @@ func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (inte
 	// Pull out the acl id
 	args.ACL = strings.TrimPrefix(req.URL.Path, "/v1/acl/clone/")
 	if args.ACL == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}
@@ -193,7 +193,7 @@ func (s *HTTPServer) ACLGet(resp http.ResponseWriter, req *http.Request) (interf
 	// Pull out the acl id
 	args.ACL = strings.TrimPrefix(req.URL.Path, "/v1/acl/info/")
 	if args.ACL == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -16,7 +16,7 @@ type aclCreateResponse struct {
 
 // ACLDisabled handles if ACL datacenter is not configured
 func ACLDisabled(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	resp.WriteHeader(http.StatusUnauthorized) // 401
+	resp.WriteHeader(http.StatusUnauthorized)
 	fmt.Fprint(resp, "ACL support disabled")
 	return nil, nil
 }
@@ -51,7 +51,7 @@ func (s *HTTPServer) ACLBootstrap(resp http.ResponseWriter, req *http.Request) (
 func (s *HTTPServer) ACLDestroy(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -64,7 +64,7 @@ func (s *HTTPServer) ACLDestroy(resp http.ResponseWriter, req *http.Request) (in
 	// Pull out the acl id
 	args.ACL.ID = strings.TrimPrefix(req.URL.Path, "/v1/acl/destroy/")
 	if args.ACL.ID == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}
@@ -87,7 +87,7 @@ func (s *HTTPServer) ACLUpdate(resp http.ResponseWriter, req *http.Request) (int
 func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update bool) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -103,7 +103,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 	// Handle optional request body
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.ACL, nil); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -112,7 +112,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 	// Ensure there is an ID set for update. ID is optional for
 	// create, as one will be generated if not provided.
 	if update && args.ACL.ID == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "ACL ID must be set")
 		return nil, nil
 	}
@@ -130,7 +130,7 @@ func (s *HTTPServer) aclSet(resp http.ResponseWriter, req *http.Request, update 
 func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -145,7 +145,7 @@ func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (inte
 	// Pull out the acl id
 	args.ACL = strings.TrimPrefix(req.URL.Path, "/v1/acl/clone/")
 	if args.ACL == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}
@@ -193,7 +193,7 @@ func (s *HTTPServer) ACLGet(resp http.ResponseWriter, req *http.Request) (interf
 	// Pull out the acl id
 	args.ACL = strings.TrimPrefix(req.URL.Path, "/v1/acl/info/")
 	if args.ACL == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing ACL")
 		return nil, nil
 	}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -568,13 +568,13 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	if enable {
 		reason := params.Get("reason")
 		if err = s.agent.EnableServiceMaintenance(serviceID, reason, token); err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound) // 404
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
 	} else {
 		if err = s.agent.DisableServiceMaintenance(serviceID); err != nil {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound) // 404
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -384,7 +384,7 @@ type checkUpdate struct {
 // APIs.
 func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -530,7 +530,7 @@ func (s *HTTPServer) AgentDeregisterService(resp http.ResponseWriter, req *http.
 func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only PUT supported
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -586,7 +586,7 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only PUT supported
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -629,7 +629,7 @@ func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only GET supported.
 	if req.Method != "GET" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -252,20 +252,20 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 		return FixupCheckType(raw)
 	}
 	if err := decodeBody(req, &args, decodeCB); err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
 
 	// Verify the check has a name.
 	if args.Name == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing check name")
 		return nil, nil
 	}
 
 	if args.Status != "" && !structs.ValidStatus(args.Status) {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Bad check status")
 		return nil, nil
 	}
@@ -276,7 +276,7 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 	// Verify the check type.
 	chkType := args.CheckType()
 	if !chkType.Valid() {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, invalidCheckMessage)
 		return nil, nil
 	}
@@ -384,13 +384,13 @@ type checkUpdate struct {
 // APIs.
 func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
 	var update checkUpdate
 	if err := decodeBody(req, &update, nil); err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
@@ -400,7 +400,7 @@ func (s *HTTPServer) AgentCheckUpdate(resp http.ResponseWriter, req *http.Reques
 	case api.HealthWarning:
 	case api.HealthCritical:
 	default:
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Invalid check status: '%s'", update.Status)
 		return nil, nil
 	}
@@ -457,14 +457,14 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 		return nil
 	}
 	if err := decodeBody(req, &args, decodeCB); err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
 
 	// Verify the service has a name.
 	if args.Name == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -472,7 +472,7 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	// Check the service address here and in the catalog RPC endpoint
 	// since service registration isn't sychronous.
 	if ipaddr.IsAny(args.Address) {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Invalid service address")
 		return nil, nil
 	}
@@ -484,12 +484,12 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	chkTypes := args.CheckTypes()
 	for _, check := range chkTypes {
 		if check.Status != "" && !structs.ValidStatus(check.Status) {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(resp, "Status for checks must 'passing', 'warning', 'critical'")
 			return nil, nil
 		}
 		if !check.Valid() {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(resp, invalidCheckMessage)
 			return nil, nil
 		}
@@ -530,14 +530,14 @@ func (s *HTTPServer) AgentDeregisterService(resp http.ResponseWriter, req *http.
 func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only PUT supported
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
 	// Ensure we have a service ID
 	serviceID := strings.TrimPrefix(req.URL.Path, "/v1/agent/service/maintenance/")
 	if serviceID == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service ID")
 		return nil, nil
 	}
@@ -545,7 +545,7 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	// Ensure we have some action
 	params := req.URL.Query()
 	if _, ok := params["enable"]; !ok {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing value for enable")
 		return nil, nil
 	}
@@ -553,7 +553,7 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	raw := params.Get("enable")
 	enable, err := strconv.ParseBool(raw)
 	if err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Invalid value for enable: %q", raw)
 		return nil, nil
 	}
@@ -568,13 +568,13 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 	if enable {
 		reason := params.Get("reason")
 		if err = s.agent.EnableServiceMaintenance(serviceID, reason, token); err != nil {
-			resp.WriteHeader(http.StatusNotFound) // 404
+			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
 	} else {
 		if err = s.agent.DisableServiceMaintenance(serviceID); err != nil {
-			resp.WriteHeader(http.StatusNotFound) // 404
+			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -586,14 +586,14 @@ func (s *HTTPServer) AgentServiceMaintenance(resp http.ResponseWriter, req *http
 func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only PUT supported
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
 	// Ensure we have some action
 	params := req.URL.Query()
 	if _, ok := params["enable"]; !ok {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing value for enable")
 		return nil, nil
 	}
@@ -601,7 +601,7 @@ func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Re
 	raw := params.Get("enable")
 	enable, err := strconv.ParseBool(raw)
 	if err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Invalid value for enable: %q", raw)
 		return nil, nil
 	}
@@ -629,7 +629,7 @@ func (s *HTTPServer) AgentNodeMaintenance(resp http.ResponseWriter, req *http.Re
 func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Only GET supported.
 	if req.Method != "GET" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -657,7 +657,7 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 	filter := logger.LevelFilter()
 	filter.MinLevel = logutils.LogLevel(logLevel)
 	if !logger.ValidateLevelFilter(filter.MinLevel, filter) {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Unknown log level: %s", filter.MinLevel)
 		return nil, nil
 	}

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -11,7 +11,7 @@ import (
 func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args structs.RegisterRequest
 	if err := decodeBody(req, &args, nil); err != nil {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
@@ -33,7 +33,7 @@ func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request
 func (s *HTTPServer) CatalogDeregister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args structs.DeregisterRequest
 	if err := decodeBody(req, &args, nil); err != nil {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
@@ -123,7 +123,7 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/catalog/service/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -158,7 +158,7 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 	// Pull out the node name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/catalog/node/")
 	if args.Node == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -11,7 +11,7 @@ import (
 func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args structs.RegisterRequest
 	if err := decodeBody(req, &args, nil); err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
@@ -33,7 +33,7 @@ func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request
 func (s *HTTPServer) CatalogDeregister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	var args structs.DeregisterRequest
 	if err := decodeBody(req, &args, nil); err != nil {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprintf(resp, "Request decode failed: %v", err)
 		return nil, nil
 	}
@@ -123,7 +123,7 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/catalog/service/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -158,7 +158,7 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 	// Pull out the node name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/catalog/node/")
 	if args.Node == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}

--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -11,7 +11,7 @@ import (
 // coordinateDisabled handles all the endpoints when coordinates are not enabled,
 // returning an error message.
 func coordinateDisabled(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	resp.WriteHeader(401)
+	resp.WriteHeader(http.StatusUnauthorized) // 401
 	fmt.Fprint(resp, "Coordinate support disabled")
 	return nil, nil
 }

--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -11,7 +11,7 @@ import (
 // coordinateDisabled handles all the endpoints when coordinates are not enabled,
 // returning an error message.
 func coordinateDisabled(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	resp.WriteHeader(http.StatusUnauthorized) // 401
+	resp.WriteHeader(http.StatusUnauthorized)
 	fmt.Fprint(resp, "Coordinate support disabled")
 	return nil, nil
 }

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -69,7 +69,7 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 			fmt.Fprint(resp, acl.ErrPermissionDenied.Error())
 			return nil, nil
 		}
-		resp.WriteHeader(500)
+		resp.WriteHeader(http.StatusInternalServerError) // 500
 		return nil, err
 	}
 

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -33,7 +33,7 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	event := &UserEvent{}
 	event.Name = strings.TrimPrefix(req.URL.Path, "/v1/event/fire/")
 	if event.Name == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing name")
 		return nil, nil
 	}

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -65,7 +65,7 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
 		if acl.IsErrPermissionDenied(err) {
-			resp.WriteHeader(403)
+			resp.WriteHeader(http.StatusForbidden) // 403
 			fmt.Fprint(resp, acl.ErrPermissionDenied.Error())
 			return nil, nil
 		}

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -22,7 +22,7 @@ const (
 func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -22,7 +22,7 @@ const (
 func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -33,7 +33,7 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	event := &UserEvent{}
 	event.Name = strings.TrimPrefix(req.URL.Path, "/v1/event/fire/")
 	if event.Name == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing name")
 		return nil, nil
 	}
@@ -65,11 +65,11 @@ func (s *HTTPServer) EventFire(resp http.ResponseWriter, req *http.Request) (int
 	// Try to fire the event
 	if err := s.agent.UserEvent(dc, token, event); err != nil {
 		if acl.IsErrPermissionDenied(err) {
-			resp.WriteHeader(http.StatusForbidden) // 403
+			resp.WriteHeader(http.StatusForbidden)
 			fmt.Fprint(resp, acl.ErrPermissionDenied.Error())
 			return nil, nil
 		}
-		resp.WriteHeader(http.StatusInternalServerError) // 500
+		resp.WriteHeader(http.StatusInternalServerError)
 		return nil, err
 	}
 

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -22,7 +22,7 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.State = strings.TrimPrefix(req.URL.Path, "/v1/health/state/")
 	if args.State == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing check state")
 		return nil, nil
 	}
@@ -56,7 +56,7 @@ func (s *HTTPServer) HealthNodeChecks(resp http.ResponseWriter, req *http.Reques
 	// Pull out the service name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/health/node/")
 	if args.Node == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}
@@ -92,7 +92,7 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/health/checks/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -135,7 +135,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/health/service/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -159,7 +159,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 			var err error
 			filter, err = strconv.ParseBool(val)
 			if err != nil {
-				resp.WriteHeader(http.StatusBadRequest) // 400
+				resp.WriteHeader(http.StatusBadRequest)
 				fmt.Fprint(resp, "Invalid value for ?passing")
 				return nil, nil
 			}

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -22,7 +22,7 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.State = strings.TrimPrefix(req.URL.Path, "/v1/health/state/")
 	if args.State == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing check state")
 		return nil, nil
 	}
@@ -56,7 +56,7 @@ func (s *HTTPServer) HealthNodeChecks(resp http.ResponseWriter, req *http.Reques
 	// Pull out the service name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/health/node/")
 	if args.Node == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}
@@ -92,7 +92,7 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/health/checks/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -135,7 +135,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	// Pull out the service name
 	args.ServiceName = strings.TrimPrefix(req.URL.Path, "/v1/health/service/")
 	if args.ServiceName == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
 	}
@@ -159,7 +159,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 			var err error
 			filter, err = strconv.ParseBool(val)
 			if err != nil {
-				resp.WriteHeader(400)
+				resp.WriteHeader(http.StatusBadRequest) // 400
 				fmt.Fprint(resp, "Invalid value for ?passing")
 				return nil, nil
 			}

--- a/agent/http.go
+++ b/agent/http.go
@@ -207,7 +207,7 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 		formVals, err := url.ParseQuery(req.URL.RawQuery)
 		if err != nil {
 			s.agent.logger.Printf("[ERR] http: Failed to decode query: %s from=%s", err, req.RemoteAddr)
-			resp.WriteHeader(http.StatusInternalServerError) // 500
+			resp.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		logURL := req.URL.String()
@@ -234,10 +234,10 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			s.agent.logger.Printf("[ERR] http: Request %s %v, error: %v from=%s", req.Method, logURL, err, req.RemoteAddr)
 			switch {
 			case acl.IsErrPermissionDenied(err) || acl.IsErrNotFound(err):
-				resp.WriteHeader(http.StatusForbidden) // 403
+				resp.WriteHeader(http.StatusForbidden)
 				fmt.Fprint(resp, err.Error())
 			default:
-				resp.WriteHeader(http.StatusInternalServerError) // 500
+				resp.WriteHeader(http.StatusInternalServerError)
 				fmt.Fprint(resp, err.Error())
 			}
 		}
@@ -294,7 +294,7 @@ func (s *HTTPServer) IsUIEnabled() bool {
 func (s *HTTPServer) Index(resp http.ResponseWriter, req *http.Request) {
 	// Check if this is a non-index path
 	if req.URL.Path != "/" {
-		resp.WriteHeader(http.StatusNotFound) // 404
+		resp.WriteHeader(http.StatusNotFound)
 		return
 	}
 
@@ -378,7 +378,7 @@ func parseWait(resp http.ResponseWriter, req *http.Request, b *structs.QueryOpti
 	if wait := query.Get("wait"); wait != "" {
 		dur, err := time.ParseDuration(wait)
 		if err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(resp, "Invalid wait time")
 			return true
 		}
@@ -387,7 +387,7 @@ func parseWait(resp http.ResponseWriter, req *http.Request, b *structs.QueryOpti
 	if idx := query.Get("index"); idx != "" {
 		index, err := strconv.ParseUint(idx, 10, 64)
 		if err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(resp, "Invalid index")
 			return true
 		}
@@ -407,7 +407,7 @@ func parseConsistency(resp http.ResponseWriter, req *http.Request, b *structs.Qu
 		b.RequireConsistent = true
 	}
 	if b.AllowStale && b.RequireConsistent {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Cannot specify ?stale with ?consistent, conflicting semantics.")
 		return true
 	}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -257,7 +257,7 @@ func (s *HTTPServer) KVSDelete(resp http.ResponseWriter, req *http.Request, args
 // missingKey checks if the key is missing
 func missingKey(resp http.ResponseWriter, args *structs.KeyRequest) bool {
 	if args.Key == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing key name")
 		return true
 	}
@@ -272,7 +272,7 @@ func conflictingFlags(resp http.ResponseWriter, req *http.Request, flags ...stri
 	for _, conflict := range flags {
 		if _, ok := params[conflict]; ok {
 			if found {
-				resp.WriteHeader(400)
+				resp.WriteHeader(http.StatusBadRequest) // 400
 				fmt.Fprint(resp, "Conflicting flags: "+params.Encode())
 				return true
 			}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -184,7 +184,7 @@ func (s *HTTPServer) KVSPut(resp http.ResponseWriter, req *http.Request, args *s
 
 	// Check the content-length
 	if req.ContentLength > maxKVSize {
-		resp.WriteHeader(413)
+		resp.WriteHeader(http.StatusRequestEntityTooLarge) // 413
 		fmt.Fprintf(resp, "Value exceeds %d byte limit", maxKVSize)
 		return nil, nil
 	}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -48,7 +48,7 @@ func (s *HTTPServer) KVSEndpoint(resp http.ResponseWriter, req *http.Request) (i
 	case "DELETE":
 		return s.KVSDelete(resp, req, &args)
 	default:
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 }
@@ -73,7 +73,7 @@ func (s *HTTPServer) KVSGet(resp http.ResponseWriter, req *http.Request, args *s
 
 	// Check if we get a not found
 	if len(out.Entries) == 0 {
-		resp.WriteHeader(http.StatusNotFound) // 404
+		resp.WriteHeader(http.StatusNotFound)
 		return nil, nil
 	}
 
@@ -120,7 +120,7 @@ func (s *HTTPServer) KVSGetKeys(resp http.ResponseWriter, req *http.Request, arg
 	// Check if we get a not found. We do not generate
 	// not found for the root, but just provide the empty list
 	if len(out.Keys) == 0 && listArgs.Prefix != "" {
-		resp.WriteHeader(http.StatusNotFound) // 404
+		resp.WriteHeader(http.StatusNotFound)
 		return nil, nil
 	}
 
@@ -184,7 +184,7 @@ func (s *HTTPServer) KVSPut(resp http.ResponseWriter, req *http.Request, args *s
 
 	// Check the content-length
 	if req.ContentLength > maxKVSize {
-		resp.WriteHeader(http.StatusRequestEntityTooLarge) // 413
+		resp.WriteHeader(http.StatusRequestEntityTooLarge)
 		fmt.Fprintf(resp, "Value exceeds %d byte limit", maxKVSize)
 		return nil, nil
 	}
@@ -257,7 +257,7 @@ func (s *HTTPServer) KVSDelete(resp http.ResponseWriter, req *http.Request, args
 // missingKey checks if the key is missing
 func missingKey(resp http.ResponseWriter, args *structs.KeyRequest) bool {
 	if args.Key == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing key name")
 		return true
 	}
@@ -272,7 +272,7 @@ func conflictingFlags(resp http.ResponseWriter, req *http.Request, flags ...stri
 	for _, conflict := range flags {
 		if _, ok := params[conflict]; ok {
 			if found {
-				resp.WriteHeader(http.StatusBadRequest) // 400
+				resp.WriteHeader(http.StatusBadRequest)
 				fmt.Fprint(resp, "Conflicting flags: "+params.Encode())
 				return true
 			}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -73,7 +73,7 @@ func (s *HTTPServer) KVSGet(resp http.ResponseWriter, req *http.Request, args *s
 
 	// Check if we get a not found
 	if len(out.Entries) == 0 {
-		resp.WriteHeader(404)
+		resp.WriteHeader(http.StatusNotFound) // 404
 		return nil, nil
 	}
 
@@ -120,7 +120,7 @@ func (s *HTTPServer) KVSGetKeys(resp http.ResponseWriter, req *http.Request, arg
 	// Check if we get a not found. We do not generate
 	// not found for the root, but just provide the empty list
 	if len(out.Keys) == 0 && listArgs.Prefix != "" {
-		resp.WriteHeader(404)
+		resp.WriteHeader(http.StatusNotFound) // 404
 		return nil, nil
 	}
 

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -48,7 +48,7 @@ func (s *HTTPServer) KVSEndpoint(resp http.ResponseWriter, req *http.Request) (i
 	case "DELETE":
 		return s.KVSDelete(resp, req, &args)
 	default:
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 }

--- a/agent/operator_endpoint.go
+++ b/agent/operator_endpoint.go
@@ -90,7 +90,7 @@ func (s *HTTPServer) OperatorKeyringEndpoint(resp http.ResponseWriter, req *http
 	var args keyringArgs
 	if req.Method == "POST" || req.Method == "PUT" || req.Method == "DELETE" {
 		if err := decodeBody(req, &args, nil); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -101,14 +101,14 @@ func (s *HTTPServer) OperatorKeyringEndpoint(resp http.ResponseWriter, req *http
 	if relayFactor := req.URL.Query().Get("relay-factor"); relayFactor != "" {
 		n, err := strconv.Atoi(relayFactor)
 		if err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Error parsing relay factor: %v", err)
 			return nil, nil
 		}
 
 		args.RelayFactor, err = ParseRelayFactor(n)
 		if err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Invalid relay factor: %v", err)
 			return nil, nil
 		}
@@ -224,7 +224,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 
 		var conf api.AutopilotConfiguration
 		if err := decodeBody(req, &conf, FixupConfigDurations); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Error parsing autopilot config: %v", err)
 			return nil, nil
 		}
@@ -244,7 +244,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 		if _, ok := params["cas"]; ok {
 			casVal, err := strconv.ParseUint(params.Get("cas"), 10, 64)
 			if err != nil {
-				resp.WriteHeader(http.StatusBadRequest) // 400
+				resp.WriteHeader(http.StatusBadRequest)
 				fmt.Fprintf(resp, "Error parsing cas value: %v", err)
 				return nil, nil
 			}

--- a/agent/operator_endpoint.go
+++ b/agent/operator_endpoint.go
@@ -90,7 +90,7 @@ func (s *HTTPServer) OperatorKeyringEndpoint(resp http.ResponseWriter, req *http
 	var args keyringArgs
 	if req.Method == "POST" || req.Method == "PUT" || req.Method == "DELETE" {
 		if err := decodeBody(req, &args, nil); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -101,14 +101,14 @@ func (s *HTTPServer) OperatorKeyringEndpoint(resp http.ResponseWriter, req *http
 	if relayFactor := req.URL.Query().Get("relay-factor"); relayFactor != "" {
 		n, err := strconv.Atoi(relayFactor)
 		if err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Error parsing relay factor: %v", err)
 			return nil, nil
 		}
 
 		args.RelayFactor, err = ParseRelayFactor(n)
 		if err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Invalid relay factor: %v", err)
 			return nil, nil
 		}
@@ -224,7 +224,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 
 		var conf api.AutopilotConfiguration
 		if err := decodeBody(req, &conf, FixupConfigDurations); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Error parsing autopilot config: %v", err)
 			return nil, nil
 		}
@@ -244,7 +244,7 @@ func (s *HTTPServer) OperatorAutopilotConfiguration(resp http.ResponseWriter, re
 		if _, ok := params["cas"]; ok {
 			casVal, err := strconv.ParseUint(params.Get("cas"), 10, 64)
 			if err != nil {
-				resp.WriteHeader(400)
+				resp.WriteHeader(http.StatusBadRequest) // 400
 				fmt.Fprintf(resp, "Error parsing cas value: %v", err)
 				return nil, nil
 			}

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -111,7 +111,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound) // 404
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -155,7 +155,7 @@ func (s *HTTPServer) preparedQueryExplain(id string, resp http.ResponseWriter, r
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound) // 404
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -178,7 +178,7 @@ func (s *HTTPServer) preparedQueryGet(id string, resp http.ResponseWriter, req *
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(404)
+			resp.WriteHeader(http.StatusNotFound) // 404
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -29,7 +29,7 @@ func (s *HTTPServer) preparedQueryCreate(resp http.ResponseWriter, req *http.Req
 	s.parseToken(req, &args.Token)
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Query, nil); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -71,7 +71,7 @@ func (s *HTTPServer) PreparedQueryGeneral(resp http.ResponseWriter, req *http.Re
 		return s.preparedQueryList(resp, req)
 
 	default:
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 }
@@ -111,7 +111,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(http.StatusNotFound) // 404
+			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -155,7 +155,7 @@ func (s *HTTPServer) preparedQueryExplain(id string, resp http.ResponseWriter, r
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(http.StatusNotFound) // 404
+			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -178,7 +178,7 @@ func (s *HTTPServer) preparedQueryGet(id string, resp http.ResponseWriter, req *
 		// We have to check the string since the RPC sheds
 		// the specific error type.
 		if err.Error() == consul.ErrQueryNotFound.Error() {
-			resp.WriteHeader(http.StatusNotFound) // 404
+			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
 		}
@@ -196,7 +196,7 @@ func (s *HTTPServer) preparedQueryUpdate(id string, resp http.ResponseWriter, re
 	s.parseToken(req, &args.Token)
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Query, nil); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -261,7 +261,7 @@ func (s *HTTPServer) PreparedQuerySpecific(resp http.ResponseWriter, req *http.R
 		return s.preparedQueryDelete(id, resp, req)
 
 	default:
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 }

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -29,7 +29,7 @@ func (s *HTTPServer) preparedQueryCreate(resp http.ResponseWriter, req *http.Req
 	s.parseToken(req, &args.Token)
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Query, nil); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -196,7 +196,7 @@ func (s *HTTPServer) preparedQueryUpdate(id string, resp http.ResponseWriter, re
 	s.parseToken(req, &args.Token)
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Query, nil); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -71,7 +71,7 @@ func (s *HTTPServer) PreparedQueryGeneral(resp http.ResponseWriter, req *http.Re
 		return s.preparedQueryList(resp, req)
 
 	default:
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 }
@@ -261,7 +261,7 @@ func (s *HTTPServer) PreparedQuerySpecific(resp http.ResponseWriter, req *http.R
 		return s.preparedQueryDelete(id, resp, req)
 
 	default:
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 }

--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -29,7 +29,7 @@ type sessionCreateResponse struct {
 func (s *HTTPServer) SessionCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -50,7 +50,7 @@ func (s *HTTPServer) SessionCreate(resp http.ResponseWriter, req *http.Request) 
 	// Handle optional request body
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Session, FixupLockDelay); err != nil {
-			resp.WriteHeader(http.StatusBadRequest) // 400
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -109,7 +109,7 @@ func FixupLockDelay(raw interface{}) error {
 func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -122,7 +122,7 @@ func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request)
 	// Pull out the session id
 	args.Session.ID = strings.TrimPrefix(req.URL.Path, "/v1/session/destroy/")
 	if args.Session.ID == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -138,7 +138,7 @@ func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
+		resp.WriteHeader(http.StatusMethodNotAllowed)
 		return nil, nil
 	}
 
@@ -150,7 +150,7 @@ func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (
 	// Pull out the session id
 	args.Session = strings.TrimPrefix(req.URL.Path, "/v1/session/renew/")
 	if args.Session == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -159,7 +159,7 @@ func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (
 	if err := s.agent.RPC("Session.Renew", &args, &out); err != nil {
 		return nil, err
 	} else if out.Sessions == nil {
-		resp.WriteHeader(http.StatusNotFound) // 404
+		resp.WriteHeader(http.StatusNotFound)
 		fmt.Fprintf(resp, "Session id '%s' not found", args.Session)
 		return nil, nil
 	}
@@ -177,7 +177,7 @@ func (s *HTTPServer) SessionGet(resp http.ResponseWriter, req *http.Request) (in
 	// Pull out the session id
 	args.Session = strings.TrimPrefix(req.URL.Path, "/v1/session/info/")
 	if args.Session == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -225,7 +225,7 @@ func (s *HTTPServer) SessionsForNode(resp http.ResponseWriter, req *http.Request
 	// Pull out the node name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/session/node/")
 	if args.Node == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}

--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -29,7 +29,7 @@ type sessionCreateResponse struct {
 func (s *HTTPServer) SessionCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -109,7 +109,7 @@ func FixupLockDelay(raw interface{}) error {
 func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 
@@ -138,7 +138,7 @@ func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request)
 func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	// Mandate a PUT request
 	if req.Method != "PUT" {
-		resp.WriteHeader(405)
+		resp.WriteHeader(http.StatusMethodNotAllowed) // 405
 		return nil, nil
 	}
 

--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -159,7 +159,7 @@ func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (
 	if err := s.agent.RPC("Session.Renew", &args, &out); err != nil {
 		return nil, err
 	} else if out.Sessions == nil {
-		resp.WriteHeader(404)
+		resp.WriteHeader(http.StatusNotFound) // 404
 		fmt.Fprintf(resp, "Session id '%s' not found", args.Session)
 		return nil, nil
 	}

--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -50,7 +50,7 @@ func (s *HTTPServer) SessionCreate(resp http.ResponseWriter, req *http.Request) 
 	// Handle optional request body
 	if req.ContentLength > 0 {
 		if err := decodeBody(req, &args.Session, FixupLockDelay); err != nil {
-			resp.WriteHeader(400)
+			resp.WriteHeader(http.StatusBadRequest) // 400
 			fmt.Fprintf(resp, "Request decode failed: %v", err)
 			return nil, nil
 		}
@@ -122,7 +122,7 @@ func (s *HTTPServer) SessionDestroy(resp http.ResponseWriter, req *http.Request)
 	// Pull out the session id
 	args.Session.ID = strings.TrimPrefix(req.URL.Path, "/v1/session/destroy/")
 	if args.Session.ID == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -150,7 +150,7 @@ func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (
 	// Pull out the session id
 	args.Session = strings.TrimPrefix(req.URL.Path, "/v1/session/renew/")
 	if args.Session == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -177,7 +177,7 @@ func (s *HTTPServer) SessionGet(resp http.ResponseWriter, req *http.Request) (in
 	// Pull out the session id
 	args.Session = strings.TrimPrefix(req.URL.Path, "/v1/session/info/")
 	if args.Session == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing session")
 		return nil, nil
 	}
@@ -225,7 +225,7 @@ func (s *HTTPServer) SessionsForNode(resp http.ResponseWriter, req *http.Request
 	// Pull out the node name
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/session/node/")
 	if args.Node == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -68,7 +68,7 @@ func (s *HTTPServer) UINodeInfo(resp http.ResponseWriter, req *http.Request) (in
 	// Verify we have some DC, or use the default
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/node/")
 	if args.Node == "" {
-		resp.WriteHeader(400)
+		resp.WriteHeader(http.StatusBadRequest) // 400
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -68,7 +68,7 @@ func (s *HTTPServer) UINodeInfo(resp http.ResponseWriter, req *http.Request) (in
 	// Verify we have some DC, or use the default
 	args.Node = strings.TrimPrefix(req.URL.Path, "/v1/internal/ui/node/")
 	if args.Node == "" {
-		resp.WriteHeader(http.StatusBadRequest) // 400
+		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing node name")
 		return nil, nil
 	}


### PR DESCRIPTION
This patch replaces numeric codes with the constants from the `http` package.