### PR TITLE
Initial autocompletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,9 +42,11 @@ func realMain() int {
 	}
 
 	cli := &cli.CLI{
-		Args:     args,
-		Commands: command.Commands,
-		HelpFunc: cli.FilteredHelpFunc(cmds, cli.BasicHelpFunc("consul")),
+		Args:         args,
+		Commands:     command.Commands,
+		Autocomplete: true,
+		Name:         "consul",
+		HelpFunc:     cli.FilteredHelpFunc(cmds, cli.BasicHelpFunc("consul")),
 	}
 
 	exitCode, err := cli.Run()

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -92,8 +92,10 @@ $ consul e
 event  exec
 
 $ consul r
-raft    reload  rtt
+reload  rtt
 
+$ consul operator raft
+list-peers   remove-peer
 ```
 
 ## Environment Variables

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -79,6 +79,23 @@ Command Options
      Joins a server to another server in the WAN pool.
 ```
 
+## Autocompletion
+
+The `consul` command features opt-in subcommand autocompletion that you can
+enable for your shell with `consul -autocomplete-install`. After doing so,
+you can invoke a new shell and use the feature.
+
+For example, assume a tab is typed at the end of each prompt line:
+
+```
+$ consul e
+event  exec
+
+$ consul r
+raft    reload  rtt
+
+```
+
 ## Environment Variables
 
 In addition to CLI flags, Consul reads environment variables for behavior


### PR DESCRIPTION
Initial autocomplete spike!

- This begins to address #3291 by enabling the initial for-free sub-command
  autocompletion feature from mitchellh/cli

I vendored latest CLI and verified `consul -autocomplete-install` and basic sub-command completion was occurring for me in `zsh` :tada:

Had to add [Name:](https://github.com/mitchellh/cli/blob/master/cli.go#L65) as well because Autocomplete errors without it:

```
./consul
Error executing CLI: internal error: CLI.Name must be specified for autocomplete to work
```

As I understand it, there needs to be additional work done for completion on specific CLI flags and such to make things more complete / even fancier. :smile: but perhaps this is a good start?!
