### PR TITLE
Implement HTTP Watch handler

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -563,11 +563,11 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 		} else if hasArgs && !ok {
 			return fmt.Errorf("Watch args must be a list of strings")
 		}
-		if hasHandler && hasArgs {
-			return fmt.Errorf("Cannot define both watch handler and args")
+		if hasHandler && hasArgs || hasHandler && wp.HandlerType != "" || hasArgs && wp.HandlerType != "" {
+			return fmt.Errorf("Only one watch handler allowed")
 		}
-		if !hasHandler && !hasArgs {
-			return fmt.Errorf("Must define either watch handler or args")
+		if !hasHandler && !hasArgs && wp.HandlerType == "" {
+			return fmt.Errorf("Must define a watch handler")
 		}
 
 		// Store the watch plan
@@ -590,13 +590,14 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 	for _, wp := range watchPlans {
 		a.watchPlans = append(a.watchPlans, wp)
 		go func(wp *watch.Plan) {
-			var handler interface{}
 			if h, ok := wp.Exempt["handler"]; ok {
-				handler = h
+				wp.Handler = makeWatchHandler(a.LogOutput, h)
+			} else if h, ok := wp.Exempt["args"]; ok {
+				wp.Handler = makeWatchHandler(a.LogOutput, h)
 			} else {
-				handler = wp.Exempt["args"]
+				httpConfig := wp.Exempt["http_handler_config"].(watch.HttpHandlerConfig)
+				wp.Handler = makeHTTPWatchHandler(a.LogOutput, &httpConfig)
 			}
-			wp.Handler = makeWatchHandler(a.LogOutput, handler)
 			wp.LogOutput = a.LogOutput
 			if err := wp.Run(addr); err != nil {
 				a.logger.Printf("[ERR] Failed to run watch: %v", err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -537,7 +537,7 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 		if handlerType, ok := params["handler_type"]; !ok {
 			params["handler_type"] = "script"
 		} else if handlerType != "http" && handlerType != "script" {
-			return fmt.Errorf(fmt.Sprintf("Handler type '%s' not recognized", params["handler_type"]))
+			return fmt.Errorf("Handler type '%s' not recognized", params["handler_type"])
 		}
 
 		// Parse the watches, excluding 'handler' and 'args'

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -595,8 +595,8 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 			} else if h, ok := wp.Exempt["args"]; ok {
 				wp.Handler = makeWatchHandler(a.LogOutput, h)
 			} else {
-				httpConfig := wp.Exempt["http_handler_config"].(watch.HttpHandlerConfig)
-				wp.Handler = makeHTTPWatchHandler(a.LogOutput, &httpConfig)
+				httpConfig := wp.Exempt["http_handler_config"].(*watch.HttpHandlerConfig)
+				wp.Handler = makeHTTPWatchHandler(a.LogOutput, httpConfig)
 			}
 			wp.LogOutput = a.LogOutput
 			if err := wp.Run(addr); err != nil {

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -10,12 +10,12 @@ import (
 	"os/exec"
 	"strconv"
 
+	"crypto/tls"
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul/watch"
 	"github.com/hashicorp/go-cleanhttp"
 	"net/http"
 	"time"
-	"crypto/tls"
 )
 
 const (
@@ -107,7 +107,6 @@ func makeHTTPWatchHandler(logOutput io.Writer, method string, httpUrl string, he
 			trans.TLSClientConfig.InsecureSkipVerify = tlsSkipVerify
 		}
 
-		// TODO: put in outer scope
 		// Create the HTTP client.
 		httpClient := &http.Client{
 			Timeout:   timeout,
@@ -127,12 +126,12 @@ func makeHTTPWatchHandler(logOutput io.Writer, method string, httpUrl string, he
 			logger.Printf("[ERR] agent: Failed to setup http watch: %v", err)
 			return
 		}
+		req.Header.Add("X-Consul-Index", strconv.FormatUint(idx, 10))
 		for key, values := range headers {
 			for _, val := range values {
 				req.Header.Add(key, val)
 			}
 		}
-		req.Header.Add("X-Consul-Index", strconv.FormatUint(idx, 10))
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			logger.Printf("[ERR] agent: Failed to invoke http watch handler '%s': %v", httpUrl, err)

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -156,7 +156,7 @@ func makeHTTPWatchHandler(logOutput io.Writer, config *watch.HttpHandlerConfig) 
 
 		if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 			// Log the output
-			logger.Printf("[DEBUG] agent: http watch handler '%s' output: %s", config.Path, outputStr)
+			logger.Printf("[TRACE] agent: http watch handler '%s' output: %s", config.Path, outputStr)
 		} else {
 			logger.Printf("[ERR] agent: http watch handler '%s' got '%s' with output: %s",
 				config.Path, resp.Status, outputStr)

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -91,7 +91,7 @@ func makeWatchHandler(logOutput io.Writer, handler interface{}) watch.HandlerFun
 	return fn
 }
 
-func makeHTTPWatchHandler(logOutput io.Writer, method string, httpUrl string, headers map[string]string, timeout time.Duration) watch.HandlerFunc {
+func makeHTTPWatchHandler(logOutput io.Writer, method string, httpUrl string, headers map[string][]string, timeout time.Duration) watch.HandlerFunc {
 	logger := log.New(logOutput, "", log.LstdFlags)
 
 	fn := func(idx uint64, data interface{}) {
@@ -120,8 +120,10 @@ func makeHTTPWatchHandler(logOutput io.Writer, method string, httpUrl string, he
 			logger.Printf("[ERR] agent: Failed to setup http watch: %v", err)
 			return
 		}
-		for key, val := range headers {
-			req.Header.Add(key, val)
+		for key, values := range headers {
+			for _, val := range values {
+				req.Header.Add(key, val)
+			}
 		}
 		req.Header.Add("X-Consul-Index", strconv.FormatUint(idx, 10))
 		resp, err := httpClient.Do(req)

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -130,6 +130,7 @@ func makeHTTPWatchHandler(logOutput io.Writer, config *watch.HttpHandlerConfig) 
 			return
 		}
 		req = req.WithContext(ctx)
+		req.Header.Add("Content-Type", "application/json")
 		req.Header.Add("X-Consul-Index", strconv.FormatUint(idx, 10))
 		for key, values := range config.Header {
 			for _, val := range values {

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -20,7 +20,7 @@ func TestMakeWatchHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if string(raw) != `["foo","bar","baz"]\n` {
+	if string(raw) != "[\"foo\",\"bar\",\"baz\"]\n" {
 		t.Fatalf("bad: %s", raw)
 	}
 	raw, err = ioutil.ReadFile("handler_index_out")
@@ -34,7 +34,6 @@ func TestMakeWatchHandler(t *testing.T) {
 
 func TestMakeHTTPWatchHandler(t *testing.T) {
 	t.Parallel()
-	finishedRequest := make(chan bool)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		idx := r.Header.Get("X-Consul-Index")
 		if idx != "100" {
@@ -48,11 +47,8 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 			t.Fatalf("bad: %s", body)
 		}
 		w.Write([]byte("Ok, i see"))
-		finishedRequest <- true
 	}))
 	defer server.Close()
-	t.Log("ww")
-	handler := makeHTTPWatchHandler(os.Stderr, "POST", server.URL, nil, time.Minute)
+	handler := makeHTTPWatchHandler(os.Stderr, "POST", server.URL, nil, time.Minute, false)
 	handler(100, []string{"foo", "bar", "baz"})
-	<-finishedRequest
 }

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -46,7 +46,7 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 			t.Fatalf("bad: %s", body)
 		}
 		w.Write([]byte("Ok, i see"))
-		t.Log("goood")
+		t.Log("goood") // TODO: Clean
 	}))
 	defer server.Close()
 	t.Log("ww")

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -42,7 +42,7 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if string(body) != `["foo","bar","baz"]\n` {
+		if string(body) != `["foo","bar","baz"]` {
 			t.Fatalf("bad: %s", body)
 		}
 		w.Write([]byte("Ok, i see"))

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -39,16 +39,22 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 		if idx != "100" {
 			t.Fatalf("bad: %s", idx)
 		}
+		// Get the first one
+		customHeader := r.Header.Get("X-Custom")
+		if customHeader != "abc" {
+			t.Fatalf("bad: %s", idx)
+		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if string(body) != `["foo","bar","baz"]` {
+		if string(body) != "[\"foo\",\"bar\",\"baz\"]\n" {
 			t.Fatalf("bad: %s", body)
 		}
 		w.Write([]byte("Ok, i see"))
 	}))
 	defer server.Close()
-	handler := makeHTTPWatchHandler(os.Stderr, "POST", server.URL, nil, time.Minute, false)
+	headers := map[string][]string{"X-Custom": {"abc", "def"}}
+	handler := makeHTTPWatchHandler(os.Stderr, "POST", server.URL, headers, time.Minute, false)
 	handler(100, []string{"foo", "bar", "baz"})
 }

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -1,13 +1,13 @@
 package agent
 
 import (
+	"github.com/hashicorp/consul/watch"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
-	"github.com/hashicorp/consul/watch"
 )
 
 func TestMakeWatchHandler(t *testing.T) {

--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 	"time"
+	"github.com/hashicorp/consul/watch"
 )
 
 func TestMakeWatchHandler(t *testing.T) {
@@ -54,7 +55,11 @@ func TestMakeHTTPWatchHandler(t *testing.T) {
 		w.Write([]byte("Ok, i see"))
 	}))
 	defer server.Close()
-	headers := map[string][]string{"X-Custom": {"abc", "def"}}
-	handler := makeHTTPWatchHandler(os.Stderr, "POST", server.URL, headers, time.Minute, false)
+	config := watch.HttpHandlerConfig{
+		Path:    server.URL,
+		Header:  map[string][]string{"X-Custom": {"abc", "def"}},
+		Timeout: time.Minute,
+	}
+	handler := makeHTTPWatchHandler(os.Stderr, &config)
 	handler(100, []string{"foo", "bar", "baz"})
 }

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -98,10 +98,8 @@ func ParseExempt(params map[string]interface{}, exempt []string) (*Plan, error) 
 		plan.Exempt["http_handler_config"] = config
 		delete(params, "http_handler_config")
 
-	case "":
-		// Let continue and check for 'args' or 'handler' parameter later
-	default:
-		return nil, fmt.Errorf(fmt.Sprintf("Handler type '%s' not recognized", plan.HandlerType))
+	case "script":
+		// Let the caller check for configuration in exempt parameters
 	}
 
 	// Look for a factory function

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const DefaultTimeout = 10 * time.Second
+
 // Plan is the parsed version of a watch specification. A watch provides
 // the details of a query, which generates a view into the Consul data store.
 // This view is watched for changes and a handler is invoked to take any
@@ -177,13 +179,11 @@ func parseHttpHandlerConfig(configParams interface{}) (*HttpHandlerConfig, error
 		config.Method = "POST"
 	}
 	if config.TimeoutRaw == "" {
-		config.Timeout = 10 * time.Second
+		config.Timeout = DefaultTimeout
+	} else if timeout, err := time.ParseDuration(config.TimeoutRaw); err != nil {
+		return nil, fmt.Errorf(fmt.Sprintf("Failed to parse timeout: %v", err))
 	} else {
-		if timeout, err := time.ParseDuration(config.TimeoutRaw); err != nil {
-			return nil, fmt.Errorf(fmt.Sprintf("Failed to parse timeout: %v", err))
-		} else {
-			config.Timeout = timeout
-		}
+		config.Timeout = timeout
 	}
 
 	return &config, nil

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -40,7 +40,8 @@ type Plan struct {
 type HttpHandlerConfig struct {
 	Path          string              `mapstructure:"path"`
 	Method        string              `mapstructure:"method"`
-	Timeout       time.Duration       `mapstructure:"timeout"`
+	Timeout       time.Duration       `mapstructure:"-"`
+	TimeoutRaw    string              `mapstructure:"timeout"`
 	Header        map[string][]string `mapstructure:"header"`
 	TLSSkipVerify bool                `mapstructure:"tls_skip_verify"`
 }
@@ -97,8 +98,14 @@ func ParseExempt(params map[string]interface{}, exempt []string) (*Plan, error) 
 		if config.Method == "" {
 			config.Method = "POST"
 		}
-		if config.Timeout == 0*time.Second {
+		if config.TimeoutRaw == "" {
 			config.Timeout = 10 * time.Second
+		} else {
+			if timeout, err := time.ParseDuration(config.TimeoutRaw); err != nil {
+				return nil, fmt.Errorf(fmt.Sprintf("Failed to parse HTTP watch timeout: %v", err))
+			} else {
+				config.Timeout = timeout
+			}
 		}
 		plan.Exempt["http_handler_config"] = config
 		delete(params, "http_handler_config")

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"time"
 )
 
 // Plan is the parsed version of a watch specification. A watch provides
@@ -19,9 +20,10 @@ type Plan struct {
 	Type       string
 	Exempt     map[string]interface{}
 
-	Watcher   WatcherFunc
-	Handler   HandlerFunc
-	LogOutput io.Writer
+	Watcher     WatcherFunc
+	HandlerType string
+	Handler     HandlerFunc
+	LogOutput   io.Writer
 
 	address    string
 	client     *consulapi.Client
@@ -32,6 +34,14 @@ type Plan struct {
 	stopCh     chan struct{}
 	stopLock   sync.Mutex
 	cancelFunc context.CancelFunc
+}
+
+type HttpHandlerConfig struct {
+	Path          string
+	Method        string
+	Timeout       time.Duration
+	Header        map[string][]string
+	TLSSkipVerify bool
 }
 
 // WatcherFunc is used to watch for a diff

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -38,21 +38,6 @@ func TestParse_exempt(t *testing.T) {
 	}
 }
 
-func TestParse_httpExempt(t *testing.T) {
-	params := makeParams(t, `{"type":"key", "key":"foo", "http": "foobar"}`)
-	p, err := ParseExempt(params, []string{"handler", "http"})
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if p.Type != "key" {
-		t.Fatalf("Bad: %#v", p)
-	}
-	ex := p.Exempt["http"]
-	if ex != "foobar" {
-		t.Fatalf("bad: %v", ex)
-	}
-}
-
 func makeParams(t *testing.T, s string) map[string]interface{} {
 	var out map[string]interface{}
 	dec := json.NewDecoder(bytes.NewReader([]byte(s)))

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -38,6 +38,38 @@ func TestParse_exempt(t *testing.T) {
 	}
 }
 
+func TestParse_httpExempt(t *testing.T) {
+	params := makeParams(t, `{"type":"key", "key":"foo", "http": "foobar"}`)
+	p, err := ParseExempt(params, []string{"handler", "http"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if p.Type != "key" {
+		t.Fatalf("Bad: %#v", p)
+	}
+	ex := p.Exempt["http"]
+	if ex != "foobar" {
+		t.Fatalf("bad: %v", ex)
+	}
+}
+
+func TestParse_exempt_NoHandler(t *testing.T) {
+	params := makeParams(t, `{"type":"key", "key":"foo"}`)
+	p, err := ParseExempt(params, []string{"handler", "http"})
+	print(p)
+	if err == nil {
+		t.Fatalf("Expected ParseExempt to fail")
+	}
+}
+
+func TestParse_exempt_TooManyHandlers(t *testing.T) {
+	params := makeParams(t, `{"type":"key", "key":"foo", "handler": "foobar", "http": "barfoo"}`)
+	_, err := ParseExempt(params, []string{"handler", "http"})
+	if err == nil {
+		t.Fatalf("Expected ParseExempt to fail")
+	}
+}
+
 func makeParams(t *testing.T, s string) map[string]interface{} {
 	var out map[string]interface{}
 	dec := json.NewDecoder(bytes.NewReader([]byte(s)))

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -53,23 +53,6 @@ func TestParse_httpExempt(t *testing.T) {
 	}
 }
 
-func TestParse_exempt_NoHandler(t *testing.T) {
-	params := makeParams(t, `{"type":"key", "key":"foo"}`)
-	p, err := ParseExempt(params, []string{"handler", "http"})
-	print(p)
-	if err == nil {
-		t.Fatalf("Expected ParseExempt to fail")
-	}
-}
-
-func TestParse_exempt_TooManyHandlers(t *testing.T) {
-	params := makeParams(t, `{"type":"key", "key":"foo", "handler": "foobar", "http": "barfoo"}`)
-	_, err := ParseExempt(params, []string{"handler", "http"})
-	if err == nil {
-		t.Fatalf("Expected ParseExempt to fail")
-	}
-}
-
 func makeParams(t *testing.T, s string) map[string]interface{} {
 	var out map[string]interface{}
 	dec := json.NewDecoder(bytes.NewReader([]byte(s)))


### PR DESCRIPTION
This makes it possible to be notified for updates using HTTP requests to a chosen endpoint. When a watch is triggered, a HTTP request is done with JSON payload. Before, it could only notify changes by executing an executable.

Resolves #3305

Todo before done:
- Make request configurable
- Fix tests
- HTTPS support