### PR TITLE
API DOCS: Update snapshot curl example

### DIFF
--- a/website/source/api/snapshot.html.md
+++ b/website/source/api/snapshot.html.md
@@ -60,7 +60,7 @@ The table below shows this endpoint's support for
 With a custom datacenter:
 
 ```text
-$ curl https://consul.rocks/v1/snapshot?dc=my-datacenter
+$ curl https://consul.rocks/v1/snapshot?dc=my-datacenter -o snapshot.tgz
 ```
 
 ### Sample Response

--- a/website/source/api/snapshot.html.md
+++ b/website/source/api/snapshot.html.md
@@ -63,11 +63,7 @@ With a custom datacenter:
 $ curl https://consul.rocks/v1/snapshot?dc=my-datacenter -o snapshot.tgz
 ```
 
-### Sample Response
-
-```text
-<gzipped tarball ...>
-```
+The above example results in a tarball named `snapshot.tgz` in the current working directory.
 
 In addition to the Consul standard stale-related headers, the `X-Consul-Index`
 header will contain the index at which the snapshot took place.


### PR DESCRIPTION
The current example snapshot API `curl` command outputs binary data to stdout, which is unexpected and never a hit at parties in the terminal.

Proposing an example here that generates a tarball file instead.
