### PR TITLE
docs: add quotes around example invocation for google cloud retry join

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -318,7 +318,7 @@ will exit with an error at startup.
     project which have the given `tag_value`.
 
     ```sh
-    $ consul agent -retry-join provider=gce project_name=xxx tag_value=xxx
+    $ consul agent -retry-join "provider=gce project_name=xxx tag_value=xxx"
     ```
 
     ```json


### PR DESCRIPTION
Doesn't work without the quotes. 

It's a tiny thing but honestly took me a few days to figure out where I was going wrong.
