### PR TITLE
Fix watch error when http & https are disabled

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -515,8 +515,19 @@ func (a *Agent) serveHTTP(l net.Listener, srv *HTTPServer) error {
 // reloadWatches stops any existing watch plans and attempts to load the given
 // set of watches.
 func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
+	// Stop the current watches.
+	for _, wp := range a.watchPlans {
+		wp.Stop()
+	}
+	a.watchPlans = nil
+
+	// Return if there are no watches now.
+	if len(cfg.Watches) == 0 {
+		return nil
+	}
+
 	// Watches use the API to talk to this agent, so that must be enabled.
-	if len(cfg.HTTPAddrs) == 0 {
+	if len(cfg.HTTPAddrs) == 0 && len(cfg.HTTPSAddrs) == 0 {
 		return fmt.Errorf("watch plans require an HTTP or HTTPS endpoint")
 	}
 
@@ -539,16 +550,18 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 		watchPlans = append(watchPlans, wp)
 	}
 
-	// Stop the current watches.
-	for _, wp := range a.watchPlans {
-		wp.Stop()
-	}
-	a.watchPlans = nil
-
-	// deterine the primary http endpoint
-	addr := cfg.HTTPAddrs[0].String()
-	if cfg.HTTPAddrs[0].Network() == "unix" {
-		addr = "unix://" + addr
+	// Determine the primary http(s) endpoint.
+	var addr string
+	if len(cfg.HTTPAddrs) > 0 {
+		addr = cfg.HTTPAddrs[0].String()
+		if cfg.HTTPAddrs[0].Network() == "unix" {
+			addr = "unix://" + addr
+		}
+	} else {
+		addr = cfg.HTTPSAddrs[0].String()
+		if cfg.HTTPSAddrs[0].Network() == "unix" {
+			addr = "unix://" + addr
+		}
 	}
 
 	// Fire off a goroutine for each new watch plan.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -551,17 +551,15 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 	}
 
 	// Determine the primary http(s) endpoint.
-	var addr string
+	var netaddr net.Addr
 	if len(cfg.HTTPAddrs) > 0 {
-		addr = cfg.HTTPAddrs[0].String()
-		if cfg.HTTPAddrs[0].Network() == "unix" {
-			addr = "unix://" + addr
-		}
+		netaddr = cfg.HTTPAddrs[0]
 	} else {
-		addr = cfg.HTTPSAddrs[0].String()
-		if cfg.HTTPSAddrs[0].Network() == "unix" {
-			addr = "unix://" + addr
-		}
+		netaddr = cfg.HTTPSAddrs[0]
+	}
+	addr := netaddr.String()
+	if netaddr.Network() == "unix" {
+		addr = "unix://" + addr
 	}
 
 	// Fire off a goroutine for each new watch plan.


### PR DESCRIPTION
Remove an error in watch reloading that happens when http and https are both disabled, and use an https address for running watches if no http addresses are present.

Fixes #3425.