### PR TITLE
Renames `enable_ui` to `ui` to keep compatibility with existing configs.

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -554,7 +554,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		EnableDebug:                 b.boolVal(c.EnableDebug),
 		EnableScriptChecks:          b.boolVal(c.EnableScriptChecks),
 		EnableSyslog:                b.boolVal(c.EnableSyslog),
-		EnableUI:                    b.boolVal(c.EnableUI),
+		EnableUI:                    b.boolVal(c.UI),
 		EncryptKey:                  b.stringVal(c.EncryptKey),
 		EncryptVerifyIncoming:       b.boolVal(c.EncryptVerifyIncoming),
 		EncryptVerifyOutgoing:       b.boolVal(c.EncryptVerifyOutgoing),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -163,7 +163,6 @@ type Config struct {
 	EnableDebug                 *bool                    `json:"enable_debug,omitempty" hcl:"enable_debug" mapstructure:"enable_debug"`
 	EnableScriptChecks          *bool                    `json:"enable_script_checks,omitempty" hcl:"enable_script_checks" mapstructure:"enable_script_checks"`
 	EnableSyslog                *bool                    `json:"enable_syslog,omitempty" hcl:"enable_syslog" mapstructure:"enable_syslog"`
-	EnableUI                    *bool                    `json:"enable_ui,omitempty" hcl:"enable_ui" mapstructure:"enable_ui"`
 	EncryptKey                  *string                  `json:"encrypt,omitempty" hcl:"encrypt" mapstructure:"encrypt"`
 	EncryptVerifyIncoming       *bool                    `json:"encrypt_verify_incoming,omitempty" hcl:"encrypt_verify_incoming" mapstructure:"encrypt_verify_incoming"`
 	EncryptVerifyOutgoing       *bool                    `json:"encrypt_verify_outgoing,omitempty" hcl:"encrypt_verify_outgoing" mapstructure:"encrypt_verify_outgoing"`
@@ -209,6 +208,7 @@ type Config struct {
 	TaggedAddresses             map[string]string        `json:"tagged_addresses,omitempty" hcl:"tagged_addresses" mapstructure:"tagged_addresses"`
 	Telemetry                   Telemetry                `json:"telemetry,omitempty" hcl:"telemetry" mapstructure:"telemetry"`
 	TranslateWANAddrs           *bool                    `json:"translate_wan_addrs,omitempty" hcl:"translate_wan_addrs" mapstructure:"translate_wan_addrs"`
+	UI                          *bool                    `json:"ui,omitempty" hcl:"ui" mapstructure:"ui"`
 	UIDir                       *string                  `json:"ui_dir,omitempty" hcl:"ui_dir" mapstructure:"ui_dir"`
 	UnixSocket                  UnixSocket               `json:"unix_sockets,omitempty" hcl:"unix_sockets" mapstructure:"unix_sockets"`
 	VerifyIncoming              *bool                    `json:"verify_incoming,omitempty" hcl:"verify_incoming" mapstructure:"verify_incoming"`

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -94,7 +94,7 @@ func DevSource() Source {
 		disable_anonymous_signature = true
 		disable_keyring_file = true
 		enable_debug = true
-		enable_ui = true
+		ui = true
 		log_level = "DEBUG"
 		server = true
 		performance = {

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -98,7 +98,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.SerfBindAddrWAN, "serf-wan-bind", "Address to bind Serf WAN listeners to.")
 	add(&f.Config.ServerMode, "server", "Switches agent to server mode.")
 	add(&f.Config.EnableSyslog, "syslog", "Enables logging to syslog.")
-	add(&f.Config.EnableUI, "ui", "Enables the built-in static web UI server.")
+	add(&f.Config.UI, "ui", "Enables the built-in static web UI server.")
 	add(&f.Config.UIDir, "ui-dir", "Path to directory containing the web UI resources.")
 	add(&f.HCL, "hcl", "hcl config fragment. Can be specified multiple times.")
 }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1338,13 +1338,13 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			err:  "DNS address cannot be a unix socket",
 		},
 		{
-			desc: "enable_ui and ui_dir",
+			desc: "ui and ui_dir",
 			flags: []string{
 				`-datacenter=a`,
 				`-data-dir=` + dataDir,
 			},
-			json: []string{`{ "enable_ui": true, "ui_dir": "a" }`},
-			hcl:  []string{`enable_ui = true ui_dir = "a"`},
+			json: []string{`{ "ui": true, "ui_dir": "a" }`},
+			hcl:  []string{`ui = true ui_dir = "a"`},
 			err: "Both the ui and ui-dir flags were specified, please provide only one.\n" +
 				"If trying to use your own web UI resources, use the ui-dir flag.\n" +
 				"If using Consul version 0.7.0 or later, the web UI is included in the binary so use ui to enable it",
@@ -1958,7 +1958,6 @@ func TestFullConfig(t *testing.T) {
 			"enable_debug": true,
 			"enable_script_checks": true,
 			"enable_syslog": true,
-			"enable_ui": true,
 			"encrypt": "A4wELWqH",
 			"encrypt_verify_incoming": true,
 			"encrypt_verify_outgoing": true,
@@ -2221,6 +2220,7 @@ func TestFullConfig(t *testing.T) {
 			"tls_min_version": "pAOWafkR",
 			"tls_prefer_server_cipher_suites": true,
 			"translate_wan_addrs": true,
+			"ui": true,
 			"ui_dir": "11IFzAUn",
 			"unix_sockets": {
 				"group": "8pFodrV8",
@@ -2378,7 +2378,6 @@ func TestFullConfig(t *testing.T) {
 			enable_debug = true
 			enable_script_checks = true
 			enable_syslog = true
-			enable_ui = true
 			encrypt = "A4wELWqH"
 			encrypt_verify_incoming = true
 			encrypt_verify_outgoing = true
@@ -2641,6 +2640,7 @@ func TestFullConfig(t *testing.T) {
 			tls_min_version = "pAOWafkR"
 			tls_prefer_server_cipher_suites = true
 			translate_wan_addrs = true
+			ui = true
 			ui_dir = "11IFzAUn"
 			unix_sockets = {
 				group = "8pFodrV8"

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -717,7 +717,7 @@ func TestACLResolution(t *testing.T) {
 func TestEnableWebUI(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), `
-		enable_ui = true
+		ui = true
 	`)
 	defer a.Shutdown()
 


### PR DESCRIPTION
@magiconair this broke when I was deploying to demo.consul.io - since we didn't have this deprecated it seems disruptive to name `ui` as `enable_ui` at this time.