### PR TITLE
Metrics service prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,9 @@ BREAKING CHANGES:
     | /v1/session/node | GET |
     | /v1/status/leader | GET |
     | /v1/status/peers | GET |
-    
+
     </details>
+* **Renamed `statsite_prefix` to `metrics_prefix` in Telemetry Configuration:** Since the `statsite_prefix` applied to all telemetry providers, `statsite_prefix` was renamed to [`metrics_prefix`](https://www.consul.io/docs/agent/options.html#telemetry-metrics_prefix). Configuration files will need to be updated when upgrading to this version of Consul. [GH-3498]
 
 FEATURES:
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -539,7 +539,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		TelemetryFilterDefault:                      b.boolVal(c.Telemetry.FilterDefault),
 		TelemetryAllowedPrefixes:                    telemetryAllowedPrefixes,
 		TelemetryBlockedPrefixes:                    telemetryBlockedPrefixes,
-		TelemetryServicePrefix:                      b.stringVal(c.Telemetry.ServicePrefix),
+		TelemetryMetricsPrefix:                      b.stringVal(c.Telemetry.MetricsPrefix),
 		TelemetryStatsdAddr:                         b.stringVal(c.Telemetry.StatsdAddr),
 		TelemetryStatsiteAddr:                       b.stringVal(c.Telemetry.StatsiteAddr),
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -539,9 +539,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		TelemetryFilterDefault:                      b.boolVal(c.Telemetry.FilterDefault),
 		TelemetryAllowedPrefixes:                    telemetryAllowedPrefixes,
 		TelemetryBlockedPrefixes:                    telemetryBlockedPrefixes,
+		TelemetryServicePrefix:                      b.stringVal(c.Telemetry.ServicePrefix),
 		TelemetryStatsdAddr:                         b.stringVal(c.Telemetry.StatsdAddr),
 		TelemetryStatsiteAddr:                       b.stringVal(c.Telemetry.StatsiteAddr),
-		TelemetryStatsitePrefix:                     b.stringVal(c.Telemetry.StatsitePrefix),
 
 		// Agent
 		AdvertiseAddrLAN:            advertiseAddrLAN,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -365,9 +365,9 @@ type Telemetry struct {
 	DogstatsdTags                      []string `json:"dogstatsd_tags,omitempty" hcl:"dogstatsd_tags" mapstructure:"dogstatsd_tags"`
 	FilterDefault                      *bool    `json:"filter_default,omitempty" hcl:"filter_default" mapstructure:"filter_default"`
 	PrefixFilter                       []string `json:"prefix_filter,omitempty" hcl:"prefix_filter" mapstructure:"prefix_filter"`
+	ServicePrefix                      *string  `json:"service_prefix,omitempty" hcl:"service_prefix" mapstructure:"service_prefix"`
 	StatsdAddr                         *string  `json:"statsd_address,omitempty" hcl:"statsd_address" mapstructure:"statsd_address"`
 	StatsiteAddr                       *string  `json:"statsite_address,omitempty" hcl:"statsite_address" mapstructure:"statsite_address"`
-	StatsitePrefix                     *string  `json:"statsite_prefix,omitempty" hcl:"statsite_prefix" mapstructure:"statsite_prefix"`
 }
 
 type Ports struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -365,7 +365,7 @@ type Telemetry struct {
 	DogstatsdTags                      []string `json:"dogstatsd_tags,omitempty" hcl:"dogstatsd_tags" mapstructure:"dogstatsd_tags"`
 	FilterDefault                      *bool    `json:"filter_default,omitempty" hcl:"filter_default" mapstructure:"filter_default"`
 	PrefixFilter                       []string `json:"prefix_filter,omitempty" hcl:"prefix_filter" mapstructure:"prefix_filter"`
-	ServicePrefix                      *string  `json:"service_prefix,omitempty" hcl:"service_prefix" mapstructure:"service_prefix"`
+	MetricsPrefix                      *string  `json:"metrics_prefix,omitempty" hcl:"metrics_prefix" mapstructure:"metrics_prefix"`
 	StatsdAddr                         *string  `json:"statsd_address,omitempty" hcl:"statsd_address" mapstructure:"statsd_address"`
 	StatsiteAddr                       *string  `json:"statsite_address,omitempty" hcl:"statsite_address" mapstructure:"statsite_address"`
 }

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -76,7 +76,7 @@ func DefaultSource() Source {
 			server = ` + strconv.Itoa(consul.DefaultRPCPort) + `
 		}
 		telemetry = {
-			statsite_prefix = "consul"
+			service_prefix = "consul"
 			filter_default = true
 		}
 	`,

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -76,7 +76,7 @@ func DefaultSource() Source {
 			server = ` + strconv.Itoa(consul.DefaultRPCPort) + `
 		}
 		telemetry = {
-			service_prefix = "consul"
+			metrics_prefix = "consul"
 			filter_default = true
 		}
 	`,

--- a/agent/config/doc.go
+++ b/agent/config/doc.go
@@ -66,8 +66,8 @@
 // 	* "recursor" is deprecated. Please use "recursors" instead.
 // 	* "statsd_addr" is deprecated. Please use "telemetry.statsd_addr" instead.
 // 	* "statsite_addr" is deprecated. Please use "telemetry.statsite_addr" instead.
-// 	* "statsite_prefix" is deprecated. Please use "telemetry.service_prefix" instead.
-// 	* "telemetry.statsite_prefix" is deprecated. Please use "telemetry.service_prefix" instead.
+// 	* "statsite_prefix" is deprecated. Please use "telemetry.metrics_prefix" instead.
+// 	* "telemetry.statsite_prefix" is deprecated. Please use "telemetry.metrics_prefix" instead.
 //  * "retry_join_azure" is deprecated. Please use "retry_join" instead.
 //  * "retry_join_ec2" is deprecated. Please use "retry_join" instead.
 //  * "retry_join_gce" is deprecated. Please use "retry_join" instead.

--- a/agent/config/doc.go
+++ b/agent/config/doc.go
@@ -66,7 +66,8 @@
 // 	* "recursor" is deprecated. Please use "recursors" instead.
 // 	* "statsd_addr" is deprecated. Please use "telemetry.statsd_addr" instead.
 // 	* "statsite_addr" is deprecated. Please use "telemetry.statsite_addr" instead.
-// 	* "statsite_prefix" is deprecated. Please use "telemetry.statsite_prefix" instead.
+// 	* "statsite_prefix" is deprecated. Please use "telemetry.service_prefix" instead.
+// 	* "telemetry.statsite_prefix" is deprecated. Please use "telemetry.service_prefix" instead.
 //  * "retry_join_azure" is deprecated. Please use "retry_join" instead.
 //  * "retry_join_ec2" is deprecated. Please use "retry_join" instead.
 //  * "retry_join_gce" is deprecated. Please use "retry_join" instead.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -100,7 +100,7 @@ type RuntimeConfig struct {
 	TelemetryFilterDefault                      bool
 	TelemetryAllowedPrefixes                    []string
 	TelemetryBlockedPrefixes                    []string
-	TelemetryServicePrefix                      string
+	TelemetryMetricsPrefix                      string
 	TelemetryStatsdAddr                         string
 	TelemetryStatsiteAddr                       string
 

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -100,9 +100,9 @@ type RuntimeConfig struct {
 	TelemetryFilterDefault                      bool
 	TelemetryAllowedPrefixes                    []string
 	TelemetryBlockedPrefixes                    []string
+	TelemetryServicePrefix                      string
 	TelemetryStatsdAddr                         string
 	TelemetryStatsiteAddr                       string
-	TelemetryStatsitePrefix                     string
 
 	AdvertiseAddrLAN            *net.IPAddr
 	AdvertiseAddrWAN            *net.IPAddr

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2254,9 +2254,9 @@ func TestFullConfig(t *testing.T) {
 				"dogstatsd_tags": [ "3N81zSUB","Xtj8AnXZ" ],
 				"filter_default": true,
 				"prefix_filter": [ "+oJotS8XJ","-cazlEhGn" ],
+				"service_prefix": "ftO6DySn",
 				"statsd_address": "drce87cy",
-				"statsite_address": "HpFwKB8R",
-				"statsite_prefix": "ftO6DySn"
+				"statsite_address": "HpFwKB8R"
 			},
 			"tls_cipher_suites": "TLS_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA",
 			"tls_min_version": "pAOWafkR",
@@ -2674,9 +2674,9 @@ func TestFullConfig(t *testing.T) {
 				dogstatsd_tags = [ "3N81zSUB","Xtj8AnXZ" ]
 				filter_default = true
 				prefix_filter = [ "+oJotS8XJ","-cazlEhGn" ]
+				service_prefix = "ftO6DySn"
 				statsd_address = "drce87cy"
 				statsite_address = "HpFwKB8R"
-				statsite_prefix = "ftO6DySn"
 			}
 			tls_cipher_suites = "TLS_RSA_WITH_RC4_128_SHA,TLS_RSA_WITH_3DES_EDE_CBC_SHA"
 			tls_min_version = "pAOWafkR"
@@ -3213,9 +3213,9 @@ func TestFullConfig(t *testing.T) {
 		TelemetryFilterDefault:                      true,
 		TelemetryAllowedPrefixes:                    []string{"oJotS8XJ"},
 		TelemetryBlockedPrefixes:                    []string{"cazlEhGn"},
+		TelemetryServicePrefix:                      "ftO6DySn",
 		TelemetryStatsdAddr:                         "drce87cy",
 		TelemetryStatsiteAddr:                       "HpFwKB8R",
-		TelemetryStatsitePrefix:                     "ftO6DySn",
 		TLSCipherSuites:                             []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},
 		TLSMinVersion:                               "pAOWafkR",
 		TLSPreferServerCipherSuites:                 true,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2254,7 +2254,7 @@ func TestFullConfig(t *testing.T) {
 				"dogstatsd_tags": [ "3N81zSUB","Xtj8AnXZ" ],
 				"filter_default": true,
 				"prefix_filter": [ "+oJotS8XJ","-cazlEhGn" ],
-				"service_prefix": "ftO6DySn",
+				"metrics_prefix": "ftO6DySn",
 				"statsd_address": "drce87cy",
 				"statsite_address": "HpFwKB8R"
 			},
@@ -2674,7 +2674,7 @@ func TestFullConfig(t *testing.T) {
 				dogstatsd_tags = [ "3N81zSUB","Xtj8AnXZ" ]
 				filter_default = true
 				prefix_filter = [ "+oJotS8XJ","-cazlEhGn" ]
-				service_prefix = "ftO6DySn"
+				metrics_prefix = "ftO6DySn"
 				statsd_address = "drce87cy"
 				statsite_address = "HpFwKB8R"
 			}
@@ -3213,7 +3213,7 @@ func TestFullConfig(t *testing.T) {
 		TelemetryFilterDefault:                      true,
 		TelemetryAllowedPrefixes:                    []string{"oJotS8XJ"},
 		TelemetryBlockedPrefixes:                    []string{"cazlEhGn"},
-		TelemetryServicePrefix:                      "ftO6DySn",
+		TelemetryMetricsPrefix:                      "ftO6DySn",
 		TelemetryStatsdAddr:                         "drce87cy",
 		TelemetryStatsiteAddr:                       "HpFwKB8R",
 		TLSCipherSuites:                             []uint16{tls.TLS_RSA_WITH_RC4_128_SHA, tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA},

--- a/command/agent.go
+++ b/command/agent.go
@@ -220,7 +220,7 @@ func startupTelemetry(conf *config.RuntimeConfig) (*metrics.InmemSink, error) {
 	// metrics over stderr when there is a SIGUSR1 received.
 	memSink := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(memSink)
-	metricsConf := metrics.DefaultConfig(conf.TelemetryServicePrefix)
+	metricsConf := metrics.DefaultConfig(conf.TelemetryMetricsPrefix)
 	metricsConf.EnableHostname = !conf.TelemetryDisableHostname
 	metricsConf.FilterDefault = conf.TelemetryFilterDefault
 

--- a/command/agent.go
+++ b/command/agent.go
@@ -220,7 +220,7 @@ func startupTelemetry(conf *config.RuntimeConfig) (*metrics.InmemSink, error) {
 	// metrics over stderr when there is a SIGUSR1 received.
 	memSink := metrics.NewInmemSink(10*time.Second, time.Minute)
 	metrics.DefaultInmemSignal(memSink)
-	metricsConf := metrics.DefaultConfig(conf.TelemetryStatsitePrefix)
+	metricsConf := metrics.DefaultConfig(conf.TelemetryServicePrefix)
 	metricsConf.EnableHostname = !conf.TelemetryDisableHostname
 	metricsConf.FilterDefault = conf.TelemetryFilterDefault
 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1195,6 +1195,9 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
      This controls whether to allow metrics that have not been specified by the filter. Defaults to `true`, which will
      allow all metrics when no filters are provided. When set to `false` with no filters, no metrics will be sent.
 
+    * <a name="telemetry-metrics_prefix"></a><a href="#telemetry-metrics_prefix">`metrics_prefix`</a>
+      The prefix used while writing all telemetry data. By default, this is set to "consul".
+
     * <a name="telemetry-prefix_filter"></a><a href="#telemetry-prefix_filter">`prefix_filter`</a>
       This is a list of filter rules to apply for allowing/blocking metrics by prefix in the following format:
 
@@ -1208,9 +1211,6 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
       A leading "<b>+</b>" will enable any metrics with the given prefix, and a leading "<b>-</b>" will block them. If there
       is overlap between two rules, the more specific rule will take precedence. Blocking will take priority if the same
       prefix is listed multiple times.
-
-    * <a name="telemetry-service_prefix"></a><a href="#telemetry-service_prefix">`service_prefix`</a>
-      The prefix used while writing all telemetry data. By default, this is set to "consul".
 
     * <a name="telemetry-statsd_address"></a><a href="#telemetry-statsd_address">`statsd_address`</a> This provides the
       address of a statsd instance in the format `host:port`. If provided, Consul will send various telemetry information to that instance for

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1139,50 +1139,6 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 *   <a name="telemetry"></a><a href="#telemetry">`telemetry`</a> This is a nested object that configures where Consul
     sends its runtime telemetry, and contains the following keys:
 
-    * <a name="telemetry-statsd_address"></a><a href="#telemetry-statsd_address">`statsd_address`</a> This provides the
-      address of a statsd instance in the format `host:port`. If provided, Consul will send various telemetry information to that instance for
-      aggregation. This can be used to capture runtime information. This sends UDP packets only and can be used with
-      statsd or statsite.
-
-    * <a name="telemetry-statsite_address"></a><a href="#telemetry-statsite_address">`statsite_address`</a> This provides
-      the address of a statsite instance in the format `host:port`. If provided, Consul will stream various telemetry information to that instance
-      for aggregation. This can be used to capture runtime information. This streams via TCP and can only be used with
-      statsite.
-
-    * <a name="telemetry-statsite_prefix"></a><a href="#telemetry-statsite_prefix">`statsite_prefix`</a>
-      The prefix used while writing all telemetry data to statsite. By default, this is set to "consul".
-
-    * <a name="telemetry-dogstatsd_addr"></a><a href="#telemetry-dogstatsd_addr">`dogstatsd_addr`</a> This provides the
-      address of a DogStatsD instance in the format `host:port`. DogStatsD is a protocol-compatible flavor of
-      statsd, with the added ability to decorate metrics with tags and event information. If provided, Consul will
-      send various telemetry information to that instance for aggregation. This can be used to capture runtime
-      information.
-
-    * <a name="telemetry-dogstatsd_tags"></a><a href="#telemetry-dogstatsd_tags">`dogstatsd_tags`</a> This provides a list of global tags
-      that will be added to all telemetry packets sent to DogStatsD. It is a list of strings, where each string
-      looks like "my_tag_name:my_tag_value".
-
-    * <a name="telemetry-disable_hostname"></a><a href="#telemetry-disable_hostname">`disable_hostname`</a>
-      This controls whether or not to prepend runtime telemetry with the machine's hostname, defaults to false.
-
-    * <a name="telemetry-prefix_filter"></a><a href="#telemetry-prefix_filter">`prefix_filter`</a>
-      This is a list of filter rules to apply for allowing/blocking metrics by prefix in the following format:
-
-        ```javascript
-        [
-          "+consul.raft.apply",
-          "-consul.http",
-          "+consul.http.GET"
-        ]
-        ```
-      A leading "<b>+</b>" will enable any metrics with the given prefix, and a leading "<b>-</b>" will block them. If there
-      is overlap between two rules, the more specific rule will take precedence. Blocking will take priority if the same
-      prefix is listed multiple times.
-
-    * <a name="telemetry-filter_default"></a><a href="#telemetry-filter_default">`filter_default`</a>
-     This controls whether to allow metrics that have not been specified by the filter. Defaults to `true`, which will
-     allow all metrics when no filters are provided. When set to `false` with no filters, no metrics will be sent.
-
     * <a name="telemetry-circonus_api_token"></a><a href="#telemetry-circonus_api_token">`circonus_api_token`</a>
       A valid API Token used to create/manage check. If provided, metric management is enabled.
 
@@ -1221,6 +1177,50 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
     * <a name="telemetry-circonus_broker_select_tag"></a><a href="#telemetry-circonus_broker_select_tag">`circonus_broker_select_tag`</a>
       A special tag which will be used to select a Circonus Broker when a Broker ID is not provided. The best use of this is to as a hint for which broker should be used based on *where* this particular instance is running (e.g. a specific geo location or datacenter, dc:sfo). By default, this is left blank and not used.
+
+    * <a name="telemetry-disable_hostname"></a><a href="#telemetry-disable_hostname">`disable_hostname`</a>
+      This controls whether or not to prepend runtime telemetry with the machine's hostname, defaults to false.
+
+    * <a name="telemetry-dogstatsd_addr"></a><a href="#telemetry-dogstatsd_addr">`dogstatsd_addr`</a> This provides the
+      address of a DogStatsD instance in the format `host:port`. DogStatsD is a protocol-compatible flavor of
+      statsd, with the added ability to decorate metrics with tags and event information. If provided, Consul will
+      send various telemetry information to that instance for aggregation. This can be used to capture runtime
+      information.
+
+    * <a name="telemetry-dogstatsd_tags"></a><a href="#telemetry-dogstatsd_tags">`dogstatsd_tags`</a> This provides a list of global tags
+      that will be added to all telemetry packets sent to DogStatsD. It is a list of strings, where each string
+      looks like "my_tag_name:my_tag_value".
+
+    * <a name="telemetry-filter_default"></a><a href="#telemetry-filter_default">`filter_default`</a>
+     This controls whether to allow metrics that have not been specified by the filter. Defaults to `true`, which will
+     allow all metrics when no filters are provided. When set to `false` with no filters, no metrics will be sent.
+
+    * <a name="telemetry-prefix_filter"></a><a href="#telemetry-prefix_filter">`prefix_filter`</a>
+      This is a list of filter rules to apply for allowing/blocking metrics by prefix in the following format:
+
+        ```javascript
+        [
+          "+consul.raft.apply",
+          "-consul.http",
+          "+consul.http.GET"
+        ]
+        ```
+      A leading "<b>+</b>" will enable any metrics with the given prefix, and a leading "<b>-</b>" will block them. If there
+      is overlap between two rules, the more specific rule will take precedence. Blocking will take priority if the same
+      prefix is listed multiple times.
+
+    * <a name="telemetry-service_prefix"></a><a href="#telemetry-service_prefix">`service_prefix`</a>
+      The prefix used while writing all telemetry data. By default, this is set to "consul".
+
+    * <a name="telemetry-statsd_address"></a><a href="#telemetry-statsd_address">`statsd_address`</a> This provides the
+      address of a statsd instance in the format `host:port`. If provided, Consul will send various telemetry information to that instance for
+      aggregation. This can be used to capture runtime information. This sends UDP packets only and can be used with
+      statsd or statsite.
+
+    * <a name="telemetry-statsite_address"></a><a href="#telemetry-statsite_address">`statsite_address`</a> This provides
+      the address of a statsite instance in the format `host:port`. If provided, Consul will stream various telemetry information to that instance
+      for aggregation. This can be used to capture runtime information. This streams via TCP and can only be used with
+      statsite.
 
 * <a name="statsd_addr"></a><a href="#statsd_addr">`statsd_addr`</a> Deprecated, see
   the <a href="#telemetry">telemetry</a> structure


### PR DESCRIPTION
The metrics prefix isn't statsite specific and is in fact used
for all metrics providers. Since we are deprecating fields
anyway we should fix this one as well.

Fixes #3293
