### PR TITLE
config: drop advertise_addrs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -603,9 +603,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.RaftConfig.ElectionTimeout = a.config.ConsulRaftElectionTimeout
 
 	base.SerfLANConfig.MemberlistConfig.BindAddr = a.config.SerfBindAddrLAN.IP.String()
-	base.SerfLANConfig.MemberlistConfig.BindPort = a.config.SerfPortLAN
+	base.SerfLANConfig.MemberlistConfig.BindPort = a.config.SerfBindAddrLAN.Port
 	base.SerfLANConfig.MemberlistConfig.AdvertiseAddr = a.config.SerfAdvertiseAddrLAN.IP.String()
-	base.SerfLANConfig.MemberlistConfig.AdvertisePort = a.config.SerfPortLAN
+	base.SerfLANConfig.MemberlistConfig.AdvertisePort = a.config.SerfAdvertiseAddrLAN.Port
 	base.SerfLANConfig.MemberlistConfig.GossipVerifyIncoming = a.config.EncryptVerifyIncoming
 	base.SerfLANConfig.MemberlistConfig.GossipVerifyOutgoing = a.config.EncryptVerifyOutgoing
 	base.SerfLANConfig.MemberlistConfig.GossipInterval = a.config.ConsulSerfLANGossipInterval
@@ -614,9 +614,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.SerfLANConfig.MemberlistConfig.SuspicionMult = a.config.ConsulSerfLANSuspicionMult
 
 	base.SerfWANConfig.MemberlistConfig.BindAddr = a.config.SerfBindAddrWAN.IP.String()
-	base.SerfWANConfig.MemberlistConfig.BindPort = a.config.SerfPortWAN
+	base.SerfWANConfig.MemberlistConfig.BindPort = a.config.SerfBindAddrWAN.Port
 	base.SerfWANConfig.MemberlistConfig.AdvertiseAddr = a.config.SerfAdvertiseAddrWAN.IP.String()
-	base.SerfWANConfig.MemberlistConfig.AdvertisePort = a.config.SerfPortWAN
+	base.SerfWANConfig.MemberlistConfig.AdvertisePort = a.config.SerfAdvertiseAddrWAN.Port
 	base.SerfWANConfig.MemberlistConfig.GossipVerifyIncoming = a.config.EncryptVerifyIncoming
 	base.SerfWANConfig.MemberlistConfig.GossipVerifyOutgoing = a.config.EncryptVerifyOutgoing
 	base.SerfWANConfig.MemberlistConfig.GossipInterval = a.config.ConsulSerfWANGossipInterval

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -371,9 +371,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	// derive other advertise addresses from the advertise address
 	advertiseAddrLAN := b.makeIPAddr(b.expandFirstIP("advertise_addr", c.AdvertiseAddrLAN), advertiseAddr)
 	advertiseAddrWAN := b.makeIPAddr(b.expandFirstIP("advertise_addr_wan", c.AdvertiseAddrWAN), advertiseAddrLAN)
-	rpcAdvertiseAddr := b.makeTCPAddr(b.expandFirstIP("advertise_addresses.rpc", c.AdvertiseAddrs.RPC), advertiseAddrLAN, serverPort)
-	serfAdvertiseAddrLAN := b.makeTCPAddr(b.expandFirstIP("advertise_addresses.serf_lan", c.AdvertiseAddrs.SerfLAN), advertiseAddrLAN, serfPortLAN)
-	serfAdvertiseAddrWAN := b.makeTCPAddr(b.expandFirstIP("advertise_addresses.serf_wan", c.AdvertiseAddrs.SerfWAN), advertiseAddrWAN, serfPortWAN)
+	rpcAdvertiseAddr := &net.TCPAddr{IP: advertiseAddrLAN.IP, Port: serverPort}
+	serfAdvertiseAddrLAN := &net.TCPAddr{IP: advertiseAddrLAN.IP, Port: serfPortLAN}
+	serfAdvertiseAddrWAN := &net.TCPAddr{IP: advertiseAddrWAN.IP, Port: serfPortWAN}
 
 	// determine client addresses
 	clientAddrs := b.expandIPs("client_addr", c.ClientAddr)
@@ -682,15 +682,6 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 	}
 	if ipaddr.IsAny(rt.AdvertiseAddrWAN.IP) {
 		return fmt.Errorf("Advertise WAN address cannot be 0.0.0.0, :: or [::]")
-	}
-	if ipaddr.IsAny(rt.RPCAdvertiseAddr) {
-		return fmt.Errorf("advertise_addrs.rpc cannot be 0.0.0.0, :: or [::]")
-	}
-	if ipaddr.IsAny(rt.SerfAdvertiseAddrLAN) {
-		return fmt.Errorf("advertise_addrs.serf_lan cannot be 0.0.0.0, :: or [::]")
-	}
-	if ipaddr.IsAny(rt.SerfAdvertiseAddrWAN) {
-		return fmt.Errorf("advertise_addrs.serf_wan cannot be 0.0.0.0, :: or [::]")
 	}
 	if err := b.validateSegments(rt); err != nil {
 		return err

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -136,7 +136,6 @@ type Config struct {
 	Addresses                   Addresses                `json:"addresses,omitempty" hcl:"addresses" mapstructure:"addresses"`
 	AdvertiseAddrLAN            *string                  `json:"advertise_addr,omitempty" hcl:"advertise_addr" mapstructure:"advertise_addr"`
 	AdvertiseAddrWAN            *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
-	AdvertiseAddrs              AdvertiseAddrsConfig     `json:"advertise_addrs,omitempty" hcl:"advertise_addrs" mapstructure:"advertise_addrs"`
 	Autopilot                   Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                    *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
 	Bootstrap                   *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -674,17 +674,6 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 * <a name="serf_lan_bind"></a><a href="#serf_lan_bind">`serf_lan_bind`</a> Equivalent to
   the [`-serf-lan-bind` command-line flag](#_serf_lan_bind).
 
-*   <a name="advertise_addrs"></a><a href="#advertise_addrs">`advertise_addrs`</a> Allows to set
-    the advertised addresses for SerfLan, SerfWan and RPC together with the port. This gives
-    you more control than <a href="#_advertise">`-advertise`</a> or <a href="#_advertise-wan">`-advertise-wan`</a>
-    while it serves the same purpose. These settings might override <a href="#_advertise">`-advertise`</a> or
-    <a href="#_advertise-wan">`-advertise-wan`</a>
-
-    This is a nested setting that allows the following keys:
-    - `serf_lan` - The SerfLan address. Accepts values in the form of "host:port" like "10.23.31.101:8301".
-    - `serf_wan` - The SerfWan address. Accepts values in the form of "host:port" like "10.23.31.101:8302".
-    - `rpc` - The server RPC address. Accepts values in the form of "host:port" like "10.23.31.101:8300".
-
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).
 


### PR DESCRIPTION
This patch removes the `advertise_addrs` config option since that was not working as expected before 1.0.

Fixes #3516