### PR TITLE
Ensure all shared scripts are copied over during Terraform module installation.

### DIFF
--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -34,6 +34,9 @@ resource "aws_instance" "server" {
             "${path.module}/../shared/scripts/install.sh",
             "${path.module}/../shared/scripts/service.sh",
             "${path.module}/../shared/scripts/ip_tables.sh",
+            "${path.module}/../shared/scripts/debian_upstart.conf",
+            "${path.module}/../shared/scripts/rhel_consul.service",
+            "${path.module}/../shared/scripts/rhel_upstart.conf"
         ]
     }
 }


### PR DESCRIPTION
The following files were not being copied over during the installation of the Consul module, leading to errors such as this one: https://github.com/hashicorp/consul/issues/3518

```
debian_upstart.conf
rhel_consul.service
rhel_upstart.conf
```

I added the steps to ensure these files are copied over on installation of the Consul Terraform module.