### PR TITLE
Provide stable config for agent/self

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -20,11 +20,12 @@ import (
 )
 
 type Self struct {
-	Config map[string]interface{}
-	Coord  *coordinate.Coordinate
-	Member serf.Member
-	Stats  map[string]map[string]string
-	Meta   map[string]string
+	Config      interface{}
+	DebugConfig map[string]interface{}
+	Coord       *coordinate.Coordinate
+	Member      serf.Member
+	Stats       map[string]map[string]string
+	Meta        map[string]string
 }
 
 func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -51,12 +52,26 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 		return nil, acl.ErrPermissionDenied
 	}
 
+	config := struct {
+		Datacenter string
+		NodeName   string
+		Revision   string
+		Server     bool
+		Version    string
+	}{
+		Datacenter: s.agent.config.Datacenter,
+		NodeName:   s.agent.config.NodeName,
+		Revision:   s.agent.config.Revision,
+		Server:     s.agent.config.ServerMode,
+		Version:    s.agent.config.Version,
+	}
 	return Self{
-		Config: s.agent.config.Sanitized(),
-		Coord:  cs[s.agent.config.SegmentName],
-		Member: s.agent.LocalMember(),
-		Stats:  s.agent.Stats(),
-		Meta:   s.agent.state.Metadata(),
+		Config:      config,
+		DebugConfig: s.agent.config.Sanitized(),
+		Coord:       cs[s.agent.config.SegmentName],
+		Member:      s.agent.LocalMember(),
+		Stats:       s.agent.Stats(),
+		Meta:        s.agent.state.Metadata(),
 	}, nil
 }
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -189,7 +189,7 @@ func TestAgent_Self(t *testing.T) {
 		t.Fatalf("incorrect port: %v", obj)
 	}
 
-	if val.Config["SerfPortLAN"].(int) != a.Config.SerfPortLAN {
+	if val.DebugConfig["SerfPortLAN"].(int) != a.Config.SerfPortLAN {
 		t.Fatalf("incorrect port: %v", obj)
 	}
 

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -638,7 +638,7 @@ func TestAPI_AgentJoin(t *testing.T) {
 	}
 
 	// Join ourself
-	addr := info["Config"]["SerfAdvertiseAddrLAN"].(string)
+	addr := info["DebugConfig"]["SerfAdvertiseAddrLAN"].(string)
 	// strip off 'tcp://'
 	addr = addr[len("tcp://"):]
 	err = agent.Join(addr, false)

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -85,7 +85,10 @@ $ curl \
 ## Read Configuration
 
 This endpoint returns the configuration and member information of the local
-agent.
+agent. The `Config` element contains a subset of the configuration and its
+format will not change in a backwards incompatible way between releases.
+`DebugConfig` contains the full runtime configuration but its format is subject
+to change without notice or deprecation.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
@@ -112,42 +115,15 @@ $ curl \
 ```json
 {
   "Config": {
-    "Bootstrap": true,
-    "Server": true,
     "Datacenter": "dc1",
-    "DataDir": "/tmp/consul",
-    "DNSRecursor": "",
-    "DNSRecursors": [],
-    "Domain": "consul.",
-    "LogLevel": "INFO",
-    "NodeID": "40e4a748-2192-161a-0510-9bf59fe950b5",
     "NodeName": "foobar",
-    "ClientAddr": "127.0.0.1",
-    "BindAddr": "0.0.0.0",
-    "AdvertiseAddr": "10.1.10.12",
-    "Ports": {
-      "DNS": 8600,
-      "HTTP": 8500,
-      "RPC": 8400,
-      "SerfLan": 8301,
-      "SerfWan": 8302,
-      "Server": 8300
-    },
-    "LeaveOnTerm": false,
-    "SkipLeaveOnInt": false,
-    "StatsiteAddr": "",
-    "Protocol": 1,
-    "EnableDebug": false,
-    "VerifyIncoming": false,
-    "VerifyOutgoing": false,
-    "CAFile": "",
-    "CertFile": "",
-    "KeyFile": "",
-    "StartJoin": [],
-    "UiDir": "",
-    "PidFile": "",
-    "EnableSyslog": false,
-    "RejoinAfterLeave": false
+    "Server": true,
+    "Revision": "deadbeef",
+    "Version": "1.0.0"
+  },
+  "DebugConfig": {
+    ... full runtime configuration ...
+    ... format subject to change ...
   },
   "Coord": {
     "Adjustment": 0,


### PR DESCRIPTION
/v1/agent/self was exposing the previous internal config structure and some external services like Nomad and Consul itself relied on its format although it was never documented. Since we have refactored the runtime configuration to be independent from the config file configuration this change broke Nomad and others and we introduce a stable, documented `Config` response to the agent/self response.

Fixes #3530 
Fixes https://github.com/hashicorp/nomad/issues/3324