### PR TITLE
Backport mitchellh/cli patch for help output

### DIFF
--- a/command/agent.go
+++ b/command/agent.go
@@ -54,7 +54,9 @@ func (cmd *AgentCommand) readConfig() *config.RuntimeConfig {
 	config.AddFlags(fs, &flags)
 
 	if err := cmd.BaseCommand.Parse(cmd.args); err != nil {
-		cmd.UI.Error(fmt.Sprintf("error parsing flags: %v", err))
+		if !strings.Contains(err.Error(), "help requested") {
+			cmd.UI.Error(fmt.Sprintf("error parsing flags: %v", err))
+		}
 		return nil
 	}
 

--- a/vendor/github.com/mitchellh/cli/cli.go
+++ b/vendor/github.com/mitchellh/cli/cli.go
@@ -578,12 +578,6 @@ func (c *CLI) processArgs() {
 			break
 		}
 
-		// Check for help flags.
-		if arg == "-h" || arg == "-help" || arg == "--help" {
-			c.isHelp = true
-			continue
-		}
-
 		// Check for autocomplete flags
 		if c.Autocomplete {
 			if arg == "-"+c.AutocompleteInstall || arg == "--"+c.AutocompleteInstall {
@@ -601,6 +595,12 @@ func (c *CLI) processArgs() {
 			// Check for version flags if not in a subcommand.
 			if arg == "-v" || arg == "-version" || arg == "--version" {
 				c.isVersion = true
+				continue
+			}
+
+			// Check for help flags.
+			if arg == "-h" || arg == "-help" || arg == "--help" {
+				c.isHelp = true
 				continue
 			}
 


### PR DESCRIPTION
This patch backports a fix which will show the correct usage screen for
command line flags.

This is considered a temporary fix until the code has been refactored.
Newer versions of the cli library require that the flag set is populated
when Help() is called or that it is populated within Help() itself.

Fixes #3536