### PR TITLE
Drop hidden flags

### DIFF
--- a/command/base.go
+++ b/command/base.go
@@ -36,7 +36,6 @@ type BaseCommand struct {
 	HideNormalFlagsHelp bool
 
 	flagSet *flag.FlagSet
-	hidden  *flag.FlagSet
 
 	// These are the options which correspond to the HTTP API options
 	httpAddr      configutil.StringValue
@@ -172,16 +171,8 @@ func (c *BaseCommand) NewFlagSet(command cli.Command) *flag.FlagSet {
 	f.SetOutput(errW)
 
 	c.flagSet = f
-	c.hidden = flag.NewFlagSet("", flag.ContinueOnError)
 
 	return f
-}
-
-// HideFlags is used to set hidden flags that will not be shown in help text
-func (c *BaseCommand) HideFlags(flags ...string) {
-	for _, f := range flags {
-		c.hidden.String(f, "", "")
-	}
 }
 
 // Parse is used to parse the underlying flag set.
@@ -243,7 +234,7 @@ func (c *BaseCommand) helpFlagsFor(f *flag.FlagSet) string {
 		firstCommand := true
 		f.VisitAll(func(f *flag.Flag) {
 			// Skip HTTP flags as they will be grouped separately
-			if flagContains(httpFlagsClient, f) || flagContains(httpFlagsServer, f) || flagContains(c.hidden, f) {
+			if flagContains(httpFlagsClient, f) || flagContains(httpFlagsServer, f) {
 				return
 			}
 			if firstCommand {

--- a/command/base.go
+++ b/command/base.go
@@ -210,21 +210,15 @@ func (c *BaseCommand) helpFlagsFor(f *flag.FlagSet) string {
 
 	var out bytes.Buffer
 
-	firstHTTP := true
+	if c.hasClientHTTP() || c.hasServerHTTP() {
+		printTitle(&out, "HTTP API Options")
+	}
 	if c.hasClientHTTP() {
-		if firstHTTP {
-			printTitle(&out, "HTTP API Options")
-			firstHTTP = false
-		}
 		httpFlagsClient.VisitAll(func(f *flag.Flag) {
 			printFlag(&out, f)
 		})
 	}
 	if c.hasServerHTTP() {
-		if firstHTTP {
-			printTitle(&out, "HTTP API Options")
-			firstHTTP = false
-		}
 		httpFlagsServer.VisitAll(func(f *flag.Flag) {
 			printFlag(&out, f)
 		})

--- a/command/validate.go
+++ b/command/validate.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul/agent/config"
-	"github.com/hashicorp/consul/configutil"
 )
 
 // ValidateCommand is a Command implementation that is used to
@@ -32,28 +31,18 @@ Usage: consul validate [options] FILE_OR_DIRECTORY...
 }
 
 func (c *ValidateCommand) Run(args []string) int {
-	var configFiles []string
 	var quiet bool
 
 	f := c.BaseCommand.NewFlagSet(c)
-	f.Var((*configutil.AppendSliceValue)(&configFiles), "config-file",
-		"Path to a JSON file to read configuration from. This can be specified multiple times.")
-	f.Var((*configutil.AppendSliceValue)(&configFiles), "config-dir",
-		"Path to a directory to read configuration files from. This will read every file ending in "+
-			".json as configuration in this directory in alphabetical order.")
 	f.BoolVar(&quiet, "quiet", false,
 		"When given, a successful run will produce no output.")
-	c.BaseCommand.HideFlags("config-file", "config-dir")
 
 	if err := c.BaseCommand.Parse(args); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
 
-	if len(f.Args()) > 0 {
-		configFiles = append(configFiles, f.Args()...)
-	}
-
+	configFiles := f.Args()
 	if len(configFiles) < 1 {
 		c.UI.Error("Must specify at least one config file or directory")
 		return 1


### PR DESCRIPTION
This patch drops the last hidden flags in the `validate` command and cleans up the `BaseCommand`