### PR TITLE
Fixes handling of stop channel and failed barrier attempts.

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -33,12 +33,10 @@ func (s *Server) monitorLeadership() {
 	// cleanup and to ensure we never run multiple leader loops.
 	raftNotifyCh := s.raftNotifyCh
 
-	// This wait group will ensure that only one leader loop will ever be
-	// running at any given time. We need to run that in a goroutine so we
-	// can look for other notifications (loss of leadership) which we pass
-	// along by closing the stopCh given to the current leader loop.
-	var wg sync.WaitGroup
+	// If there's a non-nil stopCh then this routine will wait on wg to
+	// ensure that there are never overlapping leaderLoops executing.
 	var stopCh chan struct{}
+	var wg sync.WaitGroup
 	for {
 		select {
 		case isLeader := <-raftNotifyCh:


### PR DESCRIPTION
There were two issues here. First, we needed to not exit when there was a timeout trying to write the barrier, because Raft might not step down, so we'd be left as the leader but having run all the step down actions.

Second, we didn't close over the `stopCh` correctly, so it was possible to `nil` that out and have the `leaderLoop` never exit. We close over it properly AND sequence the `nil`-ing of it AFTER the `leaderLoop` exits for good measure, so the code is more robust.

We also added a pre-poll before we wait in the `leaderLoop`, since the exit condition is mixed in with a bunch of other stuff, so if we wait a long time for the barrier we will have hit the interval and may get kind of stuck waiting for the `select` to pick the `stopCh` case (making another failed attempt at doing a barrier could cost us another 2 minutes, for example).

Fixes #3545 