### PR TITLE
Makes RPC handling more robust when rolling servers.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -750,6 +750,10 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.RPCMaxBurst = a.config.RPCMaxBurst
 	}
 
+	// RPC-related performance configs.
+	if a.config.RPCHoldTimeout > 0 {
+		base.RPCHoldTimeout = a.config.RPCHoldTimeout
+	}
 	if a.config.LeaveDrainTime > 0 {
 		base.LeaveDrainTime = a.config.LeaveDrainTime
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -750,6 +750,10 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.RPCMaxBurst = a.config.RPCMaxBurst
 	}
 
+	if a.config.LeaveDrainTime > 0 {
+		base.LeaveDrainTime = a.config.LeaveDrainTime
+	}
+
 	// set the src address for outgoing rpc connections
 	// Use port 0 so that outgoing connections use a random port.
 	if !ipaddr.IsAny(base.RPCAddr.IP) {

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -597,6 +597,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		PidFile:                     b.stringVal(c.PidFile),
 		RPCAdvertiseAddr:            rpcAdvertiseAddr,
 		RPCBindAddr:                 rpcBindAddr,
+		RPCHoldTimeout:              b.durationVal("performance.rpc_hold_timeout", c.Performance.RPCHoldTimeout),
 		RPCMaxBurst:                 b.intVal(c.Limits.RPCMaxBurst),
 		RPCProtocol:                 b.intVal(c.RPCProtocol),
 		RPCRateLimit:                rate.Limit(b.float64Val(c.Limits.RPCRate)),

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -587,6 +587,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		EncryptVerifyIncoming:       b.boolVal(c.EncryptVerifyIncoming),
 		EncryptVerifyOutgoing:       b.boolVal(c.EncryptVerifyOutgoing),
 		KeyFile:                     b.stringVal(c.KeyFile),
+		LeaveDrainTime:              b.durationVal("performance.leave_drain_time", c.Performance.LeaveDrainTime),
 		LeaveOnTerm:                 leaveOnTerm,
 		LogLevel:                    b.stringVal(c.LogLevel),
 		NodeID:                      types.NodeID(b.stringVal(c.NodeID)),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -344,7 +344,8 @@ type HTTPConfig struct {
 }
 
 type Performance struct {
-	RaftMultiplier *int `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
+	RaftMultiplier *int    `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
+	LeaveDrainTime *string `json:"leave_drain_time,omitempty" hcl:"leave_drain_time" mapstructure:"leave_drain_time"`
 }
 
 type Telemetry struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -344,8 +344,8 @@ type HTTPConfig struct {
 }
 
 type Performance struct {
-	RaftMultiplier *int    `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
 	LeaveDrainTime *string `json:"leave_drain_time,omitempty" hcl:"leave_drain_time" mapstructure:"leave_drain_time"`
+	RaftMultiplier *int    `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
 	RPCHoldTimeout *string `json:"rpc_hold_timeout" hcl:"rpc_hold_timeout" mapstructure:"rpc_hold_timeout"`
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -346,6 +346,7 @@ type HTTPConfig struct {
 type Performance struct {
 	RaftMultiplier *int    `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
 	LeaveDrainTime *string `json:"leave_drain_time,omitempty" hcl:"leave_drain_time" mapstructure:"leave_drain_time"`
+	RPCHoldTimeout *string `json:"rpc_hold_timeout" hcl:"rpc_hold_timeout" mapstructure:"rpc_hold_timeout"`
 }
 
 type Telemetry struct {

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -66,6 +66,7 @@ func DefaultSource() Source {
 		}
 		performance = {
 			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `
+			leave_drain_time = "3s"
 		}
 		ports = {
 			dns = 8600

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -65,8 +65,9 @@ func DefaultSource() Source {
 			rpc_max_burst = 1000
 		}
 		performance = {
-			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `
 			leave_drain_time = "3s"
+			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `
+			rpc_hold_timeout = "7s"
 		}
 		ports = {
 			dns = 8600

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -65,7 +65,7 @@ func DefaultSource() Source {
 			rpc_max_burst = 1000
 		}
 		performance = {
-			leave_drain_time = "3s"
+			leave_drain_time = "5s"
 			raft_multiplier = ` + strconv.Itoa(int(consul.DefaultRaftMultiplier)) + `
 			rpc_hold_timeout = "7s"
 		}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -155,6 +155,7 @@ type RuntimeConfig struct {
 	PidFile                     string
 	RPCAdvertiseAddr            *net.TCPAddr
 	RPCBindAddr                 *net.TCPAddr
+	RPCHoldTimeout              time.Duration
 	RPCMaxBurst                 int
 	RPCProtocol                 int
 	RPCRateLimit                rate.Limit

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -146,6 +146,7 @@ type RuntimeConfig struct {
 	HTTPSAddrs                  []net.Addr
 	HTTPSPort                   int
 	KeyFile                     string
+	LeaveDrainTime              time.Duration
 	LeaveOnTerm                 bool
 	LogLevel                    string
 	NodeID                      types.NodeID

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2104,9 +2104,9 @@ func TestFullConfig(t *testing.T) {
 			"node_name": "otlLxGaI",
 			"non_voting_server": true,
 			"performance": {
+				"leave_drain_time": "8265s",
 				"raft_multiplier": 5,
-				"rpc_hold_timeout": "15707s",
-				"leave_drain_time": "8265s"
+				"rpc_hold_timeout": "15707s"
 			},
 			"pid_file": "43xN80Km",
 			"ports": {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2104,8 +2104,9 @@ func TestFullConfig(t *testing.T) {
 			"node_name": "otlLxGaI",
 			"non_voting_server": true,
 			"performance": {
-				"leave_drain_time": "1s",
-				"raft_multiplier": 5
+				"raft_multiplier": 5,
+				"rpc_hold_timeout": "15707s",
+				"leave_drain_time": "8265s"
 			},
 			"pid_file": "43xN80Km",
 			"ports": {
@@ -2536,8 +2537,9 @@ func TestFullConfig(t *testing.T) {
 			node_name = "otlLxGaI"
 			non_voting_server = true
 			performance {
-				leave_drain_time = "1s"
+				leave_drain_time = "8265s"
 				raft_multiplier = 5
+				rpc_hold_timeout = "15707s"
 			}
 			pid_file = "43xN80Km"
 			ports {
@@ -3090,7 +3092,7 @@ func TestFullConfig(t *testing.T) {
 		HTTPSAddrs:                []net.Addr{tcpAddr("95.17.17.19:15127")},
 		HTTPSPort:                 15127,
 		KeyFile:                   "IEkkwgIA",
-		LeaveDrainTime:            1 * time.Second,
+		LeaveDrainTime:            8265 * time.Second,
 		LeaveOnTerm:               true,
 		LogLevel:                  "k1zo9Spt",
 		NodeID:                    types.NodeID("AsUIlw99"),
@@ -3100,6 +3102,7 @@ func TestFullConfig(t *testing.T) {
 		PidFile:                   "43xN80Km",
 		RPCAdvertiseAddr:          tcpAddr("17.99.29.16:3757"),
 		RPCBindAddr:               tcpAddr("16.99.34.17:3757"),
+		RPCHoldTimeout:            15707 * time.Second,
 		RPCProtocol:               30793,
 		RPCRateLimit:              12029.43,
 		RPCMaxBurst:               44848,
@@ -3778,6 +3781,7 @@ func TestSanitize(t *testing.T) {
     "PidFile": "",
     "RPCAdvertiseAddr": "",
     "RPCBindAddr": "",
+    "RPCHoldTimeout": "0s",
     "RPCMaxBurst": 0,
     "RPCProtocol": 0,
     "RPCRateLimit": 0,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2104,6 +2104,7 @@ func TestFullConfig(t *testing.T) {
 			"node_name": "otlLxGaI",
 			"non_voting_server": true,
 			"performance": {
+				"leave_drain_time": "1s",
 				"raft_multiplier": 5
 			},
 			"pid_file": "43xN80Km",
@@ -2535,6 +2536,7 @@ func TestFullConfig(t *testing.T) {
 			node_name = "otlLxGaI"
 			non_voting_server = true
 			performance {
+				leave_drain_time = "1s"
 				raft_multiplier = 5
 			}
 			pid_file = "43xN80Km"
@@ -3088,6 +3090,7 @@ func TestFullConfig(t *testing.T) {
 		HTTPSAddrs:                []net.Addr{tcpAddr("95.17.17.19:15127")},
 		HTTPSPort:                 15127,
 		KeyFile:                   "IEkkwgIA",
+		LeaveDrainTime:            1 * time.Second,
 		LeaveOnTerm:               true,
 		LogLevel:                  "k1zo9Spt",
 		NodeID:                    types.NodeID("AsUIlw99"),
@@ -3765,6 +3768,7 @@ func TestSanitize(t *testing.T) {
     "HTTPSAddrs": [],
     "HTTPSPort": 0,
     "KeyFile": "hidden",
+    "LeaveDrainTime": "0s",
     "LeaveOnTerm": false,
     "LogLevel": "",
     "NodeID": "",

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -233,12 +233,13 @@ func (c *Client) Encrypted() bool {
 
 // RPC is used to forward an RPC call to a consul server, or fail if no servers
 func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
-	// If we happen to be connected to the leader server for our request,
-	// it's possible that we can get a no leader error if it loses
-	// leadership. By allowing a single retry we can give the other servers
-	// a chance to route it to the new leader, subject to the RPC hold
-	// timeout.
-	retry := true
+	// This is subtle but we start measuring the time on the client side
+	// right at the time of the first request, vs. on the first retry as
+	// is done on the server side inside forward(). This is because the
+	// servers may already be applying the RPCHoldTimeout up there, so by
+	// starting the timer here we won't potentially double up the delay.
+	// TODO (slackpad) Plumb a deadline here with a context.
+	firstCheck := time.Now()
 
 TRY:
 	server := c.routers.FindServer()
@@ -256,17 +257,28 @@ TRY:
 	}
 
 	// Make the request.
-	if err := c.connPool.RPC(c.config.Datacenter, server.Addr, server.Version, method, server.UseTLS, args, reply); err != nil {
-		c.routers.NotifyFailedServer(server)
-		c.logger.Printf("[ERR] consul: RPC failed to server %s: %v", server.Addr, err)
-		if retry && structs.IsErrNoLeader(err) {
-			retry = false
-			goto TRY
-		}
-		return err
+	rpcErr := c.connPool.RPC(c.config.Datacenter, server.Addr, server.Version, method, server.UseTLS, args, reply)
+	if rpcErr == nil {
+		return nil
 	}
 
-	return nil
+	// Move off to another server, and see if we can retry.
+	c.logger.Printf("[ERR] consul: %q RPC failed to server %s: %v", method, server.Addr, rpcErr)
+	c.routers.NotifyFailedServer(server)
+	if retry := canRetry(args, rpcErr); !retry {
+		return rpcErr
+	}
+
+	// We can wait a bit and retry!
+	if time.Now().Sub(firstCheck) < c.config.RPCHoldTimeout {
+		jitter := lib.RandomStagger(c.config.RPCHoldTimeout / jitterFraction)
+		select {
+		case <-time.After(jitter):
+			goto TRY
+		case <-c.shutdownCh:
+		}
+	}
+	return rpcErr
 }
 
 // SnapshotRPC sends the snapshot request to one of the servers, reading from

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -180,6 +180,70 @@ func TestClient_RPC(t *testing.T) {
 	})
 }
 
+type leaderFailer struct {
+	totalCalls int
+	onceCalls  int
+}
+
+func (l *leaderFailer) Always(args struct{}, reply *struct{}) error {
+	l.totalCalls++
+	return structs.ErrNoLeader
+}
+
+func (l *leaderFailer) Once(args struct{}, reply *struct{}) error {
+	l.totalCalls++
+	l.onceCalls++
+
+	switch {
+	case l.onceCalls == 1:
+		return structs.ErrNoLeader
+
+	default:
+		return nil
+	}
+}
+
+func TestClient_RPC_Retry(t *testing.T) {
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	dir2, c1 := testClient(t)
+	defer os.RemoveAll(dir2)
+	defer c1.Shutdown()
+
+	joinLAN(t, c1, s1)
+	retry.Run(t, func(r *retry.R) {
+		var out struct{}
+		if err := c1.RPC("Status.Ping", struct{}{}, &out); err != nil {
+			r.Fatalf("err: %v", err)
+		}
+	})
+
+	failer := &leaderFailer{}
+	if err := s1.RegisterEndpoint("Fail", failer); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	var out struct{}
+	if err := c1.RPC("Fail.Always", struct{}{}, &out); !structs.IsErrNoLeader(err) {
+		t.Fatalf("err: %v", err)
+	}
+	if got, want := failer.totalCalls, 2; got != want {
+		t.Fatalf("got %d want %d", got, want)
+	}
+	if err := c1.RPC("Fail.Once", struct{}{}, &out); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got, want := failer.onceCalls, 2; got != want {
+		t.Fatalf("got %d want %d", got, want)
+	}
+	if got, want := failer.totalCalls, 4; got != want {
+		t.Fatalf("got %d want %d", got, want)
+	}
+}
+
 func TestClient_RPC_Pool(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServer(t)

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -329,6 +329,10 @@ type Config struct {
 	RPCRate     rate.Limit
 	RPCMaxBurst int
 
+	// LeaveDrainTime is used to wait after a server has left the LAN Serf
+	// pool for RPCs to drain and new requests to be sent to other servers.
+	LeaveDrainTime time.Duration
+
 	// AutopilotConfig is used to apply the initial autopilot config when
 	// bootstrapping.
 	AutopilotConfig *structs.AutopilotConfig

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -410,12 +410,6 @@ func DefaultConfig() *Config {
 		CoordinateUpdateBatchSize:  128,
 		CoordinateUpdateMaxBatches: 5,
 
-		// This holds RPCs during leader elections. For the default Raft
-		// config the election timeout is 5 seconds, so we set this a
-		// bit longer to try to cover that period. This should be more
-		// than enough when running in the high performance mode.
-		RPCHoldTimeout: 7 * time.Second,
-
 		RPCRate:     rate.Inf,
 		RPCMaxBurst: 1000,
 

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -178,6 +177,24 @@ func (s *Server) handleSnapshotConn(conn net.Conn) {
 	}()
 }
 
+// canRetry returns true if the given situation is safe for a retry.
+func canRetry(args interface{}, err error) bool {
+	// No leader errors are always safe to retry since no state could have
+	// been changed.
+	if structs.IsErrNoLeader(err) {
+		return true
+	}
+
+	// Reads are safe to retry for stream errors, such as if a server was
+	// being shut down.
+	info, ok := args.(structs.RPCInfo)
+	if ok && info.IsRead() && lib.IsErrEOF(err) {
+		return true
+	}
+
+	return false
+}
+
 // forward is used to forward to a remote DC or to forward to the local leader
 // Returns a bool of if forwarding was performed, as well as any error
 func (s *Server) forward(method string, info structs.RPCInfo, args interface{}, reply interface{}) (bool, error) {
@@ -196,8 +213,15 @@ func (s *Server) forward(method string, info structs.RPCInfo, args interface{}, 
 	}
 
 CHECK_LEADER:
+	// Fail fast if we are in the process of leaving
+	select {
+	case <-s.leaveCh:
+		return true, structs.ErrNoLeader
+	default:
+	}
+
 	// Find the leader
-	isLeader, remoteServer := s.getLeader()
+	isLeader, leader := s.getLeader()
 
 	// Handle the case we are the leader
 	if isLeader {
@@ -205,21 +229,14 @@ CHECK_LEADER:
 	}
 
 	// Handle the case of a known leader
-	if remoteServer != nil {
-		// A no leader error can happen if the remote server loses
-		// leadership, so it's worth to retry for that case.
-		err := s.forwardLeader(remoteServer, method, args, reply)
-		if structs.IsErrNoLeader(err) {
+	rpcErr := structs.ErrNoLeader
+	if leader != nil {
+		rpcErr = s.connPool.RPC(s.config.Datacenter, leader.Addr,
+			leader.Version, method, leader.UseTLS, args, reply)
+		if rpcErr != nil && canRetry(info, rpcErr) {
 			goto RETRY
 		}
-		return true, err
-	} else {
-		// If we are leaving and don't know about the leader, we
-		// likely never will, so fail fast. This depends on the
-		// client agents doing a retry in their RPC path.
-		if drain := atomic.LoadInt32(&s.leaveDrain); drain > 0 {
-			return true, structs.ErrNoLeader
-		}
+		return true, rpcErr
 	}
 
 RETRY:
@@ -232,12 +249,13 @@ RETRY:
 		select {
 		case <-time.After(jitter):
 			goto CHECK_LEADER
+		case <-s.leaveCh:
 		case <-s.shutdownCh:
 		}
 	}
 
 	// No leader found and hold time exceeded
-	return true, structs.ErrNoLeader
+	return true, rpcErr
 }
 
 // getLeader returns if the current node is the leader, and if not then it
@@ -260,15 +278,6 @@ func (s *Server) getLeader() (bool, *metadata.Server) {
 
 	// Server could be nil
 	return false, server
-}
-
-// forwardLeader is used to forward an RPC call to the leader, or fail if no leader
-func (s *Server) forwardLeader(server *metadata.Server, method string, args interface{}, reply interface{}) error {
-	// Handle a missing server
-	if server == nil {
-		return structs.ErrNoLeader
-	}
-	return s.connPool.RPC(s.config.Datacenter, server.Addr, server.Version, method, server.UseTLS, args, reply)
 }
 
 // forwardDC is used to forward an RPC call to a remote DC, or fail if no servers

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -413,9 +413,6 @@ func TestServer_LeaveLeader(t *testing.T) {
 	if err := leader.Leave(); err != nil {
 		t.Fatal("leave failed: ", err)
 	}
-	if drain := atomic.LoadInt32(&leader.leaveDrain); drain == 0 {
-		t.Fatal("should have set drain flag")
-	}
 
 	// Should lose a peer
 	retry.Run(t, func(r *retry.R) {
@@ -453,9 +450,6 @@ func TestServer_Leave(t *testing.T) {
 	}
 	if err := nonleader.Leave(); err != nil {
 		t.Fatal("leave failed: ", err)
-	}
-	if drain := atomic.LoadInt32(&nonleader.leaveDrain); drain == 0 {
-		t.Fatal("should have set drain flag")
 	}
 
 	// Should lose a peer

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -94,6 +94,11 @@ func testServerConfig(t *testing.T) (string, *Config) {
 
 	config.CoordinateUpdatePeriod = 100 * time.Millisecond
 	config.LeaveDrainTime = 1 * time.Millisecond
+
+	// TODO (slackpad) - We should be able to run all tests w/o this, but it
+	// looks like several depend on it.
+	config.RPCHoldTimeout = 5 * time.Second
+
 	return dir, config
 }
 

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -23,6 +23,10 @@ var (
 	ErrRPCRateExceeded            = errors.New(errRPCRateExceeded)
 )
 
+func IsErrNoLeader(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errNoLeader)
+}
+
 func IsErrRPCRateExceeded(err error) bool {
-	return strings.Contains(err.Error(), errRPCRateExceeded)
+	return err != nil && strings.Contains(err.Error(), errRPCRateExceeded)
 }

--- a/lib/eof.go
+++ b/lib/eof.go
@@ -1,0 +1,27 @@
+package lib
+
+import (
+	"io"
+	"strings"
+
+	"github.com/hashicorp/yamux"
+)
+
+var yamuxStreamClosed = yamux.ErrStreamClosed.Error()
+var yamuxSessionShutdown = yamux.ErrSessionShutdown.Error()
+
+// IsErrEOF returns true if we get an EOF error from the socket itself, or
+// an EOF equivalent error from yamux.
+func IsErrEOF(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, yamuxStreamClosed) ||
+		strings.Contains(errStr, yamuxSessionShutdown) {
+		return true
+	}
+
+	return false
+}

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -958,6 +958,12 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
     Consul. See the [Server Performance](/docs/guides/performance.html) guide for more details. The
     following parameters are available:
 
+    *   <a name="leave_drain_time"></a><a href="#leave_drain_time">`leave_drain_time`</a> - A duration
+        that a server will dwell during a graceful leave in order to allow requests to be retried against
+        other Consul servers. Under normal circumstances, this can prevent clients from experiencing
+        "no leader" errors when performing a rolling update of the Consul servers. This was added in
+        Consul 1.0. Must be a duration value such as 10s. Defaults to 3s.
+
     *   <a name="raft_multiplier"></a><a href="#raft_multiplier">`raft_multiplier`</a> - An integer
         multiplier used by Consul servers to scale key Raft timing parameters. Omitting this value
         or setting it to 0 uses default timing described below. Lower values are used to tighten
@@ -975,11 +981,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         See the note on [last contact](/docs/guides/performance.html#last-contact) timing for more
         details on tuning this parameter. The maximum allowed value is 10.
 
-    *   <a name="leave_drain_time"></a><a href="#leave_drain_time">`leave_drain_time`</a> - A duration
-        that a server will dwell during a graceful leave in order to allow requests to be retried against
-        other Consul servers. Under normal circumstances, this can prevent clients from experiencing
-        "no leader" errors when performing a rolling update of the Consul servers. This was added in
-        Consul 1.0. Must be a duration value such as 10s. Defaults to 3s.
+    *   <a name="rpc_hold_timeout"></a><a href="#rpc_hold_timeout">`rpc_hold_timeout`</a> - A duration
+        that a server will retry internal RPC requests during leader elections. Under normal circumstances,
+        this can prevent clients from experiencing "no leader" errors. This was added in Consul 1.0. Must
+        be a duration value such as 10s. Defaults to 7s.
 
 * <a name="ports"></a><a href="#ports">`ports`</a> This is a nested object that allows setting
   the bind ports for the following keys:

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -982,9 +982,9 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         details on tuning this parameter. The maximum allowed value is 10.
 
     *   <a name="rpc_hold_timeout"></a><a href="#rpc_hold_timeout">`rpc_hold_timeout`</a> - A duration
-        that a server will retry internal RPC requests during leader elections. Under normal circumstances,
-        this can prevent clients from experiencing "no leader" errors. This was added in Consul 1.0. Must
-        be a duration value such as 10s. Defaults to 7s.
+        that a client or server will retry internal RPC requests during leader elections. Under normal
+        circumstances, this can prevent clients from experiencing "no leader" errors. This was added in
+        Consul 1.0. Must be a duration value such as 10s. Defaults to 7s.
 
 * <a name="ports"></a><a href="#ports">`ports`</a> This is a nested object that allows setting
   the bind ports for the following keys:

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -962,7 +962,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         that a server will dwell during a graceful leave in order to allow requests to be retried against
         other Consul servers. Under normal circumstances, this can prevent clients from experiencing
         "no leader" errors when performing a rolling update of the Consul servers. This was added in
-        Consul 1.0. Must be a duration value such as 10s. Defaults to 3s.
+        Consul 1.0. Must be a duration value such as 10s. Defaults to 5s.
 
     *   <a name="raft_multiplier"></a><a href="#raft_multiplier">`raft_multiplier`</a> - An integer
         multiplier used by Consul servers to scale key Raft timing parameters. Omitting this value

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -975,6 +975,12 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         See the note on [last contact](/docs/guides/performance.html#last-contact) timing for more
         details on tuning this parameter. The maximum allowed value is 10.
 
+    *   <a name="leave_drain_time"></a><a href="#leave_drain_time">`leave_drain_time`</a> - A duration
+        that a server will dwell during a graceful leave in order to allow requests to be retried against
+        other Consul servers. Under normal circumstances, this can prevent clients from experiencing
+        "no leader" errors when performing a rolling update of the Consul servers. This was added in
+        Consul 1.0. Must be a duration value such as 10s. Defaults to 3s.
+
 * <a name="ports"></a><a href="#ports">`ports`</a> This is a nested object that allows setting
   the bind ports for the following keys:
     * <a name="dns_port"></a><a href="#dns_port">`dns`</a> - The DNS server, -1 to disable. Default 8600.


### PR DESCRIPTION
This adds several mechanisms that work together to help shield clients from "no leader" errors during a nominal server roll (like doing a planned upgrade). This addresses all of the points on #3514 (the EOF errors are paved over by the drain logic).

Closes #3514.