### PR TITLE
upgrading ubuntu ami to 16.04, switching to systemd, allowing multipl…

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,3 +3,5 @@
 This folder contains modules for Terraform that can setup Consul for
 various systems. The infrastructure provider that is used is designated
 by the folder above. See the `variables.tf` file in each for more documentation. 
+
+To deploy Consul in multiple Subnets/AZ on AWS - supply:  -var 'vpc_id=vpc-1234567' -var 'subnets={ "0" = "subnet-12345", "1" = "subnet-23456", "2" = "subnet-34567"}'

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -17,16 +17,20 @@ variable "ami" {
   description = "AWS AMI Id, if you change, make sure it is compatible with instance type, not all AMIs allow all instance types "
 
   default = {
-    us-east-1-ubuntu      = "ami-fce3c696"
-    us-east-2-ubuntu      = "ami-b7075dd2"
-    us-west-1-ubuntu      = "ami-a9a8e4c9"
-    us-west-2-ubuntu      = "ami-9abea4fb"
-    eu-west-1-ubuntu      = "ami-47a23a30"
-    eu-central-1-ubuntu   = "ami-accff2b1"
-    ap-northeast-1-ubuntu = "ami-90815290"
-    ap-northeast-2-ubuntu = "ami-58af6136"
-    ap-southeast-1-ubuntu = "ami-0accf458"
-    ap-southeast-2-ubuntu = "ami-1dc8b127"
+    ap-south-1-ubuntu	  = "ami-08a5e367"
+    us-east-1-ubuntu	  = "ami-d651b8ac"
+    ap-northeast-1-ubuntu = "ami-8422ebe2"
+    eu-west-1-ubuntu	  = "ami-17d11e6e"
+    ap-southeast-1-ubuntu = "ami-e6d3a585"
+    ca-central-1-ubuntu	  = "ami-e59c2581"
+    us-west-1-ubuntu	  = "ami-2d5c6d4d"
+    eu-central-1-ubuntu	  = "ami-5a922335"
+    sa-east-1-ubuntu	  = "ami-a3e39ecf"
+    ap-southeast-2-ubuntu = "ami-391ff95b"
+    eu-west-2-ubuntu	  = "ami-e1f2e185"
+    ap-northeast-2-ubuntu = "ami-0f6fb461"
+    us-west-2-ubuntu	  = "ami-ecc63a94"
+    us-east-2-ubuntu  	  = "ami-9686a4f3"
     us-east-1-rhel6       = "ami-0d28fe66"
     us-east-2-rhel6       = "ami-aff2a9ca"
     us-west-2-rhel6       = "ami-3d3c0a0d"
@@ -44,7 +48,7 @@ variable "ami" {
 
 variable "service_conf" {
   default = {
-    ubuntu  = "debian_upstart.conf"
+    ubuntu  = "debian_consul.service"
     rhel6   = "rhel_upstart.conf"
     centos6 = "rhel_upstart.conf"
     centos7 = "rhel_consul.service"
@@ -54,7 +58,7 @@ variable "service_conf" {
 
 variable "service_conf_dest" {
   default = {
-    ubuntu  = "upstart.conf"
+    ubuntu  = "consul.service"
     rhel6   = "upstart.conf"
     centos6 = "upstart.conf"
     centos7 = "consul.service"
@@ -88,4 +92,14 @@ variable "instance_type" {
 variable "tagName" {
   default     = "consul"
   description = "Name tag for the servers"
+}
+
+variable "subnets" {
+  type = "map"
+  description = "map of subnets to deploy your infrastructure in, must have as many keys as your server count (default 3), -var 'subnets={\"0\"=\"subnet-12345\",\"1\"=\"subnets-23456\"}' "
+}
+
+variable "vpc_id" {
+  type = "string"
+  description = "ID of the VPC to use - in case your account doesn't have default VPC"
 }

--- a/terraform/shared/scripts/debian_consul.service
+++ b/terraform/shared/scripts/debian_consul.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=consul agent
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/sysconfig/consul
+Restart=on-failure
+ExecStart=/usr/local/bin/consul agent $CONSUL_FLAGS -config-dir=/etc/systemd/system/consul.d
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/terraform/shared/scripts/install.sh
+++ b/terraform/shared/scripts/install.sh
@@ -3,8 +3,7 @@ set -e
 
 echo "Installing dependencies..."
 if [ -x "$(command -v apt-get)" ]; then
-  sudo apt-get update -y
-  sudo apt-get install -y unzip
+  sudo su -s /bin/bash -c 'sleep 30 && apt-get update && apt-get install unzip' root
 else
   sudo yum update -y
   sudo yum install -y unzip wget
@@ -12,7 +11,7 @@ fi
 
 
 echo "Fetching Consul..."
-CONSUL=0.9.0
+CONSUL=0.9.3
 cd /tmp
 wget https://releases.hashicorp.com/consul/${CONSUL}/consul_${CONSUL}_linux_amd64.zip -O consul.zip --quiet
 
@@ -43,9 +42,11 @@ then
   sudo chmod 0644 /etc/service/consul
 else
   echo "Installing Systemd service..."
+  sudo mkdir -p /etc/sysconfig
   sudo mkdir -p /etc/systemd/system/consul.d
   sudo chown root:root /tmp/consul.service
   sudo mv /tmp/consul.service /etc/systemd/system/consul.service
+  sudo mv /tmp/consul*json /etc/systemd/system/consul.d/ || echo
   sudo chmod 0644 /etc/systemd/system/consul.service
   sudo mv /tmp/consul_flags /etc/sysconfig/consul
   sudo chown root:root /etc/sysconfig/consul


### PR DESCRIPTION
…e AZ/subnets through subnets={} map, upgrading consul to 0.9.3


Upgrading ubuntu from 14 to 16.04 LTS (this also means systemd instead of upstart)

Upgrading consul version to 0.9.3

Allowing to install in multiple Availability Zones on AWS - simply supply subnets map on the command line and assign indices to subnets

Sample run:

AWS_ACCESS_KEY_ID=111111111111 AWS_SECRET_ACCESS_KEY="111111111111" terraform apply -var 'key_name=my-ssh-key' -var 'key_path=~/.ssh/id_rsa.pem' -var 'platform=ubuntu' -var 'datacenterName=aws-east1' -var 'vpc_id=vpc-444444' -var 'subnets={ "0" = "subnet-333333", "1" = "subnet-111111", "2" = "subnet-1122222"}'
