### PR TITLE
Kill check processes after the timeout is reached

### DIFF
--- a/agent/check.go
+++ b/agent/check.go
@@ -144,7 +144,9 @@ func (c *CheckMonitor) check() {
 		} else {
 			c.Logger.Printf("[WARN] Timed out running check '%s'", c.Script)
 		}
-		err = <-waitCh
+
+		err = fmt.Errorf("Timed out running check '%s'", c.Script)
+		<-waitCh
 
 	case err = <-waitCh:
 		// The process returned before the timeout, proceed normally

--- a/agent/check.go
+++ b/agent/check.go
@@ -122,6 +122,7 @@ func (c *CheckMonitor) check() {
 	output, _ := circbuf.NewBuffer(CheckBufSize)
 	cmd.Stdout = output
 	cmd.Stderr = output
+	SetSysProcAttr(cmd)
 
 	// Start the check
 	if err := cmd.Start(); err != nil {
@@ -142,7 +143,7 @@ func (c *CheckMonitor) check() {
 	}
 	select {
 	case <-time.After(timeout):
-		if err := cmd.Process.Kill(); err != nil {
+		if err := KillCommandSubtree(cmd); err != nil {
 			c.Logger.Printf("[WARN] Timed out running check '%s': error killing process: %v", cmdDisplay, err)
 		} else {
 			c.Logger.Printf("[WARN] Timed out (%s) running check '%s'", timeout.String(), cmdDisplay)

--- a/agent/check_test.go
+++ b/agent/check_test.go
@@ -95,7 +95,7 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 	check := &CheckMonitor{
 		Notify:     notif,
 		CheckID:    types.CheckID("foo"),
-		ScriptArgs: []string{"sh", "-c", "sleep 1 && exit 0"},
+		ScriptArgs: []string{"sleep", "1"},
 		Interval:   50 * time.Millisecond,
 		Timeout:    25 * time.Millisecond,
 		Logger:     log.New(ioutil.Discard, UniqueID(), log.LstdFlags),

--- a/agent/check_test.go
+++ b/agent/check_test.go
@@ -95,7 +95,7 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 	check := &CheckMonitor{
 		Notify:     notif,
 		CheckID:    types.CheckID("foo"),
-		ScriptArgs: []string{"sleep", "1"},
+		ScriptArgs: []string{"sh", "-c", "sleep 1 && exit 0"},
 		Interval:   50 * time.Millisecond,
 		Timeout:    25 * time.Millisecond,
 		Logger:     log.New(ioutil.Discard, UniqueID(), log.LstdFlags),

--- a/agent/util_other.go
+++ b/agent/util_other.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 // ExecScript returns a command to execute a script through a shell.
@@ -14,4 +15,13 @@ func ExecScript(script string) (*exec.Cmd, error) {
 		shell = other
 	}
 	return exec.Command(shell, "-c", script), nil
+}
+
+func SetSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// KillCommandSubtree kills the command process and any child processes
+func KillCommandSubtree(cmd *exec.Cmd) error {
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }

--- a/agent/util_windows.go
+++ b/agent/util_windows.go
@@ -22,3 +22,9 @@ func ExecScript(script string) (*exec.Cmd, error) {
 	}
 	return cmd, nil
 }
+
+func SetSysProcAttr(cmd *exec.Cmd) {}
+
+func KillCommandSubtree(cmd *exec.Cmd) error {
+	return cmd.Process.Kill()
+}

--- a/website/source/docs/agent/checks.html.md
+++ b/website/source/docs/agent/checks.html.md
@@ -24,9 +24,11 @@ There are five different kinds of checks:
   a script check is limited to 4KB. Output larger than this will be truncated.
   By default, Script checks will be configured with a timeout equal to 30 seconds.
   It is possible to configure a custom Script check timeout value by specifying the
-  `timeout` field in the check definition. In Consul 0.9.0 and later, the agent
-  must be configured with [`enable_script_checks`](/docs/agent/options.html#_enable_script_checks)
-  set to `true` in order to enable script checks.
+  `timeout` field in the check definition. On Windows, Consul will wait for any child processes
+  spawned by the script to finish once the timeout is reached (instead of killing them immediately,
+  as on other platforms). In Consul 0.9.0 and later, the agent must be configured with
+  [`enable_script_checks`](/docs/agent/options.html#_enable_script_checks) set to `true`
+  in order to enable script checks.
 
 * HTTP + Interval - These checks make an HTTP `GET` request every Interval (e.g.
   every 30 seconds) to the specified URL. The status of the service depends on


### PR DESCRIPTION
Kill the subprocess spawned by a script check once the timeout is reached. Previously Consul just marked the check critical and left the subprocess around.

Fixes #3565.