### PR TITLE
Update retry_join cloud discovery docs with proxy info

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -265,6 +265,10 @@ will exit with an error at startup.
     combined with static IP or DNS addresses or even multiple configurations
     for different providers.
 
+    In order to use discovery behind a proxy, you will need to set
+    `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables per
+    [Golang `net/http` library](https://golang.org/pkg/net/http/#ProxyFromEnvironment).
+
     The following sections give the options specific to each supported cloud
     provider.
 


### PR DESCRIPTION
Update docs for retry_join cloud discovery to include snippet around using `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` env vars when needed. 