### PR TITLE
enable kv put -cas with -modify-index=0 for non-existent keys

### DIFF
--- a/command/kv/put/kv_put.go
+++ b/command/kv/put/kv_put.go
@@ -100,12 +100,6 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	// ModifyIndex is required for CAS
-	if c.cas && c.modifyIndex == 0 {
-		c.UI.Error("Must specify -modify-index with -cas!")
-		return 1
-	}
-
 	// Create and test the HTTP client
 	client, err := c.http.APIClient()
 	if err != nil {
@@ -129,6 +123,10 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		if !ok {
+			if pair.ModifyIndex == 0 {
+				c.UI.Error("Must specify -modify-index with -cas for existing key!")
+				return 1
+			}
 			c.UI.Error(fmt.Sprintf("Error! Did not write to %s: CAS failed", key))
 			return 1
 		}

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -39,10 +39,6 @@ func TestKVPutCommand_Validation(t *testing.T) {
 			[]string{"-release", "foo"},
 			"Missing -session",
 		},
-		"-cas no -modify-index": {
-			[]string{"-cas", "foo"},
-			"Must specify -modify-index",
-		},
 		"no key": {
 			[]string{},
 			"Missing KEY argument",


### PR DESCRIPTION
This change addresses #3052 in the simplest manner possible: allow executing `consul kv put -cas` without specifying `-modify-index` or by explicitly supplying a zero value. The `put` will succeed on first write, i.e.:

```
$ consul kv put -cas gerp gorp
Success! Data written to: gerp

$ consul kv put -cas gerp gorp
Must specify -modify-index with -cas for existing key!

$ consul kv get -detailed gerp
CreateIndex      10
Flags            0
Key              gerp
LockIndex        0
ModifyIndex      10
Session          -
Value            gorp

$ consul kv put -cas -modify-index 10 gerp GORP
Success! Data written to: gerp

$ consul kv put -cas -modify-index 10 gerp GORP
Error! Did not write to gerp: CAS failed
```