### PR TITLE
Replace hcl and mapstructure monkeypatches

### DIFF
--- a/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
+++ b/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
@@ -38,12 +38,6 @@ func DecodeHookExec(
 	raw DecodeHookFunc,
 	from reflect.Type, to reflect.Type,
 	data interface{}) (interface{}, error) {
-	// Build our arguments that reflect expects
-	argVals := make([]reflect.Value, 3)
-	argVals[0] = reflect.ValueOf(from)
-	argVals[1] = reflect.ValueOf(to)
-	argVals[2] = reflect.ValueOf(data)
-
 	switch f := typedDecodeHook(raw).(type) {
 	case DecodeHookFuncType:
 		return f(from, to, data)
@@ -121,6 +115,11 @@ func StringToTimeDurationHookFunc() DecodeHookFunc {
 	}
 }
 
+// WeaklyTypedHook is a DecodeHookFunc which adds support for weak typing to
+// the decoder.
+//
+// Note that this is significantly different from the WeaklyTypedInput option
+// of the DecoderConfig.
 func WeaklyTypedHook(
 	f reflect.Kind,
 	t reflect.Kind,
@@ -132,9 +131,8 @@ func WeaklyTypedHook(
 		case reflect.Bool:
 			if dataVal.Bool() {
 				return "1", nil
-			} else {
-				return "0", nil
 			}
+			return "0", nil
 		case reflect.Float32:
 			return strconv.FormatFloat(dataVal.Float(), 'f', -1, 64), nil
 		case reflect.Int:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -67,7 +67,7 @@
 		{"path":"github.com/mitchellh/cli","checksumSHA1":"GzfpPGtV2UJH9hFsKwzGjKrhp/A=","revision":"dff723fff508858a44c1f4bd0911f00d73b0202f","revisionTime":"2017-09-05T22:10:09Z"},
 		{"path":"github.com/mitchellh/copystructure","checksumSHA1":"86nE93o1VIND0Doe8PuhCXnhUx0=","revision":"cdac8253d00f2ecf0a0b19fbff173a9a72de4f82","revisionTime":"2016-08-04T03:23:30Z"},
 		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"V/quM7+em2ByJbWBLOsEwnY3j/Q=","revision":"b8bc1bf767474819792c23f32d8286a45736f1c6","revisionTime":"2016-12-03T19:45:07Z"},
-		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"LUrnGREfnifW4WDMaavmc9MlLI0=","revision":"ca63d7c062ee3c9f34db231e352b60012b4fd0c1","revisionTime":"2016-08-08T18:12:53Z"},
+		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"gILp4IL+xwXLH6tJtRLrnZ56F24=","revision":"06020f85339e21b2478f756a78e295255ffa4d6a","revisionTime":"2017-10-17T17:18:08Z"},
 		{"path":"github.com/mitchellh/reflectwalk","checksumSHA1":"mrqMlK6gqe//WsJSrJ1HgkPM0lM=","revision":"eecf4c70c626c7cfbb95c90195bc34d386c74ac6","revisionTime":"2015-05-27T15:31:53Z"},
 		{"path":"github.com/pascaldekloe/goe/verify","checksumSHA1":"5h+ERzHw3Rl2G0kFPxoJzxiA9s0=","revision":"07ebd1e2481f616a278ab431cf04cc5cf5ab3ebe","revisionTime":"2017-03-28T18:37:59Z"},
 		{"path":"github.com/pkg/errors","checksumSHA1":"ynJSWoF6v+3zMnh9R0QmmG6iGV8=","revision":"ff09b135c25aae272398c51a07235b90a75aa4f0","revisionTime":"2017-03-16T20:15:38Z","tree":true},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -43,7 +43,7 @@
 		{"path":"github.com/hashicorp/go-version","checksumSHA1":"tUGxc7rfX0cmhOOUDhMuAZ9rWsA=","revision":"03c5bf6be031b6dd45afec16b1cf94fc8938bc77","revisionTime":"2017-02-02T08:07:59Z"},
 		{"path":"github.com/hashicorp/golang-lru","checksumSHA1":"d9PxF1XQGLMJZRct2R8qVM/eYlE=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
 		{"path":"github.com/hashicorp/golang-lru/simplelru","checksumSHA1":"2nOpYjx8Sn57bqlZq17yM4YJuM4=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
-		{"path":"github.com/hashicorp/hcl","checksumSHA1":"7JBkp3EZoc0MSbiyWfzVhO4RYoY=","revision":"8f6b1344a92ff8877cf24a5de9177bf7d0a2a187","revisionTime":"2017-04-17T18:02:14Z"},
+		{"path":"github.com/hashicorp/hcl","checksumSHA1":"HtpYAWHvd9mq+mHkpo7z8PGzMik=","revision":"23c074d0eceb2b8a5bfdbb271ab780cde70f05a8","revisionTime":"2017-10-17T18:19:29Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"IxyvRpCFeoJBGl2obLKJV7RCGjg=","revision":"d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1","revisionTime":"2016-07-11T23:17:52Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"l2oQxBsZRwn6eZjf+whXr8c9+8c=","revision":"d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1","revisionTime":"2016-07-11T23:17:52Z"},
 		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"vjhDQVlgHhdxml1V8/cj0vOe+j8=","revision":"d8c773c4cba11b11539e3d45f93daeaa5dcf1fa1","revisionTime":"2016-07-11T23:17:52Z"},


### PR DESCRIPTION
This replaces the monkey patches for hashicorp/hcl#213 and mitchellh/mapstructure#101 added in 12216583.