### PR TITLE
porter: add better warning if missing

### DIFF
--- a/test/porter/client.go
+++ b/test/porter/client.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 )
 
 var DefaultAddr = "127.0.0.1:7965"
@@ -23,6 +24,9 @@ func RandomPorts(n int) ([]int, error) {
 	}
 	resp, err := http.Get(fmt.Sprintf("http://%s/%d", addr, n))
 	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			return nil, fmt.Errorf("Are you running porter?\nInstall with 'go install github.com/hashicorp/consul/test/porter/cmd/porter'\nThen run 'porter go test ...'\n%s", err)
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
This patch adds some instructions on what to do if `porter` isn't running and tests are failing because of it.