### PR TITLE
Documentation: Fixed indentation in Health check Script + Interval

### DIFF
--- a/website/source/docs/agent/checks.html.md
+++ b/website/source/docs/agent/checks.html.md
@@ -22,14 +22,12 @@ There are five different kinds of checks:
   generates some output. A script is paired with an invocation interval (e.g.
   every 30 seconds). This is similar to the Nagios plugin system. The output of
   a script check is limited to 4KB. Output larger than this will be truncated.
-
   By default, Script checks will be configured with a timeout equal to 30 seconds.
   It is possible to configure a custom Script check timeout value by specifying the
   `timeout` field in the check definition. When the timeout is reached on Windows,
   Consul will wait for any child processes spawned by the script to finish. For any
   other system, Consul will attempt to force-kill the script and any child processes
   it has spawned once the timeout has passed.
-
   In Consul 0.9.0 and later, the agent must be configured with [`enable_script_checks`]
   (/docs/agent/options.html#_enable_script_checks) set to `true` in order to enable script checks.
 


### PR DESCRIPTION
Remove newlines which were causing the text to not be rendered under the intended bullet point.