### PR TITLE
watch: Disable monotonicity check for lastIndex when type is "event"

### DIFF
--- a/watch/plan.go
+++ b/watch/plan.go
@@ -86,7 +86,7 @@ OUTER:
 		if oldIndex != 0 && reflect.DeepEqual(p.lastResult, result) {
 			continue
 		}
-		if p.lastIndex < oldIndex {
+		if p.Type != "event" && p.lastIndex < oldIndex {
 			p.lastIndex = 0
 		}
 


### PR DESCRIPTION
In Consul v0.8.4 or later, `consul watch -type event child` invokes a child process several time with the same events, which is unexpected.
Description: https://gist.github.com/yunazuno/798372ec53b01cf36e7ef00b691ba3ae

This problem is possibly caused by a monotonicity check for `p.lastIndex` in `watch/plan.go`.
Unlike the other watch types, "event" doesn't have monotonic index. Therefore, the monotonicity check sometime unexpectedly resets `p.lastIndex`.

This PR disables the monotonicity check when type of a watch is "event" in order to prevent the issue.
