### PR TITLE
config: add -config-format option

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -21,15 +21,15 @@ type Source struct {
 	Data   string
 }
 
-func NewSource(name, data string) Source {
-	return Source{Name: name, Format: FormatFrom(name), Data: data}
-}
-
 func FormatFrom(name string) string {
-	if strings.HasSuffix(name, ".hcl") {
+	switch {
+	case strings.HasSuffix(name, ".json"):
+		return "json"
+	case strings.HasSuffix(name, ".hcl"):
 		return "hcl"
+	default:
+		return ""
 	}
-	return "json"
 }
 
 // Parse parses a config fragment in either JSON or HCL format.

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -16,11 +16,15 @@ type Flags struct {
 	// that should be read.
 	ConfigFiles []string
 
+	// ConfigFormat forces all config files to be interpreted as this
+	// format independent of their extension.
+	ConfigFormat *string
+
+	// HCL contains an arbitrary config in hcl format.
 	// DevMode indicates whether the agent should be started in development
 	// mode. This cannot be configured in a config file.
 	DevMode *bool
 
-	// HCL contains an arbitrary config in hcl format.
 	HCL []string
 
 	// Args contains the remaining unparsed flags.
@@ -57,6 +61,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.ClientAddr, "client", "Sets the address to bind for client access. This includes RPC, DNS, HTTP and HTTPS (if configured).")
 	add(&f.ConfigFiles, "config-dir", "Path to a directory to read configuration files from. This will read every file ending in '.json' as configuration in this directory in alphabetical order. Can be specified multiple times.")
 	add(&f.ConfigFiles, "config-file", "Path to a JSON file to read configuration from. Can be specified multiple times.")
+	add(&f.ConfigFormat, "config-format", "Config files are in this format irrespective of their extension. Must be 'hcl' or 'json'")
 	add(&f.Config.DataDir, "data-dir", "Path to a data directory to store agent state.")
 	add(&f.Config.Datacenter, "datacenter", "Datacenter of the agent.")
 	add(&f.DevMode, "dev", "Starts the agent in development mode.")

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -362,6 +362,43 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
+			desc: "-config-format=json",
+			args: []string{
+				`-data-dir=` + dataDir,
+				`-config-format=json`,
+				`-config-file`, filepath.Join(dataDir, "conf"),
+			},
+			patch: func(rt *RuntimeConfig) {
+				rt.Datacenter = "a"
+				rt.DataDir = dataDir
+			},
+			pre: func() {
+				writeFile(filepath.Join(dataDir, "conf"), []byte(`{"datacenter":"a"}`))
+			},
+		},
+		{
+			desc: "-config-format=hcl",
+			args: []string{
+				`-data-dir=` + dataDir,
+				`-config-format=hcl`,
+				`-config-file`, filepath.Join(dataDir, "conf"),
+			},
+			patch: func(rt *RuntimeConfig) {
+				rt.Datacenter = "a"
+				rt.DataDir = dataDir
+			},
+			pre: func() {
+				writeFile(filepath.Join(dataDir, "conf"), []byte(`datacenter = "a"`))
+			},
+		},
+		{
+			desc: "-config-format invalid",
+			args: []string{
+				`-config-format=foobar`,
+			},
+			err: "-config-format must be either 'hcl' or 'json'",
+		},
+		{
 			desc: "-http-port",
 			args: []string{
 				`-http-port=123`,
@@ -1976,14 +2013,14 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 				// read the source fragements
 				for i, data := range srcs {
 					b.Sources = append(b.Sources, Source{
-						Name:   fmt.Sprintf("%s-%d", format, i),
+						Name:   fmt.Sprintf("src-%d.%s", i, format),
 						Format: format,
 						Data:   data,
 					})
 				}
 				for i, data := range tails {
 					b.Tail = append(b.Tail, Source{
-						Name:   fmt.Sprintf("%s-%d", format, i),
+						Name:   fmt.Sprintf("tail-%d.%s", i, format),
 						Format: format,
 						Data:   data,
 					})
@@ -3526,7 +3563,7 @@ func TestFullConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewBuilder: %s", err)
 			}
-			b.Sources = append(b.Sources, Source{Name: "full", Format: format, Data: data})
+			b.Sources = append(b.Sources, Source{Name: "full." + format, Data: data})
 			b.Tail = append(b.Tail, tail[format]...)
 			b.Tail = append(b.Tail, VersionSource("JNtPSav3", "R909Hblt", "ZT1JOQLn"))
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1723,9 +1723,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			pre: func() {
 				writeFile(filepath.Join(dataDir, SerfLANKeyring), []byte("i0P+gFTkLPg0h53eNYjydg=="))
 			},
-			post: func() {
-				os.Remove(filepath.Join(filepath.Join(dataDir, SerfLANKeyring)))
-			},
 			warns: []string{`WARNING: LAN keyring exists but -encrypt given, using keyring`},
 		},
 		{
@@ -1744,9 +1741,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			pre: func() {
 				writeFile(filepath.Join(dataDir, SerfWANKeyring), []byte("i0P+gFTkLPg0h53eNYjydg=="))
-			},
-			post: func() {
-				os.Remove(filepath.Join(filepath.Join(dataDir, SerfWANKeyring)))
 			},
 			warns: []string{`WARNING: WAN keyring exists but -encrypt given, using keyring`},
 		},
@@ -1855,6 +1849,9 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 func testConfig(t *testing.T, tests []configTest, dataDir string) {
 	for _, tt := range tests {
 		for pass, format := range []string{"json", "hcl"} {
+			// clean data dir before every test
+			cleanDir(dataDir)
+
 			// when we test only flags then there are no JSON or HCL
 			// sources and we need to make only one pass over the
 			// tests.
@@ -4023,6 +4020,19 @@ func writeFile(path string, data []byte) {
 		panic(err)
 	}
 	if err := ioutil.WriteFile(path, data, 0640); err != nil {
+		panic(err)
+	}
+}
+
+func cleanDir(path string) {
+	root := path
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if path == root {
+			return nil
+		}
+		return os.RemoveAll(path)
+	})
+	if err != nil {
 		panic(err)
 	}
 }

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -125,6 +125,12 @@ will exit with an error at startup.
   For more information on the format of the configuration files, see the
   [Configuration Files](#configuration_files) section.
 
+* <a name="_config_format"></a><a href="#_config_format">`-config-format`</a> - The format
+  of the configuration files to load. Normally, Consul detects the format of the
+  config files from the ".json" or ".hcl" extension. Setting this option to
+  either "json" or "hcl" forces Consul to interpret any file with or without
+  extension to be interpreted in that format.
+
 * <a name="_data_dir"></a><a href="#_data_dir">`-data-dir`</a> - This flag provides
   a data directory for the agent to store state.
   This is required for all agents. The directory should be durable across reboots.


### PR DESCRIPTION
Starting with Consul 1.0 all config files must have a '.json' or '.hcl'
extension to make it unambigous how the data should be parsed. Some
automation tools generate temporary files by appending a random string
to the generated file which obfuscates the extension and prevents the
file type detection.

This patch adds a -config-format option which can be used to override
the auto-detection behavior by forcing all config files or all files
within a config directory independent of their extension to be
interpreted as of this format.

Fixes #3620