### PR TITLE
Integer division rounding to zero for rate scaling

### DIFF
--- a/lib/cluster.go
+++ b/lib/cluster.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// minRate is the minimum rate at which we allow an action to be performed
-	// acorss the whole cluster. The value is once a day: 1 / (1 * time.Day)
+	// across the whole cluster. The value is once a day: 1 / (1 * time.Day)
 	minRate = 1.0 / 86400
 )
 

--- a/lib/cluster.go
+++ b/lib/cluster.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+const (
+	// minRate is the minimum rate at which we allow an action to be performed
+	// acorss the whole cluster. The value is once a day: 1 / (1 * time.Day)
+	minRate = 1.0 / 86400
+)
+
 // DurationMinusBuffer returns a duration, minus a buffer and jitter
 // subtracted from the duration.  This function is used primarily for
 // servicing Consul TTL Checks in advance of the TTL.
@@ -43,7 +49,6 @@ func RandomStagger(intv time.Duration) time.Duration {
 // order to target an aggregate number of actions per second across the whole
 // cluster.
 func RateScaledInterval(rate float64, min time.Duration, n int) time.Duration {
-	const minRate = 1 / 86400 // 1/(1 * time.Day)
 	if rate <= minRate {
 		return min
 	}

--- a/lib/cluster_test.go
+++ b/lib/cluster_test.go
@@ -158,6 +158,10 @@ func TestRateScaledInterval(t *testing.T) {
 	if v := RateScaledInterval(rate, min, 10000); v != 50*time.Second {
 		t.Fatalf("Bad: %v", v)
 	}
+	halfMin := minRate / 2.0
+	if v := RateScaledInterval(halfMin, min, 100); v != min {
+		t.Fatalf("Bad: %v", v)
+	}
 	if v := RateScaledInterval(0, min, 10000); v != min {
 		t.Fatalf("Bad: %v", v)
 	}


### PR DESCRIPTION
This fixes an issue in which integer division was scaling down to zero.