### PR TITLE
[Fix] Service tags not added to health checks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1603,6 +1603,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 			Notes:       chkType.Notes,
 			ServiceID:   service.ID,
 			ServiceName: service.Service,
+			ServiceTags: service.Tags,
 		}
 		if chkType.Status != "" {
 			check.Status = chkType.Status

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -290,6 +290,7 @@ func TestAgent_AddService(t *testing.T) {
 					Notes:       "note1",
 					ServiceID:   "svcid1",
 					ServiceName: "svcname1",
+					ServiceTags: []string{"tag1"},
 				},
 			},
 		},
@@ -329,6 +330,7 @@ func TestAgent_AddService(t *testing.T) {
 					Notes:       "note1",
 					ServiceID:   "svcid2",
 					ServiceName: "svcname2",
+					ServiceTags: []string{"tag2"},
 				},
 				"check-noname": &structs.HealthCheck{
 					Node:        "node1",
@@ -337,6 +339,7 @@ func TestAgent_AddService(t *testing.T) {
 					Status:      "critical",
 					ServiceID:   "svcid2",
 					ServiceName: "svcname2",
+					ServiceTags: []string{"tag2"},
 				},
 				"service:svcid2:3": &structs.HealthCheck{
 					Node:        "node1",
@@ -345,6 +348,7 @@ func TestAgent_AddService(t *testing.T) {
 					Status:      "critical",
 					ServiceID:   "svcid2",
 					ServiceName: "svcname2",
+					ServiceTags: []string{"tag2"},
 				},
 				"service:svcid2:4": &structs.HealthCheck{
 					Node:        "node1",
@@ -353,6 +357,7 @@ func TestAgent_AddService(t *testing.T) {
 					Status:      "critical",
 					ServiceID:   "svcid2",
 					ServiceName: "svcname2",
+					ServiceTags: []string{"tag2"},
 				},
 			},
 		},

--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -55,7 +55,8 @@ $ curl \
     "Notes": "",
     "Output": "",
     "ServiceID": "redis",
-    "ServiceName": "redis"
+    "ServiceName": "redis",
+    "ServiceTags": ["primary"]
   }
 }
 ```

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -51,7 +51,7 @@ $ curl \
   "redis": {
     "ID": "redis",
     "Service": "redis",
-    "Tags": null,
+    "Tags": [],
     "Address": "",
     "Port": 8000
   }

--- a/website/source/api/health.html.md
+++ b/website/source/api/health.html.md
@@ -62,7 +62,7 @@ $ curl \
     "Output": "",
     "ServiceID": "",
     "ServiceName": "",
-    "ServiceTags": null
+    "ServiceTags": []
   },
   {
     "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
@@ -239,7 +239,7 @@ $ curl \
         "Output": "",
         "ServiceID": "",
         "ServiceName": "",
-		"ServiceTags": null 
+        "ServiceTags": []
       }
     ]
   }
@@ -303,7 +303,7 @@ $ curl \
     "Output": "",
     "ServiceID": "",
     "ServiceName": "",
-	"ServiceTags": null
+    "ServiceTags": []
   },
   {
     "Node": "foobar",

--- a/website/source/intro/getting-started/checks.html.md
+++ b/website/source/intro/getting-started/checks.html.md
@@ -75,7 +75,7 @@ can be run on either node):
 
 ```text
 vagrant@n1:~$ curl http://localhost:8500/v1/health/state/critical
-[{"Node":"agent-two","CheckID":"service:web","Name":"Service 'web' check","Status":"critical","Notes":"","ServiceID":"web","ServiceName":"web"}]
+[{"Node":"agent-two","CheckID":"service:web","Name":"Service 'web' check","Status":"critical","Notes":"","ServiceID":"web","ServiceName":"web","ServiceTags":["rails"]}]
 ```
 
 We can see that there is only a single check, our `web` service check, in the


### PR DESCRIPTION
Since commit 9685bdcd0ba4b4b3adb04f9c1dd67d637ca7894e, service tags are added to the health checks.
Otherwise, when adding a service, tags are not added to its check.

In updateSyncState, we compare the checks of the local agent with the checks of the catalog.
It appears that the service tags are different (missing in one case), and so the check is synchronized.
That increase the ModifyIndex periodically when nothing changes.

Fixed it by adding serviceTags to the check.

Note that the issue appeared in version 0.8.2.
Looks related to issue #3259.