### PR TITLE
try to fix issue #3317, send http response header before sending logs

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -769,6 +769,8 @@ func (s *HTTPServer) AgentMonitor(resp http.ResponseWriter, req *http.Request) (
 	defer s.agent.LogWriter.DeregisterHandler(handler)
 	notify := resp.(http.CloseNotifier).CloseNotify()
 
+    // Send Http Header first
+	flusher.Flush()
 	// Stream logs until the connection is closed.
 	for {
 		select {


### PR DESCRIPTION
the client freezes because agent didn't send response header, so just call flusher.Flush() to send http header to client before send any logs