### PR TITLE
Removes timeout when restoring snapshots.

### DIFF
--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"time"
 
 	"github.com/hashicorp/raft"
 )
@@ -185,7 +184,7 @@ func Restore(logger *log.Logger, in io.Reader, r *raft.Raft) error {
 	}
 
 	// Feed the snapshot into Raft.
-	if err := r.Restore(&metadata, snap, 60*time.Second); err != nil {
+	if err := r.Restore(&metadata, snap, 0); err != nil {
 		return fmt.Errorf("Raft error when restoring snapshot: %v", err)
 	}
 


### PR DESCRIPTION
Fixes #3326

Originally I started out making this configurable, but realized it wasn't
worth the complexity. If you are restoring a snapshot, you really need to
wait until it's done, or something bad happens like losing leadership, which
will already trigger an error. Rather than have operators have to tune this
to cover whatever their snapshot size is, we just make it block here. There's
also already a bocking barrier right after the restore that hasn't been a
problem.