### PR TITLE
human readability for dns requests debug log

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -230,8 +230,8 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 			[]metrics.Label{{Name: "node", Value: d.agent.config.NodeName}})
 		metrics.MeasureSinceWithLabels([]string{"dns", "domain_query"}, s,
 			[]metrics.Label{{Name: "node", Value: d.agent.config.NodeName}})
-		d.logger.Printf("[DEBUG] dns: request for %v (%v) from client %s (%s)",
-			q, time.Since(s), resp.RemoteAddr().String(),
+		d.logger.Printf("[DEBUG] dns: request for name %v type %v class %v (took %v) from client %s (%s)",
+			q.Name, dns.Type(q.Qtype), dns.Class(q.Qclass), time.Since(s), resp.RemoteAddr().String(),
 			resp.RemoteAddr().Network())
 	}(time.Now())
 


### PR DESCRIPTION
After having some hard time debugging dns failures, iImade debug log a bit more human readable changing it from 
`[DEBUG] dns: request for {consul.service.consul. 1 1} (20.547109748s) from client 127.0.0.1:38319 (udp)
`
to
`[DEBUG] dns: request for name consul.service.consul. type A class IN (took 219.656µs) from client 127.0.0.1:46223 (udp)`