### PR TITLE
Added telemetry around Catalog APIs

### DIFF
--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -12,7 +12,8 @@ import (
 var durations = NewDurationFixer("interval", "timeout", "deregistercriticalserviceafter")
 
 func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_register"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_register"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "PUT" {
 		return nil, MethodNotAllowedError{req.Method, []string{"PUT"}}
 	}
@@ -33,15 +34,18 @@ func (s *HTTPServer) CatalogRegister(resp http.ResponseWriter, req *http.Request
 	// Forward to the servers
 	var out struct{}
 	if err := s.agent.RPC("Catalog.Register", &args, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_register"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_register"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_register"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_register"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return true, nil
 }
 
 func (s *HTTPServer) CatalogDeregister(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_deregister"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_deregister"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "PUT" {
 		return nil, MethodNotAllowedError{req.Method, []string{"PUT"}}
 	}
@@ -62,30 +66,36 @@ func (s *HTTPServer) CatalogDeregister(resp http.ResponseWriter, req *http.Reque
 	// Forward to the servers
 	var out struct{}
 	if err := s.agent.RPC("Catalog.Deregister", &args, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_deregister"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_deregister"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_deregister"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_deregister"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return true, nil
 }
 
 func (s *HTTPServer) CatalogDatacenters(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_datacenters"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_datacenters"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "GET" {
 		return nil, MethodNotAllowedError{req.Method, []string{"GET"}}
 	}
 
 	var out []string
 	if err := s.agent.RPC("Catalog.ListDatacenters", struct{}{}, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_datacenters"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_datacenters"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_datacenters"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_datacenters"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return out, nil
 }
 
 func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_nodes"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_nodes"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "GET" {
 		return nil, MethodNotAllowedError{req.Method, []string{"GET"}}
 	}
@@ -95,7 +105,8 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	s.parseSource(req, &args.Source)
 	args.NodeMetaFilters = s.parseMetaFilter(req)
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_nodes"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_nodes"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, nil
 	}
 
@@ -110,12 +121,14 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	if out.Nodes == nil {
 		out.Nodes = make(structs.Nodes, 0)
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_nodes"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_nodes"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return out.Nodes, nil
 }
 
 func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_services"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_services"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "GET" {
 		return nil, MethodNotAllowedError{req.Method, []string{"GET"}}
 	}
@@ -130,7 +143,8 @@ func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request
 	var out structs.IndexedServices
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Catalog.ListServices", &args, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_services"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_services"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
 
@@ -138,12 +152,14 @@ func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request
 	if out.Services == nil {
 		out.Services = make(structs.Services, 0)
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_services"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_services"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return out.Services, nil
 }
 
 func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_service_nodes"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_service_nodes"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "GET" {
 		return nil, MethodNotAllowedError{req.Method, []string{"GET"}}
 	}
@@ -175,7 +191,8 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	var out structs.IndexedServiceNodes
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Catalog.ServiceNodes", &args, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_service_nodes"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_service_nodes"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
 	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes)
@@ -189,12 +206,14 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 			s.ServiceTags = make([]string, 0)
 		}
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_service_nodes"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_service_nodes"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return out.ServiceNodes, nil
 }
 
 func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	metrics.IncrCounter([]string{"client", "api", "catalog_node_services"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "catalog_node_services"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	if req.Method != "GET" {
 		return nil, MethodNotAllowedError{req.Method, []string{"GET"}}
 	}
@@ -217,7 +236,8 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 	var out structs.IndexedNodeServices
 	defer setMeta(resp, &out.QueryMeta)
 	if err := s.agent.RPC("Catalog.NodeServices", &args, &out); err != nil {
-		metrics.IncrCounter([]string{"client", "rpc", "error", "catalog_node_services"}, 1)
+		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_node_services"}, 1,
+			[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 		return nil, err
 	}
 	if out.NodeServices != nil && out.NodeServices.Node != nil {
@@ -232,6 +252,7 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 			}
 		}
 	}
-	metrics.IncrCounter([]string{"client", "api", "success", "catalog_node_services"}, 1)
+	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_node_services"}, 1,
+		[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 	return out.NodeServices, nil
 }

--- a/agent/http.go
+++ b/agent/http.go
@@ -139,6 +139,11 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 	}
 }
 
+// nodeName returns the node name of the agent
+func (s *HTTPServer) nodeName() string {
+	return s.agent.config.NodeName
+}
+
 // aclEndpointRE is used to find old ACL endpoints that take tokens in the URL
 // so that we can redact them. The ACL endpoints that take the token in the URL
 // are all of the form /v1/acl/<verb>/<token>, and can optionally include query

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -75,6 +75,90 @@ These metrics are used to monitor the health of specific Consul agents.
     <td>counter</td>
   </tr>
   <tr>
+    <td>`consul.client.api.catalog_register`</td>
+    <td>This increments whenever a Consul agent receives a catalog register request.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_register`</td>
+    <td>This increments whenever a Consul agent successfully responds to a catalog register request.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_deregister`</td>
+    <td>This increments whenever a Consul agent receives a catalog de-register request.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_deregister`</td>
+    <td>This increments whenever a Consul agent successfully responds to a catalog de-register request.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_datacenters`</td>
+    <td>This increments whenever a Consul agent receives a request to list datacenters in the catalog.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_datacenters`</td>
+    <td>This increments whenever a Consul agent successfully responds to a request to list datacenters.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_nodes`</td>
+    <td>This increments whenever a Consul agent receives a request to list nodes from the catalog.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_nodes`</td>
+    <td>This increments whenever a Consul agent successfully responds to a request to list nodes.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_services`</td>
+    <td>This increments whenever a Consul agent receives a request to list services from the catalog.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_services`</td>
+    <td>This increments whenever a Consul agent successfully responds to a request to list services.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_service_nodes`</td>
+    <td>This increments whenever a Consul agent receives a request to list nodes offering a service.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_service_nodes`</td>
+    <td>This increments whenever a Consul agent successfully responds to a request to list nodes offering a service.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.catalog_node_services`</td>
+    <td>This increments whenever a Consul agent receives a request to list services registered in a node.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.client.api.success.catalog_node_services`</td>
+    <td>This increments whenever a Consul agent successfully responds to a request to list services in a service.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
     <td>`consul.runtime.num_goroutines`</td>
     <td>This tracks the number of running goroutines and is a general load pressure indicator. This may burst from time to time but should return to a steady state value.</td>
     <td>number of goroutines</td>

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -75,85 +75,85 @@ These metrics are used to monitor the health of specific Consul agents.
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_register`</td>
+    <td>`consul.client.api.catalog_register.<node>`</td>
     <td>This increments whenever a Consul agent receives a catalog register request.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_register`</td>
+    <td>`consul.client.api.success.catalog_register.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a catalog register request.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_deregister`</td>
+    <td>`consul.client.api.catalog_deregister.<node>`</td>
     <td>This increments whenever a Consul agent receives a catalog de-register request.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_deregister`</td>
+    <td>`consul.client.api.success.catalog_deregister.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a catalog de-register request.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_datacenters`</td>
+    <td>`consul.client.api.catalog_datacenters.<node>`</td>
     <td>This increments whenever a Consul agent receives a request to list datacenters in the catalog.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_datacenters`</td>
+    <td>`consul.client.api.success.catalog_datacenters.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a request to list datacenters.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_nodes`</td>
+    <td>`consul.client.api.catalog_nodes.<node>`</td>
     <td>This increments whenever a Consul agent receives a request to list nodes from the catalog.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_nodes`</td>
+    <td>`consul.client.api.success.catalog_nodes.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a request to list nodes.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_services`</td>
+    <td>`consul.client.api.catalog_services.<node>`</td>
     <td>This increments whenever a Consul agent receives a request to list services from the catalog.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_services`</td>
+    <td>`consul.client.api.success.catalog_services.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a request to list services.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_service_nodes`</td>
+    <td>`consul.client.api.catalog_service_nodes.<node>`</td>
     <td>This increments whenever a Consul agent receives a request to list nodes offering a service.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_service_nodes`</td>
+    <td>`consul.client.api.success.catalog_service_nodes.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a request to list nodes offering a service.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.catalog_node_services`</td>
+    <td>`consul.client.api.catalog_node_services.<node>`</td>
     <td>This increments whenever a Consul agent receives a request to list services registered in a node.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
-    <td>`consul.client.api.success.catalog_node_services`</td>
+    <td>`consul.client.api.success.catalog_node_services.<node>`</td>
     <td>This increments whenever a Consul agent successfully responds to a request to list services in a service.</td>
     <td>requests</td>
     <td>counter</td>


### PR DESCRIPTION
Adding some metrics to indicate the rate of Catalog requests, and RPC failures. These metrics are useful for operators to understand the health of Consul from the perspective of the users.

cc/ @slackpad I didn't add support for labels. Is Consul doing tagged metrics like Nomad these days?

An example -
```
{
   Name: "consul.client.api.success.catalog_list_services",
   Count: 5,
   Sum: 5, 
   Min: 1,
   Max: 1,
   Mean: 1,
   Stddev: 0,
   Labels: {
        "node": "node-name"
   }
},
```