### PR TITLE
Allow for default GOPATH

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,6 +13,7 @@ GOTAGS ?=
 GOFILES ?= $(shell go list ./... | grep -v /vendor/)
 GOOS=$(shell go env GOOS)
 GOARCH=$(shell go env GOARCH)
+GOPATH=$(shell go env GOPATH)
 
 # Get the git commit
 GIT_COMMIT=$(shell git rev-parse --short HEAD)


### PR DESCRIPTION
`GOPATH` defaults were [introduced](https://rakyll.org/default-gopath/) in 1.8, and Consul [requires](https://github.com/hashicorp/consul#developing-consul) 1.9+.