### PR TITLE
Provide hint about test over-parallelization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ $ bin/consul
 
 *Note: `make` will also place a copy of the binary in the first part of your `$GOPATH`.*
 
-You can run tests by typing `make test`.
+You can run tests by typing `make test`. The test suite may fail if
+over-parallelized, so if you are seeing stochastic failures try
+`GOTEST_FLAGS="-p 2 -parallel 2" make test`.
 
 If you make any changes to the code, run `make format` in order to automatically
 format the code according to Go standards.

--- a/command/operator/autopilot/set/operator_autopilot_set_test.go
+++ b/command/operator/autopilot/set/operator_autopilot_set_test.go
@@ -18,7 +18,7 @@ func TestOperatorAutopilotSetConfigCommand_noTabs(t *testing.T) {
 	}
 }
 
-func TestOperatorAutopilotSetConfigCommmand(t *testing.T) {
+func TestOperatorAutopilotSetConfigCommand(t *testing.T) {
 	t.Parallel()
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()


### PR DESCRIPTION
I found that running `make test` on my machine resulted in stochastic test failures. Limiting the parallelization to two cores (the number [on Travis](https://docs.travis-ci.com/user/reference/overview/), where the test suite passes ... when it has network connectivity ;) dodges the problem.

Plus bonus typo fix. 🐭