### PR TITLE
Added CheckID and Name to AgentServiceCheck struct

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -81,6 +81,8 @@ type AgentCheckRegistration struct {
 
 // AgentServiceCheck is used to define a node or service level check
 type AgentServiceCheck struct {
+	CheckID           string              `json:",omitempty"`
+	Name              string              `json:",omitempty"`
 	Args              []string            `json:"ScriptArgs,omitempty"`
 	Script            string              `json:",omitempty"` // Deprecated, use Args.
 	DockerContainerID string              `json:",omitempty"`

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -246,6 +246,34 @@ func TestAPI_AgentServices_CheckBadStatus(t *testing.T) {
 	}
 }
 
+func TestAPI_AgentServices_CheckID(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	agent := c.Agent()
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		Tags: []string{"bar", "baz"},
+		Port: 8000,
+		Check: &AgentServiceCheck{
+			CheckID: "foo-ttl",
+			TTL:     "15s",
+		},
+	}
+	if err := agent.ServiceRegister(reg); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	checks, err := agent.Checks()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if _, ok := checks["foo-ttl"]; !ok {
+		t.Fatalf("missing check: %v", checks)
+	}
+}
+
 func TestAPI_AgentServiceAddress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)


### PR DESCRIPTION
See discussion in gitter.

Without `CheckID` and `Name` in the `AgentServiceCheck` struct, we can't set a name or ID when creating a check with a service. Ideally `AgentServiceRegistration` would just have a slice of `AgentCheckRegistration` structs but that would break existing clients.