### PR TITLE
Adds the NodeID field back to the /v1/agent/self Config block.

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -57,12 +57,14 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 	config := struct {
 		Datacenter string
 		NodeName   string
+		NodeID     string
 		Revision   string
 		Server     bool
 		Version    string
 	}{
 		Datacenter: s.agent.config.Datacenter,
 		NodeName:   s.agent.config.NodeName,
+		NodeID:     string(s.agent.config.NodeID),
 		Revision:   s.agent.config.Revision,
 		Server:     s.agent.config.ServerMode,
 		Version:    s.agent.config.Version,

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -117,6 +117,7 @@ $ curl \
   "Config": {
     "Datacenter": "dc1",
     "NodeName": "foobar",
+    "NodeID": "9d754d17-d864-b1d3-e758-f3fe25a9874f",
     "Server": true,
     "Revision": "deadbeef",
     "Version": "1.0.0"


### PR DESCRIPTION
Fixes #3778