### PR TITLE
Removes stale TLS config clone() in favor of new supported method.

### DIFF
--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -187,39 +187,6 @@ func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// Clone returns a copy of c. Only the exported fields are copied. This
-// was copied from https://golang.org/src/crypto/tls/common.go since that
-// isn't exported and Go 1.7's vet uncovered an unsafe copy of a mutex in
-// here.
-//
-// TODO (slackpad) - This can be removed once we move to Go 1.8, see
-// https://github.com/golang/go/commit/d24f446 for details.
-func clone(c *tls.Config) *tls.Config {
-	return &tls.Config{
-		Rand:                        c.Rand,
-		Time:                        c.Time,
-		Certificates:                c.Certificates,
-		NameToCertificate:           c.NameToCertificate,
-		GetCertificate:              c.GetCertificate,
-		RootCAs:                     c.RootCAs,
-		NextProtos:                  c.NextProtos,
-		ServerName:                  c.ServerName,
-		ClientAuth:                  c.ClientAuth,
-		ClientCAs:                   c.ClientCAs,
-		InsecureSkipVerify:          c.InsecureSkipVerify,
-		CipherSuites:                c.CipherSuites,
-		PreferServerCipherSuites:    c.PreferServerCipherSuites,
-		SessionTicketsDisabled:      c.SessionTicketsDisabled,
-		SessionTicketKey:            c.SessionTicketKey,
-		ClientSessionCache:          c.ClientSessionCache,
-		MinVersion:                  c.MinVersion,
-		MaxVersion:                  c.MaxVersion,
-		CurvePreferences:            c.CurvePreferences,
-		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
-		Renegotiation:               c.Renegotiation,
-	}
-}
-
 // OutgoingTLSWrapper returns a a DCWrapper based on the OutgoingTLS
 // configuration. If hostname verification is on, the wrapper
 // will properly generate the dynamic server name for verification.
@@ -245,7 +212,7 @@ func (c *Config) OutgoingTLSWrapper() (DCWrapper, error) {
 	// Generate the wrapper based on hostname verification
 	if c.VerifyServerHostname {
 		wrapper = func(dc string, conn net.Conn) (net.Conn, error) {
-			conf := clone(tlsConfig)
+			conf := tlsConfig.Clone()
 			conf.ServerName = "server." + dc + "." + domain
 			return WrapTLSClient(conn, conf)
 		}


### PR DESCRIPTION
Closes #3761