### PR TITLE
add service annotation

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4029,6 +4029,7 @@ func TestSanitize(t *testing.T) {
     "Services": [
         {
             "Address": "",
+            "Annotation": {},
             "Check": {
                 "CheckID": "",
                 "DeregisterCriticalServiceAfter": "0s",

--- a/agent/structs/service_definition.go
+++ b/agent/structs/service_definition.go
@@ -5,6 +5,7 @@ type ServiceDefinition struct {
 	ID                string
 	Name              string
 	Tags              []string
+	Annotation        map[string]string
 	Address           string
 	Port              int
 	Check             CheckType
@@ -18,6 +19,7 @@ func (s *ServiceDefinition) NodeService() *NodeService {
 		ID:                s.ID,
 		Service:           s.Name,
 		Tags:              s.Tags,
+		Annotation:        s.Annotation,
 		Address:           s.Address,
 		Port:              s.Port,
 		EnableTagOverride: s.EnableTagOverride,

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -367,6 +367,7 @@ type ServiceNode struct {
 	ServiceID                string
 	ServiceName              string
 	ServiceTags              []string
+	ServiceAnnotation        map[string]string
 	ServiceAddress           string
 	ServicePort              int
 	ServiceEnableTagOverride bool
@@ -380,6 +381,11 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 	tags := make([]string, len(s.ServiceTags))
 	copy(tags, s.ServiceTags)
 
+	annotation := make(map[string]string)
+	for k, v := range s.ServiceAnnotation {
+		annotation[k] = v
+	}
+
 	return &ServiceNode{
 		// Skip ID, see above.
 		Node: s.Node,
@@ -388,6 +394,7 @@ func (s *ServiceNode) PartialClone() *ServiceNode {
 		ServiceID:                s.ServiceID,
 		ServiceName:              s.ServiceName,
 		ServiceTags:              tags,
+		ServiceAnnotation:        annotation,
 		ServiceAddress:           s.ServiceAddress,
 		ServicePort:              s.ServicePort,
 		ServiceEnableTagOverride: s.ServiceEnableTagOverride,
@@ -404,6 +411,7 @@ func (s *ServiceNode) ToNodeService() *NodeService {
 		ID:                s.ServiceID,
 		Service:           s.ServiceName,
 		Tags:              s.ServiceTags,
+		Annotation:        s.ServiceAnnotation,
 		Address:           s.ServiceAddress,
 		Port:              s.ServicePort,
 		EnableTagOverride: s.ServiceEnableTagOverride,
@@ -421,6 +429,7 @@ type NodeService struct {
 	ID                string
 	Service           string
 	Tags              []string
+	Annotation        map[string]string
 	Address           string
 	Port              int
 	EnableTagOverride bool
@@ -436,6 +445,7 @@ func (s *NodeService) IsSame(other *NodeService) bool {
 	if s.ID != other.ID ||
 		s.Service != other.Service ||
 		!reflect.DeepEqual(s.Tags, other.Tags) ||
+		!reflect.DeepEqual(s.Annotation, other.Annotation) ||
 		s.Address != other.Address ||
 		s.Port != other.Port ||
 		s.EnableTagOverride != other.EnableTagOverride {
@@ -455,6 +465,7 @@ func (s *NodeService) ToServiceNode(node string) *ServiceNode {
 		ServiceID:                s.ID,
 		ServiceName:              s.Service,
 		ServiceTags:              s.Tags,
+		ServiceAnnotation:        s.Annotation,
 		ServiceAddress:           s.Address,
 		ServicePort:              s.Port,
 		ServiceEnableTagOverride: s.EnableTagOverride,

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -133,9 +133,12 @@ func testServiceNode() *ServiceNode {
 		NodeMeta: map[string]string{
 			"tag": "value",
 		},
-		ServiceID:                "service1",
-		ServiceName:              "dogs",
-		ServiceTags:              []string{"prod", "v1"},
+		ServiceID:   "service1",
+		ServiceName: "dogs",
+		ServiceTags: []string{"prod", "v1"},
+		ServiceAnnotation: map[string]string{
+			"weight": "100",
+		},
 		ServiceAddress:           "127.0.0.2",
 		ServicePort:              8080,
 		ServiceEnableTagOverride: true,
@@ -172,6 +175,11 @@ func TestStructs_ServiceNode_PartialClone(t *testing.T) {
 	}
 
 	sn.ServiceTags = append(sn.ServiceTags, "hello")
+	if reflect.DeepEqual(sn, clone) {
+		t.Fatalf("clone wasn't independent of the original")
+	}
+
+	sn.ServiceAnnotation["hello"] = "world"
 	if reflect.DeepEqual(sn, clone) {
 		t.Fatalf("clone wasn't independent of the original")
 	}

--- a/api/agent.go
+++ b/api/agent.go
@@ -23,6 +23,7 @@ type AgentService struct {
 	ID                string
 	Service           string
 	Tags              []string
+	Annotation        map[string]string
 	Port              int
 	Address           string
 	EnableTagOverride bool
@@ -60,12 +61,13 @@ type MembersOpts struct {
 
 // AgentServiceRegistration is used to register a new service
 type AgentServiceRegistration struct {
-	ID                string   `json:",omitempty"`
-	Name              string   `json:",omitempty"`
-	Tags              []string `json:",omitempty"`
-	Port              int      `json:",omitempty"`
-	Address           string   `json:",omitempty"`
-	EnableTagOverride bool     `json:",omitempty"`
+	ID                string            `json:",omitempty"`
+	Name              string            `json:",omitempty"`
+	Tags              []string          `json:",omitempty"`
+	Annotation        map[string]string `json:",omitempty"`
+	Port              int               `json:",omitempty"`
+	Address           string            `json:",omitempty"`
+	EnableTagOverride bool              `json:",omitempty"`
 	Check             *AgentServiceCheck
 	Checks            AgentServiceChecks
 }

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -22,6 +22,7 @@ type CatalogService struct {
 	ServiceName              string
 	ServiceAddress           string
 	ServiceTags              []string
+	ServiceAnnotation        map[string]string
 	ServicePort              int
 	ServiceEnableTagOverride bool
 	CreateIndex              uint64

--- a/api/health.go
+++ b/api/health.go
@@ -25,15 +25,16 @@ const (
 
 // HealthCheck is used to represent a single check
 type HealthCheck struct {
-	Node        string
-	CheckID     string
-	Name        string
-	Status      string
-	Notes       string
-	Output      string
-	ServiceID   string
-	ServiceName string
-	ServiceTags []string
+	Node              string
+	CheckID           string
+	Name              string
+	Status            string
+	Notes             string
+	Output            string
+	ServiceID         string
+	ServiceName       string
+	ServiceTags       []string
+	ServiceAnnotation map[string]string
 
 	Definition HealthCheckDefinition
 }


### PR DESCRIPTION
Add a annotation filed in service, consul don't need to understand and interpret this annotation filed, service register & service discover can use this filed to store some extra info per service instance(like nginx upstream weight).

@slackpad PTAL :)