### PR TITLE
Adjust link to Java HTTP API

### DIFF
--- a/website/source/api/libraries-and-sdks.html.md
+++ b/website/source/api/libraries-and-sdks.html.md
@@ -43,7 +43,7 @@ the community.
     <a href="https://github.com/Verizon/helm">helm</a> - A native Scala client for interacting with Consul
   </li>
   <li>
-    <a href="https://github.com/OrbitzWorldwide/consul-client">consul-client</a> - Java client for the Consul HTTP API
+    <a href="https://github.com/rickfast/consul-client">consul-client</a> - Java client for the Consul HTTP API
   </li>
   <li>
     <a href="https://github.com/Ecwid/consul-api">consul-api</a> - Java client for the Consul HTTP API


### PR DESCRIPTION
OrbitzWorldwide/consul-client has moved to rickfast/consul-client.