### PR TITLE
Fix service tags not added to health check. Part two

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1664,6 +1664,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			return fmt.Errorf("ServiceID %q does not exist", check.ServiceID)
 		}
 		check.ServiceName = s.Service
+		check.ServiceTags = s.Tags
 	}
 
 	a.checkLock.Lock()


### PR DESCRIPTION
This fixes the issue in my comment
https://github.com/hashicorp/consul/issues/3259#issuecomment-361107726 on #3259 

It also adds the ServiceTags to the check, otherwise the check will differ because the local one has a nil entry for ServiceTags but the server state has the actual ServiceTags in the check.

Related to #3642