### PR TITLE
Support sockaddr templates in start-join and retry-join configuration

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -432,6 +432,28 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		}
 	}
 
+	// expand addresses in start join lan configuration
+	startJoinLAN := make([]string, len(c.StartJoinAddrsLAN))
+
+	for _, configStartJoinAddrsLAN := range c.StartJoinAddrsLAN {
+		startJoinAddrs := b.expandOptionalAddrs("start_join", &configStartJoinAddrsLAN)
+
+		if startJoinAddrs != nil {
+			startJoinLAN = append(startJoinLAN, startJoinAddrs...)
+		}
+	}
+
+	// expand addresses in retry join lan configuration
+	retryJoinLan := make([]string, len(c.RetryJoinLAN))
+
+	for _, retryJoinLanElement := range c.RetryJoinLAN {
+		retryJoinAddrs := b.expandOptionalAddrs("retry_join", &retryJoinLanElement)
+
+		if retryJoinAddrs != nil {
+			retryJoinLan = append(retryJoinLan, retryJoinAddrs...)
+		}
+	}
+
 	// expand dns recursors
 	uniq := map[string]bool{}
 	dnsRecursors := []string{}
@@ -677,7 +699,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		RejoinAfterLeave:            b.boolVal(c.RejoinAfterLeave),
 		RetryJoinIntervalLAN:        b.durationVal("retry_interval", c.RetryJoinIntervalLAN),
 		RetryJoinIntervalWAN:        b.durationVal("retry_interval_wan", c.RetryJoinIntervalWAN),
-		RetryJoinLAN:                c.RetryJoinLAN,
+		RetryJoinLAN:                retryJoinLan,
 		RetryJoinMaxAttemptsLAN:     b.intVal(c.RetryJoinMaxAttemptsLAN),
 		RetryJoinMaxAttemptsWAN:     b.intVal(c.RetryJoinMaxAttemptsWAN),
 		RetryJoinWAN:                c.RetryJoinWAN,
@@ -695,7 +717,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		Services:                    services,
 		SessionTTLMin:               b.durationVal("session_ttl_min", c.SessionTTLMin),
 		SkipLeaveOnInt:              skipLeaveOnInt,
-		StartJoinAddrsLAN:           c.StartJoinAddrsLAN,
+		StartJoinAddrsLAN:           startJoinLAN,
 		StartJoinAddrsWAN:           c.StartJoinAddrsWAN,
 		SyslogFacility:              b.stringVal(c.SyslogFacility),
 		TLSCipherSuites:             b.tlsCipherSuites("tls_cipher_suites", c.TLSCipherSuites),
@@ -1110,6 +1132,32 @@ func (b *Builder) expandAddrs(name string, s *string) []net.Addr {
 	return addrs
 }
 
+// expandOptionalAddrs expands the go-sockaddr template in s and returns the
+// result as a list of strings. If s does not contain a go-sockaddr template,
+// the result list will contain the input string as a single element with no
+// error set. In contrast to expandAddrs, expandOptionalAddrs does not validate
+// if the result contains valid addresses and returns a list of strings.
+// However, if the expansion of the go-sockaddr template fails an error is set.
+func (b *Builder) expandOptionalAddrs(name string, s *string) []string {
+	if s == nil || *s == "" {
+		return nil
+	}
+
+	x, err := template.Parse(*s)
+	if err != nil {
+		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %q: %s", name, s, err))
+		return nil
+	}
+
+	if x != *s {
+		// A template has been expanded, split the results from go-sockaddr
+		return strings.Fields(x)
+	} else {
+		// No template has been expanded, pass through the input
+		return []string{*s}
+	}
+}
+
 // expandIPs expands the go-sockaddr template in s and returns a list of
 // *net.IPAddr. If one of the expanded addresses is a unix socket
 // address an error is set and nil is returned.
@@ -1159,7 +1207,7 @@ func (b *Builder) expandFirstAddr(name string, s *string) net.Addr {
 	return addrs[0]
 }
 
-// expandFirstIP exapnds the go-sockaddr template in s and returns the
+// expandFirstIP expands the go-sockaddr template in s and returns the
 // first address if it is not a unix socket address. If the template
 // expands to multiple addresses an error is set and nil is returned.
 func (b *Builder) expandFirstIP(name string, s *string) *net.IPAddr {

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -435,22 +435,22 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	// expand addresses in start join lan configuration
 	startJoinLAN := make([]string, len(c.StartJoinAddrsLAN))
 
-	for _, configStartJoinAddrsLAN := range c.StartJoinAddrsLAN {
-		startJoinAddrs := b.expandOptionalAddrs("start_join", &configStartJoinAddrsLAN)
+	for _, a := range c.StartJoinAddrsLAN {
+		addrs := b.expandOptionalAddrs("start_join", &a)
 
-		if startJoinAddrs != nil {
-			startJoinLAN = append(startJoinLAN, startJoinAddrs...)
+		if addrs != nil {
+			startJoinLAN = append(startJoinLAN, addrs...)
 		}
 	}
 
 	// expand addresses in retry join lan configuration
-	retryJoinLan := make([]string, len(c.RetryJoinLAN))
+	retryJoinLAN := make([]string, len(c.RetryJoinLAN))
 
-	for _, retryJoinLanElement := range c.RetryJoinLAN {
-		retryJoinAddrs := b.expandOptionalAddrs("retry_join", &retryJoinLanElement)
+	for _, a := range c.RetryJoinLAN {
+		addrs := b.expandOptionalAddrs("retry_join", &a)
 
-		if retryJoinAddrs != nil {
-			retryJoinLan = append(retryJoinLan, retryJoinAddrs...)
+		if addrs != nil {
+			retryJoinLAN = append(retryJoinLAN, addrs...)
 		}
 	}
 


### PR DESCRIPTION
This pull request adds support for sockaddr templates in the start-join and retry-join configuration fields. This allows to resolve addresses to a join an existing cluster based on the network configuration of the consul agent host.

### Use case example

This use case describes a scenario in which the feature is essential.

- A consul cluster should be established in a /24 network which contains all hosts of the cluster
- Different environments for this consul cluster have different network prefixes (e.g. the test cluster has the subnet 10.0.1.0/24 and the production cluster has the subnet 10.0.2.0/24)
- In a subnet, three host machines which run consul servers exist with the addresses .1, .2, and .3 relative to the subnet (e.g. the first consul server in the test environment  has the address 10.0.1.1/24)
- A variable number of worker machines exist in an environment and run consul in client mode
- Instances of worker machines are spawned depending on the application load from an worker machine image which is equal in all environments 

Using the following configuration, the consul agents on the worker machines are able to find the consul server machines relative to the subnet they are deployed in.

```
$ consul agent -retry-join '{{ GetAllInterfaces | include "type" "IPv4" | exclude "flags" "loopback" | sort "address" | math "network" "+1" | attr "address" }}'
```

```
{
  "retry_join": [
    "{{ GetAllInterfaces | include \"type\" \"IPv4\" | exclude \"flags\" \"loopback\" | sort \"address\" | math \"network\" \"+1\" | attr \"address\" }}",
    "{{ GetAllInterfaces | include \"type\" \"IPv4\" | exclude \"flags\" \"loopback\" | sort \"address\" | math \"network\" \"+2\" | attr \"address\" }}",
    "{{ GetAllInterfaces | include \"type\" \"IPv4\" | exclude \"flags\" \"loopback\" | sort \"address\" | math \"network\" \"+3\" | attr \"address\" }}"
  ]
}
```

### Reference

- https://github.com/hashicorp/consul/issues/3665 suggests this feature

### Testing

As part of this pull request, I did not include tests to cover this functionality. Any hints on how and where to implement the corresponding tests are appreciated. 

### Open tasks

- [ ] Implement tests
- [ ] Write documentation
