### PR TITLE
Use empty list instead of nil when adding services (removes unnecessary churn)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1551,6 +1551,11 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 			"all alpha-numerics and dashes.", service.Service)
 	}
 
+	// Use empty list instead of nil
+	if service.Tags == nil {
+		service.Tags = make([]string, 0)
+	}
+
 	// Warn if any tags are incompatible with DNS
 	for _, tag := range service.Tags {
 		if InvalidDnsRe.MatchString(tag) {


### PR DESCRIPTION
This fixes an issue introduced by previous PR #3845

When doing the service checks for services without Service Tags we get `[]string{}` back from master, but the service was locally created with `[]string(nil)` which is again  a difference and causes services (without service tags) to get synced again every ~2 minutes

cc: @slackpad 

