### PR TITLE
Fixes accidental state store updates from output-side fixups.

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -170,10 +170,11 @@ func (s *HTTPServer) AgentChecks(resp http.ResponseWriter, req *http.Request) (i
 	}
 
 	// Use empty list instead of nil
-	// checks needs to be a deep copy for this not be racy
-	for _, c := range checks {
+	for id, c := range checks {
 		if c.ServiceTags == nil {
-			c.ServiceTags = make([]string, 0)
+			clone := *c
+			clone.ServiceTags = make([]string, 0)
+			checks[id] = &clone
 		}
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -146,9 +146,11 @@ func (s *HTTPServer) AgentServices(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	// Use empty list instead of nil
-	for _, s := range services {
+	for id, s := range services {
 		if s.Tags == nil {
-			s.Tags = make([]string, 0)
+			clone := *s
+			clone.Tags = make([]string, 0)
+			services[id] = &clone
 		}
 	}
 

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -246,6 +246,15 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices.Node)
 	}
 
+	// TODO: The NodeServices object in IndexedNodeServices is a pointer to
+	// something that's created for each request by the state store way down
+	// in https://github.com/hashicorp/consul/blob/v1.0.4/agent/consul/state/catalog.go#L953-L963.
+	// Since this isn't a pointer to a real state store object, it's safe to
+	// modify out.NodeServices.Services in the loop below without making a
+	// copy here. Same for the Tags in each service entry, since that was
+	// created by .ToNodeService() which made a copy. This is safe as-is but
+	// this whole business is tricky and subtle. See #3867 for more context.
+
 	// Use empty list instead of nil
 	if out.NodeServices != nil {
 		for _, s := range out.NodeServices.Services {

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -201,9 +201,11 @@ func (s *HTTPServer) CatalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	if out.ServiceNodes == nil {
 		out.ServiceNodes = make(structs.ServiceNodes, 0)
 	}
-	for _, s := range out.ServiceNodes {
+	for i, s := range out.ServiceNodes {
 		if s.ServiceTags == nil {
-			s.ServiceTags = make([]string, 0)
+			clone := *s
+			clone.ServiceTags = make([]string, 0)
+			out.ServiceNodes[i] = &clone
 		}
 	}
 	metrics.IncrCounterWithLabels([]string{"client", "api", "success", "catalog_service_nodes"}, 1,

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -42,9 +42,11 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 	if out.HealthChecks == nil {
 		out.HealthChecks = make(structs.HealthChecks, 0)
 	}
-	for _, c := range out.HealthChecks {
+	for i, c := range out.HealthChecks {
 		if c.ServiceTags == nil {
-			c.ServiceTags = make([]string, 0)
+			clone := *c
+			clone.ServiceTags = make([]string, 0)
+			out.HealthChecks[i] = &clone
 		}
 	}
 	return out.HealthChecks, nil
@@ -80,9 +82,11 @@ func (s *HTTPServer) HealthNodeChecks(resp http.ResponseWriter, req *http.Reques
 	if out.HealthChecks == nil {
 		out.HealthChecks = make(structs.HealthChecks, 0)
 	}
-	for _, c := range out.HealthChecks {
+	for i, c := range out.HealthChecks {
 		if c.ServiceTags == nil {
-			c.ServiceTags = make([]string, 0)
+			clone := *c
+			clone.ServiceTags = make([]string, 0)
+			out.HealthChecks[i] = &clone
 		}
 	}
 	return out.HealthChecks, nil
@@ -120,9 +124,11 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 	if out.HealthChecks == nil {
 		out.HealthChecks = make(structs.HealthChecks, 0)
 	}
-	for _, c := range out.HealthChecks {
+	for i, c := range out.HealthChecks {
 		if c.ServiceTags == nil {
-			c.ServiceTags = make([]string, 0)
+			clone := *c
+			clone.ServiceTags = make([]string, 0)
+			out.HealthChecks[i] = &clone
 		}
 	}
 	return out.HealthChecks, nil
@@ -194,19 +200,20 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 		out.Nodes = make(structs.CheckServiceNodes, 0)
 	}
 	for i := range out.Nodes {
-		// TODO (slackpad) It's lame that this isn't a slice of pointers
-		// but it's not a well-scoped change to fix this. We should
-		// change this at the next opportunity.
 		if out.Nodes[i].Checks == nil {
 			out.Nodes[i].Checks = make(structs.HealthChecks, 0)
 		}
-		for _, c := range out.Nodes[i].Checks {
+		for j, c := range out.Nodes[i].Checks {
 			if c.ServiceTags == nil {
-				c.ServiceTags = make([]string, 0)
+				clone := *c
+				clone.ServiceTags = make([]string, 0)
+				out.Nodes[i].Checks[j] = &clone
 			}
 		}
 		if out.Nodes[i].Service != nil && out.Nodes[i].Service.Tags == nil {
-			out.Nodes[i].Service.Tags = make([]string, 0)
+			clone := *out.Nodes[i].Service
+			clone.Tags = make([]string, 0)
+			out.Nodes[i].Service = &clone
 		}
 	}
 	return out.Nodes, nil

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -600,6 +600,8 @@ type IndexedServiceNodes struct {
 }
 
 type IndexedNodeServices struct {
+	// TODO: This should not be a pointer, see comments in
+	// agent/catalog_endpoint.go.
 	NodeServices *NodeServices
 	QueryMeta
 }


### PR DESCRIPTION
While looking into the follow up PR #3866 we realized there was something strange going on (see [this comment](https://github.com/hashicorp/consul/pull/3866#issuecomment-363621243)):

> While I was testing I noticed that node-level checks also have churn now as well, so I'm going to expand the unit test coverage and try to nail all the combinations so we know we've got a complete fix for this.

It turns out that this was a super subtle manifestation of some output-side fixups attempting to avoid `null` in JSON output for empty slices. Here's an example of some offending code - https://github.com/hashicorp/consul/blob/v1.0.4/agent/agent_endpoint.go#L172-L178. Since the slice is of pointers, this code is actually updating the underlying service objects in a racy way, when all it wants to do is fixup the output JSON.

Here's an even more insidious example - https://github.com/hashicorp/consul/blob/v1.0.4/agent/health_endpoint.go#L45-L49. For a client agent this is OK, since it's messing with a copy of an object that is received from the RPC call, which is a throwaway thing. If you hit this endpoint from a server, though, the in-memory RPC handler doesn't do a copy as a performance optimization, so you end up getting pointers back into the state store. Since this is immutable, that's totally fine, but it's not fine to _update_ those objects.

Because we are subtly corrupting state, but in a kind of an equivalent way (subbing a `make([]string, 0)` for a `nil` slice), things mostly work OK, except in the anti-entropy syncing code which ends up in https://github.com/hashicorp/consul/blob/v1.0.4/agent/structs/structs.go#L514, which doesn't consider those things equal.

By auditing for code like this and properly copying these objects before modifying, we can avoid this corruption, which is what this PR does. By fixing it at what we think is the root cause, I think we can close #3866, which I think was working around the issue.