### PR TITLE
Fixes a panic on TCP-based DNS lookups.

### DIFF
--- a/vendor/github.com/miekg/dns/server.go
+++ b/vendor/github.com/miekg/dns/server.go
@@ -495,6 +495,7 @@ func (srv *Server) serveTCP(l net.Listener) error {
 				rw.Close()
 				return
 			}
+			srv.inFlight.Add(1)
 			srv.serve(rw.RemoteAddr(), handler, m, nil, nil, rw)
 		}()
 


### PR DESCRIPTION
This came in via the monkey patch in #3861.

Fixes #3877