### PR TITLE
Fix the coordinate update endpoint not passing the ACL token

### DIFF
--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -168,6 +168,7 @@ func (s *HTTPServer) CoordinateUpdate(resp http.ResponseWriter, req *http.Reques
 		return nil, nil
 	}
 	s.parseDC(req, &args.Datacenter)
+	s.parseToken(req, &args.Token)
 
 	var reply struct{}
 	if err := s.agent.RPC("Coordinate.Update", &args, &reply); err != nil {

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/serf/coordinate"
 )
@@ -324,4 +325,32 @@ func TestCoordinate_Update(t *testing.T) {
 		coordinates[0].Node != "foo" {
 		t.Fatalf("bad: %v", coordinates)
 	}
+}
+
+func TestCoordinate_Update_ACLDeny(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t.Name(), TestACLConfig())
+	defer a.Shutdown()
+
+	coord := coordinate.NewCoordinate(coordinate.DefaultConfig())
+	coord.Height = -5.0
+	body := structs.CoordinateUpdateRequest{
+		Datacenter: "dc1",
+		Node:       "foo",
+		Coord:      coord,
+	}
+
+	t.Run("no token", func(t *testing.T) {
+		req, _ := http.NewRequest("PUT", "/v1/coordinate/update", jsonReader(body))
+		if _, err := a.srv.CoordinateUpdate(nil, req); !acl.IsErrPermissionDenied(err) {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	t.Run("valid token", func(t *testing.T) {
+		req, _ := http.NewRequest("PUT", "/v1/coordinate/update?token=root", jsonReader(body))
+		if _, err := a.srv.CoordinateUpdate(nil, req); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
The coordinate update HTTP endpoint was leaving the token empty on its RPC call - the agents internally hit the RPC endpoint directly for coordinate updates so this was only affecting external tools that called it.