### PR TITLE
Services Indexes modified per service instead of using a global Index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 3 -parallel 1" make test
+  - GOTEST_FLAGS="-p 2 -parallel 2" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 1 -parallel 1" make test
+  - GOTEST_FLAGS="-p 2 -parallel 2" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 2 -parallel 2" make test
+  - GOTEST_FLAGS="-p 4 -parallel 1" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 2 -parallel 2" make test
+  - GOTEST_FLAGS="-p 1 -parallel 1" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 4 -parallel 1" make test
+  - GOTEST_FLAGS="-p 3 -parallel 1" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 2 -parallel 2" make test
+  - GOTEST_FLAGS="-p 2 -parallel 1" make test
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 2 -parallel 1" make test
+  - GOTEST_FLAGS="-p 2 -parallel 2" make test
 
 sudo: false

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -760,8 +760,9 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string)
 }
 
 // maxIndexForService return the maximum Raft Index for a service
-// If the index is not set for the service, it will return the max
-// Raft Index of "nodes", "services"
+// If the index is not set for the service, it will return:
+// - maxIndex(nodes, services) if checks if false
+// - maxIndex(nodes, services, checks) if checks if false
 func maxIndexForService(tx *memdb.Txn, serviceName string, checks bool) (uint64, error) {
 	transaction, err := tx.First("index", "id", serviceIndexName(serviceName))
 	if err == nil {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -759,9 +759,9 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string)
 	return idx, results, nil
 }
 
-// maxIndexForService return the maximum transaction number for a service
-// If the transaction is not set for the service, it will return the max
-// transaction number of "nodes", "services"
+// maxIndexForService return the maximum Raft Index for a service
+// If the index is not set for the service, it will return the max
+// Raft Index of "nodes", "services"
 func maxIndexForService(tx *memdb.Txn, serviceName string) (uint64, error) {
 	transaction, err := tx.First("index", "id", serviceIndexName(serviceName))
 	if err == nil {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/consul/agent/structs"
@@ -618,9 +619,12 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	// conversion doesn't populate any of the node-specific information.
 	// That's always populated when we read from the state store.
 	entry := svc.ToServiceNode(node)
+	hasSameTags := false
 	if existing != nil {
 		entry.CreateIndex = existing.(*structs.ServiceNode).CreateIndex
 		entry.ModifyIndex = idx
+		eSvc := existing.(*structs.ServiceNode)
+		hasSameTags = reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
 	} else {
 		entry.CreateIndex = idx
 		entry.ModifyIndex = idx
@@ -639,8 +643,11 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	if err := tx.Insert("services", entry); err != nil {
 		return fmt.Errorf("failed inserting service: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+	if !hasSameTags {
+		// We need to update /catalog/services only tags are different
+		if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
 	}
 	if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.Service), idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1052,8 +1052,8 @@ func (s *Store) deleteServiceTxn(tx *memdb.Txn, idx uint64, nodeName, serviceID 
 	}
 
 	svc := service.(*structs.ServiceNode)
-	if remainingServicesItr, err := tx.Get("services", "service", svc.ServiceName); err == nil {
-		if remainingServicesItr != nil && remainingServicesItr.Next() != nil {
+	if remainingService, err := tx.First("services", "service", svc.ServiceName); err == nil {
+		if remainingService != nil {
 			// We have at least one remaining service, update the index
 			if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.ServiceName), idx}); err != nil {
 				return fmt.Errorf("failed updating index: %s", err)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -517,7 +517,11 @@ func (s *Store) deleteNodeTxn(tx *memdb.Txn, idx uint64, nodeName string) error 
 	}
 	var sids []string
 	for service := services.Next(); service != nil; service = services.Next() {
-		sids = append(sids, service.(*structs.ServiceNode).ServiceID)
+		svc := service.(*structs.ServiceNode)
+		sids = append(sids, svc.ServiceID)
+		if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.ServiceName), idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
 	}
 
 	// Do the delete in a separate loop so we don't trash the iterator.
@@ -638,6 +642,9 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
+	if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.Service), idx}); err != nil {
+		return fmt.Errorf("failed updating index: %s", err)
+	}
 
 	return nil
 }
@@ -752,14 +759,29 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string)
 	return idx, results, nil
 }
 
+// maxIndexForService return the maximum transaction number for a service
+// If the transaction is not set for the service, it will return the max
+// transaction number of "nodes", "services"
+func maxIndexForService(tx *memdb.Txn, serviceName string) (uint64, error) {
+	transaction, err := tx.First("index", "id", serviceIndexName(serviceName))
+	if err == nil {
+		if idx, ok := transaction.(*IndexEntry); ok {
+			return idx.Value, nil
+		}
+	}
+	return maxIndexTxn(tx, "nodes", "services"), nil
+}
+
 // ServiceNodes returns the nodes associated with a given service name.
 func (s *Store) ServiceNodes(ws memdb.WatchSet, serviceName string) (uint64, structs.ServiceNodes, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := maxIndexTxn(tx, "nodes", "services")
-
+	idx, err := maxIndexForService(tx, serviceName)
+	if err != nil {
+		panic(fmt.Sprintf("Could not retrieve maxIndex for %s: %s", serviceName, err))
+	}
 	// List all the services.
 	services, err := tx.Get("services", "service", serviceName)
 	if err != nil {
@@ -787,7 +809,10 @@ func (s *Store) ServiceTagNodes(ws memdb.WatchSet, service string, tag string) (
 	defer tx.Abort()
 
 	// Get the table index.
-	idx := maxIndexTxn(tx, "nodes", "services")
+	idx, err := maxIndexForService(tx, service)
+	if err != nil {
+		panic(fmt.Sprintf("Could not retrieve maxIndex for %s: %s", service, err))
+	}
 
 	// List all the services.
 	services, err := tx.Get("services", "service", service)
@@ -979,6 +1004,10 @@ func (s *Store) DeleteService(idx uint64, nodeName, serviceID string) error {
 	return nil
 }
 
+func serviceIndexName(name string) string {
+	return fmt.Sprintf("service.%s", name)
+}
+
 // deleteServiceTxn is the inner method called to remove a service
 // registration within an existing transaction.
 func (s *Store) deleteServiceTxn(tx *memdb.Txn, idx uint64, nodeName, serviceID string) error {
@@ -1022,6 +1051,26 @@ func (s *Store) deleteServiceTxn(tx *memdb.Txn, idx uint64, nodeName, serviceID 
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
+	svc := service.(*structs.ServiceNode)
+	if remainingServicesItr, err := tx.Get("services", "service", svc.ServiceName); err == nil {
+		if remainingServicesItr != nil && remainingServicesItr.Next() != nil {
+			// We have at least one remaining service, update the index
+			if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.ServiceName), idx}); err != nil {
+				return fmt.Errorf("failed updating index: %s", err)
+			}
+		} else {
+			// There are no more service instances, cleanup the service.<serviceName> index
+			serviceIndex, err := tx.First("index", "id", serviceIndexName(svc.ServiceName))
+			if err == nil && serviceIndex != nil {
+				// we found service.<serviceName> index, garbage collect it
+				if errW := tx.Delete("index", serviceIndex); errW != nil {
+					return fmt.Errorf("[FAILED] deleting serviceIndex %s: %s", svc.ServiceName, err)
+				}
+			}
+		}
+	} else {
+		return fmt.Errorf("Could not find any service %s: %s", svc.ServiceName, err)
+	}
 	return nil
 }
 
@@ -1087,6 +1136,21 @@ func (s *Store) ensureCheckTxn(tx *memdb.Txn, idx uint64, hc *structs.HealthChec
 		svc := service.(*structs.ServiceNode)
 		hc.ServiceName = svc.ServiceName
 		hc.ServiceTags = svc.ServiceTags
+		if err = tx.Insert("index", &IndexEntry{serviceIndexName(svc.ServiceName), idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
+	} else {
+		// Update the status for all the services associated with this node
+		services, err := tx.Get("services", "node", hc.Node)
+		if err != nil {
+			return fmt.Errorf("failed updating services for node %s: %s", hc.Node, err)
+		}
+		for service := services.Next(); service != nil; service = services.Next() {
+			svc := service.(*structs.ServiceNode).ToNodeService()
+			if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.Service), idx}); err != nil {
+				return fmt.Errorf("failed updating index: %s", err)
+			}
+		}
 	}
 
 	// Delete any sessions for this check if the health is critical.
@@ -1327,6 +1391,22 @@ func (s *Store) deleteCheckTxn(tx *memdb.Txn, idx uint64, node string, checkID t
 	}
 	if hc == nil {
 		return nil
+	}
+	existing := hc.(*structs.HealthCheck)
+	if existing != nil && existing.ServiceID != "" {
+		service, err := tx.First("services", "id", node, existing.ServiceID)
+		if err != nil {
+			return fmt.Errorf("failed service lookup: %s", err)
+		}
+		if service == nil {
+			return ErrMissingService
+		}
+
+		// Updated index of service
+		svc := service.(*structs.ServiceNode)
+		if err = tx.Insert("index", &IndexEntry{serviceIndexName(svc.ServiceName), idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
 	}
 
 	// Delete the check from the DB and update the index.

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -2168,6 +2168,7 @@ func TestStateStore_DeleteCheck(t *testing.T) {
 
 func ensureServiceVersion(t *testing.T, s *Store, ws memdb.WatchSet, serviceID string, expectedIdx uint64, expectedSize int) {
 	idx, services, err := s.ServiceNodes(ws, serviceID)
+	t.Helper()
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -2304,7 +2304,8 @@ func TestStateStore_CheckServiceNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 7 {
+	// registered with ensureServiceVersion(t, s, ws, "service1", 6, 1)
+	if idx != 6 {
 		t.Fatalf("bad index: %d", idx)
 	}
 
@@ -2329,7 +2330,8 @@ func TestStateStore_CheckServiceNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 8 {
+	// service1 has been registered at idx=6, other different registrations do not count
+	if idx != 6 {
 		t.Fatalf("bad index: %d", idx)
 	}
 

--- a/website/source/docs/upgrading.html.md
+++ b/website/source/docs/upgrading.html.md
@@ -38,16 +38,24 @@ Consul is A, and version B is released.
 
 ## Upgrade from Version 1.0.6 to higher
 
-In version 1.0.7 and higher, when requesting a specific service (/health or
-/catalog endpoints), the X-Consul-Index returned is now the index at which the
-service has been modified, not the global Raft Index of all services.
+In version 1.0.7 and higher, when requesting a specific service
+(`/v1/health/:service` or `/v1/catalog/:service` endpoints), the
+`X-Consul-Index` returned is now the index at which that specific service was
+last modified.
+In version 1.0.6 and earlier the X-Consul-Index returned was the index at
+which any service was last modified. See
+[GH-3890](https://github.com/hashicorp/consul/issues/3890) for more details.
 
-Thus, if several versions of Consul are pre 1.0.7 and post 1.0.7, (ie: during an
-upgrade) it is possible to have a lower X-Consul-Index returned than the previous
-X-Consul-Index issued for this service.
+During upgrades from 1.0.6 or lower to 1.0.7 or higher, watchers are likely to
+see `X-Consul-Index` for these endpoints decrease between blocking calls.
 
-It should not be an issue unless library code does issue an error if it expects
-X-Consul-Index to be strictly increasing.
+Consul’s watch feature and consul-template should gracefully handle this case.
+Other tools relying on blocking service or health queries are also likely to
+work; some may require a restart. It is possible external tools could break and
+either stop working or continually re-request data without blocking if they
+have assumed indexes can never decrease or be reset and/or persist index
+values. Please test any blocking query integrations in a controlled environment
+before proceeding.
 
 ## Backward Incompatible Upgrades
 

--- a/website/source/docs/upgrading.html.md
+++ b/website/source/docs/upgrading.html.md
@@ -36,6 +36,18 @@ Consul is A, and version B is released.
    by running `consul members` to make sure all members have the latest
    build and highest protocol version.
 
+## Upgrade from Version 1.0.6 to higher
+
+In version 1.0.7 and higher, when requesting a specific service (/health or
+/catalog endpoints), the X-Consul-Index returned is now the index at which the
+service has been modified, not the global Raft Index of all services.
+
+Thus, if several versions of Consul are pre 1.0.7 and post 1.0.7, (ie: during an
+upgrade) it is possible to have a lower X-Consul-Index returned than the previous
+X-Consul-Index issued for this service.
+
+It should not be an issue unless library code does issue an error if it expects
+X-Consul-Index to be strictly increasing.
 
 ## Backward Incompatible Upgrades
 


### PR DESCRIPTION
This patch improves the watches for services on large cluster:
each service has now its own index, such watches on a specific service
are not modified by changes in the global catalog.

It should improve a lot the performance of tools such as consul-template
or libraries performing watches on very large clusters with many
services/watches.

Full description of the issue: https://github.com/hashicorp/consul/issues/3890

Description of the implementation: https://github.com/hashicorp/consul/issues/3890#issuecomment-366436108