### PR TITLE
Fixed flakyness of Travis due to parallelisation within test class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ branches:
     - master
 
 script:
-  - GOTEST_FLAGS="-p 2 -parallel 2" make test
+  - GOTEST_FLAGS="-p 3 -parallel 1" make test
 
 sudo: false


### PR DESCRIPTION
This patch will avoid Travis tests being too flaky:
* `-parallel 1` => reduce the tests of same test case being run in //
* `-p 3` allow to have tests compiled in // to avoid timeouts in travis