### PR TITLE
Make sure revokeLeadership is called if establishLeadership errors

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -761,3 +761,22 @@ func TestServer_TLSToFullVerify(t *testing.T) {
 		t.Fatalf("bad: %v", success)
 	}
 }
+
+func TestServer_RevokeLeadershipIdempotent(t *testing.T) {
+	t.Parallel()
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	err:= s1.revokeLeadership()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s1.revokeLeadership()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -767,8 +767,7 @@ func TestServer_RevokeLeadershipIdempotent(t *testing.T) {
 	dir1, s1 := testServer(t)
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
-
-
+	
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	err:= s1.revokeLeadership()


### PR DESCRIPTION
This PR ports over a fix from @dadgar in Nomad (https://github.com/hashicorp/nomad/pull/3890) that leaves partially initialized state around when the establishLeadership method returns an error. This caused us to not call revokeLeadership if there was an event in the stop channel (losing leadership). 

This, combined with https://github.com/hashicorp/consul/pull/3908 makes sure that revokeLeadership is idempotent. 
