### PR TITLE
Fix test running in non-bash shells

### DIFF
--- a/agent/watch_handler_test.go
+++ b/agent/watch_handler_test.go
@@ -15,7 +15,7 @@ func TestMakeWatchHandler(t *testing.T) {
 	t.Parallel()
 	defer os.Remove("handler_out")
 	defer os.Remove("handler_index_out")
-	script := "echo $CONSUL_INDEX >> handler_index_out && cat >> handler_out"
+	script := "bash -c 'echo $CONSUL_INDEX >> handler_index_out && cat >> handler_out'"
 	handler := makeWatchHandler(os.Stderr, script)
 	handler(100, []string{"foo", "bar", "baz"})
 	raw, err := ioutil.ReadFile("handler_out")


### PR DESCRIPTION
I run fish shell locally and this test always fails because `&&` are not valid in fish scripts.

This fix explicitly invokes bash around the test script and passes locally now should be more portable to most *NIX environments although presumably will fail on Windows etc. still. Not sure if we support dev on Windows well in general though.