### PR TITLE
website: override automatic linking of list items for softlayer dc

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -398,7 +398,7 @@ will exit with an error at startup.
     ```
 
     - `provider` (required) - the name of the provider ("softlayer" in this case).
-    - `datacenter` (required) - the name of the datacenter to auto-join in.
+    - <a name="sl_datacenter"></a><a href="#sl_datacenter"><code>datacenter</code></a></a> (required) - the name of the datacenter to auto-join in.
     - `tag_value` (required) - the value of the tag to auto-join on.
     - `username` (required) - the username to use for auth.
     - `api_key` (required) - the api key to use for auth.


### PR DESCRIPTION
This avoids a conflict with #datacenter later on the page. We're mixing
historic manually specified anchors with generated anchors (via
redcarpet / middleman-hashicorp) so we have to manually override the
automatic generation here.

I was tempted to rewrite the old manual anchors to use the automatic
generation, but there is no way to maintain backwards compatibility,
so will leave that for a time when it is appropriate for us to break
links (or redirect them, etc).

Fixes #3916