### PR TITLE
Docs: Clarify encrypt key for WAN joined DCs

### DIFF
--- a/website/source/docs/agent/encryption.html.md
+++ b/website/source/docs/agent/encryption.html.md
@@ -18,6 +18,8 @@ Enabling gossip encryption only requires that you set an encryption key when
 starting the Consul agent. The key can be set via the `encrypt` parameter: the
 value of this setting is a configuration file containing the encryption key.
 
+~> **WAN Joined Datacenters Note:** If using multiple WAN joined datacenters, be sure to use _the same encryption key_ in all datacenters.
+
 The key must be 16-bytes, Base64 encoded. As a convenience, Consul provides the
 [`consul keygen`](/docs/commands/keygen.html) command to generate a
 cryptographically suitable key:


### PR DESCRIPTION
A little note to help folks who might be hitting an issue whereby all their gossip encryption keys differ from datacenter to datacenter and WAN joining doesn't work.