### PR TITLE
Highlighting the dead link in documentation

### DIFF
--- a/website/source/docs/guides/bootstrapping.html.md
+++ b/website/source/docs/guides/bootstrapping.html.md
@@ -52,7 +52,7 @@ To trigger leader election, we must join these machines together and create a cl
 Choose the method which best suits your environment and specific use case.
 
 ~> **Notice:** The hosted version of Consul Enterprise was deprecated on
-  March 7th, 2017 and the Atlas `auto-join` feature is no longer available. For details, see https://atlas.hashicorp.com/help/consul/alternatives.
+  March 7th, 2017 and the Atlas `auto-join` feature is no longer available. 
 
 ### Manually Creating a Cluster
 


### PR DESCRIPTION
I am proposing to remove a dead link in documentation (https://www.consul.io/docs/guides/bootstrapping.html) The documentation page references https://atlas.hashicorp.com/help/consul/alternatives, which doesn't seem to exist. If the referenced resource has moved and the new location is known, it would be of course better to update the link rather than remove it.