### PR TITLE
Watch /catalog/services optimization: X-Consul-Index changes less often

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1075,8 +1075,11 @@ func (s *Store) deleteServiceTxn(tx *memdb.Txn, idx uint64, nodeName, serviceID 
 	svc := service.(*structs.ServiceNode)
 	// In some cases, it would be possible to avoid updating this index if
 	// the tags of this service instance are all present in other instances
+	// and if the removed service is NOT the last one.
 	// But the optimization might be costly since we would have to run thru the
 	// whole list of services.
+	// We are here optimizing the most common use case which ensures the service does exists
+	// and we consider the removal of a service to be a less common scenario.
 	if err := tx.Insert("index", &IndexEntry{"service-catalog", idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/consul/agent/structs"
@@ -617,10 +618,13 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	// Create the service node entry and populate the indexes. Note that
 	// conversion doesn't populate any of the node-specific information.
 	// That's always populated when we read from the state store.
+	hasSameTags := false
 	entry := svc.ToServiceNode(node)
 	if existing != nil {
 		entry.CreateIndex = existing.(*structs.ServiceNode).CreateIndex
 		entry.ModifyIndex = idx
+		eSvc := existing.(*structs.ServiceNode)
+		hasSameTags = reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
 	} else {
 		entry.CreateIndex = idx
 		entry.ModifyIndex = idx
@@ -639,8 +643,11 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	if err := tx.Insert("services", entry); err != nil {
 		return fmt.Errorf("failed inserting service: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+	if !hasSameTags {
+		// We need to update /catalog/services only tags are different
+		if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
 	}
 	if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.Service), idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -899,9 +906,6 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	// Get the table index.
-	idx := maxIndexTxn(tx, "services")
-
 	// Query the service
 	service, err := tx.First("services", "id", nodeName, serviceID)
 	if err != nil {
@@ -909,8 +913,11 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 	}
 
 	if service != nil {
-		return idx, service.(*structs.ServiceNode).ToNodeService(), nil
+		svc := service.(*structs.ServiceNode).ToNodeService()
+		return svc.ModifyIndex, svc, nil
 	}
+	// Get the table index.
+	idx := maxIndexForService(tx, serviceID, true)
 	return idx, nil, nil
 }
 
@@ -918,9 +925,6 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *structs.NodeServices, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
-
-	// Get the table index.
-	idx := maxIndexTxn(tx, "nodes", "services")
 
 	// Query the node by node name
 	watchCh, n, err := tx.FirstWatch("nodes", "id", nodeNameOrID)
@@ -964,6 +968,7 @@ func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *s
 	}
 
 	node := n.(*structs.Node)
+	idx := node.ModifyIndex
 	nodeName := node.Node
 
 	// Read all of the services
@@ -983,6 +988,9 @@ func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *s
 	for service := services.Next(); service != nil; service = services.Next() {
 		svc := service.(*structs.ServiceNode).ToNodeService()
 		ns.Services[svc.ID] = svc
+		if svc.ModifyIndex > idx {
+			idx = svc.ModifyIndex
+		}
 	}
 
 	return idx, ns, nil

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -905,11 +905,18 @@ func TestStateStore_EnsureService(t *testing.T) {
 
 	// Retrieve the services.
 	ws = memdb.NewWatchSet()
+	idx2, _, err2 := s.NodeServices(ws, "node2")
+	if err2 != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx2 != 30 {
+		t.Fatalf("bad index: %d", idx)
+	}
 	idx, out, err := s.NodeServices(ws, "node1")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 30 {
+	if idx != 20 {
 		t.Fatalf("bad index: %d", idx)
 	}
 
@@ -962,10 +969,46 @@ func TestStateStore_EnsureService(t *testing.T) {
 		t.Fatalf("bad: %#v", svc)
 	}
 
-	// Index tables were updated.
-	if idx := s.maxIndex("services"); idx != 40 {
+	// Index tables not updated since service did already exist
+	if idx := s.maxIndex("services"); idx != 30 {
 		t.Fatalf("bad index: %d", idx)
 	}
+
+	ns4 := &structs.NodeService{
+		ID:      "service4",
+		Service: "web",
+		Tags:    []string{"prod"},
+		Address: "1.1.1.1",
+		Port:    8000,
+	}
+	if err = s.EnsureService(50, "node1", ns4); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+	// Retrieve the service again and ensure it matches..
+	idx, out, err = s.NodeServices(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 50 {
+		t.Fatalf("bad index: %d", idx)
+	}
+	if out == nil || len(out.Services) != 3 {
+		t.Fatalf("bad: %#v", out)
+	}
+	expect4 := *ns4
+	expect4.CreateIndex, expect4.ModifyIndex = 50, 50
+	if svc := out.Services["service4"]; !reflect.DeepEqual(&expect4, svc) {
+		t.Fatalf("bad: %#v\nVS               : %#v", svc, expect4)
+	}
+
+	// Index tables not updated since service did already exist
+	if idx := s.maxIndex("services"); idx != 50 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
 }
 
 func TestStateStore_Services(t *testing.T) {


### PR DESCRIPTION
A previous PR https://github.com/hashicorp/consul/pull/3899 was adding optimization of watches for a given service name (see also https://github.com/hashicorp/consul/issues/3890)

This optimization does the same for `/catalog/services`.
Thus, it will dramatically change the bandwidth usage of consul-template and all tools (example prometheus) watching for changes in /catalog/services

What it does is:

* Only apply changes in /catalog/services when index of services do change
* Change less often /catalog/services (only when tags do change when declaring / unregistering services)

On a typical large cluster of more than 5k nodes with services with the same kind of tags - meaning no host specific tags -, it will decrease the number of watches from around 3 per second to only a few changes every seconds/minutes. This change will benefit a lot to prometheus performing discovery on /catalog/services (see https://github.com/prometheus/prometheus/pull/3814 )