### PR TITLE
Switch web analytics to segment

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.30"
+gem "middleman-hashicorp", "0.3.34"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/hashicorp/middleman-hashicorp
-  revision: 9cd0ee84bfd883d1805a1756ab98e6a54303fd61
-  specs:
-    middleman-hashicorp (0.3.29)
-      bootstrap-sass (~> 3.3)
-      builder (~> 3.2)
-      middleman (~> 3.4)
-      middleman-livereload (~> 3.4)
-      middleman-syntax (~> 3.0)
-      redcarpet (~> 3.3)
-      turbolinks (~> 5.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,7 +6,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    autoprefixer-rails (8.1.0)
+    autoprefixer-rails (8.2.0)
       execjs
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
@@ -91,6 +78,14 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
+    middleman-hashicorp (0.3.34)
+      bootstrap-sass (~> 3.3)
+      builder (~> 3.2)
+      middleman (~> 3.4)
+      middleman-livereload (~> 3.4)
+      middleman-syntax (~> 3.0)
+      redcarpet (~> 3.3)
+      turbolinks (~> 5.0)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -118,9 +113,9 @@ GEM
     padrino-support (0.12.9)
       activesupport (>= 3.1)
     rack (1.6.9)
-    rack-livereload (0.3.16)
+    rack-livereload (0.3.17)
       rack
-    rack-test (0.8.3)
+    rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -158,7 +153,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp!
+  middleman-hashicorp (= 0.3.34)
 
 BUNDLED WITH
    1.16.1

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.28"
+VERSION?="0.3.34"
 
 build:
 	@echo "==> Starting build in Docker..."
@@ -7,6 +7,7 @@ build:
 		--rm \
 		--tty \
 		--volume "$(shell pwd):/website" \
+		-e "ENV=production" \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
 

--- a/website/config.rb
+++ b/website/config.rb
@@ -7,6 +7,16 @@ activate :hashicorp do |h|
 end
 
 helpers do
+  # Returns a segment tracking ID such that local development is not
+  # tracked to production systems.
+  def segmentId()
+    if (ENV['ENV'] == 'production')
+      'IyzLrqXkox5KJ8XL4fo8vTYNGfiKlTCm'
+    else
+      '0EXTgkNx0Ydje2PGXVbRhpKKoe5wtzcE'
+    end
+  end
+
   # Returns the FQDN of the image URL.
   #
   # @param [String] path

--- a/website/packer.json
+++ b/website/packer.json
@@ -3,6 +3,7 @@
     "aws_access_key_id": "{{ env `AWS_ACCESS_KEY_ID` }}",
     "aws_secret_access_key": "{{ env `AWS_SECRET_ACCESS_KEY` }}",
     "aws_region": "{{ env `AWS_REGION` }}",
+    "website_environment": "production",
     "fastly_api_key": "{{ env `FASTLY_API_KEY` }}"
   },
   "builders": [
@@ -22,6 +23,7 @@
         "AWS_ACCESS_KEY_ID={{ user `aws_access_key_id` }}",
         "AWS_SECRET_ACCESS_KEY={{ user `aws_secret_access_key` }}",
         "AWS_REGION={{ user `aws_region` }}",
+        "ENV={{ user `website_environment` }}",
         "FASTLY_API_KEY={{ user `fastly_api_key` }}"
       ],
       "inline": [

--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', function() {
+  track('.downloads .download .details li a', function(el) {
+    var m = el.href.match(/consul_(.*?)_(.*?)_(.*?)\.zip/)
+    return {
+      event: 'Download',
+      category: 'Button',
+      label: 'Consul | v' + m[1] + ' | ' + m[2] + ' | ' + m[3],
+      version: m[1],
+      os: m[2],
+      architecture: m[3],
+      product: 'consul'
+    }
+  })
+})

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -3,3 +3,6 @@
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
+//= require hashicorp/analytics
+
+//= require analytics

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -34,13 +34,6 @@
     <![endif]-->
     <%= javascript_include_tag "application" %>
 
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NR2SD7C');</script>
-
     <!-- Typekit script to import Klavika font -->
     <script src="https://use.typekit.net/wxf7mfi.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
@@ -123,14 +116,18 @@
     </div>
 
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-50021714-1', 'consul.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
+      // ga async load
+      window['GoogleAnalyticsObject'] = 'ga';
+      window['ga'] = window['ga'] || function() {
+        (window['ga'].q = window['ga'].q || []).push(arguments)
+      };
+      // analytics.js
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
+      analytics.load("<%= segmentId %>");
+      analytics.page();
+      }}();
+      // optinmonster
+      var om597a23d58fd32,om597a23d58fd32_poll=function(){var b=0;return function(d,c){clearInterval(b);b=setInterval(d,c)}}();!function(b,d,c){if(b.getElementById(c))om597a23d58fd32_poll(function(){if(window.om_loaded&&!om597a23d58fd32)return om597a23d58fd32=new OptinMonsterApp,om597a23d58fd32.init({s:"35109.597a23d58fd32",staging:0,dev:0,beta:0})},25);else{var e=!1,a=b.createElement(d);a.id=c;a.src="//a.optnmstr.com/app/js/api.min.js";a.async=!0;a.onload=a.onreadystatechange=function(){if(!(e||this.readyState&&"loaded"!==this.readyState&&"complete"!==this.readyState))try{e=om_loaded=!0,om597a23d58fd32=new OptinMonsterApp,om597a23d58fd32.init({s:"35109.597a23d58fd32",staging:0,dev:0,beta:0}),a.onload=a.onreadystatechange=null}catch(f){}};(document.getElementsByTagName("head")[0]||document.documentElement).appendChild(a)}}(document,"script","omapi-script");
     </script>
 
     <script type="application/ld+json">


### PR DESCRIPTION
We're going through a process of switching over to using segment for our analytics. Segment will still send data to google analytics, so it should behave the same as before for those relying on the GA interface, but segment has the ability also to send the data elsewhere, so we can integrate cleanly with other analytics tooling as well.

This PR switches over from pure GA to segment. In production, data will be logged to the same GA property as before, and in development it won't be logged to GA at all, to prevent pollution. I added a "production" environment flag to the make build command to adjust for this. Let me know if there's a better way to accomplish this!