### PR TITLE
Sync tags checks services

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -625,6 +625,31 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 		entry.ModifyIndex = idx
 		eSvc := existing.(*structs.ServiceNode)
 		hasSameTags = reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
+		if !hasSameTags {
+			checks, err := tx.Get("checks", "node_service", node, eSvc.ServiceID)
+			if err != nil {
+				return fmt.Errorf("failed service check lookup: %s", err)
+			}
+			checksIndexNeedsUpdate := false
+			for check := checks.Next(); check != nil; check = checks.Next() {
+				scheck := check.(*structs.HealthCheck)
+				checkWithSameTag := reflect.DeepEqual(svc.Tags, scheck.ServiceTags)
+				if !checkWithSameTag {
+					checksIndexNeedsUpdate = true
+					scheck.ServiceTags = eSvc.ServiceTags
+					cerr := s.ensureCheckTxn(tx, idx, scheck)
+					if cerr != nil {
+						return fmt.Errorf("failed updating check index: %s", err)
+					}
+				}
+			}
+			if checksIndexNeedsUpdate {
+				// Update the index.
+				if err := tx.Insert("index", &IndexEntry{"checks", idx}); err != nil {
+					return fmt.Errorf("failed updating index: %s", err)
+				}
+			}
+		}
 	} else {
 		entry.CreateIndex = idx
 		entry.ModifyIndex = idx

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/consul/agent/structs"
@@ -617,10 +618,13 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	// Create the service node entry and populate the indexes. Note that
 	// conversion doesn't populate any of the node-specific information.
 	// That's always populated when we read from the state store.
+	hasSameTags := false
 	entry := svc.ToServiceNode(node)
 	if existing != nil {
 		entry.CreateIndex = existing.(*structs.ServiceNode).CreateIndex
 		entry.ModifyIndex = idx
+		eSvc := existing.(*structs.ServiceNode)
+		hasSameTags = reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
 	} else {
 		entry.CreateIndex = idx
 		entry.ModifyIndex = idx
@@ -639,8 +643,11 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	if err := tx.Insert("services", entry); err != nil {
 		return fmt.Errorf("failed inserting service: %s", err)
 	}
-	if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
-		return fmt.Errorf("failed updating index: %s", err)
+	if !hasSameTags {
+		// We need to update /catalog/services only tags are different
+		if err := tx.Insert("index", &IndexEntry{"services", idx}); err != nil {
+			return fmt.Errorf("failed updating index: %s", err)
+		}
 	}
 	if err := tx.Insert("index", &IndexEntry{serviceIndexName(svc.Service), idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -899,9 +906,6 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 
-	// Get the table index.
-	idx := maxIndexTxn(tx, "services")
-
 	// Query the service
 	service, err := tx.First("services", "id", nodeName, serviceID)
 	if err != nil {
@@ -909,8 +913,11 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 	}
 
 	if service != nil {
-		return idx, service.(*structs.ServiceNode).ToNodeService(), nil
+		svc := service.(*structs.ServiceNode).ToNodeService()
+		return svc.ModifyIndex, svc, nil
 	}
+	// Get the table index.
+	idx := maxIndexForService(tx, serviceID, true)
 	return idx, nil, nil
 }
 
@@ -918,9 +925,6 @@ func (s *Store) NodeService(nodeName string, serviceID string) (uint64, *structs
 func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *structs.NodeServices, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
-
-	// Get the table index.
-	idx := maxIndexTxn(tx, "nodes", "services")
 
 	// Query the node by node name
 	watchCh, n, err := tx.FirstWatch("nodes", "id", nodeNameOrID)
@@ -964,6 +968,7 @@ func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *s
 	}
 
 	node := n.(*structs.Node)
+	idx := node.ModifyIndex
 	nodeName := node.Node
 
 	// Read all of the services
@@ -983,6 +988,9 @@ func (s *Store) NodeServices(ws memdb.WatchSet, nodeNameOrID string) (uint64, *s
 	for service := services.Next(); service != nil; service = services.Next() {
 		svc := service.(*structs.ServiceNode).ToNodeService()
 		ns.Services[svc.ID] = svc
+		if svc.ModifyIndex > idx {
+			idx = svc.ModifyIndex
+		}
 	}
 
 	return idx, ns, nil

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1868,6 +1868,30 @@ func TestStateStore_EnsureCheck(t *testing.T) {
 	if idx := s.maxIndex("checks"); idx != 4 {
 		t.Fatalf("bad index: %d", idx)
 	}
+
+	// Test sync of tags with Services
+	if err := s.EnsureService(42, "node1", &structs.NodeService{ID: "service1", Service: "service1", Tags: []string{"brand_new_tag"}, Address: "1.1.1.1", Port: 1111}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	idx, checks, err = s.NodeChecks(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 42 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Test sync of tags -> same tags
+	if err := s.EnsureService(50, "node1", &structs.NodeService{ID: "service1", Service: "service1", Tags: []string{"brand_new_tag"}, Address: "1.1.1.1", Port: 1111}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	idx, checks, err = s.NodeChecks(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 42 {
+		t.Fatalf("bad index: %d", idx)
+	}
 }
 
 func TestStateStore_EnsureCheck_defaultStatus(t *testing.T) {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -905,11 +905,18 @@ func TestStateStore_EnsureService(t *testing.T) {
 
 	// Retrieve the services.
 	ws = memdb.NewWatchSet()
+	idx2, _, err2 := s.NodeServices(ws, "node2")
+	if err2 != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx2 != 30 {
+		t.Fatalf("bad index: %d", idx)
+	}
 	idx, out, err := s.NodeServices(ws, "node1")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if idx != 30 {
+	if idx != 20 {
 		t.Fatalf("bad index: %d", idx)
 	}
 
@@ -962,10 +969,46 @@ func TestStateStore_EnsureService(t *testing.T) {
 		t.Fatalf("bad: %#v", svc)
 	}
 
-	// Index tables were updated.
-	if idx := s.maxIndex("services"); idx != 40 {
+	// Index tables not updated since service did already exist
+	if idx := s.maxIndex("services"); idx != 30 {
 		t.Fatalf("bad index: %d", idx)
 	}
+
+	ns4 := &structs.NodeService{
+		ID:      "service4",
+		Service: "web",
+		Tags:    []string{"prod"},
+		Address: "1.1.1.1",
+		Port:    8000,
+	}
+	if err = s.EnsureService(50, "node1", ns4); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if !watchFired(ws) {
+		t.Fatalf("bad")
+	}
+	// Retrieve the service again and ensure it matches..
+	idx, out, err = s.NodeServices(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 50 {
+		t.Fatalf("bad index: %d", idx)
+	}
+	if out == nil || len(out.Services) != 3 {
+		t.Fatalf("bad: %#v", out)
+	}
+	expect4 := *ns4
+	expect4.CreateIndex, expect4.ModifyIndex = 50, 50
+	if svc := out.Services["service4"]; !reflect.DeepEqual(&expect4, svc) {
+		t.Fatalf("bad: %#v\nVS               : %#v", svc, expect4)
+	}
+
+	// Index tables not updated since service did already exist
+	if idx := s.maxIndex("services"); idx != 50 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
 }
 
 func TestStateStore_Services(t *testing.T) {


### PR DESCRIPTION
This patch solves #3869 aka ServiceTags field in checks not synced correctly.

It is based on work done in https://github.com/hashicorp/consul/pull/3934 since this PR already check for tag changes.