### PR TITLE
📝 Clarify the list of supported TLS cipher suites

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1341,8 +1341,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="tls_cipher_suites"></a><a href="#tls_cipher_suites">`tls_cipher_suites`</a> Added in Consul
   0.8.2, this specifies the list of supported ciphersuites as a comma-separated-list. The list of all
-  supported ciphersuites is available in the [`tlsutil.ParseCiphers` source as the keys of the `cipherMap`
-  map](https://github.com/hashicorp/consul/blob/6378d607fd887327cfd1aadccf1ccb683da745b6/tlsutil/config.go#L363).
+  supported ciphersuites is available in the [source code](https://github.com/hashicorp/consul/blob/6378d607fd887327cfd1aadccf1ccb683da745b6/tlsutil/config.go#L363).
 
 * <a name="tls_prefer_server_cipher_suites"></a><a href="#tls_prefer_server_cipher_suites">
   `tls_prefer_server_cipher_suites`</a> Added in Consul 0.8.2, this will cause Consul to prefer the

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1341,7 +1341,8 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="tls_cipher_suites"></a><a href="#tls_cipher_suites">`tls_cipher_suites`</a> Added in Consul
   0.8.2, this specifies the list of supported ciphersuites as a comma-separated-list. The list of all
-  available ciphersuites is available in the [Golang TLS documentation](https://golang.org/src/crypto/tls/cipher_suites.go).
+  supported ciphersuites is available in the [`tlsutil.ParseCiphers` source as the keys of the `cipherMap`
+  map](https://github.com/hashicorp/consul/blob/6378d607fd887327cfd1aadccf1ccb683da745b6/tlsutil/config.go#L363).
 
 * <a name="tls_prefer_server_cipher_suites"></a><a href="#tls_prefer_server_cipher_suites">
   `tls_prefer_server_cipher_suites`</a> Added in Consul 0.8.2, this will cause Consul to prefer the

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1341,7 +1341,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
 * <a name="tls_cipher_suites"></a><a href="#tls_cipher_suites">`tls_cipher_suites`</a> Added in Consul
   0.8.2, this specifies the list of supported ciphersuites as a comma-separated-list. The list of all
-  supported ciphersuites is available in the [source code](https://github.com/hashicorp/consul/blob/6378d607fd887327cfd1aadccf1ccb683da745b6/tlsutil/config.go#L363).
+  supported ciphersuites is available in the [source code](https://github.com/hashicorp/consul/blob/master/tlsutil/config.go#L363).
 
 * <a name="tls_prefer_server_cipher_suites"></a><a href="#tls_prefer_server_cipher_suites">
   `tls_prefer_server_cipher_suites`</a> Added in Consul 0.8.2, this will cause Consul to prefer the


### PR DESCRIPTION
Previously, the documentation linked to Golang's source code, which can drift from the list of cipher suites supported by Consul. Consul has a hard-coded mapping of string values to Golang cipher suites, so this is a more direct source of truth to help users understand which string values are accepted in the `tls_cipher_suites` configuration value.
