### PR TITLE
ServiceTags field in checks not synced correctly (issue #3869)

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -618,13 +618,12 @@ func (s *Store) ensureServiceTxn(tx *memdb.Txn, idx uint64, node string, svc *st
 	// Create the service node entry and populate the indexes. Note that
 	// conversion doesn't populate any of the node-specific information.
 	// That's always populated when we read from the state store.
-	hasSameTags := false
 	entry := svc.ToServiceNode(node)
 	if existing != nil {
 		entry.CreateIndex = existing.(*structs.ServiceNode).CreateIndex
 		entry.ModifyIndex = idx
 		eSvc := existing.(*structs.ServiceNode)
-		hasSameTags = reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
+		hasSameTags := reflect.DeepEqual(eSvc.ServiceTags, svc.Tags)
 		if !hasSameTags {
 			checks, err := tx.Get("checks", "node_service", node, eSvc.ServiceID)
 			if err != nil {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1671,6 +1671,30 @@ func TestStateStore_EnsureCheck(t *testing.T) {
 	if idx := s.maxIndex("checks"); idx != 4 {
 		t.Fatalf("bad index: %d", idx)
 	}
+
+	// Test sync of tags with Services
+	if err := s.EnsureService(42, "node1", &structs.NodeService{ID: "service1", Service: "service1", Tags: []string{"brand_new_tag"}, Address: "1.1.1.1", Port: 1111}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	idx, checks, err = s.NodeChecks(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 42 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Test sync of tags -> same tags
+	if err := s.EnsureService(50, "node1", &structs.NodeService{ID: "service1", Service: "service1", Tags: []string{"brand_new_tag"}, Address: "1.1.1.1", Port: 1111}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	idx, checks, err = s.NodeChecks(nil, "node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 42 {
+		t.Fatalf("bad index: %d", idx)
+	}
 }
 
 func TestStateStore_EnsureCheck_defaultStatus(t *testing.T) {


### PR DESCRIPTION
This patch solves #3869 aka ServiceTags field in checks not synced correctly.

This is a rewrite of https://github.com/hashicorp/consul/pull/3956 but without depending of PR https://github.com/hashicorp/consul/pull/3934