### PR TITLE
Consolidate logging output

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -659,7 +659,7 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 			}
 			wp.LogOutput = a.LogOutput
 			if err := wp.Run(addr); err != nil {
-				a.logger.Printf("[ERR] Failed to run watch: %v", err)
+				a.logger.Printf("[ERR] agent: Failed to run watch: %v", err)
 			}
 		}(wp)
 	}
@@ -908,7 +908,7 @@ func (a *Agent) makeRandomID() (string, error) {
 		return "", err
 	}
 
-	a.logger.Printf("[DEBUG] Using random ID %q as node ID", id)
+	a.logger.Printf("[DEBUG] agent: Using random ID %q as node ID", id)
 	return id, nil
 }
 
@@ -926,7 +926,7 @@ func (a *Agent) makeNodeID() (string, error) {
 	// Try to get a stable ID associated with the host itself.
 	info, err := host.Info()
 	if err != nil {
-		a.logger.Printf("[DEBUG] Couldn't get a unique ID from the host: %v", err)
+		a.logger.Printf("[DEBUG] agent: Couldn't get a unique ID from the host: %v", err)
 		return a.makeRandomID()
 	}
 
@@ -934,7 +934,7 @@ func (a *Agent) makeNodeID() (string, error) {
 	// control over this process.
 	id := strings.ToLower(info.HostID)
 	if _, err := uuid.ParseUUID(id); err != nil {
-		a.logger.Printf("[DEBUG] Unique ID %q from host isn't formatted as a UUID: %v",
+		a.logger.Printf("[DEBUG] agent: Unique ID %q from host isn't formatted as a UUID: %v",
 			id, err)
 		return a.makeRandomID()
 	}
@@ -950,7 +950,7 @@ func (a *Agent) makeNodeID() (string, error) {
 		buf[8:10],
 		buf[10:16])
 
-	a.logger.Printf("[DEBUG] Using unique ID %q from host as node ID", id)
+	a.logger.Printf("[DEBUG] agent: Using unique ID %q from host as node ID", id)
 	return id, nil
 }
 
@@ -1280,10 +1280,10 @@ func (a *Agent) JoinWAN(addrs []string) (n int, err error) {
 
 // ForceLeave is used to remove a failed node from the cluster
 func (a *Agent) ForceLeave(node string) (err error) {
-	a.logger.Printf("[INFO] Force leaving node: %v", node)
+	a.logger.Printf("[INFO] agent: Force leaving node: %v", node)
 	err = a.delegate.RemoveFailedNode(node)
 	if err != nil {
-		a.logger.Printf("[WARN] Failed to remove node: %v", err)
+		a.logger.Printf("[WARN] agent: Failed to remove node: %v", err)
 	}
 	return err
 }
@@ -1546,7 +1546,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 
 	// Warn if the service name is incompatible with DNS
 	if InvalidDnsRe.MatchString(service.Service) {
-		a.logger.Printf("[WARN] Service name %q will not be discoverable "+
+		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", service.Service)
 	}
@@ -1554,7 +1554,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 	// Warn if any tags are incompatible with DNS
 	for _, tag := range service.Tags {
 		if InvalidDnsRe.MatchString(tag) {
-			a.logger.Printf("[DEBUG] Service tag %q will not be discoverable "+
+			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to invalid characters. Valid characters include "+
 				"all alpha-numerics and dashes.", tag)
 		}
@@ -2182,7 +2182,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 
 		// Skip all partially written temporary files
 		if strings.HasSuffix(fi.Name(), "tmp") {
-			a.logger.Printf("[WARN] Ignoring temporary service file %v", fi.Name())
+			a.logger.Printf("[WARN] agent: Ignoring temporary service file %v", fi.Name())
 			continue
 		}
 
@@ -2205,7 +2205,7 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 		if err := json.Unmarshal(buf, &p); err != nil {
 			// Backwards-compatibility for pre-0.5.1 persisted services
 			if err := json.Unmarshal(buf, &p.Service); err != nil {
-				a.logger.Printf("[ERR] Failed decoding service file %q: %s", file, err)
+				a.logger.Printf("[ERR] agent: Failed decoding service file %q: %s", file, err)
 				continue
 			}
 		}
@@ -2285,7 +2285,7 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig) error {
 		// Decode the check
 		var p persistedCheck
 		if err := json.Unmarshal(buf, &p); err != nil {
-			a.logger.Printf("[ERR] Failed decoding check file %q: %s", file, err)
+			a.logger.Printf("[ERR] agent: Failed decoding check file %q: %s", file, err)
 			continue
 		}
 		checkID := p.Check.CheckID

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -783,6 +783,6 @@ func (s *HTTPServer) AgentToken(resp http.ResponseWriter, req *http.Request) (in
 		return nil, nil
 	}
 
-	s.agent.logger.Printf("[INFO] Updated agent's ACL token %q", target)
+	s.agent.logger.Printf("[INFO] agent: Updated agent's ACL token %q", target)
 	return nil, nil
 }

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -150,11 +150,11 @@ func (c *CheckMonitor) check() {
 	select {
 	case <-time.After(timeout):
 		if err := exec.KillCommandSubtree(cmd); err != nil {
-			c.Logger.Printf("[WARN] Check %q failed to kill after timeout: %s", c.CheckID, err)
+			c.Logger.Printf("[WARN] agent: Check %q failed to kill after timeout: %s", c.CheckID, err)
 		}
 
 		msg := fmt.Sprintf("Timed out (%s) running check", timeout.String())
-		c.Logger.Printf("[WARN] Check %q: %s", c.CheckID, msg)
+		c.Logger.Printf("[WARN] agent: Check %q: %s", c.CheckID, msg)
 
 		outputStr := truncateAndLogOutput()
 		if len(outputStr) > 0 {
@@ -625,10 +625,10 @@ func (c *CheckDocker) doCheck() (string, *circbuf.Buffer, error) {
 	case 0:
 		return api.HealthPassing, buf, nil
 	case 1:
-		c.Logger.Printf("[DEBUG] Check %q failed with exit code: %d", c.CheckID, exitCode)
+		c.Logger.Printf("[DEBUG] agent: Check %q failed with exit code: %d", c.CheckID, exitCode)
 		return api.HealthWarning, buf, nil
 	default:
-		c.Logger.Printf("[DEBUG] Check %q failed with exit code: %d", c.CheckID, exitCode)
+		c.Logger.Printf("[DEBUG] agent: Check %q failed with exit code: %d", c.CheckID, exitCode)
 		return api.HealthCritical, buf, nil
 	}
 }
@@ -684,10 +684,10 @@ func (c *CheckGRPC) run() {
 func (c *CheckGRPC) check() {
 	err := c.probe.Check()
 	if err != nil {
-		c.Logger.Printf("[DEBUG] Check %q failed: %s", c.CheckID, err.Error())
+		c.Logger.Printf("[DEBUG] agent: Check %q failed: %s", c.CheckID, err.Error())
 		c.Notify.UpdateCheck(c.CheckID, api.HealthCritical, err.Error())
 	} else {
-		c.Logger.Printf("[DEBUG] Check %q is passing", c.CheckID)
+		c.Logger.Printf("[DEBUG] agent: Check %q is passing", c.CheckID)
 		c.Notify.UpdateCheck(c.CheckID, api.HealthPassing, fmt.Sprintf("gRPC check %s: success", c.GRPC))
 	}
 }

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -697,7 +697,7 @@ func (l *State) updateSyncState() error {
 			// The Serf check is created automatically and does not
 			// need to be deregistered.
 			if id == structs.SerfCheckID {
-				l.logger.Printf("[DEBUG] Skipping remote check %q since it is managed automatically", id)
+				l.logger.Printf("[DEBUG] agent: Skipping remote check %q since it is managed automatically", id)
 				continue
 			}
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -76,7 +76,7 @@ func (c *cmd) init() {
 func (c *cmd) Run(args []string) int {
 	code := c.run(args)
 	if c.logger != nil {
-		c.logger.Println("[INFO] Exit code:", code)
+		c.logger.Println("[INFO] agent: Exit code:", code)
 	}
 	return code
 }
@@ -400,7 +400,7 @@ func (c *cmd) run(args []string) int {
 		case <-c.shutdownCh:
 			sig = os.Interrupt
 		case err := <-agent.RetryJoinCh():
-			c.logger.Println("[ERR] Retry join failed: ", err)
+			c.logger.Println("[ERR] agent: Retry join failed: ", err)
 			return 1
 		case <-agent.ShutdownCh():
 			// agent is already down!
@@ -412,14 +412,14 @@ func (c *cmd) run(args []string) int {
 			continue
 
 		case syscall.SIGHUP:
-			c.logger.Println("[INFO] Caught signal: ", sig)
+			c.logger.Println("[INFO] agent: Caught signal: ", sig)
 
 			conf, err := c.handleReload(agent, config)
 			if conf != nil {
 				config = conf
 			}
 			if err != nil {
-				c.logger.Println("[ERR] Reload config failed: ", err)
+				c.logger.Println("[ERR] agent: Reload config failed: ", err)
 			}
 			// Send result back if reload was called via HTTP
 			if reloadErrCh != nil {
@@ -427,19 +427,19 @@ func (c *cmd) run(args []string) int {
 			}
 
 		default:
-			c.logger.Println("[INFO] Caught signal: ", sig)
+			c.logger.Println("[INFO] agent: Caught signal: ", sig)
 
 			graceful := (sig == os.Interrupt && !(config.SkipLeaveOnInt)) || (sig == syscall.SIGTERM && (config.LeaveOnTerm))
 			if !graceful {
-				c.logger.Println("[INFO] Graceful shutdown disabled. Exiting")
+				c.logger.Println("[INFO] agent: Graceful shutdown disabled. Exiting")
 				return 1
 			}
 
-			c.logger.Println("[INFO] Gracefully shutting down agent...")
+			c.logger.Println("[INFO] agent: Gracefully shutting down agent...")
 			gracefulCh := make(chan struct{})
 			go func() {
 				if err := agent.Leave(); err != nil {
-					c.logger.Println("[ERR] Error on leave:", err)
+					c.logger.Println("[ERR] agent: Error on leave:", err)
 					return
 				}
 				close(gracefulCh)
@@ -448,13 +448,13 @@ func (c *cmd) run(args []string) int {
 			gracefulTimeout := 15 * time.Second
 			select {
 			case <-signalCh:
-				c.logger.Printf("[INFO] Caught second signal %v. Exiting\n", sig)
+				c.logger.Printf("[INFO] agent: Caught second signal %v. Exiting\n", sig)
 				return 1
 			case <-time.After(gracefulTimeout):
-				c.logger.Println("[INFO] Timeout on graceful leave. Exiting")
+				c.logger.Println("[INFO] agent: Timeout on graceful leave. Exiting")
 				return 1
 			case <-gracefulCh:
-				c.logger.Println("[INFO] Graceful exit completed")
+				c.logger.Println("[INFO] agent: Graceful exit completed")
 				return 0
 			}
 		}
@@ -463,7 +463,7 @@ func (c *cmd) run(args []string) int {
 
 // handleReload is invoked when we should reload our configs, e.g. SIGHUP
 func (c *cmd) handleReload(agent *agent.Agent, cfg *config.RuntimeConfig) (*config.RuntimeConfig, error) {
-	c.logger.Println("[INFO] Reloading configuration...")
+	c.logger.Println("[INFO] agent: Reloading configuration...")
 	var errs error
 	newCfg := c.readConfig()
 	if newCfg == nil {

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -62,7 +62,7 @@ OUTER:
 			if retry > maxBackoffTime {
 				retry = maxBackoffTime
 			}
-			logger.Printf("consul.watch: Watch (type: %s) errored: %v, retry in %v",
+			logger.Printf("[ERR] consul.watch: Watch (type: %s) errored: %v, retry in %v",
 				p.Type, err, retry)
 			select {
 			case <-time.After(retry):


### PR DESCRIPTION
## Description
Consolidate logging output by adding package name and log severity where is missing. 

## Why
The current logging utility doesn't enforce a specific log format; due to that log severity and format are not consistent across the codebase. 

This is a PR to cleanup the few inconsistencies that I found. Unfortunately this is an incomplete work as it's only covering the logging functionality (we also have places where `fmt.Errorf` is used instead).