### PR TITLE
Bumps go version to 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+* build: Bumped Go version to 1.10 [[GH-3988](https://github.com/hashicorp/consul/pull/3988)]
 * agent: Blocking queries on service-specific health and catalog endpoints now return a per-service `X-Consul-Index` improving watch performance on very busy clusters. [[GH-3890](https://github.com/hashicorp/consul/issues/3890)]. **Note this may break blocking clients that relied on undocumented implementation details** as noted in the [upgrade docs](https://github.com/hashicorp/consul/blob/master/website/source/docs/upgrading.html.md#upgrade-from-version-106-to-higher).
 * agent: All endpoints now respond to OPTIONS requests. [[GH-3885](https://github.com/hashicorp/consul/issues/3885)]
 * dns: Introduced a new config param to limit the number of A/AAAA records returned. [[GH-3940](https://github.com/hashicorp/consul/issues/3940)]

--- a/scripts/consul-builder/Dockerfile
+++ b/scripts/consul-builder/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic
 
-ENV GOVERSION 1.9.3
+ENV GOVERSION 1.10
 
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y -q \


### PR DESCRIPTION
## Description
Update go version to 1.10

## Why
This closes #3879, closes #3987

## Test
```
[..]
==> Building...
Number of parallel builds: 3

-->    darwin/amd64: github.com/hashicorp/consul
-->   solaris/amd64: github.com/hashicorp/consul
-->   windows/amd64: github.com/hashicorp/consul
-->       linux/386: github.com/hashicorp/consul
-->     freebsd/386: github.com/hashicorp/consul
-->   freebsd/amd64: github.com/hashicorp/consul
-->     freebsd/arm: github.com/hashicorp/consul
-->      darwin/386: github.com/hashicorp/consul
-->       linux/arm: github.com/hashicorp/consul
-->     linux/amd64: github.com/hashicorp/consul
-->     linux/arm64: github.com/hashicorp/consul
-->     windows/386: github.com/hashicorp/consul
==> Packaging...
--> freebsd_arm
  adding: consul (deflated 74%)
--> freebsd_amd64
  adding: consul (deflated 75%)
--> linux_386
  adding: consul (deflated 74%)
--> freebsd_386
  adding: consul (deflated 74%)
--> linux_arm
  adding: consul (deflated 74%)
--> darwin_amd64
  adding: consul (deflated 75%)
--> linux_arm64
  adding: consul (deflated 76%)
--> darwin_386
  adding: consul (deflated 74%)
--> windows_amd64
  adding: consul.exe (deflated 76%)
--> windows_386
  adding: consul.exe (deflated 74%)
--> linux_amd64
  adding: consul (deflated 75%)
--> solaris_amd64
  adding: consul (deflated 75%)

==> Results:
total 95312
-rwxr-xr-x  1 giaquinti  staff    47M Mar 27 17:42 consul
```