### PR TITLE
Warn when node name isnt a valid DNS label

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -274,12 +274,12 @@ func (a *Agent) Start() error {
 		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", a.config.NodeName)
-	} else if ( len(a.config.NodeName) > MaxDNSLabelLength ) {
+	} else if len(a.config.NodeName) > MaxDNSLabelLength {
 		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
 			"via DNS due to it being too long. Valid lengths are between "+
 			"1 and 63 bytes.", a.config.NodeName)
 	}
-	
+
 	// create the local state
 	a.State = local.NewState(LocalConfig(c), a.logger, a.tokens)
 
@@ -1560,7 +1560,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", service.Service)
-	} else if ( len(service.Service) > MaxDNSLabelLength ) {
+	} else if len(service.Service) > MaxDNSLabelLength {
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to it being too long. Valid lengths are between "+
 			"1 and 63 bytes.", service.Service)
@@ -1572,7 +1572,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to invalid characters. Valid characters include "+
 				"all alpha-numerics and dashes.", tag)
-		}  else if ( len(tag) > MaxDNSLabelLength ) {
+		} else if len(tag) > MaxDNSLabelLength {
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to it being too long. Valid lengths are between "+
 				"1 and 63 bytes.", tag)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -269,6 +269,17 @@ func (a *Agent) Start() error {
 		return fmt.Errorf("Failed to setup node ID: %v", err)
 	}
 
+	// Warn if the node name is incompatible with DNS
+	if InvalidDnsRe.MatchString(a.config.NodeName) {
+		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
+			"via DNS due to invalid characters. Valid characters include "+
+			"all alpha-numerics and dashes.", a.config.NodeName)
+	} else if ( len(a.config.NodeName) > MaxDNSLabelLength ) {
+		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
+			"via DNS due to it being too long. Valid lengths are between "+
+			"1 and 63 bytes.", a.config.NodeName)
+	}
+	
 	// create the local state
 	a.State = local.NewState(LocalConfig(c), a.logger, a.tokens)
 
@@ -1549,6 +1560,10 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", service.Service)
+	} else if ( len(service.Service) > MaxDNSLabelLength ) {
+		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
+			"via DNS due to it being too long. Valid lengths are between "+
+			"1 and 63 bytes.", service.Service)
 	}
 
 	// Warn if any tags are incompatible with DNS
@@ -1557,6 +1572,10 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to invalid characters. Valid characters include "+
 				"all alpha-numerics and dashes.", tag)
+		}  else if ( len(tag) > MaxDNSLabelLength ) {
+			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
+				"via DNS due to it being too long. Valid lengths are between "+
+				"1 and 63 bytes.", tag)
 		}
 	}
 

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -31,7 +31,7 @@ const (
 	staleCounterThreshold = 5 * time.Second
 
 	defaultMaxUDPSize = 512
-	
+
 	MaxDNSLabelLength = 63
 )
 

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -31,6 +31,8 @@ const (
 	staleCounterThreshold = 5 * time.Second
 
 	defaultMaxUDPSize = 512
+	
+	MaxDNSLabelLength = 63
 )
 
 var InvalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3079,14 +3079,14 @@ func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name               string
-		aRecordLimit       int
-		expectedAResults   int
+		name                string
+		aRecordLimit        int
+		expectedAResults    int
 		expectedAAAAResults int
-		expectedSRVResults int
-		numNodesTotal      int
-		udpSize            uint16
-		udpAnswerLimit     int
+		expectedSRVResults  int
+		numNodesTotal       int
+		udpSize             uint16
+		udpAnswerLimit      int
 	}{
 		// UDP + EDNS
 		{"udp-edns-1", 1, 1, 1, 30, 30, 8192, 3},

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -19,7 +19,8 @@ var extraTestEndpoints = map[string][]string{
 }
 
 // These endpoints are ignored in unit testing for response codes
-var ignoredEndpoints = []string{"/v1/status/peers","/v1/agent/monitor",  "/v1/agent/reload" }
+var ignoredEndpoints = []string{"/v1/status/peers", "/v1/agent/monitor", "/v1/agent/reload"}
+
 // These have custom logic
 var customEndpoints = []string{"/v1/query", "/v1/query/"}
 


### PR DESCRIPTION
This PR adds the warning for a DNS incompatible node name. An additional length validity check was added for the node name as well as service names.