### PR TITLE
website: document and warn users about disabling serf_wan port

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1127,7 +1127,9 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
     * <a name="http_port"></a><a href="#http_port">`http`</a> - The HTTP API, -1 to disable. Default 8500.
     * <a name="https_port"></a><a href="#https_port">`https`</a> - The HTTPS API, -1 to disable. Default -1 (disabled).
     * <a name="serf_lan_port"></a><a href="#serf_lan_port">`serf_lan`</a> - The Serf LAN port. Default 8301.
-    * <a name="serf_wan_port"></a><a href="#serf_wan_port">`serf_wan`</a> - The Serf WAN port. Default 8302.
+    * <a name="serf_wan_port"></a><a href="#serf_wan_port">`serf_wan`</a> - The Serf WAN port. Default 8302. Set to -1
+      to disable. **Note**: this will disable WAN federation which is not recommended. Various catalog and WAN related
+      endpoints will return errors or empty results.
     * <a name="server_rpc_port"></a><a href="#server_rpc_port">`server`</a> - Server RPC address. Default 8300.
 
 * <a name="protocol"></a><a href="#protocol">`protocol`</a> Equivalent to the
@@ -1434,7 +1436,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
    [watch documentation](/docs/agent/watches.html) for more detail. Watches can be
    modified when the configuration is reloaded.
 
-## <a id="ports"></a>Ports Used
+## <a id="ports-used"></a>Ports Used
 
 Consul requires up to 6 different ports to work properly, some on
 TCP, UDP, or both protocols. Below we document the requirements for each


### PR DESCRIPTION
See https://github.com/hashicorp/consul/pull/3984 for more. This also fixes a link to a heading that existed twice in the document.

![image](https://user-images.githubusercontent.com/846194/38097536-7f84041a-332a-11e8-9498-228bea741f5d.png)

cc/ @preetapan 