### PR TITLE
Update check.go

### DIFF
--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -412,7 +412,7 @@ func (c *CheckHTTP) check() {
 	}
 
 	// Format the response body
-	result := fmt.Sprintf("HTTP GET %s: %s Output: %s", c.HTTP, resp.Status, output.String())
+	result := fmt.Sprintf("HTTP %s %s: %s Output: %s", method, c.HTTP, resp.Status, output.String())
 
 	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
 		// PASSING (2xx)


### PR DESCRIPTION
Cosmetic fix to the agent's HTTP check function which always formats the result as "HTTP GET ...", ignoring any non-GET supplied HTTP method such as POST, PUT, etc.