### PR TITLE
website: Add description what the "recent events" means

### DIFF
--- a/website/source/api/event.html.md
+++ b/website/source/api/event.html.md
@@ -85,7 +85,7 @@ $ curl \
 
 ## List Events
 
-This endpoint returns the most recent events known by the agent. As a
+This endpoint returns the most recent events (up to 256) known by the agent. As a
 consequence of how the [event command](/docs/commands/event.html) works, each
 agent may have a different view of the events. Events are broadcast using the
 [gossip protocol](/docs/internals/gossip.html), so they have no global ordering


### PR DESCRIPTION
According to this answer on SO https://stackoverflow.com/a/49495985/1875339
that has references to code lines:
https://github.com/hashicorp/consul/blob/94835a2715892f48ffa9f81a9a32808d544b1ca5/agent/agent.go#L221
https://github.com/hashicorp/consul/blob/94835a2715892f48ffa9f81a9a32808d544b1ca5/agent/user_event.go#L229-L230
https://github.com/hashicorp/consul/blob/94835a2715892f48ffa9f81a9a32808d544b1ca5/agent/user_event.go#L235

we can safely assume that the recent events will be a list of max 256 entries