### PR TITLE
api/ui: return tags on internal UI endpoints

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -13,6 +13,7 @@ import (
 // ServiceSummary is used to summarize a service
 type ServiceSummary struct {
 	Name           string
+	Tags           []string
 	Nodes          []string
 	ChecksPassing  int
 	ChecksWarning  int
@@ -147,6 +148,7 @@ func summarizeServices(dump structs.NodeDump) []*ServiceSummary {
 		nodeServices := make([]*ServiceSummary, len(node.Services))
 		for idx, service := range node.Services {
 			sum := getService(service.Service)
+			sum.Tags = service.Tags
 			sum.Nodes = append(sum.Nodes, node.Node)
 			nodeServices[idx] = sum
 		}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -156,9 +156,11 @@ func TestSummarizeServices(t *testing.T) {
 			Services: []*structs.NodeService{
 				&structs.NodeService{
 					Service: "api",
+					Tags:    []string{"tag1", "tag2"},
 				},
 				&structs.NodeService{
 					Service: "web",
+					Tags:    []string{},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -182,6 +184,7 @@ func TestSummarizeServices(t *testing.T) {
 			Services: []*structs.NodeService{
 				&structs.NodeService{
 					Service: "web",
+					Tags:    []string{},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -197,6 +200,7 @@ func TestSummarizeServices(t *testing.T) {
 			Services: []*structs.NodeService{
 				&structs.NodeService{
 					Service: "cache",
+					Tags:    []string{},
 				},
 			},
 		},
@@ -209,6 +213,7 @@ func TestSummarizeServices(t *testing.T) {
 
 	expectAPI := &ServiceSummary{
 		Name:           "api",
+		Tags:           []string{"tag1", "tag2"},
 		Nodes:          []string{"foo"},
 		ChecksPassing:  1,
 		ChecksWarning:  1,
@@ -220,6 +225,7 @@ func TestSummarizeServices(t *testing.T) {
 
 	expectCache := &ServiceSummary{
 		Name:           "cache",
+		Tags:           []string{},
 		Nodes:          []string{"zip"},
 		ChecksPassing:  0,
 		ChecksWarning:  0,
@@ -231,6 +237,7 @@ func TestSummarizeServices(t *testing.T) {
 
 	expectWeb := &ServiceSummary{
 		Name:           "web",
+		Tags:           []string{},
 		Nodes:          []string{"bar", "foo"},
 		ChecksPassing:  2,
 		ChecksWarning:  0,


### PR DESCRIPTION
This is to allow the UI to display tags in the services index pages without needing to make additional queries.

```
$ cat service.json
{"service": {"name": "app", "tags": ["frontend", "production"], "port": 80}}
$ curl http://localhost:8500/v1/internal/ui/services?pretty
[
    {
        "Name": "app",
        "Tags": [
            "frontend",
            "production"
        ],
        "Nodes": [
            "pearkes"
        ],
        "ChecksPassing": 1,
        "ChecksWarning": 0,
        "ChecksCritical": 0
    },
    {
        "Name": "consul",
        "Tags": null,
        "Nodes": [
            "pearkes"
        ],
        "ChecksPassing": 1,
        "ChecksWarning": 0,
        "ChecksCritical": 0
    }
]
```