### PR TITLE
Allow ignoring checks by ID when defining a PreparedQuery. Fixes #3727.

### DIFF
--- a/agent/consul/prepared_query/template_test.go
+++ b/agent/consul/prepared_query/template_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 	"github.com/mitchellh/copystructure"
 )
 
@@ -31,6 +32,15 @@ var (
 					"${match(2)}",
 					"${agent.segment}",
 				},
+			},
+			IgnoreCheckIDs: []types.CheckID{
+				"${name.full}",
+				"${name.prefix}",
+				"${name.suffix}",
+				"${match(0)}",
+				"${match(1)}",
+				"${match(2)}",
+				"${agent.segment}",
 			},
 			Tags: []string{
 				"${name.full}",
@@ -124,6 +134,7 @@ func TestTemplate_Compile(t *testing.T) {
 	query.Template.Type = structs.QueryTemplateTypeNamePrefixMatch
 	query.Template.Regexp = "^(hello)there$"
 	query.Service.Service = "${name.full}"
+	query.Service.IgnoreCheckIDs = []types.CheckID{"${match(1)}", "${agent.segment}"}
 	query.Service.Tags = []string{"${match(1)}", "${agent.segment}"}
 	backup, err := copystructure.Copy(query)
 	if err != nil {
@@ -151,6 +162,10 @@ func TestTemplate_Compile(t *testing.T) {
 		},
 		Service: structs.ServiceQuery{
 			Service: "hellothere",
+			IgnoreCheckIDs: []types.CheckID{
+				"hello",
+				"segment-foo",
+			},
 			Tags: []string{
 				"hello",
 				"segment-foo",

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -496,7 +496,8 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 	}
 
 	// Filter out any unhealthy nodes.
-	nodes = nodes.Filter(query.Service.OnlyPassing)
+	nodes = nodes.FilterIgnore(query.Service.OnlyPassing,
+		query.Service.IgnoreCheckIDs)
 
 	// Apply the node metadata filters, if any.
 	if len(query.Service.NodeMeta) > 0 {

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 )
 
 // MockPreparedQuery is a fake endpoint that we inject into the Consul server
@@ -87,9 +88,10 @@ func TestPreparedQuery_Create(t *testing.T) {
 							NearestN:    4,
 							Datacenters: []string{"dc1", "dc2"},
 						},
-						OnlyPassing: true,
-						Tags:        []string{"foo", "bar"},
-						NodeMeta:    map[string]string{"somekey": "somevalue"},
+						IgnoreCheckIDs: []types.CheckID{"broken_check"},
+						OnlyPassing:    true,
+						Tags:           []string{"foo", "bar"},
+						NodeMeta:       map[string]string{"somekey": "somevalue"},
 					},
 					DNS: structs.QueryDNSOptions{
 						TTL: "10s",
@@ -122,9 +124,10 @@ func TestPreparedQuery_Create(t *testing.T) {
 				"NearestN":    4,
 				"Datacenters": []string{"dc1", "dc2"},
 			},
-			"OnlyPassing": true,
-			"Tags":        []string{"foo", "bar"},
-			"NodeMeta":    map[string]string{"somekey": "somevalue"},
+			"IgnoreCheckIDs": []string{"broken_check"},
+			"OnlyPassing":    true,
+			"Tags":           []string{"foo", "bar"},
+			"NodeMeta":       map[string]string{"somekey": "somevalue"},
 		},
 		"DNS": map[string]interface{}{
 			"TTL": "10s",

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -1,5 +1,7 @@
 package structs
 
+import "github.com/hashicorp/consul/types"
+
 // QueryDatacenterOptions sets options about how we fail over if there are no
 // healthy nodes in the local datacenter.
 type QueryDatacenterOptions struct {
@@ -33,6 +35,12 @@ type ServiceQuery struct {
 	// health checks (critical AND warning checks will cause a node to be
 	// discarded)
 	OnlyPassing bool
+
+	// IgnoreCheckIDs is an optional list of health check IDs to ignore when
+	// considering which nodes are healthy. It is useful as an emergency measure
+	// to temporarily override some health check that is producing false negatives
+	// for example.
+	IgnoreCheckIDs []types.CheckID
 
 	// Near allows the query to always prefer the node nearest the given
 	// node. If the node does not exist, results are returned in their

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -34,6 +34,12 @@ type ServiceQuery struct {
 	// local datacenter.
 	Failover QueryDatacenterOptions
 
+	// IgnoreCheckIDs is an optional list of health check IDs to ignore when
+	// considering which nodes are healthy. It is useful as an emergency measure
+	// to temporarily override some health check that is producing false negatives
+	// for example.
+	IgnoreCheckIDs []string
+
 	// If OnlyPassing is true then we will only include nodes with passing
 	// health checks (critical AND warning checks will cause a node to be
 	// discarded)

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -116,6 +116,53 @@ func TestAPI_PreparedQuery(t *testing.T) {
 		t.Fatalf("bad datacenter: %v", results)
 	}
 
+	// Add new node with failing health check.
+	reg2 := reg
+	reg2.Node = "failingnode"
+	reg2.Check = &AgentCheck{
+		Node:        "failingnode",
+		ServiceID:   "redis1",
+		ServiceName: "redis",
+		Name:        "failingcheck",
+		Status:      "critical",
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg2, nil); err != nil {
+			r.Fatal(err)
+		}
+		if _, _, err := catalog.Node("failingnode", nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	// Execute by ID. Should return only healthy node.
+	results, _, err = query.Execute(def.ID, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(results.Nodes) != 1 || results.Nodes[0].Node.Node != "foobar" {
+		t.Fatalf("bad: %v", results)
+	}
+	if wan, ok := results.Nodes[0].Node.TaggedAddresses["wan"]; !ok || wan != "127.0.0.1" {
+		t.Fatalf("bad: %v", results)
+	}
+
+	// Update PQ with ignore rule for the failing check
+	def.Service.IgnoreCheckIDs = []string{"failingcheck"}
+	_, err = query.Update(def, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Execute by ID. Should return BOTH nodes ignoring the failing check.
+	results, _, err = query.Execute(def.ID, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if len(results.Nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2", len(results.Nodes))
+	}
+
 	// Delete it.
 	_, err = query.Delete(def.ID, nil)
 	if err != nil {

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -25,7 +25,7 @@ section for more details about how prepared queries work with Consul's ACL syste
 ### Prepared Query Templates
 
 Consul 0.6.4 and later support prepared query templates. These are created
-similar to static templates, except with some additional fields and features.
+similar to static queries, except with some additional fields and features.
 Here is an example prepared query template:
 
 ```json
@@ -205,6 +205,13 @@ The table below shows this endpoint's support for
         `Datacenters`. A given datacenter will only be queried one time during a
         failover, even if it is selected by both `NearestN` and is listed in
         `Datacenters`.
+
+  - `IgnoreCheckIDs` `(array<string>: nil)` - Specifies a list of check IDs that
+    should be ignored when filtering unhealthy instances. This is mostly useful
+    in an emergency or as a temporary measure when a health check is found to be
+    unreliable. Being able to ignore it in centrally-defined queries can be
+    simpler than de-registering the check as an interim solution until the check
+    can be fixed.
 
   - `OnlyPassing` `(bool: false)` - Specifies the behavior of the query's health
     check filtering. If this is set to false, the results will include nodes


### PR DESCRIPTION
As documented, this new field for prepared queries allows filtering out specific checks by ID that are known to be inaccurate.

It's intended as an emergency or temporary measure where a simple update to a centrally defined query (template) can bypass a faulty check without deregistering it everywhere.

PR includes:
 - [x] Struct filtering changes and test
 - [x] RPC execute changes and test
 - [x] Agent HTTP endpoint changes and test
 - [x] `api` client struct changes and test
 - [x] Documentation update
 - [x] Added test for PreparedQuery template rendering that interpolation works inside the IgnoreCheckIDs (despite the type difference)