### PR TITLE
Add near=_ip support for prepared queries

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -406,6 +406,11 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 					break
 				}
 			}
+		} else {
+			p.srv.logger.Printf("[WARN] Prepared Query using near=_ip requires "+
+				"the source IP to be set but none was provided. No distance "+
+				"sorting will be done.")
+			
 		}
 		
 		// Either a source IP was given but we couldnt find the associated node

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -396,15 +396,17 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	} else if qs.Node == "_ip" {
 		if args.Source.Ip != "" {
 			_, nodes, err := state.Nodes(nil)
-			if err == nil {
-				for _, node := range nodes {
-					if args.Source.Ip == node.Address {
-						qs.Node = node.Node
-						break
-					}
+			if err != nil {
+				return err
+			}
+
+			for _, node := range nodes {
+				if args.Source.Ip == node.Address {
+					qs.Node = node.Node
+					break
 				}
 			}
-		} 
+		}
 		
 		// Either a source IP was given but we couldnt find the associated node
 		// or no source ip was given. In both cases we should wipe the Node value

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -393,6 +393,23 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 	// Respect the magic "_agent" flag.
 	if qs.Node == "_agent" {
 		qs.Node = args.Agent.Node
+	} else if qs.Node == "_ip" {
+		if args.Source.Ip != "" {
+			_, nodes, err := state.Nodes(nil)
+			if err == nil {
+				for _, node := range nodes {
+					if args.Source.Ip == node.Address {
+						qs.Node = node.Node
+					}
+				}
+			}
+		} 
+		
+		// Either a source IP was given but we couldnt find the associated node
+		// or no source ip was given. In both cases we should wipe the Node value
+		if qs.Node == "_ip" {
+			qs.Node = ""
+		}
 	}
 
 	// Perform the distance sort

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -400,6 +400,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 				for _, node := range nodes {
 					if args.Source.Ip == node.Address {
 						qs.Node = node.Node
+						break
 					}
 				}
 			}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -962,9 +962,11 @@ func (d *DNSServer) preparedQueryLookup(network, datacenter, query string, remot
 		args.Source.Ip = subnet.Address.String()
 	} else {
 		switch v := remoteAddr.(type) {
+			case *net.UDPAddr:
+				args.Source.Ip = v.IP.String()
 			case *net.TCPAddr:
 				args.Source.Ip = v.IP.String()				
-			case *net.UDPAddr:
+			case *net.IPAddr:
 				args.Source.Ip = v.IP.String()
 		}
 	}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -918,7 +918,7 @@ func (d *DNSServer) serviceLookup(network, datacenter, service, tag string, req,
 }
 
 func ednsSubnetForRequest(req *dns.Msg) (*dns.EDNS0_SUBNET) {
-	// Its probably not obvious but IsEdns0 returns the EDNS RR if present or nil otherwise
+	// IsEdns0 returns the EDNS RR if present or nil otherwise
 	edns := req.IsEdns0()
 	
 	if edns == nil {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	require "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1837,6 +1837,132 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 }
 
+func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
+	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
+	serviceNodes := []struct{
+			name string
+			address string
+			coord *coordinate.Coordinate
+	}{
+		{"foo1", "198.18.0.1", lib.GenerateCoordinate(1 * time.Millisecond),},
+		{"foo2", "198.18.0.2", lib.GenerateCoordinate(10 * time.Millisecond),},
+		{"foo3", "198.18.0.3", lib.GenerateCoordinate(30 * time.Millisecond),},
+	}
+	
+	t.Parallel()
+	a := NewTestAgent(t.Name(), "")
+	defer a.Shutdown()
+	
+	added := 0
+	
+	// Register nodes with a service
+	for _, cfg := range serviceNodes {
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       cfg.name,
+			Address:    cfg.address,
+			Service: &structs.NodeService{
+				Service: "db",
+				Port:    12345,
+			},
+		}
+		
+		var out struct{}
+		err := a.RPC("Catalog.Register", args, &out)
+		require.NoError(t, err)
+		
+		// Send coordinate updates
+		coordArgs := structs.CoordinateUpdateRequest{
+			Datacenter: "dc1",
+			Node:       cfg.name,
+			Coord:      cfg.coord,
+		}
+		err = a.RPC("Coordinate.Update", &coordArgs, &out)
+		require.NoError(t, err)
+		
+		added += 1
+	}
+	
+	fmt.Printf("Added %d service nodes\n", added)
+	
+	// Register a node without a service
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "bar",
+			Address:    "198.18.0.9",
+		}
+		
+		var out struct{}
+		err := a.RPC("Catalog.Register", args, &out)
+		require.NoError(t, err)
+		
+		// Send coordinate updates for a few nodes.
+		coordArgs := structs.CoordinateUpdateRequest{
+			Datacenter: "dc1",
+			Node:       "bar",
+			Coord:      ipCoord,
+		}
+		err = a.RPC("Coordinate.Update", &coordArgs, &out)
+		require.NoError(t, err)
+	}
+	
+	// Register a prepared query Near = _ip
+	{
+		args := &structs.PreparedQueryRequest{
+			Datacenter: "dc1",
+			Op:         structs.PreparedQueryCreate,
+			Query: &structs.PreparedQuery{
+				Name: "some.query.we.like",
+				Service: structs.ServiceQuery{
+					Service: "db",
+					Near: "_ip",
+				},
+			},
+		}
+
+		var id string
+		err := a.RPC("PreparedQuery.Apply", args, &id)
+		require.NoError(t, err)
+	}
+	retry.Run(t, func(r *retry.R) {
+		m := new(dns.Msg)
+		m.SetQuestion("some.query.we.like.query.consul.", dns.TypeA)
+		m.SetEdns0(4096, false)
+		o := new(dns.OPT)
+		o.Hdr.Name = "."
+		o.Hdr.Rrtype = dns.TypeOPT
+		e := new(dns.EDNS0_SUBNET)
+		e.Code = dns.EDNS0SUBNET
+		e.Family = 1
+		e.SourceNetmask = 32
+		e.SourceScope = 0
+		e.Address = net.ParseIP("198.18.0.9").To4()
+		o.Option = append(o.Option, e)
+		m.Extra = append(m.Extra, o)
+		
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			r.Fatalf("Error with call to dns.Client.Exchange: %s", err)
+		}
+		
+		if len(serviceNodes) != len(in.Answer) {
+			r.Fatalf("Expecting %d A RRs in response, Actual found was %d", len(serviceNodes), len(in.Answer))
+		}
+		
+		for i, rr := range in.Answer {
+			if aRec, ok := rr.(*dns.A); ok {
+				if actual := aRec.A.String(); serviceNodes[i].address != actual {
+					r.Fatalf("Expecting A RR #%d = %s, Actual RR was %s", i, serviceNodes[i].address, actual)
+				}
+			} else {
+				r.Fatalf("DNS Answer contained a non-A RR")
+			}
+		}
+	})
+}
+
 func TestDNS_PreparedQueryNearIP(t *testing.T) {
 	ipCoord := lib.GenerateCoordinate(1 * time.Millisecond)
 	serviceNodes := []struct{
@@ -1890,7 +2016,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 		args := &structs.RegisterRequest{
 			Datacenter: "dc1",
 			Node:       "bar",
-			Address:    "127.0.0.1",
+			Address:    "198.18.0.9",
 		}
 		
 		var out struct{}
@@ -1925,42 +2051,6 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 		err := a.RPC("PreparedQuery.Apply", args, &id)
 		require.NoError(t, err)
 	}
-	retry.Run(t, func(r *retry.R) {
-		m := new(dns.Msg)
-		m.SetQuestion("some.query.we.like.query.consul.", dns.TypeA)
-		m.SetEdns0(4096, false)
-		o := new(dns.OPT)
-		o.Hdr.Name = "."
-		o.Hdr.Rrtype = dns.TypeOPT
-		e := new(dns.EDNS0_SUBNET)
-		e.Code = dns.EDNS0SUBNET
-		e.Family = 1
-		e.SourceNetmask = 32
-		e.SourceScope = 0
-		e.Address = net.ParseIP("127.0.0.1").To4()
-		o.Option = append(o.Option, e)
-		m.Extra = append(m.Extra, o)
-		
-		c := new(dns.Client)
-		in, _, err := c.Exchange(m, a.DNSAddr())
-		if err != nil {
-			r.Fatalf("Error with call to dns.Client.Exchange: %s", err)
-		}
-		
-		if len(serviceNodes) != len(in.Answer) {
-			r.Fatalf("Expecting %d A RRs in response, Actual found was %d", len(serviceNodes), len(in.Answer))
-		}
-		
-		for i, rr := range in.Answer {
-			if aRec, ok := rr.(*dns.A); ok {
-				if actual := aRec.A.String(); serviceNodes[i].address != actual {
-					r.Fatalf("Expecting A RR #%d = %s, Actual RR was %s", i, serviceNodes[i].address, actual)
-				}
-			} else {
-				r.Fatalf("DNS Answer contained a non-A RR")
-			}
-		}
-	})
 	
 	retry.Run(t, func(r *retry.R) {
 		m := new(dns.Msg)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1926,7 +1926,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 		require.NoError(t, err)
 	}
 	retry.Run(t, func(r *retry.R) {
-		m :=new(dns.Msg)
+		m := new(dns.Msg)
 		m.SetQuestion("some.query.we.like.query.consul.", dns.TypeA)
 		m.SetEdns0(4096, false)
 		o := new(dns.OPT)
@@ -1957,7 +1957,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 					r.Fatalf("Expecting A RR #%d = %s, Actual RR was %s", i, serviceNodes[i].address, actual)
 				}
 			} else {
-				r.Fatalf("DNS Answer container a non-A RR")
+				r.Fatalf("DNS Answer contained a non-A RR")
 			}
 		}
 	})

--- a/agent/http.go
+++ b/agent/http.go
@@ -499,22 +499,22 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 }
 
 func sourceAddrFromRequest(req *http.Request) (string, error) {
+	forwardHost := req.Header.Get("X-Forwarded-For")
+	forwardIp := net.ParseIP(forwardHost)
+	if forwardIp != nil {
+		return forwardIp.String(), nil
+	} 
+	
 	host, _, err := net.SplitHostPort(req.RemoteAddr)
 	if err != nil {
 		return "", err
 	}
 
 	ip := net.ParseIP(host)
-	if ip == nil {
-		return "", fmt.Errorf("Could not get IP from request")
-	}
-
-	forwardHost := req.Header.Get("X-Forwarded-For")
-	forwardIp := net.ParseIP(forwardHost)
-	if forwardIp != nil {
-		return forwardIp.String(), nil
-	} else {
+	if ip != nil {
 		return ip.String(), nil
+	} else {
+		return "", fmt.Errorf("Could not get remote IP from HTTP Request")
 	}
 }
 

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -380,9 +380,66 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		if r.Failovers != 99 {
 			t.Fatalf("bad: %v", r)
 		}
+	})
+	
+	t.Run("", func(t *testing.T) {
+		a := NewTestAgent(t.Name(), "")
+		defer a.Shutdown()
+
+		m := MockPreparedQuery{
+			executeFn: func(args *structs.PreparedQueryExecuteRequest, reply *structs.PreparedQueryExecuteResponse) error {
+				expected := &structs.PreparedQueryExecuteRequest{
+					Datacenter:    "dc1",
+					QueryIDOrName: "my-id",
+					Limit:         5,
+					Source: structs.QuerySource{
+						Datacenter: "dc1",
+						Node: "_ip",
+						Ip:         "198.18.0.1",
+					},
+					Agent: structs.QuerySource{
+						Datacenter: a.Config.Datacenter,
+						Node:       a.Config.NodeName,
+					},
+					QueryOptions: structs.QueryOptions{
+						Token:             "my-token",
+						RequireConsistent: true,
+					},
+				}
+				if !reflect.DeepEqual(args, expected) {
+					t.Fatalf("bad: %v", args)
+				}
+
+				// Just set something so we can tell this is returned.
+				reply.Failovers = 99
+				return nil
+			},
+		}
+		if err := a.registerEndpoint("PreparedQuery", &m); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		body := bytes.NewBuffer(nil)
+		req, _ := http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
+		req.Header.Add("X-Forwarded-For", "198.18.0.1")
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.PreparedQuerySpecific(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if resp.Code != 200 {
+			t.Fatalf("bad code: %d", resp.Code)
+		}
+		r, ok := obj.(structs.PreparedQueryExecuteResponse)
+		if !ok {
+			t.Fatalf("unexpected: %T", obj)
+		}
+		if r.Failovers != 99 {
+			t.Fatalf("bad: %v", r)
+		}
 		
 		req, _ = http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
-		req.RemoteAddr = "127.0.0.1:12345"
+		req.Header.Add("X-Forwarded-For", "198.18.0.1, 198.19.0.1")
 		resp = httptest.NewRecorder()
 		obj, err = a.srv.PreparedQuerySpecific(resp, req)
 		if err != nil {

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -380,6 +380,24 @@ func TestPreparedQuery_Execute(t *testing.T) {
 		if r.Failovers != 99 {
 			t.Fatalf("bad: %v", r)
 		}
+		
+		req, _ = http.NewRequest("GET", "/v1/query/my-id/execute?token=my-token&consistent=true&near=_ip&limit=5", body)
+		req.RemoteAddr = "127.0.0.1:12345"
+		resp = httptest.NewRecorder()
+		obj, err = a.srv.PreparedQuerySpecific(resp, req)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if resp.Code != 200 {
+			t.Fatalf("bad code: %d", resp.Code)
+		}
+		r, ok = obj.(structs.PreparedQueryExecuteResponse)
+		if !ok {
+			t.Fatalf("unexpected: %T", obj)
+		}
+		if r.Failovers != 99 {
+			t.Fatalf("bad: %v", r)
+		}
 	})
 
 	// Ensure the proper params are set when no special args are passed

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -258,6 +258,7 @@ type QuerySource struct {
 	Datacenter string
 	Segment    string
 	Node       string
+	Ip         string
 }
 
 // DCSpecificRequest is used to query about a specific DC

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -176,14 +176,15 @@ The table below shows this endpoint's support for
   nearest instance to the specified node will be returned first, and subsequent
   nodes in the response will be sorted in ascending order of estimated
   round-trip times. If the node given does not exist, the nodes in the response
-  will be shuffled. Using `_agent` is supported, and will automatically return
-  results nearest the agent servicing the request. Using `_ip` is supported and 
-  will automatically return results nearest to the node associated with the 
-  source IP where the query is executed from. For HTTP the source IP is the
-  remote peer's IP address or the value of the X-Forwarded-For header with the 
-  header taking precedence. For DNS the source IP is the value of the EDNS 
-  client IP or the remote peer's IP address. If unspecified, the response 
-  will be shuffled by default.
+  will be shuffled. If unspecified, the response will be shuffled by default.
+  
+    - `_agent` - Returns results nearest the agent servicing the request.
+    - `_ip` - Returns results nearest to the node associated with the source IP
+      where the query was executed from. For HTTP the source IP is the remote
+      peer's IP address or the value of the X-Forwarded-For header with the
+      header taking precedence. For DNS the source IP is the remote peer's IP
+      address or the value of the ENDS client IP with the EDNS client IP
+      taking precedence.
 
 - `Service` `(Service: <required>)` - Specifies the structure to define the query's behavior.
 

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -177,8 +177,12 @@ The table below shows this endpoint's support for
   nodes in the response will be sorted in ascending order of estimated
   round-trip times. If the node given does not exist, the nodes in the response
   will be shuffled. Using `_agent` is supported, and will automatically return
-  results nearest the agent servicing the request. If unspecified, the response
-  will be shuffled by default.
+  results nearest the agent servicing the request. Using `_ip` is supported and 
+  will automatically return results nearest to the node associated with the 
+  source IP where the query is executed from. For HTTP the source IP is remote
+  peers IP address or the value of the X-Forwarded-For head with the header
+  taking precedence. For DNS the source IP is the value of the EDNS client IP. 
+  If unspecified, the response will be shuffled by default.
 
 - `Service` `(Service: <required>)` - Specifies the structure to define the query's behavior.
 
@@ -474,7 +478,9 @@ Token will be used.
 
 - `near` `(string: "")` - Specifies to sort the resulting list in ascending
   order based on the estimated round trip time from that node. Passing
-  `?near=_agent` will use the agent's node for the sort. If this is not present,
+  `?near=_agent` will use the agent's node for the sort. Passing `?near=_ip`
+  will use the source IP of the request or the value of the X-Forwarded-For
+  header to lookup the node to use for the sort. If this is not present,
   the default behavior will shuffle the nodes randomly each time the query is
   executed.
 

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -180,7 +180,7 @@ The table below shows this endpoint's support for
   results nearest the agent servicing the request. Using `_ip` is supported and 
   will automatically return results nearest to the node associated with the 
   source IP where the query is executed from. For HTTP the source IP is the
-  remote peer's IP address or the value of the X-Forwarded-For head with the 
+  remote peer's IP address or the value of the X-Forwarded-For header with the 
   header taking precedence. For DNS the source IP is the value of the EDNS 
   client IP or the remote peer's IP address. If unspecified, the response 
   will be shuffled by default.

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -179,10 +179,11 @@ The table below shows this endpoint's support for
   will be shuffled. Using `_agent` is supported, and will automatically return
   results nearest the agent servicing the request. Using `_ip` is supported and 
   will automatically return results nearest to the node associated with the 
-  source IP where the query is executed from. For HTTP the source IP is remote
-  peers IP address or the value of the X-Forwarded-For head with the header
-  taking precedence. For DNS the source IP is the value of the EDNS client IP. 
-  If unspecified, the response will be shuffled by default.
+  source IP where the query is executed from. For HTTP the source IP is the
+  remote peer's IP address or the value of the X-Forwarded-For head with the 
+  header taking precedence. For DNS the source IP is the value of the EDNS 
+  client IP or the remote peer's IP address. If unspecified, the response 
+  will be shuffled by default.
 
 - `Service` `(Service: <required>)` - Specifies the structure to define the query's behavior.
 


### PR DESCRIPTION
This if for issue #3798 

- [x] Initial working Code
- [x] Tests
- [x] Update documentation

When a request comes in via DNS if a EDNS subnet was provided then its used to lookup the node to be used for the near=_ip check. For HTTP, the source ip used for the node lookup is either the RemoteAddr from the http.Request object or the IP specified by the X-Forwarded-For header.

I think the new test in dns_test.go should work reliably. When the generated coordinates were closer together I was having issues with the sort producing expected results but after running the latest code a few times it succeeds every time.
