### PR TITLE
Only call signal.Notify once during agent startup

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -385,7 +385,6 @@ func (c *cmd) run(args []string) int {
 
 	// wait for signal
 	signalCh := make(chan os.Signal, 10)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGPIPE)
 
 	for {


### PR DESCRIPTION
Calling twice appears to have no adverse effects, however serves to confuse as to what the semantics of such code may be! After some experimentation it seems that the second `signal.Notify` takes precedence over the first, rather than resulting in two messages being delivered to the signal channel, so there is no change in behaviour resulting from this change.

This seems like it was probably introduced while resolving conflicts during the merge of the fix for #2404.