### PR TITLE
Enables dig in vagrant-cluster demo by installing dnsutils

### DIFF
--- a/demo/vagrant-cluster/Vagrantfile
+++ b/demo/vagrant-cluster/Vagrantfile
@@ -5,7 +5,7 @@ $script = <<SCRIPT
 
 echo "Installing dependencies ..."
 sudo apt-get update
-sudo apt-get install -y unzip curl jq
+sudo apt-get install -y unzip curl jq dnsutils
 
 echo "Determining Consul version to install ..."
 CHECKPOINT_URL="https://checkpoint-api.hashicorp.com/v1/check"


### PR DESCRIPTION
I was just going through the Getting Started guide for Consul and found that `dig` was missing when I got to the section about querying nodes, [here](https://www.consul.io/intro/getting-started/join.html#querying-nodes).

The installation of Debian used does not provide DNS tools like dig, so this new Vagrantfile includes dnsutils.