### PR TITLE
website: set a default page description

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -45,7 +45,7 @@ helpers do
   #
   # @return [String]
   def description_for(page)
-    description = (page.data.description || "")
+    description = (page.data.description || "Consul by HashiCorp")
       .gsub('"', '')
       .gsub(/\n+/, ' ')
       .squeeze(' ')


### PR DESCRIPTION
This is related to the updated unfurling behavior, see https://github.com/hashicorp/terraform-website/pull/242.