### PR TITLE
Perform a binary search to find optimal size of DNS responses

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,7 +76,7 @@ test: other-consul dev-build vet
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
-	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 6m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
+	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 5m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
 	@echo "Exit code: $$(cat exit-code)" >> test.log
 	@grep -A5 'DATA RACE' test.log || true
 	@grep -A10 'panic: test timed out' test.log || true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -76,7 +76,7 @@ test: other-consul dev-build vet
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
-	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 5m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
+	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 6m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
 	@echo "Exit code: $$(cat exit-code)" >> test.log
 	@grep -A5 'DATA RACE' test.log || true
 	@grep -A10 'panic: test timed out' test.log || true

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -717,6 +717,8 @@ func syncExtra(index map[string]dns.RR, resp *dns.Msg) {
 	resp.Extra = extra
 }
 
+// dnsBinaryTruncate find the optimal number of records using a fast binary search and return
+// it in order to return a DNS answer lower than maxSize parameter.
 func dnsBinaryTruncate(resp *dns.Msg, maxSize int, index map[string]dns.RR, hasExtra bool) int {
 	originalAnswser := resp.Answer
 	startIndex := 0

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -721,14 +721,17 @@ func syncExtra(index map[string]dns.RR, resp *dns.Msg) {
 // it in order to return a DNS answer lower than maxSize parameter.
 func dnsBinaryTruncate(resp *dns.Msg, maxSize int, index map[string]dns.RR, hasExtra bool) int {
 	originalAnswser := resp.Answer
+	originalExtra := resp.Extra
+	originalIndex := index
 	startIndex := 0
 	endIndex := len(resp.Answer) + 1
 	for endIndex-startIndex > 1 {
 		median := startIndex + (endIndex-startIndex)/2
 
 		resp.Answer = originalAnswser[:median]
-		resp.Extra = originalAnswser[:median]
 		if hasExtra {
+			resp.Extra = originalExtra[:median]
+			index := originalIndex
 			syncExtra(index, resp)
 		}
 		aLen := resp.Len()

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -721,8 +721,6 @@ func syncExtra(index map[string]dns.RR, resp *dns.Msg) {
 // it in order to return a DNS answer lower than maxSize parameter.
 func dnsBinaryTruncate(resp *dns.Msg, maxSize int, index map[string]dns.RR, hasExtra bool) int {
 	originalAnswser := resp.Answer
-	originalExtra := resp.Extra
-	originalIndex := index
 	startIndex := 0
 	endIndex := len(resp.Answer) + 1
 	for endIndex-startIndex > 1 {
@@ -730,8 +728,6 @@ func dnsBinaryTruncate(resp *dns.Msg, maxSize int, index map[string]dns.RR, hasE
 
 		resp.Answer = originalAnswser[:median]
 		if hasExtra {
-			resp.Extra = originalExtra[:median]
-			index := originalIndex
 			syncExtra(index, resp)
 		}
 		aLen := resp.Len()

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -722,7 +722,7 @@ func syncExtra(index map[string]dns.RR, resp *dns.Msg) {
 func dnsBinaryTruncate(resp *dns.Msg, maxSize int, index map[string]dns.RR, hasExtra bool) int {
 	originalAnswser := resp.Answer
 	startIndex := 0
-	endIndex := len(resp.Answer)
+	endIndex := len(resp.Answer) + 1
 	for endIndex-startIndex > 1 {
 		median := startIndex + (endIndex-startIndex)/2
 

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -2993,7 +2993,7 @@ func TestBinarySearch(t *testing.T) {
 		msgSrc.Answer = append(msgSrc.Answer, &dns.SRV{Hdr: dns.RR_Header{Name: "redis.service.consul.", Class: 1, Rrtype: dns.TypeSRV, Ttl: 0x3c}, Port: 0x4c57, Target: target})
 		msgSrc.Extra = append(msgSrc.Extra, &dns.CNAME{Hdr: dns.RR_Header{Name: target, Class: 1, Rrtype: dns.TypeCNAME, Ttl: 0x3c}, Target: fmt.Sprintf("fx.168.%d.%d.", i/256, i%256)})
 	}
-	for _, maxSize := range []int{256, 512, 8192} {
+	for idx, maxSize := range []int{12, 256, 512, 8192, 65535} {
 		msg := new(dns.Msg)
 		msgSrc.Compress = true
 		msgSrc.SetQuestion("redis.service.consul.", dns.TypeSRV)
@@ -3012,8 +3012,8 @@ func TestBinarySearch(t *testing.T) {
 		if predicted < len(buf) {
 			t.Fatalf("Bug in DNS library: %d != %d", predicted, len(buf))
 		}
-		if len(buf) > maxSize || len(buf) < 1 {
-			t.Fatalf("bad: %d > %d", predicted, maxSize)
+		if len(buf) > maxSize || (idx != 0 && len(buf) < 16) || (maxSize == 65535 && blen != 50) {
+			t.Fatalf("bad[%d]: %d > %d", idx, len(buf), maxSize)
 		}
 	}
 }

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -3349,17 +3349,17 @@ func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uin
 		case 0:
 			if (expectedService > 0 && len(in.Answer) != expectedService) ||
 				(expectedService < -1 && len(in.Answer) < lib.AbsInt(expectedService)) {
-				return false, fmt.Errorf("%d/%d answers received for type %v for %s", len(in.Answer), answerLimit, qType, question)
+				return false, fmt.Errorf("%d/%d answers received for type %v for %s, sz:=%d", len(in.Answer), answerLimit, qType, question, in.Len())
 			}
 		case 1:
 			if (expectedQuery > 0 && len(in.Answer) != expectedQuery) ||
 				(expectedQuery < -1 && len(in.Answer) < lib.AbsInt(expectedQuery)) {
-				return false, fmt.Errorf("%d/%d answers received for type %v for %s", len(in.Answer), answerLimit, qType, question)
+				return false, fmt.Errorf("%d/%d answers received for type %v for %s, sz:=%d", len(in.Answer), answerLimit, qType, question, in.Len())
 			}
 		case 2:
 			if (expectedQueryID > 0 && len(in.Answer) != expectedQueryID) ||
 				(expectedQueryID < -1 && len(in.Answer) < lib.AbsInt(expectedQueryID)) {
-				return false, fmt.Errorf("%d/%d answers received for type %v for %s", len(in.Answer), answerLimit, qType, question)
+				return false, fmt.Errorf("%d/%d answers received for type %v for %s, sz:=%d", len(in.Answer), answerLimit, qType, question, in.Len())
 			}
 		default:
 			panic("abort")
@@ -3511,7 +3511,7 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 				t.Parallel()
 				err := checkDNSService(t, test.numNodesTotal, test.aRecordLimit, qType, test.expectedAResults, test.udpSize, test.udpAnswerLimit)
 				if err != nil {
-					t.Errorf("Expected lookup %s to pass: %v", test.name, err)
+					t.Fatalf("Expected lookup %s to pass: %v", test.name, err)
 				}
 			})
 		}
@@ -3520,7 +3520,7 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 			t.Parallel()
 			err := checkDNSService(t, test.expectedSRVResults, test.aRecordLimit, dns.TypeSRV, test.numNodesTotal, test.udpSize, test.udpAnswerLimit)
 			if err != nil {
-				t.Errorf("Expected service SRV lookup %s to pass: %v", test.name, err)
+				t.Fatalf("Expected service SRV lookup %s to pass: %v", test.name, err)
 			}
 		})
 	}
@@ -3566,27 +3566,27 @@ func TestDNS_ServiceLookup_AnswerLimits(t *testing.T) {
 	}
 	for _, test := range tests {
 		test := test // capture loop var
-		t.Run("A lookup", func(t *testing.T) {
+		t.Run(fmt.Sprintf("A lookup %v", test), func(t *testing.T) {
 			t.Parallel()
 			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeA, test.expectedAService, test.expectedAQuery, test.expectedAQueryID)
 			if !ok {
-				t.Errorf("Expected service A lookup %s to pass: %v", test.name, err)
+				t.Fatalf("Expected service A lookup %s to pass: %v", test.name, err)
 			}
 		})
 
-		t.Run("AAAA lookup", func(t *testing.T) {
+		t.Run(fmt.Sprintf("AAAA lookup %v", test), func(t *testing.T) {
 			t.Parallel()
 			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeAAAA, test.expectedAAAAService, test.expectedAAAAQuery, test.expectedAAAAQueryID)
 			if !ok {
-				t.Errorf("Expected service AAAA lookup %s to pass: %v", test.name, err)
+				t.Fatalf("Expected service AAAA lookup %s to pass: %v", test.name, err)
 			}
 		})
 
-		t.Run("ANY lookup", func(t *testing.T) {
+		t.Run(fmt.Sprintf("ANY lookup %v", test), func(t *testing.T) {
 			t.Parallel()
 			ok, err := testDNSServiceLookupResponseLimits(t, test.udpAnswerLimit, dns.TypeANY, test.expectedANYService, test.expectedANYQuery, test.expectedANYQueryID)
 			if !ok {
-				t.Errorf("Expected service ANY lookup %s to pass: %v", test.name, err)
+				t.Fatalf("Expected service ANY lookup %s to pass: %v", test.name, err)
 			}
 		})
 	}


### PR DESCRIPTION
Will fix https://github.com/hashicorp/consul/issues/4036

Instead of removing one by one the entries, find the optimal
size using binary search.

For SRV records, with 5k nodes, duration of DNS lookups is
divided by 4 or more.

Results with around 5k nodes on local agent, dev mode:

Before Optimization: SRV~100ms ; A ~25ms
After Optimization: SRV ~20ms ; A ~20ms
