### PR TITLE
Update error message in agent.go

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1687,7 +1687,7 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 		}
 
 		if chkType.IsScript() && !a.config.EnableScriptChecks {
-			return fmt.Errorf("Scripts are disabled on this agent; to enable, configure 'enable_script_checks' to true")
+			return fmt.Errorf("Scripts are disabled on this agent; to enable, configure 'enable-script-checks' to true")
 		}
 	}
 


### PR DESCRIPTION
Error message was misleading, while running consul agent.
It was showing enable_script_checks to true instead of enable-script-checks.