### PR TITLE
Update index.html.md build instuctions

### DIFF
--- a/website/source/docs/install/index.html.md
+++ b/website/source/docs/install/index.html.md
@@ -50,7 +50,7 @@ a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
   needed to compile Consul:
 
     ```shell
-    $ make bootstrap
+    $ make
     ```
 
   1. Build Consul for your current system and put the binary in `./bin/`

--- a/website/source/docs/install/index.html.md
+++ b/website/source/docs/install/index.html.md
@@ -50,7 +50,7 @@ a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
   needed to compile Consul:
 
     ```shell
-    $ make
+    $ make tools
     ```
 
   1. Build Consul for your current system and put the binary in `./bin/`


### PR DESCRIPTION
No target for `$ make bootstrap` currently exists. If building from source you have to run `$ make` and then `$ make dev` to install one of the built binaries that is appropriate for your system.