### PR TITLE
Fix telemetry default prefix filter

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -514,9 +514,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	// Add a filter rule if needed for enabling the deprecated metric names
 	enableDeprecatedNames := b.boolVal(c.Telemetry.EnableDeprecatedNames)
 	if enableDeprecatedNames {
-		telemetryAllowedPrefixes = append(telemetryAllowedPrefixes, "consul.consul")
+		telemetryAllowedPrefixes = append(telemetryAllowedPrefixes, "consul.consul.")
 	} else {
-		telemetryBlockedPrefixes = append(telemetryBlockedPrefixes, "consul.consul")
+		telemetryBlockedPrefixes = append(telemetryBlockedPrefixes, "consul.consul.")
 	}
 
 	// raft performance scaling

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1811,7 +1811,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			patch: func(rt *RuntimeConfig) {
 				rt.DataDir = dataDir
 				rt.TelemetryAllowedPrefixes = []string{"foo"}
-				rt.TelemetryBlockedPrefixes = []string{"bar", "consul.consul"}
+				rt.TelemetryBlockedPrefixes = []string{"bar", "consul.consul."}
 			},
 			warns: []string{`Filter rule must begin with either '+' or '-': "nix"`},
 		},
@@ -1829,7 +1829,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			patch: func(rt *RuntimeConfig) {
 				rt.DataDir = dataDir
 				rt.TelemetryFilterDefault = false
-				rt.TelemetryAllowedPrefixes = []string{"consul.consul"}
+				rt.TelemetryAllowedPrefixes = []string{"consul.consul."}
 				rt.TelemetryBlockedPrefixes = []string{}
 			},
 		},
@@ -3633,7 +3633,7 @@ func TestFullConfig(t *testing.T) {
 		TelemetryDogstatsdAddr:                      "0wSndumK",
 		TelemetryDogstatsdTags:                      []string{"3N81zSUB", "Xtj8AnXZ"},
 		TelemetryFilterDefault:                      true,
-		TelemetryAllowedPrefixes:                    []string{"oJotS8XJ", "consul.consul"},
+		TelemetryAllowedPrefixes:                    []string{"oJotS8XJ", "consul.consul."},
 		TelemetryBlockedPrefixes:                    []string{"cazlEhGn"},
 		TelemetryMetricsPrefix:                      "ftO6DySn",
 		TelemetryPrometheusRetentionTime:            15 * time.Second,


### PR DESCRIPTION
If telemetry metrics contain a hostname starting with 'consul', the metrics will be filtered out the same way as the deprecated metrics. This is the case for all runtime metrics which include such a hostname.

For example, consul.consul01-example.runtime.num_goroutines is lost because it matches the blocked prefix.