### PR TITLE
Session Delete confirmation button and KV console error message

### DIFF
--- a/ui-v2/app/mixins/kv/with-actions.js
+++ b/ui-v2/app/mixins/kv/with-actions.js
@@ -2,7 +2,7 @@ import Mixin from '@ember/object/mixin';
 import { get, set } from '@ember/object';
 import WithFeedback from 'consul-ui/mixins/with-feedback';
 
-const transitionToList = function(key, transitionTo) {
+const transitionToList = function(key = '/', transitionTo) {
   if (key === '/') {
     return transitionTo('dc.kv.index');
   } else {
@@ -45,6 +45,7 @@ export default Mixin.create(WithFeedback, {
             .remove(item)
             .then(() => {
               switch (this.routeName) {
+                case 'dc.kv.folder':
                 case 'dc.kv.index':
                   return this.refresh();
                 default:

--- a/ui-v2/app/routes/dc/kv/folder.js
+++ b/ui-v2/app/routes/dc/kv/folder.js
@@ -4,9 +4,10 @@ import Route from './index';
 export default Route.extend({
   templateName: 'dc/kv/index',
   beforeModel: function(transition) {
+    this._super(...arguments);
     const params = this.paramsFor('dc.kv.folder');
     if (params.key === '/' || params.key == null) {
-      this.transitionTo('dc.kv.index');
+      return this.transitionTo('dc.kv.index');
     }
   },
 });

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -19,27 +19,16 @@ export default Route.extend(WithKvActions, {
         ...model,
         ...{
           items: repo.findAllBySlug(get(model.parent, 'Key'), dc).catch(e => {
-            this.cleanFolder();
             return this.transitionTo('dc.kv.index');
           }),
         },
       });
     });
   },
-  cleanFolder: function() {
-    const params = this.paramsFor(this.routeName);
-    const dc = this.modelFor('dc').dc.Name;
-    const id = JSON.stringify([dc, params.key]);
-    const record = get(this, 'store').peekRecord('kv', id);
-    if (record) {
-      record.unloadRecord();
-    }
-  },
   actions: {
     error: function(e) {
       if (e.errors && e.errors[0] && e.errors[0].status == '404') {
-        this.cleanFolder();
-        return this.transitionTo('dc.kv.index').followRedirects();
+        return this.transitionTo('dc.kv.index');
       }
       throw e;
     },

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -6,7 +6,6 @@ import WithKvActions from 'consul-ui/mixins/kv/with-actions';
 
 export default Route.extend(WithKvActions, {
   repo: service('kv'),
-  store: service('store'),
   model: function(params) {
     const key = params.key || '/';
     const dc = this.modelFor('dc').dc.Name;

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -6,6 +6,7 @@ import WithKvActions from 'consul-ui/mixins/kv/with-actions';
 
 export default Route.extend(WithKvActions, {
   repo: service('kv'),
+  store: service('store'),
   model: function(params) {
     const key = params.key || '/';
     const dc = this.modelFor('dc').dc.Name;
@@ -13,22 +14,30 @@ export default Route.extend(WithKvActions, {
     return hash({
       isLoading: false,
       parent: repo.findBySlug(key, dc),
-    })
-      .then(function(model) {
-        return hash({
-          ...model,
-          ...{
-            items: repo.findAllBySlug(get(model.parent, 'Key'), dc),
-          },
-        });
-      })
-      .catch(e => {
-        if (e.errors && e.errors[0] && e.errors[0].status == '404') {
-          this.transitionTo('dc.kv.index');
-          return;
-        }
-        throw e;
+    }).then(function(model) {
+      return hash({
+        ...model,
+        ...{
+          items: repo.findAllBySlug(get(model.parent, 'Key'), dc),
+        },
       });
+    });
+  },
+  actions: {
+    error: function(e) {
+      if (e.errors && e.errors[0] && e.errors[0].status == '404') {
+        const params = this.paramsFor(this.routeName);
+        const dc = this.modelFor('dc').dc.Name;
+        const id = JSON.stringify([dc, params.key]);
+        const record = get(this, 'store').peekRecord('kv', id);
+        if (record) {
+          record.unloadRecord();
+        }
+        this.transitionTo('dc.kv.index');
+        return false;
+      }
+      throw e;
+    },
   },
   setupController: function(controller, model) {
     this._super(...arguments);

--- a/ui-v2/app/services/feedback.js
+++ b/ui-v2/app/services/feedback.js
@@ -16,10 +16,17 @@ export default Service.extend({
         });
       })
       .catch(e => {
-        get(this, 'flashMessages').add({
-          type: 'error',
-          message: error,
-        });
+        if (e.name === 'TransitionAborted') {
+          get(this, 'flashMessages').add({
+            type: 'success',
+            message: success,
+          });
+        } else {
+          get(this, 'flashMessages').add({
+            type: 'error',
+            message: error,
+          });
+        }
       })
       .finally(function() {
         controller.set('isLoading', false);

--- a/ui-v2/app/services/kv.js
+++ b/ui-v2/app/services/kv.js
@@ -10,9 +10,18 @@ export default Service.extend({
   // this one gives you the full object so key,values and meta
   findBySlug: function(key, dc) {
     if (isFolder(key)) {
-      return Promise.resolve({
-        Key: key,
-      });
+      const id = JSON.stringify([dc, key]);
+      let item = get(this, 'store').peekRecord('kv', id);
+      if (!item) {
+        item = this.create();
+        set(item, 'Key', key);
+        set(item, 'Datacenter', dc);
+      }
+      return Promise.resolve(item);
+      // return Promise.resolve({
+      //   Key: key,
+      //   Datacenter: dc
+      // });
     }
     return get(this, 'store')
       .queryRecord('kv', {

--- a/ui-v2/app/services/kv.js
+++ b/ui-v2/app/services/kv.js
@@ -18,10 +18,6 @@ export default Service.extend({
         set(item, 'Datacenter', dc);
       }
       return Promise.resolve(item);
-      // return Promise.resolve({
-      //   Key: key,
-      //   Datacenter: dc
-      // });
     }
     return get(this, 'store')
       .queryRecord('kv', {

--- a/ui-v2/app/services/kv.js
+++ b/ui-v2/app/services/kv.js
@@ -54,6 +54,16 @@ export default Service.extend({
             set(item, 'Datacenter', dc);
             return item;
           });
+      })
+      .catch(e => {
+        if (e.errors && e.errors[0] && e.errors[0].status == '404') {
+          const id = JSON.stringify([dc, key]);
+          const record = get(this, 'store').peekRecord('kv', id);
+          if (record) {
+            record.destroyRecord();
+          }
+        }
+        throw e;
       });
   },
   create: function() {

--- a/ui-v2/app/services/kv.js
+++ b/ui-v2/app/services/kv.js
@@ -66,6 +66,6 @@ export default Service.extend({
     });
   },
   invalidate: function() {
-    get(this, 'store').unloadAll('kv');
+    return get(this, 'store').unloadAll('kv');
   },
 });

--- a/ui-v2/app/styles/components/confirmation-dialog.scss
+++ b/ui-v2/app/styles/components/confirmation-dialog.scss
@@ -1,6 +1,9 @@
 div.with-confirmation {
   @extend %confirmation-dialog, %confirmation-dialog-inline;
 }
+table div.with-confirmation.confirming {
+  background-color: $white;
+}
 %confirmation-dialog-inline p {
   color: $text-note;
 }
@@ -15,4 +18,8 @@ div.with-confirmation {
   display: flex;
   align-items: center;
   line-height: 1;
+}
+table div.with-confirmation.confirming {
+  position: absolute;
+  right: 0;
 }

--- a/ui-v2/app/templates/dc/nodes/-sessions.hbs
+++ b/ui-v2/app/templates/dc/nodes/-sessions.hbs
@@ -38,10 +38,11 @@
                         {{#block-slot 'action' as |confirm|}}
                             <button type="button" class="type-delete" {{action confirm 'invalidateSession' item}}>Invalidate</button>
                         {{/block-slot}}
-                        {{#block-slot 'dialog'}}
+                        {{#block-slot 'dialog' as |execute cancel message|}}
                             <p>
-                                Are you sure you want to invalidate {{item.ID}}?
+                                {{message}}
                             </p>
+                            <button type="button" class="type-delete" {{action execute}}>Confirm Invalidate</button>
                             <button type="button" class="type-cancel" {{ action cancel}}>Cancel</button>
                         {{/block-slot}}
                     {{/confirmation-dialog}}


### PR DESCRIPTION
This PR includes a fix for the Lock Session deletion dialog, plus silencing the console error when deleting a KV when its the only KV in a folder (only when deleted from the the listing page)