### PR TITLE
doc fix: put "Near" into "Service" in prepared_queries

### DIFF
--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -171,21 +171,6 @@ The table below shows this endpoint's support for
   to the service being queried. If the client does not supply an ACL Token, the
   anonymous token will be used.
 
-- `Near` `(string: "")` - Specifies a node to sort near based on distance
-  sorting using [Network Coordinates](/docs/internals/coordinates.html). The
-  nearest instance to the specified node will be returned first, and subsequent
-  nodes in the response will be sorted in ascending order of estimated
-  round-trip times. If the node given does not exist, the nodes in the response
-  will be shuffled. If unspecified, the response will be shuffled by default.
-  
-    - `_agent` - Returns results nearest the agent servicing the request.
-    - `_ip` - Returns results nearest to the node associated with the source IP
-      where the query was executed from. For HTTP the source IP is the remote
-      peer's IP address or the value of the X-Forwarded-For header with the
-      header taking precedence. For DNS the source IP is the remote peer's IP
-      address or the value of the ENDS client IP with the EDNS client IP
-      taking precedence.
-
 - `Service` `(Service: <required>)` - Specifies the structure to define the query's behavior.
 
   - `Service` `(string: <required>)` - Specifies the name of the service to
@@ -223,6 +208,22 @@ The table below shows this endpoint's support for
     check filtering. If this is set to false, the results will include nodes
     with checks in the passing as well as the warning states. If this is set to
     true, only nodes with checks in the passing state will be returned.
+    
+  - `Near` `(string: "")` - Specifies a node to sort near based on distance
+     sorting using [Network Coordinates](/docs/internals/coordinates.html). The
+     nearest instance to the specified node will be returned first, and subsequent
+     nodes in the response will be sorted in ascending order of estimated
+     round-trip times. If the node given does not exist, the nodes in the response
+     will be shuffled. If unspecified, the response will be shuffled by default.
+  
+       - `_agent` - Returns results nearest the agent servicing the request.    
+       - `_ip` - Returns results nearest to the node associated with the source IP
+         where the query was executed from. For HTTP the source IP is the remote
+         peer's IP address or the value of the X-Forwarded-For header with the
+         header taking precedence. For DNS the source IP is the remote peer's IP
+         address or the value of the ENDS client IP with the EDNS client IP
+         taking precedence.
+
 
   - `Tags` `(array<string>: nil)` - Specifies a list of service tags to filter
     the query results. For a service to pass the tag filter it must have *all*


### PR DESCRIPTION
In the current documentation, "Near" is an attribute of an prepared query itself whereas it seems like its an attribute of a service in practice as illustrated in the following example. As you can see, `"Near": "my-node" is silently dropped in the first query, but accepted in the second one. But according to my understanding of the current documentation, I would have expected the first one to be valid and the second one not to.

```bash
curl --request POST http://localhost:8500/v1/query --data @- <<EOF
{
  "Name": "my-query",
  "Near": "my-node",
  "Service": {
    "Service": "my-service"
  }
}
EOF
curl --request POST http://localhost:8500/v1/query --data @- <<EOF
{
  "Name": "my-other-query",
  "Service": {
    "Service": "my-service",
    "Near": "my-node"
  }
}
EOF
curl -s http://localhost:8500/v1/query | jq .
```
results in
```
[
  {
    "ID": "6f014905-9068-bb50-b54c-b84763e82a0b",
    "Name": "my-query",
    "Session": "",
    "Token": "",
    "Template": {
      "Type": "",
      "Regexp": "",
      "RemoveEmptyTags": false
    },
    "Service": {
      "Service": "my-service",
      "Failover": {
        "NearestN": 0,
        "Datacenters": null
      },
      "OnlyPassing": false,
      "IgnoreCheckIDs": null,
      "Near": "",
      "Tags": null,
      "NodeMeta": null
    },
    "DNS": {
      "TTL": ""
    },
    "CreateIndex": 12626841,
    "ModifyIndex": 12626841
  },
  {
    "ID": "ad899c77-140d-3340-020d-5f0b1bde9d55",
    "Name": "my-other-query",
    "Session": "",
    "Token": "",
    "Template": {
      "Type": "",
      "Regexp": "",
      "RemoveEmptyTags": false
    },
    "Service": {
      "Service": "my-service",
      "Failover": {
        "NearestN": 0,
        "Datacenters": null
      },
      "OnlyPassing": false,
      "IgnoreCheckIDs": null,
      "Near": "my-node",
      "Tags": null,
      "NodeMeta": null
    },
    "DNS": {
      "TTL": ""
    },
    "CreateIndex": 12626842,
    "ModifyIndex": 12626842
  }
]
```