### PR TITLE
Enterprise/Licensing Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.swp
 *.test
 .DS_Store
+.fseventsd
 .vagrant/
 /pkg
 Thumbs.db

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -73,6 +73,7 @@ type delegate interface {
 	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error
 	Stats() map[string]map[string]string
+	enterpriseDelegate
 }
 
 // notifier is called after a successful JoinLAN.

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -72,6 +72,9 @@ type Client struct {
 	shutdown     bool
 	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
+
+	// embedded struct to hold all the enterprise specific data
+	EnterpriseClient
 }
 
 // NewClient is used to construct a new Consul client from the
@@ -131,6 +134,11 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 		shutdownCh: make(chan struct{}),
 	}
 
+	if err := c.initEnterprise(); err != nil {
+		c.Shutdown()
+		return nil, err
+	}
+
 	// Initialize the LAN Serf
 	c.serf, err = c.setupSerf(config.SerfLANConfig,
 		c.eventCh, serfLANSnapshot)
@@ -146,6 +154,11 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 	// Start LAN event handlers after the router is complete since the event
 	// handlers depend on the router and the router depends on Serf.
 	go c.lanEventHandler()
+
+	if err := c.startEnterprise(); err != nil {
+		c.Shutdown()
+		return nil, err
+	}
 
 	return c, nil
 }
@@ -342,6 +355,17 @@ func (c *Client) Stats() map[string]map[string]string {
 		"serf_lan": c.serf.Stats(),
 		"runtime":  runtimeStats(),
 	}
+
+	for outerKey, outerValue := range c.enterpriseStats() {
+		if _, ok := stats[outerKey]; ok {
+			for innerKey, innerValue := range outerValue {
+				stats[outerKey][innerKey] = innerValue
+			}
+		} else {
+			stats[outerKey] = outerValue
+		}
+	}
+
 	return stats
 }
 

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -135,6 +135,8 @@ func (c *Client) localEvent(event serf.UserEvent) {
 			c.config.UserEventHandler(event)
 		}
 	default:
-		c.logger.Printf("[WARN] consul: Unhandled local event: %v", event)
+		if !c.handleEnterpriseUserEvents(event) {
+			c.logger.Printf("[WARN] consul: Unhandled local event: %v", event)
+		}
 	}
 }

--- a/agent/consul/enterprise_client_oss.go
+++ b/agent/consul/enterprise_client_oss.go
@@ -1,0 +1,25 @@
+// +build !ent
+
+package consul
+
+import (
+	"github.com/hashicorp/serf/serf"
+)
+
+type EnterpriseClient struct{}
+
+func (c *Client) initEnterprise() error {
+	return nil
+}
+
+func (c *Client) startEnterprise() error {
+	return nil
+}
+
+func (c *Client) handleEnterpriseUserEvents(event serf.UserEvent) bool {
+	return false
+}
+
+func (c *Client) enterpriseStats() map[string]map[string]string {
+	return nil
+}

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -1,0 +1,32 @@
+// +build !ent
+
+package consul
+
+import (
+	"net"
+
+	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/serf/serf"
+)
+
+type EnterpriseServer struct{}
+
+func (s *Server) initEnterprise() error {
+	return nil
+}
+
+func (s *Server) startEnterprise() error {
+	return nil
+}
+
+func (s *Server) handleEnterpriseUserEvents(event serf.UserEvent) bool {
+	return false
+}
+
+func (s *Server) handleEnterpriseRPCConn(rtype pool.RPCType, conn net.Conn, isTLS bool) bool {
+	return false
+}
+
+func (s *Server) enterpriseStats() map[string]map[string]string {
+	return nil
+}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -115,9 +115,10 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 		s.handleSnapshotConn(conn)
 
 	default:
-		s.logger.Printf("[ERR] consul.rpc: unrecognized RPC byte: %v %s", typ, logConn(conn))
-		conn.Close()
-		return
+		if !s.handleEnterpriseRPCConn(typ, conn, isTLS) {
+			s.logger.Printf("[ERR] consul.rpc: unrecognized RPC byte: %v %s", typ, logConn(conn))
+			conn.Close()
+		}
 	}
 }
 

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -198,7 +198,9 @@ func (s *Server) localEvent(event serf.UserEvent) {
 			s.config.UserEventHandler(event)
 		}
 	default:
-		s.logger.Printf("[WARN] consul: Unhandled local event: %v", event)
+		if !s.handleEnterpriseUserEvents(event) {
+			s.logger.Printf("[WARN] consul: Unhandled local event: %v", event)
+		}
 	}
 }
 

--- a/agent/enterprise_delegate_oss.go
+++ b/agent/enterprise_delegate_oss.go
@@ -1,0 +1,6 @@
+// +build !ent
+
+package agent
+
+// enterpriseDelegate has no functions in OSS
+type enterpriseDelegate interface{}

--- a/command/helpers/helpers.go
+++ b/command/helpers/helpers.go
@@ -1,0 +1,42 @@
+package helpers
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+func LoadDataSource(data string, testStdin io.Reader) (string, error) {
+	var stdin io.Reader = os.Stdin
+	if testStdin != nil {
+		stdin = testStdin
+	}
+
+	// Handle empty quoted shell parameters
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	switch data[0] {
+	case '@':
+		data, err := ioutil.ReadFile(data[1:])
+		if err != nil {
+			return "", fmt.Errorf("Failed to read file: %s", err)
+		} else {
+			return string(data), nil
+		}
+	case '-':
+		if len(data) > 1 {
+			return data, nil
+		}
+		var b bytes.Buffer
+		if _, err := io.Copy(&b, stdin); err != nil {
+			return "", fmt.Errorf("Failed to read stdin: %s", err)
+		}
+		return b.String(), nil
+	default:
+		return data, nil
+	}
+}


### PR DESCRIPTION
This PR pulls a few things out of the enterprise version of Consul and puts them into OSS.

1. gitignore of .fseventsd
2. BadRequestError for HTTP request to have endpoints return a 400 indicating that the params/payload they provided had issues
3. Move some stdin/file/string data source processing out of kv_put.go so that other CLI commands (the license put command for enterprise) can share the common functionality.

Additionally this PR sets up some file structures to make consul enterprise and consul oss code bases coexist with less friction.

At the agent/ level in the source a new enterpriseDelegate interface was added to the main agent/agent.go:delegate interface. For OSS the enterpriseDelegate is an empty interface.

At the agent/consul level in the source EnterpriseServer and EnterpriseClient structs were added (empty structs in OSS) to hold onto enterprise specific data items. Additionally a few extra functions were added to the Server/Client and are stubs in OSS for where enterprise functionality needs to hook in.