### PR TITLE
[BUGFIX] Auto calculation of listing heights + dropup menus

### DIFF
--- a/ui-v2/app/components/tabular-collection.js
+++ b/ui-v2/app/components/tabular-collection.js
@@ -62,7 +62,7 @@ export default Component.extend(SlotsMixin, {
     this._super(...arguments);
     this.change = change.bind(this);
     this.confirming = [];
-    // TODO: This should auto calculate properly from the CSS
+    // TODO: The row height should auto calculate properly from the CSS
     this['cell-layout'] = new ZIndexedGrid(get(this, 'width'), 50);
     this.handler = () => {
       this.resize(createSizeEvent());
@@ -86,12 +86,15 @@ export default Component.extend(SlotsMixin, {
     window.removeEventListener('resize', this.handler);
   },
   resize: function(e) {
-    const $footer = [...$$('#wrapper > footer')][0];
-    const $thead = [...$$('main > div')][0];
-    if ($thead) {
-      // TODO: This should auto calculate properly from the CSS
-      this.set('height', Math.max(0, new Number(e.detail.height - ($footer.clientHeight + 218))));
-      this['cell-layout'] = new ZIndexedGrid($thead.clientWidth, 50);
+    const $tbody = this.$('tbody').get(0);
+    if ($tbody) {
+      const rect = $tbody.getBoundingClientRect();
+      const $footer = [...$$('footer[role="contentinfo"]')][0];
+      const space = rect.top + $footer.clientHeight;
+      const height = new Number(e.detail.height - space);
+      this.set('height', Math.max(0, height));
+      // TODO: The row height should auto calculate properly from the CSS
+      this['cell-layout'] = new ZIndexedGrid($tbody.clientWidth, 50);
       this.updateItems();
       this.updateScrollPosition();
     }

--- a/ui-v2/app/styles/components/action-group.scss
+++ b/ui-v2/app/styles/components/action-group.scss
@@ -70,18 +70,29 @@
 %action-group ul {
   position: absolute;
   right: -10px;
-  top: 35px;
   padding: 1px;
 }
 %action-group ul::before {
   position: absolute;
   right: 18px;
-  top: -6px;
   content: '';
   display: block;
   width: 10px;
   height: 10px;
+}
+%action-group ul:not(.above) {
+  top: 35px;
+}
+%action-group ul:not(.above)::before {
+  top: -6px;
   transform: rotate(45deg);
+}
+%action-group ul.above {
+  bottom: 35px;
+}
+%action-group ul.above::before {
+  bottom: -6px;
+  transform: rotate(225deg);
 }
 %action-group li {
   position: relative;

--- a/ui-v2/app/templates/components/hashicorp-consul.hbs
+++ b/ui-v2/app/templates/components/hashicorp-consul.hbs
@@ -51,7 +51,7 @@
     <main>
 {{yield}}
     </main>
-    <footer data-test-footer>
+    <footer role="contentinfo" data-test-footer>
         <a data-test-footer-copyright href="{{env 'CONSUL_COPYRIGHT_URL'}}/" rel="noopener noreferrer" target="_blank">&copy; {{env 'CONSUL_COPYRIGHT_YEAR'}} HashiCorp</a>
         <p data-test-footer-version>Consul {{env 'CONSUL_VERSION'}}</p>
         <a data-test-footer-docs href="{{env 'CONSUL_DOCUMENTATION_URL'}}/index.html" rel="help noopener noreferrer" target="_blank">Documentation</a>


### PR DESCRIPTION
Addresses #4125

All table listings now auto calculate their own height depending on the space left in the page.

Additionally, the dropdown menus now detect whether they will be cut off by the 'masked container' and will now 'drop up' if so.