### PR TITLE
Consul 1.1.0, beta UI, autojoin via ec2 metadata, subnet under VPC

### DIFF
--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -69,14 +69,14 @@ resource "aws_security_group" "consul" {
         from_port = 22
         to_port = 22
         protocol = "tcp"
-        cidr_blocks = ["client_access_subnet"]
+        cidr_blocks = ["${var.client_access_subnet}"]
     }
 
     ingress {
         from_port = 8500
         to_port = 8500
         protocol = "tcp"
-        cidr_blocks = ["client_access_subnet"]
+        cidr_blocks = ["${var.client_access_subnet}"]
     }
 
     ingress {

--- a/terraform/aws/consul.tf
+++ b/terraform/aws/consul.tf
@@ -3,36 +3,41 @@ resource "aws_instance" "server" {
     instance_type = "${var.instance_type}"
     key_name = "${var.key_name}"
     count = "${var.servers}"
-    security_groups = ["${aws_security_group.consul.id}"]
+    vpc_security_group_ids = ["${aws_security_group.consul.id}"]
     subnet_id = "${lookup(var.subnets, count.index % var.servers)}"
+    iam_instance_profile   = "${aws_iam_instance_profile.consul-join.name}"
+
 
     connection {
         user = "${lookup(var.user, var.platform)}"
         private_key = "${file("${var.key_path}")}"
     }
 
-    #Instance tags
-    tags {
-        Name = "${var.tagName}-${count.index}"
-        ConsulRole = "Server"
-    }
+    tags = "${map(
+       "Name", "consul-server-${count.index}",
+       var.consul_join_tag_key, var.consul_join_tag_value
+    )}"
 
     provisioner "file" {
         source = "${path.module}/../shared/scripts/${lookup(var.service_conf, var.platform)}"
         destination = "/tmp/${lookup(var.service_conf_dest, var.platform)}"
     }
 
+    provisioner "file" {
+        source      = "${path.module}/../shared/scripts/install.sh",
+        destination = "/tmp/install.sh"
+    }
 
     provisioner "remote-exec" {
-        inline = [
-            "echo ${var.servers} > /tmp/consul-server-count",
-            "echo ${aws_instance.server.0.private_ip} > /tmp/consul-server-addr",
-        ]
+      inline = [
+        "chmod +x /tmp/install.sh",
+        "/tmp/install.sh ${var.servers} ${var.consul_version} ${var.consul_bind} ${var.consul_client_bind} ${var.consul_join_tag_key} ${var.consul_join_tag_value}",
+
+      ]
     }
 
     provisioner "remote-exec" {
         scripts = [
-            "${path.module}/../shared/scripts/install.sh",
             "${path.module}/../shared/scripts/service.sh",
             "${path.module}/../shared/scripts/ip_tables.sh",
         ]
@@ -64,8 +69,23 @@ resource "aws_security_group" "consul" {
         from_port = 22
         to_port = 22
         protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
+        cidr_blocks = ["client_access_subnet"]
     }
+
+    ingress {
+        from_port = 8500
+        to_port = 8500
+        protocol = "tcp"
+        cidr_blocks = ["client_access_subnet"]
+    }
+
+    ingress {
+        protocol = "icmp"
+	cidr_blocks = ["0.0.0.0/0"]
+	from_port = 8
+	to_port = 0
+    }
+
 
     // This is for outbound internet access
     egress {
@@ -75,3 +95,31 @@ resource "aws_security_group" "consul" {
         cidr_blocks = ["0.0.0.0/0"]
     }
 }
+
+# Create an IAM role for the auto-join
+resource "aws_iam_role" "consul-join" {
+  name               = "${var.platform}-consul-join"
+  assume_role_policy = "${file("${path.module}/policies/assume-role.json")}"
+}
+
+# Create the policy
+resource "aws_iam_policy" "consul-join" {
+  name        = "${var.platform}-consul-join"
+  description = "Allows Consul nodes to describe instances for joining."
+  policy      = "${file("${path.module}/policies/describe-instances.json")}"
+}
+
+# Attach the policy
+resource "aws_iam_policy_attachment" "consul-join" {
+  name       = "${var.platform}-consul-join"
+  roles      = ["${aws_iam_role.consul-join.name}"]
+  policy_arn = "${aws_iam_policy.consul-join.arn}"
+}
+
+# Create the instance profile
+resource "aws_iam_instance_profile" "consul-join" {
+  name  = "${var.platform}-consul-join"
+  role = "${aws_iam_role.consul-join.name}"
+}
+
+

--- a/terraform/aws/policies/assume-role.json
+++ b/terraform/aws/policies/assume-role.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}

--- a/terraform/aws/policies/describe-instances.json
+++ b/terraform/aws/policies/describe-instances.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DescribeInstances",
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -103,3 +103,37 @@ variable "vpc_id" {
   type = "string"
   description = "ID of the VPC to use - in case your account doesn't have default VPC"
 }
+
+variable "consul_client_bind" {
+  type = "string"
+  description = "address to bind on for client connections"
+  default = "127.0.0.1"
+}
+
+variable "consul_bind" {
+  type = "string"
+  description = "address to bind on"
+  default = "0.0.0.0"
+}
+
+variable "consul_version" {
+  type = "string"
+  description = "consul version to install"
+  default = "1.1.0"
+}
+
+variable "consul_join_tag_key" {
+  description = "The key of the tag to auto-jon on EC2."
+  default     = "consul_join"
+}
+
+variable "consul_join_tag_value" {
+  description = "The value of the tag to auto-join on EC2."
+  default     = "production"
+}
+
+variable "client_access_subnet" {
+  description = "Subnet that will have access to consul service via UI or RPC"
+  default     = "127.0.0.1"
+}
+

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -134,6 +134,6 @@ variable "consul_join_tag_value" {
 
 variable "client_access_subnet" {
   description = "Subnet that will have access to consul service via UI or RPC"
-  default     = "127.0.0.1"
+  default     = "127.0.0.1/32"
 }
 

--- a/terraform/shared/scripts/debian_consul.service
+++ b/terraform/shared/scripts/debian_consul.service
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/consul
 Restart=on-failure
-ExecStart=/usr/local/bin/consul agent $CONSUL_FLAGS -config-dir=/etc/systemd/system/consul.d
+ExecStart=CONSUL_UI_BETA=true /usr/local/bin/consul agent $CONSUL_FLAGS -config-dir=/etc/systemd/system/consul.d
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]

--- a/terraform/shared/scripts/install.sh
+++ b/terraform/shared/scripts/install.sh
@@ -3,31 +3,34 @@ set -e
 
 echo "Installing dependencies..."
 if [ -x "$(command -v apt-get)" ]; then
-  sudo su -s /bin/bash -c 'sleep 30 && apt-get update && apt-get install unzip' root
+  sudo su -s /bin/bash -c 'sleep 30 && apt-get update && apt-get -y install bsdtar' root
 else
   sudo yum update -y
-  sudo yum install -y unzip wget
+  sudo yum install -y bsdtar
 fi
 
+CONSUL_SERVER_COUNT=$1
+CONSUL_VERSION=$2
+CONSUL_BIND=$3
+CONSUL_CLIENT_BIND=$4
+CONSUL_TAG_JOIN=$5
+CONSUL_TAG_VALUE=$6
 
-echo "Fetching Consul..."
-CONSUL=1.0.0
+echo "Fetching and installing Consul..."
 cd /tmp
-wget https://releases.hashicorp.com/consul/${CONSUL}/consul_${CONSUL}_linux_amd64.zip -O consul.zip --quiet
+curl -s https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip | bsdtar -xvf-
 
-echo "Installing Consul..."
-unzip consul.zip >/dev/null
 chmod +x consul
 sudo mv consul /usr/local/bin/consul
 sudo mkdir -p /opt/consul/data
 
 # Read from the file we created
-SERVER_COUNT=$(cat /tmp/consul-server-count | tr -d '\n')
-CONSUL_JOIN=$(cat /tmp/consul-server-addr | tr -d '\n')
+#SERVER_COUNT=$(cat /tmp/consul-server-count | tr -d '\n')
+#CONSUL_JOIN=$(cat /tmp/consul-server-addr | tr -d '\n')
 
 # Write the flags to a temporary file
 cat >/tmp/consul_flags << EOF
-CONSUL_FLAGS="-server -bootstrap-expect=${SERVER_COUNT} -join=${CONSUL_JOIN} -data-dir=/opt/consul/data"
+CONSUL_FLAGS="-server -ui -client ${CONSUL_CLIENT_BIND} -bind ${CONSUL_BIND} -bootstrap-expect=${CONSUL_SERVER_COUNT} -retry-join=\"provider=aws tag_key=${CONSUL_TAG_JOIN} tag_value=${CONSUL_TAG_VALUE}\" -data-dir=/opt/consul/data"
 EOF
 
 if [ -f /tmp/upstart.conf ];


### PR DESCRIPTION
Support for auto-discovery of other consul instances - borrowed from https://github.com/hashicorp/consul-ec2-auto-join-example
    Auto-detection has been updated to use go-discover (https://github.com/hashicorp/go-discover). The instances provisioned with terraform will automatically create and attach relevant policy allowing them to query each other's metadata.

    Files with other members' IP addresses are no longer necessary, in favor of an env var specifying all the information.

    Doesn't install wget nor unzip, in favor of bsdtar, and the download+unpack happens in one step using curl | bsdtar.

    Supports additional variables:
      var.consul_version - defaults to 1.0.0
      var.consul_bind - address on which to bind for server communication, defaults to 0.0.0.0 (it is possible to bind on 127.0.0.1 but the cluster will not form)
      var.consul_client_bind - address on which to bind for client communication (including UI), defaults to 127.0.0.1

    Thanks to auto-discovery, it is possible to grow the cluster, and newly added nodes will simply join the existing ones having the same tag (in this example it's "production").

WARNING, this was only tested under AWS, there's a good chance that it breaks gcloud, openstack, digitalocean examples. (I plan to get gcloud to work and also add azure example).