### PR TITLE
demo: Added udp port forwarding for DNS

### DIFF
--- a/demo/docker-compose-cluster/docker-compose.yml
+++ b/demo/docker-compose-cluster/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "8400:8400"
       - "8500:8500"
       - "8600:8600"
+      - "8600:8600/udp"
     command: "agent -server -bootstrap-expect 3 -ui -client 0.0.0.0"
 
 networks:


### PR DESCRIPTION
Current docker-compose.yml doesn't enable us to use DNS service from the host machine.
This is because udp port isn't mapped. So I fixed this problem.
