### PR TITLE
Add systemd-resolved DNS forwarding guide

### DIFF
--- a/website/source/docs/guides/forwarding.html.md
+++ b/website/source/docs/guides/forwarding.html.md
@@ -179,6 +179,9 @@ mapping.
 [root@localhost ~]# iptables -t nat -A OUTPUT -d localhost -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 8600
 ```
 
+Note: With this setup, PTR record queries will still be sent out
+to the other configured resolvers in addition to Consul. 
+
 ### iptables Setup
 
 On Linux systems that support it, incoming requests and requests to

--- a/website/source/docs/guides/forwarding.html.md
+++ b/website/source/docs/guides/forwarding.html.md
@@ -158,7 +158,7 @@ include: "/etc/unbound/unbound.conf.d/*.conf"
 
 ### systemd-resolved Setup
 
-systemd-resolved is typically configured with `/etc/systemd/resolved.conf`. 
+`systemd-resolved` is typically configured with `/etc/systemd/resolved.conf`. 
 To configure systemd-resolved to send queries for the consul domain to
 Consul, configure resolved.conf to contain the following:
 


### PR DESCRIPTION
Fixes #4155

Added a section to the docs on how to forward DNS queries for the consul domain to Consul using systemd-resolved configuration.