### PR TITLE
Update yamux vendoring

### DIFF
--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -309,8 +309,10 @@ func (s *Session) keepalive() {
 		case <-time.After(s.config.KeepAliveInterval):
 			_, err := s.Ping()
 			if err != nil {
-				s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
-				s.exitErr(ErrKeepAliveTimeout)
+				if err != ErrSessionShutdown {
+					s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
+					s.exitErr(ErrKeepAliveTimeout)
+				}
 				return
 			}
 		case <-s.shutdownCh:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -77,7 +77,7 @@
 		{"path":"github.com/hashicorp/raft-boltdb","checksumSHA1":"QAxukkv54/iIvLfsUP6IK4R0m/A=","revision":"d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee","revisionTime":"2015-02-01T20:08:39Z"},
 		{"path":"github.com/hashicorp/serf/coordinate","checksumSHA1":"0PeWsO2aI+2PgVYlYlDPKfzCLEQ=","revision":"4b67f2c2b2bb5b748d934a6d48221062e43d2274","revisionTime":"2018-05-04T20:06:40Z"},
 		{"path":"github.com/hashicorp/serf/serf","checksumSHA1":"QrT+nzyXsD/MmhTjjhcPdnALZ1I=","revision":"4b67f2c2b2bb5b748d934a6d48221062e43d2274","revisionTime":"2018-05-04T20:06:40Z"},
-		{"path":"github.com/hashicorp/yamux","checksumSHA1":"NnWv17i1tpvBNJtpdRRWpE6j4LY=","revision":"2658be15c5f05e76244154714161f17e3e77de2e","revisionTime":"2018-03-14T20:07:45Z"},
+		{"path":"github.com/hashicorp/yamux","checksumSHA1":"jJouEcBeEAO0ejDRJoT67jL8NjQ=","revision":"3520598351bb3500a49ae9563f5539666ae0a27c","revisionTime":"2018-06-04T19:48:46Z"},
 		{"path":"github.com/joyent/triton-go","checksumSHA1":"LuvUVcxSYc0KkzpqNJArgiPMtNU=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
 		{"path":"github.com/joyent/triton-go/authentication","checksumSHA1":"yNrArK8kjkVkU0bunKlemd6dFkE=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
 		{"path":"github.com/joyent/triton-go/client","checksumSHA1":"nppv6i9E2yqdbQ6qJkahCwELSeI=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
@@ -85,7 +85,7 @@
 		{"path":"github.com/joyent/triton-go/errors","checksumSHA1":"d/Py6j/uMgOAFNFGpsQrNnSsO+k=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
 		{"path":"github.com/mattn/go-isatty","checksumSHA1":"xZuhljnmBysJPta/lMyYmJdujCg=","revision":"66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8","revisionTime":"2016-08-06T12:27:52Z"},
 		{"path":"github.com/matttproud/golang_protobuf_extensions/pbutil","checksumSHA1":"bKMZjd2wPw13VwoE7mBeSv5djFA=","revision":"c12348ce28de40eed0136aa2b644d0ee0650e56c","revisionTime":"2016-04-24T11:30:07Z"},
-                {"path":"github.com/miekg/dns","checksumSHA1":"ybBd9oDdeJEZj9YmIKGqaBVqZok=","revision":"e57bf427e68187a27e22adceac868350d7a7079b","revisionTime":"2018-05-16T07:59:02Z","version":"v1.0.7","versionExact":"v1.0.7"},
+		{"path":"github.com/miekg/dns","checksumSHA1":"ybBd9oDdeJEZj9YmIKGqaBVqZok=","revision":"e57bf427e68187a27e22adceac868350d7a7079b","revisionTime":"2018-05-16T07:59:02Z","version":"v1.0.7","versionExact":"v1.0.7"},
 		{"path":"github.com/mitchellh/cli","checksumSHA1":"GzfpPGtV2UJH9hFsKwzGjKrhp/A=","revision":"dff723fff508858a44c1f4bd0911f00d73b0202f","revisionTime":"2017-09-05T22:10:09Z"},
 		{"path":"github.com/mitchellh/copystructure","checksumSHA1":"86nE93o1VIND0Doe8PuhCXnhUx0=","revision":"cdac8253d00f2ecf0a0b19fbff173a9a72de4f82","revisionTime":"2016-08-04T03:23:30Z"},
 		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"V/quM7+em2ByJbWBLOsEwnY3j/Q=","revision":"b8bc1bf767474819792c23f32d8286a45736f1c6","revisionTime":"2016-12-03T19:45:07Z"},
@@ -171,7 +171,8 @@
 		{"path":"google.golang.org/grpc/stats","checksumSHA1":"G9lgXNi7qClo5sM2s6TbTHLFR3g=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
 		{"path":"google.golang.org/grpc/status","checksumSHA1":"tUo+M0Cb0W9ZEIt5BH30wJz/Kjc=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
 		{"path":"google.golang.org/grpc/tap","checksumSHA1":"qvArRhlrww5WvRmbyMF2mUfbJew=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
-		{"path":"google.golang.org/grpc/transport","checksumSHA1":"iV2B3kx0Ifym+zumJt+9jLgwqK8=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"}
+		{"path":"google.golang.org/grpc/transport","checksumSHA1":"iV2B3kx0Ifym+zumJt+9jLgwqK8=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
+		{"path":"https://github.com/hashicorp/yamux","revision":""}
 	],
 	"rootPath": "github.com/hashicorp/consul"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,8 +171,7 @@
 		{"path":"google.golang.org/grpc/stats","checksumSHA1":"G9lgXNi7qClo5sM2s6TbTHLFR3g=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
 		{"path":"google.golang.org/grpc/status","checksumSHA1":"tUo+M0Cb0W9ZEIt5BH30wJz/Kjc=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
 		{"path":"google.golang.org/grpc/tap","checksumSHA1":"qvArRhlrww5WvRmbyMF2mUfbJew=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
-		{"path":"google.golang.org/grpc/transport","checksumSHA1":"iV2B3kx0Ifym+zumJt+9jLgwqK8=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"},
-		{"path":"https://github.com/hashicorp/yamux","revision":""}
+		{"path":"google.golang.org/grpc/transport","checksumSHA1":"iV2B3kx0Ifym+zumJt+9jLgwqK8=","revision":"e975017b473bd9b2a3d5b23428a8549fe20b1153","revisionTime":"2018-01-04T19:16:47Z"}
 	],
 	"rootPath": "github.com/hashicorp/consul"
 }


### PR DESCRIPTION
Fixes #3040 

The log messages now are never output as they aren't really errors but rather the keepalive go routine noticed that the yamux session was closed while it was doing a yamux ping.