### PR TITLE
Fix KV del command validation error

### DIFF
--- a/command/kv/del/kv_delete.go
+++ b/command/kv/del/kv_delete.go
@@ -84,6 +84,7 @@ func (c *cmd) Run(args []string) int {
 	// Specifying a ModifyIndex for a non-CAS operation is not possible.
 	if c.modifyIndex != 0 && !c.cas {
 		c.UI.Error("Cannot specify -modify-index without -cas!")
+		return 1
 	}
 
 	// It is not valid to use a CAS and recurse in the same call


### PR DESCRIPTION
This has an explicit unit test already https://github.com/hashicorp/consul/blob/495c3914965bb21bc40091c892f97fc4f938f62d/command/kv/del/kv_delete_test.go#L37-L40
which somehow passes at least some of the time. I suspect it passes because under some conditions the actual KV delete fails and returns non-zero as well as printing the warning which is what is being checked for in the test.

For some reason despite "working" for quite some time like this, I now have a branch in which this test fails consistently. It may be a timing/env issue where another process running an agent causes the delete to be successful so the command returns a 0 by chance. Either way this is clearly wrong and fixing it stops the test being flaky in my branch.