### PR TITLE
Support reloading TLS configuration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -722,7 +722,6 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 }
 
 // reloadTLSConfig performs TLS config reloads. Must be called from HandleReload.
-// This currently only handles changes to the key pair (CertFile and KeyFile).
 func (a *Agent) reloadTLSConfig(newCfg *config.RuntimeConfig) error {
 	tc, err := newCfg.TLSConfig()
 	if err == nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1966,14 +1966,14 @@ func (a *Agent) AddCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 // setupAgentTLSClientConfig returns TLS client configuration for connecting
 // to agents.
 func (a *Agent) setupAgentTLSClientConfig(skipVerify bool) (*tls.Config, error) {
-	// Start with the outgoing TLS config for connecting to agents
-	tlscfg, err := a.config.OutgoingAgentTLSConfig()
+	// Start with the outgoing TLS config
+	tlscfg, err := a.GetTLSLoader().OutgoingTLSConfig()
 	if err != nil {
 		return tlscfg, err
 	}
 
 	if tlscfg == nil {
-		// Agent TLS disabled, so no TLS config
+		// Outgoing TLS disabled, so no TLS config
 		return nil, nil
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logger"
+	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/watch"
 	"github.com/hashicorp/go-uuid"
@@ -194,6 +195,10 @@ type Agent struct {
 	// be updated at runtime, so should always be used instead of going to
 	// the configuration directly.
 	tokens *token.Store
+
+	// tlsLoader dynamically reloads TLS configuration.
+	tlsLoader     *tlsutil.Loader
+	tlsLoaderLock sync.Mutex
 }
 
 func New(c *config.RuntimeConfig) (*Agent, error) {
@@ -253,6 +258,19 @@ func LocalConfig(cfg *config.RuntimeConfig) local.Config {
 	return lc
 }
 
+// GetTLSLoader returns the TLS configuration loader for an Agent object.
+// If the loader has not been initialized, it will first do so.
+func (a *Agent) GetTLSLoader() *tlsutil.Loader {
+	a.tlsLoaderLock.Lock()
+	defer a.tlsLoaderLock.Unlock()
+
+	// If the loader has not yet been initialized, do it here
+	if a.tlsLoader == nil {
+		a.tlsLoader = &tlsutil.Loader{}
+	}
+	return a.tlsLoader
+}
+
 func (a *Agent) Start() error {
 	c := a.config
 
@@ -287,6 +305,14 @@ func (a *Agent) Start() error {
 	// create the state synchronization manager which performs
 	// regular and on-demand state synchronizations (anti-entropy).
 	a.sync = ae.NewStateSyncer(a.State, c.AEInterval, a.shutdownCh, a.logger)
+
+	tc, err := c.TLSConfig()
+	if err == nil {
+		err = a.GetTLSLoader().Reload(tc)
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to setup TLS configuration: %v", err)
+	}
 
 	// create the config for the rpc server/client
 	consulCfg, err := a.consulConfig()
@@ -458,7 +484,7 @@ func (a *Agent) listenHTTP() ([]*HTTPServer, error) {
 				l = &tcpKeepAliveListener{l.(*net.TCPListener)}
 
 				if proto == "https" {
-					tlscfg, err = a.config.IncomingHTTPSConfig()
+					tlscfg, err = a.GetTLSLoader().IncomingTLSConfig()
 					if err != nil {
 						return err
 					}
@@ -698,56 +724,11 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 // reloadTLSConfig performs TLS config reloads. Must be called from HandleReload.
 // This currently only handles changes to the key pair (CertFile and KeyFile).
 func (a *Agent) reloadTLSConfig(newCfg *config.RuntimeConfig) error {
-	haveNewPair := newCfg.CertFile != "" && newCfg.KeyFile != ""
-	haveOldPair := a.config.CertFile != "" && a.config.KeyFile != ""
-
-	if haveNewPair != haveOldPair {
-		// unimplemented: enabling or disabling TLS while running
-		if haveNewPair {
-			return fmt.Errorf("Cannot enable TLS while running")
-		} else {
-			return fmt.Errorf("Cannot disable TLS while running")
-		}
+	tc, err := newCfg.TLSConfig()
+	if err == nil {
+		err = a.GetTLSLoader().Reload(tc)
 	}
-
-	if newCfg.VerifyIncoming != a.config.VerifyIncoming {
-		return fmt.Errorf("Cannot modify verify-incoming while running")
-	}
-	if newCfg.VerifyOutgoing != a.config.VerifyOutgoing {
-		return fmt.Errorf("Cannot modify verify-outgoing while running")
-	}
-
-	// TODO(ag) : Support reloading CA cert.
-	if newCfg.CAFile != a.config.CAFile || newCfg.CAPath != a.config.CAPath {
-		return fmt.Errorf("Cannot modify CA certs while running")
-	}
-
-	// TODO(ag) : Support reloading node/server name and TLS cipher config.
-	if newCfg.NodeName != a.config.NodeName {
-		return fmt.Errorf("Cannot modify node name while running")
-	}
-	if newCfg.ServerName != a.config.ServerName {
-		return fmt.Errorf("Cannot modify server name while running")
-	}
-	minverMismatch := newCfg.TLSMinVersion != a.config.TLSMinVersion
-	// cipher compare is not 100% correct, but should be fine for catching changes
-	cipherMismatch := len(newCfg.TLSCipherSuites) != len(a.config.TLSCipherSuites)
-	preferMismatch := newCfg.TLSPreferServerCipherSuites != a.config.TLSPreferServerCipherSuites
-	if minverMismatch || cipherMismatch || preferMismatch {
-		return fmt.Errorf("Cannot modify TLS cipher suites while running")
-	}
-
-	// Phew, everything is compatible, so reload key pair
-	_, err := a.config.GetKeyLoader().LoadKeyPair(newCfg.CertFile, newCfg.KeyFile)
-	if err != nil {
-		return err
-	}
-
-	// Successfully reloaded key pair, so update local config to reflect that
-	a.config.CertFile = newCfg.CertFile
-	a.config.KeyFile = newCfg.KeyFile
-
-	return nil
+	return err
 }
 
 // consulConfig is used to return a consul configuration
@@ -926,7 +907,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.CAPath = a.config.CAPath
 	base.CertFile = a.config.CertFile
 	base.KeyFile = a.config.KeyFile
-	base.KeyLoader = a.config.GetKeyLoader()
 	base.ServerName = a.config.ServerName
 	base.Domain = a.config.DNSDomain
 	base.TLSMinVersion = a.config.TLSMinVersion
@@ -2007,14 +1987,19 @@ func (a *Agent) setupAgentTLSClientConfig(skipVerify bool) (*tls.Config, error) 
 // setupCheckTLSClientConfig returns TLS client configuration for performing
 // checks.
 func (a *Agent) setupCheckTLSClientConfig(skipVerify bool) (*tls.Config, error) {
-	// Start with the outgoing TLS config for connecting for checks
-	tlscfg, err := a.config.OutgoingCheckTLSConfig()
+	if !a.config.EnableAgentTLSForChecks {
+		// Check TLS disabled, so return empty TLS configuration
+		return nil, nil
+	}
+
+	// Start with the outgoing TLS config
+	tlscfg, err := a.GetTLSLoader().OutgoingTLSConfig()
 	if err != nil {
 		return tlscfg, err
 	}
 
 	if tlscfg == nil {
-		// Check TLS disabled, so no TLS config
+		// Outgoing TLS disabled, so no TLS config
 		return nil, nil
 	}
 
@@ -2589,6 +2574,12 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	}
 	a.unloadMetadata()
 
+	// Reload TLS configuration before service/check definitions so that changes may
+	// take effect.
+	if err := a.reloadTLSConfig(newCfg); err != nil {
+		return fmt.Errorf("Failed reloading TLS configuration: %s", err)
+	}
+
 	// Reload service/check definitions and metadata.
 	if err := a.loadServices(newCfg); err != nil {
 		return fmt.Errorf("Failed reloading services: %s", err)
@@ -2602,11 +2593,6 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 
 	if err := a.reloadWatches(newCfg); err != nil {
 		return fmt.Errorf("Failed reloading watches: %v", err)
-	}
-
-	// Reload TLS configuration.
-	if err := a.reloadTLSConfig(newCfg); err != nil {
-		return fmt.Errorf("Failed reloading TLS configuration: %s", err)
 	}
 
 	// Update filtered metrics

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1987,8 +1987,11 @@ func (a *Agent) setupAgentTLSClientConfig(skipVerify bool) (*tls.Config, error) 
 // checks.
 func (a *Agent) setupCheckTLSClientConfig(skipVerify bool) (*tls.Config, error) {
 	if !a.config.EnableAgentTLSForChecks {
-		// Check TLS disabled, so return empty TLS configuration
-		return nil, nil
+		// Re-use the API client's TLS structure, leaving key info blank
+		tlsConfig := &api.TLSConfig{
+			InsecureSkipVerify: skipVerify,
+		}
+		return api.SetupTLSConfig(tlsConfig)
 	}
 
 	// Start with the outgoing TLS config

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1279,15 +1279,21 @@ type RuntimeConfig struct {
 // TLSConfig returns the full TLS configuration for both incoming and
 // outgoing connections.
 func (c *RuntimeConfig) TLSConfig() (*tlsutil.Config, error) {
+	useClientVerify := c.VerifyOutgoing || c.VerifyServerHostname
+	useClientCA := c.CAFile != "" || c.CAPath != ""
+
 	tc := &tlsutil.Config{
 		VerifyIncoming:           c.VerifyIncoming || c.VerifyIncomingHTTPS,
 		VerifyOutgoing:           c.VerifyOutgoing,
+		VerifyServerHostname:     c.VerifyServerHostname,
+		UseTLS:                   useClientVerify || useClientCA,
 		CAFile:                   c.CAFile,
 		CAPath:                   c.CAPath,
 		CertFile:                 c.CertFile,
 		KeyFile:                  c.KeyFile,
 		NodeName:                 c.NodeName,
 		ServerName:               c.ServerName,
+		Domain:                   c.DNSDomain,
 		TLSMinVersion:            c.TLSMinVersion,
 		CipherSuites:             c.TLSCipherSuites,
 		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"reflect"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
@@ -807,11 +806,6 @@ type RuntimeConfig struct {
 	// hcl: key_file = string
 	KeyFile string
 
-	// KeyLoader dynamically reloads TLS configuration.
-	KeyLoader *tlsutil.KeyLoader
-
-	keyloaderLock sync.Mutex
-
 	// LeaveDrainTime is used to wait after a server has left the LAN Serf
 	// pool for RPCs to drain and new requests to be sent to other servers.
 	//
@@ -1292,7 +1286,6 @@ func (c *RuntimeConfig) TLSConfig() (*tlsutil.Config, error) {
 		CAPath:                   c.CAPath,
 		CertFile:                 c.CertFile,
 		KeyFile:                  c.KeyFile,
-		KeyLoader:                c.GetKeyLoader(),
 		NodeName:                 c.NodeName,
 		ServerName:               c.ServerName,
 		TLSMinVersion:            c.TLSMinVersion,
@@ -1354,19 +1347,6 @@ func (c *RuntimeConfig) OutgoingCheckTLSConfig() (*tls.Config, error) {
 	}
 
 	return tc.OutgoingTLSConfig()
-}
-
-// GetKeyLoader returns the keyloader for a RuntimeConfig object. If the
-// keyloader has not been initialized, it will first do so.
-func (c *RuntimeConfig) GetKeyLoader() *tlsutil.KeyLoader {
-	c.keyloaderLock.Lock()
-	defer c.keyloaderLock.Unlock()
-
-	// If the keyloader has not yet been initialized, do it here
-	if c.KeyLoader == nil {
-		c.KeyLoader = &tlsutil.KeyLoader{}
-	}
-	return c.KeyLoader
 }
 
 // Sanitized returns a JSON/HCL compatible representation of the runtime

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -188,9 +188,6 @@ type Config struct {
 	// Must be provided to serve TLS connections.
 	KeyFile string
 
-	// KeyLoader dynamically reloads TLS configuration.
-	KeyLoader *tlsutil.KeyLoader
-
 	// ServerName is used with the TLS certificate to ensure the name we
 	// provide matches the certificate
 	ServerName string
@@ -471,7 +468,6 @@ func (c *Config) tlsConfig() *tlsutil.Config {
 		CAPath:                   c.CAPath,
 		CertFile:                 c.CertFile,
 		KeyFile:                  c.KeyFile,
-		KeyLoader:                c.KeyLoader,
 		NodeName:                 c.NodeName,
 		ServerName:               c.ServerName,
 		Domain:                   c.Domain,

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -188,6 +188,9 @@ type Config struct {
 	// Must be provided to serve TLS connections.
 	KeyFile string
 
+	// KeyLoader dynamically reloads TLS configuration.
+	KeyLoader *tlsutil.KeyLoader
+
 	// ServerName is used with the TLS certificate to ensure the name we
 	// provide matches the certificate
 	ServerName string
@@ -468,6 +471,7 @@ func (c *Config) tlsConfig() *tlsutil.Config {
 		CAPath:                   c.CAPath,
 		CertFile:                 c.CertFile,
 		KeyFile:                  c.KeyFile,
+		KeyLoader:                c.KeyLoader,
 		NodeName:                 c.NodeName,
 		ServerName:               c.ServerName,
 		Domain:                   c.Domain,

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-rootcerts"
+	"golang.org/x/net/http2"
 )
 
 // DCWrapper is a function that is used to wrap a non-TLS connection
@@ -293,6 +294,7 @@ func (c *Config) IncomingTLSConfig() (*tls.Config, error) {
 		ServerName: c.ServerName,
 		ClientCAs:  x509.NewCertPool(),
 		ClientAuth: tls.NoClientCert,
+		NextProtos: []string{http2.NextProtoTLS},
 	}
 	if tlsConfig.ServerName == "" {
 		tlsConfig.ServerName = c.NodeName

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-rootcerts"
@@ -68,6 +69,9 @@ type Config struct {
 	// Must be provided to serve TLS connections.
 	KeyFile string
 
+	// KeyLoader dynamically reloads TLS configuration.
+	KeyLoader *KeyLoader
+
 	// Node name is the name we use to advertise. Defaults to hostname.
 	NodeName string
 
@@ -87,6 +91,59 @@ type Config struct {
 	// PreferServerCipherSuites specifies whether to prefer the server's ciphersuite
 	// over the client ciphersuites.
 	PreferServerCipherSuites bool
+}
+
+type KeyLoader struct {
+	cacheLock   sync.Mutex
+	certificate *tls.Certificate
+}
+
+func (k *KeyLoader) LoadKeyPair(certFile, keyFile string) (*tls.Certificate, error) {
+	k.cacheLock.Lock()
+	defer k.cacheLock.Unlock()
+
+	// Allow downgrading
+	if certFile == "" && keyFile == "" {
+		k.certificate = nil
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load cert/key pair: %v", err)
+	}
+
+	k.certificate = &cert
+	return k.certificate, nil
+}
+
+// GetOutgoingCertificate fetches the currently-loaded certificate when
+// accepting a TLS connection. This currently does not consider information in
+// the ClientHello and only returns the certificate that was last loaded.
+func (k *KeyLoader) GetOutgoingCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	k.cacheLock.Lock()
+	defer k.cacheLock.Unlock()
+	return k.certificate, nil
+}
+
+// GetClientCertificate fetches the currently-loaded certificate when the Server
+// requests a certificate from the caller. This currently does not consider
+// information in the ClientHello and only returns the certificate that was last
+// loaded.
+func (k *KeyLoader) GetClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	k.cacheLock.Lock()
+	defer k.cacheLock.Unlock()
+	return k.certificate, nil
+}
+
+func (k *KeyLoader) Copy() *KeyLoader {
+	if k == nil {
+		return nil
+	}
+
+	new := KeyLoader{}
+	new.certificate = k.certificate
+	return &new
 }
 
 // AppendCA opens and parses the CA file and adds the certificates to
@@ -109,21 +166,27 @@ func (c *Config) AppendCA(pool *x509.CertPool) error {
 	return nil
 }
 
-// KeyPair is used to open and parse a certificate and key file
-func (c *Config) KeyPair() (*tls.Certificate, error) {
+// LoadKeyPair is used to open and parse a certificate and key file
+func (c *Config) LoadKeyPair() (*tls.Certificate, error) {
 	if c.CertFile == "" || c.KeyFile == "" {
 		return nil, nil
 	}
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+
+	if c.KeyLoader == nil {
+		return nil, fmt.Errorf("No Keyloader object to perform LoadKeyPair")
+	}
+
+	cert, err := c.KeyLoader.LoadKeyPair(c.CertFile, c.KeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load cert/key pair: %v", err)
 	}
-	return &cert, err
+	return cert, err
 }
 
 // OutgoingTLSConfig generates a TLS configuration for outgoing
 // requests. It will return a nil config if this configuration should
-// not use TLS for outgoing connections.
+// not use TLS for outgoing connections. Provides a callback to
+// fetch certificates, allowing for reloading on the fly.
 func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
 	// If VerifyServerHostname is true, that implies VerifyOutgoing
 	if c.VerifyServerHostname {
@@ -168,11 +231,12 @@ func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
 	}
 
 	// Add cert/key
-	cert, err := c.KeyPair()
+	cert, err := c.LoadKeyPair()
 	if err != nil {
 		return nil, err
 	} else if cert != nil {
-		tlsConfig.Certificates = []tls.Certificate{*cert}
+		tlsConfig.GetCertificate = c.KeyLoader.GetOutgoingCertificate
+		tlsConfig.GetClientCertificate = c.KeyLoader.GetClientCertificate
 	}
 
 	// Check if a minimum TLS version was set
@@ -321,11 +385,11 @@ func (c *Config) IncomingTLSConfig() (*tls.Config, error) {
 	}
 
 	// Add cert/key
-	cert, err := c.KeyPair()
+	cert, err := c.LoadKeyPair()
 	if err != nil {
 		return nil, err
 	} else if cert != nil {
-		tlsConfig.Certificates = []tls.Certificate{*cert}
+		tlsConfig.GetCertificate = c.KeyLoader.GetOutgoingCertificate
 	}
 
 	// Check if we require verification

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -55,7 +55,7 @@ func TestConfig_CAPath_Valid(t *testing.T) {
 
 func TestConfig_KeyPair_None(t *testing.T) {
 	conf := &Config{}
-	cert, err := conf.KeyPair()
+	cert, err := conf.LoadKeyPair()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestConfig_KeyPair_Valid(t *testing.T) {
 		CertFile: "../test/key/ourdomain.cer",
 		KeyFile:  "../test/key/ourdomain.key",
 	}
-	cert, err := conf.KeyPair()
+	cert, err := conf.LoadKeyPair()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/tlsutil/loader.go
+++ b/tlsutil/loader.go
@@ -1,0 +1,74 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"sync"
+)
+
+type Loader struct {
+	// serverConfig is the currently loaded TLS configuration for incoming connections
+	serverConfig *tls.Config
+
+	// serverCert is the currently loaded TLS certificate for incoming connections
+	serverCert *tls.Certificate
+
+	// clientConfig is the currently loaded TLS configuration for outgoing connections
+	clientConfig *tls.Config
+
+	// clientCert is the currently loaded TLS certificate for outgoing connections
+	clientCert *tls.Certificate
+
+	loaderLock sync.RWMutex
+}
+
+
+// GetConfigForClient returns the currently-loaded server TLS configuration when
+// the Server accepts an incoming connection. This currently does not consider
+// information in the ClientHello and only returns the last loaded configuration.
+func (l *Loader) GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	l.loaderLock.RLock()
+	defer l.loaderLock.RUnlock()
+
+	// it's acceptable for this callback to return nil, so this is safe even when
+	// server configuration has not been loaded (or TLS is disabled)
+	return l.serverConfig, nil
+}
+
+// Reload triggers a configuration update using the Loader fields.
+// TODO(ag) : Allow TLS configuration errors related to cert loading.
+//            In that case, continue using the previously loaded cert.
+func (l *Loader) Reload(config *Config) error {
+	l.loaderLock.Lock()
+	defer l.loaderLock.Unlock()
+
+	var err error
+
+	l.serverConfig, err = config.IncomingTLSConfig()
+	if err != nil {
+		return err
+	}
+
+	l.clientConfig, err = config.OutgoingTLSConfig()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// IncomingTLSConfig generates a TLS configuration for incoming connections.
+// Provides a callback to provide per-connection configuration, allowing for
+// reloading on the fly.
+func (l *Loader) IncomingTLSConfig() (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	tlsConfig.GetConfigForClient = l.GetConfigForClient
+	return tlsConfig, nil
+}
+
+func (l *Loader) OutgoingTLSConfig() (*tls.Config, error) {
+	l.loaderLock.RLock()
+	defer l.loaderLock.RUnlock()
+
+	// this may return nil, which indicates that TLS is disabled
+	return l.clientConfig, nil
+}

--- a/tlsutil/loader.go
+++ b/tlsutil/loader.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 )
 
+// Loader supports dynamic TLS reconfiguration.
 type Loader struct {
 	// serverConfig is the currently loaded TLS configuration for incoming connections
 	serverConfig *tls.Config
@@ -20,7 +21,6 @@ type Loader struct {
 
 	loaderLock sync.RWMutex
 }
-
 
 // GetConfigForClient returns the currently-loaded server TLS configuration when
 // the Server accepts an incoming connection. This currently does not consider
@@ -65,6 +65,7 @@ func (l *Loader) IncomingTLSConfig() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// OutgoingTLSConfig generates a TLS configuration for outgoing connections.
 func (l *Loader) OutgoingTLSConfig() (*tls.Config, error) {
 	l.loaderLock.RLock()
 	defer l.loaderLock.RUnlock()


### PR DESCRIPTION
# Features

  - [x] Reload key-pair (changes to `"key_file"`, and `"cert_file"` and/or underlying files)
  - [x] Reload CA cert (changes to `"ca_file"`/`"ca_path"` and/or underlying files)
  - [x] Reconfigure verify incoming/outgoing settings (`"verify_incoming"`, and `"verify_outgoing"`)
  - [x] Enable/disable TLS for agent checks (`"enable_agent_tls_for_checks"`)
  - [x] Reconfigure server name used for verify outgoing (`"node_name"`/`"server_name"`)
  - [x] Reconfigure TLS handshake settings (`"tls_min_version"`, `"tls_cipher_suites"`, and `"tls_prefer_server_cipher_suites"`)
  - [ ] Fall back on previously loaded key-pair if reloading fails (e.g. key file is deleted after startup)

## Still TODO

  - [ ] Tests

## Use-cases

Reload short-lived/automated certificates without downtime. See #2584.

# Design

The design is based around a `Loader` object that supplies TLS configuration dynamically via callbacks. This is similar to the `KeyLoader` approach used in Nomad ([see this pr](https://github.com/hashicorp/nomad/pull/3479)).

The `Agent` holds a reference to the `Loader` instance that generates TLS configurations for both incoming and outgoing connections. During agent reload, the new configuration is passed to the `Loader`, which is subsequently used for any new connections.

# Implementation

The `Loader` sets up the callback `GetConfigForClient` to provide a `tls.Config` for each incoming connection.

When calling `Reload`, the `Loader` pre-calculates the incoming and outgoing `tls.Config` and returns them as appropriate.

# Questions

  1. Are there any session-related implications for using the callback approach? There's a note about it in the [docs](https://golang.org/pkg/crypto/tls/#Config) about `SessionTicketKey` that I don't fully understand.
  2. Is it reasonable to have the `Loader` be a part of `Agent`? I wanted to avoid modifying `RuntimeConfig`, but I'm not sure if there is a better place to put it.
  3. What should happen if there are errors during TLS reconfigure? I assumed that errors should abort the rest of the reload with one exception (the last point on the feature list).