### PR TITLE
Explicitly sort by Key after folder/file

### DIFF
--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -35,7 +35,7 @@
     {{#block-slot 'content'}}
 {{#if (gt filtered.length 0)}}
         {{#tabular-collection
-            items=(sort-by 'isFolder:desc' filtered) as |item index|
+            items=(sort-by 'isFolder:desc' 'Key:asc' filtered) as |item index|
         }}
             {{#block-slot 'header'}}
                 <th>Name</th>


### PR DESCRIPTION
Partly addresses #4116 

KVs are now specifically sorted by Key after folder/file to ensure Chrome's unstable sorting doesn't reorder the order of KV's from the API.