### PR TITLE
[BUGFIX] prevent empty form submission

### DIFF
--- a/ui-v2/app/models/acl.js
+++ b/ui-v2/app/models/acl.js
@@ -7,7 +7,12 @@ export const SLUG_KEY = 'ID';
 export default Model.extend({
   [PRIMARY_KEY]: attr('string'),
   [SLUG_KEY]: attr('string'),
-  Name: attr('string'),
+  Name: attr('string', {
+    // TODO: Why didn't I have to do this for KV's?
+    // this is to ensure that Name is '' and not null when creating
+    // maybe its due to the fact that `Key` is the primaryKey in Kv's
+    defaultValue: '',
+  }),
   Type: attr('string'),
   Rules: attr('string'),
   CreateIndex: attr('number'),

--- a/ui-v2/app/routes/dc/acls/create.js
+++ b/ui-v2/app/routes/dc/acls/create.js
@@ -13,8 +13,6 @@ export default Route.extend(WithAclActions, {
   },
   model: function(params) {
     this.item = get(this, 'repo').create();
-    // TODO: Why didn't I have to do this for KV's?
-    set(this.item, 'Name', '');
     set(this.item, 'Datacenter', this.modelFor('dc').dc.Name);
     return hash({
       create: true,

--- a/ui-v2/app/routes/dc/acls/create.js
+++ b/ui-v2/app/routes/dc/acls/create.js
@@ -13,6 +13,8 @@ export default Route.extend(WithAclActions, {
   },
   model: function(params) {
     this.item = get(this, 'repo').create();
+    // TODO: Why didn't I have to do this for KV's?
+    set(this.item, 'Name', '');
     set(this.item, 'Datacenter', this.modelFor('dc').dc.Name);
     return hash({
       create: true,

--- a/ui-v2/app/templates/dc/acls/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/-form.hbs
@@ -26,12 +26,13 @@
     </fieldset>
     <div>
 {{#if create }}
-        <button type="submit" {{ action "create" item}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
+        {{! we only need to check for an empty name here as ember munges autofocus, once we have autofocus back revisit this}}
+        <button type="submit" {{ action "create" item}} disabled={{if (or item.isPristine item.isInvalid (eq item.Name '')) 'disabled'}}>Save</button>
 {{ else }}
         <button type="submit" {{ action "update" item}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
-{{# if (and item.ID (not-eq item.ID 'anonymous')) }}
+{{# if (and (not create) (not-eq item.ID 'anonymous')) }}
         {{#confirmation-dialog message='Are you sure you want to delete this ACL token?'}}
             {{#block-slot 'action' as |confirm|}}
                 <button type="button" class="type-delete" {{action confirm 'delete' item parent}}>Delete</button>

--- a/ui-v2/app/templates/dc/kv/-form.hbs
+++ b/ui-v2/app/templates/dc/kv/-form.hbs
@@ -24,8 +24,10 @@
         </div>
 {{/if}}
     </fieldset>
+    {{!TODO This has a <div> around it in acls, remove or add for consistency }}
 {{#if create }}
-    <button type="submit" {{ action "create" item parent}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
+    {{! we only need to check for an empty keyname here as ember munges autofocus, once we have autofocus back revisit this}}
+    <button type="submit" {{ action "create" item parent}} disabled={{if (or item.isPristine item.isInvalid (eq (left-trim item.Key parent.Key) '')) 'disabled'}}>Save</button>
 {{ else }}
     <button type="submit" {{ action "update" item parent}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
     <button type="reset" {{ action "cancel" item parent}}>Cancel changes</button>

--- a/ui-v2/app/validations/acl.js
+++ b/ui-v2/app/validations/acl.js
@@ -2,5 +2,4 @@ import { validatePresence, validateLength } from 'ember-changeset-validations/va
 export default {
   Name: [validatePresence(true), validateLength({ min: 1 })],
   Type: validatePresence(true),
-  ID: validateLength({ min: 1 }),
 };

--- a/ui-v2/tests/acceptance/dc/acls/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/update.feature
@@ -11,6 +11,7 @@ Feature: dc / acls / update: ACL Update
       dc: datacenter
       acl: key
     ---
+    Then the url should be /datacenter/acls/key
     Then I type with yaml
     ---
       name: [Name]

--- a/ui-v2/tests/acceptance/dc/kvs/update.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/update.feature
@@ -11,6 +11,7 @@ Feature: dc / kvs / update: KV Update
       dc: datacenter
       kv: [Name]
     ---
+    Then the url should be /datacenter/kv/[Name]/edit
     Then I type with yaml
     ---
       value: [Value]

--- a/ui-v2/tests/acceptance/steps/submit-blank-steps.js
+++ b/ui-v2/tests/acceptance/steps/submit-blank-steps.js
@@ -1,0 +1,10 @@
+import steps from './steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/submit-blank.feature
+++ b/ui-v2/tests/acceptance/submit-blank.feature
@@ -1,0 +1,24 @@
+@setupApplicationTest
+Feature: submit blank
+  In order to prevent form's being saved without values
+  As a user
+  I shouldn't be able to submit a blank form
+  Scenario: Visiting a blank form for [Model]
+    Given 1 datacenter model with the value "datacenter"
+    When I visit the [Model] page for yaml
+    ---
+      dc: datacenter
+    ---
+    Then the url should be /datacenter/[Slug]/create
+    And I submit
+    Then the url should be /datacenter/[Slug]/create
+  Where:
+    ------------------
+    | Model   | Slug |
+    | kv      | kv   |
+    | acl     | acls |
+    ------------------
+@ignore
+  Scenario: The button is disabled
+    Then ok
+

--- a/ui-v2/tests/lib/page-object/visitable.js
+++ b/ui-v2/tests/lib/page-object/visitable.js
@@ -35,7 +35,22 @@ function appendQueryParams(path, queryParams) {
 
   return path;
 }
-
+/**
+ * Custom implementation of `visitable`
+ * Currently aims to be compatible and as close as possible to the
+ * actual `ember-cli-page-object` version
+ *
+ * Additions:
+ * 1. Injectable encoder, for when you don't want your segments to be encoded
+ *    or you have specific encoding needs
+ *    Specifically in my case for KV urls where the `Key`/Slug shouldn't be encoded,
+ *    defaults to the browsers `encodeURIComponent` for compatibility and ease.
+ * 2. `path` can be an array of (string) paths OR a string for compatibility.
+ *    If a path cannot be generated due to a lack of properties on the
+ *    dynamic segment params, if will keep trying 'path' in the array
+ *    until it finds one that it can construct. This follows the same thinking
+ *    as 'if you don't specify an item, then we are looking to create one'
+ */
 export function visitable(path, encoder = encodeURIComponent) {
   return {
     isDescriptor: true,

--- a/ui-v2/tests/lib/page-object/visitable.js
+++ b/ui-v2/tests/lib/page-object/visitable.js
@@ -44,9 +44,22 @@ export function visitable(path, encoder = encodeURIComponent) {
       let executionContext = getExecutionContext(this);
 
       return executionContext.runAsync(context => {
-        let params = assign({}, dynamicSegmentsAndQueryParams);
-        let fullPath = fillInDynamicSegments(path, params, encoder);
-
+        var params;
+        let fullPath = (function _try(paths) {
+          const path = paths.shift();
+          params = assign({}, dynamicSegmentsAndQueryParams);
+          var fullPath;
+          try {
+            fullPath = fillInDynamicSegments(path, params, encoder);
+          } catch (e) {
+            if (paths.length > 0) {
+              fullPath = _try(paths);
+            } else {
+              throw e;
+            }
+          }
+          return fullPath;
+        })(typeof path === 'string' ? [path] : path.slice(0));
         fullPath = appendQueryParams(fullPath, params);
 
         return context.visit(fullPath);

--- a/ui-v2/tests/pages/dc/acls/edit.js
+++ b/ui-v2/tests/pages/dc/acls/edit.js
@@ -2,6 +2,7 @@ import { create, clickable, triggerable } from 'ember-cli-page-object';
 import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
+  // custom visitable
   visit: visitable(['/:dc/acls/:acl', '/:dc/acls/create']),
   // fillIn: fillable('input, textarea, [contenteditable]'),
   name: triggerable('keypress', '[name="name"]'),

--- a/ui-v2/tests/pages/dc/acls/edit.js
+++ b/ui-v2/tests/pages/dc/acls/edit.js
@@ -1,7 +1,8 @@
-import { create, visitable, clickable, triggerable } from 'ember-cli-page-object';
+import { create, clickable, triggerable } from 'ember-cli-page-object';
+import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
-  visit: visitable('/:dc/acls/:acl'),
+  visit: visitable(['/:dc/acls/:acl', '/:dc/acls/create']),
   // fillIn: fillable('input, textarea, [contenteditable]'),
   name: triggerable('keypress', '[name="name"]'),
   submit: clickable('[type=submit]'),

--- a/ui-v2/tests/pages/dc/kv/edit.js
+++ b/ui-v2/tests/pages/dc/kv/edit.js
@@ -2,6 +2,7 @@ import { create, clickable } from 'ember-cli-page-object';
 import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
+  // custom visitable
   visit: visitable(['/:dc/kv/:kv/edit', '/:dc/kv/create'], str => str),
   // fillIn: fillable('input, textarea, [contenteditable]'),
   // name: triggerable('keypress', '[name="additional"]'),

--- a/ui-v2/tests/pages/dc/kv/edit.js
+++ b/ui-v2/tests/pages/dc/kv/edit.js
@@ -2,7 +2,7 @@ import { create, clickable } from 'ember-cli-page-object';
 import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
-  visit: visitable('/:dc/kv/:kv/edit', str => str),
+  visit: visitable(['/:dc/kv/:kv/edit', '/:dc/kv/create'], str => str),
   // fillIn: fillable('input, textarea, [contenteditable]'),
   // name: triggerable('keypress', '[name="additional"]'),
   submit: clickable('[type=submit]'),

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -65,6 +65,8 @@ export default function(assert) {
         ['I visit the $name page for yaml\n$yaml', 'I visit the $name page for json\n$json'],
         function(name, data) {
           currentPage = pages[name];
+          // TODO: Consider putting an assertion here for testing the current url
+          // do I absolutely definitely need that all the time?
           return pages[name].visit(data);
         }
       )


### PR DESCRIPTION
Prevents forms from being submitted if you haven't actually filled anything out yet by keeping the submit button in disabled state.

This is possibly a temporary measure as it looks as though this also may be solved by making autofocus work between pages (it works on page initial load, just not after ember transitions). Autofocus work is likely to come as part of a larger update.

Also adds support for dynamically choosing whether to visit a 'create' page or an 'edit' page depending on whether you don't specify a slug for your 'item' or not.