### PR TITLE
UI - Search ACLs by token aswell as name

### DIFF
--- a/ui-v2/app/controllers/dc/acls/index.js
+++ b/ui-v2/app/controllers/dc/acls/index.js
@@ -28,10 +28,14 @@ export default Controller.extend(WithFiltering, {
     });
   }),
   filter: function(item, { s = '', type = '' }) {
+    const sLower = s.toLowerCase();
     return (
-      get(item, 'Name')
+      (get(item, 'Name')
         .toLowerCase()
-        .indexOf(s.toLowerCase()) !== -1 &&
+        .indexOf(sLower) !== -1 ||
+        get(item, 'ID')
+          .toLowerCase()
+          .indexOf(sLower) !== -1) &&
       (type === '' || get(item, 'Type') === type)
     );
   },

--- a/ui-v2/app/templates/components/acl-filter.hbs
+++ b/ui-v2/app/templates/components/acl-filter.hbs
@@ -1,4 +1,4 @@
 {{!<form>}}
-    {{freetext-filter onchange=(action onchange) value=search placeholder="Search by name"}}
+    {{freetext-filter onchange=(action onchange) value=search placeholder="Search by name/token"}}
     {{radio-group name="type" value=type items=filters onchange=(action onchange)}}
 {{!</form>}}

--- a/ui-v2/tests/acceptance/components/acl-filter.feature
+++ b/ui-v2/tests/acceptance/components/acl-filter.feature
@@ -1,5 +1,8 @@
 @setupApplicationTest
-Feature: Acl Filter
+Feature: dc / components /acl filter: Acl Filter
+  In order to find the acl token I'm looking for easier
+  As a user
+  I should be able to filter by type and freetext search tokens by name and token
   Scenario: Filtering [Model]
     Given 1 datacenter model with the value "dc-1"
     And 2 [Model] models
@@ -27,6 +30,11 @@ Feature: Acl Filter
     s: Anonymous Token
     ---
     And I see 1 [Model] model with the name "Anonymous Token"
+    Then I type with yaml
+    ---
+    s: secret
+    ---
+    And I see 1 [Model] model with the name "Master Token"
 
   Where:
     -------------------------------------------------


### PR DESCRIPTION
Adds ability to search ACLs by token.

Please note tokens remain invisible in the UI listing for the moment at least. Therefore it may look like there are some false positives in the search as you can only see the name of the token, not the token itself, and the token itself may contain the search term.

Partly addresses: #4124 