### PR TITLE
Add rsync to consul-builder

### DIFF
--- a/scripts/consul-builder/Dockerfile
+++ b/scripts/consul-builder/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update -y && \
             zip \
             zlib1g-dev \
             nodejs \
-            npm && \
+            npm \
+            rsync && \
     gem install bundler && \
     npm install --global yarn && \
     npm install --global ember-cli


### PR DESCRIPTION
The V2 UI build now requires `rsync` to be installed as part of its build process.

Without this, `make ui` will fail today.