### PR TITLE
Switch over to defaulting to the new UI

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -157,9 +157,9 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 	}
 
 	if s.IsUIEnabled() {
-		new_ui, err := strconv.ParseBool(os.Getenv("CONSUL_UI_BETA"))
+		legacy_ui, err := strconv.ParseBool(os.Getenv("CONSUL_UI_LEGACY"))
 		if err != nil {
-			new_ui = false
+			legacy_ui = false
 		}
 		var uifs http.FileSystem
 
@@ -169,15 +169,15 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 		} else {
 			fs := assetFS()
 
-			if new_ui {
-				fs.Prefix += "/v2/"
-			} else {
+			if legacy_ui {
 				fs.Prefix += "/v1/"
+			} else {
+				fs.Prefix += "/v2/"
 			}
 			uifs = fs
 		}
 
-		if new_ui {
+		if !legacy_ui {
 			uifs = &redirectFS{fs: uifs}
 		}
 

--- a/website/source/intro/getting-started/ui.html.md
+++ b/website/source/intro/getting-started/ui.html.md
@@ -27,13 +27,13 @@ By default this is `http://localhost:8500/ui`.
 You can view a live demo of the Consul Web UI
 [here](http://demo.consul.io).
 
-## How to Use the New UI
+## How to Use the Legacy UI
 
-On May 11, 2018, our redesign of the web UI went into beta. You can use it with
-Consul 1.1.0 by setting the environment variable `CONSUL_UI_BETA` to `true`.
-Without this environment variable, the web UI will default to the old version. To
-use the old UI version, either set `CONSUL_UI_BETA` to false, or don't include
-that environment variable at all.
+As of Consul version 1.2.0 the original Consul UI is deprecated. You can
+still enable it by setting the environment variable `CONSUL_UI_LEGACY` to `true`.
+Without this environment variable, the web UI will default to the latest version.
+To use the latest UI version, either set `CONSUL_UI_LEGACY` to false or don't 
+include that environment variable at all.
 
 ## Next Steps
 


### PR DESCRIPTION
This makes the new UI the default and switches env vars.

CONSUL_UI_LEGACY now is available to force loading of the old ui. I also updated the docs to reflect the changes.