### PR TITLE
Move the rsync dependency to the test scripts

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -14,10 +14,10 @@
     "lint:js": "eslint -c .eslintrc.js --fix ./*.js ./.*.js app config lib server tests",
     "format:js": "prettier --write \"{app,config,lib,server,tests}/**/*.js\" ./*.js ./.*.js",
     "start": "ember serve",
-    "test": "ember test",
-    "test:view": "ember test --server",
-    "precommit": "lint-staged",
-    "postinstall": "rsync -aq ./node_modules/@hashicorp/consul-api-double/ ./public/consul-api-double/"
+    "test:sync": "rsync -aq ./node_modules/@hashicorp/consul-api-double/ ./public/consul-api-double/",
+    "test": "yarn run test:sync;ember test",
+    "test:view": "yarn run test:sync;ember test --server",
+    "precommit": "lint-staged"
   },
   "lint-staged": {
     "{app,config,lib,server,tests}/**/*.js": [


### PR DESCRIPTION
1. You only need the fixtures for testing, don't force rsync on people
for just building
2. Eventually this will go and be replaced by something broccoli-y