### PR TITLE
UI - Use `.match` for searching

### DIFF
--- a/ui-v2/app/controllers/dc/acls/index.js
+++ b/ui-v2/app/controllers/dc/acls/index.js
@@ -32,10 +32,10 @@ export default Controller.extend(WithFiltering, {
     return (
       (get(item, 'Name')
         .toLowerCase()
-        .indexOf(sLower) !== -1 ||
+        .match(sLower) ||
         get(item, 'ID')
           .toLowerCase()
-          .indexOf(sLower) !== -1) &&
+          .match(sLower)) &&
       (type === '' || get(item, 'Type') === type)
     );
   },

--- a/ui-v2/app/controllers/dc/kv/index.js
+++ b/ui-v2/app/controllers/dc/kv/index.js
@@ -13,6 +13,6 @@ export default Controller.extend(WithFiltering, {
     const key = rightTrim(get(item, 'Key'), '/')
       .split('/')
       .pop();
-    return key.toLowerCase().indexOf(s.toLowerCase()) !== -1;
+    return key.toLowerCase().match(s.toLowerCase());
   },
 });

--- a/ui-v2/app/controllers/dc/nodes/index.js
+++ b/ui-v2/app/controllers/dc/nodes/index.js
@@ -21,7 +21,7 @@ export default Controller.extend(WithHealthFiltering, {
     return (
       get(item, 'Node')
         .toLowerCase()
-        .indexOf(s.toLowerCase()) !== -1 && item.hasStatus(status)
+        .match(s.toLowerCase()) && item.hasStatus(status)
     );
   },
 });

--- a/ui-v2/app/controllers/dc/nodes/show.js
+++ b/ui-v2/app/controllers/dc/nodes/show.js
@@ -22,11 +22,11 @@ export default Controller.extend(WithFiltering, {
     return (
       get(item, 'Service')
         .toLowerCase()
-        .indexOf(term) !== -1 ||
+        .match(term) ||
       get(item, 'Port')
         .toString()
         .toLowerCase()
-        .indexOf(term) !== -1
+        .match(term)
     );
   },
   actions: {

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -29,7 +29,7 @@ export default Controller.extend(WithHealthFiltering, {
     return (
       get(item, 'Name')
         .toLowerCase()
-        .indexOf(s.toLowerCase()) !== -1 && item.hasStatus(status)
+        .match(s.toLowerCase()) && item.hasStatus(status)
     );
   },
   totalWidth: computed('{maxPassing,maxWarning,maxCritical}', function() {

--- a/ui-v2/tests/acceptance/components/acl-filter.feature
+++ b/ui-v2/tests/acceptance/components/acl-filter.feature
@@ -30,11 +30,19 @@ Feature: dc / components /acl filter: Acl Filter
     s: Anonymous Token
     ---
     And I see 1 [Model] model with the name "Anonymous Token"
+    Then the url should be [Url]?filter=Anonymous%20Token
+    Then I type with yaml
+    ---
+    s: Master|Anonymous
+    ---
+    And I see 2 [Model] models
+    Then the url should be [Url]?filter=Master%7CAnonymous
     Then I type with yaml
     ---
     s: secret
     ---
     And I see 1 [Model] model with the name "Master Token"
+    Then the url should be [Url]?filter=secret
 
   Where:
     -------------------------------------------------

--- a/ui-v2/tests/acceptance/components/catalog-filter.feature
+++ b/ui-v2/tests/acceptance/components/catalog-filter.feature
@@ -52,6 +52,13 @@ Feature: components / catalog-filter
     s: [Model]-0
     ---
     And I see 1 [Model] model with the name "[Model]-0"
+    Then the url should be [Url]?filter=[Model]-0
+    Then I type with yaml
+    ---
+    s: 1|2
+    ---
+    And I see 2 [Model] models
+    Then the url should be [Url]?filter=1%7C2
 
   Where:
     -------------------------------------------------
@@ -70,6 +77,7 @@ Feature: components / catalog-filter
       dc: dc1
       node: node-0
     ---
+    Then the url should be [Url]
     # And I see 3 healthcheck model with the name "Disk Util"
     # And then pause for 5000
     When I click services on the tabs
@@ -81,8 +89,15 @@ Feature: components / catalog-filter
     ---
     And I see 1 [Model] model
     And I see 1 [Model] model with the port "65535"
+    Then the url should be [Url]?filter=65535
+    Then I type with yaml
+    ---
+    s: -1|65535
+    ---
+    Then the url should be [Url]?filter=-1%7C65535
+    And I see 2 [Model] models
   Where:
     -------------------------------------------------
     | Model   | Page     | Url                       |
-    | service | node     | /dc-1/nodes/node-0        |
+    | service | node     | /dc1/nodes/node-0        |
     -------------------------------------------------

--- a/ui-v2/tests/acceptance/components/kv-filter.feature
+++ b/ui-v2/tests/acceptance/components/kv-filter.feature
@@ -17,6 +17,7 @@ Feature: components / kv-filter
     s: [Text]
     ---
     And I see 1 [Model] model with the name "[Text]"
+    Then the url should be [Url]?filter=[Text]
 
   Where:
     ----------------------------------------------------------------
@@ -24,3 +25,25 @@ Feature: components / kv-filter
     | kv      | kvs      | /dc-1/kv   | hi              | name     |
     | kv      | kvs      | /dc-1/kv   | there           | name     |
     ----------------------------------------------------------------
+  Scenario: Filtering using the freetext filter and a regexp
+    Given 1 datacenter model with the value "dc-1"
+    And 5 kv models from yaml
+    ---
+      - hi
+      - there
+      - how
+      - are
+      - you
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/kv
+    Then I type with yaml
+    ---
+    s: hi|there
+    ---
+    And I see 2 kv models with the name "[Text]"
+    Then the url should be /dc-1/kv?filter=hi%7Cthere
+


### PR DESCRIPTION
This PR switches to use `.match` for searching to slightly improve searching in the short term.

Fixes #4201 