### PR TITLE
Sets code editor height to be automatic (growable), with a reasonable min height

### DIFF
--- a/ui-v2/app/styles/components/code-editor.scss
+++ b/ui-v2/app/styles/components/code-editor.scss
@@ -19,7 +19,10 @@ $syntax-dark-gray: #535f73;
 
 $syntax-gutter-grey: #2a2f36;
 $syntax-yellow: $yellow;
-
+.CodeMirror {
+  min-height: 300px;
+  height: auto;
+}
 .CodeMirror-lint-tooltip {
   background-color: #f9f9fa;
   border: 1px solid $syntax-light-gray;


### PR DESCRIPTION
Partly addresses #4218 

Whilst this doesn't bring manual resizing of the code text editor, it brings auto resizing, so the area will grow as you add text.

There's also an issue #4138 (a fix for which has been merged down) which means that when not in 'code editor' mode, you have a native resizable textarea as opposed to an input field.