### PR TITLE
[BUGFIX]: Sessions TTL should be of type string in ui-v2

### DIFF
--- a/ui-v2/app/models/session.js
+++ b/ui-v2/app/models/session.js
@@ -13,7 +13,7 @@ export default Model.extend({
   ModifyIndex: attr('number'),
   LockDelay: attr('number'),
   Behavior: attr('string'),
-  TTL: attr('number'),
+  TTL: attr('string'),
   Checks: attr({
     defaultValue: function() {
       return [];


### PR DESCRIPTION
Sessions TTL needs to be cast as string.

https://github.com/hashicorp/consul/blob/8d0a048408f32a5fd0fe5c781f541fe5664e536f/api/session.go#L31