### PR TITLE
[BUGFIX] UI - Make sure lock session TTLs are shown

### DIFF
--- a/ui-v2/app/models/session.js
+++ b/ui-v2/app/models/session.js
@@ -13,7 +13,7 @@ export default Model.extend({
   ModifyIndex: attr('number'),
   LockDelay: attr('number'),
   Behavior: attr('string'),
-  TTL: attr('number'),
+  TTL: attr('string'),
   Checks: attr({
     defaultValue: function() {
       return [];

--- a/ui-v2/app/templates/dc/nodes/-sessions.hbs
+++ b/ui-v2/app/templates/dc/nodes/-sessions.hbs
@@ -1,5 +1,6 @@
 {{#if (gt sessions.length 0)}}
     {{#tabular-collection
+        data-test-sessions
         class="sessions"
         items=sessions as |item index|
     }}
@@ -22,7 +23,7 @@
                 <td>
                     {{item.LockDelay}}
                 </td>
-                <td>
+                <td data-test-session-ttl="{{item.TTL}}">
                     {{item.TTL}}
                 </td>
                 <td>

--- a/ui-v2/tests/acceptance/dc/nodes/sessions/list.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/sessions/list.feature
@@ -1,0 +1,28 @@
+@setupApplicationTest
+Feature: dc / nodes / sessions /list: List Lock Sessions
+  In order to get information regarding lock sessions
+  As a user
+  I should be able to see a listing of lock sessions with necessary information under the lock sessions tab for a node
+  Scenario: Given 2 session with string TTLs
+    Given 1 datacenter model with the value "dc1"
+    And 1 node model from yaml
+    ---
+    - ID: node-0
+    ---
+    And 2 session models from yaml
+    ---
+    - TTL: 30s
+    - TTL: 60m
+    ---
+    When I visit the node page for yaml
+    ---
+      dc: dc1
+      node: node-0
+    ---
+    And I click lockSessions on the tabs
+    Then I see lockSessionsIsSelected on the tabs
+    Then I see TTL on the sessions like yaml
+    ---
+    - 30s
+    - 60m
+    ---

--- a/ui-v2/tests/acceptance/steps/dc/nodes/sessions/list-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nodes/sessions/list-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/helpers/set-cookies.js
+++ b/ui-v2/tests/helpers/set-cookies.js
@@ -17,6 +17,9 @@ export default function(type, count, obj) {
       key = 'CONSUL_ACL_COUNT';
       obj['CONSUL_ENABLE_ACLS'] = 1;
       break;
+    case 'session':
+      key = 'CONSUL_SESSION_COUNT';
+      break;
   }
   if (key) {
     obj[key] = count;

--- a/ui-v2/tests/helpers/type-to-url.js
+++ b/ui-v2/tests/helpers/type-to-url.js
@@ -17,9 +17,7 @@ export default function(type) {
       url = ['/v1/acl/list'];
       break;
     case 'session':
-      url = function(url) {
-        return url.indexOf('/v1/session/node/') === 0;
-      };
+      url = ['/v1/session/node/'];
       break;
   }
   return function(actual) {

--- a/ui-v2/tests/helpers/type-to-url.js
+++ b/ui-v2/tests/helpers/type-to-url.js
@@ -16,6 +16,11 @@ export default function(type) {
     case 'acl':
       url = ['/v1/acl/list'];
       break;
+    case 'session':
+      url = function(url) {
+        return url.indexOf('/v1/session/node/') === 0;
+      };
+      break;
   }
   return function(actual) {
     if (url === null) {

--- a/ui-v2/tests/pages/dc/nodes/show.js
+++ b/ui-v2/tests/pages/dc/nodes/show.js
@@ -10,4 +10,7 @@ export default create({
   services: collection('#services [data-test-tabular-row]', {
     port: attribute('data-test-service-port', '.port'),
   }),
+  sessions: collection('#lock-sessions [data-test-tabular-row]', {
+    TTL: attribute('data-test-session-ttl', '[data-test-session-ttl]'),
+  }),
 });

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -33,6 +33,9 @@ export default function(assert) {
           case 'acls':
             model = 'acl';
             break;
+          case 'sessions':
+            model = 'session';
+            break;
         }
         cb(null, model);
       }, yadda)
@@ -218,6 +221,8 @@ export default function(assert) {
       ) {
         const _component = currentPage[component];
         const iterator = new Array(_component.length).fill(true);
+        // this will catch if we get aren't managing to select a component
+        assert.ok(iterator.length > 0);
         iterator.forEach(function(item, i, arr) {
           const actual = _component.objectAt(i)[property];
           // anything coming from the DOM is going to be text/strings


### PR DESCRIPTION
This PR supersedes #4243.

Previously Lock Session TTL's weren't being shown in the UI as we they were being cast to numbers via ember-data when they are actually strings.

This adds some failing tests to prove its broken, then includes the original fix from @shilov which makes the tests pass.

