### PR TITLE
UI - Add a beforeModel hook at dc/index to auto transition to services

### DIFF
--- a/ui-v2/app/routes/dc/index.js
+++ b/ui-v2/app/routes/dc/index.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+  beforeModel: function() {
+    this.transitionTo('dc.services');
+  },
+});

--- a/ui-v2/tests/acceptance/dc/forwarding.feature
+++ b/ui-v2/tests/acceptance/dc/forwarding.feature
@@ -1,0 +1,12 @@
+@setupApplicationTest
+Feature: dc forwarding
+  In order to arrive at a useful page when only specifying a dc in the url
+  As a user
+  I should be redirected to the services page for the dc
+  Scenario: Arriving at the datacenter index page with no other url info
+    Given 1 datacenter model with the value "datacenter"
+    When I visit the dcs page for yaml
+    ---
+    dc: datacenter
+    ---
+    Then the url should be /datacenter/services

--- a/ui-v2/tests/acceptance/steps/dc/forwarding-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/forwarding-steps.js
@@ -1,0 +1,10 @@
+import steps from '../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages/dc.js
+++ b/ui-v2/tests/pages/dc.js
@@ -1,7 +1,7 @@
 import { create, visitable, attribute, collection, clickable } from 'ember-cli-page-object';
 
 export default create({
-  visit: visitable('/:dc/services/'),
+  visit: visitable('/:dc/'),
   dcs: collection('[data-test-datacenter-picker]'),
   showDatacenters: clickable('[data-test-datacenter-selected]'),
   selectedDc: attribute('data-test-datacenter-selected', '[data-test-datacenter-selected]'),

--- a/ui-v2/tests/unit/routes/dc/index-test.js
+++ b/ui-v2/tests/unit/routes/dc/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:dc/index', 'Unit | Route | dc/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
This PR adds a `routes/dc/index` `beforeModel` hook to redirect users to `/ui/dc/services` if they accidentally navigate to `/ui/dc/`.

Initially I added a `beforeModel` hook in the `routes/dc` route which seemed to be the method of redirecting using the least amount of steps (when using `LOG_TRANSITIONS` and `LOG_TRANSITIONS_INTERNAL`).

In doing this you would expect the app to redirect all visits to anything under `/ui/dc/` to perform an un-desired transition to the `dc.services` route (even urls like `/ui/dc/acls` for example) -  strangely when using the app manually this doesn't happen. Even more strange is that when doing this and running the acceptance tests, this *does* redirect *everything* as you would expect (and obviously is undesirable).

I therefore made a `routes/dc/index` and added a `beforeModel` hook to do the same thing, which uses more steps then adding a `beforeModel` hook directly into `routes/dc` yet less than using `afterModel` or `redirect`.

I did some additional investigation into this as I already have a similar redirect on `/ui/` to `/ui/dc/services`, and it seems as though both `afterModel` and `redirect` use the same amount of steps to perform the redirect here, despite me suspecting otherwise. Therefore I decided to keep the `afterModel` hook here. The route also has a `model` hook and therefore `afterModel` reads better than `redirect` - with `redirect` it might be unclear whether this is being called before the model (or not calling model at all). Still open to changing this with good reason.



