### PR TITLE
Update kv docs detail for accuracy

### DIFF
--- a/website/source/docs/commands/kv/get.html.markdown.erb
+++ b/website/source/docs/commands/kv/get.html.markdown.erb
@@ -11,8 +11,7 @@ Command: `consul kv get`
 The `kv get` command is used to retrieve the value from Consul's KV
 store at the given key name. If no key exists with that name, an error is
 returned. If a key exists with that name but has no data, nothing is returned.
-If the name or prefix is omitted, it defaults to "" which is the root of the
-KV store.
+A key name or prefix is required.
 
 ## Usage
 


### PR DESCRIPTION
Without providing a key name, `consul kv get` does not seem to actually default to the root folder as the docs suggest. This change removes that statement from the docs. 

<img width="454" alt="screen shot 2018-06-21 at 12 50 26 pm" src="https://user-images.githubusercontent.com/6323933/41737832-05666a88-7556-11e8-8995-86f1a938e550.png">
