### PR TITLE
Add a npm configuration

### DIFF
--- a/build-support/docker/Build-UI.dockerfile
+++ b/build-support/docker/Build-UI.dockerfile
@@ -7,6 +7,7 @@ ARG YARN_VERSION=1.7.0
 
 RUN apk update && \
     apk add nodejs=${NODEJS_VERSION} nodejs-npm=${NODEJS_VERSION} make=${MAKE_VERSION} rsync && \
+    npm config set unsafe-perm true && \
     npm install --global yarn@${YARN_VERSION} && \
     mkdir /consul-src
 


### PR DESCRIPTION
This is only necessary when dockerd is running on ubuntu and I dont know why it matters.