### PR TITLE
/agent/service/register payload fix

### DIFF
--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -161,8 +161,7 @@ The table below shows this endpoint's support for
     "DeregisterCriticalServiceAfter": "90m",
     "Args": ["/usr/local/bin/check_redis.py"],
     "HTTP": "http://localhost:5000/health",
-    "Interval": "10s",
-    "TTL": "15s"
+    "Interval": "10s"
   }
 }
 ```


### PR DESCRIPTION
If you have:

"Interval": "10s",
"TTL": "15s"

you get an error:
"Invalid check: Interval and TTL cannot both be specified"