### PR TITLE
Adds version messages both before and after the ui-v2 build

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -61,7 +61,7 @@ function build_ui {
    # make sure we run within the ui dir
    pushd ${ui_dir} > /dev/null
    
-   status "Creating the UI Build Container with image: ${image_name}"
+   status "Creating the UI Build Container with image: ${image_name} and embedding as version ${version}"
    local container_id=$(docker create -it -e "CONSUL_GIT_SHA=${commit_hash}" -e "CONSUL_VERSION=${version}" ${image_name})
    local ret=$?
    if test $ret -eq 0
@@ -80,6 +80,7 @@ function build_ui {
    if test ${ret} -eq 0
    then
       rm -rf ${1}/pkg/web_ui/v2
+      mkdir -p ${1}/pkg/web_ui
       cp -r ${1}/ui-v2/dist ${1}/pkg/web_ui/v2
    fi
    popd > /dev/null

--- a/build-support/scripts/build-docker.sh
+++ b/build-support/scripts/build-docker.sh
@@ -128,6 +128,7 @@ function main {
          fi
          status_stage "==> Building UI"
          build_ui "${sdir}" "${image}" || return 1
+         status_stage "==> UI V2 Built with embedded version: $(cat ${sdir}/pkg/web_ui/v2/index.html | sed -n -e 's/.*CONSUL_VERSION%22%3A%22//p' | sed -n -e 's/%22%2C%22.*//p')"
          ;;
       ui-legacy )
          if is_set "${refresh}"


### PR DESCRIPTION
1. Prints the $version that you are passing through to the docker
container
2. Prints the CONSUL_VERSION that is used in the UI v2 footer
3. Additionally added a `mkdir -p` so so `make ui-docker` runs with a
clean exit if run in isolation