### PR TITLE
Post-release build updates

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -79,7 +79,7 @@ PUB_GIT_ARG=
 endif
 
 ifeq ($(PUB_WEBSITE),1)
-PUB_WEBSITE_ARG=-g
+PUB_WEBSITE_ARG=-w
 else
 PUB_WEBSITE_ARG=
 endif

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -84,6 +84,9 @@ else
 PUB_WEBSITE_ARG=
 endif
 
+NOGOX?=1
+
+export NOGOX
 export GO_BUILD_TAG
 export UI_BUILD_TAG
 export UI_LEGACY_BUILD_TAG
@@ -93,6 +96,7 @@ export GIT_DIRTY
 export GIT_DESCRIBE
 export GOTAGS
 export GOLDFLAGS
+
 
 DEV_PUSH?=0
 ifeq ($(DEV_PUSH),1)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -94,6 +94,13 @@ export GIT_DESCRIBE
 export GOTAGS
 export GOLDFLAGS
 
+DEV_PUSH?=0
+ifeq ($(DEV_PUSH),1)
+DEV_PUSH_ARG=
+else
+DEV_PUSH_ARG=--no-push
+endif
+
 # all builds binaries for all targets
 all: bin
 
@@ -129,7 +136,7 @@ publish:
 	@$(SHELL) $(CURDIR)/build-support/scripts/publish.sh $(PUB_GIT_ARG) $(PUB_WEBSITE_ARG)
 
 dev-tree:
-	@$(SHELL) $(CURDIR)/build-support/scripts/dev.sh
+	@$(SHELL) $(CURDIR)/build-support/scripts/dev.sh $(DEV_PUSH_ARG)
 
 cov:
 	gocov test $(GOFILES) | gocov-html > /tmp/coverage.html

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -131,7 +131,10 @@ linux:
 # dist builds binaries for all platforms and packages them for distribution
 dist:
 	@$(SHELL) $(CURDIR)/build-support/scripts/release.sh -t '$(DIST_TAG)' -b '$(DIST_BUILD)' -S '$(DIST_SIGN)' $(DIST_VERSION_ARG) $(DIST_DATE_ARG) $(DIST_REL_ARG)
-	
+
+verify:
+	@$(SHELL) $(CURDIR)/build-support/scripts/verify.sh	
+
 publish:
 	@$(SHELL) $(CURDIR)/build-support/scripts/publish.sh $(PUB_GIT_ARG) $(PUB_WEBSITE_ARG)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -108,7 +108,8 @@ endif
 # all builds binaries for all targets
 all: bin
 
-bin: tools dev-build
+bin: tools
+	@$(SHELL) $(CURDIR)/build-support/scripts/build-local.sh
 
 # dev creates binaries for testing locally - these are put into ./bin and $GOPATH
 dev: changelogfmt vendorfmt dev-build

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Consul provides several key features:
 * **Multi-Datacenter** - Consul is built to be datacenter aware, and can
   support any number of regions without complex configuration.
 
+* **Service Segmentation** - Consul Connect enables secure service-to-service 
+communication with automatic TLS encryption and identity-based authorization.
+
 Consul runs on Linux, Mac OS X, FreeBSD, Solaris, and Windows. A commercial
 version called [Consul Enterprise](https://www.hashicorp.com/products/consul)
 is also available.

--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -919,3 +919,23 @@ function shasum_directory {
    
    return $ret
 }
+
+ function ui_version {
+   # Arguments:
+   #   $1 - path to index.html
+   #
+   # Returns:
+   #   0 - success
+   #   * -failure
+   #
+   # Notes: echoes the version to stdout upon success
+   if ! test -f "$1"
+   then
+      err "ERROR: No such file: '$1'"
+      return 1
+   fi
+   
+   local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' < "$1") || return 1
+   echo "$ui_version"
+   return 0
+ }

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -67,7 +67,7 @@ function build_ui {
    # make sure we run within the ui dir
    pushd ${ui_dir} > /dev/null
    
-   status "Creating the UI Build Container with image: ${image_name} and embedding as version ${version}"
+   status "Creating the UI Build Container with image: ${image_name} and version '${version}'"
    local container_id=$(docker create -it -e "CONSUL_GIT_SHA=${commit_hash}" -e "CONSUL_VERSION=${version}" ${image_name})
    local ret=$?
    if test $ret -eq 0
@@ -85,10 +85,18 @@ function build_ui {
    
    if test ${ret} -eq 0
    then
-      rm -rf ${1}/pkg/web_ui/v2
-      mkdir -p ${1}/pkg/web_ui
-      cp -r ${1}/ui-v2/dist ${1}/pkg/web_ui/v2
+      local ui_vers=$(ui_version "${1}/ui-v2/dist/index.html")
+      if test "${version}" != "${ui_vers}"
+      then
+         err "ERROR: UI version mismatch. Expecting: '${version}' found '${ui_vers}'"
+         ret=1
+      else
+         rm -rf ${1}/pkg/web_ui/v2
+         mkdir -p ${1}/pkg/web_ui
+         cp -r ${1}/ui-v2/dist ${1}/pkg/web_ui/v2 
+      fi
    fi
+   
    popd > /dev/null
    return $ret
 }

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -424,10 +424,17 @@ function build_consul_local {
          do
             outdir="pkg.bin.new/${extra_dir}${os}_${arch}"
             osarch="${os}/${arch}"
-            if test "${osarch}" == "darwin/arm" -o "${osarch}" == "darwin/arm64"
+            if test "${osarch}" == "darwin/arm" -o "${osarch}" == "darwin/arm64" -o "${osarch}" == "freebsd/arm64" -o "${osarch}" == "windows/arm" -o "${osarch}" == "windows/arm64"
             then
                continue
             fi
+            
+            if test "${os}" == "solaris" -a "${arch}" != "amd64"
+            then
+               continue 
+            fi
+            
+            echo "--->   ${osarch}"
             
             mkdir -p "${outdir}"
             CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/consul" "${outdir}/consul"

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -26,6 +26,7 @@ function build_ui {
    # Arguments:
    #   $1 - Path to the top level Consul source
    #   $2 - The docker image to run the build within (optional)
+   #   $3 - Version override
    #
    # Returns:
    #   0 - success
@@ -51,6 +52,11 @@ function build_ui {
    
    # parse the version
    version=$(parse_version "${sdir}")
+   
+   if test -n "$3"
+   then
+      version="$3"
+   fi
    
    local commit_hash="${GIT_COMMIT}"
    if test -z "${commit_hash}"

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -430,7 +430,7 @@ function build_consul_local {
             fi
             
             mkdir -p "${outdir}"
-            GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/consul" "${outdir}/consul"
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/consul" "${outdir}/consul"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"

--- a/build-support/functions/30-release.sh
+++ b/build-support/functions/30-release.sh
@@ -448,7 +448,8 @@ function build_release {
       fi
       
       status_stage "==> Building UI for version ${vers}"
-      build_ui "${sdir}" "${UI_BUILD_TAG}"
+      # passing the version to override the version determined via tags
+      build_ui "${sdir}" "${UI_BUILD_TAG}" "${vers}"
       if test $? -ne 0
       then
          err "ERROR: Failed to build the ui" 

--- a/build-support/functions/30-release.sh
+++ b/build-support/functions/30-release.sh
@@ -301,7 +301,6 @@ function check_release_one {
          ret=1
       fi
    done
-   popd > /dev/null
    
    for fname in "${expected_files[@]}"
    do      
@@ -309,6 +308,24 @@ function check_release_one {
       ret=1
    done
    
+   if test $ret -eq 0
+   then
+      if ! shasum -c -s "${CONSUL_PKG_NAME}_${2}_SHA256SUMS" 
+      then
+         err "ERROR: Failed SHA-256 hash verification"
+         shasum -c "${CONSUL_PKG_NAME}_${2}_SHA256SUMS"
+         ret=1
+      fi
+   fi
+   
+   if test $ret -eq 0 && is_set "${3}"
+   then
+      if ! gpg --verify "${CONSUL_PKG_NAME}_${2}_SHA256SUMS.sig" "${CONSUL_PKG_NAME}_${2}_SHA256SUMS" > /dev/null 2>&1
+      then
+         err "ERROR: Failed GPG verification of SHA256SUMS signature"
+         ret=1
+      fi
+   fi
    
    if test $ret -eq 0
    then
@@ -318,6 +335,8 @@ function check_release_one {
          echo "    $fname"
       done
    fi
+
+   popd > /dev/null
 
    return $ret
 }
@@ -455,6 +474,7 @@ function build_release {
          err "ERROR: Failed to build the ui" 
          return 1
       fi
+      status "UI Built with Version: $(ui_version "${sdir}/pkg/web_ui/v2/index.html")"
       
       status_stage "==> Building Static Assets for version ${vers}"
       build_assetfs "${sdir}" "${GO_BUILD_TAG}"

--- a/build-support/scripts/build-docker.sh
+++ b/build-support/scripts/build-docker.sh
@@ -128,7 +128,7 @@ function main {
          fi
          status_stage "==> Building UI"
          build_ui "${sdir}" "${image}" || return 1
-         status_stage "==> UI V2 Built with embedded version: $(cat ${sdir}/pkg/web_ui/v2/index.html | sed -n -e 's/.*CONSUL_VERSION%22%3A%22//p' | sed -n -e 's/%22%2C%22.*//p')"
+         status "==> UI Built with Version: $(ui_version ${sdir}/pkg/web_ui/v2/index.html)"
          ;;
       ui-legacy )
          if is_set "${refresh}"

--- a/build-support/scripts/dev.sh
+++ b/build-support/scripts/dev.sh
@@ -43,6 +43,7 @@ function main {
    declare    build_os=""
    declare    build_arch=""
    declare -i do_git=1
+   declare -i do_push=1
    
    
    while test $# -gt 0
@@ -72,6 +73,10 @@ function main {
             do_git=0
             shift
             ;;
+         --no-push )
+            do_push=0
+            shift
+            ;;
          * )
             err_usage "ERROR: Unknown argument: '$1'"
             return 1
@@ -86,11 +91,14 @@ function main {
       status_stage "==> Commiting Dev Mode Changes"
       commit_dev_mode "${sdir}" || return 1
       
-      status_stage "==> Confirming Git Changes"
-      confirm_git_push_changes "${sdir}" || return 1
-      
-      status_stage "==> Pushing to Git"
-      git_push_ref "${sdir}" || return 1
+      if is_set "${do_push}"
+      then
+         status_stage "==> Confirming Git Changes"
+         confirm_git_push_changes "${sdir}" || return 1
+         
+         status_stage "==> Pushing to Git"
+         git_push_ref "${sdir}" || return 1
+      fi
    fi
    
    return 0

--- a/build-support/scripts/verify.sh
+++ b/build-support/scripts/verify.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+SCRIPT_NAME="$(basename ${BASH_SOURCE[0]})"
+pushd $(dirname ${BASH_SOURCE[0]}) > /dev/null
+SCRIPT_DIR=$(pwd)
+pushd ../.. > /dev/null
+SOURCE_DIR=$(pwd)
+popd > /dev/null
+pushd ../functions > /dev/null
+FN_DIR=$(pwd)
+popd > /dev/null
+popd > /dev/null
+
+source "${SCRIPT_DIR}/functions.sh"
+
+function usage {
+cat <<-EOF
+Usage: ${SCRIPT_NAME}  [<options ...>]
+
+Description:
+
+   This script will verify a Consul release build. It will check for prebuilt
+   files, verify shasums and gpg signatures as well as run some commands
+   and prompt for manual verification where required.
+
+Options:                       
+   -s | --source     DIR         Path to source to build.
+                                 Defaults to "${SOURCE_DIR}"
+   
+   -h | --help                   Print this help text.
+EOF
+}
+
+function err_usage {
+   err "$1"
+   err ""
+   err "$(usage)"
+}
+
+function main {
+   declare    sdir="${SOURCE_DIR}" 
+   declare    vers="$(parse_version true false)"
+   
+   while test $# -gt 0
+   do
+      case "$1" in
+         -h | --help )
+            usage
+            return 0
+            ;;
+         -s | --source )
+            if test -z "$2"
+            then
+               err_usage "ERROR: option -s/--source requires an argument"
+               return 1
+            fi
+            
+            if ! test -d "$2"
+            then
+               err_usage "ERROR: '$2' is not a directory and not suitable for the value of -s/--source"
+               return 1
+            fi
+            
+            sdir="$2"
+            shift 2
+            ;;
+         -v | --version )
+            if test -z "$2"
+            then
+               err_usage "ERROR: option -v/--version requires an argument"
+               return 1
+            fi
+            
+            vers="$2"
+            shift 2
+            ;;
+         *)
+            err_usage "ERROR: Unknown argument: '$1'"
+            return 1
+            ;;
+      esac
+   done
+   
+   status_stage "=> Starting release verification for version: ${version}"
+   verify_release_build "${sdir}" "${vers}" || return 1
+   
+   return 0
+}
+
+main "$@"
+exit $?
+   

--- a/build-support/scripts/verify.sh
+++ b/build-support/scripts/verify.sh
@@ -38,7 +38,7 @@ function err_usage {
 
 function main {
    declare    sdir="${SOURCE_DIR}" 
-   declare    vers="$(parse_version true false)"
+   declare    vers=""
    
    while test $# -gt 0
    do
@@ -79,6 +79,11 @@ function main {
             ;;
       esac
    done
+   
+   if test -z "${vers}"
+   then
+      vers=$(parse_version "${sdir}" true false)
+   fi
    
    status_stage "=> Starting release verification for version: ${version}"
    verify_release_build "${sdir}" "${vers}" || return 1


### PR DESCRIPTION
Fixes #4276
Supercedes #4279

This fixes a few different problems.

* Puts back `make` building for multiple platforms (this worked with the first rewrite but then broke after updating to fix a travis build issue)
* Fixes issue with UI / Consul binary version inconsistencies
* Adds shasum verification to release verification
* Adds gpg signature verification to release verification
* Adds UI version verification to new ui build
* Adds agent UI version verification to verification process
* Creates make verify target to verify the release build (without publishing)
* Defaults dev-build to not use gox
* Fixes a bug in publishing that prevented auto-pub to the website