### PR TITLE
Fix layout issue with discovery_max_stale

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -752,7 +752,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   to the Consul raft log in environments where health checks have volatile output like
   timestamps, process ids, ...
 
-  * <a name="discovery_max_stale"></a><a href="#discovery_max_stale">`discovery_max_stale`</a> - Enables
+* <a name="discovery_max_stale"></a><a href="#discovery_max_stale">`discovery_max_stale`</a> - Enables
   stale requests for all service discovery HTTP endpoints. This is equivalent to the
   [`max_stale`](#max_stale) configuration for DNS requests. If this value is zero (default), all service
   discovery HTTP endpoints are forwarded to the leader. If this value is greater than zero, any Consul server


### PR DESCRIPTION
Fixes #4273 

The discovery_max_stale config entry isn't related to the discard_check_output entry and now looks like it (instead of previously being a sub-bullet item)

It was indented when it shouldn't have been.