### PR TITLE
website: correct parameter for service meta on catalog register

### DIFF
--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -54,7 +54,7 @@ The table below shows this endpoint's support for
 - `Service` `(Service: nil)` - Specifies to register a service. If `ID` is not
   provided, it will be defaulted to the value of the `Service.Service` property.
   Only one service with a given `ID` may be present per node. The service
-  `Tags`, `Address`, `ServiceMeta`, and `Port` fields are all optional.
+  `Tags`, `Address`, `Meta`, and `Port` fields are all optional.
 
 - `Check` `(Check: nil)` - Specifies to register a check. The register API
   manipulates the health check entry in the Catalog, but it does not setup the


### PR DESCRIPTION
I believe this doc change may have been missed as part of #3994. Note that the API _returns_ `ServiceMeta`, but accepts `Meta`. We were previously documenting it as accepting `ServiceMeta`. In that case, it does not reject the request but does not set the metadata.

```
$ curl -X PUT -d \
  '{
    "Datacenter": "dc1",
    "Node": "example",
    "Address": "www.example.com",
    "Service": {
      "Service": "example-service",
      "Port": 80,
      "Meta": {"foo": "bar"}
      }
  }' \
  http://localhost:8500/v1/catalog/register

$ curl localhost:8500/v1/catalog/service/example-service
[
  {
    "ID": "",
    "Node": "example",
    "Address": "www.example.com",
    "Datacenter": "dc1",
    "TaggedAddresses": null,
    "NodeMeta": null,
    "ServiceKind": "",
    "ServiceID": "example-service",
    "ServiceName": "example-service",
    "ServiceTags": [],
    "ServiceAddress": "",
    "ServiceMeta": {
      "foo": "bar"
    },
    "ServicePort": 80,
    "ServiceEnableTagOverride": false,
    "ServiceProxyDestination": "",
    "ServiceConnect": {
      "Native": false,
      "Proxy": null
    },
    "CreateIndex": 11,
    "ModifyIndex": 37
  }
]
```