### PR TITLE
Clarify beta release/feature and spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ FEATURES:
 
 * **Connect Feature Beta**: This version includes a major new feature for Consul named Connect. Connect enables secure service-to-service communication with automatic TLS encryption and identity-based authorization. For more details and links to demos and getting started guides, see the [announcement blog post](https://www.hashicorp.com/blog/consul-1-2-service-mesh). 
   * Connect must be enabled explicitly in configuration so upgrading a cluster will not affect any existing functionality until it's enabled.
-  * This is a Beta release, we don't recommend enabling this in production yet. Please see the documentation for more information.
+  * This is a Beta feature, we don't recommend enabling this in production yet. Please see the documentation for more information.
 * dns: Enable PTR record lookups for services with IPs that have no registered node [[PR-4083](https://github.com/hashicorp/consul/pull/4083)]
-* ui: Default to serving the new UI. Setting the `CONSUL_UI_LEGACY` environment variable to `1` of `true` will revert to serving the old UI
+* ui: Default to serving the new UI. Setting the `CONSUL_UI_LEGACY` environment variable to `1` or `true` will revert to serving the old UI
 
 IMPROVEMENTS:
 


### PR DESCRIPTION
Changed beta release to beta feature to clarify connect is beta feature and 1.2 is not beta release.