### PR TITLE
Catalog Register: Generate UUID for services registered without one

### DIFF
--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -37,7 +37,15 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 		if _, err := uuid.ParseUUID(string(args.ID)); err != nil {
 			return fmt.Errorf("Bad node ID: %v", err)
 		}
-	}
+	} else {
+      id, err := uuid.GenerateUUID()
+      if err != nil {
+         return fmt.Errorf("Failed to generate ID: %v", err)
+      }
+      
+      args.ID = types.NodeID(id)
+   }
+
 
 	// Fetch the ACL token, if any.
 	rule, err := c.srv.resolveToken(args.Token)


### PR DESCRIPTION
Fixes #4249

This makes the behavior line up with the docs and expected behavior