### PR TITLE
agent: 400 error on invalid UUID format, api handles errors properly

### DIFF
--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -212,6 +212,14 @@ func (s *HTTPServer) IntentionSpecificGet(id string, resp http.ResponseWriter, r
 			return nil, nil
 		}
 
+		// Not ideal, but there are a number of error scenarios that are not
+		// user error (400). We look for a specific case of invalid UUID
+		// to detect a parameter error and return a 400 response. The error
+		// is not a constant type or message, so we have to use strings.Contains
+		if strings.Contains(err.Error(), "UUID") {
+			return nil, BadRequestError{Reason: err.Error()}
+		}
+
 		return nil, err
 	}
 

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -355,6 +355,23 @@ func TestIntentionsSpecificGet_good(t *testing.T) {
 	assert.Equal(ixn, value)
 }
 
+func TestIntentionsSpecificGet_invalidId(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	a := NewTestAgent(t.Name(), "")
+	defer a.Shutdown()
+
+	// Read intention with bad ID
+	req, _ := http.NewRequest("GET", "/v1/connect/intentions/hello", nil)
+	resp := httptest.NewRecorder()
+	obj, err := a.srv.IntentionSpecific(resp, req)
+	require.Nil(obj)
+	require.Error(err)
+	require.IsType(BadRequestError{}, err)
+	require.Contains(err.Error(), "UUID")
+}
+
 func TestIntentionsSpecificUpdate_good(t *testing.T) {
 	t.Parallel()
 

--- a/api/connect_intention.go
+++ b/api/connect_intention.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"time"
 )
 
@@ -172,7 +174,10 @@ func (h *Connect) IntentionGet(id string, q *QueryOptions) (*Intention, *QueryMe
 	if resp.StatusCode == 404 {
 		return nil, qm, nil
 	} else if resp.StatusCode != 200 {
-		return nil, nil, fmt.Errorf("Unexpected response code: %d", resp.StatusCode)
+		var buf bytes.Buffer
+		io.Copy(&buf, resp.Body)
+		return nil, nil, fmt.Errorf(
+			"Unexpected response %d: %s", resp.StatusCode, buf.String())
 	}
 
 	var out Intention

--- a/api/connect_intention_test.go
+++ b/api/connect_intention_test.go
@@ -61,6 +61,22 @@ func TestAPI_ConnectIntentionCreateListGetUpdateDelete(t *testing.T) {
 	require.Nil(actual)
 }
 
+func TestAPI_ConnectIntentionGet_invalidId(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	connect := c.Connect()
+
+	// Get it
+	actual, _, err := connect.IntentionGet("hello", nil)
+	require.Nil(actual)
+	require.Error(err)
+	require.Contains(err.Error(), "UUID") // verify it contains the message
+}
+
 func TestAPI_ConnectIntentionMatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #4292 

This makes two changes:

  1. The intention HTTP endpoint returns a 400 for invalid ID values on read. This unfortunately has to be done with a gross `strings.Contains` since there is no surefire way I could find to detect this error, and there are a number of error cases which are not 400 code.

  2. API package for intentions reads the body for errors. 

Both tested.