### PR TITLE
Only send one single ACL cache refresh across network when TTL is over

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -158,7 +158,7 @@ test: other-consul dev-build vet
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
-	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 5m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
+	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 7m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
 	@echo "Exit code: $$(cat exit-code)" >> test.log
 	@# This prints all the race report between ====== lines
 	@awk '/^WARNING: DATA RACE/ {do_print=1; print "=================="} do_print==1 {print} /^={10,}/ {do_print=0}' test.log || true

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -103,8 +103,7 @@ func newACLManager(config *config.RuntimeConfig) (*aclManager, error) {
 		down = acl.AllowAll()
 	case "deny":
 		down = acl.DenyAll()
-	case "extend-cache":
-	case "async-cache":
+	case "async-cache", "extend-cache":
 		// Leave the down policy as nil to signal this.
 	default:
 		return nil, fmt.Errorf("invalid ACL down policy %q", config.ACLDownPolicy)

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -104,6 +104,7 @@ func newACLManager(config *config.RuntimeConfig) (*aclManager, error) {
 	case "deny":
 		down = acl.DenyAll()
 	case "extend-cache":
+	case "async-cache":
 		// Leave the down policy as nil to signal this.
 	default:
 		return nil, fmt.Errorf("invalid ACL down policy %q", config.ACLDownPolicy)

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -277,9 +277,9 @@ func TestACL_Down_Extend(t *testing.T) {
 	aclExtendPolicies := []string{"extend-cache", "async-cache"}
 	for _, aclDownPolicy := range aclExtendPolicies {
 		a := NewTestAgent(t.Name(), TestACLConfig()+`
-		acl_down_policy = "`+aclDownPolicy+`"
-		acl_enforce_version_8 = true
-	`)
+			acl_down_policy = "`+aclDownPolicy+`"
+			acl_enforce_version_8 = true
+		`)
 		defer a.Shutdown()
 
 		m := MockServer{

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -94,8 +94,10 @@ type RuntimeConfig struct {
 	//                    ACL's to be used to service requests. This
 	//                    is the default. If the ACL is not in the cache,
 	//                    this acts like deny.
+	//   * async-cache - Same behaviour as extend-cache, but perform ACL
+	//                   Lookups asynchronously when cache TTL is expired.
 	//
-	// hcl: acl_down_policy = ("allow"|"deny"|"extend-cache")
+	// hcl: acl_down_policy = ("allow"|"deny"|"extend-cache"|"async-cache")
 	ACLDownPolicy string
 
 	// ACLEnforceVersion8 is used to gate a set of ACL policy features that

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -277,8 +277,7 @@ ACL_DOWN:
 	case "allow":
 		c.fireResult(id, acl.AllowAll(), nil)
 		return
-	case "async-cache":
-	case "extend-cache":
+	case "async-cache", "extend-cache":
 		if cached != nil {
 			c.fireResult(id, cached.ACL, nil)
 			return

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -235,8 +235,9 @@ type Config struct {
 
 	// ACLDownPolicy controls the behavior of ACLs if the ACLDatacenter
 	// cannot be contacted. It can be either "deny" to deny all requests,
-	// or "extend-cache" which ignores the ACLCacheInterval and uses
-	// cached policies. If a policy is not in the cache, it acts like deny.
+	// "extend-cache" or "async-cache" which ignores the ACLCacheInterval and
+	// uses cached policies.
+	// If a policy is not in the cache, it acts like deny.
 	// "allow" can be used to allow all requests. This is not recommended.
 	ACLDownPolicy string
 
@@ -378,6 +379,7 @@ func (c *Config) CheckACL() error {
 	switch c.ACLDownPolicy {
 	case "allow":
 	case "deny":
+	case "async-cache":
 	case "extend-cache":
 	default:
 		return fmt.Errorf("Unsupported down ACL policy: %s", c.ACLDownPolicy)

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -379,8 +379,7 @@ func (c *Config) CheckACL() error {
 	switch c.ACLDownPolicy {
 	case "allow":
 	case "deny":
-	case "async-cache":
-	case "extend-cache":
+	case "async-cache", "extend-cache":
 	default:
 		return fmt.Errorf("Unsupported down ACL policy: %s", c.ACLDownPolicy)
 	}

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -496,11 +496,13 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   to enable ACL support.
 
 * <a name="acl_down_policy"></a><a href="#acl_down_policy">`acl_down_policy`</a> - Either
-  "allow", "deny" or "extend-cache"; "extend-cache" is the default. In the case that the
+  "allow", "deny", "extend-cache" or "async-cache"; "extend-cache" is the default. In the case that the
   policy for a token cannot be read from the [`acl_datacenter`](#acl_datacenter) or leader
   node, the down policy is applied. In "allow" mode, all actions are permitted, "deny" restricts
   all operations, and "extend-cache" allows any cached ACLs to be used, ignoring their TTL
-  values. If a non-cached ACL is used, "extend-cache" acts like "deny".
+  values. If a non-cached ACL is used, "extend-cache" acts like "deny". "async-cache" acts the same
+  way as "extend-cache" but performs updates asynchronously when ACL is present but its TTL is
+  expired.
 
 * <a name="acl_agent_master_token"></a><a href="#acl_agent_master_token">`acl_agent_master_token`</a> -
   Used to access <a href="/api/agent.html">agent endpoints</a> that require agent read

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -500,9 +500,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   policy for a token cannot be read from the [`acl_datacenter`](#acl_datacenter) or leader
   node, the down policy is applied. In "allow" mode, all actions are permitted, "deny" restricts
   all operations, and "extend-cache" allows any cached ACLs to be used, ignoring their TTL
-  values. If a non-cached ACL is used, "extend-cache" acts like "deny". "async-cache" acts the same
-  way as "extend-cache" but performs updates asynchronously when ACL is present but its TTL is
-  expired.
+  values. If a non-cached ACL is used, "extend-cache" acts like "deny".
+  The value "async-cache" acts the same way as "extend-cache" but performs updates
+  asynchronously when ACL is present but its TTL is expired, thus, if latency is bad between
+  ACL authoritative and other datacenters, latency of operations is not impacted.
 
 * <a name="acl_agent_master_token"></a><a href="#acl_agent_master_token">`acl_agent_master_token`</a> -
   Used to access <a href="/api/agent.html">agent endpoints</a> that require agent read

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -1062,9 +1062,10 @@ is set to "extend-cache", tokens will be resolved during the outage using the
 replicated set of ACLs. An [ACL replication status](/api/acl.html#acl_replication_status)
 endpoint is available to monitor the health of the replication process.
 Also note that in recent versions of Consul (greater than 1.2.0), using
-`acl_down_policy = "extend-cache"` refreshes token asynchronously when an ACL is
-already cached and is expired. It allows to avoid having issues when connectivity with
-the authoritative is not completely broken, but very slow.
+`acl_down_policy = "async-cache"` refreshes token asynchronously when an ACL is
+already cached and is expired while similar semantics than "extend-cache".
+It allows to avoid having issues when connectivity with the authoritative is not completely
+broken, but very slow.
 
 Locally-resolved ACLs will be cached using the [`acl_ttl`](/docs/agent/options.html#acl_ttl)
 setting of the non-authoritative datacenter, so these entries may persist in the

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -1061,6 +1061,10 @@ and the [`acl_down_policy`](/docs/agent/options.html#acl_down_policy)
 is set to "extend-cache", tokens will be resolved during the outage using the
 replicated set of ACLs. An [ACL replication status](/api/acl.html#acl_replication_status)
 endpoint is available to monitor the health of the replication process.
+Also note that in recent versions of Consul (greater than 1.2.0), using
+`acl_down_policy = "extend-cache"` refreshes token asynchronously when an ACL is
+already cached and is expired. It allows to avoid having issues when connectivity with
+the authoritative is not completely broken, but very slow.
 
 Locally-resolved ACLs will be cached using the [`acl_ttl`](/docs/agent/options.html#acl_ttl)
 setting of the non-authoritative datacenter, so these entries may persist in the


### PR DESCRIPTION
It will allow the following:

 * when connectivity is limited (saturated linnks between DCs), only one
   single request to refresh an ACL will be sent to ACL master DC instead
   of statcking ACL refresh queries
 * when extend-cache is used for ACL, do not wait for result, but refresh
   the ACL asynchronously, so no delay is not impacting slave DC
 * When extend-cache is not used, keep the existing blocking mechanism,
   but only send a single refresh request.

This will fix https://github.com/hashicorp/consul/issues/3524