### PR TITLE
agent/config: parse upstreams with multiple service definitions

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -85,6 +85,7 @@ func Parse(data string, format string) (c Config, err error) {
 		"services.checks",
 		"watches",
 		"service.connect.proxy.config.upstreams",
+		"services.connect.proxy.config.upstreams",
 	})
 
 	// There is a difference of representation of some fields depending on

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2160,6 +2160,65 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 		},
 
 		{
+			desc: "JSON multiple services managed proxy 'upstreams'",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{
+				`{
+						"services": [{
+							"name": "web",
+							"port": 8080,
+							"connect": {
+								"proxy": {
+									"config": {
+										"upstreams": [{
+											"local_bind_port": 1234
+										}, {
+											"local_bind_port": 2345
+										}]
+									}
+								}
+							}
+						},{
+							"name": "service-A2",
+							"port": 81,
+							"tags": [],
+							"checks": []
+						}]
+					}`,
+			},
+			skipformat: true, // skipping HCL cause we get slightly diff types (okay)
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.Services = []*structs.ServiceDefinition{
+					&structs.ServiceDefinition{
+						Name: "web",
+						Port: 8080,
+						Connect: &structs.ServiceConnect{
+							Proxy: &structs.ServiceDefinitionConnectProxy{
+								Config: map[string]interface{}{
+									"upstreams": []interface{}{
+										map[string]interface{}{
+											"local_bind_port": float64(1234),
+										},
+										map[string]interface{}{
+											"local_bind_port": float64(2345),
+										},
+									},
+								},
+							},
+						},
+					},
+					&structs.ServiceDefinition{
+						Name: "service-A2",
+						Port: 81,
+					},
+				}
+			},
+		},
+
+		{
 			desc: "enabling Connect allow_managed_root",
 			args: []string{
 				`-data-dir=` + dataDir,


### PR DESCRIPTION
Fixes #4307 

This is a simple fix to parse the upstreams for a Connect proxy when in a service definition that is part of multiple `services`. 

To fix this, I forgot to support the proper HCL translation for `services` vs `service`. We need to translate because we are parsing as `interface{}` which HCL parses as the wrong type (similar to many other fields listed here). 