### PR TITLE
command/connect/proxy: ignore check doesn't exist on -register

### DIFF
--- a/command/connect/proxy/register.go
+++ b/command/connect/proxy/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -222,7 +223,9 @@ func (r *RegisterMonitor) heartbeat() {
 	// Trigger the health check passing. We don't need to retry this
 	// since we do a couple tries within the TTL period.
 	if err := r.Client.Agent().PassTTL(r.checkID(), ""); err != nil {
-		r.Logger.Printf("[WARN] proxy: heartbeat failed: %s", err)
+		if !strings.Contains(err.Error(), "does not have associated") {
+			r.Logger.Printf("[WARN] proxy: heartbeat failed: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
This is reasonably jank and I'm open to other solutions, but its also simple.

If a check doesn't exist, then we get an error that sounds scarier than it is. This modifies the `-register` flag on the `consul connect proxy` subcommand to only output heartbeat errors if they aren't the "check doesn't exist" error. This error is common if the registration fails, but isn't a big deal in itself. We perform anti-entropy in the registration so that the check will always be recreated pretty quickly so this error is not important to us.

I also thought about only calling heartbeat() if register() is succeeding, but not sure if we want to maintain that state or not.