### PR TITLE
Fix "ensures all data" from original "ensure all data"

### DIFF
--- a/website/source/segmentation.html.erb
+++ b/website/source/segmentation.html.erb
@@ -151,7 +151,7 @@ description: |-
         <div>
           <div>
             <h3>Encrypted communication</h3>
-            <p>All traffic between services is encrypted and authenticated with mutual TLS. Using TLS provides a strong guarantee of the identity of services communicating, and ensure all data in transit is encrypted.</p>
+            <p>All traffic between services is encrypted and authenticated with mutual TLS. Using TLS provides a strong guarantee of the identity of services communicating, and ensures all data in transit is encrypted.</p>
             <p>
               <a class="learn-more" href='/docs/connect/security.html'>Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>


### PR DESCRIPTION
The original text was "Using TLS...ensure all data in transit is
encrypted." It should be "ensures all data..." This patch fixes it.