### PR TITLE
Improve styling of discovery snippet

### DIFF
--- a/website/source/discovery.html.erb
+++ b/website/source/discovery.html.erb
@@ -175,7 +175,13 @@ web-frontend.service.consul. 0 IN A <code class='keyword'>10.0.1.109</code></cod
           <div>
             <span></span>
             <div class='code'>
-              <code>$ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code>
+              <code>
+$ curl http://localhost:8500/v1/catalog/datacenters
+<code class='keyword'>[
+  "dc1",
+  "dc2"
+]</code>
+$ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code>
 [
     {
         "ID": "7081dcdf-fdc0-0432-f2e8-a357d36084e1",

--- a/website/source/discovery.html.erb
+++ b/website/source/discovery.html.erb
@@ -175,14 +175,13 @@ web-frontend.service.consul. 0 IN A <code class='keyword'>10.0.1.109</code></cod
           <div>
             <span></span>
             <div class='code'>
-              <code>$ curl http://localhost:8500/v1/catalog/datacenters
-<code class='keyword'>["dc1", "dc2"]</code>$ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code>
+              <code>$ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code>
 [
     {
         "ID": "7081dcdf-fdc0-0432-f2e8-a357d36084e1",
         "Node": "10-0-1-109",
         "Address": "10.0.1.109",
-        "Datacenter": "dc2",
+        "Datacenter": "<code class='keyword'>dc2</code>",
         "TaggedAddresses": {
             "lan": "10.0.1.109",
             "wan": "10.0.1.109"


### PR DESCRIPTION
Original `discovery` snippet had a `curl` command that mentioned
multi-datacenter support. This removes part of the command that was
incorrect. It adds styling for the `dc2` section of the JSON output that
highlights the part of the query that relates to multiple data centers.