### PR TITLE
Reset `<html class>` after every test, back to its original static value

### DIFF
--- a/ui-v2/tests/acceptance/startup.feature
+++ b/ui-v2/tests/acceptance/startup.feature
@@ -3,7 +3,6 @@ Feature: startup
   In order to give users an indication as early as possible that they are at the right place
   As a user
   I should be able to see a startup logo
-@ignore
   Scenario: When loading the index.html file into a browser
     Given 1 datacenter model with the value "dc-1"
     Then the url should be ''

--- a/ui-v2/tests/helpers/yadda-annotations.js
+++ b/ui-v2/tests/helpers/yadda-annotations.js
@@ -3,6 +3,18 @@ import { skip } from 'qunit';
 import { setupApplicationTest, setupRenderingTest, setupTest } from 'ember-qunit';
 import api from 'consul-ui/tests/helpers/api';
 
+const staticClassList = [...document.documentElement.classList];
+function reset() {
+  window.localStorage.clear();
+  api.server.reset();
+  const list = document.documentElement.classList;
+  while (list.length > 0) {
+    list.remove(list.item(0));
+  }
+  staticClassList.forEach(function(item) {
+    list.add(item);
+  });
+}
 // this logic could be anything, but in this case...
 // if @ignore, then return skip (for backwards compatibility)
 // if have annotations in config, then only run those that have a matching annotation
@@ -64,8 +76,7 @@ function setupScenario(featureAnnotations, scenarioAnnotations) {
   }
   return function(model) {
     model.afterEach(function() {
-      window.localStorage.clear();
-      api.server.reset();
+      reset();
     });
   };
   // return setupFn;


### PR DESCRIPTION
This goes back to my startup logo testing.

To make sure things are isolated I reset the class name of the `<html>` element back to its static/hardcoded value at the start of every test.

It does this by saving a list of the original value before anything has been run, and then using this list as the value to rest to at the start of every test.

Means I can unignore that test so it's included in the test runs automatically.