### PR TITLE
connect/ca: add logic for pruning old stale RootCA entries

### DIFF
--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
@@ -177,6 +178,7 @@ func (s *ConnectCA) ConfigurationSet(
 		newRoot := *r
 		if newRoot.Active {
 			newRoot.Active = false
+			newRoot.RotateOutAt = time.Now().Add(caRootExpireDuration)
 		}
 		newRoots = append(newRoots, &newRoot)
 	}

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -178,7 +178,7 @@ func (s *ConnectCA) ConfigurationSet(
 		newRoot := *r
 		if newRoot.Active {
 			newRoot.Active = false
-			newRoot.RotateOutAt = time.Now().Add(caRootExpireDuration)
+			newRoot.RotatedOutAt = time.Now()
 		}
 		newRoots = append(newRoots, &newRoot)
 	}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -28,7 +28,18 @@ const (
 	barrierWriteTimeout = 2 * time.Minute
 )
 
-var minAutopilotVersion = version.Must(version.NewVersion("0.8.0"))
+var (
+	// caRootPruneInterval is how often we check for stale CARoots to remove.
+	caRootPruneInterval = time.Hour
+
+	// caRootExpireDuration is the duration after which an inactive root is considered
+	// "expired".
+	caRootExpireDuration = 7 * 24 * time.Hour
+
+	// minAutopilotVersion is the minimum Consul version in which Autopilot features
+	// are supported.
+	minAutopilotVersion = version.Must(version.NewVersion("0.8.0"))
+)
 
 // monitorLeadership is used to monitor if we acquire or lose our role
 // as the leader in the Raft cluster. There is some work the leader is
@@ -220,6 +231,8 @@ func (s *Server) establishLeadership() error {
 		return err
 	}
 
+	s.startCARootPruning()
+
 	s.setConsistentReadReady()
 	return nil
 }
@@ -235,6 +248,8 @@ func (s *Server) revokeLeadership() error {
 	if err := s.clearAllSessionTimers(); err != nil {
 		return err
 	}
+
+	s.stopCARootPruning()
 
 	s.setCAProvider(nil, nil)
 
@@ -548,6 +563,96 @@ func (s *Server) setCAProvider(newProvider ca.Provider, root *structs.CARoot) {
 	defer s.caProviderLock.Unlock()
 	s.caProvider = newProvider
 	s.caProviderRoot = root
+}
+
+// startCARootPruning starts a goroutine that looks for stale CARoots
+// and removes them from the state store.
+func (s *Server) startCARootPruning() {
+	if !s.config.ConnectEnabled {
+		return
+	}
+
+	s.caPruningLock.Lock()
+	defer s.caPruningLock.Unlock()
+
+	if s.caPruningEnabled {
+		return
+	}
+
+	s.caPruningCh = make(chan struct{})
+
+	go func() {
+		ticker := time.NewTicker(caRootPruneInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.caPruningCh:
+				return
+			case <-ticker.C:
+				if err := s.pruneCARoots(); err != nil {
+					s.logger.Printf("[ERR] connect: error pruning CA roots: %v", err)
+				}
+			}
+		}
+	}()
+
+	s.caPruningEnabled = true
+}
+
+// pruneCARoots looks for any CARoots that have been rotated out and expired.
+func (s *Server) pruneCARoots() error {
+	idx, roots, err := s.fsm.State().CARoots(nil)
+	if err != nil {
+		return err
+	}
+
+	var newRoots structs.CARoots
+	for _, r := range roots {
+		if !r.Active && !r.RotateOutAt.IsZero() && r.RotateOutAt.Before(time.Now()) {
+			s.logger.Printf("[INFO] connect: pruning old unused root CA (ID: %s)", r.ID)
+			continue
+		}
+		newRoot := *r
+		newRoots = append(newRoots, &newRoot)
+	}
+
+	// Return early if there's nothing to remove.
+	if len(newRoots) == len(roots) {
+		return nil
+	}
+
+	// Commit the new root state.
+	var args structs.CARequest
+	args.Op = structs.CAOpSetRoots
+	args.Index = idx
+	args.Roots = newRoots
+	resp, err := s.raftApply(structs.ConnectCARequestType, args)
+	if err != nil {
+		return err
+	}
+	if respErr, ok := resp.(error); ok {
+		return respErr
+	}
+
+	return nil
+}
+
+// stopCARootPruning stops the CARoot pruning process.
+func (s *Server) stopCARootPruning() {
+	if !s.config.ConnectEnabled {
+		return
+	}
+
+	s.caPruningLock.Lock()
+	defer s.caPruningLock.Unlock()
+
+	if !s.caPruningEnabled {
+		return
+	}
+
+	close(s.caPruningCh)
+	s.caPruningEnabled = false
 }
 
 // reconcileReaped is used to reconcile nodes that have failed and been reaped

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -107,6 +107,12 @@ type Server struct {
 	caProviderRoot *structs.CARoot
 	caProviderLock sync.RWMutex
 
+	// caPruningCh is used to shut down the CA root pruning goroutine when we
+	// lose leadership.
+	caPruningCh      chan struct{}
+	caPruningLock    sync.RWMutex
+	caPruningEnabled bool
+
 	// Consul configuration
 	config *Config
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -73,10 +73,10 @@ type CARoot struct {
 	// cannot be active.
 	Active bool
 
-	// RotateOutAt is the time at which this CA can be removed from the state.
+	// RotatedOutAt is the time at which this CA was removed from the state.
 	// This will only be set on roots that have been rotated out from being the
-	// active one.
-	RotateOutAt time.Time `json:"-"`
+	// active root.
+	RotatedOutAt time.Time `json:"-"`
 
 	RaftIndex
 }

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -73,6 +73,11 @@ type CARoot struct {
 	// cannot be active.
 	Active bool
 
+	// RotateOutAt is the time at which this CA can be removed from the state.
+	// This will only be set on roots that have been rotated out from being the
+	// active one.
+	RotateOutAt time.Time `json:"-"`
+
 	RaftIndex
 }
 


### PR DESCRIPTION
This PR adds a goroutine on the leader for periodically removing expired CARoots.