### PR TITLE
Move testing doubles to use data embedded in the HTML vs HTTP/fetch

### DIFF
--- a/ui-v2/.ember-cli
+++ b/ui-v2/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  "proxy": "http://localhost:3000"
 }

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -1,28 +1,31 @@
 ROOT:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 all: build
-	
+
 deps: node_modules
-	
+
 build: deps
 	yarn run build
-	
+
 start: deps
 	yarn run start
-	
+
+start-api: deps
+	yarn run start:api
+
 test: deps
 	yarn run test
-	
+
 test-view: deps
 	yarn run test:view
-		
+
 lint: deps
 	yarn run lint:js
-	
+
 format: deps
 	yarn run format:js
-		
+
 node_modules: yarn.lock package.json
 	yarn install
-	
+
 .PHONY: all deps build start test test-view lint format

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -30,9 +30,9 @@ module.exports = function(environment) {
   ENV = Object.assign({}, ENV, {
     CONSUL_GIT_SHA: (function() {
       if (process.env.CONSUL_GIT_SHA) {
-        return process.env.CONSUL_GIT_SHA
+        return process.env.CONSUL_GIT_SHA;
       }
-      
+
       return require('child_process')
         .execSync('git rev-parse --short HEAD')
         .toString()
@@ -40,7 +40,7 @@ module.exports = function(environment) {
     })(),
     CONSUL_VERSION: (function() {
       if (process.env.CONSUL_VERSION) {
-        return process.env.CONSUL_VERSION
+        return process.env.CONSUL_VERSION;
       }
       // see /scripts/dist.sh:8
       const version_go = `${path.dirname(path.dirname(__dirname))}/version/version.go`;
@@ -53,13 +53,13 @@ module.exports = function(environment) {
         .trim()
         .split('"')[1];
     })(),
-    CONSUL_BINARY_TYPE: (function() {
+    CONSUL_BINARY_TYPE: function() {
       if (process.env.CONSUL_BINARY_TYPE) {
-        return process.env.CONSUL_BINARY_TYPE
+        return process.env.CONSUL_BINARY_TYPE;
       }
-      
-      return "oss"
-    }),
+
+      return 'oss';
+    },
     CONSUL_DOCUMENTATION_URL: 'https://www.consul.io/docs',
     CONSUL_COPYRIGHT_URL: 'https://www.hashicorp.com',
     CONSUL_COPYRIGHT_YEAR: '2018',
@@ -86,6 +86,10 @@ module.exports = function(environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+    ENV['ember-cli-api-double'] = {
+      reader: 'html',
+      endpoints: ['/node_modules/@hashicorp/consul-api-double/v1'],
+    };
   }
 
   if (environment === 'production') {

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-ui",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "private": true,
   "description": "The web ui for Consul, by HashiCorp.",
   "directories": {
@@ -14,9 +14,9 @@
     "lint:js": "eslint -c .eslintrc.js --fix ./*.js ./.*.js app config lib server tests",
     "format:js": "prettier --write \"{app,config,lib,server,tests}/**/*.js\" ./*.js ./.*.js",
     "start": "ember serve",
-    "test:sync": "rsync -aq ./node_modules/@hashicorp/consul-api-double/ ./public/consul-api-double/",
-    "test": "yarn run test:sync;ember test",
-    "test:view": "yarn run test:sync;ember test --server",
+    "start:api": "api-double --dir ./node_modules/@hashicorp/consul-api-double",
+    "test": "ember test",
+    "test:view": "ember test --server",
     "precommit": "lint-staged"
   },
   "lint-staged": {
@@ -29,10 +29,9 @@
       "git add"
     ]
   },
-  "dependencies": {},
   "devDependencies": {
-    "@hashicorp/consul-api-double": "^1.0.0",
-    "@hashicorp/ember-cli-api-double": "^1.0.2",
+    "@hashicorp/consul-api-double": "^1.2.0",
+    "@hashicorp/ember-cli-api-double": "^1.3.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^2.4.5",

--- a/ui-v2/tests/helpers/api.js
+++ b/ui-v2/tests/helpers/api.js
@@ -1,4 +1,14 @@
 import getAPI from '@hashicorp/ember-cli-api-double';
 import setCookies from 'consul-ui/tests/helpers/set-cookies';
 import typeToURL from 'consul-ui/tests/helpers/type-to-url';
-export default getAPI('/consul-api-double', setCookies, typeToURL);
+import config from 'consul-ui/config/environment';
+const apiConfig = config['ember-cli-api-double'];
+let path = '/consul-api-double';
+let reader;
+if (apiConfig) {
+  const temp = apiConfig.endpoints[0].split('/');
+  reader = apiConfig.reader;
+  temp.pop();
+  path = temp.join('/');
+}
+export default getAPI(path, setCookies, typeToURL, reader);

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -69,9 +69,9 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@hashicorp/api-double@^1.1.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/api-double/-/api-double-1.2.0.tgz#d2846f79d086ac009673ae755da15301e0f2f7c3"
+"@hashicorp/api-double@^1.3.0":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/api-double/-/api-double-1.3.1.tgz#fd9d706674b934857a638459c2bb52d2f2809455"
   dependencies:
     "@gardenhq/o" "^8.0.1"
     "@gardenhq/tick-control" "^2.0.0"
@@ -81,20 +81,21 @@
     faker "^4.1.0"
     js-yaml "^3.10.0"
 
-"@hashicorp/consul-api-double@^1.0.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-1.1.0.tgz#658f9e89208fa23f251ca66c66aeb7241a13f23f"
-
-"@hashicorp/ember-cli-api-double@^1.0.2":
+"@hashicorp/consul-api-double@^1.2.0":
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/ember-cli-api-double/-/ember-cli-api-double-1.2.0.tgz#aed3a9659abb3f3c56d77e400abc7fcbdcf2b78b"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-1.2.0.tgz#2cd2a991818e13e7b97803af3d62ec6c9cb83b28"
+
+"@hashicorp/ember-cli-api-double@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-cli-api-double/-/ember-cli-api-double-1.3.0.tgz#d07b5b11701cd55d6b01cb8a47ce17c4bac21fed"
   dependencies:
-    "@hashicorp/api-double" "^1.1.0"
+    "@hashicorp/api-double" "^1.3.0"
     array-range "^1.0.1"
     ember-cli-babel "^6.6.0"
     js-yaml "^3.11.0"
     merge-options "^1.0.1"
     pretender "^2.0.0"
+    recursive-readdir-sync "^1.0.6"
 
 "@sinonjs/formatio@^2.0.0":
   version "2.0.0"
@@ -7734,6 +7735,10 @@ recast@^0.11.17, recast@^0.11.3:
     esprima "~3.1.0"
     private "~0.1.5"
     source-map "~0.5.0"
+
+recursive-readdir-sync@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/recursive-readdir-sync/-/recursive-readdir-sync-1.0.6.tgz#1dbf6d32f3c5bb8d3cde97a6c588d547a9e13d56"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Previously `api-double` usage in ember would require a bunch of `fetch`
requests to pull in the 'api double', this had a number of disadvantages.

1. The doubles needed to be available via HTTP, which meant a short term
solution of rsyncing the double files over to `public` in order to be served
over HTTP. An alternative to that would have been figuring out how to serve
something straight from `node_modules`, which would have been preferable.

2. ember/testem would not serve dot files (so anything starting with a
., like `.config`. To solve this via ember/testem would have involved
digging in to understand how to enable the serving of dot files.

3. ember/testem automatically rewrote urls for non-existant files to
folders, i.e. adding a slash for you, so `/v1/connect/intentions` would
be rewritten to `/v1/connect/intentions/`. This is undesirable, and
solving this via ember/testem would have involved digging deep to
disable that.

Serving the files via HTTP has now changed. The double files are now
embedded into the HTML has 'embedded templates' that can be found by
using the url of the file and a simple `querySelector`. This of course
only happens during testing and means I can fully control the 'serving'
of the doubles now, so I can say goodbye to the need to move files
around, worry about the need to serve dotfiles and the undesirable
trailing slashes rewriting. Winner!

Find the files and embedding them is done using a straightforward
recursive-readdir-sync (the `content-for` functionality is a synchronous
api) as oppose to getting stuck into `broccoli`.

Additionally, prettier has cleaned up a couple of files for me from mkeelers
new build scripts, and I've made running api-double in 'server mode'
more visible via package.json scripts and a Makefile target, so you can use either
