### PR TITLE
Hedge for when consul sends nodes with an empty ID

### DIFF
--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -23,6 +23,9 @@ export default Adapter.extend({
           break;
         default:
           response = response.map((item, i, arr) => {
+            if (item[SLUG_KEY] === '') {
+              item[SLUG_KEY] = item['Node'];
+            }
             return {
               ...item,
               ...{

--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -1,6 +1,14 @@
 import Adapter from './application';
 import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/node';
 import { OK as HTTP_OK } from 'consul-ui/utils/http/status';
+// TODO: Looks like ID just isn't used at all
+// consider just using .Node for the SLUG_KEY
+const fillSlug = function(item) {
+  if (item[SLUG_KEY] === '') {
+    item[SLUG_KEY] = item['Node'];
+  }
+  return item;
+};
 export default Adapter.extend({
   urlForQuery: function(query, modelName) {
     return this.appendURL('internal/ui/nodes', [], this.cleanQuery(query));
@@ -14,6 +22,7 @@ export default Adapter.extend({
       const url = this.parseURL(requestData.url);
       switch (true) {
         case this.isQueryRecord(url):
+          response = fillSlug(response);
           response = {
             ...response,
             ...{
@@ -23,9 +32,7 @@ export default Adapter.extend({
           break;
         default:
           response = response.map((item, i, arr) => {
-            if (item[SLUG_KEY] === '') {
-              item[SLUG_KEY] = item['Node'];
-            }
+            item = fillSlug(item);
             return {
               ...item,
               ...{

--- a/ui-v2/tests/acceptance/dc/nodes/empty-ids.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/empty-ids.feature
@@ -1,0 +1,33 @@
+@setupApplicationTest
+Feature: Hedge for if nodes come in over the API with no ID
+  Scenario: A node list with some missing IDs
+    Given 1 datacenter model with the value "dc-1"
+    And 5 node models from yaml
+    ---
+    - ID: id-1
+      Node: name-1
+    - ID: ""
+      Node: name-2
+    - ID: ""
+      Node: name-3
+    - ID: ""
+      Node: name-4
+    - ID: ""
+      Node: name-5
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see name on the nodes like yaml
+    ---
+      - name-1
+      - name-2
+      - name-3
+      - name-4
+      - name-5
+
+@ignore
+  Scenario: Visually comparing
+    Then the ".unhealthy" element should look like the "/node_modules/@hashicorp/consul-testing-extras/fixtures/dc/nodes/empty-ids.png" image

--- a/ui-v2/tests/acceptance/steps/dc/nodes/empty-ids-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nodes/empty-ids-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}


### PR DESCRIPTION
Addresses #4305 and #4249 also see https://github.com/hashicorp/consul/pull/4294

This uses the node `Name` as the unique 'slug' if `ID` is blank

