### PR TITLE
Use html5 oninput instead of onkeyup for native textual inputs

### DIFF
--- a/ui-v2/app/templates/components/freetext-filter.hbs
+++ b/ui-v2/app/templates/components/freetext-filter.hbs
@@ -1,6 +1,6 @@
 {{!<fieldset>}}
     <label class="type-search">
         <span>Search</span>
-        <input type="search" onsearch={{action onchange}} onkeyup={{action onchange}} name="s" value="{{value}}" placeholder="{{placeholder}}" autofocus="autofocus" />
+        <input type="search" onsearch={{action onchange}} oninput={{action onchange}} name="s" value="{{value}}" placeholder="{{placeholder}}" autofocus="autofocus" />
     </label>
 {{!</fieldset>}}

--- a/ui-v2/app/templates/dc/kv/-form.hbs
+++ b/ui-v2/app/templates/dc/kv/-form.hbs
@@ -3,14 +3,14 @@
 {{#if create }}
         <label class="type-text{{if item.error.Key ' has-error'}}">
             <span>Key or folder</span>
-            <input autofocus="autofocus" type="text" value={{left-trim item.Key parent.Key}} name="additional" onkeyup={{action 'change'}} placeholder="Key or folder" />
+            <input autofocus="autofocus" type="text" value={{left-trim item.Key parent.Key}} name="additional" oninput={{action 'change'}} placeholder="Key or folder" />
             <em>To create a folder, end a key with <code>/</code></em>
         </label>
 {{/if}}
 {{#if (or (eq (left-trim item.Key parent.Key) '') (not-eq (last item.Key) '/')) }}
         <div>
             <label class="type-toggle">
-                <input type="checkbox" name="json" checked={{if json 'checked' }} onchange={{action 'change'}} />
+                <input type="checkbox" name="json" checked={{if json 'checked' }} oninput={{action 'change'}} />
                 <span>Code</span>
             </label>
             <label class="type-text{{if item.error.Value ' has-error'}}">
@@ -18,7 +18,7 @@
 {{#if json}}
                 {{ code-editor value=(atob item.Value) onkeyup=(action 'change') }}
 {{else}}
-                <textarea autofocus={{not create}} name="value" onkeyup={{action 'change'}}>{{atob item.Value}}</textarea>
+                <textarea autofocus={{not create}} name="value" oninput={{action 'change'}}>{{atob item.Value}}</textarea>
 {{/if}}
             </label>
         </div>

--- a/ui-v2/tests/acceptance/components/acl-filter.feature
+++ b/ui-v2/tests/acceptance/components/acl-filter.feature
@@ -25,12 +25,12 @@ Feature: dc / components /acl filter: Acl Filter
 
     When I click all on the filter
     Then I see allIsSelected on the filter
-    Then I type with yaml
+    Then I fill in with yaml
     ---
     s: Anonymous Token
     ---
     And I see 1 [Model] model with the name "Anonymous Token"
-    Then I type with yaml
+    Then I fill in with yaml
     ---
     s: secret
     ---

--- a/ui-v2/tests/acceptance/components/catalog-filter.feature
+++ b/ui-v2/tests/acceptance/components/catalog-filter.feature
@@ -47,7 +47,7 @@ Feature: components / catalog-filter
 
     When I click all on the filter
     And I see allIsSelected on the filter
-    Then I type with yaml
+    Then I fill in with yaml
     ---
     s: [Model]-0
     ---
@@ -75,7 +75,7 @@ Feature: components / catalog-filter
     When I click services on the tabs
     And I see servicesIsSelected on the tabs
 
-    Then I type with yaml
+    Then I fill in with yaml
     ---
     s: 65535
     ---

--- a/ui-v2/tests/acceptance/components/kv-filter.feature
+++ b/ui-v2/tests/acceptance/components/kv-filter.feature
@@ -12,7 +12,7 @@ Feature: components / kv-filter
       dc: dc-1
     ---
     Then the url should be [Url]
-    Then I type with yaml
+    Then I fill in with yaml
     ---
     s: [Text]
     ---

--- a/ui-v2/tests/acceptance/components/text-input.feature
+++ b/ui-v2/tests/acceptance/components/text-input.feature
@@ -1,0 +1,21 @@
+@setupApplicationTest
+Feature: Text input
+  Background:
+    Given 1 datacenter model with the value "dc-1"
+  Scenario:
+    When I visit the [Page] page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be [Url]
+    Then I fill in with json
+    ---
+    [Data]
+    ---
+    Then I see submitIsEnabled
+  Where:
+    --------------------------------------------------------------------------------
+    | Page       | Url                    | Data                                   |
+    | kv        | /dc-1/kv/create         | {"additional": "hi", "value": "there"} |
+    | acl       | /dc-1/acls/create       | {"name": "hi"}                         |
+    --------------------------------------------------------------------------------

--- a/ui-v2/tests/acceptance/dc/acls/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/update.feature
@@ -12,7 +12,7 @@ Feature: dc / acls / update: ACL Update
       acl: key
     ---
     Then the url should be /datacenter/acls/key
-    Then I type with yaml
+    Then I fill in with yaml
     ---
       name: [Name]
     ---

--- a/ui-v2/tests/acceptance/dc/kvs/update.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/update.feature
@@ -12,7 +12,7 @@ Feature: dc / kvs / update: KV Update
       kv: [Name]
     ---
     Then the url should be /datacenter/kv/[Name]/edit
-    Then I type with yaml
+    Then I fill in with yaml
     ---
       value: [Value]
     ---

--- a/ui-v2/tests/acceptance/steps/components/text-input-steps.js
+++ b/ui-v2/tests/acceptance/steps/components/text-input-steps.js
@@ -1,0 +1,10 @@
+import steps from '../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/token-header.feature
+++ b/ui-v2/tests/acceptance/token-header.feature
@@ -16,7 +16,7 @@ Feature: token headers
     Given 1 datacenter model with the value "datacenter"
     When I visit the settings page
     Then the url should be /settings
-    Then I type with yaml
+    Then I fill in with yaml
     ---
       token: [Token]
     ---

--- a/ui-v2/tests/pages/dc/acls/edit.js
+++ b/ui-v2/tests/pages/dc/acls/edit.js
@@ -1,4 +1,4 @@
-import { create, clickable, triggerable } from 'ember-cli-page-object';
+import { create, clickable, triggerable, is } from 'ember-cli-page-object';
 import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
@@ -7,4 +7,5 @@ export default create({
   // fillIn: fillable('input, textarea, [contenteditable]'),
   name: triggerable('keypress', '[name="name"]'),
   submit: clickable('[type=submit]'),
+  submitIsEnabled: is(':not(:disabled)', '[type=submit]'),
 });

--- a/ui-v2/tests/pages/dc/kv/edit.js
+++ b/ui-v2/tests/pages/dc/kv/edit.js
@@ -1,4 +1,4 @@
-import { create, clickable } from 'ember-cli-page-object';
+import { create, clickable, is } from 'ember-cli-page-object';
 import { visitable } from 'consul-ui/tests/lib/page-object/visitable';
 
 export default create({
@@ -7,4 +7,5 @@ export default create({
   // fillIn: fillable('input, textarea, [contenteditable]'),
   // name: triggerable('keypress', '[name="additional"]'),
   submit: clickable('[type=submit]'),
+  submitIsEnabled: is(':not(:disabled)', '[type=submit]'),
 });

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -335,7 +335,7 @@ export default function(assert) {
           `Expected to not see ${property} on ${component}`
         );
       })
-      .then(['I see $property'], function(property, component) {
+      .then(['I see $property'], function(property) {
         assert.ok(currentPage[property], `Expected to see ${property}`);
       })
       .then(['I see the text "$text" in "$selector"'], function(text, selector) {


### PR DESCRIPTION
This enables people to enter things using the mouse to paste for example, plus possibly entering text using other means.

Fixes #4304 