### PR TITLE
Build - Tiny ui build additions

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -74,7 +74,7 @@ function build_ui {
    then
       status "Copying the source from '${ui_dir}' to /consul-src within the container"
       (
-         tar -c $(ls | grep -v "^(node_modules\|dist)") | docker cp - ${container_id}:/consul-src &&
+         tar -c $(ls -A | grep -v "^(node_modules\|dist\|tmp)") | docker cp - ${container_id}:/consul-src &&
          status "Running build in container" && docker start -i ${container_id} &&
          rm -rf ${1}/ui-v2/dist &&
          status "Copying back artifacts" && docker cp ${container_id}:/consul-src/dist ${1}/ui-v2/dist


### PR DESCRIPTION
Whilst looking into the feasibility of running the UI tests in the/a container, I came across these tinsy things. Whilst I didn't get very far with what I wanted to do, thought I'd PR these bits in:

1. Use `ls -A` to list dotfiles also, ready for tarring
2. Don't copy ember's `./tmp` if you have one

Not sure if you are doing other `ls/tar`ing elsewhere?