### PR TITLE
UI - Stop trying to remove consul-api-double we don't need to anymore

### DIFF
--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
-const stew = require('broccoli-stew');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     'ember-cli-babel': {
@@ -44,8 +43,5 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
   let tree = app.toTree();
-  if (app.env === 'production') {
-    tree = stew.rm(tree, 'consul-api-double');
-  }
   return tree;
 };

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -35,7 +35,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-stew": "^1.5.0",
     "ember-ajax": "^3.0.0",
     "ember-block-slots": "^1.1.11",
     "ember-browserify": "^1.2.2",


### PR DESCRIPTION
This PR remove the code used to ensure that /public/consul-api-double didn't end up in the production build. We don't need to do this now following https://github.com/hashicorp/consul/pull/4326, ideally this would have been part of that PR :(