### PR TITLE
Agent/Proxy : Fixes Windows's proxy problems.

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -427,7 +427,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*
 		}
 		go s.Flood(nil, portFn, s.serfWAN)
 	}
-	
+
 	// Start enterprise specific functionality
 	if err := s.startEnterprise(); err != nil {
 		s.Shutdown()

--- a/agent/proxy/manager.go
+++ b/agent/proxy/manager.go
@@ -432,7 +432,7 @@ func (m *Manager) newProxy(mp *local.ManagedProxy) (Proxy, error) {
 		if err := m.configureLogDir(id, &cmd); err != nil {
 			return nil, fmt.Errorf("error configuring proxy logs: %s", err)
 		}
-
+		cmd.Env = os.Environ()
 		// Build the daemon structure
 		proxy.Command = &cmd
 		proxy.ProxyID = id

--- a/agent/proxy/manager.go
+++ b/agent/proxy/manager.go
@@ -432,7 +432,10 @@ func (m *Manager) newProxy(mp *local.ManagedProxy) (Proxy, error) {
 		if err := m.configureLogDir(id, &cmd); err != nil {
 			return nil, fmt.Errorf("error configuring proxy logs: %s", err)
 		}
+
+		// Pass in the environmental variables for this proxy process
 		cmd.Env = os.Environ()
+
 		// Build the daemon structure
 		proxy.Command = &cmd
 		proxy.ProxyID = id

--- a/agent/proxy/manager_test.go
+++ b/agent/proxy/manager_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"testing"
 	"time"
@@ -286,27 +285,24 @@ func TestEnvironproxy(t *testing.T) {
 	go m.Run()
 
 	//Get the environmental variables from the OS
-	//envCheck := os.Environ()
-	var fileContent Bytes
+	var fileContent []byte
 	var err error
-	var data Bytes
+	var data []byte
 	envData := os.Environ()
 	sort.Strings(envData)
 	for _, envVariable := range envData {
 		data = append(data, envVariable...)
 		data = append(data, "\n"...)
 	}
-	// t.Log(data)
+
+	// Check if the file written to from the spawned process
+	// has the necessary environmental variable data
 	retry.Run(t, func(r *retry.R) {
 		if fileContent, err = ioutil.ReadFile(path); err != nil {
 			r.Fatalf("No file ya dummy")
 		}
 	})
 
-	t.Logf("Len (data) : %d , Len (fileContent) : %d", len(data), len(fileContent))
-	t.Logf("Type (data) : %s Type (fileContent) : %s", reflect.TypeOf(data), reflect.TypeOf(fileContent))
-	// t.Logf("File content: \n %s", fileContent)
-	// t.Logf("Data content: \n %s", data)
 	require.Equal(fileContent, data)
 }
 

--- a/agent/proxy/manager_test.go
+++ b/agent/proxy/manager_test.go
@@ -265,7 +265,7 @@ func TestManagerRun_daemonPid(t *testing.T) {
 // Test to check if the parent and the child processes
 // have the same environmental variables
 
-func TestEnvironproxy(t *testing.T) {
+func TestManagerPassesEnvironment(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)

--- a/agent/proxy/proxy_test.go
+++ b/agent/proxy/proxy_test.go
@@ -19,22 +19,6 @@ import (
 // *log.Logger instance.
 var testLogger = log.New(os.Stderr, "logger: ", log.LstdFlags)
 
-//SOrting interface
-type Bytes []byte
-
-//Length method for our Byte interface
-func (b Bytes) Len() int {
-	return len(b)
-}
-
-func (b Bytes) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
-}
-
-func (b Bytes) Less(i, j int) bool {
-	return b[i] < b[j]
-}
-
 // testTempDir returns a temporary directory and a cleanup function.
 func testTempDir(t *testing.T) (string, func()) {
 	t.Helper()
@@ -162,14 +146,17 @@ func TestHelperProcess(t *testing.T) {
 		signal.Notify(stop, os.Interrupt)
 		defer signal.Stop(stop)
 
-		//Write the environmental variables into the file
+		//Get the path for the file to be written to
 		path := args[0]
-		var data Bytes
-		// sort.Sort(data)
+		var data []byte
+
+		//Get the environmental variables
 		envData := os.Environ()
+
+		//Sort the env data for easier comparison
 		sort.Strings(envData)
 		for _, envVariable := range envData {
-			if strings.Contains(envVariable, "CONNECT_PROXY") {
+			if strings.HasPrefix(envVariable, "CONSUL") || strings.HasPrefix(envVariable, "CONNECT") {
 				continue
 			}
 			data = append(data, envVariable...)
@@ -181,6 +168,7 @@ func TestHelperProcess(t *testing.T) {
 
 		// Clean up after we receive the signal to exit
 		defer os.Remove(path)
+
 		<-stop
 
 	case "output":


### PR DESCRIPTION
 This PR fixes the issue that broke basic managed proxy support in windows on launch. Failing to copy the env from the agent meant that the proxy process couldn't load the right DLLs. The same is not an issue on the *NIX like environments we tested.

There are likely other issues with managing proxies on Windows that are not addressed here but will be investigated in future PRs.

This PR gets a basic Connect demo working on Windows but note that Connect is still in beta and not recommended to run in production yet on Windows or otherwise!