### PR TITLE
Fixed compilation warning about wrong type

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1198,7 +1198,7 @@ func (b *Builder) expandAddrs(name string, s *string) []net.Addr {
 
 	x, err := template.Parse(*s)
 	if err != nil {
-		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %q: %s", name, s, err))
+		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %s: %s", name, *s, err))
 		return nil
 	}
 
@@ -1237,7 +1237,7 @@ func (b *Builder) expandOptionalAddrs(name string, s *string) []string {
 
 	x, err := template.Parse(*s)
 	if err != nil {
-		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %q: %s", name, s, err))
+		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %s: %s", name, *s, err))
 		return nil
 	}
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1198,7 +1198,7 @@ func (b *Builder) expandAddrs(name string, s *string) []net.Addr {
 
 	x, err := template.Parse(*s)
 	if err != nil {
-		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %s: %s", name, *s, err))
+		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %q: %s", name, *s, err))
 		return nil
 	}
 
@@ -1237,7 +1237,7 @@ func (b *Builder) expandOptionalAddrs(name string, s *string) []string {
 
 	x, err := template.Parse(*s)
 	if err != nil {
-		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %s: %s", name, *s, err))
+		b.err = multierror.Append(b.err, fmt.Errorf("%s: error parsing %q: %s", name, *s, err))
 		return nil
 	}
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -314,7 +314,7 @@ type failer struct {
 	failed bool
 }
 
-func (f *failer) Log(args ...interface{}) { fmt.Println(args) }
+func (f *failer) Log(args ...interface{}) { fmt.Println(args...) }
 func (f *failer) FailNow()                { f.failed = true }
 
 // waitForAPI waits for only the agent HTTP endpoint to start


### PR DESCRIPTION
It fixes the following warnings:

  agent/config/builder.go:1201: Errorf format %q has arg s of wrong type *string
  agent/config/builder.go:1240: Errorf format %q has arg s of wrong type *string