### PR TITLE
Remove https://prefix from TLSConfig.Address

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -742,7 +742,8 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 				if a.config.CAFile != "" {
 					config.TLSConfig.CAFile = a.config.CAFile
 				}
-				config.TLSConfig.Address = addr
+				// use the original address without the https:// prefix
+				config.TLSConfig.Address = netaddr.String()
 			}
 
 			if err := wp.RunWithConfig(addr, config); err != nil {


### PR DESCRIPTION
Fixes #4358 

The addr we pass in the config and addr needs to have the https scheme on it. However the TLS config address needs to not have it.