### PR TITLE
UI Bugfix - kv trailing slashes

### DIFF
--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
+import isFolder from 'consul-ui/utils/isFolder';
 import WithKvActions from 'consul-ui/mixins/kv/with-actions';
 
 export default Route.extend(WithKvActions, {
@@ -13,7 +14,12 @@ export default Route.extend(WithKvActions, {
   },
   repo: service('kv'),
   model: function(params) {
-    const key = params.key || '/';
+    let key = params.key || '/';
+    // we are index or folder, so if the key doesn't have a trailing slash
+    // add one to force a fake findBySlug
+    if (!isFolder(key)) {
+      key = key + '/';
+    }
     const dc = this.modelFor('dc').dc.Name;
     const repo = get(this, 'repo');
     return hash({

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -13,13 +13,17 @@ export default Route.extend(WithKvActions, {
     },
   },
   repo: service('kv'),
-  model: function(params) {
-    let key = params.key || '/';
+  beforeModel: function() {
     // we are index or folder, so if the key doesn't have a trailing slash
     // add one to force a fake findBySlug
+    const params = this.paramsFor(this.routeName);
+    const key = params.key || '/';
     if (!isFolder(key)) {
-      key = key + '/';
+      return this.replaceWith(this.routeName, key + '/');
     }
+  },
+  model: function(params) {
+    let key = params.key || '/';
     const dc = this.modelFor('dc').dc.Name;
     const repo = get(this, 'repo');
     return hash({

--- a/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
@@ -1,0 +1,19 @@
+@setupApplicationTest
+Feature: dc / kvs / trailing slash
+  Scenario: I have 10 folders
+    Given 1 datacenter model with the value "datacenter"
+    And 10 kv models from yaml
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+      kv: foo/bar
+    ---
+    Then the url should be /datacenter/kv/foo/bar
+    And the last GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F"
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+      kv: foo/bar/
+    ---
+    Then the url should be /datacenter/kv/foo/bar/
+    And the last GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F"

--- a/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
@@ -8,7 +8,7 @@ Feature: dc / kvs / trailing slash
       dc: datacenter
       kv: foo/bar
     ---
-    Then the url should be /datacenter/kv/foo/bar
+    Then the url should be /datacenter/kv/foo/bar/
     And the last GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F"
     When I visit the kvs page for yaml
     ---

--- a/ui-v2/tests/acceptance/steps/dc/kvs/trailing-slash-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/kvs/trailing-slash-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages/dc/kv/index.js
+++ b/ui-v2/tests/pages/dc/kv/index.js
@@ -1,6 +1,6 @@
 export default function(visitable, deletable, creatable, clickable, attribute, collection) {
   return creatable({
-    visit: visitable('/:dc/kv'),
+    visit: visitable(['/:dc/kv/:kv', '/:dc/kv'], str => str),
     kvs: collection(
       '[data-test-tabular-row]',
       deletable({

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -241,6 +241,15 @@ export default function(assert) {
         );
         assert.equal(request.url, url, `Expected the request url to be ${url}, was ${request.url}`);
       })
+      .then('the last $method request was made to "$url"', function(method, url) {
+        const request = api.server.history
+          .slice(0)
+          .reverse()
+          .find(function(item) {
+            return item.method === method;
+          });
+        assert.equal(request.url, url, `Expected the request url to be ${url}, was ${request.url}`);
+      })
       .then('the url should be $url', function(url) {
         // TODO: nice! $url should be wrapped in ""
         if (url === "''") {


### PR DESCRIPTION
Fixes #4324 

This PR addresses the fact that the UI has a redirect to remove trailing slashes off any URLs, which causes problems with KV 'folders'. So if you hand type a URL with a trailing slash it will redirect you to possibly a inaccessible URL (whereas if you are navigating there using the UI/javascript, it won't).

It goes by the basic premise that if you request the `index` or `folder` route you must be asking for a 'folder' therefore if the URL/Keyname has no trailing slash, then add one when calling the API.

Also, I made sure I added a failing test as a separate first commit on this branch instead of bundling it up with the fix, so if you want see it breaking easily you can checkout one commit back and run `make test-view`, filtering by 'trailing' will take you to the broken test, re-checking out this branch will fix it. Will try and make this easier to do this moving forwards.
