### PR TITLE
Setup managed proxy environment with API client env vars

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -380,6 +380,13 @@ func (a *Agent) Start() error {
 				a.logger.Printf("[WARN] agent: error restoring proxy state: %s", err)
 			}
 		}
+
+		acfg, err := a.config.APIConfig(true)
+		if err != nil {
+			return err
+		}
+		a.proxyManager.APIConfig = acfg
+
 		go a.proxyManager.Run()
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -385,7 +385,7 @@ func (a *Agent) Start() error {
 		if err != nil {
 			return err
 		}
-		a.proxyManager.APIConfig = acfg
+		a.proxyManager.ProxyEnv = acfg.GenerateEnv()
 
 		go a.proxyManager.Run()
 	}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1223,7 +1223,7 @@ func (c *RuntimeConfig) apiAddresses(maxPerType int) (unixAddrs, httpAddrs, http
 func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) {
 	cfg := &api.Config{
 		Datacenter: c.Datacenter,
-		TLSConfig:  api.TLSConfig{InsecureSkipVerify: true},
+		TLSConfig:  api.TLSConfig{InsecureSkipVerify: !c.VerifyOutgoing},
 	}
 
 	unixAddrs, httpAddrs, httpsAddrs := c.apiAddresses(1)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1203,12 +1203,12 @@ func (c *RuntimeConfig) apiAddresses(maxPerType int) (unixAddrs, httpAddrs, http
 		http_count := 0
 		for _, addr := range c.HTTPAddrs {
 			net := addr.Network()
-			if net == "unix" && unix_count < maxPerType {
-				unixAddrs = append(unixAddrs, addr.String())
-				unix_count += 1
-			} else if net != "unix" && http_count < maxPerType {
+			if net == "tcp" && http_count < maxPerType {
 				httpAddrs = append(httpAddrs, addr.String())
 				http_count += 1
+			} else if net != "tcp" && unix_count < maxPerType {
+				unixAddrs = append(unixAddrs, addr.String())
+				unix_count += 1
 			}
 		}
 	}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1202,13 +1202,17 @@ func (c *RuntimeConfig) apiAddresses(maxPerType int) (unixAddrs, httpAddrs, http
 		unix_count := 0
 		http_count := 0
 		for _, addr := range c.HTTPAddrs {
-			net := addr.Network()
-			if net == "tcp" && http_count < maxPerType {
-				httpAddrs = append(httpAddrs, addr.String())
-				http_count += 1
-			} else if net != "tcp" && unix_count < maxPerType {
-				unixAddrs = append(unixAddrs, addr.String())
-				unix_count += 1
+			switch addr.(type) {
+			case *net.UnixAddr:
+				if unix_count < maxPerType {
+					unixAddrs = append(unixAddrs, addr.String())
+					unix_count += 1
+				}
+			default:
+				if http_count < maxPerType {
+					httpAddrs = append(httpAddrs, addr.String())
+					http_count += 1
+				}
 			}
 		}
 	}

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1238,6 +1238,8 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		cfg.Scheme = "http"
 	} else if len(unixAddrs) > 0 {
 		cfg.Address = "unix://" + unixAddrs[0]
+		// this should be ignored - however we are still talking http over a unix socket
+		// so it makes sense to set it like this
 		cfg.Scheme = "http"
 	} else {
 		return nil, fmt.Errorf("No suitable client address can be found")

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
@@ -1185,6 +1186,64 @@ func (c *RuntimeConfig) IncomingHTTPSConfig() (*tls.Config, error) {
 		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
 	}
 	return tc.IncomingTLSConfig()
+}
+
+func (c *RuntimeConfig) apiAddresses(maxPerType int) (unixAddrs, httpAddrs, httpsAddrs []string) {
+	if len(c.HTTPSAddrs) > 0 {
+		for i, addr := range c.HTTPSAddrs {
+			if i < maxPerType {
+				httpsAddrs = append(httpsAddrs, addr.String())
+			} else {
+				break
+			}
+		}
+	}
+	if len(c.HTTPAddrs) > 0 {
+		unix_count := 0
+		http_count := 0
+		for _, addr := range c.HTTPAddrs {
+			net := addr.Network()
+			if net == "unix" && unix_count < maxPerType {
+				unixAddrs = append(unixAddrs, addr.String())
+				unix_count += 1
+			} else if net != "unix" && http_count < maxPerType {
+				httpAddrs = append(httpAddrs, addr.String())
+				http_count += 1
+			}
+		}
+	}
+
+	return
+}
+
+func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) {
+	cfg := &api.Config{
+		Datacenter: c.Datacenter,
+		TLSConfig:  api.TLSConfig{InsecureSkipVerify: true},
+	}
+
+	unixAddrs, httpAddrs, httpsAddrs := c.apiAddresses(1)
+
+	if len(httpsAddrs) > 0 {
+		cfg.Address = httpsAddrs[0]
+		cfg.Scheme = "https"
+		cfg.TLSConfig.CAFile = c.CAFile
+		cfg.TLSConfig.CAPath = c.CAPath
+		if includeClientCerts {
+			cfg.TLSConfig.CertFile = c.CertFile
+			cfg.TLSConfig.KeyFile = c.KeyFile
+		}
+	} else if len(httpAddrs) > 0 {
+		cfg.Address = httpAddrs[0]
+		cfg.Scheme = "http"
+	} else if len(unixAddrs) > 0 {
+		cfg.Address = "unix://" + unixAddrs[0]
+		cfg.Scheme = "http"
+	} else {
+		return nil, fmt.Errorf("No suitable client address can be found")
+	}
+
+	return cfg, nil
 }
 
 // Sanitized returns a JSON/HCL compatible representation of the runtime

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4507,6 +4507,103 @@ func TestSanitize(t *testing.T) {
 	require.JSONEq(t, rtJSON, string(b))
 }
 
+func TestRuntime_apiAddresses(t *testing.T) {
+	rt := RuntimeConfig{
+		HTTPAddrs: []net.Addr{
+			&net.TCPAddr{IP: net.ParseIP("198.18.0.1"), Port: 5678},
+			&net.UnixAddr{Name: "/var/run/foo"},
+		},
+		HTTPSAddrs: []net.Addr{
+			&net.TCPAddr{IP: net.ParseIP("198.18.0.2"), Port: 5678},
+		}}
+
+	unixAddrs, httpAddrs, httpsAddrs := rt.apiAddresses(1)
+
+	require.Len(t, unixAddrs, 1)
+	require.Len(t, httpAddrs, 1)
+	require.Len(t, httpsAddrs, 1)
+
+	require.Equal(t, "/var/run/foo", unixAddrs[0])
+	require.Equal(t, "198.18.0.1:5678", httpAddrs[0])
+	require.Equal(t, "198.18.0.2:5678", httpsAddrs[0])
+}
+
+func TestRuntime_APIConfigHTTPS(t *testing.T) {
+	rt := RuntimeConfig{
+		HTTPAddrs: []net.Addr{
+			&net.TCPAddr{IP: net.ParseIP("198.18.0.1"), Port: 5678},
+			&net.UnixAddr{Name: "/var/run/foo"},
+		},
+		HTTPSAddrs: []net.Addr{
+			&net.TCPAddr{IP: net.ParseIP("198.18.0.2"), Port: 5678},
+		},
+		Datacenter: "dc-test",
+		CAFile:     "/etc/consul/ca.crt",
+		CAPath:     "/etc/consul/ca.dir",
+		CertFile:   "/etc/consul/server.crt",
+		KeyFile:    "/etc/consul/ssl/server.key",
+	}
+
+	cfg, err := rt.APIConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, "198.18.0.2:5678", cfg.Address)
+	require.Equal(t, "https", cfg.Scheme)
+	require.Equal(t, rt.CAFile, cfg.TLSConfig.CAFile)
+	require.Equal(t, rt.CAPath, cfg.TLSConfig.CAPath)
+	require.Equal(t, "", cfg.TLSConfig.CertFile)
+	require.Equal(t, "", cfg.TLSConfig.KeyFile)
+	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+
+	cfg, err = rt.APIConfig(true)
+	require.NoError(t, err)
+	require.Equal(t, "198.18.0.2:5678", cfg.Address)
+	require.Equal(t, "https", cfg.Scheme)
+	require.Equal(t, rt.CAFile, cfg.TLSConfig.CAFile)
+	require.Equal(t, rt.CAPath, cfg.TLSConfig.CAPath)
+	require.Equal(t, rt.CertFile, cfg.TLSConfig.CertFile)
+	require.Equal(t, rt.KeyFile, cfg.TLSConfig.KeyFile)
+	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+}
+
+func TestRuntime_APIConfigHTTP(t *testing.T) {
+	rt := RuntimeConfig{
+		HTTPAddrs: []net.Addr{
+			&net.UnixAddr{Name: "/var/run/foo"},
+			&net.TCPAddr{IP: net.ParseIP("198.18.0.1"), Port: 5678},
+		},
+		Datacenter: "dc-test",
+	}
+
+	cfg, err := rt.APIConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+	require.Equal(t, "198.18.0.1:5678", cfg.Address)
+	require.Equal(t, "http", cfg.Scheme)
+	require.Equal(t, "", cfg.TLSConfig.CAFile)
+	require.Equal(t, "", cfg.TLSConfig.CAPath)
+	require.Equal(t, "", cfg.TLSConfig.CertFile)
+	require.Equal(t, "", cfg.TLSConfig.KeyFile)
+}
+
+func TestRuntime_APIConfigUNIX(t *testing.T) {
+	rt := RuntimeConfig{
+		HTTPAddrs: []net.Addr{
+			&net.UnixAddr{Name: "/var/run/foo"},
+		},
+		Datacenter: "dc-test",
+	}
+
+	cfg, err := rt.APIConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+	require.Equal(t, "unix:///var/run/foo", cfg.Address)
+	require.Equal(t, "http", cfg.Scheme)
+	require.Equal(t, "", cfg.TLSConfig.CAFile)
+	require.Equal(t, "", cfg.TLSConfig.CAPath)
+	require.Equal(t, "", cfg.TLSConfig.CertFile)
+	require.Equal(t, "", cfg.TLSConfig.KeyFile)
+}
+
 func splitIPPort(hostport string) (net.IP, int) {
 	h, p, err := net.SplitHostPort(hostport)
 	if err != nil {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4537,11 +4537,12 @@ func TestRuntime_APIConfigHTTPS(t *testing.T) {
 		HTTPSAddrs: []net.Addr{
 			&net.TCPAddr{IP: net.ParseIP("198.18.0.2"), Port: 5678},
 		},
-		Datacenter: "dc-test",
-		CAFile:     "/etc/consul/ca.crt",
-		CAPath:     "/etc/consul/ca.dir",
-		CertFile:   "/etc/consul/server.crt",
-		KeyFile:    "/etc/consul/ssl/server.key",
+		Datacenter:     "dc-test",
+		CAFile:         "/etc/consul/ca.crt",
+		CAPath:         "/etc/consul/ca.dir",
+		CertFile:       "/etc/consul/server.crt",
+		KeyFile:        "/etc/consul/ssl/server.key",
+		VerifyOutgoing: false,
 	}
 
 	cfg, err := rt.APIConfig(false)
@@ -4553,7 +4554,9 @@ func TestRuntime_APIConfigHTTPS(t *testing.T) {
 	require.Equal(t, "", cfg.TLSConfig.CertFile)
 	require.Equal(t, "", cfg.TLSConfig.KeyFile)
 	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+	require.Equal(t, true, cfg.TLSConfig.InsecureSkipVerify)
 
+	rt.VerifyOutgoing = true
 	cfg, err = rt.APIConfig(true)
 	require.NoError(t, err)
 	require.Equal(t, "198.18.0.2:5678", cfg.Address)
@@ -4563,6 +4566,7 @@ func TestRuntime_APIConfigHTTPS(t *testing.T) {
 	require.Equal(t, rt.CertFile, cfg.TLSConfig.CertFile)
 	require.Equal(t, rt.KeyFile, cfg.TLSConfig.KeyFile)
 	require.Equal(t, rt.Datacenter, cfg.Datacenter)
+	require.Equal(t, false, cfg.TLSConfig.InsecureSkipVerify)
 }
 
 func TestRuntime_APIConfigHTTP(t *testing.T) {

--- a/agent/proxy/manager.go
+++ b/agent/proxy/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -68,6 +69,9 @@ type Manager struct {
 	//   * snapshot.json - the state of the manager
 	//
 	DataDir string
+
+	// Configuration information to tell the proxy how to talk to us
+	APIConfig *api.Config
 
 	// SnapshotPeriod is the duration between snapshots. This can be set
 	// relatively low to ensure accuracy, because if the new snapshot matches
@@ -435,6 +439,9 @@ func (m *Manager) newProxy(mp *local.ManagedProxy) (Proxy, error) {
 
 		// Pass in the environmental variables for the proxy process
 		cmd.Env = os.Environ()
+		if m.APIConfig != nil {
+			cmd.Env = append(cmd.Env, m.APIConfig.GenerateEnv()...)
+		}
 
 		// Build the daemon structure
 		proxy.Command = &cmd

--- a/agent/proxy/manager.go
+++ b/agent/proxy/manager.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -70,8 +69,8 @@ type Manager struct {
 	//
 	DataDir string
 
-	// Configuration information to tell the proxy how to talk to us
-	APIConfig *api.Config
+	// Extra environment variables to set for the proxies
+	ProxyEnv []string
 
 	// SnapshotPeriod is the duration between snapshots. This can be set
 	// relatively low to ensure accuracy, because if the new snapshot matches
@@ -438,10 +437,7 @@ func (m *Manager) newProxy(mp *local.ManagedProxy) (Proxy, error) {
 		}
 
 		// Pass in the environmental variables for the proxy process
-		cmd.Env = os.Environ()
-		if m.APIConfig != nil {
-			cmd.Env = append(cmd.Env, m.APIConfig.GenerateEnv()...)
-		}
+		cmd.Env = append(m.ProxyEnv, os.Environ()...)
 
 		// Build the daemon structure
 		proxy.Command = &cmd

--- a/api/api.go
+++ b/api/api.go
@@ -405,6 +405,27 @@ func SetupTLSConfig(tlsConfig *TLSConfig) (*tls.Config, error) {
 	return tlsClientConfig, nil
 }
 
+func (c *Config) GenerateEnv() []string {
+	env := make([]string, 10)
+
+	env[0] = fmt.Sprintf("%s=%s", HTTPAddrEnvName, c.Address)
+	env[1] = fmt.Sprintf("%s=%s", HTTPTokenEnvName, c.Token)
+	if c.HttpAuth != nil {
+		env[2] = fmt.Sprintf("%s=%s:%s", HTTPAuthEnvName, c.HttpAuth.Username, c.HttpAuth.Password)
+	} else {
+		env[2] = fmt.Sprintf("%s=", HTTPAuthEnvName)
+	}
+	env[3] = fmt.Sprintf("%s=%t", HTTPSSLEnvName, c.Scheme == "https")
+	env[4] = fmt.Sprintf("%s=%s", HTTPCAFile, c.TLSConfig.CAFile)
+	env[5] = fmt.Sprintf("%s=%s", HTTPCAPath, c.TLSConfig.CAPath)
+	env[6] = fmt.Sprintf("%s=%s", HTTPClientCert, c.TLSConfig.CertFile)
+	env[7] = fmt.Sprintf("%s=%s", HTTPClientKey, c.TLSConfig.KeyFile)
+	env[8] = fmt.Sprintf("%s=%s", HTTPTLSServerName, c.TLSConfig.Address)
+	env[9] = fmt.Sprintf("%s=%t", HTTPSSLVerifyEnvName, !c.TLSConfig.InsecureSkipVerify)
+
+	return env
+}
+
 // Client provides a client to the Consul API
 type Client struct {
 	config Config

--- a/api/api.go
+++ b/api/api.go
@@ -406,22 +406,24 @@ func SetupTLSConfig(tlsConfig *TLSConfig) (*tls.Config, error) {
 }
 
 func (c *Config) GenerateEnv() []string {
-	env := make([]string, 10)
+	env := make([]string, 0, 10)
 
-	env[0] = fmt.Sprintf("%s=%s", HTTPAddrEnvName, c.Address)
-	env[1] = fmt.Sprintf("%s=%s", HTTPTokenEnvName, c.Token)
+	env = append(env,
+		fmt.Sprintf("%s=%s", HTTPAddrEnvName, c.Address),
+		fmt.Sprintf("%s=%s", HTTPTokenEnvName, c.Token),
+		fmt.Sprintf("%s=%t", HTTPSSLEnvName, c.Scheme == "https"),
+		fmt.Sprintf("%s=%s", HTTPCAFile, c.TLSConfig.CAFile),
+		fmt.Sprintf("%s=%s", HTTPCAPath, c.TLSConfig.CAPath),
+		fmt.Sprintf("%s=%s", HTTPClientCert, c.TLSConfig.CertFile),
+		fmt.Sprintf("%s=%s", HTTPClientKey, c.TLSConfig.KeyFile),
+		fmt.Sprintf("%s=%s", HTTPTLSServerName, c.TLSConfig.Address),
+		fmt.Sprintf("%s=%t", HTTPSSLVerifyEnvName, !c.TLSConfig.InsecureSkipVerify))
+
 	if c.HttpAuth != nil {
-		env[2] = fmt.Sprintf("%s=%s:%s", HTTPAuthEnvName, c.HttpAuth.Username, c.HttpAuth.Password)
+		env = append(env, fmt.Sprintf("%s=%s:%s", HTTPAuthEnvName, c.HttpAuth.Username, c.HttpAuth.Password))
 	} else {
-		env[2] = fmt.Sprintf("%s=", HTTPAuthEnvName)
+		env = append(env, fmt.Sprintf("%s=", HTTPAuthEnvName))
 	}
-	env[3] = fmt.Sprintf("%s=%t", HTTPSSLEnvName, c.Scheme == "https")
-	env[4] = fmt.Sprintf("%s=%s", HTTPCAFile, c.TLSConfig.CAFile)
-	env[5] = fmt.Sprintf("%s=%s", HTTPCAPath, c.TLSConfig.CAPath)
-	env[6] = fmt.Sprintf("%s=%s", HTTPClientCert, c.TLSConfig.CertFile)
-	env[7] = fmt.Sprintf("%s=%s", HTTPClientKey, c.TLSConfig.KeyFile)
-	env[8] = fmt.Sprintf("%s=%s", HTTPTLSServerName, c.TLSConfig.Address)
-	env[9] = fmt.Sprintf("%s=%t", HTTPSSLVerifyEnvName, !c.TLSConfig.InsecureSkipVerify)
 
 	return env
 }


### PR DESCRIPTION
This adds:

* Function on RuntimeConfig to generate an api.Config
* Function on api.Config to generate the env vars for an API client
* Added an APIConfig member to the proxy Manager
* Proxy Manager will initialize a proxies environment by copying its environment (old behavior) and then appending all the env vars generated by the api.Config.GenerateEnv function

What I have tested thus far:

* Consul with HTTP and HTTPS. To do this I created a proxy script and then configured my service to use it as a custom proxy command. It just saves off the env to a file so I can look at the vars afterwards.
```
#!/usr/bin/env bash
env > /Users/mkeeler/env.txt
exec /Users/mkeeler/Code/repos/consul/proxy-env-vars/bin/consul connect proxy "$@"
```

* New Unit Tests for the api config's GenerateEnv function, the runtime config's APIConfig function and the proxy manager setting up the proxies env to have whatever vaules are in the ProxyEnv var.
