### PR TITLE
IPV6 only deployments cli fix

### DIFF
--- a/agent/proxy/manager_test.go
+++ b/agent/proxy/manager_test.go
@@ -323,7 +323,7 @@ func TestManagerPassesProxyEnv(t *testing.T) {
 	defer m.Kill()
 
 	penv := make([]string, 0, 2)
-	penv = append(penv, "HTTP_ADDR=127.0.0.1:8500")
+	penv = append(penv, "HTTP_ADDR=localhost:8500")
 	penv = append(penv, "HTTP_SSL=false")
 	m.ProxyEnv = penv
 
@@ -341,7 +341,7 @@ func TestManagerPassesProxyEnv(t *testing.T) {
 	var err error
 	var data []byte
 	envData := os.Environ()
-	envData = append(envData, "HTTP_ADDR=127.0.0.1:8500")
+	envData = append(envData, "HTTP_ADDR=localhost:8500")
 	envData = append(envData, "HTTP_SSL=false")
 	sort.Strings(envData)
 	for _, envVariable := range envData {

--- a/api/api.go
+++ b/api/api.go
@@ -296,7 +296,7 @@ func DefaultNonPooledConfig() *Config {
 // given function to make the transport.
 func defaultConfig(transportFn func() *http.Transport) *Config {
 	config := &Config{
-		Address:   "127.0.0.1:8500",
+		Address:   "localhost:8500",
 		Scheme:    "http",
 		Transport: transportFn(),
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -554,7 +554,7 @@ func TestAPI_GenerateEnv(t *testing.T) {
 	t.Parallel()
 
 	c := &Config{
-		Address: "127.0.0.1:8500",
+		Address: "localhost:8500",
 		Token:   "test",
 		Scheme:  "http",
 		TLSConfig: TLSConfig{
@@ -568,7 +568,7 @@ func TestAPI_GenerateEnv(t *testing.T) {
 	}
 
 	expected := []string{
-		"CONSUL_HTTP_ADDR=127.0.0.1:8500",
+		"CONSUL_HTTP_ADDR=localhost:8500",
 		"CONSUL_HTTP_TOKEN=test",
 		"CONSUL_HTTP_SSL=false",
 		"CONSUL_CACERT=",
@@ -587,7 +587,7 @@ func TestAPI_GenerateEnvHTTPS(t *testing.T) {
 	t.Parallel()
 
 	c := &Config{
-		Address: "127.0.0.1:8500",
+		Address: "localhost:8500",
 		Token:   "test",
 		Scheme:  "https",
 		TLSConfig: TLSConfig{
@@ -595,7 +595,7 @@ func TestAPI_GenerateEnvHTTPS(t *testing.T) {
 			CAPath:             "/var/consul/ca.dir",
 			CertFile:           "/var/consul/server.crt",
 			KeyFile:            "/var/consul/ssl/server.key",
-			Address:            "127.0.0.1:8500",
+			Address:            "localhost:8500",
 			InsecureSkipVerify: false,
 		},
 		HttpAuth: &HttpBasicAuth{
@@ -605,14 +605,14 @@ func TestAPI_GenerateEnvHTTPS(t *testing.T) {
 	}
 
 	expected := []string{
-		"CONSUL_HTTP_ADDR=127.0.0.1:8500",
+		"CONSUL_HTTP_ADDR=localhost:8500",
 		"CONSUL_HTTP_TOKEN=test",
 		"CONSUL_HTTP_SSL=true",
 		"CONSUL_CACERT=/var/consul/ca.crt",
 		"CONSUL_CAPATH=/var/consul/ca.dir",
 		"CONSUL_CLIENT_CERT=/var/consul/server.crt",
 		"CONSUL_CLIENT_KEY=/var/consul/ssl/server.key",
-		"CONSUL_TLS_SERVER_NAME=127.0.0.1:8500",
+		"CONSUL_TLS_SERVER_NAME=localhost:8500",
 		"CONSUL_HTTP_SSL_VERIFY=true",
 		"CONSUL_HTTP_AUTH=user:password",
 	}

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,6 +1,6 @@
 REQ=262144
 CLIENTS=64
-ADDR=http://127.0.0.1:8500/v1/kv/bench
+ADDR=http://localhost:8500/v1/kv/bench
 DATA="74a31e96-1d0f-4fa7-aa14-7212a326986e"
 MAXPROCS=4
 

--- a/bench/results-0.7.1.md
+++ b/bench/results-0.7.1.md
@@ -23,7 +23,7 @@ increased the number of requests to try to get a better sample.
 
 ```
 ===== PUT test =====
-GOMAXPROCS=4 boom -m PUT -d "74a31e96-1d0f-4fa7-aa14-7212a326986e" -n 262144 -c 64 http://127.0.0.1:8500/v1/kv/bench
+GOMAXPROCS=4 boom -m PUT -d "74a31e96-1d0f-4fa7-aa14-7212a326986e" -n 262144 -c 64 http://localhost:8500/v1/kv/bench
 262144 / 262144 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00 %
 
 Summary:
@@ -61,7 +61,7 @@ Latency distribution:
   99% in 0.0489 secs.
 
 ===== GET default test =====
-GOMAXPROCS=4 boom -n 262144 -c 64 http://127.0.0.1:8500/v1/kv/bench
+GOMAXPROCS=4 boom -n 262144 -c 64 http://localhost:8500/v1/kv/bench
 262144 / 262144 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00 %
 
 Summary:
@@ -99,7 +99,7 @@ Latency distribution:
   99% in 0.0228 secs.
 
 ===== GET stale test =====
-GOMAXPROCS=4 boom -n 262144 -c 64 http://127.0.0.1:8500/v1/kv/bench?stale
+GOMAXPROCS=4 boom -n 262144 -c 64 http://localhost:8500/v1/kv/bench?stale
 262144 / 262144 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00 %
 
 Summary:
@@ -137,7 +137,7 @@ Latency distribution:
   99% in 0.0203 secs.
 
 ===== GET consistent test =====
-GOMAXPROCS=4 boom -n 262144 -c 64 http://127.0.0.1:8500/v1/kv/bench?consistent
+GOMAXPROCS=4 boom -n 262144 -c 64 http://localhost:8500/v1/kv/bench?consistent
 262144 / 262144 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00 %
 
 Summary:
@@ -182,7 +182,7 @@ leader itself and collected pprof data. Here's the output of the benchmark:
 
 ```
 ===== GET stale test =====
-GOMAXPROCS=4 boom -n 262144 -c 64 http://127.0.0.1:8500/v1/kv/bench?stale
+GOMAXPROCS=4 boom -n 262144 -c 64 http://localhost:8500/v1/kv/bench?stale
 262144 / 262144 Booooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00 %
 
 Summary:

--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -27,7 +27,7 @@ func (f *HTTPFlags) ClientFlags() *flag.FlagSet {
 		"The `address` and port of the Consul HTTP agent. The value can be an IP "+
 			"address or DNS address, but it must also include the port. This can "+
 			"also be specified via the CONSUL_HTTP_ADDR environment variable. The "+
-			"default value is http://127.0.0.1:8500. The scheme can also be set to "+
+			"default value is http://localhost:8500. The scheme can also be set to "+
 			"HTTPS by setting the environment variable CONSUL_HTTP_SSL=true.")
 	fs.Var(&f.token, "token",
 		"ACL token to use in the request. This can also be specified via the "+

--- a/watch/plan_test.go
+++ b/watch/plan_test.go
@@ -50,7 +50,7 @@ func TestRun_Stop(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- plan.Run("127.0.0.1:8500")
+		errCh <- plan.Run("localhost:8500")
 	}()
 
 	select {
@@ -102,7 +102,7 @@ func TestRun_Stop_Hybrid(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- plan.Run("127.0.0.1:8500")
+		errCh <- plan.Run("localhost:8500")
 	}()
 
 	select {

--- a/website/source/docs/commands/_http_api_options_client.html.md
+++ b/website/source/docs/commands/_http_api_options_client.html.md
@@ -16,7 +16,7 @@
 * `-http-addr=<addr>` - Address of the Consul agent with the port. This can be
   an IP address or DNS address, but it must include the port. This can also be
   specified via the `CONSUL_HTTP_ADDR` environment variable. In Consul 0.8 and
-  later, the default value is http://127.0.0.1:8500, and https can optionally
+  later, the default value is http://localhost:8500, and https can optionally
   be used instead. The scheme can also be set to HTTPS by setting the
   environment variable `CONSUL_HTTP_SSL=true`.
 

--- a/website/source/docs/commands/index.html.md
+++ b/website/source/docs/commands/index.html.md
@@ -67,7 +67,7 @@ HTTP API Options
      The `address` and port of the Consul HTTP agent. The value can be
      an IP address or DNS address, but it must also include the port.
      This can also be specified via the CONSUL_HTTP_ADDR environment
-     variable. The default value is http://127.0.0.1:8500. The scheme
+     variable. The default value is http://localhost:8500. The scheme
      can also be set to HTTPS by setting the environment variable
      CONSUL_HTTP_SSL=true.
 
@@ -116,7 +116,7 @@ This is the HTTP API address to the *local* Consul agent
 (not the remote server) specified as a URI:
 
 ```
-CONSUL_HTTP_ADDR=127.0.0.1:8500
+CONSUL_HTTP_ADDR=localhost:8500
 ```
 
 or as a Unix socket path:

--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -78,7 +78,7 @@ Usage: `consul snapshot agent [options]`
 ```javascript
   {
     "snapshot_agent": {
-      "http_addr": "127.0.0.1:8500",
+      "http_addr": "localhost:8500",
       "token": "",
       "datacenter": "",
       "ca_file": "",

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -225,7 +225,7 @@ file. To use this approach, omit `acl_master_token` from the above config and th
 ```text
 $ curl \
     --request PUT \
-    http://127.0.0.1:8500/v1/acl/bootstrap
+    http://localhost:8500/v1/acl/bootstrap
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```
@@ -262,7 +262,7 @@ $ curl \
   "Name": "Agent Token",
   "Type": "client",
   "Rules": "node \"\" { policy = \"write\" } service \"\" { policy = \"read\" }"
-}' http://127.0.0.1:8500/v1/acl/create
+}' http://localhost:8500/v1/acl/create
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```
@@ -290,7 +290,7 @@ $ curl \
     --data \
 '{
   "Token": "fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"
-}' http://127.0.0.1:8500/v1/agent/token/acl_agent_token
+}' http://localhost:8500/v1/agent/token/acl_agent_token
 ```
 
 With that ACL agent token set, the servers will be able to sync themselves with the
@@ -325,7 +325,7 @@ $ curl \
     --data \
 '{
   "Token": "fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"
-}' http://127.0.0.1:8500/v1/agent/token/acl_agent_token
+}' http://localhost:8500/v1/agent/token/acl_agent_token
 ```
 
 We used the same ACL agent token that we created for the servers, which will work since
@@ -379,7 +379,7 @@ $ curl \
   "ID": "anonymous",
   "Type": "client",
   "Rules": "node \"\" { policy = \"read\" }"
-}' http://127.0.0.1:8500/v1/acl/update
+}' http://localhost:8500/v1/acl/update
 
 {"ID":"anonymous"}
 ```
@@ -432,7 +432,7 @@ $ curl \
   "ID": "anonymous",
   "Type": "client",
   "Rules": "node \"\" { policy = \"read\" } service \"consul\" { policy = \"read\" }"
-}' http://127.0.0.1:8500/v1/acl/update
+}' http://localhost:8500/v1/acl/update
 
 {"ID":"anonymous"}
 ```
@@ -498,7 +498,7 @@ $ curl \
   "Name": "UI Token",
   "Type": "client",
   "Rules": "key \"\" { policy = \"write\" } node \"\" { policy = \"read\" } service \"\" { policy = \"read\" }"
-}' http://127.0.0.1:8500/v1/acl/create
+}' http://localhost:8500/v1/acl/create
 {"ID":"d0a9f330-2f9d-0a8c-d2af-1e9ceda354e6"}
 ```
 

--- a/website/source/docs/guides/external.html.md
+++ b/website/source/docs/guides/external.html.md
@@ -34,7 +34,7 @@ Let us suppose we want to register a "search" service that is provided by
 $ curl -X PUT -d '{"Datacenter": "dc1", "Node": "google",
    "Address": "www.google.com",
    "Service": {"Service": "search", "Port": 80}}'
-   http://127.0.0.1:8500/v1/catalog/register
+   http://localhost:8500/v1/catalog/register
 ```
 
 Add an upstream DNS server to the list of recursors to Consul's configuration. Example with Google's public DNS server:
@@ -70,7 +70,7 @@ www.google.com.		264	IN	A	74.125.239.116
 If at any time we want to deregister the service, we simply do:
 
 ```text
-$ curl -X PUT -d '{"Datacenter": "dc1", "Node": "google"}' http://127.0.0.1:8500/v1/catalog/deregister
+$ curl -X PUT -d '{"Datacenter": "dc1", "Node": "google"}' http://localhost:8500/v1/catalog/deregister
 ```
 
 This will deregister the `google` node along with all services it provides.

--- a/website/source/docs/guides/geo-failover.html.md
+++ b/website/source/docs/guides/geo-failover.html.md
@@ -30,7 +30,7 @@ $ curl \
     "Service": "api",
     "Tags": ["v1.2.3"]
   }
-}' http://127.0.0.1:8500/v1/query
+}' http://localhost:8500/v1/query
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```
@@ -70,7 +70,7 @@ $ curl \
       "Datacenters": ["dc1", "dc2"]
     }
   }
-}' http://127.0.0.1:8500/v1/query
+}' http://localhost:8500/v1/query
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```
@@ -101,7 +101,7 @@ $ curl \
       "NearestN": 2
     }
   }
-}' http://127.0.0.1:8500/v1/query
+}' http://localhost:8500/v1/query
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```
@@ -133,7 +133,7 @@ $ curl \
       "NearestN": 2
     }
   }
-}' http://127.0.0.1:8500/v1/query
+}' http://localhost:8500/v1/query
 
 {"ID":"fe3b8d40-0ee0-8783-6cc2-ab1aa9bb16c1"}
 ```


### PR DESCRIPTION
switching 127.0.0.1 to localhost to make consul cli work by default in IPv6 only environment