### PR TITLE
UI - Tag Text Search

### DIFF
--- a/ui-v2/app/controllers/dc/nodes/show.js
+++ b/ui-v2/app/controllers/dc/nodes/show.js
@@ -26,6 +26,10 @@ export default Controller.extend(WithFiltering, {
       get(item, 'ID')
         .toLowerCase()
         .indexOf(term) !== -1 ||
+      (get(item, 'Tags') || [])
+        .join('')
+        .toLowerCase()
+        .indexOf(term) !== -1 ||
       get(item, 'Port')
         .toString()
         .toLowerCase()

--- a/ui-v2/app/controllers/dc/nodes/show.js
+++ b/ui-v2/app/controllers/dc/nodes/show.js
@@ -26,10 +26,9 @@ export default Controller.extend(WithFiltering, {
       get(item, 'ID')
         .toLowerCase()
         .indexOf(term) !== -1 ||
-      (get(item, 'Tags') || [])
-        .join('')
-        .toLowerCase()
-        .indexOf(term) !== -1 ||
+      (get(item, 'Tags') || []).some(function(item) {
+        return item.toLowerCase().indexOf(term) !== -1;
+      }) ||
       get(item, 'Port')
         .toString()
         .toLowerCase()

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -31,10 +31,9 @@ export default Controller.extend(WithHealthFiltering, {
       (get(item, 'Name')
         .toLowerCase()
         .indexOf(term) !== -1 ||
-        (get(item, 'Tags') || [])
-          .join('')
-          .toLowerCase()
-          .indexOf(term) !== -1) &&
+        (get(item, 'Tags') || []).some(function(item) {
+          return item.toLowerCase().indexOf(term) !== -1;
+        })) &&
       item.hasStatus(status)
     );
   },

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -26,10 +26,16 @@ const widthDeclaration = function(num) {
 };
 export default Controller.extend(WithHealthFiltering, {
   filter: function(item, { s = '', status = '' }) {
+    const term = s.toLowerCase();
     return (
-      get(item, 'Name')
+      (get(item, 'Name')
         .toLowerCase()
-        .indexOf(s.toLowerCase()) !== -1 && item.hasStatus(status)
+        .indexOf(term) !== -1 ||
+        (get(item, 'Tags') || [])
+          .join('')
+          .toLowerCase()
+          .indexOf(term) !== -1) &&
+      item.hasStatus(status)
     );
   },
   totalWidth: computed('{maxPassing,maxWarning,maxCritical}', function() {

--- a/ui-v2/tests/acceptance/components/catalog-filter.feature
+++ b/ui-v2/tests/acceptance/components/catalog-filter.feature
@@ -97,6 +97,11 @@ Feature: components / catalog-filter
     s: monitor
     ---
     And I see 2 [Model] models
+    Then I fill in with yaml
+    ---
+    s: wallpix
+    ---
+    And I see 0 [Model] models
   Where:
     -------------------------------------------------
     | Model   | Page     | Url                       |
@@ -156,3 +161,8 @@ Feature: components / catalog-filter
     s: three
     ---
     And I see 3 service models
+    Then I fill in with yaml
+    ---
+    s: wothre
+    ---
+    And I see 0 service models

--- a/ui-v2/tests/acceptance/components/catalog-filter.feature
+++ b/ui-v2/tests/acceptance/components/catalog-filter.feature
@@ -87,6 +87,16 @@ Feature: components / catalog-filter
     ---
     And I see 1 [Model] model
     And I see 1 [Model] model with the id "service-0-with-id"
+    Then I fill in with yaml
+    ---
+    s: hard drive
+    ---
+    And I see 1 [Model] model with the name "[Model]-1"
+    Then I fill in with yaml
+    ---
+    s: monitor
+    ---
+    And I see 2 [Model] models
   Where:
     -------------------------------------------------
     | Model   | Page     | Url                       |
@@ -117,3 +127,32 @@ Feature: components / catalog-filter
     | Model   | Page     | Url                       |
     | nodes   | service  | /dc-1/services/service-0  |
     -------------------------------------------------
+  Scenario:
+    Given 1 datacenter model with the value "dc-1"
+    And 3 service models from yaml
+    ---
+      - Tags: ['one', 'two', 'three']
+      - Tags: ['two', 'three']
+      - Tags: ['three']
+    ---
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    Then I see 3 service models
+    Then I fill in with yaml
+    ---
+    s: one
+    ---
+    And I see 1 service model with the name "service-0"
+    Then I fill in with yaml
+    ---
+    s: two
+    ---
+    And I see 2 service models
+    Then I fill in with yaml
+    ---
+    s: three
+    ---
+    And I see 3 service models

--- a/ui-v2/tests/pages/dc/nodes/show.js
+++ b/ui-v2/tests/pages/dc/nodes/show.js
@@ -7,6 +7,7 @@ export default function(visitable, deletable, clickable, attribute, collection, 
     }),
     services: collection('#services [data-test-tabular-row]', {
       id: attribute('data-test-service-id', '[data-test-service-id]'),
+      name: attribute('data-test-service-name', '[data-test-service-name]'),
       port: attribute('data-test-service-port', '.port'),
     }),
     sessions: collection(


### PR DESCRIPTION
This PR adds simple text based searching by tag.

You can now enter a tag name in the service listing pages/tabs and the result will include services with that tag.

This is a temporary text search for tags before looking into something more complex.

I've split the tests off into the first commit so if you wan to go back a commit to see it breaking you can.