### PR TITLE
Revert PR 4294 - Catalog Register: Generate UUID for services registered without one

### DIFF
--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -37,13 +37,6 @@ func (c *Catalog) Register(args *structs.RegisterRequest, reply *struct{}) error
 		if _, err := uuid.ParseUUID(string(args.ID)); err != nil {
 			return fmt.Errorf("Bad node ID: %v", err)
 		}
-	} else {
-		id, err := uuid.GenerateUUID()
-		if err != nil {
-			return fmt.Errorf("Failed to generate ID: %v", err)
-		}
-
-		args.ID = types.NodeID(id)
 	}
 
 	// Fetch the ACL token, if any.

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -50,37 +50,6 @@ func TestCatalog_Register(t *testing.T) {
 	}
 }
 
-func TestCatalog_RegisterNoID(t *testing.T) {
-	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
-
-	arg := structs.RegisterRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "127.0.0.1",
-		Service: &structs.NodeService{
-			Service: "db",
-			Tags:    []string{"master"},
-			Port:    8000,
-		},
-	}
-	var out struct{}
-
-	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
-
-	var ns structs.IndexedNodeServices
-	nodeArgs := structs.NodeSpecificRequest{
-		Datacenter: "dc1",
-		Node:       "foo",
-	}
-	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.NodeServices", &nodeArgs, &ns))
-	require.NotEqual(t, types.NodeID(""), ns.NodeServices.Node.ID)
-}
-
 func TestCatalog_RegisterService_InvalidAddress(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServer(t)

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -134,7 +134,7 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 		shutdownCh: make(chan struct{}),
 	}
 
-	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))
+    c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))
 
 	if err := c.initEnterprise(); err != nil {
 		c.Shutdown()

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -134,7 +134,7 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 		shutdownCh: make(chan struct{}),
 	}
 
-    c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))
+	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))
 
 	if err := c.initEnterprise(); err != nil {
 		c.Shutdown()


### PR DESCRIPTION
UUID auto-generation here causes trouble in a few cases. The biggest being older
nodes reregistering will fail when the UUIDs are different and the names match

This reverts commit 0f700340828f464449c2e0d5a82db0bc5456d385.
This reverts commit d1a8f9cb3f6f48dd9c8d0bc858031ff6ccff51d0.
This reverts commit cf69ec42a418ab6594a6654e9545e12160f30970.