### PR TITLE
Implement missing HTTP host to ConsulResolver func for Connect SDK.

### DIFF
--- a/connect/service.go
+++ b/connect/service.go
@@ -69,10 +69,11 @@ func NewService(serviceName string, client *api.Client) (*Service, error) {
 func NewServiceWithLogger(serviceName string, client *api.Client,
 	logger *log.Logger) (*Service, error) {
 	s := &Service{
-		service: serviceName,
-		client:  client,
-		logger:  logger,
-		tlsCfg:  newDynamicTLSConfig(defaultTLSConfig()),
+		service:              serviceName,
+		client:               client,
+		logger:               logger,
+		tlsCfg:               newDynamicTLSConfig(defaultTLSConfig()),
+		httpResolverFromAddr: ConsulResolverFromAddrFunc(client),
 	}
 
 	// Set up root and leaf watches

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -252,3 +252,28 @@ func TestService_HTTPClient(t *testing.T) {
 		}
 	})
 }
+
+func TestService_HasDefaultHTTPResolverFromAddr(t *testing.T) {
+
+	client, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+
+	s, err := NewService("foo", client)
+	require.NoError(t, err)
+
+	// Sanity check this is actually set in constructor since we always override
+	// it in tests. Full tests of the resolver func are in resolver_test.go
+	require.NotNil(t, s.httpResolverFromAddr)
+
+	fn := s.httpResolverFromAddr
+
+	expected := &ConsulResolver{
+		Client:    client,
+		Namespace: "default",
+		Name:      "foo",
+		Type:      ConsulResolverTypeService,
+	}
+	got, err := fn("foo.service.consul")
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}

--- a/website/source/docs/connect/native/go.html.md
+++ b/website/source/docs/connect/native/go.html.md
@@ -157,13 +157,32 @@ The HTTP client configuration automatically sends the correct client
 certificate, verifies the server certificate, and manages background
 goroutines for updating our certificates as necessary.
 
--> **Important:** The HTTP client _requires_ the hostname is a Consul
-DNS name. Static IP addresses and external DNS cannot be used with the
-HTTP client. For these values, please use `svc.Dial` directly.
-
 If the application already uses a manually constructed `*http.Client`,
 the `svc.HTTPDialTLS` function can be used to configure the
 `http.Transport.DialTLS` field to achieve equivalent behavior.
+
+### Hostname Requirements
+
+The hostname used in the request URL is used to identify the logical service
+discovery mechanism for the target. **It's not actually resolved via DNS** but
+used as a logical identifier for a Consul service discovery mechanism. It has
+the following specific limitations:
+
+ * The sheme must be `https://`.
+ * It must be a Consul DNS name in one of the following forms:
+   * `<name>.service[.<datacenter>].consul` to discover a healthy service
+     instance for a given service.
+   * `<name>.query[.<datacenter>].consul` to discover an instance via 
+     [Prepared Query](/api/query.html).
+ * The top-level domain _must_ be `.consul` even if your cluster has a custom
+   `domain` configured for it's DNS interface. This might be relaxed in the
+   future.
+ * Tag filters for services are not currently supported (i.e.
+   `tag1.web.service.consul`) however the same behaviour can be acheived using a
+   prepared query.
+ * External DNS names, raw IP addresses and so on will cause an error and should
+   be fetched using a separate `HTTPClient`.
+
 
 ## Raw TLS Connection
 

--- a/website/source/docs/connect/native/go.html.md
+++ b/website/source/docs/connect/native/go.html.md
@@ -168,17 +168,17 @@ discovery mechanism for the target. **It's not actually resolved via DNS** but
 used as a logical identifier for a Consul service discovery mechanism. It has
 the following specific limitations:
 
- * The sheme must be `https://`.
+ * The scheme must be `https://`.
  * It must be a Consul DNS name in one of the following forms:
    * `<name>.service[.<datacenter>].consul` to discover a healthy service
      instance for a given service.
-   * `<name>.query[.<datacenter>].consul` to discover an instance via 
+   * `<name>.query[.<datacenter>].consul` to discover an instance via
      [Prepared Query](/api/query.html).
  * The top-level domain _must_ be `.consul` even if your cluster has a custom
    `domain` configured for it's DNS interface. This might be relaxed in the
    future.
  * Tag filters for services are not currently supported (i.e.
-   `tag1.web.service.consul`) however the same behaviour can be acheived using a
+   `tag1.web.service.consul`) however the same behaviour can be achieved using a
    prepared query.
  * External DNS names, raw IP addresses and so on will cause an error and should
    be fetched using a separate `HTTPClient`.


### PR DESCRIPTION
I managed to remove a TODO in Connect SDK that was not done. I thought it was because we have tests for HTTPClient but the part that we made pluggable to ease testing actually didn't have a non-test implementation 😱 .

This fixes that.

## UX Gotcha

In general this will work OK as a basic experience. It's a bit of a gotcha that we only support `.consul` TLD in the HTTP client hostnames even if your actual Consul DNS is configured with a custom domain. The reason for that is that without making external calls and adding much complication, we don't actually know what the correct domain is, and in conjunction with the datacenter suffix being optional, it becomes impossible to unambiguously tell the difference between a custom domain segment and a datacenter name (which matters because we want to support explicit requests to other DCs).

We could potentially revisit this in the future if it seems to be a big issue for folks but it is simplest to just document it for now.

Docs updates to explain this:

![image](https://user-images.githubusercontent.com/120915/42716125-f0cdc8a2-86f1-11e8-8986-52d9f8067e99.png)
