### PR TITLE
Docs: Removed text about proxies on Windows not starting up.

### DIFF
--- a/website/source/docs/connect/proxies.html.md
+++ b/website/source/docs/connect/proxies.html.md
@@ -21,8 +21,6 @@ Consul supports both _managed_ and _unmanaged_ proxies. A managed proxy
 is started, configured, and stopped by Consul. An unmanaged proxy is the
 responsibility of the user, like any other Consul service.
 
-~> **Windows Support**: The proxy management feature was designed to run on all platforms but has a known issue on the Windows platform at Beta launch preventing it from starting proxy processes. This will be fixed in a future release.
-
 ## Managed Proxies
 
 Managed proxies are started, configured, and stopped by Consul. They are

--- a/website/source/intro/getting-started/connect.html.md
+++ b/website/source/intro/getting-started/connect.html.md
@@ -26,8 +26,6 @@ focus on ease of use with a dev-mode agent. We will _not setup_ Connect in a
 production-recommended secure way. Please read the [Connect production
 guide](/docs/guides/connect-production.html) to understand the tradeoffs.
 
-~> **Windows Support**: The proxy management feature was designed to run on all platforms but has a known issue on the Windows platform at Beta launch preventing it from starting proxy processes. This will be fixed in a future release.
-
 ## Starting a Connect-unaware Service
 
 Let's begin by starting a service that is unaware of Connect all. To


### PR DESCRIPTION
This PR updates our documentation to reflect the PR (https://github.com/hashicorp/consul/pull/4363) which fixed the issue of proxies not starting up on Windows.