### PR TITLE
Node renaming - 2nd try

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -881,6 +881,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	if a.config.NonVotingServer {
 		base.NonVoter = a.config.NonVotingServer
 	}
+	if a.config.AllowNodeRenaming {
+		base.AllowNodeRenaming = a.config.AllowNodeRenaming
+	}
 
 	// These are fully specified in the agent defaults, so we can simply
 	// copy them over.

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -600,6 +600,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		ACLToken:               b.stringVal(c.ACLToken),
 		EnableACLReplication:   b.boolVal(c.EnableACLReplication),
 
+		AllowNodeRenaming: b.boolVal(c.AllowNodeRenaming),
+
 		// Autopilot
 		AutopilotCleanupDeadServers:      b.boolVal(c.Autopilot.CleanupDeadServers),
 		AutopilotDisableUpgradeMigration: b.boolVal(c.Autopilot.DisableUpgradeMigration),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -150,6 +150,7 @@ type Config struct {
 	Addresses                   Addresses                `json:"addresses,omitempty" hcl:"addresses" mapstructure:"addresses"`
 	AdvertiseAddrLAN            *string                  `json:"advertise_addr,omitempty" hcl:"advertise_addr" mapstructure:"advertise_addr"`
 	AdvertiseAddrWAN            *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
+	AllowNodeRenaming           *bool                    `json:"allow_node_renaming,omitempty" hcl:"allow_node_renaming" mapstructure:"allow_node_renaming"`
 	Autopilot                   Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                    *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
 	Bootstrap                   *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -143,6 +143,10 @@ type RuntimeConfig struct {
 	// hcl: acl_token = string
 	ACLToken string
 
+	// AllowNodeRenaming allow to rename nodes having an ID. Defaults to false
+	// hcl: allow_node_renaming = (true|false)
+	AllowNodeRenaming bool
+
 	// AutopilotCleanupDeadServers enables the automatic cleanup of dead servers when new ones
 	// are added to the peer list. Defaults to true.
 	//

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2442,7 +2442,7 @@ func TestFullConfig(t *testing.T) {
 			"acl_default_policy": "ArK3WIfE",
 			"acl_down_policy": "vZXMfMP0",
 			"acl_enforce_version_8": true,
-		        "acl_enable_key_list_policy": true,
+			"acl_enable_key_list_policy": true,
 			"acl_master_token": "C1Q1oIwh",
 			"acl_replication_token": "LMmgy5dO",
 			"acl_token": "O1El0wan",
@@ -2454,6 +2454,7 @@ func TestFullConfig(t *testing.T) {
 			},
 			"advertise_addr": "17.99.29.16",
 			"advertise_addr_wan": "78.63.37.19",
+			"allow_node_renaming": true,
 			"autopilot": {
 				"cleanup_dead_servers": true,
 				"disable_upgrade_migration": true,
@@ -2903,7 +2904,7 @@ func TestFullConfig(t *testing.T) {
 			acl_default_policy = "ArK3WIfE"
 			acl_down_policy = "vZXMfMP0"
 			acl_enforce_version_8 = true
-		        acl_enable_key_list_policy = true
+			acl_enable_key_list_policy = true
 			acl_master_token = "C1Q1oIwh"
 			acl_replication_token = "LMmgy5dO"
 			acl_token = "O1El0wan"
@@ -2915,6 +2916,7 @@ func TestFullConfig(t *testing.T) {
 			}
 			advertise_addr = "17.99.29.16"
 			advertise_addr_wan = "78.63.37.19"
+			allow_node_renaming = true
 			autopilot = {
 				cleanup_dead_servers = true
 				disable_upgrade_migration = true
@@ -3518,6 +3520,7 @@ func TestFullConfig(t *testing.T) {
 		ACLToken:                         "O1El0wan",
 		AdvertiseAddrLAN:                 ipAddr("17.99.29.16"),
 		AdvertiseAddrWAN:                 ipAddr("78.63.37.19"),
+		AllowNodeRenaming:                true,
 		AutopilotCleanupDeadServers:      true,
 		AutopilotDisableUpgradeMigration: true,
 		AutopilotLastContactThreshold:    12705 * time.Second,
@@ -4253,6 +4256,7 @@ func TestSanitize(t *testing.T) {
     "AEInterval": "0s",
     "AdvertiseAddrLAN": "",
     "AdvertiseAddrWAN": "",
+    "AllowNodeRenaming": false,
     "AutopilotCleanupDeadServers": false,
     "AutopilotDisableUpgradeMigration": false,
     "AutopilotLastContactThreshold": "0s",

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -265,6 +265,11 @@ type Config struct {
 	// by default in Consul 1.0 and later.
 	ACLEnableKeyListPolicy bool
 
+	// AllowNodeRenaming is used to allow to rename nodes with IDs. When setting up this
+	// feature, it is not possible anymore to register nodes without IDs and not
+	// possible to 2 nodes with same name (case insensentive match)
+	AllowNodeRenaming bool
+
 	// TombstoneTTL is used to control how long KV tombstones are retained.
 	// This provides a window of time where the X-Consul-Index is monotonic.
 	// Outside this window, the index may not be monotonic. This is a result

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -41,7 +41,7 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 
 func TestFSM_RegisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFSM_RegisterNode(t *testing.T) {
 
 func TestFSM_RegisterNode_Service(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestFSM_RegisterNode_Service(t *testing.T) {
 
 func TestFSM_DeregisterService(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFSM_DeregisterService(t *testing.T) {
 
 func TestFSM_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFSM_DeregisterCheck(t *testing.T) {
 
 func TestFSM_DeregisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 
 func TestFSM_KVSDelete(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestFSM_KVSDelete(t *testing.T) {
 
 func TestFSM_KVSDeleteTree(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestFSM_KVSDeleteTree(t *testing.T) {
 
 func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestFSM_KVSCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSLock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -600,7 +600,7 @@ func TestFSM_KVSLock(t *testing.T) {
 
 func TestFSM_KVSUnlock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -663,7 +663,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 
 func TestFSM_CoordinateUpdate(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestFSM_CoordinateUpdate(t *testing.T) {
 
 func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 
 func TestFSM_ACL_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -904,7 +904,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 
 func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1002,7 +1002,7 @@ func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 
 func TestFSM_TombstoneReap(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1050,7 +1050,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 
 func TestFSM_Txn(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1092,7 +1092,7 @@ func TestFSM_Txn(t *testing.T) {
 
 func TestFSM_Autopilot(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -61,8 +61,8 @@ type FSM struct {
 }
 
 // New is used to construct a new FSM with a blank state.
-func New(gc *state.TombstoneGC, logOutput io.Writer) (*FSM, error) {
-	stateNew, err := state.NewStateStore(gc)
+func New(gc *state.TombstoneGC, logOutput io.Writer, config *state.StoreConfig) (*FSM, error) {
+	stateNew, err := state.NewStateStore(gc, config)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 	defer old.Close()
 
 	// Create a new state store.
-	stateNew, err := state.NewStateStore(c.gc)
+	stateNew, err := state.NewStateStore(c.gc, c.state.StoreConfig)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -39,7 +39,7 @@ func makeLog(buf []byte) *raft.Log {
 
 func TestFSM_IgnoreUnknown(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	assert.Nil(t, err)
 
 	// Create a new reap request

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -21,7 +21,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 
 	// Try to restore on a new FSM
-	fsm2, err := New(nil, os.Stderr)
+	fsm2, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -340,7 +340,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 func TestFSM_BadRestore_OSS(t *testing.T) {
 	t.Parallel()
 	// Create an FSM with some state.
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/issue_test.go
+++ b/agent/consul/issue_test.go
@@ -23,7 +23,7 @@ func makeLog(buf []byte) *raft.Log {
 // Testing for GH-300 and GH-279
 func TestHealthCheckRace(t *testing.T) {
 	t.Parallel()
-	fsm, err := consulfsm.New(nil, os.Stderr)
+	fsm, err := consulfsm.New(nil, os.Stderr, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -473,7 +473,9 @@ func (s *Server) setupRaft() error {
 
 	// Create the FSM.
 	var err error
-	s.fsm, err = fsm.New(s.tombstoneGC, s.config.LogOutput)
+	storeConfig := state.NewStoreConfig(nil)
+	storeConfig.AllowNodeRenaming = s.config.AllowNodeRenaming
+	s.fsm, err = fsm.New(s.tombstoneGC, s.config.LogOutput, storeConfig)
 	if err != nil {
 		return err
 	}
@@ -580,7 +582,7 @@ func (s *Server) setupRaft() error {
 				return fmt.Errorf("recovery failed to parse peers.json: %v", err)
 			}
 
-			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.LogOutput)
+			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.LogOutput, storeConfig)
 			if err != nil {
 				return fmt.Errorf("recovery failed to make temp FSM: %v", err)
 			}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -401,8 +401,9 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 	}()
 }
 
-func TestStateStore_EnsureNode(t *testing.T) {
+func TestStateStore_EnsureNodeWithoutNodeRenaming(t *testing.T) {
 	s := testStateStore(t)
+	s.StoreConfig.AllowNodeRenaming = false
 
 	// Fetching a non-existent node returns nil
 	if _, node, err := s.GetNode("node1"); node != nil || err != nil {
@@ -492,6 +493,212 @@ func TestStateStore_EnsureNode(t *testing.T) {
 	}
 }
 
+func TestStateStore_EnsureNodeWithNodeRenaming(t *testing.T) {
+	s := testStateStore(t)
+	s.StoreConfig.AllowNodeRenaming = true
+
+	// Fetching a non-existent node returns nil
+	if _, node, err := s.GetNode("node1"); node != nil || err != nil {
+		t.Fatalf("expected (nil, nil), got: (%#v, %#v)", node, err)
+	}
+
+	// Create a node registration request
+	in := &structs.Node{
+		Node:    "node1",
+		Address: "1.1.1.1",
+	}
+
+	// Ensure the node is registered in the db
+	if err := s.EnsureNode(1, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node again
+	idx, out, err := s.GetNode("node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Correct node was returned
+	if out.Node != "node1" || out.Address != "1.1.1.1" {
+		t.Fatalf("bad node returned: %#v", out)
+	}
+
+	// Indexes are set properly
+	if out.CreateIndex != 1 || out.ModifyIndex != 1 {
+		t.Fatalf("bad node index: %#v", out)
+	}
+	if idx != 1 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Update the node registration
+	in.Address = "1.1.1.2"
+	if err := s.EnsureNode(2, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node
+	idx, out, err = s.GetNode("node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.CreateIndex != 1 || out.ModifyIndex != 2 || out.Address != "1.1.1.2" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 2 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Node upsert preserves the create index
+	if err := s.EnsureNode(3, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	idx, out, err = s.GetNode("node1")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if out.CreateIndex != 1 || out.ModifyIndex != 3 || out.Address != "1.1.1.2" {
+		t.Fatalf("node was modified: %#v", out)
+	}
+	if idx != 3 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Add an ID to the node
+	in.ID = types.NodeID("cda916bc-a357-4a19-b886-59419fcee50c")
+	if err := s.EnsureNode(4, in); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Now try to add another node with the same ID
+	in = &structs.Node{
+		Node:    "nope",
+		ID:      types.NodeID("cda916bc-a357-4a19-b886-59419fcee50c"),
+		Address: "1.1.1.2",
+	}
+	if err := s.EnsureNode(6, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node
+	idx, out, err = s.GetNode("node1")
+	if out != nil {
+		t.Fatalf("Node should not exist anymore: %q", out)
+	}
+
+	idx, out, err = s.GetNode("node1-renamed")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.CreateIndex != 1 || out.ModifyIndex != 6 || out.Address != "1.1.1.2" || out.Node != "node1-renamed" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 6 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	newNodeID := types.NodeID("d0347693-65cc-4d9f-a6e0-5025b2e6513f")
+
+	// Adding another node with same name should fail
+	in = &structs.Node{
+		Node:    "node1-renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(8, in); err == nil {
+		t.Fatalf("There should be an error since node1-renamed already exists")
+	}
+
+	// Adding another node with same name but different case should fail
+	in = &structs.Node{
+		Node:    "Node1-RENAMED",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(8, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Lets add another valid node now
+	in = &structs.Node{
+		Node:    "Node1bis",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(9, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Retrieve the node
+	idx, out, err = s.GetNode("Node1bis")
+	if out == nil {
+		t.Fatalf("Node should exist, but was null")
+	}
+
+	// Renaming should fail
+	in = &structs.Node{
+		Node:    "Node1bis",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(9, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	idx, out, err = s.GetNode("Node1bis")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Node and indexes were updated
+	if out.ID != newNodeID || out.CreateIndex != 9 || out.ModifyIndex != 9 || out.Address != "1.1.1.7" || out.Node != "Node1bis" {
+		t.Fatalf("bad: %#v", out)
+	}
+	if idx != 9 {
+		t.Fatalf("bad index: %d", idx)
+	}
+
+	// Renaming to same value as first node should fail as well
+	// Adding another node with same name but different case should fail
+	in = &structs.Node{
+		Node:    "node1-renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(10, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// It should fail also with different case
+	in = &structs.Node{
+		Node:    "Node1-Renamed",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(10, in); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// But should work if names are different
+	in = &structs.Node{
+		Node:    "Node1-Renamed2",
+		ID:      newNodeID,
+		Address: "1.1.1.7",
+	}
+	if err := s.EnsureNode(11, in); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	err = s.EnsureNode(5, in)
+	if err == nil || !strings.Contains(err.Error(), "aliases existing node") {
+		t.Fatalf("err: %v", err)
+	}
+}
+
 func TestStateStore_GetNodes(t *testing.T) {
 	s := testStateStore(t)
 
@@ -551,7 +758,7 @@ func TestStateStore_GetNodes(t *testing.T) {
 }
 
 func BenchmarkGetNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, nil)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}
@@ -2575,7 +2782,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 }
 
 func BenchmarkCheckServiceNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, nil)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -21,7 +21,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc)
+	s, err := NewStateStore(gc, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -50,6 +50,24 @@ const (
 	watchLimit = 2048
 )
 
+// StoreConfig Handle a StoreConfig to handle particular behaviours
+type StoreConfig struct {
+	AllowNodeRenaming bool
+}
+
+// NewStoreConfig returns a new StoreConfig with values copied from other Config.
+// if config is not nil, will copy options from Config
+func NewStoreConfig(config *StoreConfig) *StoreConfig {
+	// Default Options to ensure compatibility with previous version
+	allowToRenameNodes := false
+	if config != nil {
+		allowToRenameNodes = config.AllowNodeRenaming
+	}
+	return &StoreConfig{
+		AllowNodeRenaming: allowToRenameNodes,
+	}
+}
+
 // Store is where we store all of Consul's state, including
 // records of node registrations, services, checks, key/value
 // pairs and more. The DB is entirely in-memory and is constructed
@@ -67,6 +85,9 @@ type Store struct {
 
 	// lockDelay holds expiration times for locks associated with keys.
 	lockDelay *Delay
+
+	// StoreConfig handle all configuration options of Store
+	StoreConfig *StoreConfig
 }
 
 // Snapshot is used to provide a point-in-time snapshot. It
@@ -101,7 +122,7 @@ type sessionCheck struct {
 }
 
 // NewStateStore creates a new in-memory state storage layer.
-func NewStateStore(gc *TombstoneGC) (*Store, error) {
+func NewStateStore(gc *TombstoneGC, config *StoreConfig) (*Store, error) {
 	// Create the in-memory DB.
 	schema := stateStoreSchema()
 	db, err := memdb.NewMemDB(schema)
@@ -116,6 +137,7 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 		abandonCh:    make(chan struct{}),
 		kvsGraveyard: NewGraveyard(gc),
 		lockDelay:    NewDelay(),
+		StoreConfig:  NewStoreConfig(config),
 	}
 	return s, nil
 }

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -26,7 +26,7 @@ func testUUID() string {
 }
 
 func testStateStore(t *testing.T) *Store {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -592,6 +592,14 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 * <a name="advertise_addr"></a><a href="#advertise_addr">`advertise_addr`</a> Equivalent to
   the [`-advertise` command-line flag](#_advertise).
 
+* <a name="allow_node_renaming"></a><a href="#allow_node_renaming">`allow_node_renaming`</a>
+  Allows to rename node with IDs. Renaming of nodes will be allowed as it does not collides
+  with another node with different ID but same name (case insensitive comparison).
+  It also enforces case insensitive match for node names when performing registration on
+  nodes without IDs.
+  Since it is a breaking change, its value is `false` by default in Consul version 1.2.1+ but
+  might be set to to `true` in next versions of Consul.
+
 * <a name="serf_wan"></a><a href="#serf_wan_bind">`serf_wan`</a> Equivalent to
   the [`-serf-wan-bind` command-line flag](#_serf_wan_bind).
 


### PR DESCRIPTION
This PR replaces https://github.com/hashicorp/consul/pull/3983

It will allow node renaming if:
 * node does not conflict with another node name (case insensitive comparison)
 * new option allow_node_renaming is set on true (false by default)

This will ensure we do not break ascending compatibility