### PR TITLE
Add configurable leaf cert TTL to Connect CA

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -544,6 +544,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 			"token":                 "Token",
 			"root_pki_path":         "RootPKIPath",
 			"intermediate_pki_path": "IntermediatePKIPath",
+
+			// Common CA config
+			"leaf_cert_ttl": "LeafCertTTL",
 		})
 	}
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2545,7 +2545,8 @@ func TestFullConfig(t *testing.T) {
 			"connect": {
 				"ca_provider": "consul",
 				"ca_config": {
-					"RotationPeriod": "90h"
+					"RotationPeriod": "90h",
+					"LeafCertTTL": "1h"
 				},
 				"enabled": true,
 				"proxy_defaults": {
@@ -3006,7 +3007,8 @@ func TestFullConfig(t *testing.T) {
 			connect {
 				ca_provider = "consul"
 				ca_config {
-					"RotationPeriod" = "90h"
+					rotation_period = "90h"
+					leaf_cert_ttl = "1h"
 				}
 				enabled = true
 				proxy_defaults {
@@ -3610,6 +3612,7 @@ func TestFullConfig(t *testing.T) {
 		ConnectCAProvider:       "consul",
 		ConnectCAConfig: map[string]interface{}{
 			"RotationPeriod": "90h",
+			"LeafCertTTL":    "1h",
 		},
 		ConnectProxyAllowManagedRoot:            false,
 		ConnectProxyAllowManagedAPIRegistration: false,

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -214,8 +214,7 @@ func (c *ConsulProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 			x509.ExtKeyUsageClientAuth,
 			x509.ExtKeyUsageServerAuth,
 		},
-		// todo(kyhavlov): add a way to set the cert lifetime here from the CA config
-		NotAfter:       effectiveNow.Add(3 * 24 * time.Hour),
+		NotAfter:       effectiveNow.Add(c.config.LeafCertTTL),
 		NotBefore:      effectiveNow,
 		AuthorityKeyId: keyId,
 		SubjectKeyId:   keyId,

--- a/agent/connect/ca/provider_consul_config.go
+++ b/agent/connect/ca/provider_consul_config.go
@@ -10,10 +10,12 @@ import (
 )
 
 func ParseConsulCAConfig(raw map[string]interface{}) (*structs.ConsulCAProviderConfig, error) {
-	var config structs.ConsulCAProviderConfig
+	config := structs.ConsulCAProviderConfig{
+		CommonCAProviderConfig: defaultCommonConfig(),
+	}
+
 	decodeConf := &mapstructure.DecoderConfig{
 		DecodeHook:       ParseDurationFunc(),
-		ErrorUnused:      true,
 		Result:           &config,
 		WeaklyTypedInput: true,
 	}
@@ -74,4 +76,10 @@ func Uint8ToString(bs []uint8) string {
 		b[i] = byte(v)
 	}
 	return string(b)
+}
+
+func defaultCommonConfig() structs.CommonCAProviderConfig {
+	return structs.CommonCAProviderConfig{
+		LeafCertTTL: 3 * 24 * time.Hour,
+	}
 }

--- a/agent/connect/ca/provider_consul_config.go
+++ b/agent/connect/ca/provider_consul_config.go
@@ -33,6 +33,10 @@ func ParseConsulCAConfig(raw map[string]interface{}) (*structs.ConsulCAProviderC
 		return nil, fmt.Errorf("must provide a private key when providing a root cert")
 	}
 
+	if err := config.CommonCAProviderConfig.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &config, nil
 }
 

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -172,7 +172,7 @@ func (v *VaultProvider) GenerateIntermediate() (string, error) {
 			"allow_any_name":   true,
 			"allowed_uri_sans": "spiffe://*",
 			"key_type":         "any",
-			"max_ttl":          fmt.Sprintf("%.0fm", v.config.LeafCertTTL.Minutes()),
+			"max_ttl":          v.config.LeafCertTTL.String(),
 			"require_cn":       false,
 		})
 		if err != nil {
@@ -227,7 +227,7 @@ func (v *VaultProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 	// Use the leaf cert role to sign a new cert for this CSR.
 	response, err := v.client.Logical().Write(v.config.IntermediatePKIPath+"sign/"+VaultCALeafCertRole, map[string]interface{}{
 		"csr": pemBuf.String(),
-		"ttl": fmt.Sprintf("%.0fm", v.config.LeafCertTTL.Minutes()),
+		"ttl": v.config.LeafCertTTL.String(),
 	})
 	if err != nil {
 		return "", fmt.Errorf("error issuing cert: %v", err)

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -172,7 +172,7 @@ func (v *VaultProvider) GenerateIntermediate() (string, error) {
 			"allow_any_name":   true,
 			"allowed_uri_sans": "spiffe://*",
 			"key_type":         "any",
-			"max_ttl":          "72h",
+			"max_ttl":          fmt.Sprintf("%.0fm", v.config.LeafCertTTL.Minutes()),
 			"require_cn":       false,
 		})
 		if err != nil {
@@ -227,7 +227,7 @@ func (v *VaultProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 	// Use the leaf cert role to sign a new cert for this CSR.
 	response, err := v.client.Logical().Write(v.config.IntermediatePKIPath+"sign/"+VaultCALeafCertRole, map[string]interface{}{
 		"csr": pemBuf.String(),
-		"ttl": fmt.Sprintf("%.0fh", v.config.LeafCertTTL.Hours()),
+		"ttl": fmt.Sprintf("%.0fm", v.config.LeafCertTTL.Minutes()),
 	})
 	if err != nil {
 		return "", fmt.Errorf("error issuing cert: %v", err)
@@ -319,6 +319,10 @@ func ParseVaultCAConfig(raw map[string]interface{}) (*structs.VaultCAProviderCon
 	}
 	if !strings.HasSuffix(config.IntermediatePKIPath, "/") {
 		config.IntermediatePKIPath += "/"
+	}
+
+	if err := config.CommonCAProviderConfig.Validate(); err != nil {
+		return nil, err
 	}
 
 	return &config, nil

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -154,7 +154,7 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 		require.NotEqual(firstSerial, parsed.SerialNumber.Uint64())
 
 		// Ensure the cert is valid now and expires within the correct limit.
-		require.True(parsed.NotAfter.Sub(time.Now()) < 3*24*time.Hour)
+		require.True(parsed.NotAfter.Sub(time.Now()) < time.Hour)
 		require.True(parsed.NotBefore.Before(time.Now()))
 	}
 }

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -16,6 +16,10 @@ import (
 )
 
 func testVaultCluster(t *testing.T) (*VaultProvider, *vault.Core, net.Listener) {
+	return testVaultClusterWithConfig(t, nil)
+}
+
+func testVaultClusterWithConfig(t *testing.T, rawConf map[string]interface{}) (*VaultProvider, *vault.Core, net.Listener) {
 	if err := vault.AddTestLogicalBackend("pki", pki.Factory); err != nil {
 		t.Fatal(err)
 	}
@@ -23,12 +27,17 @@ func testVaultCluster(t *testing.T) (*VaultProvider, *vault.Core, net.Listener) 
 
 	ln, addr := vaulthttp.TestServer(t, core)
 
-	provider, err := NewVaultProvider(map[string]interface{}{
+	conf := map[string]interface{}{
 		"Address":             addr,
 		"Token":               token,
 		"RootPKIPath":         "pki-root/",
 		"IntermediatePKIPath": "pki-intermediate/",
-	}, "asdf")
+	}
+	for k, v := range rawConf {
+		conf[k] = v
+	}
+
+	provider, err := NewVaultProvider(conf, "asdf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +96,9 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	provider, core, listener := testVaultCluster(t)
+	provider, core, listener := testVaultClusterWithConfig(t, map[string]interface{}{
+		"LeafCertTTL": "1h",
+	})
 	defer core.Shutdown()
 	defer listener.Close()
 	client, err := vaultapi.NewClient(&vaultapi.Config{
@@ -120,8 +131,9 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 		firstSerial = parsed.SerialNumber.Uint64()
 
 		// Ensure the cert is valid now and expires within the correct limit.
-		require.True(parsed.NotAfter.Sub(time.Now()) < 3*24*time.Hour)
-		require.True(parsed.NotBefore.Before(time.Now()))
+		now := time.Now()
+		require.True(parsed.NotAfter.Sub(now) < time.Hour)
+		require.True(parsed.NotBefore.Before(now))
 	}
 
 	// Generate a new cert for another service and make sure

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -68,6 +68,7 @@ func TestConnectCAConfig(t *testing.T) {
 	expected := &structs.ConsulCAProviderConfig{
 		RotationPeriod: 90 * 24 * time.Hour,
 	}
+	expected.LeafCertTTL = 72 * time.Hour
 
 	// Get the initial config.
 	{
@@ -89,7 +90,8 @@ func TestConnectCAConfig(t *testing.T) {
 		{
 			"Provider": "consul",
 			"Config": {
-				"RotationPeriod": 3600000000000
+				"LeafCertTTL": "72h",
+				"RotationPeriod": "1h"
 			}
 		}`))
 		req, _ := http.NewRequest("PUT", "/v1/connect/ca/configuration", body)

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -438,6 +438,7 @@ func DefaultConfig() *Config {
 			Provider: "consul",
 			Config: map[string]interface{}{
 				"RotationPeriod": "2160h",
+				"LeafCertTTL":    "72h",
 			},
 		},
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1008,7 +1008,6 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 func TestLeader_CARootPruning(t *testing.T) {
 	t.Parallel()
 
-	caRootExpireDuration = 500 * time.Millisecond
 	caRootPruneInterval = 200 * time.Millisecond
 
 	require := require.New(t)
@@ -1036,9 +1035,11 @@ func TestLeader_CARootPruning(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
+			"LeafCertTTL":    500 * time.Millisecond,
 			"PrivateKey":     newKey,
 			"RootCert":       "",
 			"RotationPeriod": 90 * 24 * time.Hour,
+			"SkipValidate":   true,
 		},
 	}
 	{
@@ -1056,7 +1057,7 @@ func TestLeader_CARootPruning(t *testing.T) {
 	require.NoError(err)
 	require.Len(roots, 2)
 
-	time.Sleep(caRootExpireDuration * 2)
+	time.Sleep(2 * time.Second)
 
 	// Now the old root should be pruned.
 	_, roots, err = s1.fsm.State().CARoots(nil)

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -192,7 +192,13 @@ type CAConfiguration struct {
 	RaftIndex
 }
 
+type CommonCAProviderConfig struct {
+	LeafCertTTL time.Duration
+}
+
 type ConsulCAProviderConfig struct {
+	CommonCAProviderConfig `mapstructure:",squash"`
+
 	PrivateKey     string
 	RootCert       string
 	RotationPeriod time.Duration
@@ -208,6 +214,8 @@ type CAConsulProviderState struct {
 }
 
 type VaultCAProviderConfig struct {
+	CommonCAProviderConfig `mapstructure:",squash"`
+
 	Address             string
 	Token               string
 	RootPKIPath         string

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -1,7 +1,10 @@
 package structs
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 // IndexedCARoots is the list of currently trusted CA Roots.
@@ -192,8 +195,49 @@ type CAConfiguration struct {
 	RaftIndex
 }
 
+func (c *CAConfiguration) GetCommonConfig() (*CommonCAProviderConfig, error) {
+	if c == nil {
+		return nil, fmt.Errorf("config map was nil")
+	}
+
+	var config CommonCAProviderConfig
+	decodeConf := &mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		Result:     &config,
+	}
+
+	decoder, err := mapstructure.NewDecoder(decodeConf)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := decoder.Decode(c.Config); err != nil {
+		return nil, fmt.Errorf("error decoding config: %s", err)
+	}
+
+	return &config, nil
+}
+
 type CommonCAProviderConfig struct {
 	LeafCertTTL time.Duration
+
+	SkipValidate bool
+}
+
+func (c CommonCAProviderConfig) Validate() error {
+	if c.SkipValidate {
+		return nil
+	}
+
+	if c.LeafCertTTL < time.Hour {
+		return fmt.Errorf("leaf cert TTL must be greater than 1h")
+	}
+
+	if c.LeafCertTTL > 365*24*time.Hour {
+		return fmt.Errorf("leaf cert TTL must be less than 1 year")
+	}
+
+	return nil
 }
 
 type ConsulCAProviderConfig struct {

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -21,8 +21,15 @@ type CAConfig struct {
 	ModifyIndex uint64
 }
 
+// CommonCAProviderConfig is the common options available to all CA providers.
+type CommonCAProviderConfig struct {
+	LeafCertTTL time.Duration
+}
+
 // ConsulCAProviderConfig is the config for the built-in Consul CA provider.
 type ConsulCAProviderConfig struct {
+	CommonCAProviderConfig `mapstructure:",squash"`
+
 	PrivateKey     string
 	RootCert       string
 	RotationPeriod time.Duration

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -64,6 +64,7 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 	expected := &ConsulCAProviderConfig{
 		RotationPeriod: 90 * 24 * time.Hour,
 	}
+	expected.LeafCertTTL = 72 * time.Hour
 
 	// This fails occasionally if server doesn't have time to bootstrap CA so
 	// retry

--- a/website/source/api/connect/ca.html.md
+++ b/website/source/api/connect/ca.html.md
@@ -91,8 +91,7 @@ $ curl \
 {
     "Provider": "consul",
     "Config": {
-        "PrivateKey": null,
-        "RootCert": null,
+        "LeafCertTTL": "72h",
         "RotationPeriod": "2160h"
     },
     "CreateIndex": 5,
@@ -133,8 +132,10 @@ providers, see [Provider Config](/docs/connect/ca.html).
 {
     "Provider": "consul",
     "Config": {
+        "LeafCertTTL": "72h",
         "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----...",
         "RootCert": "-----BEGIN CERTIFICATE-----...",
+        "RotationPeriod": "2160h"
     }
 }
 ```

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -717,6 +717,14 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         `write` access to this backend, as well as permission to mount the backend at this path if it is not 
         already mounted.
 
+        #### Common CA Config Options
+
+        <p>There are also a number of common configuration options supported by all providers:</p>
+        
+        * <a name="ca_leaf_cert_ttl"></a><a href="#ca_leaf_cert_ttl">`leaf_cert_ttl`</a> The lease duration of
+        a leaf certificate issued for a service, after which a new certificate will be requested by the proxy.
+        Defaults to `72h`.
+
     * <a name="connect_proxy"></a><a href="#connect_proxy">`proxy`</a> This object allows setting options for the Connect proxies. The following sub-keys are available:
 
         * <a name="connect_proxy_allow_managed_registration"></a><a href="#connect_proxy_allow_managed_registration">`allow_managed_api_registration`</a> Allows managed proxies to be configured with services that are registered via the Agent HTTP API. Enabling this would allow anyone with permission to register a service to define a command to execute for the proxy. By default, this is false to protect against arbitrary process execution.

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -721,9 +721,16 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
         <p>There are also a number of common configuration options supported by all providers:</p>
         
-        * <a name="ca_leaf_cert_ttl"></a><a href="#ca_leaf_cert_ttl">`leaf_cert_ttl`</a> The lease duration of
-        a leaf certificate issued for a service, after which a new certificate will be requested by the proxy.
-        Defaults to `72h`.
+        * <a name="ca_leaf_cert_ttl"></a><a href="#ca_leaf_cert_ttl">`leaf_cert_ttl`</a> The upper bound on the
+        lease duration of a leaf certificate issued for a service. In most cases a new leaf certificate will be
+        requested by a proxy before this limit is reached. This is also the effective limit on how long a server
+        outage can last (with no leader) before network connections will start being rejected, and as a result the
+        defaults is `72h` to last through a weekend without intervention. This value cannot be lower than 1 hour
+        or higher than 1 year.
+
+        This value is also used when rotating out old root certificates from the cluster. When a root certificate
+        has been inactive (rotated out) for more than twice the *current* `leaf_cert_ttl`, it will be removed from
+        the trusted list.
 
     * <a name="connect_proxy"></a><a href="#connect_proxy">`proxy`</a> This object allows setting options for the Connect proxies. The following sub-keys are available:
 

--- a/website/source/docs/connect/ca.html.md
+++ b/website/source/docs/connect/ca.html.md
@@ -88,6 +88,7 @@ $ curl http://localhost:8500/v1/connect/ca/configuration
 {
     "Provider": "consul",
     "Config": {
+        "LeafCertTTL": "72h",
         "RotationPeriod": "2160h"
     },
     "CreateIndex": 5,

--- a/website/source/docs/connect/ca/consul.html.md
+++ b/website/source/docs/connect/ca/consul.html.md
@@ -53,6 +53,9 @@ is used if configuring in an agent configuration file.
     bootstrap with the ".consul" TLD. The cluster identifier can be found
     using the [CA List Roots endpoint](/api/connect/ca.html#list-ca-root-certificates).
 
+There are also [common CA configuration options](/docs/agent/options.html#common-ca-config-options)
+that are supported by all CA providers.
+
 ## Specifying a Custom Private Key and Root Certificate
 
 By default, a root certificate and private key will be automatically
@@ -69,6 +72,7 @@ $ curl localhost:8500/v1/connect/ca/configuration
 {
     "Provider": "consul",
     "Config": {
+        "LeafCertTTL": "72h",
         "RotationPeriod": "2160h"
     },
     "CreateIndex": 5,
@@ -99,6 +103,7 @@ $ jq -n --arg key "$(cat root.key)"  --arg cert "$(cat root.crt)" '
 {
     "Provider": "consul",
     "Config": {
+        "LeafCertTTL": "72h",
         "PrivateKey": $key,
         "RootCert": $cert,
         "RotationPeriod": "2160h"
@@ -113,6 +118,7 @@ $ cat ca_config.json
 {
   "Provider": "consul",
   "Config": {
+    "LeafCertTTL": "72h",
     "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEArqiy1c3pbT3cSkjdEM1APALUareU...",
     "RootCert": "-----BEGIN CERTIFICATE-----\nMIIDijCCAnKgAwIBAgIJAOFZ66em1qC7MA0GCSqGSIb3...",
     "RotationPeriod": "2160h"


### PR DESCRIPTION
This adds a configurable leaf cert TTL via a new block of "common" CA config options.