### PR TITLE
Persist proxies from config files

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1803,7 +1803,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 		}
 	}
 
-	log.Printf("[DEBUG] agent: removed service %q", serviceID)
+	a.logger.Printf("[DEBUG] agent: removed service %q", serviceID)
 	return nil
 }
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -637,7 +637,7 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	}
 	// Add proxy (which will add proxy service so do it before we trigger sync)
 	if proxy != nil {
-		if err := s.agent.AddProxy(proxy, true, ""); err != nil {
+		if err := s.agent.AddProxy(proxy, true, false, ""); err != nil {
 			return nil, err
 		}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1524,7 +1524,7 @@ func TestAgent_PurgeProxyOnDuplicate(t *testing.T) {
 
 	file := filepath.Join(a.Config.DataDir, proxyDir, stringHash(proxyID))
 	_, err := os.Stat(file)
-	require.Error(err, "should have removed remote state")
+	require.NoError(err, "Config File based proxies should be persisted too")
 
 	result := a2.State.Proxy(proxyID)
 	require.NotNil(result)
@@ -2879,13 +2879,20 @@ func TestAgent_ReLoadProxiesFromConfig(t *testing.T) {
 
 	// reload the proxies and ensure the proxy token is the same
 	require.NoError(a.unloadProxies())
+	proxies = a.State.Proxies()
+	require.Len(proxies, 0)
 	require.NoError(a.loadProxies(&config))
+	proxies = a.State.Proxies()
 	require.Len(proxies, 1)
 	require.Equal(ptok, proxies[pid].ProxyToken)
 
 	// make sure when the config goes away so does the proxy
 	require.NoError(a.unloadProxies())
+	proxies = a.State.Proxies()
+	require.Len(proxies, 0)
+
 	// a.config contains no services or proxies
 	require.NoError(a.loadProxies(a.config))
+	proxies = a.State.Proxies()
 	require.Len(proxies, 0)
 }


### PR DESCRIPTION
Also change how loadProxies works. Now it will load all persisted proxies into a map, then when loading config file proxies will look up the previous proxy token in that map.

The new test is actually testing that proxy tokens are saved/restored between unloading/reloading of the proxy configuration (happens during a restart or during a online config reload). Additionally its also testing that removing a proxy from the config will remove it from what gets persisted to disk and wont get reload the next time the proxies are read from disk.

Additionally I tested manually with running a config file managed proxy, performing online reloads and restarting the process. It no longer kills the existing proxy and restarts it.

Some behavior that is currently still in there is that proxy configurations can be overwritten for config-file based proxies via the API. During the next reload the configuration will be reloaded from the config and the API registration will be effectively gone. 

There is a edge case where you have a proxy in the config, do an online register via the API, remove it from the config and when you reload/restart the API proxy is still valid and gets loaded properly. I don't think this is incorrect, just behavior that might not be immediately apparent.