### PR TITLE
UI - Bugfix: Show Service IP not the Node IP

### DIFF
--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -37,7 +37,7 @@
                         href=(href-to 'dc.nodes.show' item.Node.Node)
                         name=item.Node.Node
                         service=item.Service.ID
-                        address=(concat item.Node.Address ':' item.Service.Port)
+                        address=(concat item.Service.Address ':' item.Service.Port)
                         checks=item.Checks
                     }}
     {{/each}}
@@ -57,7 +57,7 @@
                     data-test-node=item.Node.Node
                     name=item.Node.Node
                     service=item.Service.ID
-                    address=(concat item.Node.Address ':' item.Service.Port)
+                    address=(concat item.Service.Address ':' item.Service.Port)
                     checks=item.Checks
                     status=item.Checks.[0].Status
                 }}

--- a/ui-v2/tests/acceptance/dc/services/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/show.feature
@@ -30,18 +30,21 @@ Feature: dc / services / show: Show Service
       Service:
         ID: passing-service-8080
         Port: 8080
-      Node:
         Address: 1.1.1.1
+      Node:
+        Address: 1.2.2.2
     - Service:
         ID: service-8000
         Port: 8000
-      Node:
         Address: 2.2.2.2
+      Node:
+        Address: 2.3.3.3
     - Service:
         ID: service-8888
         Port: 8888
-      Node:
         Address: 3.3.3.3
+      Node:
+        Address: 3.4.4.4
     ---
     When I visit the service page for yaml
     ---


### PR DESCRIPTION
Fixes #4175 

Show the Service.IP address instead of the Node.IP address in Service Detail view