### PR TITLE
UI - Bugfix: kv /edit/ and /create/ URLs

### DIFF
--- a/ui-v2/app/routes/dc/kv/create.js
+++ b/ui-v2/app/routes/dc/kv/create.js
@@ -3,11 +3,15 @@ import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get, set } from '@ember/object';
 import WithKvActions from 'consul-ui/mixins/kv/with-actions';
-
 export default Route.extend(WithKvActions, {
   templateName: 'dc/kv/edit',
   repo: service('kv'),
-  beforeModel: function() {
+  beforeModel: function(transition) {
+    const url = get(transition, 'intent.url');
+    const search = '/create/';
+    if (url && url.endsWith(search)) {
+      return this.replaceWith('dc.kv.folder', this.paramsFor(this.routeName).key + search);
+    }
     get(this, 'repo').invalidate();
   },
   model: function(params) {

--- a/ui-v2/app/routes/dc/kv/create.js
+++ b/ui-v2/app/routes/dc/kv/create.js
@@ -14,7 +14,7 @@ export default Route.extend(WithKvActions, {
     }
     get(this, 'repo').invalidate();
   },
-  model: function(params) {
+  model: function(params, transition) {
     const key = params.key || '/';
     const repo = get(this, 'repo');
     const dc = this.modelFor('dc').dc.Name;
@@ -24,7 +24,14 @@ export default Route.extend(WithKvActions, {
       create: true,
       isLoading: false,
       item: this.item,
-      parent: repo.findBySlug(key, dc),
+      parent: repo.findBySlug(key, dc).catch(e => {
+        if (e.errors && e.errors[0] && e.errors[0].status == '404') {
+          const url = get(transition, 'intent.url');
+          if (url.endsWith('/create')) {
+            return this.transitionTo('dc.kv.folder', key + '/create/');
+          }
+        }
+      }),
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc/kv/create.js
+++ b/ui-v2/app/routes/dc/kv/create.js
@@ -8,9 +8,13 @@ export default Route.extend(WithKvActions, {
   repo: service('kv'),
   beforeModel: function(transition) {
     const url = get(transition, 'intent.url');
-    const search = '/create/';
+    let search = '/create/';
     if (url && url.endsWith(search)) {
-      return this.replaceWith('dc.kv.folder', this.paramsFor(this.routeName).key + search);
+      const key = this.paramsFor(this.routeName).key || '';
+      if (key === '') {
+        search = 'create/';
+      }
+      return this.replaceWith('dc.kv.folder', key + search);
     }
     get(this, 'repo').invalidate();
   },
@@ -28,7 +32,7 @@ export default Route.extend(WithKvActions, {
         if (e.errors && e.errors[0] && e.errors[0].status == '404') {
           const url = get(transition, 'intent.url');
           if (url.endsWith('/create')) {
-            return this.transitionTo('dc.kv.folder', key + '/create/');
+            this.replaceWith('dc.kv.folder', key + '/create/');
           }
         }
       }),

--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -9,6 +9,13 @@ import ascend from 'consul-ui/utils/ascend';
 export default Route.extend(WithKvActions, {
   repo: service('kv'),
   sessionRepo: service('session'),
+  beforeModel: function(transition) {
+    const url = get(transition, 'intent.url');
+    const search = '/edit/';
+    if (url && url.endsWith(search)) {
+      return this.replaceWith('dc.kv.folder', this.paramsFor(this.routeName).key + search);
+    }
+  },
   model: function(params) {
     const key = params.key;
     const dc = this.modelFor('dc').dc.Name;

--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -27,7 +27,7 @@ export default Route.extend(WithKvActions, {
         if (e.errors && e.errors[0] && e.errors[0].status == '404') {
           const url = get(transition, 'intent.url');
           if (url.endsWith('/edit')) {
-            return this.replaceWith('dc.kv.folder', key + '/edit/');
+            this.replaceWith('dc.kv.folder', key + '/edit/');
           }
         }
       }),

--- a/ui-v2/app/routes/dc/kv/folder.js
+++ b/ui-v2/app/routes/dc/kv/folder.js
@@ -7,7 +7,7 @@ export default Route.extend({
     this._super(...arguments);
     const params = this.paramsFor('dc.kv.folder');
     if (params.key === '/' || params.key == null) {
-      return this.transitionTo('dc.kv.index');
+      return this.replaceWith('dc.kv.index');
     }
   },
 });

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -4,7 +4,23 @@ import { hash } from 'rsvp';
 import { get } from '@ember/object';
 import isFolder from 'consul-ui/utils/isFolder';
 import WithKvActions from 'consul-ui/mixins/kv/with-actions';
-
+/**
+ * Certain KV routes container extra `beforeModel` hooks to hedge for the
+ * fact that the `consul` binary has some 301 redirects to remove
+ * trailing slashes, whereas when testing/developing in ember this isn't replicated.
+ * There are various 'problems' related to this, including potential problems related
+ * to `create` and `edit` endpoints which could cause issues if someone has KV's
+ * called `create` or `edit`.
+ *
+ * Extra `modelFor` hooks are added in the create, edit Routes, plus one below here for
+ * more general issues with the binary 301 redirects.
+ *
+ * Lastly, documentation has been added here only to refer to all routes in KV, as
+ * `index` seemed to be the best place to do it without repeating.
+ *
+ * See https://github.com/hashicorp/consul/pull/4411, https://github.com/hashicorp/consul/pull/4373
+ *
+ */
 export default Route.extend(WithKvActions, {
   queryParams: {
     s: {

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -34,7 +34,7 @@ export default Route.extend(WithKvActions, {
         ...model,
         ...{
           items: repo.findAllBySlug(get(model.parent, 'Key'), dc).catch(e => {
-            return this.transitionTo('dc.kv.index');
+            this.replaceWith('dc.kv.index');
           }),
         },
       });

--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -58,6 +58,7 @@ module.exports = function(defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
+  app.import('node_modules/string.prototype.endswith/endswith.js');
   let tree = app.toTree();
   return tree;
 };

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -84,6 +84,7 @@
     "lint-staged": "^6.1.0",
     "loader.js": "^4.2.3",
     "prettier": "^1.10.2",
+    "string.prototype.endswith": "^0.2.0",
     "svgo": "^1.0.5",
     "text-encoder-lite": "^1.0.1"
   },

--- a/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
@@ -5,29 +5,44 @@ Feature: dc / kvs / edit create keynames
   I should be able to visit kvs with paths ending in edit/ or create/ and see the folder listing
   Background:
     Given 1 datacenter model with the value "datacenter"
-  Scenario: I have 1 key in the foo/bar/edit/ folder
-    And 1 kv model from yaml
+  Scenario: I have 1 key in the foo/bar/[Action]/ folder and I visit with a trailing slash
+    Given 1 kv model from yaml
+    ---
+      - [Action]
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+      kv: foo/bar/[Action]/
+    ---
+    Then the url should be /datacenter/kv/foo/bar/[Action]/
+    And I see 1 kv model
+    # And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
+  Where:
+    ----------
+    | Action |
+    | edit   |
+    | create |
+    ----------
+
+@ignore
+  Scenario: I have 1 key in the foo/bar/[Action]/ folder and I visit without a trailing slash
+    Given 1 kv model from yaml
     ---
       - edit
     ---
+    And the url "/v1/kv/foo/bar" responds with a 404 status
     When I visit the kvs page for yaml
     ---
       dc: datacenter
-      kv: foo/bar/edit/
+      kv: foo/bar/[Action]
     ---
-    Then the url should be /datacenter/kv/foo/bar/edit/
+    Then the url should be /datacenter/kv/foo/bar/[Action]/
     And I see 1 kv model
-    # And the last GET request was made to "/v1/kv/foo/bar/edit/?keys&dc=datacenter&separator=%2F"
-  Scenario: I have 1 key in the foo/bar/create/ folder
-    And 1 kv model from yaml
-    ---
-      - create
-    ---
-    When I visit the kvs page for yaml
-    ---
-      dc: datacenter
-      kv: foo/bar/create/
-    ---
-    Then the url should be /datacenter/kv/foo/bar/create/
-    And I see 1 kv model
-    # And the last GET request was made to "/v1/kv/foo/bar/create/?keys&dc=datacenter&separator=%2F"
+    # And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
+  Where:
+    ----------
+    | Action |
+    | edit   |
+    | create |
+    ----------

--- a/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
@@ -1,0 +1,33 @@
+@setupApplicationTest
+Feature: dc / kvs / edit create keynames
+  In order to navigate to keynames/paths ending in edit or create
+  As a user
+  I should be able to visit kvs with paths ending in edit/ or create/ and see the folder listing
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+  Scenario: I have 1 key in the foo/bar/edit/ folder
+    And 1 kv model from yaml
+    ---
+      - edit
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+      kv: foo/bar/edit/
+    ---
+    Then the url should be /datacenter/kv/foo/bar/edit/
+    And I see 1 kv model
+    # And the last GET request was made to "/v1/kv/foo/bar/edit/?keys&dc=datacenter&separator=%2F"
+  Scenario: I have 1 key in the foo/bar/create/ folder
+    And 1 kv model from yaml
+    ---
+      - create
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+      kv: foo/bar/create/
+    ---
+    Then the url should be /datacenter/kv/foo/bar/create/
+    And I see 1 kv model
+    # And the last GET request was made to "/v1/kv/foo/bar/create/?keys&dc=datacenter&separator=%2F"

--- a/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/edit-create-keynames.feature
@@ -17,7 +17,7 @@ Feature: dc / kvs / edit create keynames
     ---
     Then the url should be /datacenter/kv/foo/bar/[Action]/
     And I see 1 kv model
-    # And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
+    And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
   Where:
     ----------
     | Action |
@@ -25,7 +25,6 @@ Feature: dc / kvs / edit create keynames
     | create |
     ----------
 
-@ignore
   Scenario: I have 1 key in the foo/bar/[Action]/ folder and I visit without a trailing slash
     Given 1 kv model from yaml
     ---
@@ -39,7 +38,7 @@ Feature: dc / kvs / edit create keynames
     ---
     Then the url should be /datacenter/kv/foo/bar/[Action]/
     And I see 1 kv model
-    # And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
+    And the last GET request was made to "/v1/kv/foo/bar/[Action]/?keys&dc=datacenter&separator=%2F"
   Where:
     ----------
     | Action |

--- a/ui-v2/tests/acceptance/steps/dc/kvs/edit-create-keynames-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/kvs/edit-create-keynames-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -8666,6 +8666,10 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.endswith@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz#a19c20dee51a98777e9a47e10f09be393b9bba75"
+
 string_decoder@0.10, string_decoder@~0.10.0, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"


### PR DESCRIPTION
This is related to #4324 and the 301 redirects and somewhat similar to #4373 in that it involves trailing slashes.

Overall the problem relates to the fact that we use `/ui/kv/key-name/edit` and `/ui/kv/folder-name/create` 'endpoints' in the UI, and potentially these could be actual key/folder names (folder/in/here/create=value for example)

This is more or less dealt with when developing in the ember dev server as we don't have the additional complication of the 301 trailing slash redirects, whereas when things are baked into the consul binary the 301 removal of trailing slashes complicates matters.

Lastly, when testing manually (in the consul binary and in embers dev mode) everything works well, but when testing using embers testem test environment, I get a TransitionError so I'm not 100% happy to merge this myself yet. Mainly PR'ing so this doesn't get lost in the noise and to remind myself to get some more eyes on it to see if I can figure out where the TransitionError is coming from.

