### PR TITLE
Remove deprecated Ruby consul-client library

### DIFF
--- a/website/source/api/libraries-and-sdks.html.md
+++ b/website/source/api/libraries-and-sdks.html.md
@@ -59,9 +59,6 @@ the community.
     <a href="https://github.com/undeadlabs/discovery">discovery</a> - Erlang/OTP client for the Consul HTTP API
   </li>
   <li>
-    <a href="https://github.com/xaviershay/consul-client">consul-client</a> - Ruby client for the Consul HTTP API
-  </li>
-  <li>
     <a href="https://github.com/WeAreFarmGeek/diplomat">diplomat</a> - Ruby library to query Consul's KV-store and services directory
   </li>
   <li>


### PR DESCRIPTION
The GitHub repo for this library says that it is no longer maintained
and should not be used. The Ruby Diplomat library provides similar
functionality instead (and is already listed here).