### PR TITLE
Adjusting grays based on recent Structure changes

### DIFF
--- a/ui-v2/app/styles/components/action-group/skin.scss
+++ b/ui-v2/app/styles/components/action-group/skin.scss
@@ -20,7 +20,10 @@
 }
 %action-group input[type='radio']:checked + label:first-of-type,
 %action-group label:first-of-type:hover {
-  background-color: $gray;
+  background-color: $ui-gray-050;
+}
+%action-group label:first-of-type:active {
+  background-color: $ui-gray-100;
 }
 %action-group li a:hover {
   background-color: $ui-color-action;

--- a/ui-v2/app/styles/components/healthcheck-status.scss
+++ b/ui-v2/app/styles/components/healthcheck-status.scss
@@ -18,7 +18,7 @@
 }
 %healthcheck-status.passing {
   @extend %with-passing;
-  border-color: $ui-gray-300;
+  border-color: $ui-gray-200;
 }
 %healthcheck-status.passing::before {
   background-color: $ui-color-success !important;

--- a/ui-v2/app/styles/components/healthchecked-resource.scss
+++ b/ui-v2/app/styles/components/healthchecked-resource.scss
@@ -43,7 +43,7 @@
 }
 %healthchecked-resource,
 %healthchecked-resource li {
-  border-color: $ui-gray-300;
+  border-color: $ui-gray-200;
 }
 %healthchecked-resource,
 %healthchecked-resource header,

--- a/ui-v2/app/styles/components/product/footer.scss
+++ b/ui-v2/app/styles/components/product/footer.scss
@@ -5,7 +5,7 @@
   border-top: $decor-border-100;
 }
 %footer {
-  border-color: $keyline-darker;
+  border-color: $keyline-mid;
   background-color: $ui-white;
 }
 %footer > * {

--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -43,9 +43,6 @@ th {
 td {
   border-color: $keyline-mid;
 }
-td strong {
-  background-color: $gray;
-}
 table {
   width: 100%;
 }

--- a/ui-v2/app/styles/components/tag.scss
+++ b/ui-v2/app/styles/components/tag.scss
@@ -2,5 +2,6 @@
 %pill {
   display: inline-block;
   padding: 1px 5px;
+  background-color: $ui-gray-100;
   border-radius: $radius-small;
 }

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -16,9 +16,6 @@ main p {
 %filter-bar [role='radiogroup'] label {
   line-height: 1.7;
 }
-h1 {
-  letter-spacing: 1px;
-}
 %header-nav,
 %tab-nav {
   letter-spacing: 0.03em;

--- a/ui-v2/app/styles/routes/dc/service/index.scss
+++ b/ui-v2/app/styles/routes/dc/service/index.scss
@@ -10,6 +10,5 @@ html.template-service.template-show main dt {
 html.template-service.template-list td.tags span,
 html.template-service.template-show main dd span {
   @extend %tag;
-  background-color: $gray;
   margin-bottom: 0.5em;
 }

--- a/ui-v2/app/styles/variables/index.scss
+++ b/ui-v2/app/styles/variables/index.scss
@@ -1,12 +1,13 @@
 @import './custom-query';
 $gray: $ui-gray-200;
+$ui-gray-025: #fafbfc;
 
 $magenta-800-url-encoded: %235a1434;
 
 $keyline-light: $ui-gray-100; // h1
-$keyline-mid: $ui-gray-200; // td
-$keyline-dark: $ui-gray-400; // th
-$keyline-darker: $ui-gray-300; //footer
+$keyline-mid: $ui-gray-200; // td, footer
+$keyline-dark: $ui-gray-300; // th
+$keyline-darker: $ui-gray-400;
 
 // decoration
 // undecided


### PR DESCRIPTION
I made a few minor changes to the grays based on their intended look in our design files from both Structure and Consul. 

One thing to note: I added a custom gray, as Structure never really had a gray light enough to cover our filter bar. There are a few options here with regard to this: 

A. We can add this `-025` in Consul only (as in this PR).
B. We can add this `-025` in Iris (and I can petition to add it in Structure for parity).
C. We can bump the shades up one level. This would become `050` and all the shades would move up one notch. We use more variety of lower shades than of darker shades, so we need less of those. We have discussed this before in design but didn't change anything yet. 

Personally, I like C better than adding more shade levels.

For PRs, I like to always add screenshots of the items changed:
<img width="1282" alt="screen shot 2018-07-19 at 3 14 55 pm" src="https://user-images.githubusercontent.com/6323933/42967672-a1384d20-8b66-11e8-8704-658ba01b942c.png">
<img width="1320" alt="screen shot 2018-07-19 at 3 14 45 pm" src="https://user-images.githubusercontent.com/6323933/42967673-a1570076-8b66-11e8-8654-d943fdcd681a.png">
