### PR TITLE
Add /health/connect to docs and make consistent with /catalog/connect

### DIFF
--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -500,67 +500,8 @@ so this endpoint may be used to filter only the Connect-capable endpoints.
 | ------ | ---------------------------- | -------------------------- |
 | `GET`  | `/catalog/connect/:service`  | `application/json`         |
 
-The table below shows this endpoint's support for
-[blocking queries](/api/index.html#blocking-queries),
-[consistency modes](/api/index.html#consistency-modes), and
-[required ACLs](/api/index.html#acls).
-
-| Blocking Queries | Consistency Modes | ACL Required             |
-| ---------------- | ----------------- | ------------------------ |
-| `YES`            | `all`             | `node:read,service:read` |
-
-### Parameters
-
-- `service` `(string: <required>)` - Specifies the name of the service for which
-  to list nodes. This is specified as part of the URL.
-
-- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
-  the datacenter of the agent being queried. This is specified as part of the
-  URL as a query parameter.
-
-### Sample Request
-
-```text
-$ curl \
-    https://consul.rocks/v1/catalog/connect/my-service
-```
-
-### Sample Response
-
-```json
-[
-  {
-    "ID": "40e4a748-2192-161a-0510-9bf59fe950b5",
-    "Node": "foobar",
-    "Address": "192.168.10.10",
-    "Datacenter": "dc1",
-    "TaggedAddresses": {
-      "lan": "192.168.10.10",
-      "wan": "10.0.10.10"
-    },
-    "NodeMeta": {
-      "somekey": "somevalue"
-    },
-    "CreateIndex": 51,
-    "ModifyIndex": 51,
-    "ServiceAddress": "172.17.0.3",
-    "ServiceEnableTagOverride": false,
-    "ServiceID": "32a2a47f7992:nodea:5000",
-    "ServiceName": "foobar",
-	"ServiceKind": "connect-proxy",
-	"ServiceProxyDestination": "my-service",
-    "ServicePort": 5000,
-    "ServiceMeta": {
-        "foobar_meta_value": "baz"
-    },
-    "ServiceTags": [
-      "tacos"
-    ]
-  }
-]
-```
-
-The fields are the same as listing nodes for a service.
+Parameters and response format are the same as
+[`/catalog/service/:service`](/api/catalog.html#list-nodes-for-service).
 
 ## List Services for Node
 

--- a/website/source/api/health.html.md
+++ b/website/source/api/health.html.md
@@ -249,6 +249,21 @@ $ curl \
 ]
 ```
 
+## List Nodes for Connect-capable Service
+
+This endpoint returns the nodes providing a
+[Connect-capable](/docs/connect/index.html) service in a given datacenter.
+This will include both proxies and native integrations. A service may
+register both Connect-capable and incapable services at the same time,
+so this endpoint may be used to filter only the Connect-capable endpoints.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/health/connect/:service`   | `application/json`         |
+
+Parameters and response format are the same as
+[`/health/service/:service`](/api/health.html#list-nodes-for-service).
+
 ## List Checks in State
 
 This endpoint returns the checks in the state provided on the path.
@@ -317,7 +332,7 @@ $ curl \
     "Output": "",
     "ServiceID": "redis",
     "ServiceName": "redis",
-	"ServiceTags": ["primary"]
+	  "ServiceTags": ["primary"]
   }
 ]
 ```


### PR DESCRIPTION
Adds a missed addition to the API from connect.

@mitchellh I removed some of the docs from the Catalog endpoint since they were duplicates of the non-connect version with the one subtlety that the response happened to show a service with `"Kind": "connect-proxy"`. Given that we just explained this response fields as "the same as listing service nodes" I don't think it made a material difference to drawing attention to that as a useful indicator of proxy/native endpoint status so I removed it for consistency.

Open to suggestions if we feel that was useful context though, this seemed more concise, and just as complete.