### PR TITLE
UI: Adds bottom breathing space on the bottom of forms

### DIFF
--- a/ui-v2/app/styles/core/layout.scss
+++ b/ui-v2/app/styles/core/layout.scss
@@ -53,6 +53,10 @@ main > * {
 main p {
   margin-bottom: 1em;
 }
+main form,
+main form + div .with-confirmation {
+  margin-bottom: 2em;
+}
 html body > svg {
   display: none;
   position: absolute;


### PR DESCRIPTION
Simple CSS tweak to give the forms a little more space underneath when you are on a super short screen.

Before:

![screen_shot_2018-07-23_at_14_26_37](https://user-images.githubusercontent.com/554604/43079465-1c24f378-8e85-11e8-9e08-c4dfdfc86c81.png)

After:

![screen_shot_2018-07-23_at_14_29_33](https://user-images.githubusercontent.com/554604/43079470-2125442c-8e85-11e8-8f31-1c1b79b2ba18.png)

