### PR TITLE
ui: Switch to fullscreen layout for lists and detail, left aligned forms

### DIFF
--- a/ui-v2/app/styles/core/layout.scss
+++ b/ui-v2/app/styles/core/layout.scss
@@ -17,3 +17,6 @@ main,
 #wrapper > footer {
   @extend %content-container;
 }
+html.template-edit main {
+  @extend %content-container-restricted;
+}

--- a/ui-v2/app/styles/layouts/containers.scss
+++ b/ui-v2/app/styles/layouts/containers.scss
@@ -16,12 +16,11 @@ $ideal-content-padding: 33px;
 %viewport-container {
   margin-left: auto;
   margin-right: auto;
-  max-width: $ideal-viewport-width;
 }
 %content-container > * {
   box-sizing: border-box;
 }
-%content-container {
+%content-container-restricted {
   max-width: $ideal-content-width;
 }
 %viewport-container {


### PR DESCRIPTION
Lists use the entire available area by removing the left and right white areas on larger screens. 

Forms remain the same width yet left aligned.

Navigation and footer will now span the entire viewport area for all layouts.

Listing Before:

![screen shot 2018-07-24 at 13 58 04](https://user-images.githubusercontent.com/554604/43139458-aad9de2a-8f49-11e8-9fb3-18df7d124c7f.png)

Listing After:

![screen shot 2018-07-24 at 13 57 50](https://user-images.githubusercontent.com/554604/43139467-b09ce0dc-8f49-11e8-9d99-46ea450b9fab.png)

Form Before:

![screen shot 2018-07-24 at 13 59 58](https://user-images.githubusercontent.com/554604/43139540-edf033b2-8f49-11e8-92e9-cca200cc8d4b.png)

Form After:

![screen shot 2018-07-24 at 14 00 07](https://user-images.githubusercontent.com/554604/43139546-f3f03d0c-8f49-11e8-9884-e9663bad6ad1.png)




