### PR TITLE
Refactor test retry to only affect CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ matrix:
     - env: GOTEST_PKGS_EXCLUDE="./api|./agent|./agent/consul"
 
 script:
-  - GOTEST_FLAGS="-p 3 -parallel 1" make test
+  - make test-ci
 
 sudo: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -150,7 +150,9 @@ cov:
 	gocov test $(GOFILES) | gocov-html > /tmp/coverage.html
 	open /tmp/coverage.html
 
-test: other-consul dev-build vet
+test: other-consul dev-build vet test-internal
+
+test-internal:
 	@echo "--> Running go test"
 	@rm -f test.log exit-code
 	go test -tags '$(GOTAGS)' -i $(GOTEST_PKGS)
@@ -159,12 +161,7 @@ test: other-consul dev-build vet
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
 	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' -timeout 7m $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
-	@echo "Exit code: $$(cat exit-code)" >> test.log
-	@if [ "0" != "$$(cat exit-code)" ]; then \
-	  echo Retrying to avoid flacky tests >> test.log;\
-	  echo Retrying tests once...;\
-	  go test -p 5 -parallel 1 -tags '$(GOTAGS)' -timeout 5m $(GOTEST_PKGS) 2>&1; echo $$? > exit-code;\
-	fi
+	@echo "Exit code: $$(cat exit-code)"
 	@# This prints all the race report between ====== lines
 	@awk '/^WARNING: DATA RACE/ {do_print=1; print "=================="} do_print==1 {print} /^={10,}/ {do_print=0}' test.log || true
 	@grep -A10 'panic: ' test.log || true
@@ -180,6 +177,15 @@ test: other-consul dev-build vet
 
 test-race:
 	$(MAKE) GOTEST_FLAGS=-race
+
+# Run tests with config for CI so `make test` can still be local-dev friendly.
+test-ci: other-consul dev-build vet
+	@ if ! GOTEST_FLAGS="-p 3 -parallel 1" make test-internal; then \
+	    echo "    ============"; \
+			echo "      Retrying"; \
+	    echo "    ============"; \
+			GOTEST_FLAGS="-p 5 -parallel 1" make test-internal; \
+		fi
 
 other-consul:
 	@echo "--> Checking for other consul instances"
@@ -256,5 +262,5 @@ ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 	
 	
-.PHONY: all ci bin dev dist cov test cover format vet ui static-assets tools vendorfmt 
+.PHONY: all ci bin dev dist cov test test-ci cover format vet ui static-assets tools vendorfmt
 .PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker ui-legacy-docker version

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -264,5 +264,5 @@ ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 	
 	
-.PHONY: all ci bin dev dist cov test test-ci cover format vet ui static-assets tools vendorfmt
+.PHONY: all ci bin dev dist cov test test-ci test-internal test-install-deps cover format vet ui static-assets tools vendorfmt
 .PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker ui-legacy-docker version

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -150,12 +150,14 @@ cov:
 	gocov test $(GOFILES) | gocov-html > /tmp/coverage.html
 	open /tmp/coverage.html
 
-test: other-consul dev-build vet test-internal
+test: other-consul dev-build vet test-install-deps test-internal
+
+test-install-deps:
+	go test -tags '$(GOTAGS)' -i $(GOTEST_PKGS)
 
 test-internal:
 	@echo "--> Running go test"
 	@rm -f test.log exit-code
-	go test -tags '$(GOTAGS)' -i $(GOTEST_PKGS)
 	@# Dump verbose output to test.log so we can surface test names on failure but
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
@@ -179,7 +181,7 @@ test-race:
 	$(MAKE) GOTEST_FLAGS=-race
 
 # Run tests with config for CI so `make test` can still be local-dev friendly.
-test-ci: other-consul dev-build vet
+test-ci: other-consul dev-build vet test-install-deps
 	@ if ! GOTEST_FLAGS="-p 3 -parallel 1" make test-internal; then \
 	    echo "    ============"; \
 			echo "      Retrying"; \


### PR DESCRIPTION
Pierre's recent change to make our test suite retry to catch more flakes in Travis has been partially successful in reducing failing tests although we have much more in depth analysis to find the real causes of non-determinism in the works.

The downside to the change was:
 - make test locally is now even longer to run
 - the bash syntax used made it hard to do the same `tee` trick on the retry which means travis output is useless and overflows their limits for the UI again, and makes local runs useless too.

This change is a slight refactor to mostly undo Pierre's change for `make test` making it useful to run locally again, while keeping the retry part in Travis. It also makes the output nicer without even more gross bash hacks by moving it up a level in the make file.

A quick way to verify the behaviour is to pick a small set of packages and introduce an error into one of them:

```
$ GOTEST_PKGS="./connect/..." make test-ci
--> Checking for other consul instances
==> Building Consul - OSes: darwin, Architectures: amd64
Building sequentially with go install
--->   darwin/amd64
--> Running go vet
--> Running go test
go test -tags '' -i ./connect/...
{ go test -p 3 -parallel 1 -tags '' -timeout 7m ./connect/... 2>&1 ; echo $? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
FAIL	github.com/hashicorp/consul/connect	2.179s
ok  	github.com/hashicorp/consul/connect/proxy	1.740s
Exit code: 1
--- FAIL: TestService_Name (0.00s)
FAIL
FAIL	github.com/hashicorp/consul/connect	2.179s
make[1]: *** [test-internal] Error 1
    ============
      Retrying
    ============
--> Running go test
go test -tags '' -i ./connect/...
{ go test -p 5 -parallel 1 -tags '' -timeout 7m ./connect/... 2>&1 ; echo $? > exit-code ; } | tee test.log | egrep '^(ok|FAIL)\s*github.com/hashicorp/consul'
FAIL	github.com/hashicorp/consul/connect	2.270s
ok  	github.com/hashicorp/consul/connect/proxy	(cached)
Exit code: 1
--- FAIL: TestService_Name (0.00s)
FAIL
FAIL	github.com/hashicorp/consul/connect	2.270s
make[1]: *** [test-internal] Error 1
make: *** [test-ci] Error 2
```