### PR TITLE
Fixes #4421: General solution to stop blocking queries with index 0

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -264,5 +264,4 @@ ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 	
 	
-.PHONY: all ci bin dev dist cov test test-ci test-internal test-install-deps cover format vet ui static-assets tools vendorfmt
 .PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker ui-legacy-docker version

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -264,4 +264,5 @@ ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 	
 	
+.PHONY: all ci bin dev dist cov test test-ci test-internal test-install-deps cover format vet ui static-assets tools vendorfmt
 .PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker ui-legacy-docker version

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -108,7 +108,8 @@ func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 		return result, errors.New("invalid RootCA response type")
 	}
 	if roots.TrustDomain == "" {
-		return result, errors.New("cluster has no CA bootstrapped")
+		return result, errors.New("cluster has no CA bootstrapped: ensure Connect" +
+			" is enabled in server config")
 	}
 
 	// Build the service ID

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/y0ssar1an/q"
 )
 
 //go:generate mockery -all -inpkg
@@ -192,8 +191,6 @@ func (c *Cache) Get(t string, r Request) (interface{}, ResultMeta, error) {
 
 	// Get the actual key for our entry
 	key := c.entryKey(t, &info)
-
-	q.Q("cache GET", t, key)
 
 	// First time through
 	first := true
@@ -470,8 +467,6 @@ func (c *Cache) refresh(opts *RegisterOptions, attempt uint, t string, key strin
 	if !opts.Refresh {
 		return
 	}
-
-	q.Q("refresh", attempt, key)
 
 	// If we're over the attempt minimum, start an exponential backoff.
 	if attempt > CacheRefreshBackoffMin {

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -708,6 +708,54 @@ func TestCacheGet_expireResetGet(t *testing.T) {
 	typ.AssertExpectations(t)
 }
 
+// Test a Get with a request that returns the same cache key across
+// two different "types" returns two separate results.
+func TestCacheGet_duplicateKeyDifferentType(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	typ := TestType(t)
+	defer typ.AssertExpectations(t)
+	typ2 := TestType(t)
+	defer typ2.AssertExpectations(t)
+
+	c := TestCache(t)
+	c.RegisterType("t", typ, nil)
+	c.RegisterType("t2", typ2, nil)
+
+	// Configure the types
+	typ.Static(FetchResult{Value: 100}, nil)
+	typ2.Static(FetchResult{Value: 200}, nil)
+
+	// Get, should fetch
+	req := TestRequest(t, RequestInfo{Key: "foo"})
+	result, meta, err := c.Get("t", req)
+	require.NoError(err)
+	require.Equal(100, result)
+	require.False(meta.Hit)
+
+	// Get from t2 with same key, should fetch
+	req = TestRequest(t, RequestInfo{Key: "foo"})
+	result, meta, err = c.Get("t2", req)
+	require.NoError(err)
+	require.Equal(200, result)
+	require.False(meta.Hit)
+
+	// Get from t again with same key, should cache
+	req = TestRequest(t, RequestInfo{Key: "foo"})
+	result, meta, err = c.Get("t", req)
+	require.NoError(err)
+	require.Equal(100, result)
+	require.True(meta.Hit)
+
+	// Sleep a tiny bit just to let maybe some background calls happen
+	// then verify that we still only got the one call
+	time.Sleep(20 * time.Millisecond)
+	typ.AssertExpectations(t)
+	typ2.AssertExpectations(t)
+}
+
 // Test that Get partitions the caches based on DC so two equivalent requests
 // to different datacenters are automatically cached even if their keys are
 // the same.
@@ -750,7 +798,8 @@ func TestCacheGet_partitionToken(t *testing.T) {
 // testPartitionType implements Type for testing that simply returns a value
 // comprised of the request DC and ACL token, used for testing cache
 // partitioning.
-type testPartitionType struct{}
+type testPartitionType struct {
+}
 
 func (t *testPartitionType) Fetch(opts FetchOptions, r Request) (FetchResult, error) {
 	info := r.CacheInfo()

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -230,6 +230,7 @@ func (s *ConnectCA) Roots(
 		if err != nil {
 			return err
 		}
+
 		// Check CA is actually bootstrapped...
 		if config != nil {
 			// Build TrustDomain based on the ClusterID stored.

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -415,7 +415,18 @@ RUN_QUERY:
 
 	// Block up to the timeout if we didn't see anything fresh.
 	err := fn(ws, state)
-	if err == nil && queryMeta.Index > 0 && queryMeta.Index <= queryOpts.MinQueryIndex {
+	// Note we check queryOpts.MinQueryIndex is greater than zero to determine if
+	// blocking was requested by client, NOT meta.Index since the state function
+	// might return zero if something is not initialised and care wasn't taken to
+	// handle that special case (in practice this happened a lot so fixing it
+	// systematically here beats trying to remember to add zero checks in every
+	// state method). We also need to ensure that unless there is an error, we
+	// return an index > 0 otherwise the client will never block and burn CPU and
+	// requests.
+	if err == nil && queryMeta.Index < 1 {
+		queryMeta.Index = 1
+	}
+	if err == nil && queryOpts.MinQueryIndex > 0 && queryMeta.Index <= queryOpts.MinQueryIndex {
 		if expired := ws.Watch(timeout.C); !expired {
 			// If a restore may have woken us up then bail out from
 			// the query immediately. This is slightly race-ey since


### PR DESCRIPTION
When developing Connect we hit a few edge cases where blocking queries would return `X-Consul-Index` of `0` along with a blank request.

The root cause is that some of our state functions (for example fetching the CARoots) have no state to load at all in some cases and so have no index value to read and end up returning `meta.Index = 0`.

In general our blocking query code assumes that no well-behaved blocking query ever has this behaviour and in some places where it's possible (e.g. [KV fetches for non-existent keys](https://github.com/hashicorp/consul/blob/master/agent/consul/kvs_endpoint.go#L140-L146)) we have code to explicitly account for it. Some places account ofr it as above in the RPC endpoint code, some account for it in the actual state store transactions, but many still don't and rely on semantics or just plain unlikeliness of a given situation to never hit it.

During Connect we discussed the idea of fixing this once and for all within the `Server.blockingQuery` helper that all blocking queries use - we hypothesised this fix and were relatively sure it couldn't cause any damage as it's a fundamental assumption of the blocking query system and the only change in behaviour _seems_ to be that it will prevent a tight busy loop that eats 100% CPU. But ultimately we didn't want to take the risk of adding the more general change that would affect non-connect endpoints.

Our solution which we _thought_ covered all Connect APIs was to add the logic of using at least `1` as the index in the [agent's cache fetcher](https://github.com/hashicorp/consul/blob/master/agent/cache/cache.go#L350-L388) for connect data.

However #4421 is a subtle edge case we missed _even in connect_ endpoints.

The cause there is that the CA RPC response returns an empty result with `0` index, and the client dutifully upgrades that index to `1` for the next request. But the subsequent blocking request still has a 0 index returned from `state.CARoots` becuas there is still no CA config with connect disabled. The `blockingQuery` helper here used to check the returned meta was at least one before blocking as a proxy for "should blocking be enabled" so it never blocked in this case and caused the client agent to consume 100% CPU again.

## General fix.

The actual fix here is just to switch the zero check from `queryMeta.Index > 0` (the value returned from the state method) to `queryOpts.MinQueryIndex > 0`. As far as I understand this is a better semantic since we already explicitly checked for nil `err` from the method.

My rationale is:
 - we should block if the _client requested it_ regardless of the current index returned not based on whether the state method returned 0 index
 - yes it's arguably buggy for state method to ever return 0 index with nil err but it happens and probably will again next time we add state methods or use existing ones in new ways where it starts to matter
 - it's _never_ correct for a non-error response to have 0 index since it will cause clients to busy loop without blocking
 - it's therefore reasonable to ensure systematically that no RPC response is ever sent with 0 index, and that even if the state method responds with zero index, we still block if requested to until some state is written to deliver back.

## Tests

This is actually pretty easy to test and I think the tests added are sufficient. I was expecting to violate a bunch of other tests in the repo that expected zero indexes just because that's what they used to get but all tests pass locally - including all the `watch` package  and all blocking-related stuff!