### PR TITLE
Allow config-file based Service Definitions for unmanaged proxies

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1074,6 +1074,7 @@ func (b *Builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 		meta = v.Meta
 	}
 	return &structs.ServiceDefinition{
+		Kind:              b.serviceKindVal(v.Kind),
 		ID:                b.stringVal(v.ID),
 		Name:              b.stringVal(v.Name),
 		Tags:              v.Tags,
@@ -1083,7 +1084,20 @@ func (b *Builder) serviceVal(v *ServiceDefinition) *structs.ServiceDefinition {
 		Token:             b.stringVal(v.Token),
 		EnableTagOverride: b.boolVal(v.EnableTagOverride),
 		Checks:            checks,
+		ProxyDestination:  b.stringVal(v.ProxyDestination),
 		Connect:           b.serviceConnectVal(v.Connect),
+	}
+}
+
+func (b *Builder) serviceKindVal(v *string) structs.ServiceKind {
+	if v == nil {
+		return structs.ServiceKindTypical
+	}
+	switch *v {
+	case string(structs.ServiceKindConnectProxy):
+		return structs.ServiceKindConnectProxy
+	default:
+		return structs.ServiceKindTypical
 	}
 }
 
@@ -1102,7 +1116,8 @@ func (b *Builder) serviceConnectVal(v *ServiceConnect) *structs.ServiceConnect {
 	}
 
 	return &structs.ServiceConnect{
-		Proxy: proxy,
+		Native: b.boolVal(v.Native),
+		Proxy:  proxy,
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -317,6 +317,7 @@ type Autopilot struct {
 }
 
 type ServiceDefinition struct {
+	Kind              *string           `json:"kind,omitempty" hcl:"kind" mapstructure:"kind"`
 	ID                *string           `json:"id,omitempty" hcl:"id" mapstructure:"id"`
 	Name              *string           `json:"name,omitempty" hcl:"name" mapstructure:"name"`
 	Tags              []string          `json:"tags,omitempty" hcl:"tags" mapstructure:"tags"`
@@ -327,6 +328,7 @@ type ServiceDefinition struct {
 	Checks            []CheckDefinition `json:"checks,omitempty" hcl:"checks" mapstructure:"checks"`
 	Token             *string           `json:"token,omitempty" hcl:"token" mapstructure:"token"`
 	EnableTagOverride *bool             `json:"enable_tag_override,omitempty" hcl:"enable_tag_override" mapstructure:"enable_tag_override"`
+	ProxyDestination  *string           `json:"proxy_destination,omitempty" hcl:"proxy_destination" mapstructure:"proxy_destination"`
 	Connect           *ServiceConnect   `json:"connect,omitempty" hcl:"connect" mapstructure:"connect"`
 }
 
@@ -357,7 +359,9 @@ type CheckDefinition struct {
 
 // ServiceConnect is the connect block within a service registration
 type ServiceConnect struct {
-	// TODO(banks) add way to specify that the app is connect-native
+	// Native is true when this service can natively understand Connect.
+	Native *bool `json:"native,omitempty" hcl:"native" mapstructure:"native"`
+
 	// Proxy configures a connect proxy instance for the service
 	Proxy *ServiceConnectProxy `json:"proxy,omitempty" hcl:"proxy" mapstructure:"proxy"`
 }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2794,7 +2794,10 @@ func TestFullConfig(t *testing.T) {
 						"ttl": "1181s",
 						"deregister_critical_service_after": "4992s"
 					}
-				]
+				],
+				"connect": {
+					"native": true
+				}
 			},
 			"services": [
 				{
@@ -2888,6 +2891,13 @@ func TestFullConfig(t *testing.T) {
 							}
 						}
 					}
+				},
+				{
+					"id": "Kh81CPF6",
+					"name": "Kh81CPF6-proxy",
+					"port": 31471,
+					"kind": "connect-proxy",
+					"proxy_destination": "6L6BVfgH"
 				}
 			],
 			"session_ttl_min": "26627s",
@@ -3258,6 +3268,9 @@ func TestFullConfig(t *testing.T) {
 						deregister_critical_service_after = "4992s"
 					}
 				]
+				connect {
+					native = true
+				}
 			}
 			services = [
 				{
@@ -3351,6 +3364,13 @@ func TestFullConfig(t *testing.T) {
 							}
 						}
 					}
+				},
+				{
+					id = "Kh81CPF6"
+					name = "Kh81CPF6-proxy"
+					port = 31471
+					kind = "connect-proxy"
+					proxy_destination = "6L6BVfgH"
 				}
 			]
 			session_ttl_min = "26627s"
@@ -3862,6 +3882,13 @@ func TestFullConfig(t *testing.T) {
 				},
 			},
 			{
+				ID:               "Kh81CPF6",
+				Name:             "Kh81CPF6-proxy",
+				Port:             31471,
+				Kind:             "connect-proxy",
+				ProxyDestination: "6L6BVfgH",
+			},
+			{
 				ID:                "dLOXpSCI",
 				Name:              "o1ynPkp0",
 				Tags:              []string{"nkwshvM5", "NTDWn3ek"},
@@ -3870,6 +3897,9 @@ func TestFullConfig(t *testing.T) {
 				Meta:              map[string]string{"mymeta": "data"},
 				Port:              24237,
 				EnableTagOverride: true,
+				Connect: &structs.ServiceConnect{
+					Native: true,
+				},
 				Checks: structs.CheckTypes{
 					&structs.CheckType{
 						CheckID:    "Zv99e9Ka",

--- a/website/source/docs/agent/services.html.md
+++ b/website/source/docs/agent/services.html.md
@@ -44,6 +44,8 @@ example shows all possible fields, but note that only a few are required.
         "interval": "10s"
       }
     ],
+    "kind": "connect-proxy",
+    "proxy_destination": "redis",
     "connect": {
       "native": false,
       "proxy": {
@@ -132,14 +134,22 @@ For Consul 0.9.3 and earlier you need to use `enableTagOverride`. Consul 1.0
 supports both `enable_tag_override` and `enableTagOverride` but the latter is
 deprecated and has been removed as of Consul 1.1.
 
-The `connect` field can be specified to configure [Connect](/docs/connect/index.html)
-for a service. This field is available in Consul 1.2 and later. The `native`
-value can be set to true to advertise the service as
-[Connect-native](/docs/connect/native.html). If the `proxy` field is set
-(even to an empty object), then this will enable a
-[managed proxy](/docs/connect/proxies.html) for the service. The fields within
-`proxy` are used to configure the proxy and are specified in the
-[proxy docs](/docs/connect/proxies.html).
+The `kind` field is used to optionally identify the service as an [unmanaged
+Connect proxy](/docs/connect/proxies.html#unmanaged-proxies) instance with the
+value `connect-proxy`. For typical non-proxy instances the `kind` field must be
+omitted. The `proxy_destination` field is also required for unmanaged proxy
+registrations and is only valid if `kind` is `connect-proxy`. It's value must be
+the _name_ of the service that the proxy is handling traffic for.
+
+The `connect` field can be specified to configure
+[Connect](/docs/connect/index.html) for a service. This field is available in
+Consul 1.2 and later. The `native` value can be set to true to advertise the
+service as [Connect-native](/docs/connect/native.html). If the `proxy` field is
+set (even to an empty object), then this will enable a [managed
+proxy](/docs/connect/proxies.html) for the service. The fields within `proxy`
+are used to configure the proxy and are specified in the [proxy
+docs](/docs/connect/proxies.html). If `native` is true, it is an error to also
+specifiy a managed proxy instance.
 
 ## Multiple Service Definitions
 


### PR DESCRIPTION
Fixes  #4417

We forgot to add plumbing to config to allow these Service Definitions to exist in config files as well as API calls.

Updated docs to be comprehensive again although in general we already documented these fields as working!