### PR TITLE
Documentation: Add missing word for Watches clarification

### DIFF
--- a/website/source/configuration.html.erb
+++ b/website/source/configuration.html.erb
@@ -170,7 +170,7 @@ description: |-
         <div>
           <div>
             <h3>Watches</h3>
-            <p>Watches use blocking queries monitor for any configuration or health status updates and invoke user specified scripts to handle changes. This makes it easy to build reactive infrastructure.</p>
+            <p>Watches use blocking queries to monitor for any configuration or health status updates and invoke user specified scripts to handle changes. This makes it easy to build reactive infrastructure.</p>
             <p>
               <a class="learn-more" href='/docs/agent/watches.html'>Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>


### PR DESCRIPTION
`Watches use blocking queries monitor` reads awkwardly, I figured 'to' was missing