### PR TITLE
Replace InmemSink for proxy listener tests

### DIFF
--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -97,10 +97,22 @@ func assertTelemetryValue(t *testing.T, sink *MockSink,
 		}
 	}
 
-	assert.Equal(t, true, found, "metric not found in sink: %s", name)
+	dumpSink := func() {
+		t.Log("Sink contents:")
+		for i := 0; i < len(sink.keys); i++ {
+			k, _ := sink.flattenKeyLabels(sink.keys[i], sink.labels[i])
+			t.Logf("\t%s: %f", k, sink.vals[i])
+		}
+	}
 
-	assert.Equalf(t, value, sink.vals[idx],
-		"'%s'\n telemetry mismatch - expected: %v, got %v", name, value, sink.vals[idx])
+	if !assert.Equal(t, true, found, "metric not found in sink: %s", name) {
+		dumpSink()
+	}
+
+	if !assert.Equalf(t, value, sink.vals[idx],
+		"'%s'\n telemetry mismatch - expected: %v, got %v", name, value, sink.vals[idx]) {
+		dumpSink()
+	}
 }
 
 func TestPublicListener(t *testing.T) {


### PR DESCRIPTION
TestUpstreamListener and TestPublicListener have been consistently flaky on Travis CI. 

The error associated with the failure shows that metrics are occasionally missing from the InmemSink that was being used. After looking through how the metrics were being incremented there was no apparent issue with the aggregation intervals nor with the counter creation. Rather than digging into a potential bug with go-metrics this PR aims to replace the InmemSink with a local mock copied from [here](https://github.com/armon/go-metrics/blob/master/sink_test.go). 

Other notes:
- Methods from the MemorySink interface that are not being used were left blank.
- The previous behavior of dumping the sink if the assertion fails was preserved.