### PR TITLE
Handle resolving proxy tokens when parsing HTTP requests

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -946,6 +946,9 @@ func (s *HTTPServer) AgentConnectCALeafCert(resp http.ResponseWriter, req *http.
 	var qOpts structs.QueryOptions
 
 	// Store DC in the ConnectCALeafRequest but query opts separately
+	// Don't resolve a proxy token to a real token that will be
+	// done with a call to verifyProxyToken later along with
+	// other security relevant checks.
 	if done := s.parseWithoutResolvingProxyToken(resp, req, &args.Datacenter, &qOpts); done {
 		return nil, nil
 	}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -944,8 +944,11 @@ func (s *HTTPServer) AgentConnectCALeafCert(resp http.ResponseWriter, req *http.
 		Service: serviceName, // Need name not ID
 	}
 	var qOpts structs.QueryOptions
+
 	// Store DC in the ConnectCALeafRequest but query opts separately
-	if done := s.parse(resp, req, &args.Datacenter, &qOpts); done {
+	s.parseDC(req, &args.Datacenter)
+	s.parseTokenProxyResolve(req, &qOpts.Token, false)
+	if s.parseConsistency(resp, req, &qOpts) || parseWait(resp, req, &qOpts) {
 		return nil, nil
 	}
 	args.MinQueryIndex = qOpts.MinQueryIndex
@@ -991,7 +994,7 @@ func (s *HTTPServer) AgentConnectProxyConfig(resp http.ResponseWriter, req *http
 
 	// Parse the token
 	var token string
-	s.parseToken(req, &token)
+	s.parseTokenProxyResolve(req, &token, false)
 
 	// Parse hash specially since it's only this endpoint that uses it currently.
 	// Eventually this should happen in parseWait and end up in QueryOptions but I

--- a/agent/http.go
+++ b/agent/http.go
@@ -563,10 +563,10 @@ func (s *HTTPServer) parseDC(req *http.Request, dc *string) {
 	}
 }
 
-// parseTokenResolveProxy is used to parse the ?token query param or the X-Consul-Token header and
+// parseTokenInternal is used to parse the ?token query param or the X-Consul-Token header and
 // optionally resolve proxy tokens to real ACL tokens. If no token is specified it will populate
 // the token with the agents UserToken (acl_token in the consul configuration)
-func (s *HTTPServer) parseTokenResolveProxy(req *http.Request, token *string, resolveProxyToken bool) {
+func (s *HTTPServer) parseTokenInternal(req *http.Request, token *string, resolveProxyToken bool) {
 	tok := ""
 	if other := req.URL.Query().Get("token"); other != "" {
 		tok = other
@@ -592,12 +592,12 @@ func (s *HTTPServer) parseTokenResolveProxy(req *http.Request, token *string, re
 // parseToken is used to parse the ?token query param or the X-Consul-Token header and
 // resolve proxy tokens to real ACL tokens
 func (s *HTTPServer) parseToken(req *http.Request, token *string) {
-	s.parseTokenResolveProxy(req, token, true)
+	s.parseTokenInternal(req, token, true)
 }
 
 // parseTokenWithoutResolvingProxyToken is used to parse the ?token query param or the X-Consul-Token header
 func (s *HTTPServer) parseTokenWithoutResolvingProxyToken(req *http.Request, token *string) {
-	s.parseTokenResolveProxy(req, token, false)
+	s.parseTokenInternal(req, token, false)
 }
 
 func sourceAddrFromRequest(req *http.Request) string {
@@ -652,11 +652,11 @@ func (s *HTTPServer) parseMetaFilter(req *http.Request) map[string]string {
 	return nil
 }
 
-// parseResolveProxy is a convenience method for endpoints that need
+// parseInternal is a convenience method for endpoints that need
 // to use both parseWait and parseDC.
-func (s *HTTPServer) parseResolveProxy(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions, resolveProxyToken bool) bool {
+func (s *HTTPServer) parseInternal(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions, resolveProxyToken bool) bool {
 	s.parseDC(req, dc)
-	s.parseTokenResolveProxy(req, &b.Token, resolveProxyToken)
+	s.parseTokenInternal(req, &b.Token, resolveProxyToken)
 	if s.parseConsistency(resp, req, b) {
 		return true
 	}
@@ -666,10 +666,10 @@ func (s *HTTPServer) parseResolveProxy(resp http.ResponseWriter, req *http.Reque
 // parse is a convenience method for endpoints that need
 // to use both parseWait and parseDC.
 func (s *HTTPServer) parse(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions) bool {
-	return s.parseResolveProxy(resp, req, dc, b, true)
+	return s.parseInternal(resp, req, dc, b, true)
 }
 
 // parseWithoutResolvingProxyToken is a convenience method similar to parse except that it disables resolving proxy tokens
 func (s *HTTPServer) parseWithoutResolvingProxyToken(resp http.ResponseWriter, req *http.Request, dc *string, b *structs.QueryOptions) bool {
-	return s.parseResolveProxy(resp, req, dc, b, false)
+	return s.parseInternal(resp, req, dc, b, false)
 }

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 )
 
@@ -783,6 +784,97 @@ func TestEnableWebUI(t *testing.T) {
 	a.srv.Handler.ServeHTTP(resp, req)
 	if resp.Code != 200 {
 		t.Fatalf("should handle ui")
+	}
+}
+
+func TestParseToken_ProxyTokenResolve(t *testing.T) {
+	t.Parallel()
+
+	type endpointCheck struct {
+		endpoint string
+		handler  func(s *HTTPServer, resp http.ResponseWriter, req *http.Request) (interface{}, error)
+	}
+
+	// This is no exhaustive list of all of our endpoints and is only testing GET endpoints
+	// right now. However it provides decent coverage that the proxy token resolution
+	// is happening properly
+	tests := []endpointCheck{
+		{"/v1/acl/info/root", (*HTTPServer).ACLGet},
+		{"/v1/agent/self", (*HTTPServer).AgentSelf},
+		{"/v1/agent/metrics", (*HTTPServer).AgentMetrics},
+		{"/v1/agent/services", (*HTTPServer).AgentServices},
+		{"/v1/agent/checks", (*HTTPServer).AgentChecks},
+		{"/v1/agent/members", (*HTTPServer).AgentMembers},
+		{"/v1/agent/connect/ca/roots", (*HTTPServer).AgentConnectCARoots},
+		{"/v1/agent/connect/ca/leaf/test", (*HTTPServer).AgentConnectCALeafCert},
+		{"/v1/agent/connect/ca/proxy/test", (*HTTPServer).AgentConnectProxyConfig},
+		{"/v1/catalog/connect", (*HTTPServer).CatalogConnectServiceNodes},
+		{"/v1/catalog/datacenters", (*HTTPServer).CatalogDatacenters},
+		{"/v1/catalog/nodes", (*HTTPServer).CatalogNodes},
+		{"/v1/catalog/node/" + t.Name(), (*HTTPServer).CatalogNodeServices},
+		{"/v1/catalog/services", (*HTTPServer).CatalogServices},
+		{"/v1/catalog/service/test", (*HTTPServer).CatalogServiceNodes},
+		{"/v1/connect/ca/configuration", (*HTTPServer).ConnectCAConfiguration},
+		{"/v1/connect/ca/roots", (*HTTPServer).ConnectCARoots},
+		{"/v1/connect/intentions", (*HTTPServer).IntentionEndpoint},
+		{"/v1/coordinate/datacenters", (*HTTPServer).CoordinateDatacenters},
+		{"/v1/coordinate/nodes", (*HTTPServer).CoordinateNodes},
+		{"/v1/coordinate/node/" + t.Name(), (*HTTPServer).CoordinateNode},
+		{"/v1/event/list", (*HTTPServer).EventList},
+		{"/v1/health/node/" + t.Name(), (*HTTPServer).HealthNodeChecks},
+		{"/v1/health/checks/test", (*HTTPServer).HealthNodeChecks},
+		{"/v1/health/state/passing", (*HTTPServer).HealthChecksInState},
+		{"/v1/health/service/test", (*HTTPServer).HealthServiceNodes},
+		{"/v1/health/connect/test", (*HTTPServer).HealthConnectServiceNodes},
+		{"/v1/operator/raft/configuration", (*HTTPServer).OperatorRaftConfiguration},
+		// keyring endpoint has issues with returning errors if you haven't enabled encryption
+		// {"/v1/operator/keyring", (*HTTPServer).OperatorKeyringEndpoint},
+		{"/v1/operator/autopilot/configuration", (*HTTPServer).OperatorAutopilotConfiguration},
+		{"/v1/operator/autopilot/health", (*HTTPServer).OperatorServerHealth},
+		{"/v1/query", (*HTTPServer).PreparedQueryGeneral},
+		{"/v1/session/list", (*HTTPServer).SessionList},
+		{"/v1/status/leader", (*HTTPServer).StatusLeader},
+		{"/v1/status/peers", (*HTTPServer).StatusPeers},
+	}
+
+	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	defer a.Shutdown()
+
+	// Register a service with a managed proxy
+	{
+		reg := &structs.ServiceDefinition{
+			ID:      "test-id",
+			Name:    "test",
+			Address: "127.0.0.1",
+			Port:    8000,
+			Check: structs.CheckType{
+				TTL: 15 * time.Second,
+			},
+			Connect: &structs.ServiceConnect{
+				Proxy: &structs.ServiceDefinitionConnectProxy{},
+			},
+		}
+
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(reg))
+		resp := httptest.NewRecorder()
+		_, err := a.srv.AgentRegisterService(resp, req)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+	}
+
+	// Get the proxy token from the agent directly, since there is no API.
+	proxy := a.State.Proxy("test-id-proxy")
+	require.NotNil(t, proxy)
+	token := proxy.ProxyToken
+	require.NotEmpty(t, token)
+
+	for _, check := range tests {
+		t.Run(fmt.Sprintf("GET(%s)", check.endpoint), func(t *testing.T) {
+			req, _ := http.NewRequest("GET", fmt.Sprintf("%s?token=%s", check.endpoint, token), nil)
+			resp := httptest.NewRecorder()
+			_, err := check.handler(a.srv, resp, req)
+			require.NoError(t, err)
+		})
 	}
 }
 

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -795,7 +795,7 @@ func TestParseToken_ProxyTokenResolve(t *testing.T) {
 		handler  func(s *HTTPServer, resp http.ResponseWriter, req *http.Request) (interface{}, error)
 	}
 
-	// This is no exhaustive list of all of our endpoints and is only testing GET endpoints
+	// This is not an exhaustive list of all of our endpoints and is only testing GET endpoints
 	// right now. However it provides decent coverage that the proxy token resolution
 	// is happening properly
 	tests := []endpointCheck{


### PR DESCRIPTION
Fixes: #4441 

The underlying problem with managed proxies and ACLs was that many HTTP endpoints were not ProxyToken aware. They passed along the proxy token to the RPC endpoints on the servers which knew nothing about proxy tokens.

This PR puts proxy token -> service token translation logic into our HTTP token handling. Additionally I added the parseTokenProxyResolve to be able to disable this auto-translation in the case of a few connect specific endpoints that want to run verifyProxyToken themselves (which has a few more checks - even though they may provide only marginal benefit in the case where each service has their own ACL token).

How I tested:

1. Brought up a 3 server and 1 client cluster
   * Client is running consul with an additional `python -m SimpleHTTPServer 8080` running in the background to provide the "web" service on port 8080
2. Bootstrapped ACLs (this doesn't get less painful the more I do it)
3. Enabled the connect proxy for my web service on my client
4. Ran `consul connect proxy -service test -upstream web:9191` on one of my consul servers (the cluster was in docker behind a nat bridge so I needed to get into the network and doing it on the server was the easiest way (although I could have done it elsewhere)
5. Tried curling localhost:9191  and got a tls: bad certificate error
6. Realized my policy was setup to deny by default
7. Created intention to allow test -> web
8. Curl localhost:9191 again and get the directory listing for where my python server was running.

Currently getting this all setup for a unit test is impractical at best and impossible at worst or I would have implemented that too.