### PR TITLE
Resolve HTML Errors in Docs

### DIFF
--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -103,7 +103,7 @@ populate the query before it is executed. All of the string fields inside the
       }
     }
     ```
-  This will map all names of the form "&lt;service&gt;.query.consul" over DNS to a query
+  This will map all names of the form `<service>.query.consul` over DNS to a query
   that will select an instance of the service in the agent's own network segment.
 
 Using templates, it is possible to apply prepared query behaviors to many

--- a/website/source/docs/agent/cloud-auto-join.html.md
+++ b/website/source/docs/agent/cloud-auto-join.html.md
@@ -67,7 +67,7 @@ $ consul agent -retry-join "provider=aws tag_key=... tag_value=..."
 - `access_key_id` (optional) - the AWS access key for authentication (see below for more information about authenticating).
 - `secret_access_key` (optional) - the AWS secret access key for authentication (see below for more information about authenticating).
 
-#### Authentication &amp; Precedence
+#### Authentication & Precedence
 
 - Static credentials `access_key_id=... secret_access_key=...`
 - Environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
@@ -134,7 +134,7 @@ $ consul agent -retry-join "provider=gce project_name=... tag_value=..."
 - `zone_pattern` (optional) - the list of zones can be restricted through an RE2 compatible regular expression. If omitted, servers in all zones are returned.
 - `credentials_file` (optional) - the credentials file for authentication. See below for more information.
 
-#### Authentication &amp; Precedence
+#### Authentication & Precedence
 
 - Use credentials from `credentials_file`, if provided.
 - Use JSON file from `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
@@ -164,7 +164,7 @@ $ consul agent -retry-join "provider=softlayer datacenter=... tag_value=... user
 ```
 
 - `provider` (required) - the name of the provider ("softlayer" in this case).
-- <a name="sl_datacenter"></a><a href="#sl_datacenter"><code>datacenter</code></a></a> (required) - the name of the datacenter to auto-join in.
+- <a name="sl_datacenter"></a><a href="#sl_datacenter"><code>datacenter</code></a> (required) - the name of the datacenter to auto-join in.
 - `tag_value` (required) - the value of the tag to auto-join on.
 - `username` (required) - the username to use for auth.
 - `api_key` (required) - the api key to use for auth.
@@ -284,7 +284,7 @@ $ consul agent -retry-join "provider=triton account=testaccount url=https://us-s
 - `tag_value` (optional) - the tag value to use.
 
 
-### vSphere 
+### vSphere
 
 This returns the first private IP address of all servers for the given region with the given `tag_name` and `category_name`.
 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -691,7 +691,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
     * <a name="connect_ca_provider"></a><a href="#connect_ca_provider">`ca_provider`</a> Controls
       which CA provider to use for Connect's CA. Currently only the `consul` and `vault` providers
-      are supported. This is only used when initially bootstrapping the cluster. For an existing 
+      are supported. This is only used when initially bootstrapping the cluster. For an existing
       cluster, use the [Update CA Configuration Endpoint](/api/connect/ca.html#update-ca-configuration).
 
     * <a name="connect_ca_config"></a><a href="#connect_ca_config">`ca_config`</a> An object which
@@ -711,7 +711,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
 
         #### Vault CA Provider (`ca_provider = "vault"`)
 
-        * <a name="vault_ca_address"></a><a href="#vault_ca_address">`address`</a> The address of the Vault 
+        * <a name="vault_ca_address"></a><a href="#vault_ca_address">`address`</a> The address of the Vault
         server to connect to.
 
         * <a name="vault_ca_token"></a><a href="#vault_ca_token">`token`</a> The Vault token to use.
@@ -722,10 +722,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
         The Vault token given above must have `sudo` access to this backend, as well as permission to mount
         the backend at this path if it is not already mounted.
 
-        * <a name="vault_ca_intermediate_pki"></a><a href="#vault_ca_intermediate_pki">`intermediate_pki_path`</a> 
+        * <a name="vault_ca_intermediate_pki"></a><a href="#vault_ca_intermediate_pki">`intermediate_pki_path`</a>
         The path to use for the temporary intermediate CA pki backend in Vault. *Connect will overwrite any data
-        at this path in order to generate a temporary intermediate CA*. The Vault token given above must have 
-        `write` access to this backend, as well as permission to mount the backend at this path if it is not 
+        at this path in order to generate a temporary intermediate CA*. The Vault token given above must have
+        `write` access to this backend, as well as permission to mount the backend at this path if it is not
         already mounted.
 
         #### Common CA Config Options
@@ -870,7 +870,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
       [RFC 6724](https://tools.ietf.org/html/rfc6724) and as a result it should
       be increasingly uncommon to need to change this value with modern
       resolvers).
-      
+
     * <a name="enable_additional_node_meta_txt"></a><a href="#enable_additional_node_meta_txt">`enable_additional_node_meta_txt`</a> -
       When set to true, Consul will add TXT records for Node metadata into the Additional section of the DNS responses for several
       query types such as SRV queries. When set to false those records are not emitted. This does not impact the behavior of those
@@ -1257,10 +1257,10 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
     * <a name="telemetry-circonus_check_search_tag"></a><a href="#telemetry-circonus_check_search_tag">`circonus_check_search_tag`</a>
       A special tag which, when coupled with the instance id, helps to narrow down the search results when neither a Submission URL or Check ID is provided. By default, this is set to service:application name (e.g. "service:consul").
 
-    * <a name="telemetry-circonus_check_display_name"</a><a href="#telemetry-circonus_check_display_name">`circonus_check_display_name`</a>
+    * <a name="telemetry-circonus_check_display_name"></a><a href="#telemetry-circonus_check_display_name">`circonus_check_display_name`</a>
       Specifies a name to give a check when it is created. This name is displayed in the Circonus UI Checks list. Available in Consul 0.7.2 and later.
 
-    * <a name="telemetry-circonus_check_tags"</a><a href="#telemetry-circonus_check_tags">`circonus_check_tags`</a>
+    * <a name="telemetry-circonus_check_tags"></a><a href="#telemetry-circonus_check_tags">`circonus_check_tags`</a>
       Comma separated list of additional tags to add to a check when it is created. Available in Consul 0.7.2 and later.
 
     * <a name="telemetry-circonus_broker_id"></a><a href="#telemetry-circonus_broker_id">`circonus_broker_id`</a>
@@ -1352,7 +1352,7 @@ Consul will not enable TLS for the HTTP API unless the `https` port has been ass
   `tls_prefer_server_cipher_suites`</a> Added in Consul 0.8.2, this will cause Consul to prefer the
   server's ciphersuite over the client ciphersuites.
 
-*   <a name="translate_wan_addrs"</a><a href="#translate_wan_addrs">`translate_wan_addrs`</a> If
+*   <a name="translate_wan_addrs"></a><a href="#translate_wan_addrs">`translate_wan_addrs`</a> If
     set to true, Consul will prefer a node's configured <a href="#_advertise-wan">WAN address</a>
     when servicing DNS and HTTP requests for a node in a remote datacenter. This allows the node to
     be reached within its own datacenter using its local address, and reached from other datacenters

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -374,13 +374,11 @@ These metrics are used to monitor the health of the Consul servers.
     <td>timer</td>
   </tr>
   <tr>
-  <tr>
     <td>`consul.raft.fsm.apply`</td>
     <td>This metric gives the number of logs committed since the last interval. </td>
     <td>commit logs / interval</td>
     <td>counter</td>
   </tr>
-  <tr>
   <tr>
     <td>`consul.raft.fsm.restore`</td>
     <td>This metric measures the time taken by the FSM to restore its state from a snapshot.</td>
@@ -449,17 +447,17 @@ These metrics are used to monitor the health of the Consul servers.
     <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.raft.verify_leader`</td>
-  <td>This metric counts the number of times an agent checks whether it is still the leader or not</td>
-  <td>checks / interval</td>
-  <td>Counter</td>
+    <td>`consul.raft.verify_leader`</td>
+    <td>This metric counts the number of times an agent checks whether it is still the leader or not</td>
+    <td>checks / interval</td>
+    <td>Counter</td>
   </tr>
   <tr>
-  <td>`consul.raft.restore`</td>
-  <td>This metric counts the number of times the restore operation has been performed by the agent. Here, restore refers to the action of raft consuming an external snapshot to restore its state.</td>
-  <td>operation invoked / interval</td>
-  <td>counter</td>
-  </tr> 
+    <td>`consul.raft.restore`</td>
+    <td>This metric counts the number of times the restore operation has been performed by the agent. Here, restore refers to the action of raft consuming an external snapshot to restore its state.</td>
+    <td>operation invoked / interval</td>
+    <td>counter</td>
+  </tr>
   <tr>
     <td>`consul.raft.commitTime`</td>
     <td>This measures the time it takes to commit a new entry to the Raft log on the leader.</td>
@@ -479,70 +477,70 @@ These metrics are used to monitor the health of the Consul servers.
     <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.state.follower`</td>
-  <td>This metric counts the number of times an agent has entered the follower mode. This happens when a new agent joins the cluster or after the end of a leader election.</td>
-  <td> follower state entered / interval</td>
-  <td>counter</td>
+    <td>`consul.raft.state.follower`</td>
+    <td>This metric counts the number of times an agent has entered the follower mode. This happens when a new agent joins the cluster or after the end of a leader election.</td>
+    <td> follower state entered / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.raft.transistion.heartbeat_timeout`</td>
-  <td>This metric gives the number of times an agent has transitioned to the Candidate state, after receive no heartbeat messages from the last known leader.</td>
-  <td>timeouts / interval</td>
-  <td>counter</td>
+    <td>`consul.raft.transistion.heartbeat_timeout`</td>
+    <td>This metric gives the number of times an agent has transitioned to the Candidate state, after receive no heartbeat messages from the last known leader.</td>
+    <td>timeouts / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.raft.restoreUserSnapshot`</td>
-  <td>This metric measures the time taken by the agent to restore the FSM state from a user's snapshot</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.restoreUserSnapshot`</td>
+    <td>This metric measures the time taken by the agent to restore the FSM state from a user's snapshot</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.rpc.processHeartBeat`</td>
-  <td>This metric measures the time taken to process a heartbeat request.</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.processHeartBeat`</td>
+    <td>This metric measures the time taken to process a heartbeat request.</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.rpc.appendEntries`</td>
-  <td>This metric measures the time taken to process an append entries RPC call from an agent.</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.appendEntries`</td>
+    <td>This metric measures the time taken to process an append entries RPC call from an agent.</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.rpc.appendEntries.storeLogs`</td>
-  <td>This metric measures the time taken to add any outstanding logs for an agent, since the last appendEntries was invoked</td>  
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.appendEntries.storeLogs`</td>
+    <td>This metric measures the time taken to add any outstanding logs for an agent, since the last appendEntries was invoked</td>  
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.rpc.appendEntries.processLogs`</td>
-  <td>This metric measures the time taken to process the outstanding log entries of an agent.</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.appendEntries.processLogs`</td>
+    <td>This metric measures the time taken to process the outstanding log entries of an agent.</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <tr>
-  <td>`consul.raft.rpc.requestVote`</td>
-  <td>This metric measures the time taken to process the request vote RPC call.</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.requestVote`</td>
+    <td>This metric measures the time taken to process the request vote RPC call.</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.rpc.installSnapshot`</td>
-  <td>This metric measures the time taken to process the installSnapshot RPC call. This metric should only be seen on agents which are currently in the follower state.</td>
-  <td>ms</td>
-  <td>timer</td>
-  <tr>
-  <td>`consul.raft.replication.appendEntries.rpc`</td>
-  <td>This metric measures the time taken by the append entries RFC, to replicate the log entries of a leader agent onto its follower agent(s)</td>
-  <td>ms</td>
-  <td>timer</td>
+    <td>`consul.raft.rpc.installSnapshot`</td>
+    <td>This metric measures the time taken to process the installSnapshot RPC call. This metric should only be seen on agents which are currently in the follower state.</td>
+    <td>ms</td>
+    <td>timer</td>
   </tr>
   <tr>
-  <td>`consul.raft.replication.appendEntries.logs`</td>
-  <td>This metric measures the number of logs replicated to an agent, to bring it upto speed with the leader's logs.</td>
-  <td>logs appended/ interval</td>
-  <td>counter</td>
+    <td>`consul.raft.replication.appendEntries.rpc`</td>
+    <td>This metric measures the time taken by the append entries RFC, to replicate the log entries of a leader agent onto its follower agent(s)</td>
+    <td>ms</td>
+    <td>timer</td>
+  </tr>
+  <tr>
+    <td>`consul.raft.replication.appendEntries.logs`</td>
+    <td>This metric measures the number of logs replicated to an agent, to bring it upto speed with the leader's logs.</td>
+    <td>logs appended/ interval</td>
+    <td>counter</td>
   </tr>
   <tr>
     <td><a name="last-contact"></a>`consul.raft.leader.lastContact`</td>
@@ -784,6 +782,7 @@ These metrics are used to monitor the health of the Consul servers.
     <td>ms</td>
     <td>timer</td>
   </tr>
+  <tr>
     <td>`consul.txn.read`</td>
     <td>This measures the time spent returning a read transaction.</td>
     <td>ms</td>
@@ -803,28 +802,28 @@ These metrics give insight into the health of the cluster as a whole.
     <th>Type</th>
   </tr>
   <tr>
-  <td>`consul.memberlist.degraded.probe`</td>
-  <td>This metric counts the number of times the agent has performed failure detection on an other agent at a slower probe rate. The agent uses its own health metric as an indicator to perform this action. (If its health score is low, means that the node is healthy, and vice versa.)</td>
-  <td>probes / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.degraded.probe`</td>
+    <td>This metric counts the number of times the agent has performed failure detection on an other agent at a slower probe rate. The agent uses its own health metric as an indicator to perform this action. (If its health score is low, means that the node is healthy, and vice versa.)</td>
+    <td>probes / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.degraded.timeout`</td>
-  <td>This metric counts the number of times an agent was marked as a dead node, whilst not getting enough confirmations from a randomly selected list of agent nodes in an agent's membership.</td>
-  <td>occurrence / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.degraded.timeout`</td>
+    <td>This metric counts the number of times an agent was marked as a dead node, whilst not getting enough confirmations from a randomly selected list of agent nodes in an agent's membership.</td>
+    <td>occurrence / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.msg.dead`</td>
-  <td>This metric counts the number of times an agent has marked another agent to be a dead node.</td>
-  <td>messages / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.msg.dead`</td>
+    <td>This metric counts the number of times an agent has marked another agent to be a dead node.</td>
+    <td>messages / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.health.score`</td>
-  <td>This metric describes a node's perception of its own health based on how well it is meeting the soft real-time requirements of the protocol. This metric ranges from 0 to 8, where 0 indicates "totally healthy". This health score is used to scale the time between outgoing probes, and higher scores translate into longer probing intervals. For more details see section IV of the Lifeguard paper: https://arxiv.org/pdf/1707.00788.pdf</td>
-  <td>score</td>
-  <td>gauge</td>
+    <td>`consul.memberlist.health.score`</td>
+    <td>This metric describes a node's perception of its own health based on how well it is meeting the soft real-time requirements of the protocol. This metric ranges from 0 to 8, where 0 indicates "totally healthy". This health score is used to scale the time between outgoing probes, and higher scores translate into longer probing intervals. For more details see section IV of the Lifeguard paper: https://arxiv.org/pdf/1707.00788.pdf</td>
+    <td>score</td>
+    <td>gauge</td>
   </tr>  
   <tr>
     <td>`consul.memberlist.msg.suspect`</td>
@@ -833,28 +832,28 @@ These metrics give insight into the health of the cluster as a whole.
     <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.tcp.accept`</td>
-  <td>This metric counts the number of times an agent has accepted an incoming TCP stream connection.</td>
-  <td>connections accepted / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.tcp.accept`</td>
+    <td>This metric counts the number of times an agent has accepted an incoming TCP stream connection.</td>
+    <td>connections accepted / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.udp.sent/received`</td>
-  <td>This metric measures the total number of bytes sent/received by an agent through the UDP protocol.</td>
-  <td>bytes sent or bytes received / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.udp.sent/received`</td>
+    <td>This metric measures the total number of bytes sent/received by an agent through the UDP protocol.</td>
+    <td>bytes sent or bytes received / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.tcp.connect`</td>
-  <td>This metric counts the number of times an agent has initiated a push/pull sync with an other agent.</td>
-  <td>push/pull initiated / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.tcp.connect`</td>
+    <td>This metric counts the number of times an agent has initiated a push/pull sync with an other agent.</td>
+    <td>push/pull initiated / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
-  <td>`consul.memberlist.tcp.sent`</td>
-  <td>This metric measures the total number of bytes sent by an agent through the TCP protocol</td>
-  <td>bytes sent / interval</td>
-  <td>counter</td>
+    <td>`consul.memberlist.tcp.sent`</td>
+    <td>This metric measures the total number of bytes sent by an agent through the TCP protocol</td>
+    <td>bytes sent / interval</td>
+    <td>counter</td>
   </tr>
   <tr>
     <td>`consul.memberlist.gossip`</td>

--- a/website/source/docs/compatibility.html.md
+++ b/website/source/docs/compatibility.html.md
@@ -39,6 +39,7 @@ For more details on the specifics of upgrading, see the [upgrading page](/docs/u
     <td>0.1 - 0.3</td>
     <td>1</td>
   </tr>
+  <tr>
     <td>0.4</td>
     <td>1, 2</td>
   </tr>
@@ -57,4 +58,3 @@ For more details on the specifics of upgrading, see the [upgrading page](/docs/u
 </table>
 
 -> **Note:** Raft Protocol is versioned separately, but maintains compatibility with at least one prior version. See [here](https://www.consul.io/docs/upgrade-specific.html#raft-protocol-version-compatibility) for details.
-

--- a/website/source/docs/guides/autopilot.html.md
+++ b/website/source/docs/guides/autopilot.html.md
@@ -85,7 +85,7 @@ with the `-cleanup-dead-servers=false` option.
 ## Server Health Checking
 
 An internal health check runs on the leader to track the stability of servers.
-</br>A server is considered healthy if all of the following conditions are true:
+<br>A server is considered healthy if all of the following conditions are true:
 
 - It has a SerfHealth status of 'Alive'
 - The time since its last contact with the current leader is below

--- a/website/source/docs/guides/manual-bootstrap.html.md
+++ b/website/source/docs/guides/manual-bootstrap.html.md
@@ -38,7 +38,7 @@ options, but it is recommended to have 3 or 5 total servers per datacenter. A
 single server deployment is _**highly**_ discouraged as data loss is inevitable
 in a failure scenario. We start the next servers **without** specifying
 `-bootstrap`. This is critical, since only one server should ever be running in
-bootstrap mode*. Once `Node B` and `Node C` are started, you should see a
+bootstrap mode. Once `Node B` and `Node C` are started, you should see a
 message to the effect of:
 
 ```text

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -67,7 +67,7 @@ As part of supporting the [HCL](https://github.com/hashicorp/hcl#syntax) format 
 
 #### Deprecated Options Have Been Removed
 
-All of Consul's previously deprecated command line flags and config options have been removed, so these will need to be mapped to their equivalents before upgrading. Here's the complete list of removed options and their equivalents:</summary>
+All of Consul's previously deprecated command line flags and config options have been removed, so these will need to be mapped to their equivalents before upgrading. Here's the complete list of removed options and their equivalents:
 
 | Removed Option | Equivalent |
 | -------------- | ---------- |
@@ -585,4 +585,3 @@ fails for some reason, it is not fatal. The older version of the server
 will simply panic and stop. At that point, you can upgrade to the new version
 and restart the agent. There will be no data loss and the cluster will
 resume operations.
-


### PR DESCRIPTION
I'm working through the process of upgrading middleman for these docs sites and adding the component system we are using for hashicorp.com, which involves a pass through an html parser. This is fairly close to the minimal set of changes needed to get it through the html parser. With this in place, we should be able to port the markdown over 1:1 without changes to the new architecture 🎉 