### PR TITLE
DNS : Fixes recursors answering the DNS query to properly return the correct response.

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1308,22 +1308,20 @@ func (d *DNSServer) handleRecurse(resp dns.ResponseWriter, req *dns.Msg) {
 			// If we still have recursors to forward the query to,
 			// we move forward onto the next one else the loop ends
 			continue
-		} else {
-			if err == nil || err == dns.ErrTruncated {
-				// Compress the response; we don't know if the incoming
-				// response was compressed or not, so by not compressing
-				// we might generate an invalid packet on the way out.
-				r.Compress = !d.disableCompression.Load().(bool)
+		} else if err == nil || err == dns.ErrTruncated {
+			// Compress the response; we don't know if the incoming
+			// response was compressed or not, so by not compressing
+			// we might generate an invalid packet on the way out.
+			r.Compress = !d.disableCompression.Load().(bool)
 
-				// Forward the response
-				d.logger.Printf("[DEBUG] dns: recurse RTT for %v (%v) Recursor queried: %v", q, rtt, recursor)
-				if err := resp.WriteMsg(r); err != nil {
-					d.logger.Printf("[WARN] dns: failed to respond: %v", err)
-				}
-				return
+			// Forward the response
+			d.logger.Printf("[DEBUG] dns: recurse RTT for %v (%v) Recursor queried: %v", q, rtt, recursor)
+			if err := resp.WriteMsg(r); err != nil {
+				d.logger.Printf("[WARN] dns: failed to respond: %v", err)
 			}
-			d.logger.Printf("[ERR] dns: recurse failed: %v", err)
+			return
 		}
+		d.logger.Printf("[ERR] dns: recurse failed: %v", err)
 	}
 
 	// If all resolvers fail, return a SERVFAIL message

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -37,9 +37,15 @@ const (
 // the provided reply. This is useful for mocking a DNS recursor with
 // an expected result.
 func makeRecursor(t *testing.T, answer dns.Msg) *dns.Server {
+	a := answer
 	mux := dns.NewServeMux()
 	mux.HandleFunc(".", func(resp dns.ResponseWriter, msg *dns.Msg) {
+		// The SetReply function sets the return code of the DNS
+		// query to SUCCESS
+		// We need a way to copy the variables not addressed
+		// in SetReply
 		answer.SetReply(msg)
+		answer.Rcode = a.Rcode
 		if err := resp.WriteMsg(&answer); err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -371,6 +377,40 @@ func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	}
 }
 
+func TestDNSCycleRecursorCheck(t *testing.T) {
+	t.Parallel()
+	// Start a DNS recursor that returns a SERVFAIL
+	server1 := makeRecursor(t, dns.Msg{
+		MsgHdr: dns.MsgHdr{Rcode: dns.RcodeServerFailure},
+	})
+	// Start a DNS recursor that returns the result
+	defer server1.Shutdown()
+	server2 := makeRecursor(t, dns.Msg{
+		MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess},
+		Answer: []dns.RR{
+			dnsA("www.google.com", "172.21.45.67"),
+		},
+	})
+	defer server2.Shutdown()
+	//Mock the agent startup with the necessary configs
+	agent := NewTestAgent(t.Name(),
+		`recursors = ["`+server1.Addr+`", "`+server2.Addr+`"]
+		`)
+	defer agent.Shutdown()
+	// DNS Message init
+	m := new(dns.Msg)
+	m.SetQuestion("google.com.", dns.TypeA)
+	// Agent request
+	client := new(dns.Client)
+	in, _, _ := client.Exchange(m, agent.DNSAddr())
+	wantAnswer := []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "www.google.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Rdlength: 0x4},
+			A:   []byte{0xAC, 0x15, 0x2D, 0x43}, // 172 , 21, 45, 67
+		},
+	}
+	verify.Values(t, "Answer", in.Answer, wantAnswer)
+}
 func TestDNS_NodeLookup_CNAME(t *testing.T) {
 	t.Parallel()
 	recursor := makeRecursor(t, dns.Msg{


### PR DESCRIPTION
This PR addresses the fact that if multiple recursors are provided to the Consul agent, Consul tries to fetch the DNS query instead of prematurely returning the response received from the first known recursor. i.e If a recursor returns a response like _SERVFAIL_ or _REFUSED_ the previous behaviour was to return the DNS response, instead of moving onto the next recursor for getting the DNS query issued. 
Fixes #4426 