### PR TITLE
Temporarilly disable HTTP2 support in SDK

### DIFF
--- a/connect/service.go
+++ b/connect/service.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/watch"
-	"golang.org/x/net/http2"
 )
 
 // Service represents a Consul service that accepts and/or connects via Connect.
@@ -242,9 +241,15 @@ func (s *Service) HTTPClient() *http.Client {
 		// this and/or compatibility with http.Request.WithContext.
 		DialTLS: s.HTTPDialTLS,
 	}
+
 	// Need to manually re-enable http2 support since we set custom DialTLS.
 	// See https://golang.org/src/net/http/transport.go?s=8692:9036#L228
-	http2.ConfigureTransport(t)
+
+	// Disable for now as enabling this option causes the proxy to negotiate
+	// HTTP2 due to ALPN setting, this causes problems when the upstream
+	// can not handle this.  In addition for HTTP2 to work, RootCAs needs to be
+	// configurable for the upstream.
+	//http2.ConfigureTransport(t)
 	return &http.Client{
 		Transport: t,
 	}


### PR DESCRIPTION
Temporarily disable HTTP2 support due to problems when upstream is not capable of handling HTTP2.  

Currently the SDK HTTPClient is unable to send requests to upstreams due to HTTP2 support being reported by the proxy during the TLS Handshake.  Subsequently all requests are attempted using HTTP2 and if the upstream is not configured for HTTP2 and TLS the request fails.

This fix enables use of the HTTPClient using HTTP/1.1 until a better solution is implemented.

This relates to issue:
https://github.com/hashicorp/consul/issues/4466

Signed-off-by: nicholasjackson <jackson.nic@gmail.com>