### PR TITLE
Fixes memory leak when blocking on /event/list

### DIFF
--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -125,6 +125,7 @@ SETUP_NOTIFY:
 	if b.MinQueryIndex > 0 {
 		notifyCh = make(chan struct{}, 1)
 		s.agent.eventNotify.Wait(notifyCh)
+		defer s.agent.eventNotify.Clear(notifyCh)
 	}
 
 RUN_QUERY:

--- a/agent/notify.go
+++ b/agent/notify.go
@@ -46,10 +46,3 @@ func (n *NotifyGroup) Clear(ch chan struct{}) {
 	}
 	delete(n.notify, ch)
 }
-
-// WaitCh allocates a channel that is subscribed to notifications
-func (n *NotifyGroup) WaitCh() chan struct{} {
-	ch := make(chan struct{}, 1)
-	n.Wait(ch)
-	return ch
-}

--- a/agent/notify_test.go
+++ b/agent/notify_test.go
@@ -4,11 +4,20 @@ import (
 	"testing"
 )
 
+// Used to be defined in NotifyGroup.WaitCh but was only used in tests and prone
+// to leaking memory if anything real did use it because there is no way to
+// clear the chan later.
+func testWaitCh(t *testing.T, grp *NotifyGroup) chan struct{} {
+	ch := make(chan struct{}, 1)
+	grp.Wait(ch)
+	return ch
+}
+
 func TestNotifyGroup(t *testing.T) {
 	grp := &NotifyGroup{}
 
-	ch1 := grp.WaitCh()
-	ch2 := grp.WaitCh()
+	ch1 := testWaitCh(t, grp)
+	ch2 := testWaitCh(t, grp)
 
 	select {
 	case <-ch1:
@@ -35,7 +44,7 @@ func TestNotifyGroup(t *testing.T) {
 	}
 
 	// Should be unregistered
-	ch3 := grp.WaitCh()
+	ch3 := testWaitCh(t, grp)
 	grp.Notify()
 
 	select {
@@ -58,7 +67,7 @@ func TestNotifyGroup(t *testing.T) {
 func TestNotifyGroup_Clear(t *testing.T) {
 	grp := &NotifyGroup{}
 
-	ch1 := grp.WaitCh()
+	ch1 := testWaitCh(t, grp)
 	grp.Clear(ch1)
 
 	grp.Notify()


### PR DESCRIPTION
See #3941

This fixes the memory leak by clearing the chan from the `eventNotify` group at the end of the request.

I also grepped through to find any other callers that might be effected but the only other caller was `NotifyGroup.WaitCh` which in turn was only used in tests.

I removed that method entirely since it will _always_ leak a chan if anyone actually used it for real, and made an equivalent test helper instead where the group is on the stack and so the chans don't leak for ever.