### PR TITLE
Move travis build env back to containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ matrix:
 script:
   - make test-ci
 
-sudo: true
+sudo: false


### PR DESCRIPTION
Back in February we moved from containers to VMs on Travis for our builds. This did not seem to lead to a visible increase in test reliability, but it does lead to significantly longer boot times.

Since we would like our test suite to be stable enough to run in containers, we should revert this change.

An old Travis blog post states that CPU resources (2 cores) with containers are guaranteed:
https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

There is more information on the build environments here:
https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System