### PR TITLE
Improve flaky connect/proxy Listener tests

### DIFF
--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -149,9 +149,6 @@ func TestPublicListener(t *testing.T) {
 	// Check active conn is tracked in gauges
 	assertCurrentGaugeValue(t, sink, "consul.proxy.test.inbound.conns;dst=db", 1)
 
-	// Short sleep to allow for cw.written to increment for tx and rx before calling reportStats
-	time.Sleep(time.Millisecond)
-
 	// Close listener to ensure all conns are closed and have reported their metrics
 	l.Close()
 
@@ -213,9 +210,6 @@ func TestUpstreamListener(t *testing.T) {
 
 	// Check active conn is tracked in gauges
 	assertCurrentGaugeValue(t, sink, "consul.proxy.test.upstream.conns;src=web;dst_type=service;dst=db", 1)
-
-	// Short sleep to allow for cw.written to increment for tx and rx before calling reportStats
-	time.Sleep(time.Millisecond)
 
 	// Close listener to ensure all conns are closed and have reported their metrics
 	l.Close()

--- a/connect/proxy/testing.go
+++ b/connect/proxy/testing.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"sync/atomic"
+	"time"
 
 	"github.com/hashicorp/consul/lib/freeport"
 	"github.com/mitchellh/go-testing-interface"
@@ -104,4 +105,8 @@ func TestEchoConn(t testing.T, conn net.Conn, prefix string) {
 	}
 	require.Equal(t, expectLen, got)
 	require.Equal(t, prefix+"Hello World", string(buf[:]))
+
+	// Addresses test flakiness around returning before Write or Read finish
+	// see PR #4498
+	time.Sleep(time.Millisecond)
 }


### PR DESCRIPTION
The source of flakiness for TestUpstreamListener and TestPublicListener was due to a data race. The counter assertion was occasionally happening before the atomic counter in memory was incremented. This was remedied with a short 1ms Sleep before the listener is closed and the data gets dumped to go-metrics. (The new test passed hundreds of times locally in a constrained environment that would typically cause it to fail after < 20 iterations)

Lastly, while going through these tests I also found that on occasion the latest go-metrics interval would not contain the logged gauge data due to how the intervals are generated. That assertion was improved by checking the 2nd to last index in the metrics array.