### PR TITLE
website: use 127.0.0.1 instead of consul.rocks

### DIFF
--- a/website/source/api/acl.html.md
+++ b/website/source/api/acl.html.md
@@ -39,7 +39,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/acl/bootstrap
+    http://127.0.0.1:8500/v1/acl/bootstrap
 ```
 
 ### Sample Response
@@ -104,7 +104,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/acl/create
+    http://127.0.0.1:8500/v1/acl/create
 ```
 
 ### Sample Response
@@ -155,7 +155,7 @@ required.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/acl/update
+    http://127.0.0.1:8500/v1/acl/update
 ```
 
 ## Delete ACL Token
@@ -185,7 +185,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/acl/destroy/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/acl/destroy/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## Read ACL Token
@@ -216,7 +216,7 @@ Note: No ACL is required because the ACL is specified in the URL path.
 
 ```text
 $ curl \
-    https://consul.rocks/v1/acl/info/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/acl/info/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ### Sample Response
@@ -263,7 +263,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/acl/clone/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/acl/clone/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ### Sample Response
@@ -295,7 +295,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/acl/list
+    http://127.0.0.1:8500/v1/acl/list
 ```
 
 ### Sample Response
@@ -345,7 +345,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/acl/replication
+    http://127.0.0.1:8500/v1/acl/replication
 ```
 
 ### Sample Response

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -54,7 +54,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/members
+    http://127.0.0.1:8500/v1/agent/members
 ```
 
 ### Sample Response
@@ -107,7 +107,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/self
+    http://127.0.0.1:8500/v1/agent/self
 ```
 
 ### Sample Response
@@ -187,7 +187,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/reload
+    http://127.0.0.1:8500/v1/agent/reload
 ```
 
 ## Enable Maintenance Mode
@@ -229,7 +229,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/maintenance?enable=true&reason=For+API+docs
+    http://127.0.0.1:8500/v1/agent/maintenance?enable=true&reason=For+API+docs
 ```
 
 ## View Metrics
@@ -258,7 +258,7 @@ configuration directive
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/metrics
+    http://127.0.0.1:8500/v1/agent/metrics
 ```
 
 ### Sample Response
@@ -384,7 +384,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/monitor
+    http://127.0.0.1:8500/v1/agent/monitor
 ```
 
 ### Sample Response
@@ -429,7 +429,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/join/1.2.3.4
+    http://127.0.0.1:8500/v1/agent/join/1.2.3.4
 ```
 
 ## Graceful Leave and Shutdown
@@ -460,7 +460,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/leave
+    http://127.0.0.1:8500/v1/agent/leave
 ```
 
 ## Force Leave and Shutdown
@@ -489,7 +489,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/force-leave
+    http://127.0.0.1:8500/v1/agent/force-leave
 ```
 
 ## Update ACL Tokens
@@ -538,5 +538,5 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/agent/token/acl_token
+    http://127.0.0.1:8500/v1/agent/token/acl_token
 ```

--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -40,7 +40,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/checks
+    http://127.0.0.1:8500/v1/agent/checks
 ```
 
 ### Sample Response
@@ -204,7 +204,7 @@ The table below shows this endpoint's support for
 $ curl \
    --request PUT \
    --data @payload.json \
-   https://consul.rocks/v1/agent/check/register
+   http://127.0.0.1:8500/v1/agent/check/register
 ```
 
 ## Deregister Check
@@ -236,7 +236,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/check/deregister/my-check-id
+    http://127.0.0.1:8500/v1/agent/check/deregister/my-check-id
 ```
 
 ## TTL Check Pass
@@ -269,7 +269,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/check/pass/my-check-id
+    http://127.0.0.1:8500/v1/agent/check/pass/my-check-id
 ```
 
 ## TTL Check Warn
@@ -302,7 +302,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/check/warn/my-check-id
+    http://127.0.0.1:8500/v1/agent/check/warn/my-check-id
 ```
 
 ## TTL Check Fail
@@ -335,7 +335,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/check/fail/my-check-id
+    http://127.0.0.1:8500/v1/agent/check/fail/my-check-id
 ```
 
 ## TTL Check Update
@@ -382,5 +382,5 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/agent/check/update/my-check-id
+    http://127.0.0.1:8500/v1/agent/check/update/my-check-id
 ```

--- a/website/source/api/agent/connect.html.md
+++ b/website/source/api/agent/connect.html.md
@@ -72,7 +72,7 @@ The table below shows this endpoint's support for
 $ curl \
    --request POST \
    --data @payload.json \
-    https://consul.rocks/v1/agent/connect/authorize
+    http://127.0.0.1:8500/v1/agent/connect/authorize
 ```
 
 ### Sample Response
@@ -113,7 +113,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-   https://consul.rocks/v1/connect/ca/roots
+   http://127.0.0.1:8500/v1/connect/ca/roots
 ```
 
 ### Sample Response
@@ -179,7 +179,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-   https://consul.rocks/v1/connect/ca/leaf/web
+   http://127.0.0.1:8500/v1/connect/ca/leaf/web
 ```
 
 ### Sample Response
@@ -250,7 +250,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-   https://consul.rocks/v1/connect/proxy/web-proxy
+   http://127.0.0.1:8500/v1/connect/proxy/web-proxy
 ```
 
 ### Sample Response

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -41,7 +41,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/agent/services
+    http://127.0.0.1:8500/v1/agent/services
 ```
 
 ### Sample Response
@@ -199,7 +199,7 @@ For the `Connect` field, the parameters are:
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/agent/service/register
+    http://127.0.0.1:8500/v1/agent/service/register
 ```
 
 ## Deregister Service
@@ -233,7 +233,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/service/deregister/my-service-id
+    http://127.0.0.1:8500/v1/agent/service/deregister/my-service-id
 ```
 
 ## Enable Maintenance Mode
@@ -276,5 +276,5 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/agent/service/maintenance/my-service-id?enable=true&reason=For+the+docs
+    http://127.0.0.1:8500/v1/agent/service/maintenance/my-service-id?enable=true&reason=For+the+docs
 ```

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -134,7 +134,7 @@ and vice versa. A catalog entry can have either, neither, or both.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/catalog/register
+    http://127.0.0.1:8500/v1/catalog/register
 ```
 
 ## Deregister Entity
@@ -204,7 +204,7 @@ The behavior of the endpoint depends on what keys are provided.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/catalog/deregister
+    http://127.0.0.1:8500/v1/catalog/deregister
 ```
 
 ## List Datacenters
@@ -234,7 +234,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/catalog/datacenters
+    http://127.0.0.1:8500/v1/catalog/datacenters
 ```
 
 ### Sample Response
@@ -280,7 +280,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/catalog/nodes
+    http://127.0.0.1:8500/v1/catalog/nodes
 ```
 
 ### Sample Response
@@ -348,7 +348,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/catalog/services
+    http://127.0.0.1:8500/v1/catalog/services
 ```
 
 ### Sample Response
@@ -409,7 +409,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/catalog/service/my-service
+    http://127.0.0.1:8500/v1/catalog/service/my-service
 ```
 
 ### Sample Response
@@ -536,7 +536,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/catalog/node/my-node
+    http://127.0.0.1:8500/v1/catalog/node/my-node
 ```
 
 ### Sample Response

--- a/website/source/api/connect/ca.html.md
+++ b/website/source/api/connect/ca.html.md
@@ -34,7 +34,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/ca/roots
+    http://127.0.0.1:8500/v1/connect/ca/roots
 ```
 
 ### Sample Response
@@ -82,7 +82,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/ca/configuration
+    http://127.0.0.1:8500/v1/connect/ca/configuration
 ```
 
 ### Sample Response
@@ -146,5 +146,5 @@ providers, see [Provider Config](/docs/connect/ca.html).
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/connect/ca/configuration
+    http://127.0.0.1:8500/v1/connect/ca/configuration
 ```

--- a/website/source/api/connect/intentions.html.md
+++ b/website/source/api/connect/intentions.html.md
@@ -73,7 +73,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request POST \
     --data @payload.json \
-    https://consul.rocks/v1/connect/intentions
+    http://127.0.0.1:8500/v1/connect/intentions
 ```
 
 ### Sample Response
@@ -110,7 +110,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
+    http://127.0.0.1:8500/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
 ```
 
 ### Sample Response
@@ -157,7 +157,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/intentions
+    http://127.0.0.1:8500/v1/connect/intentions
 ```
 
 ### Sample Response
@@ -226,7 +226,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
+    http://127.0.0.1:8500/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
 ```
 
 ## Delete Intention
@@ -256,7 +256,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request DELETE \
-    https://consul.rocks/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
+    http://127.0.0.1:8500/v1/connect/intentions/e9ebc19f-d481-42b1-4871-4d298d3acd5c
 ```
 
 ## Check Intention Result
@@ -295,7 +295,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/intentions/check?source=web&destination=db
+    http://127.0.0.1:8500/v1/connect/intentions/check?source=web&destination=db
 ```
 
 ### Sample Response
@@ -338,7 +338,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/connect/intentions/match?by=source&name=web
+    http://127.0.0.1:8500/v1/connect/intentions/match?by=source&name=web
 ```
 
 ### Sample Response

--- a/website/source/api/coordinate.html.md
+++ b/website/source/api/coordinate.html.md
@@ -42,7 +42,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/coordinate/datacenters
+    http://127.0.0.1:8500/v1/coordinate/datacenters
 ```
 
 ### Sample Response
@@ -104,7 +104,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/coordinate/nodes
+    http://127.0.0.1:8500/v1/coordinate/nodes
 ```
 
 ### Sample Response
@@ -160,7 +160,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/coordinate/node/agent-one
+    http://127.0.0.1:8500/v1/coordinate/node/agent-one
 ```
 
 ### Sample Response
@@ -229,5 +229,5 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/coordinate/update
+    http://127.0.0.1:8500/v1/coordinate/update
 ```

--- a/website/source/api/event.html.md
+++ b/website/source/api/event.html.md
@@ -63,7 +63,7 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit...
 $ curl \
     --request PUT \
     --data @payload \
-    https://consul.rocks/v1/event/fire/my-event
+    http://127.0.0.1:8500/v1/event/fire/my-event
 ```
 
 ### Sample Response
@@ -122,7 +122,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/event/list
+    http://127.0.0.1:8500/v1/event/list
 ```
 
 ### Sample Response

--- a/website/source/api/health.html.md
+++ b/website/source/api/health.html.md
@@ -45,7 +45,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/health/node/my-node
+    http://127.0.0.1:8500/v1/health/node/my-node
 ```
 
 ### Sample Response
@@ -74,7 +74,7 @@ $ curl \
     "Output": "",
     "ServiceID": "redis",
     "ServiceName": "redis",
-    "ServiceTags": ["primary"] 
+    "ServiceTags": ["primary"]
   }
 ]
 ```
@@ -120,7 +120,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/health/checks/my-service
+    http://127.0.0.1:8500/v1/health/checks/my-service
 ```
 
 ### Sample Response
@@ -190,7 +190,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/health/service/my-service
+    http://127.0.0.1:8500/v1/health/service/my-service
 ```
 
 ### Sample Response
@@ -305,7 +305,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/health/state/passing
+    http://127.0.0.1:8500/v1/health/state/passing
 ```
 
 ### Sample Response

--- a/website/source/api/index.html.md
+++ b/website/source/api/index.html.md
@@ -39,7 +39,7 @@ Here is an example using `curl`:
 ```text
 $ curl \
     --header "X-Consul-Token: abcd1234" \
-    https://consul.rocks/v1/agent/members
+    http://127.0.0.1:8500/v1/agent/members
 ```
 
 Previously this was provided via a `?token=` query parameter. This functionality
@@ -140,7 +140,7 @@ Here is the same example using `curl`:
 $ curl \
     --request PUT \
     --data 'hello consul' \
-    https://consul.rocks/v1/kv/foo
+    http://127.0.0.1:8500/v1/kv/foo
 ```
 
 ## Translated Addresses

--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -69,7 +69,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/kv/my-key
+    http://127.0.0.1:8500/v1/kv/my-key
 ```
 
 ### Sample Response
@@ -208,14 +208,14 @@ The payload is arbitrary, and is loaded directly into Consul as supplied.
 $ curl \
     --request PUT \
     --data @contents \
-    https://consul.rocks/v1/kv/my-key
+    http://127.0.0.1:8500/v1/kv/my-key
 
 # or
 
 $ curl \
     --request PUT \
     --data-binary @contents \
-    https://consul.rocks/v1/kv/my-key
+    http://127.0.0.1:8500/v1/kv/my-key
 ```
 
 ### Sample Response
@@ -258,7 +258,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request DELETE \
-    https://consul.rocks/v1/kv/my-key
+    http://127.0.0.1:8500/v1/kv/my-key
 ```
 
 ### Sample Response

--- a/website/source/api/operator/area.html.md
+++ b/website/source/api/operator/area.html.md
@@ -83,7 +83,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request POST \
     --data @payload.json \
-    https://consul.rocks/v1/operator/area
+    http://127.0.0.1:8500/v1/operator/area
 ```
 
 ### Sample Response
@@ -121,7 +121,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/area
+    http://127.0.0.1:8500/v1/operator/area
 ```
 
 ### Sample Response
@@ -176,7 +176,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## List Specific Network Area
@@ -209,7 +209,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ### Sample Response
@@ -255,7 +255,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request DELETE \
-    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## Join Network Area
@@ -299,7 +299,7 @@ This can be provided as `IP`, `IP:port`, `hostname`, or `hostname:port`.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/join
+    http://127.0.0.1:8500/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/join
 ```
 
 ### Sample Response
@@ -361,7 +361,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/members
+    http://127.0.0.1:8500/v1/operator/area/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/members
 ```
 
 ### Sample Response

--- a/website/source/api/operator/autopilot.html.md
+++ b/website/source/api/operator/autopilot.html.md
@@ -47,7 +47,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/operator/autopilot/configuration
+    http://127.0.0.1:8500/operator/autopilot/configuration
 ```
 
 ### Sample Response
@@ -168,7 +168,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/autopilot/health
+    http://127.0.0.1:8500/v1/operator/autopilot/health
 ```
 
 ### Sample response
@@ -241,6 +241,6 @@ $ curl \
   - `Voter` is whether the server is a voting member of the Raft cluster.
 
   - `StableSince` is the time this server has been in its current `Healthy` state.
-  
+
   The HTTP status code will indicate the health of the cluster. If `Healthy` is true, then a
   status of 200 will be returned. If `Healthy` is false, then a status of 429 will be returned.

--- a/website/source/api/operator/keyring.html.md
+++ b/website/source/api/operator/keyring.html.md
@@ -45,7 +45,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/keyring
+    http://127.0.0.1:8500/v1/operator/keyring
 ```
 
 ### Sample Response
@@ -130,7 +130,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request POST \
     --data @payload.json \
-    https://consul.rocks/v1/operator/keyring
+    http://127.0.0.1:8500/v1/operator/keyring
 ```
 
 ## Change Primary Gossip Encryption Key
@@ -175,7 +175,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/operator/keyring
+    http://127.0.0.1:8500/v1/operator/keyring
 ```
 
 ## Delete Gossip Encryption Key
@@ -219,5 +219,5 @@ The table below shows this endpoint's support for
 $ curl \
     --request DELETE \
     --data @payload.json \
-    https://consul.rocks/v1/operator/keyring
+    http://127.0.0.1:8500/v1/operator/keyring
 ```

--- a/website/source/api/operator/license.html.md
+++ b/website/source/api/operator/license.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # License - Operator HTTP API
 
-~> **Enterprise Only!** This API endpoint and functionality only exists in 
+~> **Enterprise Only!** This API endpoint and functionality only exists in
 Consul Enterprise. This is not present in the open source version of Consul.
 
 The licensing functionality described here is available only in
@@ -34,15 +34,15 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `dc` `(string: "")` - Specifies the datacenter whose license should be retrieved. 
-  This will default to the datacenter of the agent serving the HTTP request. 
+- `dc` `(string: "")` - Specifies the datacenter whose license should be retrieved.
+  This will default to the datacenter of the agent serving the HTTP request.
   This is specified as a URL query parameter.
-  
+
 ### Sample Request
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/license
+    http://127.0.0.1:8500/v1/operator/license
 ```
 
 ### Sample Response
@@ -77,7 +77,7 @@ $ curl \
 
 ## Updating the Consul License
 
-This endpoint updates the Consul license and returns some of the 
+This endpoint updates the Consul license and returns some of the
 license contents as well as any warning messages regarding its validity.
 
 | Method | Path                         | Produces                   |
@@ -95,21 +95,21 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `dc` `(string: "")` - Specifies the datacenter whose license should be updated. 
-  This will default to the datacenter of the agent serving the HTTP request. 
+- `dc` `(string: "")` - Specifies the datacenter whose license should be updated.
+  This will default to the datacenter of the agent serving the HTTP request.
   This is specified as a URL query parameter.
-  
+
 ### Sample Payload
 
 The payload is the raw license blob.
 
-### Sample Request 
+### Sample Request
 
 ```text
 $ curl \
     --request PUT \
     --data @consul.license \
-    https://consul.rocks/v1/operator/license
+    http://127.0.0.1:8500/v1/operator/license
 ```
 
 ### Sample Response

--- a/website/source/api/operator/raft.html.md
+++ b/website/source/api/operator/raft.html.md
@@ -49,7 +49,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/raft/configuration
+    http://127.0.0.1:8500/v1/operator/raft/configuration
 ```
 
 ### Sample Response
@@ -142,5 +142,5 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request DELETE \
-    https://consul.rocks/v1/operator/raft/peer?address=1.2.3.4:5678
+    http://127.0.0.1:8500/v1/operator/raft/peer?address=1.2.3.4:5678
 ```

--- a/website/source/api/operator/segment.html.md
+++ b/website/source/api/operator/segment.html.md
@@ -49,7 +49,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/operator/segment
+    http://127.0.0.1:8500/v1/operator/segment
 ```
 
 ### Sample Response

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -276,7 +276,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request POST \
     --data @payload.json \
-    https://consul.rocks/v1/query
+    http://127.0.0.1:8500/v1/query
 ```
 
 ### Sample Response
@@ -314,7 +314,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/query
+    http://127.0.0.1:8500/v1/query
 ```
 
 ### Sample Response
@@ -383,7 +383,7 @@ more information.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## Read Prepared Query
@@ -417,7 +417,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-  https://consul.rocks/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+  http://127.0.0.1:8500/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ### Sample Response
@@ -457,7 +457,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request DELETE \
-    https://consul.rocks/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+    http://127.0.0.1:8500/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
 ## Execute Prepared Query
@@ -513,7 +513,7 @@ Token will be used.
 
 ```text
 $ curl \
-    https://consul.rocks/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/execute?near=_agent
+    http://127.0.0.1:8500/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/execute?near=_agent
 ```
 
 ### Sample Response
@@ -620,7 +620,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/explain
+    http://127.0.0.1:8500/v1/query/8f246b77-f3e1-ff88-5b48-8ec93abf3e05/explain
 ```
 
 ### Sample Response

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -77,7 +77,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/session/create
+    http://127.0.0.1:8500/v1/session/create
 ```
 
 ### Sample Response
@@ -127,7 +127,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT
-    https://consul.rocks/v1/session/destroy/adf4238a-882b-9ddc-4a9d-5b6758e4159e
+    http://127.0.0.1:8500/v1/session/destroy/adf4238a-882b-9ddc-4a9d-5b6758e4159e
 ```
 
 ### Sample Response
@@ -166,7 +166,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/session/info/adf4238a-882b-9ddc-4a9d-5b6758e4159e
+    http://127.0.0.1:8500/v1/session/info/adf4238a-882b-9ddc-4a9d-5b6758e4159e
 ```
 
 ### Sample Response
@@ -217,7 +217,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/session/node/node-abcd1234
+    http://127.0.0.1:8500/v1/session/node/node-abcd1234
 ```
 
 ### Sample Response
@@ -263,7 +263,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
-    https://consul.rocks/v1/session/list
+    http://127.0.0.1:8500/v1/session/list
 ```
 
 ### Sample Response
@@ -314,7 +314,7 @@ The table below shows this endpoint's support for
 ```text
 $ curl \
     --request PUT \
-    https://consul.rocks/v1/session/renew/adf4238a-882b-9ddc-4a9d-5b6758e4159e
+    http://127.0.0.1:8500/v1/session/renew/adf4238a-882b-9ddc-4a9d-5b6758e4159e
 ```
 
 ### Sample Response

--- a/website/source/api/snapshot.html.md
+++ b/website/source/api/snapshot.html.md
@@ -60,7 +60,7 @@ The table below shows this endpoint's support for
 With a custom datacenter:
 
 ```text
-$ curl https://consul.rocks/v1/snapshot?dc=my-datacenter -o snapshot.tgz
+$ curl http://127.0.0.1:8500/v1/snapshot?dc=my-datacenter -o snapshot.tgz
 ```
 
 The above example results in a tarball named `snapshot.tgz` in the current working directory.
@@ -104,7 +104,7 @@ The table below shows this endpoint's support for
 $ curl \
     --request PUT \
     --data-binary @snapshot \
-    https://consul.rocks/v1/snapshot
+    http://127.0.0.1:8500/v1/snapshot
 ```
 
 ~> Some tools default to www/encoded uploads. Consul expects the snapshot to be

--- a/website/source/api/status.html.md
+++ b/website/source/api/status.html.md
@@ -35,7 +35,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl https://consul.rocks/v1/status/leader
+$ curl http://127.0.0.1:8500/v1/status/leader
 ```
 
 ### Sample Response
@@ -66,7 +66,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl https://consul.rocks/v1/status/peers
+$ curl http://127.0.0.1:8500/v1/status/peers
 ```
 
 ### Sample Response

--- a/website/source/api/txn.html.md
+++ b/website/source/api/txn.html.md
@@ -100,7 +100,7 @@ atomic transaction. Up to 64 operations may be present in a single transaction.
 $ curl \
     --request PUT \
     --data @payload.json \
-    https://consul.rocks/v1/txn
+    http://127.0.0.1:8500/v1/txn
 ```
 
 ### Sample Response
@@ -151,15 +151,15 @@ that operation ("X" means a field is required and "O" means it is optional):
 
 | Verb               | Operation                                    | Key  | Value | Flags | Index | Session |
 | ------------------ | -------------------------------------------- | :--: | :---: | :---: | :---: | :-----: |
-| `set`              | Sets the `Key` to the given `Value`          | `x`  | `x`   | `o`   |       |         |  
-| `cas`              | Sets, but with CAS semantics                 | `x`  | `x`   | `o`   | `x`   |         |  
-| `lock`             | Lock with the given `Session`                | `x`  | `x`   | `o`   |       | `x`     |  
-| `unlock`           | Unlock with the given `Session`              | `x`  | `x`   | `o`   |       | `x`     |  
-| `get`              | Get the key, fails if it does not exist      | `x`  |       |       |       |         |  
-| `get-tree`         | Gets all keys with the prefix                | `x`  |       |       |       |         |  
-| `check-index`      | Fail if modify index != index                | `x`  |       |       | `x`   |         |  
-| `check-session`    | Fail if not locked by session                | `x`  |       |       |       | `x`     |  
-| `check-not-exists` | Fail if key exists                           | `x`  |       |       |       |         |  
-| `delete`           | Delete the key                               | `x`  |       |       |       |         |  
-| `delete-tree`      | Delete all keys with a prefix                | `x`  |       |       |       |         |  
-| `delete-cas`       | Delete, but with CAS semantics               | `x`  |       |       | `x`   |         |  
+| `set`              | Sets the `Key` to the given `Value`          | `x`  | `x`   | `o`   |       |         |
+| `cas`              | Sets, but with CAS semantics                 | `x`  | `x`   | `o`   | `x`   |         |
+| `lock`             | Lock with the given `Session`                | `x`  | `x`   | `o`   |       | `x`     |
+| `unlock`           | Unlock with the given `Session`              | `x`  | `x`   | `o`   |       | `x`     |
+| `get`              | Get the key, fails if it does not exist      | `x`  |       |       |       |         |
+| `get-tree`         | Gets all keys with the prefix                | `x`  |       |       |       |         |
+| `check-index`      | Fail if modify index != index                | `x`  |       |       | `x`   |         |
+| `check-session`    | Fail if not locked by session                | `x`  |       |       |       | `x`     |
+| `check-not-exists` | Fail if key exists                           | `x`  |       |       |       |         |
+| `delete`           | Delete the key                               | `x`  |       |       |       |         |
+| `delete-tree`      | Delete all keys with a prefix                | `x`  |       |       |       |         |
+| `delete-cas`       | Delete, but with CAS semantics               | `x`  |       |       | `x`   |         |

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -587,7 +587,7 @@ $ curl \
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' https://consul.rocks/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
 ```
 
 Here's an equivalent request using the JSON form:
@@ -600,7 +600,7 @@ $ curl \
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' https://consul.rocks/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
 ```
 
 On success, the token ID is returned:


### PR DESCRIPTION
By default, the Consul agent listens on the local interface at port 8500 for API requests. This change makes the API examples using `curl` copy-pasteable for this default configuration.