### PR TITLE
Improve reliability of tests with TestAgent

### DIFF
--- a/agent/kvs_endpoint_test.go
+++ b/agent/kvs_endpoint_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/consul/testrpc"
+
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -341,6 +343,8 @@ func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Acquire the lock
 	id := makeTestSession(t, a.srv)

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-type Errorer interface {
-	Fatalf(format string, args ...interface{})
-}
-
 func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session) {
 	t.Helper()
 

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -16,9 +16,7 @@ import (
 	"github.com/pascaldekloe/goe/verify"
 )
 
-func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session) {
-	t.Helper()
-
+func verifySession(r *retry.R, a *TestAgent, want structs.Session) {
 	args := &structs.SessionSpecificRequest{
 		Datacenter: "dc1",
 		Session:    want.ID,
@@ -92,7 +90,7 @@ func TestSessionCreate(t *testing.T) {
 			LockDelay: 20 * time.Second,
 			Behavior:  structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -148,7 +146,7 @@ func TestSessionCreate_Delete(t *testing.T) {
 			LockDelay: 20 * time.Second,
 			Behavior:  structs.SessionKeysDelete,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -184,7 +182,7 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 			LockDelay: 20 * time.Second,
 			Behavior:  structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 
@@ -221,7 +219,7 @@ func TestSessionCreate_NoCheck(t *testing.T) {
 			LockDelay: 20 * time.Second,
 			Behavior:  structs.SessionKeysRelease,
 		}
-		verifySession(t, r, a, want)
+		verifySession(r, a, want)
 	})
 }
 

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/testrpc"
+
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -130,6 +132,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 	t.Run("", func(t *testing.T) {
 		a := NewTestAgent(t.Name(), "")
 		defer a.Shutdown()
+		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 		// Make sure all incoming fields get converted properly to the internal
 		// RPC format.

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -305,30 +305,36 @@ func TestLockCommand_ChildExitCode(t *testing.T) {
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	t.Run("clean exit", func(t *testing.T) {
-		ui := cli.NewMockUi()
-		c := New(ui)
-		args := []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "sh", "-c", "exit", "0"}
-		if got, want := c.Run(args), 0; got != want {
-			t.Fatalf("got %d want %d", got, want)
-		}
-	})
+	tt := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{
+			name: "clean exit",
+			args: []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "sh", "-c", "exit", "0"},
+			want: 0,
+		},
+		{
+			name: "error exit",
+			args: []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "exit", "1"},
+			want: 2,
+		},
+		{
+			name: "not propagated",
+			args: []string{"-http-addr=" + a.HTTPAddr(), "test/prefix", "sh", "-c", "exit", "1"},
+			want: 0,
+		},
+	}
 
-	t.Run("error exit", func(t *testing.T) {
-		ui := cli.NewMockUi()
-		c := New(ui)
-		args := []string{"-http-addr=" + a.HTTPAddr(), "-child-exit-code", "test/prefix", "exit", "1"}
-		if got, want := c.Run(args), 2; got != want {
-			t.Fatalf("got %d want %d", got, want)
-		}
-	})
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			c := New(ui)
 
-	t.Run("not propagated", func(t *testing.T) {
-		ui := cli.NewMockUi()
-		c := New(ui)
-		args := []string{"-http-addr=" + a.HTTPAddr(), "test/prefix", "sh", "-c", "exit", "1"}
-		if got, want := c.Run(args), 0; got != want {
-			t.Fatalf("got %d want %d", got, want)
-		}
-	})
+			if got := c.Run(tc.args); got != tc.want {
+				t.Fatalf("got %d want %d", got, tc.want)
+			}
+		})
+	}
 }

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -70,7 +70,7 @@ func TestLockCommand_NoShell(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -95,7 +95,7 @@ func TestLockCommand_TryLock(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -129,7 +129,7 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -163,7 +163,7 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -198,7 +198,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -233,7 +233,7 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -268,7 +268,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)
@@ -303,7 +303,7 @@ func TestLockCommand_ChildExitCode(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	tt := []struct {
 		name string


### PR DESCRIPTION
This PR makes a few changes to improve the reliability of tests that have at some point failed due to lacking a serfHealth registration:
* Adds WaitForTestAgent to several tests in the `command/lock` and `agent` packages.
* Fixes a bug where a blocks were put inside of `retry.Run` but `t.Fatalf` was called instead of `r.Fatalf`
* Modifies verifySession to also accept `r *retry.R`
* Adds retry to TestSessionCreate

There was also an unrelated change, adding table driven tests to TestLockCommand_ChildExitCode. 


