### PR TITLE
Add support for alternate DNS domains

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -624,6 +624,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		DNSARecordLimit:       b.intVal(c.DNS.ARecordLimit),
 		DNSDisableCompression: b.boolVal(c.DNS.DisableCompression),
 		DNSDomain:             b.stringVal(c.DNSDomain),
+		DNSAltDomains:         c.DNSAltDomains,
 		DNSEnableTruncate:     b.boolVal(c.DNS.EnableTruncate),
 		DNSMaxStale:           b.durationVal("dns_config.max_stale", c.DNS.MaxStale),
 		DNSNodeTTL:            b.durationVal("dns_config.node_ttl", c.DNS.NodeTTL),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -164,6 +164,7 @@ type Config struct {
 	Connect                          Connect                  `json:"connect,omitempty" hcl:"connect" mapstructure:"connect"`
 	DNS                              DNS                      `json:"dns_config,omitempty" hcl:"dns_config" mapstructure:"dns_config"`
 	DNSDomain                        *string                  `json:"domain,omitempty" hcl:"domain" mapstructure:"domain"`
+	DNSAltDomains                    []string                 `json:"alt_domains,omitempty" hcl:"alt_domains" mapstructure:"alt_domains"`
 	DNSRecursors                     []string                 `json:"recursors,omitempty" hcl:"recursors" mapstructure:"recursors"`
 	DataDir                          *string                  `json:"data_dir,omitempty" hcl:"data_dir" mapstructure:"data_dir"`
 	Datacenter                       *string                  `json:"datacenter,omitempty" hcl:"datacenter" mapstructure:"datacenter"`

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -70,6 +70,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.DisableKeyringFile, "disable-keyring-file", "Disables the backing up of the keyring to a file.")
 	add(&f.Config.Ports.DNS, "dns-port", "DNS port to use.")
 	add(&f.Config.DNSDomain, "domain", "Domain to use for DNS interface.")
+	add(&f.Config.DNSAltDomains, "alt-domain", "Alternate domain to use for DNS interface.")
 	add(&f.Config.EnableScriptChecks, "enable-script-checks", "Enables health check scripts.")
 	add(&f.Config.EncryptKey, "encrypt", "Provides the gossip encryption key.")
 	add(&f.Config.Ports.HTTP, "http-port", "Sets the HTTP API port to listen on.")

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -223,6 +223,13 @@ type RuntimeConfig struct {
 	// flag: -domain string
 	DNSDomain string
 
+	// DNSAltDomains can be set to allow the DNS servers to resolve additional
+	// consul domains. Each entry should end with a dot.
+	//
+	// hcl: alt_domains = []string
+	// flag: -alt-domain string [-alt-domain string]
+	DNSAltDomains []string
+
 	// DNSEnableTruncate is used to enable setting the truncate
 	// flag for UDP DNS queries.  This allows unmodified
 	// clients to re-query the consul server using TCP

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -5423,6 +5423,170 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	}
 }
 
+func TestDNS_AltDomains_Service(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t.Name(), `
+		alt_domains = [ "foo-domain.", "bar-domain." ]
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Register a node with a service.
+	{
+		args := &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "test-node",
+			Address:    "127.0.0.1",
+			Service: &structs.NodeService{
+				Service: "db",
+				Tags:    []string{"master"},
+				Port:    12345,
+			},
+		}
+
+		var out struct{}
+		if err := a.RPC("Catalog.Register", args, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}
+
+	questions := []string{
+		"db.service.consul.",
+		"db.service.foo-domain.",
+		"db.service.bar-domain.",
+	}
+
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSRV)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("Bad: %#v", in)
+		}
+
+		srvRec, ok := in.Answer[0].(*dns.SRV)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+		if srvRec.Port != 12345 {
+			t.Fatalf("Bad: %#v", srvRec)
+		}
+		if srvRec.Target != "test-node.node.dc1.consul." {
+			t.Fatalf("Bad: %#v", srvRec)
+		}
+
+		aRec, ok := in.Extra[0].(*dns.A)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.Hdr.Name != "test-node.node.dc1.consul." {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+		if aRec.A.String() != "127.0.0.1" {
+			t.Fatalf("Bad: %#v", in.Extra[0])
+		}
+	}
+}
+
+func TestDNS_AltDomains_SOA(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t.Name(), `
+		node_name = "test-node"
+		alt_domains = [ "foo-domain.", "bar-domain." ]
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	questions := []string{
+		"test-node.node.consul.",
+		"test-node.node.foo-domain.",
+		"test-node.node.bar-domain.",
+	}
+
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSOA)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("Bad: %#v", in)
+		}
+
+		soaRec, ok := in.Answer[0].(*dns.SOA)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+
+		if got, want := soaRec.Hdr.Name, "consul."; got != want {
+			t.Fatalf("SOA name invalid, got %q want %q", got, want)
+		}
+		if got, want := soaRec.Ns, "ns.consul."; got != want {
+			t.Fatalf("SOA ns invalid, got %q want %q", got, want)
+		}
+	}
+}
+
+func TestDNS_AltDomains_Overlap(t *testing.T) {
+	// this tests the domain matching logic in DNSServer when encountering more
+	// than one potential match (i.e. ambiguous match)
+	// it should select the domain that produces valid labels when dispatching
+	t.Parallel()
+	a := NewTestAgent(t.Name(), `
+		node_name = "test-node"
+		alt_domains = [
+			"bar.",
+			"foo.bar.",
+			"foo.",
+			"baz.foo.bar.",
+			"node.bar.",
+		]
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	questions := []string{
+		"test-node.node.foo.bar.",
+		"test-node.node.foo.",
+		"test-node.node.baz.foo.bar.",
+		"test-node.node.node.bar.",
+	}
+
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeA)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		if len(in.Answer) != 1 {
+			t.Fatalf("failed to resolve ambiguous alt domain %q: %#v", question, in)
+		}
+
+		aRec, ok := in.Answer[0].(*dns.A)
+		if !ok {
+			t.Fatalf("Bad: %#v", in.Answer[0])
+		}
+
+		if got, want := aRec.A.To4().String(), "127.0.0.1"; got != want {
+			t.Fatalf("A ip invalid, got %v want %v", got, want)
+		}
+	}
+}
+
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), `


### PR DESCRIPTION
Alternate DNS domains are supplied with the `-alt-domain` flag or `alt_domains` configuration parameter.

The DNS resolver will attempt to parse and match each domain during resolution.

See #4165 for use-case.