### PR TITLE
Fix inconsistency caused by the autopilot StatsFetcher

### DIFF
--- a/agent/consul/stats_fetcher.go
+++ b/agent/consul/stats_fetcher.go
@@ -92,6 +92,14 @@ func (f *StatsFetcher) Fetch(ctx context.Context, members []serf.Member) map[str
 	// canceled.
 	replies := make(map[string]*autopilot.ServerStats)
 	for _, workItem := range work {
+		// Drain the reply first if there is one.
+		select {
+		case reply := <-workItem.replyCh:
+			replies[workItem.server.ID] = reply
+			continue
+		default:
+		}
+
 		select {
 		case reply := <-workItem.replyCh:
 			replies[workItem.server.ID] = reply


### PR DESCRIPTION
This fix came out of looking into an issue in the enterprise redundancy zones feature - the reads on the RPC result channels in the stats fetcher were being affected by a single failed outgoing RPC (doing a select against multiple channels does not give priority to the first channel) which was incorrectly marking other servers as failed/unhealthy. This caused some inconsistencies with autopilot promoting servers, namely around redundancy zones where the current voter in a zone could be marked as unhealthy.

Fixing this also exposed that the restriction around removing dead servers (`removalCount < peers/2`) shouldn't apply in the case of non-voting servers, since there's no downside to removing them as they can't affect the quorum.