### PR TITLE
Fix #4515: Segfault when serf_wan port was -1 but reconnect_time_wan was set

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -788,6 +788,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.SerfLANConfig.MemberlistConfig.ProbeTimeout = a.config.GossipLANProbeTimeout
 	base.SerfLANConfig.MemberlistConfig.SuspicionMult = a.config.GossipLANSuspicionMult
 	base.SerfLANConfig.MemberlistConfig.RetransmitMult = a.config.GossipLANRetransmitMult
+	if a.config.ReconnectTimeoutLAN != 0 {
+		base.SerfLANConfig.ReconnectTimeout = a.config.ReconnectTimeoutLAN
+	}
 
 	if a.config.SerfBindAddrWAN != nil {
 		base.SerfWANConfig.MemberlistConfig.BindAddr = a.config.SerfBindAddrWAN.IP.String()
@@ -802,6 +805,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.SerfWANConfig.MemberlistConfig.ProbeTimeout = a.config.GossipWANProbeTimeout
 		base.SerfWANConfig.MemberlistConfig.SuspicionMult = a.config.GossipWANSuspicionMult
 		base.SerfWANConfig.MemberlistConfig.RetransmitMult = a.config.GossipWANRetransmitMult
+		if a.config.ReconnectTimeoutWAN != 0 {
+			base.SerfWANConfig.ReconnectTimeout = a.config.ReconnectTimeoutWAN
+		}
 	} else {
 		// Disable serf WAN federation
 		base.SerfWANConfig = nil
@@ -809,13 +815,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 
 	base.RPCAddr = a.config.RPCBindAddr
 	base.RPCAdvertise = a.config.RPCAdvertiseAddr
-
-	if a.config.ReconnectTimeoutLAN != 0 {
-		base.SerfLANConfig.ReconnectTimeout = a.config.ReconnectTimeoutLAN
-	}
-	if a.config.ReconnectTimeoutWAN != 0 {
-		base.SerfWANConfig.ReconnectTimeout = a.config.ReconnectTimeoutWAN
-	}
 
 	base.Segment = a.config.SegmentName
 	if len(a.config.Segments) > 0 {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -196,6 +196,19 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 	}()
 }
 
+func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t.Name(), `
+		ports { serf_wan = -1 }
+		reconnect_timeout_wan = "36h"
+	`)
+	defer a.Shutdown()
+
+	// This is also testing that we dont panic like before #4515
+	require.Nil(t, a.consulConfig().SerfWANConfig)
+}
+
 func TestAgent_setupNodeID(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), `

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -127,9 +127,9 @@ func (a *TestAgent) Start() *TestAgent {
 
 	for i := 10; i >= 0; i-- {
 		a.Config = TestConfig(
+			randomPortsSource(a.UseTLS),
 			config.Source{Name: a.Name, Format: "hcl", Data: a.HCL},
 			config.Source{Name: a.Name + ".data_dir", Format: "hcl", Data: hclDataDir},
-			randomPortsSource(a.UseTLS),
 		)
 
 		// write the keyring


### PR DESCRIPTION
Fixes #4515 

This just slightly refactors the logic to only attempt to set the serf wan reconnect timeout when the rest of the serf wan settings are configured - thus avoiding a segfault.