### PR TITLE
Wait for serfHealth when creating testutil.TestServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 
 matrix:
   include:
-    - env: GOTEST_PKGS="./api" PARALLEL="4"
+    - env: GOTEST_PKGS="./api" PARALLEL="3"
     - env: GOTEST_PKGS="./agent" PARALLEL="4"
     - env: GOTEST_PKGS="./agent/consul" PARALLEL="4"
     - env: GOTEST_PKGS_EXCLUDE="./api|./agent|./agent/consul" PARALLEL="4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ branches:
 
 matrix:
   include:
-    - env: GOTEST_PKGS="./api"
-    - env: GOTEST_PKGS="./agent"
-    - env: GOTEST_PKGS="./agent/consul"
-    - env: GOTEST_PKGS_EXCLUDE="./api|./agent|./agent/consul"
+    - env: GOTEST_PKGS="./api" PARALLEL="4"
+    - env: GOTEST_PKGS="./agent" PARALLEL="4"
+    - env: GOTEST_PKGS="./agent/consul" PARALLEL="4"
+    - env: GOTEST_PKGS_EXCLUDE="./api|./agent|./agent/consul" PARALLEL="4"
 
 script:
   - make test-ci

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -162,7 +162,7 @@ test-internal:
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
-	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL|panic:|--- FAIL)'
+	{ go test -v $(GOTEST_FLAGS) -tags '$(GOTAGS)' $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL|panic:|--- FAIL|--- PASS)'
 	@echo "Exit code: $$(cat exit-code)"
 	@# This prints all the race report between ====== lines
 	@awk '/^WARNING: DATA RACE/ {do_print=1; print "=================="} do_print==1 {print} /^={10,}/ {do_print=0}' test.log || true
@@ -182,7 +182,7 @@ test-race:
 
 # Run tests with config for CI so `make test` can still be local-dev friendly.
 test-ci: other-consul dev-build vet test-install-deps
-	@ if ! GOTEST_FLAGS="-short -timeout 8m -parallel 4" make test-internal; then \
+	@ if ! GOTEST_FLAGS="-short -timeout 8m -parallel $(PARALLEL)" make test-internal; then \
 	    echo "    ============"; \
 	    echo "      Retrying 1/2"; \
 	    echo "    ============"; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -182,7 +182,7 @@ test-race:
 
 # Run tests with config for CI so `make test` can still be local-dev friendly.
 test-ci: other-consul dev-build vet test-install-deps
-	@ if ! GOTEST_FLAGS="-short -timeout 8m -p 3 -parallel 4" make test-internal; then \
+	@ if ! GOTEST_FLAGS="-short -timeout 8m -parallel 4" make test-internal; then \
 	    echo "    ============"; \
 	    echo "      Retrying 1/2"; \
 	    echo "    ============"; \

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -137,7 +137,7 @@ func testRemoteExecGetSpec(t *testing.T, hcl string, token string, shouldSucceed
 	a := NewTestAgent(t.Name(), hcl)
 	defer a.Shutdown()
 	if dc != "" {
-		testrpc.WaitForLeader(t, a.RPC, dc)
+		testrpc.WaitForTestAgent(t, a.RPC, dc)
 	}
 	event := &remoteExecEvent{
 		Prefix:  "_rexec",

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -278,7 +278,7 @@ func newTestServerConfigT(t *testing.T, cb ServerConfigCallback) (*TestServer, e
 
 	// Wait for the server to be ready
 	if cfg.Bootstrap {
-		err = server.waitForLeader()
+		err = server.waitForAgent()
 	} else {
 		err = server.waitForAPI()
 	}
@@ -338,12 +338,12 @@ func (s *TestServer) waitForAPI() error {
 	return nil
 }
 
-// waitForLeader waits for:
+// waitForAgent waits for:
 // 1. Consul server's HTTP API to become available
 // 2. A known leader and an index of 1 or more to be observed to confirm leader election
 // 3. Anti-entropy sync
 // 4. serfHealth check registration
-func (s *TestServer) waitForLeader() error {
+func (s *TestServer) waitForAgent() error {
 	f := &failer{}
 	var index int64
 	retry.Run(f, func(r *retry.R) {


### PR DESCRIPTION
As with [#4525](https://github.com/hashicorp/consul/pull/4525), this PR continues improving the reliability or tests that have failed due to missing the serfHealth check registration.

The api package uses a function called `makeClient` to test against, since `NewTestAgent` used by the command and agent packages would trigger an import cycle. `makeClient` already waited for a leader to be elected but often moved on before the `serfHealth` check was registered.

To address this, `waitForLeader` was renamed and expanded to also wait for serfHealth to be registered. This will have downstream effects that help 30+ flaky tests.

Additionally, The -p flag was removed from GOTEST_FLAGS in the Makefile. This is because in Travis we only have 2 cores, and the default value will take advantage of all available CPUs. (See doc [here](https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies)) Running fewer binaries at once in CI should help combat some of the resource constraints we have been running up against.