### PR TITLE
fsm: add missing CA config to snapshot/restore logic

### DIFF
--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -14,7 +14,9 @@ import (
 )
 
 // msgpackHandle is a shared handle for encoding/decoding msgpack payloads
-var msgpackHandle = &codec.MsgpackHandle{}
+var msgpackHandle = &codec.MsgpackHandle{
+	RawToString: true,
+}
 
 // command is a command method on the FSM.
 type command func(buf []byte, index uint64) interface{}

--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -23,6 +23,7 @@ func init() {
 	registerRestorer(structs.IntentionRequestType, restoreIntention)
 	registerRestorer(structs.ConnectCARequestType, restoreConnectCA)
 	registerRestorer(structs.ConnectCAProviderStateType, restoreConnectCAProviderState)
+	registerRestorer(structs.ConnectCAConfigType, restoreConnectCAConfig)
 }
 
 func persistOSS(s *snapshot, sink raft.SnapshotSink, encoder *codec.Encoder) error {
@@ -54,6 +55,9 @@ func persistOSS(s *snapshot, sink raft.SnapshotSink, encoder *codec.Encoder) err
 		return err
 	}
 	if err := s.persistConnectCAProviderState(sink, encoder); err != nil {
+		return err
+	}
+	if err := s.persistConnectCAConfig(sink, encoder); err != nil {
 		return err
 	}
 	return nil
@@ -285,6 +289,23 @@ func (s *snapshot) persistConnectCA(sink raft.SnapshotSink,
 			return err
 		}
 	}
+
+	return nil
+}
+
+func (s *snapshot) persistConnectCAConfig(sink raft.SnapshotSink,
+	encoder *codec.Encoder) error {
+	config, err := s.state.CAConfig()
+	if err != nil {
+		return err
+	}
+
+	if _, err := sink.Write([]byte{byte(structs.ConnectCAConfigType)}); err != nil {
+		return err
+	}
+	if err := encoder.Encode(config); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -459,6 +480,17 @@ func restoreConnectCAProviderState(header *snapshotHeader, restore *state.Restor
 		return err
 	}
 	if err := restore.CAProviderState(&req); err != nil {
+		return err
+	}
+	return nil
+}
+
+func restoreConnectCAConfig(header *snapshotHeader, restore *state.Restore, decoder *codec.Decoder) error {
+	var req structs.CAConfiguration
+	if err := decoder.Decode(&req); err != nil {
+		return err
+	}
+	if err := restore.CAConfig(&req); err != nil {
 		return err
 	}
 	return nil

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -131,6 +131,18 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	assert.Nil(err)
 	assert.True(ok)
 
+	// CA Config
+	caConfig := &structs.CAConfiguration{
+		ClusterID: "foo",
+		Provider:  "consul",
+		Config: map[string]interface{}{
+			"foo": "asdf",
+			"bar": 6.5,
+		},
+	}
+	err = fsm.state.CASetConfig(17, caConfig)
+	assert.Nil(err)
+
 	// Snapshot
 	snap, err := fsm.Snapshot()
 	if err != nil {
@@ -309,6 +321,11 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("foo", state.PrivateKey)
 	assert.Equal("bar", state.RootCert)
+
+	// Verify CA configuration is restored.
+	_, caConf, err := fsm2.state.CAConfig()
+	assert.Nil(err)
+	assert.Equal(caConfig, caConf)
 
 	// Snapshot
 	snap, err = fsm2.Snapshot()

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -46,6 +46,7 @@ const (
 	IntentionRequestType                   = 12
 	ConnectCARequestType                   = 13
 	ConnectCAProviderStateType             = 14
+	ConnectCAConfigType                    = 15 // FSM snapshots only.
 )
 
 const (


### PR DESCRIPTION
This PR fixes the CA config not being backed up/restored from snapshots properly, which was causing issues when servers loaded the CA state from a snapshot and the roots didn't match the CA config (because the CA config was being re-initialized from the config instead of loaded from the snapshot).