### PR TITLE
Fixed a make build issue with Windows Binaries.

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -468,7 +468,7 @@ function build_consul_local {
             if [ $os == "windows" ];then
                 binname="consul.exe"
             fi
-            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}$binname" "${outdir}/$binname"
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}${binname}" "${outdir}/${binname}"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -464,7 +464,11 @@ function build_consul_local {
             then
                GOBIN_EXTRA="${os}_${arch}/"
             fi
-            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}consul" "${outdir}/consul"
+            binname="consul"
+            if [ $os == "windows" ];then
+                binname="consul.exe"
+            fi
+            CGO_ENABLED=0 GOOS=${os} GOARCH=${arch} go install -ldflags "${GOLDFLAGS}" -tags "${GOTAGS}" && cp "${MAIN_GOPATH}/bin/${GOBIN_EXTRA}$binname" "${outdir}/$binname"
             if test $? -ne 0
             then
                err "ERROR: Failed to build Consul for ${osarch}"


### PR DESCRIPTION
This PR fixes a `makefile` build issue with the generated Windows binaries, where the binaries could not be copied due to a non-existant path. 