### PR TITLE
Revert "Rename agent/proxy package to reflect that it is limited to managed proxy processes."

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/local"
-	"github.com/hashicorp/consul/agent/proxyprocess"
+	"github.com/hashicorp/consul/agent/proxy"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/systemd"
 	"github.com/hashicorp/consul/agent/token"
@@ -210,7 +210,7 @@ type Agent struct {
 	tokens *token.Store
 
 	// proxyManager is the proxy process manager for managed Connect proxies.
-	proxyManager *proxyprocess.Manager
+	proxyManager *proxy.Manager
 
 	// proxyLock protects proxy information in the local state from concurrent modification
 	proxyLock sync.Mutex
@@ -372,7 +372,7 @@ func (a *Agent) Start() error {
 	// done here after the local state above is loaded in so we can have
 	// a more accurate initial state view.
 	if !c.ConnectTestDisableManagedProxies {
-		a.proxyManager = proxyprocess.NewManager()
+		a.proxyManager = proxy.NewManager()
 		a.proxyManager.AllowRoot = a.config.ConnectProxyAllowManagedRoot
 		a.proxyManager.State = a.State
 		a.proxyManager.Logger = a.logger

--- a/agent/proxy/daemon.go
+++ b/agent/proxy/daemon.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"fmt"

--- a/agent/proxy/daemon_test.go
+++ b/agent/proxy/daemon_test.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"io/ioutil"

--- a/agent/proxy/exitstatus_other.go
+++ b/agent/proxy/exitstatus_other.go
@@ -1,6 +1,6 @@
 // +build !darwin,!linux,!windows
 
-package proxyprocess
+package proxy
 
 import "os"
 

--- a/agent/proxy/exitstatus_syscall.go
+++ b/agent/proxy/exitstatus_syscall.go
@@ -1,6 +1,6 @@
 // +build darwin linux windows
 
-package proxyprocess
+package proxy
 
 import (
 	"os"

--- a/agent/proxy/manager.go
+++ b/agent/proxy/manager.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"fmt"

--- a/agent/proxy/manager_test.go
+++ b/agent/proxy/manager_test.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"io/ioutil"

--- a/agent/proxy/noop.go
+++ b/agent/proxy/noop.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 // Noop implements Proxy and does nothing.
 type Noop struct{}

--- a/agent/proxy/noop_test.go
+++ b/agent/proxy/noop_test.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"testing"

--- a/agent/proxy/process.go
+++ b/agent/proxy/process.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"strings"

--- a/agent/proxy/process_unix.go
+++ b/agent/proxy/process_unix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package proxyprocess
+package proxy
 
 import (
 	"fmt"

--- a/agent/proxy/process_windows.go
+++ b/agent/proxy/process_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package proxyprocess
+package proxy
 
 import (
 	"os"

--- a/agent/proxy/proxy.go
+++ b/agent/proxy/proxy.go
@@ -5,7 +5,7 @@
 //
 // This package does not contain the built-in proxy for Connect. The source
 // for that is available in the "connect/proxy" package.
-package proxyprocess
+package proxy
 
 import (
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/proxy/proxy_test.go
+++ b/agent/proxy/proxy_test.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"fmt"

--- a/agent/proxy/root.go
+++ b/agent/proxy/root.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"os"

--- a/agent/proxy/snapshot.go
+++ b/agent/proxy/snapshot.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 import (
 	"encoding/json"

--- a/agent/proxy/test.go
+++ b/agent/proxy/test.go
@@ -1,4 +1,4 @@
-package proxyprocess
+package proxy
 
 // defaultTestProxy is the test proxy that is instantiated for proxies with
 // an execution mode of ProxyExecModeTest.

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strconv"
 
-	proxyAgent "github.com/hashicorp/consul/agent/proxyprocess"
+	proxyAgent "github.com/hashicorp/consul/agent/proxy"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
 	proxyImpl "github.com/hashicorp/consul/connect/proxy"


### PR DESCRIPTION
Forgot it was based on another PR branch that's not approved yet 🤦‍♂️ 

Reverts hashicorp/consul#4550

