### PR TITLE
Fixed unstable test TestRegisterMonitor_heartbeat

### DIFF
--- a/command/connect/proxy/register_test.go
+++ b/command/connect/proxy/register_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +43,7 @@ func TestRegisterMonitor_heartbeat(t *testing.T) {
 	defer a.Shutdown()
 	client := a.Client()
 
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	m, _ := testMonitor(t, client)
 	defer m.Close()
 


### PR DESCRIPTION
Example: https://travis-ci.org/hashicorp/consul/jobs/419727592

@freddygv This test is unstable, should avoid race-concurrency issue