### PR TITLE
Implement WarningThreshold for TCP/HTTP HealthChecks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2268,6 +2268,11 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 				existing.Stop()
 				delete(a.checkHTTPs, check.CheckID)
 			}
+			if chkType.WarningThreshold >= chkType.Interval {
+				a.logger.Println(fmt.Sprintf("[WARN] agent: check HTTP '%s' has WarningThreshold=%v invalid (must be > 0 and < %v), ignoring",
+					check.CheckID, chkType.WarningThreshold, chkType.Interval))
+				chkType.WarningThreshold = time.Duration(0 * time.Second)
+			}
 			if chkType.Interval < checks.MinInterval {
 				a.logger.Println(fmt.Sprintf("[WARN] agent: check '%s' has interval below minimum of %v",
 					check.CheckID, checks.MinInterval))
@@ -2277,15 +2282,16 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			tlsClientConfig := a.tlsConfigurator.OutgoingTLSConfigForCheck(chkType.TLSSkipVerify)
 
 			http := &checks.CheckHTTP{
-				Notify:          a.State,
-				CheckID:         check.CheckID,
-				HTTP:            chkType.HTTP,
-				Header:          chkType.Header,
-				Method:          chkType.Method,
-				Interval:        chkType.Interval,
-				Timeout:         chkType.Timeout,
-				Logger:          a.logger,
-				TLSClientConfig: tlsClientConfig,
+				Notify:           a.State,
+				CheckID:          check.CheckID,
+				HTTP:             chkType.HTTP,
+				Header:           chkType.Header,
+				Method:           chkType.Method,
+				Interval:         chkType.Interval,
+				Timeout:          chkType.Timeout,
+				Logger:           a.logger,
+				TLSClientConfig:  tlsClientConfig,
+				WarningThreshold: chkType.WarningThreshold,
 			}
 			http.Start()
 			a.checkHTTPs[check.CheckID] = http
@@ -2295,6 +2301,11 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 				existing.Stop()
 				delete(a.checkTCPs, check.CheckID)
 			}
+			if chkType.WarningThreshold >= chkType.Interval {
+				a.logger.Println(fmt.Sprintf("[WARN] agent: check TCP '%s' has WarningThreshold=%v invalid (must be > 0 and < %v), ignoring",
+					check.CheckID, chkType.WarningThreshold, chkType.Interval))
+				chkType.WarningThreshold = time.Duration(0 * time.Second)
+			}
 			if chkType.Interval < checks.MinInterval {
 				a.logger.Println(fmt.Sprintf("[WARN] agent: check '%s' has interval below minimum of %v",
 					check.CheckID, checks.MinInterval))
@@ -2302,12 +2313,13 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 			}
 
 			tcp := &checks.CheckTCP{
-				Notify:   a.State,
-				CheckID:  check.CheckID,
-				TCP:      chkType.TCP,
-				Interval: chkType.Interval,
-				Timeout:  chkType.Timeout,
-				Logger:   a.logger,
+				Notify:           a.State,
+				CheckID:          check.CheckID,
+				TCP:              chkType.TCP,
+				Interval:         chkType.Interval,
+				Timeout:          chkType.Timeout,
+				Logger:           a.logger,
+				WarningThreshold: chkType.WarningThreshold,
 			}
 			tcp.Start()
 			a.checkTCPs[check.CheckID] = tcp

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1346,7 +1346,7 @@ func TestAgent_HTTPCheck_WarningThreshold(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1362,7 +1362,7 @@ func TestAgent_HTTPCheck_WarningThreshold(t *testing.T) {
 		WarningThreshold: durationMs,
 	}
 
-	err := a.AddCheck(health, chk, false, "")
+	err := a.AddCheck(health, chk, false, "", ConfigSourceLocal)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1388,7 +1388,7 @@ func TestAgent_TCPCheck_WarningThreshold(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1405,7 +1405,7 @@ func TestAgent_TCPCheck_WarningThreshold(t *testing.T) {
 		WarningThreshold: durationMs,
 	}
 
-	err := a.AddCheck(health, chk, false, "")
+	err := a.AddCheck(health, chk, false, "", ConfigSourceLocal)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -20,6 +20,7 @@ func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	for _, addr := range []string{"0.0.0.0", "::", "[::]"} {
 		t.Run("addr "+addr, func(t *testing.T) {
@@ -45,6 +46,7 @@ func TestCatalogDeregister(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register node
 	args := &structs.DeregisterRequest{Node: "foo"}
@@ -64,6 +66,7 @@ func TestCatalogDatacenters(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	retry.Run(t, func(r *retry.R) {
 		req, _ := http.NewRequest("GET", "/v1/catalog/datacenters", nil)
@@ -483,6 +486,7 @@ func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register node
 	args := &structs.RegisterRequest{

--- a/agent/config.go
+++ b/agent/config.go
@@ -28,6 +28,7 @@ func FixupCheckType(raw interface{}) error {
 		"docker_container_id":               "DockerContainerID",
 		"tls_skip_verify":                   "TLSSkipVerify",
 		"service_id":                        "ServiceID",
+		"warningthreshold":                  "WarningThreshold",
 	})
 
 	parseDuration := func(v interface{}) (time.Duration, error) {
@@ -80,7 +81,7 @@ func FixupCheckType(raw interface{}) error {
 			}
 			rawMap[k] = h
 
-		case "ttl", "interval", "timeout", "deregistercriticalserviceafter":
+		case "ttl", "interval", "timeout", "deregistercriticalserviceafter", "warningthreshold":
 			d, err := parseDuration(v)
 			if err != nil {
 				return fmt.Errorf("invalid %q: %v", k, err)

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1173,6 +1173,7 @@ func (b *Builder) checkVal(v *CheckDefinition) *structs.CheckDefinition {
 		AliasService:                   b.stringVal(v.AliasService),
 		Timeout:                        b.durationVal(fmt.Sprintf("check[%s].timeout", id), v.Timeout),
 		TTL:                            b.durationVal(fmt.Sprintf("check[%s].ttl", id), v.TTL),
+		WarningThreshold:               b.durationVal(fmt.Sprintf("check[%s].warning_threshold", id), v.WarningThreshold),
 		DeregisterCriticalServiceAfter: b.durationVal(fmt.Sprintf("check[%s].deregister_critical_service_after", id), v.DeregisterCriticalServiceAfter),
 	}
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -402,6 +402,7 @@ type CheckDefinition struct {
 	Timeout                        *string             `json:"timeout,omitempty" hcl:"timeout" mapstructure:"timeout"`
 	TTL                            *string             `json:"ttl,omitempty" hcl:"ttl" mapstructure:"ttl"`
 	DeregisterCriticalServiceAfter *string             `json:"deregister_critical_service_after,omitempty" hcl:"deregister_critical_service_after" mapstructure:"deregister_critical_service_after"`
+	WarningThreshold               *string             `json:"warning_threshold,omitempty" hcl:"warning_threshold" mapstructure:"warning_threshold"`
 }
 
 // ServiceConnect is the connect block within a service registration

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4274,10 +4274,7 @@ func TestFullConfig(t *testing.T) {
 				TLSSkipVerify:                  true,
 				Timeout:                        1813 * time.Second,
 				TTL:                            21743 * time.Second,
-<<<<<<< HEAD
-=======
 				WarningThreshold:               1524 * time.Second,
->>>>>>> Implement WarningThreshold for TCP/HTTP HealthChecks
 				DeregisterCriticalServiceAfter: 14232 * time.Second,
 			},
 			&structs.CheckDefinition{
@@ -4301,10 +4298,7 @@ func TestFullConfig(t *testing.T) {
 				TLSSkipVerify:                  true,
 				Timeout:                        18506 * time.Second,
 				TTL:                            31006 * time.Second,
-<<<<<<< HEAD
-=======
 				WarningThreshold:               14506 * time.Second,
->>>>>>> Implement WarningThreshold for TCP/HTTP HealthChecks
 				DeregisterCriticalServiceAfter: 2366 * time.Second,
 			},
 			&structs.CheckDefinition{

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3055,6 +3055,7 @@ func TestFullConfig(t *testing.T) {
 					"shell": "qAeOYy0M",
 					"tls_skip_verify": true,
 					"timeout": "1813s",
+					"warning_threshold": "1524s",
 					"ttl": "21743s",
 					"deregister_critical_service_after": "14232s"
 				},
@@ -3079,6 +3080,7 @@ func TestFullConfig(t *testing.T) {
 					"tls_skip_verify": true,
 					"timeout": "18506s",
 					"ttl": "31006s",
+					"warning_threshold": "14506s",
 					"deregister_critical_service_after": "2366s"
 				}
 			],
@@ -3621,6 +3623,7 @@ func TestFullConfig(t *testing.T) {
 					shell = "qAeOYy0M"
 					tls_skip_verify = true
 					timeout = "1813s"
+					warning_threshold = "1524s"
 					ttl = "21743s"
 					deregister_critical_service_after = "14232s"
 				},
@@ -3645,6 +3648,7 @@ func TestFullConfig(t *testing.T) {
 					tls_skip_verify = true
 					timeout = "18506s"
 					ttl = "31006s"
+					warning_threshold = "14506s"
 					deregister_critical_service_after = "2366s"
 				}
 			]
@@ -4270,6 +4274,10 @@ func TestFullConfig(t *testing.T) {
 				TLSSkipVerify:                  true,
 				Timeout:                        1813 * time.Second,
 				TTL:                            21743 * time.Second,
+<<<<<<< HEAD
+=======
+				WarningThreshold:               1524 * time.Second,
+>>>>>>> Implement WarningThreshold for TCP/HTTP HealthChecks
 				DeregisterCriticalServiceAfter: 14232 * time.Second,
 			},
 			&structs.CheckDefinition{
@@ -4293,6 +4301,10 @@ func TestFullConfig(t *testing.T) {
 				TLSSkipVerify:                  true,
 				Timeout:                        18506 * time.Second,
 				TTL:                            31006 * time.Second,
+<<<<<<< HEAD
+=======
+				WarningThreshold:               14506 * time.Second,
+>>>>>>> Implement WarningThreshold for TCP/HTTP HealthChecks
 				DeregisterCriticalServiceAfter: 2366 * time.Second,
 			},
 			&structs.CheckDefinition{
@@ -4316,6 +4328,7 @@ func TestFullConfig(t *testing.T) {
 				TLSSkipVerify:                  true,
 				Timeout:                        5954 * time.Second,
 				TTL:                            30044 * time.Second,
+				WarningThreshold:               0 * time.Second,
 				DeregisterCriticalServiceAfter: 13209 * time.Second,
 			},
 		},
@@ -4484,6 +4497,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        38333 * time.Second,
 						TTL:                            57201 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 44214 * time.Second,
 					},
 				},
@@ -4532,6 +4546,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        34738 * time.Second,
 						TTL:                            22773 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 84282 * time.Second,
 					},
 					&structs.CheckType{
@@ -4553,6 +4568,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        4868 * time.Second,
 						TTL:                            11222 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 68482 * time.Second,
 					},
 				},
@@ -4638,6 +4654,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        18913 * time.Second,
 						TTL:                            44743 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 8482 * time.Second,
 					},
 					&structs.CheckType{
@@ -4659,6 +4676,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        38282 * time.Second,
 						TTL:                            1181 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 4992 * time.Second,
 					},
 					&structs.CheckType{
@@ -4680,6 +4698,7 @@ func TestFullConfig(t *testing.T) {
 						TLSSkipVerify:                  true,
 						Timeout:                        38483 * time.Second,
 						TTL:                            10943 * time.Second,
+						WarningThreshold:               0 * time.Second,
 						DeregisterCriticalServiceAfter: 68787 * time.Second,
 					},
 				},
@@ -5107,7 +5126,8 @@ func TestSanitize(t *testing.T) {
 			"TLSSkipVerify": false,
 			"TTL": "0s",
 			"Timeout": "0s",
-			"Token": "hidden"
+			"Token": "hidden",
+			"WarningThreshold": "0s"
 		}],
 		"ClientAddrs": [],
 		"ConfigEntryBootstrap": [],
@@ -5275,7 +5295,8 @@ func TestSanitize(t *testing.T) {
 				"TCP": "",
 				"TLSSkipVerify": false,
 				"TTL": "0s",
-				"Timeout": "0s"
+				"Timeout": "0s",
+				"WarningThreshold": "0s"
 			},
 			"Checks": [],
 			"Connect": null,

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -97,7 +97,7 @@ func TestStateStore_GC(t *testing.T) {
 		if idx != 12 {
 			t.Fatalf("bad index: %d", idx)
 		}
-	case <-time.After(2 * ttl):
+	case <-time.After(2*ttl + (50 * time.Millisecond)):
 		t.Fatalf("GC never fired")
 	}
 }

--- a/agent/structs/check_definition.go
+++ b/agent/structs/check_definition.go
@@ -37,6 +37,7 @@ type CheckDefinition struct {
 	Timeout                        time.Duration
 	TTL                            time.Duration
 	DeregisterCriticalServiceAfter time.Duration
+	WarningThreshold               time.Duration
 }
 
 func (c *CheckDefinition) HealthCheck(node string) *HealthCheck {
@@ -80,5 +81,6 @@ func (c *CheckDefinition) CheckType() *CheckType {
 		Timeout:                        c.Timeout,
 		TTL:                            c.TTL,
 		DeregisterCriticalServiceAfter: c.DeregisterCriticalServiceAfter,
+		WarningThreshold:               c.WarningThreshold,
 	}
 }

--- a/agent/structs/check_definition_test.go
+++ b/agent/structs/check_definition_test.go
@@ -93,6 +93,7 @@ func TestCheckDefinitionToCheckType(t *testing.T) {
 		Timeout:                        2 * time.Second,
 		TTL:                            3 * time.Second,
 		DeregisterCriticalServiceAfter: 4 * time.Second,
+		WarningThreshold:               1 * time.Second,
 	}
 	want := &CheckType{
 		CheckID: "id",
@@ -110,6 +111,7 @@ func TestCheckDefinitionToCheckType(t *testing.T) {
 		Timeout:                        2 * time.Second,
 		TTL:                            3 * time.Second,
 		DeregisterCriticalServiceAfter: 4 * time.Second,
+		WarningThreshold:               1 * time.Second,
 	}
 	verify.Values(t, "", got.CheckType(), want)
 }

--- a/agent/structs/check_type.go
+++ b/agent/structs/check_type.go
@@ -68,6 +68,9 @@ func (c *CheckType) Validate() error {
 	if !intervalCheck && !c.IsAlias() && c.TTL <= 0 {
 		return fmt.Errorf("TTL must be > 0 for TTL checks")
 	}
+	if c.WarningThreshold < 0 {
+		return fmt.Errorf("WarningThreshold must be 0 or positive")
+	}
 	return nil
 }
 

--- a/agent/structs/check_type.go
+++ b/agent/structs/check_type.go
@@ -59,6 +59,12 @@ func (c *CheckType) Validate() error {
 	if intervalCheck && c.Interval <= 0 {
 		return fmt.Errorf("Interval must be > 0 for Script, HTTP, or TCP checks")
 	}
+	if intervalCheck && (c.Interval < c.WarningThreshold) {
+		return fmt.Errorf("WarningThreshold must be ≤ Interval")
+	}
+	if intervalCheck && c.Timeout > 0 && c.Timeout < c.WarningThreshold {
+		return fmt.Errorf("WarningThreshold must be ≤ Timeout")
+	}
 	if intervalCheck && c.IsAlias() {
 		return fmt.Errorf("Interval cannot be set for Alias checks")
 	}

--- a/agent/structs/check_type.go
+++ b/agent/structs/check_type.go
@@ -40,6 +40,7 @@ type CheckType struct {
 	TLSSkipVerify     bool
 	Timeout           time.Duration
 	TTL               time.Duration
+	WarningThreshold  time.Duration
 
 	// DeregisterCriticalServiceAfter, if >0, will cause the associated
 	// service, if any, to be deregistered if this check is critical for

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -960,6 +960,7 @@ type HealthCheckDefinition struct {
 	Interval                       time.Duration       `json:",omitempty"`
 	Timeout                        time.Duration       `json:",omitempty"`
 	DeregisterCriticalServiceAfter time.Duration       `json:",omitempty"`
+	WarningThreshold               time.Duration       `json:",omitempty"`
 }
 
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
@@ -968,11 +969,13 @@ func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 		Interval                       string `json:",omitempty"`
 		Timeout                        string `json:",omitempty"`
 		DeregisterCriticalServiceAfter string `json:",omitempty"`
+		WarningThreshold               string `json:",omitempty"`
 		*Alias
 	}{
 		Interval:                       d.Interval.String(),
 		Timeout:                        d.Timeout.String(),
 		DeregisterCriticalServiceAfter: d.DeregisterCriticalServiceAfter.String(),
+		WarningThreshold:               d.WarningThreshold.String(),
 		Alias:                          (*Alias)(d),
 	}
 	if d.Interval == 0 {
@@ -984,6 +987,9 @@ func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 	if d.DeregisterCriticalServiceAfter == 0 {
 		exported.DeregisterCriticalServiceAfter = ""
 	}
+	if d.WarningThreshold == 0 {
+		exported.WarningThreshold = ""
+	}
 
 	return json.Marshal(exported)
 }
@@ -994,6 +1000,7 @@ func (d *HealthCheckDefinition) UnmarshalJSON(data []byte) error {
 		Interval                       string
 		Timeout                        string
 		DeregisterCriticalServiceAfter string
+		WarningThreshold               string
 		*Alias
 	}{
 		Alias: (*Alias)(d),
@@ -1014,6 +1021,11 @@ func (d *HealthCheckDefinition) UnmarshalJSON(data []byte) error {
 	}
 	if aux.DeregisterCriticalServiceAfter != "" {
 		if d.DeregisterCriticalServiceAfter, err = time.ParseDuration(aux.DeregisterCriticalServiceAfter); err != nil {
+			return err
+		}
+	}
+	if aux.WarningThreshold != "" {
+		if d.WarningThreshold, err = time.ParseDuration(aux.WarningThreshold); err != nil {
 			return err
 		}
 	}

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/testrpc"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -50,6 +52,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
@@ -119,6 +122,7 @@ func TestIngestUserEvent(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	for i := 0; i < 512; i++ {
 		msg := &UserEvent{LTime: uint64(i), Name: "test"}
@@ -150,6 +154,7 @@ func TestFireReceiveEvent(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
@@ -188,6 +193,7 @@ func TestUserEventToken(t *testing.T) {
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Create an ACL token
 	args := structs.ACLRequest{

--- a/api/agent.go
+++ b/api/agent.go
@@ -204,7 +204,6 @@ type AgentServiceCheck struct {
 	GRPCUseTLS        bool                `json:",omitempty"`
 	AliasNode         string              `json:",omitempty"`
 	AliasService      string              `json:",omitempty"`
-	WarningThreshold  string              `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service
 	// may also contain this optional DeregisterCriticalServiceAfter field,
@@ -213,6 +212,7 @@ type AgentServiceCheck struct {
 	// then its associated service (and all of its associated checks) will
 	// automatically be deregistered.
 	DeregisterCriticalServiceAfter string `json:",omitempty"`
+	WarningThreshold               string `json:",omitempty"`
 }
 type AgentServiceChecks []*AgentServiceCheck
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -204,6 +204,7 @@ type AgentServiceCheck struct {
 	GRPCUseTLS        bool                `json:",omitempty"`
 	AliasNode         string              `json:",omitempty"`
 	AliasService      string              `json:",omitempty"`
+	WarningThreshold  string              `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service
 	// may also contain this optional DeregisterCriticalServiceAfter field,

--- a/api/health.go
+++ b/api/health.go
@@ -58,6 +58,7 @@ type HealthCheckDefinition struct {
 	// DEPRECATED in Consul 1.4.1. Use the above time.Duration fields instead.
 	Interval                       ReadableDuration
 	Timeout                        ReadableDuration
+	WarningThreshold               ReadableDuration
 	DeregisterCriticalServiceAfter ReadableDuration
 }
 

--- a/api/health.go
+++ b/api/health.go
@@ -58,8 +58,8 @@ type HealthCheckDefinition struct {
 	// DEPRECATED in Consul 1.4.1. Use the above time.Duration fields instead.
 	Interval                       ReadableDuration
 	Timeout                        ReadableDuration
-	WarningThreshold               ReadableDuration
 	DeregisterCriticalServiceAfter ReadableDuration
+	WarningThreshold               *ReadableDuration
 }
 
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {

--- a/command/exec/exec_test.go
+++ b/command/exec/exec_test.go
@@ -88,6 +88,8 @@ func TestExecCommand_CrossDC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	testrpc.WaitForTestAgent(t, a1.RPC, "dc2")
+	testrpc.WaitForTestAgent(t, a2.RPC, "dc1")
 
 	if got, want := len(a1.WANMembers()), 2; got != want {
 		t.Fatalf("got %d WAN members on a1 want %d", got, want)

--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -202,6 +202,10 @@ The table below shows this endpoint's support for
 
 - `Status` `(string: "")` - Specifies the initial status of the health check.
 
+- `WarningThreshold` `(string: "")` - An optional duration for HTTP/TCP HealthChecks.
+  If the check is `passing` but this duration exceeds this value, the check will
+  be considered as having a `warning` state.
+
 ### Sample Payload
 
 ```json
@@ -219,7 +223,8 @@ The table below shows this endpoint's support for
   "TCP": "example.com:22",
   "Interval": "10s",
   "TTL": "15s",
-  "TLSSkipVerify": true
+  "TLSSkipVerify": true,
+  "WarningThreshold": "250ms",
 }
 ```
 


### PR DESCRIPTION
It implements setting Warning state for HTTP 200 or when TCP
connection succeeds but is too slow as described
in https://github.com/hashicorp/consul/issues/4522

Combined with https://github.com/hashicorp/consul/pull/4468 it will
allow very easily to reduce calls/secs on slow nodes in a
completely automatic way.