### PR TITLE
TestAgentAntiEntropy: Wait until Consul service is up on the agent.

### DIFF
--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1172,7 +1172,7 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 		check_update_interval = "0s" # set to "0s" since otherwise output checks are deferred
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	inSync := func(id string) bool {
 		s := a.State.CheckState(types.CheckID(id))
@@ -1414,7 +1414,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		}`}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Register info
 	args := &structs.RegisterRequest{
@@ -1684,7 +1684,7 @@ func TestAgent_sendCoordinate(t *testing.T) {
 		}
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	t.Logf("%d %d %s",
 		a.Config.ConsulCoordinateUpdateBatchSize,

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -31,7 +31,7 @@ func TestAgentAntiEntropy_Services(t *testing.T) {
 	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register info
 	args := &structs.RegisterRequest{
@@ -240,7 +240,7 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register node info
 	var out struct{}
@@ -378,7 +378,7 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	a := &agent.TestAgent{Name: t.Name()}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -490,7 +490,7 @@ func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 	t.Parallel()
 	a := agent.NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	{
 		// Single check
@@ -765,7 +765,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 	a.Start()
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	// Register info
 	args := &structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -1172,7 +1172,7 @@ func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 		check_update_interval = "0s" # set to "0s" since otherwise output checks are deferred
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	inSync := func(id string) bool {
 		s := a.State.CheckState(types.CheckID(id))
@@ -1223,7 +1223,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	`}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Create a check
 	check := &structs.HealthCheck{
@@ -1414,7 +1414,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		}`}
 	a.Start()
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register info
 	args := &structs.RegisterRequest{
@@ -1684,7 +1684,7 @@ func TestAgent_sendCoordinate(t *testing.T) {
 		}
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	t.Logf("%d %d %s",
 		a.Config.ConsulCoordinateUpdateBatchSize,


### PR DESCRIPTION
This PR modifies some of the `AntiEntropy` tests to wait for the Consul service to be registered. This fixes most of the tests. `DeferSync` and `Enable_Tagoverride` fail because of race conditions in `SyncFull`.