### PR TITLE
Fix unit test TestDaemonRestart_pidFile

### DIFF
--- a/agent/proxy/daemon_test.go
+++ b/agent/proxy/daemon_test.go
@@ -449,6 +449,7 @@ func TestDaemonRestart_pidFile(t *testing.T) {
 	require.NotEmpty(pidRaw)
 
 	// Delete the file
+	require.NoError(os.Remove(pidPath))
 	require.NoError(os.Remove(path))
 
 	// File should re-appear because the process is restart


### PR DESCRIPTION
@freddygv pid file was not removed => possible to have it not yet generated and still equal