### PR TITLE
Ensure that errors setting up the DNS servers get propagated back to the shell

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -465,7 +465,6 @@ func (a *Agent) listenAndServeDNS() error {
 			err := s.ListenAndServe(addr.Network(), addr.String(), func() { notif <- addr })
 			if err != nil && !strings.Contains(err.Error(), "accept") {
 				errCh <- err
-				a.logger.Printf("[ERR] agent: Error starting DNS server %s (%s): %v", addr.String(), addr.Network(), err)
 			}
 		}(addr)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/consul/watch"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/memberlist"
 	"github.com/hashicorp/raft"
@@ -448,6 +449,7 @@ func (a *Agent) Start() error {
 
 func (a *Agent) listenAndServeDNS() error {
 	notif := make(chan net.Addr, len(a.config.DNSAddrs))
+	errCh := make(chan error, len(a.config.DNSAddrs))
 	for _, addr := range a.config.DNSAddrs {
 		// create server
 		s, err := NewDNSServer(a)
@@ -462,6 +464,7 @@ func (a *Agent) listenAndServeDNS() error {
 			defer a.wgServers.Done()
 			err := s.ListenAndServe(addr.Network(), addr.String(), func() { notif <- addr })
 			if err != nil && !strings.Contains(err.Error(), "accept") {
+				errCh <- err
 				a.logger.Printf("[ERR] agent: Error starting DNS server %s (%s): %v", addr.String(), addr.Network(), err)
 			}
 		}(addr)
@@ -469,16 +472,19 @@ func (a *Agent) listenAndServeDNS() error {
 
 	// wait for servers to be up
 	timeout := time.After(time.Second)
+	var merr *multierror.Error
 	for range a.config.DNSAddrs {
 		select {
 		case addr := <-notif:
 			a.logger.Printf("[INFO] agent: Started DNS server %s (%s)", addr.String(), addr.Network())
-			continue
+		case err := <-errCh:
+			merr = multierror.Append(merr, err)
 		case <-timeout:
-			return fmt.Errorf("agent: timeout starting DNS servers")
+			merr = multierror.Append(merr, fmt.Errorf("agent: timeout starting DNS servers"))
+			break
 		}
 	}
-	return nil
+	return merr.ErrorOrNil()
 }
 
 // listenHTTP binds listeners to the provided addresses and also returns

--- a/website/source/docs/guides/forwarding.html.md
+++ b/website/source/docs/guides/forwarding.html.md
@@ -179,6 +179,10 @@ mapping.
 [root@localhost ~]# iptables -t nat -A OUTPUT -d localhost -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 8600
 ```
 
+Binding to port 53 will usually require running either as a privileged user (or on Linux running with the 
+CAP_NET_BIND_SERVICE capability). If using the Consul docker image you will need to add the following to the
+environment to allow Consul to use the port: `CONSUL_ALLOW_PRIVILEGED_PORTS=yes` 
+
 Note: With this setup, PTR record queries will still be sent out
 to the other configured resolvers in addition to Consul. 
 


### PR DESCRIPTION
Fixes: #4578 

Prior to this fix if there was an error binding to ports for the DNS servers the shell output would look like:

```
==> Starting Consul agent...
==> Error starting agent: agent: timeout starting DNS servers
```

After these changes the output looks like:

```
==> Starting Consul agent...
==> Error starting agent: 1 error(s) occurred:

* listen tcp 127.0.0.1:6258: bind: address already in use
```

Or:

```
==> Starting Consul agent...
==> Error starting agent: 2 error(s) occurred:

* listen udp 127.0.0.1:53: bind: permission denied
* listen tcp 127.0.0.1:53: bind: permission denied
```

The original problem was due to using a gated log writer and buffering logs until after the agent was successfully started. In the error case those buffered logs never were output anywhere.
