### PR TITLE
Bugfix: Use "%#v" when formatting structs

### DIFF
--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -61,7 +61,7 @@ func TestStateStore_GetNodeID(t *testing.T) {
 		t.Fatalf("got err %s want nil", err)
 	}
 	if out == nil || out.ID != nodeID {
-		t.Fatalf("out should not be nil and contain nodeId, but was:=%#q", out)
+		t.Fatalf("out should not be nil and contain nodeId, but was:=%#v", out)
 	}
 	// Case insensitive lookup should work as well
 	_, out, err = s.GetNodeID(types.NodeID("00a916bC-a357-4a19-b886-59419fceeAAA"))
@@ -69,7 +69,7 @@ func TestStateStore_GetNodeID(t *testing.T) {
 		t.Fatalf("got err %s want nil", err)
 	}
 	if out == nil || out.ID != nodeID {
-		t.Fatalf("out should not be nil and contain nodeId, but was:=%#q", out)
+		t.Fatalf("out should not be nil and contain nodeId, but was:=%#v", out)
 	}
 }
 

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -32,7 +32,7 @@ func WaitUntilNoLeader(t *testing.T, rpc rpcFn, dc string) {
 	retry.Run(t, func(r *retry.R) {
 		args := &structs.DCSpecificRequest{Datacenter: dc}
 		if err := rpc("Catalog.ListNodes", args, &out); err == nil {
-			r.Fatalf("It still has a leader: %#q", out)
+			r.Fatalf("It still has a leader: %#v", out)
 		}
 		if out.QueryMeta.KnownLeader {
 			r.Fatalf("Has still a leader")


### PR DESCRIPTION
Addresses:
`testrpc/wait.go:35: R.Fatalf format %#q has arg out of wrong type`

See:
https://travis-ci.org/hashicorp/consul/jobs/421583886