### PR TITLE
Remove operator_area note from godoc overview

### DIFF
--- a/api/operator_area.go
+++ b/api/operator_area.go
@@ -1,9 +1,10 @@
+package api
+
 // The /v1/operator/area endpoints are available only in Consul Enterprise and
 // interact with its network area subsystem. Network areas are used to link
 // together Consul servers in different Consul datacenters. With network areas,
 // Consul datacenters can be linked together in ways other than a fully-connected
 // mesh, as is required for Consul's WAN.
-package api
 
 import (
 	"net"


### PR DESCRIPTION
Currently the following note about operator areas shows up as the godoc synopsys for Consul:

> The /​v1/​operator/​area endpoints are available only in Consul Enterprise and interact with its network area subsystem.

This is because it is the only comment about the api package declaration.

This PR moves the comment below `package api` since the note applies to the whole file but should not be pulled into godoc.