### PR TITLE
UI: Bugfix. Fix code toggle in Safari

### DIFF
--- a/ui-v2/app/templates/dc/kv/-form.hbs
+++ b/ui-v2/app/templates/dc/kv/-form.hbs
@@ -10,7 +10,7 @@
 {{#if (or (eq (left-trim item.Key parent.Key) '') (not-eq (last item.Key) '/')) }}
         <div>
             <label class="type-toggle">
-                <input type="checkbox" name="json" checked={{if json 'checked' }} oninput={{action 'change'}} />
+                <input type="checkbox" name="json" checked={{if json 'checked' }} onchange={{action 'change'}} />
                 <span>Code</span>
             </label>
             <label class="type-text{{if item.error.Value ' has-error'}}">


### PR DESCRIPTION
I'd mistakenly changed the checkbox event to listen to oninput, which
works in Chrome and Firefox. Changed this back to onchange as it should
be (hence a one word diff)

Fixes #4529 