### PR TITLE
Change generic http metrics to use labels

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -133,8 +133,10 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 		wrapper := func(resp http.ResponseWriter, req *http.Request) {
 			start := time.Now()
 			handler(resp, req)
-			key := append([]string{"http", req.Method}, parts...)
-			metrics.MeasureSince(key, start)
+			metrics.MeasureSinceWithLabels([]string{"http", "endpoint"}, start, []metrics.Label{
+				{Name: "method", Value: req.Method},
+				{Name: "endpoint", Value: pattern},
+			})
 		}
 
 		gzipWrapper, _ := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(0))


### PR DESCRIPTION
Partially address #4611 

This does not handle migration steps and should wait either for a major version release or #4042 and use a flag to enable new metrics