### PR TITLE
UI: Bugfix. Move to a different TextEncoder/Decoder

### DIFF
--- a/ui-v2/app/utils/atob.js
+++ b/ui-v2/app/utils/atob.js
@@ -1,8 +1,9 @@
 import TextEncoding from 'npm:text-encoding';
 import base64js from 'npm:base64-js';
 export default function(str, encoding = 'utf-8') {
-  // str = String(str).trim();
-  //decode
+  // decode
   const bytes = base64js.toByteArray(str);
-  return new ('TextDecoder' in window ? TextDecoder : TextEncoding.TextDecoder)(encoding).decode(bytes);
+  return new ('TextDecoder' in window ? TextDecoder : TextEncoding.TextDecoder)(encoding).decode(
+    bytes
+  );
 }

--- a/ui-v2/app/utils/atob.js
+++ b/ui-v2/app/utils/atob.js
@@ -1,8 +1,8 @@
-import TextEncoderLite from 'npm:text-encoder-lite';
+import TextEncoding from 'npm:text-encoding';
 import base64js from 'npm:base64-js';
 export default function(str, encoding = 'utf-8') {
   // str = String(str).trim();
   //decode
   const bytes = base64js.toByteArray(str);
-  return new (TextDecoder || TextEncoderLite)(encoding).decode(bytes);
+  return new ('TextDecoder' in window ? TextDecoder : TextEncoding.TextDecoder)(encoding).decode(bytes);
 }

--- a/ui-v2/app/utils/btoa.js
+++ b/ui-v2/app/utils/btoa.js
@@ -1,7 +1,7 @@
-import TextEncoderLite from 'npm:text-encoder-lite';
+import TextEncoding from 'npm:text-encoding';
 import base64js from 'npm:base64-js';
 export default function(str, encoding = 'utf-8') {
   // encode
-  const bytes = new (TextEncoder || TextEncoderLite)(encoding).encode(str);
+  const bytes = new ('TextEncoder' in window ? TextEncoder : TextEncoding.TextEncoder)(encoding).encode(str);
   return base64js.fromByteArray(bytes);
 }

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -85,7 +85,7 @@
     "loader.js": "^4.2.3",
     "prettier": "^1.10.2",
     "svgo": "^1.0.5",
-    "text-encoder-lite": "^1.0.1"
+    "text-encoding": "^0.6.4"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -8926,10 +8926,6 @@ testem@^2.0.0:
     tap-parser "^5.1.0"
     xmldom "^0.1.19"
 
-text-encoder-lite@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/text-encoder-lite/-/text-encoder-lite-1.0.1.tgz#121c5ee74dfeb307037770ec75748c6824ac0518"
-
 text-encoding@0.6.4, text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"


### PR DESCRIPTION
1. The previously used TextEncoder/Decoder (used as a polyfill for
browsers that don't have a native version) didn't expose an encoder via
CommonJS. Use a different polyfill that exposes both a decoder and an
encoder.
2. The feature detection itself was flawed. This does a less error prone
detection that ensures native encoding/decoding where available and polyfilled
encoding/decoding where not available.

Fixes #4570 