### PR TITLE
UI: Bugfix. Remove split view code editor

### DIFF
--- a/ui-v2/app/styles/components/code-editor/index.scss
+++ b/ui-v2/app/styles/components/code-editor/index.scss
@@ -23,6 +23,8 @@ $syntax-yellow: $ui-yellow-500;
   max-width: 1150px;
   min-height: 300px;
   height: auto;
+  /* adds some space at the bottom of the editor for when a horizonal-scroll has appeared */
+  padding-bottom: 20px;
 }
 .CodeMirror-scroll {
   overflow-x: hidden !important;

--- a/ui-v2/app/styles/components/code-editor/index.scss
+++ b/ui-v2/app/styles/components/code-editor/index.scss
@@ -20,8 +20,12 @@ $syntax-dark-gray: #535f73;
 $syntax-gutter-grey: #2a2f36;
 $syntax-yellow: $ui-yellow-500;
 .CodeMirror {
+  max-width: 1150px;
   min-height: 300px;
   height: auto;
+}
+.CodeMirror-scroll {
+  overflow-x: hidden !important;
 }
 .CodeMirror-lint-tooltip {
   background-color: #f9f9fa;
@@ -59,13 +63,13 @@ $syntax-yellow: $ui-yellow-500;
   }
 
   &.CodeMirror-focused div.CodeMirror-selected {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgb(33, 66, 131);
   }
 
   .CodeMirror-line::selection,
   .CodeMirror-line > span::selection,
   .CodeMirror-line > span > span::selection {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgb(33, 66, 131);
   }
 
   .CodeMirror-line::-moz-selection,

--- a/ui-v2/app/templates/components/code-editor.hbs
+++ b/ui-v2/app/templates/components/code-editor.hbs
@@ -3,6 +3,6 @@
     readonly=readonly
     name=name
     class=class
-    options=(hash lineNumbers=true mode=mode theme='hashi')
+    options=(hash lineNumbers=true mode=mode theme='hashi' showCursorWhenSelecting=true)
     valueUpdated=(action onkeyup)
 }}


### PR DESCRIPTION
When adding an auto resizing (heightwise) code editor, the
ivy-codemirror plugin seems to do this using more nested divs. This div
had a horizontal scroller but couldn't be seen on some platforms (with
hidden scrollbars). This commit makes the code editor slightly more
usable and more visually correct by removing the scroll bar in this div
to stop producing the 'split view look', yet keeping the horizontal
scroller at the bottom of the code editor for when you enter code that
is wider than the area. A max-width has also been added here to prevent
the text area from growing off the side of the page.

Another improvement to the code editor here is the addition of a nicer
color for hightlighting text selection so its at least visible.

Fixes #4330 