### PR TITLE
Use target service name instead of ID as connect proxy's base service name

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -661,7 +661,7 @@ func (l *State) AddProxy(proxy *structs.ConnectManagedProxy, token,
 	svc := &structs.NodeService{
 		Kind:             structs.ServiceKindConnectProxy,
 		ID:               target.ID + "-proxy",
-		Service:          target.ID + "-proxy",
+		Service:          target.Service + "-proxy",
 		ProxyDestination: target.Service,
 		Address:          cfg.BindAddress,
 		Port:             cfg.BindPort,


### PR DESCRIPTION
This should address #4619

This fix issues appearing when you define a service Name which is not a prefix of the Service ID and have ACL configured for that name

Like

"""
ID: service_id
Name: name_of_service
"""
with an ACL permitting to write only on 'name_of_service*'
