### PR TITLE
UI: Small screen CSS improvements

### DIFF
--- a/ui-v2/app/mixins/with-resizing.js
+++ b/ui-v2/app/mixins/with-resizing.js
@@ -17,14 +17,22 @@ export default Mixin.create({
   },
   didInsertElement: function() {
     this._super(...arguments);
-    get(this, 'win').addEventListener('resize', this.handler);
+    ['resize', 'orientationchange'].forEach(
+      (item) => {
+        get(this, 'win').addEventListener(item, this.handler, false);
+      }
+    );
     this.didAppear();
   },
   didAppear: function() {
     this.handler({ target: get(this, 'win') });
   },
   willDestroyElement: function() {
-    get(this, 'win').removeEventListener('resize', this.handler);
+    ['resize', 'orientationchange'].forEach(
+      (item) => {
+        get(this, 'win').removeEventListener(item, this.handler, false);
+      }
+    );
     this._super(...arguments);
   },
 });

--- a/ui-v2/app/mixins/with-resizing.js
+++ b/ui-v2/app/mixins/with-resizing.js
@@ -3,7 +3,7 @@ import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 export default Mixin.create({
   resize: function(e) {
-   assert('with-resizing.resize needs to be overridden', false);
+    assert('with-resizing.resize needs to be overridden', false);
   },
   win: window,
   init: function() {
@@ -17,22 +17,14 @@ export default Mixin.create({
   },
   didInsertElement: function() {
     this._super(...arguments);
-    ['resize', 'orientationchange'].forEach(
-      (item) => {
-        get(this, 'win').addEventListener(item, this.handler, false);
-      }
-    );
+    get(this, 'win').addEventListener('resize', this.handler, false);
     this.didAppear();
   },
   didAppear: function() {
     this.handler({ target: get(this, 'win') });
   },
   willDestroyElement: function() {
-    ['resize', 'orientationchange'].forEach(
-      (item) => {
-        get(this, 'win').removeEventListener(item, this.handler, false);
-      }
-    );
+    get(this, 'win').removeEventListener('resize', this.handler, false);
     this._super(...arguments);
   },
 });

--- a/ui-v2/app/styles/app.scss
+++ b/ui-v2/app/styles/app.scss
@@ -38,3 +38,4 @@
 @import 'routes/dc/nodes/index';
 @import 'routes/dc/intention/index';
 @import 'routes/dc/kv/index';
+@import 'routes/dc/acls/index';

--- a/ui-v2/app/styles/components/confirmation-dialog.scss
+++ b/ui-v2/app/styles/components/confirmation-dialog.scss
@@ -2,3 +2,19 @@
 div.with-confirmation {
   @extend %confirmation-dialog, %confirmation-dialog-inline;
 }
+table div.with-confirmation.confirming {
+  position: absolute;
+  right: 0;
+}
+@media #{$--lt-wide-form} {
+  %confirmation-dialog {
+    float: none;
+    margin-top: 1em;
+  }
+  %confirmation-dialog-inline {
+    display: block;
+  }
+  %confirmation-dialog-inline p {
+    margin-bottom: 1em;
+  }
+}

--- a/ui-v2/app/styles/components/confirmation-dialog/layout.scss
+++ b/ui-v2/app/styles/components/confirmation-dialog/layout.scss
@@ -10,7 +10,3 @@
   align-items: center;
   line-height: 1;
 }
-table div.with-confirmation.confirming {
-  position: absolute;
-  right: 0;
-}

--- a/ui-v2/app/styles/components/feedback-dialog.scss
+++ b/ui-v2/app/styles/components/feedback-dialog.scss
@@ -2,3 +2,13 @@
 main .with-feedback {
   @extend %feedback-dialog-inline;
 }
+@media #{$--lt-spacious-page-header} {
+  .actions .with-feedback p {
+    bottom: auto;
+    top: 0px;
+  }
+  .actions .with-feedback p::after {
+    bottom: auto;
+    top: -5px;
+  }
+}

--- a/ui-v2/app/styles/components/healthcheck-status.scss
+++ b/ui-v2/app/styles/components/healthcheck-status.scss
@@ -12,3 +12,24 @@
 %healthcheck-status.critical {
   @extend %with-critical;
 }
+@media #{$--lt-spacious-healthcheck-status} {
+  .healthcheck-status button.copy-btn {
+    margin-top: -11px;
+    margin-right: -18px;
+    padding: 0;
+    width: 20px;
+    visibility: hidden;
+  }
+  %healthcheck-status {
+    padding-left: 30px;
+    padding-top: 10px;
+    padding-bottom: 15px;
+    padding-right: 13px;
+  }
+  %healthcheck-status::before {
+    width: 15px !important;
+    height: 15px !important;
+    left: 9px;
+    top: 13px !important;
+  }
+}

--- a/ui-v2/app/styles/components/product.scss
+++ b/ui-v2/app/styles/components/product.scss
@@ -47,14 +47,15 @@ main {
   @extend %footer;
 }
 /*TODO: This should go in reset, and probably needs select etc adding  */
-@media (max-width: 420px) and (-webkit-min-device-pixel-ratio:0) {
+@media (max-width: 420px) and (-webkit-min-device-pixel-ratio: 0) {
   input {
     font-size: 16px !important;
   }
 }
 /* toggleable toolbar for short screens */
-[for="toolbar-toggle"] {
+[for='toolbar-toggle'] {
   @extend %with-magnifier;
+  color: $ui-blue-500;
   width: 20px;
   height: 20px;
   margin-left: 15px;
@@ -64,7 +65,7 @@ main {
   display: none;
 }
 @media #{$--expanded-filters} {
-  [for="toolbar-toggle"] {
+  [for='toolbar-toggle'] {
     display: none;
   }
 }

--- a/ui-v2/app/styles/components/product.scss
+++ b/ui-v2/app/styles/components/product.scss
@@ -18,6 +18,11 @@ main {
 %app-view header form {
   @extend %filter-bar;
 }
+@media #{$--lt-spacious-page-header} {
+  %app-view header .actions {
+    margin-top: 5px;
+  }
+}
 %loader circle {
   fill: $brand-magenta-100;
 }
@@ -40,4 +45,37 @@ main {
 }
 #wrapper > footer {
   @extend %footer;
+}
+/*TODO: This should go in reset, and probably needs select etc adding  */
+@media (max-width: 420px) and (-webkit-min-device-pixel-ratio:0) {
+  input {
+    font-size: 16px !important;
+  }
+}
+/* toggleable toolbar for short screens */
+[for="toolbar-toggle"] {
+  @extend %with-magnifier;
+  width: 20px;
+  height: 20px;
+  margin-left: 15px;
+  top: -3px;
+}
+#toolbar-toggle {
+  display: none;
+}
+@media #{$--expanded-filters} {
+  [for="toolbar-toggle"] {
+    display: none;
+  }
+}
+@media #{$--lt-expanded-filters} {
+  %app-view header h1 {
+    display: inline-block;
+  }
+  #toolbar-toggle + * {
+    display: none;
+  }
+  #toolbar-toggle:checked + * {
+    display: block;
+  }
 }

--- a/ui-v2/app/styles/components/product/footer.scss
+++ b/ui-v2/app/styles/components/product/footer.scss
@@ -5,7 +5,7 @@
   border-top: $decor-border-100;
 }
 %footer {
-  border-color: $keyline-mid;
+  border-color: $ui-gray-200;
   background-color: $ui-white;
 }
 %footer > * {
@@ -16,9 +16,31 @@
   justify-content: center;
   position: relative;
   z-index: 1;
-  padding: 25px;
 }
 %footer > * {
   display: block;
-  padding: 11px;
+}
+@media #{$--tall-footer} {
+  %footer {
+    padding-top: 25px;
+    padding-bottom: 25px;
+  }
+}
+@media #{$--wide-footer} {
+  %footer {
+    padding-left: 25px;
+    padding-right: 25px;
+  }
+  %footer > * {
+    padding: 11px;
+  }
+}
+@media #{$--lt-wide-footer} {
+  %footer > :first-child {
+    padding: 5px;
+    margin-left: 20px;
+  }
+  %footer > :not(:first-child) {
+    display: none;
+  }
 }

--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -119,3 +119,32 @@ td dd {
   margin-left: 22px;
   padding-right: 10px;
 }
+/* hide actions on narrow screens, you can always click in do everything from there */
+@media #{$--lt-wide-table} {
+  tr > .actions {
+    display: none;
+  }
+}
+/* ideally these would be in route css files, but left here as they */
+/* accomplish the same thing (hide non-essential columns for tables) */
+@media #{$--lt-wide-table} {
+  html.template-intention.template-list tr > :nth-last-child(2) {
+    display: none;
+  }
+  html.template-service.template-list tr > :last-child {
+    display: none;
+  }
+  html.template-node.template-show #services tr > :last-child {
+    display: none;
+  }
+  html.template-node.template-show #lock-sessions tr >
+  :not(:first-child):not(:last-child) {
+    display: none;
+  }
+  html.template-node.template-show #lock-sessions td:last-child {
+    padding: 0;
+  }
+  html.template-node.template-show #lock-sessions td:last-child button {
+    float: right;
+  }
+}

--- a/ui-v2/app/styles/components/tabs.scss
+++ b/ui-v2/app/styles/components/tabs.scss
@@ -1,5 +1,5 @@
 @import './tabs/index';
-main header nav:last-child {
+main header nav:last-of-type:not(:first-of-type) {
   @extend %tab-nav;
 }
 .tab-section {

--- a/ui-v2/app/styles/core/layout.scss
+++ b/ui-v2/app/styles/core/layout.scss
@@ -20,8 +20,26 @@ main,
 html.template-edit main {
   @extend %content-container-restricted;
 }
+
+@media #{$--lt-spacious-page-header} {
+  html.template-list:not(.template-kv) main {
+    margin-top: 10px;
+  }
+}
+@media #{$--lt-spacious-page-header} {
+  .actions button.copy-btn {
+    margin-top: -42px;
+    padding: 0;
+  }
+}
 /* TODO: keep margin below forms, move elsewhere */
 main form,
 main form + div .with-confirmation {
   margin-bottom: 2em;
+}
+@media #{$--lt-wide-form} {
+  main form [type="reset"] {
+    float: right;
+    margin-right: 0 !important;
+  }
 }

--- a/ui-v2/app/styles/routes/dc/acls/index.scss
+++ b/ui-v2/app/styles/routes/dc/acls/index.scss
@@ -1,0 +1,15 @@
+@media #{$--lt-wide-form} {
+  html.template-acl.template-edit main header .actions {
+    float: none;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1em;
+  }
+  html.template-acl.template-edit main header .actions .with-feedback {
+    position: absolute;
+    right: 0;
+  }
+  html.template-acl.template-edit main header .actions .with-confirmation {
+    margin-top: 0;
+  }
+}

--- a/ui-v2/app/styles/variables/custom-query.scss
+++ b/ui-v2/app/styles/variables/custom-query.scss
@@ -16,3 +16,24 @@ $--lt-horizontal-session-list: '(max-width: 899px)';
 
 $--min-padding: '(max-width: 600px)';
 $--max-padding: '(min-width: 1260px)';
+
+$--tall-footer: '(min-height: 815px)';
+$--lt-tall-footer: '(max-height: 814px)';
+
+$--wide-footer: '(min-width: 421px)';
+$--lt-wide-footer: '(max-width: 420px)';
+
+$--expanded-filters: '(min-width: 421px) (min-height: 815px)';
+$--lt-expanded-filters: '(max-width: 420px) (max-height: 814px)';
+
+$--spacious-page-header: '(min-width: 421px) (min-height: 815px)';
+$--lt-spacious-page-header: '(max-width: 420px) (max-height: 814px)';
+
+$--spacious-healthcheck-status: '(min-width: 421px)';
+$--lt-spacious-healthcheck-status: '(max-width: 420px)';
+
+$--wide-form: '(min-width: 421px)';
+$--lt-wide-form: '(max-width: 420px)';
+
+$--wide-table: '(min-width: 421px)';
+$--lt-wide-table: '(max-width: 420px)';

--- a/ui-v2/app/templates/components/app-view.hbs
+++ b/ui-v2/app/templates/components/app-view.hbs
@@ -19,7 +19,10 @@
             {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
         </div>
     </div>
-    {{#yield-slot 'toolbar'}}{{yield}}{{/yield-slot}}
+    {{#yield-slot 'toolbar'}}
+      <input type="checkbox" id="toolbar-toggle" />
+      {{yield}}
+    {{/yield-slot}}
 </header>
 {{/if}}
 <div>

--- a/ui-v2/app/templates/dc/acls/index.hbs
+++ b/ui-v2/app/templates/dc/acls/index.hbs
@@ -6,6 +6,7 @@
         <h1>
             ACL Tokens
         </h1>
+        <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot 'actions'}}
         <a data-test-create href="{{href-to 'dc.acls.create'}}" class="type-create">Create</a>

--- a/ui-v2/app/templates/dc/intentions/index.hbs
+++ b/ui-v2/app/templates/dc/intentions/index.hbs
@@ -6,6 +6,7 @@
         <h1>
             Intentions
         </h1>
+        <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot 'actions'}}
         <a data-test-create href="{{href-to 'dc.intentions.create'}}" class="type-create">Create</a>

--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -20,6 +20,7 @@
                 {{ take 1 (drop 1 (reverse (split parent.Key '/'))) }}
             {{/if}}
         </h1>
+        <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot 'toolbar'}}
 {{#if (gt items.length 0) }}

--- a/ui-v2/app/templates/dc/nodes/-services.hbs
+++ b/ui-v2/app/templates/dc/nodes/-services.hbs
@@ -1,4 +1,5 @@
 {{#if (gt items.length 0) }}
+    <input type="checkbox" id="toolbar-toggle" />
     <form class="filter-bar">
         {{freetext-filter onchange=(action 'filter') value=filter.s placeholder="Search by name/port"}}
     </form>

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -3,6 +3,7 @@
         <h1>
             Nodes
         </h1>
+        <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot 'toolbar'}}
 {{#if (gt items.length 0) }}

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -12,6 +12,7 @@
         <h1>
             {{ item.Node }}
         </h1>
+        <label for="toolbar-toggle"></label>
         {{tab-nav
             items=(compact
                 (array 'Health Checks' 'Services' (if tomography 'Round Trip Time' '') 'Lock Sessions')

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -7,6 +7,7 @@
         <h1>
             Services
         </h1>
+        <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot 'toolbar'}}
 {{#if (gt items.length 0) }}


### PR DESCRIPTION
Various changes to improve usage of screen real estate on small screens.

This is definitely a work in progress, but worth getting eyes on it now. Plus it's already a significant improvement, so if I can't get back to this before the next release I'd like to get this in in it's current state. Rough rundown on changes below:

1. Reduce header size when there are no breadcrumbs
2. Make the filters toggleable, closed by default
3. Reduce the size of the footer on small screens
4. Hide all non-primary columns for forms
5. Slightly change the layout of various items, mainly buttons within
forms
6. Make some confirmation dialogs work vertically on small screens.
Guessing we might be better just using native confirmations on small
screens

Partly addresses #4395 as well as others.

<img width="252" alt="01-services" src="https://user-images.githubusercontent.com/554604/44914514-6899b100-ad28-11e8-96db-3d26ba0e6d9a.png">

<img width="252" alt="02-nodes" src="https://user-images.githubusercontent.com/554604/44914519-6c2d3800-ad28-11e8-92be-f67bdca603a9.png">

<img width="252" alt="03-acls" src="https://user-images.githubusercontent.com/554604/44914523-6fc0bf00-ad28-11e8-9a74-f7f4f3b09ef4.png">

<img width="252" alt="04-acls-form" src="https://user-images.githubusercontent.com/554604/44914534-72231900-ad28-11e8-9f23-f87d300348cc.png">

<img width="252" alt="05-intentions" src="https://user-images.githubusercontent.com/554604/44914539-7818fa00-ad28-11e8-9a1a-e3f4325ad69e.png">

