### PR TITLE
Add go tool and makefile goal to debug flaky tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -194,6 +194,12 @@ test-ci: other-consul dev-build vet test-install-deps
 	    fi \
 	fi
 
+test-flake: other-consul vet test-install-deps
+	@ cd build-support/flake-repro; \
+	go build -o flake-repro; \
+	./flake-repro $(ARGS); \
+	rm flake-repro
+
 other-consul:
 	@echo "--> Checking for other consul instances"
 	@if ps -ef | grep 'consul agent' | grep -v grep ; then \


### PR DESCRIPTION
This PR adds a Go CLI tool that allows us to reproduce flaky tests inside of a Docker container. Single or package-wide tests are run for multiple iterations with a configurable amount of CPU resources. 

There is also an associated goal in the makefile called `test-flake` which builds the CLI then runs it with the `ARGS` passed.

### Basics:
- A test binary is created for the target package. (At most one package can be tested at a time)
- A script will loop over `go test` until the max number of iterations is reached or one of the tests fails. 
- The full Consul logs are dumped to `test.log` which is in the directory of the package being tested.

### Options:
```
  -pkg=""             Target package
  -test=""            Target test (requires pkg flag)
  -cpus=0.15          Amount of CPU resources for container
  -n=30               Number of times to run tests
```

### Usage examples:
Run all tests for a package:
```
make test-flake ARGS="-pkg connect/proxy"
```

Run tests matching a pattern:
```
make test-flake ARGS="-pkg connect/proxy -test Listener"
```

Run a single test 100 times with 0.5 CPUs:
```
make test-flake ARGS="-pkg connect/proxy -test TestUpstreamListener -n 100 -cpus 0.5"
```