### PR TITLE
Consul - Avoid write from a read in the past / future

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -304,7 +304,7 @@ func (s *Store) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *structs.Re
 		}
 		if existing == nil || req.ChangesNode(existing.(*structs.Node)) {
 			nodeLastRead := req.NodeLastRead
-			if nodeLastRead != 0 && existing != nil && nodeLastRead < existing.(*structs.Node).RaftIndex.ModifyIndex {
+			if nodeLastRead != 0 && existing != nil && nodeLastRead != existing.(*structs.Node).RaftIndex.ModifyIndex {
 				return fmt.Errorf("Last Node read is obsolete. It has happened at %d, we are now at %d", nodeLastRead, existing.(*structs.Node).RaftIndex.ModifyIndex)
 			}
 			if err := s.ensureNodeTxn(tx, idx, node); err != nil {
@@ -323,8 +323,8 @@ func (s *Store) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *structs.Re
 		}
 		if existing == nil || !(existing.(*structs.ServiceNode).ToNodeService()).IsSame(req.Service) {
 			svcLastRead := req.Service.RaftIndex.ModifyIndex
-			if svcLastRead != 0 && existing != nil && svcLastRead < existing.(*structs.ServiceNode).RaftIndex.ModifyIndex {
-				return fmt.Errorf("Last Service read is obsolete. It has happened at %d, we are now at %d", svcLastRead,  existing.(*structs.ServiceNode).RaftIndex.ModifyIndex)
+			if svcLastRead != 0 && existing != nil && svcLastRead != existing.(*structs.ServiceNode).RaftIndex.ModifyIndex {
+				return fmt.Errorf("Last Service read is obsolete. It has happened at %d, we are now at %d", svcLastRead, existing.(*structs.ServiceNode).RaftIndex.ModifyIndex)
 			}
 			if err := s.ensureServiceTxn(tx, idx, req.Node, req.Service); err != nil {
 				return fmt.Errorf("failed inserting service: %s", err)
@@ -1245,7 +1245,7 @@ func (s *Store) ensureCheckTxn(tx *memdb.Txn, idx uint64, hc *structs.HealthChec
 	// Set the indexes
 	if existing != nil {
 		lastRead := hc.RaftIndex.ModifyIndex
-		if lastRead != 0 && lastRead < existing.(*structs.HealthCheck).ModifyIndex {
+		if lastRead != 0 && lastRead != existing.(*structs.HealthCheck).ModifyIndex {
 			return fmt.Errorf("Last Check read is obsolete. It has happened at %d, we are not at %d", lastRead, existing.(*structs.HealthCheck).ModifyIndex)
 		}
 		hc.CreateIndex = existing.(*structs.HealthCheck).CreateIndex

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -305,7 +305,7 @@ func (s *Store) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *structs.Re
 		if existing == nil || req.ChangesNode(existing.(*structs.Node)) {
 			nodeLastRead := req.NodeLastRead
 			if nodeLastRead != 0 && existing != nil && nodeLastRead < existing.(*structs.Node).RaftIndex.ModifyIndex {
-				return fmt.Errorf("Last read is obsolete")
+				return fmt.Errorf("Last Node read is obsolete. It has happened at %d, we are now at %d", nodeLastRead, existing.(*structs.Node).RaftIndex.ModifyIndex)
 			}
 			if err := s.ensureNodeTxn(tx, idx, node); err != nil {
 				return fmt.Errorf("failed inserting node: %s", err)
@@ -324,7 +324,7 @@ func (s *Store) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *structs.Re
 		if existing == nil || !(existing.(*structs.ServiceNode).ToNodeService()).IsSame(req.Service) {
 			svcLastRead := req.Service.RaftIndex.ModifyIndex
 			if svcLastRead != 0 && existing != nil && svcLastRead < existing.(*structs.ServiceNode).RaftIndex.ModifyIndex {
-				return fmt.Errorf("Last read is obsolete")
+				return fmt.Errorf("Last Service read is obsolete. It has happened at %d, we are now at %d", svcLastRead,  existing.(*structs.ServiceNode).RaftIndex.ModifyIndex)
 			}
 			if err := s.ensureServiceTxn(tx, idx, req.Node, req.Service); err != nil {
 				return fmt.Errorf("failed inserting service: %s", err)
@@ -1246,7 +1246,7 @@ func (s *Store) ensureCheckTxn(tx *memdb.Txn, idx uint64, hc *structs.HealthChec
 	if existing != nil {
 		lastRead := hc.RaftIndex.ModifyIndex
 		if lastRead != 0 && lastRead < existing.(*structs.HealthCheck).ModifyIndex {
-			return fmt.Errorf("Obsolete read for check")
+			return fmt.Errorf("Last Check read is obsolete. It has happened at %d, we are not at %d", lastRead, existing.(*structs.HealthCheck).ModifyIndex)
 		}
 		hc.CreateIndex = existing.(*structs.HealthCheck).CreateIndex
 		hc.ModifyIndex = idx

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -156,8 +156,9 @@ func TestStateStore_EnsureNoWriteFromAOldReadForNodes(t *testing.T) {
 		NodeLastRead:    1,
 	}
 	// Lets conflict with node1 (has an ID)
-	err := s.EnsureRegistration(3, req)
-	assert.Error(t, err, "This is a stale read")
+	if err := s.EnsureRegistration(3, req); err == nil {
+		t.Fatalf("A write with a read from the past should not be allowed.")
+	}
 }
 
 func TestStateStore_EnsureNoWriteFromAFutureReadForNodes(t *testing.T) {
@@ -196,8 +197,9 @@ func TestStateStore_EnsureNoWriteFromAFutureReadForNodes(t *testing.T) {
 		NodeLastRead:    100,
 	}
 	// Lets conflict with node1 (has an ID)
-	err := s.EnsureRegistration(3, req)
-	assert.Error(t, err, "This is a read from the future")
+	if err := s.EnsureRegistration(3, req); err == nil {
+		t.Fatalf("A write with a read from the future should not be allowed.")
+	}
 }
 
 func TestStateStore_EnsureWriteFromPresentReadForNodes(t *testing.T) {
@@ -224,9 +226,9 @@ func TestStateStore_EnsureWriteFromPresentReadForNodes(t *testing.T) {
 		NodeMeta:        map[string]string{"somekey": "svvd"},
 		NodeLastRead:    1,
 	}
-	// Lets conflict with node1 (has an ID)
-	err := s.EnsureRegistration(2, req)
-	assert.NoError(t, err, "This is not a stale read")
+	if err := s.EnsureRegistration(2, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestStateStore_EnsureNoWriteFromAOldReadForChecks(t *testing.T) {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -200,7 +200,7 @@ func TestStateStore_EnsureNoWriteFromAFutureReadForNodes(t *testing.T) {
 	assert.Error(t, err, "This is a read from the future")
 }
 
-func TestStateStore_EnsureReadFromPresentDoesNotFailForNodes(t *testing.T) {
+func TestStateStore_EnsureWriteFromPresentReadForNodes(t *testing.T) {
 	t.Parallel()
 	s := testStateStore(t)
 	nodeID := makeRandomNodeID(t)

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -126,6 +126,17 @@ func TestStateStore_ensureNodeNoStaleOverwriteTxn(t *testing.T) {
 	nodeID := makeRandomNodeID(t)
 	req := &structs.RegisterRequest{
 		ID:              nodeID,
+		Node:            "node2",
+		Address:         "2.3.4.5",
+		TaggedAddresses: map[string]string{"hello": "world"},
+		NodeMeta:        map[string]string{"somekey": "somevalue"},
+	}
+	if err := s.EnsureRegistration(1, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	req = &structs.RegisterRequest{
+		ID:              nodeID,
 		Node:            "node1",
 		Address:         "1.2.3.4",
 		TaggedAddresses: map[string]string{"hello": "world"},
@@ -135,21 +146,18 @@ func TestStateStore_ensureNodeNoStaleOverwriteTxn(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	tx := s.db.Txn(true)
-	defer tx.Abort()
 	// changed the IP but stale reade NodeLastRead = 1
 	req = &structs.RegisterRequest{
 		ID:              nodeID,
 		Node:            "node1",
-		Address:         "1.2.3.5",
+		Address:         "1.2.3.4",
 		TaggedAddresses: map[string]string{"hello": "world"},
-		NodeMeta:        map[string]string{"somekey": "somevalue"},
+		NodeMeta:        map[string]string{"somekey": "fvsdv"},
 		NodeLastRead: 1,
 	}
 	// Lets conflict with node1 (has an ID)
-	if err := s.EnsureRegistration(3, req); err == nil {
-		t.Fatalf("Should return an error since another name with similar name exists")
-	}
+	err := s.EnsureRegistration(3, req);
+	assert.Error(t, err, "This is a stale read")
 }
 
 func TestStateStore_ensureNodeOkOverwriteTxn(t *testing.T) {
@@ -163,29 +171,65 @@ func TestStateStore_ensureNodeOkOverwriteTxn(t *testing.T) {
 		TaggedAddresses: map[string]string{"hello": "world"},
 		NodeMeta:        map[string]string{"somekey": "somevalue"},
 	}
-	if err := s.EnsureRegistration(2, req); err != nil {
+	if err := s.EnsureRegistration(1, req); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	tx := s.db.Txn(true)
-	defer tx.Abort()
 	// changed the IP but stale reade NodeLastRead = 1
 	req = &structs.RegisterRequest{
 		ID:              nodeID,
 		Node:            "node1",
-		Address:         "1.2.3.5",
+		Address:         "1.2.3.4",
 		TaggedAddresses: map[string]string{"hello": "world"},
-		NodeMeta:        map[string]string{"somekey": "somevalue"},
-		NodeLastRead: 2,
+		NodeMeta:        map[string]string{"somekey": "svvd"},
+		NodeLastRead: 1,
 	}
 	// Lets conflict with node1 (has an ID)
-	if err := s.EnsureRegistration(3, req); err == nil {
-		t.Fatalf("Should return an error since another name with similar name exists")
-	}
+	err := s.EnsureRegistration(2, req)
+	assert.NoError(t, err, "This is not a stale read")
 }
 
 
-func TestStateStore_EnsureNoStaleRegistrations(t *testing.T) {
+func TestStateStore_EnsureNoStaleCheckRegistrations(t *testing.T) {
+	t.Parallel()
+	s := testStateStore(t)
+
+	// Start with just a node.
+	nodeID := makeRandomNodeID(t)
+	req := &structs.RegisterRequest{
+		ID:              nodeID,
+		Node:            "node1",
+		Address:         "1.2.3.4",
+		TaggedAddresses: map[string]string{"hello": "world"},
+		NodeMeta:        map[string]string{"somekey": "somevalue"},
+	}
+	if err := s.EnsureRegistration(1, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Add in a top-level check.
+	req.Check = &structs.HealthCheck{
+		Node:    "node1",
+		CheckID: "check1",
+		Name:    "check",
+	}
+	if err := s.EnsureRegistration(4, req); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Add in a top-level check.
+	req.Check = &structs.HealthCheck{
+		Node:    "node1",
+		CheckID: "check1",
+		Name:    "check",
+		RaftIndex: structs.RaftIndex{ModifyIndex: 1},
+	}
+	if err := s.EnsureRegistration(5, req); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestStateStore_EnsureNoStaleServiceRegistrations(t *testing.T) {
 	t.Parallel()
 	s := testStateStore(t)
 
@@ -218,35 +262,14 @@ func TestStateStore_EnsureNoStaleRegistrations(t *testing.T) {
 	req.Service = &structs.NodeService{
 		ID:      "redis1",
 		Service: "redis",
-		Address: "1.1.1.1",
+		Address: "1.1.1.2",
 		Port:    8080,
 		Tags:    []string{"master"},
 		RaftIndex: structs.RaftIndex{ModifyIndex: 1},
 	}
 	if err := s.EnsureRegistration(3, req); err == nil {
 		t.Fatalf("err: %s", err)
-	}
-
-	// Add in a top-level check.
-	req.Check = &structs.HealthCheck{
-		Node:    "node1",
-		CheckID: "check1",
-		Name:    "check",
-	}
-	if err := s.EnsureRegistration(4, req); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	// Add in a top-level check.
-	req.Check = &structs.HealthCheck{
-		Node:    "node1",
-		CheckID: "check1",
-		Name:    "check",
-		RaftIndex: structs.RaftIndex{ModifyIndex: 1},
-	}
-	if err := s.EnsureRegistration(5, req); err == nil {
-		t.Fatalf("err: %s", err)
-	}
+	}	
 }
 
 func TestStateStore_EnsureOkIndexRegistrations(t *testing.T) {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -201,6 +201,7 @@ type RegisterRequest struct {
 	Service         *NodeService
 	Check           *HealthCheck
 	Checks          HealthChecks
+	NodeLastRead    uint64
 
 	// SkipNodeUpdate can be used when a register request is intended for
 	// updating a service and/or checks, but doesn't want to overwrite any


### PR DESCRIPTION
This PR is to have a functionality similar to https://www.consul.io/api/kv.html#create-update-key

`If the index is 0, Consul will only put the key if it does not already exist. If the index is non-zero, the key is only set if the index matches the ModifyIndex of that key.`

The change was done for registration in the Catalog. `ensureRegistrationTxn` is the method that is dealing with registering `Node`s, `Service`s and `Check`s. 

## Rationale
consul-esm keeps updating `Check`s for `Service`s it is monitoring. These updates may overwrite newer definitions of the `Check`s. 

Let's say at time X a new `Service` on an existing `Node` is created with `Check c1` with interval `0.1s`.
consul-esm starts monitor that service and it's going to update the check definition every 0.1s. 
Now we have a race condition. A user can use consul to update the `Check` definition at any given time and `consul-esm` is doing the same at any given time. If `consul-esm` reads an older version, when it tries to update the `Check` with the new status, it may overwrite what the user has specified.

## High level description of the change
We are trying to fix any stale overwrite. For this reason we are going to consider only the cases in which the write operation is an `Update` (i.e. the (e.g.) Node already exists). If a Node already exists we are going to check if the write operation contains a `ModifyIndex` and, if it does, that is going to be compared to the existing one. Any write that have a different `ModifyIndex` from the current one is going to be rejected.