### PR TITLE
agent: aggregate service instance meta for UI purposes

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -15,6 +15,7 @@ type ServiceSummary struct {
 	Kind           structs.ServiceKind `json:",omitempty"`
 	Name           string
 	Tags           []string
+	Meta           map[string]string
 	Nodes          []string
 	ChecksPassing  int
 	ChecksWarning  int
@@ -152,6 +153,18 @@ func summarizeServices(dump structs.NodeDump) []*ServiceSummary {
 			sum.Tags = service.Tags
 			sum.Nodes = append(sum.Nodes, node.Node)
 			sum.Kind = service.Kind
+
+			// The service meta is per instance, but we aggregate it
+			// here for the UI to know it exists for _some_ instance.
+			if len(service.Meta) > 0 {
+				if len(sum.Meta) == 0 {
+					sum.Meta = make(map[string]string)
+				}
+				for k, v := range service.Meta {
+					sum.Meta[k] = v
+				}
+			}
+
 			nodeServices[idx] = sum
 		}
 		for _, check := range node.Checks {

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -168,6 +168,7 @@ func TestSummarizeServices(t *testing.T) {
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
 					Tags:    []string{},
+					Meta:    map[string]string{"bar": "baz"},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -193,6 +194,7 @@ func TestSummarizeServices(t *testing.T) {
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
 					Tags:    []string{},
+					Meta:    map[string]string{"foo": "bar"},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -249,6 +251,7 @@ func TestSummarizeServices(t *testing.T) {
 		Kind:           structs.ServiceKindConnectProxy,
 		Name:           "web",
 		Tags:           []string{},
+		Meta:           map[string]string{"foo": "bar", "bar": "baz"},
 		Nodes:          []string{"bar", "foo"},
 		ChecksPassing:  2,
 		ChecksWarning:  0,

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -168,7 +168,7 @@ func TestSummarizeServices(t *testing.T) {
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
 					Tags:    []string{},
-					Meta:    map[string]string{"bar": "baz"},
+					Meta:    map[string]string{metaExternalSource: "k8s"},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -194,7 +194,7 @@ func TestSummarizeServices(t *testing.T) {
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
 					Tags:    []string{},
-					Meta:    map[string]string{"foo": "bar"},
+					Meta:    map[string]string{metaExternalSource: "k8s"},
 				},
 			},
 			Checks: []*structs.HealthCheck{
@@ -248,15 +248,16 @@ func TestSummarizeServices(t *testing.T) {
 	}
 
 	expectWeb := &ServiceSummary{
-		Kind:           structs.ServiceKindConnectProxy,
-		Name:           "web",
-		Tags:           []string{},
-		Meta:           map[string]string{"foo": "bar", "bar": "baz"},
-		Nodes:          []string{"bar", "foo"},
-		ChecksPassing:  2,
-		ChecksWarning:  0,
-		ChecksCritical: 1,
+		Kind:            structs.ServiceKindConnectProxy,
+		Name:            "web",
+		Tags:            []string{},
+		Nodes:           []string{"bar", "foo"},
+		ChecksPassing:   2,
+		ChecksWarning:   0,
+		ChecksCritical:  1,
+		ExternalSources: []string{"k8s"},
 	}
+	summary[2].externalSourceSet = nil
 	if !reflect.DeepEqual(summary[2], expectWeb) {
 		t.Fatalf("bad: %v", summary[2])
 	}


### PR DESCRIPTION
This adds the `Meta` field to the service summary for the internal UI endpoint, used by #4640.

Meta is per service instance, and the service summary is trying to summarize all instances. In this iteration, we've just merged the meta together. This will get #4640 working but there are obvious edge cases (multiple synced sources). Given this is an internal endpoint we can change at any time, I think this is fine for now, but open to thoughts.