### PR TITLE
connect/ca: rework initialization/root generation in providers

### DIFF
--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -8,7 +8,16 @@ import (
 // an external CA that provides leaf certificate signing for
 // given SpiffeIDServices.
 type Provider interface {
-	// Active root returns the currently active root CA for this
+	// Configure initializes the provider based on the given cluster ID, root status
+	// and configuration values.
+	Configure(clusterId string, isRoot bool, rawConfig map[string]interface{}) error
+
+	// GenerateRoot causes the creation of a new root certificate for this provider.
+	// This can also be a no-op if a root certificate already exists for the given
+	// config. If isRoot is false, calling this method is an error.
+	GenerateRoot() error
+
+	// ActiveRoot returns the currently active root CA for this
 	// provider. This should be a parent of the certificate returned by
 	// ActiveIntermediate()
 	ActiveRoot() (string, error)

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -75,7 +75,7 @@ func TestConsulCAProvider_Bootstrap(t *testing.T) {
 	conf := testConsulCAConfig()
 	delegate := newMockDelegate(t, conf)
 
-	provider := NewConsulProvider(delegate)
+	provider := &ConsulProvider{Delegate: delegate}
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
@@ -106,7 +106,7 @@ func TestConsulCAProvider_Bootstrap_WithCert(t *testing.T) {
 	}
 	delegate := newMockDelegate(t, conf)
 
-	provider := NewConsulProvider(delegate)
+	provider := &ConsulProvider{Delegate: delegate}
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
@@ -123,7 +123,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 	conf.Config["LeafCertTTL"] = "1h"
 	delegate := newMockDelegate(t, conf)
 
-	provider := NewConsulProvider(delegate)
+	provider := &ConsulProvider{Delegate: delegate}
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
@@ -186,14 +186,14 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 
 	conf1 := testConsulCAConfig()
 	delegate1 := newMockDelegate(t, conf1)
-	provider1 := NewConsulProvider(delegate1)
+	provider1 := &ConsulProvider{Delegate: delegate1}
 	require.NoError(provider1.Configure(conf1.ClusterID, true, conf1.Config))
 	require.NoError(provider1.GenerateRoot())
 
 	conf2 := testConsulCAConfig()
 	conf2.CreateIndex = 10
 	delegate2 := newMockDelegate(t, conf2)
-	provider2 := NewConsulProvider(delegate2)
+	provider2 := &ConsulProvider{Delegate: delegate2}
 	require.NoError(provider2.Configure(conf2.ClusterID, true, conf2.Config))
 	require.NoError(provider2.GenerateRoot())
 

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -28,14 +28,7 @@ type VaultProvider struct {
 	clusterId string
 }
 
-// NewVaultProvider returns a vault provider with its root and intermediate PKI
-// backends mounted and initialized. If the root backend is not set up already,
-// it will be mounted/generated as needed, but any existing state will not be
-// overwritten.
-func NewVaultProvider() *VaultProvider {
-	return &VaultProvider{}
-}
-
+// Configure sets up the provider using the given configuration.
 func (v *VaultProvider) Configure(clusterId string, isRoot bool, rawConfig map[string]interface{}) error {
 	config, err := ParseVaultCAConfig(rawConfig)
 	if err != nil {
@@ -59,6 +52,12 @@ func (v *VaultProvider) Configure(clusterId string, isRoot bool, rawConfig map[s
 	return nil
 }
 
+// ActiveRoot returns the active root CA certificate.
+func (v *VaultProvider) ActiveRoot() (string, error) {
+	return v.getCA(v.config.RootPKIPath)
+}
+
+// GenerateRoot mounts and initializes a new root PKI backend if needed.
 func (v *VaultProvider) GenerateRoot() error {
 	if !v.isRoot {
 		return fmt.Errorf("provider is not the root certificate authority")
@@ -103,10 +102,7 @@ func (v *VaultProvider) GenerateRoot() error {
 	return nil
 }
 
-func (v *VaultProvider) ActiveRoot() (string, error) {
-	return v.getCA(v.config.RootPKIPath)
-}
-
+// ActiveIntermediate returns the current intermediate certificate.
 func (v *VaultProvider) ActiveIntermediate() (string, error) {
 	return v.getCA(v.config.IntermediatePKIPath)
 }

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -38,7 +38,7 @@ func testVaultClusterWithConfig(t *testing.T, rawConf map[string]interface{}) (*
 	}
 
 	require := require.New(t)
-	provider := NewVaultProvider()
+	provider := &VaultProvider{}
 	require.NoError(provider.Configure("asdf", true, conf))
 	require.NoError(provider.GenerateRoot())
 	_, err := provider.GenerateIntermediate()

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -37,10 +37,12 @@ func testVaultClusterWithConfig(t *testing.T, rawConf map[string]interface{}) (*
 		conf[k] = v
 	}
 
-	provider, err := NewVaultProvider(conf, "asdf")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require := require.New(t)
+	provider := NewVaultProvider()
+	require.NoError(provider.Configure("asdf", true, conf))
+	require.NoError(provider.GenerateRoot())
+	_, err := provider.GenerateIntermediate()
+	require.NoError(err)
 
 	return provider, core, ln
 }

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -95,6 +95,12 @@ func (s *ConnectCA) ConfigurationSet(
 	if err != nil {
 		return fmt.Errorf("could not initialize provider: %v", err)
 	}
+	if err := newProvider.Configure(args.Config.ClusterID, true, args.Config.Config); err != nil {
+		return fmt.Errorf("error configuring provider: %v", err)
+	}
+	if err := newProvider.GenerateRoot(); err != nil {
+		return fmt.Errorf("error generating CA root certificate: %v", err)
+	}
 
 	newRootPEM, err := newProvider.ActiveRoot()
 	if err != nil {

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -526,9 +526,9 @@ func parseCARoot(pemValue, provider string) (*structs.CARoot, error) {
 func (s *Server) createCAProvider(conf *structs.CAConfiguration) (ca.Provider, error) {
 	switch conf.Provider {
 	case structs.ConsulCAProvider:
-		return ca.NewConsulProvider(&consulCADelegate{s}), nil
+		return &ca.ConsulProvider{Delegate: &consulCADelegate{s}}, nil
 	case structs.VaultCAProvider:
-		return ca.NewVaultProvider(), nil
+		return &ca.VaultProvider{}, nil
 	default:
 		return nil, fmt.Errorf("unknown CA provider %q", conf.Provider)
 	}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -427,10 +427,16 @@ func (s *Server) initializeCA() error {
 		return err
 	}
 
-	// Initialize the right provider based on the config
+	// Initialize the provider based on the current config.
 	provider, err := s.createCAProvider(conf)
 	if err != nil {
 		return err
+	}
+	if err := provider.Configure(conf.ClusterID, true, conf.Config); err != nil {
+		return fmt.Errorf("error configuring provider: %v", err)
+	}
+	if err := provider.GenerateRoot(); err != nil {
+		return fmt.Errorf("error generating CA root certificate: %v", err)
 	}
 
 	// Get the active root cert from the CA
@@ -520,9 +526,9 @@ func parseCARoot(pemValue, provider string) (*structs.CARoot, error) {
 func (s *Server) createCAProvider(conf *structs.CAConfiguration) (ca.Provider, error) {
 	switch conf.Provider {
 	case structs.ConsulCAProvider:
-		return ca.NewConsulProvider(conf.Config, &consulCADelegate{s})
+		return ca.NewConsulProvider(&consulCADelegate{s}), nil
 	case structs.VaultCAProvider:
-		return ca.NewVaultProvider(conf.Config, conf.ClusterID)
+		return ca.NewVaultProvider(), nil
 	default:
 		return nil, fmt.Errorf("unknown CA provider %q", conf.Provider)
 	}

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -253,7 +253,6 @@ type CAConsulProviderState struct {
 	ID               string
 	PrivateKey       string
 	RootCert         string
-	IsRoot           bool
 	IntermediateCert string
 
 	RaftIndex

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -250,9 +250,11 @@ type ConsulCAProviderConfig struct {
 
 // CAConsulProviderState is used to track the built-in Consul CA provider's state.
 type CAConsulProviderState struct {
-	ID         string
-	PrivateKey string
-	RootCert   string
+	ID               string
+	PrivateKey       string
+	RootCert         string
+	IsRoot           bool
+	IntermediateCert string
 
 	RaftIndex
 }


### PR DESCRIPTION
This PR has some changes to the CA provider interface in preparation for upcoming work to allow the CA to be replicated across datacenters.