### PR TITLE
Detect correct GOOS/ARCH for copying binary with build_consul_local

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -460,7 +460,7 @@ function build_consul_local {
             
             mkdir -p "${outdir}"
             GOBIN_EXTRA=""
-            if test "${os}" != "$(go env GOOS)" -o "${arch}" != "$(go env GOARCH)"
+            if test "${os}" != "$(go env GOHOSTOS)" -o "${arch}" != "$(go env GOHOSTARCH)"
             then
                GOBIN_EXTRA="${os}_${arch}/"
             fi


### PR DESCRIPTION
If GOOS/ARCH is set to something custom, we need to unset it before
testing the value so we can compare to the _original value_.