### PR TITLE
Add ECS option to EDNS responses where appropriate

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -135,6 +135,9 @@ func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
 	return d.Server.ListenAndServe()
 }
 
+// setEDNS is used to set the responses EDNS size headers and
+// possibly the ECS headers as well if they were present in the
+// original request
 func setEDNS(request *dns.Msg, response *dns.Msg, ecsGlobal bool) {
 	// Enable EDNS if enabled
 	if edns := request.IsEdns0(); edns != nil {

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -135,6 +135,37 @@ func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
 	return d.Server.ListenAndServe()
 }
 
+func setEDNS(request *dns.Msg, response *dns.Msg, ecsGlobal bool) {
+	// Enable EDNS if enabled
+	if edns := request.IsEdns0(); edns != nil {
+		// cannot just use the SetEdns0 function as we need to embed
+		// the ECS option as well
+		ednsResp := new(dns.OPT)
+		ednsResp.Hdr.Name = "."
+		ednsResp.Hdr.Rrtype = dns.TypeOPT
+		ednsResp.SetUDPSize(edns.UDPSize())
+
+		// Setup the ECS option if present
+		if subnet := ednsSubnetForRequest(request); subnet != nil {
+			subOp := new(dns.EDNS0_SUBNET)
+			subOp.Code = dns.EDNS0SUBNET
+			subOp.Family = subnet.Family
+			subOp.Address = subnet.Address
+			subOp.SourceNetmask = subnet.SourceNetmask
+			if c := response.Rcode; ecsGlobal || c == dns.RcodeNameError || c == dns.RcodeServerFailure || c == dns.RcodeRefused || c == dns.RcodeNotImplemented {
+				// reply is globally valid and should be cached accordingly
+				subOp.SourceScope = 0
+			} else {
+				// reply is only valid for the subnet it was queried with
+				subOp.SourceScope = subnet.SourceNetmask
+			}
+			ednsResp.Option = append(ednsResp.Option, subOp)
+		}
+
+		response.Extra = append(response.Extra, ednsResp)
+	}
+}
+
 // recursorAddr is used to add a port to the recursor if omitted.
 func recursorAddr(recursor string) (string, error) {
 	// Add the port if none
@@ -245,10 +276,8 @@ func (d *DNSServer) handlePtr(resp dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	// Enable EDNS if enabled
-	if edns := req.IsEdns0(); edns != nil {
-		m.SetEdns0(edns.UDPSize(), false)
-	}
+	// ptr record responses are globally valid
+	setEDNS(req, m, true)
 
 	// Write out the complete response
 	if err := resp.WriteMsg(m); err != nil {
@@ -280,6 +309,8 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 	m.Authoritative = true
 	m.RecursionAvailable = (len(d.recursors) > 0)
 
+	ecsGlobal := true
+
 	switch req.Question[0].Qtype {
 	case dns.TypeSOA:
 		ns, glue := d.nameservers(req.IsEdns0() != nil)
@@ -298,13 +329,10 @@ func (d *DNSServer) handleQuery(resp dns.ResponseWriter, req *dns.Msg) {
 		m.SetRcode(req, dns.RcodeNotImplemented)
 
 	default:
-		d.dispatch(network, resp.RemoteAddr(), req, m)
+		ecsGlobal = d.dispatch(network, resp.RemoteAddr(), req, m)
 	}
 
-	// Handle EDNS
-	if edns := req.IsEdns0(); edns != nil {
-		m.SetEdns0(edns.UDPSize(), false)
-	}
+	setEDNS(req, m, ecsGlobal)
 
 	// Write out the complete response
 	if err := resp.WriteMsg(m); err != nil {
@@ -393,7 +421,8 @@ func (d *DNSServer) nameservers(edns bool) (ns []dns.RR, extra []dns.RR) {
 }
 
 // dispatch is used to parse a request and invoke the correct handler
-func (d *DNSServer) dispatch(network string, remoteAddr net.Addr, req, resp *dns.Msg) {
+func (d *DNSServer) dispatch(network string, remoteAddr net.Addr, req, resp *dns.Msg) (ecsGlobal bool) {
+	ecsGlobal = true
 	// By default the query is in the default datacenter
 	datacenter := d.agent.config.Datacenter
 
@@ -478,6 +507,7 @@ PARSE:
 
 		// Allow a "." in the query name, just join all the parts.
 		query := strings.Join(labels[:n-1], ".")
+		ecsGlobal = false
 		d.preparedQueryLookup(network, datacenter, query, remoteAddr, req, resp)
 
 	case "addr":
@@ -547,6 +577,7 @@ INVALID:
 	d.logger.Printf("[WARN] dns: QName invalid: %s", qName)
 	d.addSOA(resp)
 	resp.SetRcode(req, dns.RcodeNameError)
+	return
 }
 
 // nodeLookup is used to handle a node query
@@ -1380,7 +1411,7 @@ func (d *DNSServer) handleRecurse(resp dns.ResponseWriter, req *dns.Msg) {
 	m.RecursionAvailable = true
 	m.SetRcode(req, dns.RcodeServerFailure)
 	if edns := req.IsEdns0(); edns != nil {
-		m.SetEdns0(edns.UDPSize(), false)
+		setEDNS(req, m, true)
 	}
 	resp.WriteMsg(m)
 }


### PR DESCRIPTION
If ECS opt is present in the request we will mirror it back and return a response with a scope of 0 (global) or with the same prefix length as the request (indicating its valid specifically for that subnet).

We only mirror the prefix-length (non-global) for prepared queries as those could potentially use nearness checks that could be affected by the subnet. In the future we could get more sophisticated with determining the scope bits and allow for better caching of prepared queries that don’t rely on nearness checks but that would require a larger change than we want to do right now.

The other thing this does not do is implement the part of the ECS RFC related to originating ECS headers when acting as a intermediate DNS server (forwarding/recursive resolver). That would take a quite a bit more effort and in general it is expected that if users have sophisticated caching infrastructure that is ECS aware they probably aren’t using Consul to resolve non-consul related information.