### PR TITLE
UI: Adds a `default` view helper for providing a default value

### DIFF
--- a/ui-v2/app/helpers/default.js
+++ b/ui-v2/app/helpers/default.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+
+export function _default(params, hash) {
+  if (params[0] === '' || typeof params[0] === 'undefined') {
+    return params[1];
+  }
+  return params[0];
+}
+
+export default helper(_default);

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -37,7 +37,7 @@
                         href=(href-to 'dc.nodes.show' item.Node.Node)
                         name=item.Node.Node
                         service=item.Service.ID
-                        address=(concat item.Service.Address ':' item.Service.Port)
+                        address=(concat (default item.Service.Address item.Node.Address) ':' item.Service.Port)
                         checks=item.Checks
                     }}
     {{/each}}
@@ -57,7 +57,7 @@
                     data-test-node=item.Node.Node
                     name=item.Node.Node
                     service=item.Service.ID
-                    address=(concat item.Service.Address ':' item.Service.Port)
+                    address=(concat (default item.Service.Address item.Node.Address) ':' item.Service.Port)
                     checks=item.Checks
                     status=item.Checks.[0].Status
                 }}

--- a/ui-v2/tests/integration/helpers/default-test.js
+++ b/ui-v2/tests/integration/helpers/default-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('default', 'helper:default', {
+  integration: true,
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{default inputValue}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    '1234'
+  );
+});
+test('it renders the default value', function(assert) {
+  this.set('inputValue', '');
+
+  this.render(hbs`{{default inputValue '1234'}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    '1234'
+  );
+});


### PR DESCRIPTION
If the first value passed to the helper is an empty string or undefined then return the second value.

This is then used for printing Service.Addresses or Node.Addresses, based on whether the former has a value.

Fixes: #4579 