### PR TITLE
UI: Set the CODE view as the default view for editing KV's

### DIFF
--- a/ui-v2/app/controllers/dc/kv/edit.js
+++ b/ui-v2/app/controllers/dc/kv/edit.js
@@ -10,7 +10,7 @@ export default Controller.extend({
   encoder: service('btoa'),
   setProperties: function(model) {
     // TODO: Potentially save whether json has been clicked to the model
-    set(this, 'json', false);
+    set(this, 'json', true);
     this.changeset = new Changeset(model.item, lookupValidator(validations), validations);
     this._super({
       ...model,

--- a/ui-v2/app/controllers/dc/kv/edit.js
+++ b/ui-v2/app/controllers/dc/kv/edit.js
@@ -6,11 +6,14 @@ import Changeset from 'ember-changeset';
 import validations from 'consul-ui/validations/kv';
 import lookupValidator from 'ember-changeset-validations';
 export default Controller.extend({
-  json: false,
+  json: true,
   encoder: service('btoa'),
   setProperties: function(model) {
-    // TODO: Potentially save whether json has been clicked to the model
-    set(this, 'json', true);
+    // TODO: Potentially save whether json has been clicked to the model,
+    // setting set(this, 'json', true) here will force the form to always default to code=on
+    // even if the user has selected code=off on another KV
+    // ideally we would save the value per KV, but I'd like to not do that on the model
+    // a set(this, 'json', valueFromSomeStorageJustForThisKV) would be added here
     this.changeset = new Changeset(model.item, lookupValidator(validations), validations);
     this._super({
       ...model,


### PR DESCRIPTION
Sets the code toggle on the KV edit/create page to be on by default, we figured most people probably prefer this view.

Fixes: #4558

And whilst doesn't completely address #4255 I would hazard a guess that it improves matters.