### PR TITLE
Update snapshot agent docs to include s3-endpoint

### DIFF
--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -174,10 +174,10 @@ if desired.
   to "." to use the current working directory. If an alternate storage option is
   configured, then local storage will be disabled and this option will be ignored.
 
-#### Amazon S3 Storage Options
-
+#### S3 Storage Options
+Note that despite the AWS references, an S3-compatible endpoint can be specified with `-aws-s3-endpoint`.
 * `-aws-access-key-id` and `-aws-secret-access-key` - These arguments supply
-  authentication information for connecting to AWS. These may also be supplied using
+  authentication information for connecting to S3. These may also be supplied using
   the following alternative methods:<br>
   - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
   - A credentials file (`~/.aws/credentials` or the file at the path specified by the
@@ -192,6 +192,9 @@ if desired.
    "consul-snapshot".
 
 * `-aws-s3-region` - S3 region to use. Required for S3 storage.
+
+* `-aws-s3-endpoint` - Optional S3 endpoint to use. Can also be specified using the
+  AWS_S3_ENDPOINT environment variable.
 
 * `-aws-s3-server-side-encryption` - Enables saving snapshots to S3 using server side encryption with [Amazon S3-Managed Encryption Keys](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html)
 

--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -175,7 +175,7 @@ if desired.
   configured, then local storage will be disabled and this option will be ignored.
 
 #### S3 Storage Options
-Note that despite the AWS references, an S3-compatible endpoint can be specified with `-aws-s3-endpoint`.
+Note that despite the AWS references, any S3-compatible endpoint can be specified with `-aws-s3-endpoint`.
 * `-aws-access-key-id` and `-aws-secret-access-key` - These arguments supply
   authentication information for connecting to S3. These may also be supplied using
   the following alternative methods:<br>

--- a/website/source/docs/enterprise/backups/index.html.md
+++ b/website/source/docs/enterprise/backups/index.html.md
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Consul Enterprise Automated Backups"
 sidebar_current: "docs-enterprise-backups"
 description: |-
-  Consul Enterprise provides a highly available service that manages taking snapshots, rotation and sending backup files offsite to Amazon S3.
+  Consul Enterprise provides a highly available service that manages taking snapshots, rotation and sending backup files offsite to Amazon S3 (or another S3-compatible endpoint).
 ---
 
 # Consul Enterprise Automated Backups
@@ -16,4 +16,4 @@ queries, sessions, and ACLs.
 [Consul Enterprise](https://www.hashicorp.com/consul.html) provides a [highly
 available service](/docs/commands/snapshot/agent.html) that
 integrates with the snapshot API to automatically manage taking snapshots,
-perform rotation and send backup files offsite to Amazon S3.
+perform rotation and send backup files offsite to Amazon S3 (or another S3-compatible endpoint).


### PR DESCRIPTION
Consul Enterprise now contains an endpoint config that allows users to send snapshots to s3 compatible storage services.

This PR updates the website docs to include that flag and clarify that AWS is not required.