### PR TITLE
Allow disabling the HTTP API unless connect is enabled.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -277,8 +277,28 @@ func LocalConfig(cfg *config.RuntimeConfig) local.Config {
 	return lc
 }
 
-func shouldRunProxyManager(cfg *config.RuntimeConfig) bool {
-	return !cfg.ConnectTestDisableManagedProxies && cfg.ConnectEnabled
+func (a *Agent) setupProxyManager() error {
+	acfg, err := a.config.APIConfig(true)
+	if err != nil {
+		return fmt.Errorf("[INFO] agent: Connect managed proxies are disabled due to providing an invalid HTTP configuration")
+	}
+	a.proxyManager = proxy.NewManager()
+	a.proxyManager.AllowRoot = a.config.ConnectProxyAllowManagedRoot
+	a.proxyManager.State = a.State
+	a.proxyManager.Logger = a.logger
+	if a.config.DataDir != "" {
+		// DataDir is required for all non-dev mode agents, but we want
+		// to allow setting the data dir for demos and so on for the agent,
+		// so do the check above instead.
+		a.proxyManager.DataDir = filepath.Join(a.config.DataDir, "proxy")
+
+		// Restore from our snapshot (if it exists)
+		if err := a.proxyManager.Restore(a.proxyManager.SnapshotPath()); err != nil {
+			a.logger.Printf("[WARN] agent: error restoring proxy state: %s", err)
+		}
+	}
+	a.proxyManager.ProxyEnv = acfg.GenerateEnv()
+	return nil
 }
 
 func (a *Agent) Start() error {
@@ -376,30 +396,12 @@ func (a *Agent) Start() error {
 	// create the proxy process manager and start it. This is purposely
 	// done here after the local state above is loaded in so we can have
 	// a more accurate initial state view.
-	if shouldRunProxyManager(c) {
-		a.proxyManager = proxy.NewManager()
-		a.proxyManager.AllowRoot = a.config.ConnectProxyAllowManagedRoot
-		a.proxyManager.State = a.State
-		a.proxyManager.Logger = a.logger
-		if a.config.DataDir != "" {
-			// DataDir is required for all non-dev mode agents, but we want
-			// to allow setting the data dir for demos and so on for the agent,
-			// so do the check above instead.
-			a.proxyManager.DataDir = filepath.Join(a.config.DataDir, "proxy")
-
-			// Restore from our snapshot (if it exists)
-			if err := a.proxyManager.Restore(a.proxyManager.SnapshotPath()); err != nil {
-				a.logger.Printf("[WARN] agent: error restoring proxy state: %s", err)
-			}
+	if !c.ConnectTestDisableManagedProxies {
+		if err := a.setupProxyManager(); err != nil {
+			a.logger.Printf(err.Error())
+		} else {
+			go a.proxyManager.Run()
 		}
-
-		acfg, err := a.config.APIConfig(true)
-		if err != nil {
-			return err
-		}
-		a.proxyManager.ProxyEnv = acfg.GenerateEnv()
-
-		go a.proxyManager.Run()
 	}
 
 	// Start watching for critical services to deregister, based on their

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -277,6 +277,10 @@ func LocalConfig(cfg *config.RuntimeConfig) local.Config {
 	return lc
 }
 
+func shouldRunProxyManager(cfg *config.RuntimeConfig) bool {
+	return !cfg.ConnectTestDisableManagedProxies && cfg.ConnectEnabled
+}
+
 func (a *Agent) Start() error {
 	c := a.config
 
@@ -372,7 +376,7 @@ func (a *Agent) Start() error {
 	// create the proxy process manager and start it. This is purposely
 	// done here after the local state above is loaded in so we can have
 	// a more accurate initial state view.
-	if !c.ConnectTestDisableManagedProxies {
+	if shouldRunProxyManager(c) {
 		a.proxyManager = proxy.NewManager()
 		a.proxyManager.AllowRoot = a.config.ConnectProxyAllowManagedRoot
 		a.proxyManager.State = a.State

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3054,3 +3054,21 @@ func TestAgent_ReLoadProxiesFromConfig(t *testing.T) {
 	proxies = a.State.Proxies()
 	require.Len(proxies, 0)
 }
+
+func TestAgent_ShouldRunProxyManager(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		Config                config.RuntimeConfig
+		ShouldRunProxyManager bool
+	}{
+		{config.RuntimeConfig{ConnectEnabled: true, ConnectTestDisableManagedProxies: true}, false},
+		{config.RuntimeConfig{ConnectEnabled: true, ConnectTestDisableManagedProxies: false}, true},
+		{config.RuntimeConfig{ConnectEnabled: false, ConnectTestDisableManagedProxies: true}, false},
+		{config.RuntimeConfig{ConnectEnabled: false, ConnectTestDisableManagedProxies: false}, false},
+	}
+	for _, tt := range tests {
+		if shouldRunProxyManager(&tt.Config) != tt.ShouldRunProxyManager {
+			t.Fatal("Mismatch")
+		}
+	}
+}


### PR DESCRIPTION
If Connect is enabled, the HTTP API needs to be enabled and there is no point in not having it. If Connect is disabled however, it should be still possible to disable the HTTP API by configuring port `-1` for it.
Fixes #4557.