### PR TITLE
Fixed unstable tests in https://travis-ci.org/hashicorp/consul/jobs/427290266

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -54,7 +54,7 @@ func TestAgent_Services(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
 		Service: "mysql",
@@ -104,7 +104,7 @@ func TestAgent_Services_ExternalConnectProxy(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	srv1 := &structs.NodeService{
 		Kind:             structs.ServiceKindConnectProxy,
 		ID:               "db-proxy",
@@ -168,7 +168,7 @@ func TestAgent_Checks(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	chk1 := &structs.HealthCheck{
 		Node:    a.Config.NodeName,
 		CheckID: "mysql",
@@ -239,7 +239,7 @@ func TestAgent_Self(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
 	obj, err := a.srv.AgentSelf(nil, req)
 	if err != nil {
@@ -351,7 +351,7 @@ func TestAgent_Reload(t *testing.T) {
 	`)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, dc1)
+	testrpc.WaitForTestAgent(t, a.RPC, dc1)
 	if a.State.Service("redis") == nil {
 		t.Fatal("missing redis service")
 	}
@@ -431,7 +431,7 @@ func TestAgent_Members(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	req, _ := http.NewRequest("GET", "/v1/agent/members", nil)
 	obj, err := a.srv.AgentMembers(nil, req)
 	if err != nil {
@@ -452,7 +452,7 @@ func TestAgent_Members_WAN(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	req, _ := http.NewRequest("GET", "/v1/agent/members?wan=true", nil)
 	obj, err := a.srv.AgentMembers(nil, req)
 	if err != nil {
@@ -770,7 +770,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.CheckDefinition{
 		Name: "test",
@@ -815,7 +815,7 @@ func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 		enable_script_checks = true
 `)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	tests := []struct {
 		name  string
@@ -898,7 +898,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.CheckDefinition{
 		Name:   "test",
@@ -934,7 +934,7 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.CheckDefinition{
 		Name:   "test",
@@ -981,7 +981,7 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
 	if err := a.AddCheck(chk, nil, false, ""); err != nil {
@@ -1033,7 +1033,7 @@ func TestAgent_PassCheck(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
 	chkType := &structs.CheckType{TTL: 15 * time.Second}
@@ -1088,7 +1088,7 @@ func TestAgent_WarnCheck(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
 	chkType := &structs.CheckType{TTL: 15 * time.Second}
@@ -1198,7 +1198,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	chk := &structs.HealthCheck{Name: "test", CheckID: "test"}
 	chkType := &structs.CheckType{TTL: 15 * time.Second}
@@ -1311,7 +1311,7 @@ func TestAgent_RegisterService(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.ServiceDefinition{
 		Name: "test",
@@ -1378,7 +1378,7 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	json := `{"name":"test", "port":8000, "enable_tag_override": true, "meta": {"some": "meta"}, "weights":{"passing": 16}}`
 	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", strings.NewReader(json))
@@ -1446,7 +1446,7 @@ func TestAgent_RegisterService_InvalidAddress(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	for _, addr := range []string{"0.0.0.0", "::", "[::]"} {
 		t.Run("addr "+addr, func(t *testing.T) {
@@ -1485,7 +1485,7 @@ func TestAgent_RegisterService_ManagedConnectProxy(t *testing.T) {
 		}
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a proxy. Note that the destination doesn't exist here on
 	// this agent or in the catalog at all. This is intended and part
@@ -1543,7 +1543,7 @@ func TestAgent_RegisterService_ManagedConnectProxy_Disabled(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a proxy. Note that the destination doesn't exist here on
 	// this agent or in the catalog at all. This is intended and part
@@ -1582,7 +1582,7 @@ func TestAgent_RegisterService_UnmanagedConnectProxy(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a proxy. Note that the destination doesn't exist here on
 	// this agent or in the catalog at all. This is intended and part
@@ -1622,7 +1622,7 @@ func TestAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.ServiceDefinition{
 		Kind:             structs.ServiceKindConnectProxy,
@@ -1653,7 +1653,7 @@ func TestAgent_RegisterService_ConnectNative(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a proxy. Note that the destination doesn't exist here on
 	// this agent or in the catalog at all. This is intended and part
@@ -1685,7 +1685,7 @@ func TestAgent_DeregisterService(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	service := &structs.NodeService{
 		ID:      "test",
@@ -1755,7 +1755,7 @@ func TestAgent_DeregisterService_withManagedProxy(t *testing.T) {
 		`)
 
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a service with a managed proxy
 	{
@@ -1811,7 +1811,7 @@ func TestAgent_DeregisterService_managedProxyDirect(t *testing.T) {
 		`)
 
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register a service with a managed proxy
 	{
@@ -1851,7 +1851,7 @@ func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	t.Run("not enabled", func(t *testing.T) {
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/maintenance/test", nil)
@@ -1891,7 +1891,7 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register the service
 	service := &structs.NodeService{
@@ -1934,7 +1934,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register the service
 	service := &structs.NodeService{
@@ -2001,7 +2001,7 @@ func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Fails when no enable flag provided
 	req, _ := http.NewRequest("PUT", "/v1/agent/self/maintenance", nil)
@@ -2018,7 +2018,7 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Force the node into maintenance mode
 	req, _ := http.NewRequest("PUT", "/v1/agent/self/maintenance?enable=true&reason=broken&token=mytoken", nil)
@@ -2051,7 +2051,7 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Force the node into maintenance mode
 	a.EnableNodeMaintenance("", "")
@@ -2097,7 +2097,7 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	args := &structs.ServiceDefinition{
 		Name: "memcache",
@@ -2149,6 +2149,7 @@ func TestAgent_Monitor(t *testing.T) {
 	}
 	a.Start()
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Try passing an invalid log level
 	req, _ := http.NewRequest("GET", "/v1/agent/monitor?loglevel=invalid", nil)
@@ -2391,7 +2392,7 @@ func TestAgentConnectCARoots_empty(t *testing.T) {
 	require := require.New(t)
 	a := NewTestAgent(t.Name(), "connect { enabled = false }")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/agent/connect/ca/roots", nil)
 	resp := httptest.NewRecorder()
@@ -2407,7 +2408,7 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 	require := require.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Set some CAs. Note that NewTestAgent already bootstraps one CA so this just
 	// adds a second and makes it active.
@@ -2746,7 +2747,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 	require := require.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
@@ -2848,7 +2849,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 	require := require.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// CA already setup by default by NewTestAgent but force a new one so we can
 	// verify it was signed easily.
@@ -2963,7 +2964,7 @@ func TestAgentConnectProxyConfig_Blocking(t *testing.T) {
 
 	a := NewTestAgent(t.Name(), testAllowProxyConfig())
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Define a local service with a managed proxy. It's registered in the test
 	// loop to make sure agent state is predictable whatever order tests execute
@@ -3675,7 +3676,7 @@ func TestAgentConnectProxyConfig_ConfigHandling(t *testing.T) {
 
 			a := NewTestAgent(t.Name(), tt.globalConfig)
 			defer a.Shutdown()
-			testrpc.WaitForLeader(t, a.RPC, "dc1")
+			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 			// Register the basic service with the required config
 			{
@@ -3719,7 +3720,7 @@ func TestAgentConnectAuthorize_badBody(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	args := []string{}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 	resp := httptest.NewRecorder()
@@ -3736,7 +3737,7 @@ func TestAgentConnectAuthorize_noTarget(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	args := &structs.ConnectAuthorizeRequest{}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 	resp := httptest.NewRecorder()
@@ -3754,7 +3755,7 @@ func TestAgentConnectAuthorize_idInvalidFormat(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "web",
 		ClientCertURI: "tubes",
@@ -3778,7 +3779,7 @@ func TestAgentConnectAuthorize_idNotService(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "web",
 		ClientCertURI: "spiffe://1234.consul",
@@ -3802,7 +3803,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	target := "db"
 
 	// Create some intentions
@@ -3899,7 +3900,7 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	target := "db"
 
 	// Create some intentions
@@ -3943,7 +3944,7 @@ func TestAgentConnectAuthorize_denyTrustDomain(t *testing.T) {
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	target := "db"
 
 	// Create some intentions
@@ -3986,7 +3987,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	target := "db"
 
@@ -4136,7 +4137,7 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 		acl_enforce_version_8 = true
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, dc1)
+	testrpc.WaitForTestAgent(t, a.RPC, dc1)
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "foo",

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -23,6 +23,7 @@ func TestConnectCARoots_empty(t *testing.T) {
 	require := require.New(t)
 	a := NewTestAgent(t.Name(), "connect { enabled = false }")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/connect/ca/roots", nil)
 	resp := httptest.NewRecorder()
@@ -66,6 +67,7 @@ func TestConnectCAConfig(t *testing.T) {
 	assert := assert.New(t)
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	expected := &structs.ConsulCAProviderConfig{
 		RotationPeriod: 90 * 24 * time.Hour,

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -39,7 +39,7 @@ func TestConnectCARoots(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Insert some CAs
 	state := s1.fsm.State()
@@ -82,7 +82,7 @@ func TestConnectCAConfig_GetSet(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Get the starting config
 	{
@@ -148,7 +148,7 @@ func TestConnectCAConfig_TriggerRotation(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Store the current root
 	rootReq := &structs.DCSpecificRequest{

--- a/agent/consul/coordinate_endpoint_test.go
+++ b/agent/consul/coordinate_endpoint_test.go
@@ -47,7 +47,7 @@ func TestCoordinate_Update(t *testing.T) {
 
 	codec := rpcClient(t, s1)
 	defer codec.Close()
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Register some nodes.
 	nodes := []string{"node1", "node2"}

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1020,7 +1020,7 @@ func TestLeader_CARootPruning(t *testing.T) {
 	codec := rpcClient(t, s1)
 	defer codec.Close()
 
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 	// Get the current root
 	rootReq := &structs.DCSpecificRequest{

--- a/agent/consul/rtt_test.go
+++ b/agent/consul/rtt_test.go
@@ -138,7 +138,7 @@ func TestRTT_sortNodesByDistanceFrom(t *testing.T) {
 
 	codec := rpcClient(t, server)
 	defer codec.Close()
-	testrpc.WaitForLeader(t, server.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)
 	nodes := structs.Nodes{
@@ -191,7 +191,7 @@ func TestRTT_sortNodesByDistanceFrom_Nodes(t *testing.T) {
 
 	codec := rpcClient(t, server)
 	defer codec.Close()
-	testrpc.WaitForLeader(t, server.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)
 	nodes := structs.Nodes{
@@ -341,7 +341,7 @@ func TestRTT_sortNodesByDistanceFrom_CheckServiceNodes(t *testing.T) {
 
 	codec := rpcClient(t, server)
 	defer codec.Close()
-	testrpc.WaitForLeader(t, server.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, server.RPC, "dc1")
 
 	seedCoordinates(t, codec, server)
 	nodes := structs.CheckServiceNodes{

--- a/agent/consul/snapshot_endpoint_test.go
+++ b/agent/consul/snapshot_endpoint_test.go
@@ -341,8 +341,8 @@ func TestSnapshot_Forward_Datacenter(t *testing.T) {
 	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()
 
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s2.RPC, "dc2")
 
 	// Try to WAN join.
 	joinWAN(t, s2, s1)

--- a/agent/consul/stats_fetcher_test.go
+++ b/agent/consul/stats_fetcher_test.go
@@ -27,9 +27,9 @@ func TestStatsFetcher(t *testing.T) {
 
 	joinLAN(t, s2, s1)
 	joinLAN(t, s3, s1)
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-	testrpc.WaitForLeader(t, s2.RPC, "dc1")
-	testrpc.WaitForLeader(t, s3.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s2.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, s3.RPC, "dc1")
 
 	members := s1.serfLAN.Members()
 	if len(members) != 3 {

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -20,6 +20,7 @@ func TestCoordinate_Disabled_Response(t *testing.T) {
 		disable_coordinates = true
 `)
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	tests := []func(resp http.ResponseWriter, req *http.Request) (interface{}, error){
 		a.srv.CoordinateDatacenters,
@@ -52,6 +53,7 @@ func TestCoordinate_Datacenters(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/coordinate/datacenters", nil)
 	resp := httptest.NewRecorder()
@@ -73,7 +75,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Make sure an empty list is non-nil.
 	req, _ := http.NewRequest("GET", "/v1/coordinate/nodes?dc=dc1", nil)
@@ -184,7 +186,7 @@ func TestCoordinate_Node(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Make sure we get a 404 with no coordinates.
 	req, _ := http.NewRequest("GET", "/v1/coordinate/node/foo?dc=dc1", nil)
@@ -288,6 +290,7 @@ func TestCoordinate_Update(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register the node.
 	reg := structs.RegisterRequest{
@@ -334,6 +337,7 @@ func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), TestACLConfig())
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	coord := coordinate.NewCoordinate(coordinate.DefaultConfig())
 	coord.Height = -5.0

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/testrpc"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/testutil/retry"
@@ -18,6 +20,7 @@ func TestEventFire(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	body := bytes.NewBuffer([]byte("test"))
 	url := "/v1/event/fire/test?node=Node&service=foo&tag=bar"
@@ -59,6 +62,7 @@ func TestEventFire_token(t *testing.T) {
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Create an ACL token
 	args := structs.ACLRequest{
@@ -118,6 +122,7 @@ func TestEventList(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	p := &UserEvent{Name: "test"}
 	if err := a.UserEvent("dc1", "root", p); err != nil {
@@ -150,6 +155,7 @@ func TestEventList_Filter(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	p := &UserEvent{Name: "test"}
 	if err := a.UserEvent("dc1", "root", p); err != nil {
@@ -187,6 +193,7 @@ func TestEventList_ACLFilter(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), TestACLConfig())
 	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Fire an event.
 	p := &UserEvent{Name: "foo"}
@@ -237,6 +244,7 @@ func TestEventList_Blocking(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	p := &UserEvent{Name: "test"}
 	if err := a.UserEvent("dc1", "root", p); err != nil {
@@ -288,6 +296,7 @@ func TestEventList_EventBufOrder(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Fire some events in a non-sequential order
 	expected := &UserEvent{Name: "foo"}

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -219,7 +219,7 @@ func TestHealthServiceChecks(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/health/checks/consul?dc=dc1", nil)
 	resp := httptest.NewRecorder()
@@ -324,7 +324,7 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Create a service check
 	args := &structs.RegisterRequest{

--- a/command/catalog/list/nodes/catalog_list_nodes_test.go
+++ b/command/catalog/list/nodes/catalog_list_nodes_test.go
@@ -35,7 +35,7 @@ func TestCatalogListNodesCommand(t *testing.T) {
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	t.Run("simple", func(t *testing.T) {
 		ui := cli.NewMockUi()
 		c := New(ui)

--- a/command/connect/ca/get/connect_ca_get_test.go
+++ b/command/connect/ca/get/connect_ca_get_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/testrpc"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/mitchellh/cli"
 )
@@ -19,6 +21,7 @@ func TestConnectCAGetConfigCommand(t *testing.T) {
 	t.Parallel()
 	a := agent.NewTestAgent(t.Name(), ``)
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)

--- a/command/connect/proxy/register_test.go
+++ b/command/connect/proxy/register_test.go
@@ -43,7 +43,7 @@ func TestRegisterMonitor_heartbeat(t *testing.T) {
 	defer a.Shutdown()
 	client := a.Client()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	m, _ := testMonitor(t, client)
 	defer m.Close()
 


### PR DESCRIPTION
@freddygv This fixes the unstable tests in https://travis-ci.org/hashicorp/consul/jobs/427290266

Use `testrpc.WaitForTestAgent()` where applicable

We are close to 99% green :-)