### PR TITLE
UI: [BUGFIX] Intentions were showing the wrong notification on creation

### DIFF
--- a/ui-v2/app/mixins/intention/with-actions.js
+++ b/ui-v2/app/mixins/intention/with-actions.js
@@ -4,7 +4,7 @@ import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
 import { INTERNAL_SERVER_ERROR as HTTP_INTERNAL_SERVER_ERROR } from 'consul-ui/utils/http/status';
 export default Mixin.create(WithBlockingActions, {
   errorCreate: function(type, e) {
-    if (e.errors && e.errors[0]) {
+    if (e && e.errors && e.errors[0]) {
       const error = e.errors[0];
       if (parseInt(error.status) === HTTP_INTERNAL_SERVER_ERROR) {
         if (error.detail.indexOf('duplicate intention found:') === 0) {

--- a/ui-v2/tests/acceptance/dc/intentions/create.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/create.feature
@@ -1,0 +1,32 @@
+@setupApplicationTest
+Feature: dc / intentions / update: Intention Create
+  In order to define intentions
+  As a user
+  I want to visit the intention create page, fill in the form and hit the create button and see a success notification
+  Scenario:
+    Given 1 datacenter model with the value "datacenter"
+    When I visit the intention page for yaml
+    ---
+      dc: datacenter
+    ---
+    Then the url should be /datacenter/intentions/create
+    # Set source
+    And I click "[data-test-source-element] .ember-power-select-trigger"
+    And I type "web" into ".ember-power-select-search-input"
+    And I click ".ember-power-select-option:first-child"
+    Then I see the text "web" in "[data-test-source-element] .ember-power-select-selected-item"
+    # Set destination
+    And I click "[data-test-destination-element] .ember-power-select-trigger"
+    And I type "db" into ".ember-power-select-search-input"
+    And I click ".ember-power-select-option:first-child"
+    Then I see the text "db" in "[data-test-destination-element] .ember-power-select-selected-item"
+    And I submit
+    Then a POST request is made to "/v1/connect/intentions?dc=datacenter" with the body from yaml
+    ---
+      SourceName: web
+      DestinationName: db
+      Action: deny
+    ---
+    Then the url should be /datacenter/intentions
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/steps/dc/intentions/create-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/intentions/create-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}


### PR DESCRIPTION
The error notification was being shown on creation of an intention. This
was as a result of #4572 and/or #4572 and has not been included in a
release.

This includes a fix, plus tests to try to prevent any further regressions.