### PR TITLE
ui: Turn off the KV code editor whilst making an edit during testing

### DIFF
--- a/ui-v2/tests/acceptance/components/text-input.feature
+++ b/ui-v2/tests/acceptance/components/text-input.feature
@@ -3,19 +3,26 @@ Feature: components / text-input: Text input
   Background:
     Given 1 datacenter model with the value "dc-1"
   Scenario:
-    When I visit the [Page] page for yaml
+    When I visit the kv page for yaml
     ---
       dc: dc-1
     ---
-    Then the url should be [Url]
+    Then the url should be /dc-1/kv/create
+    # Turn the Code Editor off so we can fill the value easier
+    And I click "[name=json]"
     Then I fill in with json
     ---
-    [Data]
+    {"additional": "hi", "value": "there"}
     ---
     Then I see submitIsEnabled
-  Where:
-    --------------------------------------------------------------------------------
-    | Page       | Url                    | Data                                   |
-    | kv        | /dc-1/kv/create         | {"additional": "hi", "value": "there"} |
-    | acl       | /dc-1/acls/create       | {"name": "hi"}                         |
-    --------------------------------------------------------------------------------
+  Scenario:
+    When I visit the acl page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/acls/create
+    Then I fill in with json
+    ---
+    {"name": "hi"}
+    ---
+    Then I see submitIsEnabled

--- a/ui-v2/tests/acceptance/dc/kvs/update.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/update.feature
@@ -13,6 +13,8 @@ Feature: dc / kvs / update: KV Update
       kv: [Name]
     ---
     Then the url should be /datacenter/kv/[Name]/edit
+    # Turn the Code Editor off so we can fill the value easier
+    And I click "[name=json]"
     Then I fill in with yaml
     ---
       value: [Value]
@@ -39,6 +41,8 @@ Feature: dc / kvs / update: KV Update
       kv: key
     ---
     Then the url should be /datacenter/kv/key/edit
+    # Turn the Code Editor off so we can fill the value easier
+    And I click "[name=json]"
     Then I fill in with yaml
     ---
       value: '   '
@@ -59,6 +63,8 @@ Feature: dc / kvs / update: KV Update
       kv: key
     ---
     Then the url should be /datacenter/kv/key/edit
+    # Turn the Code Editor off so we can fill the value easier
+    And I click "[name=json]"
     Then I fill in with yaml
     ---
       value: ''


### PR DESCRIPTION
Having the code editor on removes the text area from the DOM, making it
more difficult to enter text in the text editor during testing. This
turns the code editor off whilst making edits during testing.

No changes to UI code