### PR TITLE
use real management token instead of placeholder [skip ci]

### DIFF
--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -588,7 +588,7 @@ $ curl \
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "key \"\" { policy = \"read\" } key \"foo/\" { policy = \"write\" } key \"foo/private/\" { policy = \"deny\" } operator = \"read\""
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create?token=b1gs33cr3t
 ```
 
 Here's an equivalent request using the JSON form:
@@ -601,7 +601,7 @@ $ curl \
   "Name": "my-app-token",
   "Type": "client",
   "Rules": "{\"key\":{\"\":{\"policy\":\"read\"},\"foo/\":{\"policy\":\"write\"},\"foo/private\":{\"policy\":\"deny\"}},\"operator\":\"read\"}"
-}' http://127.0.0.1:8500/v1/acl/create?token=<management token>
+}' http://127.0.0.1:8500/v1/acl/create?token=b1gs33cr3t
 ```
 
 On success, the token ID is returned:


### PR DESCRIPTION
Since the other examples are using the real token as well, I thought it would be nicer to replace the placeholder.