### PR TITLE
Improve resilience of api pkg tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -162,7 +162,7 @@ test-internal:
 	@# hide it from travis as it exceeds their log limits and causes job to be
 	@# terminated (over 4MB and over 10k lines in the UI). We need to output
 	@# _something_ to stop them terminating us due to inactivity...
-	{ go test $(GOTEST_FLAGS) -tags '$(GOTAGS)' $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL|panic:|--- FAIL)'
+	{ go test -v $(GOTEST_FLAGS) -tags '$(GOTAGS)' $(GOTEST_PKGS) 2>&1 ; echo $$? > exit-code ; } | tee test.log | egrep '^(ok|FAIL|panic:|--- FAIL|--- PASS)'
 	@echo "Exit code: $$(cat exit-code)"
 	@# This prints all the race report between ====== lines
 	@awk '/^WARNING: DATA RACE/ {do_print=1; print "=================="} do_print==1 {print} /^={10,}/ {do_print=0}' test.log || true

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 2)
@@ -71,7 +71,7 @@ func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
 
 func TestAPI_SemaphoreForceInvalidate(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 2)
@@ -106,7 +106,7 @@ func TestAPI_SemaphoreForceInvalidate(t *testing.T) {
 
 func TestAPI_SemaphoreDeleteKey(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 2)
@@ -140,7 +140,7 @@ func TestAPI_SemaphoreDeleteKey(t *testing.T) {
 
 func TestAPI_SemaphoreContend(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	wg := &sync.WaitGroup{}
@@ -193,7 +193,7 @@ func TestAPI_SemaphoreContend(t *testing.T) {
 
 func TestAPI_SemaphoreBadLimit(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 0)
@@ -224,7 +224,7 @@ func TestAPI_SemaphoreBadLimit(t *testing.T) {
 
 func TestAPI_SemaphoreDestroy(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 2)
@@ -280,7 +280,7 @@ func TestAPI_SemaphoreDestroy(t *testing.T) {
 
 func TestAPI_SemaphoreConflict(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	lock, err := c.LockKey("test/sema/.lock")
@@ -318,7 +318,7 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 
 func TestAPI_SemaphoreMonitorRetry(t *testing.T) {
 	t.Parallel()
-	raw, s := makeClient(t)
+	raw, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	// Set up a server that always responds with 500 errors.
@@ -435,7 +435,7 @@ func TestAPI_SemaphoreMonitorRetry(t *testing.T) {
 
 func TestAPI_SemaphoreOneShot(t *testing.T) {
 	t.Parallel()
-	c, s := makeClient(t)
+	c, s := makeClientWithoutConnect(t)
 	defer s.Stop()
 
 	// Set up a semaphore as a one-shot.

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -11,18 +11,45 @@ import (
 	"time"
 )
 
-func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
-	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
-	defer s.Stop()
+func createTestSemaphore(t *testing.T, c *Client, prefix string, limit int) (*Semaphore, *Session) {
+	t.Helper()
+	session := c.Session()
 
-	sema, err := c.SemaphorePrefix("test/semaphore", 2)
+	se := &SessionEntry{
+		Name:     DefaultSemaphoreSessionName,
+		TTL:      DefaultSemaphoreSessionTTL,
+		Behavior: SessionBehaviorDelete,
+	}
+	id, _, err := session.CreateNoChecks(se, nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
+	opts := &SemaphoreOptions{
+		Prefix:      prefix,
+		Limit:       limit,
+		Session:     id,
+		SessionName: se.Name,
+		SessionTTL:  se.TTL,
+	}
+	sema, err := c.SemaphoreOpts(opts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	return sema, session
+}
+
+func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	sema, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
+
 	// Initial release should fail
-	err = sema.Release()
+	err := sema.Release()
 	if err != ErrSemaphoreNotHeld {
 		t.Fatalf("err: %v", err)
 	}
@@ -71,13 +98,11 @@ func TestAPI_SemaphoreAcquireRelease(t *testing.T) {
 
 func TestAPI_SemaphoreForceInvalidate(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
-	sema, err := c.SemaphorePrefix("test/semaphore", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
 	// Should work
 	lockCh, err := sema.Acquire(nil)
@@ -106,13 +131,11 @@ func TestAPI_SemaphoreForceInvalidate(t *testing.T) {
 
 func TestAPI_SemaphoreDeleteKey(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
-	sema, err := c.SemaphorePrefix("test/semaphore", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
 	// Should work
 	lockCh, err := sema.Acquire(nil)
@@ -140,7 +163,7 @@ func TestAPI_SemaphoreDeleteKey(t *testing.T) {
 
 func TestAPI_SemaphoreContend(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
 	wg := &sync.WaitGroup{}
@@ -149,10 +172,8 @@ func TestAPI_SemaphoreContend(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sema, err := c.SemaphorePrefix("test/semaphore", 2)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
+			sema, session := createTestSemaphore(t, c, "test/semaphore", 2)
+			defer session.Destroy(sema.opts.Session, nil)
 
 			// Should work eventually, will contend
 			lockCh, err := sema.Acquire(nil)
@@ -193,28 +214,24 @@ func TestAPI_SemaphoreContend(t *testing.T) {
 
 func TestAPI_SemaphoreBadLimit(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
 	sema, err := c.SemaphorePrefix("test/semaphore", 0)
 	if err == nil {
-		t.Fatalf("should error")
+		t.Fatalf("should error, limit must be positive")
 	}
 
-	sema, err = c.SemaphorePrefix("test/semaphore", 1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema, session := createTestSemaphore(t, c, "test/semaphore", 1)
+	defer session.Destroy(sema.opts.Session, nil)
 
 	_, err = sema.Acquire(nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	sema2, err := c.SemaphorePrefix("test/semaphore", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema2, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
 	_, err = sema2.Acquire(nil)
 	if err.Error() != "semaphore limit conflict (lock: 1, local: 2)" {
@@ -224,20 +241,16 @@ func TestAPI_SemaphoreBadLimit(t *testing.T) {
 
 func TestAPI_SemaphoreDestroy(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
-	sema, err := c.SemaphorePrefix("test/semaphore", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
-	sema2, err := c.SemaphorePrefix("test/semaphore", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema2, session := createTestSemaphore(t, c, "test/semaphore", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
-	_, err = sema.Acquire(nil)
+	_, err := sema.Acquire(nil)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -280,13 +293,11 @@ func TestAPI_SemaphoreDestroy(t *testing.T) {
 
 func TestAPI_SemaphoreConflict(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
 
-	lock, err := c.LockKey("test/sema/.lock")
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	lock, session := createTestLock(t, c, "test/sema/.lock")
+	defer session.Destroy(lock.opts.Session, nil)
 
 	// Should work
 	leaderCh, err := lock.Lock(nil)
@@ -298,10 +309,8 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 	}
 	defer lock.Unlock()
 
-	sema, err := c.SemaphorePrefix("test/sema/", 2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	sema, session := createTestSemaphore(t, c, "test/sema/", 2)
+	defer session.Destroy(sema.opts.Session, nil)
 
 	// Should conflict with lock
 	_, err = sema.Acquire(nil)
@@ -318,8 +327,10 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 
 func TestAPI_SemaphoreMonitorRetry(t *testing.T) {
 	t.Parallel()
-	raw, s := makeClientWithoutConnect(t)
+	raw, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	// Set up a server that always responds with 500 errors.
 	failer := func(w http.ResponseWriter, req *http.Request) {
@@ -435,8 +446,10 @@ func TestAPI_SemaphoreMonitorRetry(t *testing.T) {
 
 func TestAPI_SemaphoreOneShot(t *testing.T) {
 	t.Parallel()
-	c, s := makeClientWithoutConnect(t)
+	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	// Set up a semaphore as a one-shot.
 	opts := &SemaphoreOptions{

--- a/api/session_test.go
+++ b/api/session_test.go
@@ -14,6 +14,8 @@ func TestAPI_SessionCreateDestroy(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	session := c.Session()
 
 	id, meta, err := session.Create(nil, nil)
@@ -43,6 +45,8 @@ func TestAPI_SessionCreateRenewDestroy(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	session := c.Session()
 
@@ -94,6 +98,8 @@ func TestAPI_SessionCreateRenewDestroyRenew(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	session := c.Session()
 
@@ -149,6 +155,8 @@ func TestAPI_SessionCreateDestroyRenewPeriodic(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	session := c.Session()
 
 	entry := &SessionEntry{
@@ -202,6 +210,8 @@ func TestAPI_SessionRenewPeriodic_Cancel(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	session := c.Session()
 	entry := &SessionEntry{
@@ -278,6 +288,8 @@ func TestAPI_SessionInfo(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	session := c.Session()
 
@@ -358,6 +370,8 @@ func TestAPI_SessionNode(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	session := c.Session()
 
 	id, _, err := session.Create(nil, nil)
@@ -392,6 +406,8 @@ func TestAPI_SessionList(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	session := c.Session()
 


### PR DESCRIPTION
In other parts of the codebase we have been using waits to avoid running into `missing serfHealth registration`. In those cases we have been using `testrpc.WaitForTestAgent`, but that function cannot be used in the `api` package because it leads to a dependency cycle.

This PR adds a wait for serfHealth to the TestServer that is created for `api` tests.

This wait is added to session tests because in `session.Create` we require that all checks be registered.

Lastly the test client for semaphore tests is now spun up with Connect disabled, as is done in the lock tests.

After making these changes all semaphore and session tests are passing consistently in the repro environment.

------
**Update**
------
Added some more changes.

From [this](https://travis-ci.org/hashicorp/consul/jobs/428573009) CI job we can see that running the semaphore/lock tests with Connect disabled isn't enough to make them as robust as we would like.

Under the hood, locks and semaphores create sessions with `session.Create`. To avoid the associated check for serfHealth, this PR creates sessions with `session.CreateNoChecks` and then feeds that in when locks/semaphores are created.

In cases where custom semaphore/lock options were already being passed in, there is now a WaitForSerfCheck instead.

Additionally, travis will now log tests as they pass to avoid situations like [this](https://travis-ci.org/hashicorp/consul/jobs/428639509) one.