### PR TITLE
Add SidecarService Syntax sugar to Service Definition

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -277,6 +277,14 @@ func (a *Agent) vetServiceRegister(token string, service *structs.NodeService) e
 		}
 	}
 
+	// If the service is a proxy, ensure that it has write on the destination too
+	// since it can be discovered as an instance of that service.
+	if service.Kind == structs.ServiceKindConnectProxy {
+		if !rule.ServiceWrite(service.Proxy.DestinationServiceName, nil) {
+			return acl.ErrPermissionDenied
+		}
+	}
+
 	return nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1820,7 +1820,7 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	if sidecar := a.State.Service(a.sidecarServiceID(serviceID)); sidecar != nil {
 		// Double check that it's not just an ID collision and we actually added
 		// this from a sidecar.
-		if sidecar.Meta["consul-sidecar"] == "y" {
+		if sidecar.LocallyRegisteredAsSidecar {
 			// Remove it!
 			err := a.RemoveService(a.sidecarServiceID(serviceID), persist)
 			if err != nil {
@@ -2708,16 +2708,23 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 		if err != nil {
 			return fmt.Errorf("Failed to validate checks for service %q: %v", service.Name, err)
 		}
+
+		// Grab and validate sidecar if there is one too
+		sidecar, sidecarChecks, sidecarToken, err := a.sidecarServiceFromNodeService(ns, service.Token)
+		if err != nil {
+			return fmt.Errorf("Failed to validate sidecar for service %q: %v", service.Name, err)
+		}
+
+		// Remove sidecar from NodeService now it's done it's job it's just a config
+		// syntax sugar and shouldn't be persisted in local or server state.
+		ns.Connect.SidecarService = nil
+
 		if err := a.AddService(ns, chkTypes, false, service.Token); err != nil {
 			return fmt.Errorf("Failed to register service %q: %v", service.Name, err)
 		}
 
 		// If there is a sidecar service, register that too.
-		if ns.Connect.SidecarService != nil {
-			sidecar, sidecarChecks, sidecarToken, err := a.sidecarServiceFromNodeService(ns, service.Token)
-			if err != nil {
-				return fmt.Errorf("Failed to validate sidecar for service %q: %v", service.Name, err)
-			}
+		if sidecar != nil {
 			if err := a.AddService(sidecar, sidecarChecks, false, sidecarToken); err != nil {
 				return fmt.Errorf("Failed to register sidecar for service %q: %v", service.Name, err)
 			}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1779,6 +1779,7 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -1814,6 +1815,20 @@ func (a *Agent) RemoveService(serviceID string, persist bool) error {
 	}
 
 	a.logger.Printf("[DEBUG] agent: removed service %q", serviceID)
+
+	// If any Sidecar services exist for the removed service ID, remove them too.
+	if sidecar := a.State.Service(a.sidecarServiceID(serviceID)); sidecar != nil {
+		// Double check that it's not just an ID collision and we actually added
+		// this from a sidecar.
+		if sidecar.Meta["consul-sidecar"] == "y" {
+			// Remove it!
+			err := a.RemoveService(a.sidecarServiceID(serviceID), persist)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -2695,6 +2710,17 @@ func (a *Agent) loadServices(conf *config.RuntimeConfig) error {
 		}
 		if err := a.AddService(ns, chkTypes, false, service.Token); err != nil {
 			return fmt.Errorf("Failed to register service %q: %v", service.Name, err)
+		}
+
+		// If there is a sidecar service, register that too.
+		if ns.Connect.SidecarService != nil {
+			sidecar, sidecarChecks, sidecarToken, err := a.sidecarServiceFromNodeService(ns, service.Token)
+			if err != nil {
+				return fmt.Errorf("Failed to validate sidecar for service %q: %v", service.Name, err)
+			}
+			if err := a.AddService(sidecar, sidecarChecks, false, sidecarToken); err != nil {
+				return fmt.Errorf("Failed to register sidecar for service %q: %v", service.Name, err)
+			}
 		}
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -566,6 +566,24 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 			"local_service_address":    "LocalServiceAddress",
 			// SidecarService
 			"sidecar_service": "SidecarService",
+
+			// DON'T Recurse into these opaque config maps or we might mangle user's
+			// keys. Note empty canonical is a special sentinel to prevent recursion.
+			"Meta": "",
+			// upstreams is an array but this prevents recursion into config field of
+			// any item in the array.
+			"Proxy.Config":                   "",
+			"Proxy.Upstreams.Config":         "",
+			"Connect.Proxy.Config":           "",
+			"Connect.Proxy.Upstreams.Config": "",
+
+			// Same exceptions as above, but for a nested sidecar_service note we use
+			// the canonical form SidecarService since that is translated by the time
+			// the lookup here happens. Note that sidecar service doesn't support
+			// managed proxies (connect.proxy).
+			"Connect.SidecarService.Meta":                   "",
+			"Connect.SidecarService.Proxy.Config":           "",
+			"Connect.SidecarService.Proxy.Upstreams.config": "",
 		})
 
 		for k, v := range rawMap {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -695,6 +695,11 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 		if err := s.agent.vetServiceRegister(sidecarToken, sidecar); err != nil {
 			return nil, err
 		}
+		// We parsed the sidecar registration, now remove it from the NodeService
+		// for the actual service since it's done it's job and we don't want to
+		// persist it in the actual state/catalog. SidecarService is meant to be a
+		// registration syntax sugar so don't propagate it any further.
+		ns.Connect.SidecarService = nil
 	}
 
 	// Get any proxy registrations

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1392,34 +1392,50 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 		"port":8000, 
 		"enable_tag_override": true, 
 		"meta": {
-			"some": "meta"
+			"some": "meta",
+			"enable_tag_override": "meta is 'opaque' so should not get translated"
 		},
-		"kind": "connect-proxy",
-		"proxy": {
+		"kind": "connect-proxy",` +
+		// Note the uppercase P is important here - it ensures translation works
+		// correctly in case-insensitive way. Without it this test can pass even
+		// when translation is broken for other valid inputs.
+		`"Proxy": {
 			"destination_service_name": "web",
 			"destination_service_id": "web",
 			"local_service_port": 1234,
 			"local_service_address": "127.0.0.1",
+			"config": {
+				"destination_type": "proxy.config is 'opaque' so should not get translated"
+			},
 			"upstreams": [
 				{
 					"destination_type": "service",
 					"destination_namespace": "default",
 					"destination_name": "db",
 		      "local_bind_address": "127.0.0.1",
-		      "local_bind_port": 1234
+		      "local_bind_port": 1234,
+					"config": {
+						"destination_type": "proxy.upstreams.config is 'opaque' so should not get translated"
+					}
 				}
 			]
 		},
 		"connect": {
 			"proxy": {
 				"exec_mode": "script",
+				"config": {
+					"destination_type": "connect.proxy.config is 'opaque' so should not get translated"
+				},
 				"upstreams": [
 					{
 						"destination_type": "service",
 						"destination_namespace": "default",
 						"destination_name": "db",
 						"local_bind_address": "127.0.0.1",
-						"local_bind_port": 1234
+						"local_bind_port": 1234,
+						"config": {
+							"destination_type": "connect.proxy.upstreams.config is 'opaque' so should not get translated"
+						}
 					}
 				]
 			},
@@ -1428,7 +1444,8 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 				"port":8001, 
 				"enable_tag_override": true, 
 				"meta": {
-					"some": "meta"
+					"some": "meta",
+					"enable_tag_override": "sidecar_service.meta is 'opaque' so should not get translated"
 				},
 				"kind": "connect-proxy",
 				"proxy": {
@@ -1442,7 +1459,10 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 							"destination_namespace": "default",
 							"destination_name": "db",
 							"local_bind_address": "127.0.0.1",
-							"local_bind_port": 1234
+							"local_bind_port": 1234,
+							"config": {
+								"destination_type": "sidecar_service.proxy.upstreams.config is 'opaque' so should not get translated"
+							}
 						}
 					]
 				}
@@ -1458,9 +1478,12 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 	require.Equal(t, 200, rr.Code, "body: %s", rr.Body)
 
 	svc := &structs.NodeService{
-		ID:                "test",
-		Service:           "test",
-		Meta:              map[string]string{"some": "meta"},
+		ID:      "test",
+		Service: "test",
+		Meta: map[string]string{
+			"some":                "meta",
+			"enable_tag_override": "meta is 'opaque' so should not get translated",
+		},
 		Port:              8000,
 		EnableTagOverride: true,
 		Kind:              structs.ServiceKindConnectProxy,
@@ -1469,6 +1492,9 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 			DestinationServiceID:   "web",
 			LocalServiceAddress:    "127.0.0.1",
 			LocalServicePort:       1234,
+			Config: map[string]interface{}{
+				"destination_type": "proxy.config is 'opaque' so should not get translated",
+			},
 			Upstreams: structs.Upstreams{
 				{
 					DestinationType:      structs.UpstreamDestTypeService,
@@ -1476,12 +1502,18 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 					DestinationNamespace: "default",
 					LocalBindAddress:     "127.0.0.1",
 					LocalBindPort:        1234,
+					Config: map[string]interface{}{
+						"destination_type": "proxy.upstreams.config is 'opaque' so should not get translated",
+					},
 				},
 			},
 		},
 		Connect: structs.ServiceConnect{
 			Proxy: &structs.ServiceDefinitionConnectProxy{
 				ExecMode: "script",
+				Config: map[string]interface{}{
+					"destination_type": "connect.proxy.config is 'opaque' so should not get translated",
+				},
 				Upstreams: structs.Upstreams{
 					{
 						DestinationType:      structs.UpstreamDestTypeService,
@@ -1489,13 +1521,18 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 						DestinationNamespace: "default",
 						LocalBindAddress:     "127.0.0.1",
 						LocalBindPort:        1234,
+						Config: map[string]interface{}{
+							"destination_type": "connect.proxy.upstreams.config is 'opaque' so should not get translated",
+						},
 					},
 				},
 			},
 			SidecarService: &structs.ServiceDefinition{
-				Name:              "test-proxy",
-				Meta:              map[string]string{"some": "meta"},
-				Port:              8001,
+				Name: "test-proxy",
+				Meta: map[string]string{
+					"some":                "meta",
+					"enable_tag_override": "sidecar_service.meta is 'opaque' so should not get translated",
+				}, Port: 8001,
 				EnableTagOverride: true,
 				Kind:              structs.ServiceKindConnectProxy,
 				Proxy: &structs.ConnectProxyConfig{
@@ -1510,6 +1547,9 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 							DestinationNamespace: "default",
 							LocalBindAddress:     "127.0.0.1",
 							LocalBindPort:        1234,
+							Config: map[string]interface{}{
+								"destination_type": "sidecar_service.proxy.upstreams.config is 'opaque' so should not get translated",
+							},
 						},
 					},
 				},

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2010,6 +2010,10 @@ func TestAgent_loadServices_sidecar(t *testing.T) {
 	if token := a.State.ServiceToken("rabbitmq-sidecar-proxy"); token != "abc123" {
 		t.Fatalf("bad: %s", token)
 	}
+
+	// Sanity check rabbitmq service should NOT have sidecar info in state since
+	// it's done it's job and should be a registration syntax sugar only.
+	assert.Nil(t, services["rabbitmq"].Connect.SidecarService)
 }
 
 func TestAgent_loadServices_sidecarSeparateToken(t *testing.T) {

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -344,9 +344,15 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	serfPortWAN := b.portVal("ports.serf_wan", c.Ports.SerfWAN)
 	proxyMinPort := b.portVal("ports.proxy_min_port", c.Ports.ProxyMinPort)
 	proxyMaxPort := b.portVal("ports.proxy_max_port", c.Ports.ProxyMaxPort)
+	sidecarMinPort := b.portVal("ports.sidecar_min_port", c.Ports.SidecarMinPort)
+	sidecarMaxPort := b.portVal("ports.sidecar_max_port", c.Ports.SidecarMaxPort)
 	if proxyMaxPort < proxyMinPort {
 		return RuntimeConfig{}, fmt.Errorf(
 			"proxy_min_port must be less than proxy_max_port. To disable, set both to zero.")
+	}
+	if sidecarMaxPort < sidecarMinPort {
+		return RuntimeConfig{}, fmt.Errorf(
+			"sidecar_min_port must be less than sidecar_max_port. To disable, set both to zero.")
 	}
 
 	// determine the default bind and advertise address
@@ -689,6 +695,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		ConnectProxyAllowManagedAPIRegistration: b.boolVal(c.Connect.Proxy.AllowManagedAPIRegistration),
 		ConnectProxyBindMinPort:                 proxyMinPort,
 		ConnectProxyBindMaxPort:                 proxyMaxPort,
+		ConnectSidecarMinPort:                   sidecarMinPort,
+		ConnectSidecarMaxPort:                   sidecarMaxPort,
 		ConnectProxyDefaultExecMode:             proxyDefaultExecMode,
 		ConnectProxyDefaultDaemonCommand:        proxyDefaultDaemonCommand,
 		ConnectProxyDefaultScriptCommand:        proxyDefaultScriptCommand,
@@ -1177,9 +1185,15 @@ func (b *Builder) serviceConnectVal(v *ServiceConnect) *structs.ServiceConnect {
 			b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't speficy an ID"))
 			sidecar.ID = ""
 		}
-		if sidecar.Connect != nil && sidecar.Connect.SidecarService != nil {
-			b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't have a nested sidecar_service"))
-			sidecar.Connect.SidecarService = nil
+		if sidecar.Connect != nil {
+			if sidecar.Connect.SidecarService != nil {
+				b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't have a nested sidecar_service"))
+				sidecar.Connect.SidecarService = nil
+			}
+			if sidecar.Connect.Proxy != nil {
+				b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't have a managed proxy"))
+				sidecar.Connect.Proxy = nil
+			}
 		}
 	}
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1170,9 +1170,23 @@ func (b *Builder) serviceConnectVal(v *ServiceConnect) *structs.ServiceConnect {
 		}
 	}
 
+	sidecar := b.serviceVal(v.SidecarService)
+	if sidecar != nil {
+		// Sanity checks
+		if sidecar.ID != "" {
+			b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't speficy an ID"))
+			sidecar.ID = ""
+		}
+		if sidecar.Connect != nil && sidecar.Connect.SidecarService != nil {
+			b.err = multierror.Append(b.err, fmt.Errorf("sidecar_service can't have a nested sidecar_service"))
+			sidecar.Connect.SidecarService = nil
+		}
+	}
+
 	return &structs.ServiceConnect{
-		Native: b.boolVal(v.Native),
-		Proxy:  proxy,
+		Native:         b.boolVal(v.Native),
+		Proxy:          proxy,
+		SidecarService: sidecar,
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -376,6 +376,15 @@ type ServiceConnect struct {
 
 	// Proxy configures a connect proxy instance for the service
 	Proxy *ServiceConnectProxy `json:"proxy,omitempty" hcl:"proxy" mapstructure:"proxy"`
+
+	// SidecarService is a nested Service Definition to register at the same time.
+	// It's purely a convenience mechanism to allow specifying a sidecar service
+	// along with the application service definition. It's nested nature allows
+	// all of the fields to be defaulted which can reduce the amount of
+	// boilerplate needed to register a sidecar service separately, but the end
+	// result is identical to just making a second service registration via any
+	// other means.
+	SidecarService *ServiceDefinition `json:"sidecar_service,omitempty" hcl:"sidecar_service" mapstructure:"sidecar_service"`
 }
 
 type ServiceConnectProxy struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -555,14 +555,16 @@ type Telemetry struct {
 }
 
 type Ports struct {
-	DNS          *int `json:"dns,omitempty" hcl:"dns" mapstructure:"dns"`
-	HTTP         *int `json:"http,omitempty" hcl:"http" mapstructure:"http"`
-	HTTPS        *int `json:"https,omitempty" hcl:"https" mapstructure:"https"`
-	SerfLAN      *int `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
-	SerfWAN      *int `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
-	Server       *int `json:"server,omitempty" hcl:"server" mapstructure:"server"`
-	ProxyMinPort *int `json:"proxy_min_port,omitempty" hcl:"proxy_min_port" mapstructure:"proxy_min_port"`
-	ProxyMaxPort *int `json:"proxy_max_port,omitempty" hcl:"proxy_max_port" mapstructure:"proxy_max_port"`
+	DNS            *int `json:"dns,omitempty" hcl:"dns" mapstructure:"dns"`
+	HTTP           *int `json:"http,omitempty" hcl:"http" mapstructure:"http"`
+	HTTPS          *int `json:"https,omitempty" hcl:"https" mapstructure:"https"`
+	SerfLAN        *int `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
+	SerfWAN        *int `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
+	Server         *int `json:"server,omitempty" hcl:"server" mapstructure:"server"`
+	ProxyMinPort   *int `json:"proxy_min_port,omitempty" hcl:"proxy_min_port" mapstructure:"proxy_min_port"`
+	ProxyMaxPort   *int `json:"proxy_max_port,omitempty" hcl:"proxy_max_port" mapstructure:"proxy_max_port"`
+	SidecarMinPort *int `json:"sidecar_min_port,omitempty" hcl:"sidecar_min_port" mapstructure:"sidecar_min_port"`
+	SidecarMaxPort *int `json:"sidecar_max_port,omitempty" hcl:"sidecar_max_port" mapstructure:"sidecar_max_port"`
 }
 
 type UnixSocket struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -90,6 +90,13 @@ func Parse(data string, format string) (c Config, err error) {
 		"services.connect.proxy.upstreams",
 		"service.proxy.upstreams",
 		"services.proxy.upstreams",
+
+		// Need all the service(s) exceptions also for nested sidecar service except
+		// managed proxy which is explicitly not supported there.
+		"service.connect.sidecar_service.checks",
+		"services.connect.sidecar_service.checks",
+		"service.connect.sidecar_service.proxy.upstreams",
+		"services.connect.sidecar_service.proxy.upstreams",
 	})
 
 	// There is a difference of representation of some fields depending on

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -107,6 +107,8 @@ func DefaultSource() Source {
 			server = ` + strconv.Itoa(consul.DefaultRPCPort) + `
 			proxy_min_port = 20000
 			proxy_max_port = 20255
+			sidecar_min_port = 21000
+			sidecar_max_port = 21255
 		}
 		telemetry = {
 			metrics_prefix = "consul"

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -462,6 +462,16 @@ type RuntimeConfig struct {
 	// port is specified.
 	ConnectProxyBindMaxPort int
 
+	// ConnectSidecarMinPort is the inclusive start of the range of ports
+	// allocated to the agent for asigning to sidecar services where no port is
+	// specified.
+	ConnectSidecarMinPort int
+
+	// ConnectSidecarMaxPort is the inclusive end of the range of ports
+	// allocated to the agent for asigning to sidecar services where no port is
+	// specified
+	ConnectSidecarMaxPort int
+
 	// ConnectProxyAllowManagedRoot is true if Consul can execute managed
 	// proxies when running as root (EUID == 0).
 	ConnectProxyAllowManagedRoot bool

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1927,6 +1927,40 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			err: "sidecar_service can't have a nested sidecar_service",
 		},
 		{
+			desc: "sidecar_service can't have managed proxy",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+				  "service": {
+						"name": "web",
+						"port": 1234,
+						"connect": {
+							"sidecar_service": {
+								"connect": {
+									"proxy": {}
+								}
+							}
+						}
+					}
+				}`},
+			hcl: []string{`
+				service {
+					name = "web"
+					port = 1234
+					connect {
+						sidecar_service {
+							connect {
+								proxy {
+								}
+							}
+						}
+					}
+				}
+			`},
+			err: "sidecar_service can't have a managed proxy",
+		},
+		{
 			desc: "telemetry.prefix_filter cannot be empty",
 			args: []string{
 				`-data-dir=` + dataDir,
@@ -2745,7 +2779,9 @@ func TestFullConfig(t *testing.T) {
 				"https": 15127,
 				"server": 3757,
 				"proxy_min_port": 2000,
-				"proxy_max_port": 3000
+				"proxy_max_port": 3000,
+				"sidecar_min_port": 8888,
+				"sidecar_max_port": 9999
 			},
 			"protocol": 30793,
 			"raft_protocol": 19016,
@@ -3264,6 +3300,8 @@ func TestFullConfig(t *testing.T) {
 				server = 3757
 				proxy_min_port = 2000
 				proxy_max_port = 3000
+				sidecar_min_port = 8888
+				sidecar_max_port = 9999
 			}
 			protocol = 30793
 			raft_protocol = 19016
@@ -3791,6 +3829,8 @@ func TestFullConfig(t *testing.T) {
 		ConnectEnabled:          true,
 		ConnectProxyBindMinPort: 2000,
 		ConnectProxyBindMaxPort: 3000,
+		ConnectSidecarMinPort:   8888,
+		ConnectSidecarMaxPort:   9999,
 		ConnectCAProvider:       "consul",
 		ConnectCAConfig: map[string]interface{}{
 			"RotationPeriod": "90h",
@@ -4533,6 +4573,8 @@ func TestSanitize(t *testing.T) {
 		"ConnectProxyDefaultDaemonCommand": [],
 		"ConnectProxyDefaultExecMode": "",
 		"ConnectProxyDefaultScriptCommand": [],
+		"ConnectSidecarMaxPort": 0,
+		"ConnectSidecarMinPort": 0,
 		"ConnectTestDisableManagedProxies": false,
 		"ConsulCoordinateUpdateBatchSize": 0,
 		"ConsulCoordinateUpdateMaxBatches": 0,

--- a/agent/config/translate.go
+++ b/agent/config/translate.go
@@ -1,6 +1,8 @@
 package config
 
-import "strings"
+import (
+	"strings"
+)
 
 // TranslateKeys recursively translates all keys from m in-place to their
 // canonical form as defined in dict which maps an alias name to the canonical
@@ -10,21 +12,64 @@ import "strings"
 //
 // Example:
 //
-//   m = TranslateKeys(m, map[string]string{"CamelCase": "snake_case"})
+//   m = TranslateKeys(m, map[string]string{"snake_case": "CamelCase"})
 //
+// If the canonical string provided is the empty string, the effect is to stop
+// recursing into any key matching the left hand side. In this case the left
+// hand side must use periods to specify a full path e.g.
+// `connect.proxy.config`. The path must be the canonical key names (i.e.
+// CamelCase) AFTER translation so ExecMode not exec_mode. These are still match
+// in a case-insensitive way.
+//
+// This is needed for example because parts of the Service Definition are
+// "opaque" maps of metadata or config passed to another process or component.
+// If we allow translation to recurse we might mangle the "opaque" keys given
+// where the clash with key names in other parts of the definition (and they do
+// in practice with deprecated managed proxy upstreams) :sob:
+//
+// Example:
+//   m - TranslateKeys(m, map[string]string{
+//     "foo_bar": "FooBar",
+//     "widget.config": "",
+//     // Assume widgets is an array, this will prevent recursing into any
+//     // item's config field
+//     "widgets.config": "",
+//   })
 func TranslateKeys(v map[string]interface{}, dict map[string]string) {
-	ck(v, dict)
+	// Convert all dict keys for exclusions to lower. so we can match against them
+	// unambiguously with a single lookup.
+	for k, v := range dict {
+		if v == "" {
+			dict[strings.ToLower(k)] = ""
+		}
+	}
+	ck(v, dict, "")
 }
 
-func ck(v interface{}, dict map[string]string) interface{} {
+func ck(v interface{}, dict map[string]string, pathPfx string) interface{} {
+	// In array case we don't add a path segment for the item as they are all
+	// assumed to be same which is why we check the prefix doesn't already end in
+	// a .
+	if pathPfx != "" && !strings.HasSuffix(pathPfx, ".") {
+		pathPfx += "."
+	}
 	switch x := v.(type) {
 	case map[string]interface{}:
 		for k, v := range x {
-			canonKey := dict[strings.ToLower(k)]
+			lowerK := strings.ToLower(k)
+
+			// Check if this path has been excluded
+			val, ok := dict[pathPfx+lowerK]
+			if ok && val == "" {
+				// Don't recurse into this key
+				continue
+			}
+
+			canonKey, ok := dict[lowerK]
 
 			// no canonical key? -> use this key
-			if canonKey == "" {
-				x[k] = ck(v, dict)
+			if !ok {
+				x[k] = ck(v, dict, pathPfx+lowerK)
 				continue
 			}
 
@@ -37,14 +82,14 @@ func ck(v interface{}, dict map[string]string) interface{} {
 			}
 
 			// otherwise translate to the canonical key
-			x[canonKey] = ck(v, dict)
+			x[canonKey] = ck(v, dict, pathPfx+strings.ToLower(canonKey))
 		}
 		return x
 
 	case []interface{}:
 		var a []interface{}
 		for _, xv := range x {
-			a = append(a, ck(xv, dict))
+			a = append(a, ck(xv, dict, pathPfx))
 		}
 		return a
 

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -49,15 +49,11 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 			return nil, nil, "", err
 		}
 	}
-	// Always copy Meta so it's safe for us to modify here without changing the
-	// map in the input struct that is reachable by the caller which is
-	// unexpected.
-	newMeta := make(map[string]string)
-	for k, v := range sidecar.Meta {
-		newMeta[k] = v
-	}
-	newMeta["consul-sidecar"] = "y"
-	sidecar.Meta = newMeta
+
+	// Flag this as a sidecar - this is not persisted in catalog but only needed
+	// in local agent state to disambiguate lineage when deregistereing the parent
+	// service later.
+	sidecar.LocallyRegisteredAsSidecar = true
 
 	// See if there is a more specific token for the sidecar registration
 	if ns.Connect.SidecarService.Token != "" {

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func (a *Agent) sidecarServiceID(serviceID string) string {
+	return serviceID + "-sidecar-proxy"
+}
+
+// sidecarServiceFromNodeService returns a *structs.NodeService representing a
+// sidecar service with all defaults populated based on the current agent
+// config.
+//
+// It assumes the ns has been validated already which means the nested
+// SidecarService is also already validated.It also assumes that any check
+// definitions within the sidecar service definition have been validated if
+// necessary. If no sidecar service is defined in ns, then nil is returned with
+// nil error.
+//
+// The second return argument is a list of CheckTypes to register along with the
+// service.
+//
+// The third return argument is the effective Token to use for the sidecar
+// registration. This will be the same as the token parameter passed unless the
+// SidecarService definition contains a distint one.
+func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token string) (*structs.NodeService, []*structs.CheckType, string, error) {
+	if ns.Connect.SidecarService == nil {
+		return nil, nil, "", nil
+	}
+
+	// Start with normal conversion from service definition
+	sidecar := ns.Connect.SidecarService.NodeService()
+
+	// Override the ID which must always be consistent for a given outer service
+	// ID. We rely on this for lifecycle management of the nested definition.
+	sidecar.ID = a.sidecarServiceID(ns.ID)
+
+	// Set some meta we can use to disambiguate between service instances we added
+	// later and are responsible for deregistering.
+	if sidecar.Meta == nil {
+		sidecar.Meta = make(map[string]string)
+	} else {
+		// Meta is non-nil validate it before we add the special key so we can
+		// enforce that user cannot add a consul- prefix one.
+		if err := structs.ValidateMetadata(sidecar.Meta, false); err != nil {
+			return nil, nil, "", err
+		}
+	}
+	sidecar.Meta["consul-sidecar"] = "y"
+
+	// See if there is a more specific token for the sidecar registration
+	if ns.Connect.SidecarService.Token != "" {
+		token = ns.Connect.SidecarService.Token
+	}
+
+	// Setup some sane connect proxy defaults.
+	if sidecar.Kind == "" {
+		sidecar.Kind = structs.ServiceKindConnectProxy
+	}
+	if sidecar.Service == "" {
+		sidecar.Service = ns.Service + "-sidecar-proxy"
+	}
+	if sidecar.Address == "" {
+		// Inherit address from the service if it's provided
+		sidecar.Address = ns.Address
+	}
+
+	// Allocate port if needed (min and max inclusive).
+	rangeLen := a.config.ConnectSidecarMaxPort - a.config.ConnectSidecarMinPort + 1
+	if sidecar.Port < 1 && a.config.ConnectSidecarMinPort > 0 && rangeLen > 0 {
+		// This should be a really short list so don't bother optimising lookup yet.
+	OUTER:
+		for _, offset := range rand.Perm(rangeLen) {
+			p := a.config.ConnectSidecarMinPort + offset
+			// See if this port was already allocated to another service
+			for _, otherNS := range a.State.Services() {
+				if otherNS.Port == p {
+					// already taken, skip to next random pick in the range
+					continue OUTER
+				}
+			}
+			// We made it through all existing proxies without a match so claim this one
+			sidecar.Port = p
+			break
+		}
+	}
+	// If no ports left (or auto ports disabled) fail
+	if sidecar.Port < 1 {
+		return nil, nil, "", fmt.Errorf("no port provided for sidecar_service and none "+
+			" left in the configured range [%d, %d]", a.config.ConnectSidecarMinPort,
+			a.config.ConnectSidecarMaxPort)
+	}
+
+	// Setup checks
+	checks, err := ns.Connect.SidecarService.CheckTypes()
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	// Setup default check if none given
+	if len(checks) < 1 {
+		checks = []*structs.CheckType{
+			&structs.CheckType{
+				Name: "Connect Sidecar Listening",
+				// Default to localhost rather than agent/service public IP. The checks
+				// can always be overridden if a non-loopback IP is needed.
+				TCP:      fmt.Sprintf("127.0.0.1:%d", sidecar.Port),
+				Interval: 10 * time.Second,
+			},
+			&structs.CheckType{
+				Name:         "Connect Sidecar Aliasing " + ns.ID,
+				AliasService: ns.ID,
+			},
+		}
+	}
+
+	return sidecar, checks, token, nil
+}

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -44,11 +44,11 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			},
 			token: "foo",
 			wantNS: &structs.NodeService{
-				Kind:    structs.ServiceKindConnectProxy,
-				ID:      "web1-sidecar-proxy",
-				Service: "web-sidecar-proxy",
-				Port:    2222,
-				Meta:    map[string]string{"consul-sidecar": "y"},
+				Kind:                       structs.ServiceKindConnectProxy,
+				ID:                         "web1-sidecar-proxy",
+				Service:                    "web-sidecar-proxy",
+				Port:                       2222,
+				LocallyRegisteredAsSidecar: true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "web",
 					DestinationServiceID:   "web1",
@@ -108,10 +108,10 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				Tags:    []string{"foo", "bar"},
 				Address: "127.127.127.127",
 				Meta: map[string]string{
-					"foo":            "bar",
-					"consul-sidecar": "y",
+					"foo": "bar",
 				},
-				EnableTagOverride: true,
+				LocallyRegisteredAsSidecar: true,
+				EnableTagOverride:          true,
 				Proxy: structs.ConnectProxyConfig{
 					DestinationServiceName: "web",
 					DestinationServiceID:   "web1",

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -1,0 +1,248 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
+	tests := []struct {
+		name              string
+		preRegister       *structs.ServiceDefinition
+		sd                *structs.ServiceDefinition
+		token             string
+		autoPortsDisabled bool
+		wantNS            *structs.NodeService
+		wantChecks        []*structs.CheckType
+		wantToken         string
+		wantErr           string
+	}{
+		{
+			name: "no sidecar",
+			sd: &structs.ServiceDefinition{
+				Name: "web",
+				Port: 1111,
+			},
+			token:      "foo",
+			wantNS:     nil,
+			wantChecks: nil,
+			wantToken:  "",
+			wantErr:    "", // Should NOT error
+		},
+		{
+			name: "all the defaults",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{},
+				},
+			},
+			token: "foo",
+			wantNS: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				ID:      "web1-sidecar-proxy",
+				Service: "web-sidecar-proxy",
+				Port:    2222,
+				Meta:    map[string]string{"consul-sidecar": "y"},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.0.1",
+					LocalServicePort:       1111,
+				},
+			},
+			wantChecks: []*structs.CheckType{
+				&structs.CheckType{
+					Name:     "Connect Sidecar Listening",
+					TCP:      "127.0.0.1:2222",
+					Interval: 10 * time.Second,
+				},
+				&structs.CheckType{
+					Name:         "Connect Sidecar Aliasing web1",
+					AliasService: "web1",
+				},
+			},
+			wantToken: "foo",
+		},
+		{
+			name: "all the allowed overrides",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Name:    "motorbike1",
+						Port:    3333,
+						Tags:    []string{"foo", "bar"},
+						Address: "127.127.127.127",
+						Meta:    map[string]string{"foo": "bar"},
+						Check: structs.CheckType{
+							ScriptArgs: []string{"sleep", "1"},
+							Interval:   999 * time.Second,
+						},
+						Token:             "custom-token",
+						EnableTagOverride: true,
+						Proxy: &structs.ConnectProxyConfig{
+							DestinationServiceName: "web",
+							DestinationServiceID:   "web1",
+							LocalServiceAddress:    "127.0.127.0",
+							LocalServicePort:       9999,
+							Config:                 map[string]interface{}{"baz": "qux"},
+							Upstreams:              structs.TestUpstreams(t),
+						},
+					},
+				},
+			},
+			token: "foo",
+			wantNS: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				ID:      "web1-sidecar-proxy",
+				Service: "motorbike1",
+				Port:    3333,
+				Tags:    []string{"foo", "bar"},
+				Address: "127.127.127.127",
+				Meta: map[string]string{
+					"foo":            "bar",
+					"consul-sidecar": "y",
+				},
+				EnableTagOverride: true,
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "web",
+					DestinationServiceID:   "web1",
+					LocalServiceAddress:    "127.0.127.0",
+					LocalServicePort:       9999,
+					Config:                 map[string]interface{}{"baz": "qux"},
+					Upstreams:              structs.TestAddDefaultsToUpstreams(t, structs.TestUpstreams(t)),
+				},
+			},
+			wantChecks: []*structs.CheckType{
+				&structs.CheckType{
+					ScriptArgs: []string{"sleep", "1"},
+					Interval:   999 * time.Second,
+				},
+			},
+			wantToken: "custom-token",
+		},
+		{
+			name: "no auto ports available",
+			// register another sidecar consuming our 1 and only allocated auto port.
+			preRegister: &structs.ServiceDefinition{
+				Kind: structs.ServiceKindConnectProxy,
+				Name: "api-proxy-sidecar",
+				Port: 2222, // Consume the one available auto-port
+				Proxy: &structs.ConnectProxyConfig{
+					DestinationServiceName: "api",
+				},
+			},
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{},
+				},
+			},
+			token:   "foo",
+			wantErr: "none left in the configured range [2222, 2222]",
+		},
+		{
+			name:              "auto ports disabled",
+			autoPortsDisabled: true,
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{},
+				},
+			},
+			token:   "foo",
+			wantErr: "auto-assignement disabled in config",
+		},
+		{
+			name: "invalid check type",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Check: structs.CheckType{
+							TCP: "foo",
+							// Invalid since no interval specified
+						},
+					},
+				},
+			},
+			token:   "foo",
+			wantErr: "Interval must be > 0",
+		},
+		{
+			name: "invalid meta",
+			sd: &structs.ServiceDefinition{
+				ID:   "web1",
+				Name: "web",
+				Port: 1111,
+				Connect: &structs.ServiceConnect{
+					SidecarService: &structs.ServiceDefinition{
+						Meta: map[string]string{
+							"consul-reserved-key-should-be-rejected": "true",
+						},
+					},
+				},
+			},
+			token:   "foo",
+			wantErr: "reserved for internal use",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set port range to make it deterministic. This allows a single assigned
+			// port at 2222 thanks to being inclusive at both ends.
+			hcl := `
+			ports {
+				sidecar_min_port = 2222
+				sidecar_max_port = 2222
+			}
+			`
+			if tt.autoPortsDisabled {
+				hcl = `
+				ports {
+					sidecar_min_port = 0
+					sidecar_max_port = 0
+				}
+				`
+			}
+
+			require := require.New(t)
+			a := NewTestAgent("jones", hcl)
+
+			if tt.preRegister != nil {
+				err := a.AddService(tt.preRegister.NodeService(), nil, false, "")
+				require.NoError(err)
+			}
+
+			ns := tt.sd.NodeService()
+			err := ns.Validate()
+			require.NoError(err, "Invalid test case - NodeService must validate")
+
+			gotNS, gotChecks, gotToken, err := a.sidecarServiceFromNodeService(ns, tt.token)
+			if tt.wantErr != "" {
+				require.Error(err)
+				require.Contains(err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(err)
+			require.Equal(tt.wantNS, gotNS)
+			require.Equal(tt.wantChecks, gotChecks)
+			require.Equal(tt.wantToken, gotToken)
+		})
+	}
+}

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -14,7 +14,7 @@ import (
 type ConnectProxyConfig struct {
 	// DestinationServiceName is required and is the name of the service to accept
 	// traffic for.
-	DestinationServiceName string
+	DestinationServiceName string `json:",omitempty"`
 
 	// DestinationServiceID is optional and should only be specified for
 	// "side-car" style proxies where the proxy is in front of just a single
@@ -22,27 +22,27 @@ type ConnectProxyConfig struct {
 	// being represented which must be registered to the same agent. It's valid to
 	// provide a service ID that does not yet exist to avoid timing issues when
 	// bootstrapping a service with a proxy.
-	DestinationServiceID string
+	DestinationServiceID string `json:",omitempty"`
 
 	// LocalServiceAddress is the address of the local service instance. It is
 	// optional and should only be specified for "side-car" style proxies. It will
 	// default to 127.0.0.1 if the proxy is a "side-car" (DestinationServiceID is
 	// set) but otherwise will be ignored.
-	LocalServiceAddress string
+	LocalServiceAddress string `json:",omitempty"`
 
 	// LocalServicePort is the port of the local service instance. It is optional
 	// and should only be specified for "side-car" style proxies. It will default
 	// to the registered port for the instance if the proxy is a "side-car"
 	// (DestinationServiceID is set) but otherwise will be ignored.
-	LocalServicePort int
+	LocalServicePort int `json:",omitempty"`
 
 	// Config is the arbitrary configuration data provided with the proxy
 	// registration.
-	Config map[string]interface{}
+	Config map[string]interface{} `json:",omitempty"`
 
 	// Upstreams describes any upstream dependencies the proxy instance should
 	// setup.
-	Upstreams Upstreams
+	Upstreams Upstreams `json:",omitempty"`
 }
 
 // ToAPI returns the api struct with the same fields. We have duplicates to

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -697,10 +697,15 @@ func (s *NodeService) Validate() error {
 				"A SidecarService cannot specify an ID as this is managed by the "+
 					"agent"))
 		}
-		if s.Connect.SidecarService.Connect != nil &&
-			s.Connect.SidecarService.Connect.SidecarService != nil {
-			result = multierror.Append(result, fmt.Errorf(
-				"A SidecarService cannot have a nested SidecarService"))
+		if s.Connect.SidecarService.Connect != nil {
+			if s.Connect.SidecarService.Connect.SidecarService != nil {
+				result = multierror.Append(result, fmt.Errorf(
+					"A SidecarService cannot have a nested SidecarService"))
+			}
+			if s.Connect.SidecarService.Connect.Proxy != nil {
+				result = multierror.Append(result, fmt.Errorf(
+					"A SidecarService cannot have a managed proxy"))
+			}
 		}
 	}
 

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -304,6 +304,16 @@ func TestStructs_NodeService_ValidateSidecarService(t *testing.T) {
 			},
 			"SidecarService cannot have a nested SidecarService",
 		},
+
+		{
+			"Sidecar can't have managed proxy",
+			func(x *NodeService) {
+				x.Connect.SidecarService.Connect = &ServiceConnect{
+					Proxy: &ServiceDefinitionConnectProxy{},
+				}
+			},
+			"SidecarService cannot have a managed proxy",
+		},
 	}
 
 	for _, tc := range cases {

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -277,6 +277,52 @@ func TestStructs_NodeService_ValidateConnectProxy(t *testing.T) {
 	}
 }
 
+func TestStructs_NodeService_ValidateSidecarService(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Modify func(*NodeService)
+		Err    string
+	}{
+		{
+			"valid",
+			func(x *NodeService) {},
+			"",
+		},
+
+		{
+			"ID can't be set",
+			func(x *NodeService) { x.Connect.SidecarService.ID = "foo" },
+			"SidecarService cannot specify an ID",
+		},
+
+		{
+			"Nested sidecar can't be set",
+			func(x *NodeService) {
+				x.Connect.SidecarService.Connect = &ServiceConnect{
+					SidecarService: &ServiceDefinition{},
+				}
+			},
+			"SidecarService cannot have a nested SidecarService",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert := assert.New(t)
+			ns := TestNodeServiceSidecar(t)
+			tc.Modify(ns)
+
+			err := ns.Validate()
+			assert.Equal(err != nil, tc.Err != "", err)
+			if err == nil {
+				return
+			}
+
+			assert.Contains(strings.ToLower(err.Error()), strings.ToLower(tc.Err))
+		})
+	}
+}
+
 func TestStructs_NodeService_IsSame(t *testing.T) {
 	ns := &NodeService{
 		ID:      "node1",

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -48,3 +48,15 @@ func TestNodeServiceProxy(t testing.T) *NodeService {
 		Proxy:   TestConnectProxyConfig(t),
 	}
 }
+
+// TestNodeServiceSidecar returns a *NodeService representing a service
+// registration with a nested Sidecar registration.
+func TestNodeServiceSidecar(t testing.T) *NodeService {
+	return &NodeService{
+		Service: "web",
+		Port:    2222,
+		Connect: ServiceConnect{
+			SidecarService: &ServiceDefinition{},
+		},
+	}
+}

--- a/agent/structs/testing_connect_proxy_config.go
+++ b/agent/structs/testing_connect_proxy_config.go
@@ -34,3 +34,19 @@ func TestUpstreams(t testing.T) Upstreams {
 		},
 	}
 }
+
+// TestAddDefaultsToUpstreams takes an array of upstreams (such as that from
+// TestUpstreams) and adds default values that are populated during
+// refigistration. Use this for generating the expected Upstreams value after
+// registration.
+func TestAddDefaultsToUpstreams(t testing.T, upstreams []Upstream) []Upstream {
+	ups := make([]Upstream, len(upstreams))
+	for i := range upstreams {
+		ups[i] = upstreams[i]
+		// Fill in default fields we expect to have back explicitly in a response
+		if ups[i].DestinationType == "" {
+			ups[i].DestinationType = UpstreamDestTypeService
+		}
+	}
+	return ups
+}

--- a/api/agent.go
+++ b/api/agent.go
@@ -83,8 +83,9 @@ type AgentService struct {
 
 // AgentServiceConnect represents the Connect configuration of a service.
 type AgentServiceConnect struct {
-	Native bool                      `json:",omitempty"`
-	Proxy  *AgentServiceConnectProxy `json:",omitempty"`
+	Native         bool                      `json:",omitempty"`
+	Proxy          *AgentServiceConnectProxy `json:",omitempty"`
+	SidecarService *AgentServiceRegistration `json:",omitempty"`
 }
 
 // AgentServiceConnectProxy represents the Connect Proxy configuration of a


### PR DESCRIPTION
**NOTE:** this PR is against the `f-envoy` feature branch as it assumes some of the changes their to proxy definitions and will land along with that work.

SidecarService is a new configuration helper for service definitions for use with Connect.

It provided most of the automatic configuration that Managed Proxies benefit from, but without implying that we actually start and supervise the process for you. This design is detailed in the internal RFC.

This implementation includes:

 - Config and API changes to allow `service(s).connect.sidecar_service` nested service definitions
 - Tests for the default behaviour, and lifecycle management for both API and file-registrations (i.e. if you deregister a service that was registered with a `SidecarService` or remove the sidecar from a file-based config, the sidecar is automatically deregistered too.
  - API package updates to allow sidecar service registrations

## Left for future PR

 - **Documentation changes** are intentionally left for later because they will need a large restructure as part of managed proxy changes proposed.
 - **Proxy Config Endpoint/Built in proxy** changes are left for a later PR just to keep the change set smaller.

## TODO

As I wrote this PR description I realised that there is one case not tests (and I think not working):

 - [x] Updating registration via API that removes a SidecarService should cause it to be deregistered.
 - [x] Updating registration via API should also update sidecar registration (does already but not explicitly tested).

