### PR TITLE
Add -sidecar-for and new /agent/service/:service_id endpoint

### DIFF
--- a/agent/ae/ae.go
+++ b/agent/ae/ae.go
@@ -306,8 +306,9 @@ func (s *StateSyncer) Paused() bool {
 	return s.paused != 0
 }
 
-// Resume re-enables sync runs.
-func (s *StateSyncer) Resume() {
+// Resume re-enables sync runs. It returns true if it was the last pause/resume
+// pair on the stack and so actually caused the state syncer to resume.
+func (s *StateSyncer) Resume() bool {
 	s.pauseLock.Lock()
 	s.paused--
 	if s.paused < 0 {
@@ -318,4 +319,5 @@ func (s *StateSyncer) Resume() {
 	if trigger {
 		s.SyncChanges.Trigger()
 	}
+	return trigger
 }

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAE_scaleFactor(t *testing.T) {
@@ -47,14 +48,16 @@ func TestAE_Pause_nestedPauseResume(t *testing.T) {
 	if l.Paused() != true {
 		t.Fatal("syncer should STILL be Paused after second call to Pause()")
 	}
-	l.Resume()
+	gotR := l.Resume()
 	if l.Paused() != true {
 		t.Fatal("syncer should STILL be Paused after FIRST call to Resume()")
 	}
-	l.Resume()
+	assert.False(t, gotR)
+	gotR = l.Resume()
 	if l.Paused() != false {
 		t.Fatal("syncer should NOT be Paused after SECOND call to Resume()")
 	}
+	assert.True(t, gotR)
 
 	defer func() {
 		err := recover()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -126,6 +126,11 @@ type Agent struct {
 	// and the remote state.
 	sync *ae.StateSyncer
 
+	// syncMu and syncCh are used to coordinate agent endpoints that are blocking
+	// on local state during a config reload.
+	syncMu sync.Mutex
+	syncCh chan struct{}
+
 	// cache is the in-memory cache for data the Agent requests.
 	cache *cache.Cache
 
@@ -1474,14 +1479,53 @@ func (a *Agent) StartSync() {
 	a.logger.Printf("[INFO] agent: started state syncer")
 }
 
-// PauseSync is used to pause anti-entropy while bulk changes are make
+// PauseSync is used to pause anti-entropy while bulk changes are made. It also
+// sets state that agent-local watches use to "ride out" config reloads and bulk
+// updates which might spuriously unload state and reload it again.
 func (a *Agent) PauseSync() {
+	// Do this outside of lock as it has it's own locking
 	a.sync.Pause()
+
+	// Coordinate local state watchers
+	a.syncMu.Lock()
+	defer a.syncMu.Unlock()
+	if a.syncCh == nil {
+		a.syncCh = make(chan struct{})
+	}
 }
 
 // ResumeSync is used to unpause anti-entropy after bulk changes are make
 func (a *Agent) ResumeSync() {
-	a.sync.Resume()
+	// a.sync maintains a stack/ref count of Pause calls since we call
+	// Pause/Resume in nested way during a reload and AddService. We only want to
+	// trigger local state watchers if this Resume call actually started sync back
+	// up again (i.e. was the last resume on the stack). We could check that
+	// separately with a.sync.Paused but that is racey since another Pause call
+	// might be made between our Resume and checking Paused.
+	resumed := a.sync.Resume()
+
+	if !resumed {
+		// Return early so we don't notify local watchers until we are actually
+		// resumed.
+		return
+	}
+
+	// Coordinate local state watchers
+	a.syncMu.Lock()
+	defer a.syncMu.Unlock()
+
+	if a.syncCh != nil {
+		close(a.syncCh)
+		a.syncCh = nil
+	}
+}
+
+// syncPausedCh returns either a channel or nil. If nil sync is not paused. If
+// non-nil, the channel will be closed when sync resumes.
+func (a *Agent) syncPausedCh() <-chan struct{} {
+	a.syncMu.Lock()
+	defer a.syncMu.Unlock()
+	return a.syncCh
 }
 
 // GetLANCoordinate returns the coordinates of this node in the local pools

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1,8 +1,10 @@
 package agent
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -220,6 +222,154 @@ func (s *HTTPServer) AgentServices(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	return agentSvcs, nil
+}
+
+// GET /v1/agent/service/:service_id
+//
+// Returns the service definition for a single local services and allows
+// blocking watch using hash-based blocking.
+func (s *HTTPServer) AgentService(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	// Get the proxy ID. Note that this is the ID of a proxy's service instance.
+	id := strings.TrimPrefix(req.URL.Path, "/v1/agent/service/")
+
+	// DEPRECATED(managed-proxies) - remove this whole hack.
+	//
+	// Support managed proxies until they are removed entirely. Since built-in
+	// proxy will now use this endpoint, in order to not break managed proxies in
+	// the interim until they are removed, we need to mirror the default-setting
+	// behaviour they had. Rather than thread that through this whole method as
+	// special cases that need to be unwound later (and duplicate logic in the
+	// proxy config endpoint) just defer to that and then translater the response.
+	if managedProxy := s.agent.State.Proxy(id); managedProxy != nil {
+		// This is for a managed proxy, use the old endpoint's behaviour
+		req.URL.Path = "/v1/agent/connect/proxy/" + id
+		obj, err := s.AgentConnectProxyConfig(resp, req)
+		if err != nil {
+			return obj, err
+		}
+		proxyCfg, ok := obj.(*api.ConnectProxyConfig)
+		if !ok {
+			return nil, errors.New("internal error")
+		}
+		// These are all set by defaults so type checks are just sanity checks that
+		// should never fail.
+		port, ok := proxyCfg.Config["bind_port"].(int)
+		if !ok || port < 1 {
+			return nil, errors.New("invalid proxy config")
+		}
+		addr, ok := proxyCfg.Config["bind_address"].(string)
+		if !ok || addr == "" {
+			return nil, errors.New("invalid proxy config")
+		}
+		localAddr, ok := proxyCfg.Config["local_service_address"].(string)
+		if !ok || localAddr == "" {
+			return nil, errors.New("invalid proxy config")
+		}
+		// Old local_service_address was a host:port
+		localAddress, localPortRaw, err := net.SplitHostPort(localAddr)
+		if err != nil {
+			return nil, err
+		}
+		localPort, err := strconv.Atoi(localPortRaw)
+		if err != nil {
+			return nil, err
+		}
+
+		reply := &api.AgentService{
+			Kind:        api.ServiceKindConnectProxy,
+			ID:          proxyCfg.ProxyServiceID,
+			Service:     managedProxy.Proxy.ProxyService.Service,
+			Port:        port,
+			Address:     addr,
+			ContentHash: proxyCfg.ContentHash,
+			Proxy: &api.AgentServiceConnectProxyConfig{
+				DestinationServiceName: proxyCfg.TargetServiceName,
+				DestinationServiceID:   proxyCfg.TargetServiceID,
+				LocalServiceAddress:    localAddress,
+				LocalServicePort:       localPort,
+				Config:                 proxyCfg.Config,
+				Upstreams:              proxyCfg.Upstreams,
+			},
+		}
+		return reply, nil
+	}
+
+	// Maybe block
+	var queryOpts structs.QueryOptions
+	if parseWait(resp, req, &queryOpts) {
+		// parseWait returns an error itself
+		return nil, nil
+	}
+
+	// Parse the token
+	var token string
+	s.parseToken(req, &token)
+
+	// Parse hash specially. Eventually this should happen in parseWait and end up
+	// in QueryOptions but I didn't want to make very general changes right away.
+	hash := req.URL.Query().Get("hash")
+
+	return s.agentLocalBlockingQuery(resp, hash, &queryOpts,
+		func(ws memdb.WatchSet) (string, interface{}, error) {
+
+			svcState := s.agent.State.ServiceState(id)
+			if svcState == nil {
+				resp.WriteHeader(http.StatusNotFound)
+				fmt.Fprintf(resp, "unknown proxy service ID: %s", id)
+				return "", nil, nil
+			}
+
+			svc := svcState.Service
+
+			// Setup watch on the service
+			ws.Add(svcState.WatchCh)
+
+			// Check ACLs.
+			rule, err := s.agent.resolveToken(token)
+			if err != nil {
+				return "", nil, err
+			}
+			if rule != nil && !rule.ServiceRead(svc.Service) {
+				return "", nil, acl.ErrPermissionDenied
+			}
+
+			var connect *api.AgentServiceConnect
+			var proxy *api.AgentServiceConnectProxyConfig
+
+			if svc.Connect.Native {
+				connect = &api.AgentServiceConnect{
+					Native: svc.Connect.Native,
+				}
+			}
+
+			if svc.Kind == structs.ServiceKindConnectProxy {
+				proxy = svc.Proxy.ToAPI()
+			}
+
+			// Calculate the content hash over the response, minus the hash field
+			reply := &api.AgentService{
+				Kind:              api.ServiceKind(svc.Kind),
+				ID:                svc.ID,
+				Service:           svc.Service,
+				Tags:              svc.Tags,
+				Meta:              svc.Meta,
+				Port:              svc.Port,
+				Address:           svc.Address,
+				EnableTagOverride: svc.EnableTagOverride,
+				Proxy:             proxy,
+				Connect:           connect,
+			}
+
+			rawHash, err := hashstructure.Hash(reply, nil)
+			if err != nil {
+				return "", nil, err
+			}
+
+			// Include the ContentHash in the response body
+			reply.ContentHash = fmt.Sprintf("%x", rawHash)
+
+			return reply.ContentHash, reply, nil
+		})
 }
 
 func (s *HTTPServer) AgentChecks(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -1248,7 +1398,17 @@ func (s *HTTPServer) agentLocalBlockingQuery(resp http.ResponseWriter, hash stri
 			return curResp, err
 		}
 		// Watch returned false indicating a change was detected, loop and repeat
-		// the callback to load the new value.
+		// the callback to load the new value. If agent sync is paused it means
+		// local state is currently being bulk-edited e.g. config reload. In this
+		// case it's likely that local state just got unloaded and may or may not be
+		// reloaded yet. Wait a short amount of time for Sync to resume to ride out
+		// typical config reloads.
+		if syncPauseCh := s.agent.syncPausedCh(); syncPauseCh != nil {
+			select {
+			case <-syncPauseCh:
+			case <-timeout.C:
+			}
+		}
 	}
 }
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -225,6 +225,367 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 	})
 }
 
+func TestAgent_Service(t *testing.T) {
+	t.Parallel()
+
+	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	services {
+		name = "web"
+		port = 8181
+	}
+	`)
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	proxy := structs.TestConnectProxyConfig(t)
+	proxy.DestinationServiceID = "web1"
+
+	// Define a valid local sidecar proxy service
+	sidecarProxy := &structs.ServiceDefinition{
+		Kind: structs.ServiceKindConnectProxy,
+		Name: "web-sidecar-proxy",
+		Check: structs.CheckType{
+			TCP:      "127.0.0.1:8000",
+			Interval: 10 * time.Second,
+		},
+		Port:  8000,
+		Proxy: &proxy,
+	}
+
+	// Define an updated version. Be careful to copy it.
+	updatedProxy := *sidecarProxy
+	updatedProxy.Port = 9999
+
+	// Mangle the proxy config/upstreams into the expected for with defaults and
+	// API struct types.
+	expectProxy := proxy
+	expectProxy.Upstreams =
+		structs.TestAddDefaultsToUpstreams(t, sidecarProxy.Proxy.Upstreams)
+
+	expectedResponse := &api.AgentService{
+		Kind:        api.ServiceKindConnectProxy,
+		ID:          "web-sidecar-proxy",
+		Service:     "web-sidecar-proxy",
+		Port:        8000,
+		Proxy:       expectProxy.ToAPI(),
+		ContentHash: "26959a754e182054",
+	}
+
+	// Copy and modify
+	updatedResponse := *expectedResponse
+	updatedResponse.Port = 9999
+	updatedResponse.ContentHash = "1bdcf042660b33f6"
+
+	// Simple response for non-proxy service regustered in TestAgent config
+	expectWebResponse := &api.AgentService{
+		ID:          "web",
+		Service:     "web",
+		Port:        8181,
+		ContentHash: "7be2b0411161d3b1",
+	}
+
+	tests := []struct {
+		name       string
+		tokenRules string
+		url        string
+		updateFunc func()
+		wantWait   time.Duration
+		wantCode   int
+		wantErr    string
+		wantResp   *api.AgentService
+	}{
+		{
+			name:     "simple fetch - proxy",
+			url:      "/v1/agent/service/web-sidecar-proxy",
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+		{
+			name:     "simple fetch - non-proxy",
+			url:      "/v1/agent/service/web",
+			wantCode: 200,
+			wantResp: expectWebResponse,
+		},
+		{
+			name:     "blocking fetch timeout, no change",
+			url:      "/v1/agent/service/web-sidecar-proxy?hash=" + expectedResponse.ContentHash + "&wait=100ms",
+			wantWait: 100 * time.Millisecond,
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+		{
+			name:     "blocking fetch old hash should return immediately",
+			url:      "/v1/agent/service/web-sidecar-proxy?hash=123456789abcd&wait=10m",
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+		{
+			name: "blocking fetch returns change",
+			url:  "/v1/agent/service/web-sidecar-proxy?hash=" + expectedResponse.ContentHash,
+			updateFunc: func() {
+				time.Sleep(100 * time.Millisecond)
+				// Re-register with new proxy config, make sure we copy the struct so we
+				// don't alter it and affect later test cases.
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(updatedProxy))
+				resp := httptest.NewRecorder()
+				_, err := a.srv.AgentRegisterService(resp, req)
+				require.NoError(t, err)
+				require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+			},
+			wantWait: 100 * time.Millisecond,
+			wantCode: 200,
+			wantResp: &updatedResponse,
+		},
+		{
+			// This test exercises a case that caused a busy loop to eat CPU for the
+			// entire duration of the blocking query. If a service gets re-registered
+			// wth same proxy config then the old proxy config chan is closed causing
+			// blocked watchset.Watch to return false indicating a change. But since
+			// the hash is the same when the blocking fn is re-called we should just
+			// keep blocking on the next iteration. The bug hit was that the WatchSet
+			// ws was not being reset in the loop and so when you try to `Watch` it
+			// the second time it just returns immediately making the blocking loop
+			// into a busy-poll!
+			//
+			// This test though doesn't catch that because busy poll still has the
+			// correct external behaviour. I don't want to instrument the loop to
+			// assert it's not executing too fast here as I can't think of a clean way
+			// and the issue is fixed now so this test doesn't actually catch the
+			// error, but does provide an easy way to verify the behaviour by hand:
+			//  1. Make this test fail e.g. change wantErr to true
+			//  2. Add a log.Println or similar into the blocking loop/function
+			//  3. See whether it's called just once or many times in a tight loop.
+			name: "blocking fetch interrupted with no change (same hash)",
+			url:  "/v1/agent/service/web-sidecar-proxy?wait=200ms&hash=" + expectedResponse.ContentHash,
+			updateFunc: func() {
+				time.Sleep(100 * time.Millisecond)
+				// Re-register with _same_ proxy config
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(sidecarProxy))
+				resp := httptest.NewRecorder()
+				_, err := a.srv.AgentRegisterService(resp, req)
+				require.NoError(t, err)
+				require.Equal(t, 200, resp.Code, "body: %s", resp.Body.String())
+			},
+			wantWait: 200 * time.Millisecond,
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+		{
+			// When we reload config, the agent pauses Anti-entropy, then clears all
+			// services (which causes their watch chans to be closed) before loading
+			// state from config/snapshot again). If we do that naively then we don't
+			// just get a spurios wakeup on the watch if the service didn't change,
+			// but we get it wakeup and then race with the reload and probably see no
+			// services and return a 404 error which is gross. This test excercises
+			// that - even though the registrations were from API not config, they are
+			// persisted and cleared/reloaded from snapshot which has same effect.
+			//
+			// The fix for this test is to allow the same mechanism that pauses
+			// Anti-entropy during reload to also pause the hash blocking loop so we
+			// don't resume until the state is reloaded and we get a chance to see if
+			// it actually changed or not.
+			name: "blocking fetch interrupted by reload shouldn't 404 - no change",
+			url:  "/v1/agent/service/web-sidecar-proxy?wait=200ms&hash=" + expectedResponse.ContentHash,
+			updateFunc: func() {
+				time.Sleep(100 * time.Millisecond)
+				// Reload
+				require.NoError(t, a.ReloadConfig(a.Config))
+			},
+			// Should eventually timeout since there is no actual change
+			wantWait: 200 * time.Millisecond,
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+		{
+			// As above but test actually altering the service with the config reload.
+			// This simulates the API registration being overridden by a different one
+			// on disk during reload.
+			name: "blocking fetch interrupted by reload shouldn't 404 - changes",
+			url:  "/v1/agent/service/web-sidecar-proxy?wait=10m&hash=" + expectedResponse.ContentHash,
+			updateFunc: func() {
+				time.Sleep(100 * time.Millisecond)
+				// Reload
+				newConfig := *a.Config
+				newConfig.Services = append(newConfig.Services, &updatedProxy)
+				require.NoError(t, a.ReloadConfig(&newConfig))
+			},
+			wantWait: 100 * time.Millisecond,
+			wantCode: 200,
+			wantResp: &updatedResponse,
+		},
+		{
+			name:     "err: non-existent proxy",
+			url:      "/v1/agent/service/nope",
+			wantCode: 404,
+		},
+		{
+			name: "err: bad ACL for service",
+			url:  "/v1/agent/service/web-sidecar-proxy",
+			// Limited token doesn't grant read to the service
+			tokenRules: `
+			key "" {
+				policy = "read"
+			}
+			`,
+			// Note that because we return ErrPermissionDenied and handle writing
+			// status at a higher level helper this actually gets a 200 in this test
+			// case so just assert that it was an error.
+			wantErr: "Permission denied",
+		},
+		{
+			name: "good ACL for service",
+			url:  "/v1/agent/service/web-sidecar-proxy",
+			// Limited token doesn't grant read to the service
+			tokenRules: `
+			service "web-sidecar-proxy" {
+				policy = "read"
+			}
+			`,
+			wantCode: 200,
+			wantResp: expectedResponse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			// Register the basic service to ensure it's in a known state to start.
+			{
+				req, _ := http.NewRequest("PUT", "/v1/agent/service/register?token=root", jsonReader(sidecarProxy))
+				resp := httptest.NewRecorder()
+				_, err := a.srv.AgentRegisterService(resp, req)
+				require.NoError(err)
+				require.Equal(200, resp.Code, "body: %s", resp.Body.String())
+			}
+
+			req, _ := http.NewRequest("GET", tt.url, nil)
+
+			// Inject the root token for tests that don't care about ACL
+			var token = "root"
+			if tt.tokenRules != "" {
+				// Create new token and use that.
+				token = testCreateToken(t, a, tt.tokenRules)
+			}
+			req.Header.Set("X-Consul-Token", token)
+			resp := httptest.NewRecorder()
+			if tt.updateFunc != nil {
+				go tt.updateFunc()
+			}
+			start := time.Now()
+			obj, err := a.srv.AgentService(resp, req)
+			elapsed := time.Now().Sub(start)
+
+			if tt.wantErr != "" {
+				require.Error(err)
+				require.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.wantErr))
+			} else {
+				require.NoError(err)
+			}
+			if tt.wantCode != 0 {
+				require.Equal(tt.wantCode, resp.Code, "body: %s", resp.Body.String())
+			}
+			if tt.wantWait != 0 {
+				assert.True(elapsed >= tt.wantWait, "should have waited at least %s, "+
+					"took %s", tt.wantWait, elapsed)
+			} else {
+				assert.True(elapsed < 10*time.Millisecond, "should not have waited, "+
+					"took %s", elapsed)
+			}
+
+			if tt.wantResp != nil {
+				assert.Equal(tt.wantResp, obj)
+				assert.Equal(tt.wantResp.ContentHash, resp.Header().Get("X-Consul-ContentHash"))
+			} else {
+				// Janky but Equal doesn't help here because nil !=
+				// *api.AgentService((*api.AgentService)(nil))
+				assert.Nil(obj)
+			}
+		})
+	}
+}
+
+// DEPRECATED(managed-proxies) - remove this In the interim, we need the newer
+// /agent/service/service to work for managed proxies so we can swithc the built
+// in proxy to use only that without breaking managed proxies early.
+func TestAgent_Service_DeprecatedManagedProxy(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t.Name(), `
+		connect {
+			proxy {
+				allow_managed_api_registration = true
+			}
+		}
+	`)
+	defer a.Shutdown()
+
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	svc := &structs.ServiceDefinition{
+		Name: "web",
+		Port: 8000,
+		Check: structs.CheckType{
+			TTL: 10 * time.Second,
+		},
+		Connect: &structs.ServiceConnect{
+			Proxy: &structs.ServiceDefinitionConnectProxy{
+				// Fix the command otherwise the executable path ends up being random
+				// temp dir in every test run so the ContentHash will never match.
+				Command: []string{"foo"},
+				Config: map[string]interface{}{
+					"foo":          "bar",
+					"bind_address": "10.10.10.10",
+					"bind_port":    9999, // make this deterministic
+				},
+				Upstreams: structs.TestUpstreams(t),
+			},
+		},
+	}
+
+	require := require.New(t)
+
+	rr := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("POST", "/v1/agent/services/register", jsonReader(svc))
+	_, err := a.srv.AgentRegisterService(rr, req)
+	require.NoError(err)
+	require.Equal(200, rr.Code, "body:\n"+rr.Body.String())
+
+	rr = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", "/v1/agent/service/web-proxy", nil)
+	obj, err := a.srv.AgentService(rr, req)
+	require.NoError(err)
+	require.Equal(200, rr.Code, "body:\n"+rr.Body.String())
+
+	gotService, ok := obj.(*api.AgentService)
+	require.True(ok)
+
+	expect := &api.AgentService{
+		Kind:        api.ServiceKindConnectProxy,
+		ID:          "web-proxy",
+		Service:     "web-proxy",
+		Port:        9999,
+		Address:     "10.10.10.10",
+		ContentHash: "e24f099e42e88317",
+		Proxy: &api.AgentServiceConnectProxyConfig{
+			DestinationServiceID:   "web",
+			DestinationServiceName: "web",
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       8000,
+			Config: map[string]interface{}{
+				"foo":                   "bar",
+				"bind_port":             9999,
+				"bind_address":          "10.10.10.10",
+				"local_service_address": "127.0.0.1:8000",
+			},
+			Upstreams: structs.TestAddDefaultsToUpstreams(t, svc.Connect.Proxy.Upstreams).ToAPI(),
+		},
+	}
+
+	require.Equal(expect, gotService)
+}
+
 func TestAgent_Checks(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t.Name(), "")
@@ -1579,38 +1940,49 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 					},
 				},
 			},
-			SidecarService: &structs.ServiceDefinition{
-				Name: "test-proxy",
-				Meta: map[string]string{
-					"some":                "meta",
-					"enable_tag_override": "sidecar_service.meta is 'opaque' so should not get translated",
-				}, Port: 8001,
-				EnableTagOverride: true,
-				Kind:              structs.ServiceKindConnectProxy,
-				Proxy: &structs.ConnectProxyConfig{
-					DestinationServiceName: "test",
-					DestinationServiceID:   "test",
-					LocalServiceAddress:    "127.0.0.1",
-					LocalServicePort:       4321,
-					Upstreams: structs.Upstreams{
-						{
-							DestinationType:      structs.UpstreamDestTypeService,
-							DestinationName:      "db",
-							DestinationNamespace: "default",
-							LocalBindAddress:     "127.0.0.1",
-							LocalBindPort:        1234,
-							Config: map[string]interface{}{
-								"destination_type": "sidecar_service.proxy.upstreams.config is 'opaque' so should not get translated",
-							},
-						},
+			// The sidecar service is nilled since it is only config sugar and
+			// shouldn't be represented in state. We assert that the translations
+			// there worked by inspecting the registered sidecar below.
+			SidecarService: nil,
+		},
+	}
+
+	got := a.State.Service("test")
+	require.Equal(t, svc, got)
+
+	sidecarSvc := &structs.NodeService{
+		Kind:    structs.ServiceKindConnectProxy,
+		ID:      "test-sidecar-proxy",
+		Service: "test-proxy",
+		Meta: map[string]string{
+			"some":                "meta",
+			"enable_tag_override": "sidecar_service.meta is 'opaque' so should not get translated",
+		},
+		Port:                       8001,
+		EnableTagOverride:          true,
+		LocallyRegisteredAsSidecar: true,
+		Proxy: structs.ConnectProxyConfig{
+			DestinationServiceName: "test",
+			DestinationServiceID:   "test",
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       4321,
+			Upstreams: structs.Upstreams{
+				{
+					DestinationType:      structs.UpstreamDestTypeService,
+					DestinationName:      "db",
+					DestinationNamespace: "default",
+					LocalBindAddress:     "127.0.0.1",
+					LocalBindPort:        1234,
+					Config: map[string]interface{}{
+						"destination_type": "sidecar_service.proxy.upstreams.config is 'opaque' so should not get translated",
 					},
 				},
 			},
 		},
 	}
 
-	got := a.State.Service("test")
-	require.Equal(t, svc, got)
+	gotSidecar := a.State.Service("test-sidecar-proxy")
+	require.Equal(t, sidecarSvc, gotSidecar)
 }
 
 func TestAgent_RegisterService_ACLDeny(t *testing.T) {
@@ -1962,6 +2334,21 @@ func testDefaultSidecar(svc string, port int, fns ...func(*structs.NodeService))
 		fn(ns)
 	}
 	return ns
+}
+
+func testCreateToken(t *testing.T, a *TestAgent, rules string) string {
+	args := map[string]interface{}{
+		"Name":  "User Token",
+		"Type":  "client",
+		"Rules": rules,
+	}
+	req, _ := http.NewRequest("PUT", "/v1/acl/create?token=root", jsonReader(args))
+	resp := httptest.NewRecorder()
+	obj, err := a.srv.ACLCreate(resp, req)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	aclResp := obj.(aclCreateResponse)
+	return aclResp.ID
 }
 
 // This tests local agent service registration with a sidecar service. Note we
@@ -2347,18 +2734,7 @@ func TestAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T) {
 			// Create an ACL token with require policy
 			var token string
 			if tt.enableACL && tt.tokenRules != "" {
-				args := map[string]interface{}{
-					"Name":  "User Token",
-					"Type":  "client",
-					"Rules": tt.tokenRules,
-				}
-				req, _ := http.NewRequest("PUT", "/v1/acl/create?token=root", jsonReader(args))
-				resp := httptest.NewRecorder()
-				obj, err := a.srv.ACLCreate(resp, req)
-				require.NoError(err)
-				require.NotNil(obj)
-				aclResp := obj.(aclCreateResponse)
-				token = aclResp.ID
+				token = testCreateToken(t, a, tt.tokenRules)
 			}
 
 			br := bytes.NewBufferString(tt.json)

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -18,6 +18,7 @@ func init() {
 	registerEndpoint("/v1/agent/monitor", []string{"GET"}, (*HTTPServer).AgentMonitor)
 	registerEndpoint("/v1/agent/metrics", []string{"GET"}, (*HTTPServer).AgentMetrics)
 	registerEndpoint("/v1/agent/services", []string{"GET"}, (*HTTPServer).AgentServices)
+	registerEndpoint("/v1/agent/service/", []string{"GET"}, (*HTTPServer).AgentService)
 	registerEndpoint("/v1/agent/checks", []string{"GET"}, (*HTTPServer).AgentChecks)
 	registerEndpoint("/v1/agent/members", []string{"GET"}, (*HTTPServer).AgentMembers)
 	registerEndpoint("/v1/agent/join/", []string{"PUT"}, (*HTTPServer).AgentJoin)

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -51,10 +51,16 @@ type ServiceState struct {
 	// Deleted is true when the service record has been marked as deleted
 	// but has not been removed on the server yet.
 	Deleted bool
+
+	// WatchCh is closed when the service state changes suitable for use in a
+	// memdb.WatchSet when watching agent local changes with hash-based blocking.
+	WatchCh chan struct{}
 }
 
-// Clone returns a shallow copy of the object. The service record still
-// points to the original service record and must not be modified.
+// Clone returns a shallow copy of the object. The service record still points
+// to the original service record and must not be modified. The WatchCh is also
+// still pointing to the original so the clone will be update when the original
+// is.
 func (s *ServiceState) Clone() *ServiceState {
 	s2 := new(ServiceState)
 	*s2 = *s
@@ -279,6 +285,10 @@ func (l *State) RemoveService(id string) error {
 	// entry around until it is actually removed.
 	s.InSync = false
 	s.Deleted = true
+	if s.WatchCh != nil {
+		close(s.WatchCh)
+		s.WatchCh = nil
+	}
 	l.TriggerSyncChanges()
 
 	return nil
@@ -313,9 +323,10 @@ func (l *State) Services() map[string]*structs.NodeService {
 	return m
 }
 
-// ServiceState returns a shallow copy of the current service state
-// record. The service record still points to the original service
-// record and must not be modified.
+// ServiceState returns a shallow copy of the current service state record. The
+// service record still points to the original service record and must not be
+// modified. The WatchCh for the copy returned will also be closed when the
+// actual service state is changed.
 func (l *State) ServiceState(id string) *ServiceState {
 	l.RLock()
 	defer l.RUnlock()
@@ -334,7 +345,15 @@ func (l *State) SetServiceState(s *ServiceState) {
 	l.Lock()
 	defer l.Unlock()
 
+	s.WatchCh = make(chan struct{})
+
+	old, hasOld := l.services[s.Service.ID]
 	l.services[s.Service.ID] = s
+
+	if hasOld && old.WatchCh != nil {
+		close(old.WatchCh)
+	}
+
 	l.TriggerSyncChanges()
 }
 
@@ -408,13 +427,13 @@ func (l *State) AddCheck(check *structs.HealthCheck, token string) error {
 	return nil
 }
 
-// AddAliasCheck creates an alias check. When any check for the srcServiceID
-// is changed, checkID will reflect that using the same semantics as
+// AddAliasCheck creates an alias check. When any check for the srcServiceID is
+// changed, checkID will reflect that using the same semantics as
 // checks.CheckAlias.
 //
-// This is a local optimization so that the Alias check doesn't need to
-// use blocking queries against the remote server for check updates for
-// local services.
+// This is a local optimization so that the Alias check doesn't need to use
+// blocking queries against the remote server for check updates for local
+// services.
 func (l *State) AddAliasCheck(checkID types.CheckID, srcServiceID string, notifyCh chan<- struct{}) error {
 	l.Lock()
 	defer l.Unlock()

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -373,6 +373,91 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	assert.Nil(servicesInSync(a.State, 3))
 }
 
+func TestAgent_ServiceWatchCh(t *testing.T) {
+	t.Parallel()
+	a := &agent.TestAgent{Name: t.Name()}
+	a.Start()
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	require := require.New(t)
+
+	// register a local service
+	srv1 := &structs.NodeService{
+		ID:      "svc_id1",
+		Service: "svc1",
+		Tags:    []string{"tag1"},
+		Port:    6100,
+	}
+	require.NoError(a.State.AddService(srv1, ""))
+
+	verifyState := func(ss *local.ServiceState) {
+		require.NotNil(ss)
+		require.NotNil(ss.WatchCh)
+
+		// Sanity check WatchCh blocks
+		select {
+		case <-ss.WatchCh:
+			t.Fatal("should block until service changes")
+		default:
+		}
+	}
+
+	// Should be able to get a ServiceState
+	ss := a.State.ServiceState(srv1.ID)
+	verifyState(ss)
+
+	// Update service in another go routine
+	go func() {
+		srv2 := srv1
+		srv2.Port = 6200
+		require.NoError(a.State.AddService(srv2, ""))
+	}()
+
+	// We should observe WatchCh close
+	select {
+	case <-ss.WatchCh:
+		// OK!
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for WatchCh to close")
+	}
+
+	// Should also fire for state being set explicitly
+	ss = a.State.ServiceState(srv1.ID)
+	verifyState(ss)
+
+	go func() {
+		a.State.SetServiceState(&local.ServiceState{
+			Service: ss.Service,
+			Token:   "foo",
+		})
+	}()
+
+	// We should observe WatchCh close
+	select {
+	case <-ss.WatchCh:
+		// OK!
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for WatchCh to close")
+	}
+
+	// Should also fire for service being removed
+	ss = a.State.ServiceState(srv1.ID)
+	verifyState(ss)
+
+	go func() {
+		require.NoError(a.State.RemoveService(srv1.ID))
+	}()
+
+	// We should observe WatchCh close
+	select {
+	case <-ss.WatchCh:
+		// OK!
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timeout waiting for WatchCh to close")
+	}
+}
+
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name()}

--- a/agent/proxyprocess/proxy.go
+++ b/agent/proxyprocess/proxy.go
@@ -20,6 +20,11 @@ const (
 	// EnvProxyToken is the name of the environment variable that is passed
 	// to managed proxies containing the proxy token.
 	EnvProxyToken = "CONNECT_PROXY_TOKEN"
+
+	// EnvSidecarFor is the name of the environment variable that is set for
+	// sidecar proxies containing the service ID of their target on the local
+	// agent
+	EnvSidecarFor = "CONNECT_SIDECAR_FOR"
 )
 
 // Proxy is the interface implemented by all types of managed proxies.

--- a/agent/structs/testing_connect_proxy_config.go
+++ b/agent/structs/testing_connect_proxy_config.go
@@ -39,7 +39,7 @@ func TestUpstreams(t testing.T) Upstreams {
 // TestUpstreams) and adds default values that are populated during
 // refigistration. Use this for generating the expected Upstreams value after
 // registration.
-func TestAddDefaultsToUpstreams(t testing.T, upstreams []Upstream) []Upstream {
+func TestAddDefaultsToUpstreams(t testing.T, upstreams []Upstream) Upstreams {
 	ups := make([]Upstream, len(upstreams))
 	for i := range upstreams {
 		ups[i] = upstreams[i]

--- a/api/agent.go
+++ b/api/agent.go
@@ -75,6 +75,7 @@ type AgentService struct {
 	EnableTagOverride bool
 	CreateIndex       uint64 `json:",omitempty"`
 	ModifyIndex       uint64 `json:",omitempty"`
+	ContentHash       string `json:",omitempty"`
 	// DEPRECATED (ProxyDestination) - remove this field
 	ProxyDestination string                          `json:",omitempty"`
 	Proxy            *AgentServiceConnectProxyConfig `json:",omitempty"`
@@ -254,10 +255,12 @@ type ConnectProxyConfig struct {
 	TargetServiceID   string
 	TargetServiceName string
 	ContentHash       string
-	ExecMode          ProxyExecMode
-	Command           []string
-	Config            map[string]interface{}
-	Upstreams         []Upstream
+	// DEPRECATED(managed-proxies) - this struct is re-used for sidecar configs
+	// but they don't need ExecMode or Command
+	ExecMode  ProxyExecMode `json:",omitempty"`
+	Command   []string      `json:",omitempty"`
+	Config    map[string]interface{}
+	Upstreams []Upstream
 }
 
 // Upstream is the response structure for a proxy upstream configuration.
@@ -374,6 +377,33 @@ func (a *Agent) Services() (map[string]*AgentService, error) {
 	}
 
 	return out, nil
+}
+
+// Service returns a locally registered service instance and allows for
+// hash-based blocking.
+//
+// Note that this uses an unconventional blocking mechanism since it's
+// agent-local state. That means there is no persistent raft index so we block
+// based on object hash instead.
+func (a *Agent) Service(serviceID string, q *QueryOptions) (*AgentService, *QueryMeta, error) {
+	r := a.c.newRequest("GET", "/v1/agent/service/"+serviceID)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out *AgentService
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+
+	return out, qm, nil
 }
 
 // Members returns the known gossip members. The WAN

--- a/command/watch/watch.go
+++ b/command/watch/watch.go
@@ -135,7 +135,7 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	if strings.HasPrefix(wp.Type, "connect_") {
+	if strings.HasPrefix(wp.Type, "connect_") || strings.HasPrefix(wp.Type, "agent_") {
 		c.UI.Error(fmt.Sprintf("Type %s is not supported in the CLI tool", wp.Type))
 		return 1
 	}

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -53,3 +53,23 @@ func TestWatchCommandNoConnect(t *testing.T) {
 		t.Fatalf("bad: %#v", ui.ErrorWriter.String())
 	}
 }
+
+func TestWatchCommandNoAgentService(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), ``)
+	defer a.Shutdown()
+
+	ui := cli.NewMockUi()
+	c := New(ui, nil)
+	args := []string{"-http-addr=" + a.HTTPAddr(), "-type=agent_service"}
+
+	code := c.Run(args)
+	if code != 1 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+
+	if !strings.Contains(ui.ErrorWriter.String(),
+		"Type agent_service is not supported in the CLI tool") {
+		t.Fatalf("bad: %#v", ui.ErrorWriter.String())
+	}
+}

--- a/connect/tls.go
+++ b/connect/tls.go
@@ -3,6 +3,8 @@ package connect
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -81,6 +83,33 @@ func devTLSConfigFromFiles(caFile, certFile,
 	cfg.ClientCAs = roots
 
 	return cfg, nil
+}
+
+// PKIXNameFromRawSubject attempts to parse a DER encoded "Subject" as a PKIX
+// Name. It's useful for inspecting root certificates in an x509.CertPool which
+// only expose RawSubject via the Subjects method.
+func PKIXNameFromRawSubject(raw []byte) (*pkix.Name, error) {
+	var subject pkix.RDNSequence
+	if _, err := asn1.Unmarshal(raw, &subject); err != nil {
+		return nil, err
+	}
+	var name pkix.Name
+	name.FillFromRDNSequence(&subject)
+	return &name, nil
+}
+
+// CommonNamesFromCertPool returns the common names of the certificates in the
+// cert pool.
+func CommonNamesFromCertPool(p *x509.CertPool) ([]string, error) {
+	var names []string
+	for _, rawSubj := range p.Subjects() {
+		n, err := PKIXNameFromRawSubject(rawSubj)
+		if err != nil {
+			return nil, err
+		}
+		names = append(names, n.CommonName)
+	}
+	return names, nil
 }
 
 // CertURIFromConn is a helper to extract the service identifier URI from a


### PR DESCRIPTION
**Note:** this PR is against `f-envoy` and additionally depends on #4686 which adds the basic `SidecarService` mechanism.

## In this PR
 - A new endpoint `/v1/agent/service/:service_id` which is a generic way to look up the service for a single instance. The primary value here is that it:
   - **supports hash-based blocking** and so;
   - **replaces `/agent/connect/proxy/:proxy_id`** as the mechanism the built-in proxy uses to read its config.
   - It's not proxy specific and so works for any service.
   - It has a temporary shim to call through to the existing endpoint to preserve current managed proxy config defaulting behaviour until that is removed entirely (tested).
 - The built-in proxy now uses the new endpoint exclusively for it's config
 - The built-in proxy now has a `-sidecar-for` flag that allows the service ID of the _target_ service to be specified, on the condition that there is exactly one "sidecar" proxy (that is one that has `Proxy.DestinationServiceID` set) for the service registered.
 - Several fixes for edge cases for SidecarService
 - A fix for `Alias` checks - when running locally they didn't update their state until some external thing updated the target. If the target service has no checks registered as below, then the alias never made it past critical.

## Demo 🎉 

```
$ cat api.hcl
services {
  name = "api"
  port = 8080
  connect {
    sidecar_service {
      proxy {
          upstreams = [
          {
            destination_name = "db"
            local_bind_port = 7000
          },
        ]
      }
    }
  }
}
$ consul agent -dev -config-dir .
```

In another terminal:
```
$ consul connect proxy -sidecar-for api
==> Consul Connect proxy starting...
    Configuration mode: Agent API
        Sidecar for ID: api
              Proxy ID: api-sidecar-proxy

==> Log data will now stream in as it occurs:

    2018/09/18 16:44:19 [INFO] 127.0.0.1:7000->service:default/db starting on 127.0.0.1:7000
    2018/09/18 16:44:19 [INFO] Proxy loaded config and ready to serve
    2018/09/18 16:44:19 [INFO] TLS Identity: spiffe://a77e3a01-a43b-a3a3-076b-4eb0161209db.consul/ns/default/dc/dc1/svc/api
    2018/09/18 16:44:19 [INFO] TLS Roots   : [Consul CA 7]
    2018/09/18 16:44:19 [INFO] public listener starting on 0.0.0.0:21000
```

Update and reload:
```
$ cat api.hcl
services {
  name = "api"
  port = 8080
  connect {
    sidecar_service {
      proxy {
          upstreams = [
          {
            destination_name = "db"
            local_bind_port = 7000
          },
          {
            destination_name = "cache"
            local_bind_port = 9192
          },
        ]
      }
    }
  }
}
$ consul reload
```

Same proxy instance:
```
$ consul connect proxy -sidecar-for api
...
    2018/09/18 16:44:19 [INFO] public listener starting on 0.0.0.0:21000
    2018/09/18 16:45:44 [INFO] 127.0.0.1:7000->service:default/db starting on 127.0.0.1:7000
    2018/09/18 16:45:44 [INFO] 127.0.0.1:9192->service:default/cache starting on 127.0.0.1:9192
```

There is another known issue around the built in proxy no properly diffing the upstreams so technically there is an additional spurious error here but that is not new.

End to end tests with socat etc. work.