### PR TITLE
Do not bootstrap with non voters

### DIFF
--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	RaftVersion  int
 	Addr         net.Addr
 	Status       serf.MemberStatus
+	NonVoter     bool
 
 	// If true, use TLS when connecting to this server
 	UseTLS bool
@@ -139,6 +140,9 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		}
 	}
 
+	// Check if the server is a non voter
+	_, nonVoter := m.Tags["nonvoter"]
+
 	addr := &net.TCPAddr{IP: m.Addr, Port: port}
 
 	parts := &Server{
@@ -158,6 +162,7 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 		RaftVersion:  raftVsn,
 		Status:       m.Status,
 		UseTLS:       useTLS,
+		NonVoter:     nonVoter,
 	}
 	return true, parts
 }

--- a/agent/metadata/server_test.go
+++ b/agent/metadata/server_test.go
@@ -65,6 +65,7 @@ func TestIsConsulServer(t *testing.T) {
 			"expect":        "3",
 			"raft_vsn":      "3",
 			"use_tls":       "1",
+			"nonvoter":      "1",
 		},
 		Status: serf.StatusLeft,
 	}
@@ -99,6 +100,9 @@ func TestIsConsulServer(t *testing.T) {
 	if !parts.UseTLS {
 		t.Fatalf("bad: %v", parts.UseTLS)
 	}
+	if !parts.NonVoter {
+		t.Fatalf("unexpected voter")
+	}
 	m.Tags["bootstrap"] = "1"
 	m.Tags["disabled"] = "1"
 	ok, parts = metadata.IsConsulServer(m)
@@ -123,6 +127,12 @@ func TestIsConsulServer(t *testing.T) {
 	}
 	if parts.Bootstrap {
 		t.Fatalf("unexpected bootstrap")
+	}
+
+	delete(m.Tags, "nonvoter")
+	ok, parts = metadata.IsConsulServer(m)
+	if !ok || parts.NonVoter {
+		t.Fatalf("unexpected nonvoter")
 	}
 
 	delete(m.Tags, "role")


### PR DESCRIPTION
Fixes an issue a cluster could be bootstrapped by promoting non voting servers
to voters. The fix is to not bootstrap unless bootstrap expect is reached with
voting servers only.