### PR TITLE
ui: Layout fix. Small padding additions to tables

### DIFF
--- a/ui-v2/app/styles/routes/dc/service/index.scss
+++ b/ui-v2/app/styles/routes/dc/service/index.scss
@@ -11,3 +11,7 @@ html.template-service.template-list td.tags span,
 html.template-service.template-show main dd span {
   @extend %pill;
 }
+html.template-node.template-show #services th:first-child,
+html.template-service.template-list main th:first-child {
+  text-indent: 28px;
+}

--- a/ui-v2/app/templates/dc/nodes/-services.hbs
+++ b/ui-v2/app/templates/dc/nodes/-services.hbs
@@ -17,7 +17,7 @@
             <td data-test-service-name="{{item.Service}}">
               <a href={{href-to 'dc.services.show' item.Service}}>
                 <span data-test-external-source="{{service/external-source item}}" style="background-image: {{css-var (concat '--' (service/external-source item) '-color-svg') 'none'}}"></span>
-                {{item.Service}}{{#if (not-eq item.ID item.Service) }}<em data-test-service-id="{{item.ID}}">({{item.ID}})</em>{{/if}}
+                {{item.Service}}{{#if (not-eq item.ID item.Service) }} <em data-test-service-id="{{item.ID}}">({{item.ID}})</em>{{/if}}
               </a>
             </td>
             <td data-test-service-port="{{item.Port}}" class="port">


### PR DESCRIPTION
1. The 'Services' header need to be knocked ot the right slightly to line
up properly with the service name when there are no external source
icons.

## 'Services' Header Before:

![screen_shot_2018-09-20_at_12_10_25](https://user-images.githubusercontent.com/554604/45814692-4c0ceb00-bcce-11e8-9fdd-3c63f20d3ae0.png)

## 'Services' Header After:

<img width="246" alt="screen_shot_2018-09-20_at_12_10_39" src="https://user-images.githubusercontent.com/554604/45814718-5d55f780-bcce-11e8-8318-f404ded5680d.png">


2. Add a single space between ServiceName and ServiceID on the Node >
[Services] tab table.

## Node > [Services] Table Before:

![screen_shot_2018-09-20_at_12_12_54](https://user-images.githubusercontent.com/554604/45814793-a443ed00-bcce-11e8-8fc8-8fac75ca14bf.png)

## Node > [Services] Table After:

<img width="390" alt="screen_shot_2018-09-20_at_12_13_18" src="https://user-images.githubusercontent.com/554604/45814812-b887ea00-bcce-11e8-96c4-bf8d0b62930c.png">




