### PR TITLE
UI: format-number toLocaleString options

### DIFF
--- a/ui-v2/app/components/tomography-graph.js
+++ b/ui-v2/app/components/tomography-graph.js
@@ -7,7 +7,7 @@ const inset = function(num) {
   return insetSize * num;
 };
 const milliseconds = function(num, max) {
-  return max > 0 ? parseFloat((parseInt(max * num) / 100).toFixed(2)) : 0;
+  return max > 0 ? parseInt(max * num) / 100 : 0;
 };
 export default Component.extend({
   size: size,

--- a/ui-v2/app/helpers/format-number.js
+++ b/ui-v2/app/helpers/format-number.js
@@ -2,8 +2,10 @@ import { helper } from '@ember/component/helper';
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
 // the actual helper
-const toLocaleString = function(num) {
-  return num.toLocaleString();
+const toLocaleString = function(num, options) {
+  // TODO: If I make locale configurable use an option
+  // not mutiple arguments
+  return num.toLocaleString(undefined, options);
 };
 // wrap this up to help with testing the unit
 export function callIfType(type) {
@@ -12,7 +14,7 @@ export function callIfType(type) {
       if (typeof params[0] !== type) {
         return params[0];
       }
-      return cb(params[0]);
+      return cb(params[0], hash);
     };
   };
 }

--- a/ui-v2/app/templates/components/tomography-graph.hbs
+++ b/ui-v2/app/templates/components/tomography-graph.hbs
@@ -16,19 +16,19 @@
             <circle class="point" r="5"/>
             <g class="tick" transform="translate(0, {{labels.[0]}})">
                 <line x2="70"/>
-                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[0]}}ms</text>
+                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[0] maximumFractionDigits=2}}ms</text>
             </g>
             <g class="tick" transform="translate(0, {{labels.[1]}})">
                 <line x2="70"/>
-                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[1]}}ms</text>
+                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[1] maximumFractionDigits=2}}ms</text>
             </g>
             <g class="tick" transform="translate(0, {{labels.[2]}})">
                 <line x2="70"/>
-                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[2]}}ms</text>
+                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[2] maximumFractionDigits=2}}ms</text>
             </g>
             <g class="tick" transform="translate(0, {{labels.[3]}})">
                 <line x2="70"/>
-                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[3]}}ms</text>
+                <text x="75" y="0" dy=".32em">{{format-number milliseconds.[3] maximumFractionDigits=2}}ms</text>
             </g>
         </g>
     </g>

--- a/ui-v2/app/templates/dc/nodes/-rtt.hbs
+++ b/ui-v2/app/templates/dc/nodes/-rtt.hbs
@@ -3,19 +3,19 @@
         Minimum
     </dt>
     <dd>
-        {{ format-number tomography.min }}ms
+        {{ format-number tomography.min maximumFractionDigits=2}}ms
     </dd>
     <dt>
         Median
     </dt>
     <dd>
-        {{ format-number tomography.median }}ms
+        {{ format-number tomography.median maximumFractionDigits=2}}ms
     </dd>
     <dt>
         Maximum
     </dt>
     <dd>
-        {{ format-number tomography.max }}ms
+        {{ format-number tomography.max maximumFractionDigits=2}}ms
     </dd>
 </dl>
 {{tomography-graph tomography=tomography}}


### PR DESCRIPTION
See #4677 

Adds passing through the toLocaleString options via the helper. There are questions over browser support here - but it's edge casey.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#Parameters
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#Browser_compatibility

I'm fine merging it if it's approved by someone else.