### PR TITLE
Support multiple tags for health and catalog http api endpoints

### DIFF
--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -188,7 +188,7 @@ func (s *HTTPServer) catalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	// Check for a tag
 	params := req.URL.Query()
 	if _, ok := params["tag"]; ok {
-		args.ServiceTag = params.Get("tag")
+		args.ServiceTags = params["tag"]
 		args.TagFilter = true
 	}
 

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -273,7 +273,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			}
 
 			if args.TagFilter {
-				return s.ServiceTagNodes(ws, args.ServiceName, args.ServiceTag)
+				return s.ServiceTagNodes(ws, args.ServiceName, args.ServiceTags)
 			}
 
 			return s.ServiceNodes(ws, args.ServiceName)
@@ -333,6 +333,14 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 		if args.ServiceTag != "" {
 			metrics.IncrCounterWithLabels([]string{"catalog", key, "query-tag"}, 1,
 				[]metrics.Label{{Name: "service", Value: args.ServiceName}, {Name: "tag", Value: args.ServiceTag}})
+		}
+		if len(args.ServiceTags) > 0 {
+			// Build metric labels
+			labels := []metrics.Label{{Name: "service", Value: args.ServiceName}}
+			for _, tag := range args.ServiceTags {
+				labels = append(labels, metrics.Label{Name: "tag", Value: tag})
+			}
+			metrics.IncrCounterWithLabels([]string{"catalog", key, "query-tags"}, 1, labels)
 		}
 		if len(reply.ServiceNodes) == 0 {
 			metrics.IncrCounterWithLabels([]string{"catalog", key, "not-found"}, 1,

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -1589,7 +1589,7 @@ func TestCatalog_ListServiceNodes(t *testing.T) {
 	args := structs.ServiceSpecificRequest{
 		Datacenter:  "dc1",
 		ServiceName: "db",
-		ServiceTag:  "slave",
+		ServiceTags: []string{"slave"},
 		TagFilter:   false,
 	}
 	var out structs.IndexedServiceNodes
@@ -1647,16 +1647,16 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 	if err := s1.fsm.State().EnsureNode(2, node2); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s1.fsm.State().EnsureService(3, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000}); err != nil {
+	if err := s1.fsm.State().EnsureService(3, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary", "v2"}, Address: "127.0.0.1", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s1.fsm.State().EnsureService(4, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"secondary"}, Address: "127.0.0.2", Port: 5000}); err != nil {
+	if err := s1.fsm.State().EnsureService(4, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"secondary", "v2"}, Address: "127.0.0.2", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	cases := []struct {
 		filters  map[string]string
-		tag      string
+		tags     []string
 		services structs.ServiceNodes
 	}{
 		// Basic meta filter
@@ -1667,7 +1667,7 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 		// Basic meta filter, tag
 		{
 			filters:  map[string]string{"somekey": "somevalue"},
-			tag:      "primary",
+			tags:     []string{"primary"},
 			services: structs.ServiceNodes{&structs.ServiceNode{Node: "foo", ServiceID: "db"}},
 		},
 		// Common meta filter
@@ -1681,7 +1681,7 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 		// Common meta filter, tag
 		{
 			filters: map[string]string{"common": "1"},
-			tag:     "secondary",
+			tags:    []string{"secondary"},
 			services: structs.ServiceNodes{
 				&structs.ServiceNode{Node: "bar", ServiceID: "db2"},
 			},
@@ -1699,7 +1699,22 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 		// Multiple filter values, tag
 		{
 			filters:  map[string]string{"somekey": "somevalue", "common": "1"},
-			tag:      "primary",
+			tags:     []string{"primary"},
+			services: structs.ServiceNodes{&structs.ServiceNode{Node: "foo", ServiceID: "db"}},
+		},
+		// Common meta filter, single tag
+		{
+			filters: map[string]string{"common": "1"},
+			tags:    []string{"v2"},
+			services: structs.ServiceNodes{
+				&structs.ServiceNode{Node: "bar", ServiceID: "db2"},
+				&structs.ServiceNode{Node: "foo", ServiceID: "db"},
+			},
+		},
+		// Common meta filter, multiple tags
+		{
+			filters:  map[string]string{"common": "1"},
+			tags:     []string{"v2", "primary"},
 			services: structs.ServiceNodes{&structs.ServiceNode{Node: "foo", ServiceID: "db"}},
 		},
 	}
@@ -1709,8 +1724,8 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 			Datacenter:      "dc1",
 			NodeMetaFilters: tc.filters,
 			ServiceName:     "db",
-			ServiceTag:      tc.tag,
-			TagFilter:       tc.tag != "",
+			ServiceTags:     tc.tags,
+			TagFilter:       len(tc.tags) > 0,
 		}
 		var out structs.IndexedServiceNodes
 		if err := msgpackrpc.CallWithCodec(codec, "Catalog.ServiceNodes", &args, &out); err != nil {

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -1728,13 +1728,8 @@ func TestCatalog_ListServiceNodes_NodeMetaFilter(t *testing.T) {
 			TagFilter:       len(tc.tags) > 0,
 		}
 		var out structs.IndexedServiceNodes
-		if err := msgpackrpc.CallWithCodec(codec, "Catalog.ServiceNodes", &args, &out); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-
-		if len(out.ServiceNodes) != len(tc.services) {
-			t.Fatalf("bad: %v", out)
-		}
+		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.ServiceNodes", &args, &out))
+		require.Len(t, out.ServiceNodes, len(tc.services))
 
 		for i, serviceNode := range out.ServiceNodes {
 			if serviceNode.Node != tc.services[i].Node || serviceNode.ServiceID != tc.services[i].ServiceID {

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealth_ChecksInState(t *testing.T) {
@@ -628,9 +629,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 		},
 	}
 	var out struct{}
-	if err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	arg = structs.RegisterRequest{
 		Datacenter: "dc1",
@@ -647,9 +646,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 			ServiceID: "db",
 		},
 	}
-	if err := msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
 	var out2 structs.IndexedCheckServiceNodes
 	req := structs.ServiceSpecificRequest{
@@ -658,26 +655,14 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 		ServiceTags: []string{"master", "v2"},
 		TagFilter:   true,
 	}
-	if err := msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
 
 	nodes := out2.Nodes
-	if len(nodes) != 1 {
-		t.Fatalf("Bad: %v", nodes)
-	}
-	if nodes[0].Node.Node != "foo" {
-		t.Fatalf("Bad: %v", nodes[0])
-	}
-	if !lib.StrContains(nodes[0].Service.Tags, "v2") {
-		t.Fatalf("Bad: %v", nodes[0])
-	}
-	if !lib.StrContains(nodes[0].Service.Tags, "master") {
-		t.Fatalf("Bad: %v", nodes[0])
-	}
-	if nodes[0].Checks[0].Status != api.HealthPassing {
-		t.Fatalf("Bad: %v", nodes[0])
-	}
+	require.Len(t, nodes, 1)
+	require.Equal(t, nodes[0].Node.Node, "foo")
+	require.Contains(t, nodes[0].Service.Tags, "v2")
+	require.Contains(t, nodes[0].Service.Tags, "master")
+	require.Equal(t, nodes[0].Checks[0].Status, api.HealthPassing)
 }
 
 func TestHealth_ServiceNodes_NodeMetaFilter(t *testing.T) {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1809,7 +1809,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 
 	// Listing with no results returns an empty list.
 	ws := memdb.NewWatchSet()
-	idx, nodes, err := s.ServiceTagNodes(ws, "db", "master")
+	idx, nodes, err := s.ServiceTagNodes(ws, "db", []string{"master"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1842,7 +1842,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 
 	// Read everything back.
 	ws = memdb.NewWatchSet()
-	idx, nodes, err = s.ServiceTagNodes(ws, "db", "master")
+	idx, nodes, err = s.ServiceTagNodes(ws, "db", []string{"master"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1903,7 +1903,7 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	idx, nodes, err := s.ServiceTagNodes(nil, "db", "master")
+	idx, nodes, err := s.ServiceTagNodes(nil, "db", []string{"master"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1926,7 +1926,7 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 		t.Fatalf("bad: %v", nodes)
 	}
 
-	idx, nodes, err = s.ServiceTagNodes(nil, "db", "v2")
+	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1937,7 +1937,31 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 		t.Fatalf("bad: %v", nodes)
 	}
 
-	idx, nodes, err = s.ServiceTagNodes(nil, "db", "dev")
+	// Test filtering on multiple tags
+	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2", "slave"})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if idx != 19 {
+		t.Fatalf("bad: %v", idx)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("bad: %v", nodes)
+	}
+	if !lib.StrContains(nodes[0].ServiceTags, "v2") {
+		t.Fatalf("bad: %v", nodes)
+	}
+	if !lib.StrContains(nodes[0].ServiceTags, "slave") {
+		t.Fatalf("bad: %v", nodes)
+	}
+	if !lib.StrContains(nodes[1].ServiceTags, "v2") {
+		t.Fatalf("bad: %v", nodes)
+	}
+	if !lib.StrContains(nodes[1].ServiceTags, "slave") {
+		t.Fatalf("bad: %v", nodes)
+	}
+
+	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"dev"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -3088,7 +3112,7 @@ func TestStateStore_CheckServiceTagNodes(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", "master")
+	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", []string{"master"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -15,6 +15,7 @@ import (
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/pascaldekloe/goe/verify"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeRandomNodeID(t *testing.T) types.NodeID {
@@ -1904,85 +1905,37 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 	}
 
 	idx, nodes, err := s.ServiceTagNodes(nil, "db", []string{"master"})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if idx != 19 {
-		t.Fatalf("bad: %v", idx)
-	}
-	if len(nodes) != 1 {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].Node != "foo" {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].Address != "127.0.0.1" {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[0].ServiceTags, "master") {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].ServicePort != 8000 {
-		t.Fatalf("bad: %v", nodes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, int(idx), 19)
+	require.Len(t, nodes, 1)
+	require.Equal(t, nodes[0].Node, "foo")
+	require.Equal(t, nodes[0].Address, "127.0.0.1")
+	require.Contains(t, nodes[0].ServiceTags, "master")
+	require.Equal(t, nodes[0].ServicePort, 8000)
 
 	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2"})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if idx != 19 {
-		t.Fatalf("bad: %v", idx)
-	}
-	if len(nodes) != 3 {
-		t.Fatalf("bad: %v", nodes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, int(idx), 19)
+	require.Len(t, nodes, 3)
 
 	// Test filtering on multiple tags
 	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2", "slave"})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if idx != 19 {
-		t.Fatalf("bad: %v", idx)
-	}
-	if len(nodes) != 2 {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[0].ServiceTags, "v2") {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[0].ServiceTags, "slave") {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[1].ServiceTags, "v2") {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[1].ServiceTags, "slave") {
-		t.Fatalf("bad: %v", nodes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, int(idx), 19)
+	require.Len(t, nodes, 2)
+	require.Contains(t, nodes[0].ServiceTags, "v2")
+	require.Contains(t, nodes[0].ServiceTags, "slave")
+	require.Contains(t, nodes[1].ServiceTags, "v2")
+	require.Contains(t, nodes[1].ServiceTags, "slave")
 
 	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"dev"})
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if idx != 19 {
-		t.Fatalf("bad: %v", idx)
-	}
-	if len(nodes) != 1 {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].Node != "foo" {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].Address != "127.0.0.1" {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if !lib.StrContains(nodes[0].ServiceTags, "dev") {
-		t.Fatalf("bad: %v", nodes)
-	}
-	if nodes[0].ServicePort != 8001 {
-		t.Fatalf("bad: %v", nodes)
-	}
+	require.NoError(t, err)
+	require.Equal(t, int(idx), 19)
+	require.Len(t, nodes, 1)
+	require.Equal(t, nodes[0].Node, "foo")
+	require.Equal(t, nodes[0].Address, "127.0.0.1")
+	require.Contains(t, nodes[0].ServiceTags, "dev")
+	require.Equal(t, nodes[0].ServicePort, 8001)
 }
 
 func TestStateStore_DeleteService(t *testing.T) {

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -161,10 +161,10 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 		return nil, nil
 	}
 
-	// Check for a tag
+	// Check for tags
 	params := req.URL.Query()
 	if _, ok := params["tag"]; ok {
-		args.ServiceTag = params.Get("tag")
+		args.ServiceTags = params["tag"]
 		args.TagFilter = true
 	}
 

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -347,6 +347,7 @@ type ServiceSpecificRequest struct {
 	NodeMetaFilters map[string]string
 	ServiceName     string
 	ServiceTag      string
+	ServiceTags     []string
 	ServiceAddress  string
 	TagFilter       bool // Controls tag filtering
 	Source          QuerySource

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -165,23 +165,43 @@ func (c *Catalog) Services(q *QueryOptions) (map[string][]string, *QueryMeta, er
 
 // Service is used to query catalog entries for a given service
 func (c *Catalog) Service(service, tag string, q *QueryOptions) ([]*CatalogService, *QueryMeta, error) {
-	return c.service(service, tag, q, false)
+	var tags []string
+	if tag != "" {
+		tags = []string{tag}
+	}
+	return c.service(service, tags, q, false)
+}
+
+// Supports multiple tags for filtering
+func (c *Catalog) ServiceMultipleTags(service string, tags []string, q *QueryOptions) ([]*CatalogService, *QueryMeta, error) {
+	return c.service(service, tags, q, false)
 }
 
 // Connect is used to query catalog entries for a given Connect-enabled service
 func (c *Catalog) Connect(service, tag string, q *QueryOptions) ([]*CatalogService, *QueryMeta, error) {
-	return c.service(service, tag, q, true)
+	var tags []string
+	if tag != "" {
+		tags = []string{tag}
+	}
+	return c.service(service, tags, q, true)
 }
 
-func (c *Catalog) service(service, tag string, q *QueryOptions, connect bool) ([]*CatalogService, *QueryMeta, error) {
+// Supports multiple tags for filtering
+func (c *Catalog) ConnectMultipleTags(service string, tags []string, q *QueryOptions) ([]*CatalogService, *QueryMeta, error) {
+	return c.service(service, tags, q, true)
+}
+
+func (c *Catalog) service(service string, tags []string, q *QueryOptions, connect bool) ([]*CatalogService, *QueryMeta, error) {
 	path := "/v1/catalog/service/" + service
 	if connect {
 		path = "/v1/catalog/connect/" + service
 	}
 	r := c.c.newRequest("GET", path)
 	r.setQueryOptions(q)
-	if tag != "" {
-		r.params.Set("tag", tag)
+	if len(tags) > 0 {
+		for _, tag := range tags {
+			r.params.Add("tag", tag)
+		}
 	}
 	rtt, resp, err := requireOK(c.c.doRequest(r))
 	if err != nil {

--- a/api/health.go
+++ b/api/health.go
@@ -159,7 +159,15 @@ func (h *Health) Checks(service string, q *QueryOptions) (HealthChecks, *QueryMe
 // for a given service. It can optionally do server-side filtering on a tag
 // or nodes with passing health checks only.
 func (h *Health) Service(service, tag string, passingOnly bool, q *QueryOptions) ([]*ServiceEntry, *QueryMeta, error) {
-	return h.service(service, tag, passingOnly, q, false)
+	var tags []string
+	if tag != "" {
+		tags = []string{tag}
+	}
+	return h.service(service, tags, passingOnly, q, false)
+}
+
+func (h *Health) ServiceMultipleTags(service string, tags []string, passingOnly bool, q *QueryOptions) ([]*ServiceEntry, *QueryMeta, error) {
+	return h.service(service, tags, passingOnly, q, false)
 }
 
 // Connect is equivalent to Service except that it will only return services
@@ -168,18 +176,28 @@ func (h *Health) Service(service, tag string, passingOnly bool, q *QueryOptions)
 // passingOnly is true only instances where both the service and any proxy are
 // healthy will be returned.
 func (h *Health) Connect(service, tag string, passingOnly bool, q *QueryOptions) ([]*ServiceEntry, *QueryMeta, error) {
-	return h.service(service, tag, passingOnly, q, true)
+	var tags []string
+	if tag != "" {
+		tags = []string{tag}
+	}
+	return h.service(service, tags, passingOnly, q, true)
 }
 
-func (h *Health) service(service, tag string, passingOnly bool, q *QueryOptions, connect bool) ([]*ServiceEntry, *QueryMeta, error) {
+func (h *Health) ConnectMultipleTags(service string, tags []string, passingOnly bool, q *QueryOptions) ([]*ServiceEntry, *QueryMeta, error) {
+	return h.service(service, tags, passingOnly, q, true)
+}
+
+func (h *Health) service(service string, tags []string, passingOnly bool, q *QueryOptions, connect bool) ([]*ServiceEntry, *QueryMeta, error) {
 	path := "/v1/health/service/" + service
 	if connect {
 		path = "/v1/health/connect/" + service
 	}
 	r := h.c.newRequest("GET", path)
 	r.setQueryOptions(q)
-	if tag != "" {
-		r.params.Set("tag", tag)
+	if len(tags) > 0 {
+		for _, tag := range tags {
+			r.params.Add("tag", tag)
+		}
 	}
 	if passingOnly {
 		r.params.Set(HealthPassing, "1")

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -404,10 +404,12 @@ func TestAPI_HealthConnect(t *testing.T) {
 
 	// Register the proxy
 	proxyReg := &AgentServiceRegistration{
-		Name:             "foo-proxy",
-		Port:             8001,
-		Kind:             ServiceKindConnectProxy,
-		ProxyDestination: "foo",
+		Name: "foo-proxy",
+		Port: 8001,
+		Kind: ServiceKindConnectProxy,
+		Proxy: &AgentServiceConnectProxyConfig{
+			DestinationServiceName: "foo",
+		},
 	}
 	err = agent.ServiceRegister(proxyReg)
 	require.NoError(t, err)

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -283,6 +283,101 @@ func TestAPI_HealthService(t *testing.T) {
 	})
 }
 
+func TestAPI_HealthService_SingleTag(t *testing.T) {
+	t.Parallel()
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeName = "node123"
+	})
+	defer s.Stop()
+	agent := c.Agent()
+	health := c.Health()
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		ID:   "foo1",
+		Tags: []string{"bar"},
+		Check: &AgentServiceCheck{
+			Status: HealthPassing,
+			TTL:    "15s",
+		},
+	}
+	require.NoError(t, agent.ServiceRegister(reg))
+	defer agent.ServiceDeregister("foo1")
+	retry.Run(t, func(r *retry.R) {
+		services, meta, err := health.Service("foo", "bar", true, nil)
+		require.NoError(t, err)
+		require.NotEqual(t, meta.LastIndex, 0)
+		require.Len(t, services, 1)
+		require.Equal(t, services[0].Service.ID, "foo1")
+	})
+}
+func TestAPI_HealthService_MultipleTags(t *testing.T) {
+	t.Parallel()
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeName = "node123"
+	})
+	defer s.Stop()
+	agent := c.Agent()
+	health := c.Health()
+	// Make two services with a check
+	reg := &AgentServiceRegistration{
+		Name: "foo",
+		ID:   "foo1",
+		Tags: []string{"bar"},
+		Check: &AgentServiceCheck{
+			Status: HealthPassing,
+			TTL:    "15s",
+		},
+	}
+	require.NoError(t, agent.ServiceRegister(reg))
+	defer agent.ServiceDeregister("foo1")
+	reg2 := &AgentServiceRegistration{
+		Name: "foo",
+		ID:   "foo2",
+		Tags: []string{"bar", "v2"},
+		Check: &AgentServiceCheck{
+			Status: HealthPassing,
+			TTL:    "15s",
+		},
+	}
+	require.NoError(t, agent.ServiceRegister(reg2))
+	defer agent.ServiceDeregister("foo2")
+	// Test searching with one tag (two results)
+	retry.Run(t, func(r *retry.R) {
+		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar"}, true, nil)
+		require.NoError(t, err)
+		require.NotEqual(t, meta.LastIndex, 0)
+		require.Len(t, services, 2)
+	})
+	// Test searching with two tags (one result)
+	retry.Run(t, func(r *retry.R) {
+		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar", "v2"}, true, nil)
+		require.NoError(t, err)
+		require.NotEqual(t, meta.LastIndex, 0)
+		require.Len(t, services, 1)
+		require.Equal(t, services[0].Service.ID, "foo2")
+	})
+}
+
+func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
+	t.Parallel()
+	meta := map[string]string{"somekey": "somevalue"}
+	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
+		conf.NodeMeta = meta
+	})
+	defer s.Stop()
+
+	health := c.Health()
+	retry.Run(t, func(r *retry.R) {
+		// consul service should always exist...
+		checks, meta, err := health.Service("consul", "", true, &QueryOptions{NodeMeta: meta})
+		require.NoError(t, err)
+		require.NotEqual(t, meta.LastIndex, 0)
+		require.NotEqual(t, len(checks), 0)
+		require.Equal(t, checks[0].Node.Datacenter, "dc1")
+		require.Contains(t, checks[0].Node.TaggedAddresses, "wan")
+	})
+}
+
 func TestAPI_HealthConnect(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
@@ -302,12 +397,10 @@ func TestAPI_HealthConnect(t *testing.T) {
 
 	// Register the proxy
 	proxyReg := &AgentServiceRegistration{
-		Name: "foo-proxy",
-		Port: 8001,
-		Kind: ServiceKindConnectProxy,
-		Proxy: &AgentServiceConnectProxyConfig{
-			DestinationServiceName: "foo",
-		},
+		Name:             "foo-proxy",
+		Port:             8001,
+		Kind:             ServiceKindConnectProxy,
+		ProxyDestination: "foo",
 	}
 	err = agent.ServiceRegister(proxyReg)
 	require.NoError(t, err)
@@ -331,36 +424,6 @@ func TestAPI_HealthConnect(t *testing.T) {
 		}
 		if services[0].Service.Port != proxyReg.Port {
 			r.Fatalf("Bad port: %v", services[0])
-		}
-	})
-}
-
-func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
-	t.Parallel()
-	meta := map[string]string{"somekey": "somevalue"}
-	c, s := makeClientWithConfig(t, nil, func(conf *testutil.TestServerConfig) {
-		conf.NodeMeta = meta
-	})
-	defer s.Stop()
-
-	health := c.Health()
-	retry.Run(t, func(r *retry.R) {
-		// consul service should always exist...
-		checks, meta, err := health.Service("consul", "", true, &QueryOptions{NodeMeta: meta})
-		if err != nil {
-			r.Fatal(err)
-		}
-		if meta.LastIndex == 0 {
-			r.Fatalf("bad: %v", meta)
-		}
-		if len(checks) == 0 {
-			r.Fatalf("Bad: %v", checks)
-		}
-		if _, ok := checks[0].Node.TaggedAddresses["wan"]; !ok {
-			r.Fatalf("Bad: %v", checks[0].Node)
-		}
-		if checks[0].Node.Datacenter != "dc1" {
-			r.Fatalf("Bad datacenter: %v", checks[0].Node)
 		}
 	})
 }

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -316,8 +316,10 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 		conf.NodeName = "node123"
 	})
 	defer s.Stop()
+
 	agent := c.Agent()
 	health := c.Health()
+
 	// Make two services with a check
 	reg := &AgentServiceRegistration{
 		Name: "foo",
@@ -330,6 +332,7 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 	}
 	require.NoError(t, agent.ServiceRegister(reg))
 	defer agent.ServiceDeregister("foo1")
+
 	reg2 := &AgentServiceRegistration{
 		Name: "foo",
 		ID:   "foo2",
@@ -341,16 +344,20 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 	}
 	require.NoError(t, agent.ServiceRegister(reg2))
 	defer agent.ServiceDeregister("foo2")
+
 	// Test searching with one tag (two results)
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar"}, true, nil)
+
 		require.NoError(t, err)
 		require.NotEqual(t, meta.LastIndex, 0)
 		require.Len(t, services, 2)
 	})
+
 	// Test searching with two tags (one result)
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := health.ServiceMultipleTags("foo", []string{"bar", "v2"}, true, nil)
+
 		require.NoError(t, err)
 		require.NotEqual(t, meta.LastIndex, 0)
 		require.Len(t, services, 1)


### PR DESCRIPTION
Fixes #1781.

Adds a `ServiceTags` field to the ServiceSpecificRequest to support
multiple tags, updates the filter logic in the catalog store, and
propagates these change through to the health and catalog endpoints.

Note: Leaves `ServiceTag` in the struct, since it is being used as
part of the DNS lookup, which in turn uses the health check. This 
singular field takes precedence over anything in `ServiceTags`.