### PR TITLE
testutil: If testing.T is nil panic with error

### DIFF
--- a/testutil/io.go
+++ b/testutil/io.go
@@ -39,6 +39,9 @@ func TempDir(t *testing.T, name string) string {
 	name = strings.Replace(name, "/", "_", -1)
 	d, err := ioutil.TempDir(tmpdir, name)
 	if err != nil {
+		if t == nil {
+			panic(err)
+		}
 		t.Fatalf("err: %s", err)
 	}
 	return d
@@ -55,6 +58,9 @@ func TempFile(t *testing.T, name string) *os.File {
 	}
 	f, err := ioutil.TempFile(tmpdir, name)
 	if err != nil {
+		if t == nil {
+			panic(err)
+		}
 		t.Fatalf("err: %s", err)
 	}
 	return f


### PR DESCRIPTION
Currently if there's an error with `ioutil.Temp(Dir)` and a `testing.T` was passed in as nil, the test panic's and you can't actually see the underlying error that was caused.