### PR TITLE
watch: use CONSUL_TLS_SERVER_NAME for https if defined (#4718)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -750,7 +750,7 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 
 			addr := config.Address
 			if config.Scheme == "https" {
-				addr = "https://" + addr
+				addr = "https://" + config.TLSConfig.Address
 			}
 
 			if err := wp.RunWithConfig(addr, config); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -750,7 +750,7 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 
 			addr := config.Address
 			if config.Scheme == "https" {
-				addr = "https://" + config.TLSConfig.Address
+				addr = "https://" + addr
 			}
 
 			if err := wp.RunWithConfig(addr, config); err != nil {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1475,7 +1475,6 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		cfg.Scheme = "https"
 		cfg.TLSConfig.CAFile = c.CAFile
 		cfg.TLSConfig.CAPath = c.CAPath
-		cfg.TLSConfig.Address = httpsAddr
 		if includeClientCerts {
 			cfg.TLSConfig.CertFile = c.CertFile
 			cfg.TLSConfig.KeyFile = c.KeyFile

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1467,7 +1467,6 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		Datacenter: c.Datacenter,
 		TLSConfig:  api.TLSConfig{InsecureSkipVerify: !c.VerifyOutgoing},
 	}
-	dcfg := api.DefaultConfig()
 
 	unixAddr, httpAddr, httpsAddr := c.ClientAddress()
 
@@ -1476,7 +1475,7 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		cfg.Scheme = "https"
 		cfg.TLSConfig.CAFile = c.CAFile
 		cfg.TLSConfig.CAPath = c.CAPath
-		cfg.TLSConfig.Address = dcfg.TLSConfig.Address
+		cfg.TLSConfig.Address = httpsAddr
 		if includeClientCerts {
 			cfg.TLSConfig.CertFile = c.CertFile
 			cfg.TLSConfig.KeyFile = c.KeyFile

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1467,6 +1467,7 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		Datacenter: c.Datacenter,
 		TLSConfig:  api.TLSConfig{InsecureSkipVerify: !c.VerifyOutgoing},
 	}
+	dcfg := api.DefaultConfig()
 
 	unixAddr, httpAddr, httpsAddr := c.ClientAddress()
 
@@ -1475,7 +1476,7 @@ func (c *RuntimeConfig) APIConfig(includeClientCerts bool) (*api.Config, error) 
 		cfg.Scheme = "https"
 		cfg.TLSConfig.CAFile = c.CAFile
 		cfg.TLSConfig.CAPath = c.CAPath
-		cfg.TLSConfig.Address = httpsAddr
+		cfg.TLSConfig.Address = dcfg.TLSConfig.Address
 		if includeClientCerts {
 			cfg.TLSConfig.CertFile = c.CertFile
 			cfg.TLSConfig.KeyFile = c.KeyFile


### PR DESCRIPTION
I'm not sure that this is the best way of passing the configuration but it does resolve my issue