### PR TITLE
 Add LastModifyTime to catalog entities

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -80,7 +80,7 @@ func NewTestACLAgent(name string, hcl string, resolveFn func(string) (acl.Author
 	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
 
 	a.Agent.delegate = a
-	a.Agent.State = local.NewState(LocalConfig(a.Config), a.Agent.logger, a.Agent.tokens)
+	a.Agent.State = local.NewState(LocalConfig(a.Config), a.Agent.logger, a.Agent.tokens, time.Now)
 	a.Agent.State.TriggerSyncChanges = func() {}
 	return a
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -451,6 +451,8 @@ func TestAgent_AddService(t *testing.T) {
 			for k, v := range tt.healthChks {
 				t.Run(k, func(t *testing.T) {
 					got, want := a.State.Checks()[types.CheckID(k)], v
+					want.LastStatusModifyTime = a.Now
+					fmt.Println(want.LastStatusModifyTime, got.LastStatusModifyTime)
 					verify.Values(t, k, got, want)
 				})
 			}
@@ -653,9 +655,11 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	}
 
 	// check that both checks are there
+	hchk1.LastStatusModifyTime = a.Now
 	if got, want := a.State.Checks()["chk1"], hchk1; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
+	hchk2.LastStatusModifyTime = a.Now
 	if got, want := a.State.Checks()["chk2"], hchk2; !verify.Values(t, "", got, want) {
 		t.FailNow()
 	}
@@ -1978,11 +1982,12 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 		t.Fatalf("missing check registration")
 	}
 	expected := &structs.HealthCheck{
-		Node:    a2.Config.NodeName,
-		CheckID: "mem",
-		Name:    "memory check",
-		Status:  api.HealthCritical,
-		Notes:   "my cool notes",
+		Node:                 a2.Config.NodeName,
+		CheckID:              "mem",
+		Name:                 "memory check",
+		Status:               api.HealthCritical,
+		Notes:                "my cool notes",
+		LastStatusModifyTime: a2.Now,
 	}
 	if got, want := result, expected; !verify.Values(t, "", got, want) {
 		t.FailNow()

--- a/agent/check.go
+++ b/agent/check.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"time"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/types"
 )
@@ -18,8 +20,9 @@ type persistedCheck struct {
 // expiration timestamp which is used to determine staleness on later
 // agent restarts.
 type persistedCheckState struct {
-	CheckID types.CheckID
-	Output  string
-	Status  string
-	Expires int64
+	CheckID              types.CheckID
+	Output               string
+	Status               string
+	LastStatusModifyTime time.Time
+	Expires              int64
 }

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -365,7 +365,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := NewServer(conf1, time.Now)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 func TestClient_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
-	s1, err := NewServer(conf1)
+	s1, err := NewServer(conf1, time.Now)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -518,7 +518,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := NewServer(conf1, time.Now)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1311,11 +1311,12 @@ AFTER_CHECK:
 		Address:    member.Addr.String(),
 		Service:    service,
 		Check: &structs.HealthCheck{
-			Node:    member.Name,
-			CheckID: structs.SerfCheckID,
-			Name:    structs.SerfCheckName,
-			Status:  api.HealthPassing,
-			Output:  structs.SerfCheckAliveOutput,
+			Node:                 member.Name,
+			CheckID:              structs.SerfCheckID,
+			Name:                 structs.SerfCheckName,
+			Status:               api.HealthPassing,
+			Output:               structs.SerfCheckAliveOutput,
+			LastStatusModifyTime: s.clock(),
 		},
 
 		// If there's existing information about the node, do not
@@ -1356,11 +1357,12 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 		ID:         types.NodeID(member.Tags["id"]),
 		Address:    member.Addr.String(),
 		Check: &structs.HealthCheck{
-			Node:    member.Name,
-			CheckID: structs.SerfCheckID,
-			Name:    structs.SerfCheckName,
-			Status:  api.HealthCritical,
-			Output:  structs.SerfCheckFailedOutput,
+			Node:                 member.Name,
+			CheckID:              structs.SerfCheckID,
+			Name:                 structs.SerfCheckName,
+			Status:               api.HealthCritical,
+			Output:               structs.SerfCheckFailedOutput,
+			LastStatusModifyTime: s.clock(),
 		},
 
 		// If there's existing information about the node, do not

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -248,17 +248,20 @@ type Server struct {
 	shutdownCh   chan struct{}
 	shutdownLock sync.Mutex
 
+	// clock is used to timestamp healthchecks
+	clock func() time.Time
+
 	// embedded struct to hold all the enterprise specific data
 	EnterpriseServer
 }
 
-func NewServer(config *Config) (*Server, error) {
-	return NewServerLogger(config, nil, new(token.Store))
+func NewServer(config *Config, clock func() time.Time) (*Server, error) {
+	return NewServerLogger(config, nil, new(token.Store), clock)
 }
 
 // NewServer is used to construct a new Consul server from the
 // configuration, potentially returning an error
-func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*Server, error) {
+func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, clock func() time.Time) (*Server, error) {
 	// Check the protocol version.
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
@@ -346,6 +349,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*
 		tombstoneGC:      gc,
 		serverLookup:     NewServerLookup(),
 		shutdownCh:       shutdownCh,
+		clock:            clock,
 	}
 
 	// Initialize enterprise specific server functionality

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -175,7 +175,7 @@ func newServer(c *Config) (*Server, error) {
 		w = os.Stderr
 	}
 	logger := log.New(w, c.NodeName+" - ", log.LstdFlags|log.Lmicroseconds)
-	srv, err := NewServerLogger(c, logger, new(token.Store))
+	srv, err := NewServerLogger(c, logger, new(token.Store), time.Now)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -2130,16 +2131,18 @@ func TestStateStore_Service_Snapshot(t *testing.T) {
 func TestStateStore_EnsureCheck(t *testing.T) {
 	s := testStateStore(t)
 
+	now := time.Now()
 	// Create a check associated with the node
 	check := &structs.HealthCheck{
-		Node:        "node1",
-		CheckID:     "check1",
-		Name:        "redis check",
-		Status:      api.HealthPassing,
-		Notes:       "test check",
-		Output:      "aaa",
-		ServiceID:   "service1",
-		ServiceName: "redis",
+		Node:                 "node1",
+		CheckID:              "check1",
+		Name:                 "redis check",
+		Status:               api.HealthPassing,
+		Notes:                "test check",
+		Output:               "aaa",
+		ServiceID:            "service1",
+		ServiceName:          "redis",
+		LastStatusModifyTime: now,
 	}
 
 	// Creating a check without a node returns error

--- a/agent/local/testing.go
+++ b/agent/local/testing.go
@@ -3,6 +3,7 @@ package local
 import (
 	"log"
 	"os"
+	"time"
 
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/mitchellh/go-testing-interface"
@@ -13,7 +14,7 @@ func TestState(t testing.T) *State {
 	result := NewState(Config{
 		ProxyBindMinPort: 20000,
 		ProxyBindMaxPort: 20500,
-	}, log.New(os.Stderr, "", log.LstdFlags), &token.Store{})
+	}, log.New(os.Stderr, "", log.LstdFlags), &token.Store{}, time.Now)
 	result.TriggerSyncChanges = func() {}
 	return result
 }

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -57,7 +57,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 		})
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
-	state := local.NewState(local.Config{}, logger, &token.Store{})
+	state := local.NewState(local.Config{}, logger, &token.Store{}, time.Now)
 	source := &structs.QuerySource{
 		Node:       "node1",
 		Datacenter: "dc1",
@@ -225,7 +225,7 @@ func TestManager_deliverLatest(t *testing.T) {
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	cfg := ManagerConfig{
 		Cache: cache.New(nil),
-		State: local.NewState(local.Config{}, logger, &token.Store{}),
+		State: local.NewState(local.Config{}, logger, &token.Store{}, time.Now),
 		Source: &structs.QuerySource{
 			Node:       "node1",
 			Datacenter: "dc1",

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -890,6 +890,8 @@ type HealthCheck struct {
 	Definition HealthCheckDefinition
 
 	RaftIndex
+
+	LastStatusModifyTime time.Time
 }
 
 type HealthCheckDefinition struct {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -88,6 +88,8 @@ type TestAgent struct {
 	// Agent is the embedded consul agent.
 	// It is valid after Start().
 	*Agent
+
+	Now time.Time
 }
 
 // NewTestAgent returns a started agent with the given name and
@@ -95,7 +97,7 @@ type TestAgent struct {
 // caller should call Shutdown() to stop the agent and remove temporary
 // directories.
 func NewTestAgent(name string, hcl string) *TestAgent {
-	a := &TestAgent{Name: name, HCL: hcl}
+	a := &TestAgent{Name: name, HCL: hcl, Now: time.Now().UTC()}
 	a.Start()
 	return a
 }
@@ -157,6 +159,9 @@ func (a *TestAgent) Start() *TestAgent {
 		agent.LogWriter = a.LogWriter
 		agent.logger = log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
 		agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
+		agent.clock = func() time.Time {
+			return a.Now
+		}
 
 		// we need the err var in the next exit condition
 		if err := agent.Start(); err == nil {


### PR DESCRIPTION
Implementation for https://github.com/hashicorp/consul/issues/3973

> This PR is based on @pierresouchay's https://github.com/hashicorp/consul/pull/4720 as they touch the same code (https://github.com/hashicorp/consul/pull/4720 fixes cases where `ModifyIndex` is updated when it shouldn't be, and `LastModifyTime` is tied to `ModifyIndex`)

This change adds a new field `LastModifyTime` to `NodeService`, `ServiceNode`, `Node`, and `HealthCheck` structs. This field is initialized to the current time upon registration on the server side, and is then kept up to date when a mofification is made (aka when !old.IsSame(new)).