### PR TITLE
Add a Close method to cache that stops background goroutines.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1354,6 +1354,11 @@ func (a *Agent) ShutdownAgent() error {
 		}
 	}
 
+	// Stop the cache background work
+	if a.cache != nil {
+		a.cache.Close()
+	}
+
 	var err error
 	if a.delegate != nil {
 		err = a.delegate.Shutdown()


### PR DESCRIPTION
In a real agent the `cache` instance is alive until the agent shuts down so this is not a real leak in production, however in out test suite, every testAgent that is started and stops leaks goroutines that never get cleaned up which accumulate consuming CPU and memory through subsequent test in the `agent` package which doesn't help our test flakiness.

This adds a Close method that doesn't invalidate or clean up the cache, and still allows concurrent blocking queries to run (for up to 10 mins which might still affect tests). But at least it doesn't maintain them forever with background refresh and an expiry watcher routine.

It would be nice to cancel any outstanding blocking requests as well when we close but that requires much more invasive surgery right into our RPC protocol since we don't have a way to cancel requests currently.

Unscientifically this seems to make tests pass a bit quicker and more reliably locally but I can't really be sure of that!