### PR TITLE
Clarify enable_tag_override explanation

### DIFF
--- a/website/source/docs/internals/anti-entropy.html.md
+++ b/website/source/docs/internals/anti-entropy.html.md
@@ -136,7 +136,7 @@ If an error is encountered during an anti-entropy run, the error is logged and
 the agent continues to run. The anti-entropy mechanism is run periodically to
 automatically recover from these types of transient failures.
 
-### EnableTagOverride
+### Enable Tag Override
 
 Synchronization of service registration can be partially modified to
 allow external agents to change the tags for a service. This can be
@@ -146,7 +146,7 @@ database and its monitoring service Redis Sentinel have this kind of
 relationship. Redis instances are responsible for much of their
 configuration, but Sentinels determine whether the Redis instance is a
 primary or a secondary. Using the Consul service configuration item
-[EnableTagOverride](/docs/agent/services.html) you can instruct the
+[enable_tag_override](/docs/agent/services.html) you can instruct the
 Consul agent on which the Redis database is running to NOT update the
 tags during anti-entropy synchronization. For more information see
-[Services](/docs/agent/services.html) page.
+[Services](/docs/agent/services.html#enable-tag-override-and-anti-entropy) page.


### PR DESCRIPTION
In designing a potential UI for a configuration of `enable_tag_override`,
I found the documentation confusing and lengthy. Here, I've made an
attempt at re-writing this section to be more concise and clear.

I also made a few small changes to the organization of this file to map
explanations to the order of the properties listing at the top. I find
it easier to scan docs when explanations appear in the same order they
are listed at the top. For explanations that span multiple paragraphs, I
provided a subheading, which also helps in linking from other pages.

Finally, I removed a duplicated paragraph from the documentation.