### PR TITLE
ui: Add truncation to the `.Address`

### DIFF
--- a/ui-v2/app/styles/components/healthchecked-resource/layout.scss
+++ b/ui-v2/app/styles/components/healthchecked-resource/layout.scss
@@ -1,3 +1,4 @@
+%healthchecked-resource header strong,
 %healthchecked-resource header span,
 %healthchecked-resource header em,
 %healthchecked-resource li:not(:last-child) span {
@@ -48,7 +49,7 @@
 }
 %healthchecked-resource header strong {
   top: 2.8em;
-  left: 15px;
+  padding: 0 15px;
 }
 %healthchecked-resource header span {
   margin-bottom: 1.75em;


### PR DESCRIPTION
Adds truncation to `.Address` when printed into the node card.

Whilst this doesn't solve underlying issue of #4748 , it does prevent the layout error in the same way that the rest of the text is treated.

Fixes #4748 but the underlying problem remains.