### PR TITLE
api: add AliasNode and AliasService fields to the agent checks struct

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -191,6 +191,8 @@ type AgentServiceCheck struct {
 	TLSSkipVerify     bool                `json:",omitempty"`
 	GRPC              string              `json:",omitempty"`
 	GRPCUseTLS        bool                `json:",omitempty"`
+	AliasNode         string              `json:",omitempty"`
+	AliasService      string              `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service
 	// may also contain this optional DeregisterCriticalServiceAfter field,


### PR DESCRIPTION
These fields were missing from the `api` check struct, so registering services via the CLI wasn't working. I've made this PR against `f-envoy` since that's what I'm working off of.

I don't have tests since this isn't really a reasonable thing that can ever regress, we just missed it going into it. Typical problem of having to update 10 structs to add one field...