### PR TITLE
Issue 3953 - Info leader mode for checking consul ready

### DIFF
--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -61,6 +61,7 @@ import (
 	operraft "github.com/hashicorp/consul/command/operator/raft"
 	operraftlist "github.com/hashicorp/consul/command/operator/raft/listpeers"
 	operraftremove "github.com/hashicorp/consul/command/operator/raft/removepeer"
+	opready "github.com/hashicorp/consul/command/operator/ready"
 	"github.com/hashicorp/consul/command/reload"
 	"github.com/hashicorp/consul/command/rtt"
 	"github.com/hashicorp/consul/command/services"
@@ -79,7 +80,6 @@ import (
 	"github.com/hashicorp/consul/command/version"
 	"github.com/hashicorp/consul/command/watch"
 	consulversion "github.com/hashicorp/consul/version"
-
 	"github.com/mitchellh/cli"
 )
 
@@ -151,6 +151,7 @@ func init() {
 	Register("operator raft", func(cli.Ui) (cli.Command, error) { return operraft.New(), nil })
 	Register("operator raft list-peers", func(ui cli.Ui) (cli.Command, error) { return operraftlist.New(ui), nil })
 	Register("operator raft remove-peer", func(ui cli.Ui) (cli.Command, error) { return operraftremove.New(ui), nil })
+	Register("operator ready", func(ui cli.Ui) (cli.Command, error) { return opready.New(ui), nil })
 	Register("reload", func(ui cli.Ui) (cli.Command, error) { return reload.New(ui), nil })
 	Register("rtt", func(ui cli.Ui) (cli.Command, error) { return rtt.New(ui), nil })
 	Register("services", func(cli.Ui) (cli.Command, error) { return services.New(), nil })

--- a/command/operator/ready/operator_ready.go
+++ b/command/operator/ready/operator_ready.go
@@ -1,0 +1,78 @@
+package ready
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	help  string
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+
+	// flags
+	logLevel string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.logLevel, "logLevel", "",
+		"The log level needed?")
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		if err == flag.ErrHelp {
+			return 0
+		}
+		c.UI.Error(fmt.Sprintf("Failed to parse args: %v", err))
+		return 1
+	}
+
+	// Set up a client.
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	leader, err := client.Status().Leader()
+
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error getting leader: %v", err))
+		return 1
+	}
+	c.UI.Output(fmt.Sprintf("%v", leader))
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const synopsis = "Provides an indicator if ready after joining"
+const help = `
+Usage: consul operator ready [options]
+
+The Ready operator command is used to verify the agent is ready
+after it's joined a cluster
+`

--- a/command/operator/ready/operator_ready_test.go
+++ b/command/operator/ready/operator_ready_test.go
@@ -1,0 +1,34 @@
+package ready
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/mitchellh/cli"
+)
+
+func TestOperatorReadyCommand_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestOperatorReadyCommand(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), ``)
+	defer a.Shutdown()
+
+	t.Run("Test the ready command", func(t *testing.T) {
+		ui := cli.NewMockUi()
+		c := New(ui)
+		args := []string{"-http-addr=" + a.HTTPAddr(), "-address=nope"}
+
+		code := c.Run(args)
+		if code != 1 {
+			t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+		}
+	})
+
+}


### PR DESCRIPTION
Done for #3953 

Added -info flag which when used with
consul leader -info
Only gives leader address output so you can determine agent readiness.

First PR for this project so please let me know if i've gone down the wrong path of if there was a better way to do it

