### PR TITLE
UI: Move the text encoding polyfill to a a proper detecting polyfill

### DIFF
--- a/ui-v2/app/index.html
+++ b/ui-v2/app/index.html
@@ -25,6 +25,17 @@
     </noscript>
     {{content-for "body"}}
     <script src="{{rootURL}}assets/vendor.js"></script>
+    <script>
+      var appendScript = function(src) {
+        var $script = document.createElement('script');
+        $script.src = src;
+        document.body.appendChild($script);
+      }
+      if(!('TextDecoder' in window)) {
+        appendScript('{{rootURL}}assets/encoding-indexes.js');
+        appendScript('{{rootURL}}assets/encoding.js');
+      }
+    </script>
     <script src="{{rootURL}}assets/consul-ui.js"></script>
 
     {{content-for "body-footer"}}

--- a/ui-v2/app/utils/atob.js
+++ b/ui-v2/app/utils/atob.js
@@ -1,9 +1,6 @@
-import TextEncoding from 'npm:text-encoding';
 import base64js from 'npm:base64-js';
 export default function(str, encoding = 'utf-8') {
   // decode
   const bytes = base64js.toByteArray(str);
-  return new ('TextDecoder' in window ? TextDecoder : TextEncoding.TextDecoder)(encoding).decode(
-    bytes
-  );
+  return new TextDecoder(encoding).decode(bytes);
 }

--- a/ui-v2/app/utils/btoa.js
+++ b/ui-v2/app/utils/btoa.js
@@ -1,7 +1,6 @@
-import TextEncoding from 'npm:text-encoding';
 import base64js from 'npm:base64-js';
 export default function(str, encoding = 'utf-8') {
   // encode
-  const bytes = new ('TextEncoder' in window ? TextEncoder : TextEncoding.TextEncoder)(encoding).encode(str);
+  const bytes = new TextEncoder(encoding).encode(str);
   return base64js.fromByteArray(bytes);
 }

--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -65,6 +65,8 @@ module.exports = function(defaults) {
   // modules that you would like to import into your application
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
+  app.import('node_modules/text-encoding/lib/encoding-indexes.js', {outputFile: 'assets/encoding-indexes.js'})
+  app.import('node_modules/text-encoding/lib/encoding.js', {outputFile: 'assets/encoding.js'})
   let tree = app.toTree();
   return tree;
 };


### PR DESCRIPTION
I spotted a huge bump in the size of my built output from a few weeks ago:

![screen shot 2018-10-08 at 11 34 25](https://user-images.githubusercontent.com/554604/46604513-6cbaaa80-caee-11e8-95cd-a41c66554e21.png)

I followed it back to #4613 which was to add a different TextEncoder polyfill, but this wasn't exactly polyfilled. Even though certain browsers didn't need the polyfill, the polyfill was still in the bundled vendor.js file.

This PR splits this out into a proper polyfill. The TextEncoder polyfill is now only requested/downloaded if the browser you are using a browser that doesn't have a native implementation (basically IE).

Overall this puts my vendor.js file back to the size it was previously.


