### PR TITLE
website: explain script exit code 1 in health check introduction guide

### DIFF
--- a/website/source/intro/getting-started/checks.html.md
+++ b/website/source/intro/getting-started/checks.html.md
@@ -46,8 +46,9 @@ The first definition adds a host-level check named "ping". This check runs
 on a 30 second interval, invoking `ping -c1 google.com`. On a `script`-based
 health check, the check runs as the same user that started the Consul process.
 If the command exits with an exit code >= 2, then the check will be flagged as
-failing and the service will be considered unhealthy. This is the contract
-for any `script`-based health check.
+failing and the service will be considered unhealthy. An exit code of 1 will
+be considered as warning state. This is the contract for any
+[`script`-based health check](/docs/agent/checks.html#check-scripts).
 
 The second command modifies the service named `web`, adding a check that sends a
 request every 10 seconds via curl to verify that the web server is accessible.


### PR DESCRIPTION
I was reading through the "Getting started" guide and was a little confused why only exit codes >= 2 are considered as failures. Knowing other monitoring solutions like Icinga, I had a feeling how exit code 1 worked, but believe it should be mentioned in this starter guide.