### PR TITLE
Update creating-certificates.html.md

### DIFF
--- a/website/source/docs/guides/creating-certificates.html.md
+++ b/website/source/docs/guides/creating-certificates.html.md
@@ -96,8 +96,8 @@ Consul node be difficult, but using a hostname provides no security or
 functional benefits to Consul. To fulfill the desired security properties
 (above) Consul certificates are signed with their region and role such as:
 
-* `client.node.global.consul` for a client node in the `global` region
-* `server.node.us-west.consul` for a server node in the `us-west` region
+* `client.global.consul` for a client node in the `global` region
+* `server.us-west.consul` for a server node in the `us-west` region
 
 To create certificates for the client and server in the cluster with
 [cfssl][cfssl], create the following configuration file as `cfssl.json` to increase the default certificate expiration time:
@@ -121,11 +121,11 @@ To create certificates for the client and server in the cluster with
 ```shell
 # Generate a certificate for the Consul server
 $ echo '{"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=consul-ca.pem -ca-key=consul-ca-key.pem -config=cfssl.json \
-    -hostname="server.node.global.consul,localhost,127.0.0.1" - | cfssljson -bare server
+    -hostname="server.global.consul,localhost,127.0.0.1" - | cfssljson -bare server
 
 # Generate a certificate for the Consul client
 $ echo '{"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=consul-ca.pem -ca-key=consul-ca-key.pem -config=cfssl.json \
-    -hostname="client.node.global.consul,localhost,127.0.0.1" - | cfssljson -bare client
+    -hostname="client.global.consul,localhost,127.0.0.1" - | cfssljson -bare client
 
 # Generate a certificate for the CLI
 $ echo '{"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=consul-ca.pem -ca-key=consul-ca-key.pem -profile=client \


### PR DESCRIPTION
In case `verify_server_hostname` is set in the configuration, Consul checks the certificate against  `server.<datacenter>.<domain>`.

The name suggested by the guide generates errors like the following:
```
2018/10/10 12:42:20 [ERR] consul: Failed to confirm peer status for consul-3: rpc error getting client: failed to get conn: x509: certificate is valid for server.node.consul.labs, localhost, not server.consul.labs. Retrying in 16s...
```

Removing the `node` part from the certificate permits them to work also when that option is set.