### PR TITLE
Update sprockets and ffi to dodge CVEs

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.5)
     execjs (2.7.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.12.9)
       activesupport (>= 3.1)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-livereload (0.3.17)
       rack
     rack-test (1.0.0)
@@ -123,7 +123,7 @@ GEM
     redcarpet (3.4.0)
     rouge (2.2.1)
     sass (3.4.25)
-    sprockets (2.12.4)
+    sprockets (2.12.5)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
CVE-2018-1000201, CVE-2018-3760 and CVE-2014-7819.