### PR TITLE
fix some test hangs

### DIFF
--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -52,7 +52,7 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 	defer a.Shutdown()
 
 	all := []string{"GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS"}
-	const testTimeout = 5 * time.Second
+	const testTimeout = 10 * time.Second
 	client := &http.Client{
 		Timeout: testTimeout,
 		Transport: &http.Transport{


### PR DESCRIPTION
The default `http.Client` uses infinite timeouts, so if `TestHTTPAPI_MethodNotAllowed_OSS` experienced anything going wrong about setup it could hang forever.

Switching to hard coding various `http.Client` timeouts to non-infinite values at least bounds the failure time.