### PR TITLE
Update deprecated script tag in example.

### DIFF
--- a/website/source/docs/agent/checks.html.md
+++ b/website/source/docs/agent/checks.html.md
@@ -347,7 +347,7 @@ key in your configuration file.
     {
       "id": "chk3",
       "name": "cpu",
-      "script": "/bin/check_cpu",
+      "args": ["/bin/check_cpu"],
       "interval": "10s"
     },
     ...


### PR DESCRIPTION
Minor change to documentation to remove deprecated `script` tag from health check and replace with `args`

Signed-off-by: Martin Logan <mlogan@fanatics.com>