### PR TITLE
Add new command to get Raft health information

### DIFF
--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -43,6 +43,7 @@ import (
 	operraft "github.com/hashicorp/consul/command/operator/raft"
 	operraftlist "github.com/hashicorp/consul/command/operator/raft/listpeers"
 	operraftremove "github.com/hashicorp/consul/command/operator/raft/removepeer"
+	operrafthealth "github.com/hashicorp/consul/command/operator/raft/health"
 	"github.com/hashicorp/consul/command/reload"
 	"github.com/hashicorp/consul/command/rtt"
 	"github.com/hashicorp/consul/command/services"
@@ -110,6 +111,7 @@ func init() {
 	Register("operator raft", func(cli.Ui) (cli.Command, error) { return operraft.New(), nil })
 	Register("operator raft list-peers", func(ui cli.Ui) (cli.Command, error) { return operraftlist.New(ui), nil })
 	Register("operator raft remove-peer", func(ui cli.Ui) (cli.Command, error) { return operraftremove.New(ui), nil })
+	Register("operator raft health", func(ui cli.Ui) (cli.Command, error) { return operrafthealth.New(ui), nil })
 	Register("reload", func(ui cli.Ui) (cli.Command, error) { return reload.New(ui), nil })
 	Register("rtt", func(ui cli.Ui) (cli.Command, error) { return rtt.New(ui), nil })
 	Register("services", func(cli.Ui) (cli.Command, error) { return services.New(), nil })

--- a/command/operator/raft/health/operator_raft_health_test.go
+++ b/command/operator/raft/health/operator_raft_health_test.go
@@ -42,3 +42,28 @@ func TestOperatorRaftHealthCommand(t *testing.T) {
 		}
 	})
 }
+
+func TestOperatorRaftHealthCommand_Unhealthy(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), ``)
+	defer a.Shutdown()
+
+	// Test the health subcommand directly
+	ui := cli.NewMockUi()
+	c := New(ui)
+	args := []string{"-http-addr=" + a.HTTPAddr()}
+
+	code := c.Run(args)
+	if code != 2 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+	output := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "Name  Status  Leader  LastContact  LastIndex  Voter  Healthy\n0 servers can fail without causing an outage"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("bad: %q, %q", output, expected)
+	}
+	expected = "0 servers can fail without causing an outage"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("bad: %q, %q", output, expected)
+	}
+}

--- a/command/operator/raft/health/operator_raft_health_test.go
+++ b/command/operator/raft/health/operator_raft_health_test.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/mitchellh/cli"
+)
+
+func TestOperatorRaftHealthCommand_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestOperatorRaftHealthCommand(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), ``)
+	defer a.Shutdown()
+
+	// Test the health subcommand directly
+	ui := cli.NewMockUi()
+	c := New(ui)
+	args := []string{"-http-addr=" + a.HTTPAddr()}
+
+	code := c.Run(args)
+	if code != 0 {
+		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+	}
+	output := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "alive   true    0s"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("bad: %q, %q", output, expected)
+	}
+	expected = "0 servers can fail without causing an outage"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("bad: %q, %q", output, expected)
+	}
+}

--- a/command/operator/raft/health/operator_raft_health_test.go
+++ b/command/operator/raft/health/operator_raft_health_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/mitchellh/cli"
 )
 
@@ -25,17 +26,19 @@ func TestOperatorRaftHealthCommand(t *testing.T) {
 	c := New(ui)
 	args := []string{"-http-addr=" + a.HTTPAddr()}
 
-	code := c.Run(args)
-	if code != 0 {
-		t.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
-	}
-	output := strings.TrimSpace(ui.OutputWriter.String())
-	expected := "alive   true    0s"
-	if !strings.Contains(output, expected) {
-		t.Fatalf("bad: %q, %q", output, expected)
-	}
-	expected = "0 servers can fail without causing an outage"
-	if !strings.Contains(output, expected) {
-		t.Fatalf("bad: %q, %q", output, expected)
-	}
+	retry.Run(t, func(r *retry.R) {
+		code := c.Run(args)
+		if code != 0 {
+			r.Fatalf("bad: %d. %#v", code, ui.ErrorWriter.String())
+		}
+		output := strings.TrimSpace(ui.OutputWriter.String())
+		expected := "alive   true    0s"
+		if !strings.Contains(output, expected) {
+			r.Fatalf("bad: %q, %q", output, expected)
+		}
+		expected = "0 servers can fail without causing an outage"
+		if !strings.Contains(output, expected) {
+			r.Fatalf("bad: %q, %q", output, expected)
+		}
+	})
 }

--- a/website/source/docs/commands/operator/raft.html.markdown.erb
+++ b/website/source/docs/commands/operator/raft.html.markdown.erb
@@ -23,6 +23,7 @@ removing invalid peers.
 
 Subcommands:
 
+    health         Display health information about the raft cluster
     list-peers     Display the current Raft peer configuration
     remove-peer    Remove a Consul server from the Raft configuration
 ```
@@ -81,3 +82,20 @@ Usage: `consul operator raft remove-peer -address="IP:port"`
 * `-id` - ID of the server to remove.
 
 The return code will indicate success or failure.
+
+## health
+
+This command displays heath information about the current Raft consensus.
+
+Usage: `consul operator raft health`
+
+The output look like this:
+
+```
+Name       Status  Leader  LastContact  LastIndex  Voter  Healthy
+server1    alive   true    0s           39         true   true
+server2    alive   false   1.43ms       39         true   true
+0 servers can fail without causing an outage
+```
+
+The return code will be 0 when the cluster is healthy and 2 when it is not.


### PR DESCRIPTION
Raft health information was already available throught /operator/autopilot/health
(https://www.consul.io/api/operator/autopilot.html#read-health) and can
now be fetched as a subcommand of `consul operator raft`

See #4722