### PR TITLE
ui: [BUGFIX] Fix freetext searching within the nodes page

### DIFF
--- a/ui-v2/app/components/list-collection.js
+++ b/ui-v2/app/components/list-collection.js
@@ -17,6 +17,7 @@ export default Component.extend(WithResizing, {
     this.columns = [25, 25, 25, 25];
   },
   didReceiveAttrs: function() {
+    this._super(...arguments);
     this._cellLayout = this['cell-layout'] = new PercentageColumns(
       get(this, 'items.length'),
       get(this, 'columns'),

--- a/ui-v2/tests/acceptance/components/catalog-filter.feature
+++ b/ui-v2/tests/acceptance/components/catalog-filter.feature
@@ -2,7 +2,7 @@
 Feature: components / catalog-filter
   Scenario: Filtering [Model]
     Given 1 datacenter model with the value "dc-1"
-    And 3 service models from yaml
+    And 4 service models from yaml
     ---
       - ChecksPassing: 1
         ChecksWarning: 0
@@ -13,8 +13,11 @@ Feature: components / catalog-filter
       - ChecksPassing: 0
         ChecksWarning: 0
         ChecksCritical: 1
+      - ChecksPassing: 1
+        ChecksWarning: 0
+        ChecksCritical: 0
     ---
-    And 3 node models from yaml
+    And 4 node models from yaml
     ---
       - Checks:
           - Status: passing
@@ -22,7 +25,8 @@ Feature: components / catalog-filter
           - Status: warning
       - Checks:
           - Status: critical
-
+      - Checks:
+          - Status: passing
     ---
     When I visit the [Page] page for yaml
     ---
@@ -30,12 +34,12 @@ Feature: components / catalog-filter
     ---
     Then the url should be [Url]
 
-    Then I see 3 [Model] models
+    Then I see 4 [Model] models
     And I see allIsSelected on the filter
 
     When I click passing on the filter
     And I see passingIsSelected on the filter
-    And I see 1 [Model] model
+    And I see 2 [Model] models
 
     When I click warning on the filter
     And I see warningIsSelected on the filter


### PR DESCRIPTION
Essentially this was missing a call to `super` in an update from 1.2.3 > 1.3.0. The error unfortunately didn't arise in the tests as it only errors when the node list has 4 items are more (the 4 columns), and the acceptance tests by change were only filling the page with 3 nodes for test purposes.

I've bumped the amount of nodes up to 4 in the tests, which then causes the tests to fail, made the fix by adding the `super` call, and the tests now pass.

I also tested the UI/text searching on a 10,000 node system, and everything now works as expected.