### PR TITLE
Honor when ca is set but verify_outgoing is disabled.

### DIFF
--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -142,10 +142,6 @@ func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
 		InsecureSkipVerify: c.skipBuiltinVerify(),
 		ServerName:         c.ServerName,
 	}
-	if c.VerifyServerHostname {
-		// ServerName is filled in dynamically based on the target DC
-		tlsConfig.ServerName = "VerifyServerHostname"
-	}
 	if len(c.CipherSuites) != 0 {
 		tlsConfig.CipherSuites = c.CipherSuites
 	}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -121,6 +121,10 @@ func (c *Config) KeyPair() (*tls.Certificate, error) {
 	return &cert, err
 }
 
+func (c *Config) skipBuiltinVerify() bool {
+	return c.VerifyServerHostname == false && c.ServerName == ""
+}
+
 // OutgoingTLSConfig generates a TLS configuration for outgoing
 // requests. It will return a nil config if this configuration should
 // not use TLS for outgoing connections.
@@ -135,16 +139,12 @@ func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
 	// Create the tlsConfig
 	tlsConfig := &tls.Config{
 		RootCAs:            x509.NewCertPool(),
-		InsecureSkipVerify: true,
-	}
-	if c.ServerName != "" {
-		tlsConfig.ServerName = c.ServerName
-		tlsConfig.InsecureSkipVerify = false
+		InsecureSkipVerify: c.skipBuiltinVerify(),
+		ServerName:         c.ServerName,
 	}
 	if c.VerifyServerHostname {
 		// ServerName is filled in dynamically based on the target DC
 		tlsConfig.ServerName = "VerifyServerHostname"
-		tlsConfig.InsecureSkipVerify = false
 	}
 	if len(c.CipherSuites) != 0 {
 		tlsConfig.CipherSuites = c.CipherSuites
@@ -202,20 +202,15 @@ func (c *Config) OutgoingTLSWrapper() (DCWrapper, error) {
 		return nil, nil
 	}
 
-	// Strip the trailing '.' from the domain if any
-	domain := strings.TrimSuffix(c.Domain, ".")
-
-	wrapper := func(dc string, c net.Conn) (net.Conn, error) {
-		return WrapTLSClient(c, tlsConfig)
-	}
-
 	// Generate the wrapper based on hostname verification
-	if c.VerifyServerHostname {
-		wrapper = func(dc string, conn net.Conn) (net.Conn, error) {
-			conf := tlsConfig.Clone()
-			conf.ServerName = "server." + dc + "." + domain
-			return WrapTLSClient(conn, conf)
+	wrapper := func(dc string, conn net.Conn) (net.Conn, error) {
+		if c.VerifyServerHostname {
+			// Strip the trailing '.' from the domain if any
+			domain := strings.TrimSuffix(c.Domain, ".")
+			tlsConfig = tlsConfig.Clone()
+			tlsConfig.ServerName = "server." + dc + "." + domain
 		}
+		return c.wrapTLSClient(conn, tlsConfig)
 	}
 
 	return wrapper, nil
@@ -242,7 +237,7 @@ func SpecificDC(dc string, tlsWrap DCWrapper) Wrapper {
 // node names, we don't verify the certificate DNS names. Since go 1.3
 // no longer supports this mode of operation, we have to do it
 // manually.
-func WrapTLSClient(conn net.Conn, tlsConfig *tls.Config) (net.Conn, error) {
+func (c *Config) wrapTLSClient(conn net.Conn, tlsConfig *tls.Config) (net.Conn, error) {
 	var err error
 	var tlsConn *tls.Conn
 
@@ -251,6 +246,11 @@ func WrapTLSClient(conn net.Conn, tlsConfig *tls.Config) (net.Conn, error) {
 	// If crypto/tls is doing verification, there's no need to do
 	// our own.
 	if tlsConfig.InsecureSkipVerify == false {
+		return tlsConn, nil
+	}
+
+	// If verification is not turned on, don't do it.
+	if !c.VerifyOutgoing {
 		return tlsConn, nil
 	}
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -185,9 +185,6 @@ func TestConfig_OutgoingTLS_VerifyHostname(t *testing.T) {
 	if len(tls.RootCAs.Subjects()) != 1 {
 		t.Fatalf("expect root cert")
 	}
-	if tls.ServerName != "VerifyServerHostname" {
-		t.Fatalf("expect server name")
-	}
 	if tls.InsecureSkipVerify {
 		t.Fatalf("should not skip built-in verification")
 	}

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_AppendCA_None(t *testing.T) {


### PR DESCRIPTION
When setting `verify_outgoing = false` and `ca_file = /path/cert.pem` consul checks your cert against the CA although verification is disabled. This PR fixes that and https://github.com/hashicorp/consul/issues/4818.

This PR changes the public interface of consul and although I don't thing `WrapTLSClient` is being used, but who knows? Should I do it in a way that maintains the original `WrapTLSClient`?