### PR TITLE
Update the `join` command format in the k8s Running Consul section

### DIFF
--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -94,7 +94,9 @@ global:
 client:
   enabled: true
   join:
-    - "provider=my-cloud config=val ..."
+    - "provider=my-cloud"
+    - "config=val"
+    - "..."
 ```
 
 The `values.yaml` file to configure the Helm chart sets the proper


### PR DESCRIPTION
Based on info from [consul-helm issue 16](https://github.com/hashicorp/consul-helm/issues/16), the formatting of the helm chart value for joining an external cluster needs to be specified as a yaml array. This updates the documentation to reflect this.