### PR TITLE
Add the consult gem to community tools

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -65,6 +65,9 @@ description: |-
     <a href="https://github.com/criteo/consul-templaterb/">consul-templaterb</a> - Ruby <a href="https://rubygems.org/gems/consul-templaterb">gem</a> and executable hi-performance ERB templating to create configuration files, HTML, JSON, XML content from Consul discovery and KV Data. Executable `consul-templaterb` also support reload commands as well as process management.
   </li>
   <li>
+    <a href="https://github.com/veracross/consult/">consult</a> - Ruby <a href="https://rubygems.org/gems/consult">gem</a> supporting Consul and Vault templating through ERB, with easy Rails integration and support for complex templates, including templates that come from Consul itself for shared configuration across apps.
+  </li>
+  <li>
     <a href="https://github.com/Magnetme/consultant">Consultant</a> - Library for Java services to self register and deregister, fetching configuration, and subscribing to configuration changes.
   </li>
   <li>


### PR DESCRIPTION
Adds https://github.com/veracross/consult/ to the list of community tools.