### PR TITLE
Add support for multiple checks in Consul Client

### DIFF
--- a/api/catalog.go
+++ b/api/catalog.go
@@ -35,6 +35,7 @@ type CatalogService struct {
 	// We forgot to ever add ServiceProxyDestination here so no need to deprecate!
 	ServiceProxy *AgentServiceConnectProxyConfig
 	CreateIndex  uint64
+	Checks       HealthChecks
 	ModifyIndex  uint64
 }
 
@@ -52,6 +53,7 @@ type CatalogRegistration struct {
 	Datacenter      string
 	Service         *AgentService
 	Check           *AgentCheck
+	Checks          HealthChecks
 	SkipNodeUpdate  bool
 }
 


### PR DESCRIPTION
This patch adds the support to specify multiple checks in the catalog client as is accepted by the Consul API.