### PR TITLE
Adds documentation for the new ACL APIs

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -528,6 +528,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 					AccessorID:  structs.ACLTokenAnonymousID,
 					SecretID:    anonymousToken,
 					Description: "Anonymous Token",
+					CreateTime:  time.Now(),
 				}
 				token.SetHash(true)
 

--- a/api/acl.go
+++ b/api/acl.go
@@ -123,6 +123,8 @@ func (a *ACL) Bootstrap() (*ACLToken, *WriteMeta, error) {
 }
 
 // Create is used to generate a new token with the given parameters
+//
+// Deprecated: Use TokenCreate instead.
 func (a *ACL) Create(acl *ACLEntry, q *WriteOptions) (string, *WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/create")
 	r.setWriteOptions(q)
@@ -142,6 +144,8 @@ func (a *ACL) Create(acl *ACLEntry, q *WriteOptions) (string, *WriteMeta, error)
 }
 
 // Update is used to update the rules of an existing token
+//
+// Deprecated: Use TokenUpdate instead.
 func (a *ACL) Update(acl *ACLEntry, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/update")
 	r.setWriteOptions(q)
@@ -157,6 +161,8 @@ func (a *ACL) Update(acl *ACLEntry, q *WriteOptions) (*WriteMeta, error) {
 }
 
 // Destroy is used to destroy a given ACL token ID
+//
+// Deprecated: Use TokenDelete instead.
 func (a *ACL) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/destroy/"+id)
 	r.setWriteOptions(q)
@@ -171,6 +177,8 @@ func (a *ACL) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
 }
 
 // Clone is used to return a new token cloned from an existing one
+//
+// Deprecated: Use TokenClone instead.
 func (a *ACL) Clone(id string, q *WriteOptions) (string, *WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/clone/"+id)
 	r.setWriteOptions(q)
@@ -189,6 +197,8 @@ func (a *ACL) Clone(id string, q *WriteOptions) (string, *WriteMeta, error) {
 }
 
 // Info is used to query for information about an ACL token
+//
+// Deprecated: Use TokenRead instead.
 func (a *ACL) Info(id string, q *QueryOptions) (*ACLEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/info/"+id)
 	r.setQueryOptions(q)
@@ -213,6 +223,8 @@ func (a *ACL) Info(id string, q *QueryOptions) (*ACLEntry, *QueryMeta, error) {
 }
 
 // List is used to get all the ACL tokens
+//
+// Deprecated: Use TokenList instead.
 func (a *ACL) List(q *QueryOptions) ([]*ACLEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/list")
 	r.setQueryOptions(q)
@@ -254,6 +266,8 @@ func (a *ACL) Replication(q *QueryOptions) (*ACLReplicationStatus, *QueryMeta, e
 	return entries, qm, nil
 }
 
+// TokenCreate creates a new ACL token. It requires that the AccessorID and SecretID fields
+// of the ACLToken structure to be empty as these will be filled in by Consul.
 func (a *ACL) TokenCreate(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	if token.AccessorID != "" {
 		return nil, nil, fmt.Errorf("Cannot specify an AccessorID in Token Creation")
@@ -281,6 +295,9 @@ func (a *ACL) TokenCreate(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMe
 	return &out, wm, nil
 }
 
+// TokenUpdate updates a token in place without modifying its AccessorID or SecretID. A valid
+// AccessorID must be set in the ACLToken structure passed to this function but the SecretID may
+// be omitted and will be filled in by Consul with its existing value.
 func (a *ACL) TokenUpdate(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	if token.AccessorID == "" {
 		return nil, nil, fmt.Errorf("Must specify an AccessorID for Token Updating")
@@ -303,6 +320,10 @@ func (a *ACL) TokenUpdate(token *ACLToken, q *WriteOptions) (*ACLToken, *WriteMe
 	return &out, wm, nil
 }
 
+// TokenClone will create a new token with the same policies and locality as the original
+// token but will have its own auto-generated AccessorID and SecretID as well having the
+// description passed to this function. The tokenID parameter must be a valid Accessor ID
+// of an existing token.
 func (a *ACL) TokenClone(tokenID string, description string, q *WriteOptions) (*ACLToken, *WriteMeta, error) {
 	if tokenID == "" {
 		return nil, nil, fmt.Errorf("Must specify a tokenID for Token Cloning")
@@ -326,6 +347,8 @@ func (a *ACL) TokenClone(tokenID string, description string, q *WriteOptions) (*
 	return &out, wm, nil
 }
 
+// TokenDelete removes a single ACL token. The tokenID parameter must be a valid
+// Accessor ID of an existing token.
 func (a *ACL) TokenDelete(tokenID string, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("DELETE", "/v1/acl/token/"+tokenID)
 	r.setWriteOptions(q)
@@ -339,6 +362,8 @@ func (a *ACL) TokenDelete(tokenID string, q *WriteOptions) (*WriteMeta, error) {
 	return wm, nil
 }
 
+// TokenRead retrieves the full token details. The tokenID parameter must be a valid
+// Accessor ID of an existing token.
 func (a *ACL) TokenRead(tokenID string, q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/token/"+tokenID)
 	r.setQueryOptions(q)
@@ -360,6 +385,9 @@ func (a *ACL) TokenRead(tokenID string, q *QueryOptions) (*ACLToken, *QueryMeta,
 	return &out, qm, nil
 }
 
+// TokenReadSelf retrieves the full token details of the token currently
+// assigned to the API Client. In this manner its possible to read a token
+// by its Secret ID.
 func (a *ACL) TokenReadSelf(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/token/self")
 	r.setQueryOptions(q)
@@ -381,6 +409,8 @@ func (a *ACL) TokenReadSelf(q *QueryOptions) (*ACLToken, *QueryMeta, error) {
 	return &out, qm, nil
 }
 
+// TokenList lists all tokens. The listing does not contain any SecretIDs as those
+// may only be retrieved by a call to TokenRead.
 func (a *ACL) TokenList(q *QueryOptions) ([]*ACLTokenListEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/tokens")
 	r.setQueryOptions(q)
@@ -401,6 +431,8 @@ func (a *ACL) TokenList(q *QueryOptions) ([]*ACLTokenListEntry, *QueryMeta, erro
 	return entries, qm, nil
 }
 
+// PolicyCreate will create a new policy. It is not allowed for the policy parameters
+// ID field to be set as this will be generated by Consul while processing the request.
 func (a *ACL) PolicyCreate(policy *ACLPolicy, q *WriteOptions) (*ACLPolicy, *WriteMeta, error) {
 	if policy.ID != "" {
 		return nil, nil, fmt.Errorf("Cannot specify an ID in Policy Creation")
@@ -424,6 +456,8 @@ func (a *ACL) PolicyCreate(policy *ACLPolicy, q *WriteOptions) (*ACLPolicy, *Wri
 	return &out, wm, nil
 }
 
+// PolicyUpdate updates a policy. The ID field of the policy parameter must be set to an
+// existing policy ID
 func (a *ACL) PolicyUpdate(policy *ACLPolicy, q *WriteOptions) (*ACLPolicy, *WriteMeta, error) {
 	if policy.ID == "" {
 		return nil, nil, fmt.Errorf("Must specify an ID in Policy Creation")
@@ -447,6 +481,7 @@ func (a *ACL) PolicyUpdate(policy *ACLPolicy, q *WriteOptions) (*ACLPolicy, *Wri
 	return &out, wm, nil
 }
 
+// PolicyDelete deletes a policy given its ID.
 func (a *ACL) PolicyDelete(policyID string, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("DELETE", "/v1/acl/policy/"+policyID)
 	r.setWriteOptions(q)
@@ -460,6 +495,7 @@ func (a *ACL) PolicyDelete(policyID string, q *WriteOptions) (*WriteMeta, error)
 	return wm, nil
 }
 
+// PolicyRead retrieves the policy details including the rule set.
 func (a *ACL) PolicyRead(policyID string, q *QueryOptions) (*ACLPolicy, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/policy/"+policyID)
 	r.setQueryOptions(q)
@@ -481,6 +517,8 @@ func (a *ACL) PolicyRead(policyID string, q *QueryOptions) (*ACLPolicy, *QueryMe
 	return &out, qm, nil
 }
 
+// PolicyList retrieves a listing of all policies. The listing does not include the
+// rules for any policy as those should be retrieved by subsequent calls to PolicyRead.
 func (a *ACL) PolicyList(q *QueryOptions) ([]*ACLPolicyListEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/policies")
 	r.setQueryOptions(q)
@@ -501,6 +539,10 @@ func (a *ACL) PolicyList(q *QueryOptions) ([]*ACLPolicyListEntry, *QueryMeta, er
 	return entries, qm, nil
 }
 
+// RulesTranslate translates the legacy rule syntax into the current syntax.
+//
+// Deprecated: Support for the legacy syntax translation will be removed
+// when legacy ACL support is removed.
 func (a *ACL) RulesTranslate(rules io.Reader) (string, error) {
 	r := a.c.newRequest("POST", "/v1/acl/rules/translate")
 	r.body = rules
@@ -521,6 +563,11 @@ func (a *ACL) RulesTranslate(rules io.Reader) (string, error) {
 	return string(ruleBytes), nil
 }
 
+// RulesTranslateToken translates the rules associated with the legacy syntax
+// into the current syntax and returns the results.
+//
+// Deprecated: Support for the legacy syntax translation will be removed
+// when legacy ACL support is removed.
 func (a *ACL) RulesTranslateToken(tokenID string) (string, error) {
 	r := a.c.newRequest("GET", "/v1/acl/rules/translate/"+tokenID)
 	rtt, resp, err := requireOK(a.c.doRequest(r))

--- a/website/source/api/acl-legacy.html.md
+++ b/website/source/api/acl-legacy.html.md
@@ -1,14 +1,18 @@
 ---
 layout: api
-page_title: ACLs - HTTP API
-sidebar_current: api-acls
+page_title: Legacy ACLs - HTTP API
+sidebar_current: api-acls-legacy
 description: |-
-  The /acl endpoints create, update, destroy, and query ACL tokens in Consul.
+  The /acl endpoints create, update, destroy, and query Legacy ACL tokens in Consul.
 ---
+
+-> **Consul 1.4.0 deprecates the legacy ACL system completely.** It's _strongly_
+recommended you do not build anything using the legacy system and consider using
+the new ACL [Token](/docs/api/acl-token.html) and [Policy](/docs/api/acl-policy.html) APIs instead.
 
 # ACL HTTP API
 
-The `/acl` endpoints create, update, destroy, and query ACL tokens in Consul. For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
+These `/acl` endpoints create, update, destroy, and query ACL tokens in Consul. For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
 
 ## Bootstrap ACLs
 

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -1,0 +1,264 @@
+---
+layout: api
+page_title: ACLs - HTTP API
+sidebar_current: api-acl
+description: |-
+  The /acl endpoints manage the Consul's ACL system.
+---
+
+-> **1.4.0+:**  The APIs are available in Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api/acl/legacy.html)
+
+# ACL HTTP API
+
+The `/acl` endpoints create, update, destroy, and query ACL tokens and policies in Consul. For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
+
+Documentation for [Tokens](/api/acl/tokens.html) and [Policies](/api/acl/policies.html) are located on their respective pages.
+
+## Bootstrap ACLs
+
+This endpoint does a special one-time bootstrap of the ACL system, making the first
+management token if the [`acl.tokens.master`](/docs/agent/options.html#acl_tokens_master)
+configuration entry is not specified in the Consul server configuration, and if the
+cluster has not been bootstrapped previously. This is available in Consul 0.9.1 and later,
+and requires all Consul servers to be upgraded in order to operate.
+
+This provides a mechanism to bootstrap ACLs without having any secrets present in Consul's
+configuration files.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/bootstrap`             | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `none`       |
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    http://127.0.0.1:8500/v1/acl/bootstrap
+```
+
+### Sample Response
+
+-> **Deprecated** - The `ID` field in the response is for legacy compatibility and is a copy of the SecretID field. New
+applications should ignore the `ID` field as it may be removed in a future major Consul version.
+
+```json
+{
+    "ID": "527347d3-9653-07dc-adc0-598b8f2b0f4d",
+    "AccessorID": "b5b1a918-50bc-fc46-dec2-d481359da4e3",
+    "SecretID": "527347d3-9653-07dc-adc0-598b8f2b0f4d",
+    "Description": "Bootstrap Token (Global Management)",
+    "Policies": [
+        {
+            "ID": "00000000-0000-0000-0000-000000000001",
+            "Name": "global-management"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T10:34:20.843397-04:00",
+    "Hash": "oyrov6+GFLjo/KZAfqgxF/X4J/3LX0435DOBy9V22I0=",
+    "CreateIndex": 12,
+    "ModifyIndex": 12
+}
+```
+
+You can detect if something has interfered with the ACL bootstrapping process by
+checking the response code. A 200 response means that the bootstrap was a success, and
+a 403 means that the cluster has already been bootstrapped, at which point you should
+consider the cluster in a potentially compromised state.
+
+The returned token will have unrestricted privileges to manage all details of the system.
+It can then be used to further configure the ACL system. Please see the
+[ACL Guide](/docs/guides/acl.html) for more details.
+
+## Check ACL Replication
+
+This endpoint returns the status of the ACL replication processes in the
+datacenter. This is intended to be used by operators, or by automation checking
+the health of ACL replication.
+
+Please see the [ACL Guide](/docs/guides/acl.html#replication) replication
+section for more details.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/replication`           | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `consistent`      | `none`        | `none`       |
+
+### Parameters
+
+- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
+  the datacenter of the agent being queried. This is specified as part of the
+  URL as a query parameter.
+
+### Sample Request
+
+```text
+$ curl \
+    http://127.0.0.1:8500/v1/acl/replication
+```
+
+### Sample Response
+
+```json
+{
+  "Enabled": true,
+  "Running": true,
+  "SourceDatacenter": "dc1",
+  "ReplicationType" : "tokens",
+  "ReplicatedIndex": 1976,
+  "ReplicatedTokenIndex": 2018,
+  "LastSuccess": "2018-11-03T06:28:58Z",
+  "LastError": "2016-11-03T06:28:28Z"
+}
+```
+
+- `Enabled` - Reports whether ACL replication is enabled for the datacenter.
+
+- `Running` - Reports whether the ACL replication process is running. The process
+  may take approximately 60 seconds to begin running after a leader election
+  occurs.
+
+- `SourceDatacenter` - The authoritative ACL datacenter that ACLs are being
+  replicated from, and will match the
+  [`primary_datacenter`](/docs/agent/options.html#primary_datacenter) configuration.
+
+- `ReplicationType` - The kind of replication that is currently in use.
+
+   - `legacy` - ACL replication is in legacy mode and is replicating legacy ACL tokens.
+
+   - `policies` - ACL replication is only replicating policies as token replication
+     is disabled.
+
+   - `tokens` - ACL replication is replicating both policies and tokens.
+
+- `ReplicatedIndex` - The last index that was successfully replicated. Which data
+  this index refers to depends on the type of replication being used. For `legacy`
+  replication this can be compared with the value of the `X-Consul-Index` header
+  returned by the [`/v1/acl/list`](/api/acl/legacy.html#acl_list) endpoint to
+  determine if the replication process has gotten all available ACLs. When in either
+  `tokens` or `policies` mode, this index can be compared with the value of the
+  `X-Consul-Index` header returned by the [`/v1/acl/polcies`](/api/acl/policies.html#list-policies)
+  endpoint to determine if the policy replication process has gotten all available
+  ACL policies. Note that ACL replication is rate limited so the indexes may lag behind
+  the primary datacenter.
+
+- `ReplicatedTokenIndex` - The last token index that was successfully replicated.
+   This index can be compared with the value of the `X-Consul-Index` header returned
+   by the [`/v1/acl/tokens`](/api/acl/tokens.html#list) endpoint to determine
+   if the replication process has gotten all available ACL tokens. Note that ACL
+   replication is rate limited so the indexes may lag behind the primary
+   datacenter.
+
+- `LastSuccess` - The UTC time of the last successful sync operation. Since ACL
+  replication is done with a blocking query, this may not update for up to 5
+  minutes if there have been no ACL changes to replicate. A zero value of
+  "0001-01-01T00:00:00Z" will be present if no sync has been successful.
+
+- `LastError` - The UTC time of the last error encountered during a sync
+  operation. If this time is later than `LastSuccess`, you can assume the
+  replication process is not in a good state. A zero value of
+  "0001-01-01T00:00:00Z" will be present if no sync has resulted in an error.
+
+## Translate Rules
+
+-> **Deprecated** - This endpoint was introduced and deprecated in Consul 1.4.0. It
+will be removed in a future major Consul version when support for legacy ACLs is removed.
+
+This endpoint translates the legacy rule syntax into the latest syntax. It is intended
+to be used by operators managing Consul's ACLs and performing legacy token to new policy
+migrations.
+
+| Method | Path                        | Produces                   |
+| ------ | --------------------------- | -------------------------- |
+| `POST` | `/acl/rules/translate`      | `text/plain`               |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:read`   |
+
+### Sample Payload
+
+```text
+agent "" {
+   policy = "read"
+}
+```
+
+### Sample Request
+
+```text
+$ curl -XPOST http://127.0.0.1:8500/v1/acl/rules/translate -d @rules.hcl
+```
+
+### Sample Response
+
+```text
+agent_prefix "" {
+   policy = "read"
+}
+```
+
+## Translate a Legacy Token's Rules
+
+-> **Deprecated** - This endpoint was introduced and deprecated in Consul 1.4.0. It
+will be removed in a future major Consul version when support for legacy ACLs is removed.
+
+This endpoint translates the legacy rules embedded within a legacy ACL into the latest
+syntax. It is intended to be used by operators managing Consul's ACLs and performing
+legacy token to new policy migrations. Note that this API requires the auto-generated
+Accessor ID of the legacy token. This ID can be retrieved using the
+[`/v1/acl/token/self`](/api/acl/tokens.html#self) endpoint.
+
+| Method | Path                                | Produces                   |
+| ------ | ----------------------------------- | -------------------------- |
+| `GET`  | `/acl/rules/translate/:accessor_id` | `text/plain`               |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:read`   |
+
+### Sample Request
+
+```text
+$ curl http://127.0.0.1:8500/v1/acl/rules/translate/4f48f7e6-9359-4890-8e67-6144a962b0a5
+```
+
+### Sample Response
+
+```text
+agent_prefix "" {
+   policy = "read"
+}
+```

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -6,7 +6,7 @@ description: |-
   The /acl endpoints manage the Consul's ACL system.
 ---
 
--> **1.4.0+:**  The APIs are available in Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api/acl/legacy.html)
+-> **1.4.0+:**  This API documentation is for Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api/acl/legacy.html)
 
 # ACL HTTP API
 

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -182,7 +182,7 @@ $ curl \
 
 ## Translate Rules
 
--> **Deprecated** - This endpoint was introduced and deprecated in Consul 1.4.0. It
+-> **Deprecated** - This endpoint was introduced in Consul 1.4.0 for migration from the previous ACL system. It
 will be removed in a future major Consul version when support for legacy ACLs is removed.
 
 This endpoint translates the legacy rule syntax into the latest syntax. It is intended

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -227,7 +227,7 @@ agent_prefix "" {
 
 ## Translate a Legacy Token's Rules
 
--> **Deprecated** - This endpoint was introduced and deprecated in Consul 1.4.0. It
+-> **Deprecated** - This endpoint was introduced in Consul 1.4.0 for migration from the previous ACL system.. It
 will be removed in a future major Consul version when support for legacy ACLs is removed.
 
 This endpoint translates the legacy rules embedded within a legacy ACL into the latest

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -10,9 +10,9 @@ description: |-
 
 # ACL HTTP API
 
-The `/acl` endpoints create, update, destroy, and query ACL tokens and policies in Consul. For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
+The `/acl` endpoints are used to manage ACL tokens and policies in Consul, [bootstrap the ACL system](#bootstrap-acls), [check ACL replication status](#check-acl-replication), and [translate rules](#translate-rules). There are additional pages for managing [Tokens](/api/acl/tokens.html) and [Policies](/api/acl/policies.html) with the `/acl` endpoints.
 
-Documentation for [Tokens](/api/acl/tokens.html) and [Policies](/api/acl/policies.html) are located on their respective pages.
+For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
 
 ## Bootstrap ACLs
 
@@ -49,7 +49,7 @@ $ curl \
 
 ### Sample Response
 
--> **Deprecated** - The `ID` field in the response is for legacy compatibility and is a copy of the SecretID field. New
+-> **Deprecated** - The `ID` field in the response is for legacy compatibility and is a copy of the `SecretID` field. New
 applications should ignore the `ID` field as it may be removed in a future major Consul version.
 
 ```json
@@ -84,8 +84,8 @@ It can then be used to further configure the ACL system. Please see the
 ## Check ACL Replication
 
 This endpoint returns the status of the ACL replication processes in the
-datacenter. This is intended to be used by operators, or by automation checking
-the health of ACL replication.
+datacenter. This is intended to be used by operators or by automation checking 
+to discover the health of ACL replication.
 
 Please see the [ACL Guide](/docs/guides/acl.html#replication) replication
 section for more details.
@@ -114,6 +114,7 @@ The table below shows this endpoint's support for
 
 ```text
 $ curl \
+    --request GET \
     http://127.0.0.1:8500/v1/acl/replication
 ```
 
@@ -139,10 +140,10 @@ $ curl \
   occurs.
 
 - `SourceDatacenter` - The authoritative ACL datacenter that ACLs are being
-  replicated from, and will match the
+  replicated from and will match the
   [`primary_datacenter`](/docs/agent/options.html#primary_datacenter) configuration.
 
-- `ReplicationType` - The kind of replication that is currently in use.
+- `ReplicationType` - The type of replication that is currently in use.
 
    - `legacy` - ACL replication is in legacy mode and is replicating legacy ACL tokens.
 
@@ -152,7 +153,7 @@ $ curl \
    - `tokens` - ACL replication is replicating both policies and tokens.
 
 - `ReplicatedIndex` - The last index that was successfully replicated. Which data
-  this index refers to depends on the type of replication being used. For `legacy`
+  the replicated index refers to depends on the replication type. For `legacy`
   replication this can be compared with the value of the `X-Consul-Index` header
   returned by the [`/v1/acl/list`](/api/acl/legacy.html#acl_list) endpoint to
   determine if the replication process has gotten all available ACLs. When in either
@@ -213,7 +214,7 @@ agent "" {
 ### Sample Request
 
 ```text
-$ curl -XPOST http://127.0.0.1:8500/v1/acl/rules/translate -d @rules.hcl
+$ curl -X POST -d @rules.hcl http://127.0.0.1:8500/v1/acl/rules/translate 
 ```
 
 ### Sample Response
@@ -252,7 +253,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl http://127.0.0.1:8500/v1/acl/rules/translate/4f48f7e6-9359-4890-8e67-6144a962b0a5
+$ curl -X GET http://127.0.0.1:8500/v1/acl/rules/translate/4f48f7e6-9359-4890-8e67-6144a962b0a5
 ```
 
 ### Sample Response

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -10,7 +10,7 @@ description: |-
 
 # ACL HTTP API
 
-The `/acl` endpoints are used to manage ACL tokens and policies in Consul, [bootstrap the ACL system](#bootstrap-acls), [check ACL replication status](#check-acl-replication), and [translate rules](#translate-rules). There are additional pages for managing [Tokens](/api/acl/tokens.html) and [Policies](/api/acl/policies.html) with the `/acl` endpoints.
+The `/acl` endpoints are used to manage ACL tokens and policies in Consul, [bootstrap the ACL system](#bootstrap-acls), [check ACL replication status](#check-acl-replication), and [translate rules](#translate-rules). There are additional pages for managing [tokens](/api/acl/tokens.html) and [policies](/api/acl/policies.html) with the `/acl` endpoints.
 
 For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
 
@@ -18,7 +18,7 @@ For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.htm
 
 This endpoint does a special one-time bootstrap of the ACL system, making the first
 management token if the [`acl.tokens.master`](/docs/agent/options.html#acl_tokens_master)
-configuration entry is not specified in the Consul server configuration, and if the
+configuration entry is not specified in the Consul server configuration and if the
 cluster has not been bootstrapped previously. This is available in Consul 0.9.1 and later,
 and requires all Consul servers to be upgraded in order to operate.
 

--- a/website/source/api/acl/legacy.html.md
+++ b/website/source/api/acl/legacy.html.md
@@ -1,0 +1,292 @@
+---
+layout: api
+page_title: Legacy ACLs - HTTP API
+sidebar_current: api-acl-tokens-legacy
+description: |-
+  The /acl endpoints create, update, destroy, and query Legacy ACL tokens in Consul.
+---
+
+-> **Consul 1.4.0 deprecates the legacy ACL system completely.** It's _strongly_
+recommended you do not build anything using the legacy system and consider using
+the new ACL [Token](/api/acl/tokens.html) and [Policy](/api/acl/policies.html) APIs instead.
+
+# ACL HTTP API
+
+The `/acl` endpoints create, update, destroy, and query ACL tokens in Consul. For more information about ACLs, please see the [ACL Guide](/docs/guides/acl-legacy.html).
+
+## Create ACL Token
+
+This endpoint makes a new ACL token.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/create`                | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `management` |
+
+### Parameters
+
+- `ID` `(string: "")` - Specifies the ID of the ACL. If not provided, a UUID is
+  generated.
+
+- `Name` `(string: "")` - Specifies a human-friendly name for the ACL token.
+
+- `Type` `(string: "client")` - Specifies the type of ACL token. Valid values
+  are: `client` and `management`.
+
+- `Rules` `(string: "")` - Specifies rules for this ACL token. The format of the
+  `Rules` property is documented in the [ACL Guide](/docs/guides/acl-legacy.html).
+
+### Sample Payload
+
+```json
+{
+  "Name": "my-app-token",
+  "Type": "client",
+  "Rules": ""
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/create
+```
+
+### Sample Response
+
+```json
+{
+  "ID": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+}
+```
+
+## Update ACL Token
+
+This endpoint is used to modify the policy for a given ACL token. Instead of
+generating a new token ID, the `ID` field must be provided.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/update`                | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `management` |
+
+### Parameters
+
+The parameters are the same as the _create_ endpoint, except the `ID` field is
+required.
+
+### Sample Payload
+
+```json
+{
+  "ID": "adf4238a-882b-9ddc-4a9d-5b6758e4159e",
+  "Name": "my-app-token-updated",
+  "Type": "client",
+  "Rules": "# New Rules",
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/update
+```
+
+### Sample Response
+```json
+{
+  "ID": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+}
+```
+
+
+## Delete ACL Token
+
+This endpoint deletes an ACL token with the given ID.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/destroy/:uuid`         | `application/json`         |
+
+Even though the return type is application/json, the value is either true or
+false, indicating whether the delete succeeded.
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `management` |
+
+### Parameters
+
+- `uuid` `(string: <required>)` - Specifies the UUID of the ACL token to
+  destroy. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    http://127.0.0.1:8500/v1/acl/destroy/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+```
+
+### Sample Response
+```json
+true
+```
+
+## Read ACL Token
+
+This endpoint reads an ACL token with the given ID.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/info/:uuid`            | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `none`       |
+
+Note: No ACL is required because the ACL is specified in the URL path.
+
+### Parameters
+
+- `uuid` `(string: <required>)` - Specifies the UUID of the ACL token to
+  read. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl \
+    http://127.0.0.1:8500/v1/acl/info/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+```
+
+### Sample Response
+
+```json
+[
+  {
+    "CreateIndex": 3,
+    "ModifyIndex": 3,
+    "ID": "8f246b77-f3e1-ff88-5b48-8ec93abf3e05",
+    "Name": "Client Token",
+    "Type": "client",
+    "Rules": "..."
+  }
+]
+```
+
+## Clone ACL Token
+
+This endpoint clones an ACL and returns a new token `ID`. This allows a token to
+serve as a template for others, making it simple to generate new tokens without
+complex rule management.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/clone/:uuid`         | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `management` |
+
+### Parameters
+
+- `uuid` `(string: <required>)` - Specifies the UUID of the ACL token to
+  be cloned. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    http://127.0.0.1:8500/v1/acl/clone/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+```
+
+### Sample Response
+
+```json
+{
+  "ID": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"
+}
+```
+
+## List ACLs
+
+This endpoint lists all the active ACL tokens.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/list`                  | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `management` |
+
+### Sample Request
+
+```text
+$ curl \
+    http://127.0.0.1:8500/v1/acl/list
+```
+
+### Sample Response
+
+```json
+[
+  {
+    "CreateIndex": 3,
+    "ModifyIndex": 3,
+    "ID": "8f246b77-f3e1-ff88-5b48-8ec93abf3e05",
+    "Name": "Client Token",
+    "Type": "client",
+    "Rules": "..."
+  }
+]
+```

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -1,0 +1,296 @@
+---
+layout: api
+page_title: ACL Policies - HTTP API
+sidebar_current: api-acl-policies
+description: |-
+  The /acl/policy endpoints manage Consul's ACL Policies.
+---
+
+-> **1.4.0+:**  The APIs are available in Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api/acl/legacy.html)
+
+# ACL Policy HTTP API
+
+The `/acl/policy` endpoints [create](#create-a-policy), [read](#read-a-policy),
+[update](#update-a-policy), [list](#list-policies) and [delete](#delete-a-policy)  ACL policies in Consul.
+For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
+
+## Create a Policy
+
+This endpoint makes a new ACL policy.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/policy`                | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `Name` `(string: <required>)` - Specifies a name for the ACL policy. The name
+   can only contain alphanumeric characters as well as `-` and `_` and must be
+   unique.
+
+- `Description` `(string: "")` - Free form human readable description of this policy.
+
+- `Rules` `(string: "")` - Specifies rules for this ACL policy. The format of the
+  `Rules` property is documented in the [ACL Guide](/docs/guides/acl.html).
+
+- `Datacenters` `(array<string>)` - Specifies the datacenters this policy is valid within.
+   When no datacenters are provided the policy is valid in all datacenters including
+   those which do not yet exist but may in the future.
+
+### Sample Payload
+
+```json
+{
+  "Name": "node-read",
+  "Description": "Grants read access to all node information",
+  "Rules": "node_prefix \"\" { policy = \"read\"}",
+  "Datacenters": ["dc1"]
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/policy
+```
+
+### Sample Response
+
+```json
+{
+    "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+    "Name": "node-read",
+    "Description": "Grants read access to all node information",
+    "Rules": "node_prefix \"\" { policy = \"read\"}",
+    "Datacenters": [
+        "dc1"
+    ],
+    "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
+    "CreateIndex": 14,
+    "ModifyIndex": 14
+}
+
+```
+
+## Read a Policy
+
+This endpoint reads an ACL policy with the given ID.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/policy/:id`            | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `acl:read`   |
+
+### Parameters
+
+- `id` `(string: <required>)` - Specifies the UUID of the ACL policy to
+  read. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl http://127.0.0.1:8500/v1/acl/policy/e359bd81-baca-903e-7e64-1ccd9fdc78f5
+```
+
+### Sample Response
+
+```json
+{
+    "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+    "Name": "node-read",
+    "Description": "Grants read access to all node information",
+    "Rules": "node_prefix \"\" { policy = \"read\"}",
+    "Datacenters": [
+        "dc1"
+    ],
+    "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
+    "CreateIndex": 14,
+    "ModifyIndex": 14
+}
+```
+
+## Update a Policy
+
+This endpoint updates an existing ACL policy.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/policy/:id`            | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `ID` `(string: <required>)` - Specifies the ID of the policy to update. This is
+   required in the URL path but may also be specified in the JSON body. If specified
+   in both places then they must match exactly.
+
+- `Name` `(string: <required>)` - Specifies a name for the ACL policy. The name
+   can only contain alphanumeric characters as well as `-` and `_` and must be
+   unique.
+
+- `Description` `(string: "")` - Free form human readable description of this policy.
+
+- `Rules` `(string: "")` - Specifies rules for this ACL policy. The format of the
+  `Rules` property is documented in the [ACL Guide](/docs/guides/acl.html).
+
+- `Datacenters` `(array<string>)` - Specifies the datacenters this policy is valid within.
+   When no datacenters are provided the policy is valid in all datacenters including
+   those which do not yet exist but may in the future.
+
+### Sample Payload
+
+```json
+{
+  "ID": "c01a1f82-44be-41b0-a686-685fb6e0f485",
+  "Name": "register-app-service",
+  "Description": "Grants write permissions necessary to register the 'app' service",
+  "Rules": "service \"app\" { policy = \"write\"}",
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/policy/c01a1f82-44be-41b0-a686-685fb6e0f485
+```
+
+### Sample Response
+
+```json
+{
+   "ID": "c01a1f82-44be-41b0-a686-685fb6e0f485",
+   "Name": "register-app-service",
+   "Description": "Grants write permissions necessary to register the 'app' service",
+   "Rules": "service \"app\" { policy = \"write\"}",
+   "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
+   "CreateIndex": 14,
+   "ModifyIndex": 28
+}
+```
+
+## Delete a Policy
+
+This endpoint deletes an ACL policy.
+
+| Method   | Path                      | Produces                   |
+| -------- | ------------------------- | -------------------------- |
+| `DELETE` | `/acl/policy/:id`         | `application/json`         |
+
+Even though the return type is application/json, the value is either true or
+false, indicating whether the delete succeeded.
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `id` `(string: <required>)` - Specifies the UUID of the ACL policy to
+  delete. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl -XDELETE
+    http://127.0.0.1:8500/v1/acl/policy/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+```
+
+### Sample Response
+```json
+true
+```
+
+## List Policies
+
+This endpoint lists all the ACL policies.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/policies`              | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `acl:read`   |
+
+## Sample Request
+
+```text
+$ curl http://127.0.0.1:8500/v1/acl/policies
+```
+
+### Sample Response
+
+-> **Note** - The policies rules are not included in the listing and must be
+   retrieved by the [policy reading endpoint](#read-a-policy)
+
+```json
+[
+    {
+        "CreateIndex": 4,
+        "Datacenters": null,
+        "Description": "Builtin Policy that grants unlimited access",
+        "Hash": "swIQt6up+s0cV4kePfJ2aRdKCLaQyykF4Hl1Nfdeumk=",
+        "ID": "00000000-0000-0000-0000-000000000001",
+        "ModifyIndex": 4,
+        "Name": "global-management"
+    },
+    {
+        "CreateIndex": 14,
+        "Datacenters": [
+            "dc1"
+        ],
+        "Description": "Grants read access to all node information",
+        "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
+        "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+        "ModifyIndex": 14,
+        "Name": "node-read"
+    }
+]
+
+```

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -38,12 +38,12 @@ The table below shows this endpoint's support for
    can only contain alphanumeric characters as well as `-` and `_` and must be
    unique.
 
-- `Description` `(string: "")` - Free form human readable description of this policy.
+- `Description` `(string: "")` - Free form human readable description of the policy.
 
-- `Rules` `(string: "")` - Specifies rules for this ACL policy. The format of the
+- `Rules` `(string: "")` - Specifies rules for the ACL policy. The format of the
   `Rules` property is documented in the [ACL Guide](/docs/guides/acl.html).
 
-- `Datacenters` `(array<string>)` - Specifies the datacenters this policy is valid within.
+- `Datacenters` `(array<string>)` - Specifies the datacenters the policy is valid within.
    When no datacenters are provided the policy is valid in all datacenters including
    those which do not yet exist but may in the future.
 

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -16,7 +16,7 @@ For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.htm
 
 ## Create a Policy
 
-This endpoint makes a new ACL policy.
+This endpoint creates a new ACL policy.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
@@ -111,7 +111,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl http://127.0.0.1:8500/v1/acl/policy/e359bd81-baca-903e-7e64-1ccd9fdc78f5
+$ curl -X GET http://127.0.0.1:8500/v1/acl/policy/e359bd81-baca-903e-7e64-1ccd9fdc78f5
 ```
 
 ### Sample Response
@@ -211,7 +211,7 @@ This endpoint deletes an ACL policy.
 | `DELETE` | `/acl/policy/:id`         | `application/json`         |
 
 Even though the return type is application/json, the value is either true or
-false, indicating whether the delete succeeded.
+false indicating whether the delete succeeded.
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries),
@@ -231,7 +231,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl -XDELETE
+$ curl -X DELETE
     http://127.0.0.1:8500/v1/acl/policy/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
 ```
 
@@ -261,7 +261,7 @@ The table below shows this endpoint's support for
 ## Sample Request
 
 ```text
-$ curl http://127.0.0.1:8500/v1/acl/policies
+$ curl -X GET http://127.0.0.1:8500/v1/acl/policies
 ```
 
 ### Sample Response

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -1,0 +1,506 @@
+---
+layout: api
+page_title: ACL Policies - HTTP API
+sidebar_current: api-acl-tokens
+description: |-
+  The /acl/token endpoints manage Consul's ACL Policies.
+---
+
+-> **1.4.0+:**  The APIs are available in Consul versions 1.4.0 and later. The documentation for the legacy ACL API is [here](/api/acl/legacy.html)
+
+# ACL Token HTTP API
+
+The `/acl/token` endpoints [create](#create-a-token), [read](#read-a-token),
+[update](#update-a-token), [list](#list-tokens), [clone](#clone-token)and [delete](#delete-a-token)  ACL policies in Consul.
+For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
+
+## Create a Token
+
+This endpoint makes a new ACL token.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/token`                | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `Description` `(string: "")` - Free form human readable description of this token.
+
+- `Policies` `(array<PolicyLink>)` - This is the list of policies that should
+   be applied to this token. A PolicyLink is an object with an "ID" and/or "Name" field
+   to specify a policy. With this tokens can be linked to policies either by the
+   policy name or by the policy ID. When policies are linked by name they will
+   internally be resolved to the policy ID. With linking tokens internally by IDs,
+   Consul enables policy renaming without breaking tokens.
+
+- `Local` `(bool: false)` - If true, indicates that this token should not be replicated
+   globally and instead be local to the current datacenter.
+
+### Sample Payload
+
+```json
+{
+   "Description": "Agent token for 'node1'",
+   "Policies": [
+      {
+         "ID": "165d4317-e379-f732-ce70-86278c4558f7"
+      },
+      {
+         "Name": "node-read"
+      }
+   ],
+   "Local": false
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/token
+```
+
+### Sample Response
+
+```json
+{
+    "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
+    "SecretID": "45a3bd52-07c7-47a4-52fd-0745e0cfe967",
+    "Description": "Agent token for 'node1'",
+    "Policies": [
+        {
+            "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+            "Name": "node1-write"
+        },
+        {
+            "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+            "Name": "node-read"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+    "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+    "CreateIndex": 59,
+    "ModifyIndex": 59
+}
+```
+
+
+## Read a Token
+
+This endpoint reads an ACL token with the given Accessor ID.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/token/:AccessorID`     | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `acl:read`   |
+
+### Parameters
+
+- `AccessorID` `(string: <required>)` - Specifies the accessor ID of the ACL token to
+  read. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c745511
+```
+
+### Sample Response
+
+-> **Note** If the token used for accessing the API has `acl:write` permissions
+then the `SecretID` will contain the tokens real value. Only when accessed with
+a token with only `acl:read` permissions will the `SecretID` be redacted. This
+is to prevent privilege escalation whereby having `acl:read` privileges allows
+for reading other secrets which given even more permissions.
+
+```json
+{
+    "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
+    "SecretID": "<hidden>",
+    "Description": "Agent token for 'node1'",
+    "Policies": [
+        {
+            "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+            "Name": "node1-write"
+        },
+        {
+            "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+            "Name": "node-read"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+    "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+    "CreateIndex": 59,
+    "ModifyIndex": 59
+}
+```
+
+## Read Self Token
+
+This endpoint returns the ACL token details that matches the secret ID
+specified with the `X-Consul-Token` header or the `token` query parameter.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/token/:AccessorID`     | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `none`       |
+
+-> **Note** - This endpoint requires no specific privileges as it is just
+retrieving the data for a token that you must already possess its secret.
+
+### Sample Request
+
+```text
+$ curl -H "X-Consul-Token: 6a1253d2-1785-24fd-91c2-f8e78c745511" \
+   http://127.0.0.1:8500/v1/acl/token/self
+```
+
+### Sample Response
+
+```json
+{
+    "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
+    "SecretID": "45a3bd52-07c7-47a4-52fd-0745e0cfe967",
+    "Description": "Agent token for 'node1'",
+    "Policies": [
+        {
+            "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+            "Name": "node1-write"
+        },
+        {
+            "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+            "Name": "node-read"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+    "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+    "CreateIndex": 59,
+    "ModifyIndex": 59
+}
+```
+
+
+## Update a Token
+
+This endpoint updates an existing ACL token.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `PUT`  | `/acl/token/:AccessorID`     | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `AccessorID` `(string: "")` - Specifies the accessor ID of the token being updated. This is
+   required in the URL path but may also be specified in the JSON body. If specified
+   in both places then they must match exactly. This field is immutable. If not present in
+   the body and only in the URL then it will be filled in by Consul.
+
+- `SecretID` `(string: "")` - Specifies the secret ID of the token being updated. This field is
+   immutable so if present in the body then it must match the existing value. If not present
+   then the value will be filled in by Consul.
+
+- `Description` `(string: "")` - Free form human readable description of this token.
+
+- `Policies` `(array<PolicyLink>)` - This is the list of policies that should
+   be applied to this token. A PolicyLink is an object with an "ID" and/or "Name" field
+   to specify a policy. With this tokens can be linked to policies either by the
+   policy name or by the policy ID. When policies are linked by name they will
+   internally be resolved to the policy ID. With linking tokens internally by IDs,
+   Consul enables policy renaming without breaking tokens.
+
+- `Local` `(bool: false)` - If true, indicates that this token should not be replicated
+   globally and instead be local to the current datacenter. This value must match the
+   existing value or the request will return an error.
+
+### Sample Payload
+
+```json
+{
+   "Description": "Agent token for 'node1'",
+   "Policies": [
+      {
+         "ID": "165d4317-e379-f732-ce70-86278c4558f7"
+      },
+      {
+         "Name": "node-read"
+      },
+      {
+         "Name": "service-read"
+      }
+   ],
+   "Local": false
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c745511
+```
+
+### Sample Response
+
+```json
+{
+    "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
+    "SecretID": "45a3bd52-07c7-47a4-52fd-0745e0cfe967",
+    "Description": "Agent token for 'node1'",
+    "Policies": [
+        {
+            "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+            "Name": "node1-write"
+        },
+        {
+            "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+            "Name": "node-read"
+        },
+        {
+            "ID": "93d2226b-2046-4db1-993b-c0581b5d2391",
+            "Name": "service-read"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+    "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+    "CreateIndex": 59,
+    "ModifyIndex": 100
+}
+```
+
+## Clone a Token
+
+This endpoint clones an existing ACL token.
+
+| Method | Path                           | Produces                   |
+| ------ | ------------------------------ | -------------------------- |
+| `PUT`  | `/acl/token/:AccessorID/clone` | `application/json`        |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `AccessorID` `(string: <required>)` - The accessor ID of the token to clone. This is required
+   in the URL path
+
+- `Description` `(string: "")` - Free form human readable description for the cloned token.
+
+### Sample Payload
+
+```json
+{
+   "Description": "Clone of Agent token for 'node1'",
+}
+```
+
+### Sample Request
+
+```text
+$ curl \
+    --request PUT \
+    --data @payload.json \
+    http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c745511/clone
+```
+
+### Sample Response
+
+```json
+{
+    "AccessorID": "773efe2a-1f6f-451f-878c-71be10712bae",
+    "SecretID": "8b1247ef-d172-4f99-b050-4dbe5d3df0cb",
+    "Description": "Clone of Agent token for 'node1'",
+    "Policies": [
+        {
+            "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+            "Name": "node1-write"
+        },
+        {
+            "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+            "Name": "node-read"
+        },
+        {
+            "ID": "93d2226b-2046-4db1-993b-c0581b5d2391",
+            "Name": "service-read"
+        }
+    ],
+    "Local": false,
+    "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+    "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+    "CreateIndex": 128,
+    "ModifyIndex": 128
+}
+```
+
+## Delete a Token
+
+This endpoint deletes an ACL token.
+
+| Method   | Path                      | Produces                   |
+| -------- | ------------------------- | -------------------------- |
+| `DELETE` | `/acl/token/:AccessorID`  | `application/json`         |
+
+Even though the return type is application/json, the value is either true or
+false, indicating whether the delete succeeded.
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `NO`             | `none`            | `none`        | `acl:write`  |
+
+### Parameters
+
+- `id` `(string: <required>)` - Specifies the accessor ID of the ACL policy to
+  delete. This is required and is specified as part of the URL path.
+
+### Sample Request
+
+```text
+$ curl -XDELETE
+    http://127.0.0.1:8500/v1/acl/token/8f246b77-f3e1-ff88-5b48-8ec93abf3e05
+```
+
+### Sample Response
+```json
+true
+```
+
+## List Tokens
+
+This endpoint lists all the ACL tokens.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/tokens`              | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/index.html#blocking-queries),
+[consistency modes](/api/index.html#consistency-modes),
+[agent caching](/api/index.html#agent-caching), and
+[required ACLs](/api/index.html#acls).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `acl:read`   |
+
+## Parameters
+
+- `policy` `(string: "")` - Filters the token list to those tokens that
+are linked with the specific policy ID.
+
+## Sample Request
+
+```text
+$ curl http://127.0.0.1:8500/v1/acl/tokens
+```
+
+### Sample Response
+
+-> **Note** - The token secret IDs are not included in the listing and must be
+   retrieved by the [token reading endpoint](#read-a-token)
+
+```json
+[
+    {
+        "AccessorID": "6a1253d2-1785-24fd-91c2-f8e78c745511",
+        "Description": "Agent token for 'my-agent'",
+        "Policies": [
+            {
+                "ID": "165d4317-e379-f732-ce70-86278c4558f7",
+                "Name": "node1-write"
+            },
+            {
+                "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+                "Name": "node-read"
+            }
+        ],
+        "Local": false,
+        "CreateTime": "2018-10-24T12:25:06.921933-04:00",
+        "Hash": "UuiRkOQPRCvoRZHRtUxxbrmwZ5crYrOdZ0Z1FTFbTbA=",
+        "CreateIndex": 59,
+        "ModifyIndex": 59
+    },
+    {
+        "AccessorID": "00000000-0000-0000-0000-000000000002",
+        "Description": "Anonymous Token",
+        "Policies": null,
+        "Local": false,
+        "CreateTime": "0001-01-01T00:00:00Z",
+        "Hash": "RNVFSWnfd5DUOuB8vplp+imivlIna3fKQVnkUHh21cA=",
+        "CreateIndex": 5,
+        "ModifyIndex": 5
+    },
+    {
+        "AccessorID": "3328f9a6-433c-02d0-6649-7d07268dfec7",
+        "Description": "Bootstrap Token (Global Management)",
+        "Policies": [
+            {
+                "ID": "00000000-0000-0000-0000-000000000001",
+                "Name": "global-management"
+            }
+        ],
+        "Local": false,
+        "CreateTime": "2018-10-24T11:42:02.6427-04:00",
+        "Hash": "oyrov6+GFLjo/KZAfqgxF/X4J/3LX0435DOBy9V22I0=",
+        "CreateIndex": 12,
+        "ModifyIndex": 12
+    }
+]
+```

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -407,7 +407,7 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `id` `(string: <required>)` - Specifies the accessor ID of the ACL policy to
+- `AccessorID` `(string: <required>)` - Specifies the accessor ID of the ACL policy to
   delete. This is required and is specified as part of the URL path.
 
 ### Sample Request

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -11,7 +11,7 @@ description: |-
 # ACL Token HTTP API
 
 The `/acl/token` endpoints [create](#create-a-token), [read](#read-a-token),
-[update](#update-a-token), [list](#list-tokens), [clone](#clone-token)and [delete](#delete-a-token)  ACL policies in Consul.
+[update](#update-a-token), [list](#list-tokens), [clone](#clone-token) and [delete](#delete-a-token)  ACL policies in Consul.
 
 For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
 
@@ -35,16 +35,16 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `Description` `(string: "")` - Free form human readable description of this token.
+- `Description` `(string: "")` - Free form human readable description of the token.
 
-- `Policies` `(array<PolicyLink>)` - This is the list of policies that should
-   be applied to this token. A PolicyLink is an object with an "ID" and/or "Name" field
-   to specify a policy. With this tokens can be linked to policies either by the
-   policy name or by the policy ID. When policies are linked by name they will
-   internally be resolved to the policy ID. With linking tokens internally by IDs,
+- `Policies` `(array<PolicyLink>)` - The list of policies that should
+   be applied to the token. A PolicyLink is an object with an "ID" and/or "Name" field
+   to specify a policy. With the PolicyLink, tokens can be linked to policies either by the
+   policy name or by the policy ID. When policies are linked by name they will be
+   internally resolved to the policy ID. With linking tokens internally by IDs,
    Consul enables policy renaming without breaking tokens.
 
-- `Local` `(bool: false)` - If true, indicates that this token should not be replicated
+- `Local` `(bool: false)` - If true, indicates that the token should not be replicated
    globally and instead be local to the current datacenter.
 
 ### Sample Payload
@@ -130,7 +130,7 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c7
 
 ### Sample Response
 
--> **Note** If the token used for accessing the API has `acl:write` permissions
+-> **Note** If the token used for accessing the API has `acl:write` permissions,
 then the `SecretID` will contain the tokens real value. Only when accessed with
 a token with only `acl:read` permissions will the `SecretID` be redacted. This
 is to prevent privilege escalation whereby having `acl:read` privileges allows

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -12,15 +12,16 @@ description: |-
 
 The `/acl/token` endpoints [create](#create-a-token), [read](#read-a-token),
 [update](#update-a-token), [list](#list-tokens), [clone](#clone-token)and [delete](#delete-a-token)  ACL policies in Consul.
+
 For more information about ACLs, please see the [ACL Guide](/docs/guides/acl.html).
 
 ## Create a Token
 
-This endpoint makes a new ACL token.
+This endpoint creates a new ACL token.
 
 | Method | Path                         | Produces                   |
 | ------ | ---------------------------- | -------------------------- |
-| `PUT`  | `/acl/token`                | `application/json`         |
+| `PUT`  | `/acl/token`                 | `application/json`         |
 
 The table below shows this endpoint's support for
 [blocking queries](/api/index.html#blocking-queries),
@@ -124,7 +125,7 @@ The table below shows this endpoint's support for
 ### Sample Request
 
 ```text
-$ curl http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c745511
+$ curl -X GET http://127.0.0.1:8500/v1/acl/token/6a1253d2-1785-24fd-91c2-f8e78c745511
 ```
 
 ### Sample Response
@@ -448,7 +449,7 @@ are linked with the specific policy ID.
 ## Sample Request
 
 ```text
-$ curl http://127.0.0.1:8500/v1/acl/tokens
+$ curl -X GET http://127.0.0.1:8500/v1/acl/tokens
 ```
 
 ### Sample Response

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -10,8 +10,21 @@
 
       <hr>
 
-      <li<%= sidebar_current("api-acls") %>>
-        <a href="/api/acl.html">ACLs</a>
+      <li<%= sidebar_current("api-acl") %>>
+        <a href="/api/acl/acl.html">ACLs</a>
+        <ul class="nav">
+          <li<%= sidebar_current("api-acl-tokens") %>>
+            <a href="/api/acl/tokens.html">Tokens</a>
+            <ul class="nav">
+              <li<%= sidebar_current("api-acl-tokens-legacy") %>>
+                <a href="/api/acl/legacy.html">Legacy</a>
+              </li>
+            </ul>
+          </li>
+          <li<%= sidebar_current("api-acl-policies") %>>
+            <a href="/api/acl/policies.html">Policies</a>
+          </li>
+        </ul>
       </li>
       <li<%= sidebar_current("api-agent") %>>
         <a href="/api/agent.html">Agent</a>

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -15,11 +15,9 @@
         <ul class="nav">
           <li<%= sidebar_current("api-acl-tokens") %>>
             <a href="/api/acl/tokens.html">Tokens</a>
-            <ul class="nav">
-              <li<%= sidebar_current("api-acl-tokens-legacy") %>>
-                <a href="/api/acl/legacy.html">Legacy</a>
-              </li>
-            </ul>
+          </li>
+          <li<%= sidebar_current("api-acl-tokens-legacy") %>>
+            <a href="/api/acl/legacy.html">Legacy Tokens</a>
           </li>
           <li<%= sidebar_current("api-acl-policies") %>>
             <a href="/api/acl/policies.html">Policies</a>


### PR DESCRIPTION
fixes #4834 

Also sneaking in a couple minor fixes:

* Ensures the anonymous token is created with the CreateTime set
* The rule translation endpoint now requires `acl:read` permissions to use.