### PR TITLE
Fix some broken links in docs

### DIFF
--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -151,9 +151,6 @@ if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./redirects.txt" ]; then
 
     # Post the JSON body
     curl \
-      --fail \
-      --silent \
-      --output /dev/null \
       --request "PATCH" \
       --header "Fastly-Key: $FASTLY_API_KEY" \
       --header "Content-type: application/json" \
@@ -167,9 +164,6 @@ fi
 if [ -z "$NO_PURGE" ]; then
   echo "Purging Fastly cache..."
   curl \
-    --fail \
-    --silent \
-    --output /dev/null \
     --request "POST" \
     --header "Accept: application/json" \
     --header "Fastly-Key: $FASTLY_API_KEY" \

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -999,19 +999,19 @@ default will automatically work with some tooling.
 
       The following settings are available:
 
-      * <a name="soa_expire"></a><a href="soa_expire">expire</a> -
+      * <a name="soa_expire"></a><a href="#soa_expire">expire</a> -
         Configure SOA Expire duration in seconds, default value is 86400, ie: 24 hours.
 
-      * <a name="soa_min_ttl"></a><a href="soa_min_ttl">`min_ttl`</a> -
+      * <a name="soa_min_ttl"></a><a href="#soa_min_ttl">`min_ttl`</a> -
         Configure SOA DNS minimum TTL.
         As explained in [RFC-2308](https://tools.ietf.org/html/rfc2308) this also controls
         negative cache TTL in most implementations. Default value is 0, ie: no minimum
         delay or negative TTL.
 
-      * <a name="soa_refresh"></a><a href="soa_refresh">refresh</a> -
+      * <a name="soa_refresh"></a><a href="#soa_refresh">refresh</a> -
         Configure SOA Refresh duration in seconds, default value is `3600`, ie: 1 hour.
 
-      *  <a name="soa_retry"></a><a href="soa_retry">retry</a> -
+      * <a name="soa_retry"></a><a href="#soa_retry">retry</a> -
         Configures the Retry duration expressed in seconds, default value is
         600, ie: 10 minutes.
 

--- a/website/source/docs/connect/proxies/managed-deprecated.html.md
+++ b/website/source/docs/connect/proxies/managed-deprecated.html.md
@@ -4,7 +4,7 @@ page_title: "Connect - Deprecated Managed Proxies"
 sidebar_current: "docs-connect-proxies"
 description: |-
   Consul 1.2 launched it's Connect Beta period with a feature named Managed
-  Proxies which are now deprecated. This page describes how they worked and why 
+  Proxies which are now deprecated. This page describes how they worked and why
   they are no longer supported.
 ---
 
@@ -57,7 +57,7 @@ page will document how they work in the interim.
 
 -> **Deprecation Note:** It's _strongly_ recommended you do not build anything
 using Managed proxies and consider using [sidecar service
-registrations](/docs/connect/proxies.html/sidecar-service.html) instead.
+registrations](/docs/connect/proxies/sidecar-service.html) instead.
 
 Managed proxies are given
 a unique proxy-specific ACL token that allows read-only access to Connect

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -334,7 +334,7 @@ In Consul 0.9.1 and later you can also introduce the agent token using an API,
 so it doesn't need to be set in the configuration file:
 
 ```bash
-$ consul acl set-agent-token agent da666809-98ca-0e94-a99c-893c4bf5f9eb 
+$ consul acl set-agent-token agent da666809-98ca-0e94-a99c-893c4bf5f9eb
 
 ACL token "agent" set successfully
 ```
@@ -722,7 +722,7 @@ or the `CONSUL_HTTP_TOKEN` environment variable.
 #### ACL Rules
 
 The `acl` resource controls access to ACL operations in the
-[ACL API](/api/operator/acl.html).
+[ACL API](/api/acl.html).
 
 ACL rules look like this:
 


### PR DESCRIPTION
Some of these snuck in. Unclear how we could verify this in CI without actually building the site, but it was caught in our deploy process (and ignored for a few deploys).

Also made the problematic area a bit more verbose to aid future debugging. It is ok if it is noisy.