### PR TITLE
UI: Refactors the code-mirror linting

### DIFF
--- a/ui-v2/app/components/code-editor.js
+++ b/ui-v2/app/components/code-editor.js
@@ -11,7 +11,7 @@ const DEFAULTS = {
 };
 export default Component.extend({
   settings: service('settings'),
-  helper: service('code-mirror'),
+  helper: service('code-mirror/linter'),
   classNames: ['code-editor'],
   syntax: '',
   onchange: function(value) {

--- a/ui-v2/app/initializers/ivy-codemirror.js
+++ b/ui-v2/app/initializers/ivy-codemirror.js
@@ -1,43 +1,8 @@
-import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
-import lint from 'consul-ui/utils/editor/lint';
-const MODES = [
-  {
-    name: 'JSON',
-    mime: 'application/json',
-    mode: 'javascript',
-    ext: ['json', 'map'],
-    alias: ['json5'],
-  },
-  {
-    name: 'HCL',
-    mime: 'text/x-ruby',
-    mode: 'ruby',
-    ext: ['rb'],
-    alias: ['jruby', 'macruby', 'rake', 'rb', 'rbx'],
-  },
-  { name: 'YAML', mime: 'text/x-yaml', mode: 'yaml', ext: ['yaml', 'yml'], alias: ['yml'] },
-];
 export function initialize(application) {
   const IvyCodeMirrorComponent = application.resolveRegistration('component:ivy-codemirror');
-  const IvyCodeMirrorService = application.resolveRegistration('service:code-mirror');
   // Make sure ivy-codemirror respects/maintains a `name=""` attribute
   IvyCodeMirrorComponent.reopen({
     attributeBindings: ['name'],
-  });
-  // Add some method to the code-mirror service so I don't have to have 2 services
-  // for dealing with codemirror
-  IvyCodeMirrorService.reopen({
-    dom: service('dom'),
-    modes: function() {
-      return MODES;
-    },
-    lint: function() {
-      return lint(...arguments);
-    },
-    getEditor: function(element) {
-      return get(this, 'dom').element('textarea + div', element).CodeMirror;
-    },
   });
 }
 

--- a/ui-v2/app/services/code-mirror/linter.js
+++ b/ui-v2/app/services/code-mirror/linter.js
@@ -1,0 +1,33 @@
+import Service, { inject as service } from '@ember/service';
+import { get } from '@ember/object';
+import lint from 'consul-ui/utils/editor/lint';
+const MODES = [
+  {
+    name: 'JSON',
+    mime: 'application/json',
+    mode: 'javascript',
+    ext: ['json', 'map'],
+    alias: ['json5'],
+  },
+  {
+    name: 'HCL',
+    mime: 'text/x-ruby',
+    mode: 'ruby',
+    ext: ['rb'],
+    alias: ['jruby', 'macruby', 'rake', 'rb', 'rbx'],
+  },
+  { name: 'YAML', mime: 'text/x-yaml', mode: 'yaml', ext: ['yaml', 'yml'], alias: ['yml'] },
+];
+
+export default Service.extend({
+  dom: service('dom'),
+  modes: function() {
+    return MODES;
+  },
+  lint: function() {
+    return lint(...arguments);
+  },
+  getEditor: function(element) {
+    return get(this, 'dom').element('textarea + div', element).CodeMirror;
+  },
+});

--- a/ui-v2/app/templates/dc/acls/tokens/-fieldsets-legacy.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-fieldsets-legacy.hbs
@@ -15,7 +15,7 @@
 {{/if}}
         <label class="type-text">
             <span>Rules <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-            {{code-editor class=(if item.error.Rules 'error') name='Rules' value=item.Rules onkeyup=(action 'change' 'Rules')}}
+            {{code-editor class=(if item.error.Rules 'error') name='Rules' syntax='hcl' value=item.Rules onkeyup=(action 'change' 'Rules')}}
         </label>
 {{#if create }}
         <label class="type-text">

--- a/ui-v2/tests/unit/services/code-mirror/linter-test.js
+++ b/ui-v2/tests/unit/services/code-mirror/linter-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:code-mirror/linter', 'Unit | Service | code mirror/linter', {
+  // Specify the other units that are required for this test.
+  needs: ['service:dom'],
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Also see:

https://github.com/hashicorp/consul/pull/4814#issuecomment-431346912

This moves the extra code mirror linting functionality into a separate service so I'm not changing things I don't own.

I also noticed that when editing rules of legacy tokens the editor wasn't restricted to HCL only, so this adds an attribute to the component for that view to restrict the editor to HCL only.

I also considered moving the mode configuration into ember configuration, but decided against in the end as I don't want all of this configuration going in a meta tag attribute. There's still some nice work that could be done on top of this, but for now I'll at least wait until we revisit the look and feel also.

