### PR TITLE
UI: Move ACL policy and token repos to use the RepositoryService

### DIFF
--- a/ui-v2/app/services/repository/policy.js
+++ b/ui-v2/app/services/repository/policy.js
@@ -1,12 +1,11 @@
-import Service, { inject as service } from '@ember/service';
+import RepositoryService from 'consul-ui/services/repository';
 import { get } from '@ember/object';
-import { typeOf } from '@ember/utils';
-import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/policy';
 import { Promise } from 'rsvp';
 import statusFactory from 'consul-ui/utils/acls-status';
-const status = statusFactory(Promise);
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/policy';
 const MODEL_NAME = 'policy';
-export default Service.extend({
+const status = statusFactory(Promise);
+export default RepositoryService.extend({
   getModelName: function() {
     return MODEL_NAME;
   },
@@ -16,43 +15,10 @@ export default Service.extend({
   getSlugKey: function() {
     return SLUG_KEY;
   },
-  store: service('store'),
   status: function(obj) {
     return status(obj);
   },
   translate: function(item) {
     return get(this, 'store').translate('policy', get(item, 'Rules'));
-  },
-  findAllByDatacenter: function(dc) {
-    return get(this, 'store').query('policy', {
-      dc: dc,
-    });
-  },
-  findBySlug: function(slug, dc) {
-    return get(this, 'store').queryRecord('policy', {
-      id: slug,
-      dc: dc,
-    });
-  },
-  create: function(obj) {
-    return get(this, 'store').createRecord('policy', obj);
-  },
-  persist: function(item) {
-    return item.save();
-  },
-  remove: function(obj) {
-    let item = obj;
-    if (typeof obj.destroyRecord === 'undefined') {
-      item = obj.get('data');
-    }
-    if (typeOf(item) === 'object') {
-      item = get(this, 'store').peekRecord('policy', item[PRIMARY_KEY]);
-    }
-    return item.destroyRecord().then(item => {
-      return get(this, 'store').unloadRecord(item);
-    });
-  },
-  invalidate: function() {
-    get(this, 'store').unloadAll('policy');
   },
 });

--- a/ui-v2/app/services/repository/token.js
+++ b/ui-v2/app/services/repository/token.js
@@ -1,12 +1,11 @@
-import Service, { inject as service } from '@ember/service';
+import RepositoryService from 'consul-ui/services/repository';
 import { get } from '@ember/object';
-import { typeOf } from '@ember/utils';
-import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/token';
 import { Promise } from 'rsvp';
 import statusFactory from 'consul-ui/utils/acls-status';
-const status = statusFactory(Promise);
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/token';
 const MODEL_NAME = 'token';
-export default Service.extend({
+const status = statusFactory(Promise);
+export default RepositoryService.extend({
   getModelName: function() {
     return MODEL_NAME;
   },
@@ -33,40 +32,5 @@ export default Service.extend({
       policy: id,
       dc: dc,
     });
-  },
-  // TODO: RepositoryService
-  store: service('store'),
-  findAllByDatacenter: function(dc) {
-    return get(this, 'store').query(this.getModelName(), {
-      dc: dc,
-    });
-  },
-  findBySlug: function(slug, dc) {
-    return get(this, 'store').queryRecord(this.getModelName(), {
-      id: slug,
-      dc: dc,
-    });
-  },
-  create: function(obj) {
-    // TODO: This should probably return a Promise
-    return get(this, 'store').createRecord(this.getModelName(), obj);
-  },
-  persist: function(item) {
-    return item.save();
-  },
-  remove: function(obj) {
-    let item = obj;
-    if (typeof obj.destroyRecord === 'undefined') {
-      item = obj.get('data');
-    }
-    if (typeOf(item) === 'object') {
-      item = get(this, 'store').peekRecord(this.getModelName(), item[this.getPrimaryKey()]);
-    }
-    return item.destroyRecord().then(item => {
-      return get(this, 'store').unloadRecord(item);
-    });
-  },
-  invalidate: function() {
-    get(this, 'store').unloadAll(this.getModelName());
   },
 });


### PR DESCRIPTION
This PR moves the new ACL policies and tokens to use the `RepositoryService` from https://github.com/hashicorp/consul/pull/4694.