### PR TITLE
Node ID/datacenter snapshot fix

### DIFF
--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -82,7 +82,9 @@ func (s *snapshot) persistNodes(sink raft.SnapshotSink,
 	for node := nodes.Next(); node != nil; node = nodes.Next() {
 		n := node.(*structs.Node)
 		req := structs.RegisterRequest{
+			ID:              n.ID,
 			Node:            n.Node,
+			Datacenter:      n.Datacenter,
 			Address:         n.Address,
 			TaggedAddresses: n.TaggedAddresses,
 			NodeMeta:        n.Meta,


### PR DESCRIPTION
This adds the missing ID and datacenter fields to the snapshot persist logic.