### PR TITLE
Update Helm docs to include the `default` flag for catalog sync

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -261,6 +261,11 @@ and consider if they're appropriate for your deployment.
   [consul-k8s](/docs/platform/k8s/index.html#quot-consul-k8s-quot-project)
   to run the sync program.
 
+  - <a name="v-synccatalog-default" href="#v-synccatalog-default">`default`</a> (`boolean: true`) -
+  If true, all valid services in K8S are synced by default. If false,
+  the service must be [annotated](/docs/platform/k8s/service-sync.html#sync-enable-disable)
+  properly to sync. In either case an annotation can override the default.
+
   - <a name="v-synccatalog-k8sprefix" href="#v-synccatalog-k8sprefix">`k8sPrefix`</a> (`string: ""`) -
   A prefix to prepend to all services registered in Kubernetes from Consul.
   This defaults to `""` where no prefix is prepended; Consul services are

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -133,9 +133,10 @@ is routable and configured by some other system.
 
 ### Sync Enable/Disable
 
-By default, all valid services (as explained above) are synced. This default
-can be changed as configuration to the sync process. Syncing can also be
-explicitly enabled or disabled using an annotation:
+By default, all valid services (as explained above) are synced. This default can
+be changed as [configuration](/docs/platform/k8s/helm.html#v-synccatalog-default)
+to the sync process. Syncing can also be explicitly enabled or disabled using an
+annotation:
 
 ```yaml
 kind: Service
@@ -143,7 +144,7 @@ apiVersion: v1
 metadata:
   name: my-service
   annotations:
-    "consul.hashicorp.com/service-sync": false
+    "consul.hashicorp.com/service-sync": "false"
 ```
 
 ### Service Name

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -134,7 +134,7 @@ is routable and configured by some other system.
 ### Sync Enable/Disable
 
 By default, all valid services (as explained above) are synced. This default can
-be changed as [configuration](/docs/platform/k8s/helm.html#v-synccatalog-default)
+be changed using the [configuration](/docs/platform/k8s/helm.html#v-synccatalog-default).
 to the sync process. Syncing can also be explicitly enabled or disabled using an
 annotation:
 

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -135,7 +135,7 @@ is routable and configured by some other system.
 
 By default, all valid services (as explained above) are synced. This default can
 be changed using the [configuration](/docs/platform/k8s/helm.html#v-synccatalog-default).
-to the sync process. Syncing can also be explicitly enabled or disabled using an
+Syncing can also be explicitly enabled or disabled using an
 annotation:
 
 ```yaml


### PR DESCRIPTION
Additionally fixes an issue with quotes on the related annotation.

Documentation change supports [this](https://github.com/hashicorp/consul-helm/pull/54) helm chart change.