### PR TITLE
Doc and whitespace fixes for translate-rules command

### DIFF
--- a/command/acl/rules/translate.go
+++ b/command/acl/rules/translate.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/hashicorp/consul/acl"
 	aclhelpers "github.com/hashicorp/consul/command/acl"
@@ -34,7 +35,7 @@ type cmd struct {
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flags.BoolVar(&c.tokenAccessor, "token-accessor", false, "Specifies that "+
-		"the TRANSLATE argument refers to a ACL token SecretID. "+
+		"the TRANSLATE argument refers to a ACL token AccessorID. "+
 		"The rules to translate will then be read from the retrieved token")
 
 	c.flags.BoolVar(&c.tokenSecret, "token-secret", false,
@@ -64,6 +65,9 @@ func (c *cmd) Run(args []string) int {
 			c.UI.Error(fmt.Sprintf("Error connecting to Consul Agent: %s", err))
 			return 1
 		}
+
+		// Trim whitespace and newlines (e.g. from echo without -n)
+		data = strings.TrimSpace(data)
 
 		if rules, err := aclhelpers.GetRulesFromLegacyToken(client, data, c.tokenSecret); err != nil {
 			c.UI.Error(err.Error())
@@ -127,7 +131,7 @@ Usage: consul acl translate-rules  [options] TRANSLATE
 
   Translate rules for a legacy ACL token using its SecretID passed from stdin:
 
-      $ consul acl translate-rules --token-secret -
+      $ consul acl translate-rules -token-secret -
 
   Translate rules for a legacy ACL token using its AccessorID:
 


### PR DESCRIPTION
Fixes a couple of errors in the command usage doc output and an annoying issue when reading UUIDs from stdin - whitespace was not being ignored making it hard to enter manually (some shells want a newline before Ctrl-D will close Stdin.), and requireing `-n` for echo which is confusing:

## Before:

```
echo "0280f8cc-d88e-9e9e-d9cd-4daecf915621" | consul acl translate-rules -token-secret -
No such token ID with prefix: 0280f8cc-d88e-9e9e-d9cd-4daecf915621

```
```
echo -n "0280f8cc-d88e-9e9e-d9cd-4daecf915621" | consul acl translate-rules -token-secret -
service_prefix "" {
  policy = "write"
}
```
```
consul acl translate-rules -token-secret -
0280f8cc-d88e-9e9e-d9cd-4daecf915621[<== typed, Enter, Ctrl-D]
No such token ID with prefix: 0280f8cc-d88e-9e9e-d9cd-4daecf915621

```

## After

```
echo "0280f8cc-d88e-9e9e-d9cd-4daecf915621" | consul acl translate-rules -token-secret -
service_prefix "" {
  policy = "write"
}
```
```
consul acl translate-rules -token-secret -
0280f8cc-d88e-9e9e-d9cd-4daecf915621[<== typed, Enter, Ctrl-D]
service_prefix "" {
  policy = "write"
}

```