### PR TITLE
Allow ACL legacy migration via CLI

### DIFF
--- a/command/acl/rules/translate.go
+++ b/command/acl/rules/translate.go
@@ -135,5 +135,5 @@ Usage: consul acl translate-rules  [options] TRANSLATE
 
   Translate rules for a legacy ACL token using its AccessorID:
 
-      $ consul acl translate-rules 429cd746-03d5-4bbb-a83a-18b164171c89
+      $ consul acl translate-rules -token-accessor 429cd746-03d5-4bbb-a83a-18b164171c89
 `

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/y0ssar1an/q"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
@@ -158,7 +157,6 @@ func TestTokenUpdateCommand(t *testing.T) {
 			&api.QueryOptions{Token: legacyTokenSecretID})
 		r.Check(err)
 		require.NotEmpty(r, legacyToken.AccessorID)
-		q.Q(legacyToken)
 	})
 
 	// upgrade legacy token should replace rules and leave token in a "new" state!
@@ -180,7 +178,6 @@ func TestTokenUpdateCommand(t *testing.T) {
 			legacyToken.AccessorID,
 			&api.QueryOptions{Token: "root"},
 		)
-		q.Q(gotToken)
 		assert.NoError(err)
 		assert.NotNil(gotToken)
 		// Description shouldn't change

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -5,11 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"github.com/y0ssar1an/q"
+
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/testutil"
+	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,6 +29,8 @@ func TestTokenUpdateCommand_noTabs(t *testing.T) {
 func TestTokenUpdateCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
+	// Alias because we need to access require package in Retry below
+	req := require.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
@@ -44,7 +50,6 @@ func TestTokenUpdateCommand(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	cmd := New(ui)
 
 	// Create a policy
 	client := a.Client()
@@ -53,17 +58,31 @@ func TestTokenUpdateCommand(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(err)
+	req.NoError(err)
 
 	// create a token
 	token, _, err := client.ACL().TokenCreate(
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	assert.NoError(err)
+	req.NoError(err)
+
+	// create a legacy token
+	legacyTokenSecretID, _, err := client.ACL().Create(&api.ACLEntry{
+		Name:  "Legacy token",
+		Type:  "client",
+		Rules: "service \"test\" { policy = \"write\" }",
+	},
+		&api.WriteOptions{Token: "root"},
+	)
+	req.NoError(err)
+
+	// We fetch the legacy token later to give server time to async background
+	// upgrade it.
 
 	// update with policy by name
 	{
+		cmd := New(ui)
 		args := []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + token.AccessorID,
@@ -86,6 +105,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 
 	// update with policy by id
 	{
+		cmd := New(ui)
 		args := []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + token.AccessorID,
@@ -104,5 +124,71 @@ func TestTokenUpdateCommand(t *testing.T) {
 		)
 		assert.NoError(err)
 		assert.NotNil(token)
+	}
+
+	// update with no description shouldn't delete the current description
+	{
+		cmd := New(ui)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-id=" + token.AccessorID,
+			"-token=root",
+			"-policy-name=" + policy.Name,
+		}
+
+		code := cmd.Run(args)
+		assert.Equal(code, 0)
+		assert.Empty(ui.ErrorWriter.String())
+
+		token, _, err := client.ACL().TokenRead(
+			token.AccessorID,
+			&api.QueryOptions{Token: "root"},
+		)
+		assert.NoError(err)
+		assert.NotNil(token)
+		assert.Equal("test token", token.Description)
+	}
+
+	// Need legacy token now, hopefully server had time to generate an accessor ID
+	// in the background but wait for it if not.
+	var legacyToken *api.ACLToken
+	retry.Run(t, func(r *retry.R) {
+		// Fetch the legacy token via new API so we can use it's accessor ID
+		legacyToken, _, err = client.ACL().TokenReadSelf(
+			&api.QueryOptions{Token: legacyTokenSecretID})
+		r.Check(err)
+		require.NotEmpty(r, legacyToken.AccessorID)
+		q.Q(legacyToken)
+	})
+
+	// upgrade legacy token should replace rules and leave token in a "new" state!
+	{
+		cmd := New(ui)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-id=" + legacyToken.AccessorID,
+			"-token=root",
+			"-policy-name=" + policy.Name,
+			"-upgrade-legacy",
+		}
+
+		code := cmd.Run(args)
+		assert.Equal(code, 0)
+		assert.Empty(ui.ErrorWriter.String())
+
+		gotToken, _, err := client.ACL().TokenRead(
+			legacyToken.AccessorID,
+			&api.QueryOptions{Token: "root"},
+		)
+		q.Q(gotToken)
+		assert.NoError(err)
+		assert.NotNil(gotToken)
+		// Description shouldn't change
+		assert.Equal("Legacy token", gotToken.Description)
+		assert.Len(gotToken.Policies, 1)
+		// Rules should now be empty meaning this is no longer a legacy token
+		assert.Empty(gotToken.Rules)
+		// Secret should not have changes
+		assert.Equal(legacyToken.SecretID, gotToken.SecretID)
 	}
 }


### PR DESCRIPTION
In order to migrate a legacy ACL to a new policy you need to create an equivalent policy which is well supported using either `consul acl translate-rules` or more simply `consul acl policy create -from-token ...`.

To complete the migration though we need to update the legacy token to both use the new policy, and to remove it's old `Rules` fields which is what makes it a "legacy" token.

While the API supports this, the CLI `consul token update` command didn't have anyway to remove the Rules field which meant it failed validation with `Unexpected response code: 500 (Rules cannot be specified for this token)`.

This PR fixes that by adding an `-upgrade-legacy` option for `consul acl token update` which explicitly unsets the Rules causing the token to no longer be considered legacy.

## Other Minor Fixes Here

 - Another typo in the translate-rules docs I found
 - Update also reset Description even if no `-description` argument was passed effectively deleting token descriptions which is unexpected and cumbersome. Fixed and added test.
 - Tests added for new functionality
 - sharing `cmd` between tests breaks stuff since the state set by flag parsing is affected by previous test cases.