### PR TITLE
acl: fixes ACL replication for legacy tokens without AccessorIDs

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -629,6 +629,8 @@ func (s *Server) startACLUpgrade() {
 				newToken.CreateIndex = token.CreateIndex
 				newToken.ModifyIndex = token.ModifyIndex
 
+				newToken.SetHash(true)
+
 				newTokens = append(newTokens, &newToken)
 			}
 


### PR DESCRIPTION
Two main situations that this corrects for regarding legacy tokens not having AccessorIDs, and the new replication comparison code exclusively using AccessorIDs for differencing:

1. After upgrading to 1.4 and transitioning to new replication, non-primary DCs that had ever replicated legacy tokens had replication get stuck because they diff out as needing to be locally deleted, but you can't delete a token named `"" (emptystring)`.
2. After a cluster is up on 1.4 and you create a new legacy token on the primary DC, there is a window of time where the non-primary DC replication workers will poll for updates and see a new token show up with `AccessorID:"" (emptystring)"`. Further attempts to lookup details against the primary DC for a token named `"" (emptystring)` fail similarly to (1).

The patch has the differencing code try to ignore both local legacy tokens and remote legacy tokens. Skipping local legacy fixes (1) and skipping remote legacy fixes (2).

It's ok to skip local legacy as later when the primary DC backfills the AccessorID that will show up as a new change that is replicated and *won't be skipped* which eventually fixes the remote DC.

It's ok to skip remote legacy as later when the primary DC backfills the AccessorID it will suddenly participate in the differencing again.