### PR TITLE
Clarify storage usage for consul + k8s

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -122,6 +122,19 @@ and consider if they're appropriate for your deployment.
   used when bootstrapping new clusters, it has no effect during ongoing cluster
   maintenance.
 
+  - <a name="v-server-storage" href="#v-server-storage">`storage`</a> (`string: 10Gi`) -
+  This defines the disk size for configuring the servers' StatefulSet storage. For dynamically
+  provisioned storage classes, this is the desired size. For manually defined persistent
+  volumes, this should be set to the disk size of the attached volume.
+
+  - <a name="v-server-storageclass" href="#v-server-storageclass">`storageClass`</a> (`string: null`) -
+  The StorageClass to use for the servers' StatefulSet storage. It must be able to be dynamically
+  provisioned if you want the storage to be automatically created. For example, to use
+  [Local](https://kubernetes.io/docs/concepts/storage/storage-classes/#local)
+  storage classes, the PersistentVolumeClaims would need to be manually created. A `null` value will
+  use the Kubernetes cluster's default StorageClass. If a default StorageClass does not exist,
+  you will need to create one.
+
   - <a name="v-server-connect" href="#v-server-connect">`connect`</a> (`boolean: true`) -
   This will enable/disable [Connect](/docs/connect/index.html). Setting this
   to true _will not_ automatically secure pod communication, this setting will

--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -284,6 +284,11 @@ Additionally, a **PodDisruptionBudget** is configured so the Consul server
 cluster maintains quorum during voluntary operational events. The maximum
 unavailable is `(n/2)-1` where `n` is the number of server agents.
 
+-> **Note:** Kubernetes and Helm do not delete Persistent Volumes or Persistent
+Volume Claims when a
+[StatefulSet is deleted](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-storage),
+so this must done manually when removing servers.
+
 ### Client Agents
 
 The client agents are run as a **DaemonSet**. This places one agent


### PR DESCRIPTION
This adds two Helm chart values into the documentation with details
that have come up in several issues.

Additionally, it notes that persistent volumes and their claims need
to be removed manually because of current kubernetes and helm design.