### PR TITLE
UI: Make empty `Rules: ""` take priority over `Legacy: true`

### DIFF
--- a/ui-v2/app/helpers/token/is-legacy.js
+++ b/ui-v2/app/helpers/token/is-legacy.js
@@ -2,8 +2,17 @@ import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 
 const _isLegacy = function(token) {
+  // Empty Rules take priority over a Legacy: true
+  // in order to make this decision
   const rules = get(token, 'Rules');
-  return get(token, 'Legacy') || (rules != null && rules.trim() != '');
+  if (rules != null) {
+    return rules.trim() !== '';
+  }
+  const legacy = get(token, 'Legacy');
+  if (typeof legacy !== 'undefined') {
+    return legacy;
+  }
+  return false;
 };
 export function isLegacy(params, hash) {
   const token = params[0];

--- a/ui-v2/tests/unit/helpers/token/is-legacy-test.js
+++ b/ui-v2/tests/unit/helpers/token/is-legacy-test.js
@@ -19,7 +19,7 @@ test('it returns false if the token has Rules but those rules are empty', functi
   const actual = isLegacy([{ Rules: '' }]);
   assert.notOk(actual);
 });
-test('it returns false if the token has Rules but those rules are empty', function(assert) {
+test('it returns false if the token has Rules but those rules is null', function(assert) {
   const actual = isLegacy([{ Rules: null }]);
   assert.notOk(actual);
 });
@@ -42,5 +42,12 @@ test('it returns true if one token has Rules', function(assert) {
 });
 test('it returns false if tokens have no Rules, or has Rules but those rules are empty', function(assert) {
   const actual = isLegacy([[{}, { Rules: '' }]]);
+  assert.notOk(actual);
+});
+test('it returns false if a token is marked as legacy, has Rules but those rules are empty', function(assert) {
+  // this may seem strange, but empty Rules should override Legacy, this only happens
+  // when a legacy token that has already been loaded has its rules wiped out
+  // WITHOUT then the ui refreshing
+  const actual = isLegacy([{ Legacy: true, Rules: '' }]);
   assert.notOk(actual);
 });


### PR DESCRIPTION
Even if an old style token has a `Legacy` property set to true, yet it has an empty set of Rules, treat the token as a new style token, as its essentially the same as a new style token if it has no rules.

This allows you to essentially 'upgrade' an old style token using the UI by emptying out its rules.

Potentially you could create a new policy with the old rules and assign it to the token, thus creating an equivalent new token from an old legacy token.