### PR TITLE
build: fix 'make ui' scripts so that it can handle versions like "v1.4.0-rc1-55-g2c8675565-rc1 (2c8675565)"

### DIFF
--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -935,7 +935,7 @@ function shasum_directory {
       return 1
    fi
 
-   local ui_version=$(sed -n ${SED_EXT} -e 's/.*CONSUL_VERSION%22%3A%22([^%]*)%22%2C%22.*/\1/p' < "$1") || return 1
+   local ui_version="$(urldecode "$(grep '<meta name="consul-ui/config/environment' "$1" | grep -o 'content="[^"]*"' | cut -d'"' -f2)" | jq -r .CONSUL_VERSION)" || return 1
    echo "$ui_version"
    return 0
  }
@@ -966,3 +966,8 @@ function shasum_directory {
    fi
    return 0
  }
+
+function urldecode() {
+	: "${*//+/ }"
+	echo -e "${_//%/\\x}"
+}


### PR DESCRIPTION
Previously running this on master for dev purposes failed:
```
$ make ui
...(snip: the following was from the docker build portion)...
$ ember build --environment production
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: consul-ui -> ember-block-slots -> ember-cli-babel
DEPRECATION: An addon is trying to access project.nodeModulesPath. This is not a reliable way to discover npm modules. Instead, consider doing: require("resolve").sync(something, { basedir: project.root }). Accessed from:   new NPMDependencyVersionChecker (/consul-src/node_modules/ember-block-slots/node_modules/ember-cli-version-checker/src/npm-dependency-version-checker.js:11:33)
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: consul-ui -> ember-block-slots -> ember-prop-types -> ember-cli-babel
Could not start watchman
Visit https://ember-cli.com/user-guide/#watchman for more info.
cleaning up...
Built project successfully. Stored in "dist/".
File sizes:
 - dist/assets/auto-import-fastboot-d41d8cd98f00b204e9800998ecf8427e.js: 0 B
 - dist/assets/codemirror/mode/javascript/javascript-a4c0d68244e6e74f9225801e5f9d724e.js: 20.97 KB (7.39 KB gzipped)
 - dist/assets/codemirror/mode/ruby/ruby-61421add5f64c0fc261fe6049c3bd5d7.js: 5.14 KB (2.11 KB gzipped)
 - dist/assets/codemirror/mode/yaml/yaml-48498cacbe2464bb47bdb3732d4e25cb.js: 42.92 KB (13.53 KB gzipped)
 - dist/assets/consul-ui-43ebfc393b33bc22c406d75e4490b9fc.css: 82.04 KB (14.91 KB gzipped)
 - dist/assets/consul-ui-bfb6d9c0545798ad306ca59b5161ca1f.js: 356.44 KB (49.84 KB gzipped)
 - dist/assets/encoding-5ed8e95353b97ff5dd41bf66212d118e.js: 18.1 KB (5.58 KB gzipped)
 - dist/assets/encoding-indexes-75eea16b259716db4fd162ee283d2ae5.js: 517.32 KB (183.65 KB gzipped)
 - dist/assets/vendor-2e6d34075c355b8aac33f8cf47748120.js: 1.29 MB (340.49 KB gzipped)
 - dist/assets/vendor-9ea7d400c0cec7682e8871df14073823.css: 7.89 KB (2.54 KB gzipped)
Done in 41.43s.
Copying back artifacts
ERROR: UI version mismatch. Expecting: 'v1.4.0-rc1-55-g2c8675565-rc1 (2c8675565)' found ''
GNUmakefile:269: recipe for target 'ui-docker' failed
make: *** [ui-docker] Error 1
```

The tricky version extraction was doing some extremely hopeful `sed` manipulation to pull a version out of this mess:
```
$ grep '<meta name="consul-ui/config/environment' ./ui-v2/dist/index.html
<meta name="consul-ui/config/environment" content="%7B%22modulePrefix%22%3A%22consul-ui%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22/ui/%22%2C%22locationType%22%3A%22auto%22%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%22ds-improved-ajax%22%3Atrue%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Date%22%3Afalse%7D%7D%2C%22APP%22%3A%7B%22name%22%3A%22consul-ui%22%2C%22version%22%3A%222.2.0%22%7D%2C%22resizeServiceDefaults%22%3A%7B%22injectionFactories%22%3A%5B%22view%22%2C%22controller%22%2C%22component%22%5D%7D%2C%22CONSUL_GIT_SHA%22%3A%222c8675565%22%2C%22CONSUL_VERSION%22%3A%22v1.4.0-rc1-55-g2c8675565-rc1%20%282c8675565%29%22%2C%22CONSUL_BINARY_TYPE%22%3A%22oss%22%2C%22CONSUL_DOCUMENTATION_URL%22%3A%22https%3A//www.consul.io/docs%22%2C%22CONSUL_COPYRIGHT_URL%22%3A%22https%3A//www.hashicorp.com%22%2C%22CONSUL_COPYRIGHT_YEAR%22%3A%222018%22%2C%22browserify%22%3A%7B%22tests%22%3Atrue%7D%2C%22exportApplicationGlobal%22%3Afalse%7D" />
```

If you pull out that content and urldecode it:
```
{"modulePrefix":"consul-ui","environment":"production","rootURL":"/ui/","locationType":"auto","EmberENV":{"FEATURES":{"ds-improved-ajax":true},"EXTEND_PROTOTYPES":{"Date":false}},"APP":{"name":"consul-ui","version":"2.2.0"},"resizeServiceDefaults":{"injectionFactories":["view","controller","component"]},"CONSUL_GIT_SHA":"2c8675565","CONSUL_VERSION":"v1.4.0-rc1-55-g2c8675565-rc1 (2c8675565)","CONSUL_BINARY_TYPE":"oss","CONSUL_DOCUMENTATION_URL":"https://www.consul.io/docs","CONSUL_COPYRIGHT_URL":"https://www.hashicorp.com","CONSUL_COPYRIGHT_YEAR":"2018","browserify":{"tests":true},"exportApplicationGlobal":false}
```

The fix is to instead of trying to pull out the version from within this nested envelope, unpack the envelopes separately using envelope-specific tools.