### PR TITLE
UI: Test negation consistency

### DIFF
--- a/ui-v2/tests/unit/helpers/policy/is-management-test.js
+++ b/ui-v2/tests/unit/helpers/policy/is-management-test.js
@@ -9,5 +9,5 @@ test('it returns true if the policy is the management policy', function(assert) 
 });
 test("it returns false if the policy isn't the management policy", function(assert) {
   const actual = isManagement([{ ID: '00000000-0000-0000-0000-000000000000' }]);
-  assert.ok(!actual);
+  assert.notOk(actual);
 });

--- a/ui-v2/tests/unit/helpers/token/is-anonymous-test.js
+++ b/ui-v2/tests/unit/helpers/token/is-anonymous-test.js
@@ -9,5 +9,5 @@ test('it returns true if the token is the anonymous token', function(assert) {
 });
 test("it returns false if the token isn't the anonymous token", function(assert) {
   const actual = isAnonymous([{ AccessorID: '00000000-0000-0000-0000-000000000000' }]);
-  assert.ok(!actual);
+  assert.notOk(actual);
 });

--- a/ui-v2/tests/unit/search/filters/intention-test.js
+++ b/ui-v2/tests/unit/search/filters/intention-test.js
@@ -31,7 +31,7 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: '*',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });
 test('items are found by *', function(assert) {

--- a/ui-v2/tests/unit/search/filters/kv-test.js
+++ b/ui-v2/tests/unit/search/filters/kv-test.js
@@ -31,6 +31,6 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/node-test.js
+++ b/ui-v2/tests/unit/search/filters/node-test.js
@@ -25,6 +25,6 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/node/service-test.js
+++ b/ui-v2/tests/unit/search/filters/node/service-test.js
@@ -63,7 +63,7 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });
 test('tags can be empty', function(assert) {
@@ -89,6 +89,6 @@ test('tags can be empty', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/policy-test.js
+++ b/ui-v2/tests/unit/search/filters/policy-test.js
@@ -31,6 +31,6 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/service-test.js
+++ b/ui-v2/tests/unit/search/filters/service-test.js
@@ -34,7 +34,7 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });
 test('tags can be empty', function(assert) {
@@ -54,6 +54,6 @@ test('tags can be empty', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/service/node-test.js
+++ b/ui-v2/tests/unit/search/filters/service/node-test.js
@@ -51,6 +51,6 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });

--- a/ui-v2/tests/unit/search/filters/token-test.js
+++ b/ui-v2/tests/unit/search/filters/token-test.js
@@ -55,7 +55,7 @@ test('items are not found', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });
 test('policies can be empty', function(assert) {
@@ -81,6 +81,6 @@ test('policies can be empty', function(assert) {
     const actual = filter(item, {
       s: 'hit',
     });
-    assert.ok(!actual);
+    assert.notOk(actual);
   });
 });


### PR DESCRIPTION
I was using a mix of `notOk(actual)` and `ok(!actual)` throughout my testing.

This PR standardizes everything on `notOk`. I'll be trying my best to stick to it moving forwards.
