### PR TITLE
connect: remove additional trust-domain validation

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5303,9 +5303,14 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 	assert.Contains(obj.Reason, "Matched")
 }
 
-// Test when there is an intention allowing service but for a different trust
-// domain.
-func TestAgentConnectAuthorize_denyTrustDomain(t *testing.T) {
+// Test when there is an intention allowing service with a different trust
+// domain. We allow this because migration between trust domains shouldn't cause
+// an outage even if we have stale info about current trusted domains. It's safe
+// because the CA root is either unique to this cluster and not used to sign
+// anything external, or path validation can be used to ensure that the CA can
+// only issue certs that are valid for the specific cluster trust domain at x509
+// level which is enforced by TLS handshake.
+func TestAgentConnectAuthorize_allowTrustDomain(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
@@ -5345,8 +5350,8 @@ func TestAgentConnectAuthorize_denyTrustDomain(t *testing.T) {
 		assert.Equal(200, resp.Code)
 
 		obj := respRaw.(*connectAuthorizeResp)
-		assert.False(obj.Authorized)
-		assert.Contains(obj.Reason, "Identity from an external trust domain")
+		require.True(obj.Authorized)
+		require.Contains(obj.Reason, "Matched")
 	}
 }
 

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -53,9 +53,9 @@ func TestCA(t testing.T, xc *structs.CARoot) *structs.CARoot {
 
 	// Create the CA cert
 	template := x509.Certificate{
-		SerialNumber: sn,
-		Subject:      pkix.Name{CommonName: result.Name},
-		URIs:         []*url.URL{id.URI()},
+		SerialNumber:          sn,
+		Subject:               pkix.Name{CommonName: result.Name},
+		URIs:                  []*url.URL{id.URI()},
 		BasicConstraintsValid: true,
 		KeyUsage: x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign |

--- a/agent/connect_auth.go
+++ b/agent/connect_auth.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"
@@ -62,26 +61,8 @@ func (a *Agent) ConnectAuthorize(token string,
 		return returnErr(acl.ErrPermissionDenied)
 	}
 
-	// Validate the trust domain matches ours. Later we will support explicit
-	// external federation but not built yet.
-	rootArgs := &structs.DCSpecificRequest{Datacenter: a.config.Datacenter}
-	raw, _, err := a.cache.Get(cachetype.ConnectCARootName, rootArgs)
-	if err != nil {
-		return returnErr(err)
-	}
-
-	roots, ok := raw.(*structs.IndexedCARoots)
-	if !ok {
-		return returnErr(fmt.Errorf("internal error: roots response type not correct"))
-	}
-	if roots.TrustDomain == "" {
-		return returnErr(fmt.Errorf("Connect CA not bootstrapped yet"))
-	}
-	if roots.TrustDomain != strings.ToLower(uriService.Host) {
-		reason = fmt.Sprintf("Identity from an external trust domain: %s",
-			uriService.Host)
-		return false, reason, nil, nil
-	}
+	// Note that we DON'T explicitly validate the trust-domain matches ours. See
+	// the PR for this change for details.
 
 	// TODO(banks): Implement revocation list checking here.
 

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -66,8 +66,8 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 	all := []string{"GET", "PUT", "POST", "DELETE", "HEAD", "OPTIONS"}
 	const testTimeout = 10 * time.Second
 
-	fastClient := newHttpClient(10 * time.Second)
-	slowClient := newHttpClient(30 * time.Second)
+	fastClient := newHttpClient(15 * time.Second)
+	slowClient := newHttpClient(45 * time.Second)
 
 	testMethodNotAllowed := func(method string, path string, allowedMethods []string) {
 		t.Run(method+" "+path, func(t *testing.T) {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -34,10 +34,9 @@ type IndexedCARoots struct {
 	// only time the additional validation adds value is where the cluster shares
 	// an external root (e.g. organization-wide root) with another distinct Consul
 	// cluster or PKI system. In this case, x509 Name Constraints can be added to
-	// enforce that Consul's CA can cert can only validly sign or trust certs
-	// within the same trust-domain. Name constraints as enforced by TLS handshake
-	// also work seamlessly with rotation between trust domains thanks to
-	// cross-signing.
+	// enforce that Consul's CA can only validly sign or trust certs within the
+	// same trust-domain. Name constraints as enforced by TLS handshake also allow
+	// seamless rotation between trust domains thanks to cross-signing.
 	TrustDomain string
 
 	// Roots is a list of root CA certs to trust.

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -64,7 +64,7 @@ type CARoot struct {
 	SigningKeyID string
 
 	// ExternalTrustDomain is the trust domain this root was generated under. It
-	// is usually empty implying "they current cluster trust-domain". It is set
+	// is usually empty implying "the current cluster trust-domain". It is set
 	// only in the case that a cluster changes trust domain and then all old roots
 	// that are still trusted have the old trust domain set here.
 	//

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -23,11 +23,21 @@ type IndexedCARoots struct {
 	// implement other protocols in future with equivalent semantics. It should be
 	// compared against the "authority" section of a URI (i.e. host:port).
 	//
-	// NOTE(banks): Later we may support explicitly trusting external domains
-	// which may be encoded into the CARoot struct or a separate list but this
-	// domain identifier should be immutable and cluster-wide so deserves to be at
-	// the root of this response rather than duplicated through all CARoots that
-	// are not externally trusted entities.
+	// We need to support migrating a cluster between trust domains to support
+	// Multi-DC migration in Enterprise. In this case the current trust domain is
+	// here but entries in Roots may also have ExternalTrustDomain set to a
+	// non-empty value implying they were previous roots that are still trusted
+	// but under a different trust domain.
+	//
+	// Note that we DON'T validate trust domain during AuthZ since it causes
+	// issues of loss of connectivity during migration between trust domains. The
+	// only time the additional validation adds value is where the cluster shares
+	// an external root (e.g. organization-wide root) with another distinct Consul
+	// cluster or PKI system. In this case, x509 Name Constraints can be added to
+	// enforce that Consul's CA can cert can only validly sign or trust certs
+	// within the same trust-domain. Name constraints as enforced by TLS handshake
+	// also work seamlessly with rotation between trust domains thanks to
+	// cross-signing.
 	TrustDomain string
 
 	// Roots is a list of root CA certs to trust.
@@ -54,7 +64,14 @@ type CARoot struct {
 	// private key used to sign the certificate.
 	SigningKeyID string
 
-	// ExternalTrustDomain is the trust domain this root was generated under.
+	// ExternalTrustDomain is the trust domain this root was generated under. It
+	// is usually empty implying "they current cluster trust-domain". It is set
+	// only in the case that a cluster changes trust domain and then all old roots
+	// that are still trusted have the old trust domain set here.
+	//
+	// We currently DON'T validate these trust domains explicitly anywhere, see
+	// IndexedRoots.TrustDomain doc. We retain this information for debugging and
+	// future flexibility.
 	ExternalTrustDomain string
 
 	// Time validity bounds.

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -124,7 +124,9 @@ func TestConsulResolver_Resolve(t *testing.T) {
 				Name:      "web",
 				Type:      ConsulResolverTypeService,
 			},
-			wantCertURI: connect.TestSpiffeIDService(t, "web"),
+			// Want empty host since we don't enforce trust domain outside of TLS and
+			// don't need to load the current one this way.
+			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},
@@ -135,7 +137,9 @@ func TestConsulResolver_Resolve(t *testing.T) {
 				Name:      "db",
 				Type:      ConsulResolverTypeService,
 			},
-			wantCertURI: connect.TestSpiffeIDService(t, "db"),
+			// Want empty host since we don't enforce trust domain outside of TLS and
+			// don't need to load the current one this way.
+			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "db", ""),
 			wantErr:     false,
 		},
 		{
@@ -172,7 +176,9 @@ func TestConsulResolver_Resolve(t *testing.T) {
 				Name: queryId,
 				Type: ConsulResolverTypePreparedQuery,
 			},
-			wantCertURI: connect.TestSpiffeIDService(t, "web"),
+			// Want empty host since we don't enforce trust domain outside of TLS and
+			// don't need to load the current one this way.
+			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},
@@ -182,7 +188,9 @@ func TestConsulResolver_Resolve(t *testing.T) {
 				Name: "test-query",
 				Type: ConsulResolverTypePreparedQuery,
 			},
-			wantCertURI: connect.TestSpiffeIDService(t, "web"),
+			// Want empty host since we don't enforce trust domain outside of TLS and
+			// don't need to load the current one this way.
+			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -30,6 +30,14 @@ func Test_verifyServerCertMatchesURI(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			// Could happen during migration of secondary DC to multi-DC. Trust domain
+			// validity is enforced with x509 name constraints where needed.
+			name:     "different trust-domain allowed",
+			certs:    TestPeerCertificates(t, "web", ca1),
+			expected: connect.TestSpiffeIDServiceWithHost(t, "web", "other.consul"),
+			wantErr:  false,
+		},
+		{
 			name:     "mismatch",
 			certs:    TestPeerCertificates(t, "web", ca1),
 			expected: connect.TestSpiffeIDService(t, "db"),


### PR DESCRIPTION
This seems scary and deserves some explanation.

Until now, a cluster's trust domain was assumed immutable making this check easy to do always in addition to TLS verification. With multi-DC (Enterprise), this becomes problematic because a secondary DC might need to be "upgraded" to Multi-DC and so adopt the trust domain of the primary DC. This switch causes potential disruption to new Connect connections during the upgrade of the secondary's servers to use multi-DC because the new roots take some time to propagate (unbounded time in case any agent has network connectivity issues with the servers).

The problem is that an updated client using a new cert under the new trust domain won't be able to connect to any server that hasn't yet seen the new trust-domain. This is the same problem as rotating CA roots generally, however since it's not being enforced as part of the TLS chain, it can't use the same cross-signing approach we use to make CA rotation seamless.

After much soul-searching, it turns out that in the original (internal) RFC for our TLS and trust model, we actually already foresaw this and recommended that we _don't_ add validation for this on top of the existing TLS handshake. So this change brings us back to what the original design we reviewed internally decided.

This validation, it turns out, was added (by me) during implementation some weeks after writing the design and thinking deeply about this case where it seemed to be an easy thing to add having forgotten the complications that would come later.

## Why is this safe?

The only real value for this additional check comes from a specific case we wanted to support: where the CA being used for Connect is external to the cluster and potentially has a root cert/key that is shared with other distinct Consul clusters.

In this case, there si nothing stopping accidental or malicious certificates from one cluster being presented to services in another and being accepted. Specifically, if the signing key is compromised in one cluster, it would allow full access to anything in any cluster even though they are not meant to be mutually trusting.

The correct solution to this though already exists in x509 - name constraints. In this specific case where a shared CA is used for distinct clusters that should not implicitly trust each other, the intermediate given to each cluster as it's primary signing key should have a name constraint that only allows it to sign certificates for names in the cluster's unique trust domain. This prevents even a key leakage form one cluster being able to sign certificates that are accepted in another since the Intermediate's name constraint will be violated.

For the more typical case where each Consul cluster has it's own CA root (whether using built in one or some external CA provider like Vault), this validation adds no real additional security - a compromised signing key can still sign any cert it likes but those are only trusted by this cluster anyway so the validation of trust domain adds no extra protection.

So rather than expand this validation to something elaborate enough be rotated seamlessly during (rare) upgrades, we elect to just drop the poor-mans approximation of a name constraint and use real ones where it actually matters.