### PR TITLE
UI: Move legacy ACLs, KVs and Intentions to use `form` functionality

### DIFF
--- a/ui-v2/app/controllers/dc/acls/policies/edit.js
+++ b/ui-v2/app/controllers/dc/acls/policies/edit.js
@@ -25,8 +25,8 @@ export default Controller.extend({
   },
   actions: {
     change: function(e, value, item) {
-      const form = get(this, 'form');
       const event = get(this, 'dom').normalizeEvent(e, value);
+      const form = get(this, 'form');
       try {
         form.handleEvent(event);
       } catch (err) {

--- a/ui-v2/app/controllers/dc/acls/tokens/edit.js
+++ b/ui-v2/app/controllers/dc/acls/tokens/edit.js
@@ -45,8 +45,8 @@ export default Controller.extend({
         .didAppear();
     },
     change: function(e, value, item) {
-      const form = get(this, 'form');
       const event = get(this, 'dom').normalizeEvent(e, value);
+      const form = get(this, 'form');
       try {
         form.handleEvent(event);
       } catch (err) {

--- a/ui-v2/app/controllers/dc/kv/edit.js
+++ b/ui-v2/app/controllers/dc/kv/edit.js
@@ -12,11 +12,6 @@ export default Controller.extend({
     this.form = get(this, 'builder').form('kv');
   },
   setProperties: function(model) {
-    // TODO: Potentially save whether json has been clicked to the model,
-    // setting set(this, 'json', true) here will force the form to always default to code=on
-    // even if the user has selected code=off on another KV
-    // ideally we would save the value per KV, but I'd like to not do that on the model
-    // a set(this, 'json', valueFromSomeStorageJustForThisKV) would be added here
     // essentially this replaces the data with changesets
     this._super(
       Object.keys(model).reduce((prev, key, i) => {
@@ -47,6 +42,11 @@ export default Controller.extend({
             set(this.item, 'Key', `${parent !== '/' ? parent : ''}${target.value}`);
             break;
           case 'json':
+            // TODO: Potentially save whether json has been clicked to the model,
+            // setting set(this, 'json', true) here will force the form to always default to code=on
+            // even if the user has selected code=off on another KV
+            // ideally we would save the value per KV, but I'd like to not do that on the model
+            // a set(this, 'json', valueFromSomeStorageJustForThisKV) would be added here
             set(this, 'json', !get(this, 'json'));
             break;
           default:

--- a/ui-v2/app/controllers/dc/kv/edit.js
+++ b/ui-v2/app/controllers/dc/kv/edit.js
@@ -2,41 +2,56 @@ import Controller from '@ember/controller';
 import { get, set } from '@ember/object';
 import { inject as service } from '@ember/service';
 
-import Changeset from 'ember-changeset';
-import validations from 'consul-ui/validations/kv';
-import lookupValidator from 'ember-changeset-validations';
 export default Controller.extend({
-  json: true,
+  dom: service('dom'),
+  builder: service('form'),
   encoder: service('btoa'),
+  json: true,
+  init: function() {
+    this._super(...arguments);
+    this.form = get(this, 'builder').form('kv');
+  },
   setProperties: function(model) {
     // TODO: Potentially save whether json has been clicked to the model,
     // setting set(this, 'json', true) here will force the form to always default to code=on
     // even if the user has selected code=off on another KV
     // ideally we would save the value per KV, but I'd like to not do that on the model
     // a set(this, 'json', valueFromSomeStorageJustForThisKV) would be added here
-    this.changeset = new Changeset(model.item, lookupValidator(validations), validations);
-    this._super({
-      ...model,
-      ...{
-        item: this.changeset,
-      },
-    });
+    // essentially this replaces the data with changesets
+    this._super(
+      Object.keys(model).reduce((prev, key, i) => {
+        switch (key) {
+          case 'item':
+            prev[key] = this.form.setData(prev[key]).getData();
+            break;
+        }
+        return prev;
+      }, model)
+    );
   },
   actions: {
-    change: function(e) {
-      const target = e.target || { name: 'value', value: e };
-      var parent;
-      switch (target.name) {
-        case 'additional':
-          parent = get(this, 'parent.Key');
-          set(this.changeset, 'Key', `${parent !== '/' ? parent : ''}${target.value}`);
-          break;
-        case 'json':
-          set(this, 'json', !get(this, 'json'));
-          break;
-        case 'value':
-          set(this, 'item.Value', get(this, 'encoder').execute(target.value));
-          break;
+    change: function(e, value, item) {
+      const event = get(this, 'dom').normalizeEvent(e, value);
+      const form = get(this, 'form');
+      try {
+        form.handleEvent(event);
+      } catch (err) {
+        const target = event.target;
+        let parent;
+        switch (target.name) {
+          case 'value':
+            set(this.item, 'Value', get(this, 'encoder').execute(target.value));
+            break;
+          case 'additional':
+            parent = get(this, 'parent.Key');
+            set(this.item, 'Key', `${parent !== '/' ? parent : ''}${target.value}`);
+            break;
+          case 'json':
+            set(this, 'json', !get(this, 'json'));
+            break;
+          default:
+            throw err;
+        }
       }
     },
   },

--- a/ui-v2/app/forms/acl.js
+++ b/ui-v2/app/forms/acl.js
@@ -1,0 +1,6 @@
+import validations from 'consul-ui/validations/acl';
+import builderFactory from 'consul-ui/utils/form/builder';
+const builder = builderFactory();
+export default function(name = '', v = validations, form = builder) {
+  return form(name, {}).setValidators(v);
+}

--- a/ui-v2/app/forms/intention.js
+++ b/ui-v2/app/forms/intention.js
@@ -1,0 +1,6 @@
+import validations from 'consul-ui/validations/intention';
+import builderFactory from 'consul-ui/utils/form/builder';
+const builder = builderFactory();
+export default function(name = '', v = validations, form = builder) {
+  return form(name, {}).setValidators(v);
+}

--- a/ui-v2/app/forms/kv.js
+++ b/ui-v2/app/forms/kv.js
@@ -1,0 +1,6 @@
+import validations from 'consul-ui/validations/kv';
+import builderFactory from 'consul-ui/utils/form/builder';
+const builder = builderFactory();
+export default function(name = '', v = validations, form = builder) {
+  return form(name, {}).setValidators(v);
+}

--- a/ui-v2/app/forms/token.js
+++ b/ui-v2/app/forms/token.js
@@ -1,6 +1,6 @@
-import builderFactory from 'consul-ui/utils/form/builder';
 import validations from 'consul-ui/validations/token';
 import policy from 'consul-ui/forms/policy';
+import builderFactory from 'consul-ui/utils/form/builder';
 const builder = builderFactory();
 export default function(name = '', v = validations, form = builder) {
   return form(name, {})

--- a/ui-v2/app/initializers/form.js
+++ b/ui-v2/app/initializers/form.js
@@ -1,9 +1,11 @@
+import acl from 'consul-ui/forms/acl';
 import token from 'consul-ui/forms/token';
 import policy from 'consul-ui/forms/policy';
 export function initialize(application) {
   // Service-less injection using private properties at a per-project level
   const FormBuilder = application.resolveRegistration('service:form');
   const forms = {
+    acl: acl(),
     token: token(),
     policy: policy(),
   };

--- a/ui-v2/app/initializers/form.js
+++ b/ui-v2/app/initializers/form.js
@@ -1,3 +1,4 @@
+import kv from 'consul-ui/forms/kv';
 import acl from 'consul-ui/forms/acl';
 import token from 'consul-ui/forms/token';
 import policy from 'consul-ui/forms/policy';
@@ -5,6 +6,7 @@ export function initialize(application) {
   // Service-less injection using private properties at a per-project level
   const FormBuilder = application.resolveRegistration('service:form');
   const forms = {
+    kv: kv(),
     acl: acl(),
     token: token(),
     policy: policy(),

--- a/ui-v2/app/initializers/form.js
+++ b/ui-v2/app/initializers/form.js
@@ -2,6 +2,7 @@ import kv from 'consul-ui/forms/kv';
 import acl from 'consul-ui/forms/acl';
 import token from 'consul-ui/forms/token';
 import policy from 'consul-ui/forms/policy';
+import intention from 'consul-ui/forms/intention';
 export function initialize(application) {
   // Service-less injection using private properties at a per-project level
   const FormBuilder = application.resolveRegistration('service:form');
@@ -10,6 +11,7 @@ export function initialize(application) {
     acl: acl(),
     token: token(),
     policy: policy(),
+    intention: intention(),
   };
   FormBuilder.reopen({
     form: function(name) {

--- a/ui-v2/app/templates/dc/acls/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/-form.hbs
@@ -14,7 +14,7 @@
         </div>
         <label class="type-text">
             <span>Policy <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-            {{code-editor class=(if item.error.Rules 'error') name='Rules' value=item.Rules syntax="hcl" onkeyup=(action 'change')}}
+            {{code-editor class=(if item.error.Rules 'error') name='Rules' value=item.Rules syntax="hcl" onkeyup=(action 'change' 'Rules')}}
         </label>
 {{#if create }}
         <label class="type-text">

--- a/ui-v2/app/templates/dc/kv/-form.hbs
+++ b/ui-v2/app/templates/dc/kv/-form.hbs
@@ -18,7 +18,7 @@
             <label class="type-text{{if item.error.Value ' has-error'}}">
                 <span>Value</span>
 {{#if json}}
-                {{ code-editor value=(atob item.Value) onkeyup=(action 'change') }}
+                {{code-editor value=(atob item.Value) onkeyup=(action 'change' 'value')}}
 {{else}}
                 <textarea autofocus={{not create}} name="value" oninput={{action 'change'}}>{{atob item.Value}}</textarea>
 {{/if}}

--- a/ui-v2/tests/unit/controllers/dc/acls/create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/create-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/acls/create', 'Unit | Controller | dc/acls/create', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/acls/edit-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/edit-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/acls/edit', 'Unit | Controller | dc/acls/edit', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/intentions/create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/intentions/create-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/intentions/create', 'Unit | Controller | dc/intentions/create', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/intentions/edit-test.js
+++ b/ui-v2/tests/unit/controllers/dc/intentions/edit-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/intentions/edit', 'Unit | Controller | dc/intentions/edit', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/kv/create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/kv/create-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/kv/create', 'Unit | Controller | dc/kv/create', {
   // Specify the other units that are required for this test.
-  needs: ['service:btoa'],
+  needs: ['service:btoa', 'service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/kv/edit-test.js
+++ b/ui-v2/tests/unit/controllers/dc/kv/edit-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/kv/edit', 'Unit | Controller | dc/kv/edit', {
   // Specify the other units that are required for this test.
-  needs: ['service:btoa'],
+  needs: ['service:btoa', 'service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/kv/root-create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/kv/root-create-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/kv/root-create', 'Unit | Controller | dc/kv/root-create', {
   // Specify the other units that are required for this test.
-  needs: ['service:btoa'],
+  needs: ['service:btoa', 'service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
This PR moves legacy ACLs, KVs and Intentions to use the newer `form` functionality.

This brings everything consistently together and follows exactly how it is done in the rest of the app.

Also see https://github.com/hashicorp/consul/pull/4789

Further work here will involve moving the 'stranger' functionality in Intentions and KVs out of the Controllers and into the forms themselves, meaning Controllers will revert to just orchestration not functionality. What is done here has simplified it ever so slightly (especially for intentions) but I'd rather the `form` deals with this.