### PR TITLE
Update the helm chart `join` instructions

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -246,8 +246,8 @@ and consider if they're appropriate for your deployment.
       to false.
 
   - <a name="v-client-join" href="#v-client-join">`join`</a> (`array<string>: null`) -
-  A list of values to be used with the `-retry-join` command, specified
-  individually in the format "option=value". If this is `null` (default),
+  A list of valid [`-retry-join` values](/docs/agent/options.html#retry-join).
+  If this is `null` (default),
   then the clients will attempt to automatically join the server cluster
   running within Kubernetes. This means that with `server.enabled` set to true,
   clients will automatically join that cluster. If `server.enabled` is not

--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -94,9 +94,7 @@ global:
 client:
   enabled: true
   join:
-    - "provider=my-cloud"
-    - "config=val"
-    - "..."
+    - "provider=my-cloud config=val ..."
 ```
 
 The `values.yaml` file to configure the Helm chart sets the proper


### PR DESCRIPTION
This fixes some previous incorrect information about the join feature
in the Helm chart. Based on the fix for consul-helm issue 59.