### PR TITLE
tests: Bump test server version to 1.4.0

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -84,7 +84,7 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.ServerHealthInterval = 50 * time.Millisecond
 	config.AutopilotInterval = 100 * time.Millisecond
 
-	config.Build = "0.8.0"
+	config.Build = "1.4.0"
 
 	config.CoordinateUpdatePeriod = 100 * time.Millisecond
 	config.LeaveDrainTime = 1 * time.Millisecond


### PR DESCRIPTION
This is a test change around some updates to enterprise.