### PR TITLE
Please add file2consul to your tools page

### DIFF
--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -37,6 +37,14 @@ description: |-
   These Consul tools are created and managed by the amazing members of the Consul community:
 </p>
 <ul>
+ 
+  <li>
+    <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - mirror contents property files into consul 
+      go based config loader with support for multiple enviornments. Provides 
+      variable expansion interpolation, inheritance, overrides and ability to update multiple consul servers.
+      Reduces cost of maintaining larger configuration sets by reducing restatement and manual editing
+      of similar config properties across those enviornments.  
+  </li>
   <li>
     <a href="http://www.cfg4j.org">cfg4j</a> - Configuration library for Java distributed apps. Reads and auto-updates configuration from Consul KVs (and others)
   </li>

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -38,13 +38,7 @@ description: |-
 </p>
 <ul>
  
-  <li>
-    <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - Mirror property files into consul.
-      go based config loader with support for multiple enviornments. Provides 
-      variable expansion, interpolation, inheritance with overrides and ability to update multiple consul servers.
-      Reduces cost of maintaining larger configuration sets between enviornments by reducing restatement and manual editing
-      of similar or predicably changing config properties.
-  </li>
+
   <li>
     <a href="http://www.cfg4j.org">cfg4j</a> - Configuration library for Java distributed apps. Reads and auto-updates configuration from Consul KVs (and others)
   </li>
@@ -92,6 +86,12 @@ description: |-
   </li>
   <li>
     <a href="https://github.com/eBay/fabio">fabio</a> - Fast, zero-conf, consul-aware load-balancing HTTP/HTTPS router
+  </li>
+  <li>
+    <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - Update Consul values 
+      from git or files. Config loader with support for multiple environments. Provides 
+      variable expansion, interpolation, inheritance with overrides and ability to update multiple consul servers.
+      Reduces cost of maintaining larger configuration sets between environments by reducing restatement and manual editing of similar or predictably changing config properties.  MIT license, Written in GO.
   </li>
   <li>
     <a href="https://github.com/ryanbreen/git2consul">git2consul</a> - Mirror the contents of a Git repository into Consul KVs

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -39,11 +39,11 @@ description: |-
 <ul>
  
   <li>
-    <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - mirror contents property files into consul 
+    <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - Mirror property files into consul.
       go based config loader with support for multiple enviornments. Provides 
       variable expansion, interpolation, inheritance with overrides and ability to update multiple consul servers.
-      Reduces cost of maintaining larger configuration sets by reducing restatement and manual editing
-      of similar or predicably changing config properties across enviornments.  
+      Reduces cost of maintaining larger configuration sets between enviornments by reducing restatement and manual editing
+      of similar or predicably changing config properties.
   </li>
   <li>
     <a href="http://www.cfg4j.org">cfg4j</a> - Configuration library for Java distributed apps. Reads and auto-updates configuration from Consul KVs (and others)

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -41,9 +41,9 @@ description: |-
   <li>
     <a href="https://github.com/joeatbayes/file2consul">file2consul</a> - mirror contents property files into consul 
       go based config loader with support for multiple enviornments. Provides 
-      variable expansion interpolation, inheritance, overrides and ability to update multiple consul servers.
+      variable expansion, interpolation, inheritance with overrides and ability to update multiple consul servers.
       Reduces cost of maintaining larger configuration sets by reducing restatement and manual editing
-      of similar config properties across those enviornments.  
+      of similar or predicably changing config properties across enviornments.  
   </li>
   <li>
     <a href="http://www.cfg4j.org">cfg4j</a> - Configuration library for Java distributed apps. Reads and auto-updates configuration from Consul KVs (and others)


### PR DESCRIPTION
As per request from Banks moved the listing into correct Alpha order. This request replaces #4942

Please add file2consul to your tools page. It is being used by at least one large insurance company that was struggling with consul due to the large number of configuration parameters that were similar but different between environments. Suggestions for improvements are greatly appreciated. 