### PR TITLE
Fixes links to ACL API docs

### DIFF
--- a/website/source/docs/commands/acl.html.md
+++ b/website/source/docs/commands/acl.html.md
@@ -13,7 +13,7 @@ line. It exposes top-level commands for bootstrapping the ACL system,
 managing tokens and policies, translating legacy rules, and setting the
 tokens for use by an agent.
 
-ACLs are also accessible via the [HTTP API](/api/acl.html).
+ACLs are also accessible via the [HTTP API](/api/acl/acl.html).
 
 
 Bootstrap Consul's ACLs:

--- a/website/source/docs/commands/acl/acl-bootstrap.html.md.erb
+++ b/website/source/docs/commands/acl/acl-bootstrap.html.md.erb
@@ -13,7 +13,7 @@ for management purposes and output its details. This can only be done once and a
 will be disabled. If all tokens are lost and you need to bootstrap again you can follow the bootstrap
 reset procedure.
 
-The ACL system can also be bootstrapped via the [HTTP API](/api/acl.html#bootstrap-acls).
+The ACL system can also be bootstrapped via the [HTTP API](/api/acl/acl.html#bootstrap-acls).
 
 ## Usage
 
@@ -35,5 +35,3 @@ Create Time:  2018-10-22 11:27:04.479026 -0400 EDT
 Policies:
    00000000-0000-0000-0000-000000000001 - global-management
 ```
-
-

--- a/website/source/docs/commands/acl/acl-policy.html.md.erb
+++ b/website/source/docs/commands/acl/acl-policy.html.md.erb
@@ -17,7 +17,7 @@ subcommands for the individual operations that can be performed.
 * [`delete`](#delete)
 * [`list`](#list)
 
-ACL policies are also accessible via the [HTTP API](/api/acl.html).
+ACL policies are also accessible via the [HTTP API](/api/acl/acl.html).
 
 Usage: `consul acl policy <subcommand> [options] [args]`
 

--- a/website/source/docs/commands/acl/acl-token.html.md.erb
+++ b/website/source/docs/commands/acl/acl-token.html.md.erb
@@ -18,7 +18,7 @@ subcommands for the individual operations that can be performed.
 * [`delete`](#delete)
 * [`list`](#list)
 
-ACL tokens are also accessible via the [HTTP API](/api/acl.html).
+ACL tokens are also accessible via the [HTTP API](/api/acl/acl.html).
 
 Usage: `consul acl token <subcommand> [options] [args]`
 

--- a/website/source/docs/guides/acl-legacy.html.md
+++ b/website/source/docs/guides/acl-legacy.html.md
@@ -31,7 +31,7 @@ all while providing administrative insight.
 #### ACL Tokens
 
 The ACL system is based on tokens, which are managed by Consul operators via Consul's
-[ACL API](/api/acl.html), or systems like
+[ACL API](/api/acl/acl.html), or systems like
 [HashiCorp's Vault](https://www.vaultproject.io/docs/secrets/consul/index.html).
 
 Every token has an ID, name, type, and rule set. The ID is a randomly generated
@@ -48,7 +48,7 @@ token [RFC6750](https://tools.ietf.org/html/rfc6750). Consul's
 
 If no token is provided, the rules associated with a special, configurable anonymous
 token are automatically applied. The anonymous token is managed using the
-[ACL API](/api/acl.html) like any other ACL token, but using `anonymous` for the ID.
+[ACL API](/api/acl/acl.html) like any other ACL token, but using `anonymous` for the ID.
 
 #### ACL Rules and Scope
 
@@ -200,7 +200,7 @@ The first step for bootstrapping ACLs is to enable ACLs on the Consul servers in
 datacenter. In this example, we are configuring the following:
 
 1. An ACL datacenter of "dc1", which is where these servers are
-2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl.html#bootstrap-acls)
+2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl/acl.html#bootstrap-acls)
 3. A default policy of "deny" which means we are in whitelist mode
 4. A down policy of "extend-cache" which means that we will ignore token TTLs during an
    outage
@@ -228,7 +228,7 @@ a server acquires cluster leadership. If you would like to install or change the
 [`acl_master_token`](/docs/agent/options.html#acl_master_token) in the configuration
 for all servers. Once this is done, restart the current leader to force a leader election.
 
-In Consul 0.9.1 and later, you can use the [/v1/acl/bootstrap API](/api/acl.html#bootstrap-acls)
+In Consul 0.9.1 and later, you can use the [/v1/acl/bootstrap API](/api/acl/acl.html#bootstrap-acls)
 to make the initial master token, so a token never needs to be placed into a configuration
 file. To use this approach, omit `acl_master_token` from the above config and then call the API:
 
@@ -245,7 +245,7 @@ It's only possible to bootstrap one time, and bootstrapping will be disabled if 
 token was configured and created.
 
 Once the ACL system is bootstrapped, ACL tokens can be managed through the
-[ACL API](/api/acl.html).
+[ACL API](/api/acl/acl.html).
 
 #### Create an Agent Token
 
@@ -517,7 +517,7 @@ The token can then be set on the "settings" page of the UI.
 #### Next Steps
 
 The examples above configure a basic ACL environment with the ability to see all nodes
-by default, and limited access to just the "consul" service. The [ACL API](/api/acl.html)
+by default, and limited access to just the "consul" service. The [ACL API](/api/acl/acl.html)
 can be used to create tokens for applications specific to their intended use, and to create
 more specific ACL agent tokens for each agent's expected role.
 
@@ -584,7 +584,7 @@ This is equivalent to the following JSON input:
 }
 ```
 
-The [ACL API](/api/acl.html) allows either HCL or JSON to be used to define the content
+The [ACL API](/api/acl/acl.html) allows either HCL or JSON to be used to define the content
 of the rules section.
 
 Here's a sample request using the HCL form:
@@ -1070,7 +1070,7 @@ a large set of ACLs.
 If there's a partition or other outage affecting the authoritative datacenter,
 and the [`acl_down_policy`](/docs/agent/options.html#acl_down_policy)
 is set to "extend-cache", tokens will be resolved during the outage using the
-replicated set of ACLs. An [ACL replication status](/api/acl.html#acl_replication_status)
+replicated set of ACLs. An [ACL replication status](/api/acl/acl.html#acl_replication_status)
 endpoint is available to monitor the health of the replication process.
 Also note that in recent versions of Consul (greater than 1.2.0), using
 `acl_down_policy = "async-cache"` refreshes token asynchronously when an ACL is
@@ -1088,7 +1088,7 @@ using a process like this:
 1. Enable ACL replication in all datacenters to allow continuation of service
 during the migration, and to populate the target datacenter. Verify replication
 is healthy and caught up to the current ACL index in the target datacenter
-using the [ACL replication status](/api/acl.html#acl_replication_status)
+using the [ACL replication status](/api/acl/acl.html#acl_replication_status)
 endpoint.
 2. Turn down the old authoritative datacenter servers.
 3. Rolling restart the agents in the target datacenter and change the

--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -28,7 +28,7 @@ At the highest level, there are two major components to the ACL system:
  make requests to Consul.
 
  ACL Tokens and Policies are managed by Consul operators via Consul's
-[ACL API](/api/acl.html), ACL CLI or systems like
+[ACL API](/api/acl/acl.html), ACL CLI or systems like
 [HashiCorp's Vault](https://www.vaultproject.io/docs/secrets/consul/index.html).
 
 ### ACL Policies
@@ -98,7 +98,7 @@ rules:
 
 | Resource                   | Scope |
 | ------------------------ | ----- |
-| [`acl`](#acl-rules)              | Operations for managing the ACL system [ACL API](/api/acl.html) |
+| [`acl`](#acl-rules)              | Operations for managing the ACL system [ACL API](/api/acl/acl.html) |
 | [`agent`](#agent-rules)          | Utility operations in the [Agent API](/api/agent.html), other than service and check registration |
 | [`event`](#event-rules)          | Listing and firing events in the [Event API](/api/event.html) |
 | [`key`](#key-value-rules)        | Key/value store operations in the [KV Store API](/api/kv.html) |
@@ -200,7 +200,7 @@ The first step for bootstrapping ACLs is to enable ACLs on the Consul servers in
 datacenter. In this example, we are configuring the following:
 
 1. A primary datacenter of "dc1", which is where these servers are.
-2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl.html#bootstrap-acls)
+2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl/acl.html#bootstrap-acls)
 3. A default policy of "deny" which means we are in whitelist mode
 4. A down policy of "extend-cache" which means that we will ignore token TTLs during an
    outage
@@ -233,7 +233,7 @@ a server acquires cluster leadership. If you would like to install or change the
 [`acl.tokens.master`](/docs/agent/options.html#acl_tokens_master) in the configuration
 for all servers. Once this is done, restart the current leader to force a leader election.
 
-In Consul 0.9.1 and later, you can use the [/v1/acl/bootstrap API](/api/acl.html#bootstrap-acls)
+In Consul 0.9.1 and later, you can use the [/v1/acl/bootstrap API](/api/acl/acl.html#bootstrap-acls)
 to make the initial master token, so a token never needs to be placed into a configuration
 file. To use this approach, omit `acl.tokens.master` from the above config and then call the API:
 
@@ -252,7 +252,7 @@ It's only possible to bootstrap one time, and bootstrapping will be disabled if 
 token was configured and created.
 
 Once the ACL system is bootstrapped, ACL tokens can be managed through the
-[ACL API](/api/acl.html).
+[ACL API](/api/acl/acl.html).
 
 #### Create an Agent Token
 
@@ -588,7 +588,7 @@ The token can then be set on the "settings" page of the UI.
 #### Next Steps
 
 The examples above configure a basic ACL environment with the ability to see all nodes
-by default, and limited access to just the "consul" service. The [ACL API](/api/acl.html)
+by default, and limited access to just the "consul" service. The [ACL API](/api/acl/acl.html)
 can be used to create tokens for applications specific to their intended use, and to create
 more specific ACL agent tokens for each agent's expected role.
 
@@ -674,7 +674,7 @@ This is equivalent to the following JSON input:
 }
 ```
 
-The [ACL API](/api/acl.html) allows either HCL or JSON to be used to define the content
+The [ACL API](/api/acl/acl.html) allows either HCL or JSON to be used to define the content
 of the rules section of a policy.
 
 Here's a sample request using the HCL form:
@@ -722,7 +722,7 @@ or the `CONSUL_HTTP_TOKEN` environment variable.
 #### ACL Rules
 
 The `acl` resource controls access to ACL operations in the
-[ACL API](/api/acl.html).
+[ACL API](/api/acl/acl.html).
 
 ACL rules look like this:
 


### PR DESCRIPTION
Was previously pointed to `/api/acl.html` but should be `/api/acl/acl.html`.
This commit fixes all instances of the incorrect link.