### PR TITLE
comment out redirects for learn site

### DIFF
--- a/website/redirects.txt
+++ b/website/redirects.txt
@@ -40,12 +40,14 @@
 /docs/agent/http.html     /api/index.html
 /api/acl.html             /api/acl/acl.html
 
-/intro/getting-started/install.html      https://learn.hashicorp.com/consul/getting-started/install.html
-/intro/getting-started/agent.html        https://learn.hashicorp.com/consul/getting-started/agent.html
-/intro/getting-started/services.html     https://learn.hashicorp.com/consul/getting-started/services.html
-/intro/getting-started/connect.html      https://learn.hashicorp.com/consul/getting-started/connect.html
-/intro/getting-started/join.html         https://learn.hashicorp.com/consul/getting-started/join.html
-/intro/getting-started/checks.html       https://learn.hashicorp.com/consul/getting-started/checks.html
-/intro/getting-started/kv.html           https://learn.hashicorp.com/consul/getting-started/kv.html
-/intro/getting-started/ui.html           https://learn.hashicorp.com/consul/getting-started/ui.html
-/intro/getting-started/next-steps.html   https://learn.hashicorp.com/consul/getting-started/next-steps.html
+# These redirect in Fastly do not use this redirects file. They are here for completeness.
+
+# /intro/getting-started/install.html      https://learn.hashicorp.com/consul/getting-started/install.html
+# /intro/getting-started/agent.html        https://learn.hashicorp.com/consul/getting-started/agent.html
+# /intro/getting-started/services.html     https://learn.hashicorp.com/consul/getting-started/services.html
+# /intro/getting-started/connect.html      https://learn.hashicorp.com/consul/getting-started/connect.html
+# /intro/getting-started/join.html         https://learn.hashicorp.com/consul/getting-started/join.html
+# /intro/getting-started/checks.html       https://learn.hashicorp.com/consul/getting-started/checks.html
+# /intro/getting-started/kv.html           https://learn.hashicorp.com/consul/getting-started/kv.html
+# /intro/getting-started/ui.html           https://learn.hashicorp.com/consul/getting-started/ui.html
+# /intro/getting-started/next-steps.html   https://learn.hashicorp.com/consul/getting-started/next-steps.html


### PR DESCRIPTION
This fixes #4973. The learn redirects happen within Fastly and not from this redirects file. They are kept in here for completeness but commented out.

cc: @banks 