### PR TITLE
UPDATE snapshot.html.erb - fix formatting on links

### DIFF
--- a/website/source/docs/commands/snapshot.html.md
+++ b/website/source/docs/commands/snapshot.html.md
@@ -38,8 +38,8 @@ Subcommands:
 For more information, examples, and usage about a subcommand, click on the name
 of the subcommand in the sidebar or one of the links below:
 
-- [agent] (/docs/commands/snapshot/agent.html) (Consul Enterprise only)
-- [inspect] (/docs/commands/snapshot/inspect.html)
+- [agent](/docs/commands/snapshot/agent.html) (Consul Enterprise only)
+- [inspect](/docs/commands/snapshot/inspect.html)
 - [restore](/docs/commands/snapshot/restore.html)
 - [save](/docs/commands/snapshot/save.html)
 


### PR DESCRIPTION
Links to the `agent` and `inspect` docpages were broken by errant whitespace. Removing whitespace fixes links.