### PR TITLE
Add config option for state_store.watchLimit

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1113,6 +1113,8 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		return nil, fmt.Errorf("Failed to configure keyring: %v", err)
 	}
 
+	base.WatchSoftLimit = a.config.WatchSoftLimit
+
 	return base, nil
 }
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -843,6 +843,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		VerifyOutgoing:                          b.boolVal(c.VerifyOutgoing),
 		VerifyServerHostname:                    b.boolVal(c.VerifyServerHostname),
 		Watches:                                 c.Watches,
+		WatchSoftLimit:                          b.intValWithDefault(c.WatchSoftLimit, consul.DefaultSoftWatchLimit),
 	}
 
 	if rt.BootstrapExpect == 1 {
@@ -1304,6 +1305,13 @@ func (b *Builder) durationVal(name string, v *string) (d time.Duration) {
 func (b *Builder) intVal(v *int) int {
 	if v == nil {
 		return 0
+	}
+	return *v
+}
+
+func (b *Builder) intValWithDefault(v *int, defaultVal int) int {
+	if v == nil {
+		return defaultVal
 	}
 	return *v
 }

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -843,7 +843,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		VerifyOutgoing:                          b.boolVal(c.VerifyOutgoing),
 		VerifyServerHostname:                    b.boolVal(c.VerifyServerHostname),
 		Watches:                                 c.Watches,
-		WatchSoftLimit:                          b.intValWithDefault(c.WatchSoftLimit, consul.DefaultSoftWatchLimit),
+		WatchSoftLimit:                          b.intValWithDefault(c.Performance.WatchSoftLimit, consul.DefaultSoftWatchLimit),
 	}
 
 	if rt.BootstrapExpect == 1 {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -267,6 +267,7 @@ type Config struct {
 	VerifyOutgoing                   *bool                    `json:"verify_outgoing,omitempty" hcl:"verify_outgoing" mapstructure:"verify_outgoing"`
 	VerifyServerHostname             *bool                    `json:"verify_server_hostname,omitempty" hcl:"verify_server_hostname" mapstructure:"verify_server_hostname"`
 	Watches                          []map[string]interface{} `json:"watches,omitempty" hcl:"watches" mapstructure:"watches"`
+	WatchSoftLimit                   *int                     `json:"watch_soft_limit,omitempty" hcl:"watch_soft_limit" mapstructure:"watch_soft_limit"`
 
 	// This isn't used by Consul but we've documented a feature where users
 	// can deploy their snapshot agent configs alongside their Consul configs

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -267,7 +267,6 @@ type Config struct {
 	VerifyOutgoing                   *bool                    `json:"verify_outgoing,omitempty" hcl:"verify_outgoing" mapstructure:"verify_outgoing"`
 	VerifyServerHostname             *bool                    `json:"verify_server_hostname,omitempty" hcl:"verify_server_hostname" mapstructure:"verify_server_hostname"`
 	Watches                          []map[string]interface{} `json:"watches,omitempty" hcl:"watches" mapstructure:"watches"`
-	WatchSoftLimit                   *int                     `json:"watch_soft_limit,omitempty" hcl:"watch_soft_limit" mapstructure:"watch_soft_limit"`
 
 	// This isn't used by Consul but we've documented a feature where users
 	// can deploy their snapshot agent configs alongside their Consul configs
@@ -567,6 +566,7 @@ type Performance struct {
 	LeaveDrainTime *string `json:"leave_drain_time,omitempty" hcl:"leave_drain_time" mapstructure:"leave_drain_time"`
 	RaftMultiplier *int    `json:"raft_multiplier,omitempty" hcl:"raft_multiplier" mapstructure:"raft_multiplier"` // todo(fs): validate as uint
 	RPCHoldTimeout *string `json:"rpc_hold_timeout" hcl:"rpc_hold_timeout" mapstructure:"rpc_hold_timeout"`
+	WatchSoftLimit *int    `json:"watch_soft_limit,omitempty" hcl:"watch_soft_limit" mapstructure:"watch_soft_limit"`
 }
 
 type Telemetry struct {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1413,6 +1413,13 @@ type RuntimeConfig struct {
 	// ]
 	//
 	Watches []map[string]interface{}
+
+	// WatchSoftLimit is used as a soft limit to cap how many watches we allow
+	// for a given blocking query. If this is exceeded, then we will use a
+	// higher-level watch that's less fine-grained.
+	//
+	// hcl: watch_soft_limit = int
+	WatchSoftLimit int
 }
 
 // IncomingHTTPSConfig returns the TLS configuration for HTTPS

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/testutil"
@@ -3347,7 +3348,8 @@ func TestFullConfig(t *testing.T) {
 					"key": "sl3Dffu7",
 					"args": ["dltjDJ2a", "flEa7C2d"]
 				}
-			]
+			],
+			"watch_soft_limit": ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
 		}`,
 		"hcl": `
 			acl_agent_master_token = "furuQD0b"
@@ -3893,7 +3895,8 @@ func TestFullConfig(t *testing.T) {
 				datacenter = "fYrl3F5d"
 				key = "sl3Dffu7"
 				args = ["dltjDJ2a", "flEa7C2d"]
-			}]
+			}],
+			watch_soft_limit = ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
 		`}
 
 	tail := map[string][]Source{
@@ -4538,6 +4541,7 @@ func TestFullConfig(t *testing.T) {
 				"args":       []interface{}{"dltjDJ2a", "flEa7C2d"},
 			},
 		},
+		WatchSoftLimit: consul.DefaultSoftWatchLimit,
 	}
 
 	warns := []string{
@@ -5122,7 +5126,8 @@ func TestSanitize(t *testing.T) {
 		"VerifyServerHostname": false,
 		"Version": "",
 		"VersionPrerelease": "",
-		"Watches": []
+		"Watches": [],
+		"WatchSoftLimit": 0
 	}`
 	b, err := json.MarshalIndent(rt.Sanitized(), "", "    ")
 	if err != nil {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3021,7 +3021,8 @@ func TestFullConfig(t *testing.T) {
 			"performance": {
 				"leave_drain_time": "8265s",
 				"raft_multiplier": 5,
-				"rpc_hold_timeout": "15707s"
+				"rpc_hold_timeout": "15707s",
+				"watch_soft_limit": ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
 			},
 			"pid_file": "43xN80Km",
 			"ports": {
@@ -3348,8 +3349,7 @@ func TestFullConfig(t *testing.T) {
 					"key": "sl3Dffu7",
 					"args": ["dltjDJ2a", "flEa7C2d"]
 				}
-			],
-			"watch_soft_limit": ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
+			]
 		}`,
 		"hcl": `
 			acl_agent_master_token = "furuQD0b"
@@ -3571,6 +3571,7 @@ func TestFullConfig(t *testing.T) {
 				leave_drain_time = "8265s"
 				raft_multiplier = 5
 				rpc_hold_timeout = "15707s"
+				watch_soft_limit = ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
 			}
 			pid_file = "43xN80Km"
 			ports {
@@ -3895,8 +3896,7 @@ func TestFullConfig(t *testing.T) {
 				datacenter = "fYrl3F5d"
 				key = "sl3Dffu7"
 				args = ["dltjDJ2a", "flEa7C2d"]
-			}],
-			watch_soft_limit = ` + fmt.Sprint(consul.DefaultSoftWatchLimit) + `
+			}]
 		`}
 
 	tail := map[string][]Source{

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -46,7 +46,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) error {
 }
 
 func newMockDelegate(t *testing.T, conf *structs.CAConfiguration) *consulCAMockDelegate {
-	s, err := state.NewStateStore(nil)
+	s, err := state.NewStateStore(nil, 1024)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -46,7 +46,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) error {
 }
 
 func newMockDelegate(t *testing.T, conf *structs.CAConfiguration) *consulCAMockDelegate {
-	s, err := state.NewStateStore(nil, 1024)
+	s, err := state.NewStateStore(nil, 1024, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -33,6 +33,11 @@ const (
 	// MaxRaftMultiplier is a fairly arbitrary upper bound that limits the
 	// amount of performance detuning that's possible.
 	MaxRaftMultiplier uint = 10
+
+	// DefaultSoftWatchLimit is used as a soft limit to cap how many watches we allow
+	// for a given blocking query. If this is exceeded, then we will use a
+	// higher-level watch that's less fine-grained.
+	DefaultSoftWatchLimit = 2048
 )
 
 var (
@@ -380,6 +385,11 @@ type Config struct {
 
 	// ConnectReplicationToken is used to control Intention replication.
 	ConnectReplicationToken string
+
+	// WatchSoftLimit is used as a soft limit to cap how many watches we allow
+	// for a given blocking query. If this is exceeded, then we will use a
+	// higher-level watch that's less fine-grained.
+	WatchSoftLimit int
 }
 
 // CheckProtocolVersion validates the protocol version.

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -41,7 +41,7 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 
 func TestFSM_RegisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFSM_RegisterNode(t *testing.T) {
 
 func TestFSM_RegisterNode_Service(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestFSM_RegisterNode_Service(t *testing.T) {
 
 func TestFSM_DeregisterService(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFSM_DeregisterService(t *testing.T) {
 
 func TestFSM_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFSM_DeregisterCheck(t *testing.T) {
 
 func TestFSM_DeregisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 
 func TestFSM_KVSDelete(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestFSM_KVSDelete(t *testing.T) {
 
 func TestFSM_KVSDeleteTree(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestFSM_KVSDeleteTree(t *testing.T) {
 
 func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestFSM_KVSCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSLock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -600,7 +600,7 @@ func TestFSM_KVSLock(t *testing.T) {
 
 func TestFSM_KVSUnlock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -663,7 +663,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 
 func TestFSM_CoordinateUpdate(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestFSM_CoordinateUpdate(t *testing.T) {
 
 func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 
 func TestFSM_ACL_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -902,7 +902,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 
 func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1000,7 +1000,7 @@ func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 
 func TestFSM_TombstoneReap(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1048,7 +1048,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 
 func TestFSM_Txn(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestFSM_Txn(t *testing.T) {
 
 func TestFSM_Autopilot(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	assert.Nil(err)
 
 	// Create a new intention.
@@ -1223,7 +1223,7 @@ func TestFSM_CAConfig(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	assert.Nil(err)
 
 	// Set the autopilot config using a request.
@@ -1290,7 +1290,7 @@ func TestFSM_CARoots(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	assert.Nil(err)
 
 	// Roots
@@ -1322,7 +1322,7 @@ func TestFSM_CABuiltinProvider(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	assert.Nil(err)
 
 	// Provider state.

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -69,14 +69,16 @@ type FSM struct {
 
 // New is used to construct a new FSM with a blank state.
 func New(gc *state.TombstoneGC, watchLimit int, logOutput io.Writer) (*FSM, error) {
-	stateNew, err := state.NewStateStore(gc, watchLimit)
+	logger := log.New(logOutput, "", log.LstdFlags)
+
+	stateNew, err := state.NewStateStore(gc, watchLimit, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	fsm := &FSM{
 		logOutput:  logOutput,
-		logger:     log.New(logOutput, "", log.LstdFlags),
+		logger:     logger,
 		apply:      make(map[structs.MessageType]command),
 		state:      stateNew,
 		gc:         gc,
@@ -142,7 +144,7 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 	defer old.Close()
 
 	// Create a new state store.
-	stateNew, err := state.NewStateStore(c.gc, c.watchLimit)
+	stateNew, err := state.NewStateStore(c.gc, c.watchLimit, c.logger)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -39,7 +39,7 @@ func makeLog(buf []byte) *raft.Log {
 
 func TestFSM_IgnoreUnknown(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	assert.Nil(t, err)
 
 	// Create a new reap request

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -22,7 +22,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 
 	// Try to restore on a new FSM
-	fsm2, err := New(nil, os.Stderr)
+	fsm2, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 func TestFSM_BadRestore_OSS(t *testing.T) {
 	t.Parallel()
 	// Create an FSM with some state.
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, testWatchLimit, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/issue_test.go
+++ b/agent/consul/issue_test.go
@@ -23,7 +23,7 @@ func makeLog(buf []byte) *raft.Log {
 // Testing for GH-300 and GH-279
 func TestHealthCheckRace(t *testing.T) {
 	t.Parallel()
-	fsm, err := consulfsm.New(nil, os.Stderr)
+	fsm, err := consulfsm.New(nil, 1024, os.Stderr)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -496,7 +496,7 @@ func (s *Server) setupRaft() error {
 
 	// Create the FSM.
 	var err error
-	s.fsm, err = fsm.New(s.tombstoneGC, s.config.LogOutput)
+	s.fsm, err = fsm.New(s.tombstoneGC, s.config.WatchSoftLimit, s.config.LogOutput)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func (s *Server) setupRaft() error {
 				return fmt.Errorf("recovery failed to parse peers.json: %v", err)
 			}
 
-			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.LogOutput)
+			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.WatchSoftLimit, s.config.LogOutput)
 			if err != nil {
 				return fmt.Errorf("recovery failed to make temp FSM: %v", err)
 			}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1015,7 +1015,7 @@ func TestStateStore_GetNodes(t *testing.T) {
 }
 
 func BenchmarkGetNodes(b *testing.B) {
-	s, err := NewStateStore(nil, testWatchLimit)
+	s, err := NewStateStore(nil, testWatchLimit, nil)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}
@@ -3051,7 +3051,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 }
 
 func BenchmarkCheckServiceNodes(b *testing.B) {
-	s, err := NewStateStore(nil, testWatchLimit)
+	s, err := NewStateStore(nil, testWatchLimit, nil)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1015,7 +1015,7 @@ func TestStateStore_GetNodes(t *testing.T) {
 }
 
 func BenchmarkGetNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, testWatchLimit)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}
@@ -1664,7 +1664,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 
 	// Overwhelm the service tracking.
 	idx = 6
-	for i := 0; i < 2*watchLimit; i++ {
+	for i := 0; i < 2*testWatchLimit; i++ {
 		node := fmt.Sprintf("many%d", i)
 		testRegisterNodeWithMeta(t, s, idx, node, map[string]string{"common": "1"})
 		idx++
@@ -1803,7 +1803,7 @@ func TestStateStore_ServiceNodes(t *testing.T) {
 
 	// Overwhelm the node tracking.
 	idx = 19
-	for i := 0; i < 2*watchLimit; i++ {
+	for i := 0; i < 2*testWatchLimit; i++ {
 		node := fmt.Sprintf("many%d", i)
 		if err := s.EnsureNode(idx, &structs.Node{Node: node, Address: "127.0.0.1"}); err != nil {
 			t.Fatalf("err: %v", err)
@@ -2467,7 +2467,7 @@ func TestStateStore_ServiceChecksByNodeMeta(t *testing.T) {
 	}
 
 	// Overwhelm the node tracking.
-	for i := 0; i < 2*watchLimit; i++ {
+	for i := 0; i < 2*testWatchLimit; i++ {
 		node := fmt.Sprintf("many%d", idx)
 		testRegisterNodeWithMeta(t, s, idx, node, map[string]string{"common": "1"})
 		idx++
@@ -2650,7 +2650,7 @@ func TestStateStore_ChecksInStateByNodeMeta(t *testing.T) {
 	}
 
 	// Overwhelm the node tracking.
-	for i := 0; i < 2*watchLimit; i++ {
+	for i := 0; i < 2*testWatchLimit; i++ {
 		node := fmt.Sprintf("many%d", idx)
 		testRegisterNodeWithMeta(t, s, idx, node, map[string]string{"common": "1"})
 		idx++
@@ -2971,7 +2971,7 @@ func TestStateStore_CheckServiceNodes(t *testing.T) {
 
 	// Overwhelm node and check tracking.
 	idx = 13
-	for i := 0; i < 2*watchLimit; i++ {
+	for i := 0; i < 2*testWatchLimit; i++ {
 		node := fmt.Sprintf("many%d", i)
 		testRegisterNode(t, s, idx, node)
 		idx++
@@ -3051,7 +3051,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 }
 
 func BenchmarkCheckServiceNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, testWatchLimit)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -21,7 +21,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc)
+	s, err := NewStateStore(gc, testWatchLimit)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -21,7 +21,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc, testWatchLimit)
+	s, err := NewStateStore(gc, testWatchLimit, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -50,18 +50,6 @@ var (
 	ErrMissingIntentionID = errors.New("Missing Intention ID")
 )
 
-const (
-	// watchLimit is used as a soft limit to cap how many watches we allow
-	// for a given blocking query. If this is exceeded, then we will use a
-	// higher-level watch that's less fine-grained. This isn't as bad as it
-	// seems since we have made the main culprits (nodes and services) more
-	// efficient by diffing before we update via register requests.
-	//
-	// Given the current size of aFew == 32 in memdb's watch_few.go, this
-	// will allow for up to ~64 goroutines per blocking query.
-	watchLimit = 2048
-)
-
 // Store is where we store all of Consul's state, including
 // records of node registrations, services, checks, key/value
 // pairs and more. The DB is entirely in-memory and is constructed
@@ -79,6 +67,16 @@ type Store struct {
 
 	// lockDelay holds expiration times for locks associated with keys.
 	lockDelay *Delay
+
+	// watchLimit is used as a soft limit to cap how many watches we allow
+	// for a given blocking query. If this is exceeded, then we will use a
+	// higher-level watch that's less fine-grained. This isn't as bad as it
+	// seems since we have made the main culprits (nodes and services) more
+	// efficient by diffing before we update via register requests.
+	//
+	// Given the current size of aFew == 32 in memdb's watch_few.go,
+	// this will allow for up to ~ watchLimit/32 goroutines per blocking query.
+	watchLimit int
 }
 
 // Snapshot is used to provide a point-in-time snapshot. It
@@ -113,7 +111,7 @@ type sessionCheck struct {
 }
 
 // NewStateStore creates a new in-memory state storage layer.
-func NewStateStore(gc *TombstoneGC) (*Store, error) {
+func NewStateStore(gc *TombstoneGC, watchLimit int) (*Store, error) {
 	// Create the in-memory DB.
 	schema := stateStoreSchema()
 	db, err := memdb.NewMemDB(schema)
@@ -128,6 +126,7 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 		abandonCh:    make(chan struct{}),
 		kvsGraveyard: NewGraveyard(gc),
 		lockDelay:    NewDelay(),
+		watchLimit:   watchLimit,
 	}
 	return s, nil
 }

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/hashicorp/go-memdb"
 )
 
+const (
+	testWatchLimit = 1024
+)
+
 func testUUID() string {
 	buf := make([]byte, 16)
 	if _, err := crand.Read(buf); err != nil {
@@ -26,7 +30,7 @@ func testUUID() string {
 }
 
 func testStateStore(t *testing.T) *Store {
-	s, err := NewStateStore(nil)
+	s, err := NewStateStore(nil, testWatchLimit)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -30,7 +30,7 @@ func testUUID() string {
 }
 
 func testStateStore(t *testing.T) *Store {
-	s, err := NewStateStore(nil, testWatchLimit)
+	s, err := NewStateStore(nil, testWatchLimit, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -590,9 +590,9 @@ default will automatically work with some tooling.
         The ACL token used to authorize secondary datacenters with the primary datacenter for replication
         operations. This token is required for servers outside the [`primary_datacenter`](#primary_datacenter) when
         ACLs are enabled. This token may be provided later using the [agent token API](/api/agent.html#update-acl-tokens)
-        on each server. This token must have at least "read" permissions on ACL data but if ACL 
-        token replication is enabled then it must have "write" permissions. This also enables 
-        Connect replication in Consul Enterprise, for which the token will require both operator 
+        on each server. This token must have at least "read" permissions on ACL data but if ACL
+        token replication is enabled then it must have "write" permissions. This also enables
+        Connect replication in Consul Enterprise, for which the token will require both operator
         "write" and intention "read" permissions for replicating CA and Intention data.
 
 * <a name="acl_datacenter"></a><a href="#acl_datacenter">`acl_datacenter`</a> - **This field is
@@ -1239,6 +1239,13 @@ default will automatically work with some tooling.
         that a client or server will retry internal RPC requests during leader elections. Under normal
         circumstances, this can prevent clients from experiencing "no leader" errors. This was added in
         Consul 1.0. Must be a duration value such as 10s. Defaults to 7s.
+
+    *   <a name="watch_soft_limit"></a><a href="#watch_soft_limit">`watch_soft_limit`</a> - Maximum
+        number of memdb nodes that can be watched by each blocking queries. Reaching this limit will switch
+        from watching each individual entity matching the query to watching all changes for an entity type
+        (ie: watching all service changes). This limits the number of goroutines spawned by each blocking query,
+        however it may be detrimental on clusters where changes are very frequent. A warning is printed for queries
+        reaching this limit. Defaults to 2048.
 
 * <a name="ports"></a><a href="#ports">`ports`</a> This is a nested object that allows setting
   the bind ports for the following keys:


### PR DESCRIPTION
As described here : https://github.com/hashicorp/consul/issues/4984, exceeding watchLimit greatly degrades blocking queries performance. 
This patch allows to configure this parameter while keeping the current value of 2048 as default, and displays a warning when the value is reached.