### PR TITLE
UI: [Bugfix] Test fixup for new meta property

### DIFF
--- a/ui-v2/tests/integration/adapters/acl/response-test.js
+++ b/ui-v2/tests/integration/adapters/acl/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | acl | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -29,6 +30,7 @@ module('Integration | Adapter | acl | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/intention/response-test.js
+++ b/ui-v2/tests/integration/adapters/intention/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | intention | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -31,6 +32,7 @@ module('Integration | Adapter | intention | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/kv/response-test.js
+++ b/ui-v2/tests/integration/adapters/kv/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | kv | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -35,6 +36,7 @@ module('Integration | Adapter | kv | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/node/response-test.js
+++ b/ui-v2/tests/integration/adapters/node/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | node | response', function(hooks) {
   setupTest(hooks);
   test('handleResponse returns the correct data for list endpoint', function(assert) {
@@ -30,6 +31,7 @@ module('Integration | Adapter | node | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/policy/response-test.js
+++ b/ui-v2/tests/integration/adapters/policy/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | policy | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -29,6 +30,7 @@ module('Integration | Adapter | policy | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/service/response-test.js
+++ b/ui-v2/tests/integration/adapters/service/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | service | response', function(hooks) {
   setupTest(hooks);
   test('handleResponse returns the correct data for list endpoint', function(assert) {
@@ -30,6 +31,7 @@ module('Integration | Adapter | service | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
         Nodes: payload,
       };

--- a/ui-v2/tests/integration/adapters/session/response-test.js
+++ b/ui-v2/tests/integration/adapters/session/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | session | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -30,6 +31,7 @@ module('Integration | Adapter | session | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);

--- a/ui-v2/tests/integration/adapters/token/response-test.js
+++ b/ui-v2/tests/integration/adapters/token/response-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | token | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -29,6 +30,7 @@ module('Integration | Adapter | token | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
+        [META]: {},
         uid: `["${dc}","${id}"]`,
       });
       const actual = adapter.handleResponse(200, {}, payload, request);


### PR DESCRIPTION
https://github.com/hashicorp/consul/pull/4946 added a `meta` property to http responses. It seems the tests were passing even though we'd changed the shape of the data. Looks like it was due to the ember `./tmp` folder and things not being rebuilt properly.

This brings the tests back inline with the new shape of the data (additional `meta` property)

Whilst marked as a bugfix, this only effects the tests