### PR TITLE
UI: Pass GET data and clean certain values for KV's ensuring consistency

### DIFF
--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -71,6 +71,9 @@ export default Adapter.extend({
       delete _query.id;
     }
     const query = { ..._query };
+    if (typeof query.separator !== 'undefined') {
+      delete query.separator;
+    }
     delete _query[DATACENTER_QUERY_PARAM];
     return query;
   },

--- a/ui-v2/app/adapters/kv.js
+++ b/ui-v2/app/adapters/kv.js
@@ -136,6 +136,7 @@ export default Adapter.extend({
         }
         return null;
     }
+    return data;
   },
   methodForRequest: function(params) {
     switch (params.requestType) {


### PR DESCRIPTION
In order to know what the datacenter (the `?dc=`) value is for all HTTP requests, we have to do a certain amount of dancing to pass the `dc` through on the end of the URL to be able to retrieve it later in a place where the HTTP request data isn't available.

KV's were not following the same model as the rest of the app. This had no user impact, but when we need to use more query data (for example `?index`) it will not get passed through.

Returning the `data` like in the rest of the app, means that parameters could be doubled up depending on how they are passed through, and therefore need to be 'cleaned'. This is the case for `separator`, therefore we clean the url once we've read the `dc` value from it, and remove the `separator` value.

Hopefully if I go ahead with a completely new `HTTPAdapter` that is less specific than the `RESTAdapter`, all of this dance can be avoided. Also see https://github.com/hashicorp/consul/pull/4946 for more info regarding the need for this future change.

