### PR TITLE
UI: If a service has no external-source, don't show the icon

### DIFF
--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -7,7 +7,13 @@
     {{#block-slot 'header'}}
       <h1>
         {{ item.Service.Service }}
-        <span data-test-external-source="{{service/external-source item.Service}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item.Service) '-color-svg') 'none')}}} data-tooltip="Registered via {{service/external-source item.Service}}">Registered via {{service/external-source item.Service}}</span>
+{{#with (service/external-source item.Service) as |externalSource| }}
+  {{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg| }}
+    {{#if (not-eq bg 'none') }}
+        <span data-test-external-source="{{externalSource}}" style={{{ concat 'background-image:' bg }}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
+    {{/if}}
+  {{/with}}
+{{/with}}
       </h1>
     {{/block-slot}}
     {{#block-slot 'toolbar'}}

--- a/ui-v2/tests/acceptance/dc/services/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/show.feature
@@ -16,6 +16,22 @@ Feature: dc / services / show: Show Service
       service: service-0
     ---
     Then I see externalSource like "consul"
+  Scenario: Given a service with an 'unsupported' external source, there is no logo
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Tags: ['Tag1', 'Tag2']
+        Meta:
+          external-source: 'not-supported'
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    Then I don't see externalSource
   Scenario: Given various services with various tags, all tags are displayed
     Given 1 datacenter model with the value "dc1"
     And 3 node models


### PR DESCRIPTION
Currently even if a service doesn't have an `external-source`, if you hover in just the right place you will see a 'phantom' 'Registered via' tooltip.

![screen shot 2018-11-26 at 15 15 28](https://user-images.githubusercontent.com/554604/49023131-61027080-f18e-11e8-891f-632c811a9a0d.png)

This removes the phantom tooltip and only shows the tooltip if the service as an 'external-source' and an icon exists for it.

👻 

P.S. Base branch of `master` as this should go in the next release whether `ui-staging` is merged down or not.
