### PR TITLE
UI: Resolve bad rebase and add in KV test for change of GET for KVs

### DIFF
--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -3,10 +3,14 @@ import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
 import { next } from '@ember/runloop';
+import { Promise } from 'rsvp';
+
+import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
+
 const removeLoading = function($from) {
   return $from.classList.remove('ember-loading');
 };
-export default Route.extend({
+export default Route.extend(WithBlockingActions, {
   dom: service('dom'),
   init: function() {
     this._super(...arguments);

--- a/ui-v2/tests/unit/adapters/kv-test.js
+++ b/ui-v2/tests/unit/adapters/kv-test.js
@@ -85,11 +85,11 @@ module('Unit | Adapter | kv', function(hooks) {
       });
     });
     // not included in the above forEach as it's a slightly different concept
-    it('returns string KV object when calling queryRecord (or anything else) record', function() {
+    it('returns string KV object when calling queryRecord (or anything else) record', function(message) {
       const actual = adapter.dataForRequest({
         requestType: 'queryRecord',
       });
-      assert.equal(actual, null);
+      assert.deepEqual(actual, deep);
     });
   });
   test('methodForRequest returns the correct method', function(assert) {

--- a/ui-v2/tests/unit/routes/application-test.js
+++ b/ui-v2/tests/unit/routes/application-test.js
@@ -2,7 +2,14 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:application', 'Unit | Route | application', {
   // Specify the other units that are required for this test.
-  needs: ['service:repository/dc', 'service:settings', 'service:dom'],
+  needs: [
+    'service:repository/dc',
+    'service:settings',
+    'service:feedback',
+    'service:flashMessages',
+    'service:logger',
+    'service:dom',
+  ],
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
Unfortunately these tests seemed to be passing previously but it seems like I've been hit by the `./tmp` folder again.

2 things are happening here:

1. An overzealous conflict fixup during a rebase led to the removal of essential functionality, this is being readded.

See for reference:

https://github.com/hashicorp/consul/blob/master/ui-v2/tests/unit/routes/application-test.js
https://github.com/hashicorp/consul/blob/master/ui-v2/app/routes/application.js

2. An altered test case for https://github.com/hashicorp/consul/pull/4991

Looks like I'm going to add a `rm -rf ./tmp` to my test scripts, which generally I don't like doing, ideally it would be on a git hook also as this seems to be when you are switching branches a lot, but I really don't like having `rm`'s in hooks. I'm going to mull it over some more before I do anything. Any suggestions welcome!




