### PR TITLE
Updates to the Adding/Removing Servers Guide

### DIFF
--- a/website/source/docs/guides/servers.html.md
+++ b/website/source/docs/guides/servers.html.md
@@ -47,10 +47,7 @@ option to add additional servers.
 
 ## Add a Server with Agent Configuration
 
-When adding additional servers in production, you will likely want to use the
-[agent configuration](https://www.consul.io/docs/agent/options.html)
-option, either with the Consul CLI or in the agent configuration file. With either
-option, you can use the `retry_join` setting.
+In production environments, you should use the [agent configuration](https://www.consul.io/docs/agent/options.html) option, `retry_join`. `retry_join` can be used as a command line flag or in the agent configuration file. 
 
 With the Consul CLI:
 
@@ -69,9 +66,12 @@ In the agent configuration file:
 }
 ```
 
-The `retry_join` will also ensure that if any server loses connection
+[`retry_join`](https://www.consul.io/docs/agent/options.html#retry-join)
+will ensure that if any server loses connection
 with the cluster for any reason, including the node restarting, it can
-rejoin when it comes back. Both servers and clients can use this method.
+rejoin when it comes back. In additon to working with static IPs, it 
+can also be  useful for other discovery mechanisms, such as auto joining 
+based on cloud metadata and discovery. Both servers and clients can use this method.
 
 ### Server Coordination
 
@@ -119,7 +119,7 @@ the new servers up-to-date.
 Removing servers must be done carefully to avoid causing an availability outage.
 For a cluster of N servers, at least (N/2)+1 must be available for the cluster
 to function. See this [deployment table](/docs/internals/consensus.html#toc_4).
-If you have 3 servers, and 1 of them is currently failed, removing any servers
+If you have 3 servers and 1 of them is currently failing, removing any other servers
 will cause the cluster to become unavailable.
 
 To avoid this, it may be necessary to first add new servers to the cluster,

--- a/website/source/docs/guides/servers.html.md
+++ b/website/source/docs/guides/servers.html.md
@@ -157,9 +157,11 @@ The leader should also emit various logs including:
 At this point the node has been gracefully removed from the cluster, and
 will shut down.
 
-If the leader is affected by an outage, then [manual recovery](/docs/guides/outage.html#manual-recovery-using-peers-json) needs to be done.
-
 To remove all agents that accidentally joined the wrong set of servers, clear out the contents of the data directory (`-data-dir`) on both client and server nodes.
+
+These graceful methods to remove servres assumse you have a healthly cluster. 
+If the cluster has no leader due to loss of quorum or data corruption, you should 
+plan for [outage recovery](/docs/guides/outage.html#manual-recovery-using-peers-json).
 
 !> **WARNING** Removing data on server nodes will destroy all state in the cluster
 

--- a/website/source/docs/guides/servers.html.md
+++ b/website/source/docs/guides/servers.html.md
@@ -22,8 +22,8 @@ In this guide, we will cover the different methods for adding and removing serve
 
 ## Manually Add a New Server
 
-Manually adding new servers is generally straightforward. Simply start the new
-agent with the `-server` flag. At this point, the server will not be a member of
+Manually adding new servers is generally straightforward, start the new
+agent with the `-server` flag. At this point the server will not be a member of
 any cluster, and should emit something like:
 
 ```sh
@@ -76,7 +76,7 @@ rejoin when it comes back. Both servers and clients can use this method.
 ### Server Coordination
 
 To ensure Consul servers are joining the cluster properly, you should monitor
-the server coordiantion. The gossip protocol is used to properly discover all
+the server coordination. The gossip protocol is used to properly discover all
 the nodes in the cluster. Once the node has joined, the existing cluster
 leader should log something like:
 
@@ -182,8 +182,8 @@ the cluster leader will mark the node as having left the cluster and it will sto
 
 ## Summary
 
-In this guide we learned the straighforword process of adding and removing servers including;
-manually adding servers, adding servers through the agent confituration, gracefully removing
-servers, and forced removal of servers. Finally, we should restate that manually adding servers
+In this guide we learned the straightforword process of adding and removing servers including;
+manually adding servers, adding servers through the agent configuration, gracefully removing
+servers, and forcing removal of servers. Finally, we should restate that manually adding servers
  is good for testing purposes, however, for production it is recommended to add servers with
 the agent configuration.

--- a/website/source/docs/guides/servers.html.md
+++ b/website/source/docs/guides/servers.html.md
@@ -47,8 +47,8 @@ option to add additional servers.
 
 ## Add a Server with Agent Configuration
 
-When adding addtional servers in production, you will likely want to use the
-[agent configuiration](https://www.consul.io/docs/agent/options.html)
+When adding additional servers in production, you will likely want to use the
+[agent configuration](https://www.consul.io/docs/agent/options.html)
 option, either with the Consul CLI or in the agent configuration file. With either
 option, you can use the `retry_join` setting.
 
@@ -182,7 +182,7 @@ the cluster leader will mark the node as having left the cluster and it will sto
 
 ## Summary
 
-In this guide we learned the straightforword process of adding and removing servers including;
+In this guide we learned the straightforward process of adding and removing servers including;
 manually adding servers, adding servers through the agent configuration, gracefully removing
 servers, and forcing removal of servers. Finally, we should restate that manually adding servers
  is good for testing purposes, however, for production it is recommended to add servers with


### PR DESCRIPTION
Whats new:
* Section on adding servers with agent config
* Subsection for server coordination, content isn't new
* Summary

Whats removed
* Nothing

Feedback requested
* Code and command snippets, especially the `-retry-join`?
* Does the "Server Coordination" subsection make sense there?
* I added language around not using the manual adding of servers in production, are we ok with this recommendation? 