### PR TITLE
Added multiple policies for renaming nodes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -992,6 +992,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	if a.config.NonVotingServer {
 		base.NonVoter = a.config.NonVotingServer
 	}
+	if a.config.NodeRenamingPolicy != "" {
+		base.NodeRenamingPolicy = a.config.NodeRenamingPolicy
+	}
 
 	// These are fully specified in the agent defaults, so we can simply
 	// copy them over.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1296,6 +1296,7 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 		}
 		a.Start()
 		defer a.Shutdown()
+		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 		health := &structs.HealthCheck{
 			Node:    "foo",

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -790,6 +790,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		NodeID:                                  types.NodeID(b.stringVal(c.NodeID)),
 		NodeMeta:                                c.NodeMeta,
 		NodeName:                                b.nodeName(c.NodeName),
+		NodeRenamingPolicy:                      b.stringValWithDefault(c.NodeRenamingPolicy, "legacy"),
 		NonVotingServer:                         b.boolVal(c.NonVotingServer),
 		PidFile:                                 b.stringVal(c.PidFile),
 		PrimaryDatacenter:                       primaryDatacenter,

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -790,7 +790,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		NodeID:                                  types.NodeID(b.stringVal(c.NodeID)),
 		NodeMeta:                                c.NodeMeta,
 		NodeName:                                b.nodeName(c.NodeName),
-		NodeRenamingPolicy:                      b.stringValWithDefault(c.NodeRenamingPolicy, "legacy"),
+		NodeRenamingPolicy:                      b.stringValWithDefault(c.NodeRenamingPolicy, string(types.NodeRenamingDefault)),
 		NonVotingServer:                         b.boolVal(c.NonVotingServer),
 		PidFile:                                 b.stringVal(c.PidFile),
 		PrimaryDatacenter:                       primaryDatacenter,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -221,6 +221,7 @@ type Config struct {
 	NodeID                           *string                  `json:"node_id,omitempty" hcl:"node_id" mapstructure:"node_id"`
 	NodeMeta                         map[string]string        `json:"node_meta,omitempty" hcl:"node_meta" mapstructure:"node_meta"`
 	NodeName                         *string                  `json:"node_name,omitempty" hcl:"node_name" mapstructure:"node_name"`
+	NodeRenamingPolicy               *string                  `json:"node_renaming_policy,omitempty" hcl:"node_renaming_policy" mapstructure:"node_renaming_policy"`
 	NonVotingServer                  *bool                    `json:"non_voting_server,omitempty" hcl:"non_voting_server" mapstructure:"non_voting_server"`
 	Performance                      Performance              `json:"performance,omitempty" hcl:"performance" mapstructure:"performance"`
 	PidFile                          *string                  `json:"pid_file,omitempty" hcl:"pid_file" mapstructure:"pid_file"`

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"time"
+
+	"github.com/hashicorp/consul/types"
 )
 
 // Flags defines the command line flags.
@@ -84,7 +86,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.NodeName, "node", "Name of this node. Must be unique in the cluster.")
 	add(&f.Config.NodeID, "node-id", "A unique ID for this node across space and time. Defaults to a randomly-generated ID that persists in the data-dir.")
 	add(&f.Config.NodeMeta, "node-meta", "An arbitrary metadata key/value pair for this node, of the format `key:value`. Can be specified multiple times.")
-	add(&f.Config.NodeRenamingPolicy, "node-renaming-policy", "Choose between behaviours when renaming nodes, can be any of legacy|dead|strict")
+	add(&f.Config.NodeRenamingPolicy, "node-renaming-policy", fmt.Sprintf("Choose between behaviors when addin/renaming nodes, can be any of (%s|%s|%s", types.NodeRenamingLegacy, types.NodeRenamingRenameDeadNodes, types.NodeRenamingStrict))
 	add(&f.Config.NonVotingServer, "non-voting-server", "(Enterprise-only) This flag is used to make the server not participate in the Raft quorum, and have it only receive the data replication stream. This can be used to add read scalability to a cluster in cases where a high volume of reads to servers are needed.")
 	add(&f.Config.PidFile, "pid-file", "Path to file to store agent PID.")
 	add(&f.Config.RPCProtocol, "protocol", "Sets the protocol version. Defaults to latest.")

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -84,6 +84,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.NodeName, "node", "Name of this node. Must be unique in the cluster.")
 	add(&f.Config.NodeID, "node-id", "A unique ID for this node across space and time. Defaults to a randomly-generated ID that persists in the data-dir.")
 	add(&f.Config.NodeMeta, "node-meta", "An arbitrary metadata key/value pair for this node, of the format `key:value`. Can be specified multiple times.")
+	add(&f.Config.NodeRenamingPolicy, "node-renaming-policy", "Choose between behaviours when renaming nodes, can be any of legacy|dead|strict")
 	add(&f.Config.NonVotingServer, "non-voting-server", "(Enterprise-only) This flag is used to make the server not participate in the Raft quorum, and have it only receive the data replication stream. This can be used to add read scalability to a cluster in cases where a high volume of reads to servers are needed.")
 	add(&f.Config.PidFile, "pid-file", "Path to file to store agent PID.")
 	add(&f.Config.RPCProtocol, "protocol", "Sets the protocol version. Defaults to latest.")

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -819,6 +819,12 @@ type RuntimeConfig struct {
 	// flag: -node-meta "key:value" -node-meta "key:value" ...
 	NodeMeta map[string]string
 
+	// NodeRenamingPolicy exposes how renaming is handled.
+	//
+	// hcl: node_renaming_policy = (legacy|dead|strict)
+	// flag: -node-renaming-policy
+	NodeRenamingPolicy string
+
 	// NonVotingServer is whether this server will act as a non-voting member
 	// of the cluster to help provide read scalability. (Enterprise-only)
 	//

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -503,11 +503,11 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 		{
 			desc: "-node-renaming-policy",
 			args: []string{
-				`-node-renaming-policy=dead`,
+				`-node-renaming-policy=` + types.NodeRenamingRenameDeadNodes,
 				`-data-dir=` + dataDir,
 			},
 			patch: func(rt *RuntimeConfig) {
-				rt.NodeRenamingPolicy = "dead"
+				rt.NodeRenamingPolicy = types.NodeRenamingRenameDeadNodes
 				rt.DataDir = dataDir
 			},
 		},
@@ -4207,7 +4207,7 @@ func TestFullConfig(t *testing.T) {
 		NodeID:                           types.NodeID("AsUIlw99"),
 		NodeMeta:                         map[string]string{"5mgGQMBk": "mJLtVMSG", "A7ynFMJB": "0Nx6RGab"},
 		NodeName:                         "otlLxGaI",
-		NodeRenamingPolicy:               "legacy",
+		NodeRenamingPolicy:               types.NodeRenamingDefault,
 		NonVotingServer:                  true,
 		PidFile:                          "43xN80Km",
 		PrimaryDatacenter:                "ejtmd43d",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -503,11 +503,11 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 		{
 			desc: "-node-renaming-policy",
 			args: []string{
-				`-node-renaming-policy=` + types.NodeRenamingRenameDeadNodes,
+				`-node-renaming-policy=` + string(types.NodeRenamingRenameDeadNodes),
 				`-data-dir=` + dataDir,
 			},
 			patch: func(rt *RuntimeConfig) {
-				rt.NodeRenamingPolicy = types.NodeRenamingRenameDeadNodes
+				rt.NodeRenamingPolicy = string(types.NodeRenamingRenameDeadNodes)
 				rt.DataDir = dataDir
 			},
 		},
@@ -4207,7 +4207,7 @@ func TestFullConfig(t *testing.T) {
 		NodeID:                           types.NodeID("AsUIlw99"),
 		NodeMeta:                         map[string]string{"5mgGQMBk": "mJLtVMSG", "A7ynFMJB": "0Nx6RGab"},
 		NodeName:                         "otlLxGaI",
-		NodeRenamingPolicy:               types.NodeRenamingDefault,
+		NodeRenamingPolicy:               string(types.NodeRenamingDefault),
 		NonVotingServer:                  true,
 		PidFile:                          "43xN80Km",
 		PrimaryDatacenter:                "ejtmd43d",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -501,6 +501,17 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
+			desc: "-node-renaming-policy",
+			args: []string{
+				`-node-renaming-policy=dead`,
+				`-data-dir=` + dataDir,
+			},
+			patch: func(rt *RuntimeConfig) {
+				rt.NodeRenamingPolicy = "dead"
+				rt.DataDir = dataDir
+			},
+		},
+		{
 			desc: "-non-voting-server",
 			args: []string{
 				`-non-voting-server`,
@@ -4196,6 +4207,7 @@ func TestFullConfig(t *testing.T) {
 		NodeID:                           types.NodeID("AsUIlw99"),
 		NodeMeta:                         map[string]string{"5mgGQMBk": "mJLtVMSG", "A7ynFMJB": "0Nx6RGab"},
 		NodeName:                         "otlLxGaI",
+		NodeRenamingPolicy:               "legacy",
 		NonVotingServer:                  true,
 		PidFile:                          "43xN80Km",
 		PrimaryDatacenter:                "ejtmd43d",
@@ -4994,6 +5006,7 @@ func TestSanitize(t *testing.T) {
 		"NodeID": "",
 		"NodeMeta": {},
 		"NodeName": "",
+		"NodeRenamingPolicy": "",
 		"NonVotingServer": false,
 		"PidFile": "",
 		"PrimaryDatacenter": "",

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -46,7 +46,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) error {
 }
 
 func newMockDelegate(t *testing.T, conf *structs.CAConfiguration) *consulCAMockDelegate {
-	s, err := state.NewStateStore(nil)
+	s, err := state.NewStateStore(nil, state.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +47,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) error {
 }
 
 func newMockDelegate(t *testing.T, conf *structs.CAConfiguration) *consulCAMockDelegate {
-	s, err := state.NewStateStore(nil, state.NodeRenamingDefault)
+	s, err := state.NewStateStore(nil, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -107,6 +107,10 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 		return nil, err
 	}
 
+	if err := config.CheckNodeRenamingPolicy(); err != nil {
+		return nil, err
+	}
+
 	// Ensure we have a log output
 	if config.LogOutput == nil {
 		config.LogOutput = os.Stderr

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -398,15 +398,8 @@ func (c *Config) CheckProtocolVersion() error {
 
 // CheckNodeRenamingPolicy checks that node_renaming_policy has a correct value.
 func (c *Config) CheckNodeRenamingPolicy() error {
-	switch c.NodeRenamingPolicy {
-	case "": // Will use default
-	case types.NodeRenamingLegacy:
-	case types.NodeRenamingRenameDeadNodes:
-	case types.NodeRenamingStrict:
-	default:
-		return fmt.Errorf("Unsupported node_renaming_policy '%s', can be (%s|%s|%s)", c.NodeRenamingPolicy, types.NodeRenamingLegacy, types.NodeRenamingRenameDeadNodes, types.NodeRenamingStrict)
-	}
-	return nil
+	_, err := types.ConvertToNodeRenamingLegacy(c.NodeRenamingPolicy)
+	return err
 }
 
 // CheckACL validates the ACL configuration.

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -396,6 +396,19 @@ func (c *Config) CheckProtocolVersion() error {
 	return nil
 }
 
+// CheckNodeRenamingPolicy checks that node_renaming_policy has a correct value.
+func (c *Config) CheckNodeRenamingPolicy() error {
+	switch c.NodeRenamingPolicy {
+	case "": // Will use default
+	case types.NodeRenamingLegacy:
+	case types.NodeRenamingRenameDeadNodes:
+	case types.NodeRenamingStrict:
+	default:
+		return fmt.Errorf("Unsupported node_renaming_policy '%s', can be (%s|%s|%s)", c.NodeRenamingPolicy, types.NodeRenamingLegacy, types.NodeRenamingRenameDeadNodes, types.NodeRenamingStrict)
+	}
+	return nil
+}
+
 // CheckACL validates the ACL configuration.
 func (c *Config) CheckACL() error {
 	switch c.ACLDefaultPolicy {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -336,6 +336,9 @@ type Config struct {
 	// warning and discard the remaining updates.
 	CoordinateUpdateMaxBatches int
 
+	// NodeRenamingPolicy allow to handle node renaming behavior
+	NodeRenamingPolicy string
+
 	// RPCHoldTimeout is how long an RPC can be "held" before it is errored.
 	// This is used to paper over a loss of leadership by instead holding RPCs,
 	// so that the caller experiences a slow response rather than an error.

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -41,7 +41,7 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 
 func TestFSM_RegisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFSM_RegisterNode(t *testing.T) {
 
 func TestFSM_RegisterNode_Service(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestFSM_RegisterNode_Service(t *testing.T) {
 
 func TestFSM_DeregisterService(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFSM_DeregisterService(t *testing.T) {
 
 func TestFSM_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFSM_DeregisterCheck(t *testing.T) {
 
 func TestFSM_DeregisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 
 func TestFSM_KVSDelete(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestFSM_KVSDelete(t *testing.T) {
 
 func TestFSM_KVSDeleteTree(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestFSM_KVSDeleteTree(t *testing.T) {
 
 func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestFSM_KVSCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSLock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -600,7 +600,7 @@ func TestFSM_KVSLock(t *testing.T) {
 
 func TestFSM_KVSUnlock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -663,7 +663,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 
 func TestFSM_CoordinateUpdate(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestFSM_CoordinateUpdate(t *testing.T) {
 
 func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 
 func TestFSM_ACL_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -902,7 +902,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 
 func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1000,7 +1000,7 @@ func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 
 func TestFSM_TombstoneReap(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1048,7 +1048,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 
 func TestFSM_Txn(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestFSM_Txn(t *testing.T) {
 
 func TestFSM_Autopilot(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	assert.Nil(err)
 
 	// Create a new intention.
@@ -1223,7 +1223,7 @@ func TestFSM_CAConfig(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	assert.Nil(err)
 
 	// Set the autopilot config using a request.
@@ -1290,7 +1290,7 @@ func TestFSM_CARoots(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	assert.Nil(err)
 
 	// Roots
@@ -1322,7 +1322,7 @@ func TestFSM_CABuiltinProvider(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	assert.Nil(err)
 
 	// Provider state.

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -41,7 +41,7 @@ func generateRandomCoordinate() *coordinate.Coordinate {
 
 func TestFSM_RegisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestFSM_RegisterNode(t *testing.T) {
 
 func TestFSM_RegisterNode_Service(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestFSM_RegisterNode_Service(t *testing.T) {
 
 func TestFSM_DeregisterService(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestFSM_DeregisterService(t *testing.T) {
 
 func TestFSM_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestFSM_DeregisterCheck(t *testing.T) {
 
 func TestFSM_DeregisterNode(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestFSM_DeregisterNode(t *testing.T) {
 
 func TestFSM_KVSDelete(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestFSM_KVSDelete(t *testing.T) {
 
 func TestFSM_KVSDeleteTree(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestFSM_KVSDeleteTree(t *testing.T) {
 
 func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -498,7 +498,7 @@ func TestFSM_KVSDeleteCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSCheckAndSet(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestFSM_KVSCheckAndSet(t *testing.T) {
 
 func TestFSM_KVSLock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -600,7 +600,7 @@ func TestFSM_KVSLock(t *testing.T) {
 
 func TestFSM_KVSUnlock(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -663,7 +663,7 @@ func TestFSM_KVSUnlock(t *testing.T) {
 
 func TestFSM_CoordinateUpdate(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -704,7 +704,7 @@ func TestFSM_CoordinateUpdate(t *testing.T) {
 
 func TestFSM_SessionCreate_Destroy(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -784,7 +784,7 @@ func TestFSM_SessionCreate_Destroy(t *testing.T) {
 
 func TestFSM_ACL_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -902,7 +902,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 
 func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1000,7 +1000,7 @@ func TestFSM_PreparedQuery_CRUD(t *testing.T) {
 
 func TestFSM_TombstoneReap(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1048,7 +1048,7 @@ func TestFSM_TombstoneReap(t *testing.T) {
 
 func TestFSM_Txn(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1090,7 +1090,7 @@ func TestFSM_Txn(t *testing.T) {
 
 func TestFSM_Autopilot(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestFSM_Intention_CRUD(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	assert.Nil(err)
 
 	// Create a new intention.
@@ -1223,7 +1223,7 @@ func TestFSM_CAConfig(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	assert.Nil(err)
 
 	// Set the autopilot config using a request.
@@ -1290,7 +1290,7 @@ func TestFSM_CARoots(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	assert.Nil(err)
 
 	// Roots
@@ -1322,7 +1322,7 @@ func TestFSM_CABuiltinProvider(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	assert.Nil(err)
 
 	// Provider state.

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/raft"
 )
@@ -60,22 +61,23 @@ type FSM struct {
 	state     *state.Store
 
 	gc                 *state.TombstoneGC
-	nodeRenamingPolicy string
+	nodeRenamingPolicy types.NodeRenamingPolicy
 }
 
 // New is used to construct a new FSM with a blank state.
-func New(gc *state.TombstoneGC, logOutput io.Writer, nodeRenamingPolicy string) (*FSM, error) {
+func New(gc *state.TombstoneGC, logOutput io.Writer, nodeRenamingPolicy types.NodeRenamingPolicy) (*FSM, error) {
 	stateNew, err := state.NewStateStore(gc, nodeRenamingPolicy)
 	if err != nil {
 		return nil, err
 	}
 
 	fsm := &FSM{
-		logOutput: logOutput,
-		logger:    log.New(logOutput, "", log.LstdFlags),
-		apply:     make(map[structs.MessageType]command),
-		state:     stateNew,
-		gc:        gc,
+		logOutput:          logOutput,
+		logger:             log.New(logOutput, "", log.LstdFlags),
+		apply:              make(map[structs.MessageType]command),
+		state:              stateNew,
+		gc:                 gc,
+		nodeRenamingPolicy: nodeRenamingPolicy,
 	}
 
 	// Build out the apply dispatch table based on the registered commands.

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -59,12 +59,13 @@ type FSM struct {
 	stateLock sync.RWMutex
 	state     *state.Store
 
-	gc *state.TombstoneGC
+	gc                 *state.TombstoneGC
+	nodeRenamingPolicy string
 }
 
 // New is used to construct a new FSM with a blank state.
-func New(gc *state.TombstoneGC, logOutput io.Writer) (*FSM, error) {
-	stateNew, err := state.NewStateStore(gc)
+func New(gc *state.TombstoneGC, logOutput io.Writer, nodeRenamingPolicy string) (*FSM, error) {
+	stateNew, err := state.NewStateStore(gc, nodeRenamingPolicy)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 	defer old.Close()
 
 	// Create a new state store.
-	stateNew, err := state.NewStateStore(c.gc)
+	stateNew, err := state.NewStateStore(c.gc, c.nodeRenamingPolicy)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
 )
@@ -39,7 +40,7 @@ func makeLog(buf []byte) *raft.Log {
 
 func TestFSM_IgnoreUnknown(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	assert.Nil(t, err)
 
 	// Create a new reap request

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -39,7 +39,7 @@ func makeLog(buf []byte) *raft.Log {
 
 func TestFSM_IgnoreUnknown(t *testing.T) {
 	t.Parallel()
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	assert.Nil(t, err)
 
 	// Create a new reap request

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -218,7 +218,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 
 	// Try to restore on a new FSM
-	fsm2, err := New(nil, os.Stderr, "")
+	fsm2, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -22,7 +22,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 
 	// Try to restore on a new FSM
-	fsm2, err := New(nil, os.Stderr)
+	fsm2, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -418,7 +418,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 func TestFSM_BadRestore_OSS(t *testing.T) {
 	t.Parallel()
 	// Create an FSM with some state.
-	fsm, err := New(nil, os.Stderr)
+	fsm, err := New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -418,7 +419,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 func TestFSM_BadRestore_OSS(t *testing.T) {
 	t.Parallel()
 	// Create an FSM with some state.
-	fsm, err := New(nil, os.Stderr, "")
+	fsm, err := New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/issue_test.go
+++ b/agent/consul/issue_test.go
@@ -8,6 +8,7 @@ import (
 	consulfsm "github.com/hashicorp/consul/agent/consul/fsm"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/raft"
 )
 
@@ -23,7 +24,7 @@ func makeLog(buf []byte) *raft.Log {
 // Testing for GH-300 and GH-279
 func TestHealthCheckRace(t *testing.T) {
 	t.Parallel()
-	fsm, err := consulfsm.New(nil, os.Stderr, "")
+	fsm, err := consulfsm.New(nil, os.Stderr, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/issue_test.go
+++ b/agent/consul/issue_test.go
@@ -23,7 +23,7 @@ func makeLog(buf []byte) *raft.Log {
 // Testing for GH-300 and GH-279
 func TestHealthCheckRace(t *testing.T) {
 	t.Parallel()
-	fsm, err := consulfsm.New(nil, os.Stderr)
+	fsm, err := consulfsm.New(nil, os.Stderr, "")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -274,6 +274,10 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*
 		return nil, err
 	}
 
+	if err := config.CheckNodeRenamingPolicy(); err != nil {
+		return nil, err
+	}
+
 	// Ensure we have a log output and create a logger.
 	if config.LogOutput == nil {
 		config.LogOutput = os.Stderr

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -496,7 +496,7 @@ func (s *Server) setupRaft() error {
 
 	// Create the FSM.
 	var err error
-	s.fsm, err = fsm.New(s.tombstoneGC, s.config.LogOutput)
+	s.fsm, err = fsm.New(s.tombstoneGC, s.config.LogOutput, s.config.NodeRenamingPolicy)
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ func (s *Server) setupRaft() error {
 				return fmt.Errorf("recovery failed to parse peers.json: %v", err)
 			}
 
-			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.LogOutput)
+			tmpFsm, err := fsm.New(s.tombstoneGC, s.config.LogOutput, s.config.NodeRenamingPolicy)
 			if err != nil {
 				return fmt.Errorf("recovery failed to make temp FSM: %v", err)
 			}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -496,11 +496,11 @@ func (s *Store) findExistingNodeLegacy(tx *memdb.Txn, idx uint64, node *structs.
 
 // findExistingNode Find a Node with a similar name, returned value might be the node itself or another node
 func (s *Store) findExistingNode(tx *memdb.Txn, idx uint64, node *structs.Node) (*structs.Node, error) {
-	if s.nodeRenameSetting == NodeRenamingLegacy || s.nodeRenameSetting == "" {
+	if s.nodeRenameSetting == types.NodeRenamingLegacy || s.nodeRenameSetting == "" {
 		return s.findExistingNodeLegacy(tx, idx, node)
-	} else if s.nodeRenameSetting == NodeRenamingRenameDeadNodes {
+	} else if s.nodeRenameSetting == types.NodeRenamingRenameDeadNodes {
 		return s.findExistingNodeRenameDeadNodes(tx, idx, node)
-	} else if s.nodeRenameSetting == NodeRenamingStrict {
+	} else if s.nodeRenameSetting == types.NodeRenamingStrict {
 		return s.findExistingNodeStrict(tx, idx, node)
 	} else {
 		return nil, fmt.Errorf("Unknown Rename Policy %s", s.nodeRenameSetting)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -404,17 +404,17 @@ func (s *Store) findExistingNodeRenameDeadNodes(tx *memdb.Txn, idx uint64, node 
 	}
 	if dupNode != nil {
 		// There is a dup node, lets check if the node is healthy
-		dupNodeCheck, err := tx.First("checks", "id", dupNode.Node, string("serfHealth"))
+		dupNodeCheck, err := tx.First("checks", "id", dupNode.Node, string(structs.SerfCheckID))
 		if err != nil {
 			return nil, fmt.Errorf("Cannot get status of node %s due to: %s", dupNode.Node, err)
 		}
 		if dupNodeCheck == nil {
-			return nil, fmt.Errorf("Cannot validate whether node %s is healthy, cannot rename node", dupNode.Node)
+			return nil, fmt.Errorf("Cannot RenameNode since check %s not found for node %s", string(structs.SerfCheckID), dupNode.Node)
 		}
 		existingDupNodeSerf := dupNodeCheck.(*structs.HealthCheck)
 		if existingDupNodeSerf.Status != api.HealthCritical {
 			// This is ok, we allow to take the identity of that node
-			return dupNode, fmt.Errorf("Cannot rename since node %s serfHealth is '%s'", dupNode.Node, existingDupNodeSerf.Status)
+			return dupNode, fmt.Errorf("Cannot rename since node %s because check %s is '%s'", dupNode.Node, string(structs.SerfCheckID), existingDupNodeSerf.Status)
 		}
 		existing = dupNode
 	}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -412,7 +412,7 @@ func (s *Store) findExistingNodeRenameDeadNodes(tx *memdb.Txn, idx uint64, node 
 			return nil, fmt.Errorf("Cannot validate whether node %s is healthy, cannot rename node", dupNode.Node)
 		}
 		existingDupNodeSerf := dupNodeCheck.(*structs.HealthCheck)
-		if existingDupNodeSerf.Status != "critical" {
+		if existingDupNodeSerf.Status != api.HealthCritical {
 			// This is ok, we allow to take the identity of that node
 			return dupNode, fmt.Errorf("Cannot rename since node %s serfHealth is '%s'", dupNode.Node, existingDupNodeSerf.Status)
 		}
@@ -496,14 +496,14 @@ func (s *Store) findExistingNodeLegacy(tx *memdb.Txn, idx uint64, node *structs.
 
 // findExistingNode Find a Node with a similar name, returned value might be the node itself or another node
 func (s *Store) findExistingNode(tx *memdb.Txn, idx uint64, node *structs.Node) (*structs.Node, error) {
-	if s.nodeRenameSetting == types.NodeRenamingLegacy || s.nodeRenameSetting == "" {
+	if s.nodeRenameSetting == types.NodeRenamingLegacy {
 		return s.findExistingNodeLegacy(tx, idx, node)
 	} else if s.nodeRenameSetting == types.NodeRenamingRenameDeadNodes {
 		return s.findExistingNodeRenameDeadNodes(tx, idx, node)
 	} else if s.nodeRenameSetting == types.NodeRenamingStrict {
 		return s.findExistingNodeStrict(tx, idx, node)
 	} else {
-		return nil, fmt.Errorf("Unknown Rename Policy %s", s.nodeRenameSetting)
+		return nil, fmt.Errorf("Unknown Rename Policy '%s'", s.nodeRenameSetting)
 	}
 }
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -750,11 +750,12 @@ func TestStateStore_EnsureNodeRenamingWorks(t *testing.T) {
 			t.Fatalf("nodeSeftDown:=%v, policy=%s: %s", allowStealDeadNode, policy, err)
 		}
 	}
-	testFullRegistration("legacy", true, false)
+	testFullRegistration(types.NodeRenamingLegacy, true, false)
 	// "legacy" == "" (default value)
 	testFullRegistration("", true, false)
-	testFullRegistration("dead", false, true)
-	testFullRegistration("strict", false, false)
+	testFullRegistration(types.NodeRenamingDefault, true, false)
+	testFullRegistration(types.NodeRenamingRenameDeadNodes, false, true)
+	testFullRegistration(types.NodeRenamingStrict, false, false)
 }
 
 func TestStateStore_EnsureNode(t *testing.T) {

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -692,7 +692,7 @@ func TestNodeRenamingNodes(t *testing.T) {
 
 func TestStateStore_EnsureNodeRenamingWorks(t *testing.T) {
 
-	testFullRegistration := func(policy string, allowStealWithoutID, allowStealDeadNode bool) {
+	testFullRegistration := func(policy types.NodeRenamingPolicy, allowStealWithoutID, allowStealDeadNode bool) {
 		s := testStateStoreWithNodeRenamePolicy(t, policy)
 
 		registerNode := func(idx uint64, nodeName, nodeID, status, ip string) error {
@@ -751,8 +751,6 @@ func TestStateStore_EnsureNodeRenamingWorks(t *testing.T) {
 		}
 	}
 	testFullRegistration(types.NodeRenamingLegacy, true, false)
-	// "legacy" == "" (default value)
-	testFullRegistration("", true, false)
 	testFullRegistration(types.NodeRenamingDefault, true, false)
 	testFullRegistration(types.NodeRenamingRenameDeadNodes, false, true)
 	testFullRegistration(types.NodeRenamingStrict, false, false)
@@ -1083,7 +1081,7 @@ func TestStateStore_GetNodes(t *testing.T) {
 }
 
 func BenchmarkGetNodes(b *testing.B) {
-	s, err := NewStateStore(nil, NodeRenamingDefault)
+	s, err := NewStateStore(nil, types.NodeRenamingDefault)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}
@@ -3119,7 +3117,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 }
 
 func BenchmarkCheckServiceNodes(b *testing.B) {
-	s, err := NewStateStore(nil, NodeRenamingDefault)
+	s, err := NewStateStore(nil, types.NodeRenamingDefault)
 	if err != nil {
 		b.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -21,7 +21,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc)
+	s, err := NewStateStore(gc, NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-memdb"
 )
 
@@ -21,7 +22,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc, NodeRenamingDefault)
+	s, err := NewStateStore(gc, types.NodeRenamingDefault)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -81,7 +81,7 @@ type Store struct {
 	lockDelay *Delay
 
 	// Max number of watches, per store, defaults to 2048
-	nodeRenameSetting string
+	nodeRenameSetting types.NodeRenamingPolicy
 }
 
 // Snapshot is used to provide a point-in-time snapshot. It
@@ -116,7 +116,7 @@ type sessionCheck struct {
 }
 
 // NewStateStore creates a new in-memory state storage layer.
-func NewStateStore(gc *TombstoneGC, nodeRenameSetting string) (*Store, error) {
+func NewStateStore(gc *TombstoneGC, nodeRenamingPolicy types.NodeRenamingPolicy) (*Store, error) {
 	// Create the in-memory DB.
 	schema := stateStoreSchema()
 	db, err := memdb.NewMemDB(schema)
@@ -124,12 +124,6 @@ func NewStateStore(gc *TombstoneGC, nodeRenameSetting string) (*Store, error) {
 		return nil, fmt.Errorf("Failed setting up state store: %s", err)
 	}
 
-	if nodeRenameSetting == "" {
-		nodeRenameSetting = types.NodeRenamingDefault
-	}
-	if nodeRenameSetting != types.NodeRenamingLegacy && nodeRenameSetting != types.NodeRenamingRenameDeadNodes && nodeRenameSetting != types.NodeRenamingStrict {
-		return nil, fmt.Errorf("Invalid node_rename_policy, can be (%s|%s|%s), but was '%s'", nodeRenameSetting)
-	}
 	// Create and return the state store.
 	s := &Store{
 		schema:            schema,
@@ -137,7 +131,7 @@ func NewStateStore(gc *TombstoneGC, nodeRenameSetting string) (*Store, error) {
 		abandonCh:         make(chan struct{}),
 		kvsGraveyard:      NewGraveyard(gc),
 		lockDelay:         NewDelay(),
-		nodeRenameSetting: nodeRenameSetting,
+		nodeRenameSetting: nodeRenamingPolicy,
 	}
 	return s, nil
 }

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -60,12 +60,6 @@ const (
 	// Given the current size of aFew == 32 in memdb's watch_few.go, this
 	// will allow for up to ~64 goroutines per blocking query.
 	watchLimit = 2048
-
-	// LegacyMode for Node Renaming - allow empty IDs
-	NodeRenamingLegacy          = "legacy"
-	NodeRenamingRenameDeadNodes = "dead"
-	NodeRenamingStrict          = "strict"
-	NodeRenamingDefault         = NodeRenamingLegacy
 )
 
 // Store is where we store all of Consul's state, including
@@ -131,7 +125,10 @@ func NewStateStore(gc *TombstoneGC, nodeRenameSetting string) (*Store, error) {
 	}
 
 	if nodeRenameSetting == "" {
-		nodeRenameSetting = NodeRenamingDefault
+		nodeRenameSetting = types.NodeRenamingDefault
+	}
+	if nodeRenameSetting != types.NodeRenamingLegacy && nodeRenameSetting != types.NodeRenamingRenameDeadNodes && nodeRenameSetting != types.NodeRenamingStrict {
+		return nil, fmt.Errorf("Invalid node_rename_policy, can be (%s|%s|%s), but was '%s'", nodeRenameSetting)
 	}
 	// Create and return the state store.
 	s := &Store{

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -60,6 +60,12 @@ const (
 	// Given the current size of aFew == 32 in memdb's watch_few.go, this
 	// will allow for up to ~64 goroutines per blocking query.
 	watchLimit = 2048
+
+	// LegacyMode for Node Renaming - allow empty IDs
+	NodeRenamingLegacy          = "legacy"
+	NodeRenamingRenameDeadNodes = "dead"
+	NodeRenamingStrict          = "strict"
+	NodeRenamingDefault         = NodeRenamingLegacy
 )
 
 // Store is where we store all of Consul's state, including
@@ -79,6 +85,9 @@ type Store struct {
 
 	// lockDelay holds expiration times for locks associated with keys.
 	lockDelay *Delay
+
+	// Max number of watches, per store, defaults to 2048
+	nodeRenameSetting string
 }
 
 // Snapshot is used to provide a point-in-time snapshot. It
@@ -113,7 +122,7 @@ type sessionCheck struct {
 }
 
 // NewStateStore creates a new in-memory state storage layer.
-func NewStateStore(gc *TombstoneGC) (*Store, error) {
+func NewStateStore(gc *TombstoneGC, nodeRenameSetting string) (*Store, error) {
 	// Create the in-memory DB.
 	schema := stateStoreSchema()
 	db, err := memdb.NewMemDB(schema)
@@ -121,13 +130,17 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 		return nil, fmt.Errorf("Failed setting up state store: %s", err)
 	}
 
+	if nodeRenameSetting == "" {
+		nodeRenameSetting = NodeRenamingDefault
+	}
 	// Create and return the state store.
 	s := &Store{
-		schema:       schema,
-		db:           db,
-		abandonCh:    make(chan struct{}),
-		kvsGraveyard: NewGraveyard(gc),
-		lockDelay:    NewDelay(),
+		schema:            schema,
+		db:                db,
+		abandonCh:         make(chan struct{}),
+		kvsGraveyard:      NewGraveyard(gc),
+		lockDelay:         NewDelay(),
+		nodeRenameSetting: nodeRenameSetting,
 	}
 	return s, nil
 }

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -26,10 +26,10 @@ func testUUID() string {
 }
 
 func testStateStore(t *testing.T) *Store {
-	return testStateStoreWithNodeRenamePolicy(t, NodeRenamingDefault)
+	return testStateStoreWithNodeRenamePolicy(t, types.NodeRenamingDefault)
 }
 
-func testStateStoreWithNodeRenamePolicy(t *testing.T, nodeRenamingPolicy string) *Store {
+func testStateStoreWithNodeRenamePolicy(t *testing.T, nodeRenamingPolicy types.NodeRenamingPolicy) *Store {
 	s, err := NewStateStore(nil, nodeRenamingPolicy)
 	if err != nil {
 		t.Fatalf("err: %s", err)

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -26,7 +26,11 @@ func testUUID() string {
 }
 
 func testStateStore(t *testing.T) *Store {
-	s, err := NewStateStore(nil)
+	return testStateStoreWithNodeRenamePolicy(t, NodeRenamingDefault)
+}
+
+func testStateStoreWithNodeRenamePolicy(t *testing.T, nodeRenamingPolicy string) *Store {
+	s, err := NewStateStore(nil, nodeRenamingPolicy)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -372,6 +372,7 @@ func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
 		conf.NodeMeta = meta
 	})
 	defer s.Stop()
+	s.WaitForSerfCheck(t)
 
 	health := c.Health()
 	retry.Run(t, func(r *retry.R) {

--- a/types/noderenaming.go
+++ b/types/noderenaming.go
@@ -1,14 +1,34 @@
 package types
 
-// Contains definition of policies to rename nodes
+import (
+	"fmt"
+)
+
+// NodeRenamingPolicy Contains definition of policies to rename nodes
+type NodeRenamingPolicy string
 
 const (
 	// NodeRenamingLegacy Legacy mode for creating a new node name or renaming - allow empty IDs
-	NodeRenamingLegacy = "legacy"
+	NodeRenamingLegacy NodeRenamingPolicy = "legacy"
 	// NodeRenamingRenameDeadNodes Allow take name/renaming if node we want to steal the name is dead
-	NodeRenamingRenameDeadNodes = "dead"
+	NodeRenamingRenameDeadNodes NodeRenamingPolicy = "dead"
 	// NodeRenamingStrict Allow take name/renaming if no similar node exists in catalog
-	NodeRenamingStrict = "strict"
+	NodeRenamingStrict NodeRenamingPolicy = "strict"
 	// NodeRenamingDefault is the value set when nothing is set in configuration
 	NodeRenamingDefault = NodeRenamingLegacy
 )
+
+// ConvertToNodeRenamingLegacy Try converting a string into a NodeRenamingPolicy
+func ConvertToNodeRenamingLegacy(nodeRenamingPolicy string) (NodeRenamingPolicy, error) {
+	val := NodeRenamingPolicy(nodeRenamingPolicy)
+	switch val {
+	case "":
+		return NodeRenamingPolicy(NodeRenamingDefault), nil
+	case NodeRenamingLegacy:
+	case NodeRenamingRenameDeadNodes:
+	case NodeRenamingStrict:
+	default:
+		return NodeRenamingDefault, fmt.Errorf("Unsupported node_renaming_policy '%s', can be (%s|%s|%s)", nodeRenamingPolicy, NodeRenamingLegacy, NodeRenamingRenameDeadNodes, NodeRenamingStrict)
+	}
+	return val, nil
+}

--- a/types/noderenaming.go
+++ b/types/noderenaming.go
@@ -1,0 +1,14 @@
+package types
+
+// Contains definition of policies to rename nodes
+
+const (
+	// NodeRenamingLegacy Legacy mode for creating a new node name or renaming - allow empty IDs
+	NodeRenamingLegacy = "legacy"
+	// NodeRenamingRenameDeadNodes Allow take name/renaming if node we want to steal the name is dead
+	NodeRenamingRenameDeadNodes = "dead"
+	// NodeRenamingStrict Allow take name/renaming if no similar node exists in catalog
+	NodeRenamingStrict = "strict"
+	// NodeRenamingDefault is the value set when nothing is set in configuration
+	NodeRenamingDefault = NodeRenamingLegacy
+)

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -420,6 +420,15 @@ will exit with an error at startup.
 * <a name="_server_port"></a><a href="#_server_port">`-server-port`</a> - the server RPC port to listen on.
   This overrides the default server RPC port 8300. This is available in Consul 1.2.2 and later.
 
+* <a name="_node_renaming_policy"></a><a href="#_node_renaming_policy">`-node-renaming-policy`</a> Allow
+  to choose a policy for conflicts when nodes names do collide (when new nodes are coming to the cluster or
+  are renamed):
+    * `legacy` existing behavior pre 1.5.x
+    * `dead` allow to take the name of an agent if this agent is currently not up, recommended for Cloud
+      workloads where several node with the same name might be starting a short period of time sequentially
+    * `strict` allow to take the name of a server only if the server we want to replace is not in the
+      catalog anymore.
+
 * <a name="_non_voting_server"></a><a href="#_non_voting_server">`-non-voting-server`</a> - (Enterprise-only)
   This flag is used to make the server not participate in the Raft quorum, and have it only receive the data
   replication stream. This can be used to add read scalability to a cluster in cases where a high volume of
@@ -1353,6 +1362,9 @@ default will automatically work with some tooling.
 
 * <a name="server"></a><a href="#server">`server`</a> Equivalent to the
   [`-server` command-line flag](#_server).
+
+* <a name="node_renaming_policy></a><an href="#node_renaming_policy">`node_renaming_policy</a> - Equivalent
+  to the [`-node-renaming-policy` command-line flag](#(_node_renaming_policy)).
 
 * <a name="non_voting_server"></a><a href="#non_voting_server">`non_voting_server`</a> - Equivalent to the
   [`-non-voting-server` command-line flag](#_non_voting_server).


### PR DESCRIPTION
Addressing https://github.com/hashicorp/consul/issues/4414 is hard as many unit tests do rely on having empty nodeIDs.

It seems there are several usages of nodeId:
 - legacy ones (complicated, see https://github.com/hashicorp/consul/pull/4399 )
 - cloud based (see https://github.com/hashicorp/consul/issues/4741 ) where people want to replace a node with the same name quickly
 - bare-metal ones (like us) with people implementing constant nodeIds accross installations.

This PR allows to address those 3 use-cases by adding a new options `node_renaming_policy=(legacy|dead|strict)`

 * `legacy` (the default) will keep the existing behavior
 * `dead`: do not allow nodes without IDs, but allow to replace a dead node with another one with the same name, but different ID (this is DONE by checking that serfHealth is critical). Stilll allow renaming nodes
 * `strict`: do not allow empty nodeID, allow to rename nodes with the same ID, do now allow to steal a node Name as soon as the node is within the catalog.