### PR TITLE
Fixes URL paths to learn.hashicorp.com

### DIFF
--- a/website/source/configuration.html.erb
+++ b/website/source/configuration.html.erb
@@ -17,7 +17,7 @@ description: |-
         </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/kv.html" class="g-btn dark-outline">Explore Docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/kv" class="g-btn dark-outline">Explore Docs</a>
     </div>
   </section>
 
@@ -66,7 +66,7 @@ description: |-
             <h3>Key/Value Store</h3>
             <p>Feature rich  key/value store for dynamic service configuration data. Use it for feature flagging, maintenance modes, and more.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/kv.html">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/kv">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>
@@ -264,7 +264,7 @@ description: |-
         </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/kv.html" class="g-btn white-outline">Explore docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/kv" class="g-btn white-outline">Explore docs</a>
     </div>
   </section>
 

--- a/website/source/discovery.html.erb
+++ b/website/source/discovery.html.erb
@@ -18,7 +18,7 @@ description: |-
         </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/services.html" class="g-btn dark-outline">Explore Docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/services" class="g-btn dark-outline">Explore Docs</a>
     </div>
   </section>
 
@@ -64,7 +64,7 @@ description: |-
             <h3>Service Registry</h3>
             <p>Consul provides a registry of all the running nodes and services, along with their current health status. This allows operators to understand the environment, and applications and automation tools to interact with dynamic infrastructure using an HTTP API.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services.html">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>
@@ -93,7 +93,7 @@ description: |-
             <h3>DNS Query Interface</h3>
             <p>Consul enables service discovery using a built-in DNS server. This allows existing applications to easily integrate, as almost all applications support using DNS to resolve IP addresses. Using DNS instead of a static IP address allows services to scale up/down and route around failures easily.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services.html#querying-services">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services#querying-services">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>
@@ -130,7 +130,7 @@ web-frontend.service.consul. 0 IN A <code class='keyword'>10.0.1.109</code></cod
             <h3>HTTP API with Edge Triggers</h3>
             <p>Consul provides an HTTP API to query the service registry for nodes, services, and health check information. The API also supports blocking queries, or long-polling for any changes. This allows automation tools to react to services being registered or health status changes to change configurations or traffic routing in real time.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services.html#http-api">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services#http-api">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>
@@ -211,7 +211,7 @@ $ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code
             <h3>Health Checks</h3>
             <p>Pairing service discovery with health checking prevents routing requests to unhealthy hosts and enables services to easily provide circuit breakers.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/checks.html">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/checks">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>
@@ -285,7 +285,7 @@ $ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code
       </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/services.html" class="g-btn white-outline">Explore docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/services" class="g-btn white-outline">Explore docs</a>
     </div>
   </section>
 

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -69,7 +69,7 @@ in microseconds.
 
 There are several ways to try Connect in different environments.
 
- * The [Connect introduction](https://learn.hashicorp.com/consul/getting-started/connect.html) in the
+ * The [Connect introduction](https://learn.hashicorp.com/consul/getting-started/connect) in the
    Getting Started guide provides a simple walk through of getting two services
    to communicate via Connect using only Consul directly on your local machine.
 

--- a/website/source/docs/guides/connect-production.md
+++ b/website/source/docs/guides/connect-production.md
@@ -10,7 +10,7 @@ description: |-
 
 Consul Connect can secure all inter-service communication via mutual TLS. It's
 designed to work with [minimal configuration out of the
-box](https://learn.hashicorp.com/consul/getting-started/connect.html), but completing the [security
+box](https://learn.hashicorp.com/consul/getting-started/connect), but completing the [security
 checklist](/docs/connect/security.html) and understanding the [Consul security
 model](/docs/internals/security.html) are prerequisites for production
 deployments.

--- a/website/source/docs/guides/consul-template.html.md
+++ b/website/source/docs/guides/consul-template.html.md
@@ -8,66 +8,66 @@ description: |-
 
 # Consul Template
 
-The Consul template tool provides a programmatic method 
+The Consul template tool provides a programmatic method
 for rendering configuration files from a variety of locations,
-including Consul KV. It is an ideal option for replacing complicated API 
+including Consul KV. It is an ideal option for replacing complicated API
 queries that often require custom formatting.
-The template tool is based on Go templates and shares many 
-of the same attributes. 
+The template tool is based on Go templates and shares many
+of the same attributes.
 
 Consul template is a useful tool with several uses, we will focus on two
 of it's use cases.
 
 1. *Update configuration files*. The Consul template tool can be used
-to update service configuration files. A common use case is managing load 
-balancer configuration files that need to be updated regularly in a dynamic 
-infrastructure on machines many not be able to directly connect to the Consul cluster. 
+to update service configuration files. A common use case is managing load
+balancer configuration files that need to be updated regularly in a dynamic
+infrastructure on machines many not be able to directly connect to the Consul cluster.
 
-1. *Discover data about the Consul cluster and service*. It is possible to collect 
-information about the services in your Consul cluster. For example, you could 
-collect a list of all services running on the cluster or you could discover all 
-service addresses for the Redis service. Note, this use case has limited 
-scope for production. 
+1. *Discover data about the Consul cluster and service*. It is possible to collect
+information about the services in your Consul cluster. For example, you could
+collect a list of all services running on the cluster or you could discover all
+service addresses for the Redis service. Note, this use case has limited
+scope for production.
 
-In this guide we will briefly discuss how `consul-template` works, 
-how to install it, and two use cases. 
+In this guide we will briefly discuss how `consul-template` works,
+how to install it, and two use cases.
 
-Before completing this guide, we assume some familiarity with 
-[Consul KV](https://learn.hashicorp.com/consul/getting-started/kv.html)
+Before completing this guide, we assume some familiarity with
+[Consul KV](https://learn.hashicorp.com/consul/getting-started/kv)
  and [Go templates](https://golang.org/pkg/text/template/).
 
-## Introduction to Consul Template 
+## Introduction to Consul Template
 
-Consul template is a simple, yet powerful tool. When initiated, it 
-reads one or more template files and queries Consul for all 
-data needed to render them. Typically, you run `consul-template` as a 
-daemon which will fetch the initial values and then continue to watch 
-for updates, re-rendering the template whenever there are relevant changes in 
-the cluster. You can alternatively use the `-once` flag to fetch and render 
+Consul template is a simple, yet powerful tool. When initiated, it
+reads one or more template files and queries Consul for all
+data needed to render them. Typically, you run `consul-template` as a
+daemon which will fetch the initial values and then continue to watch
+for updates, re-rendering the template whenever there are relevant changes in
+the cluster. You can alternatively use the `-once` flag to fetch and render
 the template once which is useful for testing and
-setup scripts that are triggered by some other automation for example a 
-provisioning tool. Finally, the template can also run arbitrary commands after the update 
-process completes. For example, it can send the HUP signal to the 
-load balancer service after a configuration change has been made. 
+setup scripts that are triggered by some other automation for example a
+provisioning tool. Finally, the template can also run arbitrary commands after the update
+process completes. For example, it can send the HUP signal to the
+load balancer service after a configuration change has been made.
 
 The Consul template tool is flexible, it can fit into many
-different environments and workflows. Depending on the use-case, you 
-may have a single `consul-template` instance on a handful of hosts 
-or may need to run several instances on every host. Each `consul-template` 
+different environments and workflows. Depending on the use-case, you
+may have a single `consul-template` instance on a handful of hosts
+or may need to run several instances on every host. Each `consul-template`
 process can manage multiple unrelated files though and will de-duplicate
- the fetches as needed if those files share data dependencies so it can 
+ the fetches as needed if those files share data dependencies so it can
 reduce the load on Consul servers to share where possible.
 
 ## Install Consul Template
 
 For this guide, we are using a local Consul agent in development
-mode which can be started with `consul agent -dev`. To quickly set 
-up a local Consul agent, refer to the getting started [guide](https://learn.hashicorp.com/consul/getting-started/install). The 
+mode which can be started with `consul agent -dev`. To quickly set
+up a local Consul agent, refer to the getting started [guide](https://learn.hashicorp.com/consul/getting-started/install). The
 Consul agent must be running to complete all of the following
-steps. 
+steps.
 
 The Consul template tool is not included with the Consul binary and will
-need to be installed separately. It can be installed from a precompiled 
+need to be installed separately. It can be installed from a precompiled
 binary or compiled from source. We will be installing the precompiled binary.
 
 First, download the binary from the [Consul Template releases page](https://releases.hashicorp.com/consul-template/).

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -22,7 +22,7 @@ description: |-
               </svg>
               Download
             </a>
-            <a href="https://learn.hashicorp.com/consul/getting-started/install.html" class='g-btn dark-outline'>Get Started</a>
+            <a href="https://learn.hashicorp.com/consul/getting-started/install" class='g-btn dark-outline'>Get Started</a>
             <div>
               <a href='https://demo.consul.io/' class='secondary-link'>View demo of web UI</a>
             </div>

--- a/website/source/intro/index.html.md
+++ b/website/source/intro/index.html.md
@@ -86,5 +86,5 @@ forward the request to the remote datacenter and return the result.
 
 * See [how Consul compares to other software](/intro/vs/index.html) to assess how it fits into your
 existing infrastructure.
-* Continue onwards with the [getting started guide](https://learn.hashicorp.com/consul/getting-started/install.html)
+* Continue onwards with the [getting started guide](https://learn.hashicorp.com/consul/getting-started/install)
 to get Consul up and running.

--- a/website/source/segmentation.html.erb
+++ b/website/source/segmentation.html.erb
@@ -18,7 +18,7 @@ description: |-
         </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/connect.html" class="g-btn dark-outline">Explore Docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/connect" class="g-btn dark-outline">Explore Docs</a>
     </div>
   </section>
 
@@ -200,7 +200,7 @@ Secure Sockets Layer
       </svg>
         Download
       </a>
-      <a href="https://learn.hashicorp.com/consul/getting-started/connect.html" class="g-btn white-outline">Explore docs</a>
+      <a href="https://learn.hashicorp.com/consul/getting-started/connect" class="g-btn white-outline">Explore docs</a>
     </div>
   </section>
 


### PR DESCRIPTION
Removes `.html` when not needed in order to clean up analytics.