### PR TITLE
Update "testutil" documentation

### DIFF
--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -3,7 +3,6 @@ package my_program
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testutil"
 )
 
@@ -38,16 +37,16 @@ func TestFoo_bar(t *testing.T) {
 	})
 
 	// Create a service
-	srv1.AddService(t, "redis", structs.HealthPassing, []string{"master"})
+	srv1.AddService(t, "redis", testutil.HealthPassing, []string{"master"})
 
 	// Create a service that will be accessed in target source code
-	srv1.AddAccessibleService("redis", structs.HealthPassing, "127.0.0.1", 6379, []string{"master"})
+	srv1.AddAccessibleService("redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
 
 	// Create a service check
-	srv1.AddCheck(t, "service:redis", "redis", structs.HealthPassing)
+	srv1.AddCheck(t, "service:redis", "redis", testutil.HealthPassing)
 
 	// Create a node check
-	srv1.AddCheck(t, "mem", "", structs.HealthCritical)
+	srv1.AddCheck(t, "mem", "", testutil.HealthCritical)
 
 	// The HTTPAddr field contains the address of the Consul
 	// API on the new test server instance.

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -1,21 +1,3 @@
-Consul Testing Utilities
-========================
-
-This package provides some generic helpers to facilitate testing in Consul.
-
-TestServer
-==========
-
-TestServer is a harness for managing Consul agents and initializing them with
-test data. Using it, you can form test clusters, create services, add health
-checks, manipulate the K/V store, etc. This test harness is completely decoupled
-from Consul's core and API client, meaning it can be easily imported and used in
-external unit tests for various applications. It works by invoking the Consul
-CLI, which means it is a requirement to have Consul installed in the `$PATH`.
-
-Following is an example usage (_cf_. [readme_test.go](./test/readme_test.go)):
-
-```go
 package my_program
 
 import (
@@ -75,4 +57,3 @@ func TestFoo_bar(t *testing.T) {
 	wrap := srv1.Wrap(t)
 	wrap.SetKV("foo", []byte("bar"))
 }
-```

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -1,3 +1,6 @@
+// This test should be identical to the example in
+// ../testutil/README.md.  If you make changes here, please make the
+// same changes there as well.
 package my_program
 
 import (

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -16,7 +16,7 @@ func TestFoo_bar(t *testing.T) {
 
 	// Create a secondary server, passing in configuration
 	// to avoid bootstrapping as we are forming a cluster.
-	srv2, err := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+	srv2, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.Bootstrap = false
 	})
 	if err != nil {

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -40,7 +40,7 @@ func TestFoo_bar(t *testing.T) {
 	srv1.AddService(t, "redis", testutil.HealthPassing, []string{"master"})
 
 	// Create a service that will be accessed in target source code
-	srv1.AddAccessibleService("redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
+	srv1.AddAddressableService(t, "redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
 
 	// Create a service check
 	srv1.AddCheck(t, "service:redis", "redis", testutil.HealthPassing)

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -13,8 +13,7 @@ from Consul's core and API client, meaning it can be easily imported and used in
 external unit tests for various applications. It works by invoking the Consul
 CLI, which means it is a requirement to have Consul installed in the `$PATH`.
 
-Following is an example usage (maintained as
-[../test/readme_test.go](../test/readme_test.go)):
+Following is an example usage (maintained as [readme_test.go](./readme_test.go)):
 
 ```go
 package my_program

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -21,7 +21,6 @@ package my_program
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/consul/structs"
 	"github.com/hashicorp/consul/testutil"
 )
 
@@ -56,16 +55,16 @@ func TestFoo_bar(t *testing.T) {
 	})
 
 	// Create a service
-	srv1.AddService(t, "redis", structs.HealthPassing, []string{"master"})
+	srv1.AddService(t, "redis", testutil.HealthPassing, []string{"master"})
 
 	// Create a service that will be accessed in target source code
-	srv1.AddAccessibleService("redis", structs.HealthPassing, "127.0.0.1", 6379, []string{"master"})
+	srv1.AddAccessibleService("redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
 
 	// Create a service check
-	srv1.AddCheck(t, "service:redis", "redis", structs.HealthPassing)
+	srv1.AddCheck(t, "service:redis", "redis", testutil.HealthPassing)
 
 	// Create a node check
-	srv1.AddCheck(t, "mem", "", structs.HealthCritical)
+	srv1.AddCheck(t, "mem", "", testutil.HealthCritical)
 
 	// The HTTPAddr field contains the address of the Consul
 	// API on the new test server instance.

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -58,7 +58,7 @@ func TestFoo_bar(t *testing.T) {
 	srv1.AddService(t, "redis", testutil.HealthPassing, []string{"master"})
 
 	// Create a service that will be accessed in target source code
-	srv1.AddAccessibleService("redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
+	srv1.AddAddressableService(t, "redis", testutil.HealthPassing, "127.0.0.1", 6379, []string{"master"})
 
 	// Create a service check
 	srv1.AddCheck(t, "service:redis", "redis", testutil.HealthPassing)

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -13,7 +13,8 @@ from Consul's core and API client, meaning it can be easily imported and used in
 external unit tests for various applications. It works by invoking the Consul
 CLI, which means it is a requirement to have Consul installed in the `$PATH`.
 
-Following is an example usage (_cf_. [readme_test.go](./test/readme_test.go)):
+Following is an example usage (maintained as
+[../test/readme_test.go](../test/readme_test.go)):
 
 ```go
 package my_program

--- a/testutil/README.md
+++ b/testutil/README.md
@@ -34,7 +34,7 @@ func TestFoo_bar(t *testing.T) {
 
 	// Create a secondary server, passing in configuration
 	// to avoid bootstrapping as we are forming a cluster.
-	srv2, err := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+	srv2, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.Bootstrap = false
 	})
 	if err != nil {

--- a/testutil/readme_test.go
+++ b/testutil/readme_test.go
@@ -1,7 +1,6 @@
-// This test should be identical to the example in
-// ../testutil/README.md.  If you make changes here, please make the
-// same changes there as well.
-package my_program
+// This test should match the example in README.md.  If you make
+// changes here, please make the same changes there as well.
+package testutil_test
 
 import (
 	"testing"


### PR DESCRIPTION
A contribution under the heading "Improve our guides and documentation"...

Building my first application that depends on Consul, I wanted `testutil` for testing.  I discovered that the documentation in the README has been left behind by a couple of refactors.  To make that harder to happen in the future, it seems reasonable to have an executable version of the README.  There's more than one way to do that, and I'm not familiar enough with the build processes to come up with a more clever one than just to make a copy and leave breadcrumbs.  It would be amusing to make the README and the test pull from the same source.

With these changes, "`make test`" still passes.