### PR TITLE
Add connect status to info output

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1066,6 +1066,7 @@ func (s *Server) Stats() map[string]map[string]string {
 			"leader_addr":       string(s.raft.Leader()),
 			"bootstrap":         fmt.Sprintf("%v", s.config.Bootstrap),
 			"known_datacenters": toString(uint64(numKnownDCs)),
+			"connect_enabled":   strconv.FormatBool(s.config.ConnectEnabled),
 		},
 		"raft":     s.raft.Stats(),
 		"serf_lan": s.serfLAN.Stats(),


### PR DESCRIPTION
Add connect status to the `consul info` output to provide a simpler way to determine if connect is enabled on the server (or not).

Example, truncated output:

**Before**:
```
  ...
consul:
        acl = legacy
        bootstrap = false
        known_datacenters = 1
        leader = true
        leader_addr = 10.0.0.1:8300
        server = true
  ...
```

**After**:
```
  ...
consul:
        acl = legacy
        bootstrap = false
        connect_enabled = true
        known_datacenters = 1
        leader = true
        leader_addr = 10.0.0.1:8300
        server = true
  ...
```