### PR TITLE
UI: Correctly escape an inline svg icon

### DIFF
--- a/ui-v2/app/styles/components/icons/index.scss
+++ b/ui-v2/app/styles/components/icons/index.scss
@@ -189,7 +189,7 @@
 %with-inverted-tick {
   @extend %pseudo-icon;
   background-color: $ui-color-transparent;
-  background-image: url('data:image/svg+xml;charset=UTF-8,<svg width="10" height="8" xmlns="http://www.w3.org/2000/svg"><path d="M8.95 0L10 .985 3.734 8 0 4.737l.924-1.11 2.688 2.349z" fill="##{$magenta-800-no-hash}"/></svg>');
+  background-image: url('data:image/svg+xml;charset=UTF-8,<svg width="10" height="8" xmlns="http://www.w3.org/2000/svg"><path d="M8.95 0L10 .985 3.734 8 0 4.737l.924-1.11 2.688 2.349z" fill="%23#{$magenta-800-no-hash}"/></svg>');
   height: 20px !important;
   width: 16px !important;
 }


### PR DESCRIPTION
Spotted an SVG icon that wasn't escaped properly. This was one of my original icons that isn't going through the auto escaping yet.

You only get the console error when you open the dc menu (the little tick in the menu)

Before:

![screen shot 2018-11-30 at 16 40 22](https://user-images.githubusercontent.com/554604/49302900-2ebf7e80-f4c0-11e8-99f3-a79454ff3e74.png)

After:

![screen shot 2018-11-30 at 16 40 42](https://user-images.githubusercontent.com/554604/49302908-341cc900-f4c0-11e8-9dc1-306b063f05e0.png)
