### PR TITLE
Minor Session / Lock Related Documentation Fixes

### DIFF
--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -181,8 +181,8 @@ The table below shows this endpoint's support for
   index is non-zero, the key is only set if the index matches the `ModifyIndex`
   of that key.
 
-- `acquire` `(string: "")` - Specifies to use a lock acquisition operation. This
-  is useful as it allows leader election to be built on top of Consul. If the
+- `acquire` `(string: "")` - Supply a session ID to use in a lock acquisition operation.
+  This is useful as it allows leader election to be built on top of Consul. If the
   lock is not held and the session is valid, this increments the `LockIndex` and
   sets the `Session` value of the key in addition to updating the key contents.
   A key does not need to exist to be acquired. If the lock is already held by
@@ -195,7 +195,7 @@ The table below shows this endpoint's support for
     For an example of how to use the lock feature, see the [Leader Election Guide]
     (/docs/guides/leader-election.html).
 
-- `release` `(string: "")` - Specifies to use a lock release operation. This is
+- `release` `(string: "")` - Supply a session ID to use in a release operation. This is
   useful when paired with `?acquire=` as it allows clients to yield a lock. This
   will leave the `LockIndex` unmodified but will clear the associated `Session`
   of the key. The key must be held by this session to be unlocked.

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -55,8 +55,9 @@ The table below shows this endpoint's support for
 - `TTL` `(string: "")` - Specifies the number of seconds (between 10s and
   86400s). If provided, the session is invalidated if it is not renewed before
   the TTL expires. The lowest practical TTL should be used to keep the number of
-  managed sessions low. When locks are forcibly expired, such as during a leader
-  election, sessions may not be reaped for up to double this TTL, so long TTL
+  managed sessions low. When locks are forcibly expired, such as when following
+  the [leader election pattern](/docs/guides/leader-election.html) in an application,
+  sessions may not be reaped for up to double this TTL, so long TTL
   values (> 1 hour) should be avoided.
 
 ### Sample Payload

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -35,7 +35,8 @@ The table below shows this endpoint's support for
   the datacenter of the agent being queried. This is specified as part of the
   URL as a query parameter. Using this across datacenters is not recommended.
 
-- `LockDelay` `(string: "15s")` - Specifies the duration for the lock delay.
+- `LockDelay` `(string: "15s")` - Specifies the duration for the lock delay. This
+  must be greater than `0`.
 
 - `Node` `(string: "<agent>")` - Specifies the name of the node. This must refer
   to a node that is already registered.


### PR DESCRIPTION
A few session related doc fixes.

Fixes https://github.com/hashicorp/consul/issues/3813
Fixes https://github.com/hashicorp/consul/issues/4232
Fixes https://github.com/hashicorp/consul/issues/4508

I'd appreciate eyes on that last one in particular is I'm not sure I understand what might be happening here in this instance. I believe what is happening is that the LockDelay is using the default when provided `0`.