### PR TITLE
cache: health endpoints filterNonPassing modifies cached result destructively and racily

### DIFF
--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -269,7 +269,7 @@ OUTER:
 		node := nodes[i]
 		for _, check := range node.Checks {
 			if check.Status != api.HealthPassing {
-				nodes[i], nodes[n-1] = nodes[n-1], structs.CheckServiceNode{}
+				nodes[i], nodes[n-1] = nodes[n-1], nodes[i]
 				n--
 				i--
 				continue OUTER

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -977,7 +977,7 @@ OUTER:
 			}
 			if check.Status == api.HealthCritical ||
 				(onlyPassing && check.Status != api.HealthPassing) {
-				nodes[i], nodes[n-1] = nodes[n-1], CheckServiceNode{}
+				nodes[i], nodes[n-1] = nodes[n-1], nodes[i]
 				n--
 				i--
 				// Skip this _node_ now we've swapped it off the end of the list.


### PR DESCRIPTION
health_endpoints filterNonPassing set nil to cache when svc is down, then 
regardless of whether or not to add parameters passing, always got nil node from cache