### PR TITLE
UI: ACL `status` improvements

### DIFF
--- a/ui-v2/app/utils/acls-status.js
+++ b/ui-v2/app/utils/acls-status.js
@@ -23,29 +23,36 @@ export default function(isValidServerError, P = Promise) {
       }),
       [propName]: p
         .catch(function(e) {
-          switch (e.errors[0].status) {
-            case '500':
-              if (isValidServerError(e)) {
+          if (e.errors && e.errors[0]) {
+            switch (e.errors[0].status) {
+              case '500':
+                if (isValidServerError(e)) {
+                  enable(true);
+                  authorize(false);
+                } else {
+                  enable(false);
+                  authorize(false);
+                  return P.reject(e);
+                }
+                break;
+              case '403':
                 enable(true);
                 authorize(false);
-              } else {
-                return P.reject(e);
-              }
-              break;
-            case '403':
-              enable(true);
-              authorize(false);
-              break;
-            case '401':
-              enable(false);
-              authorize(false);
-              break;
-            default:
-              enable(false);
-              authorize(false);
-              throw e;
+                break;
+              case '401':
+                enable(false);
+                authorize(false);
+                break;
+              default:
+                enable(false);
+                authorize(false);
+                throw e;
+            }
+            return [];
           }
-          return [];
+          enable(false);
+          authorize(false);
+          throw e;
         })
         .then(function(res) {
           enable(true);

--- a/ui-v2/tests/unit/utils/acls-status-test.js
+++ b/ui-v2/tests/unit/utils/acls-status-test.js
@@ -1,10 +1,89 @@
+import { module } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
 import aclsStatus from 'consul-ui/utils/acls-status';
-import { module, test } from 'qunit';
 
 module('Unit | Utility | acls status');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = aclsStatus();
-  assert.ok(result);
+test('it rejects and nothing is enabled or authorized', function(assert) {
+  const isValidServerError = this.stub().returns(false);
+  const status = aclsStatus(isValidServerError);
+  [
+    this.stub().rejects(),
+    this.stub().rejects({ errors: [] }),
+    this.stub().rejects({ errors: [{ status: '404' }] }),
+  ].forEach(function(reject) {
+    const actual = status({
+      response: reject(),
+    });
+    assert.rejects(actual.response);
+    ['isAuthorized', 'isEnabled'].forEach(function(prop) {
+      actual[prop].then(function(actual) {
+        assert.notOk(actual);
+      });
+    });
+  });
+});
+test('with a 401 it resolves with an empty array and nothing is enabled or authorized', function(assert) {
+  assert.expect(3);
+  const isValidServerError = this.stub().returns(false);
+  const status = aclsStatus(isValidServerError);
+  const actual = status({
+    response: this.stub().rejects({ errors: [{ status: '401' }] })(),
+  });
+  actual.response.then(function(actual) {
+    assert.deepEqual(actual, []);
+  });
+  ['isAuthorized', 'isEnabled'].forEach(function(prop) {
+    actual[prop].then(function(actual) {
+      assert.notOk(actual);
+    });
+  });
+});
+test("with a 403 it resolves with an empty array and it's enabled but not authorized", function(assert) {
+  assert.expect(3);
+  const isValidServerError = this.stub().returns(false);
+  const status = aclsStatus(isValidServerError);
+  const actual = status({
+    response: this.stub().rejects({ errors: [{ status: '403' }] })(),
+  });
+  actual.response.then(function(actual) {
+    assert.deepEqual(actual, []);
+  });
+  actual.isEnabled.then(function(actual) {
+    assert.ok(actual);
+  });
+  actual.isAuthorized.then(function(actual) {
+    assert.notOk(actual);
+  });
+});
+test("with a 500 (but not a 'valid' error) it rejects and nothing is enabled or authorized", function(assert) {
+  assert.expect(3);
+  const isValidServerError = this.stub().returns(false);
+  const status = aclsStatus(isValidServerError);
+  const actual = status({
+    response: this.stub().rejects({ errors: [{ status: '500' }] })(),
+  });
+  assert.rejects(actual.response);
+  ['isAuthorized', 'isEnabled'].forEach(function(prop) {
+    actual[prop].then(function(actual) {
+      assert.notOk(actual);
+    });
+  });
+});
+test("with a 500 and a 'valid' error, it resolves with an empty array and it's enabled but not authorized", function(assert) {
+  assert.expect(3);
+  const isValidServerError = this.stub().returns(true);
+  const status = aclsStatus(isValidServerError);
+  const actual = status({
+    response: this.stub().rejects({ errors: [{ status: '500' }] })(),
+  });
+  actual.response.then(function(actual) {
+    assert.deepEqual(actual, []);
+  });
+  actual.isEnabled.then(function(actual) {
+    assert.ok(actual);
+  });
+  actual.isAuthorized.then(function(actual) {
+    assert.notOk(actual);
+  });
 });


### PR DESCRIPTION
1. Ensure any unexpected developer errors are passed through/shown
2. Previously when errors where returns/resolved the special
isEnabled/isAuthorized would never get resolved. This was fine as they
were set to false to start with anyway, but this resolves them again to
false for completeness
3. Improved unit testing coverage