### PR TITLE
UI: Prefer the word `cursor` for meta and add `configuration` option to repositories

### DIFF
--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -4,7 +4,6 @@ import { get } from '@ember/object';
 import {
   HEADERS_SYMBOL as HTTP_HEADERS_SYMBOL,
   HEADERS_INDEX as HTTP_HEADERS_INDEX,
-  HEADERS_DIGEST as HTTP_HEADERS_DIGEST,
 } from 'consul-ui/utils/http/consul';
 export default Serializer.extend({
   // this could get confusing if you tried to override
@@ -44,8 +43,7 @@ export default Serializer.extend({
   },
   normalizeMeta: function(store, primaryModelClass, headers, payload, id, requestType) {
     const meta = {
-      index: headers[HTTP_HEADERS_INDEX],
-      digest: headers[HTTP_HEADERS_DIGEST],
+      cursor: headers[HTTP_HEADERS_INDEX],
       date: headers['date'],
     };
     if (requestType === 'query') {

--- a/ui-v2/app/services/repository.js
+++ b/ui-v2/app/services/repository.js
@@ -14,16 +14,24 @@ export default Service.extend({
   },
   //
   store: service('store'),
-  findAllByDatacenter: function(dc) {
-    return get(this, 'store').query(this.getModelName(), {
+  findAllByDatacenter: function(dc, configuration = {}) {
+    const query = {
       dc: dc,
-    });
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
+    return get(this, 'store').query(this.getModelName(), query);
   },
-  findBySlug: function(slug, dc) {
-    return get(this, 'store').queryRecord(this.getModelName(), {
-      id: slug,
+  findBySlug: function(slug, dc, configuration = {}) {
+    const query = {
       dc: dc,
-    });
+      id: slug,
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
+    return get(this, 'store').queryRecord(this.getModelName(), query);
   },
   create: function(obj) {
     // TODO: This should probably return a Promise

--- a/ui-v2/app/services/repository/kv.js
+++ b/ui-v2/app/services/repository/kv.js
@@ -13,7 +13,7 @@ export default RepositoryService.extend({
     return PRIMARY_KEY;
   },
   // this one gives you the full object so key,values and meta
-  findBySlug: function(key, dc) {
+  findBySlug: function(key, dc, configuration = {}) {
     if (isFolder(key)) {
       const id = JSON.stringify([dc, key]);
       let item = get(this, 'store').peekRecord(this.getModelName(), id);
@@ -24,23 +24,31 @@ export default RepositoryService.extend({
       }
       return Promise.resolve(item);
     }
-    return get(this, 'store').queryRecord(this.getModelName(), {
+    const query = {
       id: key,
       dc: dc,
-    });
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
+    return get(this, 'store').queryRecord(this.getModelName(), query);
   },
   // this one only gives you keys
   // https://www.consul.io/api/kv.html
-  findAllBySlug: function(key, dc) {
+  findAllBySlug: function(key, dc, configuration = {}) {
     if (key === '/') {
       key = '';
     }
+    const query = {
+      id: key,
+      dc: dc,
+      separator: '/',
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
     return this.get('store')
-      .query(this.getModelName(), {
-        id: key,
-        dc: dc,
-        separator: '/',
-      })
+      .query(this.getModelName(), query)
       .then(function(items) {
         return items.filter(function(item) {
           return key !== get(item, 'Key');

--- a/ui-v2/app/services/repository/session.js
+++ b/ui-v2/app/services/repository/session.js
@@ -8,11 +8,15 @@ export default RepositoryService.extend({
   getModelName: function() {
     return modelName;
   },
-  findByNode: function(node, dc) {
-    return get(this, 'store').query(this.getModelName(), {
+  findByNode: function(node, dc, configuration = {}) {
+    const query = {
       id: node,
       dc: dc,
-    });
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
+    return get(this, 'store').query(this.getModelName(), query);
   },
   // TODO: Why Key? Probably should be findBySlug like the others
   findByKey: function(slug, dc) {


### PR DESCRIPTION
I'd always wanted to use a different word for the `meta.index` property. Consul has both `index` and `hash` headers, and I'd thought that `digest` seemed to fit well for `X-Consul-ContentHash`. But thanks to @banks I found a better word that covers both and fits really well with the work I'm doing - `cursor`

Also see https://github.com/hashicorp/consul/pull/4946

This changes the JSON-API `meta` key to use `cursor` instead of `index` and also removes the `digest` value (as far as I'm aware the API doesn't send both values). When we need to use an API endpoint that uses `X-Consul-ContentHash`, we can use this to assign a `cursor` by overriding the `normalizeMeta` method in the specific `Serializer`.

Additionally, this PR adds a new, optional, `configuration` value to the majority of my `Repository` classes (via the abstract class), giving you the opportunity to read a `cursor` property and then call `get('store').query()` with the query param you need for the API endpoint, `index` or `hash` or anything else.
