### PR TITLE
[Performance on large clusters] Share blocking queries between RPC requests

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -1678,7 +1678,7 @@ func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags
 	for service := iter.Next(); service != nil; service = iter.Next() {
 		svc := service.(*structs.ServiceNode)
 		if !serviceTagsFilter(svc, tags) {
-			results = append(results, svc)
+			results = append(results, service.(*structs.ServiceNode))
 		}
 	}
 	return s.parseCheckServiceNodes(tx, ws, idx, serviceName, results, err)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -384,10 +385,12 @@ func (r *ServiceSpecificRequest) CacheInfo() cache.RequestInfo {
 	// cached results, we need to be careful we maintain the same order of fields
 	// here. We could alternatively use `hash:set` struct tag on an anonymous
 	// struct to make it more robust if it becomes significant.
+	sort.Strings(r.ServiceTags)
 	v, err := hashstructure.Hash([]interface{}{
 		r.NodeMetaFilters,
 		r.ServiceName,
 		r.ServiceTag,
+		r.ServiceTags, // make the tests pass until http://github.com/hashicorp/consul/pull/4987 is merged
 		r.ServiceAddress,
 		r.TagFilter,
 		r.Connect,


### PR DESCRIPTION
Only run one blocking query per request and share the result with all RPC calls. It optimizes the blocking query process when many agents are watching the same service.

### Implementation
When a blocking query RPC call is received, the server first checks if a blocking query with the same parameters is already running. If true, then just wait for this query to complete (or `MaxWaitTime`) without doing any other work. If no blocking query is running, run one in background and wait on it.
The background blocking queries have no max time, however they are cancelled once no more requests are watching them.
The new `args.CacheInfo().Key` is used to differentiate a query from another.
A map keeps track of all running blocking queries. 

### Improvements
* As seen in this profile : [profile.zip](https://github.com/hashicorp/consul/files/2644413/profile.zip) ran on a production server when a large service was deploying the main CPU hogs are the blocking query (`ServiceNodes`) code path, and the msgpack serialization. This changes just runs one `ServiceNodes` call no matter how many watchers there are, reducing that hot path. 
* `softWatchLimit` (discussed here https://github.com/hashicorp/consul/issues/4984) aims at capping the number of goroutines used by blocking queries. This change only keeps one `WatchSet` per blocking query *type* instead of one per request, ultimately keeping the number of goroutines low.

### Notes
This PR only use shared blocking queries for `/v1/health/service` to keep it small and easy to review, and since this query consumes many G per service instance. All blocking endpoints can be migrated to this system. 

Some of our tests show a CPU usage divided by two as well as far less memory and goroutines usage.