### PR TITLE
UI: Adds controller lifecycle `reset` hook

### DIFF
--- a/ui-v2/app/initializers/controller-lifecycle.js
+++ b/ui-v2/app/initializers/controller-lifecycle.js
@@ -1,0 +1,23 @@
+import Route from '@ember/routing/route';
+/**
+ * This initializer is very similar to:
+ * https://github.com/kellyselden/ember-controller-lifecycle
+ *
+ * Why is this included here:
+ * 1. Make sure lifecycle functions are functions, not just truthy.
+ * 2. Right now we don't want a setup function (at least until we are definitely decided that we want one)
+ * This is possibly a very personal opinion so it makes sense to just include this file here.
+ */
+Route.reopen({
+  resetController(controller, exiting, transition) {
+    this._super(...arguments);
+    if (typeof controller.reset === 'function') {
+      controller.reset(exiting);
+    }
+  },
+});
+export function initialize() {}
+
+export default {
+  initialize,
+};


### PR DESCRIPTION
This adds a `Controller.reset` hook through my app, right now it's mainly used if you use the `WithListeners` mixin in a `Controller`

Also see https://github.com/hashicorp/consul/pull/4789#discussion_r238221722 which is partly related to this and the discussion above that comment gives some background on the inclusion/omission of a setup-like hook. The likelihood is we will add one 🔜 , just we don't think it should be called `setup` as it could potentially be called when you aren't 'setting up'.

This also adds an improvement to the dynamic 'psuedo-super' call, just to bind the method correctly so `this` remains what it should be _if_ there is a 'super' to be called.

