### PR TITLE
Update configuration.html.md

### DIFF
--- a/website/source/docs/connect/configuration.html.md
+++ b/website/source/docs/connect/configuration.html.md
@@ -135,7 +135,7 @@ All fields are optional with a sane default.
   specified in the opaque config map here will continue to work for
   compatibility but it's strongly recommended that you move to using the higher
   level [upstream
-  configuration](http://localhost:4567/docs/connect/proxies.html#upstream-configuration).
+  configuration](/docs/connect/proxies.html#upstream-configuration).
 
 #### Proxy Upstream Config Key Reference
 


### PR DESCRIPTION
Link to Upstream Configuration was pointing to http://localhost:4567.
Fixed reference.