### PR TITLE
clarify how `separator` should be in CLI and API

### DIFF
--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -62,9 +62,10 @@ The table below shows this endpoint's support for
   metadata). Specifying this implies `recurse`. This is specified as part of the
   URL as a query parameter.
 
-- `separator` `(string: '/')` - Specifies the character to use as a separator
-  for recursive lookups. This is specified as part of the URL as a query
-  parameter.
+- `separator` `(string: '/')` - Specifies the string to use as a separator
+  for recursive key lookups. This option is only used when paired with the `keys` 
+  parameter to limit the dept of keys returned,  only up to the given separator. 
+  This is specified as part of the URL as a query parameter.
 
 ### Sample Request
 

--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -64,7 +64,7 @@ The table below shows this endpoint's support for
 
 - `separator` `(string: '/')` - Specifies the string to use as a separator
   for recursive key lookups. This option is only used when paired with the `keys` 
-  parameter to limit the dept of keys returned,  only up to the given separator. 
+  parameter to limit the prefix of keys returned,  only up to the given separator. 
   This is specified as part of the URL as a query parameter.
 
 ### Sample Request

--- a/website/source/docs/commands/kv/get.html.markdown.erb
+++ b/website/source/docs/commands/kv/get.html.markdown.erb
@@ -38,9 +38,9 @@ Usage: `consul kv get [options] [KEY_OR_PREFIX]`
 * `-recurse` - Recursively look at all keys prefixed with the given path. The
   default value is false.
 
-* `-separator=<string>` - String to use as a separator between keys. The default
-  value is "/", but this option is only taken into account when paired with the
-  -keys flag.
+* `-separator=<string>` - String to use as a separator for recursive lookups. The 
+  default value is "/", and only used when paired with the `-keys` flag. This will 
+  limit the depth of keys returned, only up to the given separator.
 
 ## Examples
 

--- a/website/source/docs/commands/kv/get.html.markdown.erb
+++ b/website/source/docs/commands/kv/get.html.markdown.erb
@@ -40,7 +40,7 @@ Usage: `consul kv get [options] [KEY_OR_PREFIX]`
 
 * `-separator=<string>` - String to use as a separator for recursive lookups. The 
   default value is "/", and only used when paired with the `-keys` flag. This will 
-  limit the depth of keys returned, only up to the given separator.
+  limit the prefix of keys returned, only up to the given separator.
 
 ## Examples
 


### PR DESCRIPTION
This should clear up #5062 in both the CLI and API to explain how the `separator` flag/option should work.