### PR TITLE
website: frontend fixes for homepage hero and carousel components

### DIFF
--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
 //= require hashicorp/analytics
+//= require consul-connect/home-hero
 //= require analytics
 //= require gsap-custom
 //= require animations

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -1,10 +1,13 @@
 //= require turbolinks
 //= require jquery
+//= require consul-connect/vendor/object-fit-images.min.js
+//= require consul-connect/vendor/siema.min.js
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar
 //= require hashicorp/analytics
 //= require consul-connect/home-hero
+//= require consul-connect/carousel
 //= require analytics
 //= require gsap-custom
 //= require animations

--- a/website/source/assets/javascripts/consul-connect/carousel.js
+++ b/website/source/assets/javascripts/consul-connect/carousel.js
@@ -1,44 +1,55 @@
-objectFitImages()
+document.addEventListener('turbolinks:load', function () {
+  var qs = document.querySelector.bind(document)
+  var qsa = document.querySelectorAll.bind(document)
+  var carousel = qs('.siema')
 
-var qs = document.querySelector.bind(document)
-var qsa = document.querySelectorAll.bind(document)
+  if (carousel) {
+    objectFitImages()
 
-// siema carousels
-var dots = qsa('.g-carousel .pagination li')
-var carousel = new Siema({
-  selector: '.siema',
-  duration: 200,
-  easing: 'ease-out',
-  perPage: 1,
-  startIndex: 0,
-  draggable: true,
-  multipleDrag: true,
-  threshold: 20,
-  loop: true,
-  rtl: false,
-  onChange: function() {
+    // siema carousels
+    var dots = qsa('.g-carousel .pagination li')
+    var siema = new Siema({
+      selector: carousel,
+      duration: 200,
+      easing: 'ease-out',
+      perPage: 1,
+      startIndex: 0,
+      draggable: true,
+      multipleDrag: true,
+      threshold: 20,
+      loop: true,
+      rtl: false,
+      onChange: function() {
+        for (var i = 0; i < dots.length; i++) {
+          dots[i].classList.remove('active')
+        }
+        dots[siema.currentSlide].classList.add('active')
+      }
+    })
+
+    // on previous button click
+    qs('.g-carousel .prev')
+      .addEventListener('click', function() {
+        siema.prev()
+      })
+  
+    // on next button click
+    qs('.g-carousel .next')
+      .addEventListener('click', function() {
+        siema.next()
+      })
+  
+    // on dot click
     for (var i = 0; i < dots.length; i++) {
-      dots[i].classList.remove('active')
+      dots[i].addEventListener('click', function() {
+        siema.goTo(this.dataset.index)
+      })
     }
-    dots[carousel.currentSlide].classList.add('active')
-  }
+
+    document.addEventListener('turbolinks:before-cache', function() {
+      siema.goTo(0) // reset pagination
+      siema.destroy(true)
+    });
+  }  
 })
 
-// on previous button click
-qs('.g-carousel .prev')
-  .addEventListener('click', function() {
-    carousel.prev()
-  })
-
-// on next button click
-qs('.g-carousel .next')
-  .addEventListener('click', function() {
-    carousel.next()
-  })
-
-// on dot click
-for (var i = 0; i < dots.length; i++) {
-  dots[i].addEventListener('click', function() {
-    carousel.goTo(i)
-  })
-}

--- a/website/source/assets/javascripts/consul-connect/home-hero.js
+++ b/website/source/assets/javascripts/consul-connect/home-hero.js
@@ -1,109 +1,103 @@
-var qs = document.querySelector.bind(document)
-var qsa = document.querySelectorAll.bind(document)
+document.addEventListener('turbolinks:load', function () {
+  var qsa = document.querySelectorAll.bind(document)
+  var $$wrappers = qsa('#home-hero .videos > div') // all the wrappers for the videos
+  var $$videos = qsa('#home-hero video') // all the videos
+  var $$videoControls = qsa('#home-hero .controls > div') // carousel controllers
+  var $$videoProgressBars =qsa('#home-hero .progress-bar span') // carousel controller progress bars
+  var currentIndex = $$videos.length - 1 // currently playing video, inits as last video
+  var playbackRate = 2 // video playback speed
 
-var $$wrappers = qsa('#home-hero .videos > div') // all the wrappers for the videos
-var $$videos = qsa('#home-hero video') // all the videos
-var $$videoControls = qsa('#home-hero .controls > div') // carousel controllers
-var currentIndex = 1 // currently playing video
-var playbackRate = 2 // video playback speed
-
-// initiate a video change
-function initiateVideoChange(index) {
-  var wrapper = $$wrappers[currentIndex]
-  var nextWrapper = $$wrappers[index]
-
-  // pause the current video
-  $$videos[currentIndex].pause()
-
-  // deactivate the current video
-  wrapper.classList.remove('active')
-  wrapper.classList.add('deactivate')
-
-  // after the current video animates out...
-  setTimeout(function() {
-    // remove transition effect so progress-bar doesn't slowly decline
-    var loadingBar = $$videoControls[currentIndex].querySelector(
-      '.progress-bar span'
-    )
-    loadingBar.style.transitionDuration = '0s'
-
-    // reset the current video
-    if (!isNaN($$videos[currentIndex].duration)) {
-      $$videos[currentIndex].currentTime = 0
-    }
-    $$videoControls[currentIndex].classList.remove('playing')
-
-    // stop deactivation
-    wrapper.classList.remove('deactivate')
-
-    // check if the video is loaded
-    // if not, listen for it to load
-    if ($$videos[index].classList.contains('loaded')) {
-      playVideo(index, nextWrapper)
-    } else {
-      $$videos[index].addEventListener(
-        'canplaythrough',
-        playVideo(index, nextWrapper)
-      )
-    }
-  }, 1000)
-}
-
-// activate and play a video
-function playVideo(index, wrapper) {
-  // toggle
-  $$videos[index].classList.add('loaded')
-
-  // activate the next video and start playing it
-  wrapper.classList.add('active')
-  $$videoControls[index].classList.add('playing')
-  $$videos[index].play()
-
-  $$videoControls[index].querySelector(
-    '.progress-bar span'
-  ).style.transitionDuration =
-    Math.ceil($$videos[index].duration / playbackRate).toString() + 's'
-
-  // set the currentIndex to be that of the current video's index
-  currentIndex = index
-}
-
-function initiateVideos() {
-  // remove 'active' from wrappers which may be 
-  // there on page load because of turbolinks
-  for (var i = 0; i < $$wrappers.length; i++) {
-    $$wrappers[i].classList.remove('active')
-  }
-
-  // loop through videos to set up options/listeners
-  for (var i = 0; i < $$videos.length; i++) {
-    // set video default speed
-    $$videos[i].playbackRate = playbackRate
-
-    // listen for video ending, then go to the next video
-    $$videos[i].addEventListener('ended', function() {
-      var nextIndex = currentIndex + 1
-      initiateVideoChange(nextIndex < $$videos.length ? nextIndex : 0)
-    })
-  }
-
-  for (var i = 0; i < $$videoControls.length; i++) {
-    // remove 'playing' from controls which may be 
-    // there on page load because of turbolinks
-    $$videoControls[i].classList.remove('playing')
-
-    // listen for control clicks and initiate videos appropriately
-    $$videoControls[i].addEventListener('click', function() {
-      if (!this.classList.contains('playing')) {
-        initiateVideoChange(this.dataset.index)
-      }
-    })
-  }
-
-  // go to first video to start this thing
+  // if there are hero videos on the page, intiate the video carousel
   if ($$videos.length > 0) {
-    initiateVideoChange(0)
+    setup()
   }
-}
 
-document.addEventListener('turbolinks:load', initiateVideos)
+  // initiate the video carousel
+  function setup() {
+    // loop through videos to set up options/listeners
+    for (var i = 0; i < $$wrappers.length; i++) {
+      // some reseting that may need to be done
+      // to work with turbolinks
+      $$wrappers[i].classList.remove('active')
+      $$videoProgressBars[i].style.width = 0
+      $$videos[i].addEventListener('loadeddata', function () { 
+        this.currentTime = 0 
+      })
+
+      // set video default speed
+      $$videos[i].playbackRate = playbackRate
+
+      // set up progress bar
+      setupProgressBar($$videoProgressBars[i], $$videos[i])
+
+      // listen for video ending, then go to the next video
+      $$videos[i].addEventListener('ended', function() {
+        var nextIndex = currentIndex + 1
+        initiateVideoChange(nextIndex < $$videos.length ? nextIndex : 0)
+      })
+
+      // listen for control clicks and initiate videos appropriately
+      $$videoControls[i].addEventListener('click', function() {
+        if (!this.classList.contains('playing')) {
+          initiateVideoChange(this.dataset.index)
+        }
+      })
+    }
+
+    // go to first video to start this thing
+    initiateVideoChange(0)    
+  }
+
+  // set up progress bar
+  function setupProgressBar(bar, video) {
+    setInterval(function () {
+      if (!isNaN(video.duration)) {
+        bar.style.width = `${(video.currentTime / video.duration) * 100}%`
+      }
+    }, 200)
+  }
+
+  // initiate a video change
+  function initiateVideoChange(nextIndex) {
+    var currentWrapper = $$wrappers[currentIndex]
+    var nextWrapper = $$wrappers[nextIndex]
+
+    // pause the current video
+    $$videos[currentIndex].pause()
+
+    // deactivate the current video
+    currentWrapper.classList.remove('active')
+    currentWrapper.classList.add('deactivate')
+    $$videoControls[currentIndex].classList.remove('playing')
+    $$videoControls[nextIndex].classList.add('playing')
+
+    // after the current video animates out...
+    setTimeout(function() {
+      // stop deactivation
+      currentWrapper.classList.remove('deactivate')
+      $$videos[currentIndex].currentTime = 0
+
+      // check if the next video is loaded
+      // if not, listen for it to load
+      if ($$videos[nextIndex].readyState === 4) {
+        $$videos[nextIndex].currentTime = 0
+        playVideo(nextIndex, nextWrapper)
+      } else {
+        $$videos[nextIndex].addEventListener(
+          'canplaythrough',
+          playVideo(nextIndex, nextWrapper)
+        )
+      }
+    }, 1000)
+  }
+
+  // activate and play a video
+  function playVideo(nextIndex, nextWrapper) {
+    // activate the next video and start playing it
+    nextWrapper.classList.add('active')
+    $$videos[nextIndex].play()
+
+    // set the currentIndex to be that of the current video's index
+    currentIndex = nextIndex
+  }
+})

--- a/website/source/assets/stylesheets/consul-connect/pages/_home.scss
+++ b/website/source/assets/stylesheets/consul-connect/pages/_home.scss
@@ -208,13 +208,6 @@
 
         &.playing {
           color: $consul-black;
-
-          .progress-bar {
-            span {
-              transition: width linear;
-              width: 100%;
-            }
-          }
         }
 
         & > span {
@@ -234,6 +227,7 @@
             height: 2px;
             left: 0;
             position: absolute;
+            transition: width linear 0.2s;
             width: 0;
           }
         }

--- a/website/source/configuration.html.erb
+++ b/website/source/configuration.html.erb
@@ -242,8 +242,8 @@ description: |-
           </a>
         </div>
         <ul class='pagination'>
-          <li class='active'></li>
-          <li></li>
+          <li data-index='0' class='active'></li>
+          <li data-index='1'></li>
         </ul>
         <span class='prev'>
           <svg width="18px" height="14px" viewBox="0 0 18 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path d="M20.9227917,11.6173214 C20.8717917,11.4953214 20.7987917,11.3843214 20.7067917,11.2923214 L14.7067917,5.29232143 C14.3167917,4.90232143 13.6837917,4.90232143 13.2927917,5.29232143 C12.9017917,5.68332143 12.9017917,6.31632143 13.2927917,6.70632143 L17.5857917,10.9993214 L3.99979167,10.9993214 C3.44779167,10.9993214 2.99979167,11.4473214 2.99979167,11.9993214 C2.99979167,12.5523214 3.44779167,12.9993214 3.99979167,12.9993214 L17.5857917,12.9993214 L13.2927917,17.2923214 C12.9017917,17.6833214 12.9017917,18.3163214 13.2927917,18.7063214 C13.4877917,18.9023214 13.7437917,18.9993214 13.9997917,18.9993214 C14.2557917,18.9993214 14.5117917,18.9023214 14.7067917,18.7063214 L20.7067917,12.7073214 C20.7987917,12.6153214 20.8717917,12.5043214 20.9227917,12.3823214 C21.0237917,12.1373214 21.0237917,11.8623214 20.9227917,11.6173214" id="path-1"></path></defs><g id="Consul" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Consol.io-Service-Discovery-Op1" transform="translate(-1275.000000, -5150.000000)"><g id="Icons/Feather/arrow/arrow-right" transform="translate(1272.000000, 5145.000000)"><mask id="mask-2" fill="white"><use xlink:href="#path-1"></use></mask><use id="Mask" fill="#000000" fill-rule="evenodd" xlink:href="#path-1"></use><g id="Mixin/Fill/Black" mask="url(#mask-2)" fill="#000000" fill-rule="evenodd"><rect id="Rectangle" x="0" y="0" width="24" height="24"></rect></g></g></g></g></svg>
@@ -269,8 +269,3 @@ description: |-
   </section>
 
 </div>
-
-<% content_for :scripts do %>
-  <script src='/assets/javascripts/consul-connect/vendor/object-fit-images.min.js' defer></script>
-  <script src='/assets/javascripts/consul-connect/carousel.js' defer></script>
-<% end %>

--- a/website/source/discovery.html.erb
+++ b/website/source/discovery.html.erb
@@ -263,8 +263,8 @@ $ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code
           </a>
         </div>
         <ul class='pagination'>
-          <li class='active'></li>
-          <li></li>
+          <li data-index='0' class='active'></li>
+          <li data-index='1'></li>
         </ul>
         <span class='prev'>
           <svg width="18px" height="14px" viewBox="0 0 18 14" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path d="M20.9227917,11.6173214 C20.8717917,11.4953214 20.7987917,11.3843214 20.7067917,11.2923214 L14.7067917,5.29232143 C14.3167917,4.90232143 13.6837917,4.90232143 13.2927917,5.29232143 C12.9017917,5.68332143 12.9017917,6.31632143 13.2927917,6.70632143 L17.5857917,10.9993214 L3.99979167,10.9993214 C3.44779167,10.9993214 2.99979167,11.4473214 2.99979167,11.9993214 C2.99979167,12.5523214 3.44779167,12.9993214 3.99979167,12.9993214 L17.5857917,12.9993214 L13.2927917,17.2923214 C12.9017917,17.6833214 12.9017917,18.3163214 13.2927917,18.7063214 C13.4877917,18.9023214 13.7437917,18.9993214 13.9997917,18.9993214 C14.2557917,18.9993214 14.5117917,18.9023214 14.7067917,18.7063214 L20.7067917,12.7073214 C20.7987917,12.6153214 20.8717917,12.5043214 20.9227917,12.3823214 C21.0237917,12.1373214 21.0237917,11.8623214 20.9227917,11.6173214" id="path-1"></path></defs><g id="Consul" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g id="Consol.io-Service-Discovery-Op1" transform="translate(-1275.000000, -5150.000000)"><g id="Icons/Feather/arrow/arrow-right" transform="translate(1272.000000, 5145.000000)"><mask id="mask-2" fill="white"><use xlink:href="#path-1"></use></mask><use id="Mask" fill="#000000" fill-rule="evenodd" xlink:href="#path-1"></use><g id="Mixin/Fill/Black" mask="url(#mask-2)" fill="#000000" fill-rule="evenodd"><rect id="Rectangle" x="0" y="0" width="24" height="24"></rect></g></g></g></g></svg>
@@ -290,8 +290,3 @@ $ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code
   </section>
 
 </div>
-
-<% content_for :scripts do %>
-  <script src='/assets/javascripts/consul-connect/vendor/object-fit-images.min.js' defer></script>
-  <script src='/assets/javascripts/consul-connect/carousel.js' defer></script>
-<% end %>

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -12,7 +12,7 @@ description: |-
         <div>
           <div>
             <a class='notification' href='/downloads.html'>
-              <span>New</span> HashiCorp Consul 1.4 has been released! Download now <span><svg xmlns='http://www.w3.org/2000/svg' width='6' height='10' viewBox='0 0 6 10'><path fill='#650D34' d='M1.138.529a.666.666 0 1 0-.942.943L3.724 5 .195 8.53a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z'/></svg><span>
+              <span>New</span> HashiCorp Consul 1.4 has been released! Download now <span><svg xmlns='http://www.w3.org/2000/svg' width='6' height='10' viewBox='0 0 6 10'><path fill='#650D34' d='M1.138.529a.666.666 0 1 0-.942.943L3.724 5 .195 8.53a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z'/></svg></span>
             </a>
             <h1>Service Mesh Made Easy</h1>
             <p>Consul is a distributed service mesh to connect, secure, and configure services across any runtime platform and public or private cloud</p>
@@ -47,7 +47,7 @@ description: |-
                 <span></span>
               </div>
               <div class='padded'>
-                <video muted='muted'>
+                <video playsinline muted='muted'>
                   <source src='//consul-static-asssets.global.ssl.fastly.net/videos/v1/connect-video-cli.mp4' type='video/mp4'>
                 </video>
               </div>
@@ -58,7 +58,7 @@ description: |-
                 <span></span>
                 <span></span>
               </div>
-              <video muted='muted'>
+              <video playsinline muted='muted'>
                 <source src='//consul-static-asssets.global.ssl.fastly.net/videos/v1/connect-video-ui.mp4' type='video/mp4'>
               </video>
               <div class='overlay'></div>
@@ -293,9 +293,4 @@ description: |-
       </div>
     </div>
   </section>
-
 </div>
-
-<% content_for :scripts do %>
-  <script src='/assets/javascripts/consul-connect/home-hero.js' defer></script>
-<% end %>


### PR DESCRIPTION
This pull request has 2 commits with fixes for the website.  Visually, there will not be any differences.  These are strictly functionality fixes mostly around these components not working properly with turbolinks.

Changes:
- Homepage Hero
  - Wrap hero component in `turbolinks:load` event listener to properly init the component after navigating away from the homepage and then returning
  - add home-hero js to application bundle instead of bringing it in separately on the home page as recommended by turbolinks
  - some minor adjustments around video playback and video progress bars to bring the component more in line functionally with the component used on hashicorp.com

- Use Case Carousels
  - wrap carousel component in `turbolinks:load` event listener to properly init the component after navigating away from the use case pages and then returning
  - add carousel js (with siema and object-fit-images depenencies) to application bundle instead of bringing it in separately on the use case pages as recommended by turbolinks
  - fix some broken pagination functionality

cc: @pearkes @jescalan 