### PR TITLE
Documentation and changes for `verify_server_hostname`

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2619,6 +2619,24 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				}
 			},
 		},
+		{
+			// This tests checks that VerifyServerHostname implies VerifyOutgoing
+			desc: "verify_server_hostname implies verify_outgoing",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "verify_server_hostname": true
+			}`},
+			hcl: []string{`
+			  verify_server_hostname = true
+			`},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.VerifyServerHostname = true
+				rt.VerifyOutgoing = true
+			},
+		},
 	}
 
 	testConfig(t, tests, dataDir)

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -125,10 +125,6 @@ func (c *Config) KeyPair() (*tls.Certificate, error) {
 // requests. It will return a nil config if this configuration should
 // not use TLS for outgoing connections.
 func (c *Config) OutgoingTLSConfig() (*tls.Config, error) {
-	// If VerifyServerHostname is true, that implies VerifyOutgoing
-	if c.VerifyServerHostname {
-		c.VerifyOutgoing = true
-	}
 	if !c.UseTLS && !c.VerifyOutgoing {
 		return nil, nil
 	}

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -153,6 +153,7 @@ func TestConfig_OutgoingTLS_ServerName(t *testing.T) {
 
 func TestConfig_OutgoingTLS_VerifyHostname(t *testing.T) {
 	conf := &Config{
+		VerifyOutgoing:       true,
 		VerifyServerHostname: true,
 		CAFile:               "../test/ca/root.cer",
 	}
@@ -263,6 +264,7 @@ func TestConfig_outgoingWrapper_OK(t *testing.T) {
 		CertFile:             "../test/hostname/Alice.crt",
 		KeyFile:              "../test/hostname/Alice.key",
 		VerifyServerHostname: true,
+		VerifyOutgoing:       true,
 		Domain:               "consul",
 	}
 
@@ -297,6 +299,7 @@ func TestConfig_outgoingWrapper_BadDC(t *testing.T) {
 		CertFile:             "../test/hostname/Alice.crt",
 		KeyFile:              "../test/hostname/Alice.key",
 		VerifyServerHostname: true,
+		VerifyOutgoing:       true,
 		Domain:               "consul",
 	}
 
@@ -329,6 +332,7 @@ func TestConfig_outgoingWrapper_BadCert(t *testing.T) {
 		CertFile:             "../test/key/ourdomain.cer",
 		KeyFile:              "../test/key/ourdomain.key",
 		VerifyServerHostname: true,
+		VerifyOutgoing:       true,
 		Domain:               "consul",
 	}
 


### PR DESCRIPTION
Since Consul 0.5.1, our documentation and parts of our implementation have stated that setting `verify_server_hostname` to `true` would implicitly configure `verify_outgoing` to true. A bug in this implementation resulted in this being partially incorrect and resulting in plaintext communication in agent-to-agent RPC.

All affected users can add the verify_outgoing  key (set to `true`) to their configuration and restart all Consul agents - both client and server. We recommend checking the validity of the TLS certificates since the issue may have been masking expired or invalid certificates, as they were not being used. 

This corrects the documentation we will make live now, as well as the fix that will go into Consul 1.4.1. 

Note that this is assigned CVE-2018-19653 and we will be posting separately on the Consul mailing list to notify users with more detailed instructions and information.