### PR TITLE
Add documentation about the new ClusterIP syncing

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -298,6 +298,10 @@ and consider if they're appropriate for your deployment.
   If true, will sync Consul services to Kubernetes. This can be disabled to
   have a one-way sync.
 
+  - <a name="v-synccatalog-clusterip-sync" href="#v-synccatalog-clusterip-sync">`syncClusterIPServices`</a> (`boolean: true`) -
+  If true, will sync Kubernetes ClusterIP services to Consul. This can be disabled to
+  have the sync ignore ClusterIP-type services.
+
 * <a name="v-ui" href="#v-ui">`ui`</a> - Values that configure the Consul UI.
 
   - <a name="v-ui-enabled" href="#v-ui-enabled">`enabled`</a> (`boolean: global.enabled`) -

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -131,6 +131,14 @@ If an external IP list is present, a service instance in Consul will be created
 for each external IP. It is assumed that if an external IP is present that it
 is routable and configured by some other system.
 
+#### ClusterIP
+
+ClusterIP services are synced by default as of `consul-k8s` version 0.3.0. In 
+many Kubernetes clusters, ClusterIPs may not be accessible outside of the cluster,
+so you may end up with services registered in Consul that are not routeable. To
+skip syncing ClusterIP services, set [`syncClusterIPServices`](/docs/platform/k8s/helm.html#v-synccatalog-clusterip-sync)
+to `false` in the Helm chart values file.
+
 ### Sync Enable/Disable
 
 By default, all valid services (as explained above) are synced. This default can


### PR DESCRIPTION
Adds ClusterIP as a supported service type in the sync doc, as well
as add `syncClusterIPServices` to the helm chart detailed list.