### PR TITLE
Print defaults again.

### DIFF
--- a/command/flags/usage.go
+++ b/command/flags/usage.go
@@ -80,8 +80,9 @@ func printFlag(w io.Writer, f *flag.Flag) {
 	} else {
 		fmt.Fprintf(w, "  -%s\n", f.Name)
 	}
+	usage := fmt.Sprintf("%s (%s)", f.Usage, f.Value)
 
-	indented := wrapAtLength(f.Usage, 5)
+	indented := wrapAtLength(usage, 5)
 	fmt.Fprintf(w, "%s\n\n", indented)
 }
 

--- a/command/flags/usage_test.go
+++ b/command/flags/usage_test.go
@@ -1,0 +1,27 @@
+package flags
+
+import (
+	"bytes"
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stringValue string
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+func (s *stringValue) Get() interface{} { return string(*s) }
+func (s *stringValue) String() string   { return string(*s) }
+
+func TestFlagsPrintUsage(t *testing.T) {
+	v := stringValue("default")
+	f := flag.Flag{Name: "name", Usage: "usage", Value: &v, DefValue: "defvalue"}
+	var w bytes.Buffer
+	printFlag(&w, &f)
+	expected := "  -name=<value>\n     usage (default)\n\n"
+	require.Equal(t, expected, w.String())
+}


### PR DESCRIPTION
Consul's flags package doesn't print the defaults, but it should be!

Work left:

* [ ] don't show `()` if there is no default value
* [ ] remove all the handwritten defaults from the command line flags