### PR TITLE
Adds a WatchPool to optimise blocking RPC handling in servers.

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -18,8 +18,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/consul/lib/watchpool"
-
 	ca "github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 	"github.com/hashicorp/consul/agent/consul/fsm"
@@ -30,6 +28,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/lib/watchpool"
 	"github.com/hashicorp/consul/sentinel"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"

--- a/lib/watchpool/watchpool.go
+++ b/lib/watchpool/watchpool.go
@@ -1,0 +1,169 @@
+package watchpool
+
+import (
+	"context"
+	"reflect"
+	"sync"
+
+	"github.com/hashicorp/go-memdb"
+)
+
+// WatchPool is a shared indirection for memdb.WatchSet. It allows multiple
+// goroutines (e.g. blocking RPCs) to watch the same set of chans (i.e. radix
+// tree nodes), with only a single WatchSet.Watch, which may spawn many
+// goroutines for large sets.
+//
+// memdb.WatchSet can watch up to aFew (= 32 currently) chans with no additional
+// goroutine overhead, but beyond that it spawns ceiling(N/32) goroutines. For a
+// watch set containing 2048 radix nodes (e.g. ~682 service instances with
+// checks and nodes) that means each blocking query is running 64 goroutines on
+// top of the one actually serving the request. With hundreds or thousands of
+// clients watching the same things, this quickly adds up and places a lot of
+// load on the server. See https://github.com/hashicorp/consul/issues/4984 for
+// more info.
+//
+// By allowing different blocking queries that are watching the same radix nodes
+// to share a WatchSet.Watch, we can limit that number so in the example above,
+// one client still uses 64 goroutines to watch, but now 1000 clients can all be
+// blocking on that same query and still only 64 goroutines are needed (actually
+// 65 since we add a constant one more here per WatchSet).
+//
+// In the case where only a single RPC is blocked on a specific set of radix
+// nodes, we add no extra goroutines of overhead - the "leader" goroutine
+// processes the Watch just as before inline, if it times out with no change
+// observed, then it passes the leadership to one other watcher if any have come
+// along.
+//
+// To use it, just build your memdb.WatchSet like normal, but instead of calling
+// Watch or WatchCtx directly, call `pool.Watch(ctx, ws)`.
+type WatchPool struct {
+	sync.Mutex
+	watchSets map[uint64]*wsEntry
+}
+
+type wsEntry struct {
+	ws memdb.WatchSet
+	// done is closed by the leader Watch when any chan in the WatchSet is closed.
+	done chan struct{}
+	// leaderDone is NOT closed, but has a message sent on it if the current
+	// leader times out and returns to it's caller. If there are "follower" Watch
+	// calls, one of them will receive the message and take over being the leader.
+	leaderDone chan struct{}
+	// refs is a reference count for how many outstanding Watch calls there are
+	// for this WatchSet. It is incremented and decremented atomically.
+	refs uint32
+}
+
+// Watch performs a shared watch on a memdb.WatchSet. It will deduplicate calls
+// with the same WatchSets (i.e. exactly the same nodes in the state store being
+// watched) and run only one ws.WatchCtx call regardless of the number of
+// concurrent callers.
+func (p *WatchPool) Watch(ctx context.Context, ws memdb.WatchSet) error {
+	key, err := p.wsKey(ws)
+	if err != nil {
+		// This shouldn't ever really happen but if we return immediately then it
+		// turns whatever bug causes it into a blocking query hot loop. Instead,
+		// revert to normal un-pooled blocking execution.
+		return ws.WatchCtx(ctx)
+	}
+
+	// Lazy initialize the map
+	if p.watchSets == nil {
+		p.watchSets = make(map[uint64]*wsEntry)
+	}
+
+	// Whatever happens, we need to come back and decrement the ref count and
+	// possibly clean up at the end.
+	defer p.watcherDone(key)
+
+	// See if the key already exists in the share map
+	p.Lock()
+	entry, ok := p.watchSets[key]
+	if !ok {
+		// Create a new entry
+		entry = &wsEntry{
+			ws:   ws,
+			done: make(chan struct{}),
+			// Buffer in leaderChan is important to not block leader if it timesout
+			// with no followers. We rely on it to not deadlock the initial call too.
+			leaderDone: make(chan struct{}, 1),
+			refs:       1,
+		}
+		p.watchSets[key] = entry
+
+		// Trigger one of the Watch goroutines for this set to become the initial
+		// leader. It will likely be us in the select below but it could be another
+		// concurrent call that races. Note that if the select below takes a
+		// non-leader case because our context is cancelled for example, then either
+		// another Watcher will become leader instead, or all watchers will return
+		// for another reason and the state will be cleaned up by watcherDone
+		// preserving invariant that there is always one leader Watch for a given
+		// entry in the map. This won't block because we buffer this chan.
+		entry.leaderDone <- struct{}{}
+	} else {
+		// Add ourselves to the ref count
+		entry.refs++
+	}
+	// Unlock now before processing any more
+	p.Unlock()
+
+	// We are a follower
+	select {
+	case <-ctx.Done():
+		// Our context is done, just return it's error.
+		return ctx.Err()
+
+	case <-entry.done:
+		// The leader notified of a change in the watchset.
+		return nil
+
+	case <-entry.leaderDone:
+		// The current leader timed out (or we just setup the state above) and we
+		// won the race to become next leader. We need to watch until our context is
+		// done
+		watchErr := entry.ws.WatchCtx(ctx)
+		if watchErr == context.Canceled || watchErr == context.DeadlineExceeded {
+			// We timed out, pass the leader buck on to someone else (if there are any
+			// followers, if not this is harmless since it's a buffered chan).
+			entry.leaderDone <- struct{}{}
+		} else {
+			// An actual change happened, in this case notify followers and we can all
+			// be done so no need to pass on leadership.
+			close(entry.done)
+		}
+		return watchErr
+	}
+}
+
+func (p *WatchPool) watcherDone(key uint64) {
+	p.Lock()
+	defer p.Unlock()
+
+	entry, ok := p.watchSets[key]
+	if !ok || entry.refs < 1 {
+		// Shouldn't happen!
+		return
+	}
+	// Un-count watcher and possibly cleanup state.
+	entry.refs--
+	if entry.refs == 0 {
+		// Just remove the state. Any new watches will start a whole new leader etc.
+		delete(p.watchSets, key)
+	}
+}
+
+func (p *WatchPool) wsKey(ws memdb.WatchSet) (uint64, error) {
+	// Hash the map. hashstructure doesn't know how to hash a chan although
+	// reflect can do it without technically using anything unsafe via uintptr.
+	// Since memory addresses are unique already and we need them unordered since
+	// this is a set and map order is non-determinisic, just use the address as
+	// the hash an XOR them.
+	var hash uint64
+	for ch := range ws {
+		val := reflect.ValueOf(ch)
+		// Write the chan's address (!) into our buffer
+		// XOR the chan's address with our current hash
+		hash ^= uint64(val.Pointer())
+	}
+	return hash, nil
+}

--- a/lib/watchpool/watchpool_test.go
+++ b/lib/watchpool/watchpool_test.go
@@ -1,0 +1,282 @@
+package watchpool
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/testutil/retry"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchPoolWatch_Timeout(t *testing.T) {
+	ws := memdb.NewWatchSet()
+
+	wp := &WatchPool{}
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	ch3 := make(chan struct{})
+
+	ws.Add(ch1)
+	ws.Add(ch2)
+	ws.Add(ch3)
+
+	// Watch with context deadline should timeout. I test this first as it's worth
+	// relying on in other tests.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	require := require.New(t)
+	err := wp.Watch(ctx, ws)
+	require.Error(err)
+	require.Equal(context.DeadlineExceeded, err)
+}
+
+func TestWatchPoolWatch_SingleFires(t *testing.T) {
+	ws := memdb.NewWatchSet()
+
+	wp := &WatchPool{}
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	ch3 := make(chan struct{})
+
+	ws.Add(ch1)
+	ws.Add(ch2)
+	ws.Add(ch3)
+
+	// Close a chan before watch
+	close(ch2)
+
+	// Watch with context deadline should timeout. I test this first as it's worth
+	// relying on in other tests.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	require := require.New(t)
+	err := wp.Watch(ctx, ws)
+	require.NoError(err)
+}
+
+func TestWatchPoolWatch_SingleFiresAfterDelay(t *testing.T) {
+	ws := memdb.NewWatchSet()
+
+	wp := &WatchPool{}
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+	ch3 := make(chan struct{})
+
+	ws.Add(ch1)
+	ws.Add(ch2)
+	ws.Add(ch3)
+
+	// Close a chan in a bit
+	time.AfterFunc(20*time.Millisecond, func() {
+		close(ch3)
+	})
+
+	// Deadline limits test length
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	require := require.New(t)
+	start := time.Now()
+	err := wp.Watch(ctx, ws)
+	require.NoError(err)
+	require.True(time.Since(start) > 20*time.Millisecond)
+}
+
+func testMakeChans(n int) []chan struct{} {
+	chans := make([]chan struct{}, n)
+	for i := range chans {
+		chans[i] = make(chan struct{})
+	}
+	return chans
+}
+
+func testRunWatcher(ctx context.Context, wp *WatchPool, chans []chan struct{}, errCh chan error) {
+	ws := memdb.NewWatchSet()
+	for _, ch := range chans {
+		ws.Add(ch)
+	}
+	errCh <- wp.Watch(ctx, ws)
+}
+
+func testRunNWatchers(wp *WatchPool, chans []chan struct{}, n int, to time.Duration) chan error {
+	errCh := make(chan error, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), to)
+			defer cancel()
+			testRunWatcher(ctx, wp, chans, errCh)
+		}()
+	}
+	return errCh
+}
+
+func TestWatchPoolWatch_MultipleAreDeduped(t *testing.T) {
+	wp := &WatchPool{}
+
+	// Create 100 chans to watch (just in case lots makes a difference)
+	chans := testMakeChans(100)
+
+	// Run the initial watcher
+	leaderCtx, leaderCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer leaderCancel()
+	leaderErrCh := make(chan error)
+	go testRunWatcher(leaderCtx, wp, chans, leaderErrCh)
+
+	// Wait for it to be running. Reaching into private state is unpleasant but
+	// it beats relying on timing.
+	retry.Run(t, func(r *retry.R) {
+		wp.Lock()
+		defer wp.Unlock()
+		require.Len(r, wp.watchSets, 1)
+	})
+
+	// Now run a few other watchers on the same set of chans (different watch set
+	// objects).
+	n := 3
+	errCh := testRunNWatchers(wp, chans, n, 100*time.Millisecond)
+
+	// Wait a bit
+	time.Sleep(20 * time.Millisecond)
+
+	req := require.New(t)
+
+	// Sanity check only one ws in state
+	wp.Lock()
+	req.Len(wp.watchSets, 1)
+	wp.Unlock()
+
+	// Cancel the leader
+	leaderCancel()
+
+	// Should get Cancelled error from leader
+	select {
+	case err := <-leaderErrCh:
+		req.Error(err)
+		req.Equal(context.Canceled, err)
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("timedout")
+	}
+
+	// Other watchers should still be running though
+	select {
+	case err := <-errCh:
+		t.Fatalf("watchers should not have fired yet got %s (len %d)", err, len(errCh))
+	default:
+	}
+
+	// And pool should still have state
+	wp.Lock()
+	req.Len(wp.watchSets, 1)
+	wp.Unlock()
+
+	// Now close a chan being watched
+	close(chans[0])
+
+	// The watchers should all return no error since one of them should have taken
+	// over leadership
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-errCh:
+			req.NoError(err)
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("timedout")
+		}
+	}
+
+	// And pool should have had it's state cleaned up
+	wp.Lock()
+	req.Len(wp.watchSets, 0)
+	wp.Unlock()
+}
+
+func TestWatchPoolWatch_MultipleAllTimeout(t *testing.T) {
+	wp := &WatchPool{}
+
+	// Create 100 chans to watch (just in case lots makes a difference)
+	chans := testMakeChans(100)
+
+	// Now run a few other watchers on the same set of chans (different watch set
+	// objects).
+	n := 3
+	start := time.Now()
+	errCh := testRunNWatchers(wp, chans, n, 20*time.Millisecond)
+
+	// Wait for the timeout
+	for i := 0; i < n; i++ {
+		select {
+		case err := <-errCh:
+			require.Error(t, err)
+			require.Equal(t, context.DeadlineExceeded, err)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("took too long to all fail")
+		}
+	}
+	// Sanity check they all actually blocked until timeout
+	require.True(t, time.Since(start) > 20*time.Millisecond)
+
+	// Sanity check pool was left in a clean state
+	wp.Lock()
+	require.Len(t, wp.watchSets, 0)
+	wp.Unlock()
+}
+
+func TestWatchPoolWatch_KeyHash(t *testing.T) {
+
+	ch1 := make(chan struct{})
+	ch2 := make(chan struct{})
+
+	tests := []struct {
+		name     string
+		a, b     memdb.WatchSet
+		wantSame bool
+	}{
+		{
+			name:     "sets with same chan match",
+			a:        memdb.WatchSet{ch1: struct{}{}},
+			b:        memdb.WatchSet{ch1: struct{}{}},
+			wantSame: true,
+		},
+		{
+			name:     "sets with diff chans don't match",
+			a:        memdb.WatchSet{ch1: struct{}{}},
+			b:        memdb.WatchSet{ch2: struct{}{}},
+			wantSame: false,
+		},
+		{
+			name:     "sets with same chans in diff order match",
+			a:        memdb.WatchSet{ch1: struct{}{}, ch2: struct{}{}},
+			b:        memdb.WatchSet{ch2: struct{}{}, ch1: struct{}{}},
+			wantSame: true,
+		},
+		{
+			name:     "sets with subset of chans don't match",
+			a:        memdb.WatchSet{ch1: struct{}{}, ch2: struct{}{}},
+			b:        memdb.WatchSet{ch2: struct{}{}},
+			wantSame: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wp := &WatchPool{}
+			hA, err := wp.wsKey(tc.a)
+			require.NoError(t, err)
+			hB, err := wp.wsKey(tc.b)
+			require.NoError(t, err)
+
+			if tc.wantSame {
+				require.Equal(t, hA, hB)
+			} else {
+				require.NotEqual(t, hA, hB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See https://github.com/hashicorp/consul/issues/4984.

This PR adds a simple helper that allows us to share `memdb.WatchSet` processing between blocking RPCs that watch the same nodes.

The inspiration was the sharedBlocking design by @Aestek and @pierresouchay  in #5050. In that PR and the linked issue they show the huge performance gains they achieved with an equivalent optimisation.

The benefits to this PR vs #5050 are:
 - Very small code change - zero changes needed to and RPC endpoints, nor the state store
 - 100% coverage - all blocking queries will automatically benefit from this
 - In the base case where there is only a single client watching a particular set of nodes, this implementation uses exactly the same number of goroutines as before - the "leader" that actually maintains the `WatchSet.Watch` is the same RPC goroutine that was running `Watch` before. This is a minor optimisation but was relatively simple to achieve.

The benefits to this PR vs the [proposal I made in the issue](https://github.com/hashicorp/consul/issues/4984#issuecomment-445209023) are:
 - No change needed to state store and other places to switch out `memdb.WatchSet` for a different type
 - No tradeoff for queries with low numbers of clients blocking. The other proposal could worst case end up using O(3* number of service instances) for a health query goroutines which for a single client is about 38 times worse than current. That might not be too bad since only becomes a real issue with lots of concurrency, but this trade was not clear. For example even for the Consul cluster described in #5050 that may have many thousands of clients blocking on the same expensive query which would amortize the cost, it's unknown what the long-tail of queries that have fewer than 32 clients it. If there were thousands of such queries too and they were of a non-trivial size then it could start to get expensive again.