### PR TITLE
ui: Adds XHR connection management to HTTP/1.1 installs

### DIFF
--- a/ui-v2/app/initializers/client.js
+++ b/ui-v2/app/initializers/client.js
@@ -1,0 +1,15 @@
+const scripts = document.getElementsByTagName('script');
+const current = scripts[scripts.length - 1];
+
+export function initialize(application) {
+  const Client = application.resolveRegistration('service:client/http');
+  Client.reopen({
+    isCurrent: function(src) {
+      return current.src === src;
+    },
+  });
+}
+
+export default {
+  initialize,
+};

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -1,0 +1,88 @@
+import Service, { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+import { Promise } from 'rsvp';
+
+import getObjectPool from 'consul-ui/utils/get-object-pool';
+import Request from 'consul-ui/utils/http/request';
+
+const dispose = function(request) {
+  if (request.headers()['content-type'] === 'text/event-stream') {
+    const xhr = request.connection();
+    // unsent and opened get aborted
+    // headers and loading means wait for it
+    // to finish for the moment
+    if (xhr.readyState) {
+      switch (xhr.readyState) {
+        case 0:
+        case 1:
+          xhr.abort();
+          break;
+      }
+    }
+  }
+  return request;
+};
+export default Service.extend({
+  dom: service('dom'),
+  init: function() {
+    this._super(...arguments);
+    let protocol = 'http/1.1';
+    try {
+      protocol = performance.getEntriesByType('resource').reduce(function(prev, item) {
+        // for the moment assume script is likely to be
+        // the same as xmlhttprequest origins
+        if (item.initiatorType === 'script') {
+          prev = item.nextHopProtocol;
+        }
+        return prev;
+      }, 'http/1.1');
+    } catch (e) {
+      // pass through
+    }
+    let maxConnections;
+    // http/2, http2+QUIC/39 and SPDY don't have connection limits
+    switch (true) {
+      case protocol.indexOf('h2') === 0:
+      case protocol.indexOf('hq') === 0:
+      case protocol.indexOf('spdy') === 0:
+        break;
+      default:
+        // generally 6 are available
+        // reserve 1 for traffic that we can't manage
+        maxConnections = 5;
+        break;
+    }
+    set(this, 'connections', getObjectPool(dispose, maxConnections));
+    if (typeof maxConnections !== 'undefined') {
+      set(this, 'maxConnections', maxConnections);
+      const doc = get(this, 'dom').document();
+      // when the user hides the tab, abort all connections
+      doc.addEventListener('visibilitychange', e => {
+        if (e.target.hidden) {
+          get(this, 'connections').purge();
+        }
+      });
+    }
+  },
+  whenAvailable: function(e) {
+    const doc = get(this, 'dom').document();
+    // if we are using a connection limited protocol and the user has hidden the tab (hidden browser/tab switch)
+    // any aborted errors should restart
+    if (typeof get(this, 'maxConnections') !== 'undefined' && doc.hidden) {
+      return new Promise(function(resolve) {
+        doc.addEventListener('visibilitychange', function listen(event) {
+          doc.removeEventListener('visibilitychange', listen);
+          resolve(e);
+        });
+      });
+    }
+    return Promise.resolve(e);
+  },
+  request: function(options, xhr) {
+    const request = new Request(options.type, options.url, { body: options.data || {} }, xhr);
+    return get(this, 'connections').acquire(request, request.getId());
+  },
+  complete: function() {
+    return get(this, 'connections').release(...arguments);
+  },
+});

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -28,14 +28,13 @@ export default Service.extend({
     this._super(...arguments);
     let protocol = 'http/1.1';
     try {
-      protocol = performance.getEntriesByType('resource').reduce(function(prev, item) {
-        // for the moment assume script is likely to be
-        // the same as xmlhttprequest origins
-        if (item.initiatorType === 'script') {
-          prev = item.nextHopProtocol;
-        }
-        return prev;
-      }, 'http/1.1');
+      protocol = performance.getEntriesByType('resource').find(item => {
+        // isCurrent is added in initializers/client and is used
+        // to ensure we use the consul-ui.js src to sniff what the protocol
+        // is. Based on the assumption that whereever this script is it's
+        // likely to be the same as the xmlhttprequests
+        return item.initiatorType === 'script' && this.isCurrent(item.name);
+      }).nextHopProtocol;
     } catch (e) {
       // pass through
     }

--- a/ui-v2/app/services/dom.js
+++ b/ui-v2/app/services/dom.js
@@ -50,7 +50,7 @@ export default Service.extend({
   },
   elementsByTagName: function(name, context) {
     context = typeof context === 'undefined' ? get(this, 'doc') : context;
-    return context.getElementByTagName(name);
+    return context.getElementsByTagName(name);
   },
   elements: function(selector, context) {
     // don't ever be tempted to [...$$()] here

--- a/ui-v2/app/utils/get-object-pool.js
+++ b/ui-v2/app/utils/get-object-pool.js
@@ -1,0 +1,52 @@
+export default function(dispose = function() {}, max, objects = []) {
+  return {
+    acquire: function(obj, id) {
+      // TODO: what should happen if an ID already exists
+      // should we ignore and release both? Or prevent from acquiring? Or generate a unique ID?
+      // what happens if we can't get an id via getId or .id?
+      // could potentially use Set
+      objects.push(obj);
+      if (typeof max !== 'undefined') {
+        if (objects.length > max) {
+          return dispose(objects.shift());
+        }
+      }
+      return id;
+    },
+    // release releases the obj from the pool but **doesn't** dispose it
+    release: function(obj) {
+      let index = -1;
+      let id;
+      if (typeof obj === 'string') {
+        id = obj;
+      } else {
+        id = obj.id;
+      }
+      objects.forEach(function(item, i) {
+        let itemId;
+        if (typeof item.getId === 'function') {
+          itemId = item.getId();
+        } else {
+          itemId = item.id;
+        }
+        if (itemId === id) {
+          index = i;
+        }
+      });
+      if (index !== -1) {
+        return objects.splice(index, 1)[0];
+      }
+    },
+    purge: function() {
+      let obj;
+      const objs = [];
+      while ((obj = objects.shift())) {
+        objs.push(dispose(obj));
+      }
+      return objs;
+    },
+    dispose: function(id) {
+      return dispose(this.release(id));
+    },
+  };
+}

--- a/ui-v2/app/utils/http/request.js
+++ b/ui-v2/app/utils/http/request.js
@@ -1,0 +1,29 @@
+export default class {
+  constructor(method, url, headers, xhr) {
+    this._xhr = xhr;
+    this._url = url;
+    this._method = method;
+    this._headers = headers;
+    this._headers = {
+      ...headers,
+      'content-type': 'application/json',
+      'x-request-id': `${this._method} ${this._url}?${JSON.stringify(headers.body)}`,
+    };
+    if (typeof this._headers.body.index !== 'undefined') {
+      // this should probably be in a response
+      this._headers['content-type'] = 'text/event-stream';
+    }
+  }
+  headers() {
+    return this._headers;
+  }
+  getId() {
+    return this._headers['x-request-id'];
+  }
+  abort() {
+    this._xhr.abort();
+  }
+  connection() {
+    return this._xhr;
+  }
+}

--- a/ui-v2/tests/integration/services/repository/intention-test.js
+++ b/ui-v2/tests/integration/services/repository/intention-test.js
@@ -2,14 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
 const NAME = 'intention';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
-  // Specify the other units that are required for this test.
-  needs: [
-    'service:settings',
-    'service:store',
-    `adapter:${NAME}`,
-    `serializer:${NAME}`,
-    `model:${NAME}`,
-  ],
+  integration: true,
 });
 
 const dc = 'dc-1';

--- a/ui-v2/tests/unit/services/client/http-test.js
+++ b/ui-v2/tests/unit/services/client/http-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:client/http', 'Unit | Service | client/http', {
+  // Specify the other units that are required for this test.
+  needs: ['service:dom'],
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});

--- a/ui-v2/tests/unit/utils/get-object-pool-test.js
+++ b/ui-v2/tests/unit/utils/get-object-pool-test.js
@@ -18,7 +18,7 @@ test('acquire adds objects', function(assert) {
   const pool = getObjectPool(function() {}, 10, actual);
   pool.acquire(expected, expected.id);
   assert.deepEqual(actual[0], expected);
-  pool.acquire(expected2, expected2);
+  pool.acquire(expected2, expected2.id);
   assert.deepEqual(actual[1], expected2);
 });
 test('acquire adds objects and returns the id', function(assert) {

--- a/ui-v2/tests/unit/utils/get-object-pool-test.js
+++ b/ui-v2/tests/unit/utils/get-object-pool-test.js
@@ -1,0 +1,98 @@
+import getObjectPool from 'consul-ui/utils/get-object-pool';
+import { module, skip } from 'qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+
+module('Unit | Utility | get object pool');
+
+skip('Decide what to do if you add 2 objects with the same id');
+test('acquire adds objects', function(assert) {
+  const actual = [];
+  const expected = {
+    hi: 'there',
+    id: 'hi-there-123',
+  };
+  const expected2 = {
+    hi: 'there',
+    id: 'hi-there-456',
+  };
+  const pool = getObjectPool(function() {}, 10, actual);
+  pool.acquire(expected, expected.id);
+  assert.deepEqual(actual[0], expected);
+  pool.acquire(expected2, expected2);
+  assert.deepEqual(actual[1], expected2);
+});
+test('acquire adds objects and returns the id', function(assert) {
+  const arr = [];
+  const expected = 'hi-there-123';
+  const obj = {
+    hi: 'there',
+    id: expected,
+  };
+  const pool = getObjectPool(function() {}, 10, arr);
+  const actual = pool.acquire(obj, expected);
+  assert.equal(actual, expected);
+});
+test('acquire adds objects, and disposes when there is no room', function(assert) {
+  const actual = [];
+  const expected = {
+    hi: 'there',
+    id: 'hi-there-123',
+  };
+  const expected2 = {
+    hi: 'there',
+    id: 'hi-there-456',
+  };
+  const dispose = this.stub()
+    .withArgs(expected)
+    .returnsArg(0);
+  const pool = getObjectPool(dispose, 1, actual);
+  pool.acquire(expected, expected.id);
+  assert.deepEqual(actual[0], expected);
+  pool.acquire(expected2, expected2.id);
+  assert.deepEqual(actual[0], expected2);
+  assert.ok(dispose.calledOnce);
+});
+test('it disposes', function(assert) {
+  const arr = [];
+  const expected = {
+    hi: 'there',
+    id: 'hi-there-123',
+  };
+  const expected2 = {
+    hi: 'there',
+    id: 'hi-there-456',
+  };
+  const dispose = this.stub().returnsArg(0);
+  const pool = getObjectPool(dispose, 2, arr);
+  const id = pool.acquire(expected, expected.id);
+  assert.deepEqual(arr[0], expected);
+  pool.acquire(expected2, expected2.id);
+  assert.deepEqual(arr[1], expected2);
+  const actual = pool.dispose(id);
+  assert.ok(dispose.calledOnce);
+  assert.equal(arr.length, 1, 'object was removed from array');
+  assert.deepEqual(actual, expected, 'returned object is expected object');
+  assert.deepEqual(arr[0], expected2, 'object in the pool is expected object');
+});
+test('it purges', function(assert) {
+  const arr = [];
+  const expected = {
+    hi: 'there',
+    id: 'hi-there-123',
+  };
+  const expected2 = {
+    hi: 'there',
+    id: 'hi-there-456',
+  };
+  const dispose = this.stub().returnsArg(0);
+  const pool = getObjectPool(dispose, 2, arr);
+  pool.acquire(expected, expected.id);
+  assert.deepEqual(arr[0], expected);
+  pool.acquire(expected2, expected2.id);
+  assert.deepEqual(arr[1], expected2);
+  const actual = pool.purge();
+  assert.ok(dispose.calledTwice, 'dispose was called on everything');
+  assert.equal(arr.length, 0, 'the pool is empty');
+  assert.deepEqual(actual[0], expected, 'the first purged object is correct');
+  assert.deepEqual(actual[1], expected2, 'the second purged object is correct');
+});

--- a/ui-v2/tests/unit/utils/http/request-test.js
+++ b/ui-v2/tests/unit/utils/http/request-test.js
@@ -1,0 +1,10 @@
+import httpRequest from 'consul-ui/utils/http/request';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | http/request');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  const actual = httpRequest;
+  assert.ok(typeof actual === 'function');
+});


### PR DESCRIPTION
Blocking queries maintains an open connection to the `consul` API. When the API is using HTTP/1.1 to communicate, connections potentially reach 6 open connections, and as far as we are aware most browsers allow a maximum of 6 HTTP/1.1 connections per domain.

This PR includes various things:

1. An object pool to 'acquire', 'release' and 'dispose' of objects, also a 'purge' to completely empty it. This language is chosen here to try to associate these things to 'pools', I'm probably 99% happy with these, further suggestions welcome.
2. A `Request` data object, mainly for reasoning about the 'connection' object easier.
3. A pseudo http 'client' which doesn't actually control the request itself but does help to manage the connections.
4. Functionality for aborting connections if you 'hide' the browser tab (this seems to be changing via changing tabs, hiding/minimising your browser or your computer sleeping). There is nothing here for if you open a new window (as opposed to a tab)

Further details:

1. We attempt a detection of HTTP/2 on app load, this seems to be pretty well supported using the `performance` API ( https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType ). This is done in a progressive manner so we fallback to HTTP/1.1 if we can't detect - I wrapped this in a `try` to be sure. We check for other potentially multiplexing protocols here also.
2. We only abort connections if they are not currently downloading. This is to avoid wasting a download or a large amount of services/items when you open a new tab mid-download.
3. We make use of another private method to achieve this, this seems to be pretty much the only way to do this. This is another reason why I'd like to write a new `HTTPAdapter` (see https://github.com/hashicorp/consul/pull/4946 )
4. Although we think 6 is the connection limit, we limit to 5 connections to make sure we keep a connection for things we can't manage via javascript (HTML and CSS files etc). Please note, if you really really try you can make the connections fill up on a HTTP/1.1 connection by opening lots of tabs and going to certain pages. This is relatively unlikely and is only likely at all once we enable blocking queries support in the UI. Once we do this, we will also be adding a user setting to turn blocking queries on/off if desired.
5. Further work would include syncing the connection pool between tabs so that we can manage connections between tabs even if you have opened a new window instead of just a tab. This is currently out of scope but is something we've been looking at and would potentially use our work from https://github.com/hashicorp/consul/pull/5070

This is also mentioned in https://github.com/hashicorp/consul/pull/5070 and will be used for connection management for blocking queries.

> We decided not to do HTTP connection management for users accessing the API over HTTP/2 (and similar multiplexed protocols). Some of our users will be accessing the API via a TLS protected HTTP/2 enabled proxy and therefore shouldn’t have any sort of connection limits applied.
> When using HTTP/2 you could potentially open a large amount of blocking queries with the UI, especially if you have a high wait setting. We queried this with the rest of the consul team to see if there is any restriction on the amount of blocking queries we should open to consul, and there doesn’t seem to be any restrictions, or reason to restrict.
> We feel that not cancelling sent requests when the user leaves a page (unless a user as no more connections available when using HTTP/1.1) makes for a better user experience. Partly downloaded data is not wasted and changes that have happened since you left a previous page are immediately visible when you return, it doesn’t require another request to be sent back to the API. Blocking queries will naturally timeout and will not restart if the user isn’t on the page, this means that the amount of open connections will remain reasonably small even when using HTTP/2.

Most of this isn't currently in use, and is to be merged onto `ui-staging`. But if you can see any more gotchas here feedback would be most welcome.

Last but most definitely not least, big thanks to @DingoEatingFuzz as I wouldn't have even realised we needed to do this if it wasn't for him 🙌 

