### PR TITLE
website: highlight how to use agent certs for tls checks

### DIFF
--- a/website/source/docs/agent/checks.html.md
+++ b/website/source/docs/agent/checks.html.md
@@ -328,6 +328,12 @@ In the above configuration, if the web-app health check begins failing, it will
 only affect the availability of the web-app service. All other services
 provided by the node will remain unchanged.
 
+## Agent Certificates for TLS Checks
+
+The [enable_agent_tls_for_checks](/docs/agent/options.html#enable_agent_tls_for_checks)
+agent configuration option can be utilized to have HTTP or gRPC health checks
+to use the agent's credentials when configured for TLS.
+
 ## Multiple Check Definitions
 
 Multiple check definitions can be defined using the `checks` (plural)

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1032,7 +1032,7 @@ default will automatically work with some tooling.
 
 * <a name="enable_agent_tls_for_checks"></a><a href="#enable_agent_tls_for_checks">`enable_agent_tls_for_checks`</a>
   When set, uses a subset of the agent's TLS configuration (`key_file`, `cert_file`, `ca_file`, `ca_path`, and
-  `server_name`) to set up the HTTP client for HTTP health checks. This allows services requiring 2-way TLS to
+  `server_name`) to set up the client for HTTP or gRPC health checks. This allows services requiring 2-way TLS to
   be checked using the agent's credentials. This was added in Consul 1.0.1 and defaults to false.
 
 * <a name="enable_debug"></a><a href="#enable_debug">`enable_debug`</a> When set, enables some


### PR DESCRIPTION
Also clarifies that HTTP and gRPC checks both use the same TLS configuration.

ref https://github.com/hashicorp/consul/issues/5075