### PR TITLE
Serve /robots.txt when UI is enabled.

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -219,6 +219,8 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 			uifs = &redirectFS{fs: uifs}
 		}
 
+		robotHandler := http.RedirectHandler("/ui/robots.txt", 307)
+		mux.Handle("/robots.txt", robotHandler)
 		mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(uifs)))
 	}
 
@@ -414,15 +416,14 @@ func (s *HTTPServer) Index(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Give them something helpful if there's no UI so they at least know
-	// what this server is.
-	if !s.IsUIEnabled() {
+	if s.IsUIEnabled() {
+		// Redirect to the UI endpoint
+		http.Redirect(resp, req, "/ui/", http.StatusMovedPermanently) // 301
+	} else {
+		// Give them something helpful if there's no UI so they at least know
+		// what this server is.
 		fmt.Fprint(resp, "Consul Agent")
-		return
 	}
-
-	// Redirect to the UI endpoint
-	http.Redirect(resp, req, "/ui/", http.StatusMovedPermanently) // 301
 }
 
 // decodeBody is used to decode a JSON request body

--- a/agent/http.go
+++ b/agent/http.go
@@ -415,14 +415,15 @@ func (s *HTTPServer) Index(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if s.IsUIEnabled() {
-		// Redirect to the UI endpoint
-		http.Redirect(resp, req, "/ui/", http.StatusMovedPermanently) // 301
-	} else {
-		// Give them something helpful if there's no UI so they at least know
-		// what this server is.
+	// Give them something helpful if there's no UI so they at least know
+	// what this server is.
+	if !s.IsUIEnabled() {
 		fmt.Fprint(resp, "Consul Agent")
+		return
 	}
+
+	// Redirect to the UI endpoint
+	http.Redirect(resp, req, "/ui/", http.StatusMovedPermanently) // 301
 }
 
 // decodeBody is used to decode a JSON request body

--- a/agent/http.go
+++ b/agent/http.go
@@ -219,8 +219,7 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 			uifs = &redirectFS{fs: uifs}
 		}
 
-		robotHandler := http.RedirectHandler("/ui/robots.txt", 307)
-		mux.Handle("/robots.txt", robotHandler)
+		mux.Handle("/robots.txt", http.FileServer(uifs))
 		mux.Handle("/ui/", http.StripPrefix("/ui/", http.FileServer(uifs)))
 	}
 

--- a/ui-v2/public/robots.txt
+++ b/ui-v2/public/robots.txt
@@ -1,3 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
-Disallow:
+Disallow: *


### PR DESCRIPTION
Uses the solution from #5005 and fixes it as well. `robots.txt` also disallows everything now.

There was a similar issue in vault: https://github.com/hashicorp/vault/issues/5585.