### PR TITLE
connect: agent leaf cert caching improvements

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3413,9 +3413,10 @@ func (a *Agent) registerCache() {
 	})
 
 	a.cache.RegisterType(cachetype.ConnectCALeafName, &cachetype.ConnectCALeaf{
-		RPC:        a,
-		Cache:      a.cache,
-		Datacenter: a.config.Datacenter,
+		RPC:                              a,
+		Cache:                            a.cache,
+		Datacenter:                       a.config.Datacenter,
+		TestOverrideCAChangeInitialDelay: a.config.ConnectTestCALeafRootChangeSpread,
 	}, &cache.RegisterOptions{
 		// Maintain a blocking query, retry dropped connections quickly
 		Refresh:        true,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3413,8 +3413,9 @@ func (a *Agent) registerCache() {
 	})
 
 	a.cache.RegisterType(cachetype.ConnectCALeafName, &cachetype.ConnectCALeaf{
-		RPC:   a,
-		Cache: a.cache,
+		RPC:        a,
+		Cache:      a.cache,
+		Datacenter: a.config.Datacenter,
 	}, &cache.RegisterOptions{
 		// Maintain a blocking query, retry dropped connections quickly
 		Refresh:        true,

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -1,12 +1,14 @@
 package cachetype
 
 import (
-	"crypto/sha256"
+	"context"
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
+
+	"github.com/hashicorp/consul/lib"
+	"github.com/y0ssar1an/q"
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/connect"
@@ -16,29 +18,209 @@ import (
 // Recommended name for registration.
 const ConnectCALeafName = "connect-ca-leaf"
 
+// caChangeInitialJitter is the jitter we apply after noticing the CA changed
+// before requesting a new cert. Since we don't know how many services are in
+// the cluster we can't be too smart about setting this so it's a tradeoff
+// between not making root rotations take unnecessarily long on small clusters
+// and not hammering the servers to hard on large ones. Note that server's will
+// soon have CSR rate limiting that will limit the impact on big clusters, but a
+// small spread in the initial requests still seems like a good idea and limits
+// how many clients will hit the rate limit.
+const caChangeInitialJitter = 20 * time.Second
+
 // ConnectCALeaf supports fetching and generating Connect leaf
 // certificates.
 type ConnectCALeaf struct {
 	caIndex uint64 // Current index for CA roots
 
-	issuedCertsLock sync.RWMutex
-	issuedCerts     map[string]*structs.IssuedCert
+	// rootWatchMu protects access to the rootWatchSubscribers map and
+	// rootWatchCancel
+	rootWatchMu sync.Mutex
+	// rootWatchSubscribers is a set of chans, one for each currently in-flight
+	// Fetch. These chans have root updates delivered from the root watcher.
+	rootWatchSubscribers map[chan struct{}]struct{}
+	// rootWatchCancel is a func to call to stop the background root watch if any.
+	// You must hold inflightMu to read (e.g. call) or write the value.
+	rootWatchCancel func()
 
-	RPC   RPC          // RPC client for remote requests
-	Cache *cache.Cache // Cache that has CA root certs via ConnectCARoot
+	// testSetCAChangeInitialJitter allows overriding the caChangeInitialJitter in
+	// tests.
+	testSetCAChangeInitialJitter time.Duration
+
+	RPC        RPC          // RPC client for remote requests
+	Cache      *cache.Cache // Cache that has CA root certs via ConnectCARoot
+	Datacenter string       // This agent's datacenter
 }
 
-// issuedKey returns the issuedCerts cache key for a given service and token. We
-// use a hash rather than concatenating strings to provide resilience against
-// user input containing our separator - both service name and token ID can be
-// freely manipulated by user so may contain any delimiter we choose. It also
-// has the benefit of not leaking the ACL token to a new place in memory it
-// might get accidentally dumped etc.
-func issuedKey(service, token string) string {
-	hash := sha256.New()
-	hash.Write([]byte(service))
-	hash.Write([]byte(token))
-	return fmt.Sprintf("%x", hash.Sum(nil))
+// fetchState is some additional metadata we store with each cert in the cache
+// to track things like expiry and coordinate paces root rotations.
+type fetchState struct {
+	// authorityKeyID is the key ID of the CA root that signed the current cert.
+	// This is just to save parsing the whole cert everytime we have to check if
+	// the root changed.
+	authorityKeyID string
+
+	// forceExpireAfter is used to coordinate renewing certs after a CA rotation
+	// in a staggered way so that we don't overwhelm the servers.
+	forceExpireAfter time.Time
+}
+
+func (c *ConnectCALeaf) fetchStart(rootUpdateCh chan struct{}) {
+	c.rootWatchMu.Lock()
+	defer c.rootWatchMu.Unlock()
+	// Lazy allocation
+	if c.rootWatchSubscribers == nil {
+		c.rootWatchSubscribers = make(map[chan struct{}]struct{})
+	}
+	// Make sure a root watcher is running. We don't only do this on first request
+	// to be more tolerant of errors that could cause the root watcher to fail and
+	// exit.
+	c.ensureRootWatcher()
+	c.rootWatchSubscribers[rootUpdateCh] = struct{}{}
+}
+
+func (c *ConnectCALeaf) fetchDone(rootUpdateCh chan struct{}) {
+	c.rootWatchMu.Lock()
+	defer c.rootWatchMu.Unlock()
+	delete(c.rootWatchSubscribers, rootUpdateCh)
+	if len(c.rootWatchSubscribers) == 0 && c.rootWatchCancel != nil {
+		// This is was the last request. Stop the root watcher
+		c.rootWatchCancel()
+	}
+}
+
+// ensureRootWatcher must be called while holding c.inflightMu it starts a
+// background root watcher if there isn't already one running.
+func (c *ConnectCALeaf) ensureRootWatcher() {
+	if c.rootWatchCancel == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		c.rootWatchCancel = cancel
+		go c.rootWatcher(ctx)
+	}
+}
+
+func (c *ConnectCALeaf) rootWatcher(ctx context.Context) {
+	ch := make(chan cache.UpdateEvent, 1)
+	err := c.Cache.Notify(ctx, ConnectCARootName, &structs.DCSpecificRequest{
+		Datacenter: c.Datacenter,
+	}, "roots", ch)
+
+	if err != nil {
+		// TODO(banks): Hmm we should probably plumb a logger through here at least.
+		// No good place to put this otherwise. At least next Fetch will retry. We
+		// could plumb it back through to all current Fetches and fail them with the
+		// error I guess?
+		return
+	}
+
+	var oldRoots *structs.IndexedCARoots
+	// Wait for updates to roots or all requests to stop
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e := <-ch:
+			// Root response changed in some way. Note this might be the initial
+			// fetch.
+			if e.Err != nil {
+				// TODO(banks): should we pass this on to clients? Feels like if it's a
+				// temporary issue and we recover we will have shown an error to leaf
+				// watchers for nothing. On the other hand all clients watching leafs
+				// will also be watching roots too so probably already saw the same
+				// error from their own roots watch.
+				continue
+			}
+
+			roots, ok := e.Result.(*structs.IndexedCARoots)
+			if !ok {
+				// Shouldn't happen. Error handling as above.
+				continue
+			}
+
+			q.Q(roots)
+
+			// Check that the active root is actually different from the last CA
+			// config there are many reasons the config might have changed without
+			// actually updating the CA root that is signing certs in the cluster.
+			// The Fetch calls will also validate this since the first call here we
+			// don't know if it changed or not, but there is no point waking up all
+			// Fetch calls to check this if we know none of them will need to act on
+			// this update.
+			if oldRoots != nil && oldRoots.ActiveRootID == roots.ActiveRootID {
+				continue
+			}
+
+			// Distribute the update to all inflight requests - they will decide
+			// whether or not they need to act on it.
+			c.rootWatchMu.Lock()
+			for ch := range c.rootWatchSubscribers {
+				select {
+				case ch <- struct{}{}:
+				default:
+					// Don't block - chans are 1-buffered so act as an edge trigger and
+					// reload CA state directly from cache so they never "miss" updates.
+				}
+			}
+			c.rootWatchMu.Unlock()
+			oldRoots = roots
+		}
+	}
+}
+
+// calculateSoftExpiry encapsulates our logic for when to renew a cert based on
+// it's age. It returns a pair of times min, max which makes it easier to test
+// the logic without non-determinisic jitter to account for. The caller should choose a time randomly in between these.
+//
+// We want to balance a few factors here:
+//   - renew too early and it increases the aggregate CSR rate in the cluster
+//   - renew too late and it risks disruption to the service if a transient
+//     error prevents the renewal
+//   - we want a broad amount of jitter so if there is an outage, we don't end
+//     up with all services in sync and causing a thundering herd every
+//     renewal period. Broader is better for smoothing requests but pushes
+//     both earlier and later tradeoffs above.
+//
+// Somewhat arbitrarily the current strategy looks like this:
+//
+//          0                              60%             90%
+//   Issued [------------------------------|===============|!!!!!] Expires
+// 72h TTL: 0                             ~43h            ~65h
+//  1h TTL: 0                              36m             54m
+//
+// Where |===| is the soft renewal period where we jitter for the first attempt
+// and |!!!| is the danger zone where we just try immediately.
+//
+// In the happy path (no outages) the average renewal occurs half way through
+// the soft renewal region or at 75% of the cert lifetime which is ~54 hours for
+// a 72 hour cert, or 45 mins for a 1 hour cert.
+//
+// If we are already in the softRenewal period, we randomly pick a time between
+// now and the start of the danger zone.
+//
+// We pass in now to make testing easier.
+func calculateSoftExpiry(now time.Time, cert *structs.IssuedCert) (min time.Time, max time.Time) {
+
+	certLifetime := cert.ValidBefore.Sub(cert.ValidAfter)
+	if certLifetime < 10*time.Minute {
+		// Shouldn't happen as we limit to 1 hour shortest elsewhere but just be
+		// defensive against strange times or bugs.
+		return now, now
+	}
+
+	// Find the 60% mark in diagram above
+	softRenewTime := cert.ValidAfter.Add(time.Duration(float64(certLifetime) * 0.6))
+	hardRenewTime := cert.ValidAfter.Add(time.Duration(float64(certLifetime) * 0.9))
+
+	if now.After(hardRenewTime) {
+		// In the hard renew period, or already expired. Renew now!
+		return now, now
+	}
+
+	if now.After(softRenewTime) {
+		// Already in the soft renew period, make now the lower bound for jitter
+		softRenewTime = now
+	}
+	return softRenewTime, hardRenewTime
 }
 
 func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
@@ -51,92 +233,164 @@ func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 			"Internal cache failure: request wrong type: %T", req)
 	}
 
-	// This channel watches our overall timeout. The other goroutines
-	// launched in this function should end all around the same time so
-	// they clean themselves up.
-	timeoutCh := time.After(opts.Timeout)
+	// Do we already have a cert in the cache?
+	var existing *structs.IssuedCert
+	var state *fetchState
+	if opts.LastResult != nil {
+		existing, ok = opts.LastResult.Value.(*structs.IssuedCert)
+		if !ok {
+			return result, fmt.Errorf(
+				"Internal cache failure: last value wrong type: %T", req)
+		}
+		state, ok = opts.LastResult.State.(*fetchState)
+		if !ok {
+			return result, fmt.Errorf(
+				"Internal cache failure: last state wrong type: %T", req)
+		}
+	} else {
+		state = &fetchState{}
+	}
 
-	// Kick off the goroutine that waits for new CA roots. The channel buffer
-	// is so that the goroutine doesn't block forever if we return for other
-	// reasons.
-	newRootCACh := make(chan error, 1)
-	go c.waitNewRootCA(reqReal.Datacenter, newRootCACh, opts.Timeout)
+	// Handle brand new request first as it's simplest. Note that either both or
+	// neither of these should be nil but we check both just to be defensive and
+	// confident we won't have a nil pointer for the remainder of this function.
+	if existing == nil || state == nil {
+		return c.generateNewLeaf(reqReal, state)
+	}
 
-	// Generate a cache key to lookup/store the cert. We MUST generate a new cert
-	// per token used to ensure revocation by ACL token is robust.
-	issuedKey := issuedKey(reqReal.Service, reqReal.Token)
+	// Make a chan we can be notified of changes to CA roots on. It must be
+	// buffered so we don't miss broadcasts from rootsWatch. It is an edge trigger
+	// so a single element is sufficient regardless of whether we consume the
+	// updates fast enough since as soon as we see an element in it, we will
+	// reload latest CA from cache.
+	rootUpdateCh := make(chan struct{}, 1)
 
-	// Get our prior cert (if we had one) and use that to determine our
-	// expiration time. If no cert exists, we expire immediately since we
-	// need to generate.
-	c.issuedCertsLock.RLock()
-	lastCert := c.issuedCerts[issuedKey]
-	c.issuedCertsLock.RUnlock()
+	// We are now inflight. Add our state to the map and defer removing it. This
+	// may trigger background root watcher too.
+	c.fetchStart(rootUpdateCh)
+	defer c.fetchDone(rootUpdateCh)
 
-	var leafExpiryCh <-chan time.Time
-	if lastCert != nil {
-		// Determine how long we wait until triggering. If we've already
-		// expired, we trigger immediately.
-		if expiryDur := lastCert.ValidBefore.Sub(time.Now()); expiryDur > 0 {
-			leafExpiryCh = time.After(expiryDur - 1*time.Hour)
-			// TODO(mitchellh): 1 hour buffer is hardcoded above
+	// We have a certificate in cache already. Check it's still valid.
+	now := time.Now()
+	minExpire, maxExpire := calculateSoftExpiry(now, existing)
+	expiresAt := minExpire.Add(lib.RandomStagger(maxExpire.Sub(minExpire)))
 
-			// We should not depend on the cache package de-duplicating requests for
-			// the same service/token (which is all we care about keying our local
-			// issued cert cache on) since it might later make sense to partition
-			// clients for other reasons too. So if the request has a 0 MinIndex, and
-			// the cached cert is still valid, then the client is expecting an
-			// immediate response and hasn't already seen the cached cert, return it
-			// now.
-			if opts.MinIndex == 0 {
-				result.Value = lastCert
-				result.Index = lastCert.ModifyIndex
-				return result, nil
+	// Check if we have be force-expired by the root watcher because there is a
+	// new CA root.
+	if !state.forceExpireAfter.IsZero() && state.forceExpireAfter.Before(expiresAt) {
+		expiresAt = state.forceExpireAfter
+	}
+	q.Q(expiresAt.String(), now.String())
+
+	if expiresAt == now || expiresAt.Before(now) {
+		// Already expired, just make a new one right away
+		return c.generateNewLeaf(reqReal, state)
+	}
+
+	// Setup result to mirror the current value for if we timeout. This allows us
+	// to update the state even if we don't generate a new cert.
+	result.Value = existing
+	result.Index = existing.ModifyIndex
+	result.State = state
+
+	// Current cert is valid so just wait until it expires or we time out.
+	for {
+		select {
+		case <-time.After(opts.Timeout):
+			// We timed out the request with same cert.
+			return result, nil
+			// Note that we don't use now in the case below because this might be hit
+			// on a loop several minutes into the blocking request so recalculating
+			// the delay based on when the request started would be wrong!
+		case <-time.After(expiresAt.Sub(time.Now())):
+			// Cert expired or was force-expired by a root change.
+			return c.generateNewLeaf(reqReal, state)
+		case <-rootUpdateCh:
+			// A roots cache change occurred, reload them from cache.
+			roots, err := c.rootsFromCache()
+			if err != nil {
+				return result, err
 			}
+
+			// Handle _possibly_ changed roots. We still need to verify the new active
+			// root is not the same as the one our current cert was signed by since we
+			// can be notified spuriously if we are the first request since the
+			// rootsWatcher didn't know about the CA we were signed by.
+			if activeRootHasKey(roots, state.authorityKeyID) {
+				// Current active CA is the same one that signed our current cert so
+				// keep waiting for a change.
+				continue
+			}
+			// CA root changed. We add some jitter here to avoid a thundering herd.
+			// The servers will be rate limited but we can still smooth this out over
+			// a small time to limit number of requests that get made at once that
+			// will likely hit the rate limit. We can't be too smart though since we
+			// don't know how many outstanding certs there are in the whole cluster so
+			// we just have to pick something better than no jitter at all and rely on
+			// rate limiting for the rest. For now spread the initial requests over 30
+			// seconds. Which means small clusters should still rotate in around 30
+			// seconds but large ones will not be so badly hammered initially.
+			jitter := caChangeInitialJitter
+			if c.testSetCAChangeInitialJitter > 0 {
+				jitter = c.testSetCAChangeInitialJitter
+			}
+			delay := lib.RandomStagger(jitter)
+			// Force the cert to be expired after the jitter - the delay above might
+			// be longer than we have left on out timeout so we might return to the
+			// caller before we expire. We set forceExpireAfter in the cache state so
+			// the next request will notice we still need to renew and do it at the
+			// right time.
+			state.forceExpireAfter = time.Now().Add(delay)
+			// If that time is within the current timeout though, we want to renew the
+			// cert right now. This ensures that when we loop back around, we'll wait
+			// at most delay until generating a new cert, or will timeout and do it
+			// next time based on the state.
+			if state.forceExpireAfter.Before(expiresAt) {
+				expiresAt = state.forceExpireAfter
+			}
+			continue
 		}
 	}
+}
 
-	if leafExpiryCh == nil {
-		// If the channel is still nil then it means we need to generate
-		// a cert no matter what: we either don't have an existing one or
-		// it is expired.
-		leafExpiryCh = time.After(0)
-	}
-
-	// Block on the events that wake us up.
-	select {
-	case <-timeoutCh:
-		// On a timeout, we just return the empty result and no error.
-		// It isn't an error to timeout, its just the limit of time the
-		// caching system wants us to block for. By returning an empty result
-		// the caching system will ignore.
-		return result, nil
-
-	case err := <-newRootCACh:
-		// A new root CA triggers us to refresh the leaf certificate.
-		// If there was an error while getting the root CA then we return.
-		// Otherwise, we leave the select statement and move to generation.
-		if err != nil {
-			return result, err
+func activeRootHasKey(roots *structs.IndexedCARoots, currentSigningKeyID string) bool {
+	for _, ca := range roots.Roots {
+		if ca.Active {
+			if ca.SigningKeyID == currentSigningKeyID {
+				return true
+			}
+			// Found the active CA but it has changed
+			return false
 		}
-
-	case <-leafExpiryCh:
-		// The existing leaf certificate is expiring soon, so we generate a
-		// new cert with a healthy overlapping validity period (determined
-		// by the above channel).
 	}
+	// Shouldn't be possible since at least one root should be active.
+	return false
+}
 
-	// Need to lookup RootCAs response to discover trust domain. First just lookup
-	// with no blocking info - this should be a cache hit most of the time.
+func (c *ConnectCALeaf) rootsFromCache() (*structs.IndexedCARoots, error) {
 	rawRoots, _, err := c.Cache.Get(ConnectCARootName, &structs.DCSpecificRequest{
-		Datacenter: reqReal.Datacenter,
+		Datacenter: c.Datacenter,
 	})
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	roots, ok := rawRoots.(*structs.IndexedCARoots)
 	if !ok {
-		return result, errors.New("invalid RootCA response type")
+		return nil, errors.New("invalid RootCA response type")
+	}
+	return roots, nil
+}
+
+// generateNewLeaf does the actual work of creating a new private key,
+// generating a CSR and getting it signed by the servers.
+func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest, state *fetchState) (cache.FetchResult, error) {
+	var result cache.FetchResult
+
+	// Need to lookup RootCAs response to discover trust domain. First just lookup
+	// with no blocking info - this should be a cache hit most of the time.
+	roots, err := c.rootsFromCache()
+	if err != nil {
+		return result, err
 	}
 	if roots.TrustDomain == "" {
 		return result, errors.New("cluster has no CA bootstrapped yet")
@@ -145,9 +399,9 @@ func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 	// Build the service ID
 	serviceID := &connect.SpiffeIDService{
 		Host:       roots.TrustDomain,
-		Datacenter: reqReal.Datacenter,
+		Datacenter: req.Datacenter,
 		Namespace:  "default",
-		Service:    reqReal.Service,
+		Service:    req.Service,
 	}
 
 	// Create a new private key
@@ -165,8 +419,8 @@ func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 	// Request signing
 	var reply structs.IssuedCert
 	args := structs.CASignRequest{
-		WriteRequest: structs.WriteRequest{Token: reqReal.Token},
-		Datacenter:   reqReal.Datacenter,
+		WriteRequest: structs.WriteRequest{Token: req.Token},
+		Datacenter:   req.Datacenter,
 		CSR:          csr,
 	}
 	if err := c.RPC.RPC("ConnectCA.Sign", &args, &reply); err != nil {
@@ -174,80 +428,20 @@ func (c *ConnectCALeaf) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 	}
 	reply.PrivateKeyPEM = pkPEM
 
-	// Lock the issued certs map so we can insert it. We only insert if
-	// we didn't happen to get a newer one. This should never happen since
-	// the Cache should ensure only one Fetch per service, but we sanity
-	// check just in case.
-	c.issuedCertsLock.Lock()
-	defer c.issuedCertsLock.Unlock()
-	lastCert = c.issuedCerts[issuedKey]
-	if lastCert == nil || lastCert.ModifyIndex < reply.ModifyIndex {
-		if c.issuedCerts == nil {
-			c.issuedCerts = make(map[string]*structs.IssuedCert)
-		}
+	// Reset the forcedExpiry in the state
+	state.forceExpireAfter = time.Time{}
 
-		c.issuedCerts[issuedKey] = &reply
-		lastCert = &reply
-	}
-
-	result.Value = lastCert
-	result.Index = lastCert.ModifyIndex
-	return result, nil
-}
-
-// waitNewRootCA blocks until a new root CA is available or the timeout is
-// reached (on timeout ErrTimeout is returned on the channel).
-func (c *ConnectCALeaf) waitNewRootCA(datacenter string, ch chan<- error,
-	timeout time.Duration) {
-	// We always want to block on at least an initial value. If this isn't
-	minIndex := atomic.LoadUint64(&c.caIndex)
-	if minIndex == 0 {
-		minIndex = 1
-	}
-
-	// Fetch some new roots. This will block until our MinQueryIndex is
-	// matched or the timeout is reached.
-	rawRoots, _, err := c.Cache.Get(ConnectCARootName, &structs.DCSpecificRequest{
-		Datacenter: datacenter,
-		QueryOptions: structs.QueryOptions{
-			MinQueryIndex: minIndex,
-			MaxQueryTime:  timeout,
-		},
-	})
+	cert, err := connect.ParseCert(reply.CertPEM)
 	if err != nil {
-		ch <- err
-		return
+		return result, err
 	}
+	// Set the CA key ID so we can easily tell when a active root has changed.
+	state.authorityKeyID = connect.HexString(cert.AuthorityKeyId)
 
-	roots, ok := rawRoots.(*structs.IndexedCARoots)
-	if !ok {
-		// This should never happen but we don't want to even risk a panic
-		ch <- fmt.Errorf(
-			"internal error: CA root cache returned bad type: %T", rawRoots)
-		return
-	}
-
-	// We do a loop here because there can be multiple waitNewRootCA calls
-	// happening simultaneously. Each Fetch kicks off one call. These are
-	// multiplexed through Cache.Get which should ensure we only ever
-	// actually make a single RPC call. However, there is a race to set
-	// the caIndex field so do a basic CAS loop here.
-	for {
-		// We only set our index if its newer than what is previously set.
-		old := atomic.LoadUint64(&c.caIndex)
-		if old == roots.Index || old > roots.Index {
-			break
-		}
-
-		// Set the new index atomically. If the caIndex value changed
-		// in the meantime, retry.
-		if atomic.CompareAndSwapUint64(&c.caIndex, old, roots.Index) {
-			break
-		}
-	}
-
-	// Trigger the channel since we updated.
-	ch <- nil
+	result.Value = &reply
+	result.State = state
+	result.Index = reply.ModifyIndex
+	return result, nil
 }
 
 func (c *ConnectCALeaf) SupportsBlocking() bool {

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -444,6 +444,13 @@ func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint) (<-
 			fOpts.MinIndex = entry.Index
 			fOpts.Timeout = tEntry.Opts.RefreshTimeout
 		}
+		if entry.Valid {
+			fOpts.LastResult = &FetchResult{
+				Value: entry.Value,
+				State: entry.State,
+				Index: entry.Index,
+			}
+		}
 
 		// Start building the new entry by blocking on the fetch.
 		result, err := tEntry.Type.Fetch(fOpts, r)
@@ -457,6 +464,7 @@ func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint) (<-
 		if result.Value != nil {
 			// A new value was given, so we create a brand new entry.
 			newEntry.Value = result.Value
+			newEntry.State = result.State
 			newEntry.Index = result.Index
 			newEntry.FetchedAt = time.Now()
 			if newEntry.Index < 1 {

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -318,9 +318,17 @@ func TestCacheGet_emptyFetchResult(t *testing.T) {
 	c := TestCache(t)
 	c.RegisterType("t", typ, nil)
 
+	stateCh := make(chan int, 1)
+
 	// Configure the type
-	typ.Static(FetchResult{Value: 42, Index: 1}, nil).Times(1)
-	typ.Static(FetchResult{Value: nil}, nil)
+	typ.Static(FetchResult{Value: 42, State: 31, Index: 1}, nil).Times(1)
+	// Return different State, it should be ignored
+	typ.Static(FetchResult{Value: nil, State: 32}, nil).Run(func(args mock.Arguments) {
+		// We should get back the original state
+		opts := args.Get(0).(FetchOptions)
+		require.NotNil(opts.LastResult)
+		stateCh <- opts.LastResult.State.(int)
+	})
 
 	// Get, should fetch
 	req := TestRequest(t, RequestInfo{Key: "hello"})
@@ -336,6 +344,29 @@ func TestCacheGet_emptyFetchResult(t *testing.T) {
 	require.NoError(err)
 	require.Equal(42, result)
 	require.False(meta.Hit)
+
+	// State delivered to second call should be the result from first call.
+	select {
+	case state := <-stateCh:
+		require.Equal(31, state)
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("timed out")
+	}
+
+	// Next request should get the first returned state too since last Fetch
+	// returned nil result.
+	req = TestRequest(t, RequestInfo{
+		Key: "hello", MinIndex: 1, Timeout: 100 * time.Millisecond})
+	result, meta, err = c.Get("t", req)
+	require.NoError(err)
+	require.Equal(42, result)
+	require.False(meta.Hit)
+	select {
+	case state := <-stateCh:
+		require.Equal(31, state)
+	case <-time.After(20 * time.Millisecond):
+		t.Fatal("timed out")
+	}
 
 	// Sleep a tiny bit just to let maybe some background calls happen
 	// then verify that we still only got the one call

--- a/agent/cache/entry.go
+++ b/agent/cache/entry.go
@@ -12,6 +12,13 @@ import (
 type cacheEntry struct {
 	// Fields pertaining to the actual value
 	Value interface{}
+	// State can be used to store info needed by the cache type but that should
+	// not be part of the result the client gets. For example the Connect Leaf
+	// type needs to store additional data about when it last attempted a renewal
+	// that is not part of the actual IssuedCert struct it returns. It's opaque to
+	// the Cache but allows types to store additional data that is coupled to the
+	// cache entry's lifetime and will be aged out by TTL etc.
+	State interface{}
 	Error error
 	Index uint64
 

--- a/agent/cache/type.go
+++ b/agent/cache/type.go
@@ -25,8 +25,8 @@ type Type interface {
 	// the last known value. This is the default behavior of blocking RPC calls in
 	// Consul so this allows cache types to be implemented with no extra logic.
 	// Second, FetchResult can return an unset value and index. In this case, the
-	// cache will reuse the last value automatically. If a nil Value is returned,
-	// the State field will also be ignored currently.
+	// cache will reuse the last value automatically. If an unset Value is
+	// returned, the State field will also be ignored currently.
 	Fetch(FetchOptions, Request) (FetchResult, error)
 
 	// SupportsBlocking should return true if the type supports blocking queries.

--- a/agent/cache/type.go
+++ b/agent/cache/type.go
@@ -8,20 +8,25 @@ import (
 type Type interface {
 	// Fetch fetches a single unique item.
 	//
-	// The FetchOptions contain the index and timeouts for blocking queries.
-	// The MinIndex value on the Request itself should NOT be used
-	// as the blocking index since a request may be reused multiple times
-	// as part of Refresh behavior.
+	// The FetchOptions contain the index and timeouts for blocking queries. The
+	// MinIndex value on the Request itself should NOT be used as the blocking
+	// index since a request may be reused multiple times as part of Refresh
+	// behavior.
 	//
-	// The return value is a FetchResult which contains information about
-	// the fetch. If an error is given, the FetchResult is ignored. The
-	// cache does not support backends that return partial values.
+	// The return value is a FetchResult which contains information about the
+	// fetch. If an error is given, the FetchResult is ignored. The cache does not
+	// support backends that return partial values. Optional State can be added to
+	// the FetchResult which will be stored with the cache entry and provided to
+	// the next Fetch call but will not be returned to clients. This allows types
+	// to add additional bookkeeping data per cache entry that will still be aged
+	// out along with the entry's TTL.
 	//
-	// On timeout, FetchResult can behave one of two ways. First, it can
-	// return the last known value. This is the default behavior of blocking
-	// RPC calls in Consul so this allows cache types to be implemented with
-	// no extra logic. Second, FetchResult can return an unset value and index.
-	// In this case, the cache will reuse the last value automatically.
+	// On timeout, FetchResult can behave one of two ways. First, it can return
+	// the last known value. This is the default behavior of blocking RPC calls in
+	// Consul so this allows cache types to be implemented with no extra logic.
+	// Second, FetchResult can return an unset value and index. In this case, the
+	// cache will reuse the last value automatically. If a nil Value is returned,
+	// the State field will also be ignored currently.
 	Fetch(FetchOptions, Request) (FetchResult, error)
 
 	// SupportsBlocking should return true if the type supports blocking queries.
@@ -41,6 +46,14 @@ type FetchOptions struct {
 	// Timeout is the maximum time for the query. This must be implemented
 	// in the Fetch itself.
 	Timeout time.Duration
+
+	// LastResult is the result from the last successful Fetch and represents the
+	// value currently stored in the cache at the time Fetch is invoked. It will
+	// be nil on first call where there is no current cache value. There may have
+	// been other Fetch attempts that resulted in an error in the mean time. These
+	// are not explicitly represented currently. We could add that if needed this
+	// was just simpler for now.
+	LastResult *FetchResult
 }
 
 // FetchResult is the result of a Type Fetch operation and contains the
@@ -48,6 +61,12 @@ type FetchOptions struct {
 type FetchResult struct {
 	// Value is the result of the fetch.
 	Value interface{}
+
+	// State is opaque data stored in the cache but not returned to clients. It
+	// can be used by Types to maintain any bookkeeping they need between fetches
+	// (using FetchOptions.LastResult) in a way that gets automatically cleaned up
+	// by TTL expiry etc.
+	State interface{}
 
 	// Index is the corresponding index value for this data.
 	Index uint64

--- a/agent/cache/type.go
+++ b/agent/cache/type.go
@@ -53,6 +53,15 @@ type FetchOptions struct {
 	// been other Fetch attempts that resulted in an error in the mean time. These
 	// are not explicitly represented currently. We could add that if needed this
 	// was just simpler for now.
+	//
+	// The FetchResult read-only! It is constructed per Fetch call so modifying
+	// the struct directly (e.g. changing it's Index of Value field) will have no
+	// effect, however the Value and State fields may be pointers to the actual
+	// values stored in the cache entry. It is thread-unsafe to modify the Value
+	// or State via pointers since readers may be concurrently inspecting those
+	// values under the entry lock (although we guarantee only one Fetch call per
+	// entry) and modifying them even if the index doesn't change or the Fetch
+	// eventually errors will likely break logical invariants in the cache too!
 	LastResult *FetchResult
 }
 

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -531,7 +531,7 @@ type RuntimeConfig struct {
 	// ConnectReplicationToken is the ACL token used for replicating intentions.
 	ConnectReplicationToken string
 
-	// ConnectTestDisableManagedProxies is not exposed to public config but us
+	// ConnectTestDisableManagedProxies is not exposed to public config but is
 	// used by TestAgent to prevent self-executing the test binary in the
 	// background if a managed proxy is created for a test. The only place we
 	// actually want to test processes really being spun up and managed is in
@@ -540,6 +540,13 @@ type RuntimeConfig struct {
 	// all the agent state for them, just doesn't actually start external
 	// processes up.
 	ConnectTestDisableManagedProxies bool
+
+	// ConnectTestCALeafRootChangeSpread is used to control how long the CA leaf
+	// cache with spread CSRs over when a root change occurs. For now we don't
+	// expose this in public config intentionally but could later with a rename.
+	// We only set this from during tests to effectively make CA rotation tests
+	// deterministic again.
+	ConnectTestCALeafRootChangeSpread time.Duration
 
 	// DNSAddrs contains the list of TCP and UDP addresses the DNS server will
 	// bind to. If the DNS endpoint is disabled (ports.dns <= 0) the list is

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4925,6 +4925,7 @@ func TestSanitize(t *testing.T) {
 		"ConnectProxyDefaultScriptCommand": [],
 		"ConnectSidecarMaxPort": 0,
 		"ConnectSidecarMinPort": 0,
+		"ConnectTestCALeafRootChangeSpread": "0s",
 		"ConnectReplicationToken": "hidden",
 		"ConnectTestDisableManagedProxies": false,
 		"ConsulCoordinateUpdateBatchSize": 0,

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -41,6 +41,7 @@ func TestCA(t testing.T, xc *structs.CARoot) *structs.CARoot {
 	// Create the private key we'll use for this CA cert.
 	signer, keyPEM := testPrivateKey(t)
 	result.SigningKey = keyPEM
+	result.SigningKeyID = HexString(testKeyID(t, signer.Public()))
 
 	// The serial number for the cert
 	sn, err := testSerialNumber()
@@ -83,6 +84,9 @@ func TestCA(t testing.T, xc *structs.CARoot) *structs.CARoot {
 	if err != nil {
 		t.Fatalf("error generating CA ID fingerprint: %s", err)
 	}
+	result.SerialNumber = uint64(sn.Int64())
+	result.NotBefore = template.NotBefore.UTC()
+	result.NotAfter = template.NotAfter.UTC()
 
 	// If there is a prior CA to cross-sign with, then we need to create that
 	// and set it as the signing cert.
@@ -269,12 +273,12 @@ func testPrivateKey(t testing.T) (crypto.Signer, string) {
 	return pk, buf.String()
 }
 
-// testSerialNumber generates a serial number suitable for a certificate.
-// For testing, this just sets it to a random number.
-//
-// This function is taken directly from the Vault implementation.
+// testSerialNumber generates a serial number suitable for a certificate. For
+// testing, this just sets it to a random number, but one that can fix in a
+// uint64 since we use that in our datastructures and assume cert serials will
+// fit in that for now.
 func testSerialNumber() (*big.Int, error) {
-	return rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil))
+	return rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(63), nil))
 }
 
 // testUUID generates a UUID for testing.

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -274,7 +274,7 @@ func testPrivateKey(t testing.T) (crypto.Signer, string) {
 }
 
 // testSerialNumber generates a serial number suitable for a certificate. For
-// testing, this just sets it to a random number, but one that can fix in a
+// testing, this just sets it to a random number, but one that can fit in a
 // uint64 since we use that in our datastructures and assume cert serials will
 // fit in that for now.
 func testSerialNumber() (*big.Int, error) {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -59,8 +59,9 @@ type CARoot struct {
 	// SerialNumber is the x509 serial number of the certificate.
 	SerialNumber uint64
 
-	// SigningKeyID is the ID of the public key that corresponds to the
-	// private key used to sign the certificate.
+	// SigningKeyID is the ID of the public key that corresponds to the private
+	// key used to sign the certificate. Is is the HexString format of the raw
+	// AuthorityKeyID bytes.
 	SigningKeyID string
 
 	// ExternalTrustDomain is the trust domain this root was generated under. It

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -379,6 +379,10 @@ func TestConfig(sources ...config.Source) *config.RuntimeConfig {
 	// Disable connect proxy execution since it causes all kinds of problems with
 	// self-executing tests etc.
 	cfg.ConnectTestDisableManagedProxies = true
+	// Effectively disables the delay after root rotation before requesting CSRs
+	// to make test deterministic. 0 results in default jitter being applied but a
+	// tiny delay is effectively thre same.
+	cfg.ConnectTestCALeafRootChangeSpread = 1 * time.Nanosecond
 
 	return &cfg
 }


### PR DESCRIPTION
This PR contains a re-written CA leaf cache implementation that fixes several issues with the previous one. It also contains a small change to the `agent/cache` package that allows the new implementation to be cleaner. It's one PR to minimise sprawl of dependent PRs/branches and because the diffs are not too huge.

This is the first PR in a series related to agent caching in general. Others planned will fix several other known bugs and implement more complete rate limiting for CSR requests.

# Cache State

One problem with the current leaf cache is that it needs to know the current cert so it can manage expiry correctly. This was implemented by it holding it's own cache of the actual certs from which it returned pointers that are stored in the `agent/cache`.

This has the following issues:
 - The internal cert cache had to become subtly aware of the outer cache behaviour, for example we didn't initially shard by token which would have leaked certs once revocation-by-token is available. This was fixed in https://github.com/hashicorp/consul/commit/a28e4a33b2d9685642bc90035c7690efbe46af95 but is an example of why the pattern was problematic.
 - Arguably worse, the internal cache had not link to the outer cache's TTL mechanism. This means that certificates would _never_ be freed from memory. Typically certs for same service would replace existing but that assumes the same token for the lifetime. In the following realistic cases we wold "leak" the cert (and key) in memory until agent restart:
   - service stops on an agent - cert is left in memory. For high churn or dynamically named services this could grow significantly
   - service remains consistently named but rotates its token every day. After 100 days there are now 100 cache entries that will never be freed.

The above issues are solved by simply passing the current cache value if any into each `Fetch` call. In addition to this though, cache types may need to store additional state that is not part of the cache result but can be used to maintain correct behaviour between calls. This is necessary for the other feature added below. To support this, an opaque `State` is added to each cache entry.

Now the cache type can delegate all storage to the cache implementation either in the `Result` if it's just the last result that's needed, or using the new `State` field for anything else. Both of these are cleaned up by the cache TTL and any future improvements we make to bound agent cache size.

This change is made in isolation to the cache package in https://github.com/hashicorp/consul/commit/718cb2c46175f6091c7f078c96dba0322256bc53

# Updated Leaf Implementation

This solves several issues with the current CA leaf cache:
 - Cache leaking noted above
 - #4479 
 - The current implementation will re-generate all certificates on every CA config change even if the signing key didn't change. For example if a new CA is added and made active, every cert will be updated (fine), but then when the old CA is finally removed (no change in active CA) all certs would be updated a second time.

It also has a few other improvements:
 - Some jitter is applied after observing a root change to smear the initial influx of CSRs to the servers over 20 seconds (even if the current blocking query times out before then). This is not sufficient alone to solve thundering herds in large clusters but will provide a baseline of protection for servers which can then use rate limiting (mostly built but will be in an upcoming PR) to prevent from being overwhelmed. We _might_ make this configurable eventually but I want to not for now because the UX of asking operators to figure out the "right" amount of smearing based on their server size, number of service instances etc. is kinda gross. This is just a baseline and rate limiting which is simpler to reason about will control for larger deployments.
 - The shared root watcher is a little more efficient while not being significantly more complex to reason about (and solves a few subtle bugs in the old one). Mostly thanks to re-using the `Notify` mechanism that was added since the original implementation.
 - The logic for when to renew certs before their expiry is much more sophisticated. It used to be hard coded to an hour before expiry but this was not ideal for a few reasons:
   - we allow total cert lifetime to be as low as 1 hour but if you use that in practice you get a new cert every 10 mins since they are always considered "too close to expiring".
   - we don't want lots of services started together after an outage, or in sync because of a server outage to remain in sync hammering the servers all at the same time every few days, so a broad jitter is preferable.

# Misc Extras

A lot of the tests needed to be changed to generate more accurate mock data like certs that actually have the right info in PEM since we now depend on that.

There are a couple of technically unnecessary tweaks in here that I made as I went like populating a bunch more of the `TestCA` fields correctly and making sure the test serial numbers are actually representable in our `CARoot` struct which only has a `uint64` for the serial number field.

Fixes #4479 