### PR TITLE
agent: Don't leave old errors around in cache

### DIFF
--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -81,6 +81,67 @@ func TestCacheGet_initError(t *testing.T) {
 	typ.AssertExpectations(t)
 }
 
+// Test a cached error is replaced by a successful result. See
+// https://github.com/hashicorp/consul/issues/4480
+func TestCacheGet_cachedErrorsDontStick(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	typ := TestType(t)
+	defer typ.AssertExpectations(t)
+	c := TestCache(t)
+	c.RegisterType("t", typ, nil)
+
+	// Configure the type
+	fetcherr := fmt.Errorf("initial error")
+	// First fetch errors, subsequent fetches are successful and then block
+	typ.Static(FetchResult{}, fetcherr).Times(1)
+	typ.Static(FetchResult{Value: 42, Index: 123}, nil).Times(1)
+	// We trigger this to return same value to simulate a timeout.
+	triggerCh := make(chan time.Time)
+	typ.Static(FetchResult{Value: 42, Index: 123}, nil).WaitUntil(triggerCh)
+
+	// Get, should fetch and get error
+	req := TestRequest(t, RequestInfo{Key: "hello"})
+	result, meta, err := c.Get("t", req)
+	require.Error(err)
+	require.Nil(result)
+	require.False(meta.Hit)
+
+	// Get, should fetch again since our last fetch was an error, but get success
+	result, meta, err = c.Get("t", req)
+	require.NoError(err)
+	require.Equal(42, result)
+	require.False(meta.Hit)
+
+	// Now get should block until timeout and then get the same response NOT the
+	// cached error.
+	getCh1 := TestCacheGetCh(t, c, "t", TestRequest(t, RequestInfo{
+		Key:      "hello",
+		MinIndex: 123,
+		// We _don't_ set a timeout here since that doesn't trigger the bug - the
+		// bug occurs when the Fetch call times out and returns the same value when
+		// an error is set. If it returns a new value the blocking loop works too.
+	}))
+	time.AfterFunc(50*time.Millisecond, func() {
+		// "Timeout" the Fetch after a short time.
+		close(triggerCh)
+	})
+	select {
+	case result := <-getCh1:
+		t.Fatalf("result or error returned before an update happened. "+
+			"If this is nil look above for the error log: %v", result)
+	case <-time.After(100 * time.Millisecond):
+		// It _should_ keep blocking for a new value here
+	}
+
+	// Sleep a tiny bit just to let maybe some background calls happen
+	// then verify the calls.
+	time.Sleep(20 * time.Millisecond)
+	typ.AssertExpectations(t)
+}
+
 // Test a Get with a request that returns a blank cache key. This should
 // force a backend request and skip the cache entirely.
 func TestCacheGet_blankCacheKey(t *testing.T) {


### PR DESCRIPTION
Fixes #4480. 

A full description of the specific case can be found in the issue and is described in the code here.

The basic invariant that was not being correctly enforced is:

  - A cache entry _may_ have both be `Valid = true` _and_ have a non-nil `Error`.
    - This can occur when a previous Fetch succeed, but a more recent blocking fetch errored. We store the _later_ error in the entry so that all currently blocked `Get` calls can return it immediately instead of waiting their whole timeout before failing
  - Thus, an entry where both `Valid = true` and `Error != nil` implies the error is newer and gets returned to blocking clients.

Until this PR, we were failing to enforce that because we never reset the `Error` on a successful fetch so the _older_ error value could suddenly resurface after a successful Fetch value was returned but only for clients that had caught up and were blocking!

The subtleties here are staggering - even with the description in the issue, it took several attempts to write a test that triggered this reliably - it haas to be the Fetch that times out and it has to return the same index. If the Get times out instead then correct behaviour was observed.

The fix is trivial but the reasoning behind it is not! This is now correct.