### PR TITLE
Fix service syncing churn in 1.2.3/1.2.4

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1724,6 +1724,11 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 		}
 	}
 
+	// Set default weights if not specified
+	if service.Weights == nil {
+		service.Weights = &structs.Weights{Passing: 1, Warning: 1}
+	}
+
 	// Warn if the service name is incompatible with DNS
 	if InvalidDnsRe.MatchString(service.Service) {
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+


### PR DESCRIPTION
Since upgrading from 1.2.2 to 1.2.4 a few days ago I'm getting `Synced service` messages every ~2 minutes (and a higher load on the cluster).

Found the culprit to be #4468 introduced in 1.2.3 which does not set a default weights value when registering the service, causing the service comparison to fail and keeps syncing the service.

PR against backport/1.2.x 


