### PR TITLE
Adding quorum note on leave command page

### DIFF
--- a/website/source/docs/commands/leave.html.markdown.erb
+++ b/website/source/docs/commands/leave.html.markdown.erb
@@ -19,6 +19,9 @@ For nodes in server mode, the node is removed from the Raft peer set
 in a graceful manner. This is critical, as in certain situations a
 non-graceful leave can affect cluster availability.
 
+Running `consul leave` on a server explicitly will reduce the quorum size. Even if the cluster used `bootstrap_expect` to set a quorum size initially, issuing `consul leave` on a server will reconfigure the cluster to have fewer servers. 
+This means you could end up with just one server that is still able to commit writes because quorum is only 1, but those writes might be lost if that server fails before more are added.
+
 ## Usage
 
 Usage: `consul leave [options]`


### PR DESCRIPTION
Reusing the same phrasing as  https://github.com/hashicorp/consul/pull/5095/ to provide info on the effects of the `consul leave` command on Consul quorum