### PR TITLE
Revert "Fix service syncing churn in 1.2.3/1.2.4"

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1724,11 +1724,6 @@ func (a *Agent) AddService(service *structs.NodeService, chkTypes []*structs.Che
 		}
 	}
 
-	// Set default weights if not specified
-	if service.Weights == nil {
-		service.Weights = &structs.Weights{Passing: 1, Warning: 1}
-	}
-
 	// Warn if the service name is incompatible with DNS
 	if InvalidDnsRe.MatchString(service.Service) {
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+


### PR DESCRIPTION
Reverts hashicorp/consul#5096

This was PRed against a backport branch which I missed before merging. We don't have plans to backport small bug fixes for now and even if we did choose to we'd want all new changes to master.