### PR TITLE
Fix Type in go integration

### DIFF
--- a/website/source/docs/connect/native/go.html.md
+++ b/website/source/docs/connect/native/go.html.md
@@ -104,7 +104,7 @@ func main() {
   defer svc.Close()
 
   // Creating an HTTP server that serves via Connect
-  listener, _ := tls.Listen("tcp", ":8080", svc.ServeTLSConfig())
+  listener, _ := tls.Listen("tcp", ":8080", svc.ServerTLSConfig())
   defer listener.Close()
 
   // Accept


### PR DESCRIPTION
Fix Typo in second example
From svc.ServeTLSConfig() to svc.ServerTLSConfig()