### PR TITLE
Fixed gziping function for debug archive

### DIFF
--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -610,7 +610,7 @@ func (c *cmd) createArchiveTemp(path string) (tempName string, err error) {
 	}
 
 	g := gzip.NewWriter(f)
-	t := tar.NewWriter(f)
+	t := tar.NewWriter(g)
 
 	tempName = f.Name()
 

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -2,6 +2,7 @@ package debug
 
 import (
 	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -94,7 +95,11 @@ func TestDebugCommand_Archive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to open archive: %s", err)
 	}
-	tr := tar.NewReader(file)
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		t.Fatalf("failed to read gzip archive: %s", err)
+	}
+	tr := tar.NewReader(gz)
 
 	for {
 		h, err := tr.Next()


### PR DESCRIPTION
Fixed gzip step in `createArchiveTemp` function in debug package.
Modified `TestDebugCommand_Archive` unit test to check gzip headers in archive file.

Related issue: https://github.com/hashicorp/consul/issues/5141