### PR TITLE
cache: Pass through wait query param to the cache.Get

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1335,6 +1335,7 @@ func (s *HTTPServer) AgentConnectCALeafCert(resp http.ResponseWriter, req *http.
 		return nil, nil
 	}
 	args.MinQueryIndex = qOpts.MinQueryIndex
+	args.MaxQueryTime = qOpts.MaxQueryTime
 
 	// Verify the proxy token. This will check both the local proxy token
 	// as well as the ACL if the token isn't local. The checks done in

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -263,6 +263,7 @@ type ConnectCALeafRequest struct {
 	Datacenter    string
 	Service       string // Service name, not ID
 	MinQueryIndex uint64
+	MaxQueryTime  time.Duration
 }
 
 func (r *ConnectCALeafRequest) CacheInfo() cache.RequestInfo {
@@ -271,5 +272,6 @@ func (r *ConnectCALeafRequest) CacheInfo() cache.RequestInfo {
 		Key:        r.Service,
 		Datacenter: r.Datacenter,
 		MinIndex:   r.MinQueryIndex,
+		Timeout:    r.MaxQueryTime,
 	}
 }


### PR DESCRIPTION
This adds a MaxQueryTime field to the connect ca leaf cache request type and populates it via the wait query param. The cache will then do the right thing and timeout the operation as expected if no new leaf cert is available within that time.

Fixes #4462 

The reproduction scenario in the original issue now times out appropriately.