### PR TITLE
acl: Prevent tokens from deleting themselves

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -482,9 +482,15 @@ func (a *ACL) TokenDelete(args *structs.ACLTokenDeleteRequest, reply *string) er
 		return err
 	}
 
-	if !a.srv.InACLDatacenter() && !token.Local {
-		args.Datacenter = a.srv.config.ACLDatacenter
-		return a.srv.forwardDC("ACL.TokenDelete", a.srv.config.ACLDatacenter, args, reply)
+	if token != nil {
+		if args.Token == token.SecretID {
+			return fmt.Errorf("Deletion of the request's authorization token is not permitted")
+		}
+
+		if !a.srv.InACLDatacenter() && !token.Local {
+			args.Datacenter = a.srv.config.ACLDatacenter
+			return a.srv.forwardDC("ACL.TokenDelete", a.srv.config.ACLDatacenter, args, reply)
+		}
 	}
 
 	req := &structs.ACLTokenBatchDeleteRequest{

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -873,10 +873,31 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.Datacenter = "dc2"
+		// token replication is required to test deleting non-local tokens in secondary dc
+		c.ACLTokenReplication = true
+	})
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+	codec2 := rpcClient(t, s2)
+	defer codec2.Close()
+
+	s2.tokens.UpdateACLReplicationToken("root")
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+
+	// Try to join
+	joinWAN(t, s2, s1)
+
 	existingToken, err := upsertTestToken(codec, "root", "dc1")
 	assert.NoError(err)
 
 	acl := ACL{srv: s1}
+	acl2 := ACL{srv: s2}
 
 	// deletes a token
 	{
@@ -941,6 +962,30 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 
 		// token should be nil
 		tokenResp, err := retrieveTestToken(codec, "root", "dc1", existingToken.AccessorID)
+		assert.Nil(tokenResp.Token)
+		assert.NoError(err)
+	}
+
+	// don't segfault when attempting to delete non existant token in secondary dc
+	{
+		fakeID, err := uuid.GenerateUUID()
+		assert.NoError(err)
+
+		req := structs.ACLTokenDeleteRequest{
+			Datacenter:   "dc2",
+			TokenID:      fakeID,
+			WriteRequest: structs.WriteRequest{Token: "root"},
+		}
+
+		var resp string
+
+		waitForNewACls(t, s2)
+
+		err = acl2.TokenDelete(&req, &resp)
+		assert.NoError(err)
+
+		// token should be nil
+		tokenResp, err := retrieveTestToken(codec2, "root", "dc1", existingToken.AccessorID)
 		assert.Nil(tokenResp.Token)
 		assert.NoError(err)
 	}

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -979,7 +979,7 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 
 		var resp string
 
-		waitForNewACls(t, s2)
+		waitForNewACLs(t, s2)
 
 		err = acl2.TokenDelete(&req, &resp)
 		assert.NoError(err)

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -153,7 +153,7 @@ func joinWAN(t *testing.T, member, leader *Server) {
 	}
 }
 
-func waitForNewACls(t *testing.T, server *Server) {
+func waitForNewACLs(t *testing.T, server *Server) {
 	retry.Run(t, func(r *retry.R) {
 		require.False(r, server.UseLegacyACLs(), "Server cannot use new ACLs")
 	})

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/testutil/retry"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
+	"github.com/stretchr/testify/require"
 )
 
 func waitForLeader(servers ...*Server) error {
@@ -150,6 +151,14 @@ func joinWAN(t *testing.T, member, leader *Server) {
 	if !seeEachOther(leader.WANMembers(), member.WANMembers(), leaderAddr, memberAddr) {
 		t.Fatalf("leader and member cannot see each other on WAN")
 	}
+}
+
+func waitForNewACls(t *testing.T, server *Server) {
+	retry.Run(t, func(r *retry.R) {
+		require.False(r, server.UseLegacyACLs(), "Server cannot use new ACLs")
+	})
+
+	require.False(t, server.UseLegacyACLs(), "Server cannot use new ACLs")
 }
 
 func seeEachOther(a, b []serf.Member, addra, addrb string) bool {


### PR DESCRIPTION
Fixes #4897 

Also apparently token deletion could segfault in secondary DCs when attempting to delete non-existant tokens. For that reason both checks are wrapped within the non-nil check.