### PR TITLE
Store leaf cert indexes in raft and use for the ModifyIndex on the returned certs

### DIFF
--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -410,7 +410,7 @@ func (s *ConnectCA) Sign(
 		WriteRequest: structs.WriteRequest{Token: args.Token},
 	}
 
-	resp, err := s.srv.raftApply(structs.ConnectCALeafRequestType, &req)
+	resp, err := s.srv.raftApply(structs.ConnectCALeafRequestType|structs.IgnoreUnknownTypeFlag, &req)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -396,16 +396,28 @@ func (s *ConnectCA) Sign(
 	}
 
 	// TODO(banks): when we implement IssuedCerts table we can use the insert to
-	// that as the raft index to return in response. Right now we can rely on only
-	// the built-in provider being supported and the implementation detail that we
-	// have to write a SerialIndex update to the provider config table for every
-	// cert issued so in all cases this index will be higher than any previous
-	// sign response. This has to be reloaded after the provider.Sign call to
-	// observe the index update.
-	state = s.srv.fsm.State()
-	modIdx, _, err := state.CAConfig()
+	// that as the raft index to return in response.
+	//
+	// UPDATE(mkeeler): The original implementation relied on updating the CAConfig
+	// and using its index as the ModifyIndex for certs. This was buggy. The long
+	// term goal is still to insert some metadata into raft about the certificates
+	// and use that raft index for the ModifyIndex. This is a partial step in that
+	// direction except that we only are setting an index and not storing the
+	// metadata.
+	req := structs.CALeafRequest{
+		Op:           structs.CALeafOpIncrementIndex,
+		Datacenter:   s.srv.config.Datacenter,
+		WriteRequest: structs.WriteRequest{Token: args.Token},
+	}
+
+	resp, err := s.srv.raftApply(structs.ConnectCALeafRequestType, &req)
 	if err != nil {
 		return err
+	}
+
+	modIdx, ok := resp.(uint64)
+	if !ok {
+		return fmt.Errorf("Invalid response from updating the leaf cert index")
 	}
 
 	cert, err := connect.ParseCert(pem)

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -316,6 +316,18 @@ func TestConnectCASign(t *testing.T) {
 	var reply structs.IssuedCert
 	require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.Sign", args, &reply))
 
+	// Generate a second CSR and request signing
+	spiffeId2 := connect.TestSpiffeIDService(t, "web2")
+	csr, _ = connect.TestCSR(t, spiffeId2)
+	args = &structs.CASignRequest{
+		Datacenter: "dc1",
+		CSR:        csr,
+	}
+
+	var reply2 structs.IssuedCert
+	require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.Sign", args, &reply2))
+	require.True(reply2.ModifyIndex > reply.ModifyIndex)
+
 	// Get the current CA
 	state := s1.fsm.State()
 	_, ca, err := state.CARootActive(nil)

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -11,6 +11,7 @@ const (
 	caBuiltinProviderTableName = "connect-ca-builtin"
 	caConfigTableName          = "connect-ca-config"
 	caRootTableName            = "connect-ca-roots"
+	caLeafIndexName            = "connect-ca-leaf-certs"
 )
 
 // caBuiltinProviderTableSchema returns a new table schema used for storing
@@ -442,4 +443,11 @@ func (s *Store) CADeleteProviderState(id string) error {
 	tx.Commit()
 
 	return nil
+}
+
+func (s *Store) CALeafSetIndex(index uint64) error {
+	tx := s.db.Txn(true)
+	defer tx.Abort()
+
+	return indexUpdateMaxTxn(tx, index, caLeafIndexName)
 }

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -295,6 +295,33 @@ type VaultCAProviderConfig struct {
 	TLSSkipVerify bool
 }
 
+// CALeafOp is the operation for a request related to leaf certificates.
+type CALeafOp string
+
+const (
+	CALeafOpIncrementIndex CALeafOp = "increment-index"
+)
+
+// CALeafRequest is used to modify connect CA leaf data. This is used by the
+// FSM (agent/consul/fsm) to apply changes.
+type CALeafRequest struct {
+	// Op is the type of operation being requested. This determines what
+	// other fields are required.
+	Op CALeafOp
+
+	// Datacenter is the target for this request.
+	Datacenter string
+
+	// WriteRequest is a common struct containing ACL tokens and other
+	// write-related common elements for requests.
+	WriteRequest
+}
+
+// RequestDatacenter returns the datacenter for a given request.
+func (q *CALeafRequest) RequestDatacenter() string {
+	return q.Datacenter
+}
+
 // ParseDurationFunc is a mapstructure hook for decoding a string or
 // []uint8 into a time.Duration value.
 func ParseDurationFunc() mapstructure.DecodeHookFunc {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -53,6 +53,7 @@ const (
 	ACLTokenDeleteRequestType              = 18
 	ACLPolicySetRequestType                = 19
 	ACLPolicyDeleteRequestType             = 20
+	ConnectCALeafRequestType               = 21
 )
 
 const (


### PR DESCRIPTION
This ensures that future certificate signings will have a strictly greater ModifyIndex than any previous certs signed.

Fixes #4463 

In the future we should be able to add fields to the `CALeafRequest` and add other `CALeafOp` types for storing certificate metadata. The raft request type shouldn't need to change and unknown fields should be ignored during decoding (which could happen while upgrading Consul servers from this next version to the one where we fully implement cert metadata storage).