### PR TITLE
Add a security warning about the default Helm chart installation

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -22,6 +22,14 @@ properly installed and configured with your Kubernetes cluster.
 may still change significantly over time. Please always run Helm with
 `--dry-run` before any install or upgrade to verify changes.
 
+~> **Warning:** By default, the chart will install an insecure configuration
+of Consul. This provides a less complicated out-of-box experience for new users,
+but is not appropriate for a production setup. It is highly recommended to use
+a properly secured Kubernetes cluster or make sure that you understand and enable
+the [recommended security features](/docs/internals/security.html.md). Currently,
+some of these features are not supported in the Helm chart and require additional
+manual configuration.
+
 ## Using the Helm Chart
 
 To use the Helm chart, you must download or clone the

--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -35,6 +35,14 @@ cluster with sane defaults out of the box. Prior to going to production,
 it is highly recommended that you
 [learn about the configuration options](/docs/platform/k8s/helm.html#configuration-values-).
 
+~> **Warning:** By default, the chart will install an insecure configuration
+of Consul. This provides a less complicated out-of-box experience for new users,
+but is not appropriate for a production setup. It is highly recommended to use
+a properly secured Kubernetes cluster or make sure that you understand and enable
+the [recommended security features](/docs/internals/security.html.md). Currently,
+some of these features are not supported in the Helm chart and require additional
+manual configuration.
+
 ## How-To
 
 ### Installing Consul


### PR DESCRIPTION
If a user installs the default Helm chart Consul on a Kubernetes
cluster that is open to the internet, it is lacking some important
security configurations.