### PR TITLE
Initial support for blocking prepared queries

### DIFF
--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -205,8 +205,9 @@ func TestPreparedQuery_List(t *testing.T) {
 				expected := &structs.DCSpecificRequest{
 					Datacenter: "dc1",
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: map[string]uint64{},
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
@@ -298,8 +299,9 @@ func TestPreparedQuery_Execute(t *testing.T) {
 						Node:       a.Config.NodeName,
 					},
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: map[string]uint64{},
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
@@ -354,8 +356,9 @@ func TestPreparedQuery_Execute(t *testing.T) {
 						Node:       a.Config.NodeName,
 					},
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: map[string]uint64{},
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
@@ -411,8 +414,9 @@ func TestPreparedQuery_Execute(t *testing.T) {
 						Node:       a.Config.NodeName,
 					},
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: map[string]uint64{},
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
@@ -691,8 +695,9 @@ func TestPreparedQuery_Explain(t *testing.T) {
 						Node:       a.Config.NodeName,
 					},
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: map[string]uint64{},
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
@@ -777,12 +782,13 @@ func TestPreparedQuery_Get(t *testing.T) {
 					Datacenter: "dc1",
 					QueryID:    "my-id",
 					QueryOptions: structs.QueryOptions{
-						Token:             "my-token",
-						RequireConsistent: true,
+						Token:                "my-token",
+						RequireConsistent:    true,
+						MinQueryCrossDCIndex: make(map[string]uint64),
 					},
 				}
 				if !reflect.DeepEqual(args, expected) {
-					t.Fatalf("bad: %v", args)
+					t.Fatalf("bad: %+v", args)
 				}
 
 				query := &structs.PreparedQuery{

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -116,6 +116,8 @@ type QueryOptions struct {
 	// with MaxQueryTime.
 	MinQueryIndex uint64
 
+	MinQueryCrossDCIndex map[string]uint64
+
 	// Provided with MinQueryIndex to wait for change.
 	MaxQueryTime time.Duration
 
@@ -213,6 +215,10 @@ func (w WriteRequest) TokenSecret() string {
 type QueryMeta struct {
 	// This is the index associated with the read
 	Index uint64
+
+	// In case of cross dc reads, contains each dc index associated
+	// with the read
+	CrossDCIndex map[string]uint64
 
 	// If AllowStale is used, this is time elapsed since
 	// last contact between the follower and leader. This


### PR DESCRIPTION
This changeset adds initial support for multi datacenter blocking prepared queries.
It allows to watch for changes across multiple DCs and fallback between them according to the prepared query settings.

## Goals

* A prepared query execution in non-blocking mode (without consul index) should behave the same as on master
* Extends the prepared query behavior :
  * Always prefer nodes from the closest DC
  * Do not query a DC unless the previous (in distance order) failed or has no results
* Keep blocking query blocking query behavior :
  * `&wait=` is respected
  * A request with no index never blocks
  * A request with index tries its best to block until a change happens since that index

## Consul Index

When performing a normal blocking query the server sends back its index in the form `X-Consul-Index: 42`.
This index is used in the next request using `&index=42` so the server knows it needs to block until a change happens.

We extend this mechanic to support multiple datacenters by adding a new parameter and header :
* `X-Consul-CrossDC-Index: dc1:42,dc2:45`
* `&cdcindex=dc1:42,dc2:45`

The cross dc index contains each DC index up to the one (distance-wise) that provided results for the request.

## Behavior

Lets say we have 3 DCs: `dc1`, `dc2` and `dc3`. `dc1` is the local datacenter, `dc3` is the farthest datacenter.
A prepared query request without index works like on master: each DC is queried in order until results satifying the parameters are found.
For this example `dc1` does not have results but `dc2` does. Nodes from `dc2` are return along with `X-Consul-CrossDC-Index: dc1:50,dc2:52`.
The client receives the result and sends a new request with the consul cross dc index it just received.
Upon receiving the request the server run background blocking queries to each dcs in `&cdcindex`.

* If a change happens in `dc1` and it now has nodes we return these nodes along `X-Consul-CrossDC-Index: dc1:54`. Note that `dc2` is not returned in the cross dc index since it did not participate in the results.
* If `dc2` fails, or has no nodes anymore we then query `dc3`.
  * If `dc3` has nodes we return them with index `X-Consul-CrossDC-Index: dc1:54,dc2:52,dc3:53`.
  * If `dc3` has no nodes we return an empty response to the client : we know that `dc1` does not have nodes for us because it is not the last dc distance-wise in the index we received. We also know that `dc2` and `dc3` failed because we just called them.