### PR TITLE
UI: Removes delete button from pages that show your current token

### DIFF
--- a/ui-v2/app/templates/dc/acls/tokens/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-form.hbs
@@ -13,7 +13,7 @@
         <button type="submit" {{ action "update" item}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
 {{/if}}
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
-{{# if (and (not create) (not (token/is-anonymous item))) }}
+{{# if (and (not create) (not (token/is-anonymous item)) (not-eq item.AccessorID token.AccessorID) ) }}
         {{#confirmation-dialog message='Are you sure you want to delete this Token?'}}
             {{#block-slot 'action' as |confirm|}}
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -90,7 +90,7 @@
                                     <a data-test-use onclick={{queue (action confirm 'use' item) (action change)}}>Use</a>
                                 </li>
 {{/if}}
-{{#unless (token/is-anonymous item) }}
+{{#unless (or (token/is-anonymous item) (eq item.AccessorID token.AccessorID)) }}
                                 <li>
                                     <a data-test-delete onclick={{action confirm 'delete' item}}>Delete</a>
                                 </li>
@@ -102,9 +102,6 @@
                         <p>
                             {{#if (eq name 'delete')}}
                               {{message}}
-  {{#if (eq item.AccessorID token.AccessorID)}}
-                              Warning: This is the token you are currently using!
-  {{/if}}
                             {{else if (eq name 'logout')}}
                                 Are you sure you want to stop using this ACL token? This will log you out.
                             {{else if (eq name 'use')}}

--- a/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
@@ -1,0 +1,37 @@
+@setupApplicationTest
+Feature: dc / acls / tokens / own no delete: The your current token has no delete buttons
+  Background:
+    Given 1 datacenter model with the value "dc-1"
+    And 1 token model from yaml
+    ---
+      AccessorID: token
+      SecretID: ee52203d-989f-4f7a-ab5a-2bef004164ca
+    ---
+  Scenario: On the listing page
+    Then I have settings like yaml
+    ---
+    consul:token: ~
+    ---
+    When I visit the tokens page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/acls/tokens
+    And I click actions on the tokens
+    And I click use on the tokens
+    And I click confirmUse on the tokens
+    Then "[data-notification]" has the "notification-use" class
+    And "[data-notification]" has the "success" class
+    Then I have settings like yaml
+    ---
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\"}"
+    ---
+    And I click actions on the tokens
+    Then I don't see delete on the tokens
+    And I visit the token page for yaml
+    ---
+    dc: dc-1
+    token: ee52203d-989f-4f7a-ab5a-2bef004164ca
+    ---
+    Then the url should be /dc-1/acls/tokens/ee52203d-989f-4f7a-ab5a-2bef004164ca
+    Then I don't see confirmDelete

--- a/ui-v2/tests/acceptance/steps/dc/acls/tokens/own-no-delete-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/acls/tokens/own-no-delete-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}


### PR DESCRIPTION
Tokens can no longer delete themselves.

See https://github.com/hashicorp/consul/pull/5210.

We add the additional logic here to reflect this in the UI by removing the delete buttons to allow you to do that from the UI.