### PR TITLE
Update to Go 1.11.4 and UI build container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   # Please keep this in-sync with the go version we build against in
   # build-support/docker/Build-Go.dockerfile.
-  - "1.11.1"
+  - "1.11.4"
 
 branches:
   only:

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.11.1
+ARG GOLANG_VERSION=1.11.4
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Build-UI.dockerfile
+++ b/build-support/docker/Build-UI.dockerfile
@@ -1,12 +1,12 @@
-ARG ALPINE_VERSION=3.7
+ARG ALPINE_VERSION=3.8
 FROM alpine:${ALPINE_VERSION}
 
-ARG NODEJS_VERSION=8.9.3-r1
-ARG MAKE_VERSION=4.2.1-r0
-ARG YARN_VERSION=1.7.0
+ARG NODEJS_VERSION=8.14.0-r0
+ARG MAKE_VERSION=4.2.1-r2
+ARG YARN_VERSION=1.13
 
 RUN apk update && \
-    apk add nodejs=${NODEJS_VERSION} nodejs-npm=${NODEJS_VERSION} make=${MAKE_VERSION} rsync && \
+    apk add nodejs=${NODEJS_VERSION} nodejs-npm=${NODEJS_VERSION} make=${MAKE_VERSION} && \
     npm config set unsafe-perm true && \
     npm install --global yarn@${YARN_VERSION} && \
     mkdir /consul-src


### PR DESCRIPTION
This will build our releases with Go 1.11.4 by default.

It also pulls in some UI build dependencies necessary.