### PR TITLE
[Docs] New ACL Landing Page

### DIFF
--- a/website/source/docs/guides/acl-index.html.md
+++ b/website/source/docs/guides/acl-index.html.md
@@ -1,0 +1,29 @@
+---
+layout: "docs"
+page_title: "ACL Guides"
+sidebar_current: "docs-guides-acl-index"
+description: |-
+  Consul provides an optional Access Control List (ACL) system which can be used to control access to data and APIs. Select the following guide for your use case.
+---
+
+# ACL Guides
+
+We have several guides for setting up and configuring Consul's ACL system. They include how to bootstrap the ACL system in Consul version 1.4.0 and newer, how to bootstrap the ACL system in older versions of Consul, and how to migrate tokens from the legacy system to the new system in Consul 1.4.0.
+
+Please select one of the following guides to get started.
+
+## Bootstrapping Guide
+
+Learn how to control access to Consul resources with this step-by-step [guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide) on bootstrapping the ACL system in Consul 1.4.0 and newer. This guide also includes additional steps for configuring the anonymous token, setting up agent-specific default tokens, and creating tokens for Consul UI use. 
+
+## Legacy ACL System
+
+The ACL system in Consul 1.3.1 and older is now called legacy. For information on bootstrapping the legacy system, ACL rules, and a general ACL system overview, read the legacy [guide](/docs/guides/acl-legacy.html).
+
+## Migrating Tokens
+
+[This guide](/docs/guides/acl-migrate-tokens.html) documents how to upgrade
+existing legacy tokens after upgrading to 1.4.0. It will briefly describe what changed, and then walk through the high-level migration process options, finally giving some specific examples of migration strategies. The new ACL system has improvements for the security and management of ACL tokens and policies.
+
+
+

--- a/website/source/docs/guides/index.html.md
+++ b/website/source/docs/guides/index.html.md
@@ -14,7 +14,7 @@ guidance to do them safely.
 
 The following guides are available:
 
-* [ACLs](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide) - This guide covers Consul's Access Control List (ACL) capability, which can be used to control access to Consul resources.
+* [ACLs](/docs/guides/acl-index.html) - This set of guides covers Consul's Access Control List (ACL) capability, which can be used to control access to Consul resources.
 
 * [Adding/Removing Servers](https://learn.hashicorp.com/consul/day-2-operations/advanced-operations/servers) - This guide covers how to safely add and remove Consul servers from the cluster. This should be done carefully to avoid availability outages.
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -392,15 +392,7 @@
         <a href="/docs/guides/index.html">Guides</a>
         <ul class="nav">
           <li<%= sidebar_current("docs-guides-acl") %>>
-            <a href="https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide">ACLs</a>
-            <ul class="nav">
-              <li<%= sidebar_current("docs-guides-acl-legacy") %>>
-                <a href="/docs/guides/acl-legacy.html">Legacy</a>
-              </li>
-              <li<%= sidebar_current("docs-guides-acl-migrate-tokens") %>>
-                <a href="/docs/guides/acl-migrate-tokens.html">Token Migration</a>
-              </li>
-            </ul>
+            <a href="/docs/guides/acl-index.html">ACL Guides</a>
           </li>
           <li<%= sidebar_current("docs-guides-servers") %>>
             <a href="https://learn.hashicorp.com/consul/day-2-operations/advanced-operations/servers">Adding & Removing Servers</a>


### PR DESCRIPTION
Created a new index page that links to all the ACL guides. I also removed the sidebar nav drop down to be more consistent with the other guides.

These changes stemmed from a conversation on PR 5093 https://github.com/hashicorp/consul/pull/5093#discussion_r245142250