### PR TITLE
Disregard rules when set on a management token

### DIFF
--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -190,18 +190,18 @@ func (t *ACLToken) EmbeddedPolicy() *ACLPolicy {
 	// Additionally for management tokens we must embed the policy rules
 	// as well
 	policy := &ACLPolicy{}
-	if t.Rules != "" || t.Type == ACLTokenTypeClient {
-		hasher := fnv.New128a()
-		policy.ID = fmt.Sprintf("%x", hasher.Sum([]byte(t.Rules)))
-		policy.Name = fmt.Sprintf("legacy-policy-%s", policy.ID)
-		policy.Rules = t.Rules
-		policy.Syntax = acl.SyntaxLegacy
-	} else if t.Type == ACLTokenTypeManagement {
+	if t.Type == ACLTokenTypeManagement {
 		hasher := fnv.New128a()
 		policy.ID = fmt.Sprintf("%x", hasher.Sum([]byte(ACLPolicyGlobalManagement)))
 		policy.Name = "legacy-management"
 		policy.Rules = ACLPolicyGlobalManagement
 		policy.Syntax = acl.SyntaxCurrent
+	} else if t.Rules != "" || t.Type == ACLTokenTypeClient {
+		hasher := fnv.New128a()
+		policy.ID = fmt.Sprintf("%x", hasher.Sum([]byte(t.Rules)))
+		policy.Name = fmt.Sprintf("legacy-policy-%s", policy.ID)
+		policy.Rules = t.Rules
+		policy.Syntax = acl.SyntaxLegacy
 	} else {
 		return nil
 	}

--- a/agent/structs/acl_test.go
+++ b/agent/structs/acl_test.go
@@ -56,6 +56,26 @@ func TestStructs_ACLToken_PolicyIDs(t *testing.T) {
 		require.Equal(t, ACLPolicyGlobalManagement, embedded.Rules)
 	})
 
+	t.Run("Legacy Management With Rules", func(t *testing.T) {
+		t.Parallel()
+
+		a := &ACL{
+			ID:    "root",
+			Type:  ACLTokenTypeManagement,
+			Name:  "management",
+			Rules: "operator = \"write\"",
+		}
+
+		token := a.Convert()
+
+		policyIDs := token.PolicyIDs()
+		require.Len(t, policyIDs, 0)
+
+		embedded := token.EmbeddedPolicy()
+		require.NotNil(t, embedded)
+		require.Equal(t, ACLPolicyGlobalManagement, embedded.Rules)
+	})
+
 	t.Run("No Policies", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Legacy management tokens were expected not to have associated rules but apparently we never prevented this from happening. They would previously have been ignored. In 1.4.0 the place where we handle embedded policies treated having any rules as a client token and would ignore the token type. This PR flips the precedence around so that management type tokens always use the embedded global management policy rule set.