### PR TITLE
fix watch event behavior

### DIFF
--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -157,16 +157,20 @@ RUN_QUERY:
 
 	// Determine the index
 	var index uint64
+	var ltime uint64
 	if len(events) == 0 {
 		// Return a non-zero index to prevent a hot query loop. This
 		// can be caused by a watch for example when there is no matching
 		// events.
 		index = 1
+		ltime = 0
 	} else {
 		last := events[len(events)-1]
 		index = uuidToUint64(last.ID)
+		ltime = last.LTime
 	}
 	setIndex(resp, index)
+	setLtime(resp, ltime)
 
 	// Check for exact match on the query value. Because
 	// the index value is not monotonic, we just ensure it is

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -148,6 +148,11 @@ func TestEventList(t *testing.T) {
 		if header == "" || header == "0" {
 			r.Fatalf("bad: %#v", header)
 		}
+
+		ltime := resp.Header().Get("X-Consul-LTime")
+		if ltime == "" {
+			r.Fatalf("bad: %#v", ltime)
+		}
 	})
 }
 

--- a/agent/http.go
+++ b/agent/http.go
@@ -543,6 +543,10 @@ func setIndex(resp http.ResponseWriter, index uint64) {
 	resp.Header().Set("X-Consul-Index", strconv.FormatUint(index, 10))
 }
 
+func setLtime(resp http.ResponseWriter, ltime uint64) {
+	resp.Header().Set("X-Consul-LTime", strconv.FormatUint(ltime, 10))
+}
+
 // setKnownLeader is used to set the known leader header
 func setKnownLeader(resp http.ResponseWriter, known bool) {
 	s := "true"

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -220,6 +220,20 @@ func TestSetIndex(t *testing.T) {
 	}
 }
 
+func TestSetLtime(t *testing.T) {
+	t.Parallel()
+	resp := httptest.NewRecorder()
+	setLtime(resp, 1000)
+	header := resp.Header().Get("X-Consul-Ltime")
+	if header != "1000" {
+		t.Fatalf("Bad: %v", header)
+	}
+	setLtime(resp, 2000)
+	if v := resp.Header()["X-Consul-Ltime"]; len(v) != 1 {
+		t.Fatalf("bad: %#v", v)
+	}
+}
+
 func TestSetKnownLeader(t *testing.T) {
 	t.Parallel()
 	resp := httptest.NewRecorder()

--- a/api/api.go
+++ b/api/api.go
@@ -206,6 +206,10 @@ type QueryMeta struct {
 	// a blocking query
 	LastIndex uint64
 
+	// LastLtime. This can be used as a WaitIndexAndLtime to perform
+	// a blocking query
+	LastLtime uint64
+
 	// LastContentHash. This can be used as a WaitHash to perform a blocking query
 	// for endpoints that support hash-based blocking. Endpoints that do not
 	// support it will return an empty hash.
@@ -825,6 +829,15 @@ func parseQueryMeta(resp *http.Response, q *QueryMeta) error {
 		}
 		q.LastIndex = index
 	}
+
+	if ltimeStr := header.Get("X-Consul-LTime"); ltimeStr != "" {
+		ltime, err := strconv.ParseUint(ltimeStr, 10, 64)
+		if err != nil {
+			return fmt.Errorf("Failed to parse X-Consul-Ltime: %v", err)
+		}
+		q.LastLtime = ltime
+	}
+
 	q.LastContentHash = header.Get("X-Consul-ContentHash")
 
 	// Parse the X-Consul-LastContact

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -482,6 +482,7 @@ func TestAPI_ParseQueryMeta(t *testing.T) {
 		Header: make(map[string][]string),
 	}
 	resp.Header.Set("X-Consul-Index", "12345")
+	resp.Header.Set("X-Consul-Ltime", "123")
 	resp.Header.Set("X-Consul-LastContact", "80")
 	resp.Header.Set("X-Consul-KnownLeader", "true")
 	resp.Header.Set("X-Consul-Translate-Addresses", "true")
@@ -492,6 +493,9 @@ func TestAPI_ParseQueryMeta(t *testing.T) {
 	}
 
 	if qm.LastIndex != 12345 {
+		t.Fatalf("Bad: %v", qm)
+	}
+	if qm.LastLtime != 123 {
 		t.Fatalf("Bad: %v", qm)
 	}
 	if qm.LastContact != 80*time.Millisecond {

--- a/watch/funcs.go
+++ b/watch/funcs.go
@@ -225,12 +225,13 @@ func eventWatch(params map[string]interface{}) (WatcherFunc, error) {
 
 		// Prune to only the new events
 		for i := 0; i < len(events); i++ {
-			if WaitIndexVal(event.IDToIndex(events[i].ID)).Equal(p.lastParamVal) {
+			wil := WaitIndexAndLtimeVal{event.IDToIndex(events[i].ID), events[i].LTime}
+			if wil.Equal(p.lastParamVal) {
 				events = events[i+1:]
 				break
 			}
 		}
-		return WaitIndexVal(meta.LastIndex), events, err
+		return WaitIndexAndLtimeVal{meta.LastIndex, meta.LastLtime}, events, err
 	}
 	return fn, nil
 }
@@ -340,6 +341,8 @@ func makeQueryOptionsWithContext(p *Plan, stale bool) consulapi.QueryOptions {
 	switch param := p.lastParamVal.(type) {
 	case WaitIndexVal:
 		opts.WaitIndex = uint64(param)
+	case WaitIndexAndLtimeVal:
+		opts.WaitIndex = uint64(param.Index)
 	case WaitHashVal:
 		opts.WaitHash = string(param)
 	}

--- a/watch/plan.go
+++ b/watch/plan.go
@@ -115,12 +115,15 @@ OUTER:
 		if p.HybridHandler != nil {
 			p.HybridHandler(blockParamVal, result)
 		} else if p.Handler != nil {
-			idx, ok := blockParamVal.(WaitIndexVal)
-			if !ok {
+			switch param := p.lastParamVal.(type) {
+			case WaitIndexVal:
+				p.Handler(uint64(param), result)
+			case WaitIndexAndLtimeVal:
+				p.Handler(uint64(param.Index), result)
+			default:
 				logger.Printf("[ERR] consul.watch: Handler only supports index-based " +
 					" watches but non index-based watch run. Skipping Handler.")
 			}
-			p.Handler(uint64(idx), result)
 		}
 	}
 	return nil

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -95,6 +95,30 @@ func (idx WaitIndexVal) Next(previous BlockingParamVal) BlockingParamVal {
 	return idx
 }
 
+type WaitIndexAndLtimeVal struct {
+	Index uint64
+	Ltime uint64
+}
+
+func (wil WaitIndexAndLtimeVal) Equal(other BlockingParamVal) bool {
+	if otherWil, ok := other.(WaitIndexAndLtimeVal); ok {
+		return wil == otherWil
+	}
+	return false
+}
+
+func (wil WaitIndexAndLtimeVal) Next(previous BlockingParamVal) BlockingParamVal {
+	if previous == nil {
+		return wil
+	}
+	prevWil, ok := previous.(WaitIndexAndLtimeVal)
+	if ok && prevWil.Index > wil.Index && prevWil.Ltime > wil.Ltime {
+		// This value is smaller than the previous index, reset.
+		return WaitIndexAndLtimeVal{0, 0}
+	}
+	return wil
+}
+
 // WaitHashVal is a type representing a Consul content hash that implements
 // BlockingParamVal.
 type WaitHashVal string


### PR DESCRIPTION
Fixes: #3742

consul watch holds the index of the previous event.
If the index of this event is smaller than the index of the previous event, execute the handler once, give the event that can be acquired by the event list api, and execute handler again.
since index is calculated based on event id and event id is completely randomly generated by uuid, it is not guaranteed that the index of the new event is larger than the index of the old event.

In other words, handler will be executed multiple times at random by firing one event.
In order to prevent this problem, I monotonously increase ltime as metadata of event list api, and consider ltime with logic to initialize index to 0.