### PR TITLE
5254 Reference last command's last field instead of background PID

### DIFF
--- a/website/source/docs/install/index.html.md
+++ b/website/source/docs/install/index.html.md
@@ -41,7 +41,7 @@ a copy of [`git`](https://www.git-scm.com/) in your `PATH`.
   1. Clone the Consul repository from GitHub into your `GOPATH`:
 
     ```shell
-    $ mkdir -p $GOPATH/src/github.com/hashicorp && cd $!
+    $ mkdir -p $GOPATH/src/github.com/hashicorp && cd !$
     $ git clone https://github.com/hashicorp/consul.git
     $ cd consul
     ```


### PR DESCRIPTION
The previous code references the PID of the last backgrounded process. For me that was nothing so this would change my directory to home. Others would likely get an error if an number was returned.

Anyways, fixed to be the last field of the last command.