### PR TITLE
Make sure empty fields are omitted when Marshalling HealthChecks.

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2003,6 +2003,9 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 		Name:    "memory check",
 		Status:  api.HealthCritical,
 		Notes:   "my cool notes",
+		Definition: structs.HealthCheckDefinition{
+			Interval: 30 * time.Second,
+		},
 	}
 	if got, want := result, expected; !verify.Values(t, "", got, want) {
 		t.FailNow()

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -917,27 +917,26 @@ type HealthCheckDefinition struct {
 	DeregisterCriticalServiceAfter time.Duration       `json:",omitempty"`
 }
 
+type Alias HealthCheckDefinition
+type ExportedHealthCheckDefinition struct {
+	Interval                       string `json:",omitempty"`
+	Timeout                        string `json:",omitempty"`
+	DeregisterCriticalServiceAfter string `json:",omitempty"`
+	*Alias
+}
+
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
-	type Alias HealthCheckDefinition
-	exported := &struct {
-		Interval                       string
-		Timeout                        string
-		DeregisterCriticalServiceAfter string
-		*Alias
-	}{
-		Interval:                       d.Interval.String(),
-		Timeout:                        d.Timeout.String(),
-		DeregisterCriticalServiceAfter: d.DeregisterCriticalServiceAfter.String(),
-		Alias:                          (*Alias)(d),
+	exported := &ExportedHealthCheckDefinition{
+		Alias: (*Alias)(d),
 	}
-	if d.Interval == 0 {
-		exported.Interval = ""
+	if d.Interval != 0 {
+		exported.Interval = d.Interval.String()
 	}
-	if d.Timeout == 0 {
-		exported.Timeout = ""
+	if d.Timeout != 0 {
+		exported.Timeout = d.Interval.String()
 	}
-	if d.DeregisterCriticalServiceAfter == 0 {
-		exported.DeregisterCriticalServiceAfter = ""
+	if d.DeregisterCriticalServiceAfter != 0 {
+		exported.DeregisterCriticalServiceAfter = d.Interval.String()
 	}
 
 	return json.Marshal(exported)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -918,7 +918,7 @@ type HealthCheckDefinition struct {
 }
 
 type Alias HealthCheckDefinition
-type ExportedHealthCheckDefinition struct {
+type exportedHealthCheckDefinition struct {
 	Interval                       string `json:",omitempty"`
 	Timeout                        string `json:",omitempty"`
 	DeregisterCriticalServiceAfter string `json:",omitempty"`
@@ -926,7 +926,7 @@ type ExportedHealthCheckDefinition struct {
 }
 
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
-	exported := &ExportedHealthCheckDefinition{
+	exported := &exportedHealthCheckDefinition{
 		Alias: (*Alias)(d),
 	}
 	if d.Interval != 0 {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -917,26 +917,27 @@ type HealthCheckDefinition struct {
 	DeregisterCriticalServiceAfter time.Duration       `json:",omitempty"`
 }
 
-type Alias HealthCheckDefinition
-type exportedHealthCheckDefinition struct {
-	Interval                       string `json:",omitempty"`
-	Timeout                        string `json:",omitempty"`
-	DeregisterCriticalServiceAfter string `json:",omitempty"`
-	*Alias
-}
-
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
-	exported := &exportedHealthCheckDefinition{
-		Alias: (*Alias)(d),
+	type Alias HealthCheckDefinition
+	exported := &struct {
+		Interval                       string `json:",omitempty"`
+		Timeout                        string `json:",omitempty"`
+		DeregisterCriticalServiceAfter string `json:",omitempty"`
+		*Alias
+	}{
+		Interval:                       d.Interval.String(),
+		Timeout:                        d.Timeout.String(),
+		DeregisterCriticalServiceAfter: d.DeregisterCriticalServiceAfter.String(),
+		Alias:                          (*Alias)(d),
 	}
-	if d.Interval != 0 {
-		exported.Interval = d.Interval.String()
+	if d.Interval == 0 {
+		exported.Interval = ""
 	}
-	if d.Timeout != 0 {
-		exported.Timeout = d.Interval.String()
+	if d.Timeout == 0 {
+		exported.Timeout = ""
 	}
-	if d.DeregisterCriticalServiceAfter != 0 {
-		exported.DeregisterCriticalServiceAfter = d.Interval.String()
+	if d.DeregisterCriticalServiceAfter == 0 {
+		exported.DeregisterCriticalServiceAfter = ""
 	}
 
 	return json.Marshal(exported)

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -640,7 +640,7 @@ func TestStructs_HealthCheck_IsSame(t *testing.T) {
 	checkStringField(&other.ServiceName)
 }
 
-func TestStructs_HealthCheck_Unmarshalling(t *testing.T) {
+func TestStructs_HealthCheck_Marshalling(t *testing.T) {
 	d := &HealthCheckDefinition{}
 	buf, err := d.MarshalJSON()
 	require.NoError(t, err)

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -640,6 +640,15 @@ func TestStructs_HealthCheck_IsSame(t *testing.T) {
 	checkStringField(&other.ServiceName)
 }
 
+func TestStructs_HealthCheck_Unmarshalling(t *testing.T) {
+	d := &HealthCheckDefinition{}
+	buf, err := d.MarshalJSON()
+	require.NoError(t, err)
+	require.NotContains(t, string(buf), `"Interval":""`)
+	require.NotContains(t, string(buf), `"Timeout":""`)
+	require.NotContains(t, string(buf), `"DeregisterCriticalServiceAfter":""`)
+}
+
 func TestStructs_HealthCheck_Clone(t *testing.T) {
 	hc := &HealthCheck{
 		Node:        "node1",

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -239,9 +239,9 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 							Header:                         check.Definition.Header,
 							Method:                         check.Definition.Method,
 							TCP:                            check.Definition.TCP,
-							Interval:                       check.Definition.Interval,
-							Timeout:                        check.Definition.Timeout,
-							DeregisterCriticalServiceAfter: check.Definition.DeregisterCriticalServiceAfter,
+							Interval:                       check.Definition.IntervalDuration,
+							Timeout:                        check.Definition.TimeoutDuration,
+							DeregisterCriticalServiceAfter: check.Definition.DeregisterCriticalServiceAfterDuration,
 						},
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: check.ModifyIndex,

--- a/api/health.go
+++ b/api/health.go
@@ -46,19 +46,24 @@ type HealthCheck struct {
 // HealthCheckDefinition is used to store the details about
 // a health check's execution.
 type HealthCheckDefinition struct {
-	HTTP                           string
-	Header                         map[string][]string
-	Method                         string
-	TLSSkipVerify                  bool
-	TCP                            string
-	Interval                       time.Duration
-	Timeout                        time.Duration
-	DeregisterCriticalServiceAfter time.Duration
+	HTTP                                   string
+	Header                                 map[string][]string
+	Method                                 string
+	TLSSkipVerify                          bool
+	TCP                                    string
+	IntervalDuration                       time.Duration `json:"-"`
+	TimeoutDuration                        time.Duration `json:"-"`
+	DeregisterCriticalServiceAfterDuration time.Duration `json:"-"`
+
+	// DEPRECATED in Consul 1.4.1. Use the above time.Duration fields instead.
+	Interval                       ReadableDuration
+	Timeout                        ReadableDuration
+	DeregisterCriticalServiceAfter ReadableDuration
 }
 
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 	type Alias HealthCheckDefinition
-	return json.Marshal(&struct {
+	out := &struct {
 		Interval                       string
 		Timeout                        string
 		DeregisterCriticalServiceAfter string
@@ -68,7 +73,25 @@ func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 		Timeout:                        d.Timeout.String(),
 		DeregisterCriticalServiceAfter: d.DeregisterCriticalServiceAfter.String(),
 		Alias:                          (*Alias)(d),
-	})
+	}
+
+	if d.IntervalDuration != 0 {
+		out.Interval = d.IntervalDuration.String()
+	} else if d.Interval != 0 {
+		out.Interval = d.Interval.String()
+	}
+	if d.TimeoutDuration != 0 {
+		out.Timeout = d.TimeoutDuration.String()
+	} else if d.Timeout != 0 {
+		out.Timeout = d.Timeout.String()
+	}
+	if d.DeregisterCriticalServiceAfterDuration != 0 {
+		out.DeregisterCriticalServiceAfter = d.DeregisterCriticalServiceAfterDuration.String()
+	} else if d.DeregisterCriticalServiceAfter != 0 {
+		out.DeregisterCriticalServiceAfter = d.DeregisterCriticalServiceAfter.String()
+	}
+
+	return json.Marshal(out)
 }
 
 func (d *HealthCheckDefinition) UnmarshalJSON(data []byte) error {
@@ -84,21 +107,26 @@ func (d *HealthCheckDefinition) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+
+	// Parse the values into both the time.Duration and old ReadableDuration fields.
 	var err error
 	if aux.Interval != "" {
-		if d.Interval, err = time.ParseDuration(aux.Interval); err != nil {
+		if d.IntervalDuration, err = time.ParseDuration(aux.Interval); err != nil {
 			return err
 		}
+		d.Interval = ReadableDuration(d.IntervalDuration)
 	}
 	if aux.Timeout != "" {
-		if d.Timeout, err = time.ParseDuration(aux.Timeout); err != nil {
+		if d.TimeoutDuration, err = time.ParseDuration(aux.Timeout); err != nil {
 			return err
 		}
+		d.Timeout = ReadableDuration(d.TimeoutDuration)
 	}
 	if aux.DeregisterCriticalServiceAfter != "" {
-		if d.DeregisterCriticalServiceAfter, err = time.ParseDuration(aux.DeregisterCriticalServiceAfter); err != nil {
+		if d.DeregisterCriticalServiceAfterDuration, err = time.ParseDuration(aux.DeregisterCriticalServiceAfter); err != nil {
 			return err
 		}
+		d.DeregisterCriticalServiceAfter = ReadableDuration(d.DeregisterCriticalServiceAfterDuration)
 	}
 	return nil
 }


### PR DESCRIPTION
When Interval, Timeout or DeregisterCriticalServiceAfter is not set, it will still be render with an empty string. This is a breaking change which we did not intend to make.