### PR TITLE
Don't generate TXT records just to discard them

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6330,3 +6330,22 @@ func TestDNSInvalidRegex(t *testing.T) {
 
 	}
 }
+
+func TestDNS_formatNodeRecord(t *testing.T) {
+	s := &DNSServer{}
+
+	node := &structs.Node{
+		Meta: map[string]string{
+			"key":  "value",
+			"key2": "value2",
+		},
+	}
+
+	records, meta := s.formatNodeRecord(node, "198.18.0.1", "test.node.consul", dns.TypeA, 5*time.Minute, false, 3, false)
+	require.Len(t, records, 1)
+	require.Len(t, meta, 0)
+
+	records, meta = s.formatNodeRecord(node, "198.18.0.1", "test.node.consul", dns.TypeA, 5*time.Minute, false, 3, true)
+	require.Len(t, records, 1)
+	require.Len(t, meta, 2)
+}


### PR DESCRIPTION
Fixes #5271 

Functionally there is no difference to this PR. However it does provide a noticeable improvement.

Testing:

1. Run `consul agent -dev -node-meta=foo:bar -node-meta=key:value -node-meta=env:prod -hcl 'dns_config { enable_additional_node_meta_txt = false}' -log-level INFO`
2. In another shell run:
```
for ((i=1;i<17;i++))
do
   ./test.sh &
done
```
Where `test.sh` was:
```
#!/bin/bash

while true
do
   dig @127.0.0.1 -p 8600 consul.service.consul >/dev/null
done
```
3. Monitor CPU usage

Basically this runs a dev server and spawns 16 processes to constantly resolve `consul.service.consul`.

Prior to the change Consuls CPU usage hovered at about 20% of a core on my mac. After the change it averaged about 10% of a core. This is not that huge of a load but the more node meta and the longer the node meta and the issue will be exacerbated further. I also checked some go profiling to ensure that `encodeKVasRFC1464` was never being called to ensure that the meta TXT wasn't being generated.

I also ran this without disabling the TXT records and there was no noticeable performance difference (which is to be expected).

