### PR TITLE
ui: pin to using bundler v1 for now

### DIFF
--- a/build-support/docker/Build-UI-Legacy.dockerfile
+++ b/build-support/docker/Build-UI-Legacy.dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
             ruby-dev \
             zip \
             zlib1g-dev && \
-    gem install bundler
+    gem install bundler -v '1.17.3'
 
 WORKDIR /consul-src/ui
 CMD make dist


### PR DESCRIPTION
With the latest base image of `ubuntu:bionic` rebuilding the legacy ui (which is a prerequisite for `make ui`) now fails:
```
$ make ui-legacy-docker
Building Legacy UI build container
sha256:0e93d6f64e22cc7d0de413dbc6e60aeacd8a194a0996c965b131b0c9bd23820e
==> Building UI
Creating the Legacy UI Build Container with image: consul-build-ui-legacy
Copying the source from '/home/rboyer/src/go/src/github.com/hashicorp/consul/ui' to /consul-src/ui within the container
Running build in container
Traceback (most recent call last):
    2: from /usr/local/bin/bundle:23:in `<main>'
    1: from /usr/lib/ruby/2.5.0/rubygems.rb:308:in `activate_bin_path'
/usr/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
GNUmakefile:10: recipe for target 'dist' failed
make: *** [dist] Error 1
GNUmakefile:274: recipe for target 'ui-legacy-docker' failed
make: *** [ui-legacy-docker] Error 1
```
This is likely due to bundler [defaulting to v2](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html) now.