### PR TITLE
Healthcheck duration fix

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2003,6 +2003,9 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 		Name:    "memory check",
 		Status:  api.HealthCritical,
 		Notes:   "my cool notes",
+		Definition: structs.HealthCheckDefinition{
+			Interval: 30 * time.Second,
+		},
 	}
 	if got, want := result, expected; !verify.Values(t, "", got, want) {
 		t.FailNow()

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -239,9 +239,9 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 							Header:                         check.Definition.Header,
 							Method:                         check.Definition.Method,
 							TCP:                            check.Definition.TCP,
-							Interval:                       check.Definition.Interval,
-							Timeout:                        check.Definition.Timeout,
-							DeregisterCriticalServiceAfter: check.Definition.DeregisterCriticalServiceAfter,
+							Interval:                       check.Definition.IntervalDuration,
+							Timeout:                        check.Definition.TimeoutDuration,
+							DeregisterCriticalServiceAfter: check.Definition.DeregisterCriticalServiceAfterDuration,
 						},
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: check.ModifyIndex,

--- a/api/health.go
+++ b/api/health.go
@@ -77,12 +77,18 @@ func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 
 	if d.IntervalDuration != 0 {
 		out.Interval = d.IntervalDuration.String()
+	} else if d.Interval != 0 {
+		out.Interval = d.Interval.String()
 	}
 	if d.TimeoutDuration != 0 {
 		out.Timeout = d.TimeoutDuration.String()
+	} else if d.Timeout != 0 {
+		out.Timeout = d.Timeout.String()
 	}
 	if d.DeregisterCriticalServiceAfterDuration != 0 {
 		out.DeregisterCriticalServiceAfter = d.DeregisterCriticalServiceAfterDuration.String()
+	} else if d.DeregisterCriticalServiceAfter != 0 {
+		out.DeregisterCriticalServiceAfter = d.DeregisterCriticalServiceAfter.String()
 	}
 
 	return json.Marshal(out)


### PR DESCRIPTION
I re-added the ReadableDuration fields to the health check definition struct on top of @i0rek's changes to maintain backwards compatibility with the older client api code. 