### PR TITLE
Document atomicity of recursive KV reads

### DIFF
--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -26,6 +26,8 @@ For multi-key updates, please consider using [transaction](/api/txn.html).
 This endpoint returns the specified key. If no key exists at the given path, a
 404 is returned instead of a 200 response.
 
+A recursive request is served from a single, consistent snapshot.
+
 For multi-key reads, please consider using [transaction](/api/txn.html).
 
 | Method | Path                         | Produces                   |


### PR DESCRIPTION
Performing a recursive read on a set of KVs returns values from the same
snapshot. This is guaranteed by the implementation, but not explicitly
mentioned in the documentation.

See https://groups.google.com/d/msg/consul-tool/nCVUt3hIuKg/M3S4aFlIAgAJ