### PR TITLE
Remove the misleading default separator for listing keys.

### DIFF
--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -62,7 +62,7 @@ The table below shows this endpoint's support for
   metadata). Specifying this implies `recurse`. This is specified as part of the
   URL as a query parameter.
 
-- `separator` `(string: '/')` - Specifies the string to use as a separator
+- `separator` `(string: '')` - Specifies the string to use as a separator
   for recursive key lookups. This option is only used when paired with the `keys` 
   parameter to limit the prefix of keys returned,  only up to the given separator. 
   This is specified as part of the URL as a query parameter.


### PR DESCRIPTION
The default separator for key listing is an empty string - the docs incorrectly made it seem as if the default was `/`.