### PR TITLE
Improve Connect with Prepared Queries

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -534,6 +534,11 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 		nodes = nodeMetaFilter(query.Service.NodeMeta, nodes)
 	}
 
+	// Apply the service metadata filters, if any.
+	if len(query.Service.ServiceMeta) > 0 {
+		nodes = serviceMetaFilter(query.Service.ServiceMeta, nodes)
+	}
+
 	// Apply the tag filters, if any.
 	if len(query.Service.Tags) > 0 {
 		nodes = tagFilter(query.Service.Tags, nodes)
@@ -610,6 +615,16 @@ func nodeMetaFilter(filters map[string]string, nodes structs.CheckServiceNodes) 
 	var filtered structs.CheckServiceNodes
 	for _, node := range nodes {
 		if structs.SatisfiesMetaFilters(node.Node.Meta, filters) {
+			filtered = append(filtered, node)
+		}
+	}
+	return filtered
+}
+
+func serviceMetaFilter(filters map[string]string, nodes structs.CheckServiceNodes) structs.CheckServiceNodes {
+	var filtered structs.CheckServiceNodes
+	for _, node := range nodes {
+		if structs.SatisfiesMetaFilters(node.Service.Meta, filters) {
 			filtered = append(filtered, node)
 		}
 	}

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -96,6 +96,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 						OnlyPassing:    true,
 						Tags:           []string{"foo", "bar"},
 						NodeMeta:       map[string]string{"somekey": "somevalue"},
+						ServiceMeta:    map[string]string{"env": "prod"},
 					},
 					DNS: structs.QueryDNSOptions{
 						TTL: "10s",
@@ -132,6 +133,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 			"OnlyPassing":    true,
 			"Tags":           []string{"foo", "bar"},
 			"NodeMeta":       map[string]string{"somekey": "somevalue"},
+			"ServiceMeta":    map[string]string{"env": "prod"},
 		},
 		"DNS": map[string]interface{}{
 			"TTL": "10s",

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -49,6 +49,21 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 		}
 	}
 
+	// Copy the service metadata from the original service if no other meta was provided
+	if len(sidecar.Meta) == 0 && len(ns.Meta) > 0 {
+		if sidecar.Meta == nil {
+			sidecar.Meta = make(map[string]string)
+		}
+		for k, v := range ns.Meta {
+			sidecar.Meta[k] = v
+		}
+	}
+
+	// Copy the tags from the original service if no other tags were specified
+	if len(sidecar.Tags) == 0 && len(ns.Tags) > 0 {
+		sidecar.Tags = append(sidecar.Tags, ns.Tags...)
+	}
+
 	// Flag this as a sidecar - this is not persisted in catalog but only needed
 	// in local agent state to disambiguate lineage when deregistering the parent
 	// service later.

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -64,6 +64,11 @@ type ServiceQuery struct {
 	// service entry to be returned.
 	NodeMeta map[string]string
 
+	// ServiceMeta is a map of required service metadata fields. If a key/value
+	// pair is in this map it must be present on the node in order for the
+	// service entry to be returned.
+	ServiceMeta map[string]string
+
 	// Connect if true will filter the prepared query results to only
 	// include Connect-capable services. These include both native services
 	// and proxies for matching services. Note that if a proxy matches,

--- a/api/prepared_query.go
+++ b/api/prepared_query.go
@@ -55,6 +55,11 @@ type ServiceQuery struct {
 	// service entry to be returned.
 	NodeMeta map[string]string
 
+	// ServiceMeta is a map of required service metadata fields. If a key/value
+	// pair is in this map it must be present on the node in order for the
+	// service entry to be returned.
+	ServiceMeta map[string]string
+
 	// Connect if true will filter the prepared query results to only
 	// include Connect-capable services. These include both native services
 	// and proxies for matching services. Note that if a proxy matches,

--- a/api/prepared_query_test.go
+++ b/api/prepared_query_test.go
@@ -25,6 +25,7 @@ func TestAPI_PreparedQuery(t *testing.T) {
 			ID:      "redis1",
 			Service: "redis",
 			Tags:    []string{"master", "v1"},
+			Meta:    map[string]string{"redis-version": "4.0"},
 			Port:    8000,
 		},
 	}
@@ -43,8 +44,9 @@ func TestAPI_PreparedQuery(t *testing.T) {
 	def := &PreparedQueryDefinition{
 		Name: "test",
 		Service: ServiceQuery{
-			Service:  "redis",
-			NodeMeta: map[string]string{"somekey": "somevalue"},
+			Service:     "redis",
+			NodeMeta:    map[string]string{"somekey": "somevalue"},
+			ServiceMeta: map[string]string{"redis-version": "4.0"},
 		},
 	}
 

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -234,6 +234,10 @@ The table below shows this endpoint's support for
     key/value pairs that will be used for filtering the query results to nodes
     with the given metadata values present.
 
+  - `ServiceMeta` `(map<string|string>: nil)` - Specifies a list of user-defined
+    key/value pairs that will be used for filtering the query results to services
+    with the given metadata values present.
+
   - `Connect` `(bool: false)` - If true, only [Connect-capable](/docs/connect/index.html) services
     for the specified service name will be returned. This includes both
 	natively integrated services and proxies. For proxies, the proxy name
@@ -264,6 +268,7 @@ The table below shows this endpoint's support for
     "OnlyPassing": false,
     "Tags": ["primary", "!experimental"],
     "NodeMeta": {"instance_type": "m3.large"}
+    "ServiceMeta": {"environment": "production"}
   },
   "DNS": {
     "TTL": "10s"
@@ -337,6 +342,7 @@ $ curl \
       "OnlyPassing": false,
       "Tags": ["primary", "!experimental"],
       "NodeMeta": {"instance_type": "m3.large"}
+      "ServiceMeta": {"environment": "production"}
     },
     "DNS": {
       "TTL": "10s"

--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -267,7 +267,7 @@ The table below shows this endpoint's support for
     "Near": "node1",
     "OnlyPassing": false,
     "Tags": ["primary", "!experimental"],
-    "NodeMeta": {"instance_type": "m3.large"}
+    "NodeMeta": {"instance_type": "m3.large"},
     "ServiceMeta": {"environment": "production"}
   },
   "DNS": {
@@ -341,7 +341,7 @@ $ curl \
       },
       "OnlyPassing": false,
       "Tags": ["primary", "!experimental"],
-      "NodeMeta": {"instance_type": "m3.large"}
+      "NodeMeta": {"instance_type": "m3.large"},
       "ServiceMeta": {"environment": "production"}
     },
     "DNS": {

--- a/website/source/docs/connect/proxies/sidecar-service.md
+++ b/website/source/docs/connect/proxies/sidecar-service.md
@@ -122,6 +122,8 @@ proxy.
    be overridden as it is used to [manage the lifecycle](#lifecycle) of the
    registration.
  - `name` - Defaults to being `<parent-service-name>-sidecar-proxy`.
+ - `tags` - Defaults to the tags of the parent service.
+ - `meta` - Defaults to the service metadata of the parent service.
  - `port` - Defaults to being auto-assigned from a [configurable
    range](/docs/agent/options.html#sidecar_min_port) that is
    by default `[21000, 21255]`.


### PR DESCRIPTION
Given a query like:

```
{
   "Name": "tagged-connect-query",
   "Service": {
      "Service": "foo",
      "Tags": ["tag"],
      "Connect": true
   }
}
```

And a Consul configuration like:

```
{
   "services": [
      "name": "foo",
      "port": 8080,
      "connect": { "sidecar_service": {} },
      "tags": ["tag"]
   ]
}
```

If you executed the query it would always turn up with 0 results. This was because the sidecar service was being created without any tags. You could instead make your config look like:

```
{
   "services": [
      "name": "foo",
      "port": 8080,
      "connect": { "sidecar_service": {
         "tags": ["tag"]
      } },
      "tags": ["tag"]
   ]
}
```

However that is a bit redundant for most cases. This PR ensures that the tags and service meta of the parent service get copied to the sidecar service. If there are any tags or service meta set in the sidecar service definition then this copying does not take place. After the changes, the query will now return the expected results.

A second change was made to prepared queries in this PR which is to allow filtering on ServiceMeta just like we allow for filtering on NodeMeta.