### PR TITLE
Update k8s ACL documentation

### DIFF
--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -74,7 +74,7 @@ then the sync program should work.
 
 For Consul, if ACLs are configured on the cluster, a Consul [ACL token](/docs/guides/acl.html)
 will need to be provided. The process accepts this token by using the
-`CONSUL_HTTP_TOKEN` environment variable. This token should be set as a
+[`CONSUL_HTTP_TOKEN`](docs/commands/index.html#consul_http_token) environment variable. This token should be set as a
 [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets)
 and referenced in the Helm chart.
 

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -67,16 +67,16 @@ sync to understand how the syncing works.
 The sync process must authenticate to both Kubernetes and Consul to read
 and write services.
 
-For Consul, the process accepts both the standard CLI flag `-token` and
-the environment variable `CONSUL_HTTP_TOKEN`. This should be set to an
-Consul [ACL token](/docs/guides/acl.html) if ACLs are enabled. This
-can also be configured using the Helm chart to read from a Kubernetes
-secret.
-
 For Kubernetes, a valid kubeconfig file must be provided with cluster
 and auth information. The sync process will look into the default locations
 for both in-cluster and out-of-cluster authentication. If `kubectl` works,
 then the sync program should work.
+
+For Consul, if ACLs are configured on the cluster, a Consul [ACL token](/docs/guides/acl.html)
+will need to be provided. The process accepts this token by using the
+`CONSUL_HTTP_TOKEN` environment variable. This token should be set as a
+[Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets)
+and referenced in the Helm chart.
 
 ## Kubernetes to Consul
 

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -73,7 +73,7 @@ for both in-cluster and out-of-cluster authentication. If `kubectl` works,
 then the sync program should work.
 
 For Consul, if ACLs are configured on the cluster, a Consul [ACL token](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide)
-will need to be provided. The process accepts this token by using the
+will need to be provided. Review the [ACL rules](/docs/agent/acl-rules.html) when creating a token with only the necessary privileges. The process accepts this token by using the
 [`CONSUL_HTTP_TOKEN`](docs/commands/index.html#consul_http_token) environment variable. This token should be set as a
 [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets)
 and referenced in the Helm chart.

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -68,11 +68,11 @@ The sync process must authenticate to both Kubernetes and Consul to read
 and write services.
 
 For Kubernetes, a valid kubeconfig file must be provided with cluster
-and auth information. The sync process will look into the default locations
+and authentication information. The sync process will look into the default locations
 for both in-cluster and out-of-cluster authentication. If `kubectl` works,
 then the sync program should work.
 
-For Consul, if ACLs are configured on the cluster, a Consul [ACL token](/docs/guides/acl.html)
+For Consul, if ACLs are configured on the cluster, a Consul [ACL token](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide)
 will need to be provided. The process accepts this token by using the
 [`CONSUL_HTTP_TOKEN`](docs/commands/index.html#consul_http_token) environment variable. This token should be set as a
 [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets)

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -72,9 +72,12 @@ and authentication information. The sync process will look into the default loca
 for both in-cluster and out-of-cluster authentication. If `kubectl` works,
 then the sync program should work.
 
-For Consul, if ACLs are configured on the cluster, a Consul [ACL token](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide)
-will need to be provided. Review the [ACL rules](/docs/agent/acl-rules.html) when creating a token with only the necessary privileges. The process accepts this token by using the
-[`CONSUL_HTTP_TOKEN`](docs/commands/index.html#consul_http_token) environment variable. This token should be set as a
+For Consul, if ACLs are configured on the cluster, a Consul
+[ACL token](https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide)
+will need to be provided. Review the [ACL rules](/docs/agent/acl-rules.html)
+when creating this token so that it only allows the necessary privileges. The catalog
+sync process accepts this token by using the [`CONSUL_HTTP_TOKEN`](docs/commands/index.html#consul_http_token)
+environment variable. This token should be set as a
 [Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets)
 and referenced in the Helm chart.
 


### PR DESCRIPTION
Clarifies that an ACL token only needs to be provided when ACLs are
enabled within the Consul cluster.