### PR TITLE
testutil: redirect some test agent logs to testing.T.Logf

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -43,6 +43,7 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.Bootstrap = true
 	config.Datacenter = "dc1"
 	config.DataDir = dir
+	config.LogOutput = testutil.TestWriter(t)
 
 	// bind the rpc server to a random port. config.RPCAdvertise will be
 	// set to the listen address unless it was set in the configuration.

--- a/testutil/testlog.go
+++ b/testutil/testlog.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"io"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestLogger(t testing.TB) *log.Logger {
+	return log.New(&testWriter{t}, "test: ", log.LstdFlags)
+}
+
+func TestLoggerWithName(t testing.TB, name string) *log.Logger {
+	return log.New(&testWriter{t}, "test["+name+"]: ", log.LstdFlags)
+}
+
+func TestWriter(t testing.TB) io.Writer {
+	return &testWriter{t}
+}
+
+type testWriter struct {
+	t testing.TB
+}
+
+func (tw *testWriter) Write(p []byte) (n int, err error) {
+	tw.t.Helper()
+	tw.t.Log(strings.TrimSpace(string(p)))
+	return len(p), nil
+}


### PR DESCRIPTION
When tests fail, only the logs for the failing run are dumped to the console which helps in diagnosis. This is easily added to other test scenarios as they come up.