### PR TITLE
Remove consul-docs automatic PR review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Consul docs reviewers
-/website/source/ @hashicorp/consul-docs


### PR DESCRIPTION
We no longer want this single codeowner rule, though we are keeping this group.