### PR TITLE
Call RemoveServer for reap events

### DIFF
--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -68,14 +68,12 @@ func (c *Client) lanEventHandler() {
 		select {
 		case e := <-c.eventCh:
 			switch e.EventType() {
-			case serf.EventMemberJoin:
+			case serf.EventMemberJoin, serf.EventMemberUpdate:
 				c.nodeJoin(e.(serf.MemberEvent))
-			case serf.EventMemberLeave, serf.EventMemberFailed:
+			case serf.EventMemberLeave, serf.EventMemberFailed, serf.EventMemberReap:
 				c.nodeFail(e.(serf.MemberEvent))
 			case serf.EventUser:
 				c.localEvent(e.(serf.UserEvent))
-			case serf.EventMemberUpdate: // Ignore
-			case serf.EventMemberReap: // Ignore
 			case serf.EventQuery: // Ignore
 			default:
 				c.logger.Printf("[WARN] consul: unhandled LAN Serf Event: %#v", e)

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -68,12 +68,13 @@ func (c *Client) lanEventHandler() {
 		select {
 		case e := <-c.eventCh:
 			switch e.EventType() {
-			case serf.EventMemberJoin, serf.EventMemberUpdate:
+			case serf.EventMemberJoin:
 				c.nodeJoin(e.(serf.MemberEvent))
 			case serf.EventMemberLeave, serf.EventMemberFailed, serf.EventMemberReap:
 				c.nodeFail(e.(serf.MemberEvent))
 			case serf.EventUser:
 				c.localEvent(e.(serf.UserEvent))
+			case serf.EventMemberUpdate: // Ignore
 			case serf.EventQuery: // Ignore
 			default:
 				c.logger.Printf("[WARN] consul: unhandled LAN Serf Event: %#v", e)

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -133,20 +133,16 @@ func (s *Server) lanEventHandler() {
 		select {
 		case e := <-s.eventChLAN:
 			switch e.EventType() {
-			case serf.EventMemberJoin:
+			case serf.EventMemberJoin, serf.EventMemberUpdate:
 				s.lanNodeJoin(e.(serf.MemberEvent))
 				s.localMemberEvent(e.(serf.MemberEvent))
 
-			case serf.EventMemberLeave, serf.EventMemberFailed:
+			case serf.EventMemberLeave, serf.EventMemberFailed, serf.EventMemberReap:
 				s.lanNodeFailed(e.(serf.MemberEvent))
 				s.localMemberEvent(e.(serf.MemberEvent))
 
-			case serf.EventMemberReap:
-				s.localMemberEvent(e.(serf.MemberEvent))
 			case serf.EventUser:
 				s.localEvent(e.(serf.UserEvent))
-			case serf.EventMemberUpdate:
-				s.localMemberEvent(e.(serf.MemberEvent))
 			case serf.EventQuery: // Ignore
 			default:
 				s.logger.Printf("[WARN] consul: Unhandled LAN Serf Event: %#v", e)

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -133,7 +133,7 @@ func (s *Server) lanEventHandler() {
 		select {
 		case e := <-s.eventChLAN:
 			switch e.EventType() {
-			case serf.EventMemberJoin, serf.EventMemberUpdate:
+			case serf.EventMemberJoin:
 				s.lanNodeJoin(e.(serf.MemberEvent))
 				s.localMemberEvent(e.(serf.MemberEvent))
 
@@ -143,6 +143,8 @@ func (s *Server) lanEventHandler() {
 
 			case serf.EventUser:
 				s.localEvent(e.(serf.UserEvent))
+			case serf.EventMemberUpdate:
+				s.localMemberEvent(e.(serf.MemberEvent))
 			case serf.EventQuery: // Ignore
 			default:
 				s.logger.Printf("[WARN] consul: Unhandled LAN Serf Event: %#v", e)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -237,6 +237,67 @@ func TestServer_JoinLAN(t *testing.T) {
 	})
 }
 
+func TestServer_LANReap(t *testing.T) {
+	t.Parallel()
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+		c.SerfFloodInterval = 100 * time.Millisecond
+		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.ReapInterval = 500 * time.Millisecond
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = false
+		c.SerfFloodInterval = 100 * time.Millisecond
+		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.ReapInterval = 500 * time.Millisecond
+	})
+	defer os.RemoveAll(dir2)
+
+	dir3, s3 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = false
+		c.SerfFloodInterval = 100 * time.Millisecond
+		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.ReapInterval = 500 * time.Millisecond
+	})
+	defer os.RemoveAll(dir3)
+	defer s3.Shutdown()
+
+	// Try to join
+	joinLAN(t, s2, s1)
+	joinLAN(t, s3, s1)
+
+	testrpc.WaitForLeader(t, s3.RPC, "dc1")
+
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, s1.LANMembers(), 3)
+		require.Len(r, s2.LANMembers(), 3)
+		require.Len(r, s3.LANMembers(), 3)
+	})
+
+	// Check the router has both
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, s1.serverLookup.Servers(), 3)
+		require.Len(r, s2.serverLookup.Servers(), 3)
+		require.Len(r, s3.serverLookup.Servers(), 3)
+	})
+
+	// shutdown the second dc
+	s2.Shutdown()
+
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, s1.LANMembers(), 2)
+		servers := s1.serverLookup.Servers()
+		require.Len(r, servers, 2)
+		// require.Equal(r, s1.config.NodeName, servers[0].Name)
+	})
+}
+
 func TestServer_JoinWAN(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServer(t)

--- a/agent/router/serf_adapter.go
+++ b/agent/router/serf_adapter.go
@@ -53,7 +53,7 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 			case serf.EventMemberJoin:
 				handleMemberEvent(logger, router.AddServer, areaID, e)
 
-			case serf.EventMemberLeave:
+			case serf.EventMemberLeave, serf.EventMemberReap:
 				handleMemberEvent(logger, router.RemoveServer, areaID, e)
 
 			case serf.EventMemberFailed:
@@ -61,7 +61,6 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 
 			// All of these event types are ignored.
 			case serf.EventMemberUpdate:
-			case serf.EventMemberReap:
 			case serf.EventUser:
 			case serf.EventQuery:
 

--- a/agent/router/serf_adapter.go
+++ b/agent/router/serf_adapter.go
@@ -50,7 +50,7 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 
 		case e := <-eventCh:
 			switch e.EventType() {
-			case serf.EventMemberJoin:
+			case serf.EventMemberJoin, serf.EventMemberUpdate:
 				handleMemberEvent(logger, router.AddServer, areaID, e)
 
 			case serf.EventMemberLeave, serf.EventMemberReap:
@@ -60,7 +60,6 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 				handleMemberEvent(logger, router.FailServer, areaID, e)
 
 			// All of these event types are ignored.
-			case serf.EventMemberUpdate:
 			case serf.EventUser:
 			case serf.EventQuery:
 

--- a/agent/router/serf_adapter.go
+++ b/agent/router/serf_adapter.go
@@ -50,7 +50,7 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 
 		case e := <-eventCh:
 			switch e.EventType() {
-			case serf.EventMemberJoin, serf.EventMemberUpdate:
+			case serf.EventMemberJoin:
 				handleMemberEvent(logger, router.AddServer, areaID, e)
 
 			case serf.EventMemberLeave, serf.EventMemberReap:
@@ -60,6 +60,7 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 				handleMemberEvent(logger, router.FailServer, areaID, e)
 
 			// All of these event types are ignored.
+			case serf.EventMemberUpdate:
 			case serf.EventUser:
 			case serf.EventQuery:
 


### PR DESCRIPTION
In both the leaving and reaping case the server is no longer available and therefore we must remove it from our list of servers.

If we do not remove servers for a reap event they may stay around forever until the node gets restarted.

Update: Also ensure that `EventMemberUpdate` events are handled just like joins to updated the server info. `AddServers` internally handles update vs new addition.

