### PR TITLE
[DOCS] website: Update UI Policy recommendations from Guide

### DIFF
--- a/website/source/docs/guides/acl.html.md
+++ b/website/source/docs/guides/acl.html.md
@@ -403,7 +403,7 @@ First create the new policy.
 ```bash
 $ consul acl policy create -name "ui-policy" \
                            -description "Necessary permissions for UI functionality" \
-                           -rules 'key "" { policy = "write" } node "" { policy = "read" } service "" { policy = "read" }'
+                           -rules 'key_prefix "" { policy = "write" } node_prefix "" { policy = "read" } service_prefix "" { policy = "read" }'
 
 ID:           9cb99b2b-3c20-81d4-a7c0-9ffdc2fbf08a
 Name:         ui-policy


### PR DESCRIPTION
The guide currently uses node, service, and service for the UI Policy.
This will cause a practically useless UI. This patch uses the _prefix
variants instead which will have the intended behavior.