### PR TITLE
Remove invalid option -name from ACL token read documentation

### DIFF
--- a/website/source/docs/commands/acl/acl-token.html.md.erb
+++ b/website/source/docs/commands/acl/acl-token.html.md.erb
@@ -169,8 +169,6 @@ Usage: `consul acl token read [options] [args]`
 * `-meta` - Indicates that policy metadata such as the content hash and raft
   indices should be shown for each entry.
 
-* `-name=<string>` - The name of the policy to read.
-
 * `-self` - Indicates that the current HTTP token should be read by secret ID
    instead of expecting a -id option.
 


### PR DESCRIPTION
It appears that the `read` command for ACL policies was used to template the `read` command for ACL tokens, and an invalid option was not dropped from the docs.  