### PR TITLE
Docs EA update RA and DG

### DIFF
--- a/website/source/docs/guides/deployment-guide.html.md
+++ b/website/source/docs/guides/deployment-guide.html.md
@@ -5,7 +5,8 @@ sidebar_current: "docs-guides-deployment-guide"
 description: |-
   This deployment guide covers the steps required to install and
   configure a single HashiCorp Consul cluster as defined in the
-  Consul Reference Architecture
+  Consul Reference Architecture.
+ea_version: 1.3
 ---
 
 # Consul Deployment Guide

--- a/website/source/docs/guides/deployment.html.md
+++ b/website/source/docs/guides/deployment.html.md
@@ -5,7 +5,7 @@ sidebar_current: "docs-guides-reference-architecture"
 description: |-
   This document provides recommended practices and a reference
   architecture for HashiCorp Consul production deployments.
-product_version: 1.2
+ea_version: 1.3
 ---
 
 # Consul Reference Architecture


### PR DESCRIPTION
Manual testing of Consul 1.3 version using the existing Reference Architecture and Deployment Guide. This change adds frontmatter to identify the version of Consul these documents are verified against. To avoid confusion the frontmatter has been changed from `product_version` to `ea_version` as this is a verification carried out by the EA team.