### PR TITLE
clarify the ACL.PolicyDelete endpoint

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -328,8 +328,8 @@ func (s *HTTPServer) ACLPolicyDelete(resp http.ResponseWriter, req *http.Request
 	}
 	s.parseToken(req, &args.Token)
 
-	var out string
-	if err := s.agent.RPC("ACL.PolicyDelete", args, &out); err != nil {
+	var ignored string
+	if err := s.agent.RPC("ACL.PolicyDelete", args, &ignored); err != nil {
 		return nil, err
 	}
 
@@ -497,8 +497,8 @@ func (s *HTTPServer) ACLTokenDelete(resp http.ResponseWriter, req *http.Request,
 	}
 	s.parseToken(req, &args.Token)
 
-	var out string
-	if err := s.agent.RPC("ACL.TokenDelete", args, &out); err != nil {
+	var ignored string
+	if err := s.agent.RPC("ACL.TokenDelete", args, &ignored); err != nil {
 		return nil, err
 	}
 	return true, nil

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -811,10 +811,6 @@ func (a *ACL) PolicyDelete(args *structs.ACLPolicyDeleteRequest, reply *string) 
 
 	a.srv.acls.cache.RemovePolicy(policy.ID)
 
-	if resp == nil {
-		return nil
-	}
-
 	if respErr, ok := resp.(error); ok {
 		return respErr
 	}


### PR DESCRIPTION
There was an errant early-return in PolicyDelete() that bypassed the
rest of the function.  This was ok because the only caller of this
function ignores the results.

This removes the early-return making it structurally behave like
TokenDelete() and for both PolicyDelete and TokenDelete clarify the lone
callers to indicate that the return values are ignored.

We may wish to avoid the entire return value as well, but this patch
doesn't go that far.