### PR TITLE
Pass a testing.T into NewTestAgent and TestAgent.Start

### DIFF
--- a/agent/acl_endpoint_legacy_test.go
+++ b/agent/acl_endpoint_legacy_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestACL_Legacy_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	tests := []func(resp http.ResponseWriter, req *http.Request) (interface{}, error){
@@ -71,7 +71,7 @@ func makeTestACL(t *testing.T, srv *HTTPServer) string {
 
 func TestACL_Legacy_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -101,7 +101,7 @@ func TestACL_Legacy_Update(t *testing.T) {
 
 func TestACL_Legacy_UpdateUpsert(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer(nil)
@@ -130,7 +130,7 @@ func TestACL_Legacy_UpdateUpsert(t *testing.T) {
 
 func TestACL_Legacy_Destroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -162,7 +162,7 @@ func TestACL_Legacy_Destroy(t *testing.T) {
 
 func TestACL_Legacy_Clone(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -207,7 +207,7 @@ func TestACL_Legacy_Clone(t *testing.T) {
 func TestACL_Legacy_Get(t *testing.T) {
 	t.Parallel()
 	t.Run("wrong id", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), TestACLConfig())
+		a := NewTestAgent(t, t.Name(), TestACLConfig())
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/acl/info/nope", nil)
@@ -227,7 +227,7 @@ func TestACL_Legacy_Get(t *testing.T) {
 	})
 
 	t.Run("right id", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), TestACLConfig())
+		a := NewTestAgent(t, t.Name(), TestACLConfig())
 		defer a.Shutdown()
 
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -251,7 +251,7 @@ func TestACL_Legacy_Get(t *testing.T) {
 
 func TestACL_Legacy_List(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -280,7 +280,7 @@ func TestACL_Legacy_List(t *testing.T) {
 
 func TestACLReplicationStatus(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/acl/replication", nil)

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestACL_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	type testCase struct {
@@ -64,7 +64,7 @@ func jsonBody(v interface{}) io.Reader {
 
 func TestACL_Bootstrap(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
       acl_master_token = ""
    `)
 	defer a.Shutdown()
@@ -112,7 +112,7 @@ func TestACL_Bootstrap(t *testing.T) {
 
 func TestACL_HTTP(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -53,7 +53,7 @@ func makeReadOnlyAgentACL(t *testing.T, srv *HTTPServer) string {
 
 func TestAgent_Services(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -105,7 +105,7 @@ func TestAgent_Services_ExternalConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -142,7 +142,7 @@ func TestAgent_Services_Sidecar(t *testing.T) {
 
 	require := require.New(t)
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -189,7 +189,7 @@ func TestAgent_Services_Sidecar(t *testing.T) {
 
 func TestAgent_Services_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -229,7 +229,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 func TestAgent_Service(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
 	services {
 		name = "web"
 		port = 8181
@@ -524,7 +524,7 @@ func TestAgent_Service(t *testing.T) {
 // in proxy to use only that without breaking managed proxies early.
 func TestAgent_Service_DeprecatedManagedProxy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		connect {
 			proxy {
 				allow_managed_api_registration = true
@@ -601,7 +601,7 @@ func TestAgent_Service_DeprecatedManagedProxy(t *testing.T) {
 
 func TestAgent_Checks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -629,7 +629,7 @@ func TestAgent_Checks(t *testing.T) {
 
 func TestAgent_HealthServiceByID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -824,7 +824,7 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 
 func TestAgent_HealthServiceByName(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	service := &structs.NodeService{
@@ -1067,7 +1067,7 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 
 func TestAgent_Checks_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1106,7 +1106,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 
 func TestAgent_Self(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_meta {
 			somekey = "somevalue"
 		}
@@ -1144,7 +1144,7 @@ func TestAgent_Self(t *testing.T) {
 
 func TestAgent_Self_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1173,7 +1173,7 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 func TestAgent_Metrics_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1203,7 +1203,7 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 func TestAgent_Reload(t *testing.T) {
 	t.Parallel()
 	dc1 := "dc1"
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		acl_enforce_version_8 = false
 		services = [
 			{
@@ -1275,7 +1275,7 @@ func TestAgent_Reload(t *testing.T) {
 
 func TestAgent_Reload_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1302,7 +1302,7 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 
 func TestAgent_Members(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1323,7 +1323,7 @@ func TestAgent_Members(t *testing.T) {
 
 func TestAgent_Members_WAN(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1344,7 +1344,7 @@ func TestAgent_Members_WAN(t *testing.T) {
 
 func TestAgent_Members_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1375,9 +1375,9 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 
 func TestAgent_Join(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), "")
+	a1 := NewTestAgent(t, t.Name(), "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t.Name(), "")
+	a2 := NewTestAgent(t, t.Name(), "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1405,9 +1405,9 @@ func TestAgent_Join(t *testing.T) {
 
 func TestAgent_Join_WAN(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), "")
+	a1 := NewTestAgent(t, t.Name(), "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t.Name(), "")
+	a2 := NewTestAgent(t, t.Name(), "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1435,9 +1435,9 @@ func TestAgent_Join_WAN(t *testing.T) {
 
 func TestAgent_Join_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), TestACLConfig())
+	a1 := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t.Name(), "")
+	a2 := NewTestAgent(t, t.Name(), "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1477,11 +1477,11 @@ func (n *mockNotifier) Notify(state string) error {
 
 func TestAgent_JoinLANNotify(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), "")
+	a1 := NewTestAgent(t, t.Name(), "")
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		server = false
 		bootstrap = false
 	`)
@@ -1503,11 +1503,11 @@ func TestAgent_JoinLANNotify(t *testing.T) {
 
 func TestAgent_Leave(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), "")
+	a1 := NewTestAgent(t, t.Name(), "")
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
  		server = false
  		bootstrap = false
  	`)
@@ -1539,7 +1539,7 @@ func TestAgent_Leave(t *testing.T) {
 
 func TestAgent_Leave_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1570,9 +1570,9 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 
 func TestAgent_ForceLeave(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), "")
+	a1 := NewTestAgent(t, t.Name(), "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t.Name(), "")
+	a2 := NewTestAgent(t, t.Name(), "")
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
 
@@ -1613,7 +1613,7 @@ func TestAgent_ForceLeave(t *testing.T) {
 
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1642,7 +1642,7 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 
 func TestAgent_RegisterCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1685,7 +1685,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 // support as a result of https://github.com/hashicorp/consul/issues/3587.
 func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 `)
 	defer a.Shutdown()
@@ -1770,7 +1770,7 @@ func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 
 func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1796,7 +1796,7 @@ func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 
 func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_local_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1824,7 +1824,7 @@ func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 
 func TestAgent_RegisterCheck_Passing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1860,7 +1860,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 
 func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1881,7 +1881,7 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 
 func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1907,7 +1907,7 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1933,7 +1933,7 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 
 func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1959,7 +1959,7 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 
 func TestAgent_PassCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1987,7 +1987,7 @@ func TestAgent_PassCheck(t *testing.T) {
 
 func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2014,7 +2014,7 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_WarnCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2042,7 +2042,7 @@ func TestAgent_WarnCheck(t *testing.T) {
 
 func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2069,7 +2069,7 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_FailCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2097,7 +2097,7 @@ func TestAgent_FailCheck(t *testing.T) {
 
 func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2124,7 +2124,7 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_UpdateCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2208,7 +2208,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 
 func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2237,7 +2237,7 @@ func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_RegisterService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2304,7 +2304,7 @@ func TestAgent_RegisterService(t *testing.T) {
 
 func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	connect {
 		proxy {
 			allow_managed_api_registration = true
@@ -2507,7 +2507,7 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 
 func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2545,7 +2545,7 @@ func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 
 func TestAgent_RegisterService_InvalidAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2578,7 +2578,7 @@ func TestAgent_RegisterService_ManagedConnectProxy(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		connect {
 			proxy {
 				allow_managed_api_registration = true
@@ -2649,7 +2649,7 @@ func TestAgent_RegisterService_ManagedConnectProxyDeprecated(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		connect {
 			proxy {
 				allow_managed_api_registration = true
@@ -2746,7 +2746,7 @@ func TestAgent_RegisterService_ManagedConnectProxy_Disabled(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), ``)
+	a := NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2785,7 +2785,7 @@ func TestAgent_RegisterService_UnmanagedConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3252,7 +3252,7 @@ func TestAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T) {
 				hcl = hcl + TestACLConfig()
 			}
 
-			a := NewTestAgent(t.Name(), hcl)
+			a := NewTestAgent(t, t.Name(), hcl)
 			defer a.Shutdown()
 			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3353,7 +3353,7 @@ func TestAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3386,7 +3386,7 @@ func TestAgent_RegisterService_ConnectNative(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3418,7 +3418,7 @@ func TestAgent_RegisterService_ConnectNative(t *testing.T) {
 
 func TestAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3454,7 +3454,7 @@ func TestAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T) {
 
 func TestAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_local_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -3492,7 +3492,7 @@ func TestAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T) {
 
 func TestAgent_DeregisterService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3525,7 +3525,7 @@ func TestAgent_DeregisterService(t *testing.T) {
 
 func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3555,7 +3555,7 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 func TestAgent_DeregisterService_withManagedProxy(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		connect {
 			proxy {
 				allow_managed_api_registration = true
@@ -3611,7 +3611,7 @@ func TestAgent_DeregisterService_withManagedProxy(t *testing.T) {
 func TestAgent_DeregisterService_managedProxyDirect(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		connect {
 			proxy {
 				allow_managed_api_registration = true
@@ -3658,7 +3658,7 @@ func TestAgent_DeregisterService_managedProxyDirect(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3698,7 +3698,7 @@ func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3741,7 +3741,7 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3778,7 +3778,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3808,7 +3808,7 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 
 func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3825,7 +3825,7 @@ func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 
 func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3858,7 +3858,7 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 
 func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3883,7 +3883,7 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 
 func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3904,7 +3904,7 @@ func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 
 func TestAgent_RegisterCheck_Service(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3956,7 +3956,7 @@ func TestAgent_Monitor(t *testing.T) {
 		LogWriter: logWriter,
 		LogOutput: io.MultiWriter(os.Stderr, logWriter),
 	}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4018,7 +4018,7 @@ func (r *closableRecorder) CloseNotify() <-chan bool {
 
 func TestAgent_Monitor_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4040,7 +4040,7 @@ func TestAgent_Token(t *testing.T) {
 	// The behavior of this handler when ACLs are disabled is vetted over
 	// in TestACL_Disabled_Response since there's already good infra set
 	// up over there to test this, and it calls the common function.
-	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
 		acl_token = ""
 		acl_agent_token = ""
 		acl_agent_master_token = ""
@@ -4199,7 +4199,7 @@ func TestAgentConnectCARoots_empty(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "connect { enabled = false }")
+	a := NewTestAgent(t, t.Name(), "connect { enabled = false }")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4215,7 +4215,7 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4292,7 +4292,7 @@ func TestAgentConnectCALeafCert_aclDefaultDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4329,7 +4329,7 @@ func TestAgentConnectCALeafCert_aclProxyToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4375,7 +4375,7 @@ func TestAgentConnectCALeafCert_aclProxyTokenOther(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4440,7 +4440,7 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4498,7 +4498,7 @@ func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4554,7 +4554,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4656,7 +4656,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4790,7 +4790,7 @@ func requireLeafValidUnderCA(t *testing.T, issued *structs.IssuedCert,
 func TestAgentConnectProxyConfig_Blocking(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4997,7 +4997,7 @@ func TestAgentConnectProxyConfig_aclDefaultDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5033,7 +5033,7 @@ func TestAgentConnectProxyConfig_aclProxyToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5081,7 +5081,7 @@ func TestAgentConnectProxyConfig_aclServiceWrite(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5140,7 +5140,7 @@ func TestAgentConnectProxyConfig_aclServiceReadDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -5506,7 +5506,7 @@ func TestAgentConnectProxyConfig_ConfigHandling(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			a := NewTestAgent(t.Name(), tt.globalConfig)
+			a := NewTestAgent(t, t.Name(), tt.globalConfig)
 			defer a.Shutdown()
 			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -5550,7 +5550,7 @@ func TestAgentConnectAuthorize_badBody(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5570,7 +5570,7 @@ func TestAgentConnectAuthorize_noTarget(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5591,7 +5591,7 @@ func TestAgentConnectAuthorize_idInvalidFormat(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5615,7 +5615,7 @@ func TestAgentConnectAuthorize_idNotService(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5638,7 +5638,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5735,7 +5735,7 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5785,7 +5785,7 @@ func TestAgentConnectAuthorize_allowTrustDomain(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5830,7 +5830,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -5910,7 +5910,7 @@ func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5948,7 +5948,7 @@ func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5973,7 +5973,7 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 
 	assert := assert.New(t)
 	dc1 := "dc1"
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		acl_datacenter = "`+dc1+`"
 		acl_default_policy = "allow"
 		acl_master_token = "root"
@@ -6019,7 +6019,7 @@ func TestAgent_Host(t *testing.T) {
 	assert := assert.New(t)
 
 	dc1 := "dc1"
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "allow"
 	acl_master_token = "master"
@@ -6047,7 +6047,7 @@ func TestAgent_HostBadACL(t *testing.T) {
 	assert := assert.New(t)
 
 	dc1 := "dc1"
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "deny"
 	acl_master_token = "root"

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -50,7 +50,7 @@ func TestAgent_MultiStartStop(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			a := NewTestAgent(t.Name(), "")
+			a := NewTestAgent(t, t.Name(), "")
 			time.Sleep(250 * time.Millisecond)
 			a.Shutdown()
 		})
@@ -93,7 +93,7 @@ func TestAgent_ConnectClusterIDConfig(t *testing.T) {
 			testFn := func() {
 				a := &TestAgent{Name: "test", HCL: tt.hcl}
 				a.ExpectConfigError = tt.wantPanic
-				a.Start()
+				a.Start(t)
 				defer a.Shutdown()
 
 				cfg := a.consulConfig()
@@ -111,7 +111,7 @@ func TestAgent_ConnectClusterIDConfig(t *testing.T) {
 
 func TestAgent_StartStop(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	if err := a.Leave(); err != nil {
@@ -130,7 +130,7 @@ func TestAgent_StartStop(t *testing.T) {
 
 func TestAgent_RPCPing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	var out struct{}
@@ -142,7 +142,7 @@ func TestAgent_RPCPing(t *testing.T) {
 func TestAgent_TokenStore(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		acl_token = "user"
 		acl_agent_token = "agent"
 		acl_agent_master_token = "master"`,
@@ -163,7 +163,7 @@ func TestAgent_TokenStore(t *testing.T) {
 func TestAgent_ReconnectConfigSettings(t *testing.T) {
 	t.Parallel()
 	func() {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		lan := a.consulConfig().SerfLANConfig.ReconnectTimeout
@@ -178,7 +178,7 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 	}()
 
 	func() {
-		a := NewTestAgent(t.Name(), `
+		a := NewTestAgent(t, t.Name(), `
 			reconnect_timeout = "24h"
 			reconnect_timeout_wan = "36h"
 		`)
@@ -199,7 +199,7 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		ports { serf_wan = -1 }
 		reconnect_timeout_wan = "36h"
 	`)
@@ -211,7 +211,7 @@ func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
 
 func TestAgent_setupNodeID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_id = ""
 	`)
 	defer a.Shutdown()
@@ -279,7 +279,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 
 func TestAgent_makeNodeID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_id = ""
 	`)
 	defer a.Shutdown()
@@ -325,7 +325,7 @@ func TestAgent_makeNodeID(t *testing.T) {
 
 func TestAgent_AddService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "node1"
 	`)
 	defer a.Shutdown()
@@ -497,7 +497,7 @@ func TestAgent_AddService(t *testing.T) {
 
 func TestAgent_AddServiceNoExec(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "node1"
 	`)
 	defer a.Shutdown()
@@ -527,7 +527,7 @@ func TestAgent_AddServiceNoExec(t *testing.T) {
 
 func TestAgent_AddServiceNoRemoteExec(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "node1"
 		enable_local_script_checks = true
 	`)
@@ -553,7 +553,7 @@ func TestAgent_AddServiceNoRemoteExec(t *testing.T) {
 
 func TestAgent_RemoveService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Remove a service that doesn't exist
@@ -647,7 +647,7 @@ func TestAgent_RemoveService(t *testing.T) {
 
 func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "node1"
 	`)
 	defer a.Shutdown()
@@ -715,7 +715,7 @@ func TestAgent_IndexChurn(t *testing.T) {
 func verifyIndexChurn(t *testing.T, tags []string) {
 	t.Helper()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	weights := &structs.Weights{
@@ -807,7 +807,7 @@ func verifyIndexChurn(t *testing.T, tags []string) {
 
 func TestAgent_AddCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -846,7 +846,7 @@ func TestAgent_AddCheck(t *testing.T) {
 
 func TestAgent_AddCheck_StartPassing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -885,7 +885,7 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 
 func TestAgent_AddCheck_MinInterval(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -920,7 +920,7 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 
 func TestAgent_AddCheck_MissingService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -943,7 +943,7 @@ func TestAgent_AddCheck_MissingService(t *testing.T) {
 
 func TestAgent_AddCheck_RestoreState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create some state and persist it
@@ -987,7 +987,7 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1024,7 +1024,7 @@ func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_local_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1053,7 +1053,7 @@ func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
 
 func TestAgent_AddCheck_GRPC(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1092,7 +1092,7 @@ func TestAgent_AddCheck_Alias(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1126,7 +1126,7 @@ func TestAgent_AddCheck_Alias_setToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1154,7 +1154,7 @@ func TestAgent_AddCheck_Alias_userToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 acl_token = "hello"
 	`)
 	defer a.Shutdown()
@@ -1184,7 +1184,7 @@ func TestAgent_AddCheck_Alias_userAndSetToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 acl_token = "hello"
 	`)
 	defer a.Shutdown()
@@ -1212,7 +1212,7 @@ acl_token = "hello"
 
 func TestAgent_RemoveCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1267,7 +1267,7 @@ func TestAgent_HTTPCheck_TLSSkipVerify(t *testing.T) {
 	server := httptest.NewTLSServer(handler)
 	defer server.Close()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1315,7 +1315,7 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 				cert_file = "../test/client_certs/server.crt"
 			` + ca,
 		}
-		a.Start()
+		a.Start(t)
 		defer a.Shutdown()
 
 		health := &structs.HealthCheck{
@@ -1366,7 +1366,7 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 
 func TestAgent_updateTTLCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1407,7 +1407,7 @@ func TestAgent_PersistService(t *testing.T) {
 		data_dir = "` + dataDir + `"
 	`
 	a := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a.Start()
+	a.Start(t)
 	defer os.RemoveAll(dataDir)
 	defer a.Shutdown()
 
@@ -1473,7 +1473,7 @@ func TestAgent_PersistService(t *testing.T) {
 
 	// Should load it back during later start
 	a2 := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a2.Start()
+	a2.Start(t)
 	defer a2.Shutdown()
 
 	restored := a2.State.ServiceState(svc.ID)
@@ -1491,7 +1491,7 @@ func TestAgent_PersistService(t *testing.T) {
 func TestAgent_persistedService_compat(t *testing.T) {
 	t.Parallel()
 	// Tests backwards compatibility of persisted services from pre-0.5.1
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -1534,7 +1534,7 @@ func TestAgent_persistedService_compat(t *testing.T) {
 
 func TestAgent_PurgeService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -1580,7 +1580,7 @@ func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
 		bootstrap = false
 	`
 	a := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	defer os.RemoveAll(dataDir)
 
@@ -1607,7 +1607,7 @@ func TestAgent_PurgeServiceOnDuplicate(t *testing.T) {
 			port = 9000
 		}
 	`, DataDir: dataDir}
-	a2.Start()
+	a2.Start(t)
 	defer a2.Shutdown()
 
 	file := filepath.Join(a.Config.DataDir, servicesDir, stringHash(svc1.ID))
@@ -1632,7 +1632,7 @@ func TestAgent_PersistProxy(t *testing.T) {
 		data_dir = "` + dataDir + `"
 	`
 	a := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a.Start()
+	a.Start(t)
 	defer os.RemoveAll(dataDir)
 	defer a.Shutdown()
 
@@ -1692,7 +1692,7 @@ func TestAgent_PersistProxy(t *testing.T) {
 
 	// Should load it back during later start
 	a2 := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a2.Start()
+	a2.Start(t)
 	defer a2.Shutdown()
 
 	restored := a2.State.Proxy("redis-proxy")
@@ -1705,7 +1705,7 @@ func TestAgent_PersistProxy(t *testing.T) {
 
 func TestAgent_PurgeProxy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	require := require.New(t)
@@ -1752,7 +1752,7 @@ func TestAgent_PurgeProxyOnDuplicate(t *testing.T) {
 		bootstrap = false
 	`
 	a := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	defer os.RemoveAll(dataDir)
 
@@ -1792,7 +1792,7 @@ func TestAgent_PurgeProxyOnDuplicate(t *testing.T) {
 			}
 		}
 	`, DataDir: dataDir}
-	a2.Start()
+	a2.Start(t)
 	defer a2.Shutdown()
 
 	file := filepath.Join(a.Config.DataDir, proxyDir, stringHash(proxyID))
@@ -1814,7 +1814,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 		enable_script_checks = true
 	`
 	a := &TestAgent{Name: t.Name(), HCL: cfg, DataDir: dataDir}
-	a.Start()
+	a.Start(t)
 	defer os.RemoveAll(dataDir)
 	defer a.Shutdown()
 
@@ -1886,7 +1886,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 
 	// Should load it back during later start
 	a2 := &TestAgent{Name: t.Name() + "-a2", HCL: cfg, DataDir: dataDir}
-	a2.Start()
+	a2.Start(t)
 	defer a2.Shutdown()
 
 	result := a2.State.Check(check.CheckID)
@@ -1911,7 +1911,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 
 func TestAgent_PurgeCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	check := &structs.HealthCheck{
@@ -1947,7 +1947,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	t.Parallel()
 	nodeID := NodeID()
 	dataDir := testutil.TempDir(t, "agent")
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	    node_id = "`+nodeID+`"
 	    node_name = "Node `+nodeID+`"
 		data_dir = "`+dataDir+`"
@@ -1972,7 +1972,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	a.Shutdown()
 
 	// Start again with the check registered in config
-	a2 := NewTestAgent(t.Name()+"-a2", `
+	a2 := NewTestAgent(t, t.Name()+"-a2", `
 	    node_id = "`+nodeID+`"
 	    node_name = "Node `+nodeID+`"
 		data_dir = "`+dataDir+`"
@@ -2011,7 +2011,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 
 func TestAgent_loadChecks_token(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		check = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2032,7 +2032,7 @@ func TestAgent_loadChecks_token(t *testing.T) {
 
 func TestAgent_unloadChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2084,7 +2084,7 @@ func TestAgent_unloadChecks(t *testing.T) {
 
 func TestAgent_loadServices_token(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2105,7 +2105,7 @@ func TestAgent_loadServices_token(t *testing.T) {
 
 func TestAgent_loadServices_sidecar(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2139,7 +2139,7 @@ func TestAgent_loadServices_sidecar(t *testing.T) {
 
 func TestAgent_loadServices_sidecarSeparateToken(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2172,7 +2172,7 @@ func TestAgent_loadServices_sidecarSeparateToken(t *testing.T) {
 func TestAgent_loadServices_sidecarInheritMeta(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2209,7 +2209,7 @@ func TestAgent_loadServices_sidecarInheritMeta(t *testing.T) {
 func TestAgent_loadServices_sidecarOverrideMeta(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2249,7 +2249,7 @@ func TestAgent_loadServices_sidecarOverrideMeta(t *testing.T) {
 
 func TestAgent_unloadServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2285,7 +2285,7 @@ func TestAgent_unloadServices(t *testing.T) {
 
 func TestAgent_loadProxies(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2323,7 +2323,7 @@ func TestAgent_loadProxies(t *testing.T) {
 
 func TestAgent_loadProxies_nilProxy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2344,7 +2344,7 @@ func TestAgent_loadProxies_nilProxy(t *testing.T) {
 
 func TestAgent_unloadProxies(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2375,7 +2375,7 @@ func TestAgent_unloadProxies(t *testing.T) {
 
 func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2439,7 +2439,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 
 func TestAgent_Service_Reap(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		check_reap_interval = "50ms"
 		check_deregister_interval_min = "0s"
 	`)
@@ -2514,7 +2514,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 
 func TestAgent_Service_NoReap(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		check_reap_interval = "50ms"
 		check_deregister_interval_min = "0s"
 	`)
@@ -2567,7 +2567,7 @@ func TestAgent_Service_NoReap(t *testing.T) {
 
 func TestAgent_AddService_restoresSnapshot(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2610,7 +2610,7 @@ func TestAgent_AddService_restoresSnapshot(t *testing.T) {
 
 func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2653,7 +2653,7 @@ func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 
 func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Enter maintenance mode for the node
@@ -2698,7 +2698,7 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 
 func TestAgent_checkStateSnapshot(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2755,7 +2755,7 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 
 func TestAgent_loadChecks_checkFails(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Persist a health check with an invalid service ID
@@ -2790,7 +2790,7 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 
 func TestAgent_persistCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create the TTL check to persist
@@ -2837,7 +2837,7 @@ func TestAgent_persistCheckState(t *testing.T) {
 
 func TestAgent_loadCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create a check whose state will expire immediately
@@ -2898,7 +2898,7 @@ func TestAgent_loadCheckState(t *testing.T) {
 
 func TestAgent_purgeCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// No error if the state does not exist
@@ -2931,7 +2931,7 @@ func TestAgent_purgeCheckState(t *testing.T) {
 func TestAgent_GetCoordinate(t *testing.T) {
 	t.Parallel()
 	check := func(server bool) {
-		a := NewTestAgent(t.Name(), `
+		a := NewTestAgent(t, t.Name(), `
 			server = true
 		`)
 		defer a.Shutdown()
@@ -2951,7 +2951,7 @@ func TestAgent_GetCoordinate(t *testing.T) {
 
 func TestAgent_reloadWatches(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Normal watch with http addr set, should succeed
@@ -3010,7 +3010,7 @@ func TestAgent_reloadWatches(t *testing.T) {
 func TestAgent_reloadWatchesHTTPS(t *testing.T) {
 	t.Parallel()
 	a := TestAgent{Name: t.Name(), UseTLS: true}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	// Normal watch with http addr set, should succeed
@@ -3186,7 +3186,7 @@ func TestAgent_AddProxy(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			require := require.New(t)
 
-			a := NewTestAgent(t.Name(), `
+			a := NewTestAgent(t, t.Name(), `
 				node_name = "node1"
 
 				# Explicit test because proxies inheriting this value must have a health
@@ -3256,7 +3256,7 @@ func TestAgent_AddProxy(t *testing.T) {
 
 func TestAgent_RemoveProxy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "node1"
 	`)
 	defer a.Shutdown()
@@ -3295,7 +3295,7 @@ func TestAgent_RemoveProxy(t *testing.T) {
 
 func TestAgent_ReLoadProxiesFromConfig(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(),
+	a := NewTestAgent(t, t.Name(),
 		`node_name = "node1"
 	`)
 	defer a.Shutdown()

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	for _, addr := range []string{"0.0.0.0", "::", "[::]"} {
@@ -42,7 +42,7 @@ func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 
 func TestCatalogDeregister(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Register node
@@ -61,7 +61,7 @@ func TestCatalogDeregister(t *testing.T) {
 
 func TestCatalogDatacenters(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	retry.Run(t, func(r *retry.R) {
@@ -80,7 +80,7 @@ func TestCatalogDatacenters(t *testing.T) {
 
 func TestCatalogNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -114,7 +114,7 @@ func TestCatalogNodes(t *testing.T) {
 
 func TestCatalogNodes_MetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -155,7 +155,7 @@ func TestCatalogNodes_MetaFilter(t *testing.T) {
 
 func TestCatalogNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -163,7 +163,7 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -253,7 +253,7 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 
 func TestCatalogNodes_Blocking(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -323,7 +323,7 @@ func TestCatalogNodes_Blocking(t *testing.T) {
 
 func TestCatalogNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -408,7 +408,7 @@ func TestCatalogNodes_DistanceSort(t *testing.T) {
 
 func TestCatalogServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -444,7 +444,7 @@ func TestCatalogServices(t *testing.T) {
 
 func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Register node
@@ -485,7 +485,7 @@ func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 
 func TestCatalogServiceNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	assert := assert.New(t)
@@ -598,7 +598,7 @@ func TestCatalogServiceNodes(t *testing.T) {
 
 func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is returned, not a nil
@@ -653,14 +653,14 @@ func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 
 func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -738,7 +738,7 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -830,7 +830,7 @@ func TestCatalogServiceNodes_ConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -860,7 +860,7 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -886,7 +886,7 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 
 func TestCatalogNodeServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -933,7 +933,7 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -957,7 +957,7 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 
 func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -965,7 +965,7 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -21,7 +21,7 @@ func TestConnectCARoots_empty(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "connect { enabled = false }")
+	a := NewTestAgent(t, t.Name(), "connect { enabled = false }")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -36,7 +36,7 @@ func TestConnectCARoots_list(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -65,7 +65,7 @@ func TestConnectCAConfig(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestCoordinate_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		disable_coordinates = true
 `)
 	defer a.Shutdown()
@@ -51,7 +51,7 @@ func TestCoordinate_Disabled_Response(t *testing.T) {
 
 func TestCoordinate_Datacenters(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -73,7 +73,7 @@ func TestCoordinate_Datacenters(t *testing.T) {
 
 func TestCoordinate_Nodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -184,7 +184,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 
 func TestCoordinate_Node(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -288,7 +288,7 @@ func TestCoordinate_Node(t *testing.T) {
 
 func TestCoordinate_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -335,7 +335,7 @@ func TestCoordinate_Update(t *testing.T) {
 
 func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -142,7 +142,7 @@ func TestEncodeKVasRFC1464(t *testing.T) {
 
 func TestDNS_Over_TCP(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -175,7 +175,7 @@ func TestDNS_Over_TCP(t *testing.T) {
 
 func TestDNS_NodeLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -270,7 +270,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 
 func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -302,7 +302,7 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -342,7 +342,7 @@ func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 
 func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -399,7 +399,7 @@ func TestDNSCycleRecursorCheck(t *testing.T) {
 	})
 	defer server2.Shutdown()
 	//Mock the agent startup with the necessary configs
-	agent := NewTestAgent(t.Name(),
+	agent := NewTestAgent(t, t.Name(),
 		`recursors = ["`+server1.Addr+`", "`+server2.Addr+`"]
 		`)
 	defer agent.Shutdown()
@@ -433,7 +433,7 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 	})
 	defer server3.Shutdown()
 	//Mock the agent startup with the necessary configs
-	agent := NewTestAgent(t.Name(),
+	agent := NewTestAgent(t, t.Name(),
 		`recursors = ["`+server1.Addr+`", "`+server2.Addr+`","`+server3.Addr+`"]
 		`)
 	defer agent.Shutdown()
@@ -457,7 +457,7 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -506,7 +506,7 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT(t *testing.T) {
-	a := NewTestAgent(t.Name(), ``)
+	a := NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -552,7 +552,7 @@ func TestDNS_NodeLookup_TXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
-	a := NewTestAgent(t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -598,7 +598,7 @@ func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY(t *testing.T) {
-	a := NewTestAgent(t.Name(), ``)
+	a := NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -639,7 +639,7 @@ func TestDNS_NodeLookup_ANY(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
-	a := NewTestAgent(t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -680,7 +680,7 @@ func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
-	a := NewTestAgent(t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -717,7 +717,7 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 
 func TestDNS_EDNS0(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -757,7 +757,7 @@ func TestDNS_EDNS0(t *testing.T) {
 
 func TestDNS_EDNS0_ECS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -849,7 +849,7 @@ func TestDNS_EDNS0_ECS(t *testing.T) {
 
 func TestDNS_ReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -889,7 +889,7 @@ func TestDNS_ReverseLookup(t *testing.T) {
 
 func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		domain = "custom"
 	`)
 	defer a.Shutdown()
@@ -931,7 +931,7 @@ func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 
 func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -971,7 +971,7 @@ func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1019,7 +1019,7 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1067,7 +1067,7 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		domain = "custom"
 	`)
 	defer a.Shutdown()
@@ -1118,7 +1118,7 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 func TestDNS_SOA_Settings(t *testing.T) {
 	t.Parallel()
 	testSoaWithConfig := func(config string, ttl, expire, refresh, retry uint) {
-		a := NewTestAgent(t.Name(), config)
+		a := NewTestAgent(t, t.Name(), config)
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1150,7 +1150,7 @@ func TestDNS_SOA_Settings(t *testing.T) {
 
 func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1198,7 +1198,7 @@ func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 
 func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1253,7 +1253,7 @@ func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1311,7 +1311,7 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1385,7 +1385,7 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1506,7 +1506,7 @@ func TestDNS_ServiceLookup(t *testing.T) {
 
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "my.test-node"
 	`)
 	defer a.Shutdown()
@@ -1569,7 +1569,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1613,7 +1613,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 
 func TestDNS_ExternalServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1686,7 +1686,7 @@ func TestDNS_ExternalServiceLookup(t *testing.T) {
 func TestDNS_InifiniteRecursion(t *testing.T) {
 	// This test should not create an infinite recursion
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		domain = "CONSUL."
 		node_name = "test node"
 	`)
@@ -1740,7 +1740,7 @@ func TestDNS_InifiniteRecursion(t *testing.T) {
 
 func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		domain = "CONSUL."
 		node_name = "test node"
 	`)
@@ -1853,7 +1853,7 @@ func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 
 func TestDNS_NSRecords(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		domain = "CONSUL."
 		node_name = "server1"
 	`)
@@ -1888,7 +1888,7 @@ func TestDNS_NSRecords(t *testing.T) {
 
 func TestDNS_NSRecords_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
  		domain = "CONSUL."
  		node_name = "server1"
  		advertise_addr = "::1"
@@ -1925,7 +1925,7 @@ func TestDNS_NSRecords_IPV6(t *testing.T) {
 
 func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "test-node"
 	`)
 	defer a.Shutdown()
@@ -2067,7 +2067,7 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2160,7 +2160,7 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 
 func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2253,7 +2253,7 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2346,14 +2346,14 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 
 func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -2534,7 +2534,7 @@ func TestDNS_ServiceLookup_WanAddress(t *testing.T) {
 
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2605,7 +2605,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2688,7 +2688,7 @@ func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2815,7 +2815,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2920,7 +2920,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2999,7 +2999,7 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3102,7 +3102,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 
 func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3238,7 +3238,7 @@ func TestDNS_Recurse(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -3270,7 +3270,7 @@ func TestDNS_Recurse_Truncation(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -3311,7 +3311,7 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 	}
 	defer resolver.Close()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+resolver.LocalAddr().String()+`"] // host must cause a connection|read|write timeout
 		dns_config {
 			recursor_timeout = "`+serverClientTimeout.String()+`"
@@ -3350,7 +3350,7 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3506,7 +3506,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3619,7 +3619,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			only_passing = true
 		}
@@ -3744,7 +3744,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3875,7 +3875,7 @@ func TestBinarySearch(t *testing.T) {
 
 func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			enable_truncate = true
 		}
@@ -3973,7 +3973,7 @@ func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 
 func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			enable_truncate = true
 		}
@@ -4042,7 +4042,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			enable_truncate = true
 		}
@@ -4144,7 +4144,7 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 
 func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uint16,
 	expectedService, expectedQuery, expectedQueryID int) (bool, error) {
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "test-node"
 		dns_config {
 			udp_answer_limit = `+fmt.Sprintf("%d", answerLimit)+`
@@ -4233,7 +4233,7 @@ func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uin
 
 func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType uint16,
 	expectedResultsCount int, udpSize uint16, udpAnswerLimit int) error {
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		node_name = "test-node"
 		dns_config {
 			a_record_limit = `+fmt.Sprintf("%d", aRecordLimit)+`
@@ -4465,7 +4465,7 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -4562,7 +4562,7 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 		dns_config {
 			node_ttl = "10s"
@@ -4680,7 +4680,7 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 
 func TestDNS_ServiceLookup_TTL(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			service_ttl = {
 				"d*" = "42s"
@@ -4758,7 +4758,7 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 
 func TestDNS_PreparedQuery_TTL(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			service_ttl = {
 				"d*" = "42s"
@@ -4878,14 +4878,14 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 
 func TestDNS_PreparedQuery_Failover(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -4990,7 +4990,7 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 
 func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5065,7 +5065,7 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 
 func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5149,7 +5149,7 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("ACLToken == "+tt.token, func(t *testing.T) {
-			a := NewTestAgent(t.Name(), `
+			a := NewTestAgent(t, t.Name(), `
 				acl_token = "`+tt.token+`"
 				acl_master_token = "root"
 				acl_datacenter = "dc1"
@@ -5192,7 +5192,7 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
-	a := NewTestAgent(t.Name(), `dns_config = { enable_additional_node_meta_txt = true }`)
+	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = true }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5238,7 +5238,7 @@ func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
-	a := NewTestAgent(t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5282,7 +5282,7 @@ func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
 
 func TestDNS_AddressLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5319,7 +5319,7 @@ func TestDNS_AddressLookup(t *testing.T) {
 
 func TestDNS_AddressLookupIPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5357,7 +5357,7 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 
 func TestDNS_NonExistingLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5386,7 +5386,7 @@ func TestDNS_NonExistingLookup(t *testing.T) {
 
 func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5525,7 +5525,7 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		dns_config {
 			allow_stale = true
 			max_stale = "1s"
@@ -5575,7 +5575,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 
 func TestDNS_InvalidQueries(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5617,7 +5617,7 @@ func TestDNS_InvalidQueries(t *testing.T) {
 
 func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6123,7 +6123,7 @@ func TestDNS_Compression_trimUDPResponse(t *testing.T) {
 
 func TestDNS_Compression_Query(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6210,7 +6210,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 
 func TestDNS_Compression_ReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6267,7 +6267,7 @@ func TestDNS_Compression_Recurse(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestEventFire(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -58,7 +58,7 @@ func TestEventFire(t *testing.T) {
 
 func TestEventFire_token(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()
@@ -120,7 +120,7 @@ func TestEventFire_token(t *testing.T) {
 
 func TestEventList(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -153,7 +153,7 @@ func TestEventList(t *testing.T) {
 
 func TestEventList_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -191,7 +191,7 @@ func TestEventList_Filter(t *testing.T) {
 
 func TestEventList_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -242,7 +242,7 @@ func TestEventList_ACLFilter(t *testing.T) {
 
 func TestEventList_Blocking(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -294,7 +294,7 @@ func TestEventList_Blocking(t *testing.T) {
 
 func TestEventList_EventBufOrder(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -21,7 +21,7 @@ import (
 func TestHealthChecksInState(t *testing.T) {
 	t.Parallel()
 	t.Run("warning", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/health/state/warning?dc=dc1", nil)
@@ -44,7 +44,7 @@ func TestHealthChecksInState(t *testing.T) {
 	})
 
 	t.Run("passing", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/health/state/passing?dc=dc1", nil)
@@ -69,7 +69,7 @@ func TestHealthChecksInState(t *testing.T) {
 
 func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	args := &structs.RegisterRequest{
@@ -109,7 +109,7 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 
 func TestHealthChecksInState_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	args := &structs.RegisterRequest{
@@ -183,7 +183,7 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 
 func TestHealthNodeChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -218,7 +218,7 @@ func TestHealthNodeChecks(t *testing.T) {
 
 func TestHealthServiceChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -270,7 +270,7 @@ func TestHealthServiceChecks(t *testing.T) {
 
 func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -323,7 +323,7 @@ func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 
 func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -403,7 +403,7 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 
 func TestHealthServiceNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -529,7 +529,7 @@ func TestHealthServiceNodes(t *testing.T) {
 
 func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -582,7 +582,7 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 
 func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	dc := "dc1"
 	// Create a service check
@@ -661,7 +661,7 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	dc := "dc1"
@@ -757,7 +757,7 @@ func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 
 func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t.Name(), `
+	a1 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -765,7 +765,7 @@ func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t.Name(), `
+	a2 := NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -846,7 +846,7 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Register
@@ -871,7 +871,7 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Register

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -64,7 +64,7 @@ func newHttpClient(timeout time.Duration) *http.Client {
 func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 	// To avoid actually triggering RPCs that are allowed, lock everything down
 	// with default-deny ACLs. This drops the test runtime from 11s to 0.6s.
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled        = true
@@ -127,7 +127,7 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
-	a := NewTestAgent(t.Name(), `acl_datacenter = "dc1"`)
+	a := NewTestAgent(t, t.Name(), `acl_datacenter = "dc1"`)
 	a.Agent.LogWriter = logger.NewLogWriter(512)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -164,7 +164,7 @@ func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_AllowedNets_OSS(t *testing.T) {
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		acl_datacenter = "dc1"
 		http_config {
 			allow_write_http_from = ["127.0.0.1/8"]

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -40,7 +40,7 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 
 	// Only testing mode, since uid/gid might not be settable
 	// from test environment.
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		addresses {
 			http = "unix://`+socket+`"
 		}
@@ -109,7 +109,7 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 		t.Fatalf("not a regular file: %s", socket)
 	}
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		addresses {
 			http = "unix://`+socket+`"
 		}
@@ -139,7 +139,7 @@ func TestHTTPServer_H2(t *testing.T) {
 			ca_file = "../test/client_certs/rootca.crt"
 		`,
 	}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	// Make an HTTP/2-enabled client, using the API helpers to set
@@ -286,7 +286,7 @@ func TestSetMeta(t *testing.T) {
 func TestHTTPAPI_BlockEndpoints(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		http_config {
 			block_endpoints = ["/v1/agent/self"]
 		}
@@ -319,7 +319,7 @@ func TestHTTPAPI_BlockEndpoints(t *testing.T) {
 }
 
 func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
@@ -331,7 +331,7 @@ func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
 }
 
 func TestHTTPAPI_Allow_Nonprintable_Characters_With_Flag(t *testing.T) {
-	a := NewTestAgent(t.Name(), "disable_http_unprintable_char_filter = true")
+	a := NewTestAgent(t, t.Name(), "disable_http_unprintable_char_filter = true")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
@@ -347,7 +347,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 	t.Parallel()
 	// Header should not be present if address translation is off.
 	{
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		resp := httptest.NewRecorder()
@@ -366,7 +366,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 
 	// Header should be set to true if it's turned on.
 	{
-		a := NewTestAgent(t.Name(), `
+		a := NewTestAgent(t, t.Name(), `
 			translate_wan_addrs = true
 		`)
 		defer a.Shutdown()
@@ -388,7 +388,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 
 func TestHTTPAPIResponseHeaders(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		http_config {
 			response_headers = {
 				"Access-Control-Allow-Origin" = "*"
@@ -419,7 +419,7 @@ func TestHTTPAPIResponseHeaders(t *testing.T) {
 
 func TestContentTypeIsJSON(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -442,7 +442,7 @@ func TestHTTP_wrap_obfuscateLog(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
 	a := &TestAgent{Name: t.Name(), LogOutput: buf}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	handler := func(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -503,7 +503,7 @@ func TestPrettyPrintBare(t *testing.T) {
 }
 
 func testPrettyPrint(pretty string, t *testing.T) {
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	r := &structs.DirEntry{Key: "key"}
@@ -531,7 +531,7 @@ func testPrettyPrint(pretty string, t *testing.T) {
 
 func TestParseSource(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Default is agent's DC and no node (since the user didn't care, then
@@ -729,7 +729,7 @@ func TestParseWait(t *testing.T) {
 func TestPProfHandlers_EnableDebug(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "enable_debug = true")
+	a := NewTestAgent(t, t.Name(), "enable_debug = true")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -742,7 +742,7 @@ func TestPProfHandlers_EnableDebug(t *testing.T) {
 func TestPProfHandlers_DisableDebugNoACLs(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "enable_debug = false")
+	a := NewTestAgent(t, t.Name(), "enable_debug = false")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -758,7 +758,7 @@ func TestPProfHandlers_ACLs(t *testing.T) {
 	assert := assert.New(t)
 	dc1 := "dc1"
 
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "deny"
 	acl_master_token = "master"
@@ -861,7 +861,7 @@ func TestParseConsistency(t *testing.T) {
 	var b structs.QueryOptions
 
 	req, _ := http.NewRequest("GET", "/v1/catalog/nodes?stale", nil)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	if d := a.srv.parseConsistency(resp, req, &b); d {
 		t.Fatalf("unexpected done")
@@ -913,7 +913,7 @@ func ensureConsistency(t *testing.T, a *TestAgent, path string, maxStale time.Du
 }
 
 func TestParseConsistencyAndMaxStale(t *testing.T) {
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Default => Consistent
@@ -949,7 +949,7 @@ func TestParseConsistency_Invalid(t *testing.T) {
 	var b structs.QueryOptions
 
 	req, _ := http.NewRequest("GET", "/v1/catalog/nodes?stale&consistent", nil)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	if d := a.srv.parseConsistency(resp, req, &b); !d {
 		t.Fatalf("expected done")
@@ -1010,7 +1010,7 @@ func TestACLResolution(t *testing.T) {
 	reqAuthBearerAndXToken.Header.Add("X-Consul-Token", "xtoken")
 	reqAuthBearerAndXToken.Header.Add("Authorization", "Bearer bearer-token")
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Check when no token is set
@@ -1100,7 +1100,7 @@ func TestACLResolution(t *testing.T) {
 
 func TestEnableWebUI(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		ui = true
 	`)
 	defer a.Shutdown()
@@ -1163,7 +1163,7 @@ func TestParseToken_ProxyTokenResolve(t *testing.T) {
 		{"/v1/status/peers", (*HTTPServer).StatusPeers},
 	}
 
-	a := NewTestAgent(t.Name(), TestACLConfig()+testAllowProxyConfig())
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+testAllowProxyConfig())
 	defer a.Shutdown()
 
 	// Register a service with a managed proxy
@@ -1268,7 +1268,7 @@ func TestAllowedNets(t *testing.T) {
 		a := &TestAgent{
 			Name: t.Name(),
 		}
-		a.Start()
+		a.Start(t)
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -15,7 +15,7 @@ func TestIntentionsList_empty(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is non-nil.
@@ -33,7 +33,7 @@ func TestIntentionsList_values(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create some intentions, note we create the lowest precedence first to test
@@ -72,7 +72,7 @@ func TestIntentionsMatch_basic(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create some intentions
@@ -137,7 +137,7 @@ func TestIntentionsMatch_noBy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Request
@@ -154,7 +154,7 @@ func TestIntentionsMatch_byInvalid(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Request
@@ -171,7 +171,7 @@ func TestIntentionsMatch_noName(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Request
@@ -188,7 +188,7 @@ func TestIntentionsCheck_basic(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create some intentions
@@ -244,7 +244,7 @@ func TestIntentionsCheck_noSource(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Request
@@ -261,7 +261,7 @@ func TestIntentionsCheck_noDestination(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Request
@@ -278,7 +278,7 @@ func TestIntentionsCreate_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is non-nil.
@@ -309,7 +309,7 @@ func TestIntentionsCreate_good(t *testing.T) {
 func TestIntentionsCreate_noBody(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Create with no body
@@ -323,7 +323,7 @@ func TestIntentionsSpecificGet_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// The intention
@@ -359,7 +359,7 @@ func TestIntentionsSpecificGet_invalidId(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// Read intention with bad ID
@@ -376,7 +376,7 @@ func TestIntentionsSpecificUpdate_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// The intention
@@ -422,7 +422,7 @@ func TestIntentionsSpecificDelete_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	// The intention

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -33,7 +33,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Should be no configured keyring file by default
 	t.Run("no keys", func(t *testing.T) {
-		a1 := NewTestAgent(t.Name(), "")
+		a1 := NewTestAgent(t, t.Name(), "")
 		defer a1.Shutdown()
 
 		c1 := a1.consulConfig()
@@ -54,7 +54,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 	// Server should auto-load LAN and WAN keyring files
 	t.Run("server with keys", func(t *testing.T) {
 		a2 := &TestAgent{Name: t.Name(), Key: key}
-		a2.Start()
+		a2.Start(t)
 		defer a2.Shutdown()
 
 		c2 := a2.consulConfig()
@@ -84,7 +84,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 			server = false
 			bootstrap = false
 		`, Key: key}
-		a3.Start()
+		a3.Start(t)
 		defer a3.Shutdown()
 
 		c3 := a3.consulConfig()
@@ -112,7 +112,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 
 	// Should be no configured keyring file by default
 	t.Run("no keys", func(t *testing.T) {
-		a1 := NewTestAgent(t.Name(), "")
+		a1 := NewTestAgent(t, t.Name(), "")
 		defer a1.Shutdown()
 
 		c1 := a1.consulConfig()
@@ -136,7 +136,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 			encrypt = "` + key + `"
 			disable_keyring_file = true
 		`}
-		a2.Start()
+		a2.Start(t)
 		defer a2.Shutdown()
 
 		c2 := a2.consulConfig()
@@ -168,7 +168,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 			bootstrap = false
 			disable_keyring_file = true
 		`}
-		a3.Start()
+		a3.Start(t)
 		defer a3.Shutdown()
 
 		c3 := a3.consulConfig()
@@ -207,7 +207,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 			disable_keyring_file = true
 			data_dir = "` + dir + `"
 		`}
-		a4.Start()
+		a4.Start(t)
 		defer a4.Shutdown()
 
 		c4 := a4.consulConfig()
@@ -281,7 +281,7 @@ func TestAgentKeyring_ACL(t *testing.T) {
 		acl_master_token = "root"
 		acl_default_policy = "deny"
 	`, Key: key1}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	// List keys without access fails

--- a/agent/kvs_endpoint_test.go
+++ b/agent/kvs_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -74,7 +74,7 @@ func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 
 func TestKVSEndpoint_Recurse(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -150,7 +150,7 @@ func TestKVSEndpoint_Recurse(t *testing.T) {
 
 func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	{
@@ -216,7 +216,7 @@ func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 
 func TestKVSEndpoint_CAS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	{
@@ -292,7 +292,7 @@ func TestKVSEndpoint_CAS(t *testing.T) {
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -341,7 +341,7 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 
 func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -400,7 +400,7 @@ func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 
 func TestKVSEndpoint_GET_Raw(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte("test"))
@@ -430,7 +430,7 @@ func TestKVSEndpoint_GET_Raw(t *testing.T) {
 
 func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("PUT", "/v1/kv/test?cas=0&acquire=xxx", nil)
@@ -449,7 +449,7 @@ func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 
 func TestKVSEndpoint_DELETE_ConflictingFlags(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("DELETE", "/v1/kv/test?recurse&cas=0", nil)

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -29,7 +29,7 @@ import (
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name()}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -262,7 +262,7 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 
 	assert := assert.New(t)
 	a := &agent.TestAgent{Name: t.Name()}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -420,7 +420,7 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 func TestAgent_ServiceWatchCh(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name()}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -505,7 +505,7 @@ func TestAgent_ServiceWatchCh(t *testing.T) {
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name()}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -637,7 +637,7 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 
 func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -772,7 +772,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 		acl_master_token = "root"
 		acl_default_policy = "deny"
 		acl_enforce_version_8 = true`}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -919,7 +919,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
 	a := &agent.TestAgent{Name: t.Name()}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1118,7 +1118,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 		acl_master_token = "root"
 		acl_default_policy = "deny"
 		acl_enforce_version_8 = true`}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, dc)
@@ -1332,7 +1332,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 
 func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		discard_check_output = true
 		check_update_interval = "0s" # set to "0s" since otherwise output checks are deferred
 	`)
@@ -1386,7 +1386,7 @@ func TestAgentAntiEntropy_Check_DeferSync(t *testing.T) {
 	a := &agent.TestAgent{Name: t.Name(), HCL: `
 		check_update_interval = "500ms"
 	`}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1577,7 +1577,7 @@ func TestAgentAntiEntropy_NodeInfo(t *testing.T) {
 		node_meta {
 			somekey = "somevalue"
 		}`}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1837,7 +1837,7 @@ func TestAgent_AliasCheck(t *testing.T) {
 
 func TestAgent_sendCoordinate(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		sync_coordinate_interval_min = "1ms"
 		sync_coordinate_rate_target = 10.0
 		consul = {

--- a/agent/operator_endpoint_test.go
+++ b/agent/operator_endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestOperator_RaftConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer(nil)
@@ -45,7 +45,7 @@ func TestOperator_RaftConfiguration(t *testing.T) {
 func TestOperator_RaftPeer(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -61,7 +61,7 @@ func TestOperator_RaftPeer(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -81,7 +81,7 @@ func TestOperator_KeyringInstall(t *testing.T) {
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		encrypt = "`+oldKey+`"
 	`)
 	defer a.Shutdown()
@@ -116,7 +116,7 @@ func TestOperator_KeyringInstall(t *testing.T) {
 func TestOperator_KeyringList(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -165,7 +165,7 @@ func TestOperator_KeyringRemove(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	tempKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -223,7 +223,7 @@ func TestOperator_KeyringUse(t *testing.T) {
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		encrypt = "`+oldKey+`"
 	`)
 	defer a.Shutdown()
@@ -266,7 +266,7 @@ func TestOperator_KeyringUse(t *testing.T) {
 func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -291,7 +291,7 @@ func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 
 func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -316,7 +316,7 @@ func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 
 func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
@@ -344,7 +344,7 @@ func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 
 func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
@@ -411,7 +411,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 
 func TestOperator_ServerHealth(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		raft_protocol = 3
 	`)
 	defer a.Shutdown()
@@ -443,7 +443,7 @@ func TestOperator_ServerHealth(t *testing.T) {
 
 func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		raft_protocol = 3
 		autopilot {
 			last_contact_threshold = "-1s"

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -75,7 +75,7 @@ func (m *MockPreparedQuery) Explain(args *structs.PreparedQueryExecuteRequest,
 
 func TestPreparedQuery_Create(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -164,7 +164,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 func TestPreparedQuery_List(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -197,7 +197,7 @@ func TestPreparedQuery_List(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -247,7 +247,7 @@ func TestPreparedQuery_List(t *testing.T) {
 func TestPreparedQuery_Execute(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -280,7 +280,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -335,7 +335,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -392,7 +392,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -468,7 +468,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure the proper params are set when no special args are passed
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -499,7 +499,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure WAN translation occurs for a response outside of the local DC.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), `
+		a := NewTestAgent(t, t.Name(), `
 			datacenter = "dc1"
 			translate_wan_addrs = true
 		`)
@@ -549,7 +549,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure WAN translation doesn't occur for the local DC.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), `
+		a := NewTestAgent(t, t.Name(), `
 			datacenter = "dc1"
 			translate_wan_addrs = true
 		`)
@@ -598,7 +598,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -616,7 +616,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 func TestPreparedQuery_ExecuteCached(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	failovers := int32(99)
@@ -673,7 +673,7 @@ func TestPreparedQuery_ExecuteCached(t *testing.T) {
 func TestPreparedQuery_Explain(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -728,7 +728,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -744,7 +744,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 
 	// Ensure that Connect is passed through
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		require := require.New(t)
 
@@ -768,7 +768,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 func TestPreparedQuery_Get(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -816,7 +816,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -833,7 +833,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 
 func TestPreparedQuery_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -911,7 +911,7 @@ func TestPreparedQuery_Update(t *testing.T) {
 
 func TestPreparedQuery_Delete(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -988,7 +988,7 @@ func TestPreparedQuery_parseLimit(t *testing.T) {
 // correctly when calling through to the real endpoints.
 func TestPreparedQuery_Integration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -134,7 +134,7 @@ func TestRemoteExecGetSpec_ACLDeny(t *testing.T) {
 }
 
 func testRemoteExecGetSpec(t *testing.T, hcl string, token string, shouldSucceed bool, dc string) {
-	a := NewTestAgent(t.Name(), hcl)
+	a := NewTestAgent(t, t.Name(), hcl)
 	defer a.Shutdown()
 	if dc != "" {
 		testrpc.WaitForLeader(t, a.RPC, dc)
@@ -206,7 +206,7 @@ func TestRemoteExecWrites_ACLDeny(t *testing.T) {
 }
 
 func testRemoteExecWrites(t *testing.T, hcl string, token string, shouldSucceed bool, dc string) {
-	a := NewTestAgent(t.Name(), hcl)
+	a := NewTestAgent(t, t.Name(), hcl)
 	defer a.Shutdown()
 	if dc != "" {
 		testrpc.WaitForLeader(t, a.RPC, dc)
@@ -268,7 +268,7 @@ func testRemoteExecWrites(t *testing.T, hcl string, token string, shouldSucceed 
 }
 
 func testHandleRemoteExec(t *testing.T, command string, expectedSubstring string, expectedReturnCode string) {
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	retry.Run(t, func(r *retry.R) {

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -39,7 +39,7 @@ func verifySession(r *retry.R, a *TestAgent, want structs.Session) {
 
 func TestSessionCreate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -96,7 +96,7 @@ func TestSessionCreate(t *testing.T) {
 
 func TestSessionCreate_Delete(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -152,7 +152,7 @@ func TestSessionCreate_Delete(t *testing.T) {
 
 func TestSessionCreate_DefaultCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -188,7 +188,7 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 
 func TestSessionCreate_NoCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -307,7 +307,7 @@ func makeTestSessionTTL(t *testing.T, srv *HTTPServer, ttl string) string {
 
 func TestSessionDestroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -327,7 +327,7 @@ func TestSessionDestroy(t *testing.T) {
 func TestSessionCustomTTL(t *testing.T) {
 	t.Parallel()
 	ttl := 250 * time.Millisecond
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		session_ttl_min = "250ms"
 	`)
 	defer a.Shutdown()
@@ -371,7 +371,7 @@ func TestSessionCustomTTL(t *testing.T) {
 func TestSessionTTLRenew(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	ttl := 250 * time.Millisecond
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		session_ttl_min = "250ms"
 	`)
 	defer a.Shutdown()
@@ -451,7 +451,7 @@ func TestSessionTTLRenew(t *testing.T) {
 func TestSessionGet(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -473,7 +473,7 @@ func TestSessionGet(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -497,7 +497,7 @@ func TestSessionGet(t *testing.T) {
 
 func TestSessionList(t *testing.T) {
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -517,7 +517,7 @@ func TestSessionList(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -545,7 +545,7 @@ func TestSessionList(t *testing.T) {
 func TestSessionsForNode(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -565,7 +565,7 @@ func TestSessionsForNode(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -592,7 +592,7 @@ func TestSessionsForNode(t *testing.T) {
 
 func TestSessionDeleteDestroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -321,7 +321,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			require := require.New(t)
-			a := NewTestAgent("jones", hcl)
+			a := NewTestAgent(t, "jones", hcl)
 
 			if tt.preRegister != nil {
 				err := a.AddService(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -15,7 +15,7 @@ func TestSnapshot(t *testing.T) {
 	t.Parallel()
 	var snap io.Reader
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -41,7 +41,7 @@ func TestSnapshot(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("PUT", "/v1/snapshot?token=root", snap)
@@ -56,7 +56,7 @@ func TestSnapshot_Options(t *testing.T) {
 	t.Parallel()
 	for _, method := range []string{"GET", "PUT"} {
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t.Name(), TestACLConfig())
+			a := NewTestAgent(t, t.Name(), TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
@@ -69,7 +69,7 @@ func TestSnapshot_Options(t *testing.T) {
 		})
 
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t.Name(), TestACLConfig())
+			a := NewTestAgent(t, t.Name(), TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
@@ -82,7 +82,7 @@ func TestSnapshot_Options(t *testing.T) {
 		})
 
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t.Name(), TestACLConfig())
+			a := NewTestAgent(t, t.Name(), TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)

--- a/agent/status_endpoint_test.go
+++ b/agent/status_endpoint_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStatusLeader(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -26,7 +26,7 @@ func TestStatusLeader(t *testing.T) {
 
 func TestStatusPeers(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/status/peers", nil)

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -93,7 +93,7 @@ type TestAgent struct {
 }
 
 // NewTestAgent returns a started agent with the given name and
-// configuration. It panics if the agent could not be started. The
+// configuration. It fails the test if the Agent could not be started. The
 // caller should call Shutdown() to stop the agent and remove temporary
 // directories.
 func NewTestAgent(t *testing.T, name string, hcl string) *TestAgent {
@@ -102,7 +102,7 @@ func NewTestAgent(t *testing.T, name string, hcl string) *TestAgent {
 	return a
 }
 
-// Start starts a test agent. It panics if the agent could not be started.
+// Start starts a test agent. It fails the test if the agent could not be started.
 func (a *TestAgent) Start(t *testing.T) *TestAgent {
 	require := require.New(t)
 	require.Nil(a.Agent, "TestAgent already started")

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte("{"))
@@ -35,7 +35,7 @@ func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 
 func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -61,7 +61,7 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 
 func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	value := strings.Repeat("X", maxKVSize/2)
@@ -102,7 +102,7 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 
 func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -130,7 +130,7 @@ func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 func TestTxnEndpoint_KV_Actions(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -366,7 +366,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 
 	// Verify an error inside a transaction.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t.Name(), "")
+		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 
 		buf := bytes.NewBuffer([]byte(`

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -27,7 +27,7 @@ func TestUiIndex(t *testing.T) {
 	defer os.RemoveAll(uiDir)
 
 	// Make the server
-	a := NewTestAgent(t.Name(), `
+	a := NewTestAgent(t, t.Name(), `
 		ui_dir = "`+uiDir+`"
 	`)
 	defer a.Shutdown()
@@ -66,7 +66,7 @@ func TestUiIndex(t *testing.T) {
 
 func TestUiNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -104,7 +104,7 @@ func TestUiNodes(t *testing.T) {
 
 func TestUiNodeInfo(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -48,7 +48,7 @@ func TestValidateUserEventParams(t *testing.T) {
 
 func TestShouldProcessUserEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	srv1 := &structs.NodeService{
@@ -117,7 +117,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 
 func TestIngestUserEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	for i := 0; i < 512; i++ {
@@ -148,7 +148,7 @@ func TestIngestUserEvent(t *testing.T) {
 
 func TestFireReceiveEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
 	srv1 := &structs.NodeService{
@@ -184,7 +184,7 @@ func TestFireReceiveEvent(t *testing.T) {
 
 func TestUserEventToken(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()

--- a/command/acl/agenttokens/agent_tokens_test.go
+++ b/command/acl/agenttokens/agent_tokens_test.go
@@ -29,7 +29,7 @@ func TestAgentTokensCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bootstrap/bootstrap_test.go
+++ b/command/acl/bootstrap/bootstrap_test.go
@@ -29,7 +29,7 @@ func TestBootstrapCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -29,7 +29,7 @@ func TestPolicyCreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -30,7 +30,7 @@ func TestPolicyDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -30,7 +30,7 @@ func TestPolicyListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -30,7 +30,7 @@ func TestPolicyReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -30,7 +30,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -30,7 +30,7 @@ func TestRulesTranslateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -65,7 +65,7 @@ func TestTokenCloneCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
    primary_datacenter = "dc1"
    acl {
       enabled = true

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -29,7 +29,7 @@ func TestTokenCreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -30,7 +30,7 @@ func TestTokenDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -30,7 +30,7 @@ func TestTokenListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -30,7 +30,7 @@ func TestTokenReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -34,7 +34,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -83,7 +83,7 @@ func TestConfigFail(t *testing.T) {
 
 func TestRetryJoin(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/command/catalog/list/dc/catalog_list_datacenters_test.go
+++ b/command/catalog/list/dc/catalog_list_datacenters_test.go
@@ -53,7 +53,7 @@ func TestCatalogListDatacentersCommand_Validation(t *testing.T) {
 
 func TestCatalogListDatacentersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/catalog/list/nodes/catalog_list_nodes_test.go
+++ b/command/catalog/list/nodes/catalog_list_nodes_test.go
@@ -32,7 +32,7 @@ func TestCatalogListNodesCommand_Validation(t *testing.T) {
 
 func TestCatalogListNodesCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/catalog/list/services/catalog_list_services_test.go
+++ b/command/catalog/list/services/catalog_list_services_test.go
@@ -34,7 +34,7 @@ func TestCatalogListServicesCommand_Validation(t *testing.T) {
 
 func TestCatalogListServicesCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/connect/ca/get/connect_ca_get_test.go
+++ b/command/connect/ca/get/connect_ca_get_test.go
@@ -19,7 +19,7 @@ func TestConnectCAGetConfigCommand_noTabs(t *testing.T) {
 
 func TestConnectCAGetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/connect/ca/set/connect_ca_set_test.go
+++ b/command/connect/ca/set/connect_ca_set_test.go
@@ -24,7 +24,7 @@ func TestConnectCASetConfigCommand_noTabs(t *testing.T) {
 func TestConnectCASetConfigCommand(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/connect/proxy/proxy_test.go
+++ b/command/connect/proxy/proxy_test.go
@@ -113,7 +113,7 @@ func TestCommandConfigWatcher(t *testing.T) {
 			require := require.New(t)
 
 			// Register a few services with 0, 1 and 2 sidecars
-			a := agent.NewTestAgent(t.Name(), `
+			a := agent.NewTestAgent(t, t.Name(), `
 			services {
 				name = "no-sidecar"
 				port = 1111

--- a/command/connect/proxy/register_test.go
+++ b/command/connect/proxy/register_test.go
@@ -15,7 +15,7 @@ func TestRegisterMonitor_good(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -39,7 +39,7 @@ func TestRegisterMonitor_heartbeat(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -31,7 +31,7 @@ func TestDebugCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	enable_debug = true
 	`)
 	a.Agent.LogWriter = logger.NewLogWriter(512)
@@ -69,7 +69,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	enable_debug = true
 	`)
 	defer a.Shutdown()
@@ -154,7 +154,7 @@ func TestDebugCommand_OutputPathBad(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -186,7 +186,7 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	a.Agent.LogWriter = logger.NewLogWriter(512)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -268,7 +268,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 		testDir := testutil.TempDir(t, "debug")
 		defer os.RemoveAll(testDir)
 
-		a := agent.NewTestAgent(t.Name(), `
+		a := agent.NewTestAgent(t, t.Name(), `
 		enable_debug = true
 		`)
 		a.Agent.LogWriter = logger.NewLogWriter(512)
@@ -335,7 +335,7 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	enable_debug = true
 	`)
 	a.Agent.LogWriter = logger.NewLogWriter(512)
@@ -414,7 +414,7 @@ func TestDebugCommand_ValidateTiming(t *testing.T) {
 		testDir := testutil.TempDir(t, "debug")
 		defer os.RemoveAll(testDir)
 
-		a := agent.NewTestAgent(t.Name(), "")
+		a := agent.NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -446,7 +446,7 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	enable_debug = false
 	`)
 	a.Agent.LogWriter = logger.NewLogWriter(512)

--- a/command/event/event_test.go
+++ b/command/event/event_test.go
@@ -17,7 +17,7 @@ func TestEventCommand_noTabs(t *testing.T) {
 
 func TestEventCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), ``)
+	a1 := agent.NewTestAgent(t, t.Name(), ``)
 	defer a1.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/exec/exec_test.go
+++ b/command/exec/exec_test.go
@@ -22,7 +22,7 @@ func TestExecCommand_noTabs(t *testing.T) {
 
 func TestExecCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -45,7 +45,7 @@ func TestExecCommand(t *testing.T) {
 
 func TestExecCommand_NoShell(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -68,14 +68,14 @@ func TestExecCommand_NoShell(t *testing.T) {
 
 func TestExecCommand_CrossDC(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), `
+	a1 := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a1.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := agent.NewTestAgent(t.Name(), `
+	a2 := agent.NewTestAgent(t, t.Name(), `
 		datacenter = "dc2"
 		disable_remote_exec = false
 	`)
@@ -148,7 +148,7 @@ func TestExecCommand_Validate(t *testing.T) {
 
 func TestExecCommand_Sessions(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -188,7 +188,7 @@ func TestExecCommand_Sessions(t *testing.T) {
 
 func TestExecCommand_Sessions_Foreign(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -238,7 +238,7 @@ func TestExecCommand_Sessions_Foreign(t *testing.T) {
 
 func TestExecCommand_UploadDestroy(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -295,7 +295,7 @@ func TestExecCommand_UploadDestroy(t *testing.T) {
 
 func TestExecCommand_StreamResults(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()

--- a/command/forceleave/forceleave_test.go
+++ b/command/forceleave/forceleave_test.go
@@ -19,8 +19,8 @@ func TestForceLeaveCommand_noTabs(t *testing.T) {
 
 func TestForceLeaveCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), ``)
-	a2 := agent.NewTestAgent(t.Name(), ``)
+	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a2 := agent.NewTestAgent(t, t.Name(), ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 

--- a/command/info/info_test.go
+++ b/command/info/info_test.go
@@ -17,7 +17,7 @@ func TestInfoCommand_noTabs(t *testing.T) {
 
 func TestInfoCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), ``)
+	a1 := agent.NewTestAgent(t, t.Name(), ``)
 	defer a1.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/intention/check/check_test.go
+++ b/command/intention/check/check_test.go
@@ -68,7 +68,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/create/create_test.go
+++ b/command/intention/create/create_test.go
@@ -60,7 +60,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -85,7 +85,7 @@ func TestCommand_deny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -111,7 +111,7 @@ func TestCommand_meta(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -137,7 +137,7 @@ func TestCommand_File(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -171,7 +171,7 @@ func TestCommand_FileNoExist(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -191,7 +191,7 @@ func TestCommand_replace(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/delete/delete_test.go
+++ b/command/intention/delete/delete_test.go
@@ -63,7 +63,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/finder/finder_test.go
+++ b/command/intention/finder/finder_test.go
@@ -12,7 +12,7 @@ func TestFinder(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/get/get_test.go
+++ b/command/intention/get/get_test.go
@@ -63,7 +63,7 @@ func TestCommand_id(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -95,7 +95,7 @@ func TestCommand_srcDst(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/match/match_test.go
+++ b/command/intention/match/match_test.go
@@ -68,7 +68,7 @@ func TestCommand_matchDst(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -111,7 +111,7 @@ func TestCommand_matchSource(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/join/join_test.go
+++ b/command/join/join_test.go
@@ -17,8 +17,8 @@ func TestJoinCommand_noTabs(t *testing.T) {
 
 func TestJoinCommandJoin_lan(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), ``)
-	a2 := agent.NewTestAgent(t.Name(), ``)
+	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a2 := agent.NewTestAgent(t, t.Name(), ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 
@@ -41,8 +41,8 @@ func TestJoinCommandJoin_lan(t *testing.T) {
 
 func TestJoinCommand_wan(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t.Name(), ``)
-	a2 := agent.NewTestAgent(t.Name(), ``)
+	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a2 := agent.NewTestAgent(t, t.Name(), ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 

--- a/command/keyring/keyring_test.go
+++ b/command/keyring/keyring_test.go
@@ -21,7 +21,7 @@ func TestKeyringCommand(t *testing.T) {
 	key2 := "kZyFABeAmc64UMTrm9XuKA=="
 
 	// Begin with a single key
-	a1 := agent.NewTestAgent(t.Name(), `
+	a1 := agent.NewTestAgent(t, t.Name(), `
 		encrypt = "`+key1+`"
 	`)
 	defer a1.Shutdown()

--- a/command/kv/del/kv_delete_test.go
+++ b/command/kv/del/kv_delete_test.go
@@ -72,7 +72,7 @@ func TestKVDeleteCommand_Validation(t *testing.T) {
 
 func TestKVDeleteCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -109,7 +109,7 @@ func TestKVDeleteCommand(t *testing.T) {
 
 func TestKVDeleteCommand_Recurse(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -153,7 +153,7 @@ func TestKVDeleteCommand_Recurse(t *testing.T) {
 
 func TestKVDeleteCommand_CAS(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/exp/kv_export_test.go
+++ b/command/kv/exp/kv_export_test.go
@@ -21,7 +21,7 @@ func TestKVExportCommand_noTabs(t *testing.T) {
 
 func TestKVExportCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/get/kv_get_test.go
+++ b/command/kv/get/kv_get_test.go
@@ -59,7 +59,7 @@ func TestKVGetCommand_Validation(t *testing.T) {
 
 func TestKVGetCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -93,7 +93,7 @@ func TestKVGetCommand(t *testing.T) {
 
 func TestKVGetCommand_Base64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -128,7 +128,7 @@ func TestKVGetCommand_Base64(t *testing.T) {
 
 func TestKVGetCommand_Missing(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -147,7 +147,7 @@ func TestKVGetCommand_Missing(t *testing.T) {
 
 func TestKVGetCommand_Empty(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -176,7 +176,7 @@ func TestKVGetCommand_Empty(t *testing.T) {
 
 func TestKVGetCommand_Detailed(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -220,7 +220,7 @@ func TestKVGetCommand_Detailed(t *testing.T) {
 
 func TestKVGetCommand_Keys(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -255,7 +255,7 @@ func TestKVGetCommand_Keys(t *testing.T) {
 
 func TestKVGetCommand_Recurse(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -295,7 +295,7 @@ func TestKVGetCommand_Recurse(t *testing.T) {
 
 func TestKVGetCommand_RecurseBase64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -336,7 +336,7 @@ func TestKVGetCommand_RecurseBase64(t *testing.T) {
 
 func TestKVGetCommand_DetailedBase64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/imp/kv_import_test.go
+++ b/command/kv/imp/kv_import_test.go
@@ -17,7 +17,7 @@ func TestKVImportCommand_noTabs(t *testing.T) {
 
 func TestKVImportCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -77,7 +77,7 @@ func TestKVPutCommand_Validation(t *testing.T) {
 
 func TestKVPutCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -106,7 +106,7 @@ func TestKVPutCommand(t *testing.T) {
 
 func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -135,7 +135,7 @@ func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
 
 func TestKVPutCommand_Base64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -172,7 +172,7 @@ func TestKVPutCommand_Base64(t *testing.T) {
 
 func TestKVPutCommand_File(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -227,7 +227,7 @@ func TestKVPutCommand_FileNoExist(t *testing.T) {
 
 func TestKVPutCommand_Stdin(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -264,7 +264,7 @@ func TestKVPutCommand_Stdin(t *testing.T) {
 
 func TestKVPutCommand_NegativeVal(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -293,7 +293,7 @@ func TestKVPutCommand_NegativeVal(t *testing.T) {
 
 func TestKVPutCommand_Flags(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -323,7 +323,7 @@ func TestKVPutCommand_Flags(t *testing.T) {
 
 func TestKVPutCommand_CAS(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/leave/leave_test.go
+++ b/command/leave/leave_test.go
@@ -17,7 +17,7 @@ func TestLeaveCommand_noTabs(t *testing.T) {
 
 func TestLeaveCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -36,7 +36,7 @@ func TestLeaveCommand(t *testing.T) {
 
 func TestLeaveCommand_FailOnNonFlagArgs(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -42,7 +42,7 @@ func TestLockCommand_BadArgs(t *testing.T) {
 
 func TestLockCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -67,7 +67,7 @@ func TestLockCommand(t *testing.T) {
 
 func TestLockCommand_NoShell(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -92,7 +92,7 @@ func TestLockCommand_NoShell(t *testing.T) {
 
 func TestLockCommand_TryLock(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -126,7 +126,7 @@ func TestLockCommand_TryLock(t *testing.T) {
 
 func TestLockCommand_TrySemaphore(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -160,7 +160,7 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -195,7 +195,7 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -230,7 +230,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -265,7 +265,7 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -300,7 +300,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 
 func TestLockCommand_ChildExitCode(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/maint/maint_test.go
+++ b/command/maint/maint_test.go
@@ -41,7 +41,7 @@ func TestMaintCommand_ConflictingArgs(t *testing.T) {
 
 func TestMaintCommand_NoArgs(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	// Register the service and put it into maintenance mode
@@ -90,7 +90,7 @@ func TestMaintCommand_NoArgs(t *testing.T) {
 
 func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -114,7 +114,7 @@ func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
 
 func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -137,7 +137,7 @@ func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
 
 func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	// Register the service
@@ -171,7 +171,7 @@ func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 
 func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	// Register the service
@@ -204,7 +204,7 @@ func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 
 func TestMaintCommand_ServiceMaintenance_NoService(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/members/members_test.go
+++ b/command/members/members_test.go
@@ -18,7 +18,7 @@ func TestMembersCommand_noTabs(t *testing.T) {
 
 func TestMembersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -50,7 +50,7 @@ func TestMembersCommand(t *testing.T) {
 
 func TestMembersCommand_WAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -71,7 +71,7 @@ func TestMembersCommand_WAN(t *testing.T) {
 
 func TestMembersCommand_statusFilter(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -95,7 +95,7 @@ func TestMembersCommand_statusFilter(t *testing.T) {
 
 func TestMembersCommand_statusFilter_failed(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/monitor/monitor_test.go
+++ b/command/monitor/monitor_test.go
@@ -20,7 +20,7 @@ func TestMonitorCommand_exitsOnSignalBeforeLinesArrive(t *testing.T) {
 		LogWriter: logWriter,
 		LogOutput: io.MultiWriter(os.Stderr, logWriter),
 	}
-	a.Start()
+	a.Start(t)
 	defer a.Shutdown()
 
 	shutdownCh := make(chan struct{})

--- a/command/operator/autopilot/get/operator_autopilot_get_test.go
+++ b/command/operator/autopilot/get/operator_autopilot_get_test.go
@@ -19,7 +19,7 @@ func TestOperatorAutopilotGetConfigCommand_noTabs(t *testing.T) {
 
 func TestOperatorAutopilotGetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/operator/autopilot/set/operator_autopilot_set_test.go
+++ b/command/operator/autopilot/set/operator_autopilot_set_test.go
@@ -22,7 +22,7 @@ func TestOperatorAutopilotSetConfigCommand_noTabs(t *testing.T) {
 
 func TestOperatorAutopilotSetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/operator/raft/listpeers/operator_raft_list_test.go
+++ b/command/operator/raft/listpeers/operator_raft_list_test.go
@@ -18,7 +18,7 @@ func TestOperatorRaftListPeersCommand_noTabs(t *testing.T) {
 
 func TestOperatorRaftListPeersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	expected := fmt.Sprintf("%s  %s  127.0.0.1:%d  leader  true   3",

--- a/command/operator/raft/removepeer/operator_raft_remove_test.go
+++ b/command/operator/raft/removepeer/operator_raft_remove_test.go
@@ -17,7 +17,7 @@ func TestOperatorRaftRemovePeerCommand_noTabs(t *testing.T) {
 
 func TestOperatorRaftRemovePeerCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	t.Run("Test the remove-peer subcommand directly", func(t *testing.T) {

--- a/command/reload/reload_test.go
+++ b/command/reload/reload_test.go
@@ -17,7 +17,7 @@ func TestReloadCommand_noTabs(t *testing.T) {
 
 func TestReloadCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	// Setup a dummy response to errCh to simulate a successful reload

--- a/command/rtt/rtt_test.go
+++ b/command/rtt/rtt_test.go
@@ -46,7 +46,7 @@ func TestRTTCommand_BadArgs(t *testing.T) {
 
 func TestRTTCommand_LAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 		consul = {
 			coordinate = {
 				update_period = "10ms"
@@ -155,7 +155,7 @@ func TestRTTCommand_LAN(t *testing.T) {
 
 func TestRTTCommand_WAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/command/services/deregister/deregister_test.go
+++ b/command/services/deregister/deregister_test.go
@@ -64,7 +64,7 @@ func TestCommand_File_id(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -101,7 +101,7 @@ func TestCommand_File_nameOnly(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -138,7 +138,7 @@ func TestCommand_Flag(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -63,7 +63,7 @@ func TestCommand_File(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -96,7 +96,7 @@ func TestCommand_Flags(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/inspect/snapshot_inspect_test.go
+++ b/command/snapshot/inspect/snapshot_inspect_test.go
@@ -61,7 +61,7 @@ func TestSnapshotInspectCommand_Validation(t *testing.T) {
 
 func TestSnapshotInspectCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/restore/snapshot_restore_test.go
+++ b/command/snapshot/restore/snapshot_restore_test.go
@@ -61,7 +61,7 @@ func TestSnapshotRestoreCommand_Validation(t *testing.T) {
 
 func TestSnapshotRestoreCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -60,7 +60,7 @@ func TestSnapshotSaveCommand_Validation(t *testing.T) {
 
 func TestSnapshotSaveCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -18,7 +18,7 @@ func TestWatchCommand_noTabs(t *testing.T) {
 
 func TestWatchCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -38,7 +38,7 @@ func TestWatchCommand(t *testing.T) {
 
 func TestWatchCommandNoConnect(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -59,7 +59,7 @@ func TestWatchCommandNoConnect(t *testing.T) {
 
 func TestWatchCommandNoAgentService(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -82,7 +82,7 @@ func TestUpstreamResolverFuncFromClient(t *testing.T) {
 func TestAgentConfigWatcherManagedProxy(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent("agent_smith", `
+	a := agent.NewTestAgent(t, "agent_smith", `
 	connect {
 		enabled = true
 		proxy {
@@ -180,7 +180,7 @@ func TestAgentConfigWatcherManagedProxy(t *testing.T) {
 func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent("agent_smith", ``)
+	a := agent.NewTestAgent(t, "agent_smith", ``)
 	defer a.Shutdown()
 
 	client := a.Client()

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -24,7 +24,7 @@ func TestProxy_public(t *testing.T) {
 	require := require.New(t)
 	ports := freeport.GetT(t, 1)
 
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -42,7 +42,7 @@ func TestStaticResolver_Resolve(t *testing.T) {
 
 func TestConsulResolver_Resolve(t *testing.T) {
 	// Setup a local test agent to query
-	agent := agent.NewTestAgent("test-consul", "")
+	agent := agent.NewTestAgent(t, "test-consul", "")
 	defer agent.Shutdown()
 
 	cfg := api.DefaultConfig()

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -127,7 +127,7 @@ func TestService_Dial(t *testing.T) {
 func TestService_ServerTLSConfig(t *testing.T) {
 	require := require.New(t)
 
-	a := agent.NewTestAgent("007", "")
+	a := agent.NewTestAgent(t, "007", "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -151,7 +151,7 @@ func TestServerSideVerifier(t *testing.T) {
 	apiCA2 := testCertPEMBlock(t, apiCA2PEM)
 
 	// Setup a local test agent to query
-	agent := agent.NewTestAgent("test-consul", "")
+	agent := agent.NewTestAgent(t, "test-consul", "")
 	defer agent.Shutdown()
 	testrpc.WaitForTestAgent(t, agent.RPC, "dc1")
 

--- a/watch/funcs_test.go
+++ b/watch/funcs_test.go
@@ -31,7 +31,7 @@ func makeInvokeCh() chan error {
 
 func TestKeyWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -86,7 +86,7 @@ func TestKeyWatch(t *testing.T) {
 
 func TestKeyWatch_With_PrefixDelete(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -141,7 +141,7 @@ func TestKeyWatch_With_PrefixDelete(t *testing.T) {
 
 func TestKeyPrefixWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -195,7 +195,7 @@ func TestKeyPrefixWatch(t *testing.T) {
 
 func TestServicesWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -250,7 +250,7 @@ func TestServicesWatch(t *testing.T) {
 
 func TestNodesWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -302,7 +302,7 @@ func TestNodesWatch(t *testing.T) {
 
 func TestServiceWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -359,7 +359,7 @@ func TestServiceWatch(t *testing.T) {
 
 func TestChecksWatch_State(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -421,7 +421,7 @@ func TestChecksWatch_State(t *testing.T) {
 
 func TestChecksWatch_Service(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -488,7 +488,7 @@ func TestChecksWatch_Service(t *testing.T) {
 
 func TestEventWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -541,7 +541,7 @@ func TestEventWatch(t *testing.T) {
 func TestConnectRootsWatch(t *testing.T) {
 	t.Parallel()
 	// NewTestAgent will bootstrap a new CA
-	a := agent.NewTestAgent(t.Name(), "")
+	a := agent.NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -595,7 +595,7 @@ func TestConnectRootsWatch(t *testing.T) {
 func TestConnectLeafWatch(t *testing.T) {
 	t.Parallel()
 	// NewTestAgent will bootstrap a new CA
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -666,7 +666,7 @@ func TestConnectLeafWatch(t *testing.T) {
 
 func TestConnectProxyConfigWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), `
+	a := agent.NewTestAgent(t, t.Name(), `
 	connect {
 		enabled = true
 		proxy {
@@ -738,7 +738,7 @@ func TestConnectProxyConfigWatch(t *testing.T) {
 
 func TestAgentServiceWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 


### PR DESCRIPTION
This way we can avoid unnecessary panics which cause other tests not to run.

The branch name mentions circleci but I rebased the branch after testing with @alvin-huang in Circle to remove his commits.

In Circle we noticed that different numbers of tests were being run. Apparently when there is a panic the test binary being run is stopped and no further tests from that binary are executed. The changes in this PR replace the TestAgent's usage of the `panicFailer` with usage of a `testing.T`. This allows the go testing infrastructure to better manage the tests and get more of them to run even in the case where there is a test failure.

This doesn't remove all the possibilities for panics causing other tests not to run. Those other can be fixed separately.