### PR TITLE
testutil: Set the environment variable NOLOGBUFFER=1 to have test agent logs go straight to stdout

### DIFF
--- a/testutil/testlog.go
+++ b/testutil/testlog.go
@@ -1,11 +1,19 @@
 package testutil
 
 import (
+	"fmt"
 	"io"
 	"log"
+	"os"
 	"strings"
 	"testing"
 )
+
+var sendTestLogsToStdout bool
+
+func init() {
+	sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
+}
 
 func TestLogger(t testing.TB) *log.Logger {
 	return log.New(&testWriter{t}, "test: ", log.LstdFlags)
@@ -25,6 +33,10 @@ type testWriter struct {
 
 func (tw *testWriter) Write(p []byte) (n int, err error) {
 	tw.t.Helper()
-	tw.t.Log(strings.TrimSpace(string(p)))
+	if sendTestLogsToStdout {
+		fmt.Fprint(os.Stdout, strings.TrimSpace(string(p))+"\n")
+	} else {
+		tw.t.Log(strings.TrimSpace(string(p)))
+	}
 	return len(p), nil
 }


### PR DESCRIPTION
This is a followup to the testing feature added in #5304.

While it is very nice to have test agent logs to through `testing.T.Logf` so that only logs from failed tests are emitted, if a test is hanging or taking a long time those logs are delayed. In that case setting `NOLOGBUFFER=1` will temporarily redirect them to stdout so you can see immediate feedback about hangs when running the tests in verbose mode.

One current example of a test where this can be relevant is:

    $ go test ./agent/consul -run 'TestCatalog_ListServices_Stale' -v