### PR TITLE
UI: Add setting to enable/disable blocking queries

### DIFF
--- a/ui-v2/app/controllers/settings.js
+++ b/ui-v2/app/controllers/settings.js
@@ -1,0 +1,29 @@
+import Controller from '@ember/controller';
+import { get, set } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  repo: service('settings'),
+  dom: service('dom'),
+  actions: {
+    change: function(e, value, item) {
+      const event = get(this, 'dom').normalizeEvent(e, value);
+      // TODO: Switch to using forms like the rest of the app
+      // setting utils/form/builder for things to be done before we
+      // can do that. For the moment just do things normally its a simple
+      // enough form at the moment
+
+      const target = event.target;
+      const blocking = get(this, 'item.client.blocking');
+      switch (target.name) {
+        case 'client[blocking]':
+          if (typeof blocking === 'undefined') {
+            set(this, 'item.client', {});
+          }
+          set(this, 'item.client.blocking', !blocking);
+          this.send('update', get(this, 'item'));
+          break;
+      }
+    },
+  },
+});

--- a/ui-v2/app/router.js
+++ b/ui-v2/app/router.js
@@ -88,9 +88,9 @@ export const routes = {
     _options: { path: '/' },
   },
   // The settings page is global.
-  // settings: {
-  //   _options: { path: '/setting' },
-  // },
+  settings: {
+    _options: { path: '/setting' },
+  },
   notfound: {
     _options: { path: '/*path' },
   },

--- a/ui-v2/app/routes/settings.js
+++ b/ui-v2/app/routes/settings.js
@@ -3,8 +3,8 @@ import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
 
-import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
-export default Route.extend(WithBlockingActions, {
+export default Route.extend({
+  client: service('client/http'),
   repo: service('settings'),
   dcRepo: service('repository/dc'),
   model: function(params) {
@@ -24,8 +24,12 @@ export default Route.extend(WithBlockingActions, {
     this._super(...arguments);
     controller.setProperties(model);
   },
-  // overwrite afterUpdate and afterDelete hooks
-  // to avoid the default 'return to listing page'
-  afterUpdate: function() {},
-  afterDelete: function() {},
+  actions: {
+    update: function(item) {
+      if (!get(item, 'client.blocking')) {
+        get(this, 'client').abort();
+      }
+      get(this, 'repo').persist(item);
+    },
+  },
 });

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -63,6 +63,9 @@ export default Service.extend({
       });
     }
   },
+  abort: function(id = null) {
+    get(this, 'connections').purge();
+  },
   whenAvailable: function(e) {
     const doc = get(this, 'dom').document();
     // if we are using a connection limited protocol and the user has hidden the tab (hidden browser/tab switch)

--- a/ui-v2/app/templates/components/hashicorp-consul.hbs
+++ b/ui-v2/app/templates/components/hashicorp-consul.hbs
@@ -44,11 +44,9 @@
                     <li data-test-main-nav-docs>
                         <a href="{{ env 'CONSUL_DOCUMENTATION_URL'}}/index.html" rel="help noopener noreferrer" target="_blank">Documentation</a>
                     </li>
-{{#if false }}
                     <li data-test-main-nav-settings class={{if (is-href 'settings') 'is-active'}}>
                         <a href={{href-to 'settings'}}>Settings</a>
                     </li>
-{{/if}}
                 </ul>
             </nav>
         </div>

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -1,20 +1,5 @@
 {{#hashicorp-consul id="wrapper" dcs=dcs dc=dc}}
     {{#app-view class="settings show"}}
-        {{#block-slot 'notification' as |status type|}}
-          {{#if (eq type 'update')}}
-            {{#if (eq status 'success') }}
-              Your settings were saved.
-            {{else}}
-              There was an error saving your settings.
-            {{/if}}
-          {{ else if (eq type 'delete')}}
-            {{#if (eq status 'success') }}
-              You settings have been reset.
-            {{else}}
-              There was an error resetting your settings.
-            {{/if}}
-          {{/if}}
-        {{/block-slot}}
         {{#block-slot 'header'}}
             <h1>
                 Settings
@@ -26,13 +11,13 @@
             </p>
             <form>
                 <fieldset>
-                    <label class="type-text">
-                        <span>ACL Token</span>
-                        {{ input type='password' value=item.token name="token" }}
-                        <em>The token is sent with requests as the <code>X-Consul-Token</code> HTTP header parameter. This is used to control the ACL for the web UI.</em>
-                    </label>
+                    <div class="type-toggle">
+                      <label>
+                          <input type="checkbox" name="client[blocking]" checked={{if item.client.blocking 'checked' }} onchange={{action 'change'}} />
+                          <span>Enable Catalog realtime updates (blocking queries)</span>
+                      </label>
+                    </div>
                 </fieldset>
-                <button type="submit" {{action 'update' item}}>Save</button>
             </form>
         {{/block-slot}}
     {{/app-view}}

--- a/ui-v2/app/utils/dom/event-source/cache.js
+++ b/ui-v2/app/utils/dom/event-source/cache.js
@@ -2,7 +2,11 @@ export default function(source, DefaultEventSource, P = Promise) {
   return function(sources) {
     return function(cb, configuration) {
       const key = configuration.key;
-      if (typeof sources[key] !== 'undefined') {
+      if (typeof sources[key] !== 'undefined' && configuration.settings.enabled) {
+        if (typeof sources[key].configuration === 'undefined') {
+          sources[key].configuration = {};
+        }
+        sources[key].configuration.settings = configuration.settings;
         return source(sources[key]);
       } else {
         const EventSource = configuration.type || DefaultEventSource;

--- a/ui-v2/app/utils/form/builder.js
+++ b/ui-v2/app/utils/form/builder.js
@@ -77,9 +77,13 @@ export default function(changeset = defaultChangeset, getFormNameProperty = pars
         }
         const data = this.getData();
         // ember-data/changeset dance
+        // TODO: This works for ember-data RecordSets and Changesets but not for plain js Objects
+        // see settings
         const json = typeof data.toJSON === 'function' ? data.toJSON() : get(data, 'data').toJSON();
         // if the form doesn't include a property then throw so it can be
         // caught outside, therefore the user can deal with things that aren't in the data
+        // TODO: possibly need to add support for deeper properties using `get` here
+        // for example `client.blocking` instead of just `blocking`
         if (!Object.keys(json).includes(prop)) {
           const error = new Error(`${prop} property doesn't exist`);
           error.target = target;

--- a/ui-v2/tests/unit/controllers/settings-test.js
+++ b/ui-v2/tests/unit/controllers/settings-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:settings', 'Unit | Controller | settings', {
+  // Specify the other units that are required for this test.
+  needs: ['service:settings', 'service:dom'],
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/ui-v2/tests/unit/routes/settings-test.js
+++ b/ui-v2/tests/unit/routes/settings-test.js
@@ -3,6 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('route:settings', 'Unit | Route | settings', {
   // Specify the other units that are required for this test.
   needs: [
+    'service:client/http',
     'service:repository/dc',
     'service:settings',
     'service:logger',

--- a/ui-v2/tests/unit/utils/dom/event-source/cache-test.js
+++ b/ui-v2/tests/unit/utils/dom/event-source/cache-test.js
@@ -74,11 +74,17 @@ test('cache creates the default EventSource and keeps it open when there is a cu
   const cache = getCache(obj);
   const promisedEventSource = cache(cb, {
     key: 'key',
+    settings: {
+      enabled: true,
+    },
   });
   assert.ok(source.calledOnce, 'promisifying source called once');
   assert.ok(promisedEventSource instanceof Promise, 'source returns a Promise');
   const retrievedEventSource = cache(cb, {
     key: 'key',
+    settings: {
+      enabled: true,
+    },
   });
   assert.deepEqual(promisedEventSource, retrievedEventSource);
   assert.ok(source.calledTwice, 'promisifying source called once');
@@ -100,6 +106,9 @@ test('cache creates the default EventSource and keeps it open when there is a cu
   const cache = getCache(obj);
   const promisedEventSource = cache(cb, {
     key: 0,
+    settings: {
+      enabled: true,
+    },
   });
   assert.ok(source.calledOnce, 'promisifying source called once');
   assert.ok(cb.calledOnce, 'callable event source callable called once');


### PR DESCRIPTION
This PR:

1. Re-enables the settings page
2. Adds a toggle to enable/disable blocking queries at a UI level
3. Ensures that the setting isn't cached in the event source cache
4. Ensure that changing the setting cancels any existing requests
5. Also ties up cancelling and restarting requests on tab switch

...and is to be merged down onto https://github.com/hashicorp/consul/pull/5070

## Notes:

### On/off setting cache

Previous to this, the on/off setting was a planned addition to the EventSource/blocking queries/live updates feature. Until now I'd simply used a manual edit of localStorage to test this (see https://github.com/hashicorp/consul/pull/5267).

Here we've  added the on/off toggle and once we did this I noticed that the on/off setting was also being cached in the EventSource caching code. This meant that changing the UI setting after an EventSource had been cached had no effect. An unplanned hiccup! As well as adding the UI toggle here, we've re-plumbed this setting slightly in the caching code to make sure that it works properly there.

The setting is off by default, I would imagine we may release like this and then make it default enabled at a later date, but thats open for discussion.

On a related note, I had previously thought this cache does too much, and the way we've approached this could be simplified further. We essentially cache the `EventSource` entirely rather than the `cursor` and the last response/resultset. I had thought to change this but figured that in the scheme of things it's not that important - now I've realized the little hiccup we've fixed here. It gives me more impetus to slightly rearrange this so the cache does less. Potentially we could replace the caching with something form ember core as we should be able to remove all `EventSource` related things from the caching code. In saying that, it's still low down on my list of things to do,

### Settings page

We'd left the settings page in but disabled for a little while, this uncomments the code to enable the settings page again. We removed a lot of the existing code as its no longer needed now the ACL login form is in the actual ACLs area.

### Settings form

Ideally we would have like to use my `form` work here. But as it's not backed by an ember-data `Record` it's slightly different and will need a tiny bit of code adding to support that. I'd rather do this in a separate PR as it's not really related to this. So for the moment the settings form uses a simpler approach. The form is really simple anyway so its no biggie either way, but once settings gets more complicated we'd rather use the `form` work.

We've added some todo notes in here for when we come to do this additional work.

### Aborting on tab 'hide' (and then restarting)

We also plumbed in the work from https://github.com/hashicorp/consul/pull/5083 to restart aborted requests here. It's not really related to this specific PR, but felt it best to get this in here so we can get everything merged down ASAP. 

Apart from adding more tests, and generally kicking the tyres a lot, the only further thing we may add before merging this in to my base branch will be looking at some sort of automatic rate limiting. We currently use a 'throttle' setting, which I'd imagined would be in the settings page. We're holding off on doing this just now until I have chance to look at something something automatic.

I'll add some inline comments here also.

Just incase you can try this after a clone by starting the fake API using `make start-api` then in another terminal `make start`. You can control the latency/response rate of the blocking queries by adding a `CONSUL_LATENCY` cookie using web inspector. This value is in milliseconds.

![screenshot 2019-02-15 at 13 43 48](https://user-images.githubusercontent.com/554604/52860617-d0518600-3127-11e9-9c78-1a1fd1bae5e7.png)





