### PR TITLE
acl: tokens can be created with an optional expiration time

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -31,8 +31,15 @@ const (
 	// with all tokens in it.
 	aclUpgradeBatchSize = 128
 
-	// aclUpgradeRateLimit is the number of batch upgrade requests per second.
+	// aclUpgradeRateLimit is the number of batch upgrade requests per second allowed.
 	aclUpgradeRateLimit rate.Limit = 1.0
+
+	// aclTokenReapingRateLimit is the number of batch token reaping requests per second allowed.
+	aclTokenReapingRateLimit rate.Limit = 1.0
+
+	// aclTokenReapingBurst is the number of batch token reaping requests per second
+	// that can burst after a period of idleness.
+	aclTokenReapingBurst = 5
 
 	// aclBatchDeleteSize is the number of deletions to send in a single batch operation. 4096 should produce a batch that is <150KB
 	// in size but should be sufficiently large to handle 1 replication round in a single batch
@@ -607,6 +614,8 @@ func (r *ACLResolver) resolveTokenToIdentityAndPolicies(token string) (structs.A
 		if err != nil {
 			return nil, nil, err
 		} else if identity == nil {
+			return nil, nil, acl.ErrNotFound
+		} else if identity.IsExpired(time.Now()) {
 			return nil, nil, acl.ErrNotFound
 		}
 

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -468,6 +468,7 @@ func (s *Server) replicateACLTokens(lastRemoteIndex uint64, ctx context.Context)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to retrieve local ACL tokens: %v", err)
 	}
+	// Do not filter by expiration times. Wait until the tokens are explicitly deleted.
 
 	// If the remote index ever goes backwards, it's a good indication that
 	// the remote side was rebuilt and we should do a full sync since we

--- a/agent/consul/acl_replication_legacy.go
+++ b/agent/consul/acl_replication_legacy.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -143,8 +143,13 @@ func (s *Server) fetchLocalLegacyACLs() (structs.ACLs, error) {
 		return nil, err
 	}
 
+	now := time.Now()
+
 	var acls structs.ACLs
 	for _, token := range local {
+		if token.IsExpired(now) {
+			continue
+		}
 		if acl, err := token.Convert(); err == nil && acl != nil {
 			acls = append(acls, acl)
 		}

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -20,6 +20,16 @@ func (s *Server) startACLTokenReaping() {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.aclTokenReapCancel = cancel
 
+	// Do a quick check for config settings that would imply the goroutine
+	// below will just spin forever.
+	//
+	// We can only check the config settings here that cannot change without a
+	// restart, so we omit the check for a non-empty replication token as that
+	// can be changed at runtime.
+	if !s.InACLDatacenter() && !s.config.ACLTokenReplication {
+		return
+	}
+
 	go func() {
 		limiter := rate.NewLimiter(aclTokenReapingRateLimit, aclTokenReapingBurst)
 

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -1,0 +1,134 @@
+package consul
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"golang.org/x/time/rate"
+)
+
+func (s *Server) startACLTokenReaping() {
+	s.aclTokenReapLock.Lock()
+	defer s.aclTokenReapLock.Unlock()
+
+	if s.aclTokenReapEnabled {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.aclTokenReapCancel = cancel
+
+	go func() {
+		limiter := rate.NewLimiter(aclTokenReapingRateLimit, aclTokenReapingBurst)
+
+		for {
+			if err := limiter.Wait(ctx); err != nil {
+				return
+			}
+
+			if s.LocalTokensEnabled() {
+				if _, err := s.reapExpiredLocalACLTokens(); err != nil {
+					s.logger.Printf("[ERR] acl: error reaping expired local ACL tokens: %v", err)
+				}
+			}
+			if s.InACLDatacenter() {
+				if _, err := s.reapExpiredGlobalACLTokens(); err != nil {
+					s.logger.Printf("[ERR] acl: error reaping expired global ACL tokens: %v", err)
+				}
+			}
+		}
+	}()
+
+	s.aclTokenReapEnabled = true
+}
+
+func (s *Server) stopACLTokenReaping() {
+	s.aclTokenReapLock.Lock()
+	defer s.aclTokenReapLock.Unlock()
+
+	if !s.aclTokenReapEnabled {
+		return
+	}
+
+	s.aclTokenReapCancel()
+	s.aclTokenReapCancel = nil
+	s.aclTokenReapEnabled = false
+}
+
+func (s *Server) reapExpiredGlobalACLTokens() (int, error) {
+	return s.reapExpiredACLTokens(false, true)
+}
+func (s *Server) reapExpiredLocalACLTokens() (int, error) {
+	return s.reapExpiredACLTokens(true, false)
+}
+func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
+	if !s.ACLsEnabled() {
+		return 0, nil
+	}
+	if s.UseLegacyACLs() {
+		return 0, nil
+	}
+	if local == global {
+		return 0, fmt.Errorf("cannot reap both local and global tokens in the same request")
+	}
+
+	locality := localityName(local)
+
+	minExpiredTime, err := s.fsm.State().ACLTokenMinExpirationTime(local)
+	if err != nil {
+		return 0, err
+	}
+
+	now := time.Now()
+
+	if minExpiredTime.After(now) {
+		return 0, nil // nothing to do
+	}
+
+	tokens, _, err := s.fsm.State().ACLTokenListExpired(local, now, aclBatchDeleteSize)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(tokens) == 0 {
+		return 0, nil
+	}
+
+	var (
+		secretIDs []string
+		req       structs.ACLTokenBatchDeleteRequest
+	)
+	for _, token := range tokens {
+		if token.Local != local {
+			return 0, fmt.Errorf("expired index for local=%v returned a mismatched token with local=%v: %s", local, token.Local, token.AccessorID)
+		}
+		req.TokenIDs = append(req.TokenIDs, token.AccessorID)
+		secretIDs = append(secretIDs, token.SecretID)
+	}
+
+	s.logger.Printf("[INFO] acl: deleting %d expired %s tokens", len(req.TokenIDs), locality)
+	resp, err := s.raftApply(structs.ACLTokenDeleteRequestType, &req)
+	if err != nil {
+		return 0, fmt.Errorf("Failed to apply token expiration deletions: %v", err)
+	}
+
+	// Purge the identities from the cache
+	for _, secretID := range secretIDs {
+		s.acls.cache.RemoveIdentity(secretID)
+	}
+
+	if respErr, ok := resp.(error); ok {
+		return 0, respErr
+	}
+
+	return len(req.TokenIDs), nil
+}
+
+func localityName(local bool) string {
+	if local {
+		return "local"
+	}
+	return "global"
+}

--- a/agent/consul/acl_token_exp_test.go
+++ b/agent/consul/acl_token_exp_test.go
@@ -1,0 +1,219 @@
+package consul
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestACLTokenReap_Primary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("global", func(t *testing.T) {
+		t.Parallel()
+		testACLTokenReap_Primary(t, false, true)
+	})
+	t.Run("local", func(t *testing.T) {
+		t.Parallel()
+		testACLTokenReap_Primary(t, true, false)
+	})
+}
+
+func testACLTokenReap_Primary(t *testing.T, local, global bool) {
+	// -------------------------------------------
+	// A word of caution when testing reapExpiredACLTokens():
+	//
+	// The underlying memdb index used for reaping has a minimum granularity of
+	// 1 second as it delegates to `time.Unix()`. This test will have to be
+	// deliberately slow to allow for necessary sleeps.  If you try to make it
+	// operate faster (using expiration ttls of milliseconds) it will be flaky.
+	// -------------------------------------------
+
+	t.Helper()
+	require.NotEqual(t, local, global)
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLMasterToken = "root"
+		c.ACLTokenMinExpirationTTL = 10 * time.Millisecond
+		c.ACLTokenMaxExpirationTTL = 8 * time.Second
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	acl := ACL{s1}
+
+	masterTokenAccessorID, err := retrieveTestTokenAccessorForSecret(codec, "root", "dc1", "root")
+	require.NoError(t, err)
+
+	listTokens := func() (localTokens, globalTokens []string, err error) {
+		req := structs.ACLTokenListRequest{
+			Datacenter:   "dc1",
+			QueryOptions: structs.QueryOptions{Token: "root"},
+		}
+
+		var res structs.ACLTokenListResponse
+		err = acl.TokenList(&req, &res)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, tok := range res.Tokens {
+			if tok.Local {
+				localTokens = append(localTokens, tok.AccessorID)
+			} else {
+				globalTokens = append(globalTokens, tok.AccessorID)
+			}
+		}
+
+		return localTokens, globalTokens, nil
+	}
+
+	requireTokenMatch := func(t *testing.T, expect []string) {
+		t.Helper()
+
+		var expectLocal, expectGlobal []string
+		// The master token and the anonymous token are always going to be
+		// present and global.
+		expectGlobal = append(expectGlobal, masterTokenAccessorID)
+		expectGlobal = append(expectGlobal, structs.ACLTokenAnonymousID)
+
+		if local {
+			expectLocal = append(expectLocal, expect...)
+		} else {
+			expectGlobal = append(expectGlobal, expect...)
+		}
+
+		localTokens, globalTokens, err := listTokens()
+		require.NoError(t, err)
+		require.ElementsMatch(t, expectLocal, localTokens)
+		require.ElementsMatch(t, expectGlobal, globalTokens)
+	}
+
+	// initial sanity check
+	requireTokenMatch(t, []string{})
+
+	t.Run("no tokens", func(t *testing.T) {
+		n, err := s1.reapExpiredACLTokens(local, global)
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		requireTokenMatch(t, []string{})
+	})
+
+	// 2 normal
+	token1, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.Local = local
+	})
+	require.NoError(t, err)
+	token2, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.Local = local
+	})
+	require.NoError(t, err)
+
+	requireTokenMatch(t, []string{
+		token1.AccessorID,
+		token2.AccessorID,
+	})
+
+	t.Run("only normal tokens", func(t *testing.T) {
+		n, err := s1.reapExpiredACLTokens(local, global)
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		requireTokenMatch(t, []string{
+			token1.AccessorID,
+			token2.AccessorID,
+		})
+	})
+
+	// 2 expiring
+	token3, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.ExpirationTTL = 1 * time.Second
+		token.Local = local
+	})
+	require.NoError(t, err)
+	token4, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.ExpirationTTL = 5 * time.Second
+		token.Local = local
+	})
+	require.NoError(t, err)
+
+	// 2 more normal
+	token5, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.Local = local
+	})
+	require.NoError(t, err)
+	token6, err := upsertTestToken(codec, "root", "dc1", func(token *structs.ACLToken) {
+		token.Local = local
+	})
+	require.NoError(t, err)
+
+	requireTokenMatch(t, []string{
+		token1.AccessorID,
+		token2.AccessorID,
+		token3.AccessorID,
+		token4.AccessorID,
+		token5.AccessorID,
+		token6.AccessorID,
+	})
+
+	t.Run("mixed but nothing expired yet", func(t *testing.T) {
+		n, err := s1.reapExpiredACLTokens(local, global)
+		require.NoError(t, err)
+		require.Equal(t, 0, n)
+
+		requireTokenMatch(t, []string{
+			token1.AccessorID,
+			token2.AccessorID,
+			token3.AccessorID,
+			token4.AccessorID,
+			token5.AccessorID,
+			token6.AccessorID,
+		})
+	})
+
+	time.Sleep(token3.ExpirationTime.Sub(time.Now()) + 10*time.Millisecond)
+
+	t.Run("one should be reaped", func(t *testing.T) {
+		n, err := s1.reapExpiredACLTokens(local, global)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		requireTokenMatch(t, []string{
+			token1.AccessorID,
+			token2.AccessorID,
+			// token3.AccessorID,
+			token4.AccessorID,
+			token5.AccessorID,
+			token6.AccessorID,
+		})
+	})
+
+	time.Sleep(token4.ExpirationTime.Sub(time.Now()) + 10*time.Millisecond)
+
+	t.Run("two should be reaped", func(t *testing.T) {
+		n, err := s1.reapExpiredACLTokens(local, global)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+
+		requireTokenMatch(t, []string{
+			token1.AccessorID,
+			token2.AccessorID,
+			// token3.AccessorID,
+			// token4.AccessorID,
+			token5.AccessorID,
+			token6.AccessorID,
+		})
+	})
+}

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -313,6 +313,16 @@ type Config struct {
 	// Minimum Session TTL
 	SessionTTLMin time.Duration
 
+	// maxTokenExpirationDuration is the maximum difference allowed between
+	// ACLToken CreateTime and ExpirationTime values if ExpirationTime is set
+	// on a token.
+	ACLTokenMaxExpirationTTL time.Duration
+
+	// ACLTokenMinExpirationTTL is the minimum difference allowed between
+	// ACLToken CreateTime and ExpirationTime values if ExpirationTime is set
+	// on a token.
+	ACLTokenMinExpirationTTL time.Duration
+
 	// ServerUp callback can be used to trigger a notification that
 	// a Consul server is now up and known about.
 	ServerUp func()
@@ -452,6 +462,8 @@ func DefaultConfig() *Config {
 		TombstoneTTL:             15 * time.Minute,
 		TombstoneTTLGranularity:  30 * time.Second,
 		SessionTTLMin:            10 * time.Second,
+		ACLTokenMinExpirationTTL: 1 * time.Minute,
+		ACLTokenMaxExpirationTTL: 24 * time.Hour,
 
 		// These are tuned to provide a total throughput of 128 updates
 		// per second. If you update these, you should update the client-

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 )
@@ -164,6 +164,7 @@ func (c *FSM) applyACLOperation(buf []byte, index uint64) interface{} {
 			return err
 		}
 
+		// No need to check expiration times as those did not exist in legacy tokens.
 		if _, token, err := c.state.ACLTokenGetBySecret(nil, req.ACL.ID); err != nil {
 			return err
 		} else {

--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -174,6 +174,8 @@ func (s *snapshot) persistACLs(sink raft.SnapshotSink,
 		return err
 	}
 
+	// Don't check expiration times. Wait for explicit deletions.
+
 	for token := tokens.Next(); token != nil; token = tokens.Next() {
 		if _, err := sink.Write([]byte{byte(structs.ACLTokenSetRequestType)}); err != nil {
 			return err

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/connect"
 	ca "github.com/hashicorp/consul/agent/connect/ca"
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/consul/types"
 	memdb "github.com/hashicorp/go-memdb"
 	uuid "github.com/hashicorp/go-uuid"
-	"github.com/hashicorp/go-version"
+	version "github.com/hashicorp/go-version"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 	"golang.org/x/time/rate"
@@ -295,6 +295,8 @@ func (s *Server) revokeLeadership() error {
 
 	s.setCAProvider(nil, nil)
 
+	s.stopACLTokenReaping()
+
 	s.stopACLUpgrade()
 
 	s.resetConsistentReadReady()
@@ -316,6 +318,7 @@ func (s *Server) initializeLegacyACL() error {
 	if err != nil {
 		return fmt.Errorf("failed to get anonymous token: %v", err)
 	}
+	// Ignoring expiration times to avoid an insertion collision.
 	if token == nil {
 		req := structs.ACLRequest{
 			Datacenter: authDC,
@@ -339,6 +342,7 @@ func (s *Server) initializeLegacyACL() error {
 		if err != nil {
 			return fmt.Errorf("failed to get master token: %v", err)
 		}
+		// Ignoring expiration times to avoid an insertion collision.
 		if token == nil {
 			req := structs.ACLRequest{
 				Datacenter: authDC,
@@ -469,6 +473,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to get master token: %v", err)
 			}
+			// Ignoring expiration times to avoid an insertion collision.
 			if token == nil {
 				accessor, err := lib.GenerateUUID(s.checkTokenUUID)
 				if err != nil {
@@ -530,6 +535,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to get anonymous token: %v", err)
 		}
+		// Ignoring expiration times to avoid an insertion collision.
 		if token == nil {
 			// DEPRECATED (ACL-Legacy-Compat) - Don't need to query for previous "anonymous" token
 			// check for legacy token that needs an upgrade
@@ -537,6 +543,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to get anonymous token: %v", err)
 			}
+			// Ignoring expiration times to avoid an insertion collision.
 
 			// the token upgrade routine will take care of upgrading the token if a legacy version exists
 			if legacyToken == nil {
@@ -559,6 +566,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 				s.logger.Printf("[INFO] consul: Created ACL anonymous token from configuration")
 			}
 		}
+		// launch the upgrade go routine to generate accessors for everything
 		s.startACLUpgrade()
 	} else {
 		if s.UseLegacyACLs() && !upgrade {
@@ -575,7 +583,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 		s.startACLReplication()
 	}
 
-	// launch the upgrade go routine to generate accessors for everything
+	s.startACLTokenReaping()
 
 	return nil
 }
@@ -604,6 +612,7 @@ func (s *Server) startACLUpgrade() {
 			if err != nil {
 				s.logger.Printf("[WARN] acl: encountered an error while searching for tokens without accessor ids: %v", err)
 			}
+			// No need to check expiration time here, as that only exists for v2 tokens.
 
 			if len(tokens) == 0 {
 				ws := memdb.NewWatchSet()
@@ -784,10 +793,10 @@ func (s *Server) startACLReplication() {
 
 	if s.config.ACLTokenReplication {
 		replicationType = structs.ACLReplicateTokens
-
 		go func() {
 			var failedAttempts uint
 			limiter := rate.NewLimiter(rate.Limit(s.config.ACLReplicationRate), s.config.ACLReplicationBurst)
+
 			var lastRemoteIndex uint64
 			for {
 				if err := limiter.Wait(ctx); err != nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -109,6 +109,12 @@ type Server struct {
 	aclReplicationLock    sync.RWMutex
 	aclReplicationEnabled bool
 
+	// aclTokenReapCancel is used to shut down the ACL Token expiration reap
+	// goroutine when we lose leadership.
+	aclTokenReapCancel  context.CancelFunc
+	aclTokenReapLock    sync.RWMutex
+	aclTokenReapEnabled bool
+
 	// DEPRECATED (ACL-Legacy-Compat) - only needed while we support both
 	// useNewACLs is used to determine whether we can use new ACLs or not
 	useNewACLs int32

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -1,10 +1,12 @@
 package state
 
 import (
+	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-memdb"
+	memdb "github.com/hashicorp/go-memdb"
 )
 
 type TokenPoliciesIndex struct {
@@ -58,6 +60,54 @@ func (s *TokenPoliciesIndex) PrefixFromArgs(args ...interface{}) ([]byte, error)
 	return val, nil
 }
 
+type TokenExpirationIndex struct {
+	LocalFilter bool
+}
+
+func (s *TokenExpirationIndex) encodeTime(t time.Time) []byte {
+	val := t.Unix()
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(val))
+	return buf
+}
+
+func (s *TokenExpirationIndex) FromObject(obj interface{}) (bool, []byte, error) {
+	token, ok := obj.(*structs.ACLToken)
+	if !ok {
+		return false, nil, fmt.Errorf("object is not an ACLToken")
+	}
+	if s.LocalFilter != token.Local {
+		return false, nil, nil
+	}
+	if token.ExpirationTime.IsZero() {
+		return false, nil, nil
+	}
+	if token.ExpirationTime.Unix() < 0 {
+		return false, nil, fmt.Errorf("token expiration time cannot be before the unix epoch: %s", token.ExpirationTime)
+	}
+
+	buf := s.encodeTime(token.ExpirationTime)
+
+	return true, buf, nil
+}
+
+func (s *TokenExpirationIndex) FromArgs(args ...interface{}) ([]byte, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("must provide only a single argument")
+	}
+	arg, ok := args[0].(time.Time)
+	if !ok {
+		return nil, fmt.Errorf("argument must be a time.Time: %#v", args[0])
+	}
+	if arg.Unix() < 0 {
+		return nil, fmt.Errorf("argument must be a time.Time after the unix epoch: %s", args[0])
+	}
+
+	buf := s.encodeTime(arg)
+
+	return buf, nil
+}
+
 func tokensTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
 		Name: "acl-tokens",
@@ -99,6 +149,18 @@ func tokensTableSchema() *memdb.TableSchema {
 						return false, nil
 					},
 				},
+			},
+			"expires-global": {
+				Name:         "expires-global",
+				AllowMissing: true,
+				Unique:       false,
+				Indexer:      &TokenExpirationIndex{LocalFilter: false},
+			},
+			"expires-local": {
+				Name:         "expires-local",
+				AllowMissing: true,
+				Unique:       false,
+				Indexer:      &TokenExpirationIndex{LocalFilter: true},
 			},
 
 			//DEPRECATED (ACL-Legacy-Compat) - This index is only needed while we support upgrading v1 to v2 acls
@@ -405,7 +467,7 @@ func (s *Store) aclTokenSetTxn(tx *memdb.Txn, idx uint64, token *structs.ACLToke
 	}
 
 	if legacy && original != nil {
-		if len(original.Policies) > 0 || original.Type == "" {
+		if original.UsesNonLegacyFields() {
 			return fmt.Errorf("failed inserting acl token: cannot use legacy endpoint to modify a non-legacy token")
 		}
 
@@ -584,6 +646,63 @@ func (s *Store) ACLTokenListUpgradeable(max int) (structs.ACLTokens, <-chan stru
 	}
 
 	return tokens, iter.WatchCh(), nil
+}
+
+func (s *Store) ACLTokenMinExpirationTime(local bool) (time.Time, error) {
+	tx := s.db.Txn(false)
+	defer tx.Abort()
+
+	item, err := tx.First("acl-tokens", s.expiresIndexName(local))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed acl token listing: %v", err)
+	}
+
+	if item == nil {
+		return time.Time{}, nil
+	}
+
+	token := item.(*structs.ACLToken)
+
+	return token.ExpirationTime, nil
+}
+
+// ACLTokenListExpires lists tokens that are expires as of the provided time.
+// The returned set will be no larger than the max value provided.
+func (s *Store) ACLTokenListExpired(local bool, asOf time.Time, max int) (structs.ACLTokens, <-chan struct{}, error) {
+	tx := s.db.Txn(false)
+	defer tx.Abort()
+
+	iter, err := tx.Get("acl-tokens", s.expiresIndexName(local))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed acl token listing: %v", err)
+	}
+
+	var (
+		tokens structs.ACLTokens
+		i      int
+	)
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		token := raw.(*structs.ACLToken)
+
+		if !token.ExpirationTime.Before(asOf) {
+			return tokens, nil, nil
+		}
+
+		tokens = append(tokens, token)
+		i += 1
+		if i >= max {
+			return tokens, nil, nil
+		}
+	}
+
+	return tokens, iter.WatchCh(), nil
+}
+
+func (s *Store) expiresIndexName(local bool) string {
+	if local {
+		return "expires-local"
+	}
+	return "expires-global"
 }
 
 // ACLTokenDeleteBySecret is used to remove an existing ACL from the state store. If

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -113,6 +113,7 @@ type ACLIdentity interface {
 	SecretToken() string
 	PolicyIDs() []string
 	EmbeddedPolicy() *ACLPolicy
+	IsExpired(asOf time.Time) bool
 }
 
 type ACLTokenPolicyLink struct {
@@ -149,6 +150,19 @@ type ACLToken struct {
 	// Whether this token is DC local. This means that it will not be synced
 	// to the ACL datacenter and replicated to others.
 	Local bool
+
+	// ExpirationTime represents the point after which a token should be
+	// considered revoked and is eligible for destruction. The zero value
+	// represents NO expiration.
+	ExpirationTime time.Time `json:",omitempty"`
+
+	// ExpirationTTL is a convenience field for helping set ExpirationTime to a
+	// value of CreateTime+ExpirationTTL. This can only be set during
+	// TokenCreate and is cleared and used to initialize the ExpirationTime
+	// field before being persisted to the state store or raft log.
+	//
+	// This is a string version of a time.Duration like "2m".
+	ExpirationTTL time.Duration `json:",omitempty"`
 
 	// The time when this token was created
 	CreateTime time.Time `json:",omitempty"`
@@ -191,6 +205,20 @@ func (t *ACLToken) PolicyIDs() []string {
 	return ids
 }
 
+func (t *ACLToken) IsExpired(asOf time.Time) bool {
+	if asOf.IsZero() || t.ExpirationTime.IsZero() {
+		return false
+	}
+	return t.ExpirationTime.Before(asOf)
+}
+
+func (t *ACLToken) UsesNonLegacyFields() bool {
+	return len(t.Policies) > 0 ||
+		t.Type == "" ||
+		!t.ExpirationTime.IsZero() ||
+		t.ExpirationTTL != 0
+}
+
 func (t *ACLToken) EmbeddedPolicy() *ACLPolicy {
 	// DEPRECATED (ACL-Legacy-Compat)
 	//
@@ -229,6 +257,14 @@ func (t *ACLToken) SetHash(force bool) []byte {
 			panic(err)
 		}
 
+		// Any non-immutable "content" fields should be involved with the
+		// overall hash. The IDs are immutable which is why they aren't here.
+		// The raft indices are metadata similar to the hash which is why they
+		// aren't incorporated. CreateTime is similarly immutable
+		//
+		// The Hash is really only used for replication to determine if a token
+		// has changed and should be updated locally.
+
 		// Write all the user set fields
 		hash.Write([]byte(t.Description))
 		hash.Write([]byte(t.Type))
@@ -254,8 +290,8 @@ func (t *ACLToken) SetHash(force bool) []byte {
 }
 
 func (t *ACLToken) EstimateSize() int {
-	// 33 = 16 (RaftIndex) + 8 (Hash) + 8 (CreateTime) + 1 (Local)
-	size := 33 + len(t.AccessorID) + len(t.SecretID) + len(t.Description) + len(t.Type) + len(t.Rules)
+	// 41 = 16 (RaftIndex) + 8 (Hash) + 8 (ExpirationTime) + 8 (CreateTime) + 1 (Local)
+	size := 41 + len(t.AccessorID) + len(t.SecretID) + len(t.Description) + len(t.Type) + len(t.Rules)
 	for _, link := range t.Policies {
 		size += len(link.ID) + len(link.Name)
 	}
@@ -266,30 +302,32 @@ func (t *ACLToken) EstimateSize() int {
 type ACLTokens []*ACLToken
 
 type ACLTokenListStub struct {
-	AccessorID  string
-	Description string
-	Policies    []ACLTokenPolicyLink
-	Local       bool
-	CreateTime  time.Time `json:",omitempty"`
-	Hash        []byte
-	CreateIndex uint64
-	ModifyIndex uint64
-	Legacy      bool `json:",omitempty"`
+	AccessorID     string
+	Description    string
+	Policies       []ACLTokenPolicyLink
+	Local          bool
+	ExpirationTime time.Time `json:",omitempty"`
+	CreateTime     time.Time `json:",omitempty"`
+	Hash           []byte
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	Legacy         bool `json:",omitempty"`
 }
 
 type ACLTokenListStubs []*ACLTokenListStub
 
 func (token *ACLToken) Stub() *ACLTokenListStub {
 	return &ACLTokenListStub{
-		AccessorID:  token.AccessorID,
-		Description: token.Description,
-		Policies:    token.Policies,
-		Local:       token.Local,
-		CreateTime:  token.CreateTime,
-		Hash:        token.Hash,
-		CreateIndex: token.CreateIndex,
-		ModifyIndex: token.ModifyIndex,
-		Legacy:      token.Rules != "",
+		AccessorID:     token.AccessorID,
+		Description:    token.Description,
+		Policies:       token.Policies,
+		Local:          token.Local,
+		ExpirationTime: token.ExpirationTime,
+		CreateTime:     token.CreateTime,
+		Hash:           token.Hash,
+		CreateIndex:    token.CreateIndex,
+		ModifyIndex:    token.ModifyIndex,
+		Legacy:         token.Rules != "",
 	}
 }
 
@@ -384,6 +422,14 @@ func (p *ACLPolicy) SetHash(force bool) []byte {
 			panic(err)
 		}
 
+		// Any non-immutable "content" fields should be involved with the
+		// overall hash. The ID is immutable which is why it isn't here.  The
+		// raft indices are metadata similar to the hash which is why they
+		// aren't incorporated. CreateTime is similarly immutable
+		//
+		// The Hash is really only used for replication to determine if a policy
+		// has changed and should be updated locally.
+
 		// Write all the user set fields
 		hash.Write([]byte(p.Name))
 		hash.Write([]byte(p.Description))
@@ -414,7 +460,7 @@ func (p *ACLPolicy) EstimateSize() int {
 	return size
 }
 
-// ACLPolicyListHash returns a consistent hash for a set of policies.
+// HashKey returns a consistent hash for a set of policies.
 func (policies ACLPolicies) HashKey() string {
 	cacheKeyHash, err := blake2b.New256(nil)
 	if err != nil {

--- a/agent/structs/acl_test.go
+++ b/agent/structs/acl_test.go
@@ -208,7 +208,7 @@ func TestStructs_ACLToken_EstimateSize(t *testing.T) {
 
 	// this test is very contrived. Basically just tests that the
 	// math is okay and returns the value.
-	require.Equal(t, 120, token.EstimateSize())
+	require.Equal(t, 128, token.EstimateSize())
 }
 
 func TestStructs_ACLToken_Stub(t *testing.T) {

--- a/api/acl.go
+++ b/api/acl.go
@@ -22,15 +22,17 @@ type ACLTokenPolicyLink struct {
 
 // ACLToken represents an ACL Token
 type ACLToken struct {
-	CreateIndex uint64
-	ModifyIndex uint64
-	AccessorID  string
-	SecretID    string
-	Description string
-	Policies    []*ACLTokenPolicyLink
-	Local       bool
-	CreateTime  time.Time `json:",omitempty"`
-	Hash        []byte    `json:",omitempty"`
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	AccessorID     string
+	SecretID       string
+	Description    string
+	Policies       []*ACLTokenPolicyLink
+	Local          bool
+	ExpirationTTL  time.Duration `json:",omitempty"`
+	ExpirationTime time.Time     `json:",omitempty"`
+	CreateTime     time.Time     `json:",omitempty"`
+	Hash           []byte        `json:",omitempty"`
 
 	// DEPRECATED (ACL-Legacy-Compat)
 	// Rules will only be present for legacy tokens returned via the new APIs
@@ -38,15 +40,16 @@ type ACLToken struct {
 }
 
 type ACLTokenListEntry struct {
-	CreateIndex uint64
-	ModifyIndex uint64
-	AccessorID  string
-	Description string
-	Policies    []*ACLTokenPolicyLink
-	Local       bool
-	CreateTime  time.Time
-	Hash        []byte
-	Legacy      bool
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	AccessorID     string
+	Description    string
+	Policies       []*ACLTokenPolicyLink
+	Local          bool
+	ExpirationTime time.Time `json:",omitempty"`
+	CreateTime     time.Time
+	Hash           []byte
+	Legacy         bool
 }
 
 // ACLEntry is used to represent a legacy ACL token

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -10,15 +10,18 @@ import (
 )
 
 func PrintToken(token *api.ACLToken, ui cli.Ui, showMeta bool) {
-	ui.Info(fmt.Sprintf("AccessorID:   %s", token.AccessorID))
-	ui.Info(fmt.Sprintf("SecretID:     %s", token.SecretID))
-	ui.Info(fmt.Sprintf("Description:  %s", token.Description))
-	ui.Info(fmt.Sprintf("Local:        %t", token.Local))
-	ui.Info(fmt.Sprintf("Create Time:  %v", token.CreateTime))
+	ui.Info(fmt.Sprintf("AccessorID:       %s", token.AccessorID))
+	ui.Info(fmt.Sprintf("SecretID:         %s", token.SecretID))
+	ui.Info(fmt.Sprintf("Description:      %s", token.Description))
+	ui.Info(fmt.Sprintf("Local:            %t", token.Local))
+	ui.Info(fmt.Sprintf("Create Time:      %v", token.CreateTime))
+	if !token.ExpirationTime.IsZero() {
+		ui.Info(fmt.Sprintf("Expiration Time:  %v", token.ExpirationTime))
+	}
 	if showMeta {
-		ui.Info(fmt.Sprintf("Hash:         %x", token.Hash))
-		ui.Info(fmt.Sprintf("Create Index: %d", token.CreateIndex))
-		ui.Info(fmt.Sprintf("Modify Index: %d", token.ModifyIndex))
+		ui.Info(fmt.Sprintf("Hash:             %x", token.Hash))
+		ui.Info(fmt.Sprintf("Create Index:     %d", token.CreateIndex))
+		ui.Info(fmt.Sprintf("Modify Index:     %d", token.ModifyIndex))
 	}
 	ui.Info(fmt.Sprintf("Policies:"))
 	for _, policy := range token.Policies {
@@ -31,15 +34,18 @@ func PrintToken(token *api.ACLToken, ui cli.Ui, showMeta bool) {
 }
 
 func PrintTokenListEntry(token *api.ACLTokenListEntry, ui cli.Ui, showMeta bool) {
-	ui.Info(fmt.Sprintf("AccessorID:   %s", token.AccessorID))
-	ui.Info(fmt.Sprintf("Description:  %s", token.Description))
-	ui.Info(fmt.Sprintf("Local:        %t", token.Local))
-	ui.Info(fmt.Sprintf("Create Time:  %v", token.CreateTime))
-	ui.Info(fmt.Sprintf("Legacy:       %t", token.Legacy))
+	ui.Info(fmt.Sprintf("AccessorID:       %s", token.AccessorID))
+	ui.Info(fmt.Sprintf("Description:      %s", token.Description))
+	ui.Info(fmt.Sprintf("Local:            %t", token.Local))
+	ui.Info(fmt.Sprintf("Create Time:      %v", token.CreateTime))
+	if !token.ExpirationTime.IsZero() {
+		ui.Info(fmt.Sprintf("Expiration Time:  %v", token.ExpirationTime))
+	}
+	ui.Info(fmt.Sprintf("Legacy:           %t", token.Legacy))
 	if showMeta {
-		ui.Info(fmt.Sprintf("Hash:         %x", token.Hash))
-		ui.Info(fmt.Sprintf("Create Index: %d", token.CreateIndex))
-		ui.Info(fmt.Sprintf("Modify Index: %d", token.ModifyIndex))
+		ui.Info(fmt.Sprintf("Hash:             %x", token.Hash))
+		ui.Info(fmt.Sprintf("Create Index:     %d", token.CreateIndex))
+		ui.Info(fmt.Sprintf("Modify Index:     %d", token.ModifyIndex))
 	}
 	ui.Info(fmt.Sprintf("Policies:"))
 	for _, policy := range token.Policies {

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -19,11 +19,11 @@ import (
 func parseCloneOutput(t *testing.T, output string) *api.ACLToken {
 	// This will only work for non-legacy tokens
 	re := regexp.MustCompile("Token cloned successfully.\n" +
-		"AccessorID:   ([a-zA-Z0-9\\-]{36})\n" +
-		"SecretID:     ([a-zA-Z0-9\\-]{36})\n" +
-		"Description:  ([^\n]*)\n" +
-		"Local:        (true|false)\n" +
-		"Create Time:  ([^\n]+)\n" +
+		"AccessorID:       ([a-zA-Z0-9\\-]{36})\n" +
+		"SecretID:         ([a-zA-Z0-9\\-]{36})\n" +
+		"Description:      ([^\n]*)\n" +
+		"Local:            (true|false)\n" +
+		"Create Time:      ([^\n]+)\n" +
 		"Policies:\n" +
 		"(   [a-zA-Z0-9\\-]{36} - [^\n]+\n)*")
 

--- a/command/acl/token/create/token_create.go
+++ b/command/acl/token/create/token_create.go
@@ -3,6 +3,7 @@ package tokencreate
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/acl"
@@ -22,11 +23,12 @@ type cmd struct {
 	http  *flags.HTTPFlags
 	help  string
 
-	policyIDs   []string
-	policyNames []string
-	description string
-	local       bool
-	showMeta    bool
+	policyIDs     []string
+	policyNames   []string
+	expirationTTL time.Duration
+	description   string
+	local         bool
+	showMeta      bool
 }
 
 func (c *cmd) init() {
@@ -39,6 +41,8 @@ func (c *cmd) init() {
 		"policy to use for this token. May be specified multiple times")
 	c.flags.Var((*flags.AppendSliceValue)(&c.policyNames), "policy-name", "Name of a "+
 		"policy to use for this token. May be specified multiple times")
+	c.flags.DurationVar(&c.expirationTTL, "expires-ttl", 0, "Duration of time this "+
+		"token should be valid for")
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
 	flags.Merge(c.flags, c.http.ServerFlags())
@@ -64,6 +68,9 @@ func (c *cmd) Run(args []string) int {
 	newToken := &api.ACLToken{
 		Description: c.description,
 		Local:       c.local,
+	}
+	if c.expirationTTL > 0 {
+		newToken.ExpirationTTL = c.expirationTTL
 	}
 
 	for _, policyName := range c.policyNames {
@@ -109,7 +116,7 @@ Usage: consul acl token create [options]
 
   Create a new token:
 
-          $ consul acl token create -description "Replication token"
-                                            -policy-id b52fc3de-5
-                                            -policy-name "acl-replication"
+          $ consul acl token create -description "Replication token" \
+                                    -policy-id b52fc3de-5 \
+                                    -policy-name "acl-replication"
 `

--- a/command/acl/token/update/token_update.go
+++ b/command/acl/token/update/token_update.go
@@ -192,7 +192,9 @@ Usage: consul acl token update [options]
 
         $ consul acl token update -id abcd -description "replication" -merge-policies
 
-      Update all editable fields of the token:
+    Update all editable fields of the token:
 
-          $ consul acl token update -id abcd -description "replication" -policy-name "token-replication"
+        $ consul acl token update -id abcd \
+                                  -description "replication" \
+                                  -policy-name "token-replication"
 `

--- a/vendor/github.com/hashicorp/consul/api/acl.go
+++ b/vendor/github.com/hashicorp/consul/api/acl.go
@@ -22,15 +22,17 @@ type ACLTokenPolicyLink struct {
 
 // ACLToken represents an ACL Token
 type ACLToken struct {
-	CreateIndex uint64
-	ModifyIndex uint64
-	AccessorID  string
-	SecretID    string
-	Description string
-	Policies    []*ACLTokenPolicyLink
-	Local       bool
-	CreateTime  time.Time `json:",omitempty"`
-	Hash        []byte    `json:",omitempty"`
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	AccessorID     string
+	SecretID       string
+	Description    string
+	Policies       []*ACLTokenPolicyLink
+	Local          bool
+	ExpirationTTL  time.Duration `json:",omitempty"`
+	ExpirationTime time.Time     `json:",omitempty"`
+	CreateTime     time.Time     `json:",omitempty"`
+	Hash           []byte        `json:",omitempty"`
 
 	// DEPRECATED (ACL-Legacy-Compat)
 	// Rules will only be present for legacy tokens returned via the new APIs
@@ -38,15 +40,16 @@ type ACLToken struct {
 }
 
 type ACLTokenListEntry struct {
-	CreateIndex uint64
-	ModifyIndex uint64
-	AccessorID  string
-	Description string
-	Policies    []*ACLTokenPolicyLink
-	Local       bool
-	CreateTime  time.Time
-	Hash        []byte
-	Legacy      bool
+	CreateIndex    uint64
+	ModifyIndex    uint64
+	AccessorID     string
+	Description    string
+	Policies       []*ACLTokenPolicyLink
+	Local          bool
+	ExpirationTime time.Time `json:",omitempty"`
+	CreateTime     time.Time
+	Hash           []byte
+	Legacy         bool
 }
 
 // ACLEntry is used to represent a legacy ACL token


### PR DESCRIPTION
Note: this is merging into a long lived feature branch, not master. Future PRs in this series may adjust the contents here slightly as needed. These are separated out for digestibility.

I'm mostly looking for early feedback on portions of the overall changeset. The final product that merges into master may end up with small adjustments in further PRs as issues arise.

There are a pair of new memdb indexes used to to keep track of upcoming tokens to expire (one for local tokens and one for global tokens). I would have preferred a single composite index of `(local, expirationTime)` but I could not figure out how to find the min/max elements of a composite index when presented with an exact match for one portion of the composite index.

- [x] expiration time takes immediate effect and lazily deleted
- [x] figure out if any of the magic numbers should move to config
- [x] api updates
- [x] cli updates
- [x] write tests
- [ ] website updates
- [ ] UI updates