### PR TITLE
Bugfix: Connect Intentions API, blocking queries

### DIFF
--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -33,6 +33,7 @@ func (s *HTTPServer) IntentionList(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	var reply structs.IndexedIntentions
+	defer setMeta(resp, &reply.QueryMeta)
 	if err := s.agent.RPC("Intention.List", &args, &reply); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hi there,

As I've been working on building out a service hoping to take advantage of blocking queries with Consul intentions, I came across the same issue as seen here: https://github.com/hashicorp/consul/issues/4989

After making the change seen in this PR, a request to a local dev consul succeeds and returns consul headers:
```
curl -i -X GET 'http://localhost:8500/v1/connect/intentions'

HTTP/1.1 200 OK
Content-Type: application/json
Vary: Accept-Encoding
X-Consul-Index: 1
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
Date: Sat, 16 Feb 2019 01:02:26 GMT
Content-Length: 3

[]
```