### PR TITLE
Centralise tls configuration part 1

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1052,7 +1052,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 
 	// Copy the TLS configuration
 	base.VerifyIncoming = a.config.VerifyIncoming || a.config.VerifyIncomingRPC
-
 	if a.config.CAPath != "" || a.config.CAFile != "" {
 		base.UseTLS = true
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -386,6 +386,8 @@ func (a *Agent) Start() error {
 	// waiting to discover a consul server
 	consulCfg.ServerUp = a.sync.SyncFull.Trigger
 
+	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig())
+
 	// Setup either the client or the server.
 	if c.ServerMode {
 		server, err := consul.NewServerLogger(consulCfg, a.logger, a.tokens, a.tlsConfigurator)
@@ -481,8 +483,6 @@ func (a *Agent) Start() error {
 	if err := a.listenAndServeDNS(); err != nil {
 		return err
 	}
-
-	a.tlsConfigurator = tlsutil.NewConfigurator(a.config.ToTLSUtilConfig())
 
 	// Create listeners and unstarted servers; see comment on listenHTTP why
 	// we are doing this.
@@ -1051,7 +1051,9 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.Build = fmt.Sprintf("%s%s:%s", a.config.Version, a.config.VersionPrerelease, revision)
 
 	// Copy the TLS configuration
-	base.VerifyIncoming = a.config.VerifyIncoming || a.config.VerifyIncomingRPC
+	base.VerifyIncoming = a.config.VerifyIncoming
+	base.VerifyIncomingRPC = a.config.VerifyIncomingRPC
+
 	if a.config.CAPath != "" || a.config.CAFile != "" {
 		base.UseTLS = true
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -396,7 +396,7 @@ func (a *Agent) Start() error {
 		}
 		a.delegate = server
 	} else {
-		client, err := consul.NewClientLogger(consulCfg, a.logger)
+		client, err := consul.NewClientLogger(consulCfg, a.logger, a.tlsConfigurator)
 		if err != nil {
 			return fmt.Errorf("Failed to start Consul client: %v", err)
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -388,7 +388,7 @@ func (a *Agent) Start() error {
 
 	// Setup either the client or the server.
 	if c.ServerMode {
-		server, err := consul.NewServerLogger(consulCfg, a.logger, a.tokens)
+		server, err := consul.NewServerLogger(consulCfg, a.logger, a.tokens, a.tlsConfigurator)
 		if err != nil {
 			return fmt.Errorf("Failed to start Consul server: %v", err)
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1051,8 +1051,7 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.Build = fmt.Sprintf("%s%s:%s", a.config.Version, a.config.VersionPrerelease, revision)
 
 	// Copy the TLS configuration
-	base.VerifyIncoming = a.config.VerifyIncoming
-	base.VerifyIncomingRPC = a.config.VerifyIncomingRPC
+	base.VerifyIncoming = a.config.VerifyIncoming || a.config.VerifyIncomingRPC
 
 	if a.config.CAPath != "" || a.config.CAFile != "" {
 		base.UseTLS = true

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1587,6 +1587,25 @@ func (c *RuntimeConfig) Sanitized() map[string]interface{} {
 	return sanitize("rt", reflect.ValueOf(c)).Interface().(map[string]interface{})
 }
 
+func (c *RuntimeConfig) ToTLSUtilConfig() *tlsutil.Config {
+	return &tlsutil.Config{
+		VerifyIncoming:           c.VerifyIncoming,
+		VerifyIncomingRPC:        c.VerifyIncomingRPC,
+		VerifyIncomingHTTPS:      c.VerifyIncomingHTTPS,
+		VerifyOutgoing:           c.VerifyOutgoing,
+		CAFile:                   c.CAFile,
+		CAPath:                   c.CAPath,
+		CertFile:                 c.CertFile,
+		KeyFile:                  c.KeyFile,
+		NodeName:                 c.NodeName,
+		ServerName:               c.ServerName,
+		TLSMinVersion:            c.TLSMinVersion,
+		CipherSuites:             c.TLSCipherSuites,
+		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
+		EnableAgentTLSForChecks:  c.EnableAgentTLSForChecks,
+	}
+}
+
 // isSecret determines whether a field name represents a field which
 // may contain a secret.
 func isSecret(name string) bool {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net"
 	"reflect"
@@ -1428,25 +1427,6 @@ type RuntimeConfig struct {
 	// ]
 	//
 	Watches []map[string]interface{}
-}
-
-// IncomingHTTPSConfig returns the TLS configuration for HTTPS
-// connections to consul.
-func (c *RuntimeConfig) IncomingHTTPSConfig() (*tls.Config, error) {
-	tc := &tlsutil.Config{
-		VerifyIncoming:           c.VerifyIncoming || c.VerifyIncomingHTTPS,
-		VerifyOutgoing:           c.VerifyOutgoing,
-		CAFile:                   c.CAFile,
-		CAPath:                   c.CAPath,
-		CertFile:                 c.CertFile,
-		KeyFile:                  c.KeyFile,
-		NodeName:                 c.NodeName,
-		ServerName:               c.ServerName,
-		TLSMinVersion:            c.TLSMinVersion,
-		CipherSuites:             c.TLSCipherSuites,
-		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
-	}
-	return tc.IncomingTLSConfig()
 }
 
 func (c *RuntimeConfig) apiAddresses(maxPerType int) (unixAddrs, httpAddrs, httpsAddrs []string) {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5418,7 +5418,7 @@ func TestRuntime_ClientAddressAnyV6(t *testing.T) {
 	require.Equal(t, "[::1]:5688", https)
 }
 
-func TestHansRuntime_ToTLSUtilConfig(t *testing.T) {
+func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 	c := &RuntimeConfig{
 		VerifyIncoming:              true,
 		VerifyIncomingRPC:           true,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5418,6 +5418,40 @@ func TestRuntime_ClientAddressAnyV6(t *testing.T) {
 	require.Equal(t, "[::1]:5688", https)
 }
 
+func TestHansRuntime_ToTLSUtilConfig(t *testing.T) {
+	c := &RuntimeConfig{
+		VerifyIncoming:              true,
+		VerifyIncomingRPC:           true,
+		VerifyIncomingHTTPS:         true,
+		VerifyOutgoing:              true,
+		CAFile:                      "a",
+		CAPath:                      "b",
+		CertFile:                    "c",
+		KeyFile:                     "d",
+		NodeName:                    "e",
+		ServerName:                  "f",
+		TLSMinVersion:               "tls12",
+		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305},
+		TLSPreferServerCipherSuites: true,
+		EnableAgentTLSForChecks:     true,
+	}
+	r := c.ToTLSUtilConfig()
+	require.Equal(t, c.VerifyIncoming, r.VerifyIncoming)
+	require.Equal(t, c.VerifyIncomingRPC, r.VerifyIncomingRPC)
+	require.Equal(t, c.VerifyIncomingHTTPS, r.VerifyIncomingHTTPS)
+	require.Equal(t, c.VerifyOutgoing, r.VerifyOutgoing)
+	require.Equal(t, c.CAFile, r.CAFile)
+	require.Equal(t, c.CAPath, r.CAPath)
+	require.Equal(t, c.CertFile, r.CertFile)
+	require.Equal(t, c.KeyFile, r.KeyFile)
+	require.Equal(t, c.NodeName, r.NodeName)
+	require.Equal(t, c.ServerName, r.ServerName)
+	require.Equal(t, c.TLSMinVersion, r.TLSMinVersion)
+	require.Equal(t, c.TLSCipherSuites, r.CipherSuites)
+	require.Equal(t, c.TLSPreferServerCipherSuites, r.PreferServerCipherSuites)
+	require.Equal(t, c.EnableAgentTLSForChecks, r.EnableAgentTLSForChecks)
+}
+
 func splitIPPort(hostport string) (net.IP, int) {
 	h, p, err := net.SplitHostPort(hostport)
 	if err != nil {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -113,7 +113,7 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 	}
 
 	// Create the tls Wrapper
-	tlsWrap, err := config.tlsConfig().OutgoingTLSWrapper()
+	tlsWrap, err := config.ToTLSUtilConfig().OutgoingTLSWrapper()
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/serf/serf"
 	"golang.org/x/time/rate"
 )
@@ -88,10 +89,10 @@ type Client struct {
 // NewClient is used to construct a new Consul client from the
 // configuration, potentially returning an error
 func NewClient(config *Config) (*Client, error) {
-	return NewClientLogger(config, nil)
+	return NewClientLogger(config, nil, tlsutil.NewConfigurator(config.ToTLSUtilConfig()))
 }
 
-func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
+func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsutil.Configurator) (*Client, error) {
 	// Check the protocol version
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
@@ -113,7 +114,7 @@ func NewClientLogger(config *Config, logger *log.Logger) (*Client, error) {
 	}
 
 	// Create the tls Wrapper
-	tlsWrap, err := config.ToTLSUtilConfig().OutgoingTLSWrapper()
+	tlsWrap, err := tlsConfigurator.OutgoingRPCWrapper()
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -160,8 +160,6 @@ type Config struct {
 	// must match a provided certificate authority. This can be used to force client auth.
 	VerifyIncoming bool
 
-	VerifyIncomingRPC bool
-
 	// VerifyOutgoing is used to force verification of the authenticity of outgoing connections.
 	// This means that TLS requests are used, and TCP requests are not made. TLS connections
 	// must match a provided certificate authority.
@@ -387,7 +385,6 @@ type Config struct {
 func (c *Config) ToTLSUtilConfig() *tlsutil.Config {
 	return &tlsutil.Config{
 		VerifyIncoming:           c.VerifyIncoming,
-		VerifyIncomingRPC:        c.VerifyIncomingRPC,
 		VerifyOutgoing:           c.VerifyOutgoing,
 		CAFile:                   c.CAFile,
 		CAPath:                   c.CAPath,

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -519,23 +519,3 @@ func DefaultConfig() *Config {
 
 	return conf
 }
-
-// tlsConfig maps this config into a tlsutil config.
-func (c *Config) tlsConfig() *tlsutil.Config {
-	tlsConf := &tlsutil.Config{
-		VerifyIncoming:           c.VerifyIncoming,
-		VerifyOutgoing:           c.VerifyOutgoing,
-		VerifyServerHostname:     c.VerifyServerHostname,
-		UseTLS:                   c.UseTLS,
-		CAFile:                   c.CAFile,
-		CAPath:                   c.CAPath,
-		CertFile:                 c.CertFile,
-		KeyFile:                  c.KeyFile,
-		NodeName:                 c.NodeName,
-		ServerName:               c.ServerName,
-		Domain:                   c.Domain,
-		TLSMinVersion:            c.TLSMinVersion,
-		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
-	}
-	return tlsConf
-}

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -160,6 +160,8 @@ type Config struct {
 	// must match a provided certificate authority. This can be used to force client auth.
 	VerifyIncoming bool
 
+	VerifyIncomingRPC bool
+
 	// VerifyOutgoing is used to force verification of the authenticity of outgoing connections.
 	// This means that TLS requests are used, and TCP requests are not made. TLS connections
 	// must match a provided certificate authority.
@@ -380,6 +382,23 @@ type Config struct {
 
 	// ConnectReplicationToken is used to control Intention replication.
 	ConnectReplicationToken string
+}
+
+func (c *Config) ToTLSUtilConfig() *tlsutil.Config {
+	return &tlsutil.Config{
+		VerifyIncoming:           c.VerifyIncoming,
+		VerifyIncomingRPC:        c.VerifyIncomingRPC,
+		VerifyOutgoing:           c.VerifyOutgoing,
+		CAFile:                   c.CAFile,
+		CAPath:                   c.CAPath,
+		CertFile:                 c.CertFile,
+		KeyFile:                  c.KeyFile,
+		NodeName:                 c.NodeName,
+		ServerName:               c.ServerName,
+		TLSMinVersion:            c.TLSMinVersion,
+		CipherSuites:             c.TLSCipherSuites,
+		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
+	}
 }
 
 // CheckProtocolVersion validates the protocol version.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -253,7 +253,7 @@ type Server struct {
 }
 
 func NewServer(config *Config) (*Server, error) {
-	return NewServerLogger(config, nil, new(token.Store), nil)
+	return NewServerLogger(config, nil, new(token.Store), tlsutil.NewConfigurator(config.ToTLSUtilConfig()))
 }
 
 // NewServer is used to construct a new Consul server from the

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -297,7 +297,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 	}
 
 	// Create the TLS wrapper for outgoing connections.
-	tlsConf := config.tlsConfig()
+	tlsConf := config.ToTLSUtilConfig()
 	tlsWrap, err := tlsConf.OutgoingTLSWrapper()
 	if err != nil {
 		return nil, err

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -253,12 +253,12 @@ type Server struct {
 }
 
 func NewServer(config *Config) (*Server, error) {
-	return NewServerLogger(config, nil, new(token.Store))
+	return NewServerLogger(config, nil, new(token.Store), nil)
 }
 
 // NewServer is used to construct a new Consul server from the
 // configuration, potentially returning an error
-func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*Server, error) {
+func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tlsConfigurator *tlsutil.Configurator) (*Server, error) {
 	// Check the protocol version.
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
@@ -304,7 +304,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store) (*
 	}
 
 	// Get the incoming TLS config.
-	incomingTLS, err := tlsConf.IncomingTLSConfig()
+	incomingTLS, err := tlsConfigurator.IncomingRPCConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -297,8 +297,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 	}
 
 	// Create the TLS wrapper for outgoing connections.
-	tlsConf := config.ToTLSUtilConfig()
-	tlsWrap, err := tlsConf.OutgoingTLSWrapper()
+	tlsWrap, err := tlsConfigurator.OutgoingRPCWrapper()
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-uuid"
 )
@@ -176,7 +177,7 @@ func newServer(c *Config) (*Server, error) {
 		w = os.Stderr
 	}
 	logger := log.New(w, c.NodeName+" - ", log.LstdFlags|log.Lmicroseconds)
-	srv, err := NewServerLogger(c, logger, new(token.Store))
+	srv, err := NewServerLogger(c, logger, new(token.Store), tlsutil.NewConfigurator(c.ToTLSUtilConfig()))
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -807,7 +807,7 @@ func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
 	}
 }
 
-func TestHansServer_TLSToFullVerify(t *testing.T) {
+func TestServer_TLSToFullVerify(t *testing.T) {
 	t.Parallel()
 	// Set up a server with TLS and VerifyIncoming set
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -807,7 +807,7 @@ func TestServer_TLSForceOutgoingToNoTLS(t *testing.T) {
 	}
 }
 
-func TestServer_TLSToFullVerify(t *testing.T) {
+func TestHansServer_TLSToFullVerify(t *testing.T) {
 	t.Parallel()
 	// Set up a server with TLS and VerifyIncoming set
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/consul/lib/freeport"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/hashicorp/consul/tlsutil"
 
 	"github.com/stretchr/testify/require"
 )
@@ -148,6 +149,7 @@ func (a *TestAgent) Start(t *testing.T) *TestAgent {
 		agent.LogWriter = a.LogWriter
 		agent.logger = log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
 		agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
+		agent.tlsConfigurator = tlsutil.NewConfigurator(a.Config.ToTLSUtilConfig())
 
 		// we need the err var in the next exit condition
 		if err := agent.Start(); err == nil {

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -281,51 +281,6 @@ func (c *Config) wrapTLSClient(conn net.Conn, tlsConfig *tls.Config) (net.Conn, 
 	return tlsConn, err
 }
 
-// ParseCiphers parse ciphersuites from the comma-separated string into recognized slice
-func ParseCiphers(cipherStr string) ([]uint16, error) {
-	suites := []uint16{}
-
-	cipherStr = strings.TrimSpace(cipherStr)
-	if cipherStr == "" {
-		return []uint16{}, nil
-	}
-	ciphers := strings.Split(cipherStr, ",")
-
-	cipherMap := map[string]uint16{
-		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-		"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-		"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-		"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-		"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
-		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
-		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
-	}
-	for _, cipher := range ciphers {
-		if v, ok := cipherMap[cipher]; ok {
-			suites = append(suites, v)
-		} else {
-			return suites, fmt.Errorf("unsupported cipher %q", cipher)
-		}
-	}
-
-	return suites, nil
-}
-
 type Configurator struct {
 	base *Config
 }
@@ -431,4 +386,49 @@ func (c *Configurator) IncomingHTTPSConfig() (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+// ParseCiphers parse ciphersuites from the comma-separated string into recognized slice
+func ParseCiphers(cipherStr string) ([]uint16, error) {
+	suites := []uint16{}
+
+	cipherStr = strings.TrimSpace(cipherStr)
+	if cipherStr == "" {
+		return []uint16{}, nil
+	}
+	ciphers := strings.Split(cipherStr, ",")
+
+	cipherMap := map[string]uint16{
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	}
+	for _, cipher := range ciphers {
+		if v, ok := cipherMap[cipher]; ok {
+			suites = append(suites, v)
+		} else {
+			return suites, fmt.Errorf("unsupported cipher %q", cipher)
+		}
+	}
+
+	return suites, nil
 }

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -129,35 +129,6 @@ func (c *Config) skipBuiltinVerify() bool {
 	return c.VerifyServerHostname == false && c.ServerName == ""
 }
 
-// // OutgoingTLSWrapper returns a a DCWrapper based on the OutgoingTLS
-// // configuration. If hostname verification is on, the wrapper
-// // will properly generate the dynamic server name for verification.
-// func (c *Config) OutgoingTLSWrapper() (DCWrapper, error) {
-// 	// Get the TLS config
-// 	tlsConfig, err := c.OutgoingTLSConfig()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	// Check if TLS is not enabled
-// 	if tlsConfig == nil {
-// 		return nil, nil
-// 	}
-
-// 	// Generate the wrapper based on hostname verification
-// 	wrapper := func(dc string, conn net.Conn) (net.Conn, error) {
-// 		if c.VerifyServerHostname {
-// 			// Strip the trailing '.' from the domain if any
-// 			domain := strings.TrimSuffix(c.Domain, ".")
-// 			tlsConfig = tlsConfig.Clone()
-// 			tlsConfig.ServerName = "server." + dc + "." + domain
-// 		}
-// 		return c.wrapTLSClient(conn, tlsConfig)
-// 	}
-
-// 	return wrapper, nil
-// }
-
 // SpecificDC is used to invoke a static datacenter
 // and turns a DCWrapper into a Wrapper type.
 func SpecificDC(dc string, tlsWrap DCWrapper) Wrapper {

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -335,6 +335,9 @@ func NewConfigurator(config *Config) *Configurator {
 }
 
 func (c *Configurator) commonConfig() (*tls.Config, error) {
+	if c.base == nil {
+		return nil, fmt.Errorf("No config")
+	}
 	tlsConfig := &tls.Config{
 		ServerName: c.base.ServerName,
 		ClientCAs:  x509.NewCertPool(),

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -65,7 +65,7 @@ func TestConfig_KeyPair_Valid(t *testing.T) {
 	}
 }
 
-func TestHansConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
+func TestConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
 	conf := &Config{
 		VerifyOutgoing: true,
 	}
@@ -75,7 +75,7 @@ func TestHansConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
 	require.Nil(t, tlsConf)
 }
 
-func TestHansConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
+func TestConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
 	conf := &Config{
 		CAFile: "../test/ca/root.cer",
 	}
@@ -85,7 +85,7 @@ func TestHansConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
 	require.NotNil(t, tlsConf)
 }
 
-func TestHansConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
+func TestConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
 	conf := &Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
@@ -116,7 +116,7 @@ func TestConfig_SkipBuiltinVerify(t *testing.T) {
 	}
 }
 
-func TestHansConfigurator_OutgoingTLS_ServerName(t *testing.T) {
+func TestConfigurator_OutgoingTLS_ServerName(t *testing.T) {
 	conf := &Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
@@ -131,7 +131,7 @@ func TestHansConfigurator_OutgoingTLS_ServerName(t *testing.T) {
 	require.False(t, tlsConf.InsecureSkipVerify)
 }
 
-func TestHansConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
+func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
 	conf := &Config{
 		VerifyOutgoing:       true,
 		VerifyServerHostname: true,
@@ -145,7 +145,7 @@ func TestHansConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
 	require.False(t, tlsConf.InsecureSkipVerify)
 }
 
-func TestHansConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
+func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
 	conf := &Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
@@ -160,7 +160,7 @@ func TestHansConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
 	require.Equal(t, len(tlsConf.Certificates), 1)
 }
 
-func TestHansConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
+func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
 		conf := &Config{
@@ -214,7 +214,7 @@ func startTLSServer(config *Config) (net.Conn, chan error) {
 	return clientConn, errc
 }
 
-func TestHansConfigurator_outgoingWrapper_OK(t *testing.T) {
+func TestConfigurator_outgoingWrapper_OK(t *testing.T) {
 	config := &Config{
 		CAFile:               "../test/hostname/CertAuth.crt",
 		CertFile:             "../test/hostname/Alice.crt",
@@ -244,7 +244,7 @@ func TestHansConfigurator_outgoingWrapper_OK(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHansConfigurator_outgoingWrapper_BadDC(t *testing.T) {
+func TestConfigurator_outgoingWrapper_BadDC(t *testing.T) {
 	config := &Config{
 		CAFile:               "../test/hostname/CertAuth.crt",
 		CertFile:             "../test/hostname/Alice.crt",
@@ -274,7 +274,7 @@ func TestHansConfigurator_outgoingWrapper_BadDC(t *testing.T) {
 	<-errc
 }
 
-func TestHansConfigurator_outgoingWrapper_BadCert(t *testing.T) {
+func TestConfigurator_outgoingWrapper_BadCert(t *testing.T) {
 	config := &Config{
 		CAFile:               "../test/ca/root.cer",
 		CertFile:             "../test/key/ourdomain.cer",
@@ -305,7 +305,7 @@ func TestHansConfigurator_outgoingWrapper_BadCert(t *testing.T) {
 	<-errc
 }
 
-func TestHansConfigurator_wrapTLS_OK(t *testing.T) {
+func TestConfigurator_wrapTLS_OK(t *testing.T) {
 	config := &Config{
 		CAFile:         "../test/ca/root.cer",
 		CertFile:       "../test/key/ourdomain.cer",
@@ -330,7 +330,7 @@ func TestHansConfigurator_wrapTLS_OK(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHansConfigurator_wrapTLS_BadCert(t *testing.T) {
+func TestConfigurator_wrapTLS_BadCert(t *testing.T) {
 	serverConfig := &Config{
 		CertFile: "../test/key/ssl-cert-snakeoil.pem",
 		KeyFile:  "../test/key/ssl-cert-snakeoil.key",
@@ -421,7 +421,7 @@ func TestConfig_ParseCiphers(t *testing.T) {
 	}
 }
 
-func TestHansConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
+func TestConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
 	conf := &Config{CAPath: "../test/ca_path"}
 
 	c := NewConfigurator(conf)
@@ -430,7 +430,7 @@ func TestHansConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
 	require.Equal(t, len(tlsConf.ClientCAs.Subjects()), 2)
 }
 
-func TestHansConfigurator_IncomingHTTPS(t *testing.T) {
+func TestConfigurator_IncomingHTTPS(t *testing.T) {
 	conf := &Config{
 		VerifyIncoming: true,
 		CAFile:         "../test/ca/root.cer",
@@ -446,7 +446,7 @@ func TestHansConfigurator_IncomingHTTPS(t *testing.T) {
 	require.Equal(t, len(tlsConf.Certificates), 1)
 }
 
-func TestHansConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
+func TestConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
 	conf := &Config{
 		VerifyIncoming: true,
 		CertFile:       "../test/key/ourdomain.cer",
@@ -457,7 +457,7 @@ func TestHansConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestHansConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
+func TestConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
 	conf := &Config{
 		VerifyIncoming: true,
 		CAFile:         "../test/ca/root.cer",
@@ -467,7 +467,7 @@ func TestHansConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestHansConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
+func TestConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
 	conf := &Config{}
 	c := NewConfigurator(conf)
 	tlsConf, err := c.IncomingHTTPSConfig()
@@ -478,7 +478,7 @@ func TestHansConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
 	require.Equal(t, len(tlsConf.Certificates), 0)
 }
 
-func TestHansConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
+func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
 		conf := &Config{
@@ -496,7 +496,7 @@ func TestHansConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 	}
 }
 
-func TestHansConfigurator_IncomingHTTPSCAPath_Valid(t *testing.T) {
+func TestConfigurator_IncomingHTTPSCAPath_Valid(t *testing.T) {
 	conf := &Config{
 		CAPath: "../test/ca_path",
 	}


### PR DESCRIPTION
In order to be able to reload the TLS configuration, we need one way to generate the different configurations.

This PR introduces a `tlsutil.Configurator` which holds a `tlsutil.Config`. Afterwards it is responsible for rendering every `tls.Config`. In this particular PR I moved `IncomingHTTPSConfig`, `IncomingTLSConfig`, and `OutgoingTLSWrapper` into `tlsutil.Configurator`.

This PR is a pure refactoring - not a single feature added. And not a single test added. I only slightly modified existing tests as necessary.

There will be follow up PRs that are putting `tlsutil.Configurator` into more places.

Todo:

* [x] code comment new fields and functions