### PR TITLE
Expose consul dc

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -206,7 +206,7 @@ func (c *cmd) run(args []string) int {
 	// Setup gRPC logger to use the same output/filtering
 	grpclog.SetLoggerV2(logger.NewGRPCLogger(logConfig, c.logger))
 
-	memSink, err := lib.InitTelemetry(config.Telemetry)
+	memSink, err := lib.InitTelemetry(config.Telemetry, &config.Datacenter)
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/connect/proxy/proxy.go
+++ b/connect/proxy/proxy.go
@@ -54,7 +54,7 @@ func (p *Proxy) Serve() error {
 				// Initial setup
 
 				// Setup telemetry if configured
-				_, err := lib.InitTelemetry(newCfg.Telemetry)
+				_, err := lib.InitTelemetry(newCfg.Telemetry, nil)
 				if err != nil {
 					p.logger.Printf("[ERR] proxy telemetry config error: %s", err)
 				}

--- a/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
+++ b/vendor/github.com/armon/go-metrics/prometheus/prometheus.go
@@ -26,6 +26,7 @@ type PrometheusOpts struct {
 	// Expiration is the duration a metric is valid for, after which it will be
 	// untracked. If the value is zero, a metric is never expired.
 	Expiration time.Duration
+    Registerer prometheus.Registerer
 }
 
 type PrometheusSink struct {
@@ -52,7 +53,12 @@ func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
 		expiration: opts.Expiration,
 	}
 
-	return sink, prometheus.Register(sink)
+	reg := opts.Registerer
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+
+	return sink, reg.Register(sink)
 }
 
 // Describe is needed to meet the Collector interface.

--- a/vendor/github.com/prometheus/client_golang/prometheus/collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/collector.go
@@ -29,25 +29,70 @@ type Collector interface {
 	// collected by this Collector to the provided channel and returns once
 	// the last descriptor has been sent. The sent descriptors fulfill the
 	// consistency and uniqueness requirements described in the Desc
-	// documentation. (It is valid if one and the same Collector sends
-	// duplicate descriptors. Those duplicates are simply ignored. However,
-	// two different Collectors must not send duplicate descriptors.) This
-	// method idempotently sends the same descriptors throughout the
-	// lifetime of the Collector. If a Collector encounters an error while
-	// executing this method, it must send an invalid descriptor (created
-	// with NewInvalidDesc) to signal the error to the registry.
+	// documentation.
+	//
+	// It is valid if one and the same Collector sends duplicate
+	// descriptors. Those duplicates are simply ignored. However, two
+	// different Collectors must not send duplicate descriptors.
+	//
+	// Sending no descriptor at all marks the Collector as “unchecked”,
+	// i.e. no checks will be performed at registration time, and the
+	// Collector may yield any Metric it sees fit in its Collect method.
+	//
+	// This method idempotently sends the same descriptors throughout the
+	// lifetime of the Collector. It may be called concurrently and
+	// therefore must be implemented in a concurrency safe way.
+	//
+	// If a Collector encounters an error while executing this method, it
+	// must send an invalid descriptor (created with NewInvalidDesc) to
+	// signal the error to the registry.
 	Describe(chan<- *Desc)
 	// Collect is called by the Prometheus registry when collecting
 	// metrics. The implementation sends each collected metric via the
 	// provided channel and returns once the last metric has been sent. The
-	// descriptor of each sent metric is one of those returned by
-	// Describe. Returned metrics that share the same descriptor must differ
-	// in their variable label values. This method may be called
-	// concurrently and must therefore be implemented in a concurrency safe
-	// way. Blocking occurs at the expense of total performance of rendering
-	// all registered metrics. Ideally, Collector implementations support
-	// concurrent readers.
+	// descriptor of each sent metric is one of those returned by Describe
+	// (unless the Collector is unchecked, see above). Returned metrics that
+	// share the same descriptor must differ in their variable label
+	// values.
+	//
+	// This method may be called concurrently and must therefore be
+	// implemented in a concurrency safe way. Blocking occurs at the expense
+	// of total performance of rendering all registered metrics. Ideally,
+	// Collector implementations support concurrent readers.
 	Collect(chan<- Metric)
+}
+
+// DescribeByCollect is a helper to implement the Describe method of a custom
+// Collector. It collects the metrics from the provided Collector and sends
+// their descriptors to the provided channel.
+//
+// If a Collector collects the same metrics throughout its lifetime, its
+// Describe method can simply be implemented as:
+//
+//   func (c customCollector) Describe(ch chan<- *Desc) {
+//   	DescribeByCollect(c, ch)
+//   }
+//
+// However, this will not work if the metrics collected change dynamically over
+// the lifetime of the Collector in a way that their combined set of descriptors
+// changes as well. The shortcut implementation will then violate the contract
+// of the Describe method. If a Collector sometimes collects no metrics at all
+// (for example vectors like CounterVec, GaugeVec, etc., which only collect
+// metrics after a metric with a fully specified label set has been accessed),
+// it might even get registered as an unchecked Collecter (cf. the Register
+// method of the Registerer interface). Hence, only use this shortcut
+// implementation of Describe if you are certain to fulfill the contract.
+//
+// The Collector example demonstrates a use of DescribeByCollect.
+func DescribeByCollect(c Collector, descs chan<- *Desc) {
+	metrics := make(chan Metric)
+	go func() {
+		c.Collect(metrics)
+		close(metrics)
+	}()
+	for m := range metrics {
+		descs <- m.Desc()
+	}
 }
 
 // selfCollector implements Collector for a single Metric so that the Metric

--- a/vendor/github.com/prometheus/client_golang/prometheus/counter.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/counter.go
@@ -136,7 +136,7 @@ func NewCounterVec(opts CounterOpts, labelNames []string) *CounterVec {
 	return &CounterVec{
 		metricVec: newMetricVec(desc, func(lvs ...string) Metric {
 			if len(lvs) != len(desc.variableLabels) {
-				panic(errInconsistentCardinality)
+				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels, lvs))
 			}
 			result := &counter{desc: desc, labelPairs: makeLabelPairs(desc, lvs)}
 			result.init(result) // Init self-collection.

--- a/vendor/github.com/prometheus/client_golang/prometheus/desc.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/desc.go
@@ -67,7 +67,7 @@ type Desc struct {
 
 // NewDesc allocates and initializes a new Desc. Errors are recorded in the Desc
 // and will be reported on registration time. variableLabels and constLabels can
-// be nil if no such labels should be set. fqName and help must not be empty.
+// be nil if no such labels should be set. fqName must not be empty.
 //
 // variableLabels only contain the label names. Their label values are variable
 // and therefore not part of the Desc. (They are managed within the Metric.)
@@ -79,10 +79,6 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 		fqName:         fqName,
 		help:           help,
 		variableLabels: variableLabels,
-	}
-	if help == "" {
-		d.err = errors.New("empty help string")
-		return d
 	}
 	if !model.IsValidMetricName(model.LabelValue(fqName)) {
 		d.err = fmt.Errorf("%q is not a valid metric name", fqName)
@@ -97,7 +93,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	// First add only the const label names and sort them...
 	for labelName := range constLabels {
 		if !checkLabelName(labelName) {
-			d.err = fmt.Errorf("%q is not a valid label name", labelName)
+			d.err = fmt.Errorf("%q is not a valid label name for metric %q", labelName, fqName)
 			return d
 		}
 		labelNames = append(labelNames, labelName)
@@ -119,7 +115,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	// dimension with a different mix between preset and variable labels.
 	for _, labelName := range variableLabels {
 		if !checkLabelName(labelName) {
-			d.err = fmt.Errorf("%q is not a valid label name", labelName)
+			d.err = fmt.Errorf("%q is not a valid label name for metric %q", labelName, fqName)
 			return d
 		}
 		labelNames = append(labelNames, "$"+labelName)
@@ -156,7 +152,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 			Value: proto.String(v),
 		})
 	}
-	sort.Sort(LabelPairSorter(d.constLabelPairs))
+	sort.Sort(labelPairSorter(d.constLabelPairs))
 	return d
 }
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/doc.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/doc.go
@@ -121,7 +121,17 @@
 // NewConstSummary (and their respective Must… versions). That will happen in
 // the Collect method. The Describe method has to return separate Desc
 // instances, representative of the “throw-away” metrics to be created later.
-// NewDesc comes in handy to create those Desc instances.
+// NewDesc comes in handy to create those Desc instances. Alternatively, you
+// could return no Desc at all, which will marke the Collector “unchecked”.  No
+// checks are porformed at registration time, but metric consistency will still
+// be ensured at scrape time, i.e. any inconsistencies will lead to scrape
+// errors. Thus, with unchecked Collectors, the responsibility to not collect
+// metrics that lead to inconsistencies in the total scrape result lies with the
+// implementer of the Collector. While this is not a desirable state, it is
+// sometimes necessary. The typical use case is a situatios where the exact
+// metrics to be returned by a Collector cannot be predicted at registration
+// time, but the implementer has sufficient knowledge of the whole system to
+// guarantee metric consistency.
 //
 // The Collector example illustrates the use case. You can also look at the
 // source code of the processCollector (mirroring process metrics), the

--- a/vendor/github.com/prometheus/client_golang/prometheus/fnv.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/fnv.go
@@ -1,3 +1,16 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package prometheus
 
 // Inline and byte-free variant of hash/fnv's fnv64a.

--- a/vendor/github.com/prometheus/client_golang/prometheus/gauge.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/gauge.go
@@ -147,7 +147,7 @@ func NewGaugeVec(opts GaugeOpts, labelNames []string) *GaugeVec {
 	return &GaugeVec{
 		metricVec: newMetricVec(desc, func(lvs ...string) Metric {
 			if len(lvs) != len(desc.variableLabels) {
-				panic(errInconsistentCardinality)
+				panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels, lvs))
 			}
 			result := &gauge{desc: desc, labelPairs: makeLabelPairs(desc, lvs)}
 			result.init(result) // Init self-collection.

--- a/vendor/github.com/prometheus/client_golang/prometheus/histogram.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/histogram.go
@@ -16,7 +16,9 @@ package prometheus
 import (
 	"fmt"
 	"math"
+	"runtime"
 	"sort"
+	"sync"
 	"sync/atomic"
 
 	"github.com/golang/protobuf/proto"
@@ -108,8 +110,9 @@ func ExponentialBuckets(start, factor float64, count int) []float64 {
 }
 
 // HistogramOpts bundles the options for creating a Histogram metric. It is
-// mandatory to set Name and Help to a non-empty string. All other fields are
-// optional and can safely be left at their zero value.
+// mandatory to set Name to a non-empty string. All other fields are optional
+// and can safely be left at their zero value, although it is strongly
+// encouraged to set a Help string.
 type HistogramOpts struct {
 	// Namespace, Subsystem, and Name are components of the fully-qualified
 	// name of the Histogram (created by joining these components with
@@ -120,7 +123,7 @@ type HistogramOpts struct {
 	Subsystem string
 	Name      string
 
-	// Help provides information about this Histogram. Mandatory!
+	// Help provides information about this Histogram.
 	//
 	// Metrics with the same fully-qualified name must have the same Help
 	// string.
@@ -162,7 +165,7 @@ func NewHistogram(opts HistogramOpts) Histogram {
 
 func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogram {
 	if len(desc.variableLabels) != len(labelValues) {
-		panic(errInconsistentCardinality)
+		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels, labelValues))
 	}
 
 	for _, n := range desc.variableLabels {
@@ -184,6 +187,7 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 		desc:        desc,
 		upperBounds: opts.Buckets,
 		labelPairs:  makeLabelPairs(desc, labelValues),
+		counts:      [2]*histogramCounts{&histogramCounts{}, &histogramCounts{}},
 	}
 	for i, upperBound := range h.upperBounds {
 		if i < len(h.upperBounds)-1 {
@@ -200,28 +204,53 @@ func newHistogram(desc *Desc, opts HistogramOpts, labelValues ...string) Histogr
 			}
 		}
 	}
-	// Finally we know the final length of h.upperBounds and can make counts.
-	h.counts = make([]uint64, len(h.upperBounds))
+	// Finally we know the final length of h.upperBounds and can make counts
+	// for both states:
+	h.counts[0].buckets = make([]uint64, len(h.upperBounds))
+	h.counts[1].buckets = make([]uint64, len(h.upperBounds))
 
 	h.init(h) // Init self-collection.
 	return h
 }
 
-type histogram struct {
+type histogramCounts struct {
 	// sumBits contains the bits of the float64 representing the sum of all
 	// observations. sumBits and count have to go first in the struct to
 	// guarantee alignment for atomic operations.
 	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	sumBits uint64
 	count   uint64
+	buckets []uint64
+}
+
+type histogram struct {
+	// countAndHotIdx is a complicated one. For lock-free yet atomic
+	// observations, we need to save the total count of observations again,
+	// combined with the index of the currently-hot counts struct, so that
+	// we can perform the operation on both values atomically. The least
+	// significant bit defines the hot counts struct. The remaining 63 bits
+	// represent the total count of observations. This happens under the
+	// assumption that the 63bit count will never overflow. Rationale: An
+	// observations takes about 30ns. Let's assume it could happen in
+	// 10ns. Overflowing the counter will then take at least (2^63)*10ns,
+	// which is about 3000 years.
+	//
+	// This has to be first in the struct for 64bit alignment. See
+	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	countAndHotIdx uint64
 
 	selfCollector
-	// Note that there is no mutex required.
-
-	desc *Desc
+	desc     *Desc
+	writeMtx sync.Mutex // Only used in the Write method.
 
 	upperBounds []float64
-	counts      []uint64
+
+	// Two counts, one is "hot" for lock-free observations, the other is
+	// "cold" for writing out a dto.Metric. It has to be an array of
+	// pointers to guarantee 64bit alignment of the histogramCounts, see
+	// http://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	counts [2]*histogramCounts
+	hotIdx int // Index of currently-hot counts. Only used within Write.
 
 	labelPairs []*dto.LabelPair
 }
@@ -241,36 +270,113 @@ func (h *histogram) Observe(v float64) {
 	// 100 buckets: 78.1 ns/op linear - binary 54.9 ns/op
 	// 300 buckets: 154 ns/op linear - binary 61.6 ns/op
 	i := sort.SearchFloat64s(h.upperBounds, v)
-	if i < len(h.counts) {
-		atomic.AddUint64(&h.counts[i], 1)
+
+	// We increment h.countAndHotIdx by 2 so that the counter in the upper
+	// 63 bits gets incremented by 1. At the same time, we get the new value
+	// back, which we can use to find the currently-hot counts.
+	n := atomic.AddUint64(&h.countAndHotIdx, 2)
+	hotCounts := h.counts[n%2]
+
+	if i < len(h.upperBounds) {
+		atomic.AddUint64(&hotCounts.buckets[i], 1)
 	}
-	atomic.AddUint64(&h.count, 1)
 	for {
-		oldBits := atomic.LoadUint64(&h.sumBits)
+		oldBits := atomic.LoadUint64(&hotCounts.sumBits)
 		newBits := math.Float64bits(math.Float64frombits(oldBits) + v)
-		if atomic.CompareAndSwapUint64(&h.sumBits, oldBits, newBits) {
+		if atomic.CompareAndSwapUint64(&hotCounts.sumBits, oldBits, newBits) {
 			break
 		}
 	}
+	// Increment count last as we take it as a signal that the observation
+	// is complete.
+	atomic.AddUint64(&hotCounts.count, 1)
 }
 
 func (h *histogram) Write(out *dto.Metric) error {
-	his := &dto.Histogram{}
-	buckets := make([]*dto.Bucket, len(h.upperBounds))
+	var (
+		his                   = &dto.Histogram{}
+		buckets               = make([]*dto.Bucket, len(h.upperBounds))
+		hotCounts, coldCounts *histogramCounts
+		count                 uint64
+	)
 
-	his.SampleSum = proto.Float64(math.Float64frombits(atomic.LoadUint64(&h.sumBits)))
-	his.SampleCount = proto.Uint64(atomic.LoadUint64(&h.count))
-	var count uint64
+	// For simplicity, we mutex the rest of this method. It is not in the
+	// hot path, i.e.  Observe is called much more often than Write. The
+	// complication of making Write lock-free isn't worth it.
+	h.writeMtx.Lock()
+	defer h.writeMtx.Unlock()
+
+	// This is a bit arcane, which is why the following spells out this if
+	// clause in English:
+	//
+	// If the currently-hot counts struct is #0, we atomically increment
+	// h.countAndHotIdx by 1 so that from now on Observe will use the counts
+	// struct #1. Furthermore, the atomic increment gives us the new value,
+	// which, in its most significant 63 bits, tells us the count of
+	// observations done so far up to and including currently ongoing
+	// observations still using the counts struct just changed from hot to
+	// cold. To have a normal uint64 for the count, we bitshift by 1 and
+	// save the result in count. We also set h.hotIdx to 1 for the next
+	// Write call, and we will refer to counts #1 as hotCounts and to counts
+	// #0 as coldCounts.
+	//
+	// If the currently-hot counts struct is #1, we do the corresponding
+	// things the other way round. We have to _decrement_ h.countAndHotIdx
+	// (which is a bit arcane in itself, as we have to express -1 with an
+	// unsigned int...).
+	if h.hotIdx == 0 {
+		count = atomic.AddUint64(&h.countAndHotIdx, 1) >> 1
+		h.hotIdx = 1
+		hotCounts = h.counts[1]
+		coldCounts = h.counts[0]
+	} else {
+		count = atomic.AddUint64(&h.countAndHotIdx, ^uint64(0)) >> 1 // Decrement.
+		h.hotIdx = 0
+		hotCounts = h.counts[0]
+		coldCounts = h.counts[1]
+	}
+
+	// Now we have to wait for the now-declared-cold counts to actually cool
+	// down, i.e. wait for all observations still using it to finish. That's
+	// the case once the count in the cold counts struct is the same as the
+	// one atomically retrieved from the upper 63bits of h.countAndHotIdx.
+	for {
+		if count == atomic.LoadUint64(&coldCounts.count) {
+			break
+		}
+		runtime.Gosched() // Let observations get work done.
+	}
+
+	his.SampleCount = proto.Uint64(count)
+	his.SampleSum = proto.Float64(math.Float64frombits(atomic.LoadUint64(&coldCounts.sumBits)))
+	var cumCount uint64
 	for i, upperBound := range h.upperBounds {
-		count += atomic.LoadUint64(&h.counts[i])
+		cumCount += atomic.LoadUint64(&coldCounts.buckets[i])
 		buckets[i] = &dto.Bucket{
-			CumulativeCount: proto.Uint64(count),
+			CumulativeCount: proto.Uint64(cumCount),
 			UpperBound:      proto.Float64(upperBound),
 		}
 	}
+
 	his.Bucket = buckets
 	out.Histogram = his
 	out.Label = h.labelPairs
+
+	// Finally add all the cold counts to the new hot counts and reset the cold counts.
+	atomic.AddUint64(&hotCounts.count, count)
+	atomic.StoreUint64(&coldCounts.count, 0)
+	for {
+		oldBits := atomic.LoadUint64(&hotCounts.sumBits)
+		newBits := math.Float64bits(math.Float64frombits(oldBits) + his.GetSampleSum())
+		if atomic.CompareAndSwapUint64(&hotCounts.sumBits, oldBits, newBits) {
+			atomic.StoreUint64(&coldCounts.sumBits, 0)
+			break
+		}
+	}
+	for i := range h.upperBounds {
+		atomic.AddUint64(&hotCounts.buckets[i], atomic.LoadUint64(&coldCounts.buckets[i]))
+		atomic.StoreUint64(&coldCounts.buckets[i], 0)
+	}
 	return nil
 }
 
@@ -454,7 +560,7 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 // bucket.
 //
 // NewConstHistogram returns an error if the length of labelValues is not
-// consistent with the variable labels in Desc.
+// consistent with the variable labels in Desc or if Desc is invalid.
 func NewConstHistogram(
 	desc *Desc,
 	count uint64,
@@ -462,6 +568,9 @@ func NewConstHistogram(
 	buckets map[float64]uint64,
 	labelValues ...string,
 ) (Metric, error) {
+	if desc.err != nil {
+		return nil, desc.err
+	}
 	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/prometheus/client_golang/prometheus/http.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/http.go
@@ -15,9 +15,7 @@ package prometheus
 
 import (
 	"bufio"
-	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -41,19 +39,10 @@ const (
 	acceptEncodingHeader  = "Accept-Encoding"
 )
 
-var bufPool sync.Pool
-
-func getBuf() *bytes.Buffer {
-	buf := bufPool.Get()
-	if buf == nil {
-		return &bytes.Buffer{}
-	}
-	return buf.(*bytes.Buffer)
-}
-
-func giveBuf(buf *bytes.Buffer) {
-	buf.Reset()
-	bufPool.Put(buf)
+var gzipPool = sync.Pool{
+	New: func() interface{} {
+		return gzip.NewWriter(nil)
+	},
 }
 
 // Handler returns an HTTP handler for the DefaultGatherer. It is
@@ -61,66 +50,48 @@ func giveBuf(buf *bytes.Buffer) {
 // name).
 //
 // Deprecated: Please note the issues described in the doc comment of
-// InstrumentHandler. You might want to consider using
-// promhttp.InstrumentedHandler instead.
+// InstrumentHandler. You might want to consider using promhttp.Handler instead.
 func Handler() http.Handler {
 	return InstrumentHandler("prometheus", UninstrumentedHandler())
 }
 
 // UninstrumentedHandler returns an HTTP handler for the DefaultGatherer.
 //
-// Deprecated: Use promhttp.Handler instead. See there for further documentation.
+// Deprecated: Use promhttp.HandlerFor(DefaultGatherer, promhttp.HandlerOpts{})
+// instead. See there for further documentation.
 func UninstrumentedHandler() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(rsp http.ResponseWriter, req *http.Request) {
 		mfs, err := DefaultGatherer.Gather()
 		if err != nil {
-			http.Error(w, "An error has occurred during metrics collection:\n\n"+err.Error(), http.StatusInternalServerError)
+			httpError(rsp, err)
 			return
 		}
 
 		contentType := expfmt.Negotiate(req.Header)
-		buf := getBuf()
-		defer giveBuf(buf)
-		writer, encoding := decorateWriter(req, buf)
-		enc := expfmt.NewEncoder(writer, contentType)
-		var lastErr error
+		header := rsp.Header()
+		header.Set(contentTypeHeader, string(contentType))
+
+		w := io.Writer(rsp)
+		if gzipAccepted(req.Header) {
+			header.Set(contentEncodingHeader, "gzip")
+			gz := gzipPool.Get().(*gzip.Writer)
+			defer gzipPool.Put(gz)
+
+			gz.Reset(w)
+			defer gz.Close()
+
+			w = gz
+		}
+
+		enc := expfmt.NewEncoder(w, contentType)
+
 		for _, mf := range mfs {
 			if err := enc.Encode(mf); err != nil {
-				lastErr = err
-				http.Error(w, "An error has occurred during metrics encoding:\n\n"+err.Error(), http.StatusInternalServerError)
+				httpError(rsp, err)
 				return
 			}
 		}
-		if closer, ok := writer.(io.Closer); ok {
-			closer.Close()
-		}
-		if lastErr != nil && buf.Len() == 0 {
-			http.Error(w, "No metrics encoded, last error:\n\n"+lastErr.Error(), http.StatusInternalServerError)
-			return
-		}
-		header := w.Header()
-		header.Set(contentTypeHeader, string(contentType))
-		header.Set(contentLengthHeader, fmt.Sprint(buf.Len()))
-		if encoding != "" {
-			header.Set(contentEncodingHeader, encoding)
-		}
-		w.Write(buf.Bytes())
 	})
-}
-
-// decorateWriter wraps a writer to handle gzip compression if requested.  It
-// returns the decorated writer and the appropriate "Content-Encoding" header
-// (which is empty if no compression is enabled).
-func decorateWriter(request *http.Request, writer io.Writer) (io.Writer, string) {
-	header := request.Header.Get(acceptEncodingHeader)
-	parts := strings.Split(header, ",")
-	for _, part := range parts {
-		part := strings.TrimSpace(part)
-		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
-			return gzip.NewWriter(writer), "gzip"
-		}
-	}
-	return writer, ""
 }
 
 var instLabels = []string{"method", "code"}
@@ -139,16 +110,6 @@ var now nower = nowFunc(func() time.Time {
 	return time.Now()
 })
 
-func nowSeries(t ...time.Time) nower {
-	return nowFunc(func() time.Time {
-		defer func() {
-			t = t[1:]
-		}()
-
-		return t[0]
-	})
-}
-
 // InstrumentHandler wraps the given HTTP handler for instrumentation. It
 // registers four metric collectors (if not already done) and reports HTTP
 // metrics to the (newly or already) registered collectors: http_requests_total
@@ -159,21 +120,14 @@ func nowSeries(t ...time.Time) nower {
 // (label name "method") and HTTP status code (label name "code").
 //
 // Deprecated: InstrumentHandler has several issues. Use the tooling provided in
-// package promhttp instead. The issues are the following:
-//
-// - It uses Summaries rather than Histograms. Summaries are not useful if
-// aggregation across multiple instances is required.
-//
-// - It uses microseconds as unit, which is deprecated and should be replaced by
-// seconds.
-//
-// - The size of the request is calculated in a separate goroutine. Since this
-// calculator requires access to the request header, it creates a race with
-// any writes to the header performed during request handling.
-// httputil.ReverseProxy is a prominent example for a handler
-// performing such writes.
-//
-// - It has additional issues with HTTP/2, cf.
+// package promhttp instead. The issues are the following: (1) It uses Summaries
+// rather than Histograms. Summaries are not useful if aggregation across
+// multiple instances is required. (2) It uses microseconds as unit, which is
+// deprecated and should be replaced by seconds. (3) The size of the request is
+// calculated in a separate goroutine. Since this calculator requires access to
+// the request header, it creates a race with any writes to the header performed
+// during request handling.  httputil.ReverseProxy is a prominent example for a
+// handler performing such writes. (4) It has additional issues with HTTP/2, cf.
 // https://github.com/prometheus/client_golang/issues/272.
 func InstrumentHandler(handlerName string, handler http.Handler) http.HandlerFunc {
 	return InstrumentHandlerFunc(handlerName, handler.ServeHTTP)
@@ -317,7 +271,7 @@ func InstrumentHandlerFuncWithOpts(opts SummaryOpts, handlerFunc func(http.Respo
 }
 
 func computeApproximateRequestSize(r *http.Request) <-chan int {
-	// Get URL length in current go routine for avoiding a race condition.
+	// Get URL length in current goroutine for avoiding a race condition.
 	// HandlerFunc that runs in parallel may modify the URL.
 	s := 0
 	if r.URL != nil {
@@ -352,10 +306,9 @@ func computeApproximateRequestSize(r *http.Request) <-chan int {
 type responseWriterDelegator struct {
 	http.ResponseWriter
 
-	handler, method string
-	status          int
-	written         int64
-	wroteHeader     bool
+	status      int
+	written     int64
+	wroteHeader bool
 }
 
 func (r *responseWriterDelegator) WriteHeader(code int) {
@@ -520,4 +473,32 @@ func sanitizeCode(s int) string {
 	default:
 		return strconv.Itoa(s)
 	}
+}
+
+// gzipAccepted returns whether the client will accept gzip-encoded content.
+func gzipAccepted(header http.Header) bool {
+	a := header.Get(acceptEncodingHeader)
+	parts := strings.Split(a, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "gzip" || strings.HasPrefix(part, "gzip;") {
+			return true
+		}
+	}
+	return false
+}
+
+// httpError removes any content-encoding header and then calls http.Error with
+// the provided error and http.StatusInternalServerErrer. Error contents is
+// supposed to be uncompressed plain text. However, same as with a plain
+// http.Error, any header settings will be void if the header has already been
+// sent. The error message will still be written to the writer, but it will
+// probably be of limited use.
+func httpError(rsp http.ResponseWriter, err error) {
+	rsp.Header().Del(contentEncodingHeader)
+	http.Error(
+		rsp,
+		"An error has occurred while serving metrics:\n\n"+err.Error(),
+		http.StatusInternalServerError,
+	)
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/internal/metric.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/internal/metric.go
@@ -1,0 +1,85 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"sort"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// metricSorter is a sortable slice of *dto.Metric.
+type metricSorter []*dto.Metric
+
+func (s metricSorter) Len() int {
+	return len(s)
+}
+
+func (s metricSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s metricSorter) Less(i, j int) bool {
+	if len(s[i].Label) != len(s[j].Label) {
+		// This should not happen. The metrics are
+		// inconsistent. However, we have to deal with the fact, as
+		// people might use custom collectors or metric family injection
+		// to create inconsistent metrics. So let's simply compare the
+		// number of labels in this case. That will still yield
+		// reproducible sorting.
+		return len(s[i].Label) < len(s[j].Label)
+	}
+	for n, lp := range s[i].Label {
+		vi := lp.GetValue()
+		vj := s[j].Label[n].GetValue()
+		if vi != vj {
+			return vi < vj
+		}
+	}
+
+	// We should never arrive here. Multiple metrics with the same
+	// label set in the same scrape will lead to undefined ingestion
+	// behavior. However, as above, we have to provide stable sorting
+	// here, even for inconsistent metrics. So sort equal metrics
+	// by their timestamp, with missing timestamps (implying "now")
+	// coming last.
+	if s[i].TimestampMs == nil {
+		return false
+	}
+	if s[j].TimestampMs == nil {
+		return true
+	}
+	return s[i].GetTimestampMs() < s[j].GetTimestampMs()
+}
+
+// NormalizeMetricFamilies returns a MetricFamily slice with empty
+// MetricFamilies pruned and the remaining MetricFamilies sorted by name within
+// the slice, with the contained Metrics sorted within each MetricFamily.
+func NormalizeMetricFamilies(metricFamiliesByName map[string]*dto.MetricFamily) []*dto.MetricFamily {
+	for _, mf := range metricFamiliesByName {
+		sort.Sort(metricSorter(mf.Metric))
+	}
+	names := make([]string, 0, len(metricFamiliesByName))
+	for name, mf := range metricFamiliesByName {
+		if len(mf.Metric) > 0 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	result := make([]*dto.MetricFamily, 0, len(names))
+	for _, name := range names {
+		result = append(result, metricFamiliesByName[name])
+	}
+	return result
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/labels.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/labels.go
@@ -1,3 +1,16 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package prometheus
 
 import (
@@ -24,9 +37,22 @@ const reservedLabelPrefix = "__"
 
 var errInconsistentCardinality = errors.New("inconsistent label cardinality")
 
+func makeInconsistentCardinalityError(fqName string, labels, labelValues []string) error {
+	return fmt.Errorf(
+		"%s: %q has %d variable labels named %q but %d values %q were provided",
+		errInconsistentCardinality, fqName,
+		len(labels), labels,
+		len(labelValues), labelValues,
+	)
+}
+
 func validateValuesInLabels(labels Labels, expectedNumberOfValues int) error {
 	if len(labels) != expectedNumberOfValues {
-		return errInconsistentCardinality
+		return fmt.Errorf(
+			"%s: expected %d label values but got %d in %#v",
+			errInconsistentCardinality, expectedNumberOfValues,
+			len(labels), labels,
+		)
 	}
 
 	for name, val := range labels {
@@ -40,7 +66,11 @@ func validateValuesInLabels(labels Labels, expectedNumberOfValues int) error {
 
 func validateLabelValues(vals []string, expectedNumberOfValues int) error {
 	if len(vals) != expectedNumberOfValues {
-		return errInconsistentCardinality
+		return fmt.Errorf(
+			"%s: expected %d label values but got %d in %#v",
+			errInconsistentCardinality, expectedNumberOfValues,
+			len(vals), vals,
+		)
 	}
 
 	for _, val := range vals {

--- a/vendor/github.com/prometheus/client_golang/prometheus/metric.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/metric.go
@@ -15,6 +15,9 @@ package prometheus
 
 import (
 	"strings"
+	"time"
+
+	"github.com/golang/protobuf/proto"
 
 	dto "github.com/prometheus/client_model/go"
 )
@@ -43,9 +46,8 @@ type Metric interface {
 	// While populating dto.Metric, it is the responsibility of the
 	// implementation to ensure validity of the Metric protobuf (like valid
 	// UTF-8 strings or syntactically valid metric and label names). It is
-	// recommended to sort labels lexicographically. (Implementers may find
-	// LabelPairSorter useful for that.) Callers of Write should still make
-	// sure of sorting if they depend on it.
+	// recommended to sort labels lexicographically. Callers of Write should
+	// still make sure of sorting if they depend on it.
 	Write(*dto.Metric) error
 	// TODO(beorn7): The original rationale of passing in a pre-allocated
 	// dto.Metric protobuf to save allocations has disappeared. The
@@ -57,8 +59,9 @@ type Metric interface {
 // implementation XXX has its own XXXOpts type, but in most cases, it is just be
 // an alias of this type (which might change when the requirement arises.)
 //
-// It is mandatory to set Name and Help to a non-empty string. All other fields
-// are optional and can safely be left at their zero value.
+// It is mandatory to set Name to a non-empty string. All other fields are
+// optional and can safely be left at their zero value, although it is strongly
+// encouraged to set a Help string.
 type Opts struct {
 	// Namespace, Subsystem, and Name are components of the fully-qualified
 	// name of the Metric (created by joining these components with
@@ -69,7 +72,7 @@ type Opts struct {
 	Subsystem string
 	Name      string
 
-	// Help provides information about this metric. Mandatory!
+	// Help provides information about this metric.
 	//
 	// Metrics with the same fully-qualified name must have the same Help
 	// string.
@@ -110,35 +113,20 @@ func BuildFQName(namespace, subsystem, name string) string {
 	return name
 }
 
-// LabelPairSorter implements sort.Interface. It is used to sort a slice of
-// dto.LabelPair pointers. This is useful for implementing the Write method of
-// custom metrics.
-type LabelPairSorter []*dto.LabelPair
+// labelPairSorter implements sort.Interface. It is used to sort a slice of
+// dto.LabelPair pointers.
+type labelPairSorter []*dto.LabelPair
 
-func (s LabelPairSorter) Len() int {
+func (s labelPairSorter) Len() int {
 	return len(s)
 }
 
-func (s LabelPairSorter) Swap(i, j int) {
+func (s labelPairSorter) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (s LabelPairSorter) Less(i, j int) bool {
+func (s labelPairSorter) Less(i, j int) bool {
 	return s[i].GetName() < s[j].GetName()
-}
-
-type hashSorter []uint64
-
-func (s hashSorter) Len() int {
-	return len(s)
-}
-
-func (s hashSorter) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s hashSorter) Less(i, j int) bool {
-	return s[i] < s[j]
 }
 
 type invalidMetric struct {
@@ -156,3 +144,31 @@ func NewInvalidMetric(desc *Desc, err error) Metric {
 func (m *invalidMetric) Desc() *Desc { return m.desc }
 
 func (m *invalidMetric) Write(*dto.Metric) error { return m.err }
+
+type timestampedMetric struct {
+	Metric
+	t time.Time
+}
+
+func (m timestampedMetric) Write(pb *dto.Metric) error {
+	e := m.Metric.Write(pb)
+	pb.TimestampMs = proto.Int64(m.t.Unix()*1000 + int64(m.t.Nanosecond()/1000000))
+	return e
+}
+
+// NewMetricWithTimestamp returns a new Metric wrapping the provided Metric in a
+// way that it has an explicit timestamp set to the provided Time. This is only
+// useful in rare cases as the timestamp of a Prometheus metric should usually
+// be set by the Prometheus server during scraping. Exceptions include mirroring
+// metrics with given timestamps from other metric
+// sources.
+//
+// NewMetricWithTimestamp works best with MustNewConstMetric,
+// MustNewConstHistogram, and MustNewConstSummary, see example.
+//
+// Currently, the exposition formats used by Prometheus are limited to
+// millisecond resolution. Thus, the provided time will be rounded down to the
+// next full millisecond value.
+func NewMetricWithTimestamp(t time.Time, m Metric) Metric {
+	return timestampedMetric{Metric: m, t: t}
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/process_collector.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/process_collector.go
@@ -13,46 +13,74 @@
 
 package prometheus
 
-import "github.com/prometheus/procfs"
+import (
+	"errors"
+	"os"
+
+	"github.com/prometheus/procfs"
+)
 
 type processCollector struct {
-	pid             int
 	collectFn       func(chan<- Metric)
 	pidFn           func() (int, error)
+	reportErrors    bool
 	cpuTotal        *Desc
 	openFDs, maxFDs *Desc
-	vsize, rss      *Desc
+	vsize, maxVsize *Desc
+	rss             *Desc
 	startTime       *Desc
+}
+
+// ProcessCollectorOpts defines the behavior of a process metrics collector
+// created with NewProcessCollector.
+type ProcessCollectorOpts struct {
+	// PidFn returns the PID of the process the collector collects metrics
+	// for. It is called upon each collection. By default, the PID of the
+	// current process is used, as determined on construction time by
+	// calling os.Getpid().
+	PidFn func() (int, error)
+	// If non-empty, each of the collected metrics is prefixed by the
+	// provided string and an underscore ("_").
+	Namespace string
+	// If true, any error encountered during collection is reported as an
+	// invalid metric (see NewInvalidMetric). Otherwise, errors are ignored
+	// and the collected metrics will be incomplete. (Possibly, no metrics
+	// will be collected at all.) While that's usually not desired, it is
+	// appropriate for the common "mix-in" of process metrics, where process
+	// metrics are nice to have, but failing to collect them should not
+	// disrupt the collection of the remaining metrics.
+	ReportErrors bool
 }
 
 // NewProcessCollector returns a collector which exports the current state of
 // process metrics including CPU, memory and file descriptor usage as well as
-// the process start time for the given process ID under the given namespace.
+// the process start time. The detailed behavior is defined by the provided
+// ProcessCollectorOpts. The zero value of ProcessCollectorOpts creates a
+// collector for the current process with an empty namespace string and no error
+// reporting.
 //
 // Currently, the collector depends on a Linux-style proc filesystem and
 // therefore only exports metrics for Linux.
-func NewProcessCollector(pid int, namespace string) Collector {
-	return NewProcessCollectorPIDFn(
-		func() (int, error) { return pid, nil },
-		namespace,
-	)
-}
-
-// NewProcessCollectorPIDFn works like NewProcessCollector but the process ID is
-// determined on each collect anew by calling the given pidFn function.
-func NewProcessCollectorPIDFn(
-	pidFn func() (int, error),
-	namespace string,
-) Collector {
+//
+// Note: An older version of this function had the following signature:
+//
+//     NewProcessCollector(pid int, namespace string) Collector
+//
+// Most commonly, it was called as
+//
+//     NewProcessCollector(os.Getpid(), "")
+//
+// The following call of the current version is equivalent to the above:
+//
+//     NewProcessCollector(ProcessCollectorOpts{})
+func NewProcessCollector(opts ProcessCollectorOpts) Collector {
 	ns := ""
-	if len(namespace) > 0 {
-		ns = namespace + "_"
+	if len(opts.Namespace) > 0 {
+		ns = opts.Namespace + "_"
 	}
 
-	c := processCollector{
-		pidFn:     pidFn,
-		collectFn: func(chan<- Metric) {},
-
+	c := &processCollector{
+		reportErrors: opts.ReportErrors,
 		cpuTotal: NewDesc(
 			ns+"process_cpu_seconds_total",
 			"Total user and system CPU time spent in seconds.",
@@ -73,6 +101,11 @@ func NewProcessCollectorPIDFn(
 			"Virtual memory size in bytes.",
 			nil, nil,
 		),
+		maxVsize: NewDesc(
+			ns+"process_virtual_memory_max_bytes",
+			"Maximum amount of virtual memory available in bytes.",
+			nil, nil,
+		),
 		rss: NewDesc(
 			ns+"process_resident_memory_bytes",
 			"Resident memory size in bytes.",
@@ -85,12 +118,23 @@ func NewProcessCollectorPIDFn(
 		),
 	}
 
+	if opts.PidFn == nil {
+		pid := os.Getpid()
+		c.pidFn = func() (int, error) { return pid, nil }
+	} else {
+		c.pidFn = opts.PidFn
+	}
+
 	// Set up process metric collection if supported by the runtime.
 	if _, err := procfs.NewStat(); err == nil {
 		c.collectFn = c.processCollect
+	} else {
+		c.collectFn = func(ch chan<- Metric) {
+			c.reportError(ch, nil, errors.New("process metrics not supported on this platform"))
+		}
 	}
 
-	return &c
+	return c
 }
 
 // Describe returns all descriptions of the collector.
@@ -99,6 +143,7 @@ func (c *processCollector) Describe(ch chan<- *Desc) {
 	ch <- c.openFDs
 	ch <- c.maxFDs
 	ch <- c.vsize
+	ch <- c.maxVsize
 	ch <- c.rss
 	ch <- c.startTime
 }
@@ -108,16 +153,16 @@ func (c *processCollector) Collect(ch chan<- Metric) {
 	c.collectFn(ch)
 }
 
-// TODO(ts): Bring back error reporting by reverting 7faf9e7 as soon as the
-// client allows users to configure the error behavior.
 func (c *processCollector) processCollect(ch chan<- Metric) {
 	pid, err := c.pidFn()
 	if err != nil {
+		c.reportError(ch, nil, err)
 		return
 	}
 
 	p, err := procfs.NewProc(pid)
 	if err != nil {
+		c.reportError(ch, nil, err)
 		return
 	}
 
@@ -127,14 +172,33 @@ func (c *processCollector) processCollect(ch chan<- Metric) {
 		ch <- MustNewConstMetric(c.rss, GaugeValue, float64(stat.ResidentMemory()))
 		if startTime, err := stat.StartTime(); err == nil {
 			ch <- MustNewConstMetric(c.startTime, GaugeValue, startTime)
+		} else {
+			c.reportError(ch, c.startTime, err)
 		}
+	} else {
+		c.reportError(ch, nil, err)
 	}
 
 	if fds, err := p.FileDescriptorsLen(); err == nil {
 		ch <- MustNewConstMetric(c.openFDs, GaugeValue, float64(fds))
+	} else {
+		c.reportError(ch, c.openFDs, err)
 	}
 
 	if limits, err := p.NewLimits(); err == nil {
 		ch <- MustNewConstMetric(c.maxFDs, GaugeValue, float64(limits.OpenFiles))
+		ch <- MustNewConstMetric(c.maxVsize, GaugeValue, float64(limits.AddressSpace))
+	} else {
+		c.reportError(ch, nil, err)
 	}
+}
+
+func (c *processCollector) reportError(ch chan<- Metric, desc *Desc, err error) {
+	if !c.reportErrors {
+		return
+	}
+	if desc == nil {
+		desc = NewInvalidDesc(err)
+	}
+	ch <- NewInvalidMetric(desc, err)
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -15,17 +15,22 @@ package prometheus
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"unicode/utf8"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/common/expfmt"
 
 	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus/internal"
 )
 
 const (
@@ -38,12 +43,13 @@ const (
 // Registerer and Gatherer interface a number of convenience functions in this
 // package act on. Initially, both variables point to the same Registry, which
 // has a process collector (currently on Linux only, see NewProcessCollector)
-// and a Go collector (see NewGoCollector) already registered. This approach to
-// keep default instances as global state mirrors the approach of other packages
-// in the Go standard library. Note that there are caveats. Change the variables
-// with caution and only if you understand the consequences. Users who want to
-// avoid global state altogether should not use the convenience functions and
-// act on custom instances instead.
+// and a Go collector (see NewGoCollector, in particular the note about
+// stop-the-world implication with Go versions older than 1.9) already
+// registered. This approach to keep default instances as global state mirrors
+// the approach of other packages in the Go standard library. Note that there
+// are caveats. Change the variables with caution and only if you understand the
+// consequences. Users who want to avoid global state altogether should not use
+// the convenience functions and act on custom instances instead.
 var (
 	defaultRegistry              = NewRegistry()
 	DefaultRegisterer Registerer = defaultRegistry
@@ -51,7 +57,7 @@ var (
 )
 
 func init() {
-	MustRegister(NewProcessCollector(os.Getpid(), ""))
+	MustRegister(NewProcessCollector(ProcessCollectorOpts{}))
 	MustRegister(NewGoCollector())
 }
 
@@ -67,7 +73,8 @@ func NewRegistry() *Registry {
 
 // NewPedanticRegistry returns a registry that checks during collection if each
 // collected Metric is consistent with its reported Desc, and if the Desc has
-// actually been registered with the registry.
+// actually been registered with the registry. Unchecked Collectors (those whose
+// Describe methed does not yield any descriptors) are excluded from the check.
 //
 // Usually, a Registry will be happy as long as the union of all collected
 // Metrics is consistent and valid even if some metrics are not consistent with
@@ -97,8 +104,13 @@ type Registerer interface {
 	// returned error is an instance of AlreadyRegisteredError, which
 	// contains the previously registered Collector.
 	//
-	// It is in general not safe to register the same Collector multiple
-	// times concurrently.
+	// A Collector whose Describe method does not yield any Desc is treated
+	// as unchecked. Registration will always succeed. No check for
+	// re-registering (see previous paragraph) is performed. Thus, the
+	// caller is responsible for not double-registering the same unchecked
+	// Collector, and for providing a Collector that will not cause
+	// inconsistent metrics on collection. (This would lead to scrape
+	// errors.)
 	Register(Collector) error
 	// MustRegister works like Register but registers any number of
 	// Collectors and panics upon the first registration that causes an
@@ -107,7 +119,9 @@ type Registerer interface {
 	// Unregister unregisters the Collector that equals the Collector passed
 	// in as an argument.  (Two Collectors are considered equal if their
 	// Describe method yields the same set of descriptors.) The function
-	// returns whether a Collector was unregistered.
+	// returns whether a Collector was unregistered. Note that an unchecked
+	// Collector cannot be unregistered (as its Describe method does not
+	// yield any descriptor).
 	//
 	// Note that even after unregistering, it will not be possible to
 	// register a new Collector that is inconsistent with the unregistered
@@ -125,15 +139,23 @@ type Registerer interface {
 type Gatherer interface {
 	// Gather calls the Collect method of the registered Collectors and then
 	// gathers the collected metrics into a lexicographically sorted slice
-	// of MetricFamily protobufs. Even if an error occurs, Gather attempts
-	// to gather as many metrics as possible. Hence, if a non-nil error is
-	// returned, the returned MetricFamily slice could be nil (in case of a
-	// fatal error that prevented any meaningful metric collection) or
-	// contain a number of MetricFamily protobufs, some of which might be
-	// incomplete, and some might be missing altogether. The returned error
-	// (which might be a MultiError) explains the details. In scenarios
-	// where complete collection is critical, the returned MetricFamily
-	// protobufs should be disregarded if the returned error is non-nil.
+	// of uniquely named MetricFamily protobufs. Gather ensures that the
+	// returned slice is valid and self-consistent so that it can be used
+	// for valid exposition. As an exception to the strict consistency
+	// requirements described for metric.Desc, Gather will tolerate
+	// different sets of label names for metrics of the same metric family.
+	//
+	// Even if an error occurs, Gather attempts to gather as many metrics as
+	// possible. Hence, if a non-nil error is returned, the returned
+	// MetricFamily slice could be nil (in case of a fatal error that
+	// prevented any meaningful metric collection) or contain a number of
+	// MetricFamily protobufs, some of which might be incomplete, and some
+	// might be missing altogether. The returned error (which might be a
+	// MultiError) explains the details. Note that this is mostly useful for
+	// debugging purposes. If the gathered protobufs are to be used for
+	// exposition in actual monitoring, it is almost always better to not
+	// expose an incomplete result and instead disregard the returned
+	// MetricFamily protobufs in case the returned error is non-nil.
 	Gather() ([]*dto.MetricFamily, error)
 }
 
@@ -234,6 +256,7 @@ type Registry struct {
 	collectorsByID        map[uint64]Collector // ID is a hash of the descIDs.
 	descIDs               map[uint64]struct{}
 	dimHashesByName       map[string]uint64
+	uncheckedCollectors   []Collector
 	pedanticChecksEnabled bool
 }
 
@@ -251,7 +274,12 @@ func (r *Registry) Register(c Collector) error {
 		close(descChan)
 	}()
 	r.mtx.Lock()
-	defer r.mtx.Unlock()
+	defer func() {
+		// Drain channel in case of premature return to not leak a goroutine.
+		for range descChan {
+		}
+		r.mtx.Unlock()
+	}()
 	// Conduct various tests...
 	for desc := range descChan {
 
@@ -291,9 +319,10 @@ func (r *Registry) Register(c Collector) error {
 			}
 		}
 	}
-	// Did anything happen at all?
+	// A Collector yielding no Desc at all is considered unchecked.
 	if len(newDescIDs) == 0 {
-		return errors.New("collector has no descriptors")
+		r.uncheckedCollectors = append(r.uncheckedCollectors, c)
+		return nil
 	}
 	if existing, exists := r.collectorsByID[collectorID]; exists {
 		return AlreadyRegisteredError{
@@ -367,20 +396,24 @@ func (r *Registry) MustRegister(cs ...Collector) {
 // Gather implements Gatherer.
 func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 	var (
-		metricChan        = make(chan Metric, capMetricChan)
-		metricHashes      = map[uint64]struct{}{}
-		dimHashes         = map[string]uint64{}
-		wg                sync.WaitGroup
-		errs              MultiError          // The collected errors to return in the end.
-		registeredDescIDs map[uint64]struct{} // Only used for pedantic checks
+		checkedMetricChan   = make(chan Metric, capMetricChan)
+		uncheckedMetricChan = make(chan Metric, capMetricChan)
+		metricHashes        = map[uint64]struct{}{}
+		wg                  sync.WaitGroup
+		errs                MultiError          // The collected errors to return in the end.
+		registeredDescIDs   map[uint64]struct{} // Only used for pedantic checks
 	)
 
 	r.mtx.RLock()
-	goroutineBudget := len(r.collectorsByID)
+	goroutineBudget := len(r.collectorsByID) + len(r.uncheckedCollectors)
 	metricFamiliesByName := make(map[string]*dto.MetricFamily, len(r.dimHashesByName))
-	collectors := make(chan Collector, len(r.collectorsByID))
+	checkedCollectors := make(chan Collector, len(r.collectorsByID))
+	uncheckedCollectors := make(chan Collector, len(r.uncheckedCollectors))
 	for _, collector := range r.collectorsByID {
-		collectors <- collector
+		checkedCollectors <- collector
+	}
+	for _, collector := range r.uncheckedCollectors {
+		uncheckedCollectors <- collector
 	}
 	// In case pedantic checks are enabled, we have to copy the map before
 	// giving up the RLock.
@@ -397,12 +430,14 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 	collectWorker := func() {
 		for {
 			select {
-			case collector := <-collectors:
-				collector.Collect(metricChan)
-				wg.Done()
+			case collector := <-checkedCollectors:
+				collector.Collect(checkedMetricChan)
+			case collector := <-uncheckedCollectors:
+				collector.Collect(uncheckedMetricChan)
 			default:
 				return
 			}
+			wg.Done()
 		}
 	}
 
@@ -410,53 +445,128 @@ func (r *Registry) Gather() ([]*dto.MetricFamily, error) {
 	go collectWorker()
 	goroutineBudget--
 
-	// Close the metricChan once all collectors are collected.
+	// Close checkedMetricChan and uncheckedMetricChan once all collectors
+	// are collected.
 	go func() {
 		wg.Wait()
-		close(metricChan)
+		close(checkedMetricChan)
+		close(uncheckedMetricChan)
 	}()
 
-	// Drain metricChan in case of premature return.
+	// Drain checkedMetricChan and uncheckedMetricChan in case of premature return.
 	defer func() {
-		for range metricChan {
+		if checkedMetricChan != nil {
+			for range checkedMetricChan {
+			}
+		}
+		if uncheckedMetricChan != nil {
+			for range uncheckedMetricChan {
+			}
 		}
 	}()
 
-collectLoop:
+	// Copy the channel references so we can nil them out later to remove
+	// them from the select statements below.
+	cmc := checkedMetricChan
+	umc := uncheckedMetricChan
+
 	for {
 		select {
-		case metric, ok := <-metricChan:
+		case metric, ok := <-cmc:
 			if !ok {
-				// metricChan is closed, we are done.
-				break collectLoop
+				cmc = nil
+				break
 			}
 			errs.Append(processMetric(
 				metric, metricFamiliesByName,
-				metricHashes, dimHashes,
+				metricHashes,
 				registeredDescIDs,
 			))
+		case metric, ok := <-umc:
+			if !ok {
+				umc = nil
+				break
+			}
+			errs.Append(processMetric(
+				metric, metricFamiliesByName,
+				metricHashes,
+				nil,
+			))
 		default:
-			if goroutineBudget <= 0 || len(collectors) == 0 {
-				// All collectors are aleady being worked on or
+			if goroutineBudget <= 0 || len(checkedCollectors)+len(uncheckedCollectors) == 0 {
+				// All collectors are already being worked on or
 				// we have already as many goroutines started as
-				// there are collectors. Just process metrics
-				// from now on.
-				for metric := range metricChan {
+				// there are collectors. Do the same as above,
+				// just without the default.
+				select {
+				case metric, ok := <-cmc:
+					if !ok {
+						cmc = nil
+						break
+					}
 					errs.Append(processMetric(
 						metric, metricFamiliesByName,
-						metricHashes, dimHashes,
+						metricHashes,
 						registeredDescIDs,
 					))
+				case metric, ok := <-umc:
+					if !ok {
+						umc = nil
+						break
+					}
+					errs.Append(processMetric(
+						metric, metricFamiliesByName,
+						metricHashes,
+						nil,
+					))
 				}
-				break collectLoop
+				break
 			}
 			// Start more workers.
 			go collectWorker()
 			goroutineBudget--
 			runtime.Gosched()
 		}
+		// Once both checkedMetricChan and uncheckdMetricChan are closed
+		// and drained, the contraption above will nil out cmc and umc,
+		// and then we can leave the collect loop here.
+		if cmc == nil && umc == nil {
+			break
+		}
 	}
-	return normalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
+	return internal.NormalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
+}
+
+// WriteToTextfile calls Gather on the provided Gatherer, encodes the result in the
+// Prometheus text format, and writes it to a temporary file. Upon success, the
+// temporary file is renamed to the provided filename.
+//
+// This is intended for use with the textfile collector of the node exporter.
+// Note that the node exporter expects the filename to be suffixed with ".prom".
+func WriteToTextfile(filename string, g Gatherer) error {
+	tmp, err := ioutil.TempFile(filepath.Dir(filename), filepath.Base(filename))
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	mfs, err := g.Gather()
+	if err != nil {
+		return err
+	}
+	for _, mf := range mfs {
+		if _, err := expfmt.MetricFamilyToText(tmp, mf); err != nil {
+			return err
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Chmod(tmp.Name(), 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), filename)
 }
 
 // processMetric is an internal helper method only used by the Gather method.
@@ -464,16 +574,20 @@ func processMetric(
 	metric Metric,
 	metricFamiliesByName map[string]*dto.MetricFamily,
 	metricHashes map[uint64]struct{},
-	dimHashes map[string]uint64,
 	registeredDescIDs map[uint64]struct{},
 ) error {
 	desc := metric.Desc()
+	// Wrapped metrics collected by an unchecked Collector can have an
+	// invalid Desc.
+	if desc.err != nil {
+		return desc.err
+	}
 	dtoMetric := &dto.Metric{}
 	if err := metric.Write(dtoMetric); err != nil {
 		return fmt.Errorf("error collecting metric %v: %s", desc, err)
 	}
 	metricFamily, ok := metricFamiliesByName[desc.fqName]
-	if ok {
+	if ok { // Existing name.
 		if metricFamily.GetHelp() != desc.help {
 			return fmt.Errorf(
 				"collected metric %s %s has help %q but should have %q",
@@ -520,7 +634,7 @@ func processMetric(
 		default:
 			panic("encountered MetricFamily with invalid type")
 		}
-	} else {
+	} else { // New name.
 		metricFamily = &dto.MetricFamily{}
 		metricFamily.Name = proto.String(desc.fqName)
 		metricFamily.Help = proto.String(desc.help)
@@ -539,9 +653,12 @@ func processMetric(
 		default:
 			return fmt.Errorf("empty metric collected: %s", dtoMetric)
 		}
+		if err := checkSuffixCollisions(metricFamily, metricFamiliesByName); err != nil {
+			return err
+		}
 		metricFamiliesByName[desc.fqName] = metricFamily
 	}
-	if err := checkMetricConsistency(metricFamily, dtoMetric, metricHashes, dimHashes); err != nil {
+	if err := checkMetricConsistency(metricFamily, dtoMetric, metricHashes); err != nil {
 		return err
 	}
 	if registeredDescIDs != nil {
@@ -583,7 +700,6 @@ func (gs Gatherers) Gather() ([]*dto.MetricFamily, error) {
 	var (
 		metricFamiliesByName = map[string]*dto.MetricFamily{}
 		metricHashes         = map[uint64]struct{}{}
-		dimHashes            = map[string]uint64{}
 		errs                 MultiError // The collected errors to return in the end.
 	)
 
@@ -620,10 +736,14 @@ func (gs Gatherers) Gather() ([]*dto.MetricFamily, error) {
 				existingMF.Name = mf.Name
 				existingMF.Help = mf.Help
 				existingMF.Type = mf.Type
+				if err := checkSuffixCollisions(existingMF, metricFamiliesByName); err != nil {
+					errs = append(errs, err)
+					continue
+				}
 				metricFamiliesByName[mf.GetName()] = existingMF
 			}
 			for _, m := range mf.Metric {
-				if err := checkMetricConsistency(existingMF, m, metricHashes, dimHashes); err != nil {
+				if err := checkMetricConsistency(existingMF, m, metricHashes); err != nil {
 					errs = append(errs, err)
 					continue
 				}
@@ -631,88 +751,80 @@ func (gs Gatherers) Gather() ([]*dto.MetricFamily, error) {
 			}
 		}
 	}
-	return normalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
+	return internal.NormalizeMetricFamilies(metricFamiliesByName), errs.MaybeUnwrap()
 }
 
-// metricSorter is a sortable slice of *dto.Metric.
-type metricSorter []*dto.Metric
-
-func (s metricSorter) Len() int {
-	return len(s)
-}
-
-func (s metricSorter) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s metricSorter) Less(i, j int) bool {
-	if len(s[i].Label) != len(s[j].Label) {
-		// This should not happen. The metrics are
-		// inconsistent. However, we have to deal with the fact, as
-		// people might use custom collectors or metric family injection
-		// to create inconsistent metrics. So let's simply compare the
-		// number of labels in this case. That will still yield
-		// reproducible sorting.
-		return len(s[i].Label) < len(s[j].Label)
+// checkSuffixCollisions checks for collisions with the “magic” suffixes the
+// Prometheus text format and the internal metric representation of the
+// Prometheus server add while flattening Summaries and Histograms.
+func checkSuffixCollisions(mf *dto.MetricFamily, mfs map[string]*dto.MetricFamily) error {
+	var (
+		newName              = mf.GetName()
+		newType              = mf.GetType()
+		newNameWithoutSuffix = ""
+	)
+	switch {
+	case strings.HasSuffix(newName, "_count"):
+		newNameWithoutSuffix = newName[:len(newName)-6]
+	case strings.HasSuffix(newName, "_sum"):
+		newNameWithoutSuffix = newName[:len(newName)-4]
+	case strings.HasSuffix(newName, "_bucket"):
+		newNameWithoutSuffix = newName[:len(newName)-7]
 	}
-	for n, lp := range s[i].Label {
-		vi := lp.GetValue()
-		vj := s[j].Label[n].GetValue()
-		if vi != vj {
-			return vi < vj
+	if newNameWithoutSuffix != "" {
+		if existingMF, ok := mfs[newNameWithoutSuffix]; ok {
+			switch existingMF.GetType() {
+			case dto.MetricType_SUMMARY:
+				if !strings.HasSuffix(newName, "_bucket") {
+					return fmt.Errorf(
+						"collected metric named %q collides with previously collected summary named %q",
+						newName, newNameWithoutSuffix,
+					)
+				}
+			case dto.MetricType_HISTOGRAM:
+				return fmt.Errorf(
+					"collected metric named %q collides with previously collected histogram named %q",
+					newName, newNameWithoutSuffix,
+				)
+			}
 		}
 	}
-
-	// We should never arrive here. Multiple metrics with the same
-	// label set in the same scrape will lead to undefined ingestion
-	// behavior. However, as above, we have to provide stable sorting
-	// here, even for inconsistent metrics. So sort equal metrics
-	// by their timestamp, with missing timestamps (implying "now")
-	// coming last.
-	if s[i].TimestampMs == nil {
-		return false
-	}
-	if s[j].TimestampMs == nil {
-		return true
-	}
-	return s[i].GetTimestampMs() < s[j].GetTimestampMs()
-}
-
-// normalizeMetricFamilies returns a MetricFamily slice with empty
-// MetricFamilies pruned and the remaining MetricFamilies sorted by name within
-// the slice, with the contained Metrics sorted within each MetricFamily.
-func normalizeMetricFamilies(metricFamiliesByName map[string]*dto.MetricFamily) []*dto.MetricFamily {
-	for _, mf := range metricFamiliesByName {
-		sort.Sort(metricSorter(mf.Metric))
-	}
-	names := make([]string, 0, len(metricFamiliesByName))
-	for name, mf := range metricFamiliesByName {
-		if len(mf.Metric) > 0 {
-			names = append(names, name)
+	if newType == dto.MetricType_SUMMARY || newType == dto.MetricType_HISTOGRAM {
+		if _, ok := mfs[newName+"_count"]; ok {
+			return fmt.Errorf(
+				"collected histogram or summary named %q collides with previously collected metric named %q",
+				newName, newName+"_count",
+			)
+		}
+		if _, ok := mfs[newName+"_sum"]; ok {
+			return fmt.Errorf(
+				"collected histogram or summary named %q collides with previously collected metric named %q",
+				newName, newName+"_sum",
+			)
 		}
 	}
-	sort.Strings(names)
-	result := make([]*dto.MetricFamily, 0, len(names))
-	for _, name := range names {
-		result = append(result, metricFamiliesByName[name])
+	if newType == dto.MetricType_HISTOGRAM {
+		if _, ok := mfs[newName+"_bucket"]; ok {
+			return fmt.Errorf(
+				"collected histogram named %q collides with previously collected metric named %q",
+				newName, newName+"_bucket",
+			)
+		}
 	}
-	return result
+	return nil
 }
 
 // checkMetricConsistency checks if the provided Metric is consistent with the
-// provided MetricFamily. It also hashed the Metric labels and the MetricFamily
+// provided MetricFamily. It also hashes the Metric labels and the MetricFamily
 // name. If the resulting hash is already in the provided metricHashes, an error
-// is returned. If not, it is added to metricHashes. The provided dimHashes maps
-// MetricFamily names to their dimHash (hashed sorted label names). If dimHashes
-// doesn't yet contain a hash for the provided MetricFamily, it is
-// added. Otherwise, an error is returned if the existing dimHashes in not equal
-// the calculated dimHash.
+// is returned. If not, it is added to metricHashes.
 func checkMetricConsistency(
 	metricFamily *dto.MetricFamily,
 	dtoMetric *dto.Metric,
 	metricHashes map[uint64]struct{},
-	dimHashes map[string]uint64,
 ) error {
+	name := metricFamily.GetName()
+
 	// Type consistency with metric family.
 	if metricFamily.GetType() == dto.MetricType_GAUGE && dtoMetric.Gauge == nil ||
 		metricFamily.GetType() == dto.MetricType_COUNTER && dtoMetric.Counter == nil ||
@@ -720,46 +832,64 @@ func checkMetricConsistency(
 		metricFamily.GetType() == dto.MetricType_HISTOGRAM && dtoMetric.Histogram == nil ||
 		metricFamily.GetType() == dto.MetricType_UNTYPED && dtoMetric.Untyped == nil {
 		return fmt.Errorf(
-			"collected metric %s %s is not a %s",
-			metricFamily.GetName(), dtoMetric, metricFamily.GetType(),
+			"collected metric %q { %s} is not a %s",
+			name, dtoMetric, metricFamily.GetType(),
 		)
 	}
 
+	previousLabelName := ""
 	for _, labelPair := range dtoMetric.GetLabel() {
-		if !utf8.ValidString(*labelPair.Value) {
-			return fmt.Errorf("collected metric's label %s is not utf8: %#v", *labelPair.Name, *labelPair.Value)
+		labelName := labelPair.GetName()
+		if labelName == previousLabelName {
+			return fmt.Errorf(
+				"collected metric %q { %s} has two or more labels with the same name: %s",
+				name, dtoMetric, labelName,
+			)
 		}
+		if !checkLabelName(labelName) {
+			return fmt.Errorf(
+				"collected metric %q { %s} has a label with an invalid name: %s",
+				name, dtoMetric, labelName,
+			)
+		}
+		if dtoMetric.Summary != nil && labelName == quantileLabel {
+			return fmt.Errorf(
+				"collected metric %q { %s} must not have an explicit %q label",
+				name, dtoMetric, quantileLabel,
+			)
+		}
+		if !utf8.ValidString(labelPair.GetValue()) {
+			return fmt.Errorf(
+				"collected metric %q { %s} has a label named %q whose value is not utf8: %#v",
+				name, dtoMetric, labelName, labelPair.GetValue())
+		}
+		previousLabelName = labelName
 	}
 
-	// Is the metric unique (i.e. no other metric with the same name and the same label values)?
+	// Is the metric unique (i.e. no other metric with the same name and the same labels)?
 	h := hashNew()
-	h = hashAdd(h, metricFamily.GetName())
+	h = hashAdd(h, name)
 	h = hashAddByte(h, separatorByte)
-	dh := hashNew()
 	// Make sure label pairs are sorted. We depend on it for the consistency
 	// check.
-	sort.Sort(LabelPairSorter(dtoMetric.Label))
+	if !sort.IsSorted(labelPairSorter(dtoMetric.Label)) {
+		// We cannot sort dtoMetric.Label in place as it is immutable by contract.
+		copiedLabels := make([]*dto.LabelPair, len(dtoMetric.Label))
+		copy(copiedLabels, dtoMetric.Label)
+		sort.Sort(labelPairSorter(copiedLabels))
+		dtoMetric.Label = copiedLabels
+	}
 	for _, lp := range dtoMetric.Label {
+		h = hashAdd(h, lp.GetName())
+		h = hashAddByte(h, separatorByte)
 		h = hashAdd(h, lp.GetValue())
 		h = hashAddByte(h, separatorByte)
-		dh = hashAdd(dh, lp.GetName())
-		dh = hashAddByte(dh, separatorByte)
 	}
 	if _, exists := metricHashes[h]; exists {
 		return fmt.Errorf(
-			"collected metric %s %s was collected before with the same name and label values",
-			metricFamily.GetName(), dtoMetric,
+			"collected metric %q { %s} was collected before with the same name and label values",
+			name, dtoMetric,
 		)
-	}
-	if dimHash, ok := dimHashes[metricFamily.GetName()]; ok {
-		if dimHash != dh {
-			return fmt.Errorf(
-				"collected metric %s %s has label dimensions inconsistent with previously collected metrics in the same metric family",
-				metricFamily.GetName(), dtoMetric,
-			)
-		}
-	} else {
-		dimHashes[metricFamily.GetName()] = dh
 	}
 	metricHashes[h] = struct{}{}
 	return nil
@@ -779,8 +909,8 @@ func checkDescConsistency(
 	}
 
 	// Is the desc consistent with the content of the metric?
-	lpsFromDesc := make([]*dto.LabelPair, 0, len(dtoMetric.Label))
-	lpsFromDesc = append(lpsFromDesc, desc.constLabelPairs...)
+	lpsFromDesc := make([]*dto.LabelPair, len(desc.constLabelPairs), len(dtoMetric.Label))
+	copy(lpsFromDesc, desc.constLabelPairs)
 	for _, l := range desc.variableLabels {
 		lpsFromDesc = append(lpsFromDesc, &dto.LabelPair{
 			Name: proto.String(l),
@@ -792,7 +922,7 @@ func checkDescConsistency(
 			metricFamily.GetName(), dtoMetric, desc,
 		)
 	}
-	sort.Sort(LabelPairSorter(lpsFromDesc))
+	sort.Sort(labelPairSorter(lpsFromDesc))
 	for i, lpFromDesc := range lpsFromDesc {
 		lpFromMetric := dtoMetric.Label[i]
 		if lpFromDesc.GetName() != lpFromMetric.GetName() ||

--- a/vendor/github.com/prometheus/client_golang/prometheus/summary.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/summary.go
@@ -37,7 +37,7 @@ const quantileLabel = "quantile"
 // A typical use-case is the observation of request latencies. By default, a
 // Summary provides the median, the 90th and the 99th percentile of the latency
 // as rank estimations. However, the default behavior will change in the
-// upcoming v0.10 of the library. There will be no rank estiamtions at all by
+// upcoming v0.10 of the library. There will be no rank estimations at all by
 // default. For a sane transition, it is recommended to set the desired rank
 // estimations explicitly.
 //
@@ -81,10 +81,10 @@ const (
 )
 
 // SummaryOpts bundles the options for creating a Summary metric. It is
-// mandatory to set Name and Help to a non-empty string. While all other fields
-// are optional and can safely be left at their zero value, it is recommended to
-// explicitly set the Objectives field to the desired value as the default value
-// will change in the upcoming v0.10 of the library.
+// mandatory to set Name to a non-empty string. While all other fields are
+// optional and can safely be left at their zero value, it is recommended to set
+// a help string and to explicitly set the Objectives field to the desired value
+// as the default value will change in the upcoming v0.10 of the library.
 type SummaryOpts struct {
 	// Namespace, Subsystem, and Name are components of the fully-qualified
 	// name of the Summary (created by joining these components with
@@ -95,7 +95,7 @@ type SummaryOpts struct {
 	Subsystem string
 	Name      string
 
-	// Help provides information about this Summary. Mandatory!
+	// Help provides information about this Summary.
 	//
 	// Metrics with the same fully-qualified name must have the same Help
 	// string.
@@ -104,6 +104,11 @@ type SummaryOpts struct {
 	// ConstLabels are used to attach fixed labels to this metric. Metrics
 	// with the same fully-qualified name must have the same label names in
 	// their ConstLabels.
+	//
+	// Due to the way a Summary is represented in the Prometheus text format
+	// and how it is handled by the Prometheus server internally, “quantile”
+	// is an illegal label name. Construction of a Summary or SummaryVec
+	// will panic if this label name is used in ConstLabels.
 	//
 	// ConstLabels are only used rarely. In particular, do not use them to
 	// attach the same labels to all your metrics. Those use cases are
@@ -176,7 +181,7 @@ func NewSummary(opts SummaryOpts) Summary {
 
 func newSummary(desc *Desc, opts SummaryOpts, labelValues ...string) Summary {
 	if len(desc.variableLabels) != len(labelValues) {
-		panic(errInconsistentCardinality)
+		panic(makeInconsistentCardinalityError(desc.fqName, desc.variableLabels, labelValues))
 	}
 
 	for _, n := range desc.variableLabels {
@@ -402,7 +407,16 @@ type SummaryVec struct {
 
 // NewSummaryVec creates a new SummaryVec based on the provided SummaryOpts and
 // partitioned by the given label names.
+//
+// Due to the way a Summary is represented in the Prometheus text format and how
+// it is handled by the Prometheus server internally, “quantile” is an illegal
+// label name. NewSummaryVec will panic if this label name is used.
 func NewSummaryVec(opts SummaryOpts, labelNames []string) *SummaryVec {
+	for _, ln := range labelNames {
+		if ln == quantileLabel {
+			panic(errQuantileLabelNotAllowed)
+		}
+	}
 	desc := NewDesc(
 		BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
 		opts.Help,
@@ -572,7 +586,7 @@ func (s *constSummary) Write(out *dto.Metric) error {
 //     map[float64]float64{0.5: 0.23, 0.99: 0.56}
 //
 // NewConstSummary returns an error if the length of labelValues is not
-// consistent with the variable labels in Desc.
+// consistent with the variable labels in Desc or if Desc is invalid.
 func NewConstSummary(
 	desc *Desc,
 	count uint64,
@@ -580,6 +594,9 @@ func NewConstSummary(
 	quantiles map[float64]float64,
 	labelValues ...string,
 ) (Metric, error) {
+	if desc.err != nil {
+		return nil, desc.err
+	}
 	if err := validateLabelValues(labelValues, len(desc.variableLabels)); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/prometheus/client_golang/prometheus/timer.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/timer.go
@@ -39,13 +39,16 @@ func NewTimer(o Observer) *Timer {
 
 // ObserveDuration records the duration passed since the Timer was created with
 // NewTimer. It calls the Observe method of the Observer provided during
-// construction with the duration in seconds as an argument. ObserveDuration is
-// usually called with a defer statement.
+// construction with the duration in seconds as an argument. The observed
+// duration is also returned. ObserveDuration is usually called with a defer
+// statement.
 //
 // Note that this method is only guaranteed to never observe negative durations
 // if used with Go1.9+.
-func (t *Timer) ObserveDuration() {
+func (t *Timer) ObserveDuration() time.Duration {
+	d := time.Since(t.begin)
 	if t.observer != nil {
-		t.observer.Observe(time.Since(t.begin).Seconds())
+		t.observer.Observe(d.Seconds())
 	}
+	return d
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/vec.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/vec.go
@@ -277,6 +277,9 @@ func (m *metricMap) deleteByHashWithLabelValues(
 func (m *metricMap) deleteByHashWithLabels(
 	h uint64, labels Labels, curry []curriedLabelValue,
 ) bool {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
 	metrics, ok := m.metrics[h]
 	if !ok {
 		return false

--- a/vendor/github.com/prometheus/client_golang/prometheus/wrap.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/wrap.go
@@ -1,0 +1,179 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prometheus
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/golang/protobuf/proto"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// WrapRegistererWith returns a Registerer wrapping the provided
+// Registerer. Collectors registered with the returned Registerer will be
+// registered with the wrapped Registerer in a modified way. The modified
+// Collector adds the provided Labels to all Metrics it collects (as
+// ConstLabels). The Metrics collected by the unmodified Collector must not
+// duplicate any of those labels.
+//
+// WrapRegistererWith provides a way to add fixed labels to a subset of
+// Collectors. It should not be used to add fixed labels to all metrics exposed.
+//
+// The Collector example demonstrates a use of WrapRegistererWith.
+func WrapRegistererWith(labels Labels, reg Registerer) Registerer {
+	return &wrappingRegisterer{
+		wrappedRegisterer: reg,
+		labels:            labels,
+	}
+}
+
+// WrapRegistererWithPrefix returns a Registerer wrapping the provided
+// Registerer. Collectors registered with the returned Registerer will be
+// registered with the wrapped Registerer in a modified way. The modified
+// Collector adds the provided prefix to the name of all Metrics it collects.
+//
+// WrapRegistererWithPrefix is useful to have one place to prefix all metrics of
+// a sub-system. To make this work, register metrics of the sub-system with the
+// wrapping Registerer returned by WrapRegistererWithPrefix. It is rarely useful
+// to use the same prefix for all metrics exposed. In particular, do not prefix
+// metric names that are standardized across applications, as that would break
+// horizontal monitoring, for example the metrics provided by the Go collector
+// (see NewGoCollector) and the process collector (see NewProcessCollector). (In
+// fact, those metrics are already prefixed with “go_” or “process_”,
+// respectively.)
+func WrapRegistererWithPrefix(prefix string, reg Registerer) Registerer {
+	return &wrappingRegisterer{
+		wrappedRegisterer: reg,
+		prefix:            prefix,
+	}
+}
+
+type wrappingRegisterer struct {
+	wrappedRegisterer Registerer
+	prefix            string
+	labels            Labels
+}
+
+func (r *wrappingRegisterer) Register(c Collector) error {
+	return r.wrappedRegisterer.Register(&wrappingCollector{
+		wrappedCollector: c,
+		prefix:           r.prefix,
+		labels:           r.labels,
+	})
+}
+
+func (r *wrappingRegisterer) MustRegister(cs ...Collector) {
+	for _, c := range cs {
+		if err := r.Register(c); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (r *wrappingRegisterer) Unregister(c Collector) bool {
+	return r.wrappedRegisterer.Unregister(&wrappingCollector{
+		wrappedCollector: c,
+		prefix:           r.prefix,
+		labels:           r.labels,
+	})
+}
+
+type wrappingCollector struct {
+	wrappedCollector Collector
+	prefix           string
+	labels           Labels
+}
+
+func (c *wrappingCollector) Collect(ch chan<- Metric) {
+	wrappedCh := make(chan Metric)
+	go func() {
+		c.wrappedCollector.Collect(wrappedCh)
+		close(wrappedCh)
+	}()
+	for m := range wrappedCh {
+		ch <- &wrappingMetric{
+			wrappedMetric: m,
+			prefix:        c.prefix,
+			labels:        c.labels,
+		}
+	}
+}
+
+func (c *wrappingCollector) Describe(ch chan<- *Desc) {
+	wrappedCh := make(chan *Desc)
+	go func() {
+		c.wrappedCollector.Describe(wrappedCh)
+		close(wrappedCh)
+	}()
+	for desc := range wrappedCh {
+		ch <- wrapDesc(desc, c.prefix, c.labels)
+	}
+}
+
+type wrappingMetric struct {
+	wrappedMetric Metric
+	prefix        string
+	labels        Labels
+}
+
+func (m *wrappingMetric) Desc() *Desc {
+	return wrapDesc(m.wrappedMetric.Desc(), m.prefix, m.labels)
+}
+
+func (m *wrappingMetric) Write(out *dto.Metric) error {
+	if err := m.wrappedMetric.Write(out); err != nil {
+		return err
+	}
+	if len(m.labels) == 0 {
+		// No wrapping labels.
+		return nil
+	}
+	for ln, lv := range m.labels {
+		out.Label = append(out.Label, &dto.LabelPair{
+			Name:  proto.String(ln),
+			Value: proto.String(lv),
+		})
+	}
+	sort.Sort(labelPairSorter(out.Label))
+	return nil
+}
+
+func wrapDesc(desc *Desc, prefix string, labels Labels) *Desc {
+	constLabels := Labels{}
+	for _, lp := range desc.constLabelPairs {
+		constLabels[*lp.Name] = *lp.Value
+	}
+	for ln, lv := range labels {
+		if _, alreadyUsed := constLabels[ln]; alreadyUsed {
+			return &Desc{
+				fqName:          desc.fqName,
+				help:            desc.help,
+				variableLabels:  desc.variableLabels,
+				constLabelPairs: desc.constLabelPairs,
+				err:             fmt.Errorf("attempted wrapping with already existing label name %q", ln),
+			}
+		}
+		constLabels[ln] = lv
+	}
+	// NewDesc will do remaining validations.
+	newDesc := NewDesc(prefix+desc.fqName, desc.help, desc.variableLabels, constLabels)
+	// Propagate errors if there was any. This will override any errer
+	// created by NewDesc above, i.e. earlier errors get precedence.
+	if desc.err != nil {
+		newDesc.err = desc.err
+	}
+	return newDesc
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2,496 +2,3226 @@
 	"comment": "",
 	"ignore": "test appengine",
 	"package": [
-		{"path":"cloud.google.com/go/civil","checksumSHA1":"NkpNQgmrdzGr9HUDL8Bp5YAxt0k=","revision":"0533e22fa71728e9e042e858c2e2d49d14bae0e8","revisionTime":"2018-06-20T12:26:09Z"},
-		{"path":"github.com/Azure/go-autorest/autorest","checksumSHA1":"MlFs4OQ2cCVlZvSeKSgpdUoLKBs=","revision":"28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9","revisionTime":"2018-09-05T20:55:58Z"},
-		{"path":"github.com/Azure/go-autorest/autorest/adal","checksumSHA1":"vMERbrCV9o4TWRw4dC75uaNihSc=","revision":"28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9","revisionTime":"2018-09-05T20:55:58Z"},
-		{"path":"github.com/Azure/go-autorest/autorest/azure","checksumSHA1":"vUHo41PG/G6Qq+vqD65l9KHFxUs=","revision":"28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9","revisionTime":"2018-09-05T20:55:58Z"},
-		{"path":"github.com/Azure/go-autorest/logger","revision":"a35eae345f69bbfbe3b8fa0b1d3fe98f8430b21a","revisionTime":"2018-08-30T19:44:05Z"},
-		{"path":"github.com/Azure/go-autorest/version","revision":"a35eae345f69bbfbe3b8fa0b1d3fe98f8430b21a","revisionTime":"2018-08-30T19:44:05Z"},
-		{"path":"github.com/DataDog/datadog-go/statsd","checksumSHA1":"JhyS/zIicgtrSasHSZ6WtXGWJVk=","revision":"cc2f4770f4d61871e19bfee967bc767fe730b0d9","revisionTime":"2016-03-29T13:52:53Z"},
-		{"path":"github.com/Jeffail/gabs","checksumSHA1":"eMJfN1SwbCz+TlmfzFRye82uhks=","revision":"7a0fed31069aba77993a518cc2f37b28ee7aa883","revisionTime":"2018-04-20T20:36:15Z"},
-		{"path":"github.com/Microsoft/go-winio","checksumSHA1":"AzjRkOQtVBTwIw4RJLTygFhJs3s=","revision":"c4dc1301f1dc0307acd38e611aa375a64dfe0642","revisionTime":"2017-07-12T04:46:15Z"},
-		{"path":"github.com/NYTimes/gziphandler","checksumSHA1":"GM+KgxfAv3HJdtffkEPpegaFxe0=","revision":"2600fb119af974220d3916a5916d6e31176aac1b","revisionTime":"2018-02-20T23:40:21Z","version":"v1.0.1","versionExact":"v1.0.1"},
-		{"path":"github.com/SAP/go-hdb/driver","checksumSHA1":"S+XkdKo8fsJp/vDR86X751Vravw=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SAP/go-hdb/driver/sqltrace","checksumSHA1":"bpaEqnqXJDbw8jkMUsmMcjRKXX8=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SAP/go-hdb/internal/bufio","checksumSHA1":"x7mYiUM72JbTBRdo7g8PPQC/npU=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SAP/go-hdb/internal/protocol","checksumSHA1":"1YbXqtwKuO0cxSUlJ24zskfOepE=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SAP/go-hdb/internal/unicode","checksumSHA1":"KK2U+DbcpWBexg9ZMEKGRIaqFtU=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SAP/go-hdb/internal/unicode/cesu8","checksumSHA1":"fb432MWzL2ONS0e6HyGv3P2oG1I=","revision":"4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a","revisionTime":"2018-05-20T18:19:29Z"},
-		{"path":"github.com/SermoDigital/jose","checksumSHA1":"t+uej2kiyqRyQYguygI8t9nJH2w=","revision":"803625baeddc3526d01d321b5066029f53eafc81","revisionTime":"2018-01-04T20:38:59Z"},
-		{"path":"github.com/SermoDigital/jose/crypto","checksumSHA1":"u92C5yEz1FLBeoXp8jujn3tUNFI=","revision":"803625baeddc3526d01d321b5066029f53eafc81","revisionTime":"2018-01-04T20:38:59Z"},
-		{"path":"github.com/SermoDigital/jose/jws","checksumSHA1":"FJP5enLaw1JzZNu6Fen+eEKY7Lo=","revision":"803625baeddc3526d01d321b5066029f53eafc81","revisionTime":"2018-01-04T20:38:59Z"},
-		{"path":"github.com/SermoDigital/jose/jwt","checksumSHA1":"3gGGWQ3PcKHE+2cVlkJmIlBfBlw=","revision":"803625baeddc3526d01d321b5066029f53eafc81","revisionTime":"2018-01-04T20:38:59Z"},
-		{"path":"github.com/Sirupsen/logrus","checksumSHA1":"3WMNv4WlET5Vz4pfLKI+kHlZe7w=","revision":"92052687f8ec598ff0da626d2909478cfd1e3a3c","revisionTime":"2018-07-12T20:16:18Z"},
-		{"path":"github.com/StackExchange/wmi","checksumSHA1":"9NR0rrcAT5J76C5xMS4AVksS9o0=","revision":"e54cbda6595d7293a7a468ccf9525f6bc8887f99","revisionTime":"2016-08-11T21:45:55Z"},
-		{"path":"github.com/armon/circbuf","checksumSHA1":"l0iFqayYAaEip6Olaq3/LCOa/Sg=","revision":"bbbad097214e2918d8543d5201d12bfd7bca254d","revisionTime":"2015-08-27T00:49:46Z"},
-		{"path":"github.com/armon/go-metrics","checksumSHA1":"eiRzLoenl7oEVCuoT+Ju/zWBlKg=","revision":"783273d703149aaeb9897cf58613d5af48861c25","revisionTime":"2018-02-21T18:27:44Z"},
-		{"path":"github.com/armon/go-metrics/circonus","checksumSHA1":"xCsGGM9TKBogZDfSN536KtQdLko=","revision":"783273d703149aaeb9897cf58613d5af48861c25","revisionTime":"2018-02-21T18:27:44Z"},
-		{"path":"github.com/armon/go-metrics/datadog","checksumSHA1":"Dt0n1sSivvvdZQdzc4Hu/yOG+T0=","revision":"783273d703149aaeb9897cf58613d5af48861c25","revisionTime":"2018-02-21T18:27:44Z"},
-		{"path":"github.com/armon/go-metrics/prometheus","checksumSHA1":"XfPPXw55zKziOWnZbkEGEJ96O9c=","revision":"783273d703149aaeb9897cf58613d5af48861c25","revisionTime":"2018-02-21T18:27:44Z"},
-		{"path":"github.com/armon/go-radix","checksumSHA1":"gNO0JNpLzYOdInGeq7HqMZUzx9M=","revision":"4239b77079c7b5d1243b7b4736304ce8ddb6f0f2","revisionTime":"2016-01-15T23:47:25Z"},
-		{"path":"github.com/asaskevich/govalidator","checksumSHA1":"kChwmKazQLFun0USpBail+TyUYI=","revision":"7d2e70ef918f16bd6455529af38304d6d025c952","revisionTime":"2018-03-19T08:16:51Z"},
-		{"path":"github.com/beorn7/perks/quantile","checksumSHA1":"0rido7hYHQtfq3UJzVT5LClLAWc=","revision":"3a771d992973f24aa725d07868b467d1ddfceafb","revisionTime":"2018-03-21T16:47:47Z"},
-		{"path":"github.com/bgentry/speakeasy","checksumSHA1":"dvd7Su+WNmHRP1+w1HezrPUCDsc=","revision":"e1439544d8ecd0f3e9373a636d447668096a8f81","revisionTime":"2016-05-20T23:26:10Z"},
-		{"path":"github.com/bgentry/speakeasy/example","checksumSHA1":"twtRfb6484vfr2qqjiFkLThTjcQ=","revision":"e1439544d8ecd0f3e9373a636d447668096a8f81","revisionTime":"2016-05-20T23:26:10Z"},
-		{"path":"github.com/boltdb/bolt","checksumSHA1":"R1Q34Pfnt197F/nCOO9kG8c+Z90=","revision":"2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8","revisionTime":"2017-07-17T17:11:48Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics","checksumSHA1":"szvY4u7TlXkrQ3PW8wmyJaIFy0U=","revision":"d17a8420c36e800fcb46bbd4d2a15b93c68605ea","revisionTime":"2016-11-09T19:23:37Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/api","checksumSHA1":"WUE6oF152uN5FcLmmq+nO3Yl7pU=","revision":"d17a8420c36e800fcb46bbd4d2a15b93c68605ea","revisionTime":"2016-11-09T19:23:37Z"},
-		{"path":"github.com/circonus-labs/circonus-gometrics/checkmgr","checksumSHA1":"beRBHHy2+V6Ht4cACIMmZOCnzgg=","revision":"d17a8420c36e800fcb46bbd4d2a15b93c68605ea","revisionTime":"2016-11-09T19:23:37Z"},
-		{"path":"github.com/circonus-labs/circonusllhist","checksumSHA1":"C4Z7+l5GOpOCW5DcvNYzheGvQRE=","revision":"365d370cc1459bdcaceda3499453668373dea1d0","revisionTime":"2016-11-10T00:26:50Z"},
-		{"path":"github.com/coredns/coredns/plugin/pkg/dnsutil","checksumSHA1":"EoOyMf0m3NkVWRxJ4jGUSkVCM8c=","revision":"582f91f3f3aa0b956c152b72ad9c95b8f597a2b0","revisionTime":"2018-04-23T12:44:33Z","version":"v1.1.2","versionExact":"v1.1.2"},
-		{"path":"github.com/davecgh/go-spew/spew","checksumSHA1":"dvabztWVQX8f6oMLRyv4dLH+TGY=","revision":"346938d642f2ec3594ed81d874461961cd0faa76","revisionTime":"2016-10-29T20:57:26Z"},
-		{"path":"github.com/denisenkom/go-mssqldb","checksumSHA1":"MrqqjNxb8plNG+QSHMsihMHgJT4=","revision":"94c9c97e8c9f9844d15c846854a7a6031ae2132c","revisionTime":"2018-06-20T03:28:04Z"},
-		{"path":"github.com/denisenkom/go-mssqldb/internal/cp","checksumSHA1":"wu8t19t2rmyrrfDfdu9v7f/+iag=","revision":"94c9c97e8c9f9844d15c846854a7a6031ae2132c","revisionTime":"2018-06-20T03:28:04Z"},
-		{"path":"github.com/dgrijalva/jwt-go","checksumSHA1":"mUeojTdLEyzYOki70VUAeeYr/wQ=","revision":"0b96aaa707760d6ab28d9b9d1913ff5993328bae","revisionTime":"2018-07-19T21:18:23Z"},
-		{"path":"github.com/docker/go-connections/sockets","checksumSHA1":"jUfDG3VQsA2UZHvvIXncgiddpYA=","revision":"3ede32e2033de7505e6500d6c868c2b9ed9f169d","revisionTime":"2017-06-23T20:36:43Z"},
-		{"path":"github.com/elazarl/go-bindata-assetfs","checksumSHA1":"5ftkjfUwI9A6xCQ1PwIAd5+qlo0=","revision":"e1a2a7ec64b07d04ac9ebb072404fe8b7b60de1b","revisionTime":"2016-08-03T19:23:04Z"},
-		{"path":"github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs","checksumSHA1":"CaThXbumVxZtNlItiXma5B78PwQ=","revision":"e1a2a7ec64b07d04ac9ebb072404fe8b7b60de1b","revisionTime":"2016-08-03T19:23:04Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2","checksumSHA1":"FSibauI37HqkJE62OqfFK3A9Ih0=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/auth","checksumSHA1":"MxMRiqLMQ6tZc2DXaFk8RpzZJ1k=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster","checksumSHA1":"ktA2ACmea64sl2j4C7ROuDjxwhs=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/core","checksumSHA1":"CS7onQ+gKubxzzFNrv2vsnpeg6o=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint","checksumSHA1":"XXTFdEmQ4Z87HD4AM1JRCGAEfmU=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/listener","checksumSHA1":"y9mv2tvEpzDmB3VJkwNpaNlRBmU=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/api/v2/route","checksumSHA1":"6rAy2/Yv/q73ZKyowBkNwekOyq4=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2","checksumSHA1":"wic3APn/uIE4QJ4T2VLrik4Dp74=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/config/filter/network/ext_authz/v2","checksumSHA1":"xMDMWQ3xIuECIxAtMtejMCQb2h4=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2","checksumSHA1":"aOroSRMbYtLr7X2MpiQi4p+6NBw=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2","checksumSHA1":"TTgpFT45GfVXcGje4qGCssF+LxI=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha","checksumSHA1":"2J3zPDTsC3HtOc6RDCWf2TALvfc=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2","checksumSHA1":"3DwfQPZMC1i4ZrvpB2mMZRZ7SHI=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/envoy/type","checksumSHA1":"8DtGIr6Z3Alnd5s+htx1MgDZVoo=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/pkg/cache","checksumSHA1":"hAUeY2SDlc1qkYBal5DtrlKkPyM=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/pkg/log","checksumSHA1":"dS2Ygpy2UCR0+3pDbQ044t/Bzew=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/pkg/server","checksumSHA1":"V0F+pAe0C96OntiM4PC+nL4ff8o=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/envoyproxy/go-control-plane/pkg/util","checksumSHA1":"wSN1NcSo9HdIigbVddGZ5xVxnzo=","revision":"2137d919632883e52e7786f55f0f84e52a44fbf3","revisionTime":"2018-09-19T00:28:55Z"},
-		{"path":"github.com/fatih/structs","checksumSHA1":"5BP5xofo0GoFi6FtgqFFbmHyUKI=","revision":"ebf56d35bba727c68ac77f56f2fcf90b181851aa","revisionTime":"2018-01-23T06:50:59Z"},
-		{"path":"github.com/ghodss/yaml","checksumSHA1":"nlMa0NX11OCS5UHuJszVGTBboWU=","revision":"c7ce16629ff4cd059ed96ed06419dd3856fd3577","revisionTime":"2018-08-20T08:47:58Z"},
-		{"path":"github.com/go-ole/go-ole","checksumSHA1":"oyULO1B/l2OLy2xereo+2w3hYk4=","revision":"02d3668a0cf01f58411cc85cd37c174c257ec7c2","revisionTime":"2017-06-01T13:56:11Z"},
-		{"path":"github.com/go-ole/go-ole/oleutil","checksumSHA1":"IvdiJE1NIogRmGi3WmteEKZQJB8=","revision":"5e9c030faf78847db7aa77e3661b9cc449de29b7","revisionTime":"2016-11-16T06:46:58Z"},
-		{"path":"github.com/go-sql-driver/mysql","checksumSHA1":"KsRquwj2mj2bxCjHfcnTG3GAmlA=","revision":"749ddf1598b47e3cd909414bda735fe790ef3d30","revisionTime":"2018-06-18T11:59:01Z"},
-		{"path":"github.com/gocql/gocql","checksumSHA1":"tT9gdr1U1+E1WDXHNGQcaQuq2BQ=","revision":"e06f8c1bcd787e6bf0608288b314522f08cc7848","revisionTime":"2018-06-17T11:57:10Z"},
-		{"path":"github.com/gocql/gocql/internal/lru","checksumSHA1":"7RlYIbPYgPkxDDCSEuE6bvYEEeU=","revision":"e06f8c1bcd787e6bf0608288b314522f08cc7848","revisionTime":"2018-06-17T11:57:10Z"},
-		{"path":"github.com/gocql/gocql/internal/murmur","checksumSHA1":"1D3fnN8dRoLJxWKxKGGCfz6cJXg=","revision":"e06f8c1bcd787e6bf0608288b314522f08cc7848","revisionTime":"2018-06-17T11:57:10Z"},
-		{"path":"github.com/gocql/gocql/internal/streams","checksumSHA1":"5GTGKm0C5aLdu9tynZQWQEQqRes=","revision":"e06f8c1bcd787e6bf0608288b314522f08cc7848","revisionTime":"2018-06-17T11:57:10Z"},
-		{"path":"github.com/gogo/googleapis/google/api","checksumSHA1":"Dkuhvi5lEltaq1PmJmDTSi+09nU=","revision":"8558fb44d2f1fc223118afc694129d2c2d2924d1","revisionTime":"2018-08-13T11:20:41Z"},
-		{"path":"github.com/gogo/googleapis/google/rpc","checksumSHA1":"fjbiOYNq9Dmp9Bx3xMoQFWuoKaM=","revision":"8558fb44d2f1fc223118afc694129d2c2d2924d1","revisionTime":"2018-08-13T11:20:41Z"},
-		{"path":"github.com/gogo/protobuf/gogoproto","checksumSHA1":"FhEC1RwKSm/8jvTI2MKlzDVz+Vs=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/gogo/protobuf/jsonpb","checksumSHA1":"ElpAMJyh/b5cUiFCJ+MjtKYfFAo=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/gogo/protobuf/proto","checksumSHA1":"47nJ3iu1bVvK9jPXwAinFYr4mBU=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/gogo/protobuf/protoc-gen-gogo/descriptor","checksumSHA1":"4R7X2wRYYOxdXsoXOEcyBoCakb8=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/gogo/protobuf/sortkeys","checksumSHA1":"HPVQZu059/Rfw2bAWM538bVTcUc=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/gogo/protobuf/types","checksumSHA1":"yK31P3hm7p5eA5PczMByhK0Tj2U=","revision":"e14cafb6a2c249986e51c4b65c3206bf18578715","revisionTime":"2018-09-14T05:40:05Z"},
-		{"path":"github.com/golang/glog","checksumSHA1":"HmbftipkadrLlCfzzVQ+iFHbl6g=","revision":"23def4e6c14b4da8ac2ed8007337bc5eb5007998","revisionTime":"2016-01-25T20:49:56Z"},
-		{"path":"github.com/golang/protobuf/proto","checksumSHA1":"Pyou8mceOASSFxc7GeXZuVdSMi0=","revision":"b4deda0973fb4c70b50d226b1af49f3da59f5265","revisionTime":"2018-04-30T18:52:41Z","version":"v1.1.0","versionExact":"v1.1.0"},
-		{"path":"github.com/golang/protobuf/protoc-gen-go/descriptor","checksumSHA1":"fXNL9CT3MIlkdLUCn83Aon7QVAU=","revision":"7716a980bceefe9a0213654823d9ea62d23b87a2","revisionTime":"2018-09-19T22:46:59Z"},
-		{"path":"github.com/golang/protobuf/ptypes","checksumSHA1":"VfkiItDBFFkZluaAMAzJipDXNBY=","revision":"1e59b77b52bf8e4b449a57e6f79f21226d571845","revisionTime":"2017-11-13T18:07:20Z"},
-		{"path":"github.com/golang/protobuf/ptypes/any","checksumSHA1":"UB9scpDxeFjQe5tEthuR4zCLRu4=","revision":"1e59b77b52bf8e4b449a57e6f79f21226d571845","revisionTime":"2017-11-13T18:07:20Z"},
-		{"path":"github.com/golang/protobuf/ptypes/duration","checksumSHA1":"hUjAj0dheFVDl84BAnSWj9qy2iY=","revision":"1e59b77b52bf8e4b449a57e6f79f21226d571845","revisionTime":"2017-11-13T18:07:20Z"},
-		{"path":"github.com/golang/protobuf/ptypes/timestamp","checksumSHA1":"O2ItP5rmfrgxPufhjJXbFlXuyL8=","revision":"1e59b77b52bf8e4b449a57e6f79f21226d571845","revisionTime":"2017-11-13T18:07:20Z"},
-		{"path":"github.com/golang/snappy","checksumSHA1":"h1d2lPZf6j2dW/mIqVnd1RdykDo=","revision":"2e65f85255dbc3072edf28d6b5b8efc472979f5a","revisionTime":"2018-05-18T05:39:59Z"},
-		{"path":"github.com/google/btree","checksumSHA1":"cervgtZmEhshueHN64+ILdFHmEE=","revision":"4030bb1f1f0c35b30ca7009e9ebd06849dd45306","revisionTime":"2018-08-13T15:31:12Z"},
-		{"path":"github.com/google/gofuzz","checksumSHA1":"PFtXkXPO7pwRtykVUUXtc07wc7U=","revision":"24818f796faf91cd76ec7bddd72458fbced7a6c1","revisionTime":"2017-06-12T17:47:53Z"},
-		{"path":"github.com/googleapis/gnostic/OpenAPIv2","checksumSHA1":"b7x/5HeWIHXwSRNED5Envt6tRjs=","revision":"48a0ecefe2e4190c7a2d63b477875854a2f993b3","revisionTime":"2018-05-20T01:50:35Z"},
-		{"path":"github.com/googleapis/gnostic/compiler","checksumSHA1":"IW1cHbutRLvkUTJ1QkqSjsu65bY=","revision":"48a0ecefe2e4190c7a2d63b477875854a2f993b3","revisionTime":"2018-05-20T01:50:35Z"},
-		{"path":"github.com/googleapis/gnostic/extensions","checksumSHA1":"c2QLSomDNNOk7t6Psq4cDLUDX98=","revision":"48a0ecefe2e4190c7a2d63b477875854a2f993b3","revisionTime":"2018-05-20T01:50:35Z"},
-		{"path":"github.com/gophercloud/gophercloud","checksumSHA1":"Zcapl92yLsRGDnDfmD5BMZrU0i8=","revision":"03a4c443e006c8e309fb15b3406dfc352a5f118f","revisionTime":"2018-09-05T21:52:14Z"},
-		{"path":"github.com/gophercloud/gophercloud/openstack","checksumSHA1":"WAu+jx7c6kshm05B/W34gpzw148=","revision":"03a4c443e006c8e309fb15b3406dfc352a5f118f","revisionTime":"2018-09-05T21:52:14Z"},
-		{"path":"github.com/gophercloud/gophercloud/openstack/compute/v2/servers","checksumSHA1":"BzQbqNKKDkIHN+1G6sRsMeWz4Zs=","revision":"03a4c443e006c8e309fb15b3406dfc352a5f118f","revisionTime":"2018-09-05T21:52:14Z"},
-		{"path":"github.com/gophercloud/gophercloud/pagination","checksumSHA1":"YspETi3tOMvawKIT91HyuqaA5lM=","revision":"03a4c443e006c8e309fb15b3406dfc352a5f118f","revisionTime":"2018-09-05T21:52:14Z"},
-		{"path":"github.com/gregjones/httpcache","checksumSHA1":"T1uAtgdoQP82t1GaT1eZjhYmFmM=","revision":"9cad4c3443a7200dd6400aef47183728de563a38","revisionTime":"2018-03-05T23:10:24Z"},
-		{"path":"github.com/gregjones/httpcache/diskcache","checksumSHA1":"A+TX1jxqy7iWvcb9ZldoG1b5SsY=","revision":"9cad4c3443a7200dd6400aef47183728de563a38","revisionTime":"2018-03-05T23:10:24Z"},
-		{"path":"github.com/hailocab/go-hostpool","checksumSHA1":"O0r0hj4YL+jSRNjnshkeH4GY+4s=","revision":"e80d13ce29ede4452c43dea11e79b9bc8a15b478","revisionTime":"2016-01-25T11:53:50Z"},
-		{"path":"github.com/hashicorp/errwrap","checksumSHA1":"cdOCt0Yb+hdErz8NAQqayxPmRsY=","revision":"7554cd9344cec97297fa6649b055a8c98c2a1e55","revisionTime":"2014-10-28T05:47:10Z"},
-		{"path":"github.com/hashicorp/go-checkpoint","checksumSHA1":"D267IUMW2rcb+vNe3QU+xhfSrgY=","revision":"1545e56e46dec3bba264e41fde2c1e2aa65b5dd4","revisionTime":"2017-10-09T17:35:28Z"},
-		{"path":"github.com/hashicorp/go-cleanhttp","checksumSHA1":"YAq1rqZIp+M74Q+jMBQkkMKm3VM=","revision":"d5fe4b57a186c716b0e00b8c301cbd9b4182694d","revisionTime":"2017-12-18T14:54:08Z"},
-		{"path":"github.com/hashicorp/go-discover","checksumSHA1":"qJN0TixDHZdaP3z110+oNszPlUg=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/aliyun","checksumSHA1":"Jww5zrDwjMoFF31RqBapilTdi18=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/aws","checksumSHA1":"Vit45xRjrJ6h7IGJndrBjodVUAE=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/azure","checksumSHA1":"dMU80T10KQFZNqpBBjzf7ymFNBw=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/digitalocean","checksumSHA1":"TthiY6qza4DnHPLXBq7re5ngNOY=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/gce","checksumSHA1":"bQHkaF9dUFUYJLQ0MkVLIlCIVaE=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/k8s","checksumSHA1":"z2HYgfd2QRA5/ciDKgqayGb5bNw=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/os","checksumSHA1":"SbPabgJWHX8uVsLwlGqpVLs20XU=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/packet","checksumSHA1":"y19sWSVrdVfzaRGPS3NcLWe4FpU=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/scaleway","checksumSHA1":"amLxw8GikdQQ2U+HT1+GzdZG3Dw=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/softlayer","checksumSHA1":"SIyZ44AHIUTBfI336ACpCeybsLg=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z","tree":true},
-		{"path":"github.com/hashicorp/go-discover/provider/triton","checksumSHA1":"OmBrnagVa2akyR9nbQjia28lunE=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z"},
-		{"path":"github.com/hashicorp/go-discover/provider/vsphere","checksumSHA1":"s5lxWYL2UiEeOksa3DVEYWJsH1I=","revision":"f9c9239562a8e21e5a37f1f2604d8f1c11bc3893","revisionTime":"2018-08-31T15:49:06Z"},
-		{"path":"github.com/hashicorp/go-hclog","checksumSHA1":"qhjAx0nMYBeQqRTaf7sQYpfUIq0=","revision":"69ff559dc25f3b435631604f573a5fa1efdb6433","revisionTime":"2018-04-02T20:04:05Z"},
-		{"path":"github.com/hashicorp/go-immutable-radix","checksumSHA1":"Cas2nprG6pWzf05A2F/OlnjUu2Y=","revision":"8aac2701530899b64bdea735a1de8da899815220","revisionTime":"2017-07-25T22:12:15Z"},
-		{"path":"github.com/hashicorp/go-memdb","checksumSHA1":"4Ge4Vvtbyhb5nN3o+7Vq0Za8i8U=","revision":"1289e7fffe71d8fd4d4d491ba9a412c50f244c44","revisionTime":"2018-02-23T23:30:45Z"},
-		{"path":"github.com/hashicorp/go-msgpack/codec","checksumSHA1":"TNlVzNR1OaajcNi3CbQ3bGbaLGU=","revision":"fa3f63826f7c23912c15263591e65d54d080b458","revisionTime":"2015-05-18T23:42:57Z"},
-		{"path":"github.com/hashicorp/go-multierror","checksumSHA1":"lrSl49G23l6NhfilxPM0XFs5rZo=","revision":"d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5","revisionTime":"2015-09-16T20:57:42Z"},
-		{"path":"github.com/hashicorp/go-plugin","checksumSHA1":"lbG9uwM7qJlTIBg+8mjCC88sCPc=","revision":"e8d22c780116115ae5624720c9af0c97afe4f551","revisionTime":"2018-03-31T00:25:53Z"},
-		{"path":"github.com/hashicorp/go-retryablehttp","checksumSHA1":"s6mKR1dSKP04+A3kwSsFr/PvsOU=","revision":"3b087ef2d313afe6c55b2f511d20db04ca767075","revisionTime":"2018-05-31T21:13:21Z"},
-		{"path":"github.com/hashicorp/go-rootcerts","checksumSHA1":"A1PcINvF3UiwHRKn8UcgARgvGRs=","revision":"6bb64b370b90e7ef1fa532be9e591a81c3493e00","revisionTime":"2016-05-03T14:34:40Z"},
-		{"path":"github.com/hashicorp/go-sockaddr","checksumSHA1":"J47ySO1q0gcnmoMnir1q1loKzCk=","revision":"e92cdb5343bbaf42b0a596937ae0f382270d6759","revisionTime":"2019-01-03T21:41:36Z"},
-		{"path":"github.com/hashicorp/go-sockaddr/template","checksumSHA1":"PDp9DVLvf3KWxhs4G4DpIwauMSU=","revision":"9b4c5fa5b10a683339a270d664474b9f4aee62fc","revisionTime":"2017-10-30T10:43:12Z"},
-		{"path":"github.com/hashicorp/go-syslog","checksumSHA1":"xZ7Ban1x//6uUIU1xtrTbCYNHBc=","revision":"42a2b573b664dbf281bd48c3cc12c086b17a39ba","revisionTime":"2015-02-18T18:19:46Z"},
-		{"path":"github.com/hashicorp/go-uuid","checksumSHA1":"mAkPa/RLuIwN53GbwIEMATexams=","revision":"64130c7a86d732268a38cb04cfbaf0cc987fda98","revisionTime":"2016-07-17T02:21:40Z"},
-		{"path":"github.com/hashicorp/go-version","checksumSHA1":"tUGxc7rfX0cmhOOUDhMuAZ9rWsA=","revision":"03c5bf6be031b6dd45afec16b1cf94fc8938bc77","revisionTime":"2017-02-02T08:07:59Z"},
-		{"path":"github.com/hashicorp/golang-lru","checksumSHA1":"d9PxF1XQGLMJZRct2R8qVM/eYlE=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
-		{"path":"github.com/hashicorp/golang-lru/simplelru","checksumSHA1":"2nOpYjx8Sn57bqlZq17yM4YJuM4=","revision":"a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4","revisionTime":"2016-02-07T21:47:19Z"},
-		{"path":"github.com/hashicorp/hcl","checksumSHA1":"bWGI7DqWg6IdhfamV96OD+Esa+8=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/ast","checksumSHA1":"XQmjDva9JCGGkIecOgwtBEMCJhU=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/parser","checksumSHA1":"1GmX7G0Pgf5XprOh+T3zXMXX0dc=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/printer","checksumSHA1":"encY+ZtDf4nJaMvsVL2c+EJ2r3Q=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/scanner","checksumSHA1":"+qJTCxhkwC7r+VZlPlZz8S74KmU=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/strconv","checksumSHA1":"oS3SCN9Wd6D8/LG0Yx1fu84a7gI=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/hcl/token","checksumSHA1":"c6yprzj06ASwCo18TtbbNNBHljA=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/json/parser","checksumSHA1":"PwlfXt7mFS8UYzWxOK5DOq0yxS0=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/json/scanner","checksumSHA1":"afrZ8VmAwfTdDAYVgNSXbxa4GsA=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hcl/json/token","checksumSHA1":"fNlXQCQEnb+B3k5UDL/r15xtSJY=","revision":"65a6292f0157eff210d03ed1bf6c59b190b8b906","revisionTime":"2018-09-06T18:38:39Z"},
-		{"path":"github.com/hashicorp/hil","checksumSHA1":"kqCMCHy2b+RBMKC+ER+OPqp8C3E=","revision":"1e86c6b523c55d1fa6c6e930ce80b548664c95c2","revisionTime":"2016-07-11T23:18:37Z"},
-		{"path":"github.com/hashicorp/hil/ast","checksumSHA1":"UICubs001+Q4MsUf9zl2vcMzWQQ=","revision":"1e86c6b523c55d1fa6c6e930ce80b548664c95c2","revisionTime":"2016-07-11T23:18:37Z"},
-		{"path":"github.com/hashicorp/logutils","checksumSHA1":"vt+P9D2yWDO3gdvdgCzwqunlhxU=","revision":"0dc08b1671f34c4250ce212759ebd880f743d883","revisionTime":"2015-06-09T07:04:31Z"},
-		{"path":"github.com/hashicorp/memberlist","checksumSHA1":"j4pWTjW3SFOPVwWBEZPuNHETnLE=","revision":"b38abf62d7f3ce5225722cd62a90cfb098e02519","revisionTime":"2019-02-04T18:04:39Z"},
-		{"path":"github.com/hashicorp/net-rpc-msgpackrpc","checksumSHA1":"qnlqWJYV81ENr61SZk9c65R1mDo=","revision":"a14192a58a694c123d8fe5481d4a4727d6ae82f3","revisionTime":"2015-11-16T02:03:38Z"},
-		{"path":"github.com/hashicorp/raft","checksumSHA1":"3U9bQLEMikE47n4TZP6uOdgXIyQ=","revision":"da92cfe76e0c1c9b94bbc9d884ec4b2b3b90b699","revisionTime":"2018-08-17T18:12:11Z","version":"master","versionExact":"master"},
-		{"path":"github.com/hashicorp/raft-boltdb","checksumSHA1":"QAxukkv54/iIvLfsUP6IK4R0m/A=","revision":"d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee","revisionTime":"2015-02-01T20:08:39Z"},
-		{"path":"github.com/hashicorp/serf/coordinate","checksumSHA1":"0PeWsO2aI+2PgVYlYlDPKfzCLEQ=","revision":"65da6f27f6e551e03d99364ecc0607e91e526b00","revisionTime":"2019-01-22T20:12:06Z"},
-		{"path":"github.com/hashicorp/serf/serf","checksumSHA1":"zXQ+WC7vYZLkqqM38dtDQ2Erv0E=","revision":"65da6f27f6e551e03d99364ecc0607e91e526b00","revisionTime":"2019-01-22T20:12:06Z"},
-		{"path":"github.com/hashicorp/vault/api","checksumSHA1":"LYQZ+o7zJCda/6LibdN0spFco34=","revision":"533003e27840d9646cb4e7d23b3a113895da1dd0","revisionTime":"2018-06-20T14:55:40Z","version":"v0.10.3","versionExact":"v0.10.3"},
-		{"path":"github.com/hashicorp/vault/audit","checksumSHA1":"2JOC+Ur0S3U8Gqv2cfNB3zxgSBk=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/builtin/logical/database/dbplugin","checksumSHA1":"RCwWixWwKG6j2vF9iVoxbCzo6p4=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/builtin/logical/pki","checksumSHA1":"Cq4SMVoiZkSOd4l7wZ8cw3YQI+I=","revision":"533003e27840d9646cb4e7d23b3a113895da1dd0","revisionTime":"2018-06-20T14:55:40Z","version":"v0.10.3","versionExact":"v0.10.3"},
-		{"path":"github.com/hashicorp/vault/helper/builtinplugins","checksumSHA1":"0EEhZk5anF4d8t2npA3/AKer94s=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/certutil","checksumSHA1":"o9nAIkUO5M1KKFetcqhG1+XXvgg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/compressutil","checksumSHA1":"bSdPFOHaTwEvM4PIvn0PZfn75jM=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/consts","checksumSHA1":"hMn73ZxhFAqTEM6fgD7r9/1Hbww=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/dbtxn","checksumSHA1":"PWiX5fkg8bajP3fmJL0a92pOlfg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/errutil","checksumSHA1":"fuAZjiabZXVJ7ORLb0vjLOT4+iU=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/forwarding","checksumSHA1":"N/1l6Sppn/iRIFARuYlLkEZ9mqg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/hclutil","checksumSHA1":"RlqPBLOexQ0jj6jomhiompWKaUg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/identity","checksumSHA1":"efzomhX2afkZu64i+zqjhemg/6k=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/jsonutil","checksumSHA1":"POgkM3GrjRFw6H3sw95YNEs552A=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/kdf","checksumSHA1":"Dm8C/NfkwxHIpq27XJk1GOsRnus=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/keysutil","checksumSHA1":"HXFeJ9fHzeS58ZHnMqkMGDrtW44=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/locksutil","checksumSHA1":"kPLxfKd5d4TkHZLdtAs73hMrCfQ=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/logging","checksumSHA1":"53QmBPtb7u9ZMyEApCGOISsLqbs=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/mlock","checksumSHA1":"0hby54fDnmZc1vWBF2TUCHCnLdc=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/parseutil","checksumSHA1":"zPHu2orsbQqIuiuQ/8elJIUR2Po=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/pathmanager","checksumSHA1":"lcB1+PpXYpMmK9P+Bf0EuaTVi1c=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/pgpkeys","checksumSHA1":"EPOFuDrCcLPwHZNgaCve5N7i2wU=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/pluginutil","checksumSHA1":"duVuK2lg3M9jypeWCPZJXSwPjbg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/policyutil","checksumSHA1":"tVBKLYwF7ZlbwzhAT9/RvVeuPL0=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/reload","checksumSHA1":"f0Hl9+yjkKA6Wsg+1lsFIER9R4I=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/salt","checksumSHA1":"Jo4HS6vAXhZgkBO+LgozpIUlFfQ=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/storagepacker","checksumSHA1":"t5GgJx+N2gkJ0EAOv7Bpir1k0Jc=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/strutil","checksumSHA1":"iwXQDzHqTFsjJW2ehYae0oLo2Ts=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/tlsutil","checksumSHA1":"3j8u5mMkRfs+YG0viUIFPqDWeJc=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/wrapping","checksumSHA1":"GAi7Opzj6QqWATlYBqrAcchGunw=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/helper/xor","checksumSHA1":"c66DHHA2+FAVq7pFPqy3/VXBRrk=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/http","checksumSHA1":"ffJDFnCLEl5u0xyTY9lWZTd52UE=","revision":"533003e27840d9646cb4e7d23b3a113895da1dd0","revisionTime":"2018-06-20T14:55:40Z","version":"v0.10.3","versionExact":"v0.10.3"},
-		{"path":"github.com/hashicorp/vault/logical","checksumSHA1":"Apg+J1aimN8xfNh1wi90sbY3BlU=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/logical/framework","checksumSHA1":"dmdJnpLGiLsUkxFeuPFjhQV6zIw=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/physical","checksumSHA1":"nY+zDPf6xwkJhvhMpn3yPgjkTco=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/physical/inmem","checksumSHA1":"2k8WQEW1/3b7yxzCw7GtaRAXX+U=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins","checksumSHA1":"so/TDbUxS8q3lGVcvmPGhoVSjnA=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/cassandra","checksumSHA1":"UejID1TCiSinNGvsjiXG2k6yN8E=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/hana","checksumSHA1":"HEFzFaIJ/S4M7y5OFaeaCABYlzg=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/mongodb","checksumSHA1":"wi1tCfc4QieD70+53/BQXRYcY7I=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/mssql","checksumSHA1":"2IF6rWeBM5/AYCvSaWwp/wcIrDw=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/mysql","checksumSHA1":"TaDNmuhhN1eYp45HPI3KZ6lGdio=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/database/postgresql","checksumSHA1":"ajw/HnXt19AOcfALJc71j3OKnZs=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/helper/database/connutil","checksumSHA1":"aZNqbMefIEk6uArnrIhP0Xq5ymc=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/helper/database/credsutil","checksumSHA1":"93U0UimNWRv3iVVSNf+yAAhi51A=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/plugins/helper/database/dbutil","checksumSHA1":"3aKAlts9VJzYH/TX3I+4WkLlrvs=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/shamir","checksumSHA1":"WsYazSLKu3ads8U1NxnGl4y0Ib8=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/vault/vault","checksumSHA1":"RWsMbaFcvqlE9Gmqc2IBgUs/GKI=","revision":"533003e27840d9646cb4e7d23b3a113895da1dd0","revisionTime":"2018-06-20T14:55:40Z","version":"v0.10.3","versionExact":"v0.10.3"},
-		{"path":"github.com/hashicorp/vault/version","checksumSHA1":"H9VzUv8o4ov6XoyXP3JjteY3HkM=","revision":"c737968235c8673b872350f0a047877bee396342","revisionTime":"2018-06-20T16:45:32Z"},
-		{"path":"github.com/hashicorp/yamux","checksumSHA1":"jJouEcBeEAO0ejDRJoT67jL8NjQ=","revision":"3520598351bb3500a49ae9563f5539666ae0a27c","revisionTime":"2018-06-04T19:48:46Z"},
-		{"path":"github.com/imdario/mergo","checksumSHA1":"3LWNcQT7yTaLpEmjhI/3fi8puv0=","revision":"9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4","revisionTime":"2018-07-30T21:26:40Z"},
-		{"path":"github.com/jefferai/jsonx","checksumSHA1":"cIinEjB62s8j5cpY1u7sxtg4akg=","revision":"9cc31c3135eef39b8e72585f37efa92b6ca314d0","revisionTime":"2016-07-21T23:51:17Z"},
-		{"path":"github.com/joyent/triton-go","checksumSHA1":"LuvUVcxSYc0KkzpqNJArgiPMtNU=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
-		{"path":"github.com/joyent/triton-go/authentication","checksumSHA1":"yNrArK8kjkVkU0bunKlemd6dFkE=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
-		{"path":"github.com/joyent/triton-go/client","checksumSHA1":"nppv6i9E2yqdbQ6qJkahCwELSeI=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
-		{"path":"github.com/joyent/triton-go/compute","checksumSHA1":"PTwWWEFRC4GzXM91gQj5xBMF3GM=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
-		{"path":"github.com/joyent/triton-go/errors","checksumSHA1":"d/Py6j/uMgOAFNFGpsQrNnSsO+k=","revision":"7283d1d02f7a297bf2f068178a084c5bd090002c","revisionTime":"2018-04-27T15:22:50Z"},
-		{"path":"github.com/json-iterator/go","checksumSHA1":"WqeEgS7pqqkwK8mlrAZmDgtWJMY=","revision":"1624edc4454b8682399def8740d46db5e4362ba4","revisionTime":"2018-08-06T06:07:27Z"},
-		{"path":"github.com/keybase/go-crypto/brainpool","checksumSHA1":"VJk3rOWfxEV9Ilig5lgzH1qg8Ss=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/cast5","checksumSHA1":"rnRjEJs5luF+DIXp2J6LFcQk8Gg=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/curve25519","checksumSHA1":"F5++ZQS5Vt7hd6lxPCKTffvph1A=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/ed25519","checksumSHA1":"niLm+6SukuYgFJgnCuDd/KLgPjU=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/ed25519/internal/edwards25519","checksumSHA1":"oFj+c+T9/0PTmvpz1Vlx1L6aI98=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp","checksumSHA1":"DivaBvI1xAPAW+6y8hhcf1FaBFI=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/armor","checksumSHA1":"tin/wcIHur1IM0n5f5u8nlZ/J6U=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/ecdh","checksumSHA1":"nWhmwjBJqPSvkCWqaap2Z9EiS1k=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/elgamal","checksumSHA1":"uxXG9IC/XF8jwwvZUbW65+x8/+M=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/errors","checksumSHA1":"ofZhU2758YZAAGSEJ8UjFMQLc+k=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/packet","checksumSHA1":"T7jstUu+oy2AVhZT/Md7R2lY8LM=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/openpgp/s2k","checksumSHA1":"BGDxg1Xtsz0DSPzdQGJLLQqfYc8=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/keybase/go-crypto/rsa","checksumSHA1":"rE3pp7b3gfcmBregzpIvN5IdFhY=","revision":"5114a9a81e1b256bfe283702d45dad50f8bf5ddf","revisionTime":"2018-06-14T16:04:07Z"},
-		{"path":"github.com/kr/text","checksumSHA1":"SbguDK5lY8uhaHNrmJmNbiWIGM0=","revision":"e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f","revisionTime":"2018-05-06T08:24:08Z"},
-		{"path":"github.com/lib/pq","checksumSHA1":"s6eyIXpJ7VAU06FM27GcEBM/5lo=","revision":"90697d60dd844d5ef6ff15135d0203f65d2f53b8","revisionTime":"2018-05-23T17:54:26Z"},
-		{"path":"github.com/lib/pq/oid","checksumSHA1":"AU3fA8Sm33Vj9PBoRPSeYfxLRuE=","revision":"90697d60dd844d5ef6ff15135d0203f65d2f53b8","revisionTime":"2018-05-23T17:54:26Z"},
-		{"path":"github.com/lyft/protoc-gen-validate/validate","checksumSHA1":"+03cu5aBuyzbu0O/eArpD+DptPU=","revision":"64fcb82c878efbfe3240e4f164490eefaf6b3c4b","revisionTime":"2018-09-11T18:09:27Z"},
-		{"path":"github.com/mattn/go-isatty","checksumSHA1":"xZuhljnmBysJPta/lMyYmJdujCg=","revision":"66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8","revisionTime":"2016-08-06T12:27:52Z"},
-		{"path":"github.com/matttproud/golang_protobuf_extensions/pbutil","checksumSHA1":"bKMZjd2wPw13VwoE7mBeSv5djFA=","revision":"c12348ce28de40eed0136aa2b644d0ee0650e56c","revisionTime":"2016-04-24T11:30:07Z"},
-		{"path":"github.com/miekg/dns","checksumSHA1":"ybBd9oDdeJEZj9YmIKGqaBVqZok=","revision":"e57bf427e68187a27e22adceac868350d7a7079b","revisionTime":"2018-05-16T07:59:02Z","version":"v1.0.7","versionExact":"v1.0.7"},
-		{"path":"github.com/mitchellh/cli","checksumSHA1":"GzfpPGtV2UJH9hFsKwzGjKrhp/A=","revision":"dff723fff508858a44c1f4bd0911f00d73b0202f","revisionTime":"2017-09-05T22:10:09Z"},
-		{"path":"github.com/mitchellh/copystructure","checksumSHA1":"86nE93o1VIND0Doe8PuhCXnhUx0=","revision":"cdac8253d00f2ecf0a0b19fbff173a9a72de4f82","revisionTime":"2016-08-04T03:23:30Z"},
-		{"path":"github.com/mitchellh/go-homedir","checksumSHA1":"V/quM7+em2ByJbWBLOsEwnY3j/Q=","revision":"b8bc1bf767474819792c23f32d8286a45736f1c6","revisionTime":"2016-12-03T19:45:07Z"},
-		{"path":"github.com/mitchellh/go-testing-interface","checksumSHA1":"bDdhmDk8q6utWrccBhEOa6IoGkE=","revision":"a61a99592b77c9ba629d254a693acffaeb4b7e28","revisionTime":"2017-10-04T22:19:16Z"},
-		{"path":"github.com/mitchellh/hashstructure","checksumSHA1":"tWUjKyFOGJtYExocPWVYiXBYsfE=","revision":"2bca23e0e452137f789efbc8610126fd8b94f73b","revisionTime":"2017-06-09T04:59:27Z"},
-		{"path":"github.com/mitchellh/mapstructure","checksumSHA1":"7F5KalhUJ/sCH5bU44MMgw8tqNo=","revision":"5a380f224700b8a6c4eaad048804f5bff514cb35","revisionTime":"2018-10-01T02:14:42Z"},
-		{"path":"github.com/mitchellh/reflectwalk","checksumSHA1":"AMU63CNOg4XmIhVR/S/Xttt1/f0=","revision":"63d60e9d0dbc60cf9164e6510889b0db6683d98c","revisionTime":"2017-07-26T20:21:17Z"},
-		{"path":"github.com/modern-go/concurrent","checksumSHA1":"ZTcgWKWHsrX0RXYVXn5Xeb8Q0go=","revision":"bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94","revisionTime":"2018-03-06T01:26:44Z"},
-		{"path":"github.com/modern-go/reflect2","checksumSHA1":"qvH48wzTIV3QKSDqI0dLFtVjaDI=","revision":"94122c33edd36123c84d5368cfb2b69df93a0ec8","revisionTime":"2018-07-18T01:23:57Z"},
-		{"path":"github.com/oklog/run","checksumSHA1":"nf3UoPNBIut7BL9nWE8Fw2X2j+Q=","revision":"6934b124db28979da51d3470dadfa34d73d72652","revisionTime":"2018-03-08T00:51:04Z"},
-		{"path":"github.com/packethost/packngo","checksumSHA1":"Pp5neNys4egjuZoQ9IF3ll9zYaY=","revision":"b627120f2da509ca7ff76faf2bbdf6794d873616","revisionTime":"2018-07-12T12:50:00Z"},
-		{"path":"github.com/pascaldekloe/goe/verify","checksumSHA1":"5h+ERzHw3Rl2G0kFPxoJzxiA9s0=","revision":"07ebd1e2481f616a278ab431cf04cc5cf5ab3ebe","revisionTime":"2017-03-28T18:37:59Z"},
-		{"path":"github.com/patrickmn/go-cache","checksumSHA1":"JVGDxPn66bpe6xEiexs1r+y6jF0=","revision":"9f6ff22cfff829561052f5886ec80a2ac148b4eb","revisionTime":"2018-05-27T04:33:50Z"},
-		{"path":"github.com/peterbourgon/diskv","checksumSHA1":"1DFgH7ZOfpUqg0Jsf2719jVgrew=","revision":"0646ccaebea1ed1539efcab30cae44019090093f","revisionTime":"2018-03-12T05:41:25Z"},
-		{"path":"github.com/pkg/errors","checksumSHA1":"ynJSWoF6v+3zMnh9R0QmmG6iGV8=","revision":"ff09b135c25aae272398c51a07235b90a75aa4f0","revisionTime":"2017-03-16T20:15:38Z","tree":true},
-		{"path":"github.com/pmezard/go-difflib/difflib","checksumSHA1":"LuFv4/jlrmFNnDb/5SCSEPAM9vU=","revision":"792786c7400a136282c1664665ae0a8db921c6c2","revisionTime":"2016-01-10T10:55:54Z"},
-		{"path":"github.com/posener/complete","checksumSHA1":"Nt4Ol6ZM2n0XD5zatxjwEYBpQnw=","revision":"dc2bc5a81accba8782bebea28628224643a8286a","revisionTime":"2017-11-04T09:57:02Z","version":"=v1.1","versionExact":"v1.1"},
-		{"path":"github.com/prometheus/client_golang/prometheus","checksumSHA1":"I87tkF1e/hrl4d/XIKFfkPRq1ww=","revision":"f504d69affe11ec1ccb2e5948127f86878c9fd57","revisionTime":"2018-03-28T13:04:30Z"},
-		{"path":"github.com/prometheus/client_golang/prometheus/promhttp","checksumSHA1":"BM771aKU6hC+5rap48aqvMXczII=","revision":"f504d69affe11ec1ccb2e5948127f86878c9fd57","revisionTime":"2018-03-28T13:04:30Z"},
-		{"path":"github.com/prometheus/client_model/go","checksumSHA1":"DvwvOlPNAgRntBzt3b3OSRMS2N4=","revision":"99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c","revisionTime":"2017-11-17T10:05:41Z"},
-		{"path":"github.com/prometheus/common/expfmt","checksumSHA1":"+wZ+Pa6NX+NOxUvayXBXGOcqFe8=","revision":"38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a","revisionTime":"2018-03-26T16:04:09Z"},
-		{"path":"github.com/prometheus/common/model","checksumSHA1":"YU+/K48IMawQnToO4ETE6a+hhj4=","revision":"38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a","revisionTime":"2018-03-26T16:04:09Z"},
-		{"path":"github.com/prometheus/procfs","checksumSHA1":"Etvt6mgzvD7ARf4Ux03LHfgSlzU=","revision":"780932d4fbbe0e69b84c34c20f5c8d0981e109ea","revisionTime":"2018-03-21T23:08:12Z"},
-		{"path":"github.com/prometheus/procfs/nfs","checksumSHA1":"HSP5hVT0CNMRa8+Xtz4z2Ic5U0E=","revision":"8b1c2da0d56deffdbb9e48d4414b4e674bd8083e","revisionTime":"2018-04-08T09:29:02Z"},
-		{"path":"github.com/prometheus/procfs/xfs","checksumSHA1":"yItvTQLUVqm/ArLEbvEhqG0T5a0=","revision":"8b1c2da0d56deffdbb9e48d4414b4e674bd8083e","revisionTime":"2018-04-08T09:29:02Z"},
-		{"path":"github.com/ryanuber/columnize","checksumSHA1":"ExnVEVNT8APpFTm26cUb5T09yR4=","comment":"v2.0.1-8-g983d3a5","revision":"9b3edd62028f107d7cabb19353292afd29311a4e","revisionTime":"2016-07-12T16:32:29Z"},
-		{"path":"github.com/ryanuber/go-glob","checksumSHA1":"6JP37UqrI0H80Gpk0Y2P+KXgn5M=","revision":"256dc444b735e061061cf46c809487313d5b0065","revisionTime":"2017-01-28T01:21:29Z"},
-		{"path":"github.com/sean-/seed","checksumSHA1":"A/YUMbGg1LHIeK2+NLZBt+MIAao=","revision":"3c72d44db0c567f7c901f9c5da5fe68392227750","revisionTime":"2017-02-08T16:47:21Z"},
-		{"path":"github.com/shirou/gopsutil","checksumSHA1":"KUrV5Esg6Wdcrv+hDc6/p0Q3/qw=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/cpu","checksumSHA1":"ZRkivbqqxTXH267b+mFAEk55HRI=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/disk","checksumSHA1":"JRyOki26wb3vORGErYK95N4tAeQ=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/host","checksumSHA1":"j+lnhiTHzGU2/EOd2k2EceD7Mak=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/internal/common","checksumSHA1":"GR7l7Ez4ppxIfonl7aJayYRVPWc=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/mem","checksumSHA1":"ehcscnqRvxDZYb1nBDVzZi8vFi8=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/net","checksumSHA1":"wAc1Qo6T9MTYdSog78uJfCYZPtc=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/gopsutil/process","checksumSHA1":"eI4qh+sc46gqKAfBt2jspO2l448=","revision":"48177ef5f8809fc72b716c414435f2d4cff8e24d","revisionTime":"2018-11-07T11:16:21Z"},
-		{"path":"github.com/shirou/w32","checksumSHA1":"Nve7SpDmjsv6+rhkXAkfg/UQx94=","revision":"bb4de0191aa41b5507caa14b0650cdbddcd9280b","revisionTime":"2016-09-30T03:27:40Z"},
-		{"path":"github.com/spf13/pflag","checksumSHA1":"WVKhLVXQFxXwmuRX+IRzebUmxjE=","revision":"298182f68c66c05229eb03ac171abe6e309ee79a","revisionTime":"2018-08-31T15:14:32Z"},
-		{"path":"github.com/stretchr/objx","checksumSHA1":"n+vQ7Bmp+ODWGmCp8cI5MFsaZVA=","revision":"a5cfa15c000af5f09784e5355969ba7eb66ef0de","revisionTime":"2018-04-26T10:50:06Z"},
-		{"path":"github.com/stretchr/testify/assert","checksumSHA1":"6LwXZI7kXm1C0h4Ui0Y52p9uQhk=","revision":"c679ae2cc0cb27ec3293fea7e254e47386f05d69","revisionTime":"2018-03-14T08:05:35Z"},
-		{"path":"github.com/stretchr/testify/mock","checksumSHA1":"Qloi2PTvZv+D9FDHXM/banCoaFY=","revision":"c679ae2cc0cb27ec3293fea7e254e47386f05d69","revisionTime":"2018-03-14T08:05:35Z"},
-		{"path":"github.com/stretchr/testify/require","checksumSHA1":"KqYmXUcuGwsvBL6XVsQnXsFb3LI=","revision":"c679ae2cc0cb27ec3293fea7e254e47386f05d69","revisionTime":"2018-03-14T08:05:35Z"},
-		{"path":"github.com/vmware/govmomi","checksumSHA1":"3axQiX2sKB0pNGLIPwPqKIoZW90=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/find","checksumSHA1":"xFi1dbYQR8VwSRojdJMdvRGOmIw=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/list","checksumSHA1":"J3JrwZagGYMX6oNMkdsUFf8hHo8=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/nfc","checksumSHA1":"kYO3J9/MIfRkiKxPMTUwOvIOSso=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/object","checksumSHA1":"QcM9lF0o6EPkeuZmritWyGE+0g4=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/property","checksumSHA1":"CPOocvkED4p4GhKZxwov8v7xfoA=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/session","checksumSHA1":"X0FWJTv6W/92YB21IBuEp3Mf3z4=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/task","checksumSHA1":"FQR3yNgiShaqUiJREkeqQCKYJ84=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25","checksumSHA1":"7TYb0QwZ9DawKt89GlGABc9ufco=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/debug","checksumSHA1":"xLvppq0NUD6Hv2GIx1gh75xUzyM=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/methods","checksumSHA1":"YfxE/jP0aAGIAhBQTVEAjZG1CKc=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/mo","checksumSHA1":"rAfxxiPj4cguQnmCzCpkKsuTsBc=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/progress","checksumSHA1":"OLrtV4J/PfHWhl0OZLb1zmqlt6E=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/soap","checksumSHA1":"yxGB1R4/Se+vJDUuds0GZz4cbkQ=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/types","checksumSHA1":"F58FP8qS+yAPVSCUPRsv2lhkfA0=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/govmomi/vim25/xml","checksumSHA1":"6XLRzLEvncx5ORtvBjp41KfRTjc=","revision":"0627a5e7a9dc71f6e02b25f781a9b82f5985b084","revisionTime":"2018-07-14T17:07:08Z"},
-		{"path":"github.com/vmware/vic/pkg/vsphere/tags","checksumSHA1":"ZLGAwcBpN5I+RNzoxt5pTssyobU=","revision":"e0dd53e0e72531b36976839a79093a3cf8126411","revisionTime":"2018-07-12T16:27:50Z"},
-		{"path":"golang.org/x/crypto/blake2b","checksumSHA1":"ejjxT0+wDWWncfh0Rt3lSH4IbXQ=","revision":"0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb","revisionTime":"2018-10-15T00:23:17Z"},
-		{"path":"golang.org/x/crypto/chacha20poly1305","checksumSHA1":"XeVtoYW/XdZj+VJpmHmPKcqJO+o=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/cryptobyte","checksumSHA1":"VrW/nowBxVcqQhIrqDJNxr5NWu0=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/cryptobyte/asn1","checksumSHA1":"YEoV2AiZZPDuF7pMVzDt7buS9gc=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/curve25519","checksumSHA1":"IQkUIOnvlf0tYloFx9mLaXSvXWQ=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/ed25519","checksumSHA1":"VqyzfAMKyP6SoLnPHcwhkrICBo0=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/ed25519/internal/edwards25519","checksumSHA1":"0JTAFXPkankmWcZGQJGScLDiaN8=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/hkdf","checksumSHA1":"4D8hxMIaSDEW5pCQk22Xj4DcDh4=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/internal/chacha20","checksumSHA1":"SEPNUEkZaGKt3dkO3B13pRAp6ho=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/internal/subtle","checksumSHA1":"voGom9bAyXrZZkdtqCV41+U4iPo=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/md4","checksumSHA1":"MCeXr2RNeiG1XG6V+er1OR0qyeo=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/crypto/poly1305","checksumSHA1":"kVKE0OX1Xdw5mG7XKT86DLLKE2I=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/ssh","checksumSHA1":"acLRVrKhcyCKY585ZGjamSwx2jQ=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/ssh/agent","checksumSHA1":"R9VBzgWGaphXv2/b4DLeMAbq9Xg=","revision":"2d027ae1dddd4694d54f7a8b6cbe78dca8720226","revisionTime":"2018-05-09T20:48:04Z"},
-		{"path":"golang.org/x/crypto/ssh/terminal","checksumSHA1":"BGm8lKZmvJbf/YOJLeL1rw2WVjA=","revision":"a49355c7e3f8fe157a85be2f77e6e269a0f89602","revisionTime":"2018-06-20T09:14:27Z"},
-		{"path":"golang.org/x/net/bpf","checksumSHA1":"NjyXtXsaf0ulRJn6HQSP1FqGL4A=","revision":"f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd","revisionTime":"2018-05-08T00:58:03Z"},
-		{"path":"golang.org/x/net/context","checksumSHA1":"GtamqiJoL7PGHsN454AoffBFMa8=","revision":"afe8f62b1d6bbd81f31868121a50b06d8188e1f9","revisionTime":"2018-06-20T20:20:43Z"},
-		{"path":"golang.org/x/net/context/ctxhttp","checksumSHA1":"WHc3uByvGaMcnSoI21fhzYgbOgg=","revision":"075e191f18186a8ff2becaf64478e30f4545cdad","revisionTime":"2016-08-05T06:12:51Z"},
-		{"path":"golang.org/x/net/http2","checksumSHA1":"aaproqDPgHPV5s7lKzClAdCaDKQ=","revision":"01c190206fbdffa42f334f4b2bf2220f50e64920","revisionTime":"2017-11-02T18:53:09Z"},
-		{"path":"golang.org/x/net/http2/hpack","checksumSHA1":"ezWhc7n/FtqkLDQKeU2JbW+80tE=","revision":"01c190206fbdffa42f334f4b2bf2220f50e64920","revisionTime":"2017-11-02T18:53:09Z"},
-		{"path":"golang.org/x/net/idna","checksumSHA1":"RcrB7tgYS/GMW4QrwVdMOTNqIU8=","revision":"01c190206fbdffa42f334f4b2bf2220f50e64920","revisionTime":"2017-11-02T18:53:09Z"},
-		{"path":"golang.org/x/net/internal/iana","checksumSHA1":"KZoApXkpu6ucvSiKDep+5bQDNUo=","revision":"f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd","revisionTime":"2018-05-08T00:58:03Z"},
-		{"path":"golang.org/x/net/internal/socket","checksumSHA1":"YsXlbexuTtUXHyhSv927ILOkf6A=","revision":"f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd","revisionTime":"2018-05-08T00:58:03Z"},
-		{"path":"golang.org/x/net/internal/timeseries","checksumSHA1":"UxahDzW2v4mf/+aFxruuupaoIwo=","revision":"d866cfc389cec985d6fda2859936a575a55a3ab6","revisionTime":"2017-12-11T20:45:21Z"},
-		{"path":"golang.org/x/net/ipv4","checksumSHA1":"ncLr3evob5ZOUHJS528IQoI8CTg=","revision":"f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd","revisionTime":"2018-05-08T00:58:03Z"},
-		{"path":"golang.org/x/net/ipv6","checksumSHA1":"xqt5auCDSuvg5dm07p60loM67/A=","revision":"f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd","revisionTime":"2018-05-08T00:58:03Z"},
-		{"path":"golang.org/x/net/lex/httplex","checksumSHA1":"3xyuaSNmClqG4YWC7g0isQIbUTc=","revision":"01c190206fbdffa42f334f4b2bf2220f50e64920","revisionTime":"2017-11-02T18:53:09Z"},
-		{"path":"golang.org/x/net/proxy","checksumSHA1":"QEm/dePZ0lOnyOs+m22KjXfJ/IU=","revision":"02ac38e2528ff4adea90f184d71a3faa04b4b1b0","revisionTime":"2017-07-18T17:12:47Z"},
-		{"path":"golang.org/x/net/trace","checksumSHA1":"u/r66lwYfgg682u5hZG7/E7+VCY=","revision":"d866cfc389cec985d6fda2859936a575a55a3ab6","revisionTime":"2017-12-11T20:45:21Z"},
-		{"path":"golang.org/x/oauth2","revision":""},
-		{"path":"golang.org/x/oauth2/google","revision":""},
-		{"path":"golang.org/x/sys/cpu","checksumSHA1":"REkmyB368pIiip76LiqMLspgCRk=","revision":"ad87a3a340fa7f3bed189293fbfa7a9b7e021ae1","revisionTime":"2018-06-18T16:37:21Z"},
-		{"path":"golang.org/x/sys/unix","checksumSHA1":"su2QDjUzrUO0JnOH9m0cNg0QqsM=","revision":"ac767d655b305d4e9612f5f6e33120b9176c4ad4","revisionTime":"2018-07-08T03:57:06Z"},
-		{"path":"golang.org/x/sys/windows","checksumSHA1":"P8Y8GFwxybTfltfh8Q0lHqlEYIM=","revision":"ac767d655b305d4e9612f5f6e33120b9176c4ad4","revisionTime":"2018-07-08T03:57:06Z"},
-		{"path":"golang.org/x/sys/windows/svc","checksumSHA1":"Fes9OIPy6lS/ghzodqAbMlZZTTQ=","revision":"1b2967e3c290b7c545b3db0deeda16e9be4f98a2","revisionTime":"2018-07-06T09:56:39Z"},
-		{"path":"golang.org/x/text/secure/bidirule","checksumSHA1":"tltivJ/uj/lqLk05IqGfCv2F/E8=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/text/transform","checksumSHA1":"ziMb9+ANGRJSSIuxYdRbA+cDRBQ=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/text/unicode/bidi","checksumSHA1":"tk+lpF2CDV7e5RwwRY5ZTCGrd9o=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/text/unicode/norm","checksumSHA1":"BwRNKgzIMUxk56OScxyr43BV6IE=","revision":"88f656faf3f37f690df1a32515b479415e1a6769","revisionTime":"2017-10-26T07:52:28Z"},
-		{"path":"golang.org/x/time/rate","checksumSHA1":"vGfePfr0+weQUeTM/71mu+LCFuE=","revision":"8be79e1e0910c292df4e79c241bb7e8f7e725959","revisionTime":"2017-04-24T23:28:54Z"},
-		{"path":"google.golang.org/genproto/googleapis/rpc/status","checksumSHA1":"Tc3BU26zThLzcyqbVtiSEp7EpU8=","revision":"a8101f21cf983e773d0c1133ebc5424792003214","revisionTime":"2017-12-12T23:19:43Z"},
-		{"path":"google.golang.org/grpc","checksumSHA1":"38oYmvI4bUVd0ciabO8Kk+cuK2c=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/balancer","checksumSHA1":"B+kZFVP8zRiQMpoEb39Mp2oSmqg=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/balancer/base","checksumSHA1":"lw+L836hLeH8+//le+C+ycddCCU=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/balancer/roundrobin","checksumSHA1":"DJ1AtOk4Pu7bqtUMob95Hw8HPNw=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/codes","checksumSHA1":"R3tuACGAPyK4lr+oSNt1saUzC0M=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/connectivity","checksumSHA1":"XH2WYcDNwVO47zYShREJjcYXm0Y=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/credentials","checksumSHA1":"wA6y5rkH1v4bWBe5M1r/Hdtgma4=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/encoding","checksumSHA1":"cfLb+pzWB+Glwp82rgfcEST1mv8=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/encoding/proto","checksumSHA1":"LKKkn7EYA+Do9Qwb2/SUKLFNxoo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/grpclog","checksumSHA1":"ZPPSFisPDz2ANO4FBZIft+fRxyk=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/health","checksumSHA1":"5f4iDmBsp267R75UdXD6s01l+hk=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/health/grpc_health_v1","checksumSHA1":"KfgIKMqGJ8FdFbWlGDsnmrCY7eE=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal","checksumSHA1":"8uLpHZuwD6Ug/QlvN94QyHaOack=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal/backoff","checksumSHA1":"uDJA7QK2iGnEwbd9TPqkLaM+xuU=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal/channelz","checksumSHA1":"KCnkjqO49gNTv2JmnBdJqxQ7JT0=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal/envconfig","checksumSHA1":"5dFUCEaPjKwza9kwKqgljp8ckU4=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal/grpcrand","checksumSHA1":"70gndc/uHwyAl3D45zqp7vyHWlo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/internal/transport","checksumSHA1":"ZJ3AWjJzHj33TjFnwFLCQbg6oZQ=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/keepalive","checksumSHA1":"hcuHgKp8W0wIzoCnNfKI8NUss5o=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/metadata","checksumSHA1":"OjIAi5AzqlQ7kLtdAyjvdgMf6hc=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/naming","checksumSHA1":"VvGBoawND0urmYDy11FT+U1IHtU=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/peer","checksumSHA1":"n5EgDdBqFMa2KQFhtl+FF/4gIFo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/resolver","checksumSHA1":"GEq6wwE1qWLmkaM02SjxBmmnHDo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/resolver/dns","checksumSHA1":"90rwIeFK1zLW8M57MfzmejpCwP4=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/resolver/passthrough","checksumSHA1":"zs9M4xE8Lyg4wvuYvR00XoBxmuw=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/stats","checksumSHA1":"YclPgme2gT3S0hTkHVdE1zAxJdo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/status","checksumSHA1":"hFyBO5vgsMamKhUOSyPCqROk1vo=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/tap","checksumSHA1":"qvArRhlrww5WvRmbyMF2mUfbJew=","revision":"8997b5fa08730b06a4b589dba174c115796fbb7b","revisionTime":"2018-09-20T23:48:47Z"},
-		{"path":"google.golang.org/grpc/transport","revision":""},
-		{"path":"gopkg.in/inf.v0","checksumSHA1":"COfXAfInbcFT/YRsvLUQnNKHzF0=","revision":"d2d2541c53f18d2a059457998ce2876cc8e67cbf","revisionTime":"2018-03-26T17:23:32Z"},
-		{"path":"gopkg.in/mgo.v2","checksumSHA1":"1D8GzeoFGUs5FZOoyC2DpQg8c5Y=","revision":"3f83fa5005286a7fe593b055f0d7771a7dce4655","revisionTime":"2016-08-18T02:01:20Z"},
-		{"path":"gopkg.in/mgo.v2/bson","checksumSHA1":"YsB2DChSV9HxdzHaKATllAUKWSI=","revision":"3f83fa5005286a7fe593b055f0d7771a7dce4655","revisionTime":"2016-08-18T02:01:20Z"},
-		{"path":"gopkg.in/mgo.v2/internal/json","checksumSHA1":"XQsrqoNT1U0KzLxOFcAZVvqhLfk=","revision":"3f83fa5005286a7fe593b055f0d7771a7dce4655","revisionTime":"2016-08-18T02:01:20Z"},
-		{"path":"gopkg.in/mgo.v2/internal/sasl","checksumSHA1":"LEvMCnprte47qdAxWvQ/zRxVF1U=","revision":"3f83fa5005286a7fe593b055f0d7771a7dce4655","revisionTime":"2016-08-18T02:01:20Z"},
-		{"path":"gopkg.in/mgo.v2/internal/scram","checksumSHA1":"+1WDRPaOphSCmRMxVPIPBV4aubc=","revision":"3f83fa5005286a7fe593b055f0d7771a7dce4655","revisionTime":"2016-08-18T02:01:20Z"},
-		{"path":"gopkg.in/yaml.v2","checksumSHA1":"ZSWoOPUNRr5+3dhkLK3C4cZAQPk=","revision":"5420a8b6744d3b0345ab293f6fcba19c978f1183","revisionTime":"2018-03-28T19:50:20Z"},
-		{"path":"k8s.io/api/admissionregistration/v1alpha1","checksumSHA1":"MZhbJkGlnufR04wphtaqnIrvUXE=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/admissionregistration/v1beta1","checksumSHA1":"LV8lAXfGlzO6TnEHFGxWQTeVfZw=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/apps/v1","checksumSHA1":"GnbNRbv0YsPeb8ZN8ts/Yg7v2EE=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/apps/v1beta1","checksumSHA1":"jONDsh/YSvUhZpoewV9s5RGEHRo=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/apps/v1beta2","checksumSHA1":"JMvBWExtBYkgVs6fq1LbvMMzJBs=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/authentication/v1","checksumSHA1":"le4PBPMZHpcCcnCy7s23kiGcupQ=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/authentication/v1beta1","checksumSHA1":"nwkaJ0FGHrod4HMg9aMOhqrB6SA=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/authorization/v1","checksumSHA1":"Nw1hwhyWLlF6G5GNPcTWqDlYYLM=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/authorization/v1beta1","checksumSHA1":"/094azqDGwUiublPaN3SKKKOBcs=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/autoscaling/v1","checksumSHA1":"NNwY4ZV8Bu6aVNR0EBce7DImmZM=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/autoscaling/v2beta1","checksumSHA1":"/TdMLEL832PiJNNYDl2TTVDyEMw=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/batch/v1","checksumSHA1":"1R37YUBCjiP9duWalC3OdLqh0lU=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/batch/v1beta1","checksumSHA1":"rgKyNFcqc28Y6Tfirbn5LwEj6ys=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/batch/v2alpha1","checksumSHA1":"CLqbZZRf59px0DV4LwOGPQ2QeyY=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/certificates/v1beta1","checksumSHA1":"gEvyhegm3mSVhQfo8qRknXdVTxg=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/coordination/v1beta1","revision":"release-1.11","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/core/v1","checksumSHA1":"FMQkvFeNFYwbs5jt/0eGVn3Jfwc=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/events/v1beta1","checksumSHA1":"abj6F0RsOqLJ1fWetZU0XH8GoKM=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/extensions/v1beta1","checksumSHA1":"Nm/fuoYAGHjBwOw5qgoKHhGrbyk=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/networking/v1","checksumSHA1":"OVP9gFpoHnRm1aIYeql/uYlbhMI=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/policy/v1beta1","checksumSHA1":"vrJtdnzz4Jm07d7xVUQKn4Ir5dg=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/rbac/v1","checksumSHA1":"GBHuXdjnqUl3AjZW32aPdSGfC1M=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/rbac/v1alpha1","checksumSHA1":"EiWnS6grzHNDA3X5Uk3JYOCdRTo=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/rbac/v1beta1","checksumSHA1":"vySY1lIcWUNjo/DExJZ9lGI+rMo=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/scheduling/v1alpha1","checksumSHA1":"DM8D5XET8VbCe75jnTNLgfWuPYU=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/scheduling/v1beta1","checksumSHA1":"uTxm08OkUZCzOdyfTcnX4+yVv0Q=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/settings/v1alpha1","checksumSHA1":"rjiQeUhQgV2wsnJvq/OCXH/8sjg=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/storage/v1","checksumSHA1":"RMN7XvN8lkaHlbHAEPvKW53Pyok=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/storage/v1alpha1","checksumSHA1":"aVJ4X26+m5xsAt/zXLrHYgOUrTU=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/api/storage/v1beta1","checksumSHA1":"vnbX68mKqOrVD+jO3hpGuUy6VKE=","revision":"4e7be11eab3ffcfc1876898b8272df53785a9504","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/api/errors","checksumSHA1":"eD3XRvVzKmBUr4mFMD9hAMMuLSE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/api/meta","checksumSHA1":"f8wIbNQndGers0bKQdewuuaF6l4=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/api/resource","checksumSHA1":"+RdhegNU1doq6g05bXbtUAkqFMo=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/apis/meta/v1","checksumSHA1":"yq49mken7zxQC/tF0SscW+tS5ms=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured","checksumSHA1":"lqyM0x9dK8ld+UIco6ZIp+BwQmQ=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/apis/meta/v1beta1","checksumSHA1":"cFrJa803bweNTF8VoaTJLfXL7CU=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/conversion","checksumSHA1":"5BuGgpCIBZ4o6tT0QjfZD99hbPQ=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/conversion/queryparams","checksumSHA1":"lZgVHIUDKFlQKJBYQVWqED5sDnE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/fields","checksumSHA1":"zgYf1VhDcfCpouwRgF5Zodz+g6M=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/labels","checksumSHA1":"rQgW7h6N5U40wFE9/zgmjwOrf8w=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime","checksumSHA1":"p1v3yQ8OqJSerPiuKPBDSY81bPk=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/schema","checksumSHA1":"2G7sQ/l95SGzZg4jd2lPIykCYwE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer","checksumSHA1":"zrzqafjVBMG7MbUDRkDjvb/tKjM=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer/json","checksumSHA1":"jpkekuS0xyd/I6OOxqISFR35WbA=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer/protobuf","checksumSHA1":"inmKlIskO3iMYraepPTfQPf6a+I=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer/recognizer","checksumSHA1":"CxRm8Ny1sWZVlEw1WBfbOMtJP40=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer/streaming","checksumSHA1":"U768j7bVYHO5DwtNAHdIuBtpFMc=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/runtime/serializer/versioning","checksumSHA1":"nVwU3gx4pfiMyHOUBgrxyQFaeIM=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/selection","checksumSHA1":"p9Wv7xurZXAW0jYL/SLNPbiUjaA=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/types","checksumSHA1":"SwEleXXE22RGlg0t7wirGDuisO4=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/clock","checksumSHA1":"Gtwo9p42g21v46mUVvj/Qh8yUSE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/errors","checksumSHA1":"hHYW7OWXFMbRVotl2830pa4kO+Y=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/framer","checksumSHA1":"bQOeFTINeXcfMOAOPArjRma/1mk=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/intstr","checksumSHA1":"9nShqMfXfw5Ct0Rr7P2QhQObVhw=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/json","checksumSHA1":"NaIzEbjlhEMikewzRXivi2r0xyM=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/naming","checksumSHA1":"y1dxj1ipJgt2PRXXSXDmXrSka6A=","revision":"6429050ef506887d121f3e7306e894f8900d8a63","revisionTime":"2018-09-04T00:17:49Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/net","checksumSHA1":"OrKcR7aVHsamDGWtb2Z0/kAVOtk=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/runtime","checksumSHA1":"keWEyQHGKGkDo2SARgphbGgN608=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/sets","checksumSHA1":"ozEwMzA48zwMyQ50SwNKSM852U4=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/validation","checksumSHA1":"0zZltQ8NUw+PeVotck4dqCKT/JY=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/validation/field","checksumSHA1":"bEa1fAicif72PvAU9r4GGylfVa0=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/wait","checksumSHA1":"WVUAXkkBeN3m2LenBRySrdk97PE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/util/yaml","checksumSHA1":"1bUNGHe9gSNhcdE2EKl+h+VPuDY=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/version","checksumSHA1":"A8tJJJhCK3xynuOJMiSw4jz27wg=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/pkg/watch","checksumSHA1":"LmSsUNmqd9ipMsZvsC8a3ZNsodE=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/apimachinery/third_party/forked/golang/reflect","checksumSHA1":"9sFA+EjKrjpmK4OofQH0p0Rowfg=","revision":"def12e63c512da17043b4f0293f52d1006603d9f","revisionTime":"2018-09-04T19:39:09Z","version":"release-1.11","versionExact":"release-1.11"},
-		{"path":"k8s.io/client-go/discovery","checksumSHA1":"WMIZypTArr2Rj7YIOmbmp/+yZkY=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes","checksumSHA1":"Uvb/9qGnLy/XSRWjpHlEfWYU+As=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/scheme","checksumSHA1":"NpFjNGtZNV0o0Jo7oG7jmjIJ4W0=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1","checksumSHA1":"2sVEoijJZ8VDJRY+Q38NnxMQqzc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1","checksumSHA1":"gpF24Wissl7J5PSi6h1FE+5cKt4=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/apps/v1","checksumSHA1":"xVKYvZSUmsh5gdX4cKpqMucuKIs=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/apps/v1beta1","checksumSHA1":"/u8hJMzPAhaRnYV3N/2kWeo6Gbc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/apps/v1beta2","checksumSHA1":"7nPY3WCV09+bSkK0fK1pkcYOP3Q=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/authentication/v1","checksumSHA1":"z8RBQhqz0ef52GAYcGnHbdkRLQw=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/authentication/v1beta1","checksumSHA1":"xNCsaw6UsrEtSjg+2rMYZueCBIM=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/authorization/v1","checksumSHA1":"m8sWDYsVaRB+meitgU1dx+1P0ow=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/authorization/v1beta1","checksumSHA1":"XucNO6BHSXXNkSQAM1ZdiwDmksc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/autoscaling/v1","checksumSHA1":"5D9gl3fKkhnLSC17fkz9XIV9STc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1","checksumSHA1":"iCPo6cOIT5Z9diNHHUcGyrMDZn8=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/batch/v1","checksumSHA1":"PxB/TF7pmos3op2z+LIJLjZO8jM=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/batch/v1beta1","checksumSHA1":"UFKWPad/llvBljTbZqyekULpPKM=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/batch/v2alpha1","checksumSHA1":"7FFOahu3KVI7fiWhA/k1yluvIJY=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/certificates/v1beta1","checksumSHA1":"ugmMQOQlWNAEOR+ncbnL+uxkjJ8=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/coordination/v1beta1","revision":"release-8.0","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/core/v1","checksumSHA1":"0E6RtvR8px6fkUWtT5FYjVcowEI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/events/v1beta1","checksumSHA1":"EG2zaZ66o181NTvDIA1pF+sR+mI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/extensions/v1beta1","checksumSHA1":"X5wptrr04pFFgjZBvNejIFKf3YU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/networking/v1","checksumSHA1":"2BNRJgbx2OKqe4PnZrEo/LUI1gI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/policy/v1beta1","checksumSHA1":"iv+leVP2ERDUBKVaD82rrt8x5EI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/rbac/v1","checksumSHA1":"t1v/kvkiHgsoRGB2SpS9wx7Kd1s=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/rbac/v1alpha1","checksumSHA1":"WBzIRDYpTWf5X0fl7Q9ZsYaayOI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/rbac/v1beta1","checksumSHA1":"2Db2rdjkeF2FUjL3zcAT518HNUw=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1","checksumSHA1":"E2UC+VmKSUekz96/0UX+fK0jOGg=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/scheduling/v1beta1","checksumSHA1":"S9JHuu0Bwyc7RumKvhMJC49MtkU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/settings/v1alpha1","checksumSHA1":"L7SxjL9g+rlgK8AEj4SocDiMzjU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/storage/v1","checksumSHA1":"NG+izjfroQyI3r6Ar1IK47KQknU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/storage/v1alpha1","checksumSHA1":"hLN5UXfDgw36zcIfpgo4WCZraCA=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/kubernetes/typed/storage/v1beta1","checksumSHA1":"uhq68WTNsbCjKPqAwym7TPUx9Xg=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/pkg/apis/clientauthentication","checksumSHA1":"HIYqO9vnahkaPT5sfAEdKRb86Qc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1","checksumSHA1":"fQTlkuSI3D1S4Hm6KXcKm1do9pQ=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/pkg/apis/clientauthentication/v1beta1","checksumSHA1":"ilihkLzytTmhvOcCmJJmubYwak0=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/pkg/version","checksumSHA1":"SKxW+zPUzKmMZDo5SO9rAHf4FcM=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth","checksumSHA1":"LnDpHo8KDmZEH4kqmaZKng/M0W8=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth/azure","checksumSHA1":"IOkY+hKZisSfu06aExZRItVNLEQ=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth/exec","checksumSHA1":"QaTKrEXAUJLXMiyStJ1vgfg5YEU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth/gcp","checksumSHA1":"MFODIOSPWNU+/KgDfSaGX7OUcyA=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth/oidc","checksumSHA1":"cXj/nD+hFYaclmGd2j6FHtmLDCg=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/plugin/pkg/client/auth/openstack","checksumSHA1":"fezR9MxENOINJ6+82EYz5T61INw=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/rest","checksumSHA1":"WAtl5P1bup5IS4is2kEc5WBN3YU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/rest/watch","checksumSHA1":"+wYCwQaVc1GvMWwOWc3wXd2GT5s=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/third_party/forked/golang/template","checksumSHA1":"j3Th2B1Hpv6UFLMEmA0ZdbO4kGU=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/auth","checksumSHA1":"/QeKYX2M+m1OFCDyH9PHYp6w510=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/clientcmd","checksumSHA1":"TCBw/2DobQ3JpcvXy0hW3IbNWb8=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/clientcmd/api","checksumSHA1":"ynHaVRHZ3FI66y573C05GL3s0t4=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/clientcmd/api/latest","checksumSHA1":"6cVFBhDYvRiAwBf0QYbmUoLi5lQ=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/clientcmd/api/v1","checksumSHA1":"IJn5sCK9Y+KBibFIUMyKU18SGUI=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/metrics","checksumSHA1":"rRC9GCWXfyIXKHBCeKpw7exVybE=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/tools/reference","checksumSHA1":"n2h6CjJR1o+JM2snIIsCdcMMDWs=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/transport","checksumSHA1":"J+lqqSPbequTb2ELV838v31MfWc=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/cert","checksumSHA1":"rIxDMrsqcf1cjy3dgMaEZw/TvJs=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/connrotation","checksumSHA1":"KSB22yQOaax0P/RkHCDp80u+Jcs=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/flowcontrol","checksumSHA1":"yXKT7cJNCv5vjwGKhpc/DUsQg+A=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/homedir","checksumSHA1":"WRb0rXGx56fwcCisVW7GoI6gO/A=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/integer","checksumSHA1":"W6bJiNAwgNwNJC+y+TPtacgUGlY=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"},
-		{"path":"k8s.io/client-go/util/jsonpath","checksumSHA1":"1+CyY2zkEQX4VrByn/77x6gWy78=","revision":"f2f85107cac6fe04c30435ca0ac0c3318fd1b94c","revisionTime":"2018-08-21T04:50:00Z","version":"release-8.0","versionExact":"release-8.0"}
+		{
+			"checksumSHA1": "NkpNQgmrdzGr9HUDL8Bp5YAxt0k=",
+			"path": "cloud.google.com/go/civil",
+			"revision": "0533e22fa71728e9e042e858c2e2d49d14bae0e8",
+			"revisionTime": "2018-06-20T12:26:09Z"
+		},
+		{
+			"checksumSHA1": "MlFs4OQ2cCVlZvSeKSgpdUoLKBs=",
+			"path": "github.com/Azure/go-autorest/autorest",
+			"revision": "28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9",
+			"revisionTime": "2018-09-05T20:55:58Z"
+		},
+		{
+			"checksumSHA1": "vMERbrCV9o4TWRw4dC75uaNihSc=",
+			"path": "github.com/Azure/go-autorest/autorest/adal",
+			"revision": "28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9",
+			"revisionTime": "2018-09-05T20:55:58Z"
+		},
+		{
+			"checksumSHA1": "vUHo41PG/G6Qq+vqD65l9KHFxUs=",
+			"path": "github.com/Azure/go-autorest/autorest/azure",
+			"revision": "28a9bd4b31fbc149c9ff251b269b1c64ee92e3f9",
+			"revisionTime": "2018-09-05T20:55:58Z"
+		},
+		{
+			"path": "github.com/Azure/go-autorest/logger",
+			"revision": "a35eae345f69bbfbe3b8fa0b1d3fe98f8430b21a",
+			"revisionTime": "2018-08-30T19:44:05Z"
+		},
+		{
+			"path": "github.com/Azure/go-autorest/version",
+			"revision": "a35eae345f69bbfbe3b8fa0b1d3fe98f8430b21a",
+			"revisionTime": "2018-08-30T19:44:05Z"
+		},
+		{
+			"checksumSHA1": "JhyS/zIicgtrSasHSZ6WtXGWJVk=",
+			"path": "github.com/DataDog/datadog-go/statsd",
+			"revision": "cc2f4770f4d61871e19bfee967bc767fe730b0d9",
+			"revisionTime": "2016-03-29T13:52:53Z"
+		},
+		{
+			"checksumSHA1": "eMJfN1SwbCz+TlmfzFRye82uhks=",
+			"path": "github.com/Jeffail/gabs",
+			"revision": "7a0fed31069aba77993a518cc2f37b28ee7aa883",
+			"revisionTime": "2018-04-20T20:36:15Z"
+		},
+		{
+			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
+			"path": "github.com/Microsoft/go-winio",
+			"revision": "c4dc1301f1dc0307acd38e611aa375a64dfe0642",
+			"revisionTime": "2017-07-12T04:46:15Z"
+		},
+		{
+			"checksumSHA1": "GM+KgxfAv3HJdtffkEPpegaFxe0=",
+			"path": "github.com/NYTimes/gziphandler",
+			"revision": "2600fb119af974220d3916a5916d6e31176aac1b",
+			"revisionTime": "2018-02-20T23:40:21Z",
+			"version": "v1.0.1",
+			"versionExact": "v1.0.1"
+		},
+		{
+			"checksumSHA1": "S+XkdKo8fsJp/vDR86X751Vravw=",
+			"path": "github.com/SAP/go-hdb/driver",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "bpaEqnqXJDbw8jkMUsmMcjRKXX8=",
+			"path": "github.com/SAP/go-hdb/driver/sqltrace",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "x7mYiUM72JbTBRdo7g8PPQC/npU=",
+			"path": "github.com/SAP/go-hdb/internal/bufio",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "1YbXqtwKuO0cxSUlJ24zskfOepE=",
+			"path": "github.com/SAP/go-hdb/internal/protocol",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "KK2U+DbcpWBexg9ZMEKGRIaqFtU=",
+			"path": "github.com/SAP/go-hdb/internal/unicode",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "fb432MWzL2ONS0e6HyGv3P2oG1I=",
+			"path": "github.com/SAP/go-hdb/internal/unicode/cesu8",
+			"revision": "4e1c5bf7d81c4a7cd2c64f4eec5bc64068500b5a",
+			"revisionTime": "2018-05-20T18:19:29Z"
+		},
+		{
+			"checksumSHA1": "t+uej2kiyqRyQYguygI8t9nJH2w=",
+			"path": "github.com/SermoDigital/jose",
+			"revision": "803625baeddc3526d01d321b5066029f53eafc81",
+			"revisionTime": "2018-01-04T20:38:59Z"
+		},
+		{
+			"checksumSHA1": "u92C5yEz1FLBeoXp8jujn3tUNFI=",
+			"path": "github.com/SermoDigital/jose/crypto",
+			"revision": "803625baeddc3526d01d321b5066029f53eafc81",
+			"revisionTime": "2018-01-04T20:38:59Z"
+		},
+		{
+			"checksumSHA1": "FJP5enLaw1JzZNu6Fen+eEKY7Lo=",
+			"path": "github.com/SermoDigital/jose/jws",
+			"revision": "803625baeddc3526d01d321b5066029f53eafc81",
+			"revisionTime": "2018-01-04T20:38:59Z"
+		},
+		{
+			"checksumSHA1": "3gGGWQ3PcKHE+2cVlkJmIlBfBlw=",
+			"path": "github.com/SermoDigital/jose/jwt",
+			"revision": "803625baeddc3526d01d321b5066029f53eafc81",
+			"revisionTime": "2018-01-04T20:38:59Z"
+		},
+		{
+			"checksumSHA1": "3WMNv4WlET5Vz4pfLKI+kHlZe7w=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "92052687f8ec598ff0da626d2909478cfd1e3a3c",
+			"revisionTime": "2018-07-12T20:16:18Z"
+		},
+		{
+			"checksumSHA1": "9NR0rrcAT5J76C5xMS4AVksS9o0=",
+			"path": "github.com/StackExchange/wmi",
+			"revision": "e54cbda6595d7293a7a468ccf9525f6bc8887f99",
+			"revisionTime": "2016-08-11T21:45:55Z"
+		},
+		{
+			"checksumSHA1": "l0iFqayYAaEip6Olaq3/LCOa/Sg=",
+			"path": "github.com/armon/circbuf",
+			"revision": "bbbad097214e2918d8543d5201d12bfd7bca254d",
+			"revisionTime": "2015-08-27T00:49:46Z"
+		},
+		{
+			"checksumSHA1": "eiRzLoenl7oEVCuoT+Ju/zWBlKg=",
+			"path": "github.com/armon/go-metrics",
+			"revision": "783273d703149aaeb9897cf58613d5af48861c25",
+			"revisionTime": "2018-02-21T18:27:44Z"
+		},
+		{
+			"checksumSHA1": "xCsGGM9TKBogZDfSN536KtQdLko=",
+			"path": "github.com/armon/go-metrics/circonus",
+			"revision": "783273d703149aaeb9897cf58613d5af48861c25",
+			"revisionTime": "2018-02-21T18:27:44Z"
+		},
+		{
+			"checksumSHA1": "Dt0n1sSivvvdZQdzc4Hu/yOG+T0=",
+			"path": "github.com/armon/go-metrics/datadog",
+			"revision": "783273d703149aaeb9897cf58613d5af48861c25",
+			"revisionTime": "2018-02-21T18:27:44Z"
+		},
+		{
+			"checksumSHA1": "XfPPXw55zKziOWnZbkEGEJ96O9c=",
+			"path": "github.com/armon/go-metrics/prometheus",
+			"revision": "783273d703149aaeb9897cf58613d5af48861c25",
+			"revisionTime": "2018-02-21T18:27:44Z"
+		},
+		{
+			"checksumSHA1": "gNO0JNpLzYOdInGeq7HqMZUzx9M=",
+			"path": "github.com/armon/go-radix",
+			"revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2",
+			"revisionTime": "2016-01-15T23:47:25Z"
+		},
+		{
+			"checksumSHA1": "kChwmKazQLFun0USpBail+TyUYI=",
+			"path": "github.com/asaskevich/govalidator",
+			"revision": "7d2e70ef918f16bd6455529af38304d6d025c952",
+			"revisionTime": "2018-03-19T08:16:51Z"
+		},
+		{
+			"checksumSHA1": "0rido7hYHQtfq3UJzVT5LClLAWc=",
+			"path": "github.com/beorn7/perks/quantile",
+			"revision": "3a771d992973f24aa725d07868b467d1ddfceafb",
+			"revisionTime": "2018-03-21T16:47:47Z"
+		},
+		{
+			"checksumSHA1": "dvd7Su+WNmHRP1+w1HezrPUCDsc=",
+			"path": "github.com/bgentry/speakeasy",
+			"revision": "e1439544d8ecd0f3e9373a636d447668096a8f81",
+			"revisionTime": "2016-05-20T23:26:10Z"
+		},
+		{
+			"checksumSHA1": "twtRfb6484vfr2qqjiFkLThTjcQ=",
+			"path": "github.com/bgentry/speakeasy/example",
+			"revision": "e1439544d8ecd0f3e9373a636d447668096a8f81",
+			"revisionTime": "2016-05-20T23:26:10Z"
+		},
+		{
+			"checksumSHA1": "R1Q34Pfnt197F/nCOO9kG8c+Z90=",
+			"path": "github.com/boltdb/bolt",
+			"revision": "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8",
+			"revisionTime": "2017-07-17T17:11:48Z"
+		},
+		{
+			"checksumSHA1": "szvY4u7TlXkrQ3PW8wmyJaIFy0U=",
+			"path": "github.com/circonus-labs/circonus-gometrics",
+			"revision": "d17a8420c36e800fcb46bbd4d2a15b93c68605ea",
+			"revisionTime": "2016-11-09T19:23:37Z"
+		},
+		{
+			"checksumSHA1": "WUE6oF152uN5FcLmmq+nO3Yl7pU=",
+			"path": "github.com/circonus-labs/circonus-gometrics/api",
+			"revision": "d17a8420c36e800fcb46bbd4d2a15b93c68605ea",
+			"revisionTime": "2016-11-09T19:23:37Z"
+		},
+		{
+			"checksumSHA1": "beRBHHy2+V6Ht4cACIMmZOCnzgg=",
+			"path": "github.com/circonus-labs/circonus-gometrics/checkmgr",
+			"revision": "d17a8420c36e800fcb46bbd4d2a15b93c68605ea",
+			"revisionTime": "2016-11-09T19:23:37Z"
+		},
+		{
+			"checksumSHA1": "C4Z7+l5GOpOCW5DcvNYzheGvQRE=",
+			"path": "github.com/circonus-labs/circonusllhist",
+			"revision": "365d370cc1459bdcaceda3499453668373dea1d0",
+			"revisionTime": "2016-11-10T00:26:50Z"
+		},
+		{
+			"checksumSHA1": "EoOyMf0m3NkVWRxJ4jGUSkVCM8c=",
+			"path": "github.com/coredns/coredns/plugin/pkg/dnsutil",
+			"revision": "582f91f3f3aa0b956c152b72ad9c95b8f597a2b0",
+			"revisionTime": "2018-04-23T12:44:33Z",
+			"version": "v1.1.2",
+			"versionExact": "v1.1.2"
+		},
+		{
+			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
+		},
+		{
+			"checksumSHA1": "MrqqjNxb8plNG+QSHMsihMHgJT4=",
+			"path": "github.com/denisenkom/go-mssqldb",
+			"revision": "94c9c97e8c9f9844d15c846854a7a6031ae2132c",
+			"revisionTime": "2018-06-20T03:28:04Z"
+		},
+		{
+			"checksumSHA1": "wu8t19t2rmyrrfDfdu9v7f/+iag=",
+			"path": "github.com/denisenkom/go-mssqldb/internal/cp",
+			"revision": "94c9c97e8c9f9844d15c846854a7a6031ae2132c",
+			"revisionTime": "2018-06-20T03:28:04Z"
+		},
+		{
+			"checksumSHA1": "mUeojTdLEyzYOki70VUAeeYr/wQ=",
+			"path": "github.com/dgrijalva/jwt-go",
+			"revision": "0b96aaa707760d6ab28d9b9d1913ff5993328bae",
+			"revisionTime": "2018-07-19T21:18:23Z"
+		},
+		{
+			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
+			"path": "github.com/docker/go-connections/sockets",
+			"revision": "3ede32e2033de7505e6500d6c868c2b9ed9f169d",
+			"revisionTime": "2017-06-23T20:36:43Z"
+		},
+		{
+			"checksumSHA1": "5ftkjfUwI9A6xCQ1PwIAd5+qlo0=",
+			"path": "github.com/elazarl/go-bindata-assetfs",
+			"revision": "e1a2a7ec64b07d04ac9ebb072404fe8b7b60de1b",
+			"revisionTime": "2016-08-03T19:23:04Z"
+		},
+		{
+			"checksumSHA1": "CaThXbumVxZtNlItiXma5B78PwQ=",
+			"path": "github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs",
+			"revision": "e1a2a7ec64b07d04ac9ebb072404fe8b7b60de1b",
+			"revisionTime": "2016-08-03T19:23:04Z"
+		},
+		{
+			"checksumSHA1": "FSibauI37HqkJE62OqfFK3A9Ih0=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "MxMRiqLMQ6tZc2DXaFk8RpzZJ1k=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "ktA2ACmea64sl2j4C7ROuDjxwhs=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "CS7onQ+gKubxzzFNrv2vsnpeg6o=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/core",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "XXTFdEmQ4Z87HD4AM1JRCGAEfmU=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "y9mv2tvEpzDmB3VJkwNpaNlRBmU=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "6rAy2/Yv/q73ZKyowBkNwekOyq4=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/api/v2/route",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "wic3APn/uIE4QJ4T2VLrik4Dp74=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/config/filter/accesslog/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "xMDMWQ3xIuECIxAtMtejMCQb2h4=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/ext_authz/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "aOroSRMbYtLr7X2MpiQi4p+6NBw=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "TTgpFT45GfVXcGje4qGCssF+LxI=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "2J3zPDTsC3HtOc6RDCWf2TALvfc=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2alpha",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "3DwfQPZMC1i4ZrvpB2mMZRZ7SHI=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "8DtGIr6Z3Alnd5s+htx1MgDZVoo=",
+			"path": "github.com/envoyproxy/go-control-plane/envoy/type",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "hAUeY2SDlc1qkYBal5DtrlKkPyM=",
+			"path": "github.com/envoyproxy/go-control-plane/pkg/cache",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "dS2Ygpy2UCR0+3pDbQ044t/Bzew=",
+			"path": "github.com/envoyproxy/go-control-plane/pkg/log",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "V0F+pAe0C96OntiM4PC+nL4ff8o=",
+			"path": "github.com/envoyproxy/go-control-plane/pkg/server",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "wSN1NcSo9HdIigbVddGZ5xVxnzo=",
+			"path": "github.com/envoyproxy/go-control-plane/pkg/util",
+			"revision": "2137d919632883e52e7786f55f0f84e52a44fbf3",
+			"revisionTime": "2018-09-19T00:28:55Z"
+		},
+		{
+			"checksumSHA1": "5BP5xofo0GoFi6FtgqFFbmHyUKI=",
+			"path": "github.com/fatih/structs",
+			"revision": "ebf56d35bba727c68ac77f56f2fcf90b181851aa",
+			"revisionTime": "2018-01-23T06:50:59Z"
+		},
+		{
+			"checksumSHA1": "nlMa0NX11OCS5UHuJszVGTBboWU=",
+			"path": "github.com/ghodss/yaml",
+			"revision": "c7ce16629ff4cd059ed96ed06419dd3856fd3577",
+			"revisionTime": "2018-08-20T08:47:58Z"
+		},
+		{
+			"checksumSHA1": "oyULO1B/l2OLy2xereo+2w3hYk4=",
+			"path": "github.com/go-ole/go-ole",
+			"revision": "02d3668a0cf01f58411cc85cd37c174c257ec7c2",
+			"revisionTime": "2017-06-01T13:56:11Z"
+		},
+		{
+			"checksumSHA1": "IvdiJE1NIogRmGi3WmteEKZQJB8=",
+			"path": "github.com/go-ole/go-ole/oleutil",
+			"revision": "5e9c030faf78847db7aa77e3661b9cc449de29b7",
+			"revisionTime": "2016-11-16T06:46:58Z"
+		},
+		{
+			"checksumSHA1": "KsRquwj2mj2bxCjHfcnTG3GAmlA=",
+			"path": "github.com/go-sql-driver/mysql",
+			"revision": "749ddf1598b47e3cd909414bda735fe790ef3d30",
+			"revisionTime": "2018-06-18T11:59:01Z"
+		},
+		{
+			"checksumSHA1": "tT9gdr1U1+E1WDXHNGQcaQuq2BQ=",
+			"path": "github.com/gocql/gocql",
+			"revision": "e06f8c1bcd787e6bf0608288b314522f08cc7848",
+			"revisionTime": "2018-06-17T11:57:10Z"
+		},
+		{
+			"checksumSHA1": "7RlYIbPYgPkxDDCSEuE6bvYEEeU=",
+			"path": "github.com/gocql/gocql/internal/lru",
+			"revision": "e06f8c1bcd787e6bf0608288b314522f08cc7848",
+			"revisionTime": "2018-06-17T11:57:10Z"
+		},
+		{
+			"checksumSHA1": "1D3fnN8dRoLJxWKxKGGCfz6cJXg=",
+			"path": "github.com/gocql/gocql/internal/murmur",
+			"revision": "e06f8c1bcd787e6bf0608288b314522f08cc7848",
+			"revisionTime": "2018-06-17T11:57:10Z"
+		},
+		{
+			"checksumSHA1": "5GTGKm0C5aLdu9tynZQWQEQqRes=",
+			"path": "github.com/gocql/gocql/internal/streams",
+			"revision": "e06f8c1bcd787e6bf0608288b314522f08cc7848",
+			"revisionTime": "2018-06-17T11:57:10Z"
+		},
+		{
+			"checksumSHA1": "Dkuhvi5lEltaq1PmJmDTSi+09nU=",
+			"path": "github.com/gogo/googleapis/google/api",
+			"revision": "8558fb44d2f1fc223118afc694129d2c2d2924d1",
+			"revisionTime": "2018-08-13T11:20:41Z"
+		},
+		{
+			"checksumSHA1": "fjbiOYNq9Dmp9Bx3xMoQFWuoKaM=",
+			"path": "github.com/gogo/googleapis/google/rpc",
+			"revision": "8558fb44d2f1fc223118afc694129d2c2d2924d1",
+			"revisionTime": "2018-08-13T11:20:41Z"
+		},
+		{
+			"checksumSHA1": "FhEC1RwKSm/8jvTI2MKlzDVz+Vs=",
+			"path": "github.com/gogo/protobuf/gogoproto",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "ElpAMJyh/b5cUiFCJ+MjtKYfFAo=",
+			"path": "github.com/gogo/protobuf/jsonpb",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "47nJ3iu1bVvK9jPXwAinFYr4mBU=",
+			"path": "github.com/gogo/protobuf/proto",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "4R7X2wRYYOxdXsoXOEcyBoCakb8=",
+			"path": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "HPVQZu059/Rfw2bAWM538bVTcUc=",
+			"path": "github.com/gogo/protobuf/sortkeys",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "yK31P3hm7p5eA5PczMByhK0Tj2U=",
+			"path": "github.com/gogo/protobuf/types",
+			"revision": "e14cafb6a2c249986e51c4b65c3206bf18578715",
+			"revisionTime": "2018-09-14T05:40:05Z"
+		},
+		{
+			"checksumSHA1": "HmbftipkadrLlCfzzVQ+iFHbl6g=",
+			"path": "github.com/golang/glog",
+			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+			"revisionTime": "2016-01-25T20:49:56Z"
+		},
+		{
+			"checksumSHA1": "Pyou8mceOASSFxc7GeXZuVdSMi0=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
+			"revisionTime": "2018-04-30T18:52:41Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "fXNL9CT3MIlkdLUCn83Aon7QVAU=",
+			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
+			"revision": "7716a980bceefe9a0213654823d9ea62d23b87a2",
+			"revisionTime": "2018-09-19T22:46:59Z"
+		},
+		{
+			"checksumSHA1": "VfkiItDBFFkZluaAMAzJipDXNBY=",
+			"path": "github.com/golang/protobuf/ptypes",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "UB9scpDxeFjQe5tEthuR4zCLRu4=",
+			"path": "github.com/golang/protobuf/ptypes/any",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "hUjAj0dheFVDl84BAnSWj9qy2iY=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "O2ItP5rmfrgxPufhjJXbFlXuyL8=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revisionTime": "2017-11-13T18:07:20Z"
+		},
+		{
+			"checksumSHA1": "h1d2lPZf6j2dW/mIqVnd1RdykDo=",
+			"path": "github.com/golang/snappy",
+			"revision": "2e65f85255dbc3072edf28d6b5b8efc472979f5a",
+			"revisionTime": "2018-05-18T05:39:59Z"
+		},
+		{
+			"checksumSHA1": "cervgtZmEhshueHN64+ILdFHmEE=",
+			"path": "github.com/google/btree",
+			"revision": "4030bb1f1f0c35b30ca7009e9ebd06849dd45306",
+			"revisionTime": "2018-08-13T15:31:12Z"
+		},
+		{
+			"checksumSHA1": "PFtXkXPO7pwRtykVUUXtc07wc7U=",
+			"path": "github.com/google/gofuzz",
+			"revision": "24818f796faf91cd76ec7bddd72458fbced7a6c1",
+			"revisionTime": "2017-06-12T17:47:53Z"
+		},
+		{
+			"checksumSHA1": "b7x/5HeWIHXwSRNED5Envt6tRjs=",
+			"path": "github.com/googleapis/gnostic/OpenAPIv2",
+			"revision": "48a0ecefe2e4190c7a2d63b477875854a2f993b3",
+			"revisionTime": "2018-05-20T01:50:35Z"
+		},
+		{
+			"checksumSHA1": "IW1cHbutRLvkUTJ1QkqSjsu65bY=",
+			"path": "github.com/googleapis/gnostic/compiler",
+			"revision": "48a0ecefe2e4190c7a2d63b477875854a2f993b3",
+			"revisionTime": "2018-05-20T01:50:35Z"
+		},
+		{
+			"checksumSHA1": "c2QLSomDNNOk7t6Psq4cDLUDX98=",
+			"path": "github.com/googleapis/gnostic/extensions",
+			"revision": "48a0ecefe2e4190c7a2d63b477875854a2f993b3",
+			"revisionTime": "2018-05-20T01:50:35Z"
+		},
+		{
+			"checksumSHA1": "Zcapl92yLsRGDnDfmD5BMZrU0i8=",
+			"path": "github.com/gophercloud/gophercloud",
+			"revision": "03a4c443e006c8e309fb15b3406dfc352a5f118f",
+			"revisionTime": "2018-09-05T21:52:14Z"
+		},
+		{
+			"checksumSHA1": "WAu+jx7c6kshm05B/W34gpzw148=",
+			"path": "github.com/gophercloud/gophercloud/openstack",
+			"revision": "03a4c443e006c8e309fb15b3406dfc352a5f118f",
+			"revisionTime": "2018-09-05T21:52:14Z"
+		},
+		{
+			"checksumSHA1": "BzQbqNKKDkIHN+1G6sRsMeWz4Zs=",
+			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
+			"revision": "03a4c443e006c8e309fb15b3406dfc352a5f118f",
+			"revisionTime": "2018-09-05T21:52:14Z"
+		},
+		{
+			"checksumSHA1": "YspETi3tOMvawKIT91HyuqaA5lM=",
+			"path": "github.com/gophercloud/gophercloud/pagination",
+			"revision": "03a4c443e006c8e309fb15b3406dfc352a5f118f",
+			"revisionTime": "2018-09-05T21:52:14Z"
+		},
+		{
+			"checksumSHA1": "T1uAtgdoQP82t1GaT1eZjhYmFmM=",
+			"path": "github.com/gregjones/httpcache",
+			"revision": "9cad4c3443a7200dd6400aef47183728de563a38",
+			"revisionTime": "2018-03-05T23:10:24Z"
+		},
+		{
+			"checksumSHA1": "A+TX1jxqy7iWvcb9ZldoG1b5SsY=",
+			"path": "github.com/gregjones/httpcache/diskcache",
+			"revision": "9cad4c3443a7200dd6400aef47183728de563a38",
+			"revisionTime": "2018-03-05T23:10:24Z"
+		},
+		{
+			"checksumSHA1": "O0r0hj4YL+jSRNjnshkeH4GY+4s=",
+			"path": "github.com/hailocab/go-hostpool",
+			"revision": "e80d13ce29ede4452c43dea11e79b9bc8a15b478",
+			"revisionTime": "2016-01-25T11:53:50Z"
+		},
+		{
+			"checksumSHA1": "cdOCt0Yb+hdErz8NAQqayxPmRsY=",
+			"path": "github.com/hashicorp/errwrap",
+			"revision": "7554cd9344cec97297fa6649b055a8c98c2a1e55",
+			"revisionTime": "2014-10-28T05:47:10Z"
+		},
+		{
+			"checksumSHA1": "D267IUMW2rcb+vNe3QU+xhfSrgY=",
+			"path": "github.com/hashicorp/go-checkpoint",
+			"revision": "1545e56e46dec3bba264e41fde2c1e2aa65b5dd4",
+			"revisionTime": "2017-10-09T17:35:28Z"
+		},
+		{
+			"checksumSHA1": "YAq1rqZIp+M74Q+jMBQkkMKm3VM=",
+			"path": "github.com/hashicorp/go-cleanhttp",
+			"revision": "d5fe4b57a186c716b0e00b8c301cbd9b4182694d",
+			"revisionTime": "2017-12-18T14:54:08Z"
+		},
+		{
+			"checksumSHA1": "qJN0TixDHZdaP3z110+oNszPlUg=",
+			"path": "github.com/hashicorp/go-discover",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z"
+		},
+		{
+			"checksumSHA1": "Jww5zrDwjMoFF31RqBapilTdi18=",
+			"path": "github.com/hashicorp/go-discover/provider/aliyun",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "Vit45xRjrJ6h7IGJndrBjodVUAE=",
+			"path": "github.com/hashicorp/go-discover/provider/aws",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "dMU80T10KQFZNqpBBjzf7ymFNBw=",
+			"path": "github.com/hashicorp/go-discover/provider/azure",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "TthiY6qza4DnHPLXBq7re5ngNOY=",
+			"path": "github.com/hashicorp/go-discover/provider/digitalocean",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "bQHkaF9dUFUYJLQ0MkVLIlCIVaE=",
+			"path": "github.com/hashicorp/go-discover/provider/gce",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "z2HYgfd2QRA5/ciDKgqayGb5bNw=",
+			"path": "github.com/hashicorp/go-discover/provider/k8s",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z"
+		},
+		{
+			"checksumSHA1": "SbPabgJWHX8uVsLwlGqpVLs20XU=",
+			"path": "github.com/hashicorp/go-discover/provider/os",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "y19sWSVrdVfzaRGPS3NcLWe4FpU=",
+			"path": "github.com/hashicorp/go-discover/provider/packet",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z"
+		},
+		{
+			"checksumSHA1": "amLxw8GikdQQ2U+HT1+GzdZG3Dw=",
+			"path": "github.com/hashicorp/go-discover/provider/scaleway",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "SIyZ44AHIUTBfI336ACpCeybsLg=",
+			"path": "github.com/hashicorp/go-discover/provider/softlayer",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "OmBrnagVa2akyR9nbQjia28lunE=",
+			"path": "github.com/hashicorp/go-discover/provider/triton",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z"
+		},
+		{
+			"checksumSHA1": "s5lxWYL2UiEeOksa3DVEYWJsH1I=",
+			"path": "github.com/hashicorp/go-discover/provider/vsphere",
+			"revision": "f9c9239562a8e21e5a37f1f2604d8f1c11bc3893",
+			"revisionTime": "2018-08-31T15:49:06Z"
+		},
+		{
+			"checksumSHA1": "qhjAx0nMYBeQqRTaf7sQYpfUIq0=",
+			"path": "github.com/hashicorp/go-hclog",
+			"revision": "69ff559dc25f3b435631604f573a5fa1efdb6433",
+			"revisionTime": "2018-04-02T20:04:05Z"
+		},
+		{
+			"checksumSHA1": "Cas2nprG6pWzf05A2F/OlnjUu2Y=",
+			"path": "github.com/hashicorp/go-immutable-radix",
+			"revision": "8aac2701530899b64bdea735a1de8da899815220",
+			"revisionTime": "2017-07-25T22:12:15Z"
+		},
+		{
+			"checksumSHA1": "4Ge4Vvtbyhb5nN3o+7Vq0Za8i8U=",
+			"path": "github.com/hashicorp/go-memdb",
+			"revision": "1289e7fffe71d8fd4d4d491ba9a412c50f244c44",
+			"revisionTime": "2018-02-23T23:30:45Z"
+		},
+		{
+			"checksumSHA1": "TNlVzNR1OaajcNi3CbQ3bGbaLGU=",
+			"path": "github.com/hashicorp/go-msgpack/codec",
+			"revision": "fa3f63826f7c23912c15263591e65d54d080b458",
+			"revisionTime": "2015-05-18T23:42:57Z"
+		},
+		{
+			"checksumSHA1": "lrSl49G23l6NhfilxPM0XFs5rZo=",
+			"path": "github.com/hashicorp/go-multierror",
+			"revision": "d30f09973e19c1dfcd120b2d9c4f168e68d6b5d5",
+			"revisionTime": "2015-09-16T20:57:42Z"
+		},
+		{
+			"checksumSHA1": "lbG9uwM7qJlTIBg+8mjCC88sCPc=",
+			"path": "github.com/hashicorp/go-plugin",
+			"revision": "e8d22c780116115ae5624720c9af0c97afe4f551",
+			"revisionTime": "2018-03-31T00:25:53Z"
+		},
+		{
+			"checksumSHA1": "s6mKR1dSKP04+A3kwSsFr/PvsOU=",
+			"path": "github.com/hashicorp/go-retryablehttp",
+			"revision": "3b087ef2d313afe6c55b2f511d20db04ca767075",
+			"revisionTime": "2018-05-31T21:13:21Z"
+		},
+		{
+			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",
+			"path": "github.com/hashicorp/go-rootcerts",
+			"revision": "6bb64b370b90e7ef1fa532be9e591a81c3493e00",
+			"revisionTime": "2016-05-03T14:34:40Z"
+		},
+		{
+			"checksumSHA1": "J47ySO1q0gcnmoMnir1q1loKzCk=",
+			"path": "github.com/hashicorp/go-sockaddr",
+			"revision": "e92cdb5343bbaf42b0a596937ae0f382270d6759",
+			"revisionTime": "2019-01-03T21:41:36Z"
+		},
+		{
+			"checksumSHA1": "PDp9DVLvf3KWxhs4G4DpIwauMSU=",
+			"path": "github.com/hashicorp/go-sockaddr/template",
+			"revision": "9b4c5fa5b10a683339a270d664474b9f4aee62fc",
+			"revisionTime": "2017-10-30T10:43:12Z"
+		},
+		{
+			"checksumSHA1": "xZ7Ban1x//6uUIU1xtrTbCYNHBc=",
+			"path": "github.com/hashicorp/go-syslog",
+			"revision": "42a2b573b664dbf281bd48c3cc12c086b17a39ba",
+			"revisionTime": "2015-02-18T18:19:46Z"
+		},
+		{
+			"checksumSHA1": "mAkPa/RLuIwN53GbwIEMATexams=",
+			"path": "github.com/hashicorp/go-uuid",
+			"revision": "64130c7a86d732268a38cb04cfbaf0cc987fda98",
+			"revisionTime": "2016-07-17T02:21:40Z"
+		},
+		{
+			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
+			"path": "github.com/hashicorp/go-version",
+			"revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
+			"revisionTime": "2017-02-02T08:07:59Z"
+		},
+		{
+			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
+			"path": "github.com/hashicorp/golang-lru",
+			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4",
+			"revisionTime": "2016-02-07T21:47:19Z"
+		},
+		{
+			"checksumSHA1": "2nOpYjx8Sn57bqlZq17yM4YJuM4=",
+			"path": "github.com/hashicorp/golang-lru/simplelru",
+			"revision": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4",
+			"revisionTime": "2016-02-07T21:47:19Z"
+		},
+		{
+			"checksumSHA1": "bWGI7DqWg6IdhfamV96OD+Esa+8=",
+			"path": "github.com/hashicorp/hcl",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "XQmjDva9JCGGkIecOgwtBEMCJhU=",
+			"path": "github.com/hashicorp/hcl/hcl/ast",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "1GmX7G0Pgf5XprOh+T3zXMXX0dc=",
+			"path": "github.com/hashicorp/hcl/hcl/parser",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "encY+ZtDf4nJaMvsVL2c+EJ2r3Q=",
+			"path": "github.com/hashicorp/hcl/hcl/printer",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "+qJTCxhkwC7r+VZlPlZz8S74KmU=",
+			"path": "github.com/hashicorp/hcl/hcl/scanner",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "oS3SCN9Wd6D8/LG0Yx1fu84a7gI=",
+			"path": "github.com/hashicorp/hcl/hcl/strconv",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
+			"path": "github.com/hashicorp/hcl/hcl/token",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "PwlfXt7mFS8UYzWxOK5DOq0yxS0=",
+			"path": "github.com/hashicorp/hcl/json/parser",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "afrZ8VmAwfTdDAYVgNSXbxa4GsA=",
+			"path": "github.com/hashicorp/hcl/json/scanner",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
+			"path": "github.com/hashicorp/hcl/json/token",
+			"revision": "65a6292f0157eff210d03ed1bf6c59b190b8b906",
+			"revisionTime": "2018-09-06T18:38:39Z"
+		},
+		{
+			"checksumSHA1": "kqCMCHy2b+RBMKC+ER+OPqp8C3E=",
+			"path": "github.com/hashicorp/hil",
+			"revision": "1e86c6b523c55d1fa6c6e930ce80b548664c95c2",
+			"revisionTime": "2016-07-11T23:18:37Z"
+		},
+		{
+			"checksumSHA1": "UICubs001+Q4MsUf9zl2vcMzWQQ=",
+			"path": "github.com/hashicorp/hil/ast",
+			"revision": "1e86c6b523c55d1fa6c6e930ce80b548664c95c2",
+			"revisionTime": "2016-07-11T23:18:37Z"
+		},
+		{
+			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",
+			"path": "github.com/hashicorp/logutils",
+			"revision": "0dc08b1671f34c4250ce212759ebd880f743d883",
+			"revisionTime": "2015-06-09T07:04:31Z"
+		},
+		{
+			"checksumSHA1": "j4pWTjW3SFOPVwWBEZPuNHETnLE=",
+			"path": "github.com/hashicorp/memberlist",
+			"revision": "b38abf62d7f3ce5225722cd62a90cfb098e02519",
+			"revisionTime": "2019-02-04T18:04:39Z"
+		},
+		{
+			"checksumSHA1": "qnlqWJYV81ENr61SZk9c65R1mDo=",
+			"path": "github.com/hashicorp/net-rpc-msgpackrpc",
+			"revision": "a14192a58a694c123d8fe5481d4a4727d6ae82f3",
+			"revisionTime": "2015-11-16T02:03:38Z"
+		},
+		{
+			"checksumSHA1": "3U9bQLEMikE47n4TZP6uOdgXIyQ=",
+			"path": "github.com/hashicorp/raft",
+			"revision": "da92cfe76e0c1c9b94bbc9d884ec4b2b3b90b699",
+			"revisionTime": "2018-08-17T18:12:11Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "QAxukkv54/iIvLfsUP6IK4R0m/A=",
+			"path": "github.com/hashicorp/raft-boltdb",
+			"revision": "d1e82c1ec3f15ee991f7cc7ffd5b67ff6f5bbaee",
+			"revisionTime": "2015-02-01T20:08:39Z"
+		},
+		{
+			"checksumSHA1": "0PeWsO2aI+2PgVYlYlDPKfzCLEQ=",
+			"path": "github.com/hashicorp/serf/coordinate",
+			"revision": "65da6f27f6e551e03d99364ecc0607e91e526b00",
+			"revisionTime": "2019-01-22T20:12:06Z"
+		},
+		{
+			"checksumSHA1": "zXQ+WC7vYZLkqqM38dtDQ2Erv0E=",
+			"path": "github.com/hashicorp/serf/serf",
+			"revision": "65da6f27f6e551e03d99364ecc0607e91e526b00",
+			"revisionTime": "2019-01-22T20:12:06Z"
+		},
+		{
+			"checksumSHA1": "LYQZ+o7zJCda/6LibdN0spFco34=",
+			"path": "github.com/hashicorp/vault/api",
+			"revision": "533003e27840d9646cb4e7d23b3a113895da1dd0",
+			"revisionTime": "2018-06-20T14:55:40Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
+		},
+		{
+			"checksumSHA1": "2JOC+Ur0S3U8Gqv2cfNB3zxgSBk=",
+			"path": "github.com/hashicorp/vault/audit",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "RCwWixWwKG6j2vF9iVoxbCzo6p4=",
+			"path": "github.com/hashicorp/vault/builtin/logical/database/dbplugin",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "Cq4SMVoiZkSOd4l7wZ8cw3YQI+I=",
+			"path": "github.com/hashicorp/vault/builtin/logical/pki",
+			"revision": "533003e27840d9646cb4e7d23b3a113895da1dd0",
+			"revisionTime": "2018-06-20T14:55:40Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
+		},
+		{
+			"checksumSHA1": "0EEhZk5anF4d8t2npA3/AKer94s=",
+			"path": "github.com/hashicorp/vault/helper/builtinplugins",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "o9nAIkUO5M1KKFetcqhG1+XXvgg=",
+			"path": "github.com/hashicorp/vault/helper/certutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "bSdPFOHaTwEvM4PIvn0PZfn75jM=",
+			"path": "github.com/hashicorp/vault/helper/compressutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "hMn73ZxhFAqTEM6fgD7r9/1Hbww=",
+			"path": "github.com/hashicorp/vault/helper/consts",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "PWiX5fkg8bajP3fmJL0a92pOlfg=",
+			"path": "github.com/hashicorp/vault/helper/dbtxn",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "fuAZjiabZXVJ7ORLb0vjLOT4+iU=",
+			"path": "github.com/hashicorp/vault/helper/errutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "N/1l6Sppn/iRIFARuYlLkEZ9mqg=",
+			"path": "github.com/hashicorp/vault/helper/forwarding",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "RlqPBLOexQ0jj6jomhiompWKaUg=",
+			"path": "github.com/hashicorp/vault/helper/hclutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "efzomhX2afkZu64i+zqjhemg/6k=",
+			"path": "github.com/hashicorp/vault/helper/identity",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "POgkM3GrjRFw6H3sw95YNEs552A=",
+			"path": "github.com/hashicorp/vault/helper/jsonutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "Dm8C/NfkwxHIpq27XJk1GOsRnus=",
+			"path": "github.com/hashicorp/vault/helper/kdf",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "HXFeJ9fHzeS58ZHnMqkMGDrtW44=",
+			"path": "github.com/hashicorp/vault/helper/keysutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "kPLxfKd5d4TkHZLdtAs73hMrCfQ=",
+			"path": "github.com/hashicorp/vault/helper/locksutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "53QmBPtb7u9ZMyEApCGOISsLqbs=",
+			"path": "github.com/hashicorp/vault/helper/logging",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "0hby54fDnmZc1vWBF2TUCHCnLdc=",
+			"path": "github.com/hashicorp/vault/helper/mlock",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "zPHu2orsbQqIuiuQ/8elJIUR2Po=",
+			"path": "github.com/hashicorp/vault/helper/parseutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "lcB1+PpXYpMmK9P+Bf0EuaTVi1c=",
+			"path": "github.com/hashicorp/vault/helper/pathmanager",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "EPOFuDrCcLPwHZNgaCve5N7i2wU=",
+			"path": "github.com/hashicorp/vault/helper/pgpkeys",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "duVuK2lg3M9jypeWCPZJXSwPjbg=",
+			"path": "github.com/hashicorp/vault/helper/pluginutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "tVBKLYwF7ZlbwzhAT9/RvVeuPL0=",
+			"path": "github.com/hashicorp/vault/helper/policyutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "f0Hl9+yjkKA6Wsg+1lsFIER9R4I=",
+			"path": "github.com/hashicorp/vault/helper/reload",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "Jo4HS6vAXhZgkBO+LgozpIUlFfQ=",
+			"path": "github.com/hashicorp/vault/helper/salt",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "t5GgJx+N2gkJ0EAOv7Bpir1k0Jc=",
+			"path": "github.com/hashicorp/vault/helper/storagepacker",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "iwXQDzHqTFsjJW2ehYae0oLo2Ts=",
+			"path": "github.com/hashicorp/vault/helper/strutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "3j8u5mMkRfs+YG0viUIFPqDWeJc=",
+			"path": "github.com/hashicorp/vault/helper/tlsutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "GAi7Opzj6QqWATlYBqrAcchGunw=",
+			"path": "github.com/hashicorp/vault/helper/wrapping",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "c66DHHA2+FAVq7pFPqy3/VXBRrk=",
+			"path": "github.com/hashicorp/vault/helper/xor",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "ffJDFnCLEl5u0xyTY9lWZTd52UE=",
+			"path": "github.com/hashicorp/vault/http",
+			"revision": "533003e27840d9646cb4e7d23b3a113895da1dd0",
+			"revisionTime": "2018-06-20T14:55:40Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
+		},
+		{
+			"checksumSHA1": "Apg+J1aimN8xfNh1wi90sbY3BlU=",
+			"path": "github.com/hashicorp/vault/logical",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "dmdJnpLGiLsUkxFeuPFjhQV6zIw=",
+			"path": "github.com/hashicorp/vault/logical/framework",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "nY+zDPf6xwkJhvhMpn3yPgjkTco=",
+			"path": "github.com/hashicorp/vault/physical",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "2k8WQEW1/3b7yxzCw7GtaRAXX+U=",
+			"path": "github.com/hashicorp/vault/physical/inmem",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "so/TDbUxS8q3lGVcvmPGhoVSjnA=",
+			"path": "github.com/hashicorp/vault/plugins",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "UejID1TCiSinNGvsjiXG2k6yN8E=",
+			"path": "github.com/hashicorp/vault/plugins/database/cassandra",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "HEFzFaIJ/S4M7y5OFaeaCABYlzg=",
+			"path": "github.com/hashicorp/vault/plugins/database/hana",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "wi1tCfc4QieD70+53/BQXRYcY7I=",
+			"path": "github.com/hashicorp/vault/plugins/database/mongodb",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "2IF6rWeBM5/AYCvSaWwp/wcIrDw=",
+			"path": "github.com/hashicorp/vault/plugins/database/mssql",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "TaDNmuhhN1eYp45HPI3KZ6lGdio=",
+			"path": "github.com/hashicorp/vault/plugins/database/mysql",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "ajw/HnXt19AOcfALJc71j3OKnZs=",
+			"path": "github.com/hashicorp/vault/plugins/database/postgresql",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "aZNqbMefIEk6uArnrIhP0Xq5ymc=",
+			"path": "github.com/hashicorp/vault/plugins/helper/database/connutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "93U0UimNWRv3iVVSNf+yAAhi51A=",
+			"path": "github.com/hashicorp/vault/plugins/helper/database/credsutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "3aKAlts9VJzYH/TX3I+4WkLlrvs=",
+			"path": "github.com/hashicorp/vault/plugins/helper/database/dbutil",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "WsYazSLKu3ads8U1NxnGl4y0Ib8=",
+			"path": "github.com/hashicorp/vault/shamir",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "RWsMbaFcvqlE9Gmqc2IBgUs/GKI=",
+			"path": "github.com/hashicorp/vault/vault",
+			"revision": "533003e27840d9646cb4e7d23b3a113895da1dd0",
+			"revisionTime": "2018-06-20T14:55:40Z",
+			"version": "v0.10.3",
+			"versionExact": "v0.10.3"
+		},
+		{
+			"checksumSHA1": "H9VzUv8o4ov6XoyXP3JjteY3HkM=",
+			"path": "github.com/hashicorp/vault/version",
+			"revision": "c737968235c8673b872350f0a047877bee396342",
+			"revisionTime": "2018-06-20T16:45:32Z"
+		},
+		{
+			"checksumSHA1": "jJouEcBeEAO0ejDRJoT67jL8NjQ=",
+			"path": "github.com/hashicorp/yamux",
+			"revision": "3520598351bb3500a49ae9563f5539666ae0a27c",
+			"revisionTime": "2018-06-04T19:48:46Z"
+		},
+		{
+			"checksumSHA1": "3LWNcQT7yTaLpEmjhI/3fi8puv0=",
+			"path": "github.com/imdario/mergo",
+			"revision": "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4",
+			"revisionTime": "2018-07-30T21:26:40Z"
+		},
+		{
+			"checksumSHA1": "cIinEjB62s8j5cpY1u7sxtg4akg=",
+			"path": "github.com/jefferai/jsonx",
+			"revision": "9cc31c3135eef39b8e72585f37efa92b6ca314d0",
+			"revisionTime": "2016-07-21T23:51:17Z"
+		},
+		{
+			"checksumSHA1": "LuvUVcxSYc0KkzpqNJArgiPMtNU=",
+			"path": "github.com/joyent/triton-go",
+			"revision": "7283d1d02f7a297bf2f068178a084c5bd090002c",
+			"revisionTime": "2018-04-27T15:22:50Z"
+		},
+		{
+			"checksumSHA1": "yNrArK8kjkVkU0bunKlemd6dFkE=",
+			"path": "github.com/joyent/triton-go/authentication",
+			"revision": "7283d1d02f7a297bf2f068178a084c5bd090002c",
+			"revisionTime": "2018-04-27T15:22:50Z"
+		},
+		{
+			"checksumSHA1": "nppv6i9E2yqdbQ6qJkahCwELSeI=",
+			"path": "github.com/joyent/triton-go/client",
+			"revision": "7283d1d02f7a297bf2f068178a084c5bd090002c",
+			"revisionTime": "2018-04-27T15:22:50Z"
+		},
+		{
+			"checksumSHA1": "PTwWWEFRC4GzXM91gQj5xBMF3GM=",
+			"path": "github.com/joyent/triton-go/compute",
+			"revision": "7283d1d02f7a297bf2f068178a084c5bd090002c",
+			"revisionTime": "2018-04-27T15:22:50Z"
+		},
+		{
+			"checksumSHA1": "d/Py6j/uMgOAFNFGpsQrNnSsO+k=",
+			"path": "github.com/joyent/triton-go/errors",
+			"revision": "7283d1d02f7a297bf2f068178a084c5bd090002c",
+			"revisionTime": "2018-04-27T15:22:50Z"
+		},
+		{
+			"checksumSHA1": "WqeEgS7pqqkwK8mlrAZmDgtWJMY=",
+			"path": "github.com/json-iterator/go",
+			"revision": "1624edc4454b8682399def8740d46db5e4362ba4",
+			"revisionTime": "2018-08-06T06:07:27Z"
+		},
+		{
+			"checksumSHA1": "VJk3rOWfxEV9Ilig5lgzH1qg8Ss=",
+			"path": "github.com/keybase/go-crypto/brainpool",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "rnRjEJs5luF+DIXp2J6LFcQk8Gg=",
+			"path": "github.com/keybase/go-crypto/cast5",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "F5++ZQS5Vt7hd6lxPCKTffvph1A=",
+			"path": "github.com/keybase/go-crypto/curve25519",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "niLm+6SukuYgFJgnCuDd/KLgPjU=",
+			"path": "github.com/keybase/go-crypto/ed25519",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "oFj+c+T9/0PTmvpz1Vlx1L6aI98=",
+			"path": "github.com/keybase/go-crypto/ed25519/internal/edwards25519",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "DivaBvI1xAPAW+6y8hhcf1FaBFI=",
+			"path": "github.com/keybase/go-crypto/openpgp",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "tin/wcIHur1IM0n5f5u8nlZ/J6U=",
+			"path": "github.com/keybase/go-crypto/openpgp/armor",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "nWhmwjBJqPSvkCWqaap2Z9EiS1k=",
+			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
+			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "ofZhU2758YZAAGSEJ8UjFMQLc+k=",
+			"path": "github.com/keybase/go-crypto/openpgp/errors",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "T7jstUu+oy2AVhZT/Md7R2lY8LM=",
+			"path": "github.com/keybase/go-crypto/openpgp/packet",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
+			"path": "github.com/keybase/go-crypto/openpgp/s2k",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",
+			"path": "github.com/keybase/go-crypto/rsa",
+			"revision": "5114a9a81e1b256bfe283702d45dad50f8bf5ddf",
+			"revisionTime": "2018-06-14T16:04:07Z"
+		},
+		{
+			"checksumSHA1": "SbguDK5lY8uhaHNrmJmNbiWIGM0=",
+			"path": "github.com/kr/text",
+			"revision": "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f",
+			"revisionTime": "2018-05-06T08:24:08Z"
+		},
+		{
+			"checksumSHA1": "s6eyIXpJ7VAU06FM27GcEBM/5lo=",
+			"path": "github.com/lib/pq",
+			"revision": "90697d60dd844d5ef6ff15135d0203f65d2f53b8",
+			"revisionTime": "2018-05-23T17:54:26Z"
+		},
+		{
+			"checksumSHA1": "AU3fA8Sm33Vj9PBoRPSeYfxLRuE=",
+			"path": "github.com/lib/pq/oid",
+			"revision": "90697d60dd844d5ef6ff15135d0203f65d2f53b8",
+			"revisionTime": "2018-05-23T17:54:26Z"
+		},
+		{
+			"checksumSHA1": "+03cu5aBuyzbu0O/eArpD+DptPU=",
+			"path": "github.com/lyft/protoc-gen-validate/validate",
+			"revision": "64fcb82c878efbfe3240e4f164490eefaf6b3c4b",
+			"revisionTime": "2018-09-11T18:09:27Z"
+		},
+		{
+			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
+			"revisionTime": "2016-08-06T12:27:52Z"
+		},
+		{
+			"checksumSHA1": "bKMZjd2wPw13VwoE7mBeSv5djFA=",
+			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"revision": "c12348ce28de40eed0136aa2b644d0ee0650e56c",
+			"revisionTime": "2016-04-24T11:30:07Z"
+		},
+		{
+			"checksumSHA1": "ybBd9oDdeJEZj9YmIKGqaBVqZok=",
+			"path": "github.com/miekg/dns",
+			"revision": "e57bf427e68187a27e22adceac868350d7a7079b",
+			"revisionTime": "2018-05-16T07:59:02Z",
+			"version": "v1.0.7",
+			"versionExact": "v1.0.7"
+		},
+		{
+			"checksumSHA1": "GzfpPGtV2UJH9hFsKwzGjKrhp/A=",
+			"path": "github.com/mitchellh/cli",
+			"revision": "dff723fff508858a44c1f4bd0911f00d73b0202f",
+			"revisionTime": "2017-09-05T22:10:09Z"
+		},
+		{
+			"checksumSHA1": "86nE93o1VIND0Doe8PuhCXnhUx0=",
+			"path": "github.com/mitchellh/copystructure",
+			"revision": "cdac8253d00f2ecf0a0b19fbff173a9a72de4f82",
+			"revisionTime": "2016-08-04T03:23:30Z"
+		},
+		{
+			"checksumSHA1": "V/quM7+em2ByJbWBLOsEwnY3j/Q=",
+			"path": "github.com/mitchellh/go-homedir",
+			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",
+			"revisionTime": "2016-12-03T19:45:07Z"
+		},
+		{
+			"checksumSHA1": "bDdhmDk8q6utWrccBhEOa6IoGkE=",
+			"path": "github.com/mitchellh/go-testing-interface",
+			"revision": "a61a99592b77c9ba629d254a693acffaeb4b7e28",
+			"revisionTime": "2017-10-04T22:19:16Z"
+		},
+		{
+			"checksumSHA1": "tWUjKyFOGJtYExocPWVYiXBYsfE=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "2bca23e0e452137f789efbc8610126fd8b94f73b",
+			"revisionTime": "2017-06-09T04:59:27Z"
+		},
+		{
+			"checksumSHA1": "7F5KalhUJ/sCH5bU44MMgw8tqNo=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "5a380f224700b8a6c4eaad048804f5bff514cb35",
+			"revisionTime": "2018-10-01T02:14:42Z"
+		},
+		{
+			"checksumSHA1": "AMU63CNOg4XmIhVR/S/Xttt1/f0=",
+			"path": "github.com/mitchellh/reflectwalk",
+			"revision": "63d60e9d0dbc60cf9164e6510889b0db6683d98c",
+			"revisionTime": "2017-07-26T20:21:17Z"
+		},
+		{
+			"checksumSHA1": "ZTcgWKWHsrX0RXYVXn5Xeb8Q0go=",
+			"path": "github.com/modern-go/concurrent",
+			"revision": "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94",
+			"revisionTime": "2018-03-06T01:26:44Z"
+		},
+		{
+			"checksumSHA1": "qvH48wzTIV3QKSDqI0dLFtVjaDI=",
+			"path": "github.com/modern-go/reflect2",
+			"revision": "94122c33edd36123c84d5368cfb2b69df93a0ec8",
+			"revisionTime": "2018-07-18T01:23:57Z"
+		},
+		{
+			"checksumSHA1": "nf3UoPNBIut7BL9nWE8Fw2X2j+Q=",
+			"path": "github.com/oklog/run",
+			"revision": "6934b124db28979da51d3470dadfa34d73d72652",
+			"revisionTime": "2018-03-08T00:51:04Z"
+		},
+		{
+			"checksumSHA1": "Pp5neNys4egjuZoQ9IF3ll9zYaY=",
+			"path": "github.com/packethost/packngo",
+			"revision": "b627120f2da509ca7ff76faf2bbdf6794d873616",
+			"revisionTime": "2018-07-12T12:50:00Z"
+		},
+		{
+			"checksumSHA1": "5h+ERzHw3Rl2G0kFPxoJzxiA9s0=",
+			"path": "github.com/pascaldekloe/goe/verify",
+			"revision": "07ebd1e2481f616a278ab431cf04cc5cf5ab3ebe",
+			"revisionTime": "2017-03-28T18:37:59Z"
+		},
+		{
+			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
+			"path": "github.com/patrickmn/go-cache",
+			"revision": "9f6ff22cfff829561052f5886ec80a2ac148b4eb",
+			"revisionTime": "2018-05-27T04:33:50Z"
+		},
+		{
+			"checksumSHA1": "1DFgH7ZOfpUqg0Jsf2719jVgrew=",
+			"path": "github.com/peterbourgon/diskv",
+			"revision": "0646ccaebea1ed1539efcab30cae44019090093f",
+			"revisionTime": "2018-03-12T05:41:25Z"
+		},
+		{
+			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
+			"path": "github.com/pkg/errors",
+			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",
+			"revisionTime": "2017-03-16T20:15:38Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "Nt4Ol6ZM2n0XD5zatxjwEYBpQnw=",
+			"path": "github.com/posener/complete",
+			"revision": "dc2bc5a81accba8782bebea28628224643a8286a",
+			"revisionTime": "2017-11-04T09:57:02Z",
+			"version": "=v1.1",
+			"versionExact": "v1.1"
+		},
+		{
+			"checksumSHA1": "72GXEVomX5rdB9CRPs9FR97lJCs=",
+			"path": "github.com/prometheus/client_golang/prometheus",
+			"revision": "505eaef017263e299324067d40ca2c48f6a2cf50",
+			"revisionTime": "2018-12-07T10:51:17Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
+		},
+		{
+			"checksumSHA1": "UBqhkyjCz47+S19MVTigxJ2VjVQ=",
+			"path": "github.com/prometheus/client_golang/prometheus/internal",
+			"revision": "505eaef017263e299324067d40ca2c48f6a2cf50",
+			"revisionTime": "2018-12-07T10:51:17Z",
+			"version": "v0.9.2",
+			"versionExact": "v0.9.2"
+		},
+		{
+			"checksumSHA1": "BM771aKU6hC+5rap48aqvMXczII=",
+			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"revision": "f504d69affe11ec1ccb2e5948127f86878c9fd57",
+			"revisionTime": "2018-03-28T13:04:30Z"
+		},
+		{
+			"checksumSHA1": "DvwvOlPNAgRntBzt3b3OSRMS2N4=",
+			"path": "github.com/prometheus/client_model/go",
+			"revision": "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c",
+			"revisionTime": "2017-11-17T10:05:41Z"
+		},
+		{
+			"checksumSHA1": "+wZ+Pa6NX+NOxUvayXBXGOcqFe8=",
+			"path": "github.com/prometheus/common/expfmt",
+			"revision": "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a",
+			"revisionTime": "2018-03-26T16:04:09Z"
+		},
+		{
+			"checksumSHA1": "YU+/K48IMawQnToO4ETE6a+hhj4=",
+			"path": "github.com/prometheus/common/model",
+			"revision": "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a",
+			"revisionTime": "2018-03-26T16:04:09Z"
+		},
+		{
+			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
+			"path": "github.com/prometheus/procfs",
+			"revision": "780932d4fbbe0e69b84c34c20f5c8d0981e109ea",
+			"revisionTime": "2018-03-21T23:08:12Z"
+		},
+		{
+			"checksumSHA1": "HSP5hVT0CNMRa8+Xtz4z2Ic5U0E=",
+			"path": "github.com/prometheus/procfs/nfs",
+			"revision": "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e",
+			"revisionTime": "2018-04-08T09:29:02Z"
+		},
+		{
+			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
+			"path": "github.com/prometheus/procfs/xfs",
+			"revision": "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e",
+			"revisionTime": "2018-04-08T09:29:02Z"
+		},
+		{
+			"checksumSHA1": "ExnVEVNT8APpFTm26cUb5T09yR4=",
+			"comment": "v2.0.1-8-g983d3a5",
+			"path": "github.com/ryanuber/columnize",
+			"revision": "9b3edd62028f107d7cabb19353292afd29311a4e",
+			"revisionTime": "2016-07-12T16:32:29Z"
+		},
+		{
+			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"revisionTime": "2017-01-28T01:21:29Z"
+		},
+		{
+			"checksumSHA1": "A/YUMbGg1LHIeK2+NLZBt+MIAao=",
+			"path": "github.com/sean-/seed",
+			"revision": "3c72d44db0c567f7c901f9c5da5fe68392227750",
+			"revisionTime": "2017-02-08T16:47:21Z"
+		},
+		{
+			"checksumSHA1": "KUrV5Esg6Wdcrv+hDc6/p0Q3/qw=",
+			"path": "github.com/shirou/gopsutil",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "ZRkivbqqxTXH267b+mFAEk55HRI=",
+			"path": "github.com/shirou/gopsutil/cpu",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "JRyOki26wb3vORGErYK95N4tAeQ=",
+			"path": "github.com/shirou/gopsutil/disk",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "j+lnhiTHzGU2/EOd2k2EceD7Mak=",
+			"path": "github.com/shirou/gopsutil/host",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "GR7l7Ez4ppxIfonl7aJayYRVPWc=",
+			"path": "github.com/shirou/gopsutil/internal/common",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "ehcscnqRvxDZYb1nBDVzZi8vFi8=",
+			"path": "github.com/shirou/gopsutil/mem",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "wAc1Qo6T9MTYdSog78uJfCYZPtc=",
+			"path": "github.com/shirou/gopsutil/net",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "eI4qh+sc46gqKAfBt2jspO2l448=",
+			"path": "github.com/shirou/gopsutil/process",
+			"revision": "48177ef5f8809fc72b716c414435f2d4cff8e24d",
+			"revisionTime": "2018-11-07T11:16:21Z"
+		},
+		{
+			"checksumSHA1": "Nve7SpDmjsv6+rhkXAkfg/UQx94=",
+			"path": "github.com/shirou/w32",
+			"revision": "bb4de0191aa41b5507caa14b0650cdbddcd9280b",
+			"revisionTime": "2016-09-30T03:27:40Z"
+		},
+		{
+			"checksumSHA1": "WVKhLVXQFxXwmuRX+IRzebUmxjE=",
+			"path": "github.com/spf13/pflag",
+			"revision": "298182f68c66c05229eb03ac171abe6e309ee79a",
+			"revisionTime": "2018-08-31T15:14:32Z"
+		},
+		{
+			"checksumSHA1": "n+vQ7Bmp+ODWGmCp8cI5MFsaZVA=",
+			"path": "github.com/stretchr/objx",
+			"revision": "a5cfa15c000af5f09784e5355969ba7eb66ef0de",
+			"revisionTime": "2018-04-26T10:50:06Z"
+		},
+		{
+			"checksumSHA1": "6LwXZI7kXm1C0h4Ui0Y52p9uQhk=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "Qloi2PTvZv+D9FDHXM/banCoaFY=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "KqYmXUcuGwsvBL6XVsQnXsFb3LI=",
+			"path": "github.com/stretchr/testify/require",
+			"revision": "c679ae2cc0cb27ec3293fea7e254e47386f05d69",
+			"revisionTime": "2018-03-14T08:05:35Z"
+		},
+		{
+			"checksumSHA1": "3axQiX2sKB0pNGLIPwPqKIoZW90=",
+			"path": "github.com/vmware/govmomi",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "xFi1dbYQR8VwSRojdJMdvRGOmIw=",
+			"path": "github.com/vmware/govmomi/find",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "J3JrwZagGYMX6oNMkdsUFf8hHo8=",
+			"path": "github.com/vmware/govmomi/list",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "kYO3J9/MIfRkiKxPMTUwOvIOSso=",
+			"path": "github.com/vmware/govmomi/nfc",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "QcM9lF0o6EPkeuZmritWyGE+0g4=",
+			"path": "github.com/vmware/govmomi/object",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "CPOocvkED4p4GhKZxwov8v7xfoA=",
+			"path": "github.com/vmware/govmomi/property",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "X0FWJTv6W/92YB21IBuEp3Mf3z4=",
+			"path": "github.com/vmware/govmomi/session",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "FQR3yNgiShaqUiJREkeqQCKYJ84=",
+			"path": "github.com/vmware/govmomi/task",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "7TYb0QwZ9DawKt89GlGABc9ufco=",
+			"path": "github.com/vmware/govmomi/vim25",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "xLvppq0NUD6Hv2GIx1gh75xUzyM=",
+			"path": "github.com/vmware/govmomi/vim25/debug",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "YfxE/jP0aAGIAhBQTVEAjZG1CKc=",
+			"path": "github.com/vmware/govmomi/vim25/methods",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "rAfxxiPj4cguQnmCzCpkKsuTsBc=",
+			"path": "github.com/vmware/govmomi/vim25/mo",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "OLrtV4J/PfHWhl0OZLb1zmqlt6E=",
+			"path": "github.com/vmware/govmomi/vim25/progress",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "yxGB1R4/Se+vJDUuds0GZz4cbkQ=",
+			"path": "github.com/vmware/govmomi/vim25/soap",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "F58FP8qS+yAPVSCUPRsv2lhkfA0=",
+			"path": "github.com/vmware/govmomi/vim25/types",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "6XLRzLEvncx5ORtvBjp41KfRTjc=",
+			"path": "github.com/vmware/govmomi/vim25/xml",
+			"revision": "0627a5e7a9dc71f6e02b25f781a9b82f5985b084",
+			"revisionTime": "2018-07-14T17:07:08Z"
+		},
+		{
+			"checksumSHA1": "ZLGAwcBpN5I+RNzoxt5pTssyobU=",
+			"path": "github.com/vmware/vic/pkg/vsphere/tags",
+			"revision": "e0dd53e0e72531b36976839a79093a3cf8126411",
+			"revisionTime": "2018-07-12T16:27:50Z"
+		},
+		{
+			"checksumSHA1": "ejjxT0+wDWWncfh0Rt3lSH4IbXQ=",
+			"path": "golang.org/x/crypto/blake2b",
+			"revision": "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb",
+			"revisionTime": "2018-10-15T00:23:17Z"
+		},
+		{
+			"checksumSHA1": "XeVtoYW/XdZj+VJpmHmPKcqJO+o=",
+			"path": "golang.org/x/crypto/chacha20poly1305",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "VrW/nowBxVcqQhIrqDJNxr5NWu0=",
+			"path": "golang.org/x/crypto/cryptobyte",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "YEoV2AiZZPDuF7pMVzDt7buS9gc=",
+			"path": "golang.org/x/crypto/cryptobyte/asn1",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "IQkUIOnvlf0tYloFx9mLaXSvXWQ=",
+			"path": "golang.org/x/crypto/curve25519",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "VqyzfAMKyP6SoLnPHcwhkrICBo0=",
+			"path": "golang.org/x/crypto/ed25519",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "0JTAFXPkankmWcZGQJGScLDiaN8=",
+			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "4D8hxMIaSDEW5pCQk22Xj4DcDh4=",
+			"path": "golang.org/x/crypto/hkdf",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "SEPNUEkZaGKt3dkO3B13pRAp6ho=",
+			"path": "golang.org/x/crypto/internal/chacha20",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "voGom9bAyXrZZkdtqCV41+U4iPo=",
+			"path": "golang.org/x/crypto/internal/subtle",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "MCeXr2RNeiG1XG6V+er1OR0qyeo=",
+			"path": "golang.org/x/crypto/md4",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "kVKE0OX1Xdw5mG7XKT86DLLKE2I=",
+			"path": "golang.org/x/crypto/poly1305",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "acLRVrKhcyCKY585ZGjamSwx2jQ=",
+			"path": "golang.org/x/crypto/ssh",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "R9VBzgWGaphXv2/b4DLeMAbq9Xg=",
+			"path": "golang.org/x/crypto/ssh/agent",
+			"revision": "2d027ae1dddd4694d54f7a8b6cbe78dca8720226",
+			"revisionTime": "2018-05-09T20:48:04Z"
+		},
+		{
+			"checksumSHA1": "BGm8lKZmvJbf/YOJLeL1rw2WVjA=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
+			"revisionTime": "2018-06-20T09:14:27Z"
+		},
+		{
+			"checksumSHA1": "NjyXtXsaf0ulRJn6HQSP1FqGL4A=",
+			"path": "golang.org/x/net/bpf",
+			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+			"revisionTime": "2018-05-08T00:58:03Z"
+		},
+		{
+			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
+			"path": "golang.org/x/net/context",
+			"revision": "afe8f62b1d6bbd81f31868121a50b06d8188e1f9",
+			"revisionTime": "2018-06-20T20:20:43Z"
+		},
+		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "075e191f18186a8ff2becaf64478e30f4545cdad",
+			"revisionTime": "2016-08-05T06:12:51Z"
+		},
+		{
+			"checksumSHA1": "aaproqDPgHPV5s7lKzClAdCaDKQ=",
+			"path": "golang.org/x/net/http2",
+			"revision": "01c190206fbdffa42f334f4b2bf2220f50e64920",
+			"revisionTime": "2017-11-02T18:53:09Z"
+		},
+		{
+			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "01c190206fbdffa42f334f4b2bf2220f50e64920",
+			"revisionTime": "2017-11-02T18:53:09Z"
+		},
+		{
+			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
+			"path": "golang.org/x/net/idna",
+			"revision": "01c190206fbdffa42f334f4b2bf2220f50e64920",
+			"revisionTime": "2017-11-02T18:53:09Z"
+		},
+		{
+			"checksumSHA1": "KZoApXkpu6ucvSiKDep+5bQDNUo=",
+			"path": "golang.org/x/net/internal/iana",
+			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+			"revisionTime": "2018-05-08T00:58:03Z"
+		},
+		{
+			"checksumSHA1": "YsXlbexuTtUXHyhSv927ILOkf6A=",
+			"path": "golang.org/x/net/internal/socket",
+			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+			"revisionTime": "2018-05-08T00:58:03Z"
+		},
+		{
+			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"checksumSHA1": "ncLr3evob5ZOUHJS528IQoI8CTg=",
+			"path": "golang.org/x/net/ipv4",
+			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+			"revisionTime": "2018-05-08T00:58:03Z"
+		},
+		{
+			"checksumSHA1": "xqt5auCDSuvg5dm07p60loM67/A=",
+			"path": "golang.org/x/net/ipv6",
+			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
+			"revisionTime": "2018-05-08T00:58:03Z"
+		},
+		{
+			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"path": "golang.org/x/net/lex/httplex",
+			"revision": "01c190206fbdffa42f334f4b2bf2220f50e64920",
+			"revisionTime": "2017-11-02T18:53:09Z"
+		},
+		{
+			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
+			"path": "golang.org/x/net/proxy",
+			"revision": "02ac38e2528ff4adea90f184d71a3faa04b4b1b0",
+			"revisionTime": "2017-07-18T17:12:47Z"
+		},
+		{
+			"checksumSHA1": "u/r66lwYfgg682u5hZG7/E7+VCY=",
+			"path": "golang.org/x/net/trace",
+			"revision": "d866cfc389cec985d6fda2859936a575a55a3ab6",
+			"revisionTime": "2017-12-11T20:45:21Z"
+		},
+		{
+			"path": "golang.org/x/oauth2",
+			"revision": ""
+		},
+		{
+			"path": "golang.org/x/oauth2/google",
+			"revision": ""
+		},
+		{
+			"checksumSHA1": "REkmyB368pIiip76LiqMLspgCRk=",
+			"path": "golang.org/x/sys/cpu",
+			"revision": "ad87a3a340fa7f3bed189293fbfa7a9b7e021ae1",
+			"revisionTime": "2018-06-18T16:37:21Z"
+		},
+		{
+			"checksumSHA1": "su2QDjUzrUO0JnOH9m0cNg0QqsM=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "ac767d655b305d4e9612f5f6e33120b9176c4ad4",
+			"revisionTime": "2018-07-08T03:57:06Z"
+		},
+		{
+			"checksumSHA1": "P8Y8GFwxybTfltfh8Q0lHqlEYIM=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "ac767d655b305d4e9612f5f6e33120b9176c4ad4",
+			"revisionTime": "2018-07-08T03:57:06Z"
+		},
+		{
+			"checksumSHA1": "Fes9OIPy6lS/ghzodqAbMlZZTTQ=",
+			"path": "golang.org/x/sys/windows/svc",
+			"revision": "1b2967e3c290b7c545b3db0deeda16e9be4f98a2",
+			"revisionTime": "2018-07-06T09:56:39Z"
+		},
+		{
+			"checksumSHA1": "tltivJ/uj/lqLk05IqGfCv2F/E8=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"path": "golang.org/x/text/transform",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "tk+lpF2CDV7e5RwwRY5ZTCGrd9o=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "BwRNKgzIMUxk56OScxyr43BV6IE=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "88f656faf3f37f690df1a32515b479415e1a6769",
+			"revisionTime": "2017-10-26T07:52:28Z"
+		},
+		{
+			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
+			"path": "golang.org/x/time/rate",
+			"revision": "8be79e1e0910c292df4e79c241bb7e8f7e725959",
+			"revisionTime": "2017-04-24T23:28:54Z"
+		},
+		{
+			"checksumSHA1": "Tc3BU26zThLzcyqbVtiSEp7EpU8=",
+			"path": "google.golang.org/genproto/googleapis/rpc/status",
+			"revision": "a8101f21cf983e773d0c1133ebc5424792003214",
+			"revisionTime": "2017-12-12T23:19:43Z"
+		},
+		{
+			"checksumSHA1": "38oYmvI4bUVd0ciabO8Kk+cuK2c=",
+			"path": "google.golang.org/grpc",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "B+kZFVP8zRiQMpoEb39Mp2oSmqg=",
+			"path": "google.golang.org/grpc/balancer",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "lw+L836hLeH8+//le+C+ycddCCU=",
+			"path": "google.golang.org/grpc/balancer/base",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "DJ1AtOk4Pu7bqtUMob95Hw8HPNw=",
+			"path": "google.golang.org/grpc/balancer/roundrobin",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "R3tuACGAPyK4lr+oSNt1saUzC0M=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
+			"path": "google.golang.org/grpc/connectivity",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "wA6y5rkH1v4bWBe5M1r/Hdtgma4=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "cfLb+pzWB+Glwp82rgfcEST1mv8=",
+			"path": "google.golang.org/grpc/encoding",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "LKKkn7EYA+Do9Qwb2/SUKLFNxoo=",
+			"path": "google.golang.org/grpc/encoding/proto",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "ZPPSFisPDz2ANO4FBZIft+fRxyk=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "5f4iDmBsp267R75UdXD6s01l+hk=",
+			"path": "google.golang.org/grpc/health",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "KfgIKMqGJ8FdFbWlGDsnmrCY7eE=",
+			"path": "google.golang.org/grpc/health/grpc_health_v1",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "8uLpHZuwD6Ug/QlvN94QyHaOack=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "uDJA7QK2iGnEwbd9TPqkLaM+xuU=",
+			"path": "google.golang.org/grpc/internal/backoff",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "KCnkjqO49gNTv2JmnBdJqxQ7JT0=",
+			"path": "google.golang.org/grpc/internal/channelz",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "5dFUCEaPjKwza9kwKqgljp8ckU4=",
+			"path": "google.golang.org/grpc/internal/envconfig",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "70gndc/uHwyAl3D45zqp7vyHWlo=",
+			"path": "google.golang.org/grpc/internal/grpcrand",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "ZJ3AWjJzHj33TjFnwFLCQbg6oZQ=",
+			"path": "google.golang.org/grpc/internal/transport",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
+			"path": "google.golang.org/grpc/keepalive",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "OjIAi5AzqlQ7kLtdAyjvdgMf6hc=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "VvGBoawND0urmYDy11FT+U1IHtU=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "GEq6wwE1qWLmkaM02SjxBmmnHDo=",
+			"path": "google.golang.org/grpc/resolver",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "90rwIeFK1zLW8M57MfzmejpCwP4=",
+			"path": "google.golang.org/grpc/resolver/dns",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "zs9M4xE8Lyg4wvuYvR00XoBxmuw=",
+			"path": "google.golang.org/grpc/resolver/passthrough",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "YclPgme2gT3S0hTkHVdE1zAxJdo=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "hFyBO5vgsMamKhUOSyPCqROk1vo=",
+			"path": "google.golang.org/grpc/status",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "8997b5fa08730b06a4b589dba174c115796fbb7b",
+			"revisionTime": "2018-09-20T23:48:47Z"
+		},
+		{
+			"path": "google.golang.org/grpc/transport",
+			"revision": ""
+		},
+		{
+			"checksumSHA1": "COfXAfInbcFT/YRsvLUQnNKHzF0=",
+			"path": "gopkg.in/inf.v0",
+			"revision": "d2d2541c53f18d2a059457998ce2876cc8e67cbf",
+			"revisionTime": "2018-03-26T17:23:32Z"
+		},
+		{
+			"checksumSHA1": "1D8GzeoFGUs5FZOoyC2DpQg8c5Y=",
+			"path": "gopkg.in/mgo.v2",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "YsB2DChSV9HxdzHaKATllAUKWSI=",
+			"path": "gopkg.in/mgo.v2/bson",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "XQsrqoNT1U0KzLxOFcAZVvqhLfk=",
+			"path": "gopkg.in/mgo.v2/internal/json",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "LEvMCnprte47qdAxWvQ/zRxVF1U=",
+			"path": "gopkg.in/mgo.v2/internal/sasl",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "+1WDRPaOphSCmRMxVPIPBV4aubc=",
+			"path": "gopkg.in/mgo.v2/internal/scram",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "ZSWoOPUNRr5+3dhkLK3C4cZAQPk=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "5420a8b6744d3b0345ab293f6fcba19c978f1183",
+			"revisionTime": "2018-03-28T19:50:20Z"
+		},
+		{
+			"checksumSHA1": "MZhbJkGlnufR04wphtaqnIrvUXE=",
+			"path": "k8s.io/api/admissionregistration/v1alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "LV8lAXfGlzO6TnEHFGxWQTeVfZw=",
+			"path": "k8s.io/api/admissionregistration/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "GnbNRbv0YsPeb8ZN8ts/Yg7v2EE=",
+			"path": "k8s.io/api/apps/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "jONDsh/YSvUhZpoewV9s5RGEHRo=",
+			"path": "k8s.io/api/apps/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "JMvBWExtBYkgVs6fq1LbvMMzJBs=",
+			"path": "k8s.io/api/apps/v1beta2",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "le4PBPMZHpcCcnCy7s23kiGcupQ=",
+			"path": "k8s.io/api/authentication/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "nwkaJ0FGHrod4HMg9aMOhqrB6SA=",
+			"path": "k8s.io/api/authentication/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "Nw1hwhyWLlF6G5GNPcTWqDlYYLM=",
+			"path": "k8s.io/api/authorization/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "/094azqDGwUiublPaN3SKKKOBcs=",
+			"path": "k8s.io/api/authorization/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "NNwY4ZV8Bu6aVNR0EBce7DImmZM=",
+			"path": "k8s.io/api/autoscaling/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "/TdMLEL832PiJNNYDl2TTVDyEMw=",
+			"path": "k8s.io/api/autoscaling/v2beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "1R37YUBCjiP9duWalC3OdLqh0lU=",
+			"path": "k8s.io/api/batch/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "rgKyNFcqc28Y6Tfirbn5LwEj6ys=",
+			"path": "k8s.io/api/batch/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "CLqbZZRf59px0DV4LwOGPQ2QeyY=",
+			"path": "k8s.io/api/batch/v2alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "gEvyhegm3mSVhQfo8qRknXdVTxg=",
+			"path": "k8s.io/api/certificates/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"path": "k8s.io/api/coordination/v1beta1",
+			"revision": "release-1.11",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "FMQkvFeNFYwbs5jt/0eGVn3Jfwc=",
+			"path": "k8s.io/api/core/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "abj6F0RsOqLJ1fWetZU0XH8GoKM=",
+			"path": "k8s.io/api/events/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "Nm/fuoYAGHjBwOw5qgoKHhGrbyk=",
+			"path": "k8s.io/api/extensions/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "OVP9gFpoHnRm1aIYeql/uYlbhMI=",
+			"path": "k8s.io/api/networking/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "vrJtdnzz4Jm07d7xVUQKn4Ir5dg=",
+			"path": "k8s.io/api/policy/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "GBHuXdjnqUl3AjZW32aPdSGfC1M=",
+			"path": "k8s.io/api/rbac/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "EiWnS6grzHNDA3X5Uk3JYOCdRTo=",
+			"path": "k8s.io/api/rbac/v1alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "vySY1lIcWUNjo/DExJZ9lGI+rMo=",
+			"path": "k8s.io/api/rbac/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "DM8D5XET8VbCe75jnTNLgfWuPYU=",
+			"path": "k8s.io/api/scheduling/v1alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "uTxm08OkUZCzOdyfTcnX4+yVv0Q=",
+			"path": "k8s.io/api/scheduling/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "rjiQeUhQgV2wsnJvq/OCXH/8sjg=",
+			"path": "k8s.io/api/settings/v1alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "RMN7XvN8lkaHlbHAEPvKW53Pyok=",
+			"path": "k8s.io/api/storage/v1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "aVJ4X26+m5xsAt/zXLrHYgOUrTU=",
+			"path": "k8s.io/api/storage/v1alpha1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "vnbX68mKqOrVD+jO3hpGuUy6VKE=",
+			"path": "k8s.io/api/storage/v1beta1",
+			"revision": "4e7be11eab3ffcfc1876898b8272df53785a9504",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "eD3XRvVzKmBUr4mFMD9hAMMuLSE=",
+			"path": "k8s.io/apimachinery/pkg/api/errors",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "f8wIbNQndGers0bKQdewuuaF6l4=",
+			"path": "k8s.io/apimachinery/pkg/api/meta",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "+RdhegNU1doq6g05bXbtUAkqFMo=",
+			"path": "k8s.io/apimachinery/pkg/api/resource",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "yq49mken7zxQC/tF0SscW+tS5ms=",
+			"path": "k8s.io/apimachinery/pkg/apis/meta/v1",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "lqyM0x9dK8ld+UIco6ZIp+BwQmQ=",
+			"path": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "cFrJa803bweNTF8VoaTJLfXL7CU=",
+			"path": "k8s.io/apimachinery/pkg/apis/meta/v1beta1",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "5BuGgpCIBZ4o6tT0QjfZD99hbPQ=",
+			"path": "k8s.io/apimachinery/pkg/conversion",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "lZgVHIUDKFlQKJBYQVWqED5sDnE=",
+			"path": "k8s.io/apimachinery/pkg/conversion/queryparams",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "zgYf1VhDcfCpouwRgF5Zodz+g6M=",
+			"path": "k8s.io/apimachinery/pkg/fields",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "rQgW7h6N5U40wFE9/zgmjwOrf8w=",
+			"path": "k8s.io/apimachinery/pkg/labels",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "p1v3yQ8OqJSerPiuKPBDSY81bPk=",
+			"path": "k8s.io/apimachinery/pkg/runtime",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "2G7sQ/l95SGzZg4jd2lPIykCYwE=",
+			"path": "k8s.io/apimachinery/pkg/runtime/schema",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "zrzqafjVBMG7MbUDRkDjvb/tKjM=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "jpkekuS0xyd/I6OOxqISFR35WbA=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer/json",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "inmKlIskO3iMYraepPTfQPf6a+I=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "CxRm8Ny1sWZVlEw1WBfbOMtJP40=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "U768j7bVYHO5DwtNAHdIuBtpFMc=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "nVwU3gx4pfiMyHOUBgrxyQFaeIM=",
+			"path": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "p9Wv7xurZXAW0jYL/SLNPbiUjaA=",
+			"path": "k8s.io/apimachinery/pkg/selection",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "SwEleXXE22RGlg0t7wirGDuisO4=",
+			"path": "k8s.io/apimachinery/pkg/types",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "Gtwo9p42g21v46mUVvj/Qh8yUSE=",
+			"path": "k8s.io/apimachinery/pkg/util/clock",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "hHYW7OWXFMbRVotl2830pa4kO+Y=",
+			"path": "k8s.io/apimachinery/pkg/util/errors",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "bQOeFTINeXcfMOAOPArjRma/1mk=",
+			"path": "k8s.io/apimachinery/pkg/util/framer",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "9nShqMfXfw5Ct0Rr7P2QhQObVhw=",
+			"path": "k8s.io/apimachinery/pkg/util/intstr",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "NaIzEbjlhEMikewzRXivi2r0xyM=",
+			"path": "k8s.io/apimachinery/pkg/util/json",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "y1dxj1ipJgt2PRXXSXDmXrSka6A=",
+			"path": "k8s.io/apimachinery/pkg/util/naming",
+			"revision": "6429050ef506887d121f3e7306e894f8900d8a63",
+			"revisionTime": "2018-09-04T00:17:49Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "OrKcR7aVHsamDGWtb2Z0/kAVOtk=",
+			"path": "k8s.io/apimachinery/pkg/util/net",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "keWEyQHGKGkDo2SARgphbGgN608=",
+			"path": "k8s.io/apimachinery/pkg/util/runtime",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "ozEwMzA48zwMyQ50SwNKSM852U4=",
+			"path": "k8s.io/apimachinery/pkg/util/sets",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "0zZltQ8NUw+PeVotck4dqCKT/JY=",
+			"path": "k8s.io/apimachinery/pkg/util/validation",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "bEa1fAicif72PvAU9r4GGylfVa0=",
+			"path": "k8s.io/apimachinery/pkg/util/validation/field",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "WVUAXkkBeN3m2LenBRySrdk97PE=",
+			"path": "k8s.io/apimachinery/pkg/util/wait",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "1bUNGHe9gSNhcdE2EKl+h+VPuDY=",
+			"path": "k8s.io/apimachinery/pkg/util/yaml",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "A8tJJJhCK3xynuOJMiSw4jz27wg=",
+			"path": "k8s.io/apimachinery/pkg/version",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "LmSsUNmqd9ipMsZvsC8a3ZNsodE=",
+			"path": "k8s.io/apimachinery/pkg/watch",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "9sFA+EjKrjpmK4OofQH0p0Rowfg=",
+			"path": "k8s.io/apimachinery/third_party/forked/golang/reflect",
+			"revision": "def12e63c512da17043b4f0293f52d1006603d9f",
+			"revisionTime": "2018-09-04T19:39:09Z",
+			"version": "release-1.11",
+			"versionExact": "release-1.11"
+		},
+		{
+			"checksumSHA1": "WMIZypTArr2Rj7YIOmbmp/+yZkY=",
+			"path": "k8s.io/client-go/discovery",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "Uvb/9qGnLy/XSRWjpHlEfWYU+As=",
+			"path": "k8s.io/client-go/kubernetes",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "NpFjNGtZNV0o0Jo7oG7jmjIJ4W0=",
+			"path": "k8s.io/client-go/kubernetes/scheme",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "2sVEoijJZ8VDJRY+Q38NnxMQqzc=",
+			"path": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "gpF24Wissl7J5PSi6h1FE+5cKt4=",
+			"path": "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "xVKYvZSUmsh5gdX4cKpqMucuKIs=",
+			"path": "k8s.io/client-go/kubernetes/typed/apps/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "/u8hJMzPAhaRnYV3N/2kWeo6Gbc=",
+			"path": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "7nPY3WCV09+bSkK0fK1pkcYOP3Q=",
+			"path": "k8s.io/client-go/kubernetes/typed/apps/v1beta2",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "z8RBQhqz0ef52GAYcGnHbdkRLQw=",
+			"path": "k8s.io/client-go/kubernetes/typed/authentication/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "xNCsaw6UsrEtSjg+2rMYZueCBIM=",
+			"path": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "m8sWDYsVaRB+meitgU1dx+1P0ow=",
+			"path": "k8s.io/client-go/kubernetes/typed/authorization/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "XucNO6BHSXXNkSQAM1ZdiwDmksc=",
+			"path": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "5D9gl3fKkhnLSC17fkz9XIV9STc=",
+			"path": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "iCPo6cOIT5Z9diNHHUcGyrMDZn8=",
+			"path": "k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "PxB/TF7pmos3op2z+LIJLjZO8jM=",
+			"path": "k8s.io/client-go/kubernetes/typed/batch/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "UFKWPad/llvBljTbZqyekULpPKM=",
+			"path": "k8s.io/client-go/kubernetes/typed/batch/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "7FFOahu3KVI7fiWhA/k1yluvIJY=",
+			"path": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "ugmMQOQlWNAEOR+ncbnL+uxkjJ8=",
+			"path": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"path": "k8s.io/client-go/kubernetes/typed/coordination/v1beta1",
+			"revision": "release-8.0",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "0E6RtvR8px6fkUWtT5FYjVcowEI=",
+			"path": "k8s.io/client-go/kubernetes/typed/core/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "EG2zaZ66o181NTvDIA1pF+sR+mI=",
+			"path": "k8s.io/client-go/kubernetes/typed/events/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "X5wptrr04pFFgjZBvNejIFKf3YU=",
+			"path": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "2BNRJgbx2OKqe4PnZrEo/LUI1gI=",
+			"path": "k8s.io/client-go/kubernetes/typed/networking/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "iv+leVP2ERDUBKVaD82rrt8x5EI=",
+			"path": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "t1v/kvkiHgsoRGB2SpS9wx7Kd1s=",
+			"path": "k8s.io/client-go/kubernetes/typed/rbac/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "WBzIRDYpTWf5X0fl7Q9ZsYaayOI=",
+			"path": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "2Db2rdjkeF2FUjL3zcAT518HNUw=",
+			"path": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "E2UC+VmKSUekz96/0UX+fK0jOGg=",
+			"path": "k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "S9JHuu0Bwyc7RumKvhMJC49MtkU=",
+			"path": "k8s.io/client-go/kubernetes/typed/scheduling/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "L7SxjL9g+rlgK8AEj4SocDiMzjU=",
+			"path": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "NG+izjfroQyI3r6Ar1IK47KQknU=",
+			"path": "k8s.io/client-go/kubernetes/typed/storage/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "hLN5UXfDgw36zcIfpgo4WCZraCA=",
+			"path": "k8s.io/client-go/kubernetes/typed/storage/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "uhq68WTNsbCjKPqAwym7TPUx9Xg=",
+			"path": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "HIYqO9vnahkaPT5sfAEdKRb86Qc=",
+			"path": "k8s.io/client-go/pkg/apis/clientauthentication",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "fQTlkuSI3D1S4Hm6KXcKm1do9pQ=",
+			"path": "k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "ilihkLzytTmhvOcCmJJmubYwak0=",
+			"path": "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "SKxW+zPUzKmMZDo5SO9rAHf4FcM=",
+			"path": "k8s.io/client-go/pkg/version",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "LnDpHo8KDmZEH4kqmaZKng/M0W8=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "IOkY+hKZisSfu06aExZRItVNLEQ=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth/azure",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "QaTKrEXAUJLXMiyStJ1vgfg5YEU=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth/exec",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "MFODIOSPWNU+/KgDfSaGX7OUcyA=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "cXj/nD+hFYaclmGd2j6FHtmLDCg=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth/oidc",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "fezR9MxENOINJ6+82EYz5T61INw=",
+			"path": "k8s.io/client-go/plugin/pkg/client/auth/openstack",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "WAtl5P1bup5IS4is2kEc5WBN3YU=",
+			"path": "k8s.io/client-go/rest",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "+wYCwQaVc1GvMWwOWc3wXd2GT5s=",
+			"path": "k8s.io/client-go/rest/watch",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "j3Th2B1Hpv6UFLMEmA0ZdbO4kGU=",
+			"path": "k8s.io/client-go/third_party/forked/golang/template",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "/QeKYX2M+m1OFCDyH9PHYp6w510=",
+			"path": "k8s.io/client-go/tools/auth",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "TCBw/2DobQ3JpcvXy0hW3IbNWb8=",
+			"path": "k8s.io/client-go/tools/clientcmd",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "ynHaVRHZ3FI66y573C05GL3s0t4=",
+			"path": "k8s.io/client-go/tools/clientcmd/api",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "6cVFBhDYvRiAwBf0QYbmUoLi5lQ=",
+			"path": "k8s.io/client-go/tools/clientcmd/api/latest",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "IJn5sCK9Y+KBibFIUMyKU18SGUI=",
+			"path": "k8s.io/client-go/tools/clientcmd/api/v1",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "rRC9GCWXfyIXKHBCeKpw7exVybE=",
+			"path": "k8s.io/client-go/tools/metrics",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "n2h6CjJR1o+JM2snIIsCdcMMDWs=",
+			"path": "k8s.io/client-go/tools/reference",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "J+lqqSPbequTb2ELV838v31MfWc=",
+			"path": "k8s.io/client-go/transport",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "rIxDMrsqcf1cjy3dgMaEZw/TvJs=",
+			"path": "k8s.io/client-go/util/cert",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "KSB22yQOaax0P/RkHCDp80u+Jcs=",
+			"path": "k8s.io/client-go/util/connrotation",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "yXKT7cJNCv5vjwGKhpc/DUsQg+A=",
+			"path": "k8s.io/client-go/util/flowcontrol",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "WRb0rXGx56fwcCisVW7GoI6gO/A=",
+			"path": "k8s.io/client-go/util/homedir",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "W6bJiNAwgNwNJC+y+TPtacgUGlY=",
+			"path": "k8s.io/client-go/util/integer",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		},
+		{
+			"checksumSHA1": "1+CyY2zkEQX4VrByn/77x6gWy78=",
+			"path": "k8s.io/client-go/util/jsonpath",
+			"revision": "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c",
+			"revisionTime": "2018-08-21T04:50:00Z",
+			"version": "release-8.0",
+			"versionExact": "release-8.0"
+		}
 	],
 	"rootPath": "github.com/hashicorp/consul"
 }


### PR DESCRIPTION
## Description
Expose consul DC to Prometheus which will allow us to tag each Prometheus metric directly with their consul-datacenter as label "dc". This PR depends on [this vendor PR](https://github.com/armon/go-metrics/pull/79/files).

People who prefer the new dc label to be absent in prometheus, can achieve this by adding a [labeldrop](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) for the dc label.

## Environment
Ubuntu 16.04, 4.4.0-142-generic
Binary built off of master

## Test Plan
```
radha:~$ curl -s "http://127.0.0.1:8500/v1/agent/metrics?format=prometheus" |grep -v "^#"
consul_dub_l_radha_runtime_alloc_bytes{dc="dc1"} 3.688784e+06
consul_dub_l_radha_runtime_free_count{dc="dc1"} 78679
consul_dub_l_radha_runtime_heap_objects{dc="dc1"} 22884
consul_dub_l_radha_runtime_malloc_count{dc="dc1"} 101563
consul_dub_l_radha_runtime_num_goroutines{dc="dc1"} 67
consul_dub_l_radha_runtime_sys_bytes{dc="dc1"} 7.2284408e+07
consul_dub_l_radha_runtime_total_gc_pause_ns{dc="dc1"} 646320
consul_dub_l_radha_runtime_total_gc_runs{dc="dc1"} 8
consul_dub_l_radha_session_ttl_active{dc="dc1"} 0
consul_memberlist_gossip{dc="dc1",quantile="0.5"} 0.029165999963879585
consul_memberlist_gossip{dc="dc1",quantile="0.9"} 0.04848200082778931
consul_memberlist_gossip{dc="dc1",quantile="0.99"} 0.10723800212144852
consul_memberlist_gossip_sum{dc="dc1"} 3.4050879888236523
consul_memberlist_gossip_count{dc="dc1"} 98
consul_memberlist_msg_alive{dc="dc1"} 2
consul_raft_state_follower{dc="dc1"} 1
consul_runtime_gc_pause_ns{dc="dc1",quantile="0.5"} 137446
consul_runtime_gc_pause_ns{dc="dc1",quantile="0.9"} 137446
consul_runtime_gc_pause_ns{dc="dc1",quantile="0.99"} 137446
consul_runtime_gc_pause_ns_sum{dc="dc1"} 646320
consul_runtime_gc_pause_ns_count{dc="dc1"} 8
consul_serf_member_join{dc="dc1"} 2
consul_serf_snapshot_appendLine{dc="dc1",quantile="0.5"} NaN
consul_serf_snapshot_appendLine{dc="dc1",quantile="0.9"} NaN
consul_serf_snapshot_appendLine{dc="dc1",quantile="0.99"} NaN
consul_serf_snapshot_appendLine_sum{dc="dc1"} 0.044683000072836876
consul_serf_snapshot_appendLine_count{dc="dc1"} 2
go_gc_duration_seconds{quantile="0"} 2.2362e-05
go_gc_duration_seconds{quantile="0.25"} 5.6009e-05
go_gc_duration_seconds{quantile="0.5"} 7.4268e-05
go_gc_duration_seconds{quantile="0.75"} 0.000137446
go_gc_duration_seconds{quantile="1"} 0.000162364
go_gc_duration_seconds_sum 0.00064632
go_gc_duration_seconds_count 8
go_goroutines 72
...
radha@dub-l-radha:~$
```