### PR TITLE
Centralise tls configuration part 2

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -251,6 +251,8 @@ type Agent struct {
 	// Envoy.
 	grpcServer *grpc.Server
 
+	// tlsConfigurator is the central instance to provide a *tls.Config
+	// based on the current consul configuration.
 	tlsConfigurator *tlsutil.Configurator
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2313,6 +2313,7 @@ func (a *Agent) RemoveCheck(checkID types.CheckID, persist bool) error {
 
 	// Add to the local state for anti-entropy
 	a.State.RemoveCheck(checkID)
+	a.tlsConfigurator.RemoveCheck(string(checkID))
 
 	a.checkLock.Lock()
 	defer a.checkLock.Unlock()

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -312,7 +312,7 @@ func (c *Configurator) IncomingHTTPSConfig() (*tls.Config, error) {
 func (c *Configurator) OutgoingTLSConfigForCheck(id string) (*tls.Config, error) {
 	if !c.base.EnableAgentTLSForChecks {
 		return &tls.Config{
-			InsecureSkipVerify: c.checks[id],
+			InsecureSkipVerify: c.getSkipVerifyForCheck(id),
 		}, nil
 	}
 
@@ -320,7 +320,7 @@ func (c *Configurator) OutgoingTLSConfigForCheck(id string) (*tls.Config, error)
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig.InsecureSkipVerify = c.checks[id]
+	tlsConfig.InsecureSkipVerify = c.getSkipVerifyForCheck(id)
 	return tlsConfig, nil
 }
 
@@ -376,6 +376,12 @@ func (c *Configurator) RemoveCheck(id string) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.checks, id)
+}
+
+func (c *Configurator) getSkipVerifyForCheck(id string) bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.checks[id]
 }
 
 // ParseCiphers parse ciphersuites from the comma-separated string into

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"strings"
 	"sync"
@@ -34,8 +33,16 @@ type Config struct {
 	// VerifyIncoming is used to verify the authenticity of incoming connections.
 	// This means that TCP requests are forbidden, only allowing for TLS. TLS connections
 	// must match a provided certificate authority. This can be used to force client auth.
-	VerifyIncoming      bool
-	VerifyIncomingRPC   bool
+	VerifyIncoming bool
+
+	// VerifyIncomingRPC is used to verify the authenticity of incoming RPC connections.
+	// This means that TCP requests are forbidden, only allowing for TLS. TLS connections
+	// must match a provided certificate authority. This can be used to force client auth.
+	VerifyIncomingRPC bool
+
+	// VerifyIncomingHTTPS is used to verify the authenticity of incoming HTTPS connections.
+	// This means that TCP requests are forbidden, only allowing for TLS. TLS connections
+	// must match a provided certificate authority. This can be used to force client auth.
 	VerifyIncomingHTTPS bool
 
 	// VerifyOutgoing is used to verify the authenticity of outgoing connections.
@@ -91,27 +98,12 @@ type Config struct {
 	// over the client ciphersuites.
 	PreferServerCipherSuites bool
 
+	// EnableAgentTLSForChecks is used to apply the agent's TLS settings in
+	// order to configure the HTTP client used for health checks. Enabling
+	// this allows HTTP checks to present a client certificate and verify
+	// the server using the same TLS configuration as the agent (CA, cert,
+	// and key).
 	EnableAgentTLSForChecks bool
-}
-
-// AppendCA opens and parses the CA file and adds the certificates to
-// the provided CertPool.
-func (c *Config) AppendCA(pool *x509.CertPool) error {
-	if c.CAFile == "" {
-		return nil
-	}
-
-	// Read the file
-	data, err := ioutil.ReadFile(c.CAFile)
-	if err != nil {
-		return fmt.Errorf("Failed to read CA file: %v", err)
-	}
-
-	if !pool.AppendCertsFromPEM(data) {
-		return fmt.Errorf("Failed to parse any CA certificates")
-	}
-
-	return nil
 }
 
 // KeyPair is used to open and parse a certificate and key file
@@ -199,33 +191,41 @@ func (c *Config) wrapTLSClient(conn net.Conn, tlsConfig *tls.Config) (net.Conn, 
 	return tlsConn, err
 }
 
+// Configurator holds a Config and is responsible for generating all the
+// *tls.Config necessary for Consul. Except the one in the api package.
 type Configurator struct {
 	sync.Mutex
 	base   *Config
 	checks map[string]bool
 }
 
-// Todo (Hans): should config be a value instead a pointer to avoid side effects?
+// NewConfigurator creates a new Configurator and sets the provided
+// configuration.
+// Todo (Hans): should config be a value instead a pointer to avoid side
+// effects?
 func NewConfigurator(config *Config) *Configurator {
 	return &Configurator{base: config, checks: map[string]bool{}}
 }
 
+// Update updates the internal configuration which is used to generate
+// *tls.Config.
 func (c *Configurator) Update(config *Config) {
 	c.Lock()
 	defer c.Unlock()
 	c.base = config
 }
 
-func (c *Configurator) commonTLSConfig(verifyIncoming bool) (*tls.Config, error) {
+// commonTLSConfig generates a *tls.Config from the base configuration the
+// Configurator has. It accepts an additional flag in case a config is needed
+// for incoming TLS connections.
+func (c *Configurator) commonTLSConfig(additionalVerifyIncomingFlag bool) (*tls.Config, error) {
 	if c.base == nil {
-		return nil, fmt.Errorf("No config")
+		return nil, fmt.Errorf("No base config")
 	}
 
 	tlsConfig := &tls.Config{
 		ClientAuth:         tls.NoClientCert,
-		ClientCAs:          x509.NewCertPool(),
 		InsecureSkipVerify: c.base.skipBuiltinVerify(),
-		RootCAs:            x509.NewCertPool(),
 		ServerName:         c.base.ServerName,
 	}
 
@@ -280,7 +280,8 @@ func (c *Configurator) commonTLSConfig(verifyIncoming bool) (*tls.Config, error)
 		tlsConfig.RootCAs = pool
 	}
 
-	if c.base.VerifyIncoming || verifyIncoming {
+	// Set ClientAuth if necessary
+	if c.base.VerifyIncoming || additionalVerifyIncomingFlag {
 		if c.base.CAFile == "" && c.base.CAPath == "" {
 			return nil, fmt.Errorf("VerifyIncoming set, and no CA certificate provided!")
 		}
@@ -294,14 +295,20 @@ func (c *Configurator) commonTLSConfig(verifyIncoming bool) (*tls.Config, error)
 	return tlsConfig, nil
 }
 
+// IncomingRPCConfig generates a *tls.Config for incoming RPC connections.
 func (c *Configurator) IncomingRPCConfig() (*tls.Config, error) {
 	return c.commonTLSConfig(c.base.VerifyIncomingRPC)
 }
 
+// IncomingHTTPSConfig generates a *tls.Config for incoming HTTPS connections.
 func (c *Configurator) IncomingHTTPSConfig() (*tls.Config, error) {
 	return c.commonTLSConfig(c.base.VerifyIncomingHTTPS)
 }
 
+// IncomingTLSConfig generates a *tls.Config for outgoing TLS connections for
+// checks. This function is seperated because there is an extra flag to
+// consider for checks. EnableAgentTLSForChecks and InsecureSkipVerify has to
+// be checked for checks.
 func (c *Configurator) OutgoingTLSConfigForCheck(id string) (*tls.Config, error) {
 	if !c.base.EnableAgentTLSForChecks {
 		return &tls.Config{
@@ -317,6 +324,9 @@ func (c *Configurator) OutgoingTLSConfigForCheck(id string) (*tls.Config, error)
 	return tlsConfig, nil
 }
 
+// OutgoingRPCConfig generates a *tls.Config for outgoing RPC connections. If
+// there is a CA or VerifyOutgoing is set, a *tls.Config will be provided,
+// otherwise we assume that no TLS should be used.
 func (c *Configurator) OutgoingRPCConfig() (*tls.Config, error) {
 	useTLS := c.base.CAFile != "" || c.base.CAPath != "" || c.base.VerifyOutgoing
 	if !useTLS {
@@ -325,6 +335,8 @@ func (c *Configurator) OutgoingRPCConfig() (*tls.Config, error) {
 	return c.commonTLSConfig(false)
 }
 
+// OutgoingRPCWrapper wraps the result of OutgoingRPCConfig in a DCWrapper. It
+// decides if verify server hostname should be used.
 func (c *Configurator) OutgoingRPCWrapper() (DCWrapper, error) {
 	// Get the TLS config
 	tlsConfig, err := c.OutgoingRPCConfig()
@@ -351,15 +363,23 @@ func (c *Configurator) OutgoingRPCWrapper() (DCWrapper, error) {
 	return wrapper, nil
 }
 
+// AddCheck adds a check to the internal check map together with the skipVerify
+// value, which is used when generating a *tls.Config for this check.
 func (c *Configurator) AddCheck(id string, skipVerify bool) {
+	c.Lock()
+	defer c.Unlock()
 	c.checks[id] = skipVerify
 }
 
+// RemoveCheck removes a check from the internal check map.
 func (c *Configurator) RemoveCheck(id string) {
+	c.Lock()
+	defer c.Unlock()
 	delete(c.checks, id)
 }
 
-// ParseCiphers parse ciphersuites from the comma-separated string into recognized slice
+// ParseCiphers parse ciphersuites from the comma-separated string into
+// recognized slice
 func ParseCiphers(cipherStr string) ([]uint16, error) {
 	suites := []uint16{}
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -94,9 +94,69 @@ func TestConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
-	require.Equal(t, len(tlsConf.RootCAs.Subjects()), 1)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 	require.Empty(t, tlsConf.ServerName)
 	require.True(t, tlsConf.InsecureSkipVerify)
+}
+
+func TestConfigurator_OutgoingTLS_ServerName(t *testing.T) {
+	conf := &Config{
+		VerifyOutgoing: true,
+		CAFile:         "../test/ca/root.cer",
+		ServerName:     "consul.example.com",
+	}
+	c := NewConfigurator(conf)
+	tlsConf, err := c.OutgoingRPCConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConf)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
+	require.Equal(t, tlsConf.ServerName, "consul.example.com")
+	require.False(t, tlsConf.InsecureSkipVerify)
+}
+
+func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
+	conf := &Config{
+		VerifyOutgoing:       true,
+		VerifyServerHostname: true,
+		CAFile:               "../test/ca/root.cer",
+	}
+	c := NewConfigurator(conf)
+	tlsConf, err := c.OutgoingRPCConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConf)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
+	require.False(t, tlsConf.InsecureSkipVerify)
+}
+
+func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
+	conf := &Config{
+		VerifyOutgoing: true,
+		CAFile:         "../test/ca/root.cer",
+		CertFile:       "../test/key/ourdomain.cer",
+		KeyFile:        "../test/key/ourdomain.key",
+	}
+	c := NewConfigurator(conf)
+	tlsConf, err := c.OutgoingRPCConfig()
+	require.NoError(t, err)
+	require.NotNil(t, tlsConf)
+	require.True(t, tlsConf.InsecureSkipVerify)
+	require.Len(t, tlsConf.Certificates, 1)
+}
+
+func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
+	tlsVersions := []string{"tls10", "tls11", "tls12"}
+	for _, version := range tlsVersions {
+		conf := &Config{
+			VerifyOutgoing: true,
+			CAFile:         "../test/ca/root.cer",
+			TLSMinVersion:  version,
+		}
+		c := NewConfigurator(conf)
+		tlsConf, err := c.OutgoingRPCConfig()
+		require.NoError(t, err)
+		require.NotNil(t, tlsConf)
+		require.Equal(t, tlsConf.MinVersion, TLSLookup[version])
+	}
 }
 
 func TestConfig_SkipBuiltinVerify(t *testing.T) {
@@ -113,66 +173,6 @@ func TestConfig_SkipBuiltinVerify(t *testing.T) {
 
 	for _, v := range table {
 		require.Equal(t, v.result, v.config.skipBuiltinVerify())
-	}
-}
-
-func TestConfigurator_OutgoingTLS_ServerName(t *testing.T) {
-	conf := &Config{
-		VerifyOutgoing: true,
-		CAFile:         "../test/ca/root.cer",
-		ServerName:     "consul.example.com",
-	}
-	c := NewConfigurator(conf)
-	tlsConf, err := c.OutgoingRPCConfig()
-	require.NoError(t, err)
-	require.NotNil(t, tlsConf)
-	require.Equal(t, len(tlsConf.RootCAs.Subjects()), 1)
-	require.Equal(t, tlsConf.ServerName, "consul.example.com")
-	require.False(t, tlsConf.InsecureSkipVerify)
-}
-
-func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
-	conf := &Config{
-		VerifyOutgoing:       true,
-		VerifyServerHostname: true,
-		CAFile:               "../test/ca/root.cer",
-	}
-	c := NewConfigurator(conf)
-	tlsConf, err := c.OutgoingRPCConfig()
-	require.NoError(t, err)
-	require.NotNil(t, tlsConf)
-	require.Equal(t, len(tlsConf.RootCAs.Subjects()), 1)
-	require.False(t, tlsConf.InsecureSkipVerify)
-}
-
-func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
-	conf := &Config{
-		VerifyOutgoing: true,
-		CAFile:         "../test/ca/root.cer",
-		CertFile:       "../test/key/ourdomain.cer",
-		KeyFile:        "../test/key/ourdomain.key",
-	}
-	c := NewConfigurator(conf)
-	tlsConf, err := c.OutgoingRPCConfig()
-	require.NoError(t, err)
-	require.NotNil(t, tlsConf)
-	require.True(t, tlsConf.InsecureSkipVerify)
-	require.Equal(t, len(tlsConf.Certificates), 1)
-}
-
-func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
-	tlsVersions := []string{"tls10", "tls11", "tls12"}
-	for _, version := range tlsVersions {
-		conf := &Config{
-			VerifyOutgoing: true,
-			CAFile:         "../test/ca/root.cer",
-			TLSMinVersion:  version,
-		}
-		c := NewConfigurator(conf)
-		tlsConf, err := c.OutgoingRPCConfig()
-		require.NoError(t, err)
-		require.NotNil(t, tlsConf)
-		require.Equal(t, tlsConf.MinVersion, TLSLookup[version])
 	}
 }
 
@@ -427,7 +427,7 @@ func TestConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
 	c := NewConfigurator(conf)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
-	require.Equal(t, len(tlsConf.ClientCAs.Subjects()), 2)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 }
 
 func TestConfigurator_IncomingHTTPS(t *testing.T) {
@@ -441,9 +441,9 @@ func TestConfigurator_IncomingHTTPS(t *testing.T) {
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
-	require.Equal(t, len(tlsConf.ClientCAs.Subjects()), 1)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
 	require.Equal(t, tlsConf.ClientAuth, tls.RequireAndVerifyClientCert)
-	require.Equal(t, len(tlsConf.Certificates), 1)
+	require.Len(t, tlsConf.Certificates, 1)
 }
 
 func TestConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
@@ -473,9 +473,9 @@ func TestConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
-	require.Equal(t, len(tlsConf.ClientCAs.Subjects()), 0)
+	require.Empty(t, tlsConf.ClientCAs.Subjects())
 	require.Equal(t, tlsConf.ClientAuth, tls.NoClientCert)
-	require.Equal(t, len(tlsConf.Certificates), 0)
+	require.Empty(t, tlsConf.Certificates)
 }
 
 func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
@@ -497,16 +497,142 @@ func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSCAPath_Valid(t *testing.T) {
-	conf := &Config{
-		CAPath: "../test/ca_path",
+
+	c := NewConfigurator(&Config{CAPath: "../test/ca_path"})
+	tlsConf, err := c.IncomingHTTPSConfig()
+	require.NoError(t, err)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
+}
+
+func TestConfigurator_CommonTLSConfigNoBaseConfig(t *testing.T) {
+	c := NewConfigurator(nil)
+	_, err := c.commonTLSConfig(false)
+	require.Error(t, err)
+}
+
+func TestConfigurator_CommonTLSConfigServerNameNodeName(t *testing.T) {
+	type variant struct {
+		config *Config
+		result string
+	}
+	variants := []variant{
+		{config: &Config{NodeName: "node", ServerName: "server"},
+			result: "server"},
+		{config: &Config{ServerName: "server"},
+			result: "server"},
+		{config: &Config{NodeName: "node"},
+			result: "node"},
+	}
+	for _, v := range variants {
+		c := NewConfigurator(v.config)
+		tlsConf, err := c.commonTLSConfig(false)
+		require.NoError(t, err)
+		require.Equal(t, v.result, tlsConf.ServerName)
+	}
+}
+
+func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
+	c := NewConfigurator(&Config{})
+	tlsConfig, err := c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Empty(t, tlsConfig.CipherSuites)
+
+	conf := &Config{CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305}}
+	c.Update(conf)
+	tlsConfig, err = c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, conf.CipherSuites, tlsConfig.CipherSuites)
+}
+
+func TestConfigurator_CommonTLSConfigCertKey(t *testing.T) {
+	c := NewConfigurator(&Config{})
+	tlsConf, err := c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Empty(t, tlsConf.Certificates)
+
+	c.Update(&Config{CertFile: "/something/bogus", KeyFile: "/more/bogus"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Len(t, tlsConf.Certificates, 1)
+}
+
+func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
+	tlsVersions := []string{"tls10", "tls11", "tls12"}
+	for _, version := range tlsVersions {
+		c := NewConfigurator(&Config{TLSMinVersion: version})
+		tlsConf, err := c.commonTLSConfig(false)
+		require.NoError(t, err)
+		require.Equal(t, tlsConf.MinVersion, TLSLookup[version])
 	}
 
-	c := NewConfigurator(conf)
-	tlsConf, err := c.IncomingHTTPSConfig()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if len(tlsConf.ClientCAs.Subjects()) != 2 {
-		t.Fatalf("expected certs")
-	}
+	c := NewConfigurator(&Config{TLSMinVersion: "tlsBOGUS"})
+	_, err := c.commonTLSConfig(false)
+	require.Error(t, err)
+}
+
+func TestConfigurator_CommonTLSConfigValidateVerifyOutgoingCA(t *testing.T) {
+	c := NewConfigurator(&Config{VerifyOutgoing: true})
+	_, err := c.commonTLSConfig(false)
+	require.Error(t, err)
+}
+
+func TestConfigurator_CommonTLSConfigLoadCA(t *testing.T) {
+	c := NewConfigurator(&Config{CAFile: "/something/bogus"})
+	_, err := c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{CAPath: "/something/bogus/"})
+	_, err = c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{CAFile: "../test/ca/root.cer"})
+	tlsConf, err := c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
+
+	c.Update(&Config{CAPath: "../test/ca_path"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
+
+	c.Update(&Config{CAFile: "../test/ca/root.cer", CAPath: "../test/ca_path"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
+}
+
+func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
+	c := NewConfigurator(&Config{})
+	tlsConf, err := c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
+
+	c.Update(&Config{VerifyIncoming: true})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/cert/ourdomain.cer"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.Error(t, err)
+
+	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	tlsConf, err = c.commonTLSConfig(false)
+	require.NoError(t, err)
+	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
+
+	c.Update(&Config{VerifyIncoming: false, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	tlsConf, err = c.commonTLSConfig(true)
+	require.NoError(t, err)
+	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 }


### PR DESCRIPTION
This PR is based on https://github.com/hashicorp/consul/pull/5366 and continues to centralise the tls configuration in order to be reloadable eventually!

This PR is another refactoring. No tests are changed, beyond calling other functions or cosmetic stuff. I added a bunch of tests, even though they might be redundant.