### PR TITLE
Fix tests in prep for CircleCI Migration

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -132,6 +132,7 @@ func TestAgent_RPCPing(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	var out struct{}
 	if err := a.RPC("Status.Ping", struct{}{}, &out); err != nil {

--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -517,6 +517,9 @@ func TestCheckTCPPassing(t *testing.T) {
 	if os.Getenv("TRAVIS") == "true" {
 		t.Skip("IPV6 not supported on travis-ci")
 	}
+	if os.Getenv("CIRCLECI") == "true" {
+		t.Skip("IPV6 not supported on CircleCI")
+	}
 	tcpServer = mockTCPServer(`tcp6`)
 	expectTCPStatus(t, tcpServer.Addr().String(), api.HealthPassing)
 	tcpServer.Close()

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -84,8 +84,10 @@ func TestClient_JoinLAN(t *testing.T) {
 	defer os.RemoveAll(dir2)
 	defer c1.Shutdown()
 
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 	// Try to join
 	joinLAN(t, c1, s1)
+	testrpc.WaitForTestAgent(t, c1.RPC, "dc1")
 	retry.Run(t, func(r *retry.R) {
 		if got, want := c1.routers.NumServers(), 1; got != want {
 			r.Fatalf("got %d servers want %d", got, want)

--- a/agent/consul/session_ttl_test.go
+++ b/agent/consul/session_ttl_test.go
@@ -162,10 +162,11 @@ func TestResetSessionTimerLocked(t *testing.T) {
 		t.Fatalf("missing timer")
 	}
 
-	time.Sleep(10 * time.Millisecond * structs.SessionTTLMultiplier)
-	if s1.sessionTimers.Get("foo") != nil {
-		t.Fatalf("timer should be gone")
-	}
+	retry.Run(t, func(r *retry.R) {
+		if s1.sessionTimers.Get("foo") != nil {
+			r.Fatal("timer should be gone")
+		}
+	})
 }
 
 func TestResetSessionTimerLocked_Renew(t *testing.T) {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -4151,7 +4151,7 @@ func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uin
 		}
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	for i := 0; i < generateNumNodes; i++ {
 		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)
@@ -4241,7 +4241,7 @@ func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType
 		}
 	`)
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	for i := 0; i < generateNumNodes; i++ {
 		nodeAddress := fmt.Sprintf("127.0.0.%d", i+1)

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1733,18 +1733,18 @@ func TestAgent_CheckCriticalTime(t *testing.T) {
 	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
 	} else if c.CriticalFor() > time.Millisecond {
-		t.Fatalf("bad: %#v", c)
+		t.Fatalf("bad: %#v, check was critical for %v", c, c.CriticalFor())
 	}
 
 	// Wait a while, then fail it again and make sure the time keeps track
-	// of the initial failure, and doesn't reset here.
+	// of the initial failure, and doesn't reset here. Since we are sleeping for
+	// 50ms the check should not be any less than that.
 	time.Sleep(50 * time.Millisecond)
 	l.UpdateCheck(chk.CheckID, api.HealthCritical, "")
 	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
-	} else if c.CriticalFor() < 25*time.Millisecond ||
-		c.CriticalFor() > 75*time.Millisecond {
-		t.Fatalf("bad: %#v", c)
+	} else if c.CriticalFor() < 50*time.Millisecond {
+		t.Fatalf("bad: %#v, check was critical for %v", c, c.CriticalFor())
 	}
 
 	// Set it passing again.
@@ -1759,7 +1759,7 @@ func TestAgent_CheckCriticalTime(t *testing.T) {
 	if c, ok := l.CriticalCheckStates()[checkID]; !ok {
 		t.Fatalf("should have a critical check")
 	} else if c.CriticalFor() > time.Millisecond {
-		t.Fatalf("bad: %#v", c)
+		t.Fatalf("bad: %#v, check was critical for %v", c, c.CriticalFor())
 	}
 }
 

--- a/agent/operator_endpoint_test.go
+++ b/agent/operator_endpoint_test.go
@@ -346,6 +346,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
 	req, _ := http.NewRequest("PUT", "/v1/operator/autopilot/configuration", body)

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -9,14 +9,16 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/testrpc"
 )
 
 func TestSnapshot(t *testing.T) {
 	t.Parallel()
 	var snap io.Reader
-	t.Run("", func(t *testing.T) {
+	t.Run("create snapshot", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
+		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 		body := bytes.NewBuffer(nil)
 		req, _ := http.NewRequest("GET", "/v1/snapshot?token=root", body)
@@ -40,9 +42,10 @@ func TestSnapshot(t *testing.T) {
 		}
 	})
 
-	t.Run("", func(t *testing.T) {
+	t.Run("restore snapshot", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "")
 		defer a.Shutdown()
+		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 		req, _ := http.NewRequest("PUT", "/v1/snapshot?token=root", snap)
 		resp := httptest.NewRecorder()

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -498,6 +498,7 @@ func TestAPI_ACLToken_List(t *testing.T) {
 	defer s.Stop()
 
 	acl := c.ACL()
+	s.WaitForSerfCheck(t)
 
 	policies := prepTokenPolicies(t, acl)
 

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -39,6 +39,8 @@ func TestAPI_AgentMetrics(t *testing.T) {
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
+
 	timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
 	retry.RunWith(timer, t, func(r *retry.R) {
 		metrics, err := agent.Metrics()
@@ -168,6 +170,7 @@ func TestAPI_AgentServices(t *testing.T) {
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
 
 	reg := &AgentServiceRegistration{
 		Name: "foo",
@@ -743,6 +746,7 @@ func TestAPI_AgentSetTTLStatus(t *testing.T) {
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
 
 	reg := &AgentServiceRegistration{
 		Name: "foo",
@@ -957,6 +961,7 @@ func TestAPI_AgentChecks_serviceBound(t *testing.T) {
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
 
 	// First register a service
 	serviceReg := &AgentServiceRegistration{
@@ -1198,6 +1203,7 @@ func TestAPI_NodeMaintenance(t *testing.T) {
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
 
 	// Enable maintenance mode
 	if err := agent.EnableNodeMaintenance("broken"); err != nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -293,6 +293,7 @@ func TestAPI_AgentServices_ManagedConnectProxyDeprecatedUpstreams(t *testing.T) 
 	defer s.Stop()
 
 	agent := c.Agent()
+	s.WaitForSerfCheck(t)
 
 	reg := &AgentServiceRegistration{
 		Name: "foo",

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -33,6 +33,7 @@ func TestAPI_CatalogNodes(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
 	catalog := c.Catalog()
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
 		nodes, meta, err := catalog.Nodes(nil)

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -21,6 +21,8 @@ func TestAPI_ConnectCARoots_empty(t *testing.T) {
 	})
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	connect := c.Connect()
 	_, _, err := connect.CARoots(nil)
 
@@ -60,6 +62,7 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
 	expected := &ConsulCAProviderConfig{
 		RotationPeriod: 90 * 24 * time.Hour,
 	}

--- a/api/coordinate_test.go
+++ b/api/coordinate_test.go
@@ -71,6 +71,7 @@ func TestAPI_CoordinateUpdate(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
 	node := "foo"
 	_, err := c.Catalog().Register(&CatalogRegistration{
 		Node:    node,

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -230,6 +230,8 @@ func TestAPI_HealthChecks_NodeMetaFilter(t *testing.T) {
 	agent := c.Agent()
 	health := c.Health()
 
+	s.WaitForSerfCheck(t)
+
 	// Make a service with a check
 	reg := &AgentServiceRegistration{
 		Name: "foo",
@@ -392,6 +394,8 @@ func TestAPI_HealthConnect(t *testing.T) {
 
 	agent := c.Agent()
 	health := c.Health()
+
+	s.WaitForSerfCheck(t)
 
 	// Make a service with a proxy
 	reg := &AgentServiceRegistration{

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -15,6 +15,7 @@ func TestAPI_ClientPutGetDelete(t *testing.T) {
 
 	kv := c.KV()
 
+	s.WaitForSerfCheck(t)
 	// Get a get without a key
 	key := testKey()
 	pair, _, err := kv.Get(key, nil)
@@ -229,6 +230,7 @@ func TestAPI_ClientWatchGet(t *testing.T) {
 
 	kv := c.KV()
 
+	s.WaitForSerfCheck(t)
 	// Get a get without a key
 	key := testKey()
 	pair, meta, err := kv.Get(key, nil)

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -296,6 +296,7 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
 	lock, session := createTestLock(t, c, "test/sema/.lock")
 	defer session.Destroy(lock.opts.Session, nil)
 

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -295,7 +295,6 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
-	s.WaitForSerfCheck(t)
 
 	lock, session := createTestLock(t, c, "test/sema/.lock")
 	defer session.Destroy(lock.opts.Session, nil)

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -295,6 +295,7 @@ func TestAPI_SemaphoreConflict(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+	s.WaitForSerfCheck(t)
 
 	lock, session := createTestLock(t, c, "test/sema/.lock")
 	defer session.Destroy(lock.opts.Session, nil)

--- a/api/snapshot_test.go
+++ b/api/snapshot_test.go
@@ -11,6 +11,7 @@ func TestAPI_Snapshot(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
 	// Place an initial key into the store.
 	kv := c.KV()
 	key := &KVPair{Key: testKey(), Value: []byte("hello")}

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -45,7 +45,7 @@ func TestLockCommand(t *testing.T) {
 	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
 	c := New(ui)


### PR DESCRIPTION
When running tests in CircleCI, the tests were flaky again, similar to the issues experienced in TravisCI a few months back. The retry loop within the `make ci` target does help in getting Travis running green more often as the failed tests are tried up to 3 times. While this was a way to make tests pass more often, it doesn't help fix the flakiness we sometimes see in the test suite on CI. 

In the process of migrating the configuration over to CircleCI, I removed the retry and tackled some of the most common test failures that cropped up. Most of these are documented in #5330. Some of the more convoluted errors I have included logs from are ones that were a bit outside of my knowledge of the code to fix in a reasonable amount of time.