### PR TITLE
acl: add an optional include_proxies attribute to service acl resources

### DIFF
--- a/acl/policy.go
+++ b/acl/policy.go
@@ -91,9 +91,10 @@ func (n *NodePolicy) GoString() string {
 
 // ServicePolicy represents a policy for a service
 type ServicePolicy struct {
-	Name     string `hcl:",key"`
-	Policy   string
-	Sentinel Sentinel
+	Name           string `hcl:",key"`
+	Policy         string
+	IncludeProxies bool `hcl:"include_proxies"`
+	Sentinel       Sentinel
 
 	// Intentions is the policy for intentions where this service is the
 	// destination. This may be empty, in which case the Policy determines


### PR DESCRIPTION
Parent PR: #5368
Note: this is merging into a long lived feature branch, not master.

This is meant to supersede #5369. The acl rule language is slightly amended to require folks to opt-in to having `"service:NAME:<write|read>"` additionally grant `"service:NAME-sidecar-proxy:<write|read>"`.