### PR TITLE
ui: Amend breakpoints for new numberless filter buttons

### DIFF
--- a/ui-v2/app/styles/variables/custom-query.scss
+++ b/ui-v2/app/styles/variables/custom-query.scss
@@ -1,9 +1,9 @@
 $ideal-width: 1260px;
-$--horizontal-filters: '(min-width: 850px)';
-$--lt-horizontal-filters: '(max-width: 849px)';
+$--horizontal-filters: '(min-width: 910px)';
+$--lt-horizontal-filters: '(max-width: 909px)';
 
-$--horizontal-selects: '(min-width: 615px)';
-$--lt-horizontal-selects: '(max-width: 614px)';
+$--horizontal-selects: '(min-width: 670px)';
+$--lt-horizontal-selects: '(max-width: 669px)';
 
 $--horizontal-nav: '(min-width: 850px)';
 $--lt-horizontal-nav: '(max-width: 849px)';


### PR DESCRIPTION
This alters the breakpoints slightly now that we added more words into the filters. Previously on narrower views the words would render incorrectly.

Before:

![screenshot 2019-02-25 at 12 09 52](https://user-images.githubusercontent.com/554604/53336478-a0a83800-38f6-11e9-8877-40c9ea09f656.png)


After:

![screenshot 2019-02-25 at 12 10 53](https://user-images.githubusercontent.com/554604/53336507-6c347c00-38f6-11e9-974b-bfac6698bb80.png)


