### PR TITLE
Don't hang Envoy when result set is empty

### DIFF
--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -346,7 +346,7 @@ func (t *xDSType) SendIfNew(cfgSnap *proxycfg.ConfigSnapshot, version uint64, no
 	if err != nil {
 		return err
 	}
-	if resources == nil || len(resources) == 0 {
+	if resources == nil {
 		// Nothing to send yet
 		return nil
 	}


### PR DESCRIPTION
As noted in #4868 we can sometimes cause Envoy to hang if one or more upstream has no instances available since Envoy won't continue processing xDS for listeners until it has all the endpoints resolved they'd be proxying to.

I _assume_ that this is correct and that by getting an explicit empty result Envoy will continue to resolve the config and just fail with a 503 if that upstream is connected.

## TODO

 - [ ] actually test this with Envoy
 - [ ] verify that it doesn't fail in some new way when a partial snapshot is delivered (i.e. before some resource has resolved)