### PR TITLE
website: update bootstrap-saas depenency

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
     middleman-hashicorp (0.3.35)
-      bootstrap-sass (~> 3.3)
+      bootstrap-sass (~> 3.4.1)
       builder (~> 3.2)
       middleman (~> 3.4)
       middleman-livereload (~> 3.4)


### PR DESCRIPTION
In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/

Likely doesn't affect us but bumps to avoid the affected version.