### PR TITLE
acl: ACL Tokens can now be assigned an optional set of service identities

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -645,7 +645,9 @@ func (s *Server) startACLUpgrade() {
 				}
 
 				// Assign the global-management policy to legacy management tokens
-				if len(newToken.Policies) == 0 && newToken.Type == structs.ACLTokenTypeManagement {
+				if len(newToken.Policies) == 0 &&
+					len(newToken.ServiceIdentities) == 0 &&
+					newToken.Type == structs.ACLTokenTypeManagement {
 					newToken.Policies = append(newToken.Policies, structs.ACLTokenPolicyLink{ID: structs.ACLPolicyGlobalManagementID})
 				}
 

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -478,6 +478,12 @@ func (s *Store) aclTokenSetTxn(tx *memdb.Txn, idx uint64, token *structs.ACLToke
 		return err
 	}
 
+	for _, svcid := range token.ServiceIdentities {
+		if svcid.ServiceName == "" {
+			return fmt.Errorf("Encountered a Token with an empty service identity name in the state store")
+		}
+	}
+
 	// Set the indexes
 	if original != nil {
 		if original.AccessorID != "" && token.AccessorID != original.AccessorID {

--- a/agent/structs/acl_legacy.go
+++ b/agent/structs/acl_legacy.go
@@ -73,14 +73,15 @@ func (a *ACL) Convert() *ACLToken {
 	}
 
 	return &ACLToken{
-		AccessorID:  "",
-		SecretID:    a.ID,
-		Description: a.Name,
-		Policies:    nil,
-		Type:        a.Type,
-		Rules:       a.Rules,
-		Local:       false,
-		RaftIndex:   a.RaftIndex,
+		AccessorID:        "",
+		SecretID:          a.ID,
+		Description:       a.Name,
+		Policies:          nil,
+		ServiceIdentities: nil,
+		Type:              a.Type,
+		Rules:             a.Rules,
+		Local:             false,
+		RaftIndex:         a.RaftIndex,
 	}
 }
 

--- a/agent/structs/acl_test.go
+++ b/agent/structs/acl_test.go
@@ -140,6 +140,69 @@ func TestStructs_ACLToken_EmbeddedPolicy(t *testing.T) {
 	})
 }
 
+func TestStructs_ACLServiceIdentity_SyntheticPolicy(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		serviceName string
+		datacenters []string
+		expectRules string
+	}{
+		{"web", nil, `
+service "web" {
+	policy = "write"
+}
+service "web-sidecar-proxy" {
+	policy = "write"
+}
+service_prefix "" {
+	policy = "read"
+}
+node_prefix "" {
+	policy = "read"
+}`},
+		{"companion-cube-99", []string{"dc1", "dc2"}, `
+service "companion-cube-99" {
+	policy = "write"
+}
+service "companion-cube-99-sidecar-proxy" {
+	policy = "write"
+}
+service_prefix "" {
+	policy = "read"
+}
+node_prefix "" {
+	policy = "read"
+}`},
+	} {
+		name := test.serviceName
+		if len(test.datacenters) > 0 {
+			name += " [" + strings.Join(test.datacenters, ", ") + "]"
+		}
+		t.Run(name, func(t *testing.T) {
+			svcid := &ACLServiceIdentity{
+				ServiceName: test.serviceName,
+				Datacenters: test.datacenters,
+			}
+
+			expect := &ACLPolicy{
+				Syntax:      acl.SyntaxCurrent,
+				Datacenters: test.datacenters,
+				Rules:       test.expectRules,
+			}
+
+			got := svcid.SyntheticPolicy()
+			require.NotEmpty(t, got.ID)
+			require.Equal(t, got.Name, "synthetic-policy-"+got.ID)
+			// strip irrelevant fields before equality
+			got.ID = ""
+			got.Name = ""
+			got.Hash = nil
+			require.Equal(t, expect, got)
+		})
+	}
+}
+
 func TestStructs_ACLToken_SetHash(t *testing.T) {
 	t.Parallel()
 

--- a/api/acl.go
+++ b/api/acl.go
@@ -22,17 +22,18 @@ type ACLTokenPolicyLink struct {
 
 // ACLToken represents an ACL Token
 type ACLToken struct {
-	CreateIndex    uint64
-	ModifyIndex    uint64
-	AccessorID     string
-	SecretID       string
-	Description    string
-	Policies       []*ACLTokenPolicyLink
-	Local          bool
-	ExpirationTTL  time.Duration `json:",omitempty"`
-	ExpirationTime time.Time     `json:",omitempty"`
-	CreateTime     time.Time     `json:",omitempty"`
-	Hash           []byte        `json:",omitempty"`
+	CreateIndex       uint64
+	ModifyIndex       uint64
+	AccessorID        string
+	SecretID          string
+	Description       string
+	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
+	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	Local             bool
+	ExpirationTTL     time.Duration `json:",omitempty"`
+	ExpirationTime    time.Time     `json:",omitempty"`
+	CreateTime        time.Time     `json:",omitempty"`
+	Hash              []byte        `json:",omitempty"`
 
 	// DEPRECATED (ACL-Legacy-Compat)
 	// Rules will only be present for legacy tokens returned via the new APIs
@@ -40,16 +41,17 @@ type ACLToken struct {
 }
 
 type ACLTokenListEntry struct {
-	CreateIndex    uint64
-	ModifyIndex    uint64
-	AccessorID     string
-	Description    string
-	Policies       []*ACLTokenPolicyLink
-	Local          bool
-	ExpirationTime time.Time `json:",omitempty"`
-	CreateTime     time.Time
-	Hash           []byte
-	Legacy         bool
+	CreateIndex       uint64
+	ModifyIndex       uint64
+	AccessorID        string
+	Description       string
+	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
+	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	Local             bool
+	ExpirationTime    time.Time `json:",omitempty"`
+	CreateTime        time.Time
+	Hash              []byte
+	Legacy            bool
 }
 
 // ACLEntry is used to represent a legacy ACL token
@@ -73,6 +75,14 @@ type ACLReplicationStatus struct {
 	ReplicatedTokenIndex uint64
 	LastSuccess          time.Time
 	LastError            time.Time
+}
+
+// ACLServiceIdentity represents a high-level grant of all necessary privileges
+// to assume the identity of the named Service in the Catalog and within
+// Connect.
+type ACLServiceIdentity struct {
+	ServiceName string
+	Datacenters []string `json:",omitempty"`
 }
 
 // ACLPolicy represents an ACL Policy.

--- a/vendor/github.com/hashicorp/consul/api/acl.go
+++ b/vendor/github.com/hashicorp/consul/api/acl.go
@@ -22,17 +22,18 @@ type ACLTokenPolicyLink struct {
 
 // ACLToken represents an ACL Token
 type ACLToken struct {
-	CreateIndex    uint64
-	ModifyIndex    uint64
-	AccessorID     string
-	SecretID       string
-	Description    string
-	Policies       []*ACLTokenPolicyLink
-	Local          bool
-	ExpirationTTL  time.Duration `json:",omitempty"`
-	ExpirationTime time.Time     `json:",omitempty"`
-	CreateTime     time.Time     `json:",omitempty"`
-	Hash           []byte        `json:",omitempty"`
+	CreateIndex       uint64
+	ModifyIndex       uint64
+	AccessorID        string
+	SecretID          string
+	Description       string
+	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
+	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	Local             bool
+	ExpirationTTL     time.Duration `json:",omitempty"`
+	ExpirationTime    time.Time     `json:",omitempty"`
+	CreateTime        time.Time     `json:",omitempty"`
+	Hash              []byte        `json:",omitempty"`
 
 	// DEPRECATED (ACL-Legacy-Compat)
 	// Rules will only be present for legacy tokens returned via the new APIs
@@ -40,16 +41,17 @@ type ACLToken struct {
 }
 
 type ACLTokenListEntry struct {
-	CreateIndex    uint64
-	ModifyIndex    uint64
-	AccessorID     string
-	Description    string
-	Policies       []*ACLTokenPolicyLink
-	Local          bool
-	ExpirationTime time.Time `json:",omitempty"`
-	CreateTime     time.Time
-	Hash           []byte
-	Legacy         bool
+	CreateIndex       uint64
+	ModifyIndex       uint64
+	AccessorID        string
+	Description       string
+	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
+	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	Local             bool
+	ExpirationTime    time.Time `json:",omitempty"`
+	CreateTime        time.Time
+	Hash              []byte
+	Legacy            bool
 }
 
 // ACLEntry is used to represent a legacy ACL token
@@ -73,6 +75,14 @@ type ACLReplicationStatus struct {
 	ReplicatedTokenIndex uint64
 	LastSuccess          time.Time
 	LastError            time.Time
+}
+
+// ACLServiceIdentity represents a high-level grant of all necessary privileges
+// to assume the identity of the named Service in the Catalog and within
+// Connect.
+type ACLServiceIdentity struct {
+	ServiceName string
+	Datacenters []string `json:",omitempty"`
 }
 
 // ACLPolicy represents an ACL Policy.


### PR DESCRIPTION
Parent PR: #5353 
Note: this is merging into a long lived feature branch, not master. Future PRs in this series may adjust the contents here slightly as needed. These are separated out for digestibility.

These act like a special cased version of a Policy Template for granting a token the privileges necessary to register a service and its connect proxy, and read upstreams from the catalog.

- [ ] Validate that the CLI changes are sane
- [ ] website updates
- [ ] UI updates