### PR TITLE
[Docs] Added a note to GCE auto-join credentials option

### DIFF
--- a/website/source/docs/agent/cloud-auto-join.html.md
+++ b/website/source/docs/agent/cloud-auto-join.html.md
@@ -135,7 +135,7 @@ $ consul agent -retry-join "provider=gce project_name=... tag_value=..."
 - `tag_value` (required) - the value of the tag to auto-join on.
 - `project_name` (optional) - the name of the project to auto-join on. Discovered if not set.
 - `zone_pattern` (optional) - the list of zones can be restricted through an RE2 compatible regular expression. If omitted, servers in all zones are returned.
-- `credentials_file` (optional) - the credentials file for authentication. See below for more information.
+- `credentials_file` (optional) - the credentials file for authentication. **NOTE** if you are using `-config-dir` do not store the credentials.json file in that directory as it will be parsed as a config file and consul will fail to start. See below for more information.
 
 #### Authentication & Precedence
 

--- a/website/source/docs/agent/cloud-auto-join.html.md
+++ b/website/source/docs/agent/cloud-auto-join.html.md
@@ -135,7 +135,7 @@ $ consul agent -retry-join "provider=gce project_name=... tag_value=..."
 - `tag_value` (required) - the value of the tag to auto-join on.
 - `project_name` (optional) - the name of the project to auto-join on. Discovered if not set.
 - `zone_pattern` (optional) - the list of zones can be restricted through an RE2 compatible regular expression. If omitted, servers in all zones are returned.
-- `credentials_file` (optional) - the credentials file for authentication. **NOTE** if you are using `-config-dir` do not store the credentials.json file in that directory as it will be parsed as a config file and consul will fail to start. See below for more information.
+- `credentials_file` (optional) - the credentials file for authentication. Note, if you set `-config-dir` do not store the credentials.json file in the configuration directory as it will be parsed as a config file and Consul will fail to start. See below for more information.
 
 #### Authentication & Precedence
 


### PR DESCRIPTION
Simply added a note to remind users that putting a json file in the config-dir will make consul parse it as a config file.
Hope to help someone else avoid wasting a day because of these errors:
==> Error parsing /etc/consul.d/credentials.json: 10 error(s) occurred: * invalid config key private_key