### PR TITLE
[Docs] Connect Sidecar Proxies: Fixes 'must may' typo and adds formatting to follow other docs

### DIFF
--- a/website/source/docs/connect/proxies.html.md
+++ b/website/source/docs/connect/proxies.html.md
@@ -39,15 +39,15 @@ provide information about the service they represent.
 To declare a service as a proxy, the service definition must contain
 the following fields:
 
-  * `kind` (string) must be set to `connect-proxy`. This declares that the
+  * `kind` `(string)` must be set to `connect-proxy`. This declares that the
     service is a proxy type.
 
-  * `proxy.destination_service_name` (string) must be set to the service that
+  * `proxy.destination_service_name` `(string)` must be set to the service that
     this proxy is representing. Note that this replaces `proxy_destination` in
     versions 1.2.0 to 1.3.0.
 
-  * `port` must be set so that other Connect services can discover the exact
-    address for connections. `address` is optional if the service is being
+  * `port` `(int)` must be set so that other Connect services can discover the
+    exact address for connections. `address` is optional if the service is being
     registered against an agent, since it'll inherit the node address.
 
 Minimal Example:
@@ -70,18 +70,18 @@ Connect-capable endpoint for "redis" will find this proxy.
 
 Most Connect proxies are deployed as "sidecars" which means they are co-located
 with a single service instance which they represent and proxy all inbound
-traffic to. In this case the following fields must may also be set:
+traffic to. In this case the following fields should also be set:
 
-  * `proxy.destination_service_id` (string) is set to the _id_ (and not the
-    _name_ if they are different) of the specific service instance that is being
-    proxied. The proxied service is assumed to be registered on the same agent
-    although it's not strictly validated to allow for un-coordinated
-    registrations.
+  * `proxy.destination_service_id` `(string: <required>)` is set to the _id_
+    (and not the _name_ if they are different) of the specific service instance
+    that is being proxied. The proxied service is assumed to be registered on
+    the same agent although it's not strictly validated to allow for
+    un-coordinated registrations.
 
-  * `proxy.local_service_port` (string) must specify the port the proxy should use
-    to connect to the _local_ service instance.
+  * `proxy.local_service_port` `(int: <required>)` must specify the port the
+    proxy should use to connect to the _local_ service instance.
 
-  * `proxy.local_service_address` (string) can be set to override the IP or
+  * `proxy.local_service_address` `(string: "")` can be set to override the IP or
     hostname the proxy should use to connect to the _local_ service. Defaults to
     `127.0.0.1`.
 
@@ -113,13 +113,13 @@ until at least 1.5.0 but it's highly recommended to switch to using
 
 #### Proxy Parameters
 
- - `destination_service_name` `string: <required>` - Specifies the _name_ of the
+ - `destination_service_name` `(string: <required>)` - Specifies the _name_ of the
    service this instance is proxying. Both side-car and centralized
    load-balancing proxies must specify this. It is used during service
    discovery to find the correct proxy instances to route to for a given service
    name.
 
- - `destination_service_id` `string: <optional>` - Specifies the _ID_ of a single
+ - `destination_service_id` `(string: "")` - Specifies the _ID_ of a single
    specific service instance that this proxy is representing. This is only valid
    for side-car style proxies that run on the same node. It is assumed that the
    service instance is registered via the same Consul agent so the ID is unique
@@ -127,19 +127,19 @@ until at least 1.5.0 but it's highly recommended to switch to using
    instance is a side-car for which application instance and will enable
    fine-grained analysis of the metrics coming from the proxy.
 
- - `local_service_address` `string: <optional>` - Specifies the address a side-car
+ - `local_service_address` `(string: "")` - Specifies the address a side-car
    proxy should attempt to connect to the local application instance on.
    Defaults to 127.0.0.1.
 
- - `local_service_port` `int: <optional>` - Specifies the port a side-car
+ - `local_service_port` `(int: <required>)` - Specifies the port a side-car
    proxy should attempt to connect to the local application instance on.
    Defaults to the port advertised by the service instance identified by
    `destination_service_id` if it exists otherwise it may be empty in responses.
 
- - `config` `object: <optional>` - Specifies opaque config JSON that will be
+ - `config` `(object: {})` - Specifies opaque config JSON that will be
    stored and returned along with the service instance from future API calls.
 
- - `upstreams` `array<Upstream>: <optional>` - Specifies the upstream services
+ - `upstreams` `(array<Upstream>: [])` - Specifies the upstream services
    this proxy should create listeners for. The format is defined in
    [Upstream Configuration Reference](#upstream-configuration-reference).
 
@@ -189,20 +189,20 @@ followed by documentation for each attribute.
 },
 ```
 
-* `destination_name` `string: <required>` - Specifies the name of the service or
-  prepared query to route connect to. The prepared query should be the name
+* `destination_name` `(string: <required>)` - Specifies the name of the service
+  or prepared query to route connect to. The prepared query should be the name
   or the ID of the prepared query.
-* `local_bind_port` `int: <required>` - Specifies the port to bind a local
+* `local_bind_port` `(int: <required>)` - Specifies the port to bind a local
   listener to for the application to make outbound connections to this upstream.
-* `local_bind_address` `string: <optional>` - Specifies the address to bind a
+* `local_bind_address` `(string: "")` - Specifies the address to bind a
   local listener to for the application to make outbound connections to this
   upstream. Defaults to `127.0.0.1`.
-* `destination_type` `string: <optional>` - Speficied the type of discovery
+* `destination_type` `(string: "")` - Speficied the type of discovery
   query to use to find an instance to connect to. Valid values are `service` or
   `prepared_query`. Defaults to `service`.
-* `datacenter` `string: <optional>` - Specifies the datacenter to issue the
+* `datacenter` `(string: "")` - Specifies the datacenter to issue the
   discovery query too. Defaults to the local datacenter.
-* `config` `object: <optional>` - Specifies opaque configuration options that
+* `config` `(object: {})` - Specifies opaque configuration options that
   will be provided to the proxy instance for this specific upstream. Can contain
   any valid JSON object. This might be used to configure proxy-specific features
   like timeouts or retries for the given upstream. See the [built-in proxy

--- a/website/source/docs/connect/proxies.html.md
+++ b/website/source/docs/connect/proxies.html.md
@@ -131,7 +131,7 @@ until at least 1.5.0 but it's highly recommended to switch to using
    proxy should attempt to connect to the local application instance on.
    Defaults to 127.0.0.1.
 
- - `local_service_port` `(int: <required>)` - Specifies the port a side-car
+ - `local_service_port` `(int: <optional>)` - Specifies the port a side-car
    proxy should attempt to connect to the local application instance on.
    Defaults to the port advertised by the service instance identified by
    `destination_service_id` if it exists otherwise it may be empty in responses.


### PR DESCRIPTION
1. Corrects a `must may` typo - replaced with `should` (??).
2. Adds formatting and `<required>` to follow the styling of other docs, removes 'optional' which we seem to just use empty strings for elsewhere.
3. Replaces instances of `string` with `int` in certain places (ports)

Lastly I wasn't sure whether to remove the optional thing here, but I looked elsewhere and the only place we do that is in `operator/area`. Happy to revert that if we still want that here. I think the main thing here is the `must may` typo.