### PR TITLE
Fix race condition in DNS when using cache 

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -1100,7 +1100,10 @@ func (d *DNSServer) lookupServiceNodes(datacenter, service, tag string, connect 
 	}
 
 	// Filter out any service nodes due to health checks
-	out.Nodes = out.Nodes.Filter(d.config.OnlyPassing)
+	// We copy the slice to avoid modifying the result if it comes from the cache
+	nodes := make(structs.CheckServiceNodes, len(out.Nodes))
+	copy(nodes, out.Nodes)
+	out.Nodes = nodes.Filter(d.config.OnlyPassing)
 	return out, nil
 }
 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1078,7 +1078,7 @@ default will automatically work with some tooling.
     * <a name="dns_use_cache"></a><a href="dns_use_cache">`use_cache`</a> - When set to true, DNS resolution will use the agent cache described
       in [agent caching](/api/index.html#agent-caching). This setting affects all service and prepared queries DNS requests. Implies [`allow_stale`](#allow_stale)
 
-    * <a name="dns_cache_max_age"></a><a href="dns_cache_max_age">`dns_max_age`</a> - When [use_cache](#dns_use_cache) is enabled, the agent
+    * <a name="dns_cache_max_age"></a><a href="dns_cache_max_age">`cache_max_age`</a> - When [use_cache](#dns_use_cache) is enabled, the agent
       will attempt to re-fetch the result from the servers if the cached value is older than this duration. See: [agent caching](/api/index.html#agent-caching).
 
 * <a name="domain"></a><a href="#domain">`domain`</a> Equivalent to the


### PR DESCRIPTION
Introduced in https://github.com/hashicorp/consul/pull/5300

The healthy node filtering was modifying the result from the cache, which
caused a crash when multiple queries were made to the same service
simultaneously.
We now copy the node slice before filtering to ensure we do not modify
the data stored in the cache.

Also fix an error in docs.