### PR TITLE
DO NOT MERGE: upgrade to go 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 executors:
   go:
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.12
     environment:
       - TEST_RESULTS: /tmp/test-results  # path to where test results are saved
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   # Please keep this in-sync with the go version we build against in
   # build-support/docker/Build-Go.dockerfile.
-  - "1.11.4"
+  - "1.12"
 
 branches:
   only:

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.11.4
+ARG GOLANG_VERSION=1.12
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func argFail(t *testing.T, args []string, expected string) {
+	t.Helper()
 	ui := cli.NewMockUi()
 	c := New(ui)
 	c.flags.SetOutput(ui.ErrorWriter)
@@ -35,8 +36,10 @@ func TestLockCommand_noTabs(t *testing.T) {
 
 func TestLockCommand_BadArgs(t *testing.T) {
 	t.Parallel()
-	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "invalid duration")
+	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "parse error")
 	argFail(t, []string{"-try=-10s", "test/prefix", "date"}, "Timeout must be positive")
+	argFail(t, []string{"-timeout=blah", "test/prefix", "date"}, "parse error")
+	argFail(t, []string{"-timeout=-10s", "test/prefix", "date"}, "Timeout must be positive")
 	argFail(t, []string{"-monitor-retry=-5", "test/prefix", "date"}, "must be >= 0")
 }
 


### PR DESCRIPTION
Filing this PR so that CI can run the tests.

At the very least these now seem to fail:

* `go test ./agent -run TestHTTPAPI_Ban_Nonprintable_Characters`
* `go test ./command/lock -run TestLockCommand_BadArgs`
