### PR TITLE
Dont modify memdb owned token data for get/list requests of tokens

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -392,9 +392,10 @@ func (r *ACLResolver) fireAsyncTokenResult(token string, identity structs.ACLIde
 
 func (r *ACLResolver) resolveIdentityFromTokenAsync(token string, cached *structs.IdentityCacheEntry) {
 	req := structs.ACLTokenGetRequest{
-		Datacenter:  r.delegate.ACLDatacenter(false),
-		TokenID:     token,
-		TokenIDType: structs.ACLTokenSecret,
+		Datacenter:      r.delegate.ACLDatacenter(false),
+		TokenID:         token,
+		TokenIDType:     structs.ACLTokenSecret,
+		AllowStaleLinks: true,
 		QueryOptions: structs.QueryOptions{
 			Token:      token,
 			AllowStale: true,

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -392,10 +392,12 @@ func (r *ACLResolver) fireAsyncTokenResult(token string, identity structs.ACLIde
 
 func (r *ACLResolver) resolveIdentityFromTokenAsync(token string, cached *structs.IdentityCacheEntry) {
 	req := structs.ACLTokenGetRequest{
-		Datacenter:      r.delegate.ACLDatacenter(false),
-		TokenID:         token,
-		TokenIDType:     structs.ACLTokenSecret,
-		AllowStaleLinks: true,
+		Datacenter:  r.delegate.ACLDatacenter(false),
+		TokenID:     token,
+		TokenIDType: structs.ACLTokenSecret,
+		// we don't really care about the linked policy names here but
+		// we do want to filter out deleted policies
+		AllowStaleLinks: false,
 		QueryOptions: structs.QueryOptions{
 			Token:      token,
 			AllowStale: true,

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -93,7 +93,7 @@ func aclApplyInternal(srv *Server, args *structs.ACLRequest, reply *string) erro
 			return fmt.Errorf("Invalid ACL Type")
 		}
 
-		_, existing, _ := srv.fsm.State().ACLTokenGetBySecret(nil, args.ACL.ID)
+		_, existing, _ := srv.fsm.State().ACLTokenGetBySecret(nil, args.ACL.ID, true)
 		if existing != nil && len(existing.Policies) > 0 {
 			return fmt.Errorf("Cannot use legacy endpoint to modify a non-legacy token")
 		}
@@ -205,7 +205,7 @@ func (a *ACL) Get(args *structs.ACLSpecificRequest,
 	return a.srv.blockingQuery(&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, token, err := state.ACLTokenGetBySecret(ws, args.ACL)
+			index, token, err := state.ACLTokenGetBySecret(ws, args.ACL, true)
 			if err != nil {
 				return err
 			}
@@ -249,7 +249,7 @@ func (a *ACL) List(args *structs.DCSpecificRequest,
 	return a.srv.blockingQuery(&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, tokens, err := state.ACLTokenList(ws, false, true, "")
+			index, tokens, err := state.ACLTokenList(ws, false, true, "", true)
 			if err != nil {
 				return err
 			}

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -142,7 +142,7 @@ func TestACLEndpoint_Apply(t *testing.T) {
 
 	// Verify
 	state := s1.fsm.State()
-	_, s, err := state.ACLTokenGetBySecret(nil, out)
+	_, s, err := state.ACLTokenGetBySecret(nil, out, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestACLEndpoint_Apply(t *testing.T) {
 	}
 
 	// Verify
-	_, s, err = state.ACLTokenGetBySecret(nil, id)
+	_, s, err = state.ACLTokenGetBySecret(nil, id, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestACLEndpoint_Apply_CustomID(t *testing.T) {
 
 	// Verify
 	state := s1.fsm.State()
-	_, s, err := state.ACLTokenGetBySecret(nil, out)
+	_, s, err := state.ACLTokenGetBySecret(nil, out, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/acl_replication.go
+++ b/agent/consul/acl_replication.go
@@ -319,8 +319,9 @@ func (s *Server) updateLocalACLTokens(tokens structs.ACLTokens, ctx context.Cont
 
 func (s *Server) fetchACLTokensBatch(tokenIDs []string) (*structs.ACLTokenBatchResponse, error) {
 	req := structs.ACLTokenBatchGetRequest{
-		Datacenter:  s.config.ACLDatacenter,
-		AccessorIDs: tokenIDs,
+		Datacenter:      s.config.ACLDatacenter,
+		AccessorIDs:     tokenIDs,
+		AllowStaleLinks: true,
 		QueryOptions: structs.QueryOptions{
 			AllowStale: true,
 			Token:      s.tokens.ReplicationToken(),
@@ -345,8 +346,9 @@ func (s *Server) fetchACLTokens(lastRemoteIndex uint64) (*structs.ACLTokenListRe
 			MinQueryIndex: lastRemoteIndex,
 			Token:         s.tokens.ReplicationToken(),
 		},
-		IncludeLocal:  false,
-		IncludeGlobal: true,
+		IncludeLocal:    false,
+		IncludeGlobal:   true,
+		AllowStaleLinks: true,
 	}
 
 	var response structs.ACLTokenListResponse
@@ -461,7 +463,7 @@ func (s *Server) replicateACLTokens(lastRemoteIndex uint64, ctx context.Context)
 	// replication process is.
 	defer metrics.MeasureSince([]string{"leader", "replication", "acl", "token", "apply"}, time.Now())
 
-	_, local, err := s.fsm.State().ACLTokenList(nil, false, true, "")
+	_, local, err := s.fsm.State().ACLTokenList(nil, false, true, "", true)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to retrieve local ACL tokens: %v", err)
 	}

--- a/agent/consul/acl_replication_legacy.go
+++ b/agent/consul/acl_replication_legacy.go
@@ -138,7 +138,7 @@ func reconcileLegacyACLs(local, remote structs.ACLs, lastRemoteIndex uint64) str
 
 // FetchLocalACLs returns the ACLs in the local state store.
 func (s *Server) fetchLocalLegacyACLs() (structs.ACLs, error) {
-	_, local, err := s.fsm.State().ACLTokenList(nil, false, true, "")
+	_, local, err := s.fsm.State().ACLTokenList(nil, false, true, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/consul/acl_replication_legacy_test.go
+++ b/agent/consul/acl_replication_legacy_test.go
@@ -386,11 +386,11 @@ func TestACLReplication_LegacyTokens(t *testing.T) {
 	}
 
 	checkSame := func() error {
-		index, remote, err := s1.fsm.State().ACLTokenList(nil, true, true, "")
+		index, remote, err := s1.fsm.State().ACLTokenList(nil, true, true, "", true)
 		if err != nil {
 			return err
 		}
-		_, local, err := s2.fsm.State().ACLTokenList(nil, true, true, "")
+		_, local, err := s2.fsm.State().ACLTokenList(nil, true, true, "", true)
 		if err != nil {
 			return err
 		}

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -329,9 +329,9 @@ func TestACLReplication_Tokens(t *testing.T) {
 
 	checkSame := func(t *retry.R) error {
 		// only account for global tokens - local tokens shouldn't be replicated
-		index, remote, err := s1.fsm.State().ACLTokenList(nil, false, true, "")
+		index, remote, err := s1.fsm.State().ACLTokenList(nil, false, true, "", true)
 		require.NoError(t, err)
-		_, local, err := s2.fsm.State().ACLTokenList(nil, false, true, "")
+		_, local, err := s2.fsm.State().ACLTokenList(nil, false, true, "", true)
 		require.NoError(t, err)
 
 		require.Len(t, local, len(remote))
@@ -425,7 +425,7 @@ func TestACLReplication_Tokens(t *testing.T) {
 	})
 
 	// verify dc2 local tokens didn't get blown away
-	_, local, err := s2.fsm.State().ACLTokenList(nil, true, false, "")
+	_, local, err := s2.fsm.State().ACLTokenList(nil, true, false, "", true)
 	require.NoError(t, err)
 	require.Len(t, local, 50)
 

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -29,13 +29,13 @@ var serverACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
 
 func (s *Server) checkTokenUUID(id string) (bool, error) {
 	state := s.fsm.State()
-	if _, token, err := state.ACLTokenGetByAccessor(nil, id); err != nil {
+	if _, token, err := state.ACLTokenGetByAccessor(nil, id, true); err != nil {
 		return false, err
 	} else if token != nil {
 		return false, nil
 	}
 
-	if _, token, err := state.ACLTokenGetBySecret(nil, id); err != nil {
+	if _, token, err := state.ACLTokenGetBySecret(nil, id, true); err != nil {
 		return false, err
 	} else if token != nil {
 		return false, nil
@@ -142,7 +142,7 @@ func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdenti
 		return false, nil, nil
 	}
 
-	index, aclToken, err := s.fsm.State().ACLTokenGetBySecret(nil, token)
+	index, aclToken, err := s.fsm.State().ACLTokenGetBySecret(nil, token, true)
 	if err != nil {
 		return true, nil, err
 	} else if aclToken != nil {

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -164,7 +164,7 @@ func (c *FSM) applyACLOperation(buf []byte, index uint64) interface{} {
 			return err
 		}
 
-		if _, token, err := c.state.ACLTokenGetBySecret(nil, req.ACL.ID); err != nil {
+		if _, token, err := c.state.ACLTokenGetBySecret(nil, req.ACL.ID, true); err != nil {
 			return err
 		} else {
 			acl, err := token.Convert()

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -810,7 +810,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 
 	// Get the ACL.
 	id := resp.(string)
-	_, acl, err := fsm.state.ACLTokenGetBySecret(nil, id)
+	_, acl, err := fsm.state.ACLTokenGetBySecret(nil, id, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -846,7 +846,7 @@ func TestFSM_ACL_CRUD(t *testing.T) {
 		t.Fatalf("resp: %v", resp)
 	}
 
-	_, acl, err = fsm.state.ACLTokenGetBySecret(nil, id)
+	_, acl, err = fsm.state.ACLTokenGetBySecret(nil, id, true)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -301,7 +301,7 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}
 
 	// Verify ACL Token is restored
-	_, a, err := fsm2.state.ACLTokenGetByAccessor(nil, token.AccessorID)
+	_, a, err := fsm2.state.ACLTokenGetByAccessor(nil, token.AccessorID, true)
 	require.NoError(t, err)
 	require.Equal(t, token.AccessorID, a.AccessorID)
 	require.Equal(t, token.ModifyIndex, a.ModifyIndex)

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -312,7 +312,7 @@ func (s *Server) initializeLegacyACL() error {
 
 	// Create anonymous token if missing.
 	state := s.fsm.State()
-	_, token, err := state.ACLTokenGetBySecret(nil, anonymousToken)
+	_, token, err := state.ACLTokenGetBySecret(nil, anonymousToken, true)
 	if err != nil {
 		return fmt.Errorf("failed to get anonymous token: %v", err)
 	}
@@ -335,7 +335,7 @@ func (s *Server) initializeLegacyACL() error {
 
 	// Check for configured master token.
 	if master := s.config.ACLMasterToken; len(master) > 0 {
-		_, token, err = state.ACLTokenGetBySecret(nil, master)
+		_, token, err = state.ACLTokenGetBySecret(nil, master, true)
 		if err != nil {
 			return fmt.Errorf("failed to get master token: %v", err)
 		}
@@ -450,7 +450,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 				s.logger.Printf("[WARN] consul: Configuring a non-UUID master token is deprecated")
 			}
 
-			_, token, err := state.ACLTokenGetBySecret(nil, master)
+			_, token, err := state.ACLTokenGetBySecret(nil, master, true)
 			if err != nil {
 				return fmt.Errorf("failed to get master token: %v", err)
 			}
@@ -511,14 +511,14 @@ func (s *Server) initializeACLs(upgrade bool) error {
 		}
 
 		state := s.fsm.State()
-		_, token, err := state.ACLTokenGetBySecret(nil, structs.ACLTokenAnonymousID)
+		_, token, err := state.ACLTokenGetBySecret(nil, structs.ACLTokenAnonymousID, true)
 		if err != nil {
 			return fmt.Errorf("failed to get anonymous token: %v", err)
 		}
 		if token == nil {
 			// DEPRECATED (ACL-Legacy-Compat) - Don't need to query for previous "anonymous" token
 			// check for legacy token that needs an upgrade
-			_, legacyToken, err := state.ACLTokenGetBySecret(nil, anonymousToken)
+			_, legacyToken, err := state.ACLTokenGetBySecret(nil, anonymousToken, true)
 			if err != nil {
 				return fmt.Errorf("failed to get anonymous token: %v", err)
 			}

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -983,12 +983,12 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 			testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
 			if tt.master != "" {
-				_, master, err := s1.fsm.State().ACLTokenGetBySecret(nil, tt.master)
+				_, master, err := s1.fsm.State().ACLTokenGetBySecret(nil, tt.master, true)
 				require.NoError(t, err)
 				require.NotNil(t, master)
 			}
 
-			_, anon, err := s1.fsm.State().ACLTokenGetBySecret(nil, anonymousToken)
+			_, anon, err := s1.fsm.State().ACLTokenGetBySecret(nil, anonymousToken, true)
 			require.NoError(t, err)
 			require.NotNil(t, anon)
 
@@ -1172,7 +1172,7 @@ func TestLeader_ACLUpgrade(t *testing.T) {
 
 	// wait for it to be upgraded
 	retry.Run(t, func(t *retry.R) {
-		_, token, err := s1.fsm.State().ACLTokenGetBySecret(nil, mgmt_id)
+		_, token, err := s1.fsm.State().ACLTokenGetBySecret(nil, mgmt_id, true)
 		require.NoError(t, err)
 		require.NotNil(t, token)
 		require.NotEqual(t, "", token.AccessorID)
@@ -1197,7 +1197,7 @@ func TestLeader_ACLUpgrade(t *testing.T) {
 
 	// wait for it to be upgraded
 	retry.Run(t, func(t *retry.R) {
-		_, token, err := s1.fsm.State().ACLTokenGetBySecret(nil, client_id)
+		_, token, err := s1.fsm.State().ACLTokenGetBySecret(nil, client_id, true)
 		require.NoError(t, err)
 		require.NotNil(t, token)
 		require.NotEqual(t, "", token.AccessorID)

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -140,7 +140,7 @@ func TestStateStore_ACLBootstrap(t *testing.T) {
 	require.Equal(t, uint64(3), index)
 
 	// Make sure the ACLs are in an expected state.
-	_, tokens, err := s.ACLTokenList(nil, true, true, "")
+	_, tokens, err := s.ACLTokenList(nil, true, true, "", false)
 	require.NoError(t, err)
 	require.Len(t, tokens, 1)
 	compareTokens(token1, tokens[0])
@@ -154,7 +154,7 @@ func TestStateStore_ACLBootstrap(t *testing.T) {
 	err = s.ACLBootstrap(32, index, token2.Clone(), false)
 	require.NoError(t, err)
 
-	_, tokens, err = s.ACLTokenList(nil, true, true, "")
+	_, tokens, err = s.ACLTokenList(nil, true, true, "", false)
 	require.NoError(t, err)
 	require.Len(t, tokens, 2)
 }
@@ -208,7 +208,7 @@ func TestStateStore_ACLToken_SetGet_Legacy(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(2, token, true))
 
-		idx, rtoken, err := s.ACLTokenGetBySecret(nil, token.SecretID)
+		idx, rtoken, err := s.ACLTokenGetBySecret(nil, token.SecretID, false)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
 		require.NotNil(t, rtoken)
@@ -241,7 +241,7 @@ func TestStateStore_ACLToken_SetGet_Legacy(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(3, update, true))
 
-		idx, rtoken, err := s.ACLTokenGetBySecret(nil, original.SecretID)
+		idx, rtoken, err := s.ACLTokenGetBySecret(nil, original.SecretID, false)
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), idx)
 		require.NotNil(t, rtoken)
@@ -331,7 +331,7 @@ func TestStateStore_ACLToken_SetGet(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(2, token, false))
 
-		idx, rtoken, err := s.ACLTokenGetByAccessor(nil, "daf37c07-d04d-4fd5-9678-a8206a57d61a")
+		idx, rtoken, err := s.ACLTokenGetByAccessor(nil, "daf37c07-d04d-4fd5-9678-a8206a57d61a", false)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
 		// pointer equality
@@ -369,7 +369,7 @@ func TestStateStore_ACLToken_SetGet(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(3, updated, false))
 
-		idx, rtoken, err := s.ACLTokenGetByAccessor(nil, "daf37c07-d04d-4fd5-9678-a8206a57d61a")
+		idx, rtoken, err := s.ACLTokenGetByAccessor(nil, "daf37c07-d04d-4fd5-9678-a8206a57d61a", false)
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), idx)
 		// pointer equality
@@ -402,7 +402,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenBatchSet(2, tokens, true))
 
-		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
+		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID, false)
 		require.NoError(t, err)
 		require.Nil(t, token)
 	})
@@ -434,7 +434,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenBatchSet(6, updated, true))
 
-		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
+		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID, false)
 		require.NoError(t, err)
 		require.NotNil(t, token)
 		require.Equal(t, "", token.Description)
@@ -463,7 +463,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenBatchSet(6, updated, true))
 
-		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
+		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID, false)
 		require.NoError(t, err)
 		require.NotNil(t, token)
 		require.Equal(t, "", token.Description)
@@ -488,7 +488,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
-			"a2719052-40b3-4a4b-baeb-f3df1831a217"})
+			"a2719052-40b3-4a4b-baeb-f3df1831a217"}, false)
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
@@ -544,7 +544,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
-			"a2719052-40b3-4a4b-baeb-f3df1831a217"})
+			"a2719052-40b3-4a4b-baeb-f3df1831a217"}, false)
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), idx)
@@ -790,7 +790,7 @@ func TestStateStore_ACLToken_List(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, tokens, err := s.ACLTokenList(nil, tc.local, tc.global, tc.policy)
+			_, tokens, err := s.ACLTokenList(nil, tc.local, tc.global, tc.policy, false)
 			require.NoError(t, err)
 			require.Len(t, tokens, len(tc.accessors))
 			tokens.Sort()
@@ -799,6 +799,216 @@ func TestStateStore_ACLToken_List(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStateStore_ACLToken_FixupPolicyLinks(t *testing.T) {
+	// This test wants to ensure a couple of things.
+	//
+	// 1. Doing a token list/get should never modify the data
+	//    tracked by memdb
+	// 2. Token list/get operations should return an accurate set
+	//    of policy links
+	t.Parallel()
+	s := testACLTokensStateStore(t)
+
+	// the policy specific token
+	token := &structs.ACLToken{
+		AccessorID: "47eea4da-bda1-48a6-901c-3e36d2d9262f",
+		SecretID:   "548bdb8e-c0d6-477b-bcc4-67fb836e9e61",
+		Policies: []structs.ACLTokenPolicyLink{
+			structs.ACLTokenPolicyLink{
+				ID: "a0625e95-9b3e-42de-a8d6-ceef5b6f3286",
+			},
+		},
+	}
+
+	require.NoError(t, s.ACLTokenSet(2, token, false))
+
+	_, retrieved, err := s.ACLTokenGetByAccessor(nil, token.AccessorID, false)
+	require.NoError(t, err)
+	// pointer equality check these should be identical
+	require.True(t, token == retrieved)
+	require.Len(t, retrieved.Policies, 1)
+	require.Equal(t, "node-read", retrieved.Policies[0].Name)
+
+	// rename the policy
+	renamed := &structs.ACLPolicy{
+		ID:          "a0625e95-9b3e-42de-a8d6-ceef5b6f3286",
+		Name:        "node-read-renamed",
+		Description: "Allows reading all node information",
+		Rules:       `node_prefix "" { policy = "read" }`,
+		Syntax:      acl.SyntaxCurrent,
+	}
+	renamed.SetHash(true)
+	require.NoError(t, s.ACLPolicySet(3, renamed))
+
+	// retrieve the token again
+	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, false)
+	require.NoError(t, err)
+	// pointer equality check these should be different if we cloned things appropriately
+	require.True(t, token != retrieved)
+	require.Len(t, retrieved.Policies, 1)
+	require.Equal(t, "node-read-renamed", retrieved.Policies[0].Name)
+
+	// retrieve the token with allowing stale links
+	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, true)
+	require.NoError(t, err)
+	// pointer equality check these should be identical as we are allowing stale links
+	require.True(t, token == retrieved)
+	require.Len(t, retrieved.Policies, 1)
+	require.Equal(t, "node-read", retrieved.Policies[0].Name)
+
+	// list tokens without stale links
+	_, tokens, err := s.ACLTokenList(nil, true, true, "", false)
+	require.NoError(t, err)
+
+	found := false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok != token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read-renamed", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// list tokens with stale links
+	_, tokens, err = s.ACLTokenList(nil, true, true, "", true)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok == token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// batch get without stale links
+	_, tokens, err = s.ACLTokenBatchGet(nil, []string{token.AccessorID}, false)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok != token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read-renamed", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// batch get tokens with stale links
+	_, tokens, err = s.ACLTokenBatchGet(nil, []string{token.AccessorID}, true)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok == token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// delete the policy
+	require.NoError(t, s.ACLPolicyDeleteByID(4, "a0625e95-9b3e-42de-a8d6-ceef5b6f3286"))
+
+	// retrieve the token again
+	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, false)
+	require.NoError(t, err)
+	// pointer equality check these should be different if we cloned things appropriately
+	require.True(t, token != retrieved)
+	require.Len(t, retrieved.Policies, 0)
+
+	// retrieve the token again - allowing stale links
+	_, retrieved, err = s.ACLTokenGetByAccessor(nil, token.AccessorID, true)
+	require.NoError(t, err)
+	// pointer equality check these should be identical as we are allowing stale links
+	require.True(t, token == retrieved)
+	require.Len(t, retrieved.Policies, 1)
+	require.Equal(t, "node-read", retrieved.Policies[0].Name)
+
+	// list tokens without stale links
+	_, tokens, err = s.ACLTokenList(nil, true, true, "", false)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok != token)
+			require.Len(t, tok.Policies, 0)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// list tokens with stale links
+	_, tokens, err = s.ACLTokenList(nil, true, true, "", true)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok == token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// batch get without stale links
+	_, tokens, err = s.ACLTokenBatchGet(nil, []string{token.AccessorID}, false)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok != token)
+			require.Len(t, tok.Policies, 0)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
+
+	// batch get tokens with stale links
+	_, tokens, err = s.ACLTokenBatchGet(nil, []string{token.AccessorID}, true)
+	require.NoError(t, err)
+
+	found = false
+	for _, tok := range tokens {
+		if tok.AccessorID == token.AccessorID {
+			// these pointers shouldn't be equal because the link should have been fixed
+			require.True(t, tok == token)
+			require.Len(t, tok.Policies, 1)
+			require.Equal(t, "node-read", tok.Policies[0].Name)
+			found = true
+			break
+		}
+	}
+	require.True(t, found)
 }
 
 func TestStateStore_ACLToken_Delete(t *testing.T) {
@@ -821,13 +1031,13 @@ func TestStateStore_ACLToken_Delete(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(2, token, false))
 
-		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.NotNil(t, rtoken)
 
 		require.NoError(t, s.ACLTokenDeleteByAccessor(3, "f1093997-b6c7-496d-bfb8-6b1b1895641b"))
 
-		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.Nil(t, rtoken)
 	})
@@ -849,13 +1059,13 @@ func TestStateStore_ACLToken_Delete(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenSet(2, token, false))
 
-		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.NotNil(t, rtoken)
 
 		require.NoError(t, s.ACLTokenDeleteBySecret(3, "34ec8eb3-095d-417a-a937-b439af7a8e8b"))
 
-		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.Nil(t, rtoken)
 	})
@@ -889,10 +1099,10 @@ func TestStateStore_ACLToken_Delete(t *testing.T) {
 
 		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false))
 
-		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.NotNil(t, rtoken)
-		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "a0bfe8d4-b2f3-4b48-b387-f28afb820eab")
+		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "a0bfe8d4-b2f3-4b48-b387-f28afb820eab", false)
 		require.NoError(t, err)
 		require.NotNil(t, rtoken)
 
@@ -900,10 +1110,10 @@ func TestStateStore_ACLToken_Delete(t *testing.T) {
 			"f1093997-b6c7-496d-bfb8-6b1b1895641b",
 			"a0bfe8d4-b2f3-4b48-b387-f28afb820eab"}))
 
-		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
+		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b", false)
 		require.NoError(t, err)
 		require.Nil(t, rtoken)
-		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "a0bfe8d4-b2f3-4b48-b387-f28afb820eab")
+		_, rtoken, err = s.ACLTokenGetByAccessor(nil, "a0bfe8d4-b2f3-4b48-b387-f28afb820eab", false)
 		require.NoError(t, err)
 		require.Nil(t, rtoken)
 	})
@@ -1412,7 +1622,8 @@ func TestStateStore_ACLTokens_Snapshot_Restore(t *testing.T) {
 		restore.Commit()
 
 		// Read the restored ACLs back out and verify that they match.
-		idx, res, err := s.ACLTokenList(nil, true, true, "")
+		// Allow stale links because we linked it to policies that don't exist
+		idx, res, err := s.ACLTokenList(nil, true, true, "", true)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
 		require.ElementsMatch(t, tokens, res)

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -535,9 +535,10 @@ func (r *ACLTokenSetRequest) RequestDatacenter() string {
 
 // ACLTokenGetRequest is used for token read operations at the RPC layer
 type ACLTokenGetRequest struct {
-	TokenID     string         // id used for the token lookup
-	TokenIDType ACLTokenIDType // The Type of ID used to lookup the token
-	Datacenter  string         // The datacenter to perform the request within
+	TokenID         string         // id used for the token lookup
+	TokenIDType     ACLTokenIDType // The Type of ID used to lookup the token
+	AllowStaleLinks bool           // whether stale policy links should be allowed
+	Datacenter      string         // The datacenter to perform the request within
 	QueryOptions
 }
 
@@ -558,10 +559,11 @@ func (r *ACLTokenDeleteRequest) RequestDatacenter() string {
 
 // ACLTokenListRequest is used for token listing operations at the RPC layer
 type ACLTokenListRequest struct {
-	IncludeLocal  bool   // Whether local tokens should be included
-	IncludeGlobal bool   // Whether global tokens should be included
-	Policy        string // Policy filter
-	Datacenter    string // The datacenter to perform the request within
+	IncludeLocal    bool   // Whether local tokens should be included
+	IncludeGlobal   bool   // Whether global tokens should be included
+	Policy          string // Policy filter
+	Datacenter      string // The datacenter to perform the request within
+	AllowStaleLinks bool   // whether stale policy links should be allowed
 	QueryOptions
 }
 
@@ -580,8 +582,9 @@ type ACLTokenListResponse struct {
 // different from the the token list request in that only tokens with the
 // the requested ids are returned
 type ACLTokenBatchGetRequest struct {
-	AccessorIDs []string // List of accessor ids to fetch
-	Datacenter  string   // The datacenter to perform the request within
+	AccessorIDs     []string // List of accessor ids to fetch
+	Datacenter      string   // The datacenter to perform the request within
+	AllowStaleLinks bool     // Whether to allow stale policy links
 	QueryOptions
 }
 


### PR DESCRIPTION
Previously we were fixing up the token links directly on the *ACLToken returned by memdb. This invalidated some assumptions that a snapshot is immutable as well as potentially being able to cause a crash.

The fix here is to give the policy link fixing function copy on write semantics. When no fixes are necessary we can return the memdb object directly, otherwise we copy it and create a new list of links.

Additionally get/batch get/list RPC requests can indicate that having stale links is okay in which case we wont make any attempt to detect deletions or renames of linked policies. This is particularly useful during ACL token replication where we don't care about policy names linked in the token and where we will handle deleted policies already. In that case there is no reason to make tons of copies.

Eventually we might find a better way to keep those policy links in sync but for now this fixes the issue.