### PR TITLE
Dont modify memdb owned token data for get/list requests of tokens

### DIFF
--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -266,6 +266,55 @@ func (s *Store) resolveTokenPolicyLinks(tx *memdb.Txn, token *structs.ACLToken, 
 	return nil
 }
 
+// fixupTokenPolicyLinks is to be used when retrieving tokens from memdb. The policy links could have gotten
+// stale when a linked policy was deleted or renamed. This will correct them and generate a newly allocated
+// token only when fixes are needed. If the policy links are still accurate then we just return the original
+// token.
+func (s *Store) fixupTokenPolicyLinks(tx *memdb.Txn, original *structs.ACLToken) (*structs.ACLToken, error) {
+	owned := false
+	token := original
+
+	cloneToken := func(t *structs.ACLToken, copyNumLinks int) *structs.ACLToken {
+		clone := *t
+		clone.Policies = make([]structs.ACLTokenPolicyLink, copyNumLinks)
+		copy(clone.Policies, t.Policies[:copyNumLinks])
+		return &clone
+	}
+
+	for linkIndex, link := range original.Policies {
+		if link.ID == "" {
+			return nil, fmt.Errorf("Detected corrupted token within the state store - missing policy link ID")
+		}
+
+		policy, err := s.getPolicyWithTxn(tx, nil, link.ID, "id")
+
+		if err != nil {
+			return nil, err
+		}
+
+		if policy == nil {
+			if !owned {
+				// clone the token as we cannot touch the original
+				token = cloneToken(original, linkIndex)
+				owned = true
+			}
+			// if already owned then we just don't append it.
+		} else if policy.Name != link.Name {
+			if !owned {
+				token = cloneToken(original, linkIndex)
+				owned = true
+			}
+
+			// append the corrected policy
+			token.Policies = append(token.Policies, structs.ACLTokenPolicyLink{ID: link.ID, Name: policy.Name})
+		} else if owned {
+			token.Policies = append(token.Policies, link)
+		}
+	}
+
+	return token, nil
+}
+
 // ACLTokenSet is used to insert an ACL rule into the state store.
 func (s *Store) ACLTokenSet(idx uint64, token *structs.ACLToken, legacy bool) error {
 	tx := s.db.Txn(true)
@@ -446,8 +495,8 @@ func (s *Store) aclTokenGetTxn(tx *memdb.Txn, ws memdb.WatchSet, value, index st
 	ws.Add(watchCh)
 
 	if rawToken != nil {
-		token := rawToken.(*structs.ACLToken)
-		if err := s.resolveTokenPolicyLinks(tx, token, true); err != nil {
+		token, err := s.fixupTokenPolicyLinks(tx, rawToken.(*structs.ACLToken))
+		if err != nil {
 			return nil, err
 		}
 		return token, nil
@@ -501,8 +550,9 @@ func (s *Store) ACLTokenList(ws memdb.WatchSet, local, global bool, policy strin
 
 	var result structs.ACLTokens
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		token := raw.(*structs.ACLToken)
-		if err := s.resolveTokenPolicyLinks(tx, token, true); err != nil {
+		token, err := s.fixupTokenPolicyLinks(tx, raw.(*structs.ACLToken))
+
+		if err != nil {
 			return 0, nil, err
 		}
 		result = append(result, token)


### PR DESCRIPTION
Previously we were fixing up the token links directly on the *ACLToken returned by memdb. This invalidated some assumptions that a snapshot is immutable as well as potentially being able to cause a crash.

The fix here is to give the policy link fixing function copy on write semantics. When no fixes are necessary we can return the memdb object directly, otherwise we copy it and create a new list of links.

Eventually we might find a better way to keep those policy links in sync but for now this fixes the issue.