### PR TITLE
Reload tls config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2426,9 +2426,6 @@ func (a *Agent) removeCheckLocked(checkID types.CheckID, persist bool) error {
 	// Add to the local state for anti-entropy
 	a.State.RemoveCheck(checkID)
 
-	a.checkLock.Lock()
-	defer a.checkLock.Unlock()
-
 	a.cancelCheckMonitors(checkID)
 	a.State.RemoveCheck(checkID)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3562,7 +3562,11 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	// the checks and service registrations.
 	a.loadTokens(newCfg)
 
-	a.tlsConfigurator.Update(newCfg.ToTLSUtilConfig())
+	tlsConfig := newCfg.ToTLSUtilConfig()
+	if err := a.tlsConfigurator.Check(tlsConfig); err != nil {
+		return fmt.Errorf("Failed reloading tls configuration: %s", err)
+	}
+	a.tlsConfigurator.Update(tlsConfig)
 
 	// Reload service/check definitions and metadata.
 	if err := a.loadServices(newCfg); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3562,11 +3562,11 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	// the checks and service registrations.
 	a.loadTokens(newCfg)
 
-	tlsConfig := newCfg.ToTLSUtilConfig()
-	if err := a.tlsConfigurator.Check(tlsConfig); err != nil {
+	newTLSConfig := newCfg.ToTLSUtilConfig()
+	if err := a.tlsConfigurator.Check(newTLSConfig); err != nil {
 		return fmt.Errorf("Failed reloading tls configuration: %s", err)
 	}
-	a.tlsConfigurator.Update(tlsConfig)
+	a.tlsConfigurator.Update(newTLSConfig)
 
 	// Reload service/check definitions and metadata.
 	if err := a.loadServices(newCfg); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3562,6 +3562,8 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	// the checks and service registrations.
 	a.loadTokens(newCfg)
 
+	a.tlsConfigurator.Update(newCfg.ToTLSUtilConfig())
+
 	// Reload service/check definitions and metadata.
 	if err := a.loadServices(newCfg); err != nil {
 		return fmt.Errorf("Failed reloading services: %s", err)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2423,9 +2423,6 @@ func (a *Agent) removeCheckLocked(checkID types.CheckID, persist bool) error {
 		return fmt.Errorf("CheckID missing")
 	}
 
-	// Add to the local state for anti-entropy
-	a.State.RemoveCheck(checkID)
-
 	a.cancelCheckMonitors(checkID)
 	a.State.RemoveCheck(checkID)
 
@@ -3553,8 +3550,7 @@ func (a *Agent) ReloadConfig(newCfg *config.RuntimeConfig) error {
 	// the checks and service registrations.
 	a.loadTokens(newCfg)
 
-	newTLSConfig := newCfg.ToTLSUtilConfig()
-	if err := a.tlsConfigurator.Update(newTLSConfig); err != nil {
+	if err := a.tlsConfigurator.Update(newCfg.ToTLSUtilConfig()); err != nil {
 		return fmt.Errorf("Failed reloading tls configuration: %s", err)
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -393,7 +393,7 @@ func (a *Agent) Start() error {
 	// waiting to discover a consul server
 	consulCfg.ServerUp = a.sync.SyncFull.Trigger
 
-	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig())
+	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig(), a.logger)
 
 	// Setup either the client or the server.
 	if c.ServerMode {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -666,10 +666,7 @@ func (a *Agent) listenHTTP() ([]*HTTPServer, error) {
 			var tlscfg *tls.Config
 			_, isTCP := l.(*tcpKeepAliveListener)
 			if isTCP && proto == "https" {
-				tlscfg, err = a.tlsConfigurator.IncomingHTTPSConfig()
-				if err != nil {
-					return err
-				}
+				tlscfg = a.tlsConfigurator.IncomingHTTPSConfig()
 				l = tls.NewListener(l, tlscfg)
 			}
 			srv := &HTTPServer{
@@ -2236,10 +2233,7 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 				chkType.Interval = checks.MinInterval
 			}
 
-			tlsClientConfig, err := a.tlsConfigurator.OutgoingTLSConfigForCheck(chkType.TLSSkipVerify)
-			if err != nil {
-				return fmt.Errorf("Failed to set up TLS: %v", err)
-			}
+			tlsClientConfig := a.tlsConfigurator.OutgoingTLSConfigForCheck(chkType.TLSSkipVerify)
 
 			http := &checks.CheckHTTP{
 				Notify:          a.State,
@@ -2290,11 +2284,7 @@ func (a *Agent) addCheck(check *structs.HealthCheck, chkType *structs.CheckType,
 
 			var tlsClientConfig *tls.Config
 			if chkType.GRPCUseTLS {
-				var err error
-				tlsClientConfig, err = a.tlsConfigurator.OutgoingTLSConfigForCheck(chkType.TLSSkipVerify)
-				if err != nil {
-					return fmt.Errorf("Failed to set up TLS: %v", err)
-				}
+				tlsClientConfig = a.tlsConfigurator.OutgoingTLSConfigForCheck(chkType.TLSSkipVerify)
 			}
 
 			grpc := &checks.CheckGRPC{

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3565,8 +3565,7 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 		verify_server_hostname = true
 	`
 	c := TestConfig(config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
-	err = a.ReloadConfig(c)
-	require.NoError(t, err)
+	require.NoError(t, a.ReloadConfig(c))
 	tlsConf = a.tlsConfigurator.OutgoingRPCConfig()
 	require.False(t, tlsConf.InsecureSkipVerify)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
@@ -3605,8 +3604,7 @@ func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 		verify_server_hostname = true
 	`
 	c := TestConfig(config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
-	err = a.ReloadConfig(c)
-	require.NoError(t, err)
+	require.NoError(t, a.ReloadConfig(c))
 	tlsConf, err = tlsConf.GetConfigForClient(nil)
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)
@@ -3635,8 +3633,7 @@ func TestHansAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 		verify_incoming = true
 	`
 	c := TestConfig(config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
-	err = a.ReloadConfig(c)
-	require.Error(t, err)
+	require.Error(t, a.ReloadConfig(c))
 	tlsConf, err = tlsConf.GetConfigForClient(nil)
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3553,11 +3553,13 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	tlsConf, err := a.tlsConfigurator.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.True(t, tlsConf.InsecureSkipVerify)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 
 	hcl = `
 		data_dir = "` + dataDir + `"
 		verify_outgoing = true
-		ca_file = "../test/ca/root.cer"
+		ca_path = "../test/ca_path"
 		cert_file = "../test/key/ourdomain.cer"
 		key_file = "../test/key/ourdomain.key"
 		verify_server_hostname = true
@@ -3567,7 +3569,9 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	require.NoError(t, err)
 	tlsConf, err = a.tlsConfigurator.OutgoingRPCConfig()
 	require.NoError(t, err)
-	require.True(t, tlsConf.InsecureSkipVerify)
+	require.False(t, tlsConf.InsecureSkipVerify)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 }
 
 func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
@@ -3591,11 +3595,13 @@ func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
 	require.True(t, tlsConf.InsecureSkipVerify)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 
 	hcl = `
 		data_dir = "` + dataDir + `"
 		verify_outgoing = true
-		ca_file = "../test/ca/root.cer"
+		ca_path = "../test/ca_path"
 		cert_file = "../test/key/ourdomain.cer"
 		key_file = "../test/key/ourdomain.key"
 		verify_server_hostname = true
@@ -3604,5 +3610,7 @@ func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	err = a.ReloadConfig(c)
 	require.NoError(t, err)
 	tlsConf, err = tlsConf.GetConfigForClient(nil)
-	require.True(t, tlsConf.InsecureSkipVerify)
+	require.False(t, tlsConf.InsecureSkipVerify)
+	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
+	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3551,8 +3551,7 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	`
 	a, err := NewUnstartedAgent(t, t.Name(), hcl)
 	require.NoError(t, err)
-	tlsConf, err := a.tlsConfigurator.OutgoingRPCConfig()
-	require.NoError(t, err)
+	tlsConf := a.tlsConfigurator.OutgoingRPCConfig()
 	require.True(t, tlsConf.InsecureSkipVerify)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
@@ -3568,8 +3567,7 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	c := TestConfig(config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
 	err = a.ReloadConfig(c)
 	require.NoError(t, err)
-	tlsConf, err = a.tlsConfigurator.OutgoingRPCConfig()
-	require.NoError(t, err)
+	tlsConf = a.tlsConfigurator.OutgoingRPCConfig()
 	require.False(t, tlsConf.InsecureSkipVerify)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
@@ -3589,8 +3587,7 @@ func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	`
 	a, err := NewUnstartedAgent(t, t.Name(), hcl)
 	require.NoError(t, err)
-	tlsConf, err := a.tlsConfigurator.IncomingRPCConfig()
-	require.NoError(t, err)
+	tlsConf := a.tlsConfigurator.IncomingRPCConfig()
 	require.NotNil(t, tlsConf.GetConfigForClient)
 	tlsConf, err = tlsConf.GetConfigForClient(nil)
 	require.NoError(t, err)
@@ -3631,8 +3628,7 @@ func TestHansAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	`
 	a, err := NewUnstartedAgent(t, t.Name(), hcl)
 	require.NoError(t, err)
-	tlsConf, err := a.tlsConfigurator.IncomingRPCConfig()
-	require.NoError(t, err)
+	tlsConf := a.tlsConfigurator.IncomingRPCConfig()
 
 	hcl = `
 		data_dir = "` + dataDir + `"

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3603,9 +3603,6 @@ func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	c := TestConfig(config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
 	err = a.ReloadConfig(c)
 	require.NoError(t, err)
-	tlsConf, err = a.tlsConfigurator.IncomingRPCConfig()
-	require.NoError(t, err)
-	require.NotNil(t, tlsConf.GetConfigForClient)
 	tlsConf, err = tlsConf.GetConfigForClient(nil)
 	require.True(t, tlsConf.InsecureSkipVerify)
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3537,7 +3537,7 @@ func TestAgent_loadTokens(t *testing.T) {
 	})
 }
 
-func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
+func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	defer os.RemoveAll(dataDir)
@@ -3572,7 +3572,7 @@ func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 }
 
-func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
+func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	defer os.RemoveAll(dataDir)
@@ -3612,7 +3612,7 @@ func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
 }
 
-func TestHansAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
+func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	defer os.RemoveAll(dataDir)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3536,7 +3536,7 @@ func TestAgent_loadTokens(t *testing.T) {
 	})
 }
 
-func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
+func TestHansAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	defer os.RemoveAll(dataDir)
@@ -3570,7 +3570,7 @@ func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	require.True(t, tlsConf.InsecureSkipVerify)
 }
 
-func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
+func TestHansAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
 	defer os.RemoveAll(dataDir)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1586,6 +1586,7 @@ func (c *RuntimeConfig) ToTLSUtilConfig() tlsutil.Config {
 		VerifyIncomingRPC:        c.VerifyIncomingRPC,
 		VerifyIncomingHTTPS:      c.VerifyIncomingHTTPS,
 		VerifyOutgoing:           c.VerifyOutgoing,
+		VerifyServerHostname:     c.VerifyServerHostname,
 		CAFile:                   c.CAFile,
 		CAPath:                   c.CAPath,
 		CertFile:                 c.CertFile,

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1580,8 +1580,8 @@ func (c *RuntimeConfig) Sanitized() map[string]interface{} {
 	return sanitize("rt", reflect.ValueOf(c)).Interface().(map[string]interface{})
 }
 
-func (c *RuntimeConfig) ToTLSUtilConfig() *tlsutil.Config {
-	return &tlsutil.Config{
+func (c *RuntimeConfig) ToTLSUtilConfig() tlsutil.Config {
+	return tlsutil.Config{
 		VerifyIncoming:           c.VerifyIncoming,
 		VerifyIncomingRPC:        c.VerifyIncomingRPC,
 		VerifyIncomingHTTPS:      c.VerifyIncomingHTTPS,

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5434,6 +5434,7 @@ func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 		VerifyIncomingRPC:           true,
 		VerifyIncomingHTTPS:         true,
 		VerifyOutgoing:              true,
+		VerifyServerHostname:        true,
 		CAFile:                      "a",
 		CAPath:                      "b",
 		CertFile:                    "c",
@@ -5450,6 +5451,7 @@ func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 	require.Equal(t, c.VerifyIncomingRPC, r.VerifyIncomingRPC)
 	require.Equal(t, c.VerifyIncomingHTTPS, r.VerifyIncomingHTTPS)
 	require.Equal(t, c.VerifyOutgoing, r.VerifyOutgoing)
+	require.Equal(t, c.VerifyServerHostname, r.VerifyServerHostname)
 	require.Equal(t, c.CAFile, r.CAFile)
 	require.Equal(t, c.CAPath, r.CAPath)
 	require.Equal(t, c.CertFile, r.CertFile)

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -86,8 +86,10 @@ type Client struct {
 	EnterpriseClient
 }
 
-// NewClient is used to construct a new Consul client from the
-// configuration, potentially returning an error
+// NewClient is used to construct a new Consul client from the configuration,
+// potentially returning an error.
+// NewClient only used to help setting up a client for testing. Normal code
+// exercises NewClientLogger.
 func NewClient(config *Config) (*Client, error) {
 	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
 	if err != nil {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -117,12 +117,6 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 		config.LogOutput = os.Stderr
 	}
 
-	// Create the tls Wrapper
-	tlsWrap, err := tlsConfigurator.OutgoingRPCWrapper()
-	if err != nil {
-		return nil, err
-	}
-
 	// Create a logger
 	if logger == nil {
 		logger = log.New(config.LogOutput, "", log.LstdFlags)
@@ -133,7 +127,7 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 		LogOutput:  config.LogOutput,
 		MaxTime:    clientRPCConnMaxIdle,
 		MaxStreams: clientMaxStreams,
-		TLSWrapper: tlsWrap,
+		TLSWrapper: tlsConfigurator.OutgoingRPCWrapper(),
 		ForceTLS:   config.VerifyOutgoing,
 	}
 
@@ -162,6 +156,7 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 		CacheConfig: clientACLCacheConfig,
 		Sentinel:    nil,
 	}
+	var err error
 	if c.acls, err = NewACLResolver(&aclConfig); err != nil {
 		c.Shutdown()
 		return nil, fmt.Errorf("Failed to create ACL resolver: %v", err)

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -89,7 +89,7 @@ type Client struct {
 // NewClient is used to construct a new Consul client from the
 // configuration, potentially returning an error
 func NewClient(config *Config) (*Client, error) {
-	return NewClientLogger(config, nil, tlsutil.NewConfigurator(config.ToTLSUtilConfig()))
+	return NewClientLogger(config, nil, tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil))
 }
 
 func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsutil.Configurator) (*Client, error) {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -89,7 +89,11 @@ type Client struct {
 // NewClient is used to construct a new Consul client from the
 // configuration, potentially returning an error
 func NewClient(config *Config) (*Client, error) {
-	return NewClientLogger(config, nil, tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil))
+	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewClientLogger(config, nil, c)
 }
 
 func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsutil.Configurator) (*Client, error) {

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -379,8 +379,8 @@ type Config struct {
 	CAConfig *structs.CAConfiguration
 }
 
-func (c *Config) ToTLSUtilConfig() *tlsutil.Config {
-	return &tlsutil.Config{
+func (c *Config) ToTLSUtilConfig() tlsutil.Config {
+	return tlsutil.Config{
 		VerifyIncoming:           c.VerifyIncoming,
 		VerifyOutgoing:           c.VerifyOutgoing,
 		CAFile:                   c.CAFile,

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -252,6 +252,8 @@ type Server struct {
 	EnterpriseServer
 }
 
+// NewServer is only used to help setting up a server for testing. Normal code
+// exercises NewServerLogger.
 func NewServer(config *Config) (*Server, error) {
 	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
 	if err != nil {
@@ -260,7 +262,7 @@ func NewServer(config *Config) (*Server, error) {
 	return NewServerLogger(config, nil, new(token.Store), c)
 }
 
-// NewServer is used to construct a new Consul server from the
+// NewServerLogger is used to construct a new Consul server from the
 // configuration, potentially returning an error
 func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tlsConfigurator *tlsutil.Configurator) (*Server, error) {
 	// Check the protocol version.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -253,7 +253,11 @@ type Server struct {
 }
 
 func NewServer(config *Config) (*Server, error) {
-	return NewServerLogger(config, nil, new(token.Store), tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil))
+	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewServerLogger(config, nil, new(token.Store), c)
 }
 
 // NewServer is used to construct a new Consul server from the

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -253,7 +253,7 @@ type Server struct {
 }
 
 func NewServer(config *Config) (*Server, error) {
-	return NewServerLogger(config, nil, new(token.Store), tlsutil.NewConfigurator(config.ToTLSUtilConfig()))
+	return NewServerLogger(config, nil, new(token.Store), tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil))
 }
 
 // NewServer is used to construct a new Consul server from the

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -306,12 +306,6 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		return nil, err
 	}
 
-	// Get the incoming TLS config.
-	incomingTLS, err := tlsConfigurator.IncomingRPCConfig()
-	if err != nil {
-		return nil, err
-	}
-
 	// Create the tombstone GC.
 	gc, err := state.NewTombstoneGC(config.TombstoneTTL, config.TombstoneTTLGranularity)
 	if err != nil {
@@ -342,7 +336,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		reconcileCh:      make(chan serf.Member, reconcileChSize),
 		router:           router.NewRouter(logger, config.Datacenter),
 		rpcServer:        rpc.NewServer(),
-		rpcTLS:           incomingTLS,
+		rpcTLS:           tlsConfigurator.IncomingRPCConfig(),
 		reassertLeaderCh: make(chan chan error),
 		segmentLAN:       make(map[string]*serf.Serf, len(config.Segments)),
 		sessionTimers:    NewSessionTimers(),

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -300,12 +300,6 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		}
 	}
 
-	// Create the TLS wrapper for outgoing connections.
-	tlsWrap, err := tlsConfigurator.OutgoingRPCWrapper()
-	if err != nil {
-		return nil, err
-	}
-
 	// Create the tombstone GC.
 	gc, err := state.NewTombstoneGC(config.TombstoneTTL, config.TombstoneTTLGranularity)
 	if err != nil {
@@ -320,7 +314,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		LogOutput:  config.LogOutput,
 		MaxTime:    serverRPCCache,
 		MaxStreams: serverMaxStreams,
-		TLSWrapper: tlsWrap,
+		TLSWrapper: tlsConfigurator.OutgoingRPCWrapper(),
 		ForceTLS:   config.VerifyOutgoing,
 	}
 
@@ -371,7 +365,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 	}
 
 	// Initialize the RPC layer.
-	if err := s.setupRPC(tlsWrap); err != nil {
+	if err := s.setupRPC(tlsConfigurator.OutgoingRPCWrapper()); err != nil {
 		s.Shutdown()
 		return nil, fmt.Errorf("Failed to start RPC layer: %v", err)
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -179,7 +179,11 @@ func newServer(c *Config) (*Server, error) {
 		w = os.Stderr
 	}
 	logger := log.New(w, c.NodeName+" - ", log.LstdFlags|log.Lmicroseconds)
-	srv, err := NewServerLogger(c, logger, new(token.Store), tlsutil.NewConfigurator(c.ToTLSUtilConfig()))
+	tlsConf, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), logger)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := NewServerLogger(c, logger, new(token.Store), tlsConf)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -115,7 +115,7 @@ func NewUnstartedAgent(t *testing.T, name string, hcl string) (*Agent, error) {
 	a.sync = ae.NewStateSyncer(a.State, c.AEInterval, a.shutdownCh, a.logger)
 	a.delegate = &consul.Client{}
 	a.State.TriggerSyncChanges = a.sync.SyncChanges.Trigger
-	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig())
+	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig(), nil)
 	return a, nil
 }
 
@@ -165,7 +165,7 @@ func (a *TestAgent) Start(t *testing.T) *TestAgent {
 		agent.LogWriter = a.LogWriter
 		agent.logger = log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
 		agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
-		agent.tlsConfigurator = tlsutil.NewConfigurator(a.Config.ToTLSUtilConfig())
+		agent.tlsConfigurator = tlsutil.NewConfigurator(a.Config.ToTLSUtilConfig(), nil)
 
 		// we need the err var in the next exit condition
 		if err := agent.Start(); err == nil {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -115,7 +115,11 @@ func NewUnstartedAgent(t *testing.T, name string, hcl string) (*Agent, error) {
 	a.sync = ae.NewStateSyncer(a.State, c.AEInterval, a.shutdownCh, a.logger)
 	a.delegate = &consul.Client{}
 	a.State.TriggerSyncChanges = a.sync.SyncChanges.Trigger
-	a.tlsConfigurator = tlsutil.NewConfigurator(c.ToTLSUtilConfig(), nil)
+	tlsConfigurator, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), nil)
+	if err != nil {
+		return nil, err
+	}
+	a.tlsConfigurator = tlsConfigurator
 	return a, nil
 }
 
@@ -165,7 +169,9 @@ func (a *TestAgent) Start(t *testing.T) *TestAgent {
 		agent.LogWriter = a.LogWriter
 		agent.logger = log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
 		agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
-		agent.tlsConfigurator = tlsutil.NewConfigurator(a.Config.ToTLSUtilConfig(), nil)
+		tlsConfigurator, err := tlsutil.NewConfigurator(a.Config.ToTLSUtilConfig(), nil)
+		require.NoError(err)
+		agent.tlsConfigurator = tlsConfigurator
 
 		// we need the err var in the next exit condition
 		if err := agent.Start(); err == nil {

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -289,12 +289,26 @@ func (c *Configurator) commonTLSConfig(additionalVerifyIncomingFlag bool) (*tls.
 
 // IncomingRPCConfig generates a *tls.Config for incoming RPC connections.
 func (c *Configurator) IncomingRPCConfig() (*tls.Config, error) {
-	return c.commonTLSConfig(c.base.VerifyIncomingRPC)
+	config, err := c.commonTLSConfig(c.base.VerifyIncomingRPC)
+	if err != nil {
+		return nil, err
+	}
+	config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		return c.IncomingRPCConfig()
+	}
+	return config, nil
 }
 
 // IncomingHTTPSConfig generates a *tls.Config for incoming HTTPS connections.
 func (c *Configurator) IncomingHTTPSConfig() (*tls.Config, error) {
-	return c.commonTLSConfig(c.base.VerifyIncomingHTTPS)
+	config, err := c.commonTLSConfig(c.base.VerifyIncomingHTTPS)
+	if err != nil {
+		return nil, err
+	}
+	config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		return c.IncomingHTTPSConfig()
+	}
+	return config, nil
 }
 
 // IncomingTLSConfig generates a *tls.Config for outgoing TLS connections for

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -116,14 +116,7 @@ type Config struct {
 
 // KeyPair is used to open and parse a certificate and key file
 func (c *Config) KeyPair() (*tls.Certificate, error) {
-	if c.CertFile == "" || c.KeyFile == "" {
-		return nil, nil
-	}
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to load cert/key pair: %v", err)
-	}
-	return &cert, err
+	return loadKeyPair(c.CertFile, c.KeyFile)
 }
 
 // SpecificDC is used to invoke a static datacenter
@@ -164,11 +157,11 @@ func NewConfigurator(config Config, logger *log.Logger) (*Configurator, error) {
 func (c *Configurator) Update(config Config) error {
 	c.Lock()
 	defer c.Unlock()
-	cert, err := c.loadKeyPair(config.CertFile, config.KeyFile)
+	cert, err := loadKeyPair(config.CertFile, config.KeyFile)
 	if err != nil {
 		return err
 	}
-	cas, err := c.loadCAs(config.CAFile, config.CAPath)
+	cas, err := loadCAs(config.CAFile, config.CAPath)
 	if err != nil {
 		return err
 	}
@@ -209,7 +202,7 @@ func (c *Configurator) check(config Config, cert *tls.Certificate) error {
 	return nil
 }
 
-func (c *Configurator) loadKeyPair(certFile, keyFile string) (*tls.Certificate, error) {
+func loadKeyPair(certFile, keyFile string) (*tls.Certificate, error) {
 	if certFile == "" || keyFile == "" {
 		return nil, nil
 	}
@@ -220,7 +213,7 @@ func (c *Configurator) loadKeyPair(certFile, keyFile string) (*tls.Certificate, 
 	return &cert, nil
 }
 
-func (c *Configurator) loadCAs(caFile, caPath string) (*x509.CertPool, error) {
+func loadCAs(caFile, caPath string) (*x509.CertPool, error) {
 	if caFile != "" {
 		return rootcerts.LoadCAFile(caFile)
 	} else if caPath != "" {

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -214,6 +214,7 @@ func (c *Configurator) Update(config Config) {
 	c.Lock()
 	defer c.Unlock()
 	c.base = &config
+
 }
 
 // commonTLSConfig generates a *tls.Config from the base configuration the

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -205,26 +205,22 @@ type Configurator struct {
 // configuration.
 // Todo (Hans): should config be a value instead a pointer to avoid side
 // effects?
-func NewConfigurator(config *Config) *Configurator {
-	return &Configurator{base: config, checks: map[string]bool{}}
+func NewConfigurator(config Config) *Configurator {
+	return &Configurator{base: &config, checks: map[string]bool{}}
 }
 
 // Update updates the internal configuration which is used to generate
 // *tls.Config.
-func (c *Configurator) Update(config *Config) {
+func (c *Configurator) Update(config Config) {
 	c.Lock()
 	defer c.Unlock()
-	c.base = config
+	c.base = &config
 }
 
 // commonTLSConfig generates a *tls.Config from the base configuration the
 // Configurator has. It accepts an additional flag in case a config is needed
 // for incoming TLS connections.
 func (c *Configurator) commonTLSConfig(additionalVerifyIncomingFlag bool) (*tls.Config, error) {
-	if c.base == nil {
-		return nil, fmt.Errorf("No base config")
-	}
-
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: !c.base.VerifyServerHostname,
 	}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -202,8 +202,6 @@ type Configurator struct {
 
 // NewConfigurator creates a new Configurator and sets the provided
 // configuration.
-// Todo (Hans): should config be a value instead a pointer to avoid side
-// effects?
 func NewConfigurator(config Config) *Configurator {
 	return &Configurator{base: &config}
 }

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -24,6 +24,7 @@ type Wrapper func(conn net.Conn) (net.Conn, error)
 
 // TLSLookup maps the tls_min_version configuration to the internal value
 var TLSLookup = map[string]uint16{
+	"":      tls.VersionTLS10, // default in golang
 	"tls10": tls.VersionTLS10,
 	"tls11": tls.VersionTLS11,
 	"tls12": tls.VersionTLS12,
@@ -240,9 +241,8 @@ func (c *Configurator) commonTLSConfig(additionalVerifyIncomingFlag bool) *tls.C
 	if len(c.base.CipherSuites) != 0 {
 		tlsConfig.CipherSuites = c.base.CipherSuites
 	}
-	if c.base.PreferServerCipherSuites {
-		tlsConfig.PreferServerCipherSuites = true
-	}
+
+	tlsConfig.PreferServerCipherSuites = c.base.PreferServerCipherSuites
 
 	tlsConfig.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 		return c.cert, nil
@@ -251,10 +251,8 @@ func (c *Configurator) commonTLSConfig(additionalVerifyIncomingFlag bool) *tls.C
 		return c.cert, nil
 	}
 
-	if c.cas != nil {
-		tlsConfig.ClientCAs = c.cas
-		tlsConfig.RootCAs = c.cas
-	}
+	tlsConfig.ClientCAs = c.cas
+	tlsConfig.RootCAs = c.cas
 
 	tlsConfig.MinVersion = TLSLookup[c.base.TLSMinVersion]
 

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -215,6 +215,18 @@ func (c *Configurator) Update(config Config) {
 
 }
 
+// Check is verifying the provided configuration and returns an error if the
+// config has problems.
+func (c *Configurator) Check(config Config) error {
+	c.Lock()
+	defer c.Unlock()
+	orig := c.base
+	c.base = &config
+	defer func() { c.base = orig }()
+	_, err := c.commonTLSConfig(c.base.VerifyIncomingRPC || c.base.VerifyIncomingHTTPS)
+	return err
+}
+
 // commonTLSConfig generates a *tls.Config from the base configuration the
 // Configurator has. It accepts an additional flag in case a config is needed
 // for incoming TLS connections.

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -275,8 +275,10 @@ func (c *Configurator) IncomingHTTPSConfig() *tls.Config {
 	c.RLock()
 	defer c.RUnlock()
 	config := c.commonTLSConfig(c.base.VerifyIncomingHTTPS)
-	config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-		return c.IncomingHTTPSConfig(), nil
+	config.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		config := c.IncomingHTTPSConfig()
+		config.NextProtos = hello.SupportedProtos
+		return config, nil
 	}
 	return config
 }

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -332,10 +332,9 @@ func (c *Configurator) IncomingRPCConfig() *tls.Config {
 func (c *Configurator) IncomingHTTPSConfig() *tls.Config {
 	c.log("IncomingHTTPSConfig")
 	config := c.commonTLSConfig(c.verifyIncomingHTTPS())
-	config.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
-		config := c.IncomingHTTPSConfig()
-		config.NextProtos = hello.SupportedProtos
-		return config, nil
+	config.NextProtos = []string{"h2", "http/1.1"}
+	config.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		return c.IncomingHTTPSConfig(), nil
 	}
 	return config
 }

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -363,18 +363,16 @@ func (c *Configurator) OutgoingRPCConfig() *tls.Config {
 
 // OutgoingRPCWrapper wraps the result of OutgoingRPCConfig in a DCWrapper. It
 // decides if verify server hostname should be used.
-func (c *Configurator) OutgoingRPCWrapper() (DCWrapper, error) {
+func (c *Configurator) OutgoingRPCWrapper() DCWrapper {
 	c.log("OutgoingRPCWrapper")
 	if c.outgoingRPCTLSDisabled() {
-		return nil, nil
+		return nil
 	}
 
 	// Generate the wrapper based on dc
-	wrapper := func(dc string, conn net.Conn) (net.Conn, error) {
+	return func(dc string, conn net.Conn) (net.Conn, error) {
 		return c.wrapTLSClient(dc, conn)
 	}
-
-	return wrapper, nil
 }
 
 // This function acquires a read lock because it reads from the config.

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -281,7 +281,7 @@ func TestConfigurator_wrapTLS_OK(t *testing.T) {
 	c, err := NewConfigurator(config, nil)
 	require.NoError(t, err)
 
-	tlsClient, err := c.wrapTLSClient(client, "dc1")
+	tlsClient, err := c.wrapTLSClient("dc1", client)
 	require.NoError(t, err)
 
 	tlsClient.Close()
@@ -307,7 +307,7 @@ func TestConfigurator_wrapTLS_BadCert(t *testing.T) {
 
 	c, err := NewConfigurator(clientConfig, nil)
 	require.NoError(t, err)
-	tlsClient, err := c.wrapTLSClient(client, "dc1")
+	tlsClient, err := c.wrapTLSClient("dc1", client)
 	require.Error(t, err)
 	require.Nil(t, tlsClient)
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -667,22 +667,8 @@ func TestConfigurator_IncomingRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
-	c, err := NewConfigurator(Config{
-		VerifyIncomingHTTPS: true,
-		CAFile:              "../test/ca/root.cer",
-		CertFile:            "../test/key/ourdomain.cer",
-		KeyFile:             "../test/key/ourdomain.key",
-	}, nil)
-	require.NoError(t, err)
-	tlsConf := c.IncomingHTTPSConfig()
-	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
-	require.NotNil(t, tlsConf.GetConfigForClient)
-	tlsConf, err = tlsConf.GetConfigForClient(
-		&tls.ClientHelloInfo{SupportedProtos: []string{"h2"}},
-	)
-	require.NoError(t, err)
-	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
-	require.Equal(t, []string{"h2"}, tlsConf.NextProtos)
+	c := Configurator{base: &Config{}}
+	require.Equal(t, nextProtos, c.IncomingHTTPSConfig().NextProtos)
 }
 
 func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -711,3 +711,12 @@ func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "node", tlsConf.ServerName)
 }
+
+func TestConfigurator_Check(t *testing.T) {
+	c := NewConfigurator(Config{})
+	require.NoError(t, c.Check(Config{}))
+	require.Error(t, c.Check(Config{VerifyOutgoing: true}))
+	require.Error(t, c.Check(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"}))
+	require.False(t, c.base.VerifyIncoming)
+	require.False(t, c.base.VerifyOutgoing)
+}

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -43,7 +43,7 @@ func TestConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
 	conf := Config{
 		VerifyOutgoing: true,
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.Error(t, err)
 	require.Nil(t, tlsConf)
@@ -53,7 +53,7 @@ func TestConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
 	conf := Config{
 		CAFile: "../test/ca/root.cer",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -64,7 +64,7 @@ func TestConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -79,7 +79,7 @@ func TestConfigurator_OutgoingTLS_ServerName(t *testing.T) {
 		CAFile:         "../test/ca/root.cer",
 		ServerName:     "consul.example.com",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -94,7 +94,7 @@ func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
 		VerifyServerHostname: true,
 		CAFile:               "../test/ca/root.cer",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -109,7 +109,7 @@ func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
 		CertFile:       "../test/key/ourdomain.cer",
 		KeyFile:        "../test/key/ourdomain.key",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -125,7 +125,7 @@ func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
 			CAFile:         "../test/ca/root.cer",
 			TLSMinVersion:  version,
 		}
-		c := NewConfigurator(conf)
+		c := NewConfigurator(conf, nil)
 		tlsConf, err := c.OutgoingRPCConfig()
 		require.NoError(t, err)
 		require.NotNil(t, tlsConf)
@@ -136,7 +136,7 @@ func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
 func startTLSServer(config *Config) (net.Conn, chan error) {
 	errc := make(chan error, 1)
 
-	c := NewConfigurator(*config)
+	c := NewConfigurator(*config, nil)
 	tlsConfigServer, err := c.IncomingRPCConfig()
 	if err != nil {
 		errc <- err
@@ -186,7 +186,7 @@ func TestConfigurator_outgoingWrapper_OK(t *testing.T) {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
 
-	c := NewConfigurator(config)
+	c := NewConfigurator(config, nil)
 	wrap, err := c.OutgoingRPCWrapper()
 	require.NoError(t, err)
 
@@ -216,7 +216,7 @@ func TestConfigurator_outgoingWrapper_BadDC(t *testing.T) {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
 
-	c := NewConfigurator(config)
+	c := NewConfigurator(config, nil)
 	wrap, err := c.OutgoingRPCWrapper()
 	require.NoError(t, err)
 
@@ -246,7 +246,7 @@ func TestConfigurator_outgoingWrapper_BadCert(t *testing.T) {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
 
-	c := NewConfigurator(config)
+	c := NewConfigurator(config, nil)
 	wrap, err := c.OutgoingRPCWrapper()
 	require.NoError(t, err)
 
@@ -275,7 +275,7 @@ func TestConfigurator_wrapTLS_OK(t *testing.T) {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
 
-	c := NewConfigurator(config)
+	c := NewConfigurator(config, nil)
 	clientConfig, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 
@@ -303,7 +303,7 @@ func TestConfigurator_wrapTLS_BadCert(t *testing.T) {
 		VerifyOutgoing: true,
 	}
 
-	c := NewConfigurator(clientConfig)
+	c := NewConfigurator(clientConfig, nil)
 	clientTLSConfig, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 
@@ -381,7 +381,7 @@ func TestConfig_ParseCiphers(t *testing.T) {
 func TestConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
 	conf := Config{CAPath: "../test/ca_path"}
 
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
@@ -394,7 +394,7 @@ func TestConfigurator_IncomingHTTPS(t *testing.T) {
 		CertFile:       "../test/key/ourdomain.cer",
 		KeyFile:        "../test/key/ourdomain.key",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -409,7 +409,7 @@ func TestConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
 		CertFile:       "../test/key/ourdomain.cer",
 		KeyFile:        "../test/key/ourdomain.key",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	_, err := c.IncomingHTTPSConfig()
 	require.Error(t, err)
 }
@@ -419,14 +419,14 @@ func TestConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
 		VerifyIncoming: true,
 		CAFile:         "../test/ca/root.cer",
 	}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	_, err := c.IncomingHTTPSConfig()
 	require.Error(t, err)
 }
 
 func TestConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
 	conf := Config{}
-	c := NewConfigurator(conf)
+	c := NewConfigurator(conf, nil)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.NotNil(t, tlsConf)
@@ -445,7 +445,7 @@ func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 			KeyFile:        "../test/key/ourdomain.key",
 			TLSMinVersion:  version,
 		}
-		c := NewConfigurator(conf)
+		c := NewConfigurator(conf, nil)
 		tlsConf, err := c.IncomingHTTPSConfig()
 		require.NoError(t, err)
 		require.NotNil(t, tlsConf)
@@ -455,7 +455,7 @@ func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 
 func TestConfigurator_IncomingHTTPSCAPath_Valid(t *testing.T) {
 
-	c := NewConfigurator(Config{CAPath: "../test/ca_path"})
+	c := NewConfigurator(Config{CAPath: "../test/ca_path"}, nil)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
@@ -475,7 +475,7 @@ func TestConfigurator_CommonTLSConfigServerNameNodeName(t *testing.T) {
 			result: "node"},
 	}
 	for _, v := range variants {
-		c := NewConfigurator(v.config)
+		c := NewConfigurator(v.config, nil)
 		tlsConf, err := c.commonTLSConfig(false)
 		require.NoError(t, err)
 		require.Empty(t, tlsConf.ServerName)
@@ -483,7 +483,7 @@ func TestConfigurator_CommonTLSConfigServerNameNodeName(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConfig, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Empty(t, tlsConfig.CipherSuites)
@@ -496,7 +496,7 @@ func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigCertKey(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Empty(t, tlsConf.Certificates)
@@ -514,25 +514,25 @@ func TestConfigurator_CommonTLSConfigCertKey(t *testing.T) {
 func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
-		c := NewConfigurator(Config{TLSMinVersion: version})
+		c := NewConfigurator(Config{TLSMinVersion: version}, nil)
 		tlsConf, err := c.commonTLSConfig(false)
 		require.NoError(t, err)
 		require.Equal(t, tlsConf.MinVersion, TLSLookup[version])
 	}
 
-	c := NewConfigurator(Config{TLSMinVersion: "tlsBOGUS"})
+	c := NewConfigurator(Config{TLSMinVersion: "tlsBOGUS"}, nil)
 	_, err := c.commonTLSConfig(false)
 	require.Error(t, err)
 }
 
 func TestConfigurator_CommonTLSConfigValidateVerifyOutgoingCA(t *testing.T) {
-	c := NewConfigurator(Config{VerifyOutgoing: true})
+	c := NewConfigurator(Config{VerifyOutgoing: true}, nil)
 	_, err := c.commonTLSConfig(false)
 	require.Error(t, err)
 }
 
 func TestConfigurator_CommonTLSConfigLoadCA(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Nil(t, tlsConf.RootCAs)
@@ -566,7 +566,7 @@ func TestConfigurator_CommonTLSConfigLoadCA(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
@@ -605,7 +605,7 @@ func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
 }
 
 func TestConfigurator_IncomingRPCConfig(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.IncomingRPCConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
@@ -631,7 +631,7 @@ func TestConfigurator_IncomingRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
@@ -657,7 +657,7 @@ func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.Nil(t, tlsConf)
@@ -676,7 +676,7 @@ func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
-	c := NewConfigurator(Config{EnableAgentTLSForChecks: false})
+	c := NewConfigurator(Config{EnableAgentTLSForChecks: false}, nil)
 	tlsConf, err := c.OutgoingTLSConfigForCheck(false)
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)
@@ -713,10 +713,17 @@ func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
 }
 
 func TestConfigurator_Check(t *testing.T) {
-	c := NewConfigurator(Config{})
+	c := NewConfigurator(Config{}, nil)
 	require.NoError(t, c.Check(Config{}))
 	require.Error(t, c.Check(Config{VerifyOutgoing: true}))
 	require.Error(t, c.Check(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"}))
 	require.False(t, c.base.VerifyIncoming)
 	require.False(t, c.base.VerifyOutgoing)
+}
+
+func TestConfigurator_Version(t *testing.T) {
+	c := NewConfigurator(Config{}, nil)
+	require.Equal(t, c.version, 1)
+	c.Update(Config{VerifyOutgoing: true})
+	require.Equal(t, c.version, 2)
 }

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -668,7 +668,7 @@ func TestConfigurator_IncomingRPCConfig(t *testing.T) {
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
 	c := Configurator{base: &Config{}}
-	require.Equal(t, nextProtos, c.IncomingHTTPSConfig().NextProtos)
+	require.Equal(t, []string{"h2", "http/1.1"}, c.IncomingHTTPSConfig().NextProtos)
 }
 
 func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -40,7 +40,7 @@ func TestConfig_KeyPair_Valid(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyOutgoing: true,
 	}
 	c := NewConfigurator(conf)
@@ -50,7 +50,7 @@ func TestConfigurator_OutgoingTLS_MissingCA(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		CAFile: "../test/ca/root.cer",
 	}
 	c := NewConfigurator(conf)
@@ -60,7 +60,7 @@ func TestConfigurator_OutgoingTLS_OnlyCA(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
 	}
@@ -73,8 +73,8 @@ func TestConfigurator_OutgoingTLS_VerifyOutgoing(t *testing.T) {
 	require.True(t, tlsConf.InsecureSkipVerify)
 }
 
-func TestConfigurator_OutgoingRPC_ServerName(t *testing.T) {
-	conf := &Config{
+func TestConfigurator_OutgoingTLS_ServerName(t *testing.T) {
+	conf := Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
 		ServerName:     "consul.example.com",
@@ -89,7 +89,7 @@ func TestConfigurator_OutgoingRPC_ServerName(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyOutgoing:       true,
 		VerifyServerHostname: true,
 		CAFile:               "../test/ca/root.cer",
@@ -103,7 +103,7 @@ func TestConfigurator_OutgoingTLS_VerifyHostname(t *testing.T) {
 }
 
 func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyOutgoing: true,
 		CAFile:         "../test/ca/root.cer",
 		CertFile:       "../test/key/ourdomain.cer",
@@ -120,7 +120,7 @@ func TestConfigurator_OutgoingTLS_WithKeyPair(t *testing.T) {
 func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
-		conf := &Config{
+		conf := Config{
 			VerifyOutgoing: true,
 			CAFile:         "../test/ca/root.cer",
 			TLSMinVersion:  version,
@@ -136,7 +136,7 @@ func TestConfigurator_OutgoingTLS_TLSMinVersion(t *testing.T) {
 func startTLSServer(config *Config) (net.Conn, chan error) {
 	errc := make(chan error, 1)
 
-	c := NewConfigurator(config)
+	c := NewConfigurator(*config)
 	tlsConfigServer, err := c.IncomingRPCConfig()
 	if err != nil {
 		errc <- err
@@ -172,7 +172,7 @@ func startTLSServer(config *Config) (net.Conn, chan error) {
 }
 
 func TestConfigurator_outgoingWrapper_OK(t *testing.T) {
-	config := &Config{
+	config := Config{
 		CAFile:               "../test/hostname/CertAuth.crt",
 		CertFile:             "../test/hostname/Alice.crt",
 		KeyFile:              "../test/hostname/Alice.key",
@@ -181,7 +181,7 @@ func TestConfigurator_outgoingWrapper_OK(t *testing.T) {
 		Domain:               "consul",
 	}
 
-	client, errc := startTLSServer(config)
+	client, errc := startTLSServer(&config)
 	if client == nil {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
@@ -202,7 +202,7 @@ func TestConfigurator_outgoingWrapper_OK(t *testing.T) {
 }
 
 func TestConfigurator_outgoingWrapper_BadDC(t *testing.T) {
-	config := &Config{
+	config := Config{
 		CAFile:               "../test/hostname/CertAuth.crt",
 		CertFile:             "../test/hostname/Alice.crt",
 		KeyFile:              "../test/hostname/Alice.key",
@@ -211,7 +211,7 @@ func TestConfigurator_outgoingWrapper_BadDC(t *testing.T) {
 		Domain:               "consul",
 	}
 
-	client, errc := startTLSServer(config)
+	client, errc := startTLSServer(&config)
 	if client == nil {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
@@ -232,7 +232,7 @@ func TestConfigurator_outgoingWrapper_BadDC(t *testing.T) {
 }
 
 func TestConfigurator_outgoingWrapper_BadCert(t *testing.T) {
-	config := &Config{
+	config := Config{
 		CAFile:               "../test/ca/root.cer",
 		CertFile:             "../test/key/ourdomain.cer",
 		KeyFile:              "../test/key/ourdomain.key",
@@ -241,7 +241,7 @@ func TestConfigurator_outgoingWrapper_BadCert(t *testing.T) {
 		Domain:               "consul",
 	}
 
-	client, errc := startTLSServer(config)
+	client, errc := startTLSServer(&config)
 	if client == nil {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
@@ -263,14 +263,14 @@ func TestConfigurator_outgoingWrapper_BadCert(t *testing.T) {
 }
 
 func TestConfigurator_wrapTLS_OK(t *testing.T) {
-	config := &Config{
+	config := Config{
 		CAFile:         "../test/ca/root.cer",
 		CertFile:       "../test/key/ourdomain.cer",
 		KeyFile:        "../test/key/ourdomain.key",
 		VerifyOutgoing: true,
 	}
 
-	client, errc := startTLSServer(config)
+	client, errc := startTLSServer(&config)
 	if client == nil {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
@@ -298,7 +298,7 @@ func TestConfigurator_wrapTLS_BadCert(t *testing.T) {
 		t.Fatalf("startTLSServer err: %v", <-errc)
 	}
 
-	clientConfig := &Config{
+	clientConfig := Config{
 		CAFile:         "../test/ca/root.cer",
 		VerifyOutgoing: true,
 	}
@@ -379,7 +379,7 @@ func TestConfig_ParseCiphers(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
-	conf := &Config{CAPath: "../test/ca_path"}
+	conf := Config{CAPath: "../test/ca_path"}
 
 	c := NewConfigurator(conf)
 	tlsConf, err := c.IncomingHTTPSConfig()
@@ -388,7 +388,7 @@ func TestConfigurator_IncomingHTTPSConfig_CA_PATH(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPS(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyIncoming: true,
 		CAFile:         "../test/ca/root.cer",
 		CertFile:       "../test/key/ourdomain.cer",
@@ -404,7 +404,7 @@ func TestConfigurator_IncomingHTTPS(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyIncoming: true,
 		CertFile:       "../test/key/ourdomain.cer",
 		KeyFile:        "../test/key/ourdomain.key",
@@ -415,7 +415,7 @@ func TestConfigurator_IncomingHTTPS_MissingCA(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
-	conf := &Config{
+	conf := Config{
 		VerifyIncoming: true,
 		CAFile:         "../test/ca/root.cer",
 	}
@@ -425,7 +425,7 @@ func TestConfigurator_IncomingHTTPS_MissingKey(t *testing.T) {
 }
 
 func TestConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
-	conf := &Config{}
+	conf := Config{}
 	c := NewConfigurator(conf)
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
@@ -438,7 +438,7 @@ func TestConfigurator_IncomingHTTPS_NoVerify(t *testing.T) {
 func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
-		conf := &Config{
+		conf := Config{
 			VerifyIncoming: true,
 			CAFile:         "../test/ca/root.cer",
 			CertFile:       "../test/key/ourdomain.cer",
@@ -455,29 +455,23 @@ func TestConfigurator_IncomingHTTPS_TLSMinVersion(t *testing.T) {
 
 func TestConfigurator_IncomingHTTPSCAPath_Valid(t *testing.T) {
 
-	c := NewConfigurator(&Config{CAPath: "../test/ca_path"})
+	c := NewConfigurator(Config{CAPath: "../test/ca_path"})
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 }
 
-func TestConfigurator_CommonTLSConfigNoBaseConfig(t *testing.T) {
-	c := NewConfigurator(nil)
-	_, err := c.commonTLSConfig(false)
-	require.Error(t, err)
-}
-
 func TestConfigurator_CommonTLSConfigServerNameNodeName(t *testing.T) {
 	type variant struct {
-		config *Config
+		config Config
 		result string
 	}
 	variants := []variant{
-		{config: &Config{NodeName: "node", ServerName: "server"},
+		{config: Config{NodeName: "node", ServerName: "server"},
 			result: "server"},
-		{config: &Config{ServerName: "server"},
+		{config: Config{ServerName: "server"},
 			result: "server"},
-		{config: &Config{NodeName: "node"},
+		{config: Config{NodeName: "node"},
 			result: "node"},
 	}
 	for _, v := range variants {
@@ -489,12 +483,12 @@ func TestConfigurator_CommonTLSConfigServerNameNodeName(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConfig, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Empty(t, tlsConfig.CipherSuites)
 
-	conf := &Config{CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305}}
+	conf := Config{CipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305}}
 	c.Update(conf)
 	tlsConfig, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
@@ -502,16 +496,16 @@ func TestConfigurator_CommonTLSConfigCipherSuites(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigCertKey(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Empty(t, tlsConf.Certificates)
 
-	c.Update(&Config{CertFile: "/something/bogus", KeyFile: "/more/bogus"})
+	c.Update(Config{CertFile: "/something/bogus", KeyFile: "/more/bogus"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Len(t, tlsConf.Certificates, 1)
@@ -520,51 +514,51 @@ func TestConfigurator_CommonTLSConfigCertKey(t *testing.T) {
 func TestConfigurator_CommonTLSConfigTLSMinVersion(t *testing.T) {
 	tlsVersions := []string{"tls10", "tls11", "tls12"}
 	for _, version := range tlsVersions {
-		c := NewConfigurator(&Config{TLSMinVersion: version})
+		c := NewConfigurator(Config{TLSMinVersion: version})
 		tlsConf, err := c.commonTLSConfig(false)
 		require.NoError(t, err)
 		require.Equal(t, tlsConf.MinVersion, TLSLookup[version])
 	}
 
-	c := NewConfigurator(&Config{TLSMinVersion: "tlsBOGUS"})
+	c := NewConfigurator(Config{TLSMinVersion: "tlsBOGUS"})
 	_, err := c.commonTLSConfig(false)
 	require.Error(t, err)
 }
 
 func TestConfigurator_CommonTLSConfigValidateVerifyOutgoingCA(t *testing.T) {
-	c := NewConfigurator(&Config{VerifyOutgoing: true})
+	c := NewConfigurator(Config{VerifyOutgoing: true})
 	_, err := c.commonTLSConfig(false)
 	require.Error(t, err)
 }
 
 func TestConfigurator_CommonTLSConfigLoadCA(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Nil(t, tlsConf.RootCAs)
 	require.Nil(t, tlsConf.ClientCAs)
 
-	c.Update(&Config{CAFile: "/something/bogus"})
+	c.Update(Config{CAFile: "/something/bogus"})
 	_, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{CAPath: "/something/bogus/"})
+	c.Update(Config{CAPath: "/something/bogus/"})
 	_, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{CAFile: "../test/ca/root.cer"})
+	c.Update(Config{CAFile: "../test/ca/root.cer"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 1)
 
-	c.Update(&Config{CAPath: "../test/ca_path"})
+	c.Update(Config{CAPath: "../test/ca_path"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 2)
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 
-	c.Update(&Config{CAFile: "../test/ca/root.cer", CAPath: "../test/ca_path"})
+	c.Update(Config{CAFile: "../test/ca/root.cer", CAPath: "../test/ca_path"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
@@ -572,29 +566,29 @@ func TestConfigurator_CommonTLSConfigLoadCA(t *testing.T) {
 }
 
 func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncoming: true})
+	c.Update(Config{VerifyIncoming: true})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"})
+	c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/cert/ourdomain.cer"})
+	c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/cert/ourdomain.cer"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.Error(t, err)
 
-	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.commonTLSConfig(false)
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncoming: false, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncoming: false, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.commonTLSConfig(true)
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
@@ -611,93 +605,93 @@ func TestConfigurator_CommonTLSConfigVerifyIncoming(t *testing.T) {
 }
 
 func TestConfigurator_IncomingRPCConfig(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.IncomingRPCConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingRPCConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncomingRPC: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncomingRPC: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingRPCConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncomingHTTPS: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncomingHTTPS: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingRPCConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
 }
 
 func TestConfigurator_IncomingHTTPSConfig(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncoming: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncomingHTTPS: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncomingHTTPS: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.RequireAndVerifyClientCert, tlsConf.ClientAuth)
 
-	c.Update(&Config{VerifyIncomingRPC: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
+	c.Update(Config{VerifyIncomingRPC: true, CAFile: "../test/ca/root.cer", CertFile: "../test/key/ourdomain.cer", KeyFile: "../test/key/ourdomain.key"})
 	tlsConf, err = c.IncomingHTTPSConfig()
 	require.NoError(t, err)
 	require.Equal(t, tls.NoClientCert, tlsConf.ClientAuth)
 }
 
 func TestConfigurator_OutgoingRPCConfig(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.OutgoingRPCConfig()
 	require.NoError(t, err)
 	require.Nil(t, tlsConf)
 
-	c.Update(&Config{VerifyOutgoing: true})
+	c.Update(Config{VerifyOutgoing: true})
 	tlsConf, err = c.OutgoingRPCConfig()
 	require.Error(t, err)
 
-	c.Update(&Config{VerifyOutgoing: true, CAFile: "../test/ca/root.cer"})
+	c.Update(Config{VerifyOutgoing: true, CAFile: "../test/ca/root.cer"})
 	tlsConf, err = c.OutgoingRPCConfig()
 	require.NoError(t, err)
 
-	c.Update(&Config{VerifyOutgoing: true, CAPath: "../test/ca_path"})
+	c.Update(Config{VerifyOutgoing: true, CAPath: "../test/ca_path"})
 	tlsConf, err = c.OutgoingRPCConfig()
 	require.NoError(t, err)
 }
 
 func TestConfigurator_OutgoingTLSConfigForChecks(t *testing.T) {
-	c := NewConfigurator(&Config{})
+	c := NewConfigurator(Config{})
 	tlsConf, err := c.OutgoingTLSConfigForCheck("")
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)
 
-	c.Update(&Config{EnableAgentTLSForChecks: true})
+	c.Update(Config{EnableAgentTLSForChecks: true})
 	tlsConf, err = c.OutgoingTLSConfigForCheck("")
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)
 
 	c.AddCheck("c1", true)
-	c.Update(&Config{EnableAgentTLSForChecks: true})
+	c.Update(Config{EnableAgentTLSForChecks: true})
 	tlsConf, err = c.OutgoingTLSConfigForCheck("c1")
 	require.NoError(t, err)
 	require.True(t, tlsConf.InsecureSkipVerify)
 
 	c.AddCheck("c1", false)
-	c.Update(&Config{EnableAgentTLSForChecks: true})
+	c.Update(Config{EnableAgentTLSForChecks: true})
 	tlsConf, err = c.OutgoingTLSConfigForCheck("c1")
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)
 
 	c.AddCheck("c1", false)
-	c.Update(&Config{EnableAgentTLSForChecks: true})
+	c.Update(Config{EnableAgentTLSForChecks: true})
 	tlsConf, err = c.OutgoingTLSConfigForCheck("c1")
 	require.NoError(t, err)
 	require.False(t, tlsConf.InsecureSkipVerify)

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1731,6 +1731,8 @@ items which are reloaded include:
 * Services
 * Watches
 * HTTP Client Address
+* TLS Configuration
+  * Please be aware that this is currently limited to reload a configuration that is already TLS enabled. You cannot enable or disable TLS only with reloading.
 * <a href="#node_meta">Node Metadata</a>
 * <a href="#telemetry-prefix_filter">Metric Prefix Filter</a>
 * <a href="#discard_check_output">Discard Check Output</a>


### PR DESCRIPTION
This PR introduces reloading tls configuration. The interesting thing about this is that it is not about reloading the configuration, which is easy. But about making sure the reload actually has an effect.

* [x] describe in which cases it works
  * reload certificates
  * reload CAs
  * reload `verify_incoming`, `verify_outgoing`, `verify_server_hostname`
* [x] describe limitations
  * it is not possible to turn TLS on or off! you want to have it enabled and then reload
* [x] document accordingly on website