### PR TITLE
Catalog API Doc Changes

### DIFF
--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -56,7 +56,8 @@ The table below shows this endpoint's support for
   Only one service with a given `ID` may be present per node. The service
   `Tags`, `Address`, `Meta`, and `Port` fields are all optional. For more
   infomation about these fields and the implications of setting them, 
-  see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page.
+  see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page
+  as registering services differs between using this or the Services Agent endpoint.
 
 - `Check` `(Check: nil)` - Specifies to register a check. The register API
   manipulates the health check entry in the Catalog, but it does not setup the

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -56,7 +56,7 @@ The table below shows this endpoint's support for
   Only one service with a given `ID` may be present per node. The service
   `Tags`, `Address`, `Meta`, and `Port` fields are all optional. For more
   infomation about these fields and the implications of setting them, 
-  see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page
+  see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page.
 
 - `Check` `(Check: nil)` - Specifies to register a check. The register API
   manipulates the health check entry in the Catalog, but it does not setup the

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -54,7 +54,8 @@ The table below shows this endpoint's support for
 - `Service` `(Service: nil)` - Specifies to register a service. If `ID` is not
   provided, it will be defaulted to the value of the `Service.Service` property.
   Only one service with a given `ID` may be present per node. The service
-  `Tags`, `Address`, `Meta`, and `Port` fields are all optional.
+  `Tags`, `Address`, `Meta`, and `Port` fields are all optional. For more
+  infomation about these fields, see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page
 
 - `Check` `(Check: nil)` - Specifies to register a check. The register API
   manipulates the health check entry in the Catalog, but it does not setup the

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -55,7 +55,8 @@ The table below shows this endpoint's support for
   provided, it will be defaulted to the value of the `Service.Service` property.
   Only one service with a given `ID` may be present per node. The service
   `Tags`, `Address`, `Meta`, and `Port` fields are all optional. For more
-  infomation about these fields, see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page
+  infomation about these fields and the implications of setting them, 
+  see the [Service - Agent API](https://www.consul.io/api/agent/service.html) page
 
 - `Check` `(Check: nil)` - Specifies to register a check. The register API
   manipulates the health check entry in the Catalog, but it does not setup the


### PR DESCRIPTION
Made the following change to the Catalog API docs:

* Added a link to the Service - Agent API page for the `Services` field of the [Register Entity API call](https://www.consul.io/api/catalog.html#register-entity). This came from a discussion from Bloomberg who expressed confusion of why the fields to register a Service weren't being detailed. Instead of listing all the fields in a new page since they are already in detailed in the [Service - Agent API](https://www.consul.io/api/agent/service.html) page, adding the link is a better solution