### PR TITLE
improve flaky LANReap tests by expliciting configuring the tombstone timeout

### DIFF
--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -108,6 +108,7 @@ func TestClient_LANReap(t *testing.T) {
 		c.Datacenter = "dc1"
 		c.SerfFloodInterval = 100 * time.Millisecond
 		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.TombstoneTimeout = 250 * time.Millisecond
 		c.SerfLANConfig.ReapInterval = 500 * time.Millisecond
 	})
 	defer os.RemoveAll(dir2)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -239,12 +239,19 @@ func TestServer_JoinLAN(t *testing.T) {
 }
 
 func TestServer_LANReap(t *testing.T) {
+	t.Parallel()
+
+	configureServer := func(c *Config) {
+		c.SerfFloodInterval = 100 * time.Millisecond
+		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.TombstoneTimeout = 250 * time.Millisecond
+		c.SerfLANConfig.ReapInterval = 300 * time.Millisecond
+	}
+
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = true
-		c.SerfFloodInterval = 100 * time.Millisecond
-		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
-		c.SerfLANConfig.ReapInterval = 300 * time.Millisecond
+		configureServer(c)
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -252,18 +259,14 @@ func TestServer_LANReap(t *testing.T) {
 	dir2, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = false
-		c.SerfFloodInterval = 100 * time.Millisecond
-		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
-		c.SerfLANConfig.ReapInterval = 300 * time.Millisecond
+		configureServer(c)
 	})
 	defer os.RemoveAll(dir2)
 
 	dir3, s3 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"
 		c.Bootstrap = false
-		c.SerfFloodInterval = 100 * time.Millisecond
-		c.SerfLANConfig.ReconnectTimeout = 250 * time.Millisecond
-		c.SerfLANConfig.ReapInterval = 300 * time.Millisecond
+		configureServer(c)
 	})
 	defer os.RemoveAll(dir3)
 	defer s3.Shutdown()
@@ -339,6 +342,7 @@ func TestServer_WANReap(t *testing.T) {
 		c.Bootstrap = true
 		c.SerfFloodInterval = 100 * time.Millisecond
 		c.SerfWANConfig.ReconnectTimeout = 250 * time.Millisecond
+		c.SerfWANConfig.TombstoneTimeout = 250 * time.Millisecond
 		c.SerfWANConfig.ReapInterval = 500 * time.Millisecond
 	})
 	defer os.RemoveAll(dir1)


### PR DESCRIPTION
In TestServer_LANReap autopilot is running, so the alternate flow through the serf reaping function is possible. In that situation the ReconnectTimeout is not relevant so for parity also override the TombstoneTimeout value as well.

For additional parity update the TestServer_WANReap and TestClient_LANReap versions of this test in the same way even though autopilot is irrelevant here .