### PR TITLE
fix typos

### DIFF
--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -955,7 +955,7 @@ func TestACLEndpoint_TokenDelete(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("don't segfault when attempting to delete non existant token in secondary dc", func(t *testing.T) {
+	t.Run("don't segfault when attempting to delete non existent token in secondary dc", func(t *testing.T) {
 		fakeID, err := uuid.GenerateUUID()
 		require.NoError(t, err)
 

--- a/command/acl/token/delete/token_delete.go
+++ b/command/acl/token/delete/token_delete.go
@@ -42,7 +42,7 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	if c.tokenID == "" {
-		c.UI.Error(fmt.Sprintf("Must specify the -id paramter"))
+		c.UI.Error(fmt.Sprintf("Must specify the -id parameter"))
 		return 1
 	}
 


### PR DESCRIPTION
Fixing a few typos in actual code (error messages) that #5434 didn't catch since they are not comments.