### PR TITLE
[doc] New Ports Documentation 

### DIFF
--- a/website/source/docs/install/ports.html.md
+++ b/website/source/docs/install/ports.html.md
@@ -1,0 +1,28 @@
+---
+layout: "docs"
+page_title: "Required Ports"
+sidebar_current: "docs-install-ports"
+description: |-
+  Before starting Consul it is important to have the necessary bind ports accessible.
+---
+
+# Required Ports
+
+Before running Consul, you should ensure the following bind ports are accessible. 
+The default ports can be changed in the [agent configuration](/docs/agent/options.html#ports). Note, many of the ports can be disabled by setting the configuration parameter to `-1`.
+
+
+|  Use                              | Default Ports    | 
+| --------------------------------- | ---------------- |
+| DNS: The DNS server               | 8600             |
+| HTTP: The HTTP API                | 8500             |
+| HTTPS: The HTTPs API              | disabled (8501)  | 
+| gRPC: The gRPC API                | disabled (8502)  | 
+| LAN Serf: The Serf LAN port.      | 8301             | 
+| Wan Serf: The Serf WAN port       | 8302             |
+| server: Server RPC address        | 8300             | 
+| Sidecar Proxy Min: Inclusive min port number to use for automatically assigned sidecar service registrations.   | 21000            | 
+| Sidecar Proxy Max: Inclusive max port number to use for automatically assigned sidecar service registrations. | 21255            | 
+
+For `HTTPS` and `gRPC` the ports specified in the table 
+are recommendations.

--- a/website/source/docs/install/ports.html.md
+++ b/website/source/docs/install/ports.html.md
@@ -9,20 +9,21 @@ description: |-
 # Required Ports
 
 Before running Consul, you should ensure the following bind ports are accessible. 
-The default ports can be changed in the [agent configuration](/docs/agent/options.html#ports). Note, many of the ports can be disabled by setting the configuration parameter to `-1`.
 
 
 |  Use                              | Default Ports    | 
 | --------------------------------- | ---------------- |
 | DNS: The DNS server               | 8600             |
 | HTTP: The HTTP API                | 8500             |
-| HTTPS: The HTTPs API              | disabled (8501)  | 
-| gRPC: The gRPC API                | disabled (8502)  | 
+| HTTPS: The HTTPs API              | disabled (8501)* | 
+| gRPC: The gRPC API                | disabled (8502)* | 
 | LAN Serf: The Serf LAN port.      | 8301             | 
 | Wan Serf: The Serf WAN port       | 8302             |
 | server: Server RPC address        | 8300             | 
 | Sidecar Proxy Min: Inclusive min port number to use for automatically assigned sidecar service registrations.   | 21000            | 
 | Sidecar Proxy Max: Inclusive max port number to use for automatically assigned sidecar service registrations. | 21255            | 
 
-For `HTTPS` and `gRPC` the ports specified in the table 
+*For `HTTPS` and `gRPC` the ports specified in the table 
 are recommendations.
+
+Note, the default ports can be changed in the [agent configuration](/docs/agent/options.html#ports). 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -3,6 +3,11 @@
     <ul class="nav docs-sidenav">
       <li<%= sidebar_current('docs-install-install') %>>
         <a href="/docs/install/index.html">Installing Consul</a>
+        <ul class="nav">
+          <li<%= sidebar_current("docs-install-ports") %>>
+            <a href="/docs/install/ports.html">Required Ports</a>
+          </li>
+        </ul>
       </li>
 
       <li<%= sidebar_current("docs-upgrading") %>>


### PR DESCRIPTION
Currently, we have necessary ports listed in the agent configuration section of the documentation. I think it would be nice to have a quick reference to link to from other guides, like the Reference Architecture guides.