### PR TITLE
[docs] Remove misleading encrypt param documentation

### DIFF
--- a/website/source/docs/agent/encryption.html.md
+++ b/website/source/docs/agent/encryption.html.md
@@ -16,8 +16,7 @@ If you are configuring encryption, review this [guide](/docs/guides/agent-encryp
 ## Gossip Encryption
 
 Enabling gossip encryption only requires that you set an encryption key when
-starting the Consul agent. The key can be set via the `encrypt` parameter: the
-value of this setting is a configuration file containing the encryption key.
+starting the Consul agent. The key can be set via the `encrypt` parameter.
 
 ~> **WAN Joined Datacenters Note:** If using multiple WAN joined datacenters, be sure to use _the same encryption key_ in all datacenters.
 


### PR DESCRIPTION
According to https://www.consul.io/docs/agent/options.html#_encrypt, the `encrypt` param specifies the 16-byte key to use, not the path to a config file containing the key.