### PR TITLE
Added metadata information about servers into consul service description

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1363,6 +1363,16 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 			ID:      structs.ConsulServiceID,
 			Service: structs.ConsulServiceName,
 			Port:    parts.Port,
+			Weights: &structs.Weights{
+				Passing: 1,
+				Warning: 1,
+			},
+			Meta: map[string]string{
+				"consul_voter":  strconv.FormatBool(!parts.NonVoter),
+				"raft_version":  strconv.Itoa(parts.RaftVersion),
+				"serf_protocol": fmt.Sprintf("%v (%v .. %v)", member.ProtocolCur, member.ProtocolMin, member.ProtocolMax),
+				"version":       parts.Build.String(),
+			},
 		}
 
 		// Attempt to join the consul server

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1368,10 +1368,11 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 				Warning: 1,
 			},
 			Meta: map[string]string{
-				"booted_as_consul_voter": strconv.FormatBool(!parts.NonVoter),
-				"raft_version":           strconv.Itoa(parts.RaftVersion),
-				"serf_protocol":          fmt.Sprintf("%v (%v .. %v)", member.ProtocolCur, member.ProtocolMin, member.ProtocolMax),
-				"version":                parts.Build.String(),
+				"raft_version":          strconv.Itoa(parts.RaftVersion),
+				"serf_protocol_current": strconv.FormatUint(uint64(member.ProtocolCur), 10),
+				"serf_protocol_min":     strconv.FormatUint(uint64(member.ProtocolMin), 10),
+				"serf_protocol_max":     strconv.FormatUint(uint64(member.ProtocolMax), 10),
+				"version":               parts.Build.String(),
 			},
 		}
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1368,10 +1368,10 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 				Warning: 1,
 			},
 			Meta: map[string]string{
-				"consul_voter":  strconv.FormatBool(!parts.NonVoter),
-				"raft_version":  strconv.Itoa(parts.RaftVersion),
-				"serf_protocol": fmt.Sprintf("%v (%v .. %v)", member.ProtocolCur, member.ProtocolMin, member.ProtocolMax),
-				"version":       parts.Build.String(),
+				"booted_as_consul_voter": strconv.FormatBool(!parts.NonVoter),
+				"raft_version":           strconv.Itoa(parts.RaftVersion),
+				"serf_protocol":          fmt.Sprintf("%v (%v .. %v)", member.ProtocolCur, member.ProtocolMin, member.ProtocolMax),
+				"version":                parts.Build.String(),
 			},
 		}
 


### PR DESCRIPTION
This allows have information about servers from HTTP APIs without using the command line.

It will allow to see information about servers from GUIs using the HTTP APIs for instance.