### PR TITLE
Minor changes to fix a few tests that were failing locally [Go 1.12]

### DIFF
--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -323,7 +323,9 @@ func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
 
-	req, _ := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
+	req, _ := http.NewRequest("GET", "", nil)
+	req.URL.Path = "/v1/kv/bad\x00ness"
+
 	resp := httptest.NewRecorder()
 	a.srv.Handler.ServeHTTP(resp, req)
 	if got, want := resp.Code, http.StatusBadRequest; got != want {
@@ -335,7 +337,9 @@ func TestHTTPAPI_Allow_Nonprintable_Characters_With_Flag(t *testing.T) {
 	a := NewTestAgent(t, t.Name(), "disable_http_unprintable_char_filter = true")
 	defer a.Shutdown()
 
-	req, _ := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
+	req, _ := http.NewRequest("GET", "", nil)
+	req.URL.Path = "/v1/kv/bad\x00ness"
+
 	resp := httptest.NewRecorder()
 	a.srv.Handler.ServeHTTP(resp, req)
 	// Key doesn't actually exist so we should get 404

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -35,7 +35,7 @@ func TestLockCommand_noTabs(t *testing.T) {
 
 func TestLockCommand_BadArgs(t *testing.T) {
 	t.Parallel()
-	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "invalid duration")
+	argFail(t, []string{"-try=blah", "test/prefix", "date"}, "invalid value")
 	argFail(t, []string{"-try=-10s", "test/prefix", "date"}, "Timeout must be positive")
 	argFail(t, []string{"-monitor-retry=-5", "test/prefix", "date"}, "must be >= 0")
 }


### PR DESCRIPTION
Hello,

I've made some minor changes to 3 test cases that were failing for me with Go 1.12.

P.S. I am not sure if Go 1.12 support is of any importance right now. [CONTRIBUTING.MD ](https://github.com/hashicorp/consul/blob/master/.github/CONTRIBUTING.md) only mentions Go 1.10+. If 1.12 support is not on the roadmap - this PR can be ignored.


