### PR TITLE
UI: Add proxy icons to proxy services and instances where appropriate

### DIFF
--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -51,7 +51,12 @@ export default Controller.extend(WithEventSource, WithSearching, WithHealthFilte
     return widthDeclaration(get(this, 'maxWidth'));
   }),
   remainingWidth: computed('maxWidth', function() {
-    return htmlSafe(`width: calc(50% - ${Math.round(get(this, 'maxWidth') / 2)}px)`);
+    // maxWidth is the maximum width of the healthchecks column
+    // there are currently 2 other columns so divide it by 2 and
+    // take that off 50% (100% / number of fluid columns)
+    // also we added a Type column which we've currently fixed to 100px
+    // so again divide that by 2 and take it off each fluid column
+    return htmlSafe(`width: calc(50% - 50px - ${Math.round(get(this, 'maxWidth') / 2)}px)`);
   }),
   maxPassing: computed('filtered', function() {
     return max(get(this, 'filtered'), 'ChecksPassing');

--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -1,6 +1,7 @@
 @import './app-view/index';
 @import './filter-bar/index';
 @import './buttons/index';
+@import './type-icon/index';
 main {
   @extend %app-view;
 }
@@ -15,8 +16,12 @@ main {
     margin-top: 5px;
   }
 }
-%app-view h1 span {
+// TODO: This should be its own component
+%app-view h1 span[data-tooltip] {
   @extend %with-external-source-icon;
+}
+%app-view h1 span.kind-proxy {
+  @extend %type-icon, %with-proxy;
 }
 %app-view h1 em {
   color: $gray-600;

--- a/ui-v2/app/styles/components/icons/index.scss
+++ b/ui-v2/app/styles/components/icons/index.scss
@@ -54,6 +54,7 @@
 %with-folder {
   text-indent: 30px;
 }
+%with-proxy,
 %with-hashicorp,
 %with-folder,
 %with-chevron,
@@ -77,6 +78,15 @@
   height: 20px;
   left: -25px;
   margin-top: -10px;
+  background-color: $color-transparent;
+}
+%with-proxy::before {
+  @extend %pseudo-icon;
+  background-image: url('data:image/svg+xml;charset=UTF-8,<svg width="18" height="18" xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="none"><path d="M2.242 7.138l6.963.774a1 1 0 0 1 .883.883l.774 6.963a1 1 0 0 1-1.104 1.104l-6.963-.774a1 1 0 0 1-.883-.883l-.774-6.963a1 1 0 0 1 1.104-1.104z" stroke="%23BAC1CC" fill="%23FAFBFC"/><path d="M5.242 4.138l6.963.774a1 1 0 0 1 .883.883l.774 6.963a1 1 0 0 1-1.104 1.104l-6.963-.774a1 1 0 0 1-.883-.883l-.774-6.963a1 1 0 0 1 1.104-1.104z" stroke="%238E96A3" fill="%238E96A3"/><path d="M8.242 1.138l6.963.774a1 1 0 0 1 .883.883l.774 6.963a1 1 0 0 1-1.104 1.104l-6.963-.774a1 1 0 0 1-.883-.883l-.774-6.963a1 1 0 0 1 1.104-1.104z" stroke="%23BAC1CC" fill="%23FAFBFC"/></g></svg>');
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  margin-top: -9px;
   background-color: $color-transparent;
 }
 %with-clipboard {

--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -1,5 +1,6 @@
 @import './icons/index';
 @import './table/index';
+@import './type-icon/index';
 
 html.template-service.template-list td:first-child a span,
 html.template-node.template-show #services td:first-child a span,
@@ -18,6 +19,13 @@ html.template-service.template-list main th:first-child {
 
 td.folder {
   @extend %with-folder;
+}
+td .kind-proxy {
+  @extend %type-icon, %with-proxy;
+  text-indent: -9000px !important;
+  width: 24px;
+  margin-top: -8px;
+  transform: scale(0.7);
 }
 table:not(.sessions) tr {
   cursor: pointer;

--- a/ui-v2/app/styles/components/table/layout.scss
+++ b/ui-v2/app/styles/components/table/layout.scss
@@ -65,6 +65,9 @@ td:not(.actions) a {
   html.template-policy.template-list tr > :nth-child(2) {
     display: none;
   }
+  html.template-service.template-list tr > :nth-child(2) {
+    display: none;
+  }
 }
 @media #{$--lt-wide-table} {
   html.template-intention.template-list tr > :nth-last-child(2) {

--- a/ui-v2/app/styles/components/tabular-collection.scss
+++ b/ui-v2/app/styles/components/tabular-collection.scss
@@ -174,6 +174,9 @@ html.template-node.template-show main table.sessions tr {
 // (100% / 2) - (160px / 2)
 // width: calc(50% - 160px);
 // }
+%services-row > *:nth-child(2) {
+  width: 100px;
+}
 %services-row > * {
   width: auto;
 }

--- a/ui-v2/app/styles/components/type-icon/index.scss
+++ b/ui-v2/app/styles/components/type-icon/index.scss
@@ -1,0 +1,2 @@
+@import './skin';
+@import './layout';

--- a/ui-v2/app/styles/components/type-icon/layout.scss
+++ b/ui-v2/app/styles/components/type-icon/layout.scss
@@ -1,0 +1,5 @@
+%type-icon {
+  display: inline-block;
+  text-indent: 20px;
+  padding: 3px;
+}

--- a/ui-v2/app/styles/components/type-icon/skin.scss
+++ b/ui-v2/app/styles/components/type-icon/skin.scss
@@ -1,0 +1,6 @@
+%type-icon {
+  border-radius: 4px;
+
+  background: $gray-100;
+  color: $gray-400;
+}

--- a/ui-v2/app/styles/components/with-tooltip.scss
+++ b/ui-v2/app/styles/components/with-tooltip.scss
@@ -1,4 +1,4 @@
 @import './with-tooltip/index';
-%app-view h1 span {
+%app-view h1 span[data-tooltip] {
   @extend %with-pseudo-tooltip;
 }

--- a/ui-v2/app/styles/components/with-tooltip/index.scss
+++ b/ui-v2/app/styles/components/with-tooltip/index.scss
@@ -12,7 +12,7 @@
 %with-pseudo-tooltip {
   text-indent: -9000px;
   font-size: 0;
-  top: -9px;
+  top: -7px;
 }
 
 %with-pseudo-tooltip::after,

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -54,7 +54,8 @@ th,
 %breadcrumbs li > *,
 %action-group-action,
 %tab-nav,
-%tooltip-bubble {
+%tooltip-bubble,
+%type-icon {
   font-weight: $typo-weight-medium;
 }
 main label a[rel*='help'],
@@ -96,7 +97,8 @@ caption,
 %form-element > span,
 %tooltip-bubble,
 %healthchecked-resource strong,
-%footer {
+%footer,
+%type-icon {
   font-size: $typo-size-700;
 }
 %toggle label span {

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -24,6 +24,7 @@
             }}
                 {{#block-slot 'header'}}
                     <th style={{remainingWidth}}>Service</th>
+                    <th>Type</th>
                     <th style={{totalWidth}}>Health Checks<span><em>The number of health checks for the service on all nodes</em></span></th>
                     <th style={{remainingWidth}}>Tags</th>
                 {{/block-slot}}
@@ -33,6 +34,13 @@
                         <span data-test-external-source="{{service/external-source item}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
                         {{item.Name}}
                       </a>
+                    </td>
+                    <td>
+{{#if (eq item.Kind 'connect-proxy')}}
+                        <span class="kind-proxy">Proxy</span>
+{{else}}
+                        &nbsp;
+{{/if}}
                     </td>
                     <td style={{totalWidth}}>
                       {{healthcheck-info

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -16,6 +16,9 @@
     {{/if}}
   {{/with}}
 {{/with}}
+{{#if (eq item.Kind 'connect-proxy')}}
+        <span class="kind-proxy">Proxy</span>
+{{/if}}
       </h1>
       <dl>
         <dt>Service Name</dt>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -14,6 +14,9 @@
     {{/if}}
   {{/with}}
 {{/with}}
+{{#if (eq item.Service.Kind 'connect-proxy')}}
+        <span class="kind-proxy">Proxy</span>
+{{/if}}
       </h1>
       <label for="toolbar-toggle"></label>
       {{tab-nav


### PR DESCRIPTION
This PR adds new proxy icons to services with the `Kind: connect-proxy`

<img width="83" alt="Screenshot 2019-03-11 at 10 26 19" src="https://user-images.githubusercontent.com/554604/54113227-21cbf880-43e8-11e9-9ffb-77fbaa035379.png">

In Service listing views:

<img width="892" alt="Screenshot 2019-03-11 at 10 14 48" src="https://user-images.githubusercontent.com/554604/54112584-cb11ef00-43e6-11e9-9885-69c6c363318e.png">

in Service detail/Instance listing views:

<img width="896" alt="Screenshot 2019-03-11 at 10 15 00" src="https://user-images.githubusercontent.com/554604/54112590-d107d000-43e6-11e9-8cf1-15b8c1fb45c8.png">

and Instance detail views:

<img width="893" alt="Screenshot 2019-03-11 at 10 19 08" src="https://user-images.githubusercontent.com/554604/54112746-27750e80-43e7-11e9-8766-3482c512b000.png">

An extra note here, the 'external service' icons will be changing to use a similar grey rounded box background and move to Type column in listing views. These icons will therefore move to use the new `%type-icon` CSS component in a later PR.