### PR TITLE
UI: Amends blocking queries text and toggle component in settings

### DIFF
--- a/ui-v2/app/styles/components/app-view/layout.scss
+++ b/ui-v2/app/styles/components/app-view/layout.scss
@@ -30,6 +30,11 @@
   padding-bottom: 0.2em;
   margin-bottom: 1.1em;
 }
+%app-view fieldset h2,
+%app-view fieldset p {
+  padding-bottom: 0;
+  margin-bottom: 0;
+}
 %app-view header .actions > *:not(:last-child) {
   margin-right: 12px;
 }

--- a/ui-v2/app/styles/components/app-view/skin.scss
+++ b/ui-v2/app/styles/components/app-view/skin.scss
@@ -1,6 +1,9 @@
 %app-view h2 {
   border-bottom: $decor-border-200;
 }
+%app-view fieldset h2 {
+  border-bottom: none;
+}
 @media #{$--horizontal-selects} {
   %app-view header h1 {
     border-bottom: $decor-border-200;

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -84,6 +84,7 @@ h2,
 }
 body,
 %action-group-action,
+fieldset h2,
 pre code,
 input,
 textarea,

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -7,14 +7,16 @@
         {{/block-slot}}
         {{#block-slot 'content'}}
             <p>
-                These settings allow you to configure your browser for the Consul Web UI. Everything is saved to localstorage, and persists through visits and browser usage.
+                These settings are specific to the Consul web UI. They are saved to local storage, and persist through browser usage and visits.
             </p>
             <form>
                 <fieldset>
+                    <h2>Blocking Queries</h2>
+                    <p>Automatically get updated catalog information without refreshing the page. Any changes made to services and nodes would be reflected in real time.</p>
                     <div class="type-toggle">
                       <label>
                           <input type="checkbox" name="client[blocking]" checked={{if item.client.blocking 'checked' }} onchange={{action 'change'}} />
-                          <span>Enable Catalog realtime updates (blocking queries)</span>
+                          <span>{{if item.client.blocking 'On' 'Off' }}</span>
                       </label>
                     </div>
                 </fieldset>

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -7,7 +7,7 @@
         {{/block-slot}}
         {{#block-slot 'content'}}
             <p>
-                These settings are specific to the Consul web UI. They are saved to local storage, and persist through browser usage and visits.
+                These settings are specific to the Consul web UI. They are saved to local storage and persist through browser usage and visits.
             </p>
             <form>
                 <fieldset>


### PR DESCRIPTION
This PR amends the text and toggle button for enabling/disabling blocking query support for the catalog area of the UI.

<img width="1200" alt="Screenshot 2019-03-11 at 12 52 08" src="https://user-images.githubusercontent.com/554604/54122124-81340380-43fc-11e9-9cc6-d556c1102ff6.png">
