### PR TITLE
Ensure Consul is IPv6 compliant

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2531,7 +2531,7 @@ func (a *Agent) addProxyLocked(proxy *structs.ConnectManagedProxy, persist, From
 	if chkAddr != "" {
 		bindPort, ok := proxyCfg["bind_port"].(int)
 		if !ok {
-			return fmt.Errorf("Cannot connvert bind_port=%v to an int for creating TCP Check for address %s", proxyCfg["bind_port"], chkAddr)
+			return fmt.Errorf("Cannot convert bind_port=%v to an int for creating TCP Check for address %s", proxyCfg["bind_port"], chkAddr)
 		}
 		chkTypes = []*structs.CheckType{
 			&structs.CheckType{

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2529,11 +2529,14 @@ func (a *Agent) addProxyLocked(proxy *structs.ConnectManagedProxy, persist, From
 	chkAddr := a.resolveProxyCheckAddress(proxyCfg)
 	chkTypes := []*structs.CheckType{}
 	if chkAddr != "" {
+		bindPort, ok := proxyCfg["bind_port"].(int)
+		if !ok {
+			return fmt.Errorf("Cannot connvert bind_port=%v to an int for creating TCP Check for address %s", proxyCfg["bind_port"], chkAddr)
+		}
 		chkTypes = []*structs.CheckType{
 			&structs.CheckType{
-				Name: "Connect Proxy Listening",
-				TCP: fmt.Sprintf("%s:%d", chkAddr,
-					proxyCfg["bind_port"]),
+				Name:     "Connect Proxy Listening",
+				TCP:      ipaddr.FormatAddressPort(chkAddr, bindPort),
 				Interval: 10 * time.Second,
 			},
 		}

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
 	"github.com/miekg/dns"
 )
@@ -264,7 +265,7 @@ func recursorAddr(recursor string) (string, error) {
 START:
 	_, _, err := net.SplitHostPort(recursor)
 	if ae, ok := err.(*net.AddrError); ok && ae.Err == "missing port in address" {
-		recursor = fmt.Sprintf("%s:%d", recursor, 53)
+		recursor = ipaddr.FormatAddressPort(recursor, 53)
 		goto START
 	}
 	if err != nil {

--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/consul/ipaddr"
+
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -171,7 +173,7 @@ func (a *Agent) sidecarServiceFromNodeService(ns *structs.NodeService, token str
 				Name: "Connect Sidecar Listening",
 				// Default to localhost rather than agent/service public IP. The checks
 				// can always be overridden if a non-loopback IP is needed.
-				TCP:      fmt.Sprintf("127.0.0.1:%d", sidecar.Port),
+				TCP:      ipaddr.FormatAddressPort(sidecar.Proxy.LocalServiceAddress, sidecar.Port),
 				Interval: 10 * time.Second,
 			},
 			&structs.CheckType{

--- a/connect/proxy/config.go
+++ b/connect/proxy/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
 	"github.com/hashicorp/consul/connect"
+	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/lib"
 )
 
@@ -242,7 +243,7 @@ func (w *AgentConfigWatcher) handler(blockVal watch.BlockingParamVal,
 	}
 	cfg.PublicListener.BindAddress = resp.Address
 	cfg.PublicListener.BindPort = resp.Port
-	cfg.PublicListener.LocalServiceAddress = fmt.Sprintf("%s:%d",
+	cfg.PublicListener.LocalServiceAddress = ipaddr.FormatAddressPort(
 		resp.Proxy.LocalServiceAddress, resp.Proxy.LocalServicePort)
 
 	cfg.PublicListener.applyDefaults()

--- a/connect/proxy/listener.go
+++ b/connect/proxy/listener.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"sync"
@@ -14,6 +13,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/connect"
+	"github.com/hashicorp/consul/ipaddr"
 )
 
 const (
@@ -58,7 +58,7 @@ type Listener struct {
 // connections and proxy them to the configured local application over TCP.
 func NewPublicListener(svc *connect.Service, cfg PublicListenerConfig,
 	logger *log.Logger) *Listener {
-	bindAddr := fmt.Sprintf("%s:%d", cfg.BindAddress, cfg.BindPort)
+	bindAddr := ipaddr.FormatAddressPort(cfg.BindAddress, cfg.BindPort)
 	return &Listener{
 		Service: svc,
 		listenFunc: func() (net.Listener, error) {
@@ -96,7 +96,7 @@ func NewUpstreamListener(svc *connect.Service, client *api.Client,
 func newUpstreamListenerWithResolver(svc *connect.Service, cfg UpstreamConfig,
 	resolverFunc func(UpstreamConfig) (connect.Resolver, error),
 	logger *log.Logger) *Listener {
-	bindAddr := fmt.Sprintf("%s:%d", cfg.LocalBindAddress, cfg.LocalBindPort)
+	bindAddr := ipaddr.FormatAddressPort(cfg.LocalBindAddress, cfg.LocalBindPort)
 	return &Listener{
 		Service: svc,
 		listenFunc: func() (net.Listener, error) {

--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -16,8 +16,8 @@ import (
 
 	agConnect "github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/connect"
-	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/ipaddr"
+	"github.com/hashicorp/consul/sdk/freeport"
 )
 
 func testSetupMetrics(t *testing.T) *metrics.InmemSink {

--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -17,6 +17,7 @@ import (
 	agConnect "github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/connect"
 	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/ipaddr"
 )
 
 func testSetupMetrics(t *testing.T) *metrics.InmemSink {
@@ -204,7 +205,7 @@ func TestUpstreamListener(t *testing.T) {
 	// Proxy and fake remote service are running, play the part of the app
 	// connecting to a remote connect service over TCP.
 	conn, err := net.Dial("tcp",
-		fmt.Sprintf("%s:%d", cfg.LocalBindAddress, cfg.LocalBindPort))
+		ipaddr.FormatAddressPort(cfg.LocalBindAddress, cfg.LocalBindPort))
 	require.NoError(t, err)
 
 	TestEchoConn(t, conn, "")

--- a/connect/resolver.go
+++ b/connect/resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/ipaddr"
 )
 
 // Resolver is the interface implemented by a service discovery mechanism to get
@@ -156,7 +157,7 @@ func (cr *ConsulResolver) resolveServiceEntry(entry *api.ServiceEntry) (string, 
 		Service:    service,
 	}
 
-	return fmt.Sprintf("%s:%d", addr, port), certURI, nil
+	return ipaddr.FormatAddressPort(addr, port), certURI, nil
 }
 
 func (cr *ConsulResolver) queryOptions(ctx context.Context) *api.QueryOptions {

--- a/ipaddr/ipaddr.go
+++ b/ipaddr/ipaddr.go
@@ -4,7 +4,22 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 )
+
+// AddressIsIpv6 detected whether the argument is an IPv6 Address
+func AddressIsIpv6(address string) bool {
+	ip := net.ParseIP(address)
+	return ip != nil && strings.Contains(address, ":")
+}
+
+// FormatAddressPort format a tuple address/port that works with IPv6
+func FormatAddressPort(address string, port int) string {
+	if AddressIsIpv6(address) {
+		return fmt.Sprintf("[%s]:%d", address, port)
+	}
+	return fmt.Sprintf("%s:%d", address, port)
+}
 
 // IsAny checks if the given ip address is an IPv4 or IPv6 ANY address. ip
 // can be either a *net.IP or a string. It panics on another type.

--- a/ipaddr/ipaddr.go
+++ b/ipaddr/ipaddr.go
@@ -4,21 +4,12 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
+	"strconv"
 )
 
-// AddressIsIpv6 detected whether the argument is an IPv6 Address
-func AddressIsIpv6(address string) bool {
-	ip := net.ParseIP(address)
-	return ip != nil && strings.Contains(address, ":")
-}
-
-// FormatAddressPort format a tuple address/port that works with IPv6
+// FormatAddressPort Helper for net.JoinHostPort that takes int for port
 func FormatAddressPort(address string, port int) string {
-	if AddressIsIpv6(address) {
-		return fmt.Sprintf("[%s]:%d", address, port)
-	}
-	return fmt.Sprintf("%s:%d", address, port)
+	return net.JoinHostPort(address, strconv.Itoa(port))
 }
 
 // IsAny checks if the given ip address is an IPv4 or IPv6 ANY address. ip

--- a/ipaddr/ipaddr_test.go
+++ b/ipaddr/ipaddr_test.go
@@ -1,0 +1,59 @@
+package ipaddr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsIPv6(t *testing.T) {
+	tests := []struct {
+		ip   string
+		ipv6 bool
+	}{
+		// IPv4 private addresses
+		{"10.0.0.1", false},    // private network address
+		{"100.64.0.1", false},  // shared address space
+		{"172.16.0.1", false},  // private network address
+		{"192.168.0.1", false}, // private network address
+		{"192.0.0.1", false},   // IANA address
+		{"192.0.2.1", false},   // documentation address
+		{"127.0.0.1", false},   // loopback address
+		{"169.254.0.1", false}, // link local address
+
+		// IPv4 public addresses
+		{"1.2.3.4", false},
+
+		// IPv6 private addresses
+		{"::1", true},         // loopback address
+		{"fe80::1", true},     // link local address
+		{"fc00::1", true},     // unique local address
+		{"fec0::1", true},     // site local address
+		{"2001:db8::1", true}, // documentation address
+
+		// IPv6 public addresses
+		{"2004:db6::1", true},
+
+		// hostname
+		{"example.com", false},
+		{"localhost.com", false},
+		{"1.257.0.1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			if got, want := AddressIsIpv6(tt.ip), tt.ipv6; got != want {
+				t.Fatalf("got %v for %v want %v", got, tt.ip, want)
+			}
+			port := 1234
+			formated := FormatAddressPort(tt.ip, port)
+			if tt.ipv6 {
+				if fmt.Sprintf("[%s]:%d", tt.ip, port) != formated {
+					t.Fatalf("Wrong format %s for %s", formated, tt.ip)
+				}
+			} else {
+				if fmt.Sprintf("%s:%d", tt.ip, port) != formated {
+					t.Fatalf("Wrong format %s for %s", formated, tt.ip)
+				}
+			}
+		})
+	}
+}

--- a/ipaddr/ipaddr_test.go
+++ b/ipaddr/ipaddr_test.go
@@ -35,14 +35,11 @@ func TestIsIPv6(t *testing.T) {
 
 		// hostname
 		{"example.com", false},
-		{"localhost.com", false},
+		{"localhost", false},
 		{"1.257.0.1", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.ip, func(t *testing.T) {
-			if got, want := AddressIsIpv6(tt.ip), tt.ipv6; got != want {
-				t.Fatalf("got %v for %v want %v", got, tt.ip, want)
-			}
 			port := 1234
 			formated := FormatAddressPort(tt.ip, port)
 			if tt.ipv6 {


### PR DESCRIPTION
Ensure that when we format address:port if the address is IPv6, we
format it using "[%s]:%d" instead of "%s:%d".

This should fix https://github.com/hashicorp/consul/issues/5460