### PR TITLE
[docs] Move Sentinel documentation

### DIFF
--- a/website/source/docs/agent/acl-rules.html.md
+++ b/website/source/docs/agent/acl-rules.html.md
@@ -279,7 +279,7 @@ EOF
 }
 ```
 
-For more detailed documentation, see the [Consul Sentinel Guide](/docs/guides/sentinel.html).
+For more detailed documentation, see the [Consul Sentinel Guide](/docs/agent/sentinel.html).
 
 #### Keyring Rules
 

--- a/website/source/docs/agent/acl-rules.html.md
+++ b/website/source/docs/agent/acl-rules.html.md
@@ -279,7 +279,7 @@ EOF
 }
 ```
 
-For more detailed documentation, see the [Consul Sentinel Guide](/docs/agent/sentinel.html).
+For more detailed information, see the [Consul Sentinel documentation](/docs/agent/sentinel.html).
 
 #### Keyring Rules
 

--- a/website/source/docs/agent/sentinel.html.markdown.erb
+++ b/website/source/docs/agent/sentinel.html.markdown.erb
@@ -20,19 +20,19 @@ description: |-
 
 Sentinel policies are applied during writes to the KV Store.
 
-ACL policy definitions take a `sentinel` field specifying the code and the enforcement level.
-
-
-The following policy ensures that the value written during a KV update must end with "dc1".
+An optional `sentinel` field specifying code and enforcement level can be added to [ACL policy definitions](/docs/agent/acl-rules.html#sentinel-integration) for Consul KV. The following policy ensures that the value written during a KV update must end with "dc1".
 
 ```text
+key "datacenter_name" {
+  policy = "write"
   sentinel {
       code = <<EOF
 import "strings"
-main = rule { strings.has_suffix(value,"dc1") }
-enforcementlevel = "soft-mandatory"
+main = rule { strings.has_suffix(value, "dc1") }
 EOF
+      enforcementlevel = "soft-mandatory"
   }
+}
 ```
 
 If the `enforcementlevel` property is not set, it defaults to "hard-mandatory".
@@ -59,7 +59,9 @@ Consul passes some context as variables into Sentinel, which are available to us
 
 The following are two examples of ACL policies with Sentinel rules.
 
-### Any values stored under the key prefix "dc1" must end with "dev"
+### Required Key Suffix 
+
+Any values stored under the key prefix "dc1" must end with "dev"
 
 ```text
 key "dc1" {
@@ -73,7 +75,9 @@ EOF
 }
 ```
 
-### The key "haproxy_version" can only be updated during business hours.
+### Restrited Update Time
+
+The key "haproxy_version" can only be updated during business hours.
 
 ```text
 key "haproxy_version" {

--- a/website/source/docs/agent/sentinel.html.markdown.erb
+++ b/website/source/docs/agent/sentinel.html.markdown.erb
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Sentinel in Consul"
-sidebar_current: "docs-guides-sentinel"
+sidebar_current: "docs-agent-sentinel"
 description: |-
   Consul Enterprise uses Sentinel to augment the built-in ACL system to provide advanced policy enforcement. Sentinel policies can currently execute on KV modify and service registration.
 ---
@@ -14,7 +14,7 @@ description: |-
 
  Consul 1.0 adds integration with [Sentinel](https://hashicorp.com/sentinel) for policy enforcement.
  Sentinel policies help extend the ACL system in Consul beyond the static "read", "write", and "deny"
- policies to support full conditional logic, and integration with external systems.
+ policies to support full conditional logic and integration with external systems.
 
 ## Sentinel in Consul
 
@@ -22,20 +22,18 @@ Sentinel policies are applied during writes to the KV Store.
 
 ACL policy definitions take a `sentinel` field specifying the code and the enforcement level.
 
-Here's an example:
 
+The following policy ensures that the value written during a KV update must end with "dc1".
 
 ```text
   sentinel {
       code = <<EOF
 import "strings"
-main = rule { strings.has_suffix(value,"foo") }
+main = rule { strings.has_suffix(value,"dc1") }
 enforcementlevel = "soft-mandatory"
 EOF
   }
 ```
-
-This policy ensures that the value written during a KV update must end with "foo".
 
 If the `enforcementlevel` property is not set, it defaults to "hard-mandatory".
 
@@ -57,27 +55,28 @@ Consul passes some context as variables into Sentinel, which are available to us
 | `flags`       | `uint64` | [Flags](/api/kv.html#flags) |
 
 
-## Examples
-The following are some examples of ACL policies with Sentinel rules.
+## Sentinel Examples
 
-### Any values stored under the key prefix "foo" must end with "bar"
+The following are two examples of ACL policies with Sentinel rules.
+
+### Any values stored under the key prefix "dc1" must end with "dev"
 
 ```text
-key "foo" {
+key "dc1" {
     policy = "write"
     sentinel {
         code = <<EOF
 import "strings"
-main = rule { strings.has_suffix(value, "bar") }
+main = rule { strings.has_suffix(value, "dev") }
 EOF
     }
 }
 ```
 
-### The key "foo" can only be updated during business hours.
+### The key "haproxy_version" can only be updated during business hours.
 
 ```text
-key "foo" {
+key "haproxy_version" {
     policy = "write"
     sentinel {
         code = <<EOF

--- a/website/source/docs/guides/index.html.md
+++ b/website/source/docs/guides/index.html.md
@@ -66,8 +66,6 @@ The following guides are available:
 
 * [Semaphore](/docs/guides/semaphore.html) - This guide covers using the KV store to implement a semaphore.
 
-* [Sentinel](/docs/guides/sentinel.html) - This guide covers using Sentinel for policy enforcement in Consul.
-
 * [Server Performance](/docs/guides/performance.html) - This guide covers minimum requirements for Consul servers as well as guidelines for running Consul servers in production.
 
 * [Windows Service](/docs/guides/windows-guide.html) - This guide covers how to run Consul as a service on Windows.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -300,6 +300,9 @@
           <li<%= sidebar_current("docs-agent-kv") %>>
             <a href="/docs/agent/kv.html">Consul KV</a>
           </li>
+          <li<%= sidebar_current("docs-agent-sentinel") %>>
+            <a href="/docs/agent/sentinel.html">Sentinel</a>
+          </li>
           <li<%= sidebar_current("docs-agent-encryption") %>>
             <a href="/docs/agent/encryption.html">Encryption</a>
           </li>
@@ -479,9 +482,6 @@
           </li>
           <li<%= sidebar_current("docs-guides-semaphore") %>>
             <a href="/docs/guides/semaphore.html">Semaphore</a>
-          </li>
-          <li<%= sidebar_current("docs-guides-sentinel") %>>
-            <a href="/docs/guides/sentinel.html">Sentinel</a>
           </li>
           <li<%= sidebar_current("docs-guides-performance") %>>
             <a href="/docs/guides/performance.html">Server Performance</a>


### PR DESCRIPTION
With the guide migration, the Sentinel guide was flagged to be moved into the documentation instead of Learn. In the future, we can work to create a new step-by-step guide that can be deployed on Learn. The current state of this documentation is brief, so feel free to add more context. 