### PR TITLE
UI: Adds blocking query support to the service detail page

### DIFF
--- a/ui-v2/app/computed/catchable.js
+++ b/ui-v2/app/computed/catchable.js
@@ -1,0 +1,11 @@
+import ComputedProperty from '@ember/object/computed';
+import computedFactory from 'consul-ui/utils/computed/factory';
+
+export default class Catchable extends ComputedProperty {
+  catch(cb) {
+    return this.meta({
+      catch: cb,
+    });
+  }
+}
+export const computed = computedFactory(Catchable);

--- a/ui-v2/app/instance-initializers/event-source.js
+++ b/ui-v2/app/instance-initializers/event-source.js
@@ -34,6 +34,12 @@ export function initialize(container) {
           repo: 'repository/service/event-source',
         },
       },
+      {
+        route: 'dc/services/show',
+        services: {
+          repo: 'repository/service/event-source',
+        },
+      },
     ])
     .forEach(function(definition) {
       if (typeof definition.extend !== 'undefined') {

--- a/ui-v2/app/mixins/with-event-source.js
+++ b/ui-v2/app/mixins/with-event-source.js
@@ -1,16 +1,45 @@
 import Mixin from '@ember/object/mixin';
+import { computed as catchable } from 'consul-ui/computed/catchable';
+import purify from 'consul-ui/utils/computed/purify';
 
-export default Mixin.create({
+import WithListeners from 'consul-ui/mixins/with-listeners';
+const PREFIX = '_';
+export default Mixin.create(WithListeners, {
+  setProperties: function(model) {
+    const _model = {};
+    Object.keys(model).forEach(key => {
+      // here (see comment below on deleting)
+      if (typeof this[key] !== 'undefined' && this[key].isDescriptor) {
+        _model[`${PREFIX}${key}`] = model[key];
+        const meta = this.constructor.metaForProperty(key) || {};
+        if (typeof meta.catch === 'function') {
+          if (typeof _model[`${PREFIX}${key}`].addEventListener === 'function') {
+            this.listen(_model[`_${key}`], 'error', meta.catch.bind(this));
+          }
+        }
+      } else {
+        _model[key] = model[key];
+      }
+    });
+    return this._super(_model);
+  },
   reset: function(exiting) {
     if (exiting) {
       Object.keys(this).forEach(prop => {
         if (this[prop] && typeof this[prop].close === 'function') {
           this[prop].close();
           // ember doesn't delete on 'resetController' by default
+          // right now we only call reset when we are exiting, therefore a full
+          // setProperties will be called the next time we enter the Route so this
+          // is ok for what we need and means that the above conditional works
+          // as expected (see 'here' comment above)
           delete this[prop];
         }
       });
     }
     return this._super(...arguments);
   },
+});
+export const listen = purify(catchable, function(props) {
+  return props.map(item => `${PREFIX}${item}`);
 });

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -30,6 +30,7 @@ export default Model.extend({
   Node: attr(),
   Service: attr(),
   Checks: attr(),
+  meta: attr(),
   passing: computed('ChecksPassing', 'Checks', function() {
     let num = 0;
     // TODO: use typeof

--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -15,14 +15,6 @@ export default Route.extend({
     const repo = get(this, 'repo');
     return hash({
       item: repo.findBySlug(params.name, this.modelFor('dc').dc.Name),
-    }).then(function(model) {
-      return {
-        ...model,
-        ...{
-          // Nodes happen to be the ServiceInstances here
-          items: model.item.Nodes,
-        },
-      };
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -8,6 +8,18 @@ export default RepositoryService.extend({
   findBySlug: function(slug, dc) {
     return this._super(...arguments).then(function(item) {
       const nodes = get(item, 'Nodes');
+      if (nodes.length === 0) {
+        // TODO: Add an store.error("404", "message") or similar
+        // or move all this to serializer
+        const e = new Error();
+        e.errors = [
+          {
+            status: '404',
+            title: 'Not found',
+          },
+        ];
+        throw e;
+      }
       const service = get(nodes, 'firstObject');
       const tags = nodes
         .reduce(function(prev, item) {
@@ -16,6 +28,7 @@ export default RepositoryService.extend({
         .uniq();
       set(service, 'Tags', tags);
       set(service, 'Nodes', nodes);
+      set(service, 'meta', get(item, 'meta'));
       return service;
     });
   },
@@ -36,6 +49,7 @@ export default RepositoryService.extend({
         return service;
       }
       // TODO: Add an store.error("404", "message") or similar
+      // or move all this to serializer
       const e = new Error();
       e.errors = [
         {

--- a/ui-v2/app/templates/dc/services/-notifications.hbs
+++ b/ui-v2/app/templates/dc/services/-notifications.hbs
@@ -1,0 +1,7 @@
+{{#if (eq type 'update')}}
+  {{#if (eq status 'warning') }}
+    This service has been deregistered and no longer exists in the catalog.
+  {{else}}
+  {{/if}}
+{{/if}}
+

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -1,7 +1,6 @@
 {{#app-view class="service list"}}
-    {{!TODO: Look at the item passed through to figure what partial to show, also move into its own service partial, for the moment keeping here for visibility}}
     {{#block-slot 'notification' as |status type|}}
-      {{partial 'dc/acls/notifications'}}
+      {{partial 'dc/services/notifications'}}
     {{/block-slot}}
     {{#block-slot 'header'}}
         <h1>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -1,4 +1,7 @@
 {{#app-view class="service show"}}
+    {{#block-slot 'notification' as |status type|}}
+      {{partial 'dc/services/notifications'}}
+    {{/block-slot}}
     {{#block-slot 'breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -27,7 +27,9 @@ module.exports = function(environment) {
       injectionFactories: ['view', 'controller', 'component'],
     },
   };
+  // TODO: These should probably go onto APP
   ENV = Object.assign({}, ENV, {
+    CONSUL_UI_DISABLE_REALTIME: false,
     CONSUL_GIT_SHA: (function() {
       if (process.env.CONSUL_GIT_SHA) {
         return process.env.CONSUL_GIT_SHA;

--- a/ui-v2/tests/acceptance/dc/list-blocking.feature
+++ b/ui-v2/tests/acceptance/dc/list-blocking.feature
@@ -11,8 +11,8 @@ Feature: dc / list-blocking
       blocking: 1
       throttle: 200
     ---
-  Scenario:
-    And 3 [Model] models
+  Scenario: Viewing the listing pages
+    Given 3 [Model] models
     And a network latency of 100
     When I visit the [Page] page for yaml
     ---
@@ -27,8 +27,31 @@ Feature: dc / list-blocking
     And an external edit results in 0 [Model] models
     And pause until I see 0 [Model] models
   Where:
-    --------------------------------------------
-    | Page       | Model       | Url           |
-    | services   | service     | services      |
-    | nodes      | node        | nodes         |
-    --------------------------------------------
+    ------------------------------------------------
+    | Page       | Model       | Url               |
+    | services   | service     | services          |
+    | nodes      | node        | nodes             |
+    ------------------------------------------------
+  Scenario: Viewing detail pages with a listing
+    Given 3 [Model] models
+    And a network latency of 100
+    When I visit the [Page] page for yaml
+    ---
+      dc: dc-1
+      service: service-0
+    ---
+    Then the url should be /dc-1/[Url]
+    And pause until I see 3 [Model] models
+    And an external edit results in 5 [Model] models
+    And pause until I see 5 [Model] models
+    And an external edit results in 1 [Model] model
+    And pause until I see 1 [Model] model
+    And an external edit results in 0 [Model] models
+    And pause for 300
+    And I see the text "deregistered" in "[data-notification]"
+  Where:
+    ------------------------------------------------
+    | Page       | Model       | Url               |
+    | service    | instance    | services/service-0 |
+    ------------------------------------------------
+

--- a/ui-v2/tests/helpers/set-cookies.js
+++ b/ui-v2/tests/helpers/set-cookies.js
@@ -9,6 +9,7 @@ export default function(type, count, obj) {
       key = 'CONSUL_SERVICE_COUNT';
       break;
     case 'node':
+    case 'instance':
       key = 'CONSUL_NODE_COUNT';
       break;
     case 'kv':

--- a/ui-v2/tests/helpers/type-to-url.js
+++ b/ui-v2/tests/helpers/type-to-url.js
@@ -5,6 +5,7 @@ export default function(type) {
       requests = ['/v1/catalog/datacenters'];
       break;
     case 'service':
+    case 'instance':
       requests = ['/v1/internal/ui/services', '/v1/health/service/'];
       break;
     case 'proxy':

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -68,6 +68,10 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
           const service = payload.Nodes[0];
           service.Nodes = nodes;
           service.Tags = payload.Nodes[0].Service.Tags;
+          service.meta = {
+            date: undefined,
+            cursor: undefined,
+          };
 
           return service;
         })

--- a/ui-v2/tests/unit/controllers/dc/services/show-test.js
+++ b/ui-v2/tests/unit/controllers/dc/services/show-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/services/show', 'Unit | Controller | dc/services/show', {
   // Specify the other units that are required for this test.
-  needs: ['service:search', 'service:dom'],
+  needs: ['service:search', 'service:dom', 'service:flashMessages'],
 });
 
 // Replace this with your real tests.


### PR DESCRIPTION
This PR adds blocking query support to the new Service Detail page (new in that it now lists Service Instances instead of Nodes, and lets you click into the Instances to visit a new third level/detail page)

Additionally here we always wanted to provide functionality to warn the user of the deregistration of a Service if you are on the Service Detail page at the time of deregistration. This PR includes functionality via blocking queries to detect Service deregistration and show a warning message to the user, but also keep the old data visible incase the user still needs the information on the Service.

A visual walkthrough of this can be seen in the GIF here https://github.com/hashicorp/consul/pull/5070#issuecomment-447826466 on deletion of the `cdn` Service (the page is now slightly different due to the Service Instance work)

It essentially looks like this if you are viewing a service as it is deregistered:

<img width="904" alt="Screenshot 2019-03-12 at 18 12 18" src="https://user-images.githubusercontent.com/554604/54220807-7d82a880-44f2-11e9-9df5-1aa0ce666efd.png">

# Notes:

## Meta Data

In https://github.com/hashicorp/consul/pull/4946 we used JSON-API's meta data for `X-Consul-Index`. It turns out that `ember-data` only supports JSON-API meta data usage on collections currently, not on single records/responses. There are various GH issues around that discuss this, so it seems to be a fairly common issue.

Instead of doing anything too complicated, we simply added a `meta` property to the Service `model`.

An interesting 'saviour' here is related to the fact that the Consul API uses capital case for all its properties. A lot of Consul entities/nouns/models already have a `Meta` property, so it seems like due to a piece of historical pragmatism/accident we were able to have both a `Meta` property, which is actual Consul meta data, and also a `meta` property which is more temporary JSON-API meta data (not used within templates).

Despite the fact that capital case feels a little strange in JS land, we've always liked having the capital case API data as its immediately apparent what's coming from the API and what isn't, which is especially useful whilst editing templates. But now, this fact is enabling us to add functionality without having to jump through too many hoops.

## Computed Properties  / `listen` / `setProperties`

In order to achieve a lot of what we are doing here 'transparently' (so without having to delve too much in amending templates). We've used a lot of work from https://github.com/hashicorp/consul/pull/5079 to prevent us from having to change the names of view properties/data. So for example, we continue to use `item`/`items` for names whilst taking advantage of the extra error listening functionality provided by `EventSource`s. We continue to use `setProperties` here also and there is some information on the ins and outs of that here https://github.com/hashicorp/consul/pull/4789#discussion_r229550709, and I'm still hoping to move away from using `setProperties` in the future and replace it with our own custom 'I'm ready to render now' method. Oh lastly here, thanks @meirish for helping me to figure out the correct usage of `metaForProperty` here.

## Misc

- We added a 'placeholder' compile time configuration property here (`CONSUL_UI_DISABLE_REALTIME`) to globally disable blocking queries, this probably should have gone in a past PR.
- I'm really getting to the point now where it would be better to have some of this re-shaping in the serializer where it would then make sense to use the `ember-data` specific errors rather than a default javascript error (reasons here: we currently try to keep any ember-data imports out of the repositories and only use the provided `ember-data` APIs). This currently works fine but I guess it would be best for it to throw an `ember-data` error.
- We'll probably change `consul-api-double` at some point to talk about 'instances' rather than 'nodes' its not really _required_ at the moment though so we've done whats needed here instead ('instances' equals `CONSUL_NODE_COUNT`)
- I'm still quibbling with myself on the use of `.catch` as a name for for the error catching method. At some point there will be a usecase to have other events like `add`, `delete` etc to provide finer grained functionality for specific types or property changes rather than just 'change' - the word `catch` probably wouldn't work as well here. Its fine for the moment so I left as is.

Lastly, there'll be very similar yet smaller PRs coming soon for the Nodes detail page and the Service Instance Detail page, which will take the exact same approach here, but I left these out of the PR so its easier to digest.

Another implementation of this for the service instance detail page is in a PR here: https://github.com/hashicorp/consul/pull/5487
