### PR TITLE
Connect: Fix Envoy getting stuck during load

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -9,7 +9,7 @@ import (
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	envoycluster "github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -130,7 +130,7 @@ func makeUpstreamCluster(upstream structs.Upstream, cfgSnap *proxycfg.ConfigSnap
 				},
 			},
 			// Having an empty config enables outlier detection with default config.
-			OutlierDetection: &cluster.OutlierDetection{},
+			OutlierDetection: &envoycluster.OutlierDetection{},
 		}
 	}
 

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -88,6 +88,25 @@ func makeAppCluster(cfgSnap *proxycfg.ConfigSnapshot) (*envoy.Cluster, error) {
 	return c, err
 }
 
+func parseTimeMillis(ms interface{}) (time.Duration, error) {
+	switch v := ms.(type) {
+	case string:
+		ms, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(ms) * time.Millisecond, nil
+
+	case float64: // This is what parsing from JSON results in
+		return time.Duration(v) * time.Millisecond, nil
+	// Not sure if this can ever really happen but just in case it does in
+	// some test code...
+	case int:
+		return time.Duration(v) * time.Millisecond, nil
+	}
+	return 0, errors.New("invalid type for millisecond duration")
+}
+
 func makeUpstreamCluster(upstream structs.Upstream, cfgSnap *proxycfg.ConfigSnapshot) (*envoy.Cluster, error) {
 	var c *envoy.Cluster
 	var err error
@@ -105,17 +124,8 @@ func makeUpstreamCluster(upstream structs.Upstream, cfgSnap *proxycfg.ConfigSnap
 	if c == nil {
 		conTimeout := 5 * time.Second
 		if toRaw, ok := upstream.Config["connect_timeout_ms"]; ok {
-			switch v := toRaw.(type) {
-			case string:
-				if ms, err := strconv.Atoi(v); err == nil {
-					conTimeout = time.Duration(ms) * time.Millisecond
-				}
-			case float64: // This is what parsing from JSON results in
-				conTimeout = time.Duration(v) * time.Millisecond
-			// Not sure if this can ever really happen but just in case it does in
-			// some test code...
-			case int:
-				conTimeout = time.Duration(v) * time.Millisecond
+			if ms, err := parseTimeMillis(toRaw); err == nil {
+				conTimeout = ms
 			}
 		}
 		c = &envoy.Cluster{

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -1,0 +1,76 @@
+package xds
+
+import (
+	"testing"
+	"time"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoyauth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/cluster"
+	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func Test_makeUpstreamCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		snap     proxycfg.ConfigSnapshot
+		upstream structs.Upstream
+		want     *envoy.Cluster
+	}{
+		{
+			name:     "timeout override",
+			snap:     proxycfg.ConfigSnapshot{},
+			upstream: structs.TestUpstreams(t)[0],
+			want: &envoy.Cluster{
+				Name: "service:db",
+				Type: envoy.Cluster_EDS,
+				EdsClusterConfig: &envoy.Cluster_EdsClusterConfig{
+					EdsConfig: &envoycore.ConfigSource{
+						ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
+							Ads: &envoycore.AggregatedConfigSource{},
+						},
+					},
+				},
+				ConnectTimeout:   1 * time.Second, // TestUpstreams overrides to 1000ms
+				OutlierDetection: &cluster.OutlierDetection{},
+				TlsContext: &envoyauth.UpstreamTlsContext{
+					CommonTlsContext: makeCommonTLSContext(&proxycfg.ConfigSnapshot{}),
+				},
+			},
+		},
+		{
+			name:     "timeout default",
+			snap:     proxycfg.ConfigSnapshot{},
+			upstream: structs.TestUpstreams(t)[1],
+			want: &envoy.Cluster{
+				Name: "prepared_query:geo-cache",
+				Type: envoy.Cluster_EDS,
+				EdsClusterConfig: &envoy.Cluster_EdsClusterConfig{
+					EdsConfig: &envoycore.ConfigSource{
+						ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
+							Ads: &envoycore.AggregatedConfigSource{},
+						},
+					},
+				},
+				ConnectTimeout:   5 * time.Second, // Default
+				OutlierDetection: &cluster.OutlierDetection{},
+				TlsContext: &envoyauth.UpstreamTlsContext{
+					CommonTlsContext: makeCommonTLSContext(&proxycfg.ConfigSnapshot{}),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			got, err := makeUpstreamCluster(tt.upstream, &tt.snap)
+			require.NoError(err)
+
+			require.Equal(tt.want, got)
+		})
+	}
+}

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/gogo/protobuf/proto"
 
@@ -42,7 +42,7 @@ func makeLoadAssignment(clusterName string, endpoints structs.CheckServiceNodes)
 		if addr == "" {
 			addr = ep.Node.Address
 		}
-		healthStatus := core.HealthStatus_HEALTHY
+		healthStatus := envoycore.HealthStatus_HEALTHY
 		weight := 1
 		if ep.Service.Weights != nil {
 			weight = ep.Service.Weights.Passing
@@ -52,7 +52,7 @@ func makeLoadAssignment(clusterName string, endpoints structs.CheckServiceNodes)
 			if chk.Status == api.HealthCritical {
 				// This can't actually happen now because health always filters critical
 				// but in the future it may not so set this correctly!
-				healthStatus = core.HealthStatus_UNHEALTHY
+				healthStatus = envoycore.HealthStatus_UNHEALTHY
 			}
 			if chk.Status == api.HealthWarning && ep.Service.Weights != nil {
 				weight = ep.Service.Weights.Warning
@@ -62,7 +62,7 @@ func makeLoadAssignment(clusterName string, endpoints structs.CheckServiceNodes)
 		// (likely) or Passing (weirdly) weight has been set to 0 effectively making
 		// this instance unhealthy and should not be sent traffic.
 		if weight < 1 {
-			healthStatus = core.HealthStatus_UNHEALTHY
+			healthStatus = envoycore.HealthStatus_UNHEALTHY
 			weight = 1
 		}
 		if weight > 128 {

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -1,0 +1,193 @@
+package xds
+
+import (
+	"testing"
+
+	"github.com/mitchellh/copystructure"
+
+	"github.com/stretchr/testify/require"
+
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func Test_makeLoadAssignment(t *testing.T) {
+
+	testCheckServiceNodes := structs.CheckServiceNodes{
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "node1-id",
+				Node:       "node1",
+				Address:    "10.10.10.10",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Service: "web",
+				Port:    1234,
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:    "node1",
+					CheckID: "serfHealth",
+					Status:  "passing",
+				},
+				&structs.HealthCheck{
+					Node:      "node1",
+					ServiceID: "web",
+					CheckID:   "web:check",
+					Status:    "passing",
+				},
+			},
+		},
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "node2-id",
+				Node:       "node2",
+				Address:    "10.10.10.20",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Service: "web",
+				Port:    1234,
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:    "node2",
+					CheckID: "serfHealth",
+					Status:  "passing",
+				},
+				&structs.HealthCheck{
+					Node:      "node2",
+					ServiceID: "web",
+					CheckID:   "web:check",
+					Status:    "passing",
+				},
+			},
+		},
+	}
+
+	testWeightedCheckServiceNodesRaw, err := copystructure.Copy(testCheckServiceNodes)
+	require.NoError(t, err)
+	testWeightedCheckServiceNodes := testWeightedCheckServiceNodesRaw.(structs.CheckServiceNodes)
+
+	testWeightedCheckServiceNodes[0].Service.Weights = &structs.Weights{
+		Passing: 10,
+		Warning: 1,
+	}
+	testWeightedCheckServiceNodes[1].Service.Weights = &structs.Weights{
+		Passing: 5,
+		Warning: 0,
+	}
+
+	testWarningCheckServiceNodesRaw, err := copystructure.Copy(testWeightedCheckServiceNodes)
+	require.NoError(t, err)
+	testWarningCheckServiceNodes := testWarningCheckServiceNodesRaw.(structs.CheckServiceNodes)
+
+	testWarningCheckServiceNodes[0].Checks[0].Status = "warning"
+	testWarningCheckServiceNodes[1].Checks[0].Status = "warning"
+
+	tests := []struct {
+		name        string
+		clusterName string
+		endpoints   structs.CheckServiceNodes
+		want        *envoy.ClusterLoadAssignment
+	}{
+		{
+			name:        "no instances",
+			clusterName: "service:test",
+			endpoints:   structs.CheckServiceNodes{},
+			want: &envoy.ClusterLoadAssignment{
+				ClusterName: "service:test",
+				Endpoints: []envoyendpoint.LocalityLbEndpoints{{
+					LbEndpoints: []envoyendpoint.LbEndpoint{},
+				}},
+			},
+		},
+		{
+			name:        "instances, no weights",
+			clusterName: "service:test",
+			endpoints:   testCheckServiceNodes,
+			want: &envoy.ClusterLoadAssignment{
+				ClusterName: "service:test",
+				Endpoints: []envoyendpoint.LocalityLbEndpoints{{
+					LbEndpoints: []envoyendpoint.LbEndpoint{
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.10", 1234),
+							},
+							HealthStatus:        core.HealthStatus_HEALTHY,
+							LoadBalancingWeight: makeUint32Value(1),
+						},
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.20", 1234),
+							},
+							HealthStatus:        core.HealthStatus_HEALTHY,
+							LoadBalancingWeight: makeUint32Value(1),
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:        "instances, healthy weights",
+			clusterName: "service:test",
+			endpoints:   testWeightedCheckServiceNodes,
+			want: &envoy.ClusterLoadAssignment{
+				ClusterName: "service:test",
+				Endpoints: []envoyendpoint.LocalityLbEndpoints{{
+					LbEndpoints: []envoyendpoint.LbEndpoint{
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.10", 1234),
+							},
+							HealthStatus:        core.HealthStatus_HEALTHY,
+							LoadBalancingWeight: makeUint32Value(10),
+						},
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.20", 1234),
+							},
+							HealthStatus:        core.HealthStatus_HEALTHY,
+							LoadBalancingWeight: makeUint32Value(5),
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:        "instances, warning weights",
+			clusterName: "service:test",
+			endpoints:   testWarningCheckServiceNodes,
+			want: &envoy.ClusterLoadAssignment{
+				ClusterName: "service:test",
+				Endpoints: []envoyendpoint.LocalityLbEndpoints{{
+					LbEndpoints: []envoyendpoint.LbEndpoint{
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.10", 1234),
+							},
+							HealthStatus:        core.HealthStatus_HEALTHY,
+							LoadBalancingWeight: makeUint32Value(1),
+						},
+						envoyendpoint.LbEndpoint{
+							Endpoint: &envoyendpoint.Endpoint{
+								Address: makeAddressPtr("10.10.10.20", 1234),
+							},
+							HealthStatus:        core.HealthStatus_UNHEALTHY,
+							LoadBalancingWeight: makeUint32Value(1),
+						},
+					},
+				}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := makeLoadAssignment(tt.clusterName, tt.endpoints)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -252,6 +252,9 @@ func makeCommonTLSContext(cfgSnap *proxycfg.ConfigSnapshot) *envoyauth.CommonTls
 	// Concatenate all the root PEMs into one.
 	// TODO(banks): verify this actually works with Envoy (docs are not clear).
 	rootPEMS := ""
+	if cfgSnap.Roots == nil {
+		return nil
+	}
 	for _, root := range cfgSnap.Roots.Roots {
 		rootPEMS += root.RootCert
 	}

--- a/agent/xds/response.go
+++ b/agent/xds/response.go
@@ -5,6 +5,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	prototypes "github.com/gogo/protobuf/types"
 )
 
 func createResponse(typeURL string, version, nonce string, resources []proto.Message) (*envoy.DiscoveryResponse, error) {
@@ -51,4 +52,8 @@ func makeAddress(ip string, port int) envoycore.Address {
 func makeAddressPtr(ip string, port int) *envoycore.Address {
 	a := makeAddress(ip, port)
 	return &a
+}
+
+func makeUint32Value(n int) *prototypes.UInt32Value {
+	return &prototypes.UInt32Value{Value: uint32(n)}
 }

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -346,7 +346,12 @@ func (t *xDSType) SendIfNew(cfgSnap *proxycfg.ConfigSnapshot, version uint64, no
 	if err != nil {
 		return err
 	}
-	if resources == nil || len(resources) == 0 {
+	// Note that zero length resource results are valid - e.g. a cluster with no
+	// endpoints as they've not come up yet. Envoy will ignore zero-value
+	// resources mostly, but we need to return _something_ otherwise Envoy hangs
+	// during startup if any of the upstream clusters has no endpoints and never
+	// starts accepting any traffic at all.
+	if resources == nil {
 		// Nothing to send yet
 		return nil
 	}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -346,12 +346,13 @@ func (t *xDSType) SendIfNew(cfgSnap *proxycfg.ConfigSnapshot, version uint64, no
 	if err != nil {
 		return err
 	}
-	// Note that zero length resource results are valid - e.g. a cluster with no
-	// endpoints as they've not come up yet. Envoy will ignore zero-value
-	// resources mostly, but we need to return _something_ otherwise Envoy hangs
-	// during startup if any of the upstream clusters has no endpoints and never
-	// starts accepting any traffic at all.
-	if resources == nil {
+	// Zero length resource responses should be ignored and are the result of no
+	// data yet. Notice that this caused a bug originally where we had zero
+	// healthy endpoints for an upstream that would cause Envoy to hang waiting
+	// for the EDS response. This is fixed though by ensuring we send an explicit
+	// empty LoadAssignment resource for the cluster rather than allowing junky
+	// empty resources.
+	if len(resources) == 0 {
 		// Nothing to send yet
 		return nil
 	}

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -389,7 +389,10 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 						}
 					}
 				},
-				"connectTimeout": "5s",
+				"outlierDetection": {
+
+				},
+				"connectTimeout": "1s",
 				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap) + `
 			}`,
 		"prepared_query:geo-cache": `
@@ -403,6 +406,9 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 
 						}
 					}
+				},
+				"outlierDetection": {
+
 				},
 				"connectTimeout": "5s",
 				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap) + `
@@ -461,7 +467,9 @@ func expectEndpointsJSON(t *testing.T, snap *proxycfg.ConfigSnapshot, token stri
 											"portValue": 0
 										}
 									}
-								}
+								},
+								"healthStatus": "HEALTHY",
+								"loadBalancingWeight": 1
 							},
 							{
 								"endpoint": {
@@ -471,7 +479,9 @@ func expectEndpointsJSON(t *testing.T, snap *proxycfg.ConfigSnapshot, token stri
 											"portValue": 0
 										}
 									}
-								}
+								},
+								"healthStatus": "HEALTHY",
+								"loadBalancingWeight": 1
 							}
 						]
 					}


### PR DESCRIPTION
This _may_ fix or improve the situation reported in #5332 which is a combination of things. It fixes a known issue that has come up in a few other places e.g. #4868 where an Envoy will hang on startup if one of its upstreams has no healthy instances.

The fix is to allow returning empty responses in xDS since otherwise Envoy blocks waiting for endpoints before it continues to load listeners.

This can also happen if there _were_ healthy upstream endpoints but they all got deregistered or turned unhealthy. In this case we now _will_ send the empty set, however Envoy's behaviour if it is updates with zero healthy instances for a cluster is to retain the ones it had before. This makes sense as it can't be worse than having nothing to connect to, but is confusing since in Envoy's metrics they remain marked as healthy which makes it look like Envoy isn't respecting Consul's health checks.

To help fix that, I've enabled default outlier detection on all upstreams too. This means that eventually after 5 failed attempts to connect, Envoy will internally mark the stale upstreams as "unhealthy". This is a partial solution since it will by default only allow outlier detection to mark the lower of 1 or 10% of the upstreams healthy before it ignores that again so in some cases it will still look like Consul has healthy upstreams even when none exist.

Changing Consul to return unhealthy instances with `HealthStatus: UNHEALTHY` is an option but it's not trivial since Consul has no single API that can do that currently for catalog/health and can't do that currently at all for Prepared Queries. We may work on that in the future.

Also in this PR:
 - Enabled outlier detection on upstreams which will mark instances unhealthy after 5 failures (using Envoy's defaults)
 - Enable weighted load balancing where DNS weights are configured
    - This was an easy win while I was touching this code. I did it originally because I tried to implement marking unhealthy explicitly as mentioned above before I realised we can't populate that from existing API currently.