### PR TITLE
docs: update 'sc' usage in windows-guide.html.md

### DIFF
--- a/website/source/docs/guides/windows-guide.html.md
+++ b/website/source/docs/guides/windows-guide.html.md
@@ -30,7 +30,7 @@ Download the Consul binary for your architecture.
   Use the _sc_ command to create a Service named **Consul**, which starts in the _dev_ mode.
 
    ```text
-   sc.exe create "Consul" binPath="Path to the Consul.exe arg1 arg2 ...argN"
+   sc.exe create "Consul" binPath= "Path to the Consul.exe arg1 arg2 ...argN" start= auto
    [SC] CreateService SUCCESS 
    ```
    
@@ -68,4 +68,4 @@ You have two ways to start the service.
      ```
 
 The service automatically starts up during/after boot, so you don't need to
-launch Consul from the command-line again. 
+launch Consul from the command-line again.


### PR DESCRIPTION
- the space after `=` is significant in `sc` parameters (`binPath= "<path> <args>"`, `start= auto`)
- given the text "the service automatically starts up during/after boot", added `start= auto` to
  the example,  otherwise the service will be set to Manual start mode.