### PR TITLE
[Docs] Launching K8s getting started path on Learn

### DIFF
--- a/website/source/docs/guides/index.html.md
+++ b/website/source/docs/guides/index.html.md
@@ -50,7 +50,7 @@ The following guides are available:
 
 * [Geo Failover](/docs/guides/geo-failover.html) - This guide covers using [prepared queries](/api/query.html) to implement geo failover for services.
 
-* [Minikube with Consul](https://learn.hashicorp.com/consul/getting-started-k8s/minikube) - In this guide, you'll start a local Kubernetes cluster with minikube, install Consul,and then deploy two custom services.
+* [Minikube with Consul](https://learn.hashicorp.com/consul/getting-started-k8s/minikube/) - In this guide, you'll start a local Kubernetes cluster with minikube, install Consul,and then deploy two custom services.
 
 * [Leader Election](/docs/guides/leader-election.html) - The goal of this guide is to cover how to build client-side leader election using Consul.
 

--- a/website/source/docs/guides/index.html.md
+++ b/website/source/docs/guides/index.html.md
@@ -50,7 +50,7 @@ The following guides are available:
 
 * [Geo Failover](/docs/guides/geo-failover.html) - This guide covers using [prepared queries](/api/query.html) to implement geo failover for services.
 
-* [Minikube with Consul](/docs/guides/minikube.html) - In this guide, you'll start a local Kubernetes cluster with minikube, install Consul,and then deploy two custom services.
+* [Minikube with Consul](https://learn.hashicorp.com/consul/getting-started-k8s/minikube) - In this guide, you'll start a local Kubernetes cluster with minikube, install Consul,and then deploy two custom services.
 
 * [Leader Election](/docs/guides/leader-election.html) - The goal of this guide is to cover how to build client-side leader election using Consul.
 

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -466,7 +466,7 @@
             <a href="/docs/guides/leader-election.html">Leader Election</a>
           </li>
           <li<%= sidebar_current("docs-guides-minikube") %>>
-            <a href="https://learn.hashicorp.com/consul/getting-started-k8s/minikube">Minikube with Consul</a>
+            <a href="https://learn.hashicorp.com/consul/getting-started-k8s/minikube/">Minikube with Consul</a>
           </li>
           <li<%= sidebar_current("docs-guides-monitoring-telegraf") %>>
             <a href="/docs/guides/monitoring-telegraf.html">Monitoring Consul with Telegraf</a>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -466,7 +466,7 @@
             <a href="/docs/guides/leader-election.html">Leader Election</a>
           </li>
           <li<%= sidebar_current("docs-guides-minikube") %>>
-            <a href="/docs/guides/minikube.html">Minikube with Consul</a>
+            <a href="https://learn.hashicorp.com/consul/getting-started-k8s/minikube">Minikube with Consul</a>
           </li>
           <li<%= sidebar_current("docs-guides-monitoring-telegraf") %>>
             <a href="/docs/guides/monitoring-telegraf.html">Monitoring Consul with Telegraf</a>


### PR DESCRIPTION
The minikube guide will be moved to Learn.

@alvin-huang Can you create the redirect for https://www.consul.io/docs/guides/minikube.html to https://learn.hashicorp.com/consul/getting-started-k8s/minikube 