### PR TITLE
Fix: fail messages after a node rename replace the new node definition

### DIFF
--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1350,7 +1350,13 @@ func (s *Server) handleFailedMember(member serf.Member) error {
 	if err != nil {
 		return err
 	}
-	if node != nil && node.Address == member.Addr.String() {
+
+	if node == nil {
+		s.logger.Printf("[INFO] consul: ignoring failed event for member '%s' because it does not exist in the catalog", member.Name)
+		return nil
+	}
+
+	if node.Address == member.Addr.String() {
 		// Check if the serfCheck is in the critical state
 		_, checks, err := state.NodeChecks(nil, member.Name)
 		if err != nil {


### PR DESCRIPTION
When receiving a serf faild message for a node which is not in the
catalog, do not perform a register request to set is serf heath to
critical as it could overwrite the node information and services if it
was renamed.

Fixes : #5518