### PR TITLE
UI: ACL Roles

### DIFF
--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -1,0 +1,70 @@
+import Adapter, {
+  REQUEST_CREATE,
+  REQUEST_UPDATE,
+  DATACENTER_QUERY_PARAM as API_DATACENTER_KEY,
+} from './application';
+
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/role';
+import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
+import { OK as HTTP_OK } from 'consul-ui/utils/http/status';
+import { PUT as HTTP_PUT } from 'consul-ui/utils/http/method';
+
+export default Adapter.extend({
+  urlForQuery: function(query, modelName) {
+    return this.appendURL('acl/roles', [], this.cleanQuery(query));
+  },
+  urlForQueryRecord: function(query, modelName) {
+    if (typeof query.id === 'undefined') {
+      throw new Error('You must specify an id');
+    }
+    return this.appendURL('acl/role', [query.id], this.cleanQuery(query));
+  },
+  urlForCreateRecord: function(modelName, snapshot) {
+    return this.appendURL('acl/role', [], {
+      [API_DATACENTER_KEY]: snapshot.attr(DATACENTER_KEY),
+    });
+  },
+  urlForUpdateRecord: function(id, modelName, snapshot) {
+    return this.appendURL('acl/role', [snapshot.attr(SLUG_KEY)], {
+      [API_DATACENTER_KEY]: snapshot.attr(DATACENTER_KEY),
+    });
+  },
+  urlForDeleteRecord: function(id, modelName, snapshot) {
+    return this.appendURL('acl/role', [snapshot.attr(SLUG_KEY)], {
+      [API_DATACENTER_KEY]: snapshot.attr(DATACENTER_KEY),
+    });
+  },
+  dataForRequest: function(params) {
+    const data = this._super(...arguments);
+    switch (params.requestType) {
+      case REQUEST_UPDATE:
+      case REQUEST_CREATE:
+        return data.role;
+    }
+    return data;
+  },
+  handleResponse: function(status, headers, payload, requestData) {
+    let response = payload;
+    if (status === HTTP_OK) {
+      const url = this.parseURL(requestData.url);
+      switch (true) {
+        case response === true:
+          response = this.handleBooleanResponse(url, response, PRIMARY_KEY, SLUG_KEY);
+          break;
+        case Array.isArray(response):
+          response = this.handleBatchResponse(url, response, PRIMARY_KEY, SLUG_KEY);
+          break;
+        default:
+          response = this.handleSingleResponse(url, response, PRIMARY_KEY, SLUG_KEY);
+      }
+    }
+    return this._super(status, headers, response, requestData);
+  },
+  methodForRequest: function(params) {
+    switch (params.requestType) {
+      case REQUEST_CREATE:
+        return HTTP_PUT;
+    }
+    return this._super(...arguments);
+  },
+});

--- a/ui-v2/app/components/modal-dialog.js
+++ b/ui-v2/app/components/modal-dialog.js
@@ -14,6 +14,9 @@ export default DomBufferComponent.extend(SlotsMixin, WithResizing, {
   overflowingClass: 'overflowing',
   onclose: function() {},
   onopen: function() {},
+  getBufferName: function() {
+    return this.name;
+  },
   _open: function(e) {
     set(this, 'checked', true);
     if (get(this, 'height') === null) {
@@ -38,9 +41,11 @@ export default DomBufferComponent.extend(SlotsMixin, WithResizing, {
   _close: function(e) {
     set(this, 'checked', false);
     const dialogPanel = get(this, 'dialog');
-    const overflowing = get(this, 'overflowingClass');
-    if (dialogPanel.classList.contains(overflowing)) {
-      dialogPanel.classList.remove(overflowing);
+    if (dialogPanel) {
+      const overflowing = get(this, 'overflowingClass');
+      if (dialogPanel.classList.contains(overflowing)) {
+        dialogPanel.classList.remove(overflowing);
+      }
     }
     // TODO: should we make a didDisappear?
     get(this, 'dom')

--- a/ui-v2/app/controllers/dc/acls/roles/create.js
+++ b/ui-v2/app/controllers/dc/acls/roles/create.js
@@ -1,0 +1,2 @@
+import Controller from './edit';
+export default Controller.extend();

--- a/ui-v2/app/controllers/dc/acls/roles/edit.js
+++ b/ui-v2/app/controllers/dc/acls/roles/edit.js
@@ -1,0 +1,67 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+export default Controller.extend({
+  builder: service('form'),
+  dom: service('dom'),
+  init: function() {
+    this._super(...arguments);
+    this.form = get(this, 'builder').form('role');
+  },
+  setProperties: function(model) {
+    // essentially this replaces the data with changesets
+    this._super(
+      Object.keys(model).reduce((prev, key, i) => {
+        switch (key) {
+          case 'item':
+            prev[key] = this.form.setData(prev[key]).getData();
+            break;
+        }
+        return prev;
+      }, model)
+    );
+  },
+  actions: {
+    sendClearPolicy: function(item) {
+      this.send('clearPolicy');
+    },
+    sendCreatePolicy: function(item, policies, success) {
+      this.send('createPolicy', item, policies, success);
+    },
+    refreshCodeEditor: function(selector, parent) {
+      if (parent.target) {
+        parent = undefined;
+      }
+      get(this, 'dom')
+        .component(selector, parent)
+        .didAppear();
+    },
+    change: function(e, value, item) {
+      const event = get(this, 'dom').normalizeEvent(e, value);
+      const form = get(this, 'form');
+      try {
+        form.handleEvent(event);
+      } catch (err) {
+        const target = event.target;
+        switch (target.name) {
+          case 'Policy':
+            set(value, 'CreateTime', new Date().getTime());
+            get(this, 'item.Policies').pushObject(value);
+            break;
+          case 'Details':
+            // the Details expander toggle
+            // only load on opening
+            if (target.checked) {
+              this.send('refreshCodeEditor', '.code-editor', target.parentNode);
+              if (!get(value, 'Rules')) {
+                this.send('loadPolicy', value, get(this, 'item.Policies'));
+              }
+            }
+            break;
+          default:
+            throw err;
+        }
+      }
+    },
+  },
+});

--- a/ui-v2/app/controllers/dc/acls/roles/edit.js
+++ b/ui-v2/app/controllers/dc/acls/roles/edit.js
@@ -48,7 +48,7 @@ export default Controller.extend({
             set(value, 'CreateTime', new Date().getTime());
             get(this, 'item.Policies').pushObject(value);
             break;
-          case 'Details':
+          case 'PolicyDetails':
             // the Details expander toggle
             // only load on opening
             if (target.checked) {

--- a/ui-v2/app/controllers/dc/acls/roles/index.js
+++ b/ui-v2/app/controllers/dc/acls/roles/index.js
@@ -1,0 +1,23 @@
+import Controller from '@ember/controller';
+import { get, computed } from '@ember/object';
+import WithSearching from 'consul-ui/mixins/with-searching';
+export default Controller.extend(WithSearching, {
+  queryParams: {
+    s: {
+      as: 'filter',
+      replace: true,
+    },
+  },
+  init: function() {
+    this.searchParams = {
+      role: 's',
+    };
+    this._super(...arguments);
+  },
+  searchable: computed('items', function() {
+    return get(this, 'searchables.role')
+      .add(get(this, 'items'))
+      .search(get(this, this.searchParams.role));
+  }),
+  actions: {},
+});

--- a/ui-v2/app/controllers/dc/acls/tokens/edit.js
+++ b/ui-v2/app/controllers/dc/acls/tokens/edit.js
@@ -33,8 +33,15 @@ export default Controller.extend({
       set(this, 'isScoped', false);
       this.send('clearPolicy');
     },
-    sendCreatePolicy: function(item, policies, success) {
-      this.send('createPolicy', item, policies, success);
+    sendCreatePolicy: function(item, items, success) {
+      this.send('createPolicy', item, items, success);
+    },
+    sendClearRole: function(item) {
+      set(this, 'isScoped', false);
+      this.send('clearRole');
+    },
+    sendCreateRole: function(item, items, success) {
+      this.send('createRole', item, items, success);
     },
     refreshCodeEditor: function(selector, parent) {
       if (parent.target) {
@@ -59,6 +66,10 @@ export default Controller.extend({
           case 'Policy':
             set(value, 'CreateTime', new Date().getTime());
             get(this, 'item.Policies').pushObject(value);
+            break;
+          case 'Role':
+            set(value, 'CreateTime', new Date().getTime());
+            get(this, 'item.Roles').pushObject(value);
             break;
           case 'Details':
             // the Details expander toggle

--- a/ui-v2/app/controllers/dc/acls/tokens/edit.js
+++ b/ui-v2/app/controllers/dc/acls/tokens/edit.js
@@ -71,7 +71,7 @@ export default Controller.extend({
             set(value, 'CreateTime', new Date().getTime());
             get(this, 'item.Roles').pushObject(value);
             break;
-          case 'Details':
+          case 'PolicyDetails':
             // the Details expander toggle
             // only load on opening
             if (target.checked) {

--- a/ui-v2/app/forms/role.js
+++ b/ui-v2/app/forms/role.js
@@ -1,0 +1,9 @@
+import validations from 'consul-ui/validations/role';
+import policy from 'consul-ui/forms/policy';
+import builderFactory from 'consul-ui/utils/form/builder';
+const builder = builderFactory();
+export default function(name = 'role', v = validations, form = builder) {
+  return form(name, {})
+    .setValidators(v)
+    .add(policy());
+}

--- a/ui-v2/app/initializers/form.js
+++ b/ui-v2/app/initializers/form.js
@@ -2,6 +2,7 @@ import kv from 'consul-ui/forms/kv';
 import acl from 'consul-ui/forms/acl';
 import token from 'consul-ui/forms/token';
 import policy from 'consul-ui/forms/policy';
+import role from 'consul-ui/forms/role';
 import intention from 'consul-ui/forms/intention';
 export function initialize(application) {
   // Service-less injection using private properties at a per-project level
@@ -11,6 +12,7 @@ export function initialize(application) {
     acl: acl(),
     token: token(),
     policy: policy(),
+    role: role(),
     intention: intention(),
   };
   FormBuilder.reopen({

--- a/ui-v2/app/initializers/search.js
+++ b/ui-v2/app/initializers/search.js
@@ -1,6 +1,7 @@
 import intention from 'consul-ui/search/filters/intention';
 import token from 'consul-ui/search/filters/token';
 import policy from 'consul-ui/search/filters/policy';
+import role from 'consul-ui/search/filters/role';
 import kv from 'consul-ui/search/filters/kv';
 import acl from 'consul-ui/search/filters/acl';
 import node from 'consul-ui/search/filters/node';
@@ -19,6 +20,7 @@ export function initialize(application) {
     token: token(filterable),
     acl: acl(filterable),
     policy: policy(filterable),
+    role: role(filterable),
     kv: kv(filterable),
     healthyNode: node(filterable),
     unhealthyNode: node(filterable),

--- a/ui-v2/app/mixins/policy/with-many-actions.js
+++ b/ui-v2/app/mixins/policy/with-many-actions.js
@@ -1,0 +1,98 @@
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+import { hash } from 'rsvp';
+
+import updateArrayObject from 'consul-ui/utils/update-array-object';
+
+const ERROR_PARSE_RULES = 'Failed to parse ACL rules';
+const ERROR_NAME_EXISTS = 'Invalid Policy: A Policy with Name';
+
+export default Mixin.create({
+  policyRepo: service('repository/policy'),
+  datacenterRepo: service('repository/dc'),
+  getEmptyPolicy: function() {
+    const dc = this.modelFor('dc').dc.Name;
+    return get(this, 'policyRepo').create({ Datacenter: dc });
+  },
+  model: function(params, transition) {
+    const dc = this.modelFor('dc').dc.Name;
+    const policyRepo = get(this, 'policyRepo');
+    return this._super(...arguments).then(model => {
+      return hash({
+        ...model,
+        ...{
+          // TODO: I only need these to create a new policy
+          datacenters: get(this, 'datacenterRepo').findAll(),
+          policy: this.getEmptyPolicy(),
+          policies: policyRepo.findAllByDatacenter(dc).catch(function(e) {
+            switch (get(e, 'errors.firstObject.status')) {
+              case '403':
+              case '401':
+                // do nothing the SingleRoute will have caught it already
+                return;
+            }
+            throw e;
+          }),
+        },
+      });
+    });
+  },
+  actions: {
+    // TODO: Some of this could potentially be moved to the repo services
+    loadPolicy: function(item, items) {
+      const repo = get(this, 'policyRepo');
+      const dc = this.modelFor('dc').dc.Name;
+      const slug = get(item, repo.getSlugKey());
+      repo.findBySlug(slug, dc).then(item => {
+        updateArrayObject(items, item, repo.getSlugKey());
+      });
+    },
+    remove: function(item, items) {
+      return items.removeObject(item);
+    },
+    clearPolicy: function() {
+      // TODO: I should be able to reset the ember-data object
+      // back to it original state?
+      // possibly Forms could know how to create
+      const controller = get(this, 'controller');
+      controller.setProperties({
+        policy: this.getEmptyPolicy(),
+      });
+    },
+    createPolicy: function(item, policies, success) {
+      get(this, 'policyRepo')
+        .persist(item)
+        .then(item => {
+          set(item, 'CreateTime', new Date().getTime());
+          policies.pushObject(item);
+          return item;
+        })
+        .then(function() {
+          success();
+        })
+        .catch(err => {
+          if (typeof err.errors !== 'undefined') {
+            const error = err.errors[0];
+            let prop;
+            let message = error.detail;
+            switch (true) {
+              case message.indexOf(ERROR_PARSE_RULES) === 0:
+                prop = 'Rules';
+                message = error.detail;
+                break;
+              case message.indexOf(ERROR_NAME_EXISTS) === 0:
+                prop = 'Name';
+                message = message.substr(ERROR_NAME_EXISTS.indexOf(':') + 1);
+                break;
+            }
+            if (prop) {
+              item.addError(prop, message);
+            }
+          } else {
+            throw err;
+          }
+        });
+    },
+  },
+});

--- a/ui-v2/app/mixins/role/with-actions.js
+++ b/ui-v2/app/mixins/role/with-actions.js
@@ -1,0 +1,4 @@
+import Mixin from '@ember/object/mixin';
+import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
+
+export default Mixin.create(WithBlockingActions, {});

--- a/ui-v2/app/mixins/role/with-many-actions.js
+++ b/ui-v2/app/mixins/role/with-many-actions.js
@@ -1,0 +1,90 @@
+import Mixin from '@ember/object/mixin';
+import { inject as service } from '@ember/service';
+import { get, set } from '@ember/object';
+import { hash } from 'rsvp';
+
+import updateArrayObject from 'consul-ui/utils/update-array-object';
+
+const ERROR_NAME_EXISTS = 'Invalid Role: A Role with Name';
+
+export default Mixin.create({
+  roleRepo: service('repository/role'),
+  getEmptyRole: function() {
+    const dc = this.modelFor('dc').dc.Name;
+    return get(this, 'roleRepo').create({ Datacenter: dc });
+  },
+  model: function(params, transition) {
+    const dc = this.modelFor('dc').dc.Name;
+    const repo = get(this, 'roleRepo');
+    return this._super(...arguments).then(model => {
+      return hash({
+        ...model,
+        ...{
+          role: this.getEmptyRole(),
+          roles: repo.findAllByDatacenter(dc).catch(function(e) {
+            switch (get(e, 'errors.firstObject.status')) {
+              case '403':
+              case '401':
+                // do nothing the SingleRoute will have caught it already
+                return;
+            }
+            throw e;
+          }),
+        },
+      });
+    });
+  },
+  actions: {
+    // TODO: Some of this could potentially be moved to the repo services
+    loadRole: function(item, items) {
+      const repo = get(this, 'roleRepo');
+      const dc = this.modelFor('dc').dc.Name;
+      const slug = get(item, repo.getSlugKey());
+      repo.findBySlug(slug, dc).then(item => {
+        updateArrayObject(items, item, repo.getSlugKey());
+      });
+    },
+    remove: function(item, items) {
+      return items.removeObject(item);
+    },
+    clearRole: function() {
+      // TODO: I should be able to reset the ember-data object
+      // back to it original state?
+      // possibly Forms could know how to create
+      const controller = get(this, 'controller');
+      controller.setProperties({
+        role: this.getEmptyRole(),
+      });
+    },
+    createRole: function(item, items, success) {
+      get(this, 'roleRepo')
+        .persist(item)
+        .then(item => {
+          set(item, 'CreateTime', new Date().getTime());
+          items.pushObject(item);
+          return item;
+        })
+        .then(function() {
+          success();
+        })
+        .catch(err => {
+          if (typeof err.errors !== 'undefined') {
+            const error = err.errors[0];
+            let prop;
+            let message = error.detail;
+            switch (true) {
+              case message.indexOf(ERROR_NAME_EXISTS) === 0:
+                prop = 'Name';
+                message = message.substr(ERROR_NAME_EXISTS.indexOf(':') + 1);
+                break;
+            }
+            if (prop) {
+              item.addError(prop, message);
+            }
+          } else {
+            throw err;
+          }
+        });
+    },
+  },
+});

--- a/ui-v2/app/models/role.js
+++ b/ui-v2/app/models/role.js
@@ -1,0 +1,28 @@
+import Model from 'ember-data/model';
+import attr from 'ember-data/attr';
+
+export const PRIMARY_KEY = 'uid';
+export const SLUG_KEY = 'ID';
+export default Model.extend({
+  [PRIMARY_KEY]: attr('string'),
+  [SLUG_KEY]: attr('string'),
+  Name: attr('string', {
+    defaultValue: '',
+  }),
+  Description: attr('string', {
+    defaultValue: '',
+  }),
+  Policies: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
+  // frontend only for ordering where CreateIndex can't be used
+  CreateTime: attr('date'),
+  //
+  Datacenter: attr('string'),
+  // TODO: Figure out whether we need this or not
+  Datacenters: attr(),
+  CreateIndex: attr('number'),
+  ModifyIndex: attr('number'),
+});

--- a/ui-v2/app/models/role.js
+++ b/ui-v2/app/models/role.js
@@ -17,6 +17,11 @@ export default Model.extend({
       return [];
     },
   }),
+  ServiceIdentities: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
   // frontend only for ordering where CreateIndex can't be used
   CreateTime: attr('date'),
   //

--- a/ui-v2/app/models/token.js
+++ b/ui-v2/app/models/token.js
@@ -9,6 +9,7 @@ const model = Model.extend({
   [PRIMARY_KEY]: attr('string'),
   [SLUG_KEY]: attr('string'),
   IDPName: attr('string'),
+  ExpirationTime: attr('string'),
   SecretID: attr('string'),
   // Legacy
   Type: attr('string'),
@@ -29,6 +30,11 @@ const model = Model.extend({
     },
   }),
   Roles: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
+  ServiceIdentities: attr({
     defaultValue: function() {
       return [];
     },

--- a/ui-v2/app/models/token.js
+++ b/ui-v2/app/models/token.js
@@ -8,6 +8,7 @@ export const SLUG_KEY = 'AccessorID';
 const model = Model.extend({
   [PRIMARY_KEY]: attr('string'),
   [SLUG_KEY]: attr('string'),
+  IDPName: attr('string'),
   SecretID: attr('string'),
   // Legacy
   Type: attr('string'),
@@ -27,6 +28,11 @@ const model = Model.extend({
       return [];
     },
   }),
+  Roles: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
   CreateTime: attr('date'),
   CreateIndex: attr('number'),
   ModifyIndex: attr('number'),
@@ -39,6 +45,7 @@ export const ATTRS = writable(model, [
   'Local',
   'Description',
   'Policies',
+  'Roles',
   // SecretID isn't writable but we need it to identify an
   // update via the old API, see TokenAdapter dataForRequest
   'SecretID',

--- a/ui-v2/app/router.js
+++ b/ui-v2/app/router.js
@@ -74,6 +74,15 @@ export const routes = {
           _options: { path: '/create' },
         },
       },
+      roles: {
+        _options: { path: '/roles' },
+        edit: {
+          _options: { path: '/:id' },
+        },
+        create: {
+          _options: { path: '/create' },
+        },
+      },
       tokens: {
         _options: { path: '/tokens' },
         edit: {

--- a/ui-v2/app/routes/dc/acls/roles/create.js
+++ b/ui-v2/app/routes/dc/acls/roles/create.js
@@ -1,0 +1,6 @@
+import Route from './edit';
+import CreatingRoute from 'consul-ui/mixins/creating-route';
+
+export default Route.extend(CreatingRoute, {
+  templateName: 'dc/acls/roles/edit',
+});

--- a/ui-v2/app/routes/dc/acls/roles/edit.js
+++ b/ui-v2/app/routes/dc/acls/roles/edit.js
@@ -1,0 +1,35 @@
+import SingleRoute from 'consul-ui/routing/single';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
+import { get } from '@ember/object';
+
+import WithRoleActions from 'consul-ui/mixins/role/with-actions';
+import WithManyPolicyActions from 'consul-ui/mixins/policy/with-many-actions';
+
+export default SingleRoute.extend(WithManyPolicyActions, WithRoleActions, {
+  repo: service('repository/role'),
+  tokenRepo: service('repository/token'),
+  model: function(params) {
+    const dc = this.modelFor('dc').dc.Name;
+    const tokenRepo = get(this, 'tokenRepo');
+    return this._super(...arguments).then(model => {
+      return hash({
+        ...model,
+        ...{
+          items: tokenRepo.findByRole(get(model.item, 'ID'), dc).catch(function(e) {
+            switch (get(e, 'errors.firstObject.status')) {
+              case '403':
+              case '401':
+                // do nothing the SingleRoute will have caught it already
+                return;
+            }
+            throw e;
+          }),
+        },
+      });
+    });
+  },
+  setupController: function(controller, model) {
+    controller.setProperties(model);
+  },
+});

--- a/ui-v2/app/routes/dc/acls/roles/index.js
+++ b/ui-v2/app/routes/dc/acls/roles/index.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
+import { get } from '@ember/object';
+
+import WithRoleActions from 'consul-ui/mixins/role/with-actions';
+
+export default Route.extend(WithRoleActions, {
+  repo: service('repository/role'),
+  queryParams: {
+    s: {
+      as: 'filter',
+      replace: true,
+    },
+  },
+  model: function(params) {
+    const repo = get(this, 'repo');
+    return hash({
+      ...repo.status({
+        items: repo.findAllByDatacenter(this.modelFor('dc').dc.Name),
+      }),
+      isLoading: false,
+    });
+  },
+  setupController: function(controller, model) {
+    controller.setProperties(model);
+  },
+});

--- a/ui-v2/app/routes/dc/acls/tokens/edit.js
+++ b/ui-v2/app/routes/dc/acls/tokens/edit.js
@@ -1,104 +1,25 @@
 import SingleRoute from 'consul-ui/routing/single';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
-import { set, get } from '@ember/object';
-import updateArrayObject from 'consul-ui/utils/update-array-object';
+import { get } from '@ember/object';
 
 import WithTokenActions from 'consul-ui/mixins/token/with-actions';
+import WithManyPolicyActions from 'consul-ui/mixins/policy/with-many-actions';
 
-const ERROR_PARSE_RULES = 'Failed to parse ACL rules';
-const ERROR_NAME_EXISTS = 'Invalid Policy: A Policy with Name';
-export default SingleRoute.extend(WithTokenActions, {
+export default SingleRoute.extend(WithManyPolicyActions, WithTokenActions, {
   repo: service('repository/token'),
-  policyRepo: service('repository/policy'),
-  datacenterRepo: service('repository/dc'),
   settings: service('settings'),
   model: function(params, transition) {
-    const dc = this.modelFor('dc').dc.Name;
-    const policyRepo = get(this, 'policyRepo');
     return this._super(...arguments).then(model => {
       return hash({
         ...model,
         ...{
-          // TODO: I only need these to create a new policy
-          datacenters: get(this, 'datacenterRepo').findAll(),
-          policy: this.getEmptyPolicy(),
           token: get(this, 'settings').findBySlug('token'),
-          items: policyRepo.findAllByDatacenter(dc).catch(function(e) {
-            switch (get(e, 'errors.firstObject.status')) {
-              case '403':
-              case '401':
-                // do nothing the SingleRoute will have caught it already
-                return;
-            }
-            throw e;
-          }),
         },
       });
     });
   },
   setupController: function(controller, model) {
     controller.setProperties(model);
-  },
-  getEmptyPolicy: function() {
-    const dc = this.modelFor('dc').dc.Name;
-    return get(this, 'policyRepo').create({ Datacenter: dc });
-  },
-  actions: {
-    // TODO: Some of this could potentially be moved to the repo services
-    loadPolicy: function(item, items) {
-      const repo = get(this, 'policyRepo');
-      const dc = this.modelFor('dc').dc.Name;
-      const slug = get(item, repo.getSlugKey());
-      repo.findBySlug(slug, dc).then(item => {
-        updateArrayObject(items, item, repo.getSlugKey());
-      });
-    },
-    remove: function(item, items) {
-      return items.removeObject(item);
-    },
-    clearPolicy: function() {
-      // TODO: I should be able to reset the ember-data object
-      // back to it original state?
-      // possibly Forms could know how to create
-      const controller = get(this, 'controller');
-      controller.setProperties({
-        policy: this.getEmptyPolicy(),
-      });
-    },
-    createPolicy: function(item, policies, success) {
-      get(this, 'policyRepo')
-        .persist(item)
-        .then(item => {
-          set(item, 'CreateTime', new Date().getTime());
-          policies.pushObject(item);
-          return item;
-        })
-        .then(function() {
-          success();
-        })
-        .catch(err => {
-          if (typeof err.errors !== 'undefined') {
-            const error = err.errors[0];
-            let prop;
-            let message = error.detail;
-            switch (true) {
-              case message.indexOf(ERROR_PARSE_RULES) === 0:
-                prop = 'Rules';
-                message = error.detail;
-                break;
-              case message.indexOf(ERROR_NAME_EXISTS) === 0:
-                prop = 'Name';
-                message = message.substr(ERROR_NAME_EXISTS.indexOf(':') + 1);
-                break;
-            }
-            if (prop) {
-              item.addError(prop, message);
-            }
-          } else {
-            throw err;
-          }
-        });
-    },
   },
 });

--- a/ui-v2/app/routes/dc/acls/tokens/edit.js
+++ b/ui-v2/app/routes/dc/acls/tokens/edit.js
@@ -5,8 +5,9 @@ import { get } from '@ember/object';
 
 import WithTokenActions from 'consul-ui/mixins/token/with-actions';
 import WithManyPolicyActions from 'consul-ui/mixins/policy/with-many-actions';
+import WithManyRoleActions from 'consul-ui/mixins/role/with-many-actions';
 
-export default SingleRoute.extend(WithManyPolicyActions, WithTokenActions, {
+export default SingleRoute.extend(WithManyRoleActions, WithManyPolicyActions, WithTokenActions, {
   repo: service('repository/token'),
   settings: service('settings'),
   model: function(params, transition) {

--- a/ui-v2/app/search/filters/role.js
+++ b/ui-v2/app/search/filters/role.js
@@ -1,0 +1,14 @@
+import { get } from '@ember/object';
+export default function(filterable) {
+  return filterable(function(item, { s = '' }) {
+    const sLower = s.toLowerCase();
+    return (
+      get(item, 'Name')
+        .toLowerCase()
+        .indexOf(sLower) !== -1 ||
+      get(item, 'Description')
+        .toLowerCase()
+        .indexOf(sLower) !== -1
+    );
+  });
+}

--- a/ui-v2/app/serializers/role.js
+++ b/ui-v2/app/serializers/role.js
@@ -1,0 +1,6 @@
+import Serializer from './application';
+import { PRIMARY_KEY } from 'consul-ui/models/role';
+
+export default Serializer.extend({
+  primaryKey: PRIMARY_KEY,
+});

--- a/ui-v2/app/services/repository/role.js
+++ b/ui-v2/app/services/repository/role.js
@@ -1,0 +1,24 @@
+import RepositoryService from 'consul-ui/services/repository';
+import { Promise } from 'rsvp';
+import statusFactory from 'consul-ui/utils/acls-status';
+import isValidServerErrorFactory from 'consul-ui/utils/http/acl/is-valid-server-error';
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/role';
+
+const isValidServerError = isValidServerErrorFactory();
+const status = statusFactory(isValidServerError, Promise);
+const MODEL_NAME = 'role';
+
+export default RepositoryService.extend({
+  getModelName: function() {
+    return MODEL_NAME;
+  },
+  getPrimaryKey: function() {
+    return PRIMARY_KEY;
+  },
+  getSlugKey: function() {
+    return SLUG_KEY;
+  },
+  status: function(obj) {
+    return status(obj);
+  },
+});

--- a/ui-v2/app/services/repository/token.js
+++ b/ui-v2/app/services/repository/token.js
@@ -49,4 +49,10 @@ export default RepositoryService.extend({
       dc: dc,
     });
   },
+  findByRole: function(id, dc) {
+    return get(this, 'store').query(this.getModelName(), {
+      role: id,
+      dc: dc,
+    });
+  },
 });

--- a/ui-v2/app/styles/components/tabular-collection.scss
+++ b/ui-v2/app/styles/components/tabular-collection.scss
@@ -57,11 +57,16 @@ html.template-acl.template-list main table tr {
 html.template-policy.template-list main table tr {
   @extend %policies-row;
 }
+html.template-role.template-list main table tr {
+  @extend %roles-row;
+}
 html.template-token.template-list main table tr {
   @extend %tokens-row;
 }
 html.template-policy.template-edit [role='dialog'] table tr,
-html.template-policy.template-edit main table tr {
+html.template-policy.template-edit main table tr,
+html.template-role.template-edit [role='dialog'] table tr,
+html.template-role.template-edit main table tr {
   @extend %tokens-minimal-row;
 }
 html.template-token.template-list main table tr td.me,
@@ -166,6 +171,12 @@ html.template-node.template-show main table.sessions tr {
   width: calc(33% - 20px);
 }
 %policies-row > *:last-child {
+  @extend %table-actions;
+}
+%roles-row > * {
+  width: calc(33% - 20px);
+}
+%roles-row > *:last-child {
   @extend %table-actions;
 }
 // this will get auto calculated later in tabular-collection.js

--- a/ui-v2/app/styles/routes/dc/acls/tokens/index.scss
+++ b/ui-v2/app/styles/routes/dc/acls/tokens/index.scss
@@ -1,4 +1,7 @@
-.template-token.template-edit [for='new-policy-toggle'] {
+// TODO: Move this out of here and into policy/many
+.template-role.template-edit [for='new-policy-toggle'],
+.template-token.template-edit [for='new-policy-toggle'],
+.template-token.template-edit [for='new-role-toggle'] {
   @extend %anchor;
   cursor: pointer;
   float: right;

--- a/ui-v2/app/templates/components/tab-nav.hbs
+++ b/ui-v2/app/templates/components/tab-nav.hbs
@@ -1,7 +1,7 @@
 {{!<nav role="tablist">}}
     <ul>
 {{#each items as |item|}}
-        <li class={{if (eq selected (if item.label (slugify item.label) (slugify item))) 'selected'}}>
+        <li class={{if (or item.selected (eq selected (if item.label (slugify item.label) (slugify item)))) 'selected'}}>
             <label for="radiogroup_{{name}}_{{if item.label (slugify item.label) (slugify item)}}" data-test-radiobutton="{{name}}_{{if item.label (slugify item.label) (slugify item)}}" role="tab" aria-controls="radiogroup_{{name}}_{{if item.label (slugify item.label) (slugify item)}}_panel">
 {{#if item.href }}
   <a href="{{ item.href }}">{{ item.label }}</a>

--- a/ui-v2/app/templates/dc/acls/-nav.hbs
+++ b/ui-v2/app/templates/dc/acls/-nav.hbs
@@ -3,11 +3,17 @@
       (hash
         label='Tokens'
         href=(href-to 'dc.acls.tokens')
+        selected=(is-href 'dc.acls.tokens')
+      )
+      (hash
+        label='Roles'
+        href=(href-to 'dc.acls.roles')
+        selected=(is-href 'dc.acls.roles')
       )
       (hash
         label='Policies'
         href=(href-to 'dc.acls.policies')
+        selected=(is-href 'dc.acls.policies')
       )
     )
-    selected=(if (is-href 'dc.acls.policies') 'policies' 'tokens')
 }}

--- a/ui-v2/app/templates/dc/acls/policies/-many.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/-many.hbs
@@ -23,7 +23,7 @@
 <label class="type-text" data-test-policy-element>
   <span>Apply an existing policy</span>
       {{#power-select
-        options=(difference items item.Policies item.Policies.length)
+        options=(difference policies item.Policies item.Policies.length)
         searchField='Name'
         selected=DestinationName
         searchPlaceholder='Type policy name'

--- a/ui-v2/app/templates/dc/acls/policies/-many.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/-many.hbs
@@ -25,7 +25,6 @@
       {{#power-select
         options=(difference policies item.Policies item.Policies.length)
         searchField='Name'
-        selected=DestinationName
         searchPlaceholder='Type policy name'
         onchange=(action 'change' 'Policy') as |policy|
       }}
@@ -37,7 +36,7 @@
       {{#tabular-details
           data-test-policies
           onchange=(action 'change')
-          name="Details"
+          name="PolicyDetails"
           items=(sort-by 'CreateTime:desc' 'Name:asc' item.Policies) as |item index|
       }}
         {{#block-slot 'header'}}

--- a/ui-v2/app/templates/dc/acls/roles/-fieldsets.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-fieldsets.hbs
@@ -14,8 +14,11 @@
         <textarea name="role[Description]" value={{item.Description}} oninput={{action 'change'}}></textarea>
       </label>
     </fieldset>
-<fieldset>
-  <h2>Policies</h2>
-  {{partial 'dc/acls/policies/many'}}
-</fieldset>
+{{! temporary property so we can keep things working before moving all this to components}}
+{{# if (not hideRolePolicies)}}
+    <fieldset>
+      <h2>Policies</h2>
+      {{partial 'dc/acls/policies/many'}}
+    </fieldset>
+{{/if}}
 

--- a/ui-v2/app/templates/dc/acls/roles/-fieldsets.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-fieldsets.hbs
@@ -1,0 +1,21 @@
+    <fieldset>
+        <label class="type-text{{if item.error.Name ' has-error'}}">
+            <span>Name</span>
+            {{input value=item.Name name='role[Name]' autofocus='autofocus'}}
+            <em>
+              Maximum 256 characters. May only include letters (uppercase and/or lowercase) and/or numbers. Must be unique.
+            </em>
+            {{#if item.error.Name}}
+              <strong>{{item.error.Name.validation}}</strong>
+            {{/if}}
+        </label>
+      <label class="type-text">
+        <span>Description (Optional)</span>
+        <textarea name="role[Description]" value={{item.Description}} oninput={{action 'change'}}></textarea>
+      </label>
+    </fieldset>
+<fieldset>
+  <h2>Policies</h2>
+  {{partial 'dc/acls/policies/many'}}
+</fieldset>
+

--- a/ui-v2/app/templates/dc/acls/roles/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-form.hbs
@@ -1,0 +1,50 @@
+<form>
+  {{partial 'dc/acls/roles/fieldsets'}}
+{{#if (not create) }}
+  <h2>Where is this role used?</h2>
+  <p>
+    We're only able to show information for the primary datacenter and the current datacenter. This list may not show every case where this role is applied.
+  </p>
+  {{token-list caption="Tokens" items=items}}
+{{/if}}
+    <div>
+{{#if create }}
+        {{! we only need to check for an empty name here as ember munges autofocus, once we have autofocus back revisit this}}
+        <button type="submit" {{ action "create" item}} disabled={{if (or item.isPristine item.isInvalid (eq item.Name '')) 'disabled'}}>Save</button>
+{{ else }}
+        <button type="submit" {{ action "update" item}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
+{{/if}}
+        <button type="reset" {{ action "cancel" item}}>Cancel</button>
+{{# if (not create) }}
+        {{#confirmation-dialog message='Are you sure you want to delete this Role?'}}
+            {{#block-slot 'action' as |confirm|}}
+                <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
+            {{/block-slot}}
+            {{#block-slot 'dialog' as |execute cancel message|}}
+    {{#if (gt items.length 0)}}
+              {{#modal-dialog onclose=(action cancel)}}
+                  {{#block-slot 'header'}}
+                      <h2>Role in Use</h2>
+                  {{/block-slot}}
+                  {{#block-slot 'body'}}
+                    <p>
+                      This Role is currently in use. If you choose to delete this Role, it will be removed from the following <strong>{{items.length}} Tokens</strong>:
+                    </p>
+                    {{token-list items=items target='_blank'}}
+                    <p>
+                      This action cannot be undone. {{message}}
+                    </p>
+                  {{/block-slot}}
+                  {{#block-slot 'actions' as |close|}}
+                    <button type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
+                    <button type="button" class="type-cancel" {{action close}}>Cancel</button>
+                  {{/block-slot}}
+                {{/modal-dialog}}
+    {{else}}
+                {{delete-confirmation message=message execute=execute cancel=cancel}}
+    {{/if}}
+            {{/block-slot}}
+        {{/confirmation-dialog}}
+{{/if}}
+    </div>
+</form>

--- a/ui-v2/app/templates/dc/acls/roles/-many.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-many.hbs
@@ -1,0 +1,77 @@
+<label data-test-new-role class="type-dialog" for="new-role-toggle">
+  <span>Create new role</span>
+  {{#modal-dialog data-test-role-form onclose=(action 'sendClearPolicy') onopen=(action 'refreshCodeEditor' '#policy_rules') name="new-policy-toggle"}}
+    {{#block-slot 'header'}}
+      <h2>New Policy</h2>
+    {{/block-slot}}
+    {{#block-slot 'body'}}
+      {{#with policy as |item|}}
+        {{partial 'dc/acls/policies/fieldsets'}}
+      {{/with}}
+    {{/block-slot}}
+    {{#block-slot 'actions' as |close|}}
+      <button type="submit" {{action 'sendCreatePolicy' policy item.Policies close}} disabled={{if (or policy.isSaving policy.isPristine policy.isInvalid) 'disabled'}}>
+        {{#if policy.isSaving }}
+          <div class="progress indeterminate"></div>
+        {{/if}}
+        <span>Create and apply</span>
+      </button>
+      <button type="reset" disabled={{if policy.isSaving 'disabled'}} {{action close}}>Cancel</button>
+    {{/block-slot}}
+  {{/modal-dialog}}
+</label>
+<label class="type-text" data-test-policy-element>
+  <span>Apply an existing policy</span>
+      {{#power-select
+        options=(difference policies item.Policies item.Policies.length)
+        searchField='Name'
+        selected=DestinationName
+        searchPlaceholder='Type policy name'
+        onchange=(action 'change' 'Policy') as |policy|
+      }}
+        {{policy.Name}}
+      {{/power-select}}
+</label>
+{{#if (gt item.Policies.length 0)}}
+    {{#with item as |token| }}
+      {{#tabular-details
+          data-test-policies
+          onchange=(action 'change')
+          name="Details"
+          items=(sort-by 'CreateTime:desc' 'Name:asc' item.Policies) as |item index|
+      }}
+        {{#block-slot 'header'}}
+          <th>Name</th>
+          <th>Datacenters</th>
+        {{/block-slot}}
+        {{#block-slot 'row'}}
+          <td>
+            <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
+          </td>
+          <td>
+            {{if (not item.isSaving) (join ', ' (policy/datacenters item)) 'Saving...'}}
+          </td>
+        {{/block-slot}}
+        {{#block-slot 'details'}}
+            <label class="type-text">
+              <span>Rules <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
+              {{code-editor readonly=true value=item.Rules}}
+            </label>
+            <div>
+              {{#confirmation-dialog message='Are you sure you want to remove this policy from this token?'}}
+                {{#block-slot 'action' as |confirm|}}
+                  <button data-test-delete type="button" class="type-delete" {{action confirm 'remove' item token.Policies}}>Remove</button>
+                {{/block-slot}}
+                {{#block-slot 'dialog' as |execute cancel message|}}
+                  <p>
+                    {{message}}
+                  </p>
+                  <button type="button" class="type-delete" {{action execute}}>Confirm remove</button>
+                  <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
+                {{/block-slot}}
+              {{/confirmation-dialog}}
+            </div>
+        {{/block-slot}}
+      {{/tabular-details}}
+    {{/with}}
+{{/if}}

--- a/ui-v2/app/templates/dc/acls/roles/-many.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-many.hbs
@@ -1,77 +1,75 @@
 <label data-test-new-role class="type-dialog" for="new-role-toggle">
   <span>Create new role</span>
-  {{#modal-dialog data-test-role-form onclose=(action 'sendClearPolicy') onopen=(action 'refreshCodeEditor' '#policy_rules') name="new-policy-toggle"}}
+  {{#modal-dialog data-test-role-form onclose=(action 'sendClearRole') name="new-role-toggle"}}
     {{#block-slot 'header'}}
-      <h2>New Policy</h2>
+      <h2>New Role</h2>
     {{/block-slot}}
     {{#block-slot 'body'}}
-      {{#with policy as |item|}}
-        {{partial 'dc/acls/policies/fieldsets'}}
+      {{#with role as |item|}}
+        {{#with true as |hideRolePolicies|}}
+          {{partial 'dc/acls/roles/fieldsets'}}
+        {{/with}}
       {{/with}}
     {{/block-slot}}
     {{#block-slot 'actions' as |close|}}
-      <button type="submit" {{action 'sendCreatePolicy' policy item.Policies close}} disabled={{if (or policy.isSaving policy.isPristine policy.isInvalid) 'disabled'}}>
-        {{#if policy.isSaving }}
+      <button type="submit" {{action 'sendCreateRole' role item.Roles close}} disabled={{if (or role.isSaving role.isPristine role.isInvalid) 'disabled'}}>
+        {{#if role.isSaving }}
           <div class="progress indeterminate"></div>
         {{/if}}
         <span>Create and apply</span>
       </button>
-      <button type="reset" disabled={{if policy.isSaving 'disabled'}} {{action close}}>Cancel</button>
+      <button type="reset" disabled={{if role.isSaving 'disabled'}} {{action close}}>Cancel</button>
     {{/block-slot}}
   {{/modal-dialog}}
 </label>
-<label class="type-text" data-test-policy-element>
-  <span>Apply an existing policy</span>
+<label class="type-text" data-test-role-element>
+  <span>Apply an existing role</span>
       {{#power-select
-        options=(difference policies item.Policies item.Policies.length)
+        options=(difference roles item.Roles item.Roles.length)
         searchField='Name'
-        selected=DestinationName
-        searchPlaceholder='Type policy name'
-        onchange=(action 'change' 'Policy') as |policy|
+        searchPlaceholder='Type role name'
+        onchange=(action 'change' 'Role') as |item|
       }}
-        {{policy.Name}}
+        {{item.Name}}
       {{/power-select}}
 </label>
-{{#if (gt item.Policies.length 0)}}
+{{#if (gt item.Roles.length 0)}}
     {{#with item as |token| }}
-      {{#tabular-details
-          data-test-policies
-          onchange=(action 'change')
-          name="Details"
-          items=(sort-by 'CreateTime:desc' 'Name:asc' item.Policies) as |item index|
+      {{#tabular-collection
+          data-test-roles
+          items=(sort-by 'CreateTime:desc' 'Name:asc' item.Roles) as |item index|
       }}
         {{#block-slot 'header'}}
           <th>Name</th>
-          <th>Datacenters</th>
+          <th>Description</th>
         {{/block-slot}}
         {{#block-slot 'row'}}
           <td>
-            <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
+            <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
           </td>
           <td>
-            {{if (not item.isSaving) (join ', ' (policy/datacenters item)) 'Saving...'}}
+            {{item.Description}}
           </td>
         {{/block-slot}}
-        {{#block-slot 'details'}}
-            <label class="type-text">
-              <span>Rules <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-              {{code-editor readonly=true value=item.Rules}}
-            </label>
-            <div>
-              {{#confirmation-dialog message='Are you sure you want to remove this policy from this token?'}}
-                {{#block-slot 'action' as |confirm|}}
-                  <button data-test-delete type="button" class="type-delete" {{action confirm 'remove' item token.Policies}}>Remove</button>
-                {{/block-slot}}
-                {{#block-slot 'dialog' as |execute cancel message|}}
-                  <p>
-                    {{message}}
-                  </p>
-                  <button type="button" class="type-delete" {{action execute}}>Confirm remove</button>
-                  <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
-                {{/block-slot}}
-              {{/confirmation-dialog}}
-            </div>
+        {{#block-slot 'actions' as |index change checked|}}
+          {{#confirmation-dialog confirming=false index=index message="Are you sure you want to remove this Role?"}}
+            {{#block-slot 'action' as |confirm|}}
+                {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
+                    <ul>
+                        <li>
+                            <a data-test-edit href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
+                        </li>
+                        <li>
+                            <button type="button" class="type-delete" data-test-delete {{action confirm 'remove' item token.Roles}}>Remove</button>
+                        </li>
+                    </ul>
+                {{/action-group}}
+            {{/block-slot}}
+            {{#block-slot 'dialog' as |execute cancel message name|}}
+              {{delete-confirmation message=message execute=execute cancel=cancel}}
+            {{/block-slot}}
+          {{/confirmation-dialog}}
         {{/block-slot}}
-      {{/tabular-details}}
+      {{/tabular-collection}}
     {{/with}}
 {{/if}}

--- a/ui-v2/app/templates/dc/acls/roles/-notifications.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-notifications.hbs
@@ -1,0 +1,20 @@
+{{#if (eq type 'create')}}
+  {{#if (eq status 'success') }}
+    Your role has been added.
+  {{else}}
+    There was an error adding your role.
+  {{/if}}
+{{else if (eq type 'update') }}
+  {{#if (eq status 'success') }}
+    Your role has been saved.
+  {{else}}
+    There was an error saving your role.
+  {{/if}}
+{{ else if (eq type 'delete')}}
+  {{#if (eq status 'success') }}
+    Your role was deleted.
+  {{else}}
+    There was an error deleting your role.
+  {{/if}}
+{{/if}}
+

--- a/ui-v2/app/templates/dc/acls/roles/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/edit.hbs
@@ -1,0 +1,32 @@
+{{#app-view class=(concat 'role ' (if (or isAuthorized isEnabled) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
+    {{#block-slot 'notification' as |status type|}}
+      {{partial 'dc/acls/roles/notifications'}}
+    {{/block-slot}}
+    {{#block-slot 'disabled'}}
+      {{partial 'dc/acls/disabled'}}
+    {{/block-slot}}
+    {{#block-slot 'authorization'}}
+      {{partial 'dc/acls/authorization'}}
+    {{/block-slot}}
+    {{#block-slot 'breadcrumbs'}}
+        <ol>
+            <li><a data-test-back href={{href-to 'dc.acls.roles'}}>All Roles</a></li>
+        </ol>
+    {{/block-slot}}
+    {{#block-slot 'header'}}
+        <h1>
+{{#if isAuthorized }}
+  {{#if create }}
+            New Role
+  {{else}}
+            Edit Role
+  {{/if}}
+{{else}}
+            Access Controls
+{{/if}}
+        </h1>
+    {{/block-slot}}
+    {{#block-slot 'content'}}
+      {{ partial 'dc/acls/roles/form'}}
+    {{/block-slot}}
+{{/app-view}}

--- a/ui-v2/app/templates/dc/acls/roles/index.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/index.hbs
@@ -1,0 +1,86 @@
+{{#app-view class=(concat 'role ' (if (not isAuthorized) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
+    {{#block-slot 'notification' as |status type|}}
+      {{partial 'dc/acls/roles/notifications'}}
+    {{/block-slot}}
+    {{#block-slot 'header'}}
+      <h1>
+        Access Controls
+      </h1>
+      {{#if isAuthorized }}
+        {{partial 'dc/acls/nav'}}
+      {{/if}}
+    {{/block-slot}}
+    {{#block-slot 'disabled'}}
+      {{partial 'dc/acls/disabled'}}
+    {{/block-slot}}
+    {{#block-slot 'authorization'}}
+      {{partial 'dc/acls/authorization'}}
+    {{/block-slot}}
+    {{#block-slot 'actions'}}
+        <a data-test-create href="{{href-to 'dc.acls.roles.create'}}" class="type-create">Create</a>
+    {{/block-slot}}
+    {{#block-slot 'content'}}
+{{#if (gt items.length 0) }}
+        <form class="filter-bar">
+          {{freetext-filter searchable=searchable value=s placeholder="Search"}}
+        </form>
+{{/if}}
+        {{#changeable-set dispatcher=searchable}}
+          {{#block-slot 'set' as |filtered|}}
+            {{#tabular-collection
+                items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
+            }}
+                {{#block-slot 'header'}}
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Policies</th>
+                {{/block-slot}}
+                {{#block-slot 'row' }}
+                    <td data-test-role="{{item.Name}}">
+                      <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
+                    </td>
+                    <td>
+                      {{item.Description}}
+                    </td>
+                    <td>
+                      {{#each item.Policies as |item|}}
+                        <strong class={{if (policy/is-management item) 'policy-management' }}>{{item.Name}}</strong>
+                      {{/each}}
+                    </td>
+                {{/block-slot}}
+                {{#block-slot 'actions' as |index change checked|}}
+                    {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Role?"}}
+                        {{#block-slot 'action' as |confirm|}}
+                            {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
+                                <ul>
+    {{#if (policy/is-management item)}}
+                                    <li>
+                                        <a data-test-edit href={{href-to 'dc.acls.roles.edit' item.ID}}>View</a>
+                                    </li>
+    {{else}}
+
+                                    <li>
+                                        <a data-test-edit href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
+                                    </li>
+                                    <li>
+                                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
+                                    </li>
+    {{/if}}
+                                </ul>
+                            {{/action-group}}
+                        {{/block-slot}}
+                        {{#block-slot 'dialog' as |execute cancel message name|}}
+                          {{delete-confirmation message=message execute=execute cancel=cancel}}
+                        {{/block-slot}}
+                    {{/confirmation-dialog}}
+                {{/block-slot}}
+            {{/tabular-collection}}
+          {{/block-slot}}
+          {{#block-slot 'empty'}}
+            <p>
+              There are no Roles.
+            </p>
+          {{/block-slot}}
+        {{/changeable-set}}
+    {{/block-slot}}
+{{/app-view}}

--- a/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
@@ -16,5 +16,9 @@
 </fieldset>
 <fieldset>
   <h2>Policies</h2>
-  {{partial 'dc/acls/tokens/policies'}}
+  {{partial 'dc/acls/policies/many'}}
+</fieldset>
+<fieldset>
+  <h2>Roles</h2>
+  {{partial 'dc/acls/roles/many'}}
 </fieldset>

--- a/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
@@ -15,10 +15,10 @@
   </label>
 </fieldset>
 <fieldset>
-  <h2>Policies</h2>
-  {{partial 'dc/acls/policies/many'}}
-</fieldset>
-<fieldset>
   <h2>Roles</h2>
   {{partial 'dc/acls/roles/many'}}
+</fieldset>
+<fieldset>
+  <h2>Policies</h2>
+  {{partial 'dc/acls/policies/many'}}
 </fieldset>

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -37,7 +37,7 @@
               <th>Accessor ID</th>
               <th>Scope</th>
               <th>Description</th>
-              <th>Policies</th>
+              <th>Roles &amp; Policies</th>
               <th>&nbsp;</th>
           {{/block-slot}}
           {{#block-slot 'row'}}
@@ -52,9 +52,9 @@
               </td>
               <td colspan={{if (not-eq item.AccessorID token.AccessorID) '2' }}>
 {{#if (token/is-legacy item) }}
-                  Legacy tokens have embedded policies.
+                  Legacy tokens have embedded rules.
 {{ else }}
-                  {{#each item.Policies as |item|}}
+                  {{#each (append item.Policies item.Roles) as |item|}}
                     <strong class={{if (policy/is-management item) 'policy-management' }}>{{item.Name}}</strong>
                   {{/each}}
 {{/if}}

--- a/ui-v2/app/validations/role.js
+++ b/ui-v2/app/validations/role.js
@@ -1,0 +1,4 @@
+import { validateFormat } from 'ember-changeset-validations/validators';
+export default {
+  Name: validateFormat({ regex: /^[A-Za-z0-9\-_]{1,256}$/ }),
+};

--- a/ui-v2/tests/acceptance/dc/acls/roles/index.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/index.feature
@@ -1,0 +1,12 @@
+@setupApplicationTest
+Feature: dc / acls / roles / index: ACL Roles List
+
+  Scenario:
+    Given 1 datacenter model with the value "dc-1"
+    And 3 role models
+    When I visit the roles page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/acls/roles
+    Then I see 3 role models

--- a/ui-v2/tests/acceptance/dc/acls/roles/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/update.feature
@@ -1,0 +1,44 @@
+@setupApplicationTest
+Feature: dc / acls / roles / update: ACL Role Update
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 role model from yaml
+    ---
+      ID: role-id
+    ---
+    And 3 token models
+    When I visit the role page for yaml
+    ---
+      dc: datacenter
+      role: role-id
+    ---
+    Then the url should be /datacenter/acls/roles/role-id
+    Then I see 3 token models
+  Scenario: Update to [Name], [Rules], [Description]
+    Then I fill in the role form with yaml
+    ---
+      Name: [Name]
+      Description: [Description]
+    ---
+    And I submit
+    Then a PUT request is made to "/v1/acl/role/role-id?dc=datacenter" with the body from yaml
+    ---
+      Name: [Name]
+      Description: [Description]
+    ---
+    Then the url should be /datacenter/acls/roles
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class
+    Where:
+      ------------------------------------------
+      | Name        | Description              |
+      | role-name   | role-name description    |
+      | role        | role name description    |
+      | roleName    | role%20name description  |
+      ------------------------------------------
+  Scenario: There was an error saving the key
+    Given the url "/v1/acl/role/role-id" responds with a 500 status
+    And I submit
+    Then the url should be /datacenter/acls/roles/role-id
+    Then "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "error" class

--- a/ui-v2/tests/acceptance/steps/dc/acls/roles/index-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/acls/roles/index-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/steps/dc/acls/roles/update-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/acls/roles/update-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/helpers/set-cookies.js
+++ b/ui-v2/tests/helpers/set-cookies.js
@@ -29,6 +29,10 @@ export default function(type, count, obj) {
       key = 'CONSUL_POLICY_COUNT';
       obj['CONSUL_ACLS_ENABLE'] = 1;
       break;
+    case 'role':
+      key = 'CONSUL_ROLE_COUNT';
+      obj['CONSUL_ACLS_ENABLE'] = 1;
+      break;
     case 'token':
       key = 'CONSUL_TOKEN_COUNT';
       obj['CONSUL_ACLS_ENABLE'] = 1;

--- a/ui-v2/tests/helpers/type-to-url.js
+++ b/ui-v2/tests/helpers/type-to-url.js
@@ -26,6 +26,9 @@ export default function(type) {
     case 'policy':
       requests = ['/v1/acl/policies', '/v1/acl/policy/'];
       break;
+    case 'role':
+      requests = ['/v1/acl/roles', '/v1/acl/role/'];
+      break;
     case 'token':
       requests = ['/v1/acl/tokens', '/v1/acl/token/'];
       break;

--- a/ui-v2/tests/integration/adapters/role/response-test.js
+++ b/ui-v2/tests/integration/adapters/role/response-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { get } from 'consul-ui/tests/helpers/api';
+import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+module('Integration | Adapter | role | response', function(hooks) {
+  setupTest(hooks);
+  const dc = 'dc-1';
+  const id = 'role-name';
+  test('handleResponse returns the correct data for list endpoint', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const request = {
+      url: `/v1/acl/roles?dc=${dc}`,
+    };
+    return get(request.url).then(function(payload) {
+      const expected = payload.map(item =>
+        Object.assign({}, item, {
+          Datacenter: dc,
+          uid: `["${dc}","${item.ID}"]`,
+        })
+      );
+      const actual = adapter.handleResponse(200, {}, payload, request);
+      assert.deepEqual(actual, expected);
+    });
+  });
+  test('handleResponse returns the correct data for item endpoint', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const request = {
+      url: `/v1/acl/role/${id}?dc=${dc}`,
+    };
+    return get(request.url).then(function(payload) {
+      const expected = Object.assign({}, payload, {
+        Datacenter: dc,
+        [META]: {},
+        uid: `["${dc}","${id}"]`,
+      });
+      const actual = adapter.handleResponse(200, {}, payload, request);
+      assert.deepEqual(actual, expected);
+    });
+  });
+});

--- a/ui-v2/tests/integration/adapters/role/url-test.js
+++ b/ui-v2/tests/integration/adapters/role/url-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import makeAttrable from 'consul-ui/utils/makeAttrable';
+module('Integration | Adapter | role | url', function(hooks) {
+  setupTest(hooks);
+  const dc = 'dc-1';
+  const id = 'role-name';
+  test('urlForQuery returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const expected = `/v1/acl/roles?dc=${dc}`;
+    const actual = adapter.urlForQuery({
+      dc: dc,
+    });
+    assert.equal(actual, expected);
+  });
+  test('urlForQueryRecord returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const expected = `/v1/acl/role/${id}?dc=${dc}`;
+    const actual = adapter.urlForQueryRecord({
+      dc: dc,
+      id: id,
+    });
+    assert.equal(actual, expected);
+  });
+  test("urlForQueryRecord throws if you don't specify an id", function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    assert.throws(function() {
+      adapter.urlForQueryRecord({
+        dc: dc,
+      });
+    });
+  });
+  test('urlForCreateRecord returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const expected = `/v1/acl/role?dc=${dc}`;
+    const actual = adapter.urlForCreateRecord(
+      'role',
+      makeAttrable({
+        Datacenter: dc,
+      })
+    );
+    assert.equal(actual, expected);
+  });
+  test('urlForUpdateRecord returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const expected = `/v1/acl/role/${id}?dc=${dc}`;
+    const actual = adapter.urlForUpdateRecord(
+      id,
+      'role',
+      makeAttrable({
+        Datacenter: dc,
+        ID: id,
+      })
+    );
+    assert.equal(actual, expected);
+  });
+  test('urlForDeleteRecord returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:role');
+    const expected = `/v1/acl/role/${id}?dc=${dc}`;
+    const actual = adapter.urlForDeleteRecord(
+      id,
+      'role',
+      makeAttrable({
+        Datacenter: dc,
+        ID: id,
+      })
+    );
+    assert.equal(actual, expected);
+  });
+});

--- a/ui-v2/tests/integration/services/repository/role-test.js
+++ b/ui-v2/tests/integration/services/repository/role-test.js
@@ -1,4 +1,4 @@
-import { moduleFor, test, skip } from 'ember-qunit';
+import { moduleFor, test } from 'ember-qunit';
 const NAME = 'role';
 import repo from 'consul-ui/tests/helpers/repo';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {

--- a/ui-v2/tests/integration/services/repository/role-test.js
+++ b/ui-v2/tests/integration/services/repository/role-test.js
@@ -1,20 +1,20 @@
 import { moduleFor, test, skip } from 'ember-qunit';
+const NAME = 'role';
 import repo from 'consul-ui/tests/helpers/repo';
-const NAME = 'token';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
   integration: true,
 });
 const dc = 'dc-1';
-const id = 'token-id';
+const id = 'role-name';
 test('findByDatacenter returns the correct data for list endpoint', function(assert) {
   return repo(
-    'Token',
+    'Role',
     'findAllByDatacenter',
     this.subject(),
     function retrieveStub(stub) {
-      return stub(`/v1/acl/tokens?dc=${dc}`, {
-        CONSUL_TOKEN_COUNT: '100',
+      return stub(`/v1/acl/roles?dc=${dc}`, {
+        CONSUL_ROLE_COUNT: '100',
       });
     },
     function performTest(service) {
@@ -24,13 +24,12 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
       assert.deepEqual(
         actual,
         expected(function(payload) {
-          return payload.map(function(item) {
-            return Object.assign({}, item, {
+          return payload.map(item =>
+            Object.assign({}, item, {
               Datacenter: dc,
-              CreateTime: new Date(item.CreateTime),
-              uid: `["${dc}","${item.AccessorID}"]`,
-            });
-          });
+              uid: `["${dc}","${item.ID}"]`,
+            })
+          );
         })
       );
     }
@@ -38,11 +37,11 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
 });
 test('findBySlug returns the correct data for item endpoint', function(assert) {
   return repo(
-    'Token',
+    'Role',
     'findBySlug',
     this.subject(),
     function retrieveStub(stub) {
-      return stub(`/v1/acl/token/${id}?dc=${dc}`);
+      return stub(`/v1/acl/role/${id}?dc=${dc}`);
     },
     function performTest(service) {
       return service.findBySlug(id, dc);
@@ -54,12 +53,10 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
           const item = payload;
           return Object.assign({}, item, {
             Datacenter: dc,
-            CreateTime: new Date(item.CreateTime),
-            uid: `["${dc}","${item.AccessorID}"]`,
+            uid: `["${dc}","${item.ID}"]`,
           });
         })
       );
     }
   );
 });
-skip('clone returns the correct data for the clone endpoint');

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -28,6 +28,8 @@ import acls from 'consul-ui/tests/pages/dc/acls/index';
 import acl from 'consul-ui/tests/pages/dc/acls/edit';
 import policies from 'consul-ui/tests/pages/dc/acls/policies/index';
 import policy from 'consul-ui/tests/pages/dc/acls/policies/edit';
+import roles from 'consul-ui/tests/pages/dc/acls/roles/index';
+import role from 'consul-ui/tests/pages/dc/acls/roles/edit';
 import tokens from 'consul-ui/tests/pages/dc/acls/tokens/index';
 import token from 'consul-ui/tests/pages/dc/acls/tokens/edit';
 import intentions from 'consul-ui/tests/pages/dc/intentions/index';
@@ -54,6 +56,12 @@ export default {
   ),
   policy: create(
     policy(visitable, submitable, deletable, cancelable, clickable, attribute, collection)
+  ),
+  roles: create(
+    roles(visitable, deletable, creatable, clickable, attribute, collection, freetextFilter)
+  ),
+  role: create(
+    role(visitable, submitable, deletable, cancelable, clickable, attribute, collection)
   ),
   tokens: create(
     tokens(

--- a/ui-v2/tests/pages/dc/acls/roles/edit.js
+++ b/ui-v2/tests/pages/dc/acls/roles/edit.js
@@ -1,0 +1,39 @@
+export default function(
+  visitable,
+  submitable,
+  deletable,
+  cancelable,
+  clickable,
+  attribute,
+  collection
+) {
+  return submitable(
+    cancelable(
+      deletable({
+        visit: visitable(['/:dc/acls/roles/:role', '/:dc/acls/roles/create']),
+        tokens: collection(
+          '[data-test-tokens] [data-test-tabular-row]',
+          deletable({
+            id: attribute('data-test-token', '[data-test-token]'),
+            token: clickable('a'),
+          })
+        ),
+        // TODO: Also see tokens/edit, these should get injected
+        newPolicy: clickable('[data-test-new-policy]'),
+        policyForm: submitable(
+          cancelable({}, '[data-test-policy-form]'),
+          '[data-test-policy-form]'
+        ),
+        policies: collection(
+          '[data-test-policies] [data-test-tabular-row]',
+          deletable(
+            {
+              expand: clickable('label'),
+            },
+            '+ tr'
+          )
+        ),
+      })
+    )
+  );
+}

--- a/ui-v2/tests/pages/dc/acls/roles/index.js
+++ b/ui-v2/tests/pages/dc/acls/roles/index.js
@@ -1,0 +1,14 @@
+export default function(visitable, deletable, creatable, clickable, attribute, collection, filter) {
+  return creatable({
+    visit: visitable('/:dc/acls/roles'),
+    roles: collection(
+      '[data-test-tabular-row]',
+      deletable({
+        name: attribute('data-test-role', '[data-test-role]'),
+        policy: clickable('a'),
+        actions: clickable('label'),
+      })
+    ),
+    filter: filter,
+  });
+}

--- a/ui-v2/tests/pages/dc/acls/tokens/edit.js
+++ b/ui-v2/tests/pages/dc/acls/tokens/edit.js
@@ -14,13 +14,14 @@ export default function(
           visit: visitable(['/:dc/acls/tokens/:token', '/:dc/acls/tokens/create']),
           use: clickable('[data-test-use]'),
           confirmUse: clickable('button.type-delete'),
+          // TODO: Also see tokens/edit, these should get injected
           newPolicy: clickable('[data-test-new-policy]'),
           policyForm: submitable(
             cancelable({}, '[data-test-policy-form]'),
             '[data-test-policy-form]'
           ),
           policies: collection(
-            '[data-test-tabular-row]',
+            '[data-test-policies] [data-test-tabular-row]',
             deletable(
               {
                 expand: clickable('label'),

--- a/ui-v2/tests/unit/adapters/role-test.js
+++ b/ui-v2/tests/unit/adapters/role-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | role', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let adapter = this.owner.lookup('adapter:role');
+    assert.ok(adapter);
+  });
+});

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/create-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/acls/roles/create', 'Unit | Controller | dc/acls/roles/create', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/create-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/create-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:dc/acls/roles/create', 'Unit | Controller | dc/acls/roles/create', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/edit-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/edit-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:dc/acls/roles/edit', 'Unit | Controller | dc/acls/roles/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/edit-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/edit-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/acls/roles/edit', 'Unit | Controller | dc/acls/roles/edit', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:dom', 'service:form'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/index-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/index-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:dc/acls/roles/index', 'Unit | Controller | dc/acls/roles/index', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:search', 'service:dom'],
 });
 
 // Replace this with your real tests.

--- a/ui-v2/tests/unit/controllers/dc/acls/roles/index-test.js
+++ b/ui-v2/tests/unit/controllers/dc/acls/roles/index-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:dc/acls/roles/index', 'Unit | Controller | dc/acls/roles/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/ui-v2/tests/unit/mixins/policy/with-many-actions-test.js
+++ b/ui-v2/tests/unit/mixins/policy/with-many-actions-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import PolicyWithManyActionsMixin from 'consul-ui/mixins/policy/with-many-actions';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | policy/with many actions');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let PolicyWithManyActionsObject = EmberObject.extend(PolicyWithManyActionsMixin);
+  let subject = PolicyWithManyActionsObject.create();
+  assert.ok(subject);
+});

--- a/ui-v2/tests/unit/mixins/role/with-actions-test.js
+++ b/ui-v2/tests/unit/mixins/role/with-actions-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import RoleWithActionsMixin from 'consul-ui/mixins/role/with-actions';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | role/with actions');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let RoleWithActionsObject = EmberObject.extend(RoleWithActionsMixin);
+  let subject = RoleWithActionsObject.create();
+  assert.ok(subject);
+});

--- a/ui-v2/tests/unit/mixins/role/with-actions-test.js
+++ b/ui-v2/tests/unit/mixins/role/with-actions-test.js
@@ -1,12 +1,29 @@
-import EmberObject from '@ember/object';
-import RoleWithActionsMixin from 'consul-ui/mixins/role/with-actions';
-import { module, test } from 'qunit';
+import { moduleFor } from 'ember-qunit';
+import test from 'ember-sinon-qunit/test-support/test';
+import { getOwner } from '@ember/application';
+import Route from 'consul-ui/routes/dc/acls/roles/index';
 
-module('Unit | Mixin | role/with actions');
+import Mixin from 'consul-ui/mixins/role/with-actions';
+
+moduleFor('mixin:policy/with-actions', 'Unit | Mixin | role/with actions', {
+  // Specify the other units that are required for this test.
+  needs: [
+    'mixin:with-blocking-actions',
+    'service:feedback',
+    'service:flashMessages',
+    'service:logger',
+    'service:settings',
+    'service:repository/role',
+  ],
+  subject: function() {
+    const MixedIn = Route.extend(Mixin);
+    this.register('test-container:role/with-actions-object', MixedIn);
+    return getOwner(this).lookup('test-container:role/with-actions-object');
+  },
+});
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let RoleWithActionsObject = EmberObject.extend(RoleWithActionsMixin);
-  let subject = RoleWithActionsObject.create();
+  const subject = this.subject();
   assert.ok(subject);
 });

--- a/ui-v2/tests/unit/mixins/role/with-many-actions-test.js
+++ b/ui-v2/tests/unit/mixins/role/with-many-actions-test.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import RoleWithManyActionsMixin from 'consul-ui/mixins/role/with-many-actions';
+import { module, test } from 'qunit';
+
+module('Unit | Mixin | role/with many actions');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let RoleWithManyActionsObject = EmberObject.extend(RoleWithManyActionsMixin);
+  let subject = RoleWithManyActionsObject.create();
+  assert.ok(subject);
+});

--- a/ui-v2/tests/unit/models/role-test.js
+++ b/ui-v2/tests/unit/models/role-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Model | role', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = run(() => store.createRecord('role', {}));
+    assert.ok(model);
+  });
+});

--- a/ui-v2/tests/unit/routes/dc/acls/roles/create-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/create-test.js
@@ -2,7 +2,16 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:dc/acls/roles/create', 'Unit | Route | dc/acls/roles/create', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: [
+    'service:repository/role',
+    'service:repository/policy',
+    'service:repository/token',
+    'service:repository/dc',
+    'service:feedback',
+    'service:logger',
+    'service:settings',
+    'service:flashMessages',
+  ],
 });
 
 test('it exists', function(assert) {

--- a/ui-v2/tests/unit/routes/dc/acls/roles/create-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/create-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:dc/acls/roles/create', 'Unit | Route | dc/acls/roles/create', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/ui-v2/tests/unit/routes/dc/acls/roles/edit-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/edit-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:dc/acls/roles/edit', 'Unit | Route | dc/acls/roles/edit', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/ui-v2/tests/unit/routes/dc/acls/roles/edit-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/edit-test.js
@@ -2,7 +2,16 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:dc/acls/roles/edit', 'Unit | Route | dc/acls/roles/edit', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: [
+    'service:repository/role',
+    'service:repository/policy',
+    'service:repository/token',
+    'service:repository/dc',
+    'service:feedback',
+    'service:logger',
+    'service:settings',
+    'service:flashMessages',
+  ],
 });
 
 test('it exists', function(assert) {

--- a/ui-v2/tests/unit/routes/dc/acls/roles/index-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/index-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:dc/acls/roles/index', 'Unit | Route | dc/acls/roles/index', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/ui-v2/tests/unit/routes/dc/acls/roles/index-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/roles/index-test.js
@@ -2,7 +2,13 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:dc/acls/roles/index', 'Unit | Route | dc/acls/roles/index', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: [
+    'service:repository/role',
+    'service:feedback',
+    'service:logger',
+    'service:settings',
+    'service:flashMessages',
+  ],
 });
 
 test('it exists', function(assert) {

--- a/ui-v2/tests/unit/routes/dc/acls/tokens/create-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/tokens/create-test.js
@@ -5,6 +5,7 @@ moduleFor('route:dc/acls/tokens/create', 'Unit | Route | dc/acls/tokens/create',
   needs: [
     'service:repository/token',
     'service:repository/policy',
+    'service:repository/role',
     'service:repository/dc',
     'service:feedback',
     'service:logger',

--- a/ui-v2/tests/unit/routes/dc/acls/tokens/edit-test.js
+++ b/ui-v2/tests/unit/routes/dc/acls/tokens/edit-test.js
@@ -5,6 +5,7 @@ moduleFor('route:dc/acls/tokens/edit', 'Unit | Route | dc/acls/tokens/edit', {
   needs: [
     'service:repository/token',
     'service:repository/policy',
+    'service:repository/role',
     'service:repository/dc',
     'service:feedback',
     'service:logger',

--- a/ui-v2/tests/unit/serializers/role-test.js
+++ b/ui-v2/tests/unit/serializers/role-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | role', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('role');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = run(() => store.createRecord('role', {}));
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});

--- a/ui-v2/tests/unit/services/repository/role-test.js
+++ b/ui-v2/tests/unit/services/repository/role-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:repository/role', 'Unit | Service | repository/role', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
This PR adds basic CRUD for ACL Roles (which is very similar to Policies)

This involves:

1. A new ember triplet (Route/Controller/Template) for each new Route (index/edit/create), very similar to the previous policies triplet
2. A new ember-data triplet (Adapter/Serializer/Model), very similar to the previous policies triplet
3. A new Roles Repository for separation between Model layer and Controller/Route layer.
4. A new Form, Validator and Search filter implementation specific to Roles.
5. New tests for the Adapter url generation, serialization, Repository request/responses and higher level acceptance testing with the same coverage as Policies.

Additional Changes:

1. I've added a Mixin for the moment to reuse the Policy adding functionality
2. I moved the 'child' relationship templates to a `-many` partial temporarily here.
3. Additional `selected` property for easily making a specific `tab` in the `tab-nav` component as selected.

Omissions/Notes:

1. Creating new Roles from within a Token will not let you add new Policies to the Role at the same time. The pattern involves modals, so new work is involved to avoid modal within modal inception (to be done in a future PR)
2. Somehow in here we should switch to a component for the adding children to things (so the `-many` partials/mixins. I've kept this out here so I can do this in a separate PR.
3. You'll see references to `ServiceIdentities`/`IDPName`/`ExpirationTime` in here. This is related to upcoming work, and it just made sense to include this in the Models here now.
4. There are various CSS tweaks that will need making. These will be done in a further PR once all the functionality is complete (see point 1 here)

Lastly, all the mocks for the API aren't published _yet_, so the tests here won't pass (but they 'do on my machine(tm)' 😄 ). Once I'm more sure there are no more changes to be made to the mocks/API, I'll publish, which will be before the end of this series of PRs. If this is problematic, please let me know and I can publish a release of the mocks. (for reference: https://github.com/hashicorp/consul-api-double/pull/4)

Screengrabs:

![Screenshot 2019-03-26 at 11 39 00](https://user-images.githubusercontent.com/554604/54994408-1a961480-4fbc-11e9-9194-127e0818c94f.png)

![Screenshot 2019-03-26 at 11 39 42](https://user-images.githubusercontent.com/554604/54994421-21248c00-4fbc-11e9-90c4-f67397e369bb.png)

![Screenshot 2019-03-26 at 11 40 18](https://user-images.githubusercontent.com/554604/54994431-2681d680-4fbc-11e9-9bb6-869517b9925c.png)



