### PR TITLE
ui: Fix erroneous HTML that was being fixed by either browser/ember

### DIFF
--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -39,10 +39,10 @@
                     <dt>ID</dt>
                     <dd>{{session.ID}}</dd>
                     <dt>Behavior</dt>
-                    <dd><{{session.Behavior}}/dd>
+                    <dd>{{session.Behavior}}</dd>
 {{#if session.Delay }}
                     <dt>Delay</dt>
-                    <dd><{{session.LockDelay}}/dd>
+                    <dd>{{session.LockDelay}}</dd>
 {{/if}}
 {{#if session.TTL }}
                     <dt>TTL</dt>


### PR DESCRIPTION
The resulting DOM from this template was actually correct, so we'd assume
it was being fixed by the browser.

This fixes the template to correctly formatted HTML