### PR TITLE
removing gocov packages

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,8 +147,8 @@ dev-tree:
 	@$(SHELL) $(CURDIR)/build-support/scripts/dev.sh $(DEV_PUSH_ARG)
 
 cov:
-	gocov test $(GOFILES) | gocov-html > /tmp/coverage.html
-	open /tmp/coverage.html
+	go test ./... -coverprofile=coverage.out
+	go tool cover -html=coverage.out
 
 test: other-consul dev-build vet test-install-deps test-internal
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,8 +6,6 @@ GOTOOLS = \
 	github.com/mitchellh/gox \
 	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/stringer \
-	github.com/axw/gocov/gocov \
-	gopkg.in/matm/v1/gocov-html \
 	github.com/gogo/protobuf/protoc-gen-gofast \
 	github.com/vektra/mockery/cmd/mockery
 


### PR DESCRIPTION
Now that the go has a coverage reporting tool built in, we don't need a 3rd party package.

https://blog.golang.org/cover
https://golang.org/cmd/cover/