### PR TITLE
api: Aggregate service tags for the internal ui service listing endpoint

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -156,7 +156,7 @@ func summarizeServices(dump structs.NodeDump) []*ServiceSummary {
 		nodeServices := make([]*ServiceSummary, len(node.Services))
 		for idx, service := range node.Services {
 			sum := getService(service.Service)
-			sum.Tags = service.Tags
+			sum.Tags = append(sum.Tags, service.Tags...)
 			sum.Nodes = append(sum.Nodes, node.Node)
 			sum.Kind = service.Kind
 
@@ -201,8 +201,20 @@ func summarizeServices(dump structs.NodeDump) []*ServiceSummary {
 	sort.Strings(services)
 	output := make([]*ServiceSummary, len(summary))
 	for idx, service := range services {
-		// Sort the nodes
 		sum := summary[service]
+		// Remove duplicate values from Tags
+		tags := make([]string, 0)
+		hasTag := make(map[string]struct{})
+		for _, tag := range sum.Tags {
+			if _, ok := hasTag[tag]; ok {
+				continue
+			}
+			hasTag[tag] = struct{}{}
+			tags = append(tags, tag)
+		}
+		sum.Tags = tags;
+		// Return both Tags and Nodes in sorted order
+		sort.Strings(sum.Tags)
 		sort.Strings(sum.Nodes)
 		output[idx] = sum
 	}

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -162,12 +162,12 @@ func TestSummarizeServices(t *testing.T) {
 				&structs.NodeService{
 					Kind:    structs.ServiceKindTypical,
 					Service: "api",
-					Tags:    []string{"tag1", "tag2"},
+					Tags:    []string{"api-tag1", "api-tag2"},
 				},
 				&structs.NodeService{
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
-					Tags:    []string{},
+					Tags:    []string{"web-tag1", "web-tag2"},
 					Meta:    map[string]string{metaExternalSource: "k8s"},
 				},
 			},
@@ -193,7 +193,7 @@ func TestSummarizeServices(t *testing.T) {
 				&structs.NodeService{
 					Kind:    structs.ServiceKindConnectProxy,
 					Service: "web",
-					Tags:    []string{},
+					Tags:    []string{"web-tag4", "web-tag3", "web-tag2"},
 					Meta:    map[string]string{metaExternalSource: "k8s"},
 				},
 			},
@@ -210,7 +210,7 @@ func TestSummarizeServices(t *testing.T) {
 			Services: []*structs.NodeService{
 				&structs.NodeService{
 					Service: "cache",
-					Tags:    []string{},
+					Tags:    []string{"cache-tag1", "cache-tag2"},
 				},
 			},
 		},
@@ -224,7 +224,7 @@ func TestSummarizeServices(t *testing.T) {
 	expectAPI := &ServiceSummary{
 		Kind:           structs.ServiceKindTypical,
 		Name:           "api",
-		Tags:           []string{"tag1", "tag2"},
+		Tags:           []string{"api-tag1", "api-tag2"},
 		Nodes:          []string{"foo"},
 		ChecksPassing:  1,
 		ChecksWarning:  1,
@@ -237,7 +237,7 @@ func TestSummarizeServices(t *testing.T) {
 	expectCache := &ServiceSummary{
 		Kind:           structs.ServiceKindTypical,
 		Name:           "cache",
-		Tags:           []string{},
+		Tags:           []string{"cache-tag1", "cache-tag2"},
 		Nodes:          []string{"zip"},
 		ChecksPassing:  0,
 		ChecksWarning:  0,
@@ -250,7 +250,7 @@ func TestSummarizeServices(t *testing.T) {
 	expectWeb := &ServiceSummary{
 		Kind:            structs.ServiceKindConnectProxy,
 		Name:            "web",
-		Tags:            []string{},
+		Tags:            []string{"web-tag1", "web-tag2", "web-tag3", "web-tag4"},
 		Nodes:           []string{"bar", "foo"},
 		ChecksPassing:   2,
 		ChecksWarning:   0,


### PR DESCRIPTION
This PR changes `summarizeServices` to aggregate, dedupe and sort tags for the internal ui service listing endpoint.

Fixes #4222 