### PR TITLE
agent: Add local proxy bind port DNS query

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1611,6 +1611,58 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 	}
 }
 
+func TestDNS_ConnectServiceProxyLookup(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Register
+	{
+		args := structs.TestRegisterRequestProxy(t)
+		args.Address = "127.0.0.55"
+		args.Service.Proxy.DestinationServiceName = "db"
+		args.Service.Proxy.Upstreams = structs.Upstreams{
+			structs.Upstream{
+				DestinationName: "db",
+				LocalBindPort:   13306,
+			},
+		}
+		args.Service.Address = ""
+		args.Service.Port = 12345
+		var out struct{}
+		assert.Nil(a.RPC("Catalog.Register", args, &out))
+	}
+
+	// Look up the service
+	questions := []string{
+		"db.proxy.consul.",
+	}
+	for _, question := range questions {
+		m := new(dns.Msg)
+		m.SetQuestion(question, dns.TypeSRV)
+
+		c := new(dns.Client)
+		in, _, err := c.Exchange(m, a.DNSAddr())
+		assert.Nil(err)
+		assert.Len(in.Answer, 1)
+
+		srvRec, ok := in.Answer[0].(*dns.SRV)
+		assert.True(ok)
+		assert.Equal(uint16(13306), srvRec.Port)
+		assert.Equal("local.", srvRec.Target)
+		assert.Equal(uint32(0), srvRec.Hdr.Ttl)
+
+		// cnameRec, ok := in.Extra[0].(*dns.A)
+		// assert.True(ok)
+		// assert.Equal("foo.node.dc1.consul.", cnameRec.Hdr.Name)
+		// assert.Equal(uint32(0), srvRec.Hdr.Ttl)
+		// assert.Equal("127.0.0.55", cnameRec.A.String())
+	}
+}
+
 func TestDNS_ExternalServiceLookup(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1652,14 +1652,8 @@ func TestDNS_ConnectServiceProxyLookup(t *testing.T) {
 		srvRec, ok := in.Answer[0].(*dns.SRV)
 		assert.True(ok)
 		assert.Equal(uint16(13306), srvRec.Port)
-		assert.Equal("local.", srvRec.Target)
+		assert.Equal(fmt.Sprintf("%s.addr.%s.%s", a.Agent.LocalMember().Name, "dc1", "consul"), srvRec.Target)
 		assert.Equal(uint32(0), srvRec.Hdr.Ttl)
-
-		// cnameRec, ok := in.Extra[0].(*dns.A)
-		// assert.True(ok)
-		// assert.Equal("foo.node.dc1.consul.", cnameRec.Hdr.Name)
-		// assert.Equal(uint32(0), srvRec.Hdr.Ttl)
-		// assert.Equal("127.0.0.55", cnameRec.A.String())
 	}
 }
 


### PR DESCRIPTION
This is a proposal to add support for querying the local proxy bind ports.

In the context of a Consul Connect service that has upstreams and local proxies defined, this query allows an application to retrieve the `local_bind_port` of the local proxy via a DNS SRV lookup.

For example, assuming the following service is registered with the local Consul agent:
```hcl
services {
  id   = "myservice"
  name = "myservice"
  port = 9999

  connect {
    sidecar_service {
      proxy {
        upstreams {
          destination_name = "upstream-service"
          local_bind_port  = 14001
        }
      }
    }
  }
}

```

The `local_bind_port` could be queried with:

```
dig @127.0.0.1 -p 8600 upstream-service.proxy.consul. SRV

; <<>> DiG 9.9.4-RedHat-9.9.4-73.el7_6 <<>> @127.0.0.1 -p 8600 upstream-service.proxy.consul. SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 53818
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 2
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;upstream-service.proxy.consul.	IN	SRV

;; ANSWER SECTION:
upstream-service.proxy.consul. 0	IN	SRV	1 1 14001 myvm.addr.dc1.consul.

;; ADDITIONAL SECTION:
myvm.addr.dc1.consul.	0 IN	A	127.0.0.1
```

This is my first time working with the Consul code base, so the implementation is probably not the best approach.

Also, the Unit test currently doesn't work. It seems like the test environment doesn't load local agent cache?
