### PR TITLE
Use the correct check duration fields when converting transaction ops

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
@@ -239,9 +240,9 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 							Header:                         check.Definition.Header,
 							Method:                         check.Definition.Method,
 							TCP:                            check.Definition.TCP,
-							Interval:                       check.Definition.IntervalDuration,
-							Timeout:                        check.Definition.TimeoutDuration,
-							DeregisterCriticalServiceAfter: check.Definition.DeregisterCriticalServiceAfterDuration,
+							Interval:                       time.Duration(check.Definition.Interval),
+							Timeout:                        time.Duration(check.Definition.Timeout),
+							DeregisterCriticalServiceAfter: time.Duration(check.Definition.DeregisterCriticalServiceAfter),
 						},
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: check.ModifyIndex,


### PR DESCRIPTION
This change fixes a bug in the HTTP endpoint for the transaction API where the health check definition struct wasn't being deserialized properly. In the custom unmarshaling logic [here](https://github.com/hashicorp/consul/blob/v1.4.3/api/health.go#L97-L132) we write the value of Interval/Timeout/DeregisterCriticalServiceAfter to both the new and old fields (which is covered in the go client txn tests [here](https://github.com/hashicorp/consul/blob/v1.4.3/api/txn_test.go#L182-L218)), but the HTTP endpoint doesn't actually end up calling the custom unmarshaler because we decode the body of the request to a generic `interface{}`. To get around this, the change has the HTTP endpoint use the old field names instead, which will always be set if they're provided in the request.



Fixes #5477.