### PR TITLE
agent: Add <service>.proxy.consul query to get proxy sidecar bind port

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -554,6 +554,14 @@ PARSE:
 		// name.connect.consul
 		d.serviceLookup(network, datacenter, labels[n-2], "", true, req, resp, maxRecursionLevel)
 
+	case "proxy":
+		if n == 1 {
+			goto INVALID
+		}
+
+		// name.proxy.consul
+		d.proxyLookup(datacenter, labels[n-2], req, resp)
+
 	case "node":
 		if n == 1 {
 			goto INVALID
@@ -1047,6 +1055,63 @@ func (d *DNSServer) trimDNSResponse(network string, req, resp *dns.Msg) (trimmed
 		resp.Truncated = true
 	}
 	return trimmed
+}
+
+// proxyLookup searches for retrieves local proxy details for the target service
+func (d *DNSServer) proxyLookup(datacenter, service string, req, resp *dns.Msg) {
+	// Only handle ANY, SRV type requests
+	qType := req.Question[0].Qtype
+	if qType != dns.TypeANY && qType != dns.TypeSRV {
+		return
+	}
+
+	// Determine the TTL
+	ttl, _ := d.GetTTLForService(service)
+
+	// Loop over the services registered with the local agent looking for one that
+	// has an upstream targeting the service name in the DNS request
+	for _, svc := range d.agent.State.Services() {
+		if svc != nil {
+			for _, up := range svc.Proxy.Upstreams {
+				if up.DestinationName == service {
+					// Found a local service that has an upstream matching the DNS request
+					// Create SRV response that contains the local_bind_port of the proxy
+
+					// TODO: is this an appropriate target for localhost?
+					// Consul doesn't allow simply returning "localhost" as the target, it requires a fully qualified entry
+					target := fmt.Sprintf("%s.addr.%s.%s", d.agent.LocalMember().Name, datacenter, d.domain)
+					srvRec := &dns.SRV{
+						Hdr: dns.RR_Header{
+							Name:   req.Question[0].Name,
+							Rrtype: dns.TypeSRV,
+							Class:  dns.ClassINET,
+							Ttl:    uint32(ttl / time.Second),
+						},
+						Priority: 1,
+						Weight:   uint16(1),
+						Port:     uint16(up.LocalBindPort),
+						Target:   target,
+					}
+					resp.Answer = append(resp.Answer, srvRec)
+
+					// Add an A record to the DNS response, pointing our target to 127.0.0.1
+					ip := net.ParseIP("127.0.0.1")
+					aRec := &dns.A{
+						Hdr: dns.RR_Header{
+							Name:   target,
+							Rrtype: dns.TypeA,
+							Class:  dns.ClassINET,
+							Ttl:    uint32(ttl / time.Second),
+						},
+						A: ip,
+					}
+
+					resp.Extra = append(resp.Extra, aRec)
+					break
+				}
+			}
+		}
+	}
 }
 
 // lookupServiceNodes returns nodes with a given service.


### PR DESCRIPTION
This is a proposal to add support for querying the local proxy bind ports.

In the context of a Consul Connect service that has an upstream and local sidecar proxy defined, this query allows an application to retrieve the `local_bind_port` of the local proxy via a DNS SRV lookup.

For example, assuming the following service is registered with the local Consul agent:
```hcl
services {
  id   = "myservice"
  name = "myservice"
  port = 9999

  connect {
    sidecar_service {
      proxy {
        upstreams {
          destination_name = "upstream-service"
          local_bind_port  = 14001
        }
      }
    }
  }
}

```

The `local_bind_port` could be queried with:

```
dig @127.0.0.1 -p 8600 upstream-service.proxy.consul. SRV

; <<>> DiG 9.9.4-RedHat-9.9.4-73.el7_6 <<>> @127.0.0.1 -p 8600 upstream-service.proxy.consul. SRV
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 53818
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 2
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;upstream-service.proxy.consul.	IN	SRV

;; ANSWER SECTION:
upstream-service.proxy.consul. 0	IN	SRV	1 1 14001 myvm.addr.dc1.consul.

;; ADDITIONAL SECTION:
myvm.addr.dc1.consul.	0 IN	A	127.0.0.1
```

NOTE - This is my first time working with the Consul code base, so the implementation is probably not the best approach.

Also, the Unit test currently doesn't work, I still need to investigate why. I think it has something to do with the data set the test agent loads, because the query does work on a real running consul agent instance.

This PR replaces #5551.