### PR TITLE
acl: memdb filter of tokens-by-policy was inverted

### DIFF
--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -523,16 +523,16 @@ func (s *Store) ACLTokenList(ws memdb.WatchSet, local, global bool, policy strin
 			iter = memdb.NewFilterIterator(iter, func(raw interface{}) bool {
 				token, ok := raw.(*structs.ACLToken)
 				if !ok {
-					return false
+					return true
 				}
 
 				if global && !token.Local {
-					return true
+					return false
 				} else if local && token.Local {
-					return true
+					return false
 				}
 
-				return false
+				return true
 			})
 		}
 	} else if global == local {

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -769,7 +769,6 @@ func TestStateStore_ACLToken_List(t *testing.T) {
 			policy: "a0625e95-9b3e-42de-a8d6-ceef5b6f3286",
 			accessors: []string{
 				"47eea4da-bda1-48a6-901c-3e36d2d9262f",
-				"4915fc9d-3726-4171-b588-6c271f45eecd",
 			},
 		},
 		{
@@ -788,6 +787,7 @@ func TestStateStore_ACLToken_List(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, tokens, err := s.ACLTokenList(nil, tc.local, tc.global, tc.policy)


### PR DESCRIPTION
The inversion wasn't noticed because the parallel execution of TokenList
tests was operating incorrectly due to variable shadowing.