### PR TITLE
UI: Increases the pause between blocking queries to 2000ms

### DIFF
--- a/ui-v2/app/utils/dom/event-source/blocking.js
+++ b/ui-v2/app/utils/dom/event-source/blocking.js
@@ -1,6 +1,7 @@
 import { get } from '@ember/object';
 import { Promise } from 'rsvp';
 
+const pause = 2000;
 // native EventSource retry is ~3s wait
 export const create5xxBackoff = function(ms = 3000, P = Promise, wait = setTimeout) {
   // This expects an ember-data like error
@@ -37,7 +38,7 @@ const throttle = function(configuration, prev, current) {
     return new Promise(function(resolve, reject) {
       setTimeout(function() {
         resolve(obj);
-      }, 200);
+      }, pause);
     });
   };
 };

--- a/ui-v2/tests/helpers/module-for-acceptance.js
+++ b/ui-v2/tests/helpers/module-for-acceptance.js
@@ -4,8 +4,20 @@ import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
 export default function(name, options = {}) {
+  let setTimeout = window.setTimeout;
+  let setInterval = window.setInterval;
   module(name, {
     beforeEach() {
+      const speedup = function(func) {
+        return function(cb, interval = 0) {
+          if (interval > 10) {
+            interval = Math.max(Math.round(interval / 10), 10);
+          }
+          return func(cb, interval);
+        };
+      };
+      window.setTimeout = speedup(window.setTimeout);
+      window.setInterval = speedup(window.setInterval);
       this.application = startApp();
 
       if (options.beforeEach) {
@@ -14,6 +26,8 @@ export default function(name, options = {}) {
     },
 
     afterEach() {
+      window.setTimeout = setTimeout;
+      window.setInterval = setInterval;
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
       return resolve(afterEach).then(() => destroyApp(this.application));
     },


### PR DESCRIPTION
...also:

Temporarily overwrites native setTimeout and setInterval for e2e/acceptance
testing similar to how XHR is overwritten for e2e/acceptance testing.

This makes the blocking query acceptance tests run faster until we add a
better burstable rate limiter for blocking queries.