### PR TITLE
ui: Adds uid to tabular-details for/id's used in toggling for uniqueness

### DIFF
--- a/ui-v2/app/components/tabular-details.js
+++ b/ui-v2/app/components/tabular-details.js
@@ -1,11 +1,20 @@
 import Component from '@ember/component';
 import SlotsMixin from 'block-slots';
 import { inject as service } from '@ember/service';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
+import { subscribe } from 'consul-ui/utils/computed/purify';
 
+let uid = 0;
 export default Component.extend(SlotsMixin, {
   dom: service('dom'),
   onchange: function() {},
+  init: function() {
+    this._super(...arguments);
+    set(this, 'uid', uid++);
+  },
+  inputId: subscribe('name', 'uid', function(name = 'name') {
+    return `tabular-details-${name}-toggle-${uid}_`;
+  }),
   actions: {
     click: function(e) {
       get(this, 'dom').clickFirstAnchor(e);

--- a/ui-v2/app/templates/components/tabular-details.hbs
+++ b/ui-v2/app/templates/components/tabular-details.hbs
@@ -11,14 +11,14 @@
       <tr data-test-tabular-row onclick={{action 'click'}}>
           {{#yield-slot 'row'}}{{yield item index}}{{/yield-slot}}
           <td class="actions">
-            <label for={{concat name '-summary-' index '-toggle'}}><span>Show details</span></label>
+            <label for={{concat inputId index}}><span>Show details</span></label>
           </td>
       </tr>
       <tr>
         <td colspan="3">
-          <input type="checkbox" value={{index}} name={{name}} id={{{ concat name '-summary-' index '-toggle'}}} onchange={{action 'change' item}} />
+          <input type="checkbox" value={{index}} name={{name}} id={{concat inputId index}} onchange={{action 'change' item}} />
           <div>
-            <label for={{concat name '-summary-' index '-toggle'}}><span>Hide details</span></label>
+            <label for={{concat inputId index}}><span>Hide details</span></label>
             <div>
               {{#yield-slot 'details'}}
                 {{yield item index}}


### PR DESCRIPTION
Upcoming work involves some 'inception' like reuse making it less trivial to add unique names manually, it also 'one more thing' to have to remember to add and unique name.

This PR makes tabular-details rows always unique so the toggling always works correctly when you have more than one in a page.

`tabular-component`s use the `<label>/<input>:checked` toggling thing I'm fond of, and they look like this:

![Screenshot 2019-03-29 at 15 14 06](https://user-images.githubusercontent.com/554604/55242532-57207500-5235-11e9-9bad-11339ae586cb.png)

The chevrons on the right do the toggling of the details (in this case the text editor component)
