### PR TITLE
ui: Alter resizing for tabular-collection for sizing based on rows

### DIFF
--- a/ui-v2/app/components/tabular-collection.js
+++ b/ui-v2/app/components/tabular-collection.js
@@ -113,7 +113,8 @@ export default CollectionComponent.extend(SlotsMixin, WithResizing, {
   classNames: ['dom-recycling'],
   attributeBindings: ['style'],
   width: 1150,
-  height: 500,
+  rowHeight: 50,
+  maxHeight: 500,
   style: style('getStyle'),
   checked: null,
   hasCaption: false,
@@ -123,11 +124,17 @@ export default CollectionComponent.extend(SlotsMixin, WithResizing, {
     this.change = change.bind(this);
     this.confirming = [];
     // TODO: The row height should auto calculate properly from the CSS
-    this['cell-layout'] = new ZIndexedGrid(get(this, 'width'), 50);
+    this['cell-layout'] = new ZIndexedGrid(get(this, 'width'), get(this, 'rowHeight'));
   },
-  getStyle: computed('height', function() {
+  getStyle: computed('rowHeight', '_items', 'maxRows', 'maxHeight', function() {
+    const maxRows = get(this, 'rows');
+    let rows = get(this._items || [], 'length');
+    if (maxRows) {
+      rows = Math.min(maxRows, rows);
+    }
+    const height = get(this, 'rowHeight') * rows + 29;
     return {
-      height: get(this, 'height'),
+      height: Math.min(get(this, 'maxHeight'), height),
     };
   }),
   resize: function(e) {
@@ -140,9 +147,9 @@ export default CollectionComponent.extend(SlotsMixin, WithResizing, {
       const $footer = dom.element('footer[role="contentinfo"]');
       const space = rect.top + $footer.clientHeight + border;
       const height = e.detail.height - space;
-      this.set('height', Math.max(0, height));
+      this.set('maxHeight', Math.max(0, height));
       // TODO: The row height should auto calculate properly from the CSS
-      this['cell-layout'] = new ZIndexedGrid($appContent.clientWidth, 50);
+      this['cell-layout'] = new ZIndexedGrid($appContent.clientWidth, get(this, 'rowHeight'));
       this.updateItems();
       this.updateScrollPosition();
     }

--- a/ui-v2/app/styles/components/tabular-collection.scss
+++ b/ui-v2/app/styles/components/tabular-collection.scss
@@ -3,10 +3,6 @@ table.dom-recycling {
   @extend %dom-recycling-table;
 }
 /* project specific */
-%dom-recycling-table {
-  /* minimum of 4x50px heigh rows plus top/bottom margins*/
-  min-height: 249px;
-}
 %dom-recycling-table tbody {
   /* tbodys are all absolute so,*/
   /* make room for the header */


### PR DESCRIPTION
Previously we were lucky enough to have all of these components (the dom recycling scroller components) as the last thing in the page. Therefore they could resize to take up all the remaining space in the browser.

Future work involves instances of this component that have dom elements/components/widgets underneath it on the page, which means we need to have a way to set the height of this component apart from just resizing to the bottom of the browser.

Here we've added a `rows` setting, so that we can fix the height of the component to say a maximum of say 5 rows (other rows are then viewable by scrolling). Using rows instead of pixels means we never get say half a row showing.
