### PR TITLE
Restrict the file extensions read from config dir

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -191,14 +191,12 @@ func (b *Builder) ReadPath(path string) ([]Source, error) {
 		}
 
 		sourceFormat := FormatFrom(fp)
-		if configFormat != "" {
-			if sourceFormat == "json" || sourceFormat == "hcl" || sourceFormat == configFormat {
-				src, err := b.ReadFile(fp)
-				if err != nil {
-					return nil, err
-				}
-				sources = append(sources, src)
+		if sourceFormat == "json" || sourceFormat == "hcl" || configFormat != "" {
+			src, err := b.ReadFile(fp)
+			if err != nil {
+				return nil, err
 			}
+			sources = append(sources, src)
 		}
 	}
 	return sources, nil

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -61,7 +61,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.BootstrapExpect, "bootstrap-expect", "Sets server to expect bootstrap mode.")
 	add(&f.Config.ClientAddr, "client", "Sets the address to bind for client access. This includes RPC, DNS, HTTP, HTTPS and gRPC (if configured).")
 	add(&f.ConfigFiles, "config-dir", "Path to a directory to read configuration files from. This will read every file ending in '.json' as configuration in this directory in alphabetical order. Can be specified multiple times.")
-	add(&f.ConfigFiles, "config-file", "Path to a file with JSON or HCL extension to read configuration from. Can be specified multiple times.")
+	add(&f.ConfigFiles, "config-file", "Path to a file in JSON or HCL format with a matching file extension. Can be specified multiple times.")
 	add(&f.ConfigFormat, "config-format", "Config files are in this format irrespective of their extension. Must be 'hcl' or 'json'")
 	add(&f.Config.DataDir, "data-dir", "Path to a data directory to store agent state.")
 	add(&f.Config.Datacenter, "datacenter", "Datacenter of the agent.")

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -61,7 +61,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.BootstrapExpect, "bootstrap-expect", "Sets server to expect bootstrap mode.")
 	add(&f.Config.ClientAddr, "client", "Sets the address to bind for client access. This includes RPC, DNS, HTTP, HTTPS and gRPC (if configured).")
 	add(&f.ConfigFiles, "config-dir", "Path to a directory to read configuration files from. This will read every file ending in '.json' as configuration in this directory in alphabetical order. Can be specified multiple times.")
-	add(&f.ConfigFiles, "config-file", "Path to a JSON file to read configuration from. Can be specified multiple times.")
+	add(&f.ConfigFiles, "config-file", "Path to a file with JSON or HCL extension to read configuration from. Can be specified multiple times.")
 	add(&f.ConfigFormat, "config-format", "Config files are in this format irrespective of their extension. Must be 'hcl' or 'json'")
 	add(&f.Config.DataDir, "data-dir", "Path to a data directory to store agent state.")
 	add(&f.Config.Datacenter, "datacenter", "Datacenter of the agent.")


### PR DESCRIPTION
Fixes: #4477 and #4506

This PR adjusts the config builder's behavior so that config files are read if one of the following conditions is met:
- `json` or `hcl` is set as the config-format
- The extension is either `json` or `hcl`

If a valid config-format is provided, files with extension other than `json` or `hcl` will be interpreted in that format as stated in [the docs](https://www.consul.io/docs/agent/options.html#_config_format).
