### PR TITLE
Add Documentation Previews and Checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,38 @@ jobs:
           name: middleman build
           command: bundle exec middleman build
 
+      # saves website build directory
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build
+
+  deploy-website:
+    # setting the working_directory along with the checkout path allows us to not have
+    # to cd into the website/ directory for commands
+    working_directory: ~/project/website
+    docker:
+      - image: *MIDDLEMAN_IMAGE
+    steps:
+      - checkout:
+          path: ~/project
+      # attach website build directory
+      - attach_workspace:
+          at: ~/project/website
       - run:
           name: website deploy
           command: ./scripts/deploy.sh
+
+  # Link check on a temporary netlify deployed site
+  docs-link-checker:
+    docker:
+      - image: circleci/node:lts
+    steps:
+      - checkout
+      # attach website build directory
+      - attach_workspace:
+          at: ~/project/website
+      - run: ./website/scripts/link-check.sh
 
   # build frontend yarn cache
   frontend-cache:
@@ -267,7 +296,13 @@ workflows:
             - dev-build
   website:
     jobs:
-      - build-website:
+      - build-website
+      - docs-link-checker:
+          requires:
+            - build-website
+      - deploy-website:
+          requires:
+            - docs-link-checker
           context: static-sites
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,10 @@ workflows:
       - docs-link-checker:
           requires:
             - build-website
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only run link checker on non forks
       - deploy-website:
           requires:
             - docs-link-checker

--- a/website/config.rb
+++ b/website/config.rb
@@ -6,6 +6,9 @@ activate :hashicorp do |h|
   h.github_slug = "hashicorp/consul"
 end
 
+# Netlify redirects/headers
+proxy '_redirects', 'netlify-redirects', ignore: true
+
 helpers do
   # Returns a segment tracking ID such that local development is not
   # tracked to production systems.

--- a/website/scripts/link-check.sh
+++ b/website/scripts/link-check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -xe
+
+# Install netlify-cli
+sudo npm install netlify-cli -g
+
+# Deploy site to netlify
+# Assumes NETLIFY_SITE_ID and NETLIFY_AUTH_TOKEN env variables are set
+output=$(netlify deploy --dir=./website/build)
+
+# Grab deploy URL
+url=$(echo "$output" | grep "Live Draft URL" | sed -E 's/.*(https:\/\/.*$)/\1/')
+
+# Checks broken links
+wget \
+  --delete-after \
+  --level inf \
+  --no-verbose \
+  --recursive \
+  --no-directories \
+  --no-host-directories \
+  --page-requisites \
+  --spider \
+  $url

--- a/website/source/netlify-redirects
+++ b/website/source/netlify-redirects
@@ -1,0 +1,22 @@
+# Consul Redirects
+/api.html                                  /api/index.html
+/api/acl.html                              /api/acl/acl.html
+/docs/agent/acl-rules.html                 /docs/acl/acl-rules.html
+/docs/agent/acl-system.html                /docs/acl/acl-system.html
+/docs/agent/http.html                      /api/index.html
+/docs/guides/acl-legacy.html               /docs/acl/acl-legacy.html
+/docs/guides/acl-migrate-acl-tokens.html   /docs/acl/acl-migrate-acl-tokens.html
+/docs/guides/bootstrapping.html            /docs/install/bootstrapping.html
+/docs/guides/sentinel.html                 /docs/agent/sentinel.html
+
+# Consul Learn Redirects
+/docs/guides/acl.html                          https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide
+/docs/guides/agent-encryption.html             https://learn.hashicorp.com/consul/advanced/day-1-operations/agent-encryption
+/docs/guides/autopilot.html                    https://learn.hashicorp.com/consul/day-2-operations/advanced-operations/autopilot
+/docs/guides/backup.html                       https://learn.hashicorp.com/consul/advanced/day-1-operations/backup
+/docs/guides/cluster-monitoring-metrics.html   https://learn.hashicorp.com/consul/advanced/day-1-operations/monitoring
+/docs/guides/creating-certificates.html        https://learn.hashicorp.com/consul/advanced/day-1-operations/certificates
+/docs/guides/deployment-guide.html             https://learn.hashicorp.com/consul/advanced/day-1-operations/deployment-guide
+/docs/guides/deployment.html                   https://learn.hashicorp.com/consul/advanced/day-1-operations/reference-architecture
+/docs/guides/dns-cache.html                    https://learn.hashicorp.com/consul/day-2-operations/advanced-operations/dns-caching
+/docs/guides/minikube.html                     https://learn.hashicorp.com/consul/getting-started-k8s/minikube


### PR DESCRIPTION
This PR will add link checking to all PRs and branches. There is:

* a link checking script that will use the `netlify-cli` to deploy a site, then use wget to link check this temporary website
* a netlify-redirects file is needed to capture the different redirects we have in Fastly for Consul documentation so redirects are checked properly
* CircleCI will split the website deployment into three stages
    * `build-website` to create a directory of the website to upload (on all branches + PRs)
    * `docs-link-checker` to run the link checker on an upload of the previous build directory onto Netlify (on all **non-forked** branches + PRs)
    * `deploy-website` to deploy the actual site (on the `stable-website` branch only)