### PR TITLE
ui: Expands create-listeners API to allow recursive addition and plain function addition

### DIFF
--- a/ui-v2/app/utils/dom/create-listeners.js
+++ b/ui-v2/app/utils/dom/create-listeners.js
@@ -1,32 +1,40 @@
-export default function(listeners = []) {
-  const add = function(target, event, handler) {
-    let addEventListener = 'addEventListener';
-    let removeEventListener = 'removeEventListener';
-    if (typeof target[addEventListener] === 'undefined') {
-      addEventListener = 'on';
-      removeEventListener = 'off';
+class Listeners {
+  constructor(listeners = []) {
+    this.listeners = listeners;
+  }
+  add(target, event, handler) {
+    let remove;
+    if (typeof target === 'function') {
+      remove = target;
+    } else if (target instanceof Listeners) {
+      remove = target.remove.bind(target);
+    } else {
+      let addEventListener = 'addEventListener';
+      let removeEventListener = 'removeEventListener';
+      if (typeof target[addEventListener] === 'undefined') {
+        addEventListener = 'on';
+        removeEventListener = 'off';
+      }
+      target[addEventListener](event, handler);
+      remove = function() {
+        target[removeEventListener](event, handler);
+        return handler;
+      };
     }
-    target[addEventListener](event, handler);
-    const remove = function() {
-      target[removeEventListener](event, handler);
-      return handler;
+    this.listeners.push(remove);
+    return () => {
+      const pos = this.listeners.findIndex(function(item) {
+        return item === remove;
+      });
+      return this.listeners.splice(pos, 1)[0]();
     };
-    listeners.push(remove);
-    return remove;
-  };
-  // TODO: Allow passing of a 'listener remove' in here
-  // call it, find in the array and remove
-  // Post-thoughts, pretty sure this is covered now by returning the remove
-  // function above, use-case for wanting to use this method to remove individual
-  // listeners is probably pretty limited, this method itself could be easily implemented
-  // from the outside also, but I suppose its handy to keep here
-  const remove = function() {
-    const handlers = listeners.map(item => item());
-    listeners.splice(0, listeners.length);
+  }
+  remove() {
+    const handlers = this.listeners.map(item => item());
+    this.listeners.splice(0, this.listeners.length);
     return handlers;
-  };
-  return {
-    add: add,
-    remove: remove,
-  };
+  }
+}
+export default function(listeners = []) {
+  return new Listeners(listeners);
 }

--- a/ui-v2/tests/unit/utils/dom/create-listeners-test.js
+++ b/ui-v2/tests/unit/utils/dom/create-listeners-test.js
@@ -9,7 +9,7 @@ test('it has add and remove methods', function(assert) {
   assert.ok(typeof listeners.add === 'function');
   assert.ok(typeof listeners.remove === 'function');
 });
-test('add returns an remove function', function(assert) {
+test('add returns a remove function', function(assert) {
   const listeners = createListeners();
   const remove = listeners.add({
     addEventListener: function() {},
@@ -63,6 +63,30 @@ test('listeners are removed on remove', function(assert) {
   remove();
   assert.ok(stub.calledOnce);
   assert.ok(stub.calledWith(name, handler));
+});
+test('listeners as functions are removed on remove', function(assert) {
+  const listeners = createListeners();
+  const stub = this.stub();
+  const remove = listeners.add(stub);
+  remove();
+  assert.ok(stub.calledOnce);
+});
+test('listeners as other listeners are removed on remove', function(assert) {
+  const listeners = createListeners();
+  const listeners2 = createListeners();
+  const stub = this.stub();
+  listeners2.add(stub);
+  const remove = listeners.add(listeners2);
+  remove();
+  assert.ok(stub.calledOnce);
+});
+test('listeners as functions of other listeners are removed on remove', function(assert) {
+  const listeners = createListeners();
+  const listeners2 = createListeners();
+  const stub = this.stub();
+  const remove = listeners.add(listeners2.add(stub));
+  remove();
+  assert.ok(stub.calledOnce);
 });
 test('remove returns the original handler', function(assert) {
   const listeners = createListeners();


### PR DESCRIPTION
This PR expands/improves upon the `create-listeners' utility which we added in https://github.com/hashicorp/consul/pull/4859

1. Adds a `Listeners` class.
2. Point 1 lets us then add `Listeners` recursively. So you can `createListeners().add(createListeners())` (or using the Mixin `this.listen(somethingThatReturnsListeners()`)
3. Also add the ability to `.add` as a plain function as a teardown function

This moves the entire idea more towards a generic teardown utility, potentially at some point in the future this could be renamed to reflect that.

Additionally, using the function that is returned from `add`ing a listener to tear it back down again wouldn't clean up the function from the internal `listeners` array meaning that this array could potentially grow unnecessarily. We aren't using this functionality anywhere currently but this functionality now cleans up correctly incase we ever do (also see removed comments)

To note: All of this functionality is now 'inherited' by the `WithListeners` Mixin which is basically an ember specific wrapper to `create-listeners`

Lastly we aren't using any of this extra functionality as yet (but will be), but we've added some additional tests here.
