### PR TITLE
Share Fastly and Netlify redirects

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -7,7 +7,7 @@ activate :hashicorp do |h|
 end
 
 # Netlify redirects/headers
-proxy '_redirects', 'netlify-redirects', ignore: true
+proxy '_redirects', 'redirects.txt', ignore: true
 
 helpers do
   # Returns a segment tracking ID such that local development is not

--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -5,6 +5,7 @@ PROJECT="consul"
 PROJECT_URL="www.consul.io"
 FASTLY_SERVICE_ID="7GrxRJP3PVBuqQbyxYQ0MV"
 FASTLY_DICTIONARY_ID="7d0yAgSHAQ2efWKeUC3kqW"
+REDIRECTS_FILE="./source/redirects.txt"
 
 # Ensure the proper AWS environment variables are set
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
@@ -96,7 +97,7 @@ fi
 
 # Add redirects if they exist
 # The redirects file is in the source/ directory
-if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./source/redirects.txt" ]; then
+if [ -z "$NO_REDIRECTS" ] || [ ! test -f $REDIRECTS_FILE ]; then
   echo "Adding redirects..."
   fields=()
   while read -r line; do
@@ -106,7 +107,7 @@ if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./source/redirects.txt" ]; then
     # Read fields
     IFS=" " read -ra parts <<<"$line"
     fields+=("${parts[@]}")
-  done < "./redirects.txt"
+  done < REDIRECTS_FILE
 
   # Check we have pairs
   if [ $((${#fields[@]} % 2)) -ne 0 ]; then
@@ -125,11 +126,6 @@ if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./source/redirects.txt" ]; then
   for field in "${fields[@]}"; do
     if [ "${#field}" -gt 256 ]; then
       echo "'$field' is > 256 characters!"
-      exit 1
-    fi
-
-    if [ "${field:0:1}" != "/" ]; then
-      echo "'$field' does not start with /!"
       exit 1
     fi
   done

--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -95,7 +95,8 @@ if [ -z "$NO_UPLOAD" ]; then
 fi
 
 # Add redirects if they exist
-if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./redirects.txt" ]; then
+# The redirects file is in the source/ directory
+if [ -z "$NO_REDIRECTS" ] || [ ! test -f "./source/redirects.txt" ]; then
   echo "Adding redirects..."
   fields=()
   while read -r line; do

--- a/website/source/redirects.txt
+++ b/website/source/redirects.txt
@@ -1,13 +1,13 @@
 # Consul Redirects
-/api.html                                  /api/index.html
-/api/acl.html                              /api/acl/acl.html
-/docs/agent/acl-rules.html                 /docs/acl/acl-rules.html
-/docs/agent/acl-system.html                /docs/acl/acl-system.html
-/docs/agent/http.html                      /api/index.html
-/docs/guides/acl-legacy.html               /docs/acl/acl-legacy.html
-/docs/guides/acl-migrate-acl-tokens.html   /docs/acl/acl-migrate-acl-tokens.html
-/docs/guides/bootstrapping.html            /docs/install/bootstrapping.html
-/docs/guides/sentinel.html                 /docs/agent/sentinel.html
+/api.html                                  https://www.consul.io/api/index.html
+/api/acl.html                              https://www.consul.io/api/acl/acl.html
+/docs/agent/acl-rules.html                 https://www.consul.io/docs/acl/acl-rules.html
+/docs/agent/acl-system.html                https://www.consul.io/docs/acl/acl-system.html
+/docs/agent/http.html                      https://www.consul.io/api/index.html
+/docs/guides/acl-legacy.html               https://www.consul.io/docs/acl/acl-legacy.html
+/docs/guides/acl-migrate-acl-tokens.html   https://www.consul.io/docs/acl/acl-migrate-acl-tokens.html
+/docs/guides/bootstrapping.html            https://www.consul.io/docs/install/bootstrapping.html
+/docs/guides/sentinel.html                 https://www.consul.io/docs/agent/sentinel.html
 
 # Consul Learn Redirects
 /docs/guides/acl.html                          https://learn.hashicorp.com/consul/advanced/day-1-operations/acl-guide


### PR DESCRIPTION
This PR will allow us to share one common redirects file for both the Netlify deploy previews and for Fastly. It will also allow us to manage all our redirects in this file and have it automatically update the Fastly dictionary via the Fastly API on site deploys. 