### PR TITLE
build: use only version tags in version output now api is tagged too

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,7 +25,7 @@ ASSETFS_PATH?=agent/bindata_assetfs.go
 # Get the git commit
 GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
-GIT_DESCRIBE?=$(shell git describe --tags --always)
+GIT_DESCRIBE?=$(shell git describe --tags --always --match "v*")
 GIT_IMPORT=github.com/hashicorp/consul/version
 GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY) -X $(GIT_IMPORT).GitDescribe=$(GIT_DESCRIBE)
 
@@ -267,8 +267,12 @@ ui-docker: ui-build-image
 ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 
+test-envoy-integ: dev-docker
+	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
+
 proto:
 	protoc agent/connect/ca/plugin/*.proto --gofast_out=plugins=grpc:../../..
 
 .PHONY: all ci bin dev dist cov test test-ci test-internal test-install-deps cover format vet ui static-assets tools
-.PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker ui-legacy-docker version proto
+.PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker
+.PHONY: ui-legacy-docker version proto test-envoy-integ

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -267,12 +267,9 @@ ui-docker: ui-build-image
 ui-legacy-docker: ui-legacy-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui-legacy
 
-test-envoy-integ: dev-docker
-	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
-
 proto:
 	protoc agent/connect/ca/plugin/*.proto --gofast_out=plugins=grpc:../../..
 
 .PHONY: all ci bin dev dist cov test test-ci test-internal test-install-deps cover format vet ui static-assets tools
 .PHONY: docker-images go-build-image ui-build-image ui-legacy-build-image static-assets-docker consul-docker ui-docker
-.PHONY: ui-legacy-docker version proto test-envoy-integ
+.PHONY: ui-legacy-docker version proto

--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -513,7 +513,7 @@ function update_git_env {
 
    export GIT_COMMIT=$(git rev-parse --short HEAD)
    export GIT_DIRTY=$(test -n "$(git status --porcelain)" && echo "+CHANGES")
-   export GIT_DESCRIBE=$(git describe --tags --always)
+   export GIT_DESCRIBE=$(git describe --tags --always --match "v*")
    export GIT_IMPORT=github.com/hashicorp/consul/version
    export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"
    return 0


### PR DESCRIPTION
Fixes #5621

Since we now have api package tags, our build tooling was picking up api tag when working out version to bake into builds.

This fixes it by restricting to only tags that start with `v`.

Before:

```
$ make version
Version:                    1.4.4
Version + release:          1.4.4-dev
Version + git:              api/v1.0.1-90-g3ce60db0c
Version + release + git:    api/v1.0.1-90-g3ce60db0c-dev (3ce60db0c)
```

After:

```
$ make version
Version:                    1.4.4
Version + release:          1.4.4-dev
Version + git:              v1.4.4-126-g3ce60db0c
Version + release + git:    v1.4.4-126-g3ce60db0c-dev (3ce60db0c)
```