### PR TITLE
Filter non-passing nodes without modifying cache

### DIFF
--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -264,17 +264,22 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 // filterNonPassing is used to filter out any nodes that have check that are not passing
 func filterNonPassing(nodes structs.CheckServiceNodes) structs.CheckServiceNodes {
 	n := len(nodes)
+
+	// Make a copy of the cached nodes rather than operating on the cache directly
+	out := make([]structs.CheckServiceNode, n)
+	out = append(nodes[:0:0], nodes...)
+
 OUTER:
 	for i := 0; i < n; i++ {
-		node := nodes[i]
+		node := out[i]
 		for _, check := range node.Checks {
 			if check.Status != api.HealthPassing {
-				nodes[i], nodes[n-1] = nodes[n-1], structs.CheckServiceNode{}
+				out[i], out[n-1] = out[n-1], structs.CheckServiceNode{}
 				n--
 				i--
 				continue OUTER
 			}
 		}
 	}
-	return nodes[:n]
+	return out[:n]
 }

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -266,8 +266,7 @@ func filterNonPassing(nodes structs.CheckServiceNodes) structs.CheckServiceNodes
 	n := len(nodes)
 
 	// Make a copy of the cached nodes rather than operating on the cache directly
-	out := make([]structs.CheckServiceNode, n)
-	out = append(nodes[:0:0], nodes...)
+	out := append(nodes[:0:0], nodes...)
 
 OUTER:
 	for i := 0; i < n; i++ {

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Fixes: #5198

To avoid modifying the shared cache when filtering, a copy of the cached nodes is sorted/returned.