### PR TITLE
making ACLToken.ExpirationTime a *time.Time value instead of time.Time

### DIFF
--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/hashicorp/consul/testrpc"
 	uuid "github.com/hashicorp/go-uuid"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/require"
@@ -1054,7 +1054,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 					Description:    "foobar",
 					Policies:       nil,
 					Local:          false,
-					ExpirationTime: time.Now().Add(test.offset),
+					ExpirationTime: timePointer(time.Now().Add(test.offset)),
 				},
 				WriteRequest: structs.WriteRequest{Token: "root"},
 			}
@@ -1099,7 +1099,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 				Description:    "foobar",
 				Policies:       nil,
 				Local:          false,
-				ExpirationTime: time.Now().Add(4 * time.Second),
+				ExpirationTime: timePointer(time.Now().Add(4 * time.Second)),
 				ExpirationTTL:  4 * time.Second,
 			},
 			WriteRequest: structs.WriteRequest{Token: "root"},
@@ -1138,7 +1138,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		require.NotNil(t, token.AccessorID)
 		require.Equal(t, token.Description, "foobar")
 		require.Equal(t, token.AccessorID, resp.AccessorID)
-		requireTimeEquals(t, expectExpTime, resp.ExpirationTime)
+		requireTimeEquals(t, &expectExpTime, resp.ExpirationTime)
 
 		tokenID = token.AccessorID
 	})
@@ -1152,7 +1152,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 				Description:    "foobar",
 				Policies:       nil,
 				Local:          false,
-				ExpirationTime: expTime,
+				ExpirationTime: &expTime,
 			},
 			WriteRequest: structs.WriteRequest{Token: "root"},
 		}
@@ -1170,7 +1170,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		require.NotNil(t, token.AccessorID)
 		require.Equal(t, token.Description, "foobar")
 		require.Equal(t, token.AccessorID, resp.AccessorID)
-		requireTimeEquals(t, expTime, resp.ExpirationTime)
+		requireTimeEquals(t, &expTime, resp.ExpirationTime)
 
 		tokenID = token.AccessorID
 	})
@@ -1183,7 +1183,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 			ACLToken: structs.ACLToken{
 				Description:    "new-description",
 				AccessorID:     tokenID,
-				ExpirationTime: expTime.Add(-1 * time.Second),
+				ExpirationTime: timePointer(expTime.Add(-1 * time.Second)),
 			},
 			WriteRequest: structs.WriteRequest{Token: "root"},
 		}
@@ -1202,7 +1202,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 			ACLToken: structs.ACLToken{
 				Description:    "new-description",
 				AccessorID:     tokenID,
-				ExpirationTime: expTime,
+				ExpirationTime: &expTime,
 			},
 			WriteRequest: structs.WriteRequest{Token: "root"},
 		}
@@ -1220,7 +1220,7 @@ func TestACLEndpoint_TokenSet(t *testing.T) {
 		require.NotNil(t, token.AccessorID)
 		require.Equal(t, token.Description, "new-description")
 		require.Equal(t, token.AccessorID, resp.AccessorID)
-		requireTimeEquals(t, expTime, resp.ExpirationTime)
+		requireTimeEquals(t, &expTime, resp.ExpirationTime)
 	})
 
 	t.Run("cannot update a token that is past its expiration time", func(t *testing.T) {
@@ -2217,10 +2217,16 @@ func retrieveTestPolicy(codec rpc.ClientCodec, masterToken string, datacenter st
 	return &out, nil
 }
 
-func requireTimeEquals(t *testing.T, expect, got time.Time) {
+func requireTimeEquals(t *testing.T, expect, got *time.Time) {
 	t.Helper()
-	if !expect.Equal(got) {
-		t.Fatalf("expected=%q != got=%q", expect, got)
+	if expect == nil && got == nil {
+		return
+	} else if expect == nil && got != nil {
+		t.Fatalf("expected=NIL != got=%q", *got)
+	} else if expect != nil && got == nil {
+		t.Fatalf("expected=%q != got=NIL", *expect)
+	} else if !expect.Equal(*got) {
+		t.Fatalf("expected=%q != got=%q", *expect, *got)
 	}
 }
 

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -1741,7 +1741,7 @@ func TestTokenPoliciesIndex(t *testing.T) {
 			SecretID:       newUUID(),
 			Description:    desc,
 			Local:          local,
-			ExpirationTime: expTime,
+			ExpirationTime: &expTime,
 			CreateTime:     baseTime,
 			RaftIndex: structs.RaftIndex{
 				CreateIndex: 9,

--- a/api/acl.go
+++ b/api/acl.go
@@ -31,7 +31,7 @@ type ACLToken struct {
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
 	Local             bool
 	ExpirationTTL     time.Duration `json:",omitempty"`
-	ExpirationTime    time.Time     `json:",omitempty"`
+	ExpirationTime    *time.Time    `json:",omitempty"`
 	CreateTime        time.Time     `json:",omitempty"`
 	Hash              []byte        `json:",omitempty"`
 
@@ -48,7 +48,7 @@ type ACLTokenListEntry struct {
 	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
 	Local             bool
-	ExpirationTime    time.Time `json:",omitempty"`
+	ExpirationTime    *time.Time `json:",omitempty"`
 	CreateTime        time.Time
 	Hash              []byte
 	Legacy            bool

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -15,8 +15,8 @@ func PrintToken(token *api.ACLToken, ui cli.Ui, showMeta bool) {
 	ui.Info(fmt.Sprintf("Description:      %s", token.Description))
 	ui.Info(fmt.Sprintf("Local:            %t", token.Local))
 	ui.Info(fmt.Sprintf("Create Time:      %v", token.CreateTime))
-	if !token.ExpirationTime.IsZero() {
-		ui.Info(fmt.Sprintf("Expiration Time:  %v", token.ExpirationTime))
+	if token.ExpirationTime != nil && !token.ExpirationTime.IsZero() {
+		ui.Info(fmt.Sprintf("Expiration Time:  %v", *token.ExpirationTime))
 	}
 	if showMeta {
 		ui.Info(fmt.Sprintf("Hash:             %x", token.Hash))
@@ -46,8 +46,8 @@ func PrintTokenListEntry(token *api.ACLTokenListEntry, ui cli.Ui, showMeta bool)
 	ui.Info(fmt.Sprintf("Description:      %s", token.Description))
 	ui.Info(fmt.Sprintf("Local:            %t", token.Local))
 	ui.Info(fmt.Sprintf("Create Time:      %v", token.CreateTime))
-	if !token.ExpirationTime.IsZero() {
-		ui.Info(fmt.Sprintf("Expiration Time:  %v", token.ExpirationTime))
+	if token.ExpirationTime != nil && !token.ExpirationTime.IsZero() {
+		ui.Info(fmt.Sprintf("Expiration Time:  %v", *token.ExpirationTime))
 	}
 	ui.Info(fmt.Sprintf("Legacy:           %t", token.Legacy))
 	if showMeta {

--- a/vendor/github.com/hashicorp/consul/api/acl.go
+++ b/vendor/github.com/hashicorp/consul/api/acl.go
@@ -31,7 +31,7 @@ type ACLToken struct {
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
 	Local             bool
 	ExpirationTTL     time.Duration `json:",omitempty"`
-	ExpirationTime    time.Time     `json:",omitempty"`
+	ExpirationTime    *time.Time    `json:",omitempty"`
 	CreateTime        time.Time     `json:",omitempty"`
 	Hash              []byte        `json:",omitempty"`
 
@@ -48,7 +48,7 @@ type ACLTokenListEntry struct {
 	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
 	Local             bool
-	ExpirationTime    time.Time `json:",omitempty"`
+	ExpirationTime    *time.Time `json:",omitempty"`
 	CreateTime        time.Time
 	Hash              []byte
 	Legacy            bool


### PR DESCRIPTION
_Note: this is merging into a feature branch, not master._

This is mainly to avoid having the API return "0001-01-01T00:00:00Z" as
a value for the ExpirationTime field when it is not set. Unfortunately
time.Time doesn't respect the json marshalling "omitempty" directive.