### PR TITLE
ui: Fixes RTT display, by ensuring use of ember proxies in tomography

### DIFF
--- a/ui-v2/app/components/tomography-graph.js
+++ b/ui-v2/app/components/tomography-graph.js
@@ -35,18 +35,19 @@ export default Component.extend({
         set(this, 'max', d.distance);
       }
     });
-    if (tomography.n > 360) {
-      let n = distances.length;
+    let n = get(distances, 'length');
+    if (n > 360) {
       // We have more nodes than we want to show, take a random sampling to keep
       // the number around 360.
-      const sampling = 360 / tomography.n;
+      const sampling = 360 / n;
       distances = distances.filter(function(_, i) {
         return i == 0 || i == n - 1 || Math.random() < sampling;
       });
+      n = get(distances, 'length');
     }
     return distances.map((d, i) => {
       return {
-        rotate: (i * 360) / distances.length,
+        rotate: (i * 360) / n,
         y2: -insetSize * (d.distance / get(this, 'max')),
         node: d.node,
         distance: d.distance,

--- a/ui-v2/app/components/tomography-graph.js
+++ b/ui-v2/app/components/tomography-graph.js
@@ -28,8 +28,8 @@ export default Component.extend({
     ];
   }),
   distances: computed('tomography', function() {
-    const tomography = this.get('tomography');
-    let distances = tomography.distances || [];
+    const tomography = get(this, 'tomography');
+    let distances = get(tomography, 'distances') || [];
     distances.forEach((d, i) => {
       if (d.distance > get(this, 'max')) {
         set(this, 'max', d.distance);
@@ -46,7 +46,7 @@ export default Component.extend({
     }
     return distances.map((d, i) => {
       return {
-        rotate: i * 360 / distances.length,
+        rotate: (i * 360) / distances.length,
         y2: -insetSize * (d.distance / get(this, 'max')),
         node: d.node,
         distance: d.distance,

--- a/ui-v2/app/utils/tomography.js
+++ b/ui-v2/app/utils/tomography.js
@@ -44,7 +44,6 @@ export default function(distance) {
     }
     return {
       distances: distances,
-      n: distances.length,
       min: parseInt(min * 100) / 100,
       median: parseInt(median * 100) / 100,
       max: parseInt(max * 100) / 100,

--- a/ui-v2/tests/acceptance/dc/nodes/show.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/show.feature
@@ -74,4 +74,10 @@ Feature: dc / nodes / show: Show node
     Then the url should be /dc1/nodes/node-0
     And the url "/v1/internal/ui/node/node-0" responds with a 404 status
     And pause until I see the text "no longer exists" in "[data-notification]"
+  @ignore
+    Scenario: The RTT for the node is displayed properly
+    Then ok
+  @ignore
+    Scenario: The RTT for the node displays properly whilst blocking
+    Then ok
 


### PR DESCRIPTION
Previously the tomography wasn't using ember `get` so proxy updates weren't working, specifically here whilst receiving a blocking update.

This adds `get` usage to the tomography graph component until we update to newer `get`less ember

Skipped tests are adding here to nag us to come back here at some point. Extra brackets seem to have come from prettier.


