### PR TITLE
ui: Closes the proxy blocking query for the service instance on deregister

### DIFF
--- a/ui-v2/app/controllers/dc/services/instance.js
+++ b/ui-v2/app/controllers/dc/services/instance.js
@@ -22,6 +22,10 @@ export default Controller.extend(WithEventSource, {
           type: 'warning',
           action: 'update',
         });
+        const proxy = get(this, 'proxy');
+        if (proxy) {
+          proxy.close();
+        }
       }
     }
   }),

--- a/ui-v2/tests/acceptance/dc/services/instances/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/show.feature
@@ -82,4 +82,7 @@ Feature: dc / services / instances / show: Show Service Instance
     Then the url should be /dc1/services/service-0/service-0-with-id
     And an external edit results in 0 instance models
     And pause until I see the text "deregistered" in "[data-notification]"
+  @ignore
+    Scenario: A Service Instance's proxy blocking query is closed when the instance is deregistered
+    Then ok
 


### PR DESCRIPTION
If a service instance show page is being viewed and the service instance
is deregistered, this closes the blocking query for the proxy as well as
the instance itself (the instances query will be closed on the error)

There's a `null` check as proxy service instances never have a proxy. Even if normal instances don't have a proxy, the will have a proxy blocking query to check if a proxy ever gets added.

Also adds skipped tests to nag in future