### PR TITLE
ui: Adds easily accessible `env` for user settable 'debug' settings

### DIFF
--- a/ui-v2/app/env.js
+++ b/ui-v2/app/env.js
@@ -1,0 +1,5 @@
+import config from './config/environment';
+export default function(str) {
+  const user = window.localStorage.getItem(str);
+  return user !== null ? user : config[str];
+}

--- a/ui-v2/app/instance-initializers/event-source.js
+++ b/ui-v2/app/instance-initializers/event-source.js
@@ -1,8 +1,7 @@
-import config from '../config/environment';
+import env from 'consul-ui/env';
 
-const enabled = 'CONSUL_UI_DISABLE_REALTIME';
 export function initialize(container) {
-  if (config[enabled] || window.localStorage.getItem(enabled) !== null) {
+  if (env('CONSUL_UI_DISABLE_REALTIME')) {
     return;
   }
   ['node', 'coordinate', 'session', 'service', 'proxy']


### PR DESCRIPTION
This is a synchronous only 'debug' setting accessor, uses localStorage
first and falls back to ember config.

Essentially this is 'feature flags' for the UI, but as we can't/don't use a third party '...as a service' we use localStorage instead. This is just a slight expansion on what we had previously to make it easier to use. Future work may involve an injectable Service exposing this for usage in JS classes, plus a helper for usage in templates.

Lastly, please note these are largely temporary settings/forking, and the settings themselves are extremely likely to be removed in future. They are purely to give us options if we need to debug new features with users, hence 'debug' settings, which is why we don't want a proper interface allow users to change them easily (right now at least).

'Proper' user settings will continue to be available in the Settings area of the UI.