### PR TITLE
[docs] Clarify duration string format and default for -log-rotate-duration

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -245,7 +245,7 @@ will exit with an error at startup.
 
 * <a name="_log_rotate_bytes"></a><a href="#_log_rotate_bytes">`-log-rotate-bytes`</a> - to specify the number of bytes that should be written to a log before it needs to be rotated. Unless specified, there is no limit to the number of bytes that can be written to a log file.
 
-* <a name="_log_rotate_duration"></a><a href="#_log_rotate_duration">`-log-rotate-duration`</a> - to specify the maximum duration a log should be written to before it needs to be rotated. Unless specified, logs are rotated on a daily basis (24 hrs).
+* <a name="_log_rotate_duration"></a><a href="#_log_rotate_duration">`-log-rotate-duration`</a> - to specify the maximum duration a log should be written to before it needs to be rotated. Must be a duration value such as 30s. Defaults to 24h.
 
 * <a name="_join"></a><a href="#_join">`-join`</a> - Address of another agent
   to join upon starting up. This can be


### PR DESCRIPTION
This PR makes the docs for `-log-rotate-duration` clearer and more consistent with other options such as [last_contact_threshold](https://www.consul.io/docs/agent/options.html#last_contact_threshold)

Based on feedback from the mailing list:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/consul-tool/20e4zf8Bs0A/x0-d7fJ_BgAJ