### PR TITLE
[WIP] Reorganize `learn.hashicorp.com` tracks into subdirectory

### DIFF
--- a/learn/GUIDE_TEMPLATE.md
+++ b/learn/GUIDE_TEMPLATE.md
@@ -1,0 +1,27 @@
+## What You'll Learn
+
+### Personas
+
+### The Challenge
+
+### The Solution
+
+## Prerequisites
+
+## Steps
+
+## Step 1
+
+### CLI Command
+
+### Example
+
+## Hardware Requirements
+
+## Next Steps
+
+## Help and Reference
+
+### Reference Material
+
+### Additional Discussion

--- a/learn/README.md
+++ b/learn/README.md
@@ -1,0 +1,55 @@
+# HashiCorp Learn
+
+This project is a centralized home to HashiCorp's educational content providing a self-directed learning experience for practitioners at all skill levels.
+
+Currently, this is a WIP, covering [Vault](https://vaultproject.io) to start, with content for additional products coming in the future.
+
+## Architecture
+
+This project uses Hashicorp's [base website template](https://github.com/hashicorp/middleman-template), built with [middleman](https://middlemanapp.com/),using [postcss](https://github.com/postcss/postcss), [babel](https://github.com/babel/babel), and [reshape](https://github.com/reshape/reshape).
+
+This project uses a custom html parsing pipeline that enables it to use static-rendered [preact](https://preactjs.com/) components, that are optionally rehydrated on the client side.
+
+See `/assets/js/components/readme.md` for information on working with components.
+
+Request access to HashiCorp marketing team developer documentation for more detailed information on this architecture. Jeff Escalante can help you get access.
+
+## Setup
+
+- If your ruby version (`ruby -v`) is below `2.3.1`, make sure you have the latest version of ruby installed with `brew install ruby`
+- Read the last line of `Gemfile.lock` (`BUNDLED WITH`) and install that exact version of `bundler`: `gem install bundler --version=1.16.1`
+- Make sure [node.js](https://nodejs.org/en/) is installed
+- Run `bash bootstrap.sh` script to get all the dependencies installed
+- Run `bundle exec middleman` to compile the site
+
+If you run into version errors with Bundler, try:
+
+- Delete the local `vendor/bundle` directory and re-run `bootstrap.sh`
+- Ensure that you have the correct version of Bundler: `bundler --version`
+
+## Content
+
+_Note:_ **Tracks** (e.g. 'Encryption as a Service') are a collection of **topics** (e.g. 'Transit secret re-wrapping') organized into a sequence.
+
+Content for _Learn_ is stored as Markdown files with the following path structure: `source/<product>/<track>/<name-of-topic>.md`
+
+Metadata that is _specific_ to that topic is stored within the frontmatter of the Markdown file.
+
+```yml
+name: 'Install Vault'
+content_length: 2
+description: 'Short description of the track contents'
+id: install-vault
+level: Beginner
+products_used:
+  - Vault
+  - Nomad
+---
+
+```
+
+Images to be used within topic content are stored in an `img` folder dedicated to that track. Example: `source/<product>/<track>/<img>/<name-of-asset>.jpg` These assets are then referenced in a Markdown file using standard syntax.
+
+### Track Metadata
+
+To organize topic content into tracks, `.yml` files stored in `data/<product>/<track-grouping>.yml` define metadata about the track (the name, icon used, etc.) as well as the topics and the order of the topics that make up that track.

--- a/learn/data/consul.yml
+++ b/learn/data/consul.yml
@@ -1,0 +1,102 @@
+product: Consul
+docs_url: https://www.consul.io/docs/index.html
+header: 'Learn how to deploy a service mesh with HashiCorp Consul'
+docs:
+  - label: Internals
+    url: https://www.consul.io/docs/internals/index.html
+  - label: Kubernetes
+    url: https://www.consul.io/docs/platform/k8s/index.html
+  - label: Configuration
+    url: https://www.consul.io/docs/agent/options.html
+  - label: CLI
+    url: https://www.consul.io/docs/commands/index.html
+  - label: Connect
+    url: https://www.consul.io/docs/connect/index.html
+  - label: Enterprise
+    url: https://www.consul.io/docs/enterprise/index.html
+
+footer_links:
+  - title: Docs
+    url: https://www.consul.io/docs/index.html
+  - title: API
+    url: https://www.consul.io/api/index.html
+  - title: Enterprise
+    url: https://www.hashicorp.com/products/consul
+  - title: Security
+    url: https://www.consul.io/security.html
+  - title: Press Kit
+    url: https://www.consul.io/assets/files/press-kit.zip
+
+tracks:
+  - name: 'Getting Started'
+    product: consul
+    level: getting-started
+    id: getting-started
+    description: |-
+      Consul is a service mesh solution providing a full featured control plane with service discovery, configuration, and segmentation functionality. Get started here with day 0 operations.
+    icon: grad_hat
+    topics:
+      - install
+      - agent
+      - services
+      - connect
+      - join
+      - checks
+      - kv
+      - ui
+      - next-steps
+
+  - name: 'Getting Started with Kubernetes'
+    product: consul
+    level: getting-started
+    id: getting-started-k8s
+    description: |-
+      Consul deployments on Kubernetes offers the same valuable functionality. Get started here with day 0 operations for Consul on Kubernetes.
+    icon: grad_hat
+    topics:
+      - minikube
+      - helm-deploy
+
+  - name: 'Day 1: Deploying Your First Datacenter'
+    product: consul
+    level: advanced
+    id: advanced
+    description: |-
+      Learn to deploy your first datacenter. If you are responsible for setting up and maintaining a healthy datacenter, this path will help you do so successfully.
+    icon: cubes
+    topics:
+      - /day-1-operations/path-intro
+      - /day-1-operations/reference-architecture
+      - /day-1-operations/deployment-guide
+      - /day-1-operations/backup
+      - /day-1-operations/acl-guide
+      - /day-1-operations/production-acls
+      - /day-1-operations/certificates
+      - /day-1-operations/agent-encryption
+      - /day-1-operations/monitoring
+      - /day-1-operations/path-next-steps
+      - /day-1-operations/production-checklist
+
+  - name: 'Day 2: Advanced Operations'
+    product: consul
+    level: advanced
+    id: day-2-operations
+    description: |-
+      Learn to conduct ongoing maintenance on your first datacenter. This track includes a series of guides for advanced operations that may need to be performed after the initial setup.
+    icon: cubes
+    topics:
+      - /advanced-operations/servers
+      - /advanced-operations/autopilot
+      - /advanced-operations/dns-caching
+      - /advanced-operations/outage
+      - /advanced-operations/troubleshooting
+
+  - name: 'Day 1: Kubernetes Operations'
+    product: consul
+    level: advanced
+    id: kubernetes
+    description: |-
+      Learn how to prepare a Kubernetes cluster to deploy Consul.
+    icon: cubes
+    topics:
+      - /kubernetes/kubernetes-reference

--- a/learn/source/content/consul/advanced/advanced-operations/autopilot.md
+++ b/learn/source/content/consul/advanced/advanced-operations/autopilot.md
@@ -1,0 +1,299 @@
+---
+name: "Autopilot"
+content_length: 13
+id: /advanced-operations/autopilot
+products_used: 
+  - Consul
+description: This guide covers how to configure and use Autopilot features.
+level: Advanced
+---
+
+Autopilot features allow for automatic,
+operator-friendly management of Consul servers. It includes cleanup of dead
+servers, monitoring the state of the Raft cluster, and stable server introduction.
+
+To enable Autopilot features (with the exception of dead server cleanup),
+the [`raft_protocol`](https://www.consul.io/docs/agent/options.html#_raft_protocol) setting in
+the Agent configuration must be set to 3 or higher on all servers. In Consul
+0.8 this setting defaults to 2; in Consul 1.0 it will default to 3. For more
+information, see the [Version Upgrade section](https://www.consul.io/docs/upgrade-specific.html#raft_protocol)
+on Raft Protocol versions.
+
+In this guide we will learn more about Autopilot's features.
+
+* Dead server cleanup
+* Server Stabilization
+* Redundancy zone tags
+* Upgrade migration
+
+Finally, we will review how to ensure Autopilot is healthy.
+
+Note, in this guide we are using  examples from a Consul 1.4 cluster, we
+are starting with Autopilot enabled by default.
+
+## Default Configuration
+
+The configuration of Autopilot is loaded by the leader from the agent's
+[Autopilot settings](https://www.consul.io/docs/agent/options.html#autopilot) when initially
+bootstrapping the cluster. Since Autopilot and it's features are already
+enabled, we only need to update the configuration to disable them. The
+following are the defaults.
+
+```
+{
+    "cleanup_dead_servers": true,
+    "last_contact_threshold": "200ms",
+    "max_trailing_logs": 250,
+    "server_stabilization_time": "10s",
+    "redundancy_zone_tag": "",
+    "disable_upgrade_migration": false,
+    "upgrade_version_tag": ""
+}
+```
+
+All Consul servers should have Autopilot and its features either enabled
+or disabled to ensure consistency accross servers in case of a failure. Additionally,
+Autopilot must be enabled to use any of the features, but the features themselves
+can be configured independently. Meaning you can enable or disable any of the features
+separately, at any time.
+
+After bootstrapping, the configuration can be viewed or modified either via the
+[`operator autopilot`](https://www.consul.io/docs/commands/operator/autopilot.html) subcommand or the
+[`/v1/operator/autopilot/configuration`](https://www.consul.io/api/operator.html#autopilot-configuration)
+HTTP endpoint.
+
+```
+$ consul operator autopilot get-config
+CleanupDeadServers = true
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 10s
+RedundancyZoneTag = ""
+DisableUpgradeMigration = false
+UpgradeVersionTag = ""
+```
+
+In the example above, we used the `operator autopilot get-config` subcommand to check
+the autopilot configuration. You can see we still have all the defaults.
+
+## Dead Server Cleanup
+
+If Autopilot is disabled, it will take 72 hours for dead servers to be automatically reaped
+or an operator had to script a `consul force-leave`. If another server failure occurred
+it could jeopardize the quorum, even if the failed Consul server had been automatically
+replaced. Autopilot helps prevent these kinds of outages by quickly removing failed
+servers as soon as a replacement Consul server comes online. When servers are removed
+by the cleanup process they will enter the "left" state.
+
+With Autopilot's dead server cleanup enabled, dead servers will periodically be
+cleaned up and removed from the Raft peer set to prevent them from interfering with
+the quorum size and leader elections. The cleanup process will also be automatically
+triggered whenever a new server is successfully added to the cluster.
+
+To update the dead server cleanup feature use `consul operator autopilot set-config`
+with the `-cleanup-dead-servers` flag.
+
+```sh
+$ consul operator autopilot set-config -cleanup-dead-servers=false
+Configuration updated!
+
+$ consul operator autopilot get-config
+CleanupDeadServers = false
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 10s
+RedundancyZoneTag = ""
+DisableUpgradeMigration = false
+UpgradeVersionTag = ""
+```
+
+We have disabled dead server cleanup, but sill have all the other Autopilot defaults.
+
+## Server Stabilization
+
+When a new server is added to the cluster, there is a waiting period where it
+must be healthy and stable for a certain amount of time before being promoted
+to a full, voting member. This can be configured via the `ServerStabilizationTime`
+setting.
+
+```sh
+consul operator autopilot set-config -server-stabilization-time=5s
+Configuration updated!
+
+$ consul operator autopilot get-config
+CleanupDeadServers = false
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 5s
+RedundancyZoneTag = ""
+DisableUpgradeMigration = false
+UpgradeVersionTag = ""
+```
+
+Now we have disabled dead server cleanup and set the server stabilization time to 5 seconds.
+When a new server is added to our cluster, it will only need to be healthy and stable for
+5 seconds.
+
+## Redundancy Zones
+
+Prior to Autopilot, it was difficult to deploy servers in a way that took advantage of
+isolated failure domains such as AWS Availability Zones; users would be forced to either
+have an overly-large quorum (2-3 nodes per AZ) or give up redundancy within an AZ by
+deploying just one server in each.
+
+If the `RedundancyZoneTag` setting is set, Consul will use its value to look for a
+zone in each server's specified [`-node-meta`](https://www.consul.io/docs/agent/options.html#_node_meta)
+tag. For example, if `RedundancyZoneTag` is set to `zone`, and `-node-meta zone:east1a`
+is used when starting a server, that server's redundancy zone will be `east1a`.
+
+```
+$ consul operator autopilot set-config -redundancy-zone-tag=uswest1
+Configuration updated!
+
+$ consul operator autopilot get-config
+CleanupDeadServers = false
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 5s
+RedundancyZoneTag = "uswest1"
+DisableUpgradeMigration = false
+UpgradeVersionTag = ""
+```
+
+For our Autopilot features, we now have disabled dead server cleanup, server stabilization time to 5 seconds, and
+the redundancy zone tag is uswest1.
+
+Consul will then use these values to partition the servers by redundancy zone, and will
+aim to keep one voting server per zone. Extra servers in each zone will stay as non-voters
+on standby to be promoted if the active voter leaves or dies.
+
+## Upgrade Migrations
+
+Autopilot in Consul *Enterprise* supports upgrade migrations by default. To disable this
+functionality, set `DisableUpgradeMigration` to true.
+
+```sh
+$ consul operator autopilot set-config -disable-upgrade-migration=true
+Configuration updated!
+
+$ consul operator autopilot get-config
+CleanupDeadServers = false
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 5s
+RedundancyZoneTag = "uswest1"
+DisableUpgradeMigration = true
+UpgradeVersionTag = ""
+```
+
+With upgrade migration enabled, when a new server is added and Autopilot detects that
+its Consul version is newer than that of the existing servers, Autopilot will avoid
+promoting the new server until enough newer-versioned servers have been added to the
+cluster. When the count of new servers equals or exceeds that of the old servers,
+Autopilot will begin promoting the new servers to voters and demoting the old servers.
+After this is finished, the old servers can be safely removed from the cluster.
+
+To check the consul version of the servers, you can either use the [autopilot health]
+(https://consul.io/api/operator.html#autopilot-health) endpoint or the `consul members`
+command.
+
+```
+$ consul members
+Node   Address         Status  Type    Build  Protocol  DC   Segment
+node1  127.0.0.1:8301  alive   server  1.4.0  2         dc1   <all>
+node2  127.0.0.1:8703  alive   server  1.4.0  2         dc1   <all>
+node3  127.0.0.1:8803  alive   server  1.4.0  2         dc1   <all>
+node4  127.0.0.1:8203  alive   server  1.3.0  2         dc1   <all>
+```
+
+### Migrations Without a Consul Version Change
+
+The `UpgradeVersionTag` can be used to override the version information used during
+a migration, so that the migration logic can be used for updating the cluster when
+changing configuration.
+
+If the `UpgradeVersionTag` setting is set, Consul will use its value to look for a
+version in each server's specified [`-node-meta`](https://www.consul.io/docs/agent/options.html#_node_meta)
+tag. For example, if `UpgradeVersionTag` is set to `build`, and `-node-meta build:0.0.2`
+is used when starting a server, that server's version will be `0.0.2` when considered in
+a migration. The upgrade logic will follow semantic versioning and the version string
+must be in the form of either `X`, `X.Y`, or `X.Y.Z`.
+
+```sh
+$ consul operator autopilot set-config -upgrade-version-tag=1.4.0
+Configuration updated!
+
+$ consul operator autopilot get-config
+CleanupDeadServers = false
+LastContactThreshold = 200ms
+MaxTrailingLogs = 250
+ServerStabilizationTime = 5s
+RedundancyZoneTag = "uswest1"
+DisableUpgradeMigration = true
+UpgradeVersionTag = "1.4.0"
+```
+
+## Server Health Checking
+
+An internal health check runs on the leader to track the stability of servers.
+<br>A server is considered healthy if all of the following conditions are true.
+
+- It has a SerfHealth status of 'Alive'.
+- The time since its last contact with the current leader is below
+`LastContactThreshold`.
+- Its latest Raft term matches the leader's term.
+- The number of Raft log entries it trails the leader by does not exceed
+`MaxTrailingLogs`.
+
+The status of these health checks can be viewed through the [`/v1/operator/autopilot/health`]
+(https://www.consul.io/api/operator.html#autopilot-health) HTTP endpoint, with a top level
+`Healthy` field indicating the overall status of the cluster:
+
+```
+$ curl localhost:8500/v1/operator/autopilot/health
+{
+    "Healthy": true,
+    "FailureTolerance": 0,
+    "Servers": [
+        {
+            "ID": "e349749b-3303-3ddf-959c-b5885a0e1f6e",
+            "Name": "node1",
+            "Address": "127.0.0.1:8300",
+            "SerfStatus": "alive",
+            "Version": "0.8.0",
+            "Leader": true,
+            "LastContact": "0s",
+            "LastTerm": 2,
+            "LastIndex": 10,
+            "Healthy": true,
+            "Voter": true,
+            "StableSince": "2017-03-28T18:28:52Z"
+        },
+        {
+            "ID": "e35bde83-4e9c-434f-a6ef-453f44ee21ea",
+            "Name": "node2",
+            "Address": "127.0.0.1:8705",
+            "SerfStatus": "alive",
+            "Version": "0.8.0",
+            "Leader": false,
+            "LastContact": "35.371007ms",
+            "LastTerm": 2,
+            "LastIndex": 10,
+            "Healthy": true,
+            "Voter": false,
+            "StableSince": "2017-03-28T18:29:10Z"
+        }
+    ]
+}
+```
+
+## Summary
+
+In this guide we configured most of the Autopilot features; dead server cleanup, server
+stabilization, redundancy zone tags, upgrade migration, and upgrade version tag.
+
+To learn more about the Autopilot settings we did not configure,
+[last_contact_threshold](https://www.consul.io/docs/agent/options.html#last_contact_threshold)
+and [max_trailing_logs](https://www.consul.io/docs/agent/options.html#max_trailing_logs),
+either read the agent configuration documentation or use the help flag with the
+operator autopilot `consul operator autopilot set-config -h`.

--- a/learn/source/content/consul/advanced/advanced-operations/dns-caching.md
+++ b/learn/source/content/consul/advanced/advanced-operations/dns-caching.md
@@ -1,0 +1,179 @@
+---
+name: "DNS Caching"
+content_length: 11
+id: /advanced-operations/dns-caching
+layout: content_layout
+products_used:
+  - Consul
+description: One of the main interfaces to Consul is DNS. Using DNS is a simple way to integrate Consul into an existing infrastructure without any high-touch integration.
+level: Advanced
+---
+
+One of the main interfaces to Consul is DNS. Using DNS is a simple way to
+integrate Consul into an existing infrastructure without any high-touch
+integration.
+
+By default, Consul serves all DNS results with a 0 TTL value. This prevents
+any caching. The advantage is that each DNS lookup is always re-evaluated,
+so the most timely information is served. However, this adds a latency hit
+for each lookup and can potentially exhaust the query throughput of a cluster.
+For this reason, Consul provides a number of tuning parameters that can
+customize how DNS queries are handled.
+
+In this guide, we will review important parameters for tuning
+stale reads, negative response caching, and TTL. All of the DNS config
+parameters must be set in set in the agent's configuration file.
+
+<a name="stale"></a>
+## Stale Reads
+
+Stale reads can be used to reduce latency and increase the throughput
+of DNS queries. The [settings](https://www.consul.io/docs/agent/options.html) used to control stale reads
+are:
+
+* [`dns_config.allow_stale`](https://www.consul.io/docs/agent/options.html#allow_stale) must be
+set to true to enable stale reads.
+* [`dns_config.max_stale`](https://www.consul.io/docs/agent/options.html#max_stale) limits how stale results
+are allowed to be when querying DNS.
+
+With these two settings you can allow or prevent stale reads. Below we will discuss
+the advanatages and disadvatages of both.
+
+### Allow Stale Reads
+
+Since Consul 0.7.1, `allow_stale` is enabled by default and uses a `max_stale`
+value that defaults to a near-indefinite threshold (10 years).
+This allows DNS queries to continue to be served in the event
+of a long outage with no leader. A new telemetry counter has also been added at
+`consul.dns.stale_queries` to track when agents serve DNS queries that are stale
+by more than 5 seconds.
+
+```javascript
+"dns_config" {
+  "allow_stale" = true
+  "max_stale" = "87600h"
+}
+```
+
+~> NOTE: The above example is the default setting. You do not need to set it explicitly.
+
+Doing a stale read allows any Consul server to
+service a query, but non-leader nodes may return data that is
+out-of-date. By allowing data to be slightly stale, we get horizontal
+read scalability. Now any Consul server can service the request, so we
+increase throughput by the number of servers in a cluster.
+
+### Prevent Stale Reads
+
+If you want to prevent stale reads or limit how stale they can be, you can set `allow_stale`
+to false or use a lower value for `max_stale`. Doing the first will ensure that
+all reads are serviced by a [single leader node](https://www.consul.io/docs/internals/consensus.html).
+The reads will then be strongly consistent but will be limited by the throughput
+of a single node.
+
+```javascript
+"dns_config" {
+  "allow_stale" = false
+}
+```
+
+## Negative Response Caching
+
+Some DNS clients cache negative responses - that is, Consul returning a "not
+found" style response because a service exists but there are no healthy
+endpoints. In practice, this could mean that the cached negative responses may
+cause that service to appear "down" for longer than they are actually unavailable
+when using DNS for service discovery.
+
+### Configure SOA
+
+In Consul 1.3.0 and newer, it is now possible to tune SOA
+responses and modify the negative TTL cache for some resolvers. It can
+be achieved using the [`soa.min_ttl`](https://www.consul.io/docs/agent/options.html#soa_min_ttl)
+configuration within the [`soa`](https://www.consul.io/docs/agent/options.html#soa) configuration.
+
+```javascript
+"dns_config" {
+  "soa" {
+   "min_ttl" = "60s"
+  }
+}
+```
+
+One common example is that Windows will default to caching negative responses
+for 15 minutes. DNS forwarders may also cache negative responses, with the same
+effect. To avoid this problem, check the negative response cache defaults for
+your client operating system and any DNS forwarder on the path between the
+client and Consul and set the cache values appropriately. In many cases
+"appropriately" simply is turning negative response caching off to get the best
+recovery time when a service becomes available again.
+
+<a name="ttl"></a>
+## TTL Values
+
+TTL values can be set to allow DNS results to be cached downstream of Consul. Higher
+TTL values reduce the number of lookups on the Consul servers and speed lookups for
+clients, at the cost of increasingly stale results. By default, all TTLs are zero,
+preventing any caching.
+
+```javascript
+{
+  "dns_config": {
+    "service_ttl" = "0s"
+    "node_ttl" = "0s"
+  }
+}
+```
+
+### Enable Caching
+
+To enable caching of node lookups (e.g. "foo.node.consul"), we can set the
+[`dns_config.node_ttl`](https://www.consul.io/docs/agent/options.html#node_ttl) value. This can be set to
+"10s" for example, and all node lookups will serve results with a 10 second TTL.
+
+Service TTLs can be specified in a more granular fashion. You can set TTLs
+per-service, with a wildcard TTL as the default. This is specified using the
+[`dns_config.service_ttl`](https://www.consul.io/docs/agent/options.html#service_ttl) map. The "*"
+is supported at the end of any prefix and a lower precedence than strict match,
+so 'my-service-x' has precedence over 'my-service-*', when performing wildcard
+match, the longest path is taken into account, thus 'my-service-*' TTL will
+be used instead of 'my-*' or '*'. With the same rule, '*' is the default value
+when nothing else matches. If no match is found the TTL defaults to 0.
+
+For example, a [`dns_config`](https://www.consul.io/docs/agent/options.html#dns_config) that provides
+a wildcard TTL and a specific TTL for a service might look like this:
+
+```javascript
+{
+  "dns_config": {
+    "service_ttl": {
+      "*": "5s",
+      "web": "30s",
+      "db*": "10s",
+      "db-master": "3s"
+    }
+  }
+}
+```
+
+This sets all lookups to "web.service.consul" to use a 30 second TTL
+while lookups to "api.service.consul" will use the 5 second TTL from the wildcard.
+All lookups matching "db*" would get a 10 seconds TTL except "db-master"
+that would have a 3 seconds TTL.
+
+### Prepared Queries
+
+[Prepared Queries](https://www.consul.io/api/query.html) provide an additional
+level of control over TTL. They allow for the TTL to be defined along with
+the query, and they can be changed on the fly by updating the query definition.
+If a TTL is not configured for a prepared query, then it will fall back to the
+service-specific configuration defined in the Consul agent as described above,
+and ultimately to 0 if no TTL is configured for the service in the Consul agent.
+
+## Summary
+
+In this guide we covered several of the parameters for tuning DNS queries. We reviewed
+how to enable or disable stale reads and how to configure the amount of time when stale
+reads are allowed. We also looked at the minimum TTL configuration options
+for negative responses from services. Finally, we reviewed how to setup TTLs
+for service lookups.

--- a/learn/source/content/consul/advanced/advanced-operations/outage.md
+++ b/learn/source/content/consul/advanced/advanced-operations/outage.md
@@ -1,0 +1,294 @@
+---
+name: 'Outage Recovery'
+content_length: 15
+id: /advanced-operations/outage
+layout: content_layout
+products_used:
+  - Consul
+description: Outage recovery requires an operator to intervene, however the recovery process is straightforward.
+level: Advanced
+---
+
+Don't panic! This is a critical first step.
+
+Depending on your [deployment
+configuration](https://www.consul.io/docs/internals/consensus.html#deployment_table),
+it may take only a single server failure for cluster unavailability. Recovery
+requires an operator to intervene, but the process is straightforward.
+
+This guide outlines the processes for recovering from a Consul outage due to a
+majority of server nodes in a cluster being lost. There are several types of
+outages, depending on the number of server nodes and number of failed server
+nodes. We will outline how to recover from:
+
+- Failure of a Single Server Cluster. This is when you have a single Consul
+  server and it fails.
+- Failure of a Server in a Multi-Server Cluster. This is when one server fails,
+  but the Consul cluster has three or more servers.
+- Failure of Multiple Servers in a Multi-Server Cluster. This when more than
+  one server fails in a cluster of three or more servers. This scenario is
+  potentially the most serious, because it can result in data loss.
+
+## Failure of a Single Server Cluster
+
+If you had only a single server and it has failed, simply restart it. A single
+server configuration requires the
+[`-bootstrap`](https://www.consul.io/docs/agent/options.html#_bootstrap) or
+[`-bootstrap-expect=1`](https://www.consul.io/docs/agent/options.html#_bootstrap_expect)
+flag.
+
+```sh
+consul agent -bootstrap-expect=1
+```
+
+If the server cannot be recovered, you need to bring up a new server using the
+[deployment guide](https://www.consul.io/docs/guides/deployment-guide.html).
+
+In the case of an unrecoverable server failure in a single server cluster and
+there is no backup procedure, data loss is inevitable since data was not
+replicated to any other servers. This is why a single server deploy is
+**never** recommended.
+
+Any services registered with agents will be re-populated when the new server
+comes online as agents perform
+[anti-entropy](https://www.consul.io/docs/internals/anti-entropy.html).
+
+### Failure of a Single Server Cluster: After Upgrading Raft Protocol
+
+After upgrading the server's
+[-raft-protocol](https://www.consul.io/docs/agent/options.html#_raft_protocol)
+from version `2` to `3`, server's running Raft protocol version 3 will no
+longer allow servers running an older version to be added.
+
+In a single server cluster scenario, restarting the server may result in the
+server not being able to elect itself as a leader, rendering the cluster
+unusable.
+
+To recover from this, go to the
+[`-data-dir`](https://www.consul.io/docs/agent/options.html#_data_dir) of the failing
+Consul server. Inside the data directory there will be a `raft/`
+sub-directory. Create a `raft/peers.json` file in the `raft/` directory.
+
+For Raft protocol version 3 and later, this should be formatted as a JSON array
+containing the node ID, address:port, and suffrage information of the Consul
+server, like this:
+
+```json
+[{ "id": "<node-id>", "address": "<node-ip>:8300", "non_voter": false }]
+```
+
+Make sure you replace `node-id` and `node-ip` with the correct value for your
+Consul server.
+
+Finally, restart your Consul server.
+
+## Failure of a Server in a Multi-Server Cluster
+
+If the failed server is recoverable, the best option is to bring it back online
+and have it rejoin the cluster with the same IP address. This will return the
+cluster to a fully healthy state. Similarly, if you need to rebuild a new
+Consul server, to replace the failed node, you may wish to do that immediately.
+Note, the rebuilt server needs to have the same IP address as the failed
+server. Again, once this server is online and has rejoined, the cluster will
+return to a fully healthy state.
+
+```sh
+consul agent -bootstrap-expect=3 -bind=192.172.2.4 -auto-rejoin=192.172.2.3
+```
+
+Both of these strategies involve a potentially lengthy time to reboot or
+rebuild a failed server. If this is impractical or if building a new server
+with the same IP isn't an option, you need to remove the failed server.
+Usually, you can issue a [`consul force-leave`](https://www.consul.io/docs/commands/force-leave.html) command to
+remove the failed server if it's still a member of the cluster.
+
+```sh
+consul force-leave <node.name.consul>
+```
+
+If [`consul force-leave`](https://www.consul.io/docs/commands/force-leave.html)
+isn't able to remove the server, you have two methods available to remove it,
+depending on your version of Consul:
+
+- In Consul 0.7 and later, you can use the [`consul operator`](https://www.consul.io/docs/commands/operator.html#raft-remove-peer) command to remove the stale peer server on the fly with no downtime if the cluster has a leader.
+
+- In versions of Consul prior to 0.7, you can manually remove the stale peer
+  server using the `raft/peers.json` recovery file on all remaining servers.
+  See the [section below](#peers.json) for details on this procedure. This
+  process requires a Consul downtime to complete.
+
+In Consul 0.7 and later, you can use the [`consul operator`](https://www.consul.io/docs/commands/operator.html#raft-list-peers)
+command to inspect the Raft configuration:
+
+```sh
+$ consul operator raft list-peers
+Node     ID              Address         State     Voter RaftProtocol
+alice    10.0.1.8:8300   10.0.1.8:8300   follower  true  3
+bob      10.0.1.6:8300   10.0.1.6:8300   leader    true  3
+carol    10.0.1.7:8300   10.0.1.7:8300   follower  true  3
+```
+
+## Failure of Multiple Servers in a Multi-Server Cluster
+
+In the event that multiple servers are lost, causing a loss of quorum and a
+complete outage, partial recovery is possible using data on the remaining
+servers in the cluster. There may be data loss in this situation because
+multiple servers were lost, so information about what's committed could be
+incomplete. The recovery process implicitly commits all outstanding Raft log
+entries, so it's also possible to commit data that was uncommitted before the
+failure.
+
+See the section below on manual recovery using peers.json for details of the
+recovery procedure. You simply include just the remaining servers in the
+`raft/peers.json` recovery file. The cluster should be able to elect a leader
+once the remaining servers are all restarted with an identical
+`raft/peers.json` configuration.
+
+Any new servers you introduce later can be fresh with totally clean data
+directories and joined using Consul's `join` command.
+
+```sh
+consul agent -join=192.172.2.3
+```
+
+In extreme cases, it should be possible to recover with just a single remaining
+server by starting that single server with itself as the only peer in the
+`raft/peers.json` recovery file.
+
+Prior to Consul 0.7 it wasn't always possible to recover from certain types of
+outages with `raft/peers.json` because this was ingested before any Raft log
+entries were played back. In Consul 0.7 and later, the `raft/peers.json`
+recovery file is final, and a snapshot is taken after it is ingested, so you
+are guaranteed to start with your recovered configuration. This does implicitly
+commit all Raft log entries, so should only be used to recover from an outage,
+but it should allow recovery from any situation where there's some cluster data
+available.
+
+### Manual Recovery Using peers.json
+
+To begin, stop all remaining servers. You can attempt a graceful leave, but it
+will not work in most cases. Do not worry if the leave exits with an error. The
+cluster is in an unhealthy state, so this is expected.
+
+In Consul 0.7 and later, the `peers.json` file is no longer present by default
+and is only used when performing recovery. This file will be deleted after
+Consul starts and ingests this file. Consul 0.7 also uses a new, automatically-
+created `raft/peers.info` file to avoid ingesting the `raft/peers.json` file on
+the first start after upgrading. Be sure to leave `raft/peers.info` in place
+for proper operation.
+
+Using `raft/peers.json` for recovery can cause uncommitted Raft log entries to
+be implicitly committed, so this should only be used after an outage where no
+other option is available to recover a lost server. Make sure you don't have
+any automated processes that will put the peers file in place on a periodic
+basis.
+
+The next step is to go to the
+[`-data-dir`](https://www.consul.io/docs/agent/options.html#_data_dir) of each
+Consul server. Inside that directory, there will be a `raft/` sub-directory. We
+need to create a `raft/peers.json` file. The format of this file depends on
+what the server has configured for its [Raft
+protocol](https://www.consul.io/docs/agent/options.html#_raft_protocol)
+version.
+
+For Raft protocol version 2 and earlier, this should be formatted as a JSON
+array containing the address and port of each Consul server in the cluster,
+like this:
+
+```json
+["10.1.0.1:8300", "10.1.0.2:8300", "10.1.0.3:8300"]
+```
+
+For Raft protocol version 3 and later, this should be formatted as a JSON array
+containing the node ID, address:port, and suffrage information of each Consul
+server in the cluster, like this:
+
+```json
+[
+  {
+    "id": "adf4238a-882b-9ddc-4a9d-5b6758e4159e",
+    "address": "10.1.0.1:8300",
+    "non_voter": false
+  },
+  {
+    "id": "8b6dda82-3103-11e7-93ae-92361f002671",
+    "address": "10.1.0.2:8300",
+    "non_voter": false
+  },
+  {
+    "id": "97e17742-3103-11e7-93ae-92361f002671",
+    "address": "10.1.0.3:8300",
+    "non_voter": false
+  }
+]
+```
+
+- `id` `(string: <required>)` - Specifies the [node
+  ID](https://www.consul.io/docs/agent/options.html#_node_id) of the server.
+  This can be found in the logs when the server starts up if it was
+  auto-generated, and it can also be found inside the `node-id` file in the
+  server's data directory.
+
+- `address` `(string: <required>)` - Specifies the IP and port of the server.
+  The port is the server's RPC port used for cluster communications.
+
+- `non_voter` `(bool: <false>)` - This controls whether the server is a
+  non-voter, which is used in some advanced
+  [Autopilot](/consul/day-2-operations/advanced-operations/autopilot)
+  configurations. If omitted, it will default to false, which is typical for most
+  clusters.
+
+Simply create entries for all servers. You must confirm that servers you do not
+include here have indeed failed and will not later rejoin the cluster. Ensure
+that this file is the same across all remaining server nodes.
+
+At this point, you can restart all the remaining servers. In Consul 0.7 and
+later you will see them ingest recovery file:
+
+```text
+...
+2016/08/16 14:39:20 [INFO] consul: found peers.json file,
+recovering Raft configuration...  2016/08/16 14:39:20 [INFO] consul.fsm:
+snapshot created in 12.484µs 2016/08/16 14:39:20 [INFO] snapshot: Creating new
+snapshot at /tmp/peers/raft/snapshots/2-5-1471383560779.tmp 2016/08/16 14:39:20
+[INFO] consul: deleted peers.json file after successful recovery 2016/08/16
+14:39:20 [INFO] raft: Restored from snapshot 2-5-1471383560779 2016/08/16
+14:39:20 [INFO] raft: Initial configuration (index=1): [{Suffrage:Voter
+ID:10.212.15.121:8300 Address:10.212.15.121:8300}] ...
+```
+
+If any servers managed to perform a graceful leave, you may need to have them
+rejoin the cluster using the
+[`join`](https://www.consul.io/docs/commands/join.html) command:
+
+```sh
+$ consul join <Node Address> Successfully joined cluster by contacting
+1 nodes.
+```
+
+It should be noted that any existing member can be used to rejoin the cluster
+as the gossip protocol will take care of discovering the server nodes.
+
+At this point, the cluster should be in an operable state again. One of the
+nodes should claim leadership and emit a log like:
+
+```text
+[INFO] consul: cluster leadership acquired
+```
+
+In Consul 0.7 and later, you can use the [`consul operator`](https://www.consul.io/docs/commands/operator.html#raft-list-peers)
+command to inspect the Raft configuration:
+
+```sh
+$ consul operator raft list-peers Node     ID              Address
+State     Voter  RaftProtocol alice    10.0.1.8:8300   10.0.1.8:8300   follower
+true   3 bob      10.0.1.6:8300   10.0.1.6:8300   leader    true   3 carol
+10.0.1.7:8300   10.0.1.7:8300   follower  true   3
+```
+
+## Summary
+
+In this guide, we reviewed how to recover from a Consul server outage.
+Depending on the quorum size and number of failed servers, the recovery process
+will vary. In the event of complete failure it is beneficial to have a [backup
+process](/consul/advanced/day-1-operations/backup).

--- a/learn/source/content/consul/advanced/advanced-operations/servers.md
+++ b/learn/source/content/consul/advanced/advanced-operations/servers.md
@@ -1,0 +1,194 @@
+---
+name: 'Adding & Removing Servers'
+content_length: 12
+id: /advanced-operations/servers
+layout: content_layout
+products_used:
+  - Consul
+description: There are several methods for adding or removing servers from the Consul cluster. Learn the best practices for each method.
+level: Advanced
+---
+
+Consul is designed to require minimal operator involvement, however any changes
+to the set of Consul servers must be handled carefully. To better understand
+why, reading about the [consensus protocol](https://www.consul.io/docs/internals/consensus.html) will
+be useful. In short, the Consul servers perform leader election and replication.
+For changes to be processed, a minimum quorum of servers (N/2)+1 must be available.
+That means if there are 3 server nodes, at least 2 must be available.
+
+In general, if you are ever adding and removing nodes simultaneously, it is better
+to first add the new nodes and then remove the old nodes.
+
+In this guide, we will cover the different methods for adding and removing servers.
+
+## Manually Add a New Server
+
+Manually adding new servers is generally straightforward, start the new
+agent with the `-server` flag. At this point the server will not be a member of
+any cluster, and should emit something like:
+
+```sh
+consul agent -server
+[WARN] raft: EnableSingleNode disabled, and no known peers. Aborting election.
+```
+
+This means that it does not know about any peers and is not configured to elect itself.
+This is expected, and we can now add this node to the existing cluster using `join`.
+From the new server, we can join any member of the existing cluster:
+
+```sh
+$ consul join <Existing Node Address>
+Successfully joined cluster by contacting 1 nodes.
+```
+
+It is important to note that any node, including a non-server may be specified for
+join. Generally, this method is good for testing purposes but not recommended for production
+deployments. For production clusters, you will likely want to use the agent configuration
+option to add additional servers.
+
+## Add a Server with Agent Configuration
+
+In production environments, you should use the [agent configuration](https://www.consul.io/docs/agent/options.html) option, `retry_join`. `retry_join` can be used as a command line flag or in the agent configuration file.
+
+With the Consul CLI:
+
+```sh
+$ consul agent -retry-join=["52.10.110.11", "52.10.110.12", "52.10.100.13"]
+```
+
+In the agent configuration file:
+
+```sh
+{
+  "bootstrap": false,
+  "bootstrap_expect": 3,
+  "server": true,
+  "retry_join": ["52.10.110.11", "52.10.110.12", "52.10.100.13"]
+}
+```
+
+[`retry_join`](https://www.consul.io/docs/agent/options.html#retry-join)
+will ensure that if any server loses connection
+with the cluster for any reason, including the node restarting, it can
+rejoin when it comes back. In additon to working with static IPs, it
+can also be useful for other discovery mechanisms, such as auto joining
+based on cloud metadata and discovery. Both servers and clients can use this method.
+
+### Server Coordination
+
+To ensure Consul servers are joining the cluster properly, you should monitor
+the server coordination. The gossip protocol is used to properly discover all
+the nodes in the cluster. Once the node has joined, the existing cluster
+leader should log something like:
+
+```text
+[INFO] raft: Added peer 127.0.0.2:8300, starting replication
+```
+
+This means that raft, the underlying consensus protocol, has added the peer and begun
+replicating state. Since the existing cluster may be very far ahead, it can take some
+time for the new node to catch up. To check on this, run `info` on the leader:
+
+```text
+$ consul info
+...
+raft:
+	applied_index = 47244
+	commit_index = 47244
+	fsm_pending = 0
+	last_log_index = 47244
+	last_log_term = 21
+	last_snapshot_index = 40966
+	last_snapshot_term = 20
+	num_peers = 4
+	state = Leader
+	term = 21
+...
+```
+
+This will provide various information about the state of Raft. In particular
+the `last_log_index` shows the last log that is on disk. The same `info` command
+can be run on the new server to see how far behind it is. Eventually the server
+will be caught up, and the values should match.
+
+It is best to add servers one at a time, allowing them to catch up. This avoids
+the possibility of data loss in case the existing servers fail while bringing
+the new servers up-to-date.
+
+## Manually Remove a Server
+
+Removing servers must be done carefully to avoid causing an availability outage.
+For a cluster of N servers, at least (N/2)+1 must be available for the cluster
+to function. See this [deployment table](https://www.consul.io/docs/internals/consensus.html#deployment-table).
+If you have 3 servers and 1 of them is currently failing, removing any other servers
+will cause the cluster to become unavailable.
+
+To avoid this, it may be necessary to first add new servers to the cluster,
+increasing the failure tolerance of the cluster, and then to remove old servers.
+Even if all 3 nodes are functioning, removing one leaves the cluster in a state
+that cannot tolerate the failure of any node.
+
+Once you have verified the existing servers are healthy, and that the cluster
+can handle a node leaving, the actual process is simple. You simply issue a
+`leave` command to the server.
+
+```sh
+consul leave
+```
+
+The server leaving should contain logs like:
+
+```text
+...
+[INFO] consul: server starting leave
+...
+[INFO] raft: Removed ourself, transitioning to follower
+...
+```
+
+The leader should also emit various logs including:
+
+```text
+...
+[INFO] consul: member 'node-10-0-1-8' left, deregistering
+[INFO] raft: Removed peer 10.0.1.8:8300, stopping replication
+...
+```
+
+At this point the node has been gracefully removed from the cluster, and
+will shut down.
+
+~> Running `consul leave` on a server explicitly will reduce the quorum size. Even if the cluster used `bootstrap_expect` to set a quorum size initially, issuing `consul leave` on a server will reconfigure the cluster to have fewer servers. This means you could end up with just one server that is still able to commit writes because quorum is only 1, but those writes might be lost if that server fails before more are added.
+
+To remove all agents that accidentally joined the wrong set of servers, clear out the contents of the data directory (`-data-dir`) on both client and server nodes.
+
+These graceful methods to remove servres assumse you have a healthly cluster.
+If the cluster has no leader due to loss of quorum or data corruption, you should
+plan for [outage recovery](/consul/day-2-operations/advanced-operations/outage#manual-recovery-using-peers-json).
+
+!> **WARNING** Removing data on server nodes will destroy all state in the cluster
+
+## Manual Forced Removal
+
+In some cases, it may not be possible to gracefully remove a server. For example,
+if the server simply fails, then there is no ability to issue a leave. Instead,
+the cluster will detect the failure and replication will continuously retry.
+
+If the server can be recovered, it is best to bring it back online and then gracefully
+leave the cluster. However, if this is not a possibility, then the `force-leave` command
+can be used to force removal of a server.
+
+```sh
+consul force-leave <node>
+```
+
+This is done by invoking that command with the name of the failed node. At this point,
+the cluster leader will mark the node as having left the cluster and it will stop attempting to replicate.
+
+## Summary
+
+In this guide we learned the straightforward process of adding and removing servers including;
+manually adding servers, adding servers through the agent configuration, gracefully removing
+servers, and forcing removal of servers. Finally, we should restate that manually adding servers
+is good for testing purposes, however, for production it is recommended to add servers with
+the agent configuration.

--- a/learn/source/content/consul/advanced/advanced-operations/troubleshooting.md
+++ b/learn/source/content/consul/advanced/advanced-operations/troubleshooting.md
@@ -1,0 +1,392 @@
+---
+name: 'Troubleshooting'
+content_length: 15
+id: /advanced-operations/troubleshooting
+layout: content_layout
+products_used:
+  - Consul
+description: Find and fix problems with your Consul cluster and supporting tools.
+level: Advanced
+---
+
+Troubleshooting is a fundamental skill for any devops practitioner. With that
+in mind, Consul includes several tools to help you view log messages, validate
+configuration files, examine the service catalog, and do other debugging.
+
+## Troubleshooting Steps
+
+Before you start, consider following a pre-determined troubleshooting workflow,
+which can keep distractions from interfering with finding and fixing the
+problem. You or your team might already use a workflow such as [Observe, Orient,
+Decide, Act](https://en.wikipedia.org/wiki/OODA_loop) or [Rubber duck
+debugging](https://en.wikipedia.org/wiki/Rubber_duck_debugging). We like to use
+the following process:
+
+1. Gather data
+1. Verify what works
+1. Solve one problem at a time
+1. Form a hypothesis and test it
+1. (Repeat)
+
+Consul and other tools generate log files, status messages, process lists, data
+feeds, and other useful information, which you can use when gathering data.
+We'll go over many of those tools in this guide.
+
+Verifying what works is important because Consul sits at the center of other
+highly complex systems. Making sure that core systems, networking, and services
+are working as expected can help you narrow down the problem space, and prevent
+you from spending time troubleshooting the wrong issues. If you are uncertain
+about how a component works or if it is working at all, list that uncertainty in
+your notes or take the time to verify that it is operating normally. In this
+guide we'll discuss some tools that can help you check on outside systems, but
+you should always consult their documentation as well.
+
+Because Consul is highly configurable, you'll find it easier if you solve one
+problem at a time, verify successful operation, and then proceed to the next
+issue. If necessary, build a smaller system where you can test the specific
+configuration options or features that seem to be operating incorrectly. Once
+you have verified proper syntax, correct network operation, and fully
+functioning microservices, then you can integrate those changes back into the
+main system.
+
+Hypothesis-based testing can help you focus on the one problem you've chosen.
+Write down a hypothesis (theory) about what might be causing your problem and
+how it might be fixed. Then observe the data and take action to see if your
+theory is correct (and if it fixes the problem).
+
+You may need to repeat some or all of this process to isolate each piece of the
+problem. By following a consistent process (no matter what it is), you can
+reduce the likelihood that your process will complicate the situation.
+
+## Consul-Specific Tools
+
+Now that you have a troubleshooting process, let's examine the tools and data
+available to you while operating Consul. These Consul-specific tools will help
+you gather data and verify what is already working.
+
+-> NOTE: Each of the Consul commands mentioned below can be run on a node with
+access to the `consul` agent. Use SSH or other container-specific commands to
+connect to a compute node in your datacenter.
+
+### Review Your Consul Architecture
+
+When communicating to other members of your team or to support staff, it's
+helpful to review some details about your Consul architecture, such as:
+
+- How are you querying Consul? (DNS, HTTP)
+- Is the Consul web UI available for viewing?
+- What system are you using for launching microservices? (`systemd`,
+  `kubernetes`, `upstart`, Nomad, etc.)
+
+### Members
+
+The `consul members` command will list the other servers and agents that are
+part of the Consul cluster connected to the current agent.
+
+```text
+$ consul members
+
+Node    Address         Status  Type    Build  Protocol  DC   Segment
+laptop  127.0.0.1:8301  alive   server  1.4.0  2         dc1  <all>
+```
+
+- [Consul members
+  documentation](https://www.consul.io/docs/commands/members.html)
+
+### List Peers
+
+If you need details other than those provided by `members`, try the subcommands
+of `consul operator raft`. These work with Consul at a lower level but can
+provide detail about the moment-to-moment status of the cluster. This will list
+leader state, voting status, and raft protocol version.
+
+```
+$ consul operator raft list-peers
+
+Node    ID           Address         State   Voter  RaftProtocol
+laptop  abc-def-g12  127.0.0.1:8300  leader  true   3
+```
+
+- [Consul operator
+  raft documentation](https://www.consul.io/docs/commands/operator/raft.html)
+
+### Monitor
+
+The `consul monitor` command displays log output from the Consul agent. Other
+arguments can increase the amount of information given, such as `-log-level
+debug` or `-log-level trace` for copious amounts of log data.
+
+```text
+$ consul monitor
+
+2019/01/25 17:48:33 [INFO] raft: Initial configuration (index=1): [{Suffrage:Voter ID:abcdef Address:127.0.0.1:8300}]
+2019/01/25 17:48:33 [INFO] raft: Node at 127.0.0.1:8300 [Follower] entering Follower state (Leader: "")
+2019/01/25 17:48:33 [INFO] serf: EventMemberJoin: laptop.dc1 127.0.0.1
+2019/01/25 17:48:33 [INFO] serf: EventMemberJoin: laptop 127.0.0.1
+2019/01/25 17:48:33 [INFO] consul: Adding LAN server laptop (Addr: tcp/127.0.0.1:8300) (DC: dc1)
+2019/01/25 17:48:33 [INFO] consul: Handled member-join event for server "laptop.dc1" in area "wan"
+2019/01/25 17:48:33 [ERR] agent: Failed decoding service file "services/.DS_Store": invalid character '\x00' looking for beginning of value
+2019/01/25 17:48:33 [INFO] agent: Started DNS server 127.0.0.1:8600 (tcp)
+2019/01/25 17:48:33 [INFO] agent: Started DNS server 127.0.0.1:8600 (udp)
+2019/01/25 17:48:33 [INFO] agent: Started HTTP server on 127.0.0.1:8500 (tcp)
+2019/01/25 17:48:33 [INFO] agent: Started gRPC server on 127.0.0.1:8502 (tcp)
+```
+
+- [Consul monitor
+  documentation](https://www.consul.io/docs/commands/monitor.html)
+
+### Validate
+
+The `consul validate` command can be run on a single Consul configuration file
+or, more commonly, on an entire directory of configuration files. Basic syntax
+and logical correctness will be analyzed and reported upon.
+
+This command will catch misspellings of Consul configuration keys, or the
+absence or misconfiguration of crucial attributes.
+
+```text
+$ consul validate /etc/consul.d/counting.json
+
+* invalid config key serrrvice
+```
+
+~> TIP: Run `validate` on an entire directory of Consul configuration files so
+that the complete configuration can be analyzed.
+
+- [Documentation for Consul
+  validate](https://www.consul.io/docs/commands/validate.html)
+
+### Debug
+
+The `consul debug` command can be run on a node without any other arguments. It
+will log metrics, logs, profiling data, and other data to the current directory
+for two minutes.
+
+All content is written in plain text to a compressed archive, so do not
+transmit the emitted data over unencrypted channels.
+
+However, you might find this data useful or can provide it to support staff in
+order to help you debug your Consul cluster.
+
+```text
+$ consul debug
+
+==> Starting debugger and capturing static information...
+     Agent Version: '1.4.0'
+          Interval: '30s'
+          Duration: '2m0s'
+            Output: 'consul-debug-1548721978.tar.gz'
+           Capture: 'metrics, logs, pprof, host, agent, cluster'
+==> Beginning capture interval 2019-01-28 16:32:58.56142 -0800 PST (0)
+```
+
+Unzip the archive and view the contents.
+
+```
+$ tar xvfz consul-debug-1548721978.tar.gz
+$ tree consul-debug-1548721978
+```
+
+![tree consul-debug output](/assets/images/consul-tree-debug-output.png)
+
+- [Documentation on Consul
+  debug](https://www.consul.io/docs/commands/debug.html)
+
+### Health Checks
+
+When enabled, health checks are a crucial part of the operation of the Consul
+cluster. Unhealthy services will not be published for discovery via standard
+DNS or some HTTP API calls.
+
+The easiest way to view initial health status is by visiting the [Consul Web
+UI](http://localhost:8500/ui) at `http://localhost:8500/ui`.
+
+Click through to a specific service such as the `counting` service. The status
+of the service on each node will be displayed. Click through to see the output
+of the health check.
+
+Alternately, use the HTTP API to view the entire catalog or a specific service.
+The `/v1/agent/services` endpoint will return a list of all services registered
+in the catalog.
+
+```text
+$ curl "http://127.0.0.1:8500/v1/agent/services"
+```
+
+Filters can be provided on the query string, such as this command which looks
+for `counting` services that are `passing` (healthy):
+
+```text
+$ curl 'http://localhost:8500/v1/health/service/counting?passing'
+
+[
+  {
+    "Node": {
+      "ID": "da8eb9d3-...",
+      "Node": "laptop",
+      "Address": "127.0.0.1",
+      "Datacenter": "dc1",
+    },
+    "Checks": [
+      {
+        "Node": "laptop",
+        "Output": "Agent alive and reachable"
+      },
+      {
+        "Node": "laptop",
+        "Name": "Service 'counting' check",
+        "Status": "passing",
+        "Output": "HTTP GET http://localhost:9003/health: 200 OK Output: Hello, you've hit /health\n",
+        "ServiceName": "counting"
+      }
+    ]
+  }
+]
+```
+
+Another important aspect of health checks is not only the presence of a healthy
+service, but the _continued_ presence of that healthy service. If a service is
+oscillating between healthy and unhealthy, we call that _flapping_. It may be
+due to problems inherent to the service itself (an internal crash) and the
+service itself should be investigated (or the process launcher that runs the
+process, such as `systemd`).
+
+Also consider the type of health check being run. Consider using built-in
+health checks such as TCP or HTTP rather than a script check which runs an
+external shell command to verify service health.
+
+- [Documentation on Consul health
+  checks](https://www.consul.io/docs/agent/checks.html)
+
+## External Tools
+
+Consul was designed to work within an established ecosystem of networking
+protocols which means that you can use existing tools to gather data, verify
+what is working, and debug the network, applications, and security context
+surrounding Consul.
+
+### ps
+
+Consul service discovery relies on existing process launching tools such as
+`systemd` or `upstart` or `init.d`. If you choose to use one of these tools,
+you should refer to their documentation to learn how to write configuration
+files, start/stop/restart scripts, and monitor the output of processes launched
+by these tools.
+
+A common tool on Unix systems is `ps`. Run it to verify that your service
+processes are running as expected.
+
+```text
+$ ps | grep counting
+
+79846 ttys001    0:00.07 ./counting-service
+```
+
+Or, consider `pstree` which can be installed separately with your operating
+system's package manager. It displays a hierarchy of running child processes
+and parent processes.
+
+```text
+$ pstree
+
+ | | \-+= 74259 geoffrey -zsh
+ | |   \--= 79846 geoffrey ./counting-service
+```
+
+### dig
+
+Given that Consul speaks the DNS protocol, standard DNS tools can be used with
+it. However, Consul operates by default on port `8600` instead of the DNS
+default of `53`.
+
+The `dig` tool is a command line application that interacts with DNS records of
+all kinds. To see details about a DNS record in Consul, pass the `-p 8600` flag
+and the IP address of the Consul server with `@127.0.0.1`.
+
+In this example, we find the IP address of the `counting` service.
+
+```text
+$ dig @127.0.0.1 -p 8600 counting.service.consul
+
+; <<>> DiG 9.10.6 <<>> @127.0.0.1 -p 8600 counting.service.consul ...  ;;
+ANSWER SECTION: counting.service.consul. 0	IN	A	192.168.0.35
+```
+
+-> NOTE: A DNS query to Consul will only return the IP address of a healthy
+service, not all registered services. Use the HTTP API if you want to see a
+list of all healthy services, or all registered services regardless of health.
+
+Consul also provides additional information with the `SRV` (service) argument.
+Add `SRV` to the `dig` command to see the port number that the `counting`
+service operates on (shown as port `9003` below).
+
+```text
+$ dig @127.0.0.1 -p 8600 counting.service.consul SRV
+
+;; ANSWER SECTION: counting.service.consul. 0	IN	SRV	1 1 9003
+Machine.local.node.dc1.consul.
+
+;; ADDITIONAL SECTION: Machine.local.node.dc1.consul. 0 IN	A
+192.168.0.35
+```
+
+If you have configured [DNS
+forwarding](https://www.consul.io/docs/guides/forwarding.html) to integrate
+system DNS with Consul, you can omit the IP address and port number. However,
+when debugging it is often useful to be specific so you can verify that direct
+communication to the Consul agent is working as expected.
+
+### curl
+
+As simple as it may seem, the `curl` command is extremely useful for debugging
+any web service or discovering details about content and HTTP headers.
+
+Use `curl` on your configured health endpoint to verify connectivity to a
+service. You can provide the IP address or `localhost`. You can also provide a
+port number and any other path information or querystring data (you can even
+post form data).
+
+If you have configured [DNS
+forwarding](https://www.consul.io/docs/guides/forwarding.html), you may be able
+to use Consul-specific domain names to communicate to the service (such as
+`http://counting.service.consul`).
+
+```text
+$ curl http://localhost:9003/health
+
+Hello, you've hit /health
+```
+
+-> NOTE: If a service uses Consul Connect, you may need to communicate to a
+service from a node in the cluster using `localhost` and the local port as
+configured with Consul Connect.
+
+### ping
+
+The `ping` command is a simple tool that verifies network connectivity to a
+host (if it responds to `ping`). Use an IP address to verify that one node can
+communicate to another node.
+
+`ping` is also useful for viewing the latency between nodes and the reliability
+of packet transfer between them.
+
+```text
+$ ping 10.0.1.14
+
+PING 10.0.1.14 (10.0.1.14): 56 data bytes 64 bytes from 10.0.1.14: icmp_seq=0
+ttl=64 time=0.065 ms 64 bytes from 10.0.1.14: icmp_seq=1 ttl=64 time=0.068 ms
+64 bytes from 10.0.1.14: icmp_seq=2 ttl=64 time=0.060 ms ^C --- 10.0.1.14 ping
+statistics --- 3 packets transmitted, 3 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 0.060/0.064/0.068/0.003 ms
+```
+
+## Summary
+
+You should now be able to use the Consul tools to help troubleshoot.
+
+- View log messages with `consul monitor`
+- Validate configuration files with `consul validate`
+- Examine the service catalog with the HTTP API endpoint `/v1/agent/services`
+
+Finally, you should be able to use external tools like `dig` and `curl` to help
+troubleshoot Consul issues.

--- a/learn/source/content/consul/advanced/day-1-operations/acl-guide.md
+++ b/learn/source/content/consul/advanced/day-1-operations/acl-guide.md
@@ -1,0 +1,475 @@
+---
+name: 'Bootstrapping the ACL System'
+content_length: 15
+id: /day-1-operations/acl-guide
+layout: content_layout
+products_used:
+  - Consul
+description: Consul provides an optional Access Control List (ACL) system which can be used to control access to data and APIs.
+level: Advanced
+---
+
+Consul uses Access Control Lists (ACLs) to secure the UI, API, CLI, service communications, and agent communications. For securing gossip and RPC communication please review [this guide](/consul/advanced/day-1-operations/agent-encryption). When securing your cluster you should configure the ACLs first.
+
+At the core, ACLs operate by grouping rules into policies, then associating one or more policies with a token.
+
+To complete this guide, you should have an operational Consul 1.4+ cluster. We also recommend reading the [ACL System documentation](https://www.consul.io/docs/agent/acl-system.html). For securing Consul version 1.3 and older, please read the [legacy ACL documentation](https://www.consul.io/docs/guides/acl-legacy.html).
+
+Bootstrapping the ACL system is a multi-step process, we will cover all the necessary steps in this guide.
+
+- [Enable ACLs on all the servers](#step-1-enable-acls-on-all-the-consul-servers).
+- [Create the initial bootstrap token](#step-2-create-the-bootstrap-token).
+- [Create the agent policy](#step-3-create-an-agent-token-policy).
+- [Create the agent token](#step-4-create-an-agent-token).
+- [Apply the new token to the servers](#step-5-add-the-agent-token-to-all-the-servers).
+- [Enable ACLs on the clients and apply the agent token](#step-6-enable-acls-on-the-consul-clients).
+
+At the end of this guide, there are also several additional and optional steps.
+
+## Step 1: Enable ACLs on all the Consul Servers
+
+The first step for bootstrapping the ACL system is to enable ACLs on the Consul servers in the agent configuration file. In this example, we are configuring the default policy of "deny", which means we are in whitelist mode, and a down policy of "extend-cache", which means that we will ignore token TTLs during an outage.
+
+```json
+{
+  "acl": {
+    "enabled": true,
+    "default_policy": "deny",
+    "down_policy": "extend-cache"
+  }
+}
+```
+
+The servers will need to be restarted to load the new configuration. Please take care
+to restart the servers one at a time and ensure each server has joined and is operating
+correctly before restarting another.
+
+If ACLs are enabled correctly, we will now see the following warnings and info in the leader's logs.
+
+```sh
+2018/12/12 01:36:40 [INFO] acl: Created the anonymous token
+2018/12/12 01:36:40 [INFO] consul: ACL bootstrap enabled
+2018/12/12 01:36:41 [INFO] agent: Synced node info
+2018/12/12 01:36:58 [WARN] agent: Coordinate update blocked by ACLs
+2018/12/12 01:37:40 [INFO] acl: initializing acls
+2018/12/12 01:37:40 [INFO] consul: Created ACL 'global-management' policy
+```
+
+If you do not see ACL bootstrap enabled, the anonymous token creation, and the `global-management` policy creation message in the logs, ACLs have not been properly enabled.
+
+Note, now that we have enabled ACLs, we will need a token to complete any operation. We can't do anything else to the cluster until we bootstrap and generate the first master token. For simplicity we will use the master token created during the bootstrap for the remainder of the guide.
+
+## Step 2: Create the Bootstrap Token
+
+Once ACLs have been enabled we can bootstrap our first token, the bootstrap token.
+The bootstrap token is a management token with unrestricted privileges. It will
+be shared with all the servers in the quorum, since it will be added to the
+state store.
+
+```bash
+$ consul acl bootstrap
+AccessorID: edcaacda-b6d0-1954-5939-b5aceaca7c9a
+SecretID: 4411f091-a4c9-48e6-0884-1fcb092da1c8
+Description: Bootstrap Token (Global Management)
+Local: false
+Create Time: 2018-12-06 18:03:23.742699239 +0000 UTC
+Policies:
+00000000-0000-0000-0000-000000000001 - global-management
+```
+
+On the server where the `bootstrap` command was issued we should see the following log message.
+
+```sh
+2018/12/11 15:30:23 [INFO] consul.acl: ACL bootstrap completed
+2018/12/11 15:30:23 [DEBUG] http: Request PUT /v1/acl/bootstrap (2.347965ms) from=127.0.0.1:40566
+```
+
+Since ACLs have been enabled, we will need to use it to complete any additional operations.
+For example, even checking the member list will require a token.
+
+```sh
+$ consul members -token "4411f091-a4c9-48e6-0884-1fcb092da1c8"
+Node  Address            Status  Type    Build  Protocol  DC  Segment
+fox   172.20.20.10:8301  alive   server  1.4.0  2         kc  <all>
+bear  172.20.20.11:8301  alive   server  1.4.0  2         kc  <all>
+wolf  172.20.20.12:8301  alive   server  1.4.0  2         kc  <all>
+```
+
+Note using the token on the command line with the `-token` flag is not
+recommended, instead we will set it as an environment variable once.
+
+```sh
+$ export CONSUL_HTTP_TOKEN=4411f091-a4c9-48e6-0884-1fcb092da1c8
+```
+
+The bootstrap token can also be used in the server configuration file as
+the [`master`](https://www.consul.io/docs/agent/options.html#acl_tokens_master) token.
+
+Note, the bootstrap token can only be created once, bootstrapping will be disabled after the master token was created. Once the ACL system is bootstrapped, ACL tokens can be managed through the
+[ACL API](https://www.consul.io/api/acl/acl.html).
+
+## Step 3: Create an Agent Token Policy
+
+Before we can create a token, we will need to create its associated policy. A policy is a set of rules that can be used to specify granular permissions. To learn more about rules, read the ACL rule specification [documentation](https://www.consul.io/docs/agent/acl-rules.html).
+
+```bash
+# agent-policy.hcl contains the following:
+node_prefix "" {
+   policy = "write"
+}
+service_prefix "" {
+   policy = "read"
+}
+```
+
+This policy will allow all nodes to be registered and accessed and any service to be read.
+Note, this simple policy is not recommended in production.
+It is best practice to create separate node policies and tokens for each node in the cluster
+with an exact-match node rule.
+
+We only need to create one policy and can do this on any of the servers. If you have not set the
+`CONSUL_HTTP_TOKEN` environment variable to the bootstrap token, please refer to the previous step.
+
+```
+$ consul acl policy create -name "agent-token" -description "Agent Token Policy" -rules @agent-policy.hcl
+ID:           5102b76c-6058-9fe7-82a4-315c353eb7f7
+Name:         agent-policy
+Description:  Agent Token Policy
+Datacenters:
+Rules:
+node_prefix "" {
+   policy = "write"
+}
+
+service_prefix "" {
+   policy = "read"
+}
+```
+
+The returned value is the newly-created policy that we can now use when creating our agent token.
+
+## Step 4: Create an Agent Token
+
+Using the newly created policy, we can create an agent token. Again we can complete this process on any of the servers. For this guide, all agents will share the same token. Note, the `SecretID` is the token used to authenticate API and CLI commands.
+
+```sh
+$ consul acl token create -description "Agent Token" -policy-name "agent-token"
+AccessorID:   499ab022-27f2-acb8-4e05-5a01fff3b1d1
+SecretID:     da666809-98ca-0e94-a99c-893c4bf5f9eb
+Description:  Agent Token
+Local:        false
+Create Time:  2018-10-19 14:23:40.816899 -0400 EDT
+Policies:
+   fcd68580-c566-2bd2-891f-336eadc02357 - agent-token
+```
+
+## Step 5: Add the Agent Token to all the Servers
+
+Our final step for configuring the servers is to assign the token to all of our
+Consul servers via the configuration file and reload the Consul service 
+on all of the servers, one last time
+
+```json
+{
+  "primary_datacenter": "dc1",
+  "acl": {
+    "enabled": true,
+    "default_policy": "deny",
+    "down_policy": "extend-cache",
+    "tokens": {
+      "agent": "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+    }
+  }
+}
+```
+
+~> Note: In Consul version 1.4.2 and older any ACL updates
+in the agent configuration file will require a full restart of the 
+Consul service. 
+
+At this point we should no longer see the coordinate warning in the servers logs, however, we should continue to see that the node information is in sync.
+
+```sh
+2018/12/11 15:34:20 [DEBUG] agent: Node info in sync
+```
+
+It is important to ensure the servers are configured properly, before enable ACLs
+on the clients. This will reduce any duplicate work and troubleshooting, if there
+is a misconfiguration.
+
+#### Ensure the ACL System is Configured Properly
+
+Before configuring the clients, we should check that the servers are healthy. To do this, let's view the catalog.
+
+```sh
+curl http://127.0.0.1:8500/v1/catalog/nodes -H 'x-consul-token: 4411f091-a4c9-48e6-0884-1fcb092da1c8'
+[
+    {
+        "Address": "172.20.20.10",
+        "CreateIndex": 7,
+        "Datacenter": "kc",
+        "ID": "881cfb69-2bcd-c2a9-d87c-cb79fc454df9",
+        "Meta": {
+            "consul-network-segment": ""
+        },
+        "ModifyIndex": 10,
+        "Node": "fox",
+        "TaggedAddresses": {
+            "lan": "172.20.20.10",
+            "wan": "172.20.20.10"
+        }
+    }
+]
+```
+
+All the values should be as expected. Particularly, if `TaggedAddresses` is `null` it is likely we have not configured ACLs correctly. A good place to start debugging is reviewing the Consul logs on all the servers.
+
+If you encounter issues that are unresolvable, or misplace the bootstrap token, you can reset the ACL system by updating the index. First re-run the bootstrap command to get the index number.
+
+```
+$ consul acl bootstrap
+Failed ACL bootstrapping: Unexpected response code: 403 (Permission denied: ACL bootstrap no longer allowed (reset index: 13))
+```
+
+Then write the reset index into the bootstrap reset file: (here the reset index is 13)
+
+```
+$ echo 13 >> <data-directory>/acl-bootstrap-reset
+```
+
+After reseting the ACL system you can start again at Step 2. 
+
+## Step 6: Enable ACLs on the Consul Clients
+
+Since ACL enforcement also occurs on the Consul clients, we need to also restart them
+with a configuration file that enables ACLs. We can use the same ACL agent token that we created for the servers. The same token can be used because we did not specify any node or service prefixes.
+
+```json
+{
+  "acl": {
+    "enabled": true,
+    "default_policy": "deny",
+    "down_policy": "extend-cache",
+    "tokens": {
+      "agent": "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+    }
+  }
+}
+```
+
+To ensure the agent's are configured correctly, we can again use the `/catalog` endpoint.
+
+## Additional ACL Configuration
+
+Now that the nodes have been configured to use ACLs, we can configure the CLI, UI, and nodes to use specific tokens. All of the following steps are optional examples. In your own environment you will likely need to create more fine grained policies.
+
+#### Configure the Anonymous Token (Optional)
+
+The anonymous token is created during the bootstrap process, `consul acl bootstrap`. It is implicitly used if no token is supplied. In this section we will update the existing token with a newly created policy.
+
+At this point ACLs are bootstrapped with ACL agent tokens configured, but there are no
+other policies set up. Even basic operations like `consul members` will be restricted
+by the ACL default policy of "deny":
+
+```
+$ consul members
+```
+
+We will not receive an error, since the ACL has filtered what we see and we are not allowed to
+see any nodes by default.
+
+If we supply the token we created above we will be able to see a listing of nodes because
+it has write privileges to an empty `node` prefix, meaning it has access to all nodes:
+
+```bash
+$ CONSUL_HTTP_TOKEN=4411f091-a4c9-48e6-0884-1fcb092da1c8 consul members
+Node  Address            Status  Type    Build  Protocol  DC  Segment
+fox   172.20.20.10:8301  alive   server  1.4.0  2         kc  <all>
+bear  172.20.20.11:8301  alive   server  1.4.0  2         kc  <all>
+wolf  172.20.20.12:8301  alive   server  1.4.0  2         kc  <all>
+```
+
+It is common in many environments to allow listing of all nodes, even without a
+token. The policies associated with the special anonymous token can be updated to
+configure Consul's behavior when no token is supplied. The anonymous token is managed
+like any other ACL token, except that `anonymous` is used for the ID. In this example
+we will give the anonymous token read privileges for all nodes:
+
+```bash
+$ consul acl policy create -name 'list-all-nodes' -rules 'node_prefix "" { policy = "read" }'
+ID:           e96d0a33-28b4-d0dd-9b3f-08301700ac72
+Name:         list-all-nodes
+Description:
+Datacenters:
+Rules:
+node_prefix "" { policy = "read" }
+```
+
+```bash
+$ consul acl token update -id 00000000-0000-0000-0000-000000000002 -policy-name list-all-nodes -description "Anonymous Token - Can List Nodes"
+Token updated successfully.
+AccessorID:   00000000-0000-0000-0000-000000000002
+SecretID:     anonymous
+Description:  Anonymous Token - Can List Nodes
+Local:        false
+Create Time:  0001-01-01 00:00:00 +0000 UTC
+Hash:         ee4638968d9061647ac8c3c99e9d37bfdd2af4d1eaa07a7b5f80af0389460948
+Create Index: 5
+Modify Index: 38
+Policies:
+   e96d0a33-28b4-d0dd-9b3f-08301700ac72 - list-all-nodes
+```
+
+The anonymous token is implicitly used if no token is supplied, so now we can run
+`consul members` without supplying a token and we will be able to see the nodes:
+
+```bash
+$ consul members
+Node  Address            Status  Type    Build  Protocol  DC Segment
+fox   172.20.20.10:8301  alive   server  1.4.0  2         kc  <all>
+bear  172.20.20.11:8301  alive   server  1.4.0  2         kc  <all>
+wolf  172.20.20.12:8301  alive   server  1.4.0  2         kc  <all>
+```
+
+The anonymous token is also used for DNS lookups since there is no way to pass a
+token as part of a DNS request. Here's an example lookup for the "consul" service:
+
+```
+$ dig @127.0.0.1 -p 8600 consul.service.consul
+; <<>> DiG 9.8.3-P1 <<>> @127.0.0.1 -p 8600 consul.service.consul
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 9648
+;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0
+;; WARNING: recursion requested but not available
+
+;; QUESTION SECTION:
+;consul.service.consul.         IN      A
+
+;; AUTHORITY SECTION:
+consul.                 0       IN      SOA     ns.consul. postmaster.consul. 1499584110 3600 600 86400 0
+```
+
+Now we get an `NXDOMAIN` error because the anonymous token doesn't have access to the
+"consul" service. Let's update the anonymous token's policy to allow for service reads of the "consul" service.
+
+```bash
+$ consul acl policy create -name 'service-consul-read' -rules 'service "consul" { policy = "read" }'
+ID:           3c93f536-5748-2163-bb66-088d517273ba
+Name:         service-consul-read
+Description:
+Datacenters:
+Rules:
+service "consul" { policy = "read" }
+```
+
+```bash
+$ consul acl token update -id 00000000-0000-0000-0000-000000000002 --merge-policies -description "Anonymous Token - Can List Nodes" -policy-name service-consul-read
+Token updated successfully.
+AccessorID:   00000000-0000-0000-0000-000000000002
+SecretID:     anonymous
+Description:  Anonymous Token - Can List Nodes
+Local:        false
+Create Time:  0001-01-01 00:00:00 +0000 UTC
+Hash:         2c641c4f73158ef6d62f6467c68d751fccd4db9df99b235373e25934f9bbd939
+Create Index: 5
+Modify Index: 43
+Policies:
+   e96d0a33-28b4-d0dd-9b3f-08301700ac72 - list-all-nodes
+   3c93f536-5748-2163-bb66-088d517273ba - service-consul-read
+```
+
+With that new policy in place, the DNS lookup will succeed:
+
+```
+$ dig @127.0.0.1 -p 8600 consul.service.consul
+; <<>> DiG 9.8.3-P1 <<>> @127.0.0.1 -p 8600 consul.service.consul
+; (1 server found)
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 46006
+;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; WARNING: recursion requested but not available
+
+;; QUESTION SECTION:
+;consul.service.consul.         IN      A
+
+;; ANSWER SECTION:
+consul.service.consul.  0       IN      A       127.0.0.1
+```
+
+The next section shows an alternative to the anonymous token.
+
+#### Set Agent-Specific Default Tokens (Optional)
+
+An alternative to the anonymous token is the [`acl.tokens.default`](https://www.consul.io/docs/agent/options.html#acl_tokens_default)
+configuration item. When a request is made to a particular Consul agent and no token is
+supplied, the [`acl.tokens.default`](https://www.consul.io/docs/agent/options.html#acl_tokens_default) will be used for the token, instead of being left empty which would normally invoke the anonymous token.
+
+This behaves very similarly to the anonymous token, but can be configured differently on each
+agent, if desired. For example, this allows more fine grained control of what DNS requests a
+given agent can service or can give the agent read access to some key-value store prefixes by
+default.
+
+If using [`acl.tokens.default`](https://www.consul.io/docs/agent/options.html#acl_tokens_default), then it's likely the anonymous token will have a more restrictive policy than shown in these examples.
+
+#### Create Tokens for UI Use (Optional)
+
+If you utilize the Consul UI with a restrictive ACL policy, as above, the UI will not function fully using the anonymous ACL token. It is recommended that a UI-specific ACL token is used, which can be set in the UI during the web browser session to authenticate the interface.
+
+First create the new policy.
+
+```bash
+$ consul acl policy create -name "ui-policy" \
+                           -description "Necessary permissions for UI functionality" \
+                           -rules 'key_prefix"" { policy = "write" } node_prefix "" { policy = "read" } service_prefix "" { policy = "read" }'
+
+ID:           9cb99b2b-3c20-81d4-a7c0-9ffdc2fbf08a
+Name:         ui-policy
+Description:  Necessary permissions for UI functionality
+Datacenters:
+Rules:
+key_prefix "" { policy = "write" } node_prefix "" { policy = "read" } service_prefix "" { policy = "read" }
+```
+
+With the new policy, create a token.
+
+```sh
+$ consul acl token create -description "UI Token" -policy-name "ui-policy"
+AccessorID:   56e605cf-a6f9-5f9d-5c08-a0e1323cf016
+SecretID:     117842b6-6208-446a-0d1e-daf93854857d
+Description:  UI Token
+Local:        false
+Create Time:  2018-10-19 14:55:44.254063 -0400 EDT
+Policies:
+   9cb99b2b-3c20-81d4-a7c0-9ffdc2fbf08a - ui-policy
+```
+
+The token can then be set on the "ACL" page of the UI.
+
+Note, in this example, we have also given full write access to the KV through the UI.
+
+## Summary
+
+The [ACL API](https://www.consul.io/api/acl/acl.html) can be used to create tokens for applications specific to their intended use and to create more specific ACL agent tokens for each agent's expected role.
+Now that you have bootstrapped ACLs, learn more about [ACL rules](https://www.consul.io/docs/agent/acl-rules.html)
+
+### Notes on Security
+
+In this guide we configured a basic ACL environment with the ability to see all nodes
+by default, but with limited access to discover only the "consul" service. If your environment has stricter security requirements we would like to note the following and make some additional recommendations.
+
+1. In this guide we added the agent token to the configuration file. This means the tokens are now saved on disk. If this is a security concern, tokens can be added to agents using the [Consul CLI](https://www.consul.io/docs/commands/acl/acl-set-agent-token.html). However, this process is more complicated and takes additional care.
+
+2. It is recommended that each client get an ACL agent token with `node` write privileges for just its own node name, and `service` read privileges for just the service prefixes expected to be registered on that client.
+
+3. [Anti-entropy](https://www.consul.io/docs/internals/anti-entropy.html) syncing requires the ACL agent token
+   to have `service:write` privileges for all services that may be registered with the agent.
+   We recommend providing `service:write` for each separate service via a separate token that
+   is used when registering via the API, or provided along with the [registration in the
+   configuration file](https://www.consul.io/docs/agent/services.html). Note that `service:write`
+   is the privilege required to assume the identity of a service and so Consul Connect's
+   intentions are only enforceable to the extent that each service instance is unable to gain
+   `service:write` on any other service name. For more details see the Connect security
+   [documentation](https://www.consul.io/docs/connect/security.html).

--- a/learn/source/content/consul/advanced/day-1-operations/agent-encryption.md
+++ b/learn/source/content/consul/advanced/day-1-operations/agent-encryption.md
@@ -1,0 +1,207 @@
+---
+name: 'Agent Communication Encryption'
+content_length: 10
+id: /day-1-operations/agent-encryption
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  This guide covers how to encrypt both gossip and RPC communication.
+level: Advanced
+---
+
+There are two different systems that need to be configured separately to encrypt communication within the cluster: gossip encryption and TLS. TLS is used to secure the RPC calls between agents. Gossip encryption is secured with a symmetric key, since gossip between nodes is done over UDP. In this guide we will configure both.
+
+To complete the RPC encryption section, you must have [configured agent certificates](/consul/advanced/day-1-operations/certificates).
+
+## Gossip Encryption
+
+To enable gossip encryption, you need to use an encryption key when starting the Consul agent. The key can be simple set with the `encrypt` parameter in the agent configuration file. Alternatively, the encryption key can be placed in a seperate configuration file with only the `encrypt` field, since the agent can merge multiple configuration files. The key must be 16-bytes, Base64 encoded.
+
+You can use the Consul CLI command, [`consul keygen`](https://www.consul.io/docs/commands/keygen.html), to generate a cryptographically suitable key.
+
+```sh
+$ consul keygen
+cg8StVXbQJ0gPvMd9o7yrg==
+```
+
+### Enable Gossip Encryption: New Cluster
+
+To enable gossip on a new cluster, we will add the encryption key parameter to the
+agent configuration file and then pass the file at startup with the [`-config-dir`](https://www.consul.io/docs/agent/options.html#_config_dir) flag.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw=="
+}
+```
+
+```sh
+$ consul agent -config-dir=/etc/consul.d/
+==> Starting Consul agent...
+==> Starting Consul agent RPC...
+==> Consul agent running!
+         Node name: 'Armons-MacBook-Air.local'
+        Datacenter: 'dc1'
+            Server: false (bootstrap: false)
+       Client Addr: 127.0.0.1 (HTTP: 8500, HTTPS: -1, DNS: 8600, RPC: 8400)
+      Cluster Addr: 10.1.10.12 (LAN: 8301, WAN: 8302)
+    Gossip encrypt: true, RPC-TLS: false, TLS-Incoming: false
+...
+```
+
+"Encrypt: true" will be included in the output, if encryption is properly configured.
+
+Note: all nodes within a cluster must share the same encryption key in order to send and receive cluster information, including clients and servers. Additionally, if you're using multiple WAN joined datacenters, be sure to use _the same encryption key_ in all datacenters.
+
+### Enable Gossip Encryption: Existing Cluster
+
+Gossip encryption can also be enabled on an existing cluster, but requires several extra steps. The additional configuration of the agent configuration parameters, [`encrypt_verify_incoming`](https://www.consul.io/docs/agent/options.html#encrypt_verify_incoming) and [`encrypt_verify_outgoing`](https://www.consul.io/docs/agent/options.html#encrypt_verify_outgoing) is necessary.
+
+**Step 1**: Generate an encryption key using `consul keygen`.
+
+```sh
+$ consul keygen
+JY34uTPZyfUE+6tinMYEVw==
+```
+
+**Step 2**: Set the [`encrypt`](https://www.consul.io/docs/agent/options.html#_encrypt) key, and set `encrypt_verify_incoming` and `encrypt_verify_outgoing` to `false` in the agent configuration file. Then initiate a rolling update of the cluster with these new values. After this step, the agents will be able to decrypt gossip but will not yet be sending encrypted traffic.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "encrypt_verify_incoming": false,
+  "encrypt_verify_outgoing": false
+}
+```
+
+A rolling update can be made by restarting the Consul agents (clients and servers) in turn. `consul reload` or `kill -HUP <process_id>` is _not_ sufficient to change the gossip configuration.
+
+**Step 3**: Update the `encrypt_verify_outgoing` setting to `true` and perform another rolling update of the cluster by restarting Consul on each agent. The agents will now be sending encrypted gossip but will still allow incoming unencrypted traffic.
+
+````javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "encrypt_verify_incoming": false,
+  "encrypt_verify_outgoing": true
+}
+```
+
+**Step 4**: The previous step, enabling verify outgoing, must be completed on all agents before continuing. Update the `encrypt_verify_incoming` setting to `true` and perform a final rolling update of the cluster.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "encrypt_verify_incoming": true,
+  "encrypt_verify_outgoing": true
+}
+````
+
+All the agents will now be strictly enforcing encrypted gossip. Note, the default
+behavior of both `encrypt_verify_incoming` and `encrypt_verify_outgoing` is `true`.
+We have set them in the configuration file as an explicit example.
+
+## TLS Encryption for RPC
+
+Consul supports using TLS to verify the authenticity of servers and clients. To enable TLS,
+Consul requires that all servers have certificates that are signed by a single
+Certificate Authority. Clients may optionally authenticate with a client certificate generated by the same CA. Please see
+[this guide on creating a CA and signing certificates](/consul/advanced/day-1-operations/certificates)
+using [cfssl](https://cfssl.org/).
+
+TLS can be used to verify the authenticity of the servers with [`verify_outgoing`](https://www.consul.io/docs/agent/options.html#verify_outgoing) and [`verify_server_hostname`](https://www.consul.io/docs/agent/options.html#verify_server_hostname). It can also optionally verify client certificates when using [`verify_incoming`](https://www.consul.io/docs/agent/options.html#verify_incoming)
+
+Review the [docs for specifics](https://www.consul.io/docs/agent/encryption.html).
+
+In Consul version 0.8.4 and newer, migrating to TLS encrypted traffic on a running cluster
+is supported.
+
+### Enable TLS: New Cluster
+
+After TLS has been configured on all the agents, you can start the agents and RPC communication will be encrypted.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "verify_incoming": true,
+  "verify_outgoing": true,
+  "verify_server_hostname": true,
+  "ca_file": "consul-ca.pem",
+  "cert_file": "consul.pem",
+  "key_file": "consul-key.pem
+}
+```
+
+The `verify_outgoing` parameter enables agents to verify the authenticity of Consul servers for outgoing connections. The `verify_server_hostname` parameter requires outgoing connections to perform hostname verification and is critically important to prevent compromised client agents from becoming servers and revealing all state to the attacker. Finally, the `verify_incoming` parameter enables the servers to verify the authenticity of all incoming connections.
+
+### Enable TLS: Existing Cluster
+
+Enabling TLS on an existing cluster is supported. This process assumes a starting point of a running cluster with no TLS settings configured, and involves an intermediate step in order to get to full TLS encryption.
+
+**Step 1**: [Generate the necessary keys and certificates](/consul/advanced/day-1-operations/certificates), then set the `ca_file` or `ca_path`, `cert_file`, and `key_file` settings in the configuration for each agent. Make sure the `verify_outgoing` and `verify_incoming` options are set to `false`. HTTPS for the API can be enabled at this point by setting the [`https`](https://www.consul.io/docs/agent/options.html#http_port) port.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "verify_incoming": false,
+  "verify_outgoing": false,
+  "ca_file": "consul-ca.pem",
+  "cert_file": "consul.pem",
+  "key_file": "consul-key.pem"
+}
+```
+
+Next, perform a rolling restart of each agent in the cluster. After this step, TLS should be enabled everywhere but the agents will not yet be enforcing TLS. Again, `consul reload` or `kill -HUP <process_id>` is _not_ sufficient to update the configuration.
+
+**Step 2**: (Optional, Enterprise-only) If applicable, set the `Use TLS` setting in any network areas to `true`. This can be done either through the [`consul operator area update`](https://www.consul.io/docs/commands/operator/area.html) command or the [Operator API](https://www.consul.io/api/operator/area.html).
+
+**Step 3**: Change the `verify_incoming`, `verify_outgoing`, and `verify_server_hostname` to `true` then perform another rolling restart of each agent in the cluster.
+
+```javascript
+{
+  "data_dir": "/opt/consul",
+  "log_level": "INFO",
+  "node_name": "bulldog",
+  "server": true,
+  "encrypt": "JY34uTPZyfUE+6tinMYEVw==",
+  "verify_incoming": true,
+  "verify_outgoing": true,
+  "verify_server_hostname": true,
+  "ca_file": "consul-ca.pem",
+  "cert_file": "consul.pem",
+  "key_file": "consul-key.pem"
+}
+
+```
+
+At this point, full TLS encryption for RPC communication is enabled. To disable `HTTP`
+connections, which may still be in use by clients for API and CLI communications, update
+the [agent configuration](https://www.consul.io/docs/agent/options.html#ports).
+
+## Summary
+
+In this guide we configured both gossip encryption and TLS for RPC. Securing agent communication is a recommended set in setting up a production ready cluster.

--- a/learn/source/content/consul/advanced/day-1-operations/backup.md
+++ b/learn/source/content/consul/advanced/day-1-operations/backup.md
@@ -1,0 +1,91 @@
+---
+name: 'Datacenter Backups'
+content_length: 10
+id: /day-1-operations/backup
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  Consul provide the snapshot tool for backing up and restoring data. In this guide you will learn how to use both.
+level: Advanced
+---
+
+Creating server backups is an important step in production deployments. Backups provide a mechanism for the server to recover from an outage (network loss, operator error, or a corrupted data directory). All servers write to the `-data-dir` before commit on write requests. The same directory is used on client agents to persist local state too, but this is not critical and can be rebuilt when recreating an agent. Local client state is not backed up in this guide and doesn't need to be in general, only the server's Raft store state.
+
+Consul provides the [snapshot](https://consul.io/docs/commands/snapshot.html) command which can be run using the CLI or the API. The `snapshot` command saves a point-in-time snapshot of the state of the Consul servers which includes, but is not limited to:
+
+- KV entries
+- the service catalog
+- prepared queries
+- sessions
+- ACLs
+
+With [Consul Enterprise](https://www.consul.io/docs/commands/snapshot/agent.html), the `snapshot agent` command runs periodically and writes to local or remote storage (such as Amazon S3).
+
+By default, all snapshots are taken using `consistent` mode where requests are forwarded to the leader which verifies that it is still in power before taking the snapshot. Snapshots will not be saved if the datacenter is degraded or if no leader is available. To reduce the burden on the leader, it is possible to [run the snapshot](https://www.consul.io/docs/commands/snapshot/save.html) on any non-leader server using `stale` consistency mode.
+
+This spreads the load across nodes at the possible expense of losing full consistency guarantees. Typically this means that a very small number of recent writes may not be included. The omitted writes are typically limited to data written in the last `100ms` or less from the recovery point. This is usually suitable for disaster recovery. However, the system can't guarantee how stale this may be if executed against a partitioned server.
+
+## Create Your First Backup
+
+The `snapshot save` command for backing up the datacenter state has many configuration options. In a production environment, you will want to configure ACL tokens and client certificates for security. The configuration options also allow you to specify the datacenter and server to collect the backup data from. Below are several examples.
+
+First, we will run the basic snapshot command on one of our servers with the all the defaults, including `consistent` mode.
+
+```sh
+$ consul snapshot save backup.snap
+Saved and verified snapshot to index 1176
+```
+
+The backup will be saved locally in the directory where we ran the command.
+
+You can view metadata about the backup with the `inspect` subcommand.
+
+```sh
+$ consul snapshot inspect backup.snap
+ID           2-1182-1542056499724
+Size         4115
+Index        1182
+Term         2
+Version      1
+```
+
+To understand each field review the inspect [documentation](https://www.consul.io/docs/commands/snapshot/inspect.html). Notably, the `Version` field does not correspond to the version of the data. Rather it is the snapshot format version.
+
+Next, let's collect the datacenter data from a non-leader by specifying stale mode.
+
+```sh
+$ consul snapshot save -stale backup.snap
+Saved and verified snapshot to index 2276
+```
+
+Once ACLs and agent certificates are configured, they can be passed in as environtmennt variables or flags.
+
+```sh
+$ export CONSUL_HTTP_TOKEN=<your ACL token>
+$ consul snapshot save -stale -ca-file=</path/to/file> backup.snap
+Saved and verified snapshot to index 2287
+```
+
+In the above example, we set the token as an ENV and the ca-file with a command line flag.
+
+For production use, the `snapshot save` command or [API](https://www.consul.io/api/snapshot.html) should be scripted and run frequently. In addition to frequently backing up the datacenter state, there are several use cases when you would also want to manually execute `snapshot save`. First, you should always backup the datacenter before upgrading. If the upgrade does not go according to plan it is often not possible to downgrade due to changes in the state store format. Restoring from a backup is the only option so taking one before the upgrade will ensure you have the latest data. Second, if the dataenter loses quorum it may be beneficial to save the state before the servers become divergent. Finally, you can manually snapshot a datacenter and use that to bootstrap a new datacenter with the same state.
+
+Operationally, the backup process does not need to be executed on every server. Additionally, you can use the configuration options to save the backups to a mounted filesystem. The mounted filesystem can even be cloud storage, such as Amazon S3. The enterprise command `snapshot agent` automates this process.
+
+## Restore from Backup
+
+Running the `restore` process should be straightforward. However, there are a couple of actions you can take to ensure the process goes smoothly. First, make sure the datacenter you are restoring is stable and has a leader. You can see this using `consul operator raft list-peers` and checking server logs and telemetry for signs of leader elections or network issues.
+
+You will only need to run the process once, on the leader. The Raft consensus protocol ensures that all servers restore the same state.
+
+```sh
+$ consul snapshot restore backup.snap
+Restored snapshot
+```
+
+Like the `save` subcommand, restore has many configuration options. In production, you would again want to use ACLs and certificates for security.
+
+## Summary
+
+In this guide, we learned about the `snapshot save` and `snapshot restore` commands. If you are testing the backup and restore process, you can add an extra dummy value to Consul KV. Another indicator that the backup was saved correctly is the size of the backup artifact.

--- a/learn/source/content/consul/advanced/day-1-operations/certificates.md
+++ b/learn/source/content/consul/advanced/day-1-operations/certificates.md
@@ -1,0 +1,426 @@
+---
+name: 'Creating and Configuring TLS Certificates'
+content_length: 12
+id: /day-1-operations/certificates
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  Learn how to create certificates for Consul.
+level: Advanced
+---
+
+Setting you cluster up with TLS is an important step towards a secure
+deployment. Correct TLS configuration is a prerequisite of our [Security
+Model](https://consul.io/docs/internals/security.html). Correctly configuring TLS can be a
+complex process however, especially given the wide range of deployment
+methodologies. This guide will provide you with a production ready TLS
+configuration.
+
+~> More advanced topics like key management and rotation are not covered by this
+guide. [Vault](https://www.vaultproject.io/) is the suggested solution for key generation and
+management.
+
+This guide has the following chapters:
+
+1. [Creating Certificates](#creating-certificates)
+1. [Configuring Agents](#configuring-agents)
+1. [Configuring the Consul CLI for HTTPS](#configuring-the-consul-cli-for-https)
+1. [Configuring the Consul UI for HTTPS](#configuring-the-consul-ui-for-https)
+
+This guide is structured in way that you build knowledge with every step. It is
+recommended to read the whole guide before starting with the actual work,
+because you can save time if you are aware of some of the more advanced things
+in Chapter [3](#configuring-the-consul-cli-for-https) and
+[4](#configuring-the-consul-ui-for-https).
+
+### Reference Material
+
+- [Encryption](/consul/advanced/day-1-operations/agent-encryption)
+- [Security Model](https://consul.io/docs/internals/security.html)
+
+## Creating Certificates
+
+### Prerequisites
+
+This guide assumes you have Consul 1.4.1 (or newer) in your PATH.
+
+### Introduction
+
+The first step to configuring TLS for Consul is generating certificates. In
+order to prevent unauthorized cluster access, Consul requires all certificates
+be signed by the same Certificate Authority (CA). This should be a _private_ CA
+and not a public one like [Let's Encrypt](https://letsencrypt.org/) as any certificate
+signed by this CA will be allowed to communicate with the cluster.
+
+### Step 1: Create a Certificate Authority
+
+There are a variety of tools for managing your own CA, [like the PKI secret
+backend in Vault](https://www.vaultproject.io/docs/secrets/pki/index.html), but for the sake of simplicity this guide will
+use Consul's builtin TLS helpers:
+
+```shell
+$ consul tls ca create
+==> Saved consul-agent-ca.pem
+==> Saved consul-agent-ca-key.pem
+```
+
+The CA certificate (`consul-agent-ca.pem`) contains the public key necessary to
+validate Consul certificates and therefore must be distributed to every node
+that runs a consul agent.
+
+~> The CA key (`consul-agent-ca-key.pem`) will be used to sign certificates for Consul
+nodes and must be kept private. Possession of this key allows anyone to run Consul as
+a trusted server and access all Consul data including ACL tokens.
+
+
+### Step 2: Create individual Server Certificates
+
+Create a server certificate for datacenter `dc1` and domain `consul`, if your
+datacenter or domain is different please use the appropriate flags:
+
+```shell
+$ consul tls cert create -server
+==> WARNING: Server Certificates grants authority to become a
+    server and access all state in the cluster including root keys
+    and all ACL tokens. Do not distribute them to production hosts
+    that are not server nodes. Store them as securely as CA keys.
+==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
+==> Saved dc1-server-consul-0.pem
+==> Saved dc1-server-consul-0-key.pem
+```
+
+Please repeat this process until there is an *individual* certificate for each
+server. The command can be called over and over again, it will automatically add
+a suffix.
+
+In order to authenticate Consul servers, servers are provided with a special
+certificate - one that contains `server.dc1.consul` in the `Subject Alternative
+Name`. If you enable
+[`verify_server_hostname`](https://consul.io/docs/agent/options.html#verify_server_hostname),
+only agents that provide such certificate are allowed to boot as a server.
+Without `verify_server_hostname = true` an attacker could compromise a Consul
+client agent and restart the agent as a server in order to get access to all the
+data in your cluster! This is why server certificates are special, and only
+servers should have them provisioned.
+
+~> Server keys, like the CA key, must be kept private - they effectively allow
+access to all Consul data.
+
+### Step 3: Create Client Certificates
+
+Create a client certificate:
+
+```shell
+$ consul tls cert create -client
+==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
+==> Saved dc1-client-consul-0.pem
+==> Saved dc1-client-consul-0-key.pem
+```
+
+Client certificates are also signed by your CA, but they do not have that
+special `Subject Alternative Name` which means that if `verify_server_hostname`
+is enabled, they cannot start as a server.
+
+## Configuring Agents
+
+### Prerequisites
+
+For this section you need access to your existing or new Consul cluster and have the certificates from the previous chapters available.
+
+### Notes on example configurations
+
+The example configurations from this as well as the following chapters are in
+json. You can copy each one of the examples in its own file in a directory
+([`-config-dir`](https://consul.io/docs/agent/options.html#_config_dir)) from where consul will
+load all the configuration. This is just one way to do it, you can also put them
+all into one file if you prefer that.
+
+### Introduction
+
+By now you have created the certificates you need to enable TLS in your cluster.
+The next steps show how to configure TLS for a brand new cluster. If you already
+have a cluster in production without TLS please see the [encryption
+guide](/consul/advanced/day-1-operations/agent-encryption#enable-tls-existing-cluster) for the steps needed to introduce TLS without downtime.
+
+### Step 1: Setup Consul servers with certificates
+
+This step describes how to setup one of your consul servers, you want to make
+sure to repeat the process for the other ones as well with their individual
+certificates.
+
+The following files need to be copied to your Consul server:
+
+* `consul-agent-ca.pem`: CA public certificate.
+* `consul-server-dc1-0.pem`: Consul server node public certificate for the `dc1` datacenter.
+* `consul-server-dc1-0-key.pem`: Consul server node private key for the `dc1` datacenter.
+
+Here is an example agent TLS configuration for Consul servers which mentions the
+copied files:
+
+```json
+{
+  "verify_incoming": true,
+  "verify_outgoing": true,
+  "verify_server_hostname": true,
+  "ca_file": "consul-agent-ca.pem",
+  "cert_file": "dc1-server-consul-0.pem",
+  "key_file": "dc1-server-consul-0-key.pem",
+  "ports": {
+    "http": -1,
+    "https": 8501
+  }
+}
+```
+
+This configuration disables the HTTP port to make sure there is only encryted
+communication. Existing clients that are not yet prepared to talk HTTPS won't be
+able to connect afterwards. This also affects builtin tooling like `consul
+members` and the UI. The next chapters will demonstrate how to setup secure
+access.
+
+After a Consul agent restart, your servers should be only talking TLS.
+
+### Step 2: Setup Consul clients with certificates
+
+Now copy the following files to your Consul clients:
+
+* `consul-agent-ca.pem`: CA public certificate.
+* `dc1-client-consul-0.pem`: Consul client node public certificate.
+* `dc1-client-consul-0-key.pem`: Consul client node private key.
+
+Here is an example agent TLS configuration for Consul agents which mentions the
+copied files:
+
+```json
+{
+  "verify_incoming": true,
+  "verify_outgoing": true,
+  "verify_server_hostname": true,
+  "ca_file": "consul-agent-ca.pem",
+  "cert_file": "dc1-client-consul-0.pem",
+  "key_file": "dc1-client-consul-0-key.pem",
+  "ports": {
+    "http": -1,
+    "https": 8501
+  }
+}
+```
+
+This configuration disables the HTTP port to make sure there is only encryted
+communication. Existing clients that are not yet prepared to talk HTTPS won't be
+able to connect afterwards. This also affects builtin tooling like `consul
+members` and the UI. The next chapters will demonstrate how to setup secure
+access.
+
+After a Consul agent restart, your agents should be only talking TLS.
+
+## Configuring the Consul CLI for HTTPS
+
+If your cluster is configured to only communicate via HTTPS, you will need to
+create additional certificates in order to be able to continue to access the API
+and the UI:
+
+```shell
+$ consul tls cert create -cli
+==> Using consul-agent-ca.pem and consul-agent-ca-key.pem
+==> Saved dc1-cli-consul-0.pem
+==> Saved dc1-cli-consul-0-key.pem
+```
+
+If you are trying to get members of you cluster, the CLI will return an error:
+
+```shell
+$ consul members
+Error retrieving members:
+  Get http://127.0.0.1:8500/v1/agent/members?segment=_all:
+  dial tcp 127.0.0.1:8500: connect: connection refused
+$ consul members -http-addr="https://localhost:8501"
+Error retrieving members:
+  Get https://localhost:8501/v1/agent/members?segment=_all:
+  x509: certificate signed by unknown authority
+```
+
+But it will work again if you provide the certificates you provided:
+
+```shell
+$ consul members -ca-file=consul-agent-ca.pem -client-cert=dc1-cli-consul-0.pem \
+  -client-key=dc1-cli-consul-0-key.pem -http-addr="https://localhost:8501"
+  Node     Address         Status  Type    Build     Protocol  DC   Segment
+  ...
+```
+
+This process can be cumbersome to type each time, so the Consul CLI also
+searches environment variables for default values. Set the following
+environment variables in your shell:
+
+```shell
+$ export CONSUL_HTTP_ADDR=https://localhost:8501
+$ export CONSUL_CACERT=consul-agent-ca.pem
+$ export CONSUL_CLIENT_CERT=dc1-cli-consul-0.pem
+$ export CONSUL_CLIENT_KEY=dc1-cli-consul-0-key.pem
+```
+
+* `CONSUL_HTTP_ADDR` is the URL of the Consul agent and sets the default for
+  `-http-addr`.
+* `CONSUL_CACERT` is the location of your CA certificate and sets the default
+  for `-ca-file`.
+* `CONSUL_CLIENT_CERT` is the location of your CLI certificate and sets the
+  default for `-client-cert`.
+* `CONSUL_CLIENT_KEY` is the location of your CLI key and sets the default for
+  `-client-key`.
+
+After these environment variables are correctly configured, the CLI will
+respond as expected.
+
+### Note on SANs for Server and Client Certificates
+
+Using `localhost` and `127.0.0.1` as `Subject Alternative Names` in server
+and client certificates allows tools like `curl` to be able to communicate with
+Consul's HTTPS API when run on the same host. Other SANs may be added during
+server/client certificates creation with `-additional-dnsname` to allow remote
+HTTPS requests from other hosts.
+
+## Configuring the Consul UI for HTTPS
+
+If your servers and clients are configured now like above, you won't be able to
+access the builtin UI anymore. We recommend that you pick one (or two for
+availability) Consul agent you want to run the UI on and follow the instructions
+to get the UI up and running again.
+
+### Step 1: Which interface to bind to?
+
+Depending on your setup you might need to change to which interface you are
+binding because thats `127.0.0.1` by default for the UI. Either via the
+[`addresses.https`](https://consul.io/docs/agent/options.html#https) or
+[client_addr](https://consul.io/docs/agent/options.html#client_addr) option which also impacts
+the DNS server. The Consul UI is unproteced which means you need to put some
+auth in front of it if you want to make it publicly available!
+
+Binding to `0.0.0.0` should work:
+
+```json
+{
+  "ui": true,
+  "client_addr": "0.0.0.0",
+  "enable_script_checks": false,
+  "disable_remote_exec": true
+}
+```
+
+~> Since your Consul agent is now available to the network, please make sure
+that [`enable_script_checks`](https://consul.io/docs/agent/options.html#_enable_script_checks) is
+set to `false` and
+[`disable_remote_exec`](https://www.consul.io/docs/agent/options.html#disable_remote_exec)
+is set to `true`.
+
+### Step 2: verify_incoming_rpc
+
+Your Consul agent will deny the connection straight away because
+`verify_incoming` is enabled.
+
+> If set to true, Consul requires that all incoming connections make use of TLS
+> and that the client provides a certificate signed by a Certificate Authority
+> from the ca_file or ca_path. This applies to both server RPC and to the HTTPS
+> API.
+
+Since the browser doesn't present a certificate signed by our CA, you cannot
+access the UI. If you `curl` your HTTPS UI the following happens:
+
+```shell
+$ curl https://localhost:8501/ui/ -k -I
+curl: (35) error:14094412:SSL routines:SSL3_READ_BYTES:sslv3 alert bad certificate
+```
+
+This is the Consul HTTPS server denying your connection because you are not
+presenting a client certificate signed by your Consul CA. There is a combination
+of options however that allows us to keep using `verify_incoming` for RPC, but
+not for HTTPS:
+
+```json
+{
+  "verify_incoming": false,
+  "verify_incoming_rpc": true
+}
+```
+
+~> This is the only time we are changing the value of the existing option
+`verify_incoming` to false. Make sure to only change it on the agent running the
+UI!
+
+With the new configuration, it should work:
+
+```shell
+$ curl https://localhost:8501/ui/ -k -I
+HTTP/2 200
+...
+```
+
+### Step 3: Subject Alternative Name
+
+This step will take care of setting up the domain you want to use to access the
+Consul UI. Unless you only need to access the UI over localhost or 127.0.0.1 you
+will need to go complete this step.
+
+```shell
+$ curl https://consul.example.com:8501/ui/ \
+  --resolve 'consul.example.com:8501:127.0.0.1' \
+  --cacert consul-agent-ca.pem
+curl: (51) SSL: no alternative certificate subject name matches target host name 'consul.example.com'
+...
+```
+
+The above command simulates a request a browser is making when you are trying to
+use the domain `consul.example.com` to access your UI. The problem this time is
+that your domain is not in `Subject Alternative Name` of the Certificate. We can
+fix that by creating a certificate that has our domain:
+
+```shell
+$ consul tls cert create -server -additional-dnsname consul.example.com
+...
+```
+
+And if you put your new cert into the configuration of the agent you picked to
+serve the UI and restart Consul, it works now:
+
+```shell
+$ curl https://consul.example.com:8501/ui/ \
+  --resolve 'consul.example.com:8501:127.0.0.1' \
+  --cacert consul-agent-ca.pem -I
+HTTP/2 200
+...
+```
+
+### Step 4: Trust the Consul CA
+
+So far we have provided curl with our CA so that it can verify the connection,
+but if we stop doing that it will complain and so will our browser if you visit
+your UI on `https://consul.example.com`:
+
+```shell
+$ curl https://consul.example.com:8501/ui/ \
+  --resolve 'consul.example.com:8501:127.0.0.1'
+curl: (60) SSL certificate problem: unable to get local issuer certificate
+...
+```
+
+You can fix that by trusting your Consul CA (`consul-agent-ca.pem`) on your machine,
+please use Google to find out how to do that on your OS.
+
+```shell
+$ curl https://consul.example.com:8501/ui/ \
+  --resolve 'consul.example.com:8501:127.0.0.1' -I
+HTTP/2 200
+...
+```
+
+## Summary
+
+When you have completed this guide, your Consul cluster will have TLS enabled
+and will encrypt all RPC and HTTP traffic (assuming you disabled the HTTP port).
+The other prerequisites for a secure Consul deployment are:
+
+* [Enable gossip encryption](https://consul.io/docs/agent/encryption.html#gossip-encryption)
+* [Configure ACLs](/consul/advanced/day-1-operations/acl-guide) with default deny
+
+

--- a/learn/source/content/consul/advanced/day-1-operations/deployment-guide.md
+++ b/learn/source/content/consul/advanced/day-1-operations/deployment-guide.md
@@ -1,0 +1,245 @@
+---
+name: 'Deployment Guide'
+content_length: 8
+id: /day-1-operations/deployment-guide
+layout: content_layout
+products_used:
+  - Consul
+description: Guide for deploying your first cluster.
+level: Advanced
+---
+
+This deployment guide covers the steps required to install and configure a single HashiCorp Consul cluster as defined in the [Consul Reference Architecture](/consul/advanced/day-1-operations/reference-architecture).
+
+This deployment guide is designed to work in combination with the [Consul Reference Architecture](/consul/advanced/day-1-operations/reference-architecture). Although not a strict requirement to follow the Consul Reference Architecture, it is highly recommended that you are familiar with the overall architecture design; for example installing Consul server agents on multiple physical or virtual (with correct anti-affinity) hosts for high-availability.
+
+To provide a highly-available single cluster architecture, we recommend Consul server agents be deployed to more than one host, as shown in the Consul Reference Architecture.
+
+![Reference Diagram](/assets/images/consul-arch-single.png 'Reference Diagram')
+
+These setup steps should be completed on all Consul hosts.
+
+- [Download Consul](#download-consul)
+- [Install Consul](#install-consul)
+- [Configure systemd](#configure-systemd)
+- Configure Consul [(server)](#configure-consul-server-) or [(client)](#configure-consul-client-)
+- [Start Consul](#start-consul)
+
+These instructions are for installing and configuring Consul on Linux hosts running the systemd system and service manager.
+
+## Download Consul
+
+Precompiled Consul binaries are available for download at [https://releases.hashicorp.com/consul/](https://releases.hashicorp.com/consul/) and Consul Enterprise binaries are available for download by following the instructions made available to HashiCorp Consul customers.
+
+You should perform checksum verification of the zip packages using the SHA256SUMS and SHA256SUMS.sig files available for the specific release version. HashiCorp provides [a guide on checksum verification](https://www.hashicorp.com/security.html) for precompiled binaries.
+
+```text
+CONSUL_VERSION="1.2.0"
+curl --silent --remote-name https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+curl --silent --remote-name https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS
+curl --silent --remote-name https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_SHA256SUMS.sig
+```
+
+## Install Consul
+
+Unzip the downloaded package and move the `consul` binary to `/usr/local/bin/`. Check `consul` is available on the system path.
+
+```text
+unzip consul_${CONSUL_VERSION}_linux_amd64.zip
+sudo chown root:root consul
+sudo mv consul /usr/local/bin/
+consul --version
+```
+
+The `consul` command features opt-in autocompletion for flags, subcommands, and arguments (where supported). Enable autocompletion.
+
+```text
+consul -autocomplete-install
+complete -C /usr/local/bin/consul consul
+```
+
+Create a unique, non-privileged system user to run Consul and create its data directory.
+
+```text
+sudo useradd --system --home /etc/consul.d --shell /bin/false consul
+sudo mkdir --parents /opt/consul
+sudo chown --recursive consul:consul /opt/consul
+```
+
+## Configure systemd
+
+Systemd uses [documented sane defaults](https://www.freedesktop.org/software/systemd/man/systemd.directives.html) so only non-default values must be set in the configuration file.
+
+Create a Consul service file at /etc/systemd/system/consul.service.
+
+```text
+sudo touch /etc/systemd/system/consul.service
+```
+
+Add this configuration to the Consul service file:
+
+```text
+[Unit]
+Description="HashiCorp Consul - A service mesh solution"
+Documentation=https://www.consul.io/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/consul.d/consul.hcl
+
+[Service]
+User=consul
+Group=consul
+ExecStart=/usr/local/bin/consul agent -config-dir=/etc/consul.d/
+ExecReload=/usr/local/bin/consul reload
+KillMode=process
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+```
+
+The following parameters are set for the `[Unit]` stanza:
+
+- [`Description`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description=) - Free-form string describing the consul service
+- [`Documentation`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Documentation=) - Link to the consul documentation
+- [`Requires`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=) - Configure a requirement dependency on the network service
+- [`After`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=) - Configure an ordering dependency on the network service being started before the consul service
+- [`ConditionFileNotEmpty`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionArchitecture=) - Check for a non-zero sized configuration file before consul is started
+
+The following parameters are set for the `[Service]` stanza:
+
+- [`User`, `Group`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#User=) - Run consul as the consul user
+- [`ExecStart`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart=) - Start consul with the `agent` argument and path to the configuration file
+- [`ExecReload`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecReload=) - Send consul a reload signal to trigger a configuration reload in consul
+- [`KillMode`](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=) - Treat consul as a single process
+- [`Restart`](https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartSec=) - Restart consul unless it returned a clean exit code
+- [`LimitNOFILE`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties) - Set an increased Limit for File Descriptors
+
+The following parameters are set for the `[Install]` stanza:
+
+- [`WantedBy`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#WantedBy=) - Creates a weak dependency on consul being started by the multi-user run level
+
+## Configure Consul (server)
+
+Consul uses [documented sane defaults](https://www.consul.io/docs/agent/options.html) so only non-default values must be set in the configuration file. Configuration can be read from multiple files and is loaded in lexical order. See the [full description](https://www.consul.io/docs/agent/options.html) for more information about configuration loading and merge semantics.
+
+Consul server agents typically require a superset of configuration required by Consul client agents. We will specify common configuration used by all Consul agents in `consul.hcl` and server specific configuration in `server.hcl`.
+
+### General configuration
+
+Create a configuration file at `/etc/consul.d/consul.hcl`:
+
+```text
+sudo mkdir --parents /etc/consul.d
+sudo touch /etc/consul.d/consul.hcl
+sudo chown --recursive consul:consul /etc/consul.d
+sudo chmod 640 /etc/consul.d/consul.hcl
+```
+
+Add this configuration to the `consul.hcl` configuration file:
+
+~> **NOTE** Replace the `datacenter` parameter value with the identifier you will use for the datacenter this Consul cluster is deployed in. Replace the `encrypt` parameter value with the output from running `consul keygen` on any host with the `consul` binary installed.
+
+```hcl
+datacenter = "dc1"
+data_dir = "/opt/consul"
+encrypt = "Luj2FZWwlt8475wD1WtwUQ=="
+```
+
+- [`datacenter`](https://www.consul.io/docs/agent/options.html#_datacenter) - The datacenter in which the agent is running.
+- [`data_dir`](https://www.consul.io/docs/agent/options.html#_data_dir) - The data directory for the agent to store state.
+- [`encrypt`](https://www.consul.io/docs/agent/options.html#_encrypt) - Specifies the secret key to use for encryption of Consul network traffic.
+
+### Cluster auto-join
+
+The `retry_join` parameter allows you to configure all Consul agents to automatically form a cluster using a common Consul server accessed via DNS address, IP address or using Cloud Auto-join. This removes the need to manually join the Consul cluster nodes together.
+
+Add the retry_join parameter to the `consul.hcl` configuration file:
+
+~> **NOTE** Replace the `retry_join` parameter value with the correct DNS address, IP address or [cloud auto-join configuration](https://www.consul.io/docs/agent/cloud-auto-join.html) for your environment.
+
+```hcl
+retry_join = ["172.16.0.11"]
+```
+
+- [`retry_join`](https://www.consul.io/docs/agent/options.html#retry-join) - Address of another agent to join upon starting up.
+
+### Performance stanza
+
+The [`performance`](https://www.consul.io/docs/agent/options.html#performance) stanza allows tuning the performance of different subsystems in Consul.
+
+Add the performance configuration to the `consul.hcl` configuration file:
+
+```hcl
+performance {
+  raft_multiplier = 1
+}
+```
+
+- [`raft_multiplier`](https://www.consul.io/docs/agent/options.html#raft_multiplier) - An integer multiplier used by Consul servers to scale key Raft timing parameters. Setting this to a value of 1 will configure Raft to its highest-performance mode, equivalent to the default timing of Consul prior to 0.7, and is recommended for production Consul servers.
+
+For more information on Raft tuning and the `raft_multiplier` setting, see the [server performance](https://www.consul.io/docs/guides/performance.html) documentation.
+
+### Telemetry stanza
+
+The [`telemetry`](https://www.consul.io/docs/agent/options.html#telemetry) stanza specifies various configurations for Consul to publish metrics to upstream systems.
+
+If you decide to configure Consul to publish telemetry data, you should complete the [Monitoring and Metrics guide](/consul/advanced/day-1-operations/monitoring) at the end of the Day 1 learning path.
+
+### Server configuration
+
+Create a configuration file at `/etc/consul.d/server.hcl`:
+
+```text
+sudo mkdir --parents /etc/consul.d
+sudo touch /etc/consul.d/server.hcl
+sudo chown --recursive consul:consul /etc/consul.d
+sudo chmod 640 /etc/consul.d/server.hcl
+```
+
+Add this configuration to the `server.hcl` configuration file:
+
+~> **NOTE** Replace the `bootstrap_expect` value with the number of Consul servers you will use; three or five [is recommended](https://www.consul.io/docs/internals/consensus.html#deployment-table).
+
+```hcl
+server = true
+bootstrap_expect = 3
+```
+
+- [`server`](https://www.consul.io/docs/agent/options.html#_server) - This flag is used to control if an agent is in server or client mode.
+- [`bootstrap-expect`](https://www.consul.io/docs/agent/options.html#_bootstrap_expect) - This flag provides the number of expected servers in the datacenter. Either this value should not be provided or the value must agree with other servers in the cluster.
+
+### Consul UI
+
+Consul features a web-based user interface, allowing you to easily view all services, nodes, intentions and more using a graphical user interface, rather than the CLI or API.
+
+~> **NOTE** You should consider running the Consul UI on select Consul hosts rather than all hosts.
+
+Optionally, add the UI configuration to the `server.hcl` configuration file to enable the Consul UI:
+
+```hcl
+ui = true
+```
+
+## Configure Consul (client)
+
+Consul client agents typically require a subset of configuration required by Consul server agents. All Consul clients can use the `consul.hcl` file created when [configuring the Consul servers](#general-configuration). If you have added host-specific configuration such as identifiers, you will need to set these individually.
+
+## Start Consul
+
+Enable and start Consul using the systemctl command responsible for controlling systemd managed services. Check the status of the consul service using systemctl.
+
+```text
+sudo systemctl enable consul
+sudo systemctl start consul
+sudo systemctl status consul
+```
+
+## Summary
+
+In this guide you configured servers and clients in accordance to the reference architecture. This is the first step in deploying your first datacenter. In the next guide, you will learn how to configure backups to ensure the cluster state is save encase of a failure situation.
+
+To create a secure cluster, we recommend completing the [ACL bootstrap guide](/consul/advanced/day-1-operations/acl-guide), [agent encryption guide](/consul/advanced/day-1-operations/agent-encryption), and [certificates guide](/consul/advanced/day-1-operations/certificates). All three guides are in the Day 1 learning path.
+
+Finally, we also recommend reviewing the [Windows agent guide](https://www.consul.io/docs/guides/windows-guide.html) and [Consul in containers guide](https://www.consul.io/docs/guides/consul-containers.html) for a mixed workload environment.

--- a/learn/source/content/consul/advanced/day-1-operations/monitoring.md
+++ b/learn/source/content/consul/advanced/day-1-operations/monitoring.md
@@ -1,0 +1,265 @@
+---
+name: 'Consul Cluster Monitoring and Metrics'
+content_length: 12
+id: /day-1-operations/monitoring
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  After setting up your first datacenter, it is an ideal time to make sure your cluster is healthy and establish a baseline
+level: Advanced
+---
+
+After setting up your first datacenter, it is an ideal time to make sure your cluster is healthy and establish a baseline. This guide will cover several types of metrics in two sections: Consul health and server health.
+
+**Consul health**:
+
+- Transaction timing
+- Leadership changes
+- Autopilot
+- Garbage collection
+
+**Server health**:
+
+- File descriptors
+- CPU usage
+- Network activity
+- Disk activity
+- Memory usage
+
+For each type of metric, we will review their importance and help identify when a metric is indicating a healthy or unhealthy state.
+
+First, we need to understand the three methods for collecting metrics. We will briefly cover using SIGUSR1, the HTTP API, and telemetry.
+
+Before starting this guide, we recommend configuring [ACLs](/consul/advanced/day-1-operations/acl-guide).
+
+## How to Collect Metrics
+
+There are three methods for collecting metrics. The first, and simplest, is to use `SIGUSR1` for a one-time dump of current telemetry values. The second method is to get a similar one-time dump using the HTTP API. The third method, and the one most commonly used for long-term monitoring, is to enable telemetry in the Consul configuration file.
+
+### SIGUSR1 for Local Use
+
+To get a one-time dump of current metric values, we can send the `SIGUSR1` signal to the Consul process.
+
+```sh
+$ kill -USR1 <process_id>
+```
+
+This will send the output to the system logs, such as `/var/log/messages` or to `journald`. If you are monitoring the Consul process in the terminal via `consul monitor`, you will see the metrics in the output.
+
+Although this is the easiest way to get a quick read of a single Consul agent's health, it is much more useful to look at how the values change over time.
+
+### API GET Request
+
+Next let's use the HTTP API to quickly collect metrics with curl.
+
+```ssh
+$ curl http://127.0.0.1:8500/v1/agent/metrics
+```
+
+In production you will want to set up credentials with an ACL token and [enable TLS](https://consul.io/docs/agent/encryption.html) for secure communications. Once ACLs have been configured, you can pass a token with the request.
+
+```sh
+$ curl \
+    --header "X-Consul-Token: <YOUR_ACL_TOKEN>" \
+    https://127.0.0.1:8500/v1/agent/metrics
+```
+
+In addition to being a good way to quickly collect metrics, it can be added to a script or it can be used with monitoring agents that support HTTP scraping, such as Prometheus, to visualize the data.
+
+### Enable Telemetry
+
+Finally, Consul can be configured to send telemetry data to a remote monitoring system. This allows you to monitor the health of agents over time, spot trends, and plan for future needs. You will need a monitoring agent and console for this.
+
+Consul supports the following telemetry agents:
+
+- Circonus
+- DataDog (via `dogstatsd`)
+- StatsD (via `statsd`, `statsite`, `telegraf`, etc.)
+
+If you are using StatsD, you will also need a compatible database and server, such as Grafana, Chronograf, or Prometheus.
+
+Telemetry can be enabled in the agent configuration file, for example `server.hcl`. Telemetry can be enabled on any agent, client or server. Normally, you would at least enable it on all the servers (both voting and non-voting) to monitor the health of the entire cluster.
+
+An example snippet of `server.hcl` to send telemetry to DataDog looks like this:
+
+```json
+  "telemetry": {
+    "dogstatsd_addr": "localhost:8125",
+    "disable_hostname": true
+  }
+```
+
+When enabling telemetry on an existing cluster, the Consul process will need to be reloaded. This can be done with `consul reload` or `kill -HUP <process_id>`. It is recommended to reload the servers one at a time, starting with the non-leaders.
+
+## Consul Health
+
+The Consul health metrics reveal information about the Consul cluster. They include performance metrics for the key value store, transactions, raft, leadership changes, autopilot tuning, and garbage collection.
+
+### Transaction Timing
+
+The following metrics indicate how long it takes to complete write operations
+in various parts, including Consul KV and Raft from the Consul server. Generally, these values should remain reasonably consistent and no more than a few milliseconds each.
+
+| Metric Name              | Description                                                                     |
+| :----------------------- | :------------------------------------------------------------------------------ |
+| `consul.kvs.apply`       | Measures the time it takes to complete an update to the KV store.               |
+| `consul.txn.apply`       | Measures the time spent applying a transaction operation.                       |
+| `consul.raft.apply`      | Counts the number of Raft transactions occurring over the interval.             |
+| `consul.raft.commitTime` | Measures the time it takes to commit a new entry to the Raft log on the leader. |
+
+Sudden changes in any of the timing values could be due to unexpected load on the Consul servers or due to problems on the hosts themselves. Specifically, if any of these metrics deviate more than 50% from the baseline over the previous hour, this indicates an issue. Below are examples of healthy transaction metrics.
+
+```sh
+'consul.raft.apply': Count: 1 Sum: 1.000 LastUpdated: 2018-11-16 10:55:03.673805766 -0600 CST m=+97598.238246167
+'consul.raft.commitTime': Count: 1 Sum: 0.017 LastUpdated: 2018-11-16 10:55:03.673840104 -0600 CST m=+97598.238280505
+```
+
+### Leadership Changes
+
+In a healthy environment, your Consul cluster should have a stable leader. There shouldn't be any leadership changes unless you manually change leadership (by taking a server out of the cluster, for example). If there are unexpected elections or leadership changes, you should investigate possible network issues between the Consul servers. Another possible cause could be that the Consul servers are unable to keep up with the transaction load.
+
+Note: These metrics are reported by the follower nodes, not by the leader.
+
+| Metric Name                      | Description                                                                                                    |
+| :------------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| `consul.raft.leader.lastContact` | Measures the time since the leader was last able to contact the follower nodes when checking its leader lease. |
+| `consul.raft.state.candidate`    | Increments when a Consul server starts an election process.                                                    |
+| `consul.raft.state.leader`       | Increments when a Consul server becomes a leader.                                                              |
+
+If the `candidate` or `leader` metrics are greater than 0 or the `lastContact` metric is greater than 200ms, you should look into one of the possible causes described above. Below are examples of healthy leadership metrics.
+
+```sh
+'consul.raft.leader.lastContact': Count: 4 Min: 10.000 Mean: 31.000 Max: 50.000 Stddev: 17.088 Sum: 124.000 LastUpdated: 2018-12-17 22:06:08.872973122 +0000 UTC m=+3553.639379498
+'consul.raft.state.leader': Count: 1 Sum: 1.000 LastUpdated: 2018-12-17 22:05:49.104580236 +0000 UTC m=+3533.870986584
+'consul.raft.state.candidate': Count: 1 Sum: 1.000 LastUpdated: 2018-12-17 22:05:49.097186444 +0000 UTC m=+3533.863592815
+```
+
+### Autopilot
+
+The autopilot metric is a boolean. A value of 1 indicates a healthy cluster and 0 indicates an unhealthy state.
+
+| Metric Name                | Description                                                                                                                                                             |
+| :------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `consul.autopilot.healthy` | Tracks the overall health of the local server cluster. If all servers are considered healthy by autopilot, this will be set to 1. If any are unhealthy, this will be 0. |
+
+An alert should be setup for a returned value of 0. Below is an example of a healthy cluster according to the autopilot metric.
+
+```sh
+[2018-12-17 13:03:40 -0500 EST][G] 'consul.autopilot.healthy': 1.000
+```
+
+### Garbage Collection
+
+Garbage collection (GC) pauses are a "stop-the-world" event, all runtime threads are blocked until GC completes. In a healthy environment these pauses should only last a few nanoseconds. If memory usage is high, the Go runtime may start the GC process so frequently that it will slow down Consul. You might observe more frequent leader elections or longer write times.
+
+| Metric Name                        | Description                                                                                           |
+| :--------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| `consul.runtime.total_gc_pause_ns` | Number of nanoseconds consumed by stop-the-world garbage collection (GC) pauses since Consul started. |
+
+If the value return is more than 2 seconds/minute, you should start investigating the cause. If it exceeds 5 seconds per minute, you should consider the cluster to be in a critical state and start ensuring failure recovery procedures are up-to-date and start investigating. Below is an example of healthy GC pause.
+
+```sh
+'consul.runtime.total_gc_pause_ns': 136603664.000
+```
+
+Note, `total_gc_pause_ns` is a cumulative counter, so in order to calculate rates, such as GC/minute, you will need to apply a function such as [non_negative_difference](https://docs.influxdata.com/influxdb/v1.5/query_language/functions/#non-negative-difference).
+
+## Server Health
+
+The server metrics provide information about the health of your cluster including file handles, CPU usage, network activity, disk activity, and memory usage.
+
+### File Descriptors
+
+The majority of Consul operations require a file descriptor handle, including receiving a connection from another host, sending data between servers, and writing snapshots to disk. If Consul runs out of handles, it will stop accepting connections.
+
+| Metric Name                | Description                                                         |
+| :------------------------- | :------------------------------------------------------------------ |
+| `linux_sysctl_fs.file-nr`  | Number of file handles being used across all processes on the host. |
+| `linux_sysctl_fs.file-max` | Total number of available file handles.                             |
+
+By default, process and kernel limits are conservative, you may want to increase the limits beyond the defaults. If the `linux_sysctl_fs.file-nr` value exceeds 80% of `linux_sysctl_fs.file-max`, the file handles should be increased. Below is an example of a file handle metric.
+
+```sh
+linux_sysctl_fs, host=statsbox, file-nr=768i, file-max=96763i
+```
+
+### CPU Usage
+
+Consul should not be demanding of CPU time on either server or clients. A spike in CPU usage could indicate too many operations taking place at once.
+
+| Metric Name      | Description                                                               |
+| :--------------- | :------------------------------------------------------------------------ |
+| `cpu.user_cpu`   | Percentage of CPU being used by user processes (such as Vault or Consul). |
+| `cpu.iowait_cpu` | Percentage of CPU time spent waiting for I/O tasks to complete.           |
+
+If `cpu.iowait_cpu` is greater than 10%, it should be considered critical as Consul is waiting for data to be written to disk. This could be a sign that Raft is writing snapshots to disk too often. Below is an example of a healthy CPU metric.
+
+```sh
+cpu, cpu=cpu-total, usage_idle=99.298, usage_user=0.400, usage_system=0.300, usage_iowait=0, usage_steal=0
+```
+
+### Network Activity
+
+Network activity should be consistent. A sudden spike in network traffic to Consul might be the result of a misconfigured client, such as Vault, that is causing too many requests.
+
+Most agents will report separate metrics for each network interface, so be sure you are monitoring the right one.
+
+| Metric Name      | Description                                  |
+| :--------------- | :------------------------------------------- |
+| `net.bytes_recv` | Bytes received on each network interface.    |
+| `net.bytes_sent` | Bytes transmitted on each network interface. |
+
+Sudden increases to the `net` metrics, greater than 50% deviation from baseline, indicates too many requests that are not being handled. Below is an example of a network activity metric.
+
+```sh
+net, interface=enp0s5, bytes_sent=6183357i, bytes_recv=262313256i
+```
+
+Note: The `net` metrics are counters, so in order to calculate rates, such as bytes/second,
+you will need to apply a function such as [non_negative_difference](https://docs.influxdata.com/influxdb/v1.5/query_language/functions/#non-negative-difference).
+
+### Disk Activity
+
+Normally, there is low disk activity, because Consul keeps everything in memory. If the Consul host is writing a large amount of data to disk, it could mean that Consul is under heavy write load and consequently is checkpointing Raft snapshots to disk frequently. It could also mean that debug/trace logging has accidentally been enabled in production, which can impact performance.
+
+| Metric Name          | Description                                               |
+| :------------------- | :-------------------------------------------------------- |
+| `diskio.read_bytes`  | Bytes read from each block device.                        |
+| `diskio.write_bytes` | Bytes written to each block device.                       |
+| `diskio.read_time`   | Time spent reading from disk, in cumulative milliseconds. |
+| `diskio.write_time`  | Time spent writing to disk, in cumulative milliseconds.   |
+
+Sudden, large changes to the `diskio` metrics, greater than 50% deviation from baseline
+or more than 3 standard deviations from baseline indicates Consul has too much disk I/O. Too much disk I/O can cause the rest of the system to slow down or become unavailable, as the kernel spends all its time waiting for I/O to complete. Below are examples of disk activity metrics.
+
+```sh
+diskio, name=sda5, read_bytes=522298368i,  write_bytes=1726865408i, read_time=7248i, write_time=133364i
+```
+
+Note: The `diskio` metrics are counters, so in order to calculate rates (such as bytes/second),you will need to apply a function such as [non_negative_difference][].
+
+### Memory Usage
+
+As noted previously, Consul keeps all of its data -- the KV store, the catalog, etc -- in memory. If Consul consumes all available memory, it will crash. You should monitor total available RAM to make sure some RAM is available for other system processes and swap usage should remain at 0% for best performance.
+
+| Metric Name                  | Description                                                    |
+| :--------------------------- | :------------------------------------------------------------- |
+| `consul.runtime.alloc_bytes` | Measures the number of bytes allocated by the Consul process.  |
+| `consul.runtime.sys_bytes`   | The total number of bytes of memory obtained from the OS.      |
+| `mem.total`                  | Total amount of physical memory (RAM) available on the server. |
+| `mem.used_percent`           | Percentage of physical memory in use.                          |
+| `swap.used_percent`          | Percentage of swap space in use.                               |
+
+Consul servers are running low on memory if `sys_bytes` exceeds 90% of `total_bytes`, `mem.used_percent` is over 90%, or `swap.used_percent` is greater than 0. You should increase the memory available to Consul if any of these three conditions are met. Below are examples of memory usage metrics.
+
+```sh
+'consul.runtime.alloc_bytes': 11199928.000
+'consul.runtime.sys_bytes': 24627448.000
+mem,  used_percent=31.492,  total=1036312576i
+swap, used_percent=1.343
+```
+
+## Summary
+
+In this guide we reviewed the three methods for collecting metrics. SIGUSR1 and agent HTTP API are both quick methods for collecting metrics, but enabling telemetry is the best method for moving data into monitoring software. Additionally, we outlined the various metrics collected and their significance.

--- a/learn/source/content/consul/advanced/day-1-operations/path-intro.md
+++ b/learn/source/content/consul/advanced/day-1-operations/path-intro.md
@@ -1,0 +1,70 @@
+---
+name: 'Introduction'
+content_length: 5
+id: /day-1-operations/path-intro
+layout: content_layout
+products_used:
+  - Consul
+description: Deploy your first datacenter with Consul.
+level: Advanced
+---
+
+This learning path is designed to help you deploy your first datacenter. If you are responsible for setting up and maintaining a healthy datacenter, this path will help you do so successfully. We will cover the following topics:
+
+- Infrastructure recommendations
+- Setting up a datacenter
+- Backing up the state of the datacenter
+- Securing the datacenter
+- Ensuring the datacenter is healthy
+
+Below you will find all of the guides that make up this learning path. If you want to skip ahead to any guide, feel free to use them as needed. Each guide has a description along with its objective to help you decide. However, if you are deploying your first production ready datacenter, we recommend completing these guides in order.
+
+## Reference Architecture
+
+By the end of this guide, you will be ready to create a architecture diagram for your environment. You will be able to identify which ports should be open, select hardware sizes that meet your needs, and understand how to implement datacenter design best practices.
+
+[Reference Architecture](/consul/advanced/day-1-operations/reference-architecture)
+
+## Deployment Guide
+
+By the end of the guide, you will install and configure a single Consul datacenter. You will use the examples to create your own custom configuration files for both servers and clients. The custom configuration files will help you join agents, optimize Raft performance, enable the collection of metrics, and configure the web UI. Finally, the guide will detail how to configure Systemd.
+
+[Deployment Guide](/consul/advanced/day-1-operations/deployment-guide)
+
+## Datacenter Backups
+
+By the end of this guide, you will have a backup process outlined. You will also be able to list the server data that is saved. Finally, you will understand the process for restoring from a backup.
+
+[Datacenter Backups](/consul/advanced/day-1-operations/backup)
+
+## Bootstrapping ACL System
+
+By the end of this guide, you will have ACLs configured on the Consul agents, servers and clients.
+For each step, you will be able to recognize if the process is not properly executed. Optionally, you can also configure the _anonyomous token_ and token for the UI.
+
+[Bootstrapping ACLs](/consul/advanced/day-1-operations/acl-guide)
+
+## Creating Agent Certificates
+
+By the end of the this guide, you will know how to generate certificates for your cluster. This guide will cover how to create a Certificate Authority(CA), and how to generate server certificates and client certificates.
+
+[Creating Agent Certificates](/consul/advanced/day-1-operations/certificates)
+
+## Gossip and RPC Encryption
+
+By the end of this guide, you will be able to configure gossip and RPC encryption on a your cluster. Encrypting both incoming and outgoing communication is crucial for securing the cluster.
+
+[Gossip and RPC Encryption](/consul/advanced/day-1-operations/agent-encryption)
+
+## Monitor Cluster Health
+
+By the end of the monitoring guide, you will be able to collect agent metrics. You will be able to identify the various methods for collecting metrics and configure them for your use cases; quick collection or to use with monitoring software. You will also be able to interpret the key metrics for a healthy cluster.
+
+[Monitor Cluster Health](/consul/advanced/day-1-operations/monitoring)
+
+## Get Started
+
+Now that we have reviewed the guides that make up the Day 1 Operations learning path,
+get started by either hitting the next button at the bottom of the page or select the
+guide that you are interested in. If you encounter any technical difficulties while working
+through the guides or have any feedback please send an email to the [Consul mailing list](https://groups.google.com/forum/#!forum/consul-tool).

--- a/learn/source/content/consul/advanced/day-1-operations/path-next-steps.md
+++ b/learn/source/content/consul/advanced/day-1-operations/path-next-steps.md
@@ -1,0 +1,36 @@
+--- 
+name: 'Next Steps' 
+content_length: 3 
+id: /day-1-operations/path-next-steps
+layout: content_layout 
+products_used:
+  - Consul 
+description: What's next after setting up your first cluster? Review
+    the production readiness checklist.  
+level: Advanced 
+---
+
+Congratulations, you have just completed the Day 1: Deploying your first
+Datcenter learning path!
+
+In this learning path, we covered all the topics for deploying your first
+datacenter. The guides in this path included production recommendations for:
+
+- Reference architecture
+- Deployment
+- Backups
+- Securing the datacenter
+- Monitoring the datacenter health
+
+These guides are a good start, however, gaining expertise with Consul requires a
+deeper understanding of running a datacenter and hands-on experience. To gain
+expertise, we recommend continuing with the _Day 2: Advanced Operations_ track
+and reading the [documentation](https://consul.io/docs). The _Day 2: Advanced
+Operations_ track will give you more oppurtunites to gain hands-on experience
+with guided exercises.
+
+Finally, we are including a [production readiness
+checklist](/consul/advanced/day-1-operations/production-checklist) in the
+appendix that can be used for deploying Consul. Note, this checklist is not an
+exhaustive list and you may need to add additional items depending on your
+environment.

--- a/learn/source/content/consul/advanced/day-1-operations/production-acls.md
+++ b/learn/source/content/consul/advanced/day-1-operations/production-acls.md
@@ -1,0 +1,440 @@
+---
+name: 'Securing Consul with ACLs'
+content_length: 16
+id: /day-1-operations/production-acls
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  This guide walks though securing your production Consul datacenter with ACLs.
+level: Advanced
+---
+
+The [Bootstrapping the ACL System guide](/consul/advanced/day-1-operations/acl-guide)
+walks you through how to set up ACLs on a single datacenter. Because it
+introduces the basic concepts and syntax we recommend completing it before
+starting this guide. This guide builds on the first guide with recommendations
+for production workloads on a single datacenter.
+
+After [bootstrapping the ACL system](#bootstrap-the-acl-system),
+you will learn how to create tokens with minimum privileges for:
+
+- [Servers and Clients](#apply-individual-tokens-to-agents)
+- [Services](#apply-individual-tokens-to-the-services)
+- [DNS](#token-for-dns)
+- [Consul KV](#consul-kv-tokens)
+- [Consul UI](#consul-ui-token)
+
+~> **Important:** For best results, use this guide during the [initial
+deployment](/consul/advanced/day-1-operations/deployment-guide) of a Consul (version
+1.4.3 or newer) datacenter. Specifically, you should have already installed all
+agents and configured initial service definitions, but you should not yet rely
+on Consul for any service discovery or service configuration operations.
+
+## Bootstrap the ACL System
+
+You will bootstrap the ACL system in two steps, enabling ACLs and creating the
+bootstrap token.
+
+### Enable ACLs on the Agents
+
+To enable ACLs, add the following [ACL
+parameters](https://www.consul.io/docs/agent/options.html#configuration-key-reference)
+to the agent's configuration file and then restart the Consul service. If you
+want to reduce Consul client restarts, you can enable the ACLs
+on them when you apply the token.
+
+```text
+# agent.hcl
+{
+  acl = {
+    enabled = true,
+    default_policy = "deny",
+    enable_token_persistence = true
+  }
+}
+```
+
+~> Note: Token persistence was introduced in Consul 1.4.3. In older versions
+of Consul, you cannot persist tokens when using the HTTP API.
+
+In this example, you configured the default policy of "deny", which means you
+are in whitelist mode. You also enabled token persistence when using the HTTP
+API. With persistence enabled, tokens will be persisted to disk and
+reloaded when an agent restarts.
+
+~> Note: If you are bootstrapping ACLs on an existing datacenter, enable the
+ACLs on the agents first with `default_policy=allow`. Default policy allow will
+enable ACLs, but will allow all operations, allowing the cluster to function
+normally while you create the tokens and apply them. This will reduce downtime.
+You should update the configuration files on all the servers first and then
+initiate a rolling restart.
+
+### Create the Initial Bootstrap Token
+
+To create the initial bootstrap token, use the `acl bootstrap` command on one
+of the servers.
+
+```sh
+$ consul acl bootstrap
+```
+
+The output gives you important information about the token, including the
+associated policy `global-management` and `SecretID`.
+
+~> Note: By default, Consul assigns the `global-management` policy to the
+bootstrap token, which has unrestricted privileges. It is important to have one
+token with unrestricted privileges in case of emergencies; however you should
+only give a small number of administrators access to it. The `SecretID` is a
+UUID that you will use to identify the token when using the Consul CLI or HTTP
+API.
+
+While you are setting up the ACL system, set the `CONSUL_HTTP_TOKEN`
+environment variable to the bootstrap token on one server, for this guide
+the example is on server "consul-server-one". This gives you the necessary
+privileges to continue
+creating policies and tokens. Set the environment variable temporarily with
+`export`, so that it will not persist once you've closed the session.
+
+```sh
+$ export CONSUL_HTTP_TOKEN=<your_token_here>
+```
+
+Now, all of the following commands in this guide can
+be completed on the same server, in this
+case server "consul-server-one".
+
+## Apply Individual Tokens to Agents
+
+Adding tokens to agents is a three step process.
+
+1. [Create the agent policy](#create-the-agent-policy).
+2. [Create the token with the newly created policy](#create-the-agent-token).
+3. [Add the token to the agent](#add-the-token-to-the-agent).
+
+### Create the Agent Policy
+
+We recommend creating agent policies that have write privileges for node
+related actions including registering itself in the catalog, updating node
+level health checks, and having write access on its agent configuration file. The
+example below has unrestricted privileges for node related actions for
+"consul-server-one" only.
+
+```text
+# consul-server-one-policy.hcl
+node "consul-server-one" {
+  policy = "write"
+}
+```
+
+When creating agent policies, review the [node rules](https://www.consul.io/docs/agent/acl-rules.html#node-rules). Now that you have
+specified the policy, you can initialize it using the Consul
+CLI. To create a programmatic process, you could also use
+the HTTP API.
+
+```sh
+$ consul acl policy create -name consul-server-one -rules @consul-server-one-policy.hcl
+```
+
+The command output will include the policy information.
+
+Repeat this process for all servers and clients in the Consul datacenter. Each agent should have its own policy based on the
+node name, that grants write privileges to it.
+
+### Create the Agent Token
+
+After creating the per-agent policies, create individual tokens for all the
+agents. You will need to include the policy in the `consul acl token create`
+command.
+
+```sh
+$ consul acl token create -description "consul-server-one agent token" -policy-name consul-server-one
+```
+
+This command returns the token information, which should include a description
+and policy information.
+
+Repeat this process for each agent. It is the responsibility of the operator to
+save tokens in a secure location; we recommend
+[Vault](https://www.vaultproject.io/).
+
+### Add the Token to the Agent
+
+Finally, apply the tokens to the agents.
+Start with the servers
+and ensure they are working correctly before applying the client tokens. Please
+review the Bootstrapping the ACL System [guide](/consul/advanced/day-1-operations/acl-guide) for example of setting the token in the agent configuration
+file.
+
+```sh
+$ consul acl set-agent-token -token "<your token here>" agent "<agent token here>"
+```
+
+You will need to complete this process _on_ every agent.
+
+At this point, every agent that has a token can once
+again read and write information to Consul, but only for node-related actions.
+Actions for individual services are not yet allowed.
+
+~> Note: If you are bootstrapping ACLs on and existing datacenter, remember to
+update the default policy to `default_policy = deny` and initiate another
+rolling restart after applying the token.
+
+## Apply Individual Tokens to the Services
+
+The token creation and application process for services is similar to agents.
+Create a policy. Use that policy to create a token. Add the token to the
+service. Service tokens are necessary for
+agent anti-entropy, registering and de-registering the service, and
+registering and de-registering the service's checks.
+
+Review the [service
+rules](https://www.consul.io/docs/agent/acl-rules.html#service-rules) before
+getting started.
+
+Below is an example service definition that needs a token after bootstrapping
+the ACL system.
+
+```json
+{
+  "service": {
+    "name": "dashboard",
+    "port": 9002,
+    "check": {
+      "id": "dashboard-check",
+      "http": "http://localhost:9002/health",
+      "method": "GET",
+      "interval": "1s",
+      "timeout": "1s"
+    }
+  }
+}
+```
+
+This service definition should be located in the [configuration
+directory](https://www.consul.io/docs/agent/options.html#_config_dir) on one of
+the clients.
+
+First, create the policy that will grant write privileges to only the
+"dashboard" service. This means the "dashboard" service can register
+itself, update it's health checks, and write any of the fields in the [service
+definition](https://www.consul.io/docs/agent/services.html).
+
+```text
+# dashboard-policy.hcl
+service "dashboard" {
+  policy = "write"
+}
+```
+
+Use the policy definition to initiate the policy.
+
+```sh
+$ consul acl policy create -name "dashboard-service" -rules @dashboard-policy.hcl
+```
+
+Next, create a token with the policy.
+
+```sh
+$ consul acl token create -description "Token for Dashboard Service" -policy-name dashboard-service
+```
+
+The command will return information about the token, which should include a
+description and policy information. As usual, save the token to a secure
+location.
+
+Finally, add the token to the service definition.
+
+```json
+{
+  "service": {
+    "name": "dashboard",
+    "port": 9002,
+    "token": "57c5d69a-5f19-469b-0543-12a487eecc66",
+    "check": {
+      "id": "dashboard-check",
+      "http": "http://localhost:9002/health",
+      "method": "GET",
+      "interval": "1s",
+      "timeout": "1s"
+     }
+  }
+}
+```
+
+If the service is running, you will need to restart it. Unlike with agent
+tokens, there is no HTTP API endpoint to apply the token directly to the
+service. If the service is registered with a configuration file, you must
+also set the token in the configuration file. However, if you register a
+service with the HTTP API, you can pass the token in the [header](https://www.consul.io/api/index.html#authentication) with
+`X-Consul-Token` and it will be used by the service.
+
+If you are using a sidecar proxy, it can inherit the token from the service
+definition. Alternatively, you can create a separate token.
+
+## Token for DNS
+
+Depending on your use case, the token used for DNS may need policy rules for
+[nodes](https://www.consul.io/docs/agent/acl-rules.html#node-rules),
+[services](https://www.consul.io/docs/agent/acl-rules.html#service-rules), and
+[prepared queries](https://www.consul.io/docs/agent/acl-rules.html#prepared-query-rules).
+You should apply the token to the Consul agent serving DNS requests. When the
+DNS server makes a request to Consul, it will include the token in the request.
+Consul can either authorize or revoke the request, depending on the token's
+privileges. The token creation for DNS is the same three step process you used
+for agents and services, create a policy, create a token, apply the
+token.
+
+Below is an example of a policy that provides read privileges for all services,
+nodes, and prepared queries.
+
+```text
+# dns-request-policy.hcl
+node_prefix "" {
+  policy = "read"
+}
+service_prefix "" {
+  policy = "read"
+}
+# only needed if using prepared queries
+query_prefix "" {
+  policy = "read"
+}
+```
+
+First, create the policy.
+
+```sh
+$ consul acl policy create -name "dns-requests" -rules @dns-request-policy.hcl
+```
+
+Next, create the token.
+
+```sh
+$ consul acl token create -description "Token for DNS Requests" -policy-name dns-requests
+```
+
+Finally, apply the token to the Consul agent serving DNS request in default token ACL
+configuration parameter.
+
+```sh
+$ consul acl set-agent-token -token "<your token here>" default "<dns token>"
+```
+
+Note, if you have multiple agents serving DNS requests you can use the same
+policy to create individual tokens for all of them if they are using the same rules.
+
+## Consul KV Tokens
+
+The process of creating tokens for Consul KV follows the same three step
+process as nodes and services. First create a policy, then a token, and finally
+apply or use the token. However, unlike tokens for nodes and services Consul KV
+has many varied use cases.
+
+- Services may need to access configuration data in the key-value store.
+- You may want to store distributed lock information for sessions.
+- Operators may need access to update configuration values in the key-value store.
+
+The [rules for
+KV](https://www.consul.io/docs/agent/acl-rules.html#key-value-rules) have four
+policy levels; `deny`, `write`, `read`, and `list`. Let's review several
+examples of `read` and `write`.
+
+Depending on the use case, the token will be applied differently. For services
+you will add the token to the HTTP client. For operators use, the
+operator will use the token when issuing commands, either with the CLI or API.
+
+### Recursive Reads
+
+```text
+key_prefix "redis/" {
+  policy = "read"
+}
+```
+
+In the above example, we are allowing any key with the prefix `redis/` to be
+read. If you issued the command `consul kv get -recurse redis/ -token=<your token>` you would get a list of key/values for `redis/`.
+
+This type of policy is good for allowing operators to recursively read
+configuration parameters stored in the KV. Similarly, a "write" policy with the
+same prefix would allow you to update any keys that begin with "redis/".
+
+### Write Privileges for One Key
+
+```text
+key "dashboard-app" {
+  policy = "write"
+}
+```
+
+In the above example, we are allowing read and write privileges to the
+dashboard-app key. This allows for `get`, `delete`, and `put` operations.
+
+This type of token would allow an application to update and read a value in the
+KV store. It would also be useful for operators who need access to set specific
+keys.
+
+### Read Privileges for One Key
+
+```text
+key "counting-app" {
+  policy = "read"
+}
+```
+
+In the above example, we are setting a read privileges for a single key,
+"counting-app". This allows for only `get` operations.
+
+This type of token allows an application to simply read from a key to get the
+value. This is useful for configuration parameter updates.
+
+## Consul UI Token
+
+Once you have bootstrapped the ACL system, access to the UI will be limited.
+The anonymous token grants UI access if no [default
+token](https://www.consul.io/docs/agent/options.html#acl_tokens_default) is set
+on the agents, and all operations will be denied, including viewing nodes and
+services.
+
+You can re-enable UI features (with flexible levels of access) by creating and
+distributing tokens to operators. Once you have a token, you can use it in the
+UI by adding it to the "ACL" page:
+
+![Access Controls](/assets/images/access-controls.png 'Access Controls')
+
+After saving a new token, you will be able to see your tokens.
+
+![Tokens](/assets/images/tokens.png 'Tokens')
+
+The browser stores tokens that you add to the UI. This allows you to distribute
+different levels of privileges to operators. Like other tokens, it's up to the
+operator to decide the per-token privileges.
+
+Below is an example of policy that
+will allow the operator to have read access to the UI for services, nodes,
+key/values, and intentions. You need to have "acl = read" to view policies
+and tokens. Otherwise you will not be able to access the ACL section of the UI,
+not even to view the token you used to access the UI.
+
+```text
+# operator-ui.hcl
+service_prefix "" {
+  policy = "read"
+  }
+key_prefix "" {
+  policy = "read"
+  }
+node_prefix "" {
+  policy = "read"
+  }
+```
+
+## Summary
+
+In this guide you bootstrapped the ACL system for Consul and
+applied tokens to agents and services. You assigned tokens for
+DNS, Consul KV, and the Consul UI.
+
+To learn more about Consul's security model read the
+[internals documentation](https://www.consul.io/docs/internals/security.html).
+You can find commands relating to ACLs in our [reference documentation](https://www.consul.io/docs/commands/acl.html).

--- a/learn/source/content/consul/advanced/day-1-operations/production-checklist.md
+++ b/learn/source/content/consul/advanced/day-1-operations/production-checklist.md
@@ -1,0 +1,96 @@
+---
+name: 'Appendix: Production Checklist'
+content_length: 6
+id: /day-1-operations/production-checklist
+layout: content_layout
+products_used:
+  - Consul
+description: Production readiness checklist.
+level: Advanced
+---
+
+Below is a checklist that can help you deploy your first datacenter. This checklist is not an exhaustive list and you may need to add additional tasks depending on your environment.
+
+## Infrastructure Planning
+
+- Review the [reference diagram](/consul/advanced/day-1-operations/reference-architecture#infrastructure-diagram)
+- Review the infrastructure [requirements](/consul/advanced/day-1-operations/reference-architecture#infrastructure-requirements).
+
+### Ports
+
+Refer to the [API documentation](https://www.consul.io/docs/agent/options.html#ports) for specific port numbers or alternate configuration options.
+
+- DNS server
+- HTTP API
+- HTTPS API
+- gRPC API
+- Serf LAN port
+- Serf WAN port
+- Server RPC address
+- Inclusive minimum port number to use for automatically assigned sidecar service registrations.
+- Sidecar_max_port
+
+## Deployment
+
+### Consul Servers
+
+- Read the [release notes](https://www.consul.io/docs/upgrade-specific.html) for the Consul version.
+- [Consul binary](https://www.consul.io/downloads.html) has been distributed to all servers.
+- Customize the [server configuration file](https://www.consul.io/docs/agent/options.html) or files.
+- [Autopilot](/consul/day-2-operations/advanced-operations/autopilot) is configured or disabled.
+- [TLS enabled](/consul/advanced/day-1-operations/agent-encryption#tls-encryption-for-rpc) for RPC communication
+- [Gossip encryption](/consul/advanced/day-1-operations/agent-encryption#gossip-encryption) configured
+- [Telemetry](/consul/advanced/day-1-operations/monitoring#enable-telemetry) configured.
+
+### Consul Clients
+
+- Consul binary has been distributed to all clients.
+- The configuration file has been customized.
+- TLS enabled for RPC communication
+- Gossip encryption configured
+- [External Service Monitor](https://www.consul.io/docs/guides/external.html) has been deployed to nodes that cannot run a Consul client.
+
+## Networking
+
+### Configure DNS Caching
+
+Refer to the [DNS caching guide](/consul/day-2-operations/advanced-operations/dns-caching) for step by step instructions and considerations around DNS performance.
+
+- Stale reads have been configured in the agent configuration file.
+- Negative response caching have been configured in the agent configuration file.
+- TTL values have been configured in the agent configuration file.
+
+### Setup DNS Forwarding
+
+Refer to the [DNS forwarding](https://www.consul.io/docs/guides/forwarding.html) guide for instructions on integrating Consul with system DNS.
+
+- BIND, dnsmasq, Unbound, systemd-resolved, or iptables has been configured.
+
+## Security
+
+### Encryption of Communication
+
+- TLS: RPC encryption for both incoming and outgoing communication.
+- Gossip Encryption. Both incoming and outgoing communication.
+
+### Enable ACLs
+
+Refer to the [ACL guide](/consul/advanced/day-1-operations/acl-guide) for instructions on setting up access control lists.
+
+- Tokens have been created for all agents and services.
+
+### Setup a Certificate Authority
+
+Refer to the [Certificate guide](/consul/advanced/day-1-operations/certificates) for instructions on setting up a certificate authority.
+
+- Agent certificates have been created and distributed to all agents.
+
+## Monitoring
+
+- Telemetry has been enabled.
+- API has been configured. New user and token have been created.
+
+## Failure Recovery
+
+- [Backups](/consul/advanced/day-1-operations/backup) are being periodically captured.
+- [Outage recovery](/consul/day-2-operations/advanced-operations/outage) plan has been outlined.

--- a/learn/source/content/consul/advanced/day-1-operations/reference-architecture.md
+++ b/learn/source/content/consul/advanced/day-1-operations/reference-architecture.md
@@ -1,0 +1,113 @@
+---
+name: 'Consul Reference Architecture'
+content_length: 8
+id: /day-1-operations/reference-architecture
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  This document provides recommended practices and a reference
+  architecture for HashiCorp Consul production deployments.
+level: Advanced
+---
+
+As you migrate applications to dynamically provisioned infrastructure, you will encounter challenges scaling services and managing the communications between them. Consul helps the components of dynamic applications communicate with each other by providing service discovery. It monitors the health of each node and application so that it only exposes healthy instances as discoverable. Consul's distributed Key-Value store allows you to make runtime-configuration updates across global infrastructure.
+
+This document recommends best practices and provides a reference architecture, including system requirements, datacenter design, networking, and performance optimizations for Consul production deployments.
+
+## Infrastructure Requirements
+
+### Consul Servers
+
+Consul server agents maintain the cluster state, respond to RPC queries (read operations), and process all write operations. Because Consul server agents do most of the heavy lifting, their host sizing is critical for the overall performance, efficiency, and health of the Consul cluster.
+
+The following table provides high-level server host guidelines. Of particular
+note is the strong recommendation to avoid non-fixed performance CPUs,
+or "Burstable CPU".
+
+| Type  | CPU      | Memory       | Disk  | Typical Cloud Instance Types              |
+| ----- | -------- | ------------ | ----- | ----------------------------------------- |
+| Small | 2 core   | 8-16 GB RAM  | 50GB  | **AWS**: m5.large, m5.xlarge              |
+|       |          |              |       | **Azure**: Standard_A4_v2, Standard_A8_v2 |
+|       |          |              |       | **GCE**: n1-standard-8, n1-standard-16    |
+| Large | 4-8 core | 32-64 GB RAM | 100GB | **AWS**: m5.2xlarge, m5.4xlarge           |
+|       |          |              |       | **Azure**: Standard_D4_v3, Standard_D5_v3 |
+|       |          |              |       | **GCE**: n1-standard-32, n1-standard-64   |
+
+#### Hardware Sizing Considerations
+
+- The small size would be appropriate for most initial production
+  deployments, or for development/testing environments.
+
+- The large size is for production environments where there is a
+  consistently high workload.
+
+~> **NOTE** For large workloads, ensure that the disks support a high number of IOPS to keep up with the rapid Raft log update rate.
+
+For more information on server requirements, review the [server performance](https://www.consul.io/docs/guides/performance.html) documentation.
+
+## Infrastructure Diagram
+
+![Reference Diagram](/assets/images/consul-arch.png 'Reference Diagram')
+
+## Datacenter Design
+
+You may deploy a Consul cluster (typically three or five servers plus client agents) in a single physical datacenter or across multiple datacenters. For a large cluster with high runtime reads and writes, deploying servers in the same physical location improves performance. In cloud environments, you may deploy a single datacenter across multiple availability zones, i.e., each server in a separate availability zone on a single host. Consul also supports multi-datacenter deployments via separate clusters joined by WAN links. In some cases, you may also deploy two or more Consul clusters in the same LAN environment.
+
+### Single Datacenter
+
+We recommend a single Consul cluster for applications deployed in the same datacenter. Consul supports traditional three-tier applications as well as microservices.
+
+Typically, you will need between three or five servers to balance between availability and performance. These servers together run the Raft-driven consistent state store for updating catalog, session, prepared query, ACL, and KV state.
+
+The recommended maximum cluster size for a single datacenter is 5,000 nodes. For a write-heavy and/or a read-heavy cluster, you may need to reduce the maximum number of nodes further, depending on the number and the size of KV pairs and the number of watches. As you add more client machines it takes more time for gossip to converge. Similarly, when a new server joins an existing multi-thousand node cluster with a large KV store it may take more time to replicate the store to the new server's log, and the update rate may increase.
+
+-> **TIP** For write-heavy clusters, consider scaling vertically with larger machine instances and lower latency storage.
+
+[Service tags](https://www.consul.io/docs/agent/services.html#service-definition) help you make necessary queries against your cluster. They can help you distinguish between different services, or different versions of the same service. Without them, node searches based on a a specific service are impossible.
+
+In cases where agents can't all contact each other due to network segmentation, you can use Consul's [network segments](https://www.consul.io/docs/enterprise/network-segments/index.html) (Consul Enterprise only) to create multiple tenants that share Raft servers in the same cluster. Each tenant has its own gossip pool and doesn't communicate with the agents outside this pool. All the tenants, however, do share the KV store. If you don't have access to Consul network segments you can create discrete [Consul datacenters](https://www.consul.io/docs/guides/datacenters.html) to isolate agents from each other.
+
+### Multiple Datacenters
+
+You can join Consul clusters running the same service in different datacenters by WAN links. The clusters operate independently and only communicate over the WAN on port `8302`. Unless explicitly configured via CLI or API, Consul servers will only return results from their local datacenter. Consul does not replicate data between multiple datacenters, but you can use the [consul-replicate](https://github.com/hashicorp/consul-replicate) tool to replicate the KV data periodically.
+
+-> It is good practice to enable TLS server name checking in order to avoid accidental cross-joining of agents.
+
+The [network areas](https://www.consul.io/api/operator/area.html) feature in Consul Enterprise provides advanced federation. For example, imagine that datacenter1 (dc1) hosts services like LDAP (or an ACL database) and shares them with datacenter2 (dc2) and datacenter3 (dc3). However, due to compliance issues, servers in dc2 must not connect with servers in dc3. Basic WAN federation can't isolate dc2 from dc3; it requires that all the servers in dc1, dc2 and dc3 are connected in a full mesh and opens both gossip (`8302 tcp/udp`) and RPC (`8300`) ports for communication.
+
+Network areas allows peering between datacenters to make shared services discoverable over WAN. With network areas, servers in dc1 can communicate with those in dc2 and dc3, without a connection between dc2 and dc3. This meets the compliance requirement of the organization in our example use case. Servers that are part of the network area communicate over RPC only. This removes the overhead of sharing and maintaining the symmetric key used by the gossip protocol across datacenters. It also reduces the attack surface at the gossip ports since they no longer need to be opened in security gateways or firewalls.
+
+Consul's [prepared queries](https://www.consul.io/api/query.html) allow clients to failover to another datacenter for service discovery. For example, if a service `payment` in the local datacenter dc1 goes down, a prepared query lets users define a geographic fallback order to the nearest datacenter to check for healthy instances of the same service.
+
+~> **NOTE** Consul clusters must be WAN linked for a prepared query to work across datacenters.
+
+Prepared queries, by default, resolve the query in the local datacenter first. They don't support querying KV store features, and do work with ACLs. Prepared query config/templates are maintained consistently in Raft and are executed on the servers.
+
+## Network Connectivity
+
+LAN gossip occurs between all agents in a single datacenter with each agent sending a periodic probe to random agents from its member list. Both client and server agents participate in the gossip. The initial probe is sent over UDP every second. If a node fails to acknowledge within `200ms`, the agent pings over TCP. If the TCP probe fails (10 second timeout), it asks a configurable number of random nodes to probe the same node (also known as an indirect probe). If there is no response from the peers regarding the status of the node, that agent is marked as down.
+
+The agent's status directly affects the service discovery results. If an agent is down, the services it is monitoring will also be marked as down.
+
+In addition, the agent also periodically performs a full state sync over TCP which gossips each agent's understanding of the member list around it (node names, IP addresses, and health status). These operations are expensive relative to the standard gossip protocol mentioned above and are performed at a rate determined by cluster size to keep overhead low. It's typically between 30 seconds and 5 minutes. For more details, refer to [Serf Gossip docs](https://www.serf.io/docs/internals/gossip.html).
+
+In a larger network that spans L2 segments, traffic typically traverses through a firewall and/or a router. You must update your ACL or firewall rules to allow the following ports:
+
+| Name          | Port | Flag                                        | Description                                                                   |
+| ------------- | ---- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| Server RPC    | 8300 |                                             | Used by servers to handle incoming requests from other agents. TCP only.      |
+| Serf LAN      | 8301 |                                             | Used to handle gossip in the LAN. Required by all agents. TCP and UDP.        |
+| Serf WAN      | 8302 | `-1` to disable (available in Consul 1.0.7) | Used by servers to gossip over the LAN and WAN to other servers. TCP and UDP. |
+| HTTP API      | 8500 | `-1` to disable                             | Used by clients to talk to the HTTP API. TCP only.                            |
+| DNS Interface | 8600 | `-1` to disable                             |                                                                               |
+
+-> As mentioned in the [datacenter design section](#datacenter-design), network areas and network segments can be used to prevent opening up firewall ports between different subnets.
+
+By default agents will only listen for HTTP and DNS traffic on the local interface.
+
+For more information about the ports that Consul uses, see the ports section of the [agent configuration documentation](https://www.consul.io/docs/agent/options.html#ports).
+
+## Summary
+
+In this guide we've discussed considerations for deploying Consul, including hardware sizing, datacenter design, and network connectivity. Next, review the Deployment Guide to learn the steps required to install and configure a single HashiCorp Consul cluster.

--- a/learn/source/content/consul/advanced/kubernetes/kubernetes-reference.md
+++ b/learn/source/content/consul/advanced/kubernetes/kubernetes-reference.md
@@ -1,0 +1,188 @@
+---
+name: 'Consul and Kubernetes Reference Architecture'
+content_length: 15
+id: /kubernetes/kubernetes-reference
+products_used:
+  - Consul
+description: |-
+  This document provides recommended practices and a reference architecture.
+level: Advanced
+---
+
+Preparing your Kubernetes cluster to successfully deploy and run Consul is an
+important first step in your production deployment process. In this guide you
+will prepare your Kubernetes cluster, that can be running on any platform
+(AKS, EKS, GKE, etc). However, we will call out cloud specific differences when
+applicable. Before starting this guide you should have experience with
+Kubernetes, and have `kubectl` and helm configured locally.
+
+By the end of this guide, you will be able to select the right resource limits
+for Consul pods, select the Consul datacenter design that meets your use case,
+and understand the minimum networking requirements.
+
+## Infrastructure Requirements
+
+Consul server agents are responsible for the cluster state, responding to RPC
+queries, and processing all write operations. Since the Consul servers are
+highly active and are responsible for maintaining the cluster state, server
+sizing is critical for the overall performance, efficiency, and health of the
+Consul cluster. Review the [Consul Reference
+Architecture](/consul/advanced/day-1-operations/reference-architecture#consul-servers)
+guide for sizing recommendations for small and large Consul datacenters.
+
+The CPU and memory recommendations can be used when you select the resources
+limits for the Consul pods. The disk recommendations can also be used when
+selecting the resources limits and configuring persistent volumes. You will
+need to set both `limits` and `requests` in the Helm chart. Below is an example
+Helm chart for a Consul server in a large environment.
+
+```yaml
+server
+  resources: |
+    requests:
+      memory: "32Gi"
+      cpu: "4"
+      disk: "50Gi"
+    limits:
+      memory: "32Gi"
+      cpu: "4"
+      disk: "50Gi"
+```
+
+You should also set [resource limits for Consul
+clients](https://www.consul.io/docs/platform/k8s/helm.html#v-client-resources),
+so that the client pods do not unexpectedly consume more resources than
+expected.
+
+[Persistent
+volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PV)
+allow you to have a fixed disk location for the Consul data. This ensures that
+if a Consul server is lost, the data will not be lost. This is an important
+feature of Kubernetes, but may take some additional configuration. If you are
+running Kubernetes on one of the major cloud platforms, persistent volumes
+should already be configured for you; be sure to read their documentation for more
+details. If you are setting up the persistent volumes resource in Kubernetes, you may need
+to map the Consul server to that volume with the [storage class
+parameter](https://www.consul.io/docs/platform/k8s/helm.html#v-server-storageclass).
+
+Finally, you will need to enable RBAC on your Kubernetes cluster. Review
+the [Kubernetes
+RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) documenation. You
+should also review RBAC and authentication documentation if your Kubernetes cluster
+is running on a major cloud platorom.
+
+- [AWS](https://docs.aws.amazon.com/eks/latest/userguide/managing-auth.html).
+- [GCP](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control).
+- [Azure](https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az-aks-create). In Azure, RBAC is enabled by default.
+
+## Datacenter Design
+
+There are many possible configurations for running Consul with Kubernetes. In this guide
+we will cover three of the most common.
+
+1. Consul agents can be solely deployed within Kubernetes.
+1. Consul servers
+   can be deployed outside of Kubernetes and clients inside of Kubernetes.
+1. Multiple Consul datacenters with agents inside and outside of Kubernetes.
+
+Review the Consul Kubernetes-specific
+[documentation](https://www.consul.io/docs/platform/k8s/index.html#use-cases)
+for additional use case information.
+
+Since all three use cases will also need catalog sync, review the
+implementation [details for catalog sync](https://www.consul.io/docs/platform/k8s/service-sync.html).
+
+### Consul Datacenter Deployed in Kubernetes
+
+Deploying a Consul cluster, servers and clients, in Kubernetes can be done with
+the official [Helm
+chart](https://www.consul.io/docs/platform/k8s/helm.html#using-the-helm-chart).
+This configuration is useful for managing services within Kubernetes and is
+common for users who do not already have a production Consul datacenter.
+
+![Reference Diagram](/assets/images/k8s-consul-simple.png 'Consul in Kubernetes Reference Diagram')
+
+The Consul datacenter in Kubernetes will function the same as a platform
+independent Consul datacenter, such as Consul clusters deployed on bare metal servers
+or virtual machines. Agents will communicate over LAN gossip, servers
+will participate in the Raft consensus, and client requests will be
+forwarded to the servers via RPCs.
+
+### Consul Datacenter with a Kubernetes Cluster
+
+To use an existing Consul cluster to manage services in Kubernetes, Consul
+clients can be deployed within the Kubernetes cluster. This will also allow
+Kubernetes-defined services to be synced to Consul. This design allows Consul tools
+such as envconsul, consul-template, and more to work on Kubernetes.
+
+![Reference Diagram](/assets/images/k8s-cluster-consul-datacenter.png 'Consul and Kubernetes Reference Diagram')
+
+This type of deployment in Kubernetes can also be set up with the official Helm
+chart.
+
+### Multiple Consul Clusters with a Kubernetes Cluster
+
+Consul clusters in different datacenters running the same service can be joined
+by WAN links. The clusters can operate independently and only communicate over
+the WAN. This type datacenter design is detailed in the [Reference Architecture
+guide](/consul/advanced/day-1-operations/reference-architecture#multiple-datacenters).
+In this setup, you can have a Consul cluster running outside of Kubernetes and
+a Consul cluster running inside of Kubernetes.
+
+### Catalog Sync
+
+To use catalog sync, you must enable it in the [Helm
+chart](https://www.consul.io/docs/platform/k8s/helm.html#v-synccatalog).
+Catalog sync allows you to sync services between Consul and Kubernetes. The
+sync can be unidirectional in either direction or bidirectional. Read the
+[documentation](https://www.consul.io/docs/platform/k8s/service-sync.html) to
+learn more about the configuration.
+
+Services synced from Kubernetes to Consul will be discoverable, like any other
+service within the Consul datacenter. Read more in the [network
+connectivity](#networking-connectivity) section to learn more about related
+Kubernetes configuration. Services synced from Consul to Kubernetes will be
+discoverable with the built-in Kubernetes DNS once a [Consul stub
+domain](https://www.consul.io/docs/platform/k8s/dns.html) is deployed. When
+bidirectional catalog sync is enabled, it will behave like the two
+unidirectional setups.
+
+## Networking Connectivity
+
+When running Consul as a pod inside of Kubernetes, the Consul servers will be
+automatically configured with the appropriate addresses. However, when running
+Consul servers outside of the Kubernetes cluster and clients inside Kubernetes
+as pods, there are additional [networking
+considerations](/consul/advanced/day-1-operations/reference-architecture#network-connectivity).
+
+### Network Connectivity for Services
+
+When using Consul catalog sync, to sync Kubernetes services to Consul, you will
+need to ensure the Kubernetes services are supported [service
+types](https://www.consul.io/docs/platform/k8s/service-sync.html#kubernetes-service-types)
+and configure correctly in Kubernetes. If the service is configured correctly,
+it will be discoverable by Consul like any other service in the datacenter.
+
+~> Warning: You are responsible for ensuring that external services can communicate
+with services deployed in the Kubernetes cluster. For example, `ClusterIP` type services
+may not be directly accessible by IP address from outside the Kubernetes cluster
+for some Kubernetes configurations.
+
+### Network Security
+
+Finally, you should consider securing your Consul datacenter with
+[ACLs](/consul/advanced/day-1-operations/production-acls). ACLs should be used with [Consul
+Connect](https://www.consul.io/docs/platform/k8s/connect.html) to secure
+service to service communication. The Kubernetes cluster should also be
+secured.
+
+## Summary
+
+You are now prepared to deploy Consul with Kubernetes. In this
+guide, you were introduced to several a datacenter design for a variety of use
+cases. This guide also outlined the Kubernetes prerequisites, resource
+requirements for Consul, and networking considerations. Continue onto the
+[Deploying Consul with Kubernetes
+guide](/consul/getting-started-k8s/helm-deploy) for
+information on deploying Consul with the official Helm chart or continue
+reading about Consul Operations in the [Day 1 Path](https://learn.hashicorp.com/consul/?track=advanced#advanced).

--- a/learn/source/content/consul/getting-started-k8s/helm-deploy.md
+++ b/learn/source/content/consul/getting-started-k8s/helm-deploy.md
@@ -1,0 +1,207 @@
+---
+name: "Deploy Consul with Kubernetes"
+content_length: 8
+layout: content_layout
+description: |-
+  Deploy Consul on Kubernetes with the official Helm chart.
+id: helm-deploy
+products_used:
+  - Consul
+level: Beginner
+---
+
+In this guide you will deploy a Consul datacenter with the official Helm chart.
+You do not need to update any values in the Helm chart for a basic
+installation. However, you can create a values file with parameters to allow
+access to the Consul UI. 
+
+~> **Security Warning** This guide is not for production use. By default, the
+chart will install an insecure configuration of Consul. Please refer to the
+[Kubernetes documentation](https://www.consul.io/docs/platform/k8s/index.html)
+to determine how you can secure Consul on Kubernetes in production.
+Additionally, it is highly recommended to use a properly secured Kubernetes
+cluster or make sure that you understand and enable the recommended security
+features. 
+
+To complete this guide successfully, you should have an existing Kubernetes
+cluster, and locally configured [Helm](https://helm.sh/docs/using_helm/) and 
+[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/). If you do not have an
+existing Kubernetes cluster you can use the [Minikube with Consul guide](/consul/getting-started-k8s/minikube) to get started
+with Consul on Kubernetes. 
+
+## Deploy Consul 
+
+You can deploy a complete Consul datacenter using the official Helm chart. By
+default, the chart will install three Consul
+servers and client on all Kubernetes nodes. You can review the
+[Helm chart
+values](https://www.consul.io/docs/platform/k8s/helm.html#configuration-values-)
+to learn more about the default settings. 
+
+### Download the Helm Chart
+
+First, you will need to clone the official Helm chart from HashiCorp's Github
+repo.
+
+```sh
+$ git clone https://github.com/hashicorp/consul-helm.git 
+```
+
+You do not need to update the Helm chart before deploying Consul, it comes with
+reasonable defaults. Review the [Helm chart
+documentation](https://www.consul.io/docs/platform/k8s/helm.html) to learn more
+about the chart.
+
+### Helm Install Consul
+
+To deploy Consul you will need to be in the same directory as the chart. 
+
+```sh 
+$ cd consul-helm 
+```
+
+Now, you can deploy Consul using `helm install`. This will deploy three servers
+and agents on all Kubernetes nodes. The process should be quick, less than 5
+minutes.  
+
+```sh 
+$ helm install ./consul-helm
+
+NAME:   mollified-robin LAST DEPLOYED: Mon Feb 25 15:57:18 2019 NAMESPACE: default STATUS: DEPLOYED
+NAME                             READY  STATUS             RESTARTS  AGE
+mollified-robin-consul-25r6z     0/1    ContainerCreating  0         0s
+mollified-robin-consul-4p6hr     0/1    ContainerCreating  0         0s
+mollified-robin-consul-n82j6     0/1    ContainerCreating  0         0s
+mollified-robin-consul-server-0  0/1    Pending            0         0s
+mollified-robin-consul-server-1  0/1    Pending            0         0s
+mollified-robin-consul-server-2  0/1    Pending            0         0s
+```
+
+The output above has been reduced for readability. However, you can see that
+there are three Consul servers and three Consul clients on this three node
+Kubernetes cluster. 
+
+## Access Consul UI
+
+To access the UI you will need to update the `ui` values in the Helm chart.
+Alternatively, if you do not wish to upgrade your cluster, you can set up [port
+forwarding]
+(https://www.consul.io/docs/platform/k8s/run.html#viewing-the-consul-ui) with
+`kubectl`. 
+
+### Create Values File
+
+First, create a values file that can be passed on the command line when
+upgrading.
+
+```yaml
+# values.yaml
+global: 
+  datacenter: hashidc1 
+syncCatalog: 
+  enabled: true 
+ui: 
+  service: 
+    type: "LoadBalancer" 
+server: 
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: {{ template "consul.name" . }}
+              release: "{{ .Release.Name }}"
+              component: server
+        topologyKey: kubernetes.io/hostname
+```
+
+This file renames your datacenter, enables catalog sync, sets up a load
+balancer service for the UI, and enables [affinity](https://www.consul.io/docs/platform/k8s/helm.html#v-server-affinity) to allow only one 
+Consul pod per Kubernetes node. 
+The catalog sync parameters will allow you to see
+the Kubernetes services in the Consul UI. 
+
+### Initiate Rolling Update 
+
+Finally, initiate the
+[upgrade](https://www.consul.io/docs/platform/k8s/run.html#upgrading-consul-on-kubernetes)
+with `helm upgrade` and the `-f` flag that passes in your new values file. This
+processes should also be quick, less than a minute.  
+
+```sh
+$ helm upgrade consul -f values.yaml 
+```
+
+You can now use `kubectl get services` to discover the external IP of your Consul UI.
+
+```sh 
+$ kubectl get services 
+NAME                            TYPE           CLUSTER-IP     EXTERNAL-IP             PORT(S)        AGE 
+consul                          ExternalName   <none>         consul.service.consul   <none>         11d 
+kubernetes                      ClusterIP      122.16.14.1    <none>                  443/TCP        137d
+mollified-robin-consul-dns      ClusterIP      122.16.14.25   <none>                  53/TCP,53/UDP  13d
+mollified-robin-consul-server   ClusterIP      None           <none>                  8500/TCP       13d
+mollified-robin-consul-ui       LoadBalancer   122.16.31.395  36.276.67.195           80:32718/TCP   13d
+```
+
+Additionally, you can use `kubectl get pods` to view the new catalog sync
+process. The [catalog sync](https://www.consul.io/docs/platform/k8s/helm.html#v-synccatalog) process will sync 
+Consul and Kubernetes services bidirectionally by 
+default.
+
+```
+$ kubectl get pods
+NAME                                                 READY   STATUS      RESTARTS   AGE
+mollified-robin-consul-d8mnp                          1/1     Running     0         15d
+mollified-robin-consul-p4m89                          1/1     Running     0         15d
+mollified-robin-consul-qclqc                          1/1     Running     0         15d
+mollified-robin-consul-server-0                       1/1     Running     0         15d
+mollified-robin-consul-server-1                       1/1     Running     0         15d
+mollified-robin-consul-server-2                       1/1     Running     0         15d
+mollified-robin-consul-sync-catalog-f75cd5846-wjfdk   1/1     Running     0         13d
+```
+
+The service should have `consul-ui` appended to the deployment name. Note, you
+do not need to specify a port when accessing the dashboard. 
+
+## Access Consul 
+
+In addition to accessing Consul with the UI, you can manage Consul with the
+HTTP API or by directly connecting to the pod with `kubectl`. 
+
+### Kubectl
+
+To access the pod and data directory you can exec into the pod with `kubectl` to start a shell session.
+
+```sh 
+$ kubectl exec -it mollified-robin-consul-server-0 /bin/sh 
+```
+
+This will allow you to navigate the file system and run Consul CLI commands on
+the pod. For example you can view the Consul members. 
+
+```sh 
+$ consul members 
+Node                                   Address           Status  Type    Build  Protocol  DC        Segment 
+mollified-robin-consul-server-0        172.20.2.18:8301  alive   server  1.4.2  2         hashidc1  <all>
+mollified-robin-consul-server-1        172.20.0.21:8301  alive   server  1.4.2  2         hashidc1  <all> 
+mollified-robin-consul-server-2        172.20.1.18:8301  alive   server  1.4.2  2         hashidc1  <all>
+gke-tier-2-cluster-default-pool-leri5  172.20.1.17:8301  alive   client  1.4.2  2         hashidc1  <default>
+gke-tier-2-cluster-default-pool-gnv4   172.20.2.17:8301  alive   client  1.4.2  2         hashidc1  <default>
+gke-tier-2-cluster-default-pool-zrr0   172.20.0.20:8301  alive   client  1.4.2  2         hashidc1  <default>
+```
+
+### Consul HTTP API
+
+You can use the Consul HTTP API by communicating to the local agent running on
+the Kubernetes node. You can read the
+[documentation](https://www.consul.io/docs/platform/k8s/run.html#accessing-the-consul-http-api)
+if you are interested in learning more about using the Consul HTTP API with Kubernetes.
+
+## Summary
+
+In this guide, you deployed a Consul datacenter in Kubernetes using the
+official Helm chart. You also configured access to the Consul UI. To learn more
+about deploying applications that can use Consul's service discovery and
+Connect, read the example in the [Minikube with Consul
+guide](/consul/getting-started-k8s/minikube).

--- a/learn/source/content/consul/getting-started-k8s/minikube.md
+++ b/learn/source/content/consul/getting-started-k8s/minikube.md
@@ -1,0 +1,258 @@
+---
+name: 'Consul Installation to Minikube via Helm'
+content_length: 8
+layout: content_layout
+description: |-
+  Deploy Consul on Kubernetes with the official Helm chart.
+id: minikube
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: qwhi1gvkeq
+---
+
+In this guide, you'll start a local Kubernetes cluster with Minikube. You'll install Consul with only a few commands, then deploy two custom services that use Consul to discover each other over encrypted TLS via Consul Connect. Finally, you'll tighten down Consul Connect so that only the approved applications can communicate with each other.
+
+[Demo code](https://github.com/hashicorp/demo-consul-101) is available.
+
+## Prerequisites
+
+Let's install Consul on Kubernetes with Minikube. This is a relatively quick way to try out Consul on your local machine without the need for any cloud credentials. You'll be able to use most Consul features right away.
+
+First, you'll need to follow the directions for [installing Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/), including VirtualBox or similar.
+
+You'll also need to install `kubectl` and `helm`.
+
+Mac users can install `helm` and `kubectl` with Homebrew.
+
+```sh
+$ brew install kubernetes-cli
+$ brew install kubernetes-helm
+```
+
+Windows users can use Chocolatey with the same package names:
+
+```sh
+$ choco install kubernetes-cli
+$ choco install kubernetes-helm
+```
+
+For more on Helm, see [helm.sh](https://helm.sh/).
+
+## Task 1: Start Minikube and Install Consul with Helm
+
+### Step 1: Start Minikube
+
+Start Minikube. You can use the `--memory` option with the equivalent of 4GB to 8GB so there is plenty of memory for all the pods we will run. This may take several minutes. It will download a 100-300MB of dependencies and container images.
+
+```
+$ minikube start --memory 4096
+```
+
+Next, let's view the local Kubernetes dashboard with `minikube dashboard`. Even if the previous step completed successfully, you may have to wait a minute or two for Minikube to be available. If you see an error, try again after a few minutes.
+
+Once it spins up, you'll see the dashboard in your web browser. You can view pods, nodes, and other resources.
+
+```
+$ minikube dashboard
+```
+
+![Minikube Dashboard](/assets/images/minikube-dashboard.png 'Minikube Dashboard')
+
+### Step 2: Install the Consul Helm Chart to the Cluster
+
+To perform the steps in this lab exercise, clone the [hashicorp/demo-consul-101](https://github.com/hashicorp/demo-consul-101) repository from GitHub. Go into the `demo-consul-101/k8s` directory.
+
+```
+$ git clone https://github.com/hashicorp/demo-consul-101.git
+
+$ cd demo-consul-101/k8s
+```
+
+Now we're ready to install Consul to the cluster, using the `helm` tool. Initialize Helm with `helm init`. You'll see a note that Tiller (the server-side component) has been installed. You can ignore the policy warning.
+
+```
+$ helm init
+
+$HELM_HOME has been configured at /Users/geoffrey/.helm.
+```
+
+Now we need to install Consul with Helm. To get the freshest copy of the Helm chart, clone the [hashicorp/consul-helm](https://github.com/hashicorp/consul-helm) repository.
+
+```
+$ git clone https://github.com/hashicorp/consul-helm.git
+```
+
+The chart works on its own, but we'll override a few values to help things go more smoothly with Minikube and to enable useful features.
+
+We've created `helm-consul-values.yaml` for you with overrides. See `values.yaml` in the Helm chart repository for other possible values.
+
+We've given a name to the datacenter running this Consul cluster. We've enabled the Consul web UI via a `NodePort`. When deploying to a hosted cloud that implements load balancers, we could use `LoadBalancer` instead. We'll enable secure communication between pods with Connect. We also need to enable `grpc` on the client for Connect to work properly. Finally, specify that this Consul cluster should only run one server (suitable for local development).
+
+```yaml
+# Choose an optional name for the datacenter
+global:
+  datacenter: minidc
+
+# Enable the Consul Web UI via a NodePort
+ui:
+  service:
+    type: 'NodePort'
+
+# Enable Connect for secure communication between nodes
+connectInject:
+  enabled: true
+
+client:
+  enabled: true
+  grpc: true
+
+# Use only one Consul server for local development
+server:
+  replicas: 1
+  bootstrapExpect: 1
+  disruptionBudget:
+    enabled: true
+    maxUnavailable: 0
+```
+
+Now, run `helm install` together with our overrides file and the cloned `consul-helm` chart. It will print a list of all the resources that were created.
+
+```
+$ helm install -f helm-consul-values.yaml --name hedgehog ./consul-helm
+```
+
+~> NOTE: If no `--name` is provided, the chart will create a random name for the installation. To reduce confusion, consider specifying a `--name`.
+
+## Task 2: Deploy a Consul-aware Application to the Cluster
+
+### Step 1: View the Consul Web UI
+
+Verify the installation by going back to the Kubernetes dashboard in your web browser. Find the list of services. Several include `consul` in the name and have the `app: consul` label.
+
+![Minikube Dashboard with Consul](/assets/images/minikube-dashboard-consul.png 'Minikube Dashboard with Consul')
+
+There are a few differences between running Kubernetes on a hosted cloud vs locally with Minikube. You may find that any load balancer resources don't work as expected on a local cluster. But we can still view the Consul UI and other deployed resources.
+
+Run `minikube service list` to see your services. Find the one with `consul-ui` in the name.
+
+```
+$ minikube service list
+```
+
+Run `minikube service` with the `consul-ui` service name as the argument. It will open the service in your web browser.
+
+```
+$ minikube service hedgehog-consul-ui
+```
+
+You can now view the Consul web UI with a list of Consul's services, nodes, and other resources.
+
+![Minikube Consul UI](/assets/images/minikube-consul-ui.png 'Minikube Consul UI')
+
+### Step 2: Deploy Custom Applications
+
+Now let's deploy our application. It's two services: a backend data service that returns a number (`counting` service) and a front-end `dashboard` that pulls from the `counting` service over HTTP and displays the number. The Kubernetes part is a single line: `kubectl create -f 04-yaml-connect-envoy`. This is a directory with several YAML files, each defining one or more resources (pods, containers, etc).
+
+```
+$ kubectl create -f 04-yaml-connect-envoy
+```
+
+The output shows that they have been created. In reality, they may take a few seconds to spin up. Refresh the Kubernetes dashboard a few times and you'll see that the `counting` and `dashboard` services are running. You can also click a resource to view more data about it.
+
+![Services](/assets/images/minikube-services.png 'Services')
+
+### Step 3: View the Web Application
+
+For the last step in this initial task, use the Kubernetes `port-forward` feature for the dashboard service running on port `9002`. We already know that the pod is named `dashboard` thanks to the metadata specified in the YAML we deployed.
+
+```
+$ kubectl port-forward dashboard 9002:9002
+```
+
+Visit http://localhost:9002 in your web browser. You'll see a running `dashboard` container in the kubernetes cluster that displays a number retrieved from the `counting` service using Consul service discovery and secured over the network by TLS via an Envoy proxy.
+
+![Application Dashboard](/assets/images/minikube-app-dashboard.png 'Application Dashboard')
+
+### Addendum: Review the Code
+
+Let's take a peek at the code. Relevant to this Kubernetes deployment are two YAML files in the `04` directory. The `counting` service defines an `annotation` in the `metadata` section that instructs Consul to spin up a Consul Connect proxy for this service: `connect-inject`. The relevant port number is found in the `containerPort` section (`9001`). This Pod registers a Consul service that will be available via a secure proxy.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: counting
+  annotations:
+    'consul.hashicorp.com/connect-inject': 'true'
+spec:
+  containers:
+    - name: counting
+      image: hashicorp/counting-service:0.0.2
+      ports:
+        - containerPort: 9001
+          name: http
+# ...
+```
+
+The other side is on the `dashboard` service. This declares the same `connect-inject` annotation but also adds another. The `connect-service-upstreams` in the `annotations` section configures Connect such that this Pod will have access to the `counting` service on `localhost` port `9001`. All the rest of the configuration and communication is taken care of by Consul and the Consul Helm chart.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dashboard
+  labels:
+    app: 'dashboard'
+  annotations:
+    'consul.hashicorp.com/connect-inject': 'true'
+    'consul.hashicorp.com/connect-service-upstreams': 'counting:9001'
+spec:
+  containers:
+    - name: dashboard
+      image: hashicorp/dashboard-service:0.0.3
+      ports:
+        - containerPort: 9002
+          name: http
+      env:
+        - name: COUNTING_SERVICE_URL
+          value: 'http://localhost:9001'
+# ...
+```
+
+Within our `dashboard` application, we can access the `counting` service by communicating with `localhost:9001` as seen on the last line of this snippet. Here we are looking at an environment variable that is specific to the Go application running in a container in this Pod. Instead of providing an IP address or even a Consul service URL, we tell the application to talk to `localhost:9001` where our local end of the proxy is ready and listening. Because of the annotation to `counting:9001` earlier, we know that an instance of the `counting` service is on the other end.
+
+This is what is happening in the cluster and over the network when we view the `dashboard` service in the browser.
+
+-> TIP: The full source code for the Go-based web services and all code needed to build the Docker images are available in the [repo](https://github.com/hashicorp/demo-consul-101).
+
+## Task 3: Use Consul Connect
+
+### Step 1: Create an Intention that Denies All Service Communication by Default
+
+For a final task, let's take this a step further by restricting service communication with intentions. We don't want any service to be able to communicate with any other service; only the ones we specify.
+
+Begin by navigating to the _Intentions_ screen in the Consul web UI. Click the "Create" button and define an initial intention that blocks all communication between any services by default. Choose `*` as the source and `*` as the destination. Choose the _Deny_ radio button and add an optional description. Click "Save."
+
+![Connect Deny](/assets/images/minikube-connect-deny.png 'Connect Deny')
+
+Verify this by returning to the application dashboard where you will see that the "Counting Service is Unreachable."
+
+![Application is Unreachable](/assets/images/minikube-connect-unreachable.png 'Application is Unreachable')
+
+### Step 2: Allow the Application Dashboard to Connect to the Counting Service
+
+Finally, the easy part. Click the "Create" button again and create an intention that allows the `dashboard` source service to talk to the `counting` destination service. Ensure that the "Allow" radio button is selected. Optionally add a description. Click "Save."
+
+![Allow](/assets/images/minikube-connect-allow.png 'Allow')
+
+This action does not require a reboot. It takes effect so quickly that by the time you visit the application dashboard, you'll see that it's successfully communicating with the backend `counting` service again.
+
+And there we have Consul running on a Kubernetes cluster, as demonstrated by two services which communicate with each other via Consul Connect and an Envoy proxy.
+
+![Success](/assets/images/minikube-connect-success.png 'Success')
+
+## Summary
+
+For more on Consul's integration with Kubernetes (including multi-cloud, service sync, and other features), see the [Consul with Kubernetes](https://consul.io/docs/platform/k8s/index.html) documentation. To deploy
+Consul on a full Kubernetes cluster, continue to the next guide.

--- a/learn/source/content/consul/getting-started/agent.md
+++ b/learn/source/content/consul/getting-started/agent.md
@@ -1,0 +1,144 @@
+---
+name: 'Run the Consul Agent'
+content_length: 7
+id: agent
+layout: content_layout
+description: |-
+  The Consul agent can run in either server or client mode. Learn more about both modes and how to start a development agent in this guide.
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: mqwaa7t5v7
+---
+
+After Consul is installed, the agent must be run. The agent can run either
+in server or client mode. Each datacenter must have at least one server,
+though a cluster of 3 or 5 servers is recommended. A single server deployment
+is _**highly**_ discouraged as data loss is inevitable in a failure scenario.
+
+All other agents run in client mode. A client is a very lightweight
+process that registers services, runs health checks, and forwards queries to
+servers. The agent must be running on every node that is part of the cluster.
+
+For more detail on bootstrapping a datacenter, see
+[this guide](/consul/advanced/day-1-operations/deployment-guide).
+
+## Starting the Agent
+
+For simplicity, we'll start the Consul agent in development mode for now. This
+mode is useful for bringing up a single-node Consul environment quickly and
+easily. It is **not** intended to be used in production as it does not persist
+any state.
+
+```text
+$ consul agent -dev
+
+==> Starting Consul agent...
+==> Starting Consul agent RPC...
+==> Consul agent running!
+           Version: 'v0.7.0'
+         Node name: 'Armons-MacBook-Air'
+        Datacenter: 'dc1'
+            Server: true (bootstrap: false)
+       Client Addr: 127.0.0.1 (HTTP: 8500, HTTPS: -1, DNS: 8600, RPC: 8400)
+      Cluster Addr: 127.0.0.1 (LAN: 8301, WAN: 8302)
+    Gossip encrypt: false, RPC-TLS: false, TLS-Incoming: false
+
+==> Log data will now stream in as it occurs:
+
+    2016/09/15 10:21:10 [INFO] raft: Initial configuration (index=1): [{Suffrage:Voter ID:127.0.0.1:8300 Address:127.0.0.1:8300}]
+    2016/09/15 10:21:10 [INFO] raft: Node at 127.0.0.1:8300 [Follower] entering Follower state (Leader: "")
+    2016/09/15 10:21:10 [INFO] serf: EventMemberJoin: Armons-MacBook-Air 127.0.0.1
+    2016/09/15 10:21:10 [INFO] serf: EventMemberJoin: Armons-MacBook-Air.dc1 127.0.0.1
+    2016/09/15 10:21:10 [INFO] consul: Adding LAN server Armons-MacBook-Air (Addr: tcp/127.0.0.1:8300) (DC: dc1)
+    2016/09/15 10:21:10 [INFO] consul: Adding WAN server Armons-MacBook-Air.dc1 (Addr: tcp/127.0.0.1:8300) (DC: dc1)
+    2016/09/15 10:21:13 [DEBUG] http: Request GET /v1/agent/services (180.708µs) from=127.0.0.1:52369
+    2016/09/15 10:21:13 [DEBUG] http: Request GET /v1/agent/services (15.548µs) from=127.0.0.1:52369
+    2016/09/15 10:21:17 [WARN] raft: Heartbeat timeout from "" reached, starting election
+    2016/09/15 10:21:17 [INFO] raft: Node at 127.0.0.1:8300 [Candidate] entering Candidate state in term 2
+    2016/09/15 10:21:17 [DEBUG] raft: Votes needed: 1
+    2016/09/15 10:21:17 [DEBUG] raft: Vote granted from 127.0.0.1:8300 in term 2. Tally: 1
+    2016/09/15 10:21:17 [INFO] raft: Election won. Tally: 1
+    2016/09/15 10:21:17 [INFO] raft: Node at 127.0.0.1:8300 [Leader] entering Leader state
+    2016/09/15 10:21:17 [INFO] consul: cluster leadership acquired
+    2016/09/15 10:21:17 [DEBUG] consul: reset tombstone GC to index 3
+    2016/09/15 10:21:17 [INFO] consul: New leader elected: Armons-MacBook-Air
+    2016/09/15 10:21:17 [INFO] consul: member 'Armons-MacBook-Air' joined, marking health alive
+    2016/09/15 10:21:17 [INFO] agent: Synced service 'consul'
+```
+
+As you can see, the Consul agent has started and has output some log
+data. From the log data, you can see that our agent is running in server mode
+and has claimed leadership of the cluster. Additionally, the local member has
+been marked as a healthy member of the cluster.
+
+~> **Note for OS X Users:** Consul uses your hostname as the
+default node name. If your hostname contains periods, DNS queries to
+that node will not work with Consul. To avoid this, explicitly set
+the name of your node with the `-node` flag.
+
+## Cluster Members
+
+If you run [`consul members`](https://consul.io/docs/commands/members.html) in another terminal, you
+can see the members of the Consul cluster. We'll cover joining clusters in the next
+section, but for now, you should only see one member (yourself):
+
+```text
+$ consul members
+
+Node                Address            Status  Type    Build     Protocol  DC
+Armons-MacBook-Air  172.20.20.11:8301  alive   server  0.6.1dev  2         dc1
+```
+
+The output shows our own node, the address it is running on, its
+health state, its role in the cluster, and some version information.
+Additional metadata can be viewed by providing the `-detailed` flag.
+
+The output of the [`members`](https://consul.io/docs/commands/members.html) command is based on
+the [gossip protocol](https://consul.io/docs/internals/gossip.html) and is eventually consistent.
+That is, at any point in time, the view of the world as seen by your local
+agent may not exactly match the state on the servers. For a strongly consistent
+view of the world, use the [HTTP API](https://consul.io/api/index.html) as it forwards the
+request to the Consul servers:
+
+```text
+$ curl localhost:8500/v1/catalog/nodes
+
+[{"Node":"Armons-MacBook-Air","Address":"127.0.0.1","TaggedAddresses":{"lan":"127.0.0.1","wan":"127.0.0.1"},"CreateIndex":4,"ModifyIndex":110}]
+```
+
+In addition to the HTTP API, the [DNS interface](https://consul.io/docs/agent/dns.html) can
+be used to query the node. Note that you have to make sure to point your DNS
+lookups to the Consul agent's DNS server which runs on port 8600 by default.
+The format of the DNS entries (such as "Armons-MacBook-Air.node.consul") will
+be covered in more detail later.
+
+```text
+$ dig @127.0.0.1 -p 8600 Armons-MacBook-Air.node.consul
+
+;; QUESTION SECTION:
+;Armons-MacBook-Air.node.consul.	IN	A
+
+;; ANSWER SECTION:
+Armons-MacBook-Air.node.consul.	0 IN	A	127.0.0.1
+```
+
+## Stopping the Agent
+
+You can use `Ctrl-C` (the interrupt signal) to gracefully halt the agent.
+After interrupting the agent, you should see it leave the cluster
+and shut down.
+
+By gracefully leaving, Consul notifies other cluster members that the
+node _left_. If you had forcibly killed the agent process, other members
+of the cluster would have detected that the node _failed_. When a member leaves,
+its services and checks are removed from the catalog. When a member fails,
+its health is simply marked as critical, but it is not removed from the catalog.
+Consul will automatically try to reconnect to _failed_ nodes, allowing it
+to recover from certain network conditions, while _left_ nodes are no longer contacted.
+
+Additionally, if an agent is operating as a server, a graceful leave is
+important to avoid causing a potential availability outage affecting the
+[consensus protocol](https://consul.io/docs/internals/consensus.html). See the
+[Adding and Removing Servers guide](/consul/day-2-operations/advanced-operations/servers) for details on how to
+safely add and remove servers.

--- a/learn/source/content/consul/getting-started/checks.md
+++ b/learn/source/content/consul/getting-started/checks.md
@@ -1,0 +1,117 @@
+---
+name: 'Registering Health Checks'
+content_length: 5
+layout: content_layout
+description: |-
+  In this guide, we will continue our tour of Consul by adding health checks to both nodes and services.
+id: checks
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: ck8hs1o8eh
+---
+
+We've now seen how simple it is to run Consul, add nodes and services, and
+query those nodes and services. In this section, we will continue our tour
+by adding health checks to both nodes and services. Health checks are a
+critical component of service discovery that prevent using services that
+are unhealthy.
+
+This step builds upon [the Consul cluster created previously](/consul/getting-started/join.html).
+At this point, you should have a two-node cluster running.
+
+## Defining Checks
+
+Similar to a service, a check can be registered either by providing a
+[check definition](https://consul.io/docs/agent/checks.html) or by making the
+appropriate calls to the [HTTP API](https://consul.io/api/health.html).
+
+We will use the check definition approach because, just like with
+services, definitions are the most common way to set up checks.
+
+In Consul 0.9.0 and later the agent must be configured with
+`enable_script_checks` set to true in order to enable script checks.
+
+Open a terminal session to the second node.
+
+```text
+$ vagrant ssh n2
+```
+
+Create two definition files in the Consul configuration directory of
+the second node:
+
+```text
+vagrant@n2:~$ echo '{"check": {"name": "ping",
+  "args": ["ping", "-c1", "google.com"], "interval": "30s"}}' \
+  >/etc/consul.d/ping.json
+
+vagrant@n2:~$ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80,
+  "check": {"args": ["curl", "localhost"], "interval": "10s"}}}' \
+  >/etc/consul.d/web.json
+```
+
+The first definition adds a host-level check named "ping". This check runs
+on a 30 second interval, invoking `ping -c1 google.com`. On a `script`-based
+health check, the check runs as the same user that started the Consul process.
+If the command exits with an exit code >= 2, then the check will be flagged as
+failing and the service will be considered unhealthy. An exit code of 1 will
+be considered as warning state. This is the contract for any
+[`script`-based health check](https://www.consul.io/docs/agent/checks.html#check-scripts).
+
+The second command modifies the service named `web`, adding a check that sends a
+request every 10 seconds via curl to verify that the web server is accessible.
+As with the host-level health check, if the script exits with an exit code >= 2,
+the check will be flagged as failing and the service will be considered unhealthy.
+
+Now, restart the second agent, reload it with `consul reload`, or send it a `SIGHUP` signal. You should see the
+following log lines:
+
+```text
+==> Starting Consul agent...
+...
+    [INFO] agent: Synced service 'web'
+    [INFO] agent: Synced check 'service:web'
+    [INFO] agent: Synced check 'ping'
+    [WARN] Check 'service:web' is now critical
+```
+
+The first few lines indicate that the agent has synced the new
+definitions. The last line indicates that the check we added for
+the `web` service is critical. This is because we're not actually running
+a web server, so the curl test is failing!
+
+## Checking Health Status
+
+Now that we've added some simple checks, we can use the HTTP API to inspect
+them. First, we can look for any failing checks using this command (note, this
+can be run on either node):
+
+```text
+vagrant@n1:~$ curl http://localhost:8500/v1/health/state/critical
+[{"Node":"agent-two","CheckID":"service:web","Name":"Service 'web' check","Status":"critical","Notes":"","ServiceID":"web","ServiceName":"web","ServiceTags":["rails"]}]
+```
+
+We can see that there is only a single check, our `web` service check, in the
+`critical` state.
+
+Additionally, we can attempt to query the web service using DNS. Consul
+will not return any results since the service is unhealthy:
+
+```text
+dig @127.0.0.1 -p 8600 web.service.consul
+...
+
+;; QUESTION SECTION:
+;web.service.consul.		IN	A
+```
+
+## Summary
+
+In this section, you learned how easy it is to add health checks. Check definitions
+can be updated by changing configuration files and sending a `SIGHUP` to the agent.
+Alternatively, the HTTP API can be used to add, remove, and modify checks dynamically.
+The API also allows for a "dead man's switch", a
+[TTL-based check](https://consul.io/docs/agent/checks.html#TTL). TTL checks can be used to integrate an
+application more tightly with Consul, enabling business logic to be evaluated as part
+of assessing the state of the check.

--- a/learn/source/content/consul/getting-started/connect.md
+++ b/learn/source/content/consul/getting-started/connect.md
@@ -1,0 +1,264 @@
+---
+name: 'Connect'
+content_length: 7
+layout: content_layout
+description: |-
+  Connect is a feature of Consul that provides service-to-service connection authorization and encryption using mutual TLS.
+id: connect
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: xgfglkfdmq
+---
+
+We've now registered our first service with Consul and we've shown how you
+can use the HTTP API or DNS interface to query the address and directly connect
+to that service. Consul also provides a feature called **Connect** for
+automatically connecting via an encrypted TLS connection and authorizing
+which services are allowed to connect to each other.
+
+Applications do not need to be modified at all to use Connect.
+[Sidecar proxies](https://consul.io/docs/connect/proxies.html) can be used
+to automatically establish TLS connections for inbound and outbound connections
+without being aware of Connect at all. Applications may also
+[natively integrate with Connect](https://consul.io/docs/connect/native.html)
+for optimal performance and security.
+
+-> **Security note:** The getting started guide will show Connect features and
+focus on ease of use with a dev-mode agent. We will _not setup_ Connect in a
+production-recommended secure way. Please read the [Connect production
+guide](https://consul.io/docs/guides/connect-production.html) to understand the tradeoffs.
+
+## Starting a Connect-unaware Service
+
+Let's begin by starting a service that is unaware of Connect. To keep it simple,
+let's just use `socat` to start a basic echo service. This service will accept
+TCP connections and echo back any data sent to it. If `socat` isn't installed on
+your machine, it should be easily available via a package manager.
+
+```sh
+$ socat -v tcp-l:8181,fork exec:"/bin/cat"
+```
+
+You can verify it is working by using `nc` to connect directly to it. Once
+connected, type some text and press enter. The text you typed should be
+echoed back:
+
+```
+$ nc 127.0.0.1 8181
+hello
+hello
+echo
+echo
+```
+
+`socat` is a decades-old Unix utility and our process is configured to
+only accept a basic TCP connection. It has no concept of encryption, the
+TLS protocol, etc. This can be representative of an existing service in
+your datacenter such as a database, backend web service, etc.
+
+## Registering the Service with Consul and Connect
+
+Next, let's register the service with Consul. We'll do this by writing
+a new service definition. This is the same as the previous step in the
+getting started guide, except this time we'll also configure Connect.
+
+```sh
+$ cat <<EOF | sudo tee ./consul.d/socat.json
+{
+  "service": {
+    "name": "socat",
+    "port": 8181,
+    "connect": { "sidecar_service": {} }
+  }
+}
+EOF
+```
+
+After saving this, run `consul reload` or send a `SIGHUP` signal to Consul
+so it reads the new configuration.
+
+Notice the only difference is the line starting with `"connect"`. The existence
+of this empty configuration notifies Consul to register a sidecar proxy for this
+process. The proxy process represents that specific service. It accepts inbound
+connections on a dynamically allocated port, verifies and authorizes the TLS
+connection, and proxies back a standard TCP connection to the process.
+
+The sidecar service registration here is just telling Consul that a proxy should
+be running, Consul won't actually run a proxy process for you.
+
+We need to start the proxy process in another terminal:
+
+```sh
+$ consul connect proxy -sidecar-for socat
+==> Consul Connect proxy starting...
+    Configuration mode: Agent API
+        Sidecar for ID: socat
+              Proxy ID: socat-sidecar-proxy
+
+...
+```
+
+## Connecting to the Service
+
+Next, let's connect to the service. We'll first do this by using the `consul connect proxy` command again directly. This time we use the command to configure
+and run a local proxy that can represent a service. This is a useful tool for
+development since it'll let you masquerade as any service (that you have
+permissions for) and establish connections to other services via Connect.
+
+The command below starts a proxy representing a service "web". We request
+an upstream dependency of "socat" (the service we previously registered)
+on port 9191. With this configuration, all TCP connections to 9191 will
+perform service discovery for a Connect-capable "socat" endpoint and establish
+a mutual TLS connection identifying as the service "web".
+
+```sh
+$ consul connect proxy -service web -upstream socat:9191
+==> Consul Connect proxy starting...
+    Configuration mode: Flags
+               Service: web
+              Upstream: socat => :9191
+       Public listener: Disabled
+
+...
+```
+
+With that running, we can verify it works by establishing a connection:
+
+```
+$ nc 127.0.0.1 9191
+hello
+hello
+```
+
+**The connection between proxies is now encrypted and authorized.**
+We're now communicating to the "socat" service via a TLS connection.
+The local connections to/from the proxy are unencrypted, but in production
+these will be loopback-only connections. Any traffic in and out of the
+machine is always encrypted.
+
+## Registering a Dependent Service
+
+We previously established a connection by directly running `consul connect proxy` in developer mode. Realistically, services need to establish connections
+to dependencies over Connect. Let's register a service "web" that registers
+"socat" as an upstream dependency in its sidecar registration:
+
+```sh
+$ cat <<EOF | sudo tee ./consul.d/web.json
+{
+  "service": {
+    "name": "web",
+    "port": 8080,
+    "connect": {
+      "sidecar_service": {
+        "proxy": {
+          "upstreams": [{
+             "destination_name": "socat",
+             "local_bind_port": 9191
+          }]
+        }
+      }
+    }
+  }
+}
+EOF
+```
+
+This registers a sidecar proxy for the service "web" that
+should listen on port 9191 to establish connections to "socat" as "web". The
+"web" service should then use that local port to talk to socat rather than
+directly attempting to connect.
+
+With that file in place, use `consul reload` or SIGHUP to reload Consul. If the
+proxy command from the previous section (with the inline upstream listener) is
+still running, stop it with `Ctrl-C`. Now we can start the web proxy using the
+configuration from the sidecar registration as we did for socat.
+
+```sh
+$ consul connect proxy -sidecar-for web
+==> Consul Connect proxy starting...
+    Configuration mode: Agent API
+        Sidecar for ID: web
+              Proxy ID: web-sidecar-proxy
+
+==> Log data will now stream in as it occurs:
+
+    2018/10/09 12:34:20 [INFO] 127.0.0.1:9191->service:default/socat starting on 127.0.0.1:9191
+    2018/10/09 12:34:20 [INFO] Proxy loaded config and ready to serve
+    2018/10/09 12:34:20 [INFO] TLS Identity: spiffe://df34ef6b-5971-ee61-0790-ca8622c3c287.consul/ns/default/dc/dc1/svc/web
+    2018/10/09 12:34:20 [INFO] TLS Roots   : [Consul CA 7]
+```
+
+Note in the first log line that the proxy discovered its configuration from the
+local agent and setup a local listener on port 9191 that will proxy to the socat
+service just as we configured in the sidecar registration.
+
+You can also see the identity URL from the certificate it loaded from the agent
+identifying it as the "web" service and the set of trusted root CAs it knows
+about.
+
+-> **Security note:** The Connect security model requires trusting
+loopback connections when proxies are in use. To further secure this,
+tools like network namespacing may be used.
+
+We can verify it works by establishing a new connection:
+
+```
+$ nc 127.0.0.1 9191
+hello
+hello
+```
+
+## Controlling Access with Intentions
+
+Intentions are used to define which services may communicate. Our connections
+above succeeded because in a development mode agent, the ACL system is "allow
+all" by default.
+
+Let's insert a rule to deny access from web to socat:
+
+```sh
+$ consul intention create -deny web socat
+Created: web => socat (deny)
+```
+
+With the proxy processes running that we setup previously, connection
+attempts now fail:
+
+```sh
+$ nc 127.0.0.1 9191
+$
+```
+
+Try deleting the intention and attempt the connection again.
+
+```sh
+$ consul intention delete web socat
+Intention deleted.
+$ nc 127.0.0.1 9191
+hello
+hello
+```
+
+Intentions allow services to be segmented via a centralized control plane
+(Consul). To learn more, read the reference documentation on
+[intentions](https://consul.io/docs/connect/intentions.html).
+
+Note that in the current release of Consul, changing intentions will not
+affect existing connections. Therefore, you must establish a new connection
+to see the effects of a changed intention. This will be addressed in the near
+term in a future version of Consul.
+
+## Discover More Connect
+
+This quick guide has given a taste of what Connect can do but there is much
+more. Take a look at [getting started with
+Connect](https://consul.io/docs/connect/index.html#getting-started-with-connect) for more guides
+on setting up Connect with Envoy proxy, with Docker and in Kubernetes.
+
+## Summary
+
+We've now configured a service on a single agent and used Connect for
+automatic connection authorization and encryption. This is a great feature
+highlight but let's explore the full value of Consul by setting up our
+first cluster.

--- a/learn/source/content/consul/getting-started/consul.d/web.json
+++ b/learn/source/content/consul/getting-started/consul.d/web.json
@@ -1,0 +1,1 @@
+{ "service": { "name": "web", "tags": ["rails"], "port": 80 } }

--- a/learn/source/content/consul/getting-started/install.md
+++ b/learn/source/content/consul/getting-started/install.md
@@ -1,0 +1,55 @@
+---
+name: 'Install Consul'
+content_length: 4
+id: install
+layout: content_layout
+products_used:
+  - Consul
+description: |-
+  A Consul agent must be installed on every node in the Consul cluster, in this guide we will install one Consul agent locally to explore the core set of capabilities.
+level: Beginner
+wistia_video_id: pufo7fm8eu
+---
+
+Consul must first be installed on your machine. Consul is distributed as a
+[binary package](https://www.consul.io/downloads.html) for all supported platforms and architectures.
+This page will not cover how to compile Consul from source, but compiling from
+source is covered in the [documentation](https://www.consul.io/docs/install/index.html#compiling-from-source) for those who want to
+be sure they're compiling source they trust into the final binary.
+
+## Installing Consul
+
+To install Consul, find the [appropriate package](https://www.consul.io/downloads.html) for
+your system and download it. Consul is packaged as a zip archive.
+
+After downloading Consul, unzip the package. Consul runs as a single binary
+named `consul`. Any other files in the package can be safely removed and
+Consul will still function.
+
+The final step is to make sure that the `consul` binary is available on the `PATH`.
+See [this page](https://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux)
+for instructions on setting the PATH on Linux and Mac.
+[This page](https://stackoverflow.com/questions/1618280/where-can-i-set-path-to-make-exe-on-windows)
+contains instructions for setting the PATH on Windows.
+
+## Verifying the Installation
+
+After installing Consul, verify the installation worked by opening a new
+terminal session and checking that `consul` is available. By executing
+`consul` you should see help output similar to this:
+
+```text
+$ consul
+usage: consul [--version] [--help] <command> [<args>]
+
+Available commands are:
+    agent          Runs a Consul agent
+    event          Fire a new event
+
+# ...
+```
+
+If you get an error that `consul` could not be found, your `PATH`
+environment variable was not set up properly. Please go back and ensure
+that your `PATH` variable contains the directory where Consul was
+installed.

--- a/learn/source/content/consul/getting-started/install.md
+++ b/learn/source/content/consul/getting-started/install.md
@@ -11,6 +11,8 @@ level: Beginner
 wistia_video_id: pufo7fm8eu
 ---
 
+EXPERIMENTAL EDIT TO TEST CHERRY PICKING TO A DIFFERENT REPO
+
 Consul must first be installed on your machine. Consul is distributed as a
 [binary package](https://www.consul.io/downloads.html) for all supported platforms and architectures.
 This page will not cover how to compile Consul from source, but compiling from

--- a/learn/source/content/consul/getting-started/join.md
+++ b/learn/source/content/consul/getting-started/join.md
@@ -1,0 +1,204 @@
+---
+name: 'Consul Cluster'
+content_length: 8
+layout: content_layout
+description: |-
+  In this guide we will set up a two node cluster and join the nodes together using Vagrant VMs.
+id: join
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: gomjrnkfsb
+---
+
+We've started our first agent and registered and queried a service on that
+agent. Additionally, we've configured Consul Connect to automatically authorize
+and encrypt connections between services. This showed how easy it is to use
+Consul but didn't show how this could be extended to a scalable,
+production-grade service mesh infrastructure. In this step, we'll create our
+first real cluster with multiple members.
+
+When a Consul agent is started, it begins without knowledge of any other node:
+it is an isolated cluster of one. To learn about other cluster members, the
+agent must _join_ an existing cluster. To join an existing cluster, it only
+needs to know about a _single_ existing member. After it joins, the agent will
+gossip with this member and quickly discover the other members in the cluster.
+A Consul agent can join any other agent, not just agents in server mode.
+
+## Starting the Agents
+
+To simulate a more realistic cluster, we will start a two node cluster via
+[Vagrant](https://www.vagrantup.com/). The Vagrantfile we will be using can
+be found in the [demo section of the Consul repo](https://github.com/hashicorp/consul/tree/master/demo/vagrant-cluster).
+
+We first boot our two nodes:
+
+```text
+$ vagrant up
+```
+
+Once the systems are available, we can ssh into them to begin configuration
+of our cluster. We start by logging in to the first node:
+
+```text
+$ vagrant ssh n1
+```
+
+In our previous examples, we used the [`-dev`
+flag](https://consul.io/docs/agent/options.html#_dev) to quickly set up a development server.
+However, this is not sufficient for use in a clustered environment. We will
+omit the `-dev` flag from here on, and instead specify our clustering flags as
+outlined below.
+
+Each node in a cluster must have a unique name. By default, Consul uses the
+hostname of the machine, but we'll manually override it using the [`-node`
+command-line option](https://consul.io/docs/agent/options.html#_node).
+
+We will also specify a [`bind` address](https://consul.io/docs/agent/options.html#_bind):
+this is the address that Consul listens on, and it _must_ be accessible by
+all other nodes in the cluster. While a `bind` address is not strictly
+necessary, it's always best to provide one. Consul will by default attempt to
+listen on all IPv4 interfaces on a system, but will fail to start with an
+error if multiple private IPs are found. Since production servers often
+have multiple interfaces, specifying a `bind` address assures that you will
+never bind Consul to the wrong interface.
+
+The first node will act as our sole server in this cluster, and we indicate
+this with the [`server` switch](https://consul.io/docs/agent/options.html#_server).
+
+The [`-bootstrap-expect` flag](https://consul.io/docs/agent/options.html#_bootstrap_expect)
+hints to the Consul server the number of additional server nodes we are
+expecting to join. The purpose of this flag is to delay the bootstrapping of
+the replicated log until the expected number of servers has successfully joined.
+You can read more about this in the [bootstrapping
+guide](https://consul.io/docs/guides/bootstrapping.html).
+
+We've included the [`-enable-script-checks`](https://consul.io/docs/agent/options.html#_enable_script_checks)
+flag set to `true` in order to enable health checks that can execute external scripts.
+This will be used in examples later. For production use, you'd want to configure
+[ACLs](/consul/advanced/day-1-operations/acl-guide) in conjunction with this to control the ability to
+register arbitrary scripts.
+
+Finally, we add the [`config-dir` flag](https://consul.io/docs/agent/options.html#_config_dir),
+marking where service and check definitions can be found.
+
+All together, these settings yield a
+[`consul agent`](https://consul.io/docs/commands/agent.html) command like this:
+
+```text
+vagrant@n1:~$ consul agent -server -bootstrap-expect=1 \
+	-data-dir=/tmp/consul -node=agent-one -bind=172.20.20.10 \
+	-enable-script-checks=true -config-dir=/etc/consul.d
+...
+```
+
+Now, in another terminal, we will connect to the second node:
+
+```text
+$ vagrant ssh n2
+```
+
+This time, we set the [`bind` address](https://consul.io/docs/agent/options.html#_bind)
+address to match the IP of the second node as specified in the Vagrantfile
+and the [`node` name](https://consul.io/docs/agent/options.html#_node) to be `agent-two`.
+Since this node will not be a Consul server, we don't provide a
+[`server` switch](https://consul.io/docs/agent/options.html#_server).
+
+All together, these settings yield a
+[`consul agent`](https://consul.io/docs/commands/agent.html) command like this:
+
+```text
+vagrant@n2:~$ consul agent -data-dir=/tmp/consul -node=agent-two \
+	-bind=172.20.20.11 -enable-script-checks=true -config-dir=/etc/consul.d
+...
+```
+
+At this point, you have two Consul agents running: one server and one client.
+The two Consul agents still don't know anything about each other and are each
+part of their own single-node clusters. You can verify this by running
+[`consul members`](https://consul.io/docs/commands/members.html) against each agent and noting
+that only one member is visible to each agent.
+
+## Joining a Cluster
+
+Now, we'll tell the first agent to join the second agent by running
+the following commands in a new terminal:
+
+```text
+$ vagrant ssh n1
+...
+vagrant@n1:~$ consul join 172.20.20.11
+Successfully joined cluster by contacting 1 nodes.
+```
+
+You should see some log output in each of the agent logs. If you read
+carefully, you'll see that they received join information. If you
+run [`consul members`](https://consul.io/docs/commands/members.html) against each agent,
+you'll see that both agents now know about each other:
+
+```text
+vagrant@n2:~$ consul members
+Node       Address            Status  Type    Build  Protocol
+agent-two  172.20.20.11:8301  alive   client  0.5.0  2
+agent-one  172.20.20.10:8301  alive   server  0.5.0  2
+```
+
+-> **Remember:** To join a cluster, a Consul agent only needs to
+learn about <em>one existing member</em>. After joining the cluster, the
+agents gossip with each other to propagate full membership information.
+
+## Auto-joining a Cluster on Start
+
+Ideally, whenever a new node is brought up in your datacenter, it should
+automatically join the Consul cluster without human intervention. Consul
+facilitates auto-join by enabling the auto-discovery of instances in AWS, Google
+Cloud or Azure with a given tag key/value. To use the integration, add the
+relevant [cloud auto
+join](https://www.consul.io/docs/agent/cloud-auto-join.html) nested object to
+your Consul configuration file. This will allow a new node to join the cluster
+without any hardcoded configuration. Alternatively, you can join a cluster at
+startup using the [`-join`
+flag](https://consul.io/docs/agent/options.html#_join) or [`start_join`
+setting](https://consul.io/docs/agent/options.html#start_join) with hardcoded
+addresses of other known Consul agents.
+
+## Querying Nodes
+
+Just like querying services, Consul has an API for querying the
+nodes themselves. You can do this via the DNS or HTTP API.
+
+For the DNS API, the structure of the names is `NAME.node.consul` or
+`NAME.node.DATACENTER.consul`. If the datacenter is omitted, Consul
+will only search the local datacenter.
+
+For example, from "agent-one", we can query for the address of the
+node "agent-two":
+
+```
+vagrant@n1:~$ dig @127.0.0.1 -p 8600 agent-two.node.consul
+...
+
+;; QUESTION SECTION:
+;agent-two.node.consul.	IN	A
+
+;; ANSWER SECTION:
+agent-two.node.consul.	0 IN	A	172.20.20.11
+```
+
+The ability to look up nodes in addition to services is incredibly
+useful for system administration tasks. For example, knowing the address
+of the node to SSH into is as easy as making the node a part of the
+Consul cluster and querying it.
+
+## Leaving a Cluster
+
+To leave the cluster, you can either gracefully quit an agent (using
+`Ctrl-C`) or force kill one of the agents. Gracefully leaving allows
+the node to transition into the _left_ state; otherwise, other nodes
+will detect it as having _failed_. The difference is covered
+in more detail [here](/consul/getting-started/agent.html#stopping-the-agent).
+
+## Summary
+
+We now have a multi-node Consul cluster up and running. Let's make
+our services more robust by giving them health checks.

--- a/learn/source/content/consul/getting-started/kv.md
+++ b/learn/source/content/consul/getting-started/kv.md
@@ -1,0 +1,132 @@
+---
+name: 'KV Data'
+content_length: 5
+layout: content_layout
+description: |-
+  In this guide, we will use the Consul command-line interface to add and manage data in the Consul KV.
+id: kv
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: iv5i9hcwbj
+---
+
+In addition to providing service discovery and integrated health checking,
+Consul provides an easy to use KV store. This can be used to hold
+dynamic configuration, assist in service coordination, build leader election,
+and enable anything else a developer can think to build.
+
+This step assumes you have at least one Consul agent already running.
+
+## Simple Usage
+
+To demonstrate how simple it is to get started, we will manipulate a few keys in
+the KV store. There are two ways to interact with the Consul KV store: via the
+HTTP API and via the Consul KV CLI. The examples below show using the Consul KV
+CLI because it is the easiest to get started. For more advanced integrations,
+you may want to use the [Consul KV HTTP API](https://www.consul.io/api/kv.html).
+
+First let us explore the KV store. We can ask Consul for the value of the key at
+the path named `redis/config/minconns`:
+
+```sh
+$ consul kv get redis/config/minconns
+Error! No key exists at: redis/config/minconns
+```
+
+As you can see, we get no result, which makes sense because there is no data in
+the KV store. Next we can insert or "put" values into the KV store.
+
+```sh
+$ consul kv put redis/config/minconns 1
+Success! Data written to: redis/config/minconns
+
+$ consul kv put redis/config/maxconns 25
+Success! Data written to: redis/config/maxconns
+
+$ consul kv put -flags=42 redis/config/users/admin abcd1234
+Success! Data written to: redis/config/users/admin
+```
+
+Now that we have keys in the store, we can query for the value of individual
+keys:
+
+```sh
+$ consul kv get redis/config/minconns
+1
+```
+
+Consul retains additional metadata about the field, which is retrieved using the
+`-detailed` flag:
+
+```sh
+$ consul kv get -detailed redis/config/minconns
+CreateIndex      207
+Flags            0
+Key              redis/config/minconns
+LockIndex        0
+ModifyIndex      207
+Session          -
+Value            1
+```
+
+For the key "redis/config/users/admin", we set a `flag` value of 42. All keys
+support setting a 64-bit integer flag value. This is not used internally by
+Consul, but it can be used by clients to add meaningful metadata to any KV.
+
+It is possible to list all the keys in the store using the `recurse` options.
+Results will be returned in lexicographical order:
+
+```sh
+$ consul kv get -recurse
+redis/config/maxconns:25
+redis/config/minconns:1
+redis/config/users/admin:abcd1234
+```
+
+To delete a key from the Consul KV store, issue a "delete" call:
+
+```sh
+$ consul kv delete redis/config/minconns
+Success! Deleted key: redis/config/minconns
+```
+
+It is also possible to delete an entire prefix using the `recurse` option:
+
+```sh
+$ consul kv delete -recurse redis
+Success! Deleted keys with prefix: redis
+```
+
+To update the value of an existing key, "put" a value at the same path:
+
+```sh
+$ consul kv put foo bar
+
+$ consul kv get foo
+bar
+
+$ consul kv put foo zip
+
+$ consul kv get foo
+zip
+```
+
+Consul can provide atomic key updates using a Check-And-Set operation. To perform a CAS operation, specify the `-cas` flag:
+
+```sh
+$ consul kv put -cas -modify-index=123 foo bar
+Success! Data written to: foo
+
+$ consul kv put -cas -modify-index=123 foo bar
+Error! Did not write to foo: CAS failed
+```
+
+In this case, the first CAS update succeeds because the index is 123. The second
+operation fails because the index is no longer 123.
+
+## Next Steps
+
+These are only a few examples of what the API supports. For the complete
+documentation, please see [Consul KV HTTP API](https://www.consul.io/api/kv.html) or
+[Consul KV CLI](https://www.consul.io/docs/commands/kv.html) documentation.

--- a/learn/source/content/consul/getting-started/next-steps.md
+++ b/learn/source/content/consul/getting-started/next-steps.md
@@ -1,0 +1,34 @@
+---
+name: 'Next Steps'
+content_length: 3
+layout: content_layout
+description: |-
+  This concludes the getting started guides for Consul. We've covered the basics for all of the Consul features and want to finish with some additional resources.
+id: next-steps
+products_used:
+  - Consul
+level: Beginner
+---
+
+That concludes the getting started guide for Consul. Hopefully you're able to
+see that while Consul is simple to use, it has a powerful set of features.
+We've covered the basics for all of these features in this guide.
+
+Consul is designed to be friendly to both the DevOps community and
+application developers, making it perfect for modern, elastic infrastructures.
+
+As a next step, the following resources are available:
+
+- [Day 1: Deploying Your First Datacenter](/consul/?track=advanced#advanced) - Learn to deploy your first datacenter. If you are responsible for setting up and maintaining a healthy datacenter, this path will help you do so successfully.
+
+- [Documentation](https://consul.io/docs/index.html) - The documentation is an in-depth reference
+  guide to all the features of Consul, including technical details about the
+  internals of how Consul operates.
+
+- [Guides](https://consul.io/docs/guides/index.html) - This section provides various getting
+  started guides with Consul, including how to bootstrap a new datacenter.
+
+- [Examples](https://github.com/hashicorp/consul/tree/master/demo) -
+  The work-in-progress examples folder within the GitHub
+  repository for Consul contains functional examples of various use cases
+  of Consul to help you get started with exactly what you need.

--- a/learn/source/content/consul/getting-started/services.md
+++ b/learn/source/content/consul/getting-started/services.md
@@ -1,0 +1,179 @@
+---
+name: 'Registering Services'
+content_length: 6
+layout: content_layout
+description: |-
+  A service can be registered with Consul either by providing a service definition or by making the appropriate calls to the HTTP API. In this guide we will register a service with a configuration file.
+id: services
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: seawr6n5dk
+---
+
+In the previous step we ran our first agent, saw the cluster members (well,
+our cluster _member_), and queried that node. In this guide, we'll register
+our first service and query that service.
+
+## Defining a Service
+
+A service can be registered either by providing a
+[service definition](https://www.consul.io/docs/agent/services.html) or by making the appropriate
+calls to the [HTTP API](https://www.consul.io/api/agent/service.html#register-service).
+
+A service definition is the most common way to register services, so we'll
+use that approach for this step. We'll be building on the agent configuration
+we covered in the [previous step](/consul/getting-started/agent).
+
+First, create a directory for Consul configuration. Consul loads all
+configuration files in the configuration directory, so a common convention
+on Unix systems is to name the directory something like `/etc/consul.d`
+(the `.d` suffix implies "this directory contains a set of configuration
+files").
+
+```text
+$ mkdir ./consul.d
+```
+
+Next, we'll write a service definition configuration file. Let's
+pretend we have a service named "web" running on port 80. Additionally,
+we'll give it a tag we can use as an additional way to query the service:
+
+```text
+$ echo '{"service": {"name": "web", "tags": ["rails"], "port": 80}}' \
+    > ./consul.d/web.json
+```
+
+Now, restart the agent, providing the configuration directory:
+
+```text
+$ consul agent -dev -config-dir=./consul.d
+
+==> Starting Consul agent...
+...
+    [INFO] agent: Synced service 'web'
+...
+```
+
+You'll notice in the output that it "synced" the web service. This means
+that the agent loaded the service definition from the configuration file,
+and has successfully registered it in the service catalog.
+
+If you wanted to register multiple services, you could create multiple
+service definition files in the Consul configuration directory.
+
+~> NOTE: In a production environment, you should enable service health checks
+and start a healthy service at port `80`. In order to simplify this exercise, we
+have not done either.
+
+## Querying Services
+
+Once the agent is started and the service is synced, we can query the
+service using either the DNS or HTTP API.
+
+### DNS API
+
+Let's first query our service using the DNS API. For the DNS API, the
+DNS name for services is `NAME.service.consul`. By default, all DNS names
+are always in the `consul` namespace, though
+[this is configurable](https://consul.io/docs/agent/options.html#domain). The `service`
+subdomain tells Consul we're querying services, and the `NAME` is the name
+of the service.
+
+For the web service we registered, these conventions and settings yield a
+fully-qualified domain name of `web.service.consul`:
+
+```text
+$ dig @127.0.0.1 -p 8600 web.service.consul
+
+;; QUESTION SECTION:
+;web.service.consul.		IN	A
+
+;; ANSWER SECTION:
+web.service.consul.	0	IN	A	127.0.0.1
+```
+
+As you can see, an `A` record was returned with the IP address of the node on
+which the service is available. `A` records can only hold IP addresses.
+
+~> Since we started `consul` with a minimal configuration, the `A` record will
+return `127.0.0.1`. See the Consul agent `-advertise` argument or the `address`
+field in the [service
+definition](https://www.consul.io/docs/agent/services.html) if you want to
+advertise an IP address that is meaningful to other nodes in the cluster.
+
+You can also use the DNS API to retrieve the entire address/port pair as a
+`SRV` record:
+
+```text
+$ dig @127.0.0.1 -p 8600 web.service.consul SRV
+
+;; QUESTION SECTION:
+;web.service.consul.		IN	SRV
+
+;; ANSWER SECTION:
+web.service.consul.	0	IN	SRV	1 1 80 Armons-MacBook-Air.node.dc1.consul.
+
+;; ADDITIONAL SECTION:
+Armons-MacBook-Air.node.dc1.consul. 0 IN A	127.0.0.1
+```
+
+The `SRV` record says that the web service is running on port 80 and exists on
+the node `Armons-MacBook-Air.node.dc1.consul.`. An additional section is returned by the
+DNS with the `A` record for that node.
+
+Finally, we can also use the DNS API to filter services by tags. The
+format for tag-based service queries is `TAG.NAME.service.consul`. In
+the example below, we ask Consul for all web services with the "rails"
+tag. We get a successful response since we registered our service with
+that tag:
+
+```text
+$ dig @127.0.0.1 -p 8600 rails.web.service.consul
+
+;; QUESTION SECTION:
+;rails.web.service.consul.		IN	A
+
+;; ANSWER SECTION:
+rails.web.service.consul.	0	IN	A	127.0.0.1
+```
+
+### HTTP API
+
+In addition to the DNS API, the HTTP API can be used to query services:
+
+```text
+$ curl http://localhost:8500/v1/catalog/service/web
+
+[{"Node":"Armons-MacBook-Air","Address":"172.20.20.11","ServiceID":"web", \
+	"ServiceName":"web","ServiceTags":["rails"],"ServicePort":80}]
+```
+
+The catalog API gives all nodes hosting a given service. As we will see later
+with [health checks](/consul/getting-started/checks) you'll typically want
+to query just for healthy instances where the checks are passing. This is what
+DNS is doing under the hood. Here's a query to look for only healthy instances:
+
+```text
+$ curl 'http://localhost:8500/v1/health/service/web?passing'
+
+[{"Node":"Armons-MacBook-Air","Address":"172.20.20.11","Service":{ \
+	"ID":"web", "Service":"web", "Tags":["rails"],"Port":80}, "Checks": ...}]
+```
+
+## Updating Services
+
+Service definitions can be updated by changing configuration files and
+sending a `SIGHUP` to the agent. This lets you update services without
+any downtime or unavailability to service queries.
+
+Alternatively, the HTTP API can be used to add, remove, and modify services
+dynamically.
+
+## Summary
+
+We've now configured a single agent and registered a service. Other service
+definition fields can be found in the [API
+docs](https://www.consul.io/api/agent/service.html). This is good progress,
+but let's explore the full value of Consul by learning how to automatically
+encrypt and authorize service-to service communication with Consul Connect.

--- a/learn/source/content/consul/getting-started/ui.md
+++ b/learn/source/content/consul/getting-started/ui.md
@@ -1,0 +1,41 @@
+---
+name: 'Web UI'
+content_length: 4
+layout: content_layout
+description: |-
+  Consul comes with support for a user-friendly and functional web UI out of the box. In this guide we will explore the web UI.
+id: ui
+products_used:
+  - Consul
+level: Beginner
+wistia_video_id: t0gc0r51me
+---
+
+Consul comes with support for a user-friendly and functional web UI out of the
+box. UIs can be used for viewing all services and nodes, for viewing
+all health checks and their current status, and for reading and setting
+key/value data. The UIs automatically support multi-datacenter.
+
+To set up the self-hosted UI, start the local Consul agent with the
+[`-ui` parameter](https://consul.io/docs/agent/options.html#_ui):
+
+```text
+$ consul agent -dev -ui
+...
+```
+
+The UI is available at the `/ui` path on the same port as the HTTP API.
+By default this is `http://localhost:8500/ui`.
+
+Access to the UI can be secured with [ACLs](/consul/advanced/day-1-operations/acl-guide#create-tokens-for-ui-use-optional-). Once the ACLs have been [bootstrapped](/consul/advanced/day-1-operations/acl-guide), you can limit read, write, and updated permissions for the various pages in the UI. 
+
+You can view a live demo of the Consul Web UI
+[here](http://demo.consul.io).
+
+## How to Use the Legacy UI
+
+As of Consul version 1.2.0 the original Consul UI is deprecated. You can
+still enable it by setting the environment variable `CONSUL_UI_LEGACY` to `true`.
+Without this environment variable, the web UI will default to the latest version.
+To use the latest UI version, either set `CONSUL_UI_LEGACY` to false or don't
+include that environment variable at all.


### PR DESCRIPTION
This will make it easier for us to cherry pick commits to production.

This is an edited sub-tree of the content at learn.hashicorp.com. Any commits to the content in the `learn` subdirectory can be directly cherry picked without further transformation.