### PR TITLE
Updating documentation of example systemd service to be of type notify.

### DIFF
--- a/website/source/docs/guides/deployment-guide.html.md
+++ b/website/source/docs/guides/deployment-guide.html.md
@@ -93,6 +93,7 @@ After=network-online.target
 ConditionFileNotEmpty=/etc/consul.d/consul.hcl
 
 [Service]
+Type=notify
 User=consul
 Group=consul
 ExecStart=/usr/local/bin/consul agent -config-dir=/etc/consul.d/


### PR DESCRIPTION
https://github.com/hashicorp/consul/issues/2121

https://www.freedesktop.org/software/systemd/man/systemd.service.html

When set to notify, systemd will not attempt to start any dependent
services until after consul sends the notify signal.  This is useful
in cases where there services that rely on the local consul agent
to be up and functional before they can start.  The default is simple,
which will immediately mark the service as up and functioning even
if consul has not yet joined the cluster and has started listening
for connnections.