### PR TITLE
[docs] WIP ports page

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1705,8 +1705,7 @@ default will automatically work with some tooling.
 ## <a id="ports-used"></a>Ports Used
 
 Consul requires up to 6 different ports to work properly, some on
-TCP, UDP, or both protocols. Below we document the requirements for each
-port.
+TCP, UDP, or both protocols. 
 
 Review the [required ports](/docs/install/ports.html) table for a list of 
 required ports and their default settings. 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1328,8 +1328,8 @@ default will automatically work with some tooling.
 
 * <a name="ports"></a><a href="#ports">`ports`</a> This is a nested object that allows setting
   the bind ports for the following keys:
-    * <a name="dns_port"></a><a href="#dns_port">`dns`</a> - The DNS server, -1 to disable. Default 8600.
-    * <a name="http_port"></a><a href="#http_port">`http`</a> - The HTTP API, -1 to disable. Default 8500.
+    * <a name="dns_port"></a><a href="#dns_port">`dns`</a> - The DNS server, -1 to disable. Default 8600. TCP and UDP.
+    * <a name="http_port"></a><a href="#http_port">`http`</a> - The HTTP API, -1 to disable. Default 8500. TCP only.
     * <a name="https_port"></a><a href="#https_port">`https`</a> - The HTTPS
       API, -1 to disable. Default -1 (disabled). **We recommend using `8501`** for
       `https` by convention as some tooling will work automatically with this.
@@ -1338,11 +1338,11 @@ default will automatically work with some tooling.
       `grpc` by convention as some tooling will work automatically with this.
       This is set to `8502` by default when the agent runs in `-dev` mode.
       Currently gRPC is only used to expose Envoy xDS API to Envoy proxies.
-    * <a name="serf_lan_port"></a><a href="#serf_lan_port">`serf_lan`</a> - The Serf LAN port. Default 8301.
+    * <a name="serf_lan_port"></a><a href="#serf_lan_port">`serf_lan`</a> - The Serf LAN port. Default 8301. TCP and UDP.
     * <a name="serf_wan_port"></a><a href="#serf_wan_port">`serf_wan`</a> - The Serf WAN port. Default 8302. Set to -1
       to disable. **Note**: this will disable WAN federation which is not recommended. Various catalog and WAN related
-      endpoints will return errors or empty results.
-    * <a name="server_rpc_port"></a><a href="#server_rpc_port">`server`</a> - Server RPC address. Default 8300.
+      endpoints will return errors or empty results. TCP and UDP.
+    * <a name="server_rpc_port"></a><a href="#server_rpc_port">`server`</a> - Server RPC address. Default 8300. TCP only.
     * <a name="proxy_min_port"></a><a href="#proxy_min_port">`proxy_min_port`</a> [**Deprecated**](/docs/connect/proxies/managed-deprecated.html) - Minimum port number to use for automatically assigned [managed proxies](/docs/connect/proxies/managed-deprecated.html). Default 20000.
     * <a name="proxy_max_port"></a><a href="#proxy_max_port">`proxy_max_port`</a> [**Deprecated**](/docs/connect/proxies/managed-deprecated.html) - Maximum port number to use for automatically assigned [managed proxies](/docs/connect/proxies/managed-deprecated.html). Default 20255.
     * <a name="sidecar_min_port"></a><a
@@ -1708,23 +1708,8 @@ Consul requires up to 6 different ports to work properly, some on
 TCP, UDP, or both protocols. Below we document the requirements for each
 port.
 
-* Server RPC (Default 8300). This is used by servers to handle incoming
-  requests from other agents. TCP only.
-
-* Serf LAN (Default 8301). This is used to handle gossip in the LAN.
-  Required by all agents. TCP and UDP.
-
-* Serf WAN (Default 8302). This is used by servers to gossip over the WAN, to
-  other servers. TCP and UDP. As of Consul 0.8 the WAN join flooding feature requires
-  the Serf WAN port (TCP/UDP) to be listening on both WAN and LAN interfaces. See also:
-   [Consul 0.8.0 CHANGELOG](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#080-april-5-2017) and [GH-3058](https://github.com/hashicorp/consul/issues/3058)
-
-* HTTP API (Default 8500). This is used by clients to talk to the HTTP
-  API. TCP only.
-
-* DNS Interface (Default 8600). Used to resolve DNS queries. TCP and UDP.
-
-* gRPC API (Default 8302). Currently gRPC is only used to expose Envoy xDS API to Envoy proxies.
+Review the [required ports](/docs/install/ports.html) table for a list of 
+required ports and their default settings. 
 
 ## <a id="reloadable-configuration"></a>Reloadable Configuration
 

--- a/website/source/docs/guides/deployment.html.md
+++ b/website/source/docs/guides/deployment.html.md
@@ -107,7 +107,7 @@ In a larger network that spans L3 segments, traffic typically traverses through 
 | Serf LAN      | 8301 |      | Used to handle gossip in the LAN. Required by all agents. TCP and UDP. |
 | Serf WAN      | 8302 | `-1` to disable (available in Consul 1.0.7) | Used by servers to gossip over the LAN and WAN to other servers. TCP and UDP. |
 | HTTP API      | 8500 | `-1` to disable | Used by clients to talk to the HTTP API. TCP only. |
-| DNS Interface | 8600 | `-1` to disable | |
+| DNS Interface | 8600 | `-1` to disable | Used to resolve DNS queries. TCP and UDP. |
 
 -> As mentioned in the [datacenter design section](#datacenter-design), network areas and network segments can be used to prevent opening up firewall ports between different subnets.
 

--- a/website/source/docs/install/ports.html.md
+++ b/website/source/docs/install/ports.html.md
@@ -13,7 +13,7 @@ Consul requires up to 6 different ports to work properly, some on
 TCP, UDP, or both protocols. Below we document the requirements for each
 port. 
 
-### Ports Table
+## Ports Table
 
 Before running Consul, you should ensure the following bind ports are accessible. 
 
@@ -30,15 +30,21 @@ Before running Consul, you should ensure the following bind ports are accessible
 | Sidecar Proxy Min: Inclusive min port number to use for automatically assigned sidecar service registrations.   | 21000            | 
 | Sidecar Proxy Max: Inclusive max port number to use for automatically assigned sidecar service registrations. | 21255            | 
 
+*For `HTTPS` and `gRPC` the ports specified in the table 
+are recommendations.
 
-### Port Information
+## Port Information
 
 **DNS Interface** Used to resolve DNS queries. 
 
 **HTTP API** This is used by clients to talk to the HTTP
   API.
 
-**gRPC API** Currently gRPC is only used to expose Envoy xDS API to Envoy proxies.
+**HTTPS API** (Optional) Is off by default, but port 8501 is a convention 
+  used by various tools as the default.
+
+**gRPC API** (Optional). Currently gRPC is
+   only used to expose the xDS API to Envoy proxies. It is off by default, but port 8502 is a convention used by various tools as the default. Defaults to 8502 in `-dev` mode.
 
 **Serf LAN** This is used to handle gossip in the LAN.
   Required by all agents. 
@@ -50,10 +56,5 @@ Before running Consul, you should ensure the following bind ports are accessible
 
 **Server RPC** This is used by servers to handle incoming
   requests from other agents. 
-
-
-
-*For `HTTPS` and `gRPC` the ports specified in the table 
-are recommendations.
 
 Note, the default ports can be changed in the [agent configuration](/docs/agent/options.html#ports). 

--- a/website/source/docs/install/ports.html.md
+++ b/website/source/docs/install/ports.html.md
@@ -8,20 +8,50 @@ description: |-
 
 # Required Ports
 
+
+Consul requires up to 6 different ports to work properly, some on
+TCP, UDP, or both protocols. Below we document the requirements for each
+port. 
+
+### Ports Table
+
 Before running Consul, you should ensure the following bind ports are accessible. 
 
 
 |  Use                              | Default Ports    | 
 | --------------------------------- | ---------------- |
-| DNS: The DNS server               | 8600             |
-| HTTP: The HTTP API                | 8500             |
+| DNS: The DNS server (TCP and UDP)              | 8600             |
+| HTTP: The HTTP API (TCP Only)               | 8500             |
 | HTTPS: The HTTPs API              | disabled (8501)* | 
 | gRPC: The gRPC API                | disabled (8502)* | 
-| LAN Serf: The Serf LAN port.      | 8301             | 
-| Wan Serf: The Serf WAN port       | 8302             |
-| server: Server RPC address        | 8300             | 
+| LAN Serf: The Serf LAN port (TCP and UDP)      | 8301             | 
+| Wan Serf: The Serf WAN port TCP and UDP)       | 8302             |
+| server: Server RPC address (TCP Only)   | 8300             | 
 | Sidecar Proxy Min: Inclusive min port number to use for automatically assigned sidecar service registrations.   | 21000            | 
 | Sidecar Proxy Max: Inclusive max port number to use for automatically assigned sidecar service registrations. | 21255            | 
+
+
+### Port Information
+
+**DNS Interface** Used to resolve DNS queries. 
+
+**HTTP API** This is used by clients to talk to the HTTP
+  API.
+
+**gRPC API** Currently gRPC is only used to expose Envoy xDS API to Envoy proxies.
+
+**Serf LAN** This is used to handle gossip in the LAN.
+  Required by all agents. 
+
+**Serf WAN** This is used by servers to gossip over the WAN, to
+  other servers. As of Consul 0.8 the WAN join flooding feature requires
+  the Serf WAN port (TCP/UDP) to be listening on both WAN and LAN interfaces. See also:
+   [Consul 0.8.0 CHANGELOG](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#080-april-5-2017) and [GH-3058](https://github.com/hashicorp/consul/issues/3058)
+
+**Server RPC** This is used by servers to handle incoming
+  requests from other agents. 
+
+
 
 *For `HTTPS` and `gRPC` the ports specified in the table 
 are recommendations.


### PR DESCRIPTION
Bases on issue https://github.com/hashicorp/consul/issues/5690

Updates Include:
- This PR will ensure all the documents that include port information are consistent and include TCP/UDP information. 
- It removes the port information from https://www.consul.io/docs/agent/options.html#ports-used and links to https://www.consul.io/docs/install/ports.html instead.
- https://www.consul.io/docs/install/ports.html now has the information from the "ports used" section.

Thoughts:
Do we want to remove the "ports used" section from the configuration doc? Instead we could link to the new ports required page at the beginning of the options page. The benefit of removing the "ports used" section would be to reduce spread. The benefit of having a Ports Required page is it makes this information easy to discover when navigating the site. 