### PR TITLE
Removed "Snapshotting also requires acl = "write" permissions due to …

### DIFF
--- a/website/source/docs/acl/acl-rules.html.md
+++ b/website/source/docs/acl/acl-rules.html.md
@@ -159,8 +159,7 @@ acl = "write"
 ```
 
 There is only one acl rule allowed per policy and its value is set to one of the [policy dispositions](/docs/acl/acl-rules.html#rule-specification). In the example
-above ACLs may be read or written including discovering any token's secret ID. Snapshotting also requires `acl = "write"`
-permissions due to the fact that all the token secrets are contained within the snapshot.
+above ACLs may be read or written including discovering any token's secret ID.
 
 #### Agent Rules
 


### PR DESCRIPTION
…the fact that all the token secrets are contained within the snapshot." Although this is correct, additionally, snapshot agent operations requires the following rules as well:

key_prefix "" {
   policy = "write"
}
service_prefix "" {
   policy = "write"
}
session_prefix "" {
   policy = "write"
}
node_prefix "" {
   policy = "write"
}

The only differneces between above policy and management policy are operator, event, and query. Therefore, as outlined in the following link, https://www.consul.io/docs/commands/snapshot/agent.html, "If ACLs are enabled, a management token must be supplied in order to perform snapshot operations.", for snapshot agent operations management token is required.