### PR TITLE
Update alias on local add and remove

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -488,9 +488,6 @@ func (l *State) addCheckLocked(check *structs.HealthCheck, token string) error {
 		return fmt.Errorf("Check %q refers to non-existent service %q", check.CheckID, check.ServiceID)
 	}
 
-	// If this is a check for an aliased service, then notify the waiters.
-	l.notifyIfAliased(check.ServiceID)
-
 	// hard-set the node name
 	check.Node = l.config.NodeName
 

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -2263,9 +2263,7 @@ func TestAliasNotifications_local(t *testing.T) {
 	chkt := &structs.CheckType{
 		AliasService: svcID,
 	}
-	if err := a.AddCheck(chk1, chkt, true, "", agent.ConfigSourceLocal); err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	require.NoError(t, a.AddCheck(chk1, chkt, true, "", agent.ConfigSourceLocal))
 
 	// Add a failing check to the same service ID, alias should also fail
 	maintID := types.CheckID("service:socat-maintenance")
@@ -2279,27 +2277,21 @@ func TestAliasNotifications_local(t *testing.T) {
 	a.State.AddCheck(chk2, "")
 
 	retry.Run(t, func(r *retry.R) {
-		if got, want := a.State.Check(proxyID).Status, api.HealthCritical; got != want {
-			r.Fatalf("got state %q want %q", got, want)
-		}
+		require.Equal(r, api.HealthCritical, a.State.Check(proxyID).Status)
 	})
 
 	// Remove the failing check, alias should pass
 	a.State.RemoveCheck(maintID)
 
 	retry.Run(t, func(r *retry.R) {
-		if got, want := a.State.Check(proxyID).Status, api.HealthPassing; got != want {
-			r.Fatalf("got state %q want %q", got, want)
-		}
+		require.Equal(r, api.HealthPassing, a.State.Check(proxyID).Status)
 	})
 
 	// Update TCP check to failing, alias should fail
 	a.State.UpdateCheck(tcpID, api.HealthCritical, "")
 
 	retry.Run(t, func(r *retry.R) {
-		if got, want := a.State.Check(proxyID).Status, api.HealthCritical; got != want {
-			r.Fatalf("got state %q want %q", got, want)
-		}
+		require.Equal(r, api.HealthCritical, a.State.Check(proxyID).Status)
 	})
 }
 

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -2211,6 +2211,98 @@ func TestStateProxyRestore(t *testing.T) {
 	assert.Equal(p1.ProxyService.Port, p2.ProxyService.Port)
 }
 
+// Test that alias check is updated after AddCheck, UpdateCheck, and RemoveCheck for the same service id
+func TestAliasNotifications_local(t *testing.T) {
+	t.Parallel()
+
+	a := agent.NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	// Register service with a failing TCP check
+	svcID := "socat"
+	srv := &structs.NodeService{
+		ID:      svcID,
+		Service: "echo",
+		Tags:    []string{},
+		Address: "127.0.0.10",
+		Port:    8080,
+	}
+	a.State.AddService(srv, "")
+
+	scID := "socat-sidecar-proxy"
+	sc := &structs.NodeService{
+		ID:      scID,
+		Service: scID,
+		Tags:    []string{},
+		Address: "127.0.0.10",
+		Port:    9090,
+	}
+	a.State.AddService(sc, "")
+
+	tcpID := types.CheckID("service:socat-tcp")
+	chk0 := &structs.HealthCheck{
+		Node:      "",
+		CheckID:   tcpID,
+		Name:      "tcp check",
+		Status:    api.HealthPassing,
+		ServiceID: svcID,
+	}
+	a.State.AddCheck(chk0, "")
+
+	// Register an alias for the service
+	proxyID := types.CheckID("service:socat-sidecar-proxy:2")
+	chk1 := &structs.HealthCheck{
+		Node:      "",
+		CheckID:   proxyID,
+		Name:      "Connect Sidecar Aliasing socat",
+		Status:    api.HealthPassing,
+		ServiceID: scID,
+	}
+	chkt := &structs.CheckType{
+		AliasService: svcID,
+	}
+	if err := a.AddCheck(chk1, chkt, true, "", agent.ConfigSourceLocal); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Add a failing check to the same service ID, alias should also fail
+	maintID := types.CheckID("service:socat-maintenance")
+	chk2 := &structs.HealthCheck{
+		Node:      "",
+		CheckID:   maintID,
+		Name:      "socat:Service Maintenance Mode",
+		Status:    api.HealthCritical,
+		ServiceID: svcID,
+	}
+	a.State.AddCheck(chk2, "")
+
+	retry.Run(t, func(r *retry.R) {
+		if got, want := a.State.Check(proxyID).Status, api.HealthCritical; got != want {
+			r.Fatalf("got state %q want %q", got, want)
+		}
+	})
+
+	// Remove the failing check, alias should pass
+	a.State.RemoveCheck(maintID)
+
+	retry.Run(t, func(r *retry.R) {
+		if got, want := a.State.Check(proxyID).Status, api.HealthPassing; got != want {
+			r.Fatalf("got state %q want %q", got, want)
+		}
+	})
+
+	// Update TCP check to failing, alias should fail
+	a.State.UpdateCheck(tcpID, api.HealthCritical, "")
+
+	retry.Run(t, func(r *retry.R) {
+		if got, want := a.State.Check(proxyID).Status, api.HealthCritical; got != want {
+			r.Fatalf("got state %q want %q", got, want)
+		}
+	})
+}
+
 // drainCh drains a channel by reading messages until it would block.
 func drainCh(ch chan struct{}) {
 	for {


### PR DESCRIPTION
Fixes: #5634 and #5332

Previously alias check updates were only triggered when the local state called `UpdateCheck`. 

When a service is put into `maint` mode, a new check is added when enabled and removed when disabled. Because maintenance doesn't update a check, the alias check update was never triggered.

This PR adds a check for alias notifications to the remaining local state check operations.