### PR TITLE
Add website analytics back

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,24 @@ jobs:
     steps:
       - checkout:
           path: ~/project
+
       # attach website build directory
       - attach_workspace:
           at: ~/project/website
+
+      # restores gem cache
+      - restore_cache:
+          key: *RUBYGEM_CACHE_KEY
+      # rerun build with 'ENV=production' to add analytics
+      - run:
+          name: install gems
+          command: bundle check || bundle install --path vendor/bundle --retry=3
+
+      # rerun build with 'ENV=production' to add analytics
+      - run:
+          name: middleman build
+          command: bundle exec middleman build
+
       - run:
           name: website deploy
           command: ./scripts/deploy.sh

--- a/website/scripts/deploy.sh
+++ b/website/scripts/deploy.sh
@@ -30,6 +30,12 @@ if ! command -v "s3cmd" >/dev/null 2>&1; then
   exit 1
 fi
 
+# Ensure the proper analytics Segment ID is set
+if [ "$ENV" != "production" ]; then
+  echo "ENV is not set to production for Segment Analytics!"
+  exit 1
+fi
+
 # Get the parent directory of where this script is and cd there
 DIR="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
 


### PR DESCRIPTION
When I refactored the website deploy into the `build-website` and `deploy-website` steps in #5607, I didn't realize that `ENV=production` needed to be set for the correct Segment ID for analytics here: https://github.com/hashicorp/consul/blob/master/website/config.rb#L17. Since we need the build step separate to do the link checking, I am just rebuilding with `ENV=production` set in the `deploy-website` step to add in the analytics ID to the build that gets passed around in CircleCI. I have also added a check to the deploy script to make sure `ENV=production` before we run that script so this should never happen again 😄 .