### PR TITLE
Use centralized service config on agent service registrations

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2092,8 +2092,10 @@ func (a *Agent) removeServiceLocked(serviceID string, persist bool) error {
 		return fmt.Errorf("ServiceID missing")
 	}
 
-	// Shut down the config watch in the service manager.
-	a.serviceManager.RemoveService(serviceID)
+	// Shut down the config watch in the service manager if enabled.
+	if a.config.EnableCentralServiceConfig {
+		a.serviceManager.RemoveService(serviceID)
+	}
 
 	checks := a.State.Checks()
 	var checkIDs []types.CheckID

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -243,6 +243,8 @@ type Agent struct {
 	// directly.
 	proxyConfig *proxycfg.Manager
 
+	// serviceManager is the manager for combining local service registrations with
+	// the centrally configured proxy/service defaults.
 	serviceManager *ServiceManager
 
 	// xdsServer is the Server instance that serves xDS gRPC API.

--- a/agent/cache-types/resolved_service_config.go
+++ b/agent/cache-types/resolved_service_config.go
@@ -1,0 +1,52 @@
+package cachetype
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// Recommended name for registration.
+const ResolvedServiceConfigName = "resolved-service-config"
+
+// ResolvedServiceConfig supports fetching the config for a service resolved from
+// the global proxy defaults and the centrally registered service config.
+type ResolvedServiceConfig struct {
+	RPC RPC
+}
+
+func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
+	var result cache.FetchResult
+
+	// The request should be a ServiceConfigRequest.
+	reqReal, ok := req.(*structs.ServiceConfigRequest)
+	if !ok {
+		return result, fmt.Errorf(
+			"Internal cache failure: request wrong type: %T", req)
+	}
+
+	// Set the minimum query index to our current index so we block
+	reqReal.QueryOptions.MinQueryIndex = opts.MinIndex
+	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
+
+	// Allways allow stale - there's no point in hitting leader if the request is
+	// going to be served from cache and endup arbitrarily stale anyway. This
+	// allows cached service-discover to automatically read scale across all
+	// servers too.
+	reqReal.AllowStale = true
+
+	// Fetch
+	var reply structs.ServiceConfigResponse
+	if err := c.RPC.RPC("ConfigEntry.ResolveServiceConfig", reqReal, &reply); err != nil {
+		return result, err
+	}
+
+	result.Value = &reply
+	result.Index = reply.QueryMeta.Index
+	return result, nil
+}
+
+func (c *ResolvedServiceConfig) SupportsBlocking() bool {
+	return true
+}

--- a/agent/cache-types/resolved_service_config.go
+++ b/agent/cache-types/resolved_service_config.go
@@ -30,9 +30,9 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 	reqReal.QueryOptions.MinQueryIndex = opts.MinIndex
 	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
 
-	// Allways allow stale - there's no point in hitting leader if the request is
+	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached resolved-service-config to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
 

--- a/agent/cache-types/resolved_service_config_test.go
+++ b/agent/cache-types/resolved_service_config_test.go
@@ -1,0 +1,67 @@
+package cachetype
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvedServiceConfig(t *testing.T) {
+	require := require.New(t)
+	rpc := TestRPC(t)
+	defer rpc.AssertExpectations(t)
+	typ := &ResolvedServiceConfig{RPC: rpc}
+
+	// Expect the proper RPC call. This also sets the expected value
+	// since that is return-by-pointer in the arguments.
+	var resp *structs.ServiceConfigResponse
+	rpc.On("RPC", "ConfigEntry.ResolveServiceConfig", mock.Anything, mock.Anything).Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.ServiceConfigRequest)
+			require.Equal(uint64(24), req.QueryOptions.MinQueryIndex)
+			require.Equal(1*time.Second, req.QueryOptions.MaxQueryTime)
+			require.Equal("foo", req.Name)
+			require.True(req.AllowStale)
+
+			reply := args.Get(2).(*structs.ServiceConfigResponse)
+			reply.Definition = structs.ServiceDefinition{
+				ID:   "1234",
+				Name: "foo",
+			}
+
+			reply.QueryMeta.Index = 48
+			resp = reply
+		})
+
+	// Fetch
+	resultA, err := typ.Fetch(cache.FetchOptions{
+		MinIndex: 24,
+		Timeout:  1 * time.Second,
+	}, &structs.ServiceConfigRequest{
+		Datacenter: "dc1",
+		Name:       "foo",
+	})
+	require.NoError(err)
+	require.Equal(cache.FetchResult{
+		Value: resp,
+		Index: 48,
+	}, resultA)
+}
+
+func TestResolvedServiceConfig_badReqType(t *testing.T) {
+	require := require.New(t)
+	rpc := TestRPC(t)
+	defer rpc.AssertExpectations(t)
+	typ := &ResolvedServiceConfig{RPC: rpc}
+
+	// Fetch
+	_, err := typ.Fetch(cache.FetchOptions{}, cache.TestRequest(
+		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
+	require.Error(err)
+	require.Contains(err.Error(), "wrong type")
+
+}

--- a/agent/cache/watch.go
+++ b/agent/cache/watch.go
@@ -95,7 +95,7 @@ func (c *Cache) notifyBlockingQuery(ctx context.Context, t string, r Request, co
 
 		// Check the index of the value returned in the cache entry to be sure it
 		// changed
-		if index < meta.Index {
+		if index == 0 || index < meta.Index {
 			u := UpdateEvent{correlationID, res, meta, err}
 			select {
 			case ch <- u:

--- a/agent/cache/watch_test.go
+++ b/agent/cache/watch_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -23,10 +24,14 @@ func TestCacheNotify(t *testing.T) {
 	})
 
 	// Setup triggers to control when "updates" should be delivered
-	trigger := make([]chan time.Time, 4)
+	trigger := make([]chan time.Time, 5)
 	for i := range trigger {
 		trigger[i] = make(chan time.Time)
 	}
+
+	// Send an error to fake a situation where the servers aren't reachable
+	// initially.
+	typ.Static(FetchResult{Value: nil, Index: 0}, errors.New("no servers available")).Once()
 
 	// Configure the type
 	typ.Static(FetchResult{Value: 1, Index: 4}, nil).Once().Run(func(args mock.Arguments) {
@@ -35,16 +40,16 @@ func TestCacheNotify(t *testing.T) {
 		// break in real life (hint: it did on the first attempt)
 		_, ok := args.Get(1).(*MockRequest)
 		require.True(t, ok)
-	})
-	typ.Static(FetchResult{Value: 12, Index: 5}, nil).Once().WaitUntil(trigger[0])
+	}).WaitUntil(trigger[0])
 	typ.Static(FetchResult{Value: 12, Index: 5}, nil).Once().WaitUntil(trigger[1])
-	typ.Static(FetchResult{Value: 42, Index: 7}, nil).Once().WaitUntil(trigger[2])
+	typ.Static(FetchResult{Value: 12, Index: 5}, nil).Once().WaitUntil(trigger[2])
+	typ.Static(FetchResult{Value: 42, Index: 7}, nil).Once().WaitUntil(trigger[3])
 	// It's timing dependent whether the blocking loop manages to make another
 	// call before we cancel so don't require it. We need to have a higher index
 	// here because if the index is the same then the cache Get will not return
 	// until the full 10 min timeout expires. This causes the last fetch to return
 	// after cancellation as if it had timed out.
-	typ.Static(FetchResult{Value: 42, Index: 8}, nil).WaitUntil(trigger[3])
+	typ.Static(FetchResult{Value: 42, Index: 8}, nil).WaitUntil(trigger[4])
 
 	require := require.New(t)
 
@@ -56,12 +61,12 @@ func TestCacheNotify(t *testing.T) {
 	err := c.Notify(ctx, "t", TestRequest(t, RequestInfo{Key: "hello"}), "test", ch)
 	require.NoError(err)
 
-	// Should receive the first result pretty soon
+	// Should receive the error with index == 0 first.
 	TestCacheNotifyChResult(t, ch, UpdateEvent{
 		CorrelationID: "test",
-		Result:        1,
-		Meta:          ResultMeta{Hit: false, Index: 4},
-		Err:           nil,
+		Result:        nil,
+		Meta:          ResultMeta{Hit: false, Index: 0},
+		Err:           errors.New("no servers available"),
 	})
 
 	// There should be no more updates delivered yet
@@ -69,6 +74,17 @@ func TestCacheNotify(t *testing.T) {
 
 	// Trigger blocking query to return a "change"
 	close(trigger[0])
+
+	// Should receive the first real update next.
+	TestCacheNotifyChResult(t, ch, UpdateEvent{
+		CorrelationID: "test",
+		Result:        1,
+		Meta:          ResultMeta{Hit: false, Index: 4},
+		Err:           nil,
+	})
+
+	// Trigger blocking query to return a "change"
+	close(trigger[1])
 
 	// Should receive the next result pretty soon
 	TestCacheNotifyChResult(t, ch, UpdateEvent{
@@ -99,7 +115,7 @@ func TestCacheNotify(t *testing.T) {
 	// We could wait for a full timeout but we can't directly observe it so
 	// simulate the behavior by triggering a response with the same value and
 	// index as the last one.
-	close(trigger[1])
+	close(trigger[2])
 
 	// We should NOT be notified about that. Note this is timing dependent but
 	// it's only a sanity check, if we somehow _do_ get the change delivered later
@@ -108,7 +124,7 @@ func TestCacheNotify(t *testing.T) {
 	require.Len(ch, 0)
 
 	// Trigger final update
-	close(trigger[2])
+	close(trigger[3])
 
 	TestCacheNotifyChResult(t, ch, UpdateEvent{
 		CorrelationID: "test",
@@ -134,7 +150,7 @@ func TestCacheNotify(t *testing.T) {
 	// have no way to interrupt a blocking query. In practice it's fine to know
 	// that after 10 mins max the blocking query will return and the resources
 	// will be cleaned.
-	close(trigger[3])
+	close(trigger[4])
 
 	// I want to test that canceling the context cleans up goroutines (which it
 	// does from manual verification with debugger etc). I had a check based on a

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -793,6 +793,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		DiscardCheckOutput:                      b.boolVal(c.DiscardCheckOutput),
 		DiscoveryMaxStale:                       b.durationVal("discovery_max_stale", c.DiscoveryMaxStale),
 		EnableAgentTLSForChecks:                 b.boolVal(c.EnableAgentTLSForChecks),
+		EnableCentralServiceConfig:              b.boolVal(c.EnableCentralServiceConfig),
 		EnableDebug:                             b.boolVal(c.EnableDebug),
 		EnableRemoteScriptChecks:                enableRemoteScriptChecks,
 		EnableLocalScriptChecks:                 enableLocalScriptChecks,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -201,6 +201,7 @@ type Config struct {
 	DiscoveryMaxStale                *string                  `json:"discovery_max_stale" hcl:"discovery_max_stale" mapstructure:"discovery_max_stale"`
 	EnableACLReplication             *bool                    `json:"enable_acl_replication,omitempty" hcl:"enable_acl_replication" mapstructure:"enable_acl_replication"`
 	EnableAgentTLSForChecks          *bool                    `json:"enable_agent_tls_for_checks,omitempty" hcl:"enable_agent_tls_for_checks" mapstructure:"enable_agent_tls_for_checks"`
+	EnableCentralServiceConfig       *bool                    `json:"enable_central_service_config,omitempty" hcl:"enable_central_service_config" mapstructure:"enable_central_service_config"`
 	EnableDebug                      *bool                    `json:"enable_debug,omitempty" hcl:"enable_debug" mapstructure:"enable_debug"`
 	EnableScriptChecks               *bool                    `json:"enable_script_checks,omitempty" hcl:"enable_script_checks" mapstructure:"enable_script_checks"`
 	EnableLocalScriptChecks          *bool                    `json:"enable_local_script_checks,omitempty" hcl:"enable_local_script_checks" mapstructure:"enable_local_script_checks"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -669,6 +669,12 @@ type RuntimeConfig struct {
 	// and key).
 	EnableAgentTLSForChecks bool
 
+	// EnableCentralServiceConfig controls whether the agent should incorporate
+	// centralized config such as service-defaults into local service registrations.
+	//
+	// hcl: (enable)
+	EnableCentralServiceConfig bool
+
 	// EnableDebug is used to enable various debugging features.
 	//
 	// hcl: enable_debug = (true|false)

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -672,7 +672,7 @@ type RuntimeConfig struct {
 	// EnableCentralServiceConfig controls whether the agent should incorporate
 	// centralized config such as service-defaults into local service registrations.
 	//
-	// hcl: (enable)
+	// hcl: enable_central_service_config = (true|false)
 	EnableCentralServiceConfig bool
 
 	// EnableDebug is used to enable various debugging features.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3073,6 +3073,7 @@ func TestFullConfig(t *testing.T) {
 			},
 			"enable_acl_replication": true,
 			"enable_agent_tls_for_checks": true,
+			"enable_central_service_config": true,
 			"enable_debug": true,
 			"enable_script_checks": true,
 			"enable_local_script_checks": true,
@@ -3629,6 +3630,7 @@ func TestFullConfig(t *testing.T) {
 			}
 			enable_acl_replication = true
 			enable_agent_tls_for_checks = true
+			enable_central_service_config = true
 			enable_debug = true
 			enable_script_checks = true
 			enable_local_script_checks = true
@@ -4270,6 +4272,7 @@ func TestFullConfig(t *testing.T) {
 		DiscardCheckOutput:               true,
 		DiscoveryMaxStale:                5 * time.Second,
 		EnableAgentTLSForChecks:          true,
+		EnableCentralServiceConfig:       true,
 		EnableDebug:                      true,
 		EnableRemoteScriptChecks:         true,
 		EnableLocalScriptChecks:          true,
@@ -5067,6 +5070,7 @@ func TestSanitize(t *testing.T) {
 		"DiscoveryMaxStale": "0s",
 		"EnableAgentTLSForChecks": false,
 		"EnableDebug": false,
+		"EnableCentralServiceConfig": false,
 		"EnableLocalScriptChecks": false,
 		"EnableRemoteScriptChecks": false,
 		"EnableSyslog": false,

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -191,18 +191,25 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 			if err != nil {
 				return err
 			}
-			serviceConf, ok := serviceEntry.(*structs.ServiceConfigEntry)
-			if !ok {
-				return fmt.Errorf("invalid service config type %T", serviceEntry)
+			var serviceConf *structs.ServiceConfigEntry
+			var ok bool
+			if serviceEntry != nil {
+				serviceConf, ok = serviceEntry.(*structs.ServiceConfigEntry)
+				if !ok {
+					return fmt.Errorf("invalid service config type %T", serviceEntry)
+				}
 			}
 
 			_, proxyEntry, err := state.ConfigEntry(ws, structs.ProxyDefaults, structs.ProxyConfigGlobal)
 			if err != nil {
 				return err
 			}
-			proxyConf, ok := proxyEntry.(*structs.ProxyConfigEntry)
-			if !ok {
-				return fmt.Errorf("invalid proxy config type %T", serviceEntry)
+			var proxyConf *structs.ProxyConfigEntry
+			if proxyEntry != nil {
+				proxyConf, ok = proxyEntry.(*structs.ProxyConfigEntry)
+				if !ok {
+					return fmt.Errorf("invalid proxy config type %T", proxyEntry)
+				}
 			}
 
 			// Resolve the service definition by overlaying the service config onto the global

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/consul/agent/cache"
+	cachetype "github.com/hashicorp/consul/agent/cache-types"
+	"github.com/hashicorp/consul/agent/structs"
+	"golang.org/x/net/context"
+)
+
+type ServiceManager struct {
+	services map[string]*serviceConfigWatch
+	agent    *Agent
+
+	sync.Mutex
+}
+
+func NewServiceManager(agent *Agent) *ServiceManager {
+	return &ServiceManager{
+		services: make(map[string]*serviceConfigWatch),
+		agent:    agent,
+	}
+}
+
+func (s *ServiceManager) AddService(service *structs.NodeService, chkTypes []*structs.CheckType, persist bool, token string, source configSource) {
+	s.Lock()
+	defer s.Unlock()
+
+	reg := serviceRegistration{
+		service:  service,
+		chkTypes: chkTypes,
+		persist:  persist,
+		token:    token,
+		source:   source,
+	}
+
+	// If a service watch already exists, update the registration. Otherwise,
+	// start a new config watcher.
+	watch, ok := s.services[service.ID]
+	if ok {
+		watch.updateRegistration(&reg)
+	} else {
+		watch := &serviceConfigWatch{
+			registration: &reg,
+			updateCh:     make(chan cache.UpdateEvent, 1),
+			agent:        s.agent,
+		}
+
+		s.services[service.ID] = watch
+		watch.Start()
+	}
+}
+
+func (s *ServiceManager) RemoveService(serviceID string) {
+	s.Lock()
+	defer s.Unlock()
+
+	serviceWatch, ok := s.services[serviceID]
+	if !ok {
+		return
+	}
+
+	serviceWatch.Stop()
+	delete(s.services, serviceID)
+}
+
+type serviceRegistration struct {
+	service  *structs.NodeService
+	chkTypes []*structs.CheckType
+	persist  bool
+	token    string
+	source   configSource
+}
+
+type serviceConfigWatch struct {
+	registration *serviceRegistration
+	config       *structs.ServiceDefinition
+
+	agent *Agent
+
+	updateCh   chan cache.UpdateEvent
+	ctx        context.Context
+	cancelFunc func()
+
+	sync.RWMutex
+}
+
+func (s *serviceConfigWatch) Start() error {
+	s.ctx, s.cancelFunc = context.WithCancel(context.Background())
+	if err := s.startConfigWatch(); err != nil {
+		return err
+	}
+	go s.runWatch()
+
+	return nil
+}
+
+func (s *serviceConfigWatch) runWatch() {
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case event := <-s.updateCh:
+			s.handleUpdate(event)
+		}
+	}
+}
+
+func (s *serviceConfigWatch) handleUpdate(event cache.UpdateEvent) {
+	switch event.Result.(type) {
+	case serviceRegistration:
+		s.Lock()
+		s.registration = event.Result.(*serviceRegistration)
+		s.Unlock()
+	case structs.ServiceConfigResponse:
+		s.Lock()
+		s.config = &event.Result.(*structs.ServiceConfigResponse).Definition
+		s.Unlock()
+	default:
+		s.agent.logger.Printf("[ERR] unknown update event type: %T", event)
+	}
+
+	service := s.mergeServiceConfig()
+	s.agent.logger.Printf("[INFO] updating service registration: %v, %v", service.ID, service.Meta)
+	/*err := s.agent.AddService(service, s.registration.chkTypes, s.registration.persist, s.registration.token, s.registration.source)
+	if err != nil {
+		s.agent.logger.Printf("[ERR] error updating service registration: %v", err)
+	}*/
+}
+
+func (s *serviceConfigWatch) startConfigWatch() error {
+	s.RLock()
+	name := s.registration.service.Service
+	s.RUnlock()
+
+	req := &structs.ServiceConfigRequest{
+		Name:       name,
+		Datacenter: s.agent.config.Datacenter,
+	}
+	err := s.agent.cache.Notify(s.ctx, cachetype.ResolvedServiceConfigName, req, fmt.Sprintf("service-config:%s", name), s.updateCh)
+
+	return err
+}
+
+func (s *serviceConfigWatch) updateRegistration(registration *serviceRegistration) {
+	s.updateCh <- cache.UpdateEvent{
+		Result: registration,
+	}
+}
+
+func (s *serviceConfigWatch) mergeServiceConfig() *structs.NodeService {
+	return nil
+}
+
+func (s *serviceConfigWatch) Stop() {
+	s.cancelFunc()
+}
+
+/*
+// Construct the service config request. This will be re-used with an updated
+	// index to watch for changes in the effective service config.
+	req := structs.ServiceConfigRequest{
+		Name:         s.registration.service.Service,
+		Datacenter:   s.agent.config.Datacenter,
+		QueryOptions: structs.QueryOptions{Token: s.agent.tokens.AgentToken()},
+	}
+
+	consul.RetryLoopBackoff(s.shutdownCh, func() error {
+		var reply structs.ServiceConfigResponse
+		if err := s.agent.RPC("ConfigEntry.ResolveServiceConfig", &req, &reply); err != nil {
+			return err
+		}
+
+		s.updateConfig(&reply.Definition)
+
+		req.QueryOptions.MinQueryIndex = reply.QueryMeta.Index
+		return nil
+	}, func(err error) {
+		s.agent.logger.Printf("[ERR] Error getting service config: %v", err)
+	})
+*/

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -11,7 +11,7 @@ import (
 func TestServiceManager_RegisterService(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, t.Name(), "enable_central_service_config = true")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -47,6 +47,49 @@ func TestServiceManager_RegisterService(t *testing.T) {
 				"foo": int64(1),
 			},
 		},
+		Weights: &structs.Weights{
+			Passing: 1,
+			Warning: 1,
+		},
+	}, mergedService)
+}
+
+func TestServiceManager_Disabled(t *testing.T) {
+	require := require.New(t)
+
+	a := NewTestAgent(t, t.Name(), "enable_central_service_config = false")
+	defer a.Shutdown()
+
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Register some global proxy config
+	args := &structs.ConfigEntryRequest{
+		Datacenter: "dc1",
+		Entry: &structs.ProxyConfigEntry{
+			Config: map[string]interface{}{
+				"foo": 1,
+			},
+		},
+	}
+	var out struct{}
+	require.NoError(a.RPC("ConfigEntry.Apply", args, &out))
+
+	// Now register a service locally and make sure the resulting State entry
+	// has the global config in it.
+	svc := &structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    8000,
+	}
+	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	mergedService := a.State.Service("redis")
+	require.NotNil(mergedService)
+	// The proxy config map shouldn't be present; the agent should ignore global
+	// defaults here.
+	require.Equal(&structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    8000,
 		Weights: &structs.Weights{
 			Passing: 1,
 			Warning: 1,

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceManager_RegisterService(t *testing.T) {
+	require := require.New(t)
+
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	// Register some global proxy config
+	args := &structs.ConfigEntryRequest{
+		Datacenter: "dc1",
+		Entry: &structs.ProxyConfigEntry{
+			Config: map[string]interface{}{
+				"foo": 1,
+			},
+		},
+	}
+	var out struct{}
+	require.NoError(a.RPC("ConfigEntry.Apply", args, &out))
+
+	// Now register a service locally and make sure the resulting State entry
+	// has the global config in it.
+	svc := &structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    8000,
+	}
+	require.NoError(a.AddService(svc, nil, false, "", ConfigSourceLocal))
+	mergedService := a.State.Service("redis")
+	require.NotNil(mergedService)
+	require.Equal(&structs.NodeService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    8000,
+		Proxy: structs.ConnectProxyConfig{
+			Config: map[string]interface{}{
+				"foo": int64(1),
+			},
+		},
+		Weights: &structs.Weights{
+			Passing: 1,
+			Warning: 1,
+		},
+	}, mergedService)
+}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -765,6 +765,57 @@ type ServiceConnect struct {
 	SidecarService *ServiceDefinition `json:",omitempty" bexpr:"-"`
 }
 
+// Merge overlays the given node's attributes onto the existing node.
+func (s *NodeService) Merge(other *NodeService) {
+	if other.Kind != "" {
+		s.Kind = other.Kind
+	}
+	if other.ID != "" {
+		s.ID = other.ID
+	}
+	if other.Service != "" {
+		s.Service = other.Service
+	}
+	for _, tag := range other.Tags {
+		s.Tags = append(s.Tags, tag)
+	}
+	if other.Address != "" {
+		s.Address = other.Address
+	}
+	if s.Meta == nil {
+		s.Meta = other.Meta
+	} else {
+		for k, v := range other.Meta {
+			s.Meta[k] = v
+		}
+	}
+	if other.Port != 0 {
+		s.Port = other.Port
+	}
+	if other.Weights != nil {
+		s.Weights = other.Weights
+	}
+	s.EnableTagOverride = other.EnableTagOverride
+	if other.ProxyDestination != "" {
+		s.ProxyDestination = other.ProxyDestination
+	}
+
+	// Take the incoming service's proxy fields and merge the config map.
+	proxyConf := s.Proxy.Config
+	s.Proxy = other.Proxy
+	if proxyConf == nil {
+		proxyConf = other.Proxy.Config
+	} else {
+		for k, v := range other.Proxy.Config {
+			proxyConf[k] = v
+		}
+	}
+	s.Proxy.Config = proxyConf
+
+	s.Connect = other.Connect
+	s.LocallyRegisteredAsSidecar = other.LocallyRegisteredAsSidecar
+}
+
 // Validate validates the node service configuration.
 //
 // NOTE(mitchellh): This currently only validates fields for a ConnectProxy.

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -561,6 +561,103 @@ func TestStructs_NodeService_IsSame(t *testing.T) {
 	}
 }
 
+func TestStructs_NodeService_Merge(t *testing.T) {
+	a := &NodeService{
+		Kind:    "service",
+		ID:      "foo:1",
+		Service: "foo",
+		Tags:    []string{"a", "b"},
+		Address: "127.0.0.1",
+		Meta:    map[string]string{"a": "b"},
+		Port:    1234,
+		Weights: &Weights{
+			Passing: 1,
+			Warning: 1,
+		},
+		EnableTagOverride: false,
+		ProxyDestination:  "asdf",
+		Proxy: ConnectProxyConfig{
+			DestinationServiceName: "baz",
+			DestinationServiceID:   "baz:1",
+			LocalServiceAddress:    "127.0.0.1",
+			LocalServicePort:       2345,
+			Config: map[string]interface{}{
+				"foo": 1,
+			},
+		},
+		Connect: ServiceConnect{
+			Native: false,
+		},
+		LocallyRegisteredAsSidecar: false,
+	}
+
+	b := &NodeService{
+		Kind:    "other",
+		ID:      "bar:1",
+		Service: "bar",
+		Tags:    []string{"c", "d"},
+		Address: "127.0.0.2",
+		Meta:    map[string]string{"c": "d"},
+		Port:    4567,
+		Weights: &Weights{
+			Passing: 2,
+			Warning: 2,
+		},
+		EnableTagOverride: true,
+		ProxyDestination:  "qwer",
+		Proxy: ConnectProxyConfig{
+			DestinationServiceName: "zoo",
+			DestinationServiceID:   "zoo:1",
+			LocalServiceAddress:    "127.0.0.2",
+			LocalServicePort:       6789,
+			Config: map[string]interface{}{
+				"bar": 2,
+			},
+		},
+		Connect: ServiceConnect{
+			Native: true,
+		},
+		LocallyRegisteredAsSidecar: true,
+	}
+
+	expected := &NodeService{
+		Kind:    "other",
+		ID:      "bar:1",
+		Service: "bar",
+		Tags:    []string{"a", "b", "c", "d"},
+		Address: "127.0.0.2",
+		Meta: map[string]string{
+			"a": "b",
+			"c": "d",
+		},
+		Port: 4567,
+		Weights: &Weights{
+			Passing: 2,
+			Warning: 2,
+		},
+		EnableTagOverride: true,
+		ProxyDestination:  "qwer",
+		Proxy: ConnectProxyConfig{
+			DestinationServiceName: "zoo",
+			DestinationServiceID:   "zoo:1",
+			LocalServiceAddress:    "127.0.0.2",
+			LocalServicePort:       6789,
+			Config: map[string]interface{}{
+				"foo": 1,
+				"bar": 2,
+			},
+		},
+		Connect: ServiceConnect{
+			Native: true,
+		},
+		LocallyRegisteredAsSidecar: true,
+	}
+
+	a.Merge(b)
+
+	require.Equal(t, expected, a)
+}
+
 func TestStructs_HealthCheck_IsSame(t *testing.T) {
 	hc := &HealthCheck{
 		Node:        "node1",

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/logger"
+	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
This PR adds a service registration manager to the agent as part of the centralized service config work. The service registration manager is a layer in the middle of the existing service registration workflow that is responsible for merging any local service registrations with centrally defined proxy/service defaults before the service entry is actually updated.

There's still one or two more tests to add, but everything else is finished enough for review.

The remaining things to finish out the initial central service config are:

HTTP endpoints
- [x] GET `/config/:kind/:name` 
- [x] GET `/config/:kind` HTTP endpoint
- [ ] PUT `/config` HTTP endpoint
- [x] DELETE `/config/:kind/:name` HTTP endpoint

CLI commands
- [ ] `consul config write` command
- [ ] `consul config read` command

Misc.
- [ ] Agent config field for bootstrapping the global proxy config (@mkeeler)
- [ ] Replication of config entries from the primary DC (@mkeeler)