### PR TITLE
docs/agent/options: Add go-sockaddr template examples for -bind

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -96,7 +96,22 @@ at startup. If you specify "[::]", Consul will
 IPv6 address. If there are **multiple public IPv6 addresses** available, Consul
 will exit with an error at startup.
   Consul uses both TCP and UDP and the same port for both. If you
-  have any firewalls, be sure to allow both protocols. **In Consul 1.0 and later this can be set to a [go-sockaddr](https://godoc.org/github.com/hashicorp/go-sockaddr/template) template that needs to resolve to a single address.**
+  have any firewalls, be sure to allow both protocols. **In Consul 1.0 and later this can be set to a [go-sockaddr](https://godoc.org/github.com/hashicorp/go-sockaddr/template) template that needs to resolve to a single address.** Some example templates:
+
+    ```sh
+    # Using address within a specific CIDR
+    $ consul agent -bind '{{ GetPrivateInterfaces | include "network" "10.0.0.0/8" | attr "address" }}'
+    ```
+
+    ```sh
+    # Using a static network interface name
+    $ consul agent -bind '{{ GetInterfaceIP "eth0" }}'
+    ```
+
+    ```sh
+    # Using regular expression matching for network interface name that is forwardable and up
+    $ consul agent -bind '{{ GetAllInterfaces | include "name" "^eth" | include "flags" "forwardable|up" | attr "address" }}'
+    ```
 
 * <a name="_serf_wan_bind"></a><a href="#_serf_wan_bind">`-serf-wan-bind`</a> -
   The address that should be bound to for Serf WAN gossip communications. By


### PR DESCRIPTION
Closes #4090

Examples covering a variety of potential use cases. Verified via `sockaddr eval` and `console agent -bind` on a test machine:

```console
# Baseline
$ sockaddr eval 'GetAllInterfaces'
[127.0.0.1/8 {1 65536 lo  up|loopback} ::1 {1 65536 lo  up|loopback} 10.0.0.10/8 {2 1500 eth0 b8:27:eb:7b:36:95 up|broadcast|multicast} fe80::12dc:5e4d:8ff8:2d96/64 {2 1500 eth0 b8:27:eb:7b:36:95 up|broadcast|multicast} 192.168.1.10/24 {3 1500 wlan0 b8:27:eb:2e:63:c0 up|broadcast|multicast} fe80::b6dc:5758:c306:b15b/64 {3 1500 wlan0 b8:27:eb:2e:63:c0 up|broadcast|multicast}]

# Using address within a specific CIDR
$ sockaddr eval 'GetPrivateInterfaces | include "network" "10.0.0.0/8" | attr "address"'
10.0.0.10

# Using a static network interface name
$ sockaddr eval 'GetInterfaceIP "eth0"'
10.0.0.10

# Using regular expression matching for network interface name that is forwardable and up
$ sockaddr eval 'GetAllInterfaces | include "name" "^eth" | include "flags" "forwardable|up" | attr "address"'
10.0.0.10
```