### PR TITLE
ui: Ensure an EventSource isn't opened if closed before first tick

### DIFF
--- a/ui-v2/app/utils/dom/event-source/callable.js
+++ b/ui-v2/app/utils/dom/event-source/callable.js
@@ -41,11 +41,15 @@ export default function(
               return P.resolve();
             }
           : source;
-      this.readyState = 0; // connecting
+      this.readyState = 0; // CONNECTING
       P.resolve()
         .then(() => {
+          // if we are already closed, don't do anything
+          if (this.readyState !== 0) {
+            return;
+          }
           this.readyState = 1; // open
-          // ...that the connection _was just_ opened
+          // the connection _was just_ opened
           this.dispatchEvent({ type: 'open' });
           return run(this, configuration, isClosed);
         })
@@ -63,8 +67,13 @@ export default function(
     }
     close() {
       // additional readyState 3 = CLOSING
-      if (this.readyState !== 2) {
-        this.readyState = 3;
+      switch (this.readyState) {
+        case 0: // CONNECTING
+        case 2: // CLOSED
+          this.readyState = 2; // CLOSED
+          break;
+        default:
+          this.readyState = 3; // CLOSING
       }
     }
   };

--- a/ui-v2/tests/integration/utils/dom/event-source/callable-test.js
+++ b/ui-v2/tests/integration/utils/dom/event-source/callable-test.js
@@ -81,4 +81,19 @@ module('Integration | Utility | dom/event-source/callable', function(hooks) {
       });
     });
   });
+  test("it can be closed before the first tick, and therefore doesn't run", function(assert) {
+    assert.expect(3);
+    const EventSource = domEventSourceCallable(EventTarget);
+    const listener = this.stub();
+    const source = new EventSource();
+    source.close();
+    assert.equal(source.readyState, 2);
+    source.addEventListener('open', function(e) {
+      listener();
+    });
+    return Promise.resolve().then(function() {
+      assert.notOk(listener.called);
+      assert.equal(source.readyState, 2);
+    });
+  });
 });


### PR DESCRIPTION
EventSources will wait for 1 tick before 'opening'. There is always the
chance that the EventSource is '.close()'ed before that tick. We
therefore check the 'readyState' before opening the EventSource.

Currently, within the UI application code there is no way to, or at least no where we, interact with the EventSource before the first tick, so this 'bugfix' doesn't 'fix' anything as yet.

Future work probably involves us closing an EventSource before opening it again later (in response to a user interaction rather than a URL change). We chose to always have EventSources open by default as that's how real EventSource's work (not the CallableEventSources what we talk about here)

The actual work is pretty much Ln 47-49, but we've taken the opportunity to add/edit more comments, plus we also need to consider that a `0` readyState will immediately `close` so it doesn't need a `closing` state.