### PR TITLE
Enabling "service" watch handler to accept a slice of tags

### DIFF
--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -134,7 +134,10 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 		return nil, err
 	}
 
-	var service, tag string
+	var (
+		service, tag string
+		tags         []string
+	)
 	if err := assignValue(params, "service", &service); err != nil {
 		return nil, err
 	}
@@ -146,6 +149,18 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 		return nil, err
 	}
 
+	if err := assignValueStringSlice(params, "tags", &tags); err != nil {
+		return nil, err
+	}
+
+	if tag != "" {
+		if tags == nil {
+			tags = []string{tag}
+		} else {
+			tags = append(tags, tag)
+		}
+	}
+
 	passingOnly := false
 	if err := assignValueBool(params, "passingonly", &passingOnly); err != nil {
 		return nil, err
@@ -155,7 +170,7 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 		health := p.client.Health()
 		opts := makeQueryOptionsWithContext(p, stale)
 		defer p.cancelFunc()
-		nodes, meta, err := health.Service(service, tag, passingOnly, &opts)
+		nodes, meta, err := health.ServiceMultipleTags(service, tags, passingOnly, &opts)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/api/watch/funcs.go
+++ b/api/watch/funcs.go
@@ -135,8 +135,8 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 	}
 
 	var (
-		service, tag string
-		tags         []string
+		service string
+		tags    []string
 	)
 	if err := assignValue(params, "service", &service); err != nil {
 		return nil, err
@@ -144,21 +144,8 @@ func serviceWatch(params map[string]interface{}) (WatcherFunc, error) {
 	if service == "" {
 		return nil, fmt.Errorf("Must specify a single service to watch")
 	}
-
-	if err := assignValue(params, "tag", &tag); err != nil {
+	if err := assignValueStringSlice(params, "tag", &tags); err != nil {
 		return nil, err
-	}
-
-	if err := assignValueStringSlice(params, "tags", &tags); err != nil {
-		return nil, err
-	}
-
-	if tag != "" {
-		if tags == nil {
-			tags = []string{tag}
-		} else {
-			tags = append(tags, tag)
-		}
 	}
 
 	passingOnly := false

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -430,7 +430,7 @@ func TestServiceWatch(t *testing.T) {
 
 func TestServiceMultipleTagsWatch(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t.Name(), ``)
+	a := agent.NewTestAgent(t, t.Name(), ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -428,6 +428,102 @@ func TestServiceWatch(t *testing.T) {
 	wg.Wait()
 }
 
+func TestServiceMultipleTagsWatch(t *testing.T) {
+	t.Parallel()
+	a := agent.NewTestAgent(t.Name(), ``)
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	invoke := makeInvokeCh()
+	plan := mustParse(t, `{"type":"service", "service":"foo", "tag": "bar", "tags":["buzz"], "passingonly":true}`)
+	plan.Handler = func(idx uint64, raw interface{}) {
+		if raw == nil {
+			return // ignore
+		}
+		v, ok := raw.([]*consulapi.ServiceEntry)
+		if !ok || len(v) == 0 {
+			return // ignore
+		}
+		if v[0].Service.ID != "foobarbuzzbiff" {
+			invoke <- errBadContent
+			return
+		}
+		if len(v[0].Service.Tags) == 0 {
+			invoke <- errBadContent
+			return
+		}
+		// test for our tags
+		barFound := false
+		buzzFound := false
+		for _, t := range v[0].Service.Tags {
+			if t == "bar" {
+				barFound = true
+			} else if t == "buzz" {
+				buzzFound = true
+			}
+		}
+		if !barFound || !buzzFound {
+			invoke <- errBadContent
+			return
+		}
+		invoke <- nil
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		agent := a.Client().Agent()
+
+		// we do not want to find this one.
+		time.Sleep(20 * time.Millisecond)
+		reg := &consulapi.AgentServiceRegistration{
+			ID:   "foobarbiff",
+			Name: "foo",
+			Tags: []string{"bar", "biff"},
+		}
+		if err := agent.ServiceRegister(reg); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// we do not want to find this one.
+		reg = &consulapi.AgentServiceRegistration{
+			ID:   "foobuzzbiff",
+			Name: "foo",
+			Tags: []string{"buzz", "biff"},
+		}
+		if err := agent.ServiceRegister(reg); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+
+		// we want to find this one
+		reg = &consulapi.AgentServiceRegistration{
+			ID:   "foobarbuzzbiff",
+			Name: "foo",
+			Tags: []string{"bar", "buzz", "biff"},
+		}
+		if err := agent.ServiceRegister(reg); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := plan.Run(a.HTTPAddr()); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	}()
+
+	if err := <-invoke; err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	plan.Stop()
+	wg.Wait()
+}
+
 func TestChecksWatch_State(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -435,7 +435,7 @@ func TestServiceMultipleTagsWatch(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	invoke := makeInvokeCh()
-	plan := mustParse(t, `{"type":"service", "service":"foo", "tag": "bar", "tags":["buzz"], "passingonly":true}`)
+	plan := mustParse(t, `{"type":"service", "service":"foo", "tag":["bar","buzz"], "passingonly":true}`)
 	plan.Handler = func(idx uint64, raw interface{}) {
 		if raw == nil {
 			return // ignore

--- a/api/watch/watch.go
+++ b/api/watch/watch.go
@@ -233,21 +233,30 @@ func assignValueBool(params map[string]interface{}, name string, out *bool) erro
 	return nil
 }
 
-// assignValueStringSlice is used to extract a value ensuring it is a slice of strings
+// assignValueStringSlice is used to extract a value ensuring it is either a string or a slice of strings
 func assignValueStringSlice(params map[string]interface{}, name string, out *[]string) error {
 	if raw, ok := params[name]; ok {
-		val, ok := raw.([]interface{})
-		if !ok {
-			return fmt.Errorf("Expecting %s to be a []string", name)
-		}
-		l := len(val)
-		tmp := make([]string, l, l)
-		for i := 0; i < l; i++ {
-			if s, ok := val[i].(string); !ok {
-				return fmt.Errorf("Index %d of %s expected to be string", i, name)
-			} else {
-				tmp[i] = s
+		var tmp []string
+		switch raw.(type) {
+		case string:
+			tmp = make([]string, 1, 1)
+			tmp[0] = raw.(string)
+		case []string:
+			l := len(raw.([]string))
+			tmp = make([]string, l, l)
+			copy(tmp, raw.([]string))
+		case []interface{}:
+			l := len(raw.([]interface{}))
+			tmp = make([]string, l, l)
+			for i, v := range raw.([]interface{}) {
+				if s, ok := v.(string); ok {
+					tmp[i] = s
+				} else {
+					return fmt.Errorf("Index %d of %s expected to be string", i, name)
+				}
 			}
+		default:
+			return fmt.Errorf("Expecting %s to be a string or []string", name)
 		}
 		*out = tmp
 		delete(params, name)

--- a/api/watch/watch.go
+++ b/api/watch/watch.go
@@ -233,6 +233,28 @@ func assignValueBool(params map[string]interface{}, name string, out *bool) erro
 	return nil
 }
 
+// assignValueStringSlice is used to extract a value ensuring it is a slice of strings
+func assignValueStringSlice(params map[string]interface{}, name string, out *[]string) error {
+	if raw, ok := params[name]; ok {
+		val, ok := raw.([]interface{})
+		if !ok {
+			return fmt.Errorf("Expecting %s to be a []string", name)
+		}
+		l := len(val)
+		tmp := make([]string, l, l)
+		for i := 0; i < l; i++ {
+			if s, ok := val[i].(string); !ok {
+				return fmt.Errorf("Index %d of %s expected to be string", i, name)
+			} else {
+				tmp[i] = s
+			}
+		}
+		*out = tmp
+		delete(params, name)
+	}
+	return nil
+}
+
 // Parse the 'http_handler_config' parameters
 func parseHttpHandlerConfig(configParams interface{}) (*HttpHandlerConfig, error) {
 	var config HttpHandlerConfig

--- a/command/watch/watch.go
+++ b/command/watch/watch.go
@@ -36,7 +36,7 @@ type cmd struct {
 	key         string
 	prefix      string
 	service     string
-	tag         string
+	tag         []string
 	passingOnly string
 	state       string
 	name        string
@@ -55,8 +55,8 @@ func (c *cmd) init() {
 	c.flags.StringVar(&c.service, "service", "",
 		"Specifies the service to watch. Required for 'service' type, "+
 			"optional for 'checks' type.")
-	c.flags.StringVar(&c.tag, "tag", "",
-		"Specifies the service tag to filter on. Optional for 'service' type.")
+	c.flags.Var((*flags.AppendSliceValue)(&c.tag), "tag", "Specifies the service tag(s) to filter on. "+
+		"Optional for 'service' type. May be specified multiple times")
 	c.flags.StringVar(&c.passingOnly, "passingonly", "",
 		"Specifies if only hosts passing all checks are displayed. "+
 			"Optional for 'service' type, must be one of `[true|false]`. Defaults false.")
@@ -107,7 +107,7 @@ func (c *cmd) Run(args []string) int {
 	if c.service != "" {
 		params["service"] = c.service
 	}
-	if c.tag != "" {
+	if len(c.tag) > 0 {
 		params["tag"] = c.tag
 	}
 	if c.http.Stale() {

--- a/website/source/docs/agent/watches.html.md
+++ b/website/source/docs/agent/watches.html.md
@@ -267,7 +267,7 @@ An example of the output of this command:
 The "service" watch type is used to monitor the providers
 of a single service. It requires the "service" parameter
 and optionally takes the parameters "tag" and 
-"passingonly". The "tag" parameter will filter by tag or tags.
+"passingonly". The "tag" parameter will filter by one or more tags.
 It may be either a single string value or a slice of strings.
 The "passingonly" is a boolean that will filter to only the 
 instances passing all health checks.

--- a/website/source/docs/agent/watches.html.md
+++ b/website/source/docs/agent/watches.html.md
@@ -266,26 +266,48 @@ An example of the output of this command:
 
 The "service" watch type is used to monitor the providers
 of a single service. It requires the "service" parameter
-and optionally takes the parameters "tag" and "passingonly".
-The "tag" parameter will filter by tag, and "passingonly" is
-a boolean that will filter to only the instances passing all
-health checks.
+and optionally takes the parameters "tag", "tags", and 
+"passingonly". The "tag" parameter will filter by tag or tags.
+It may be either a single string value or a slice of strings.
+The "passingonly" is a boolean that will filter to only the 
+instances passing all health checks.
+
+If you pass in both "-tag" and "-tags", the value of "-tag"
+will be appended to the list provided to "-tags".
 
 This maps to the `/v1/health/service` API internally.
 
-Here is an example configuration:
+Here is an example configuration with a single tag:
 
 ```javascript
 {
   "type": "service",
   "service": "redis",
-  "args": ["/usr/bin/my-service-handler.sh", "-redis"]
+  "args": ["/usr/bin/my-service-handler.sh", "-redis"],
+  "tag": "bar"
+}
+```
+
+Here is an example configuration with multiple tags:
+
+```javascript
+{
+  "type": "service",
+  "service": "redis",
+  "args": ["/usr/bin/my-service-handler.sh", "-redis"],
+  "tag": ["bar", "foo"]
 }
 ```
 
 Or, using the watch command:
 
-    $ consul watch -type=service -service=redis /usr/bin/my-service-handler.sh
+Single tag:
+
+    $ consul watch -type=service -service=redis -tag=bar /usr/bin/my-service-handler.sh
+
+Multiple tag:
+
+    $ consul watch -type=service -service=redis -tag=bar -tag=foo /usr/bin/my-service-handler.sh
 
 An example of the output of this command:
 
@@ -299,7 +321,10 @@ An example of the output of this command:
     "Service": {
       "ID": "redis",
       "Service": "redis",
-      "Tags": null,
+      "Tags": [
+        "bar", 
+        "foo"
+      ],
       "Port": 8000
     },
     "Checks": [

--- a/website/source/docs/agent/watches.html.md
+++ b/website/source/docs/agent/watches.html.md
@@ -272,9 +272,6 @@ It may be either a single string value or a slice of strings.
 The "passingonly" is a boolean that will filter to only the 
 instances passing all health checks.
 
-If you pass in both "-tag" and "-tags", the value of "-tag"
-will be appended to the list provided to "-tags".
-
 This maps to the `/v1/health/service` API internally.
 
 Here is an example configuration with a single tag:

--- a/website/source/docs/agent/watches.html.md
+++ b/website/source/docs/agent/watches.html.md
@@ -266,7 +266,7 @@ An example of the output of this command:
 
 The "service" watch type is used to monitor the providers
 of a single service. It requires the "service" parameter
-and optionally takes the parameters "tag", "tags", and 
+and optionally takes the parameters "tag" and 
 "passingonly". The "tag" parameter will filter by tag or tags.
 It may be either a single string value or a slice of strings.
 The "passingonly" is a boolean that will filter to only the 


### PR DESCRIPTION
Thanks @dcarbone for all the work here.

I took PR #5347 and rebased it on top of master as there were conflicts due to moving the watch package into the api module.