### PR TITLE
cli: actually allow the 'connect envoy' and 'watch' subcommands to work with -token-file

### DIFF
--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -191,6 +191,11 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	httpCfg := api.DefaultConfig()
 	c.http.MergeOntoConfig(httpCfg)
 
+	// Trigger the Client init to do any last-minute updates to the Config.
+	if _, err := api.NewClient(httpCfg); err != nil {
+		return nil, err
+	}
+
 	// Decide on TLS if the scheme is provided and indicates it, if the HTTP env
 	// suggests TLS is supported explicitly (CONSUL_HTTP_SSL) or implicitly
 	// (CONSUL_HTTP_ADDR) is https://

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -1,0 +1,60 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy"
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 8502
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+			"stats_tags": [
+				{
+			"tag_name": "local_cluster",
+			"fixed_value": "test-proxy"
+		}
+			],
+			"use_all_default_tags": true
+		},
+  "dynamic_resources": {
+    "lds_config": { "ads": {} },
+    "cds_config": { "ads": {} },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -1,0 +1,60 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy"
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 8502
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+			"stats_tags": [
+				{
+			"tag_name": "local_cluster",
+			"fixed_value": "test-proxy"
+		}
+			],
+			"use_all_default_tags": true
+		},
+  "dynamic_resources": {
+    "lds_config": { "ads": {} },
+    "cds_config": { "ads": {} },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -1,0 +1,60 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy"
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 8502
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+			"stats_tags": [
+				{
+			"tag_name": "local_cluster",
+			"fixed_value": "test-proxy"
+		}
+			],
+			"use_all_default_tags": true
+		},
+  "dynamic_resources": {
+    "lds_config": { "ads": {} },
+    "cds_config": { "ads": {} },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -1,0 +1,60 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy"
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 8502
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+			"stats_tags": [
+				{
+			"tag_name": "local_cluster",
+			"fixed_value": "test-proxy"
+		}
+			],
+			"use_all_default_tags": true
+		},
+  "dynamic_resources": {
+    "lds_config": { "ads": {} },
+    "cds_config": { "ads": {} },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -1,12 +1,17 @@
 package watch
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWatchCommand_noTabs(t *testing.T) {
@@ -34,6 +39,100 @@ func TestWatchCommand(t *testing.T) {
 	if !strings.Contains(ui.OutputWriter.String(), a.Config.NodeName) {
 		t.Fatalf("bad: %#v", ui.OutputWriter.String())
 	}
+}
+
+func TestWatchCommand_loadToken(t *testing.T) {
+	a := agent.NewTestAgent(t, t.Name(), ` `)
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	const testToken = "4a0db5a1-869f-4602-ae8a-b0306a82f1ef"
+	testDir := testutil.TempDir(t, "watchtest")
+	defer os.RemoveAll(testDir)
+
+	fullname := filepath.Join(testDir, "token.txt")
+	require.NoError(t, ioutil.WriteFile(fullname, []byte(testToken), 0600))
+
+	resetEnv := func() {
+		os.Unsetenv("CONSUL_HTTP_TOKEN")
+		os.Unsetenv("CONSUL_HTTP_TOKEN_FILE")
+	}
+
+	t.Run("token arg", func(t *testing.T) {
+		resetEnv()
+		defer resetEnv()
+
+		ui := cli.NewMockUi()
+		c := New(ui, nil)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-type=nodes",
+			"-token", testToken,
+		}
+
+		require.NoError(t, c.flags.Parse(args))
+
+		tok, err := c.loadToken()
+		require.NoError(t, err)
+		require.Equal(t, testToken, tok)
+	})
+
+	t.Run("token env", func(t *testing.T) {
+		resetEnv()
+		defer resetEnv()
+
+		ui := cli.NewMockUi()
+		c := New(ui, nil)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-type=nodes",
+		}
+		os.Setenv("CONSUL_HTTP_TOKEN", testToken)
+
+		require.NoError(t, c.flags.Parse(args))
+
+		tok, err := c.loadToken()
+		require.NoError(t, err)
+		require.Equal(t, testToken, tok)
+	})
+
+	t.Run("token file arg", func(t *testing.T) {
+		resetEnv()
+		defer resetEnv()
+
+		ui := cli.NewMockUi()
+		c := New(ui, nil)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-type=nodes",
+			"-token-file", fullname,
+		}
+
+		require.NoError(t, c.flags.Parse(args))
+
+		tok, err := c.loadToken()
+		require.NoError(t, err)
+		require.Equal(t, testToken, tok)
+	})
+
+	t.Run("token file env", func(t *testing.T) {
+		resetEnv()
+		defer resetEnv()
+
+		ui := cli.NewMockUi()
+		c := New(ui, nil)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-type=nodes",
+		}
+		os.Setenv("CONSUL_HTTP_TOKEN_FILE", fullname)
+
+		require.NoError(t, c.flags.Parse(args))
+
+		tok, err := c.loadToken()
+		require.NoError(t, err)
+		require.Equal(t, testToken, tok)
+	})
 }
 
 func TestWatchCommandNoConnect(t *testing.T) {


### PR DESCRIPTION
During end-to-end testing with connect, envoy, and the secure intro work I noticed that the `consul connect envoy` and `consul watch` subcommands didn't always pick up the consul token when it was specified in a file.