### PR TITLE
CI: Run html-proofer check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 references:
   images:
     go: &GOLANG_IMAGE circleci/golang:1.12.1
-    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.35
+    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.40
     ember: &EMBER_IMAGE circleci/node:8-browsers
 
   paths:
@@ -229,8 +229,6 @@ jobs:
       - attach_workspace:
           at: ~/project/website
 
-
-      # rerun build with 'ENV=production' to add analytics
       - run:
           name: install gems
           command: bundle check || bundle install --path vendor/bundle --retry=3
@@ -247,9 +245,12 @@ jobs:
   # HTML validation
   html-validation:
     docker:
-      - image: circleci/ruby:latest
+      - image: *MIDDLEMAN_IMAGE
     working_directory: ~/project/website
     steps:
+      - checkout:
+          path: ~/project
+
       # restores gem cache
       - restore_cache:
           key: *RUBYGEM_CACHE_KEY
@@ -261,12 +262,13 @@ jobs:
       # attach website build directory
       - attach_workspace:
           at: ~/project/website
+
       # there are a bunch of anchors we need to clean up before we can use this step to fail builds so exit 0 always for now
-      - run: htmlproofer --checks_to_ignore ImageCheck,ScriptCheck --disable-external ./build 2>&1  | tee html-validation.txt || exit 0
+      - run: bundle exec htmlproofer --checks-to-ignore ImageCheck,ScriptCheck --disable-external ./build 2>&1  | tee html-validation.txt || exit 0
       - store_artifacts:
           path: html-validation.txt
 
-  # Link check on a temporary netlify deployed site
+  # Link check on a temporary Netlify deployed site
   docs-link-checker:
     docker:
       - image: circleci/node:lts
@@ -370,62 +372,62 @@ jobs:
 
 workflows:
   version: 2
-  # build-distros:
-  #   jobs:
-  #     - go-fmt-and-vet
-  #     - build-386: &require-go-fmt-vet
-  #         requires:
-  #           - go-fmt-and-vet
-  #     - build-amd64: *require-go-fmt-vet
-  #     - build-arm-arm64: *require-go-fmt-vet
-  # test-integrations:
-  #   jobs:
-  #     - dev-build
-  #     - dev-upload-s3:
-  #         requires:
-  #           - dev-build
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only push dev builds from non forks
-  #     - nomad-integration-master:
-  #         requires:
-  #           - dev-build
-  #     - nomad-integration-0_8:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.8.0:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.9.1:
-  #         requires:
-  #           - dev-build
+  build-distros:
+    jobs:
+      - go-fmt-and-vet
+      - build-386: &require-go-fmt-vet
+          requires:
+            - go-fmt-and-vet
+      - build-amd64: *require-go-fmt-vet
+      - build-arm-arm64: *require-go-fmt-vet
+  test-integrations:
+    jobs:
+      - dev-build
+      - dev-upload-s3:
+          requires:
+            - dev-build
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only push dev builds from non forks
+      - nomad-integration-master:
+          requires:
+            - dev-build
+      - nomad-integration-0_8:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.8.0:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.9.1:
+          requires:
+            - dev-build
   website:
     jobs:
       - build-website
       - html-validation:
           requires:
             - build-website
-  #     - docs-link-checker:
-  #         requires:
-  #           - build-website
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only run link checker on non forks
-  #     - deploy-website:
-  #         requires:
-  #           - docs-link-checker
-  #         context: static-sites
-  #         filters:
-  #           branches:
-  #             only: stable-website
-  # frontend:
-  #   jobs:
-  #     - frontend-cache
-  #     - ember-build:
-  #         requires:
-  #           - frontend-cache
-  #     - ember-test:
-  #         requires:
-  #           - ember-build
+      - docs-link-checker:
+          requires:
+            - build-website
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only run link checker on non forks
+      - deploy-website:
+          requires:
+            - docs-link-checker
+          context: static-sites
+          filters:
+            branches:
+              only: stable-website
+  frontend:
+    jobs:
+      - frontend-cache
+      - ember-build:
+          requires:
+            - frontend-cache
+      - ember-test:
+          requires:
+            - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,20 @@ jobs:
           name: website deploy
           command: ./scripts/deploy.sh
 
+  # HTML validation
+  html-validation:
+    docker:
+      - image: circleci/ruby:latest
+    working_directory: ~/project/website
+    steps:
+      - run: gem install html-proofer
+      # attach website build directory
+      - attach_workspace:
+          at: ~/project/website
+      - run: htmlproofer --checks_to_ignore ImageCheck,ScriptCheck --disable-external ./build 2>&1  | tee html-validation.txt
+      - store_artifacts:
+          path: html-validation.txt
+
   # Link check on a temporary netlify deployed site
   docs-link-checker:
     docker:
@@ -350,59 +364,62 @@ jobs:
 
 workflows:
   version: 2
-  build-distros:
-    jobs:
-      - go-fmt-and-vet
-      - build-386: &require-go-fmt-vet
-          requires:
-            - go-fmt-and-vet
-      - build-amd64: *require-go-fmt-vet
-      - build-arm-arm64: *require-go-fmt-vet
-  test-integrations:
-    jobs:
-      - dev-build
-      - dev-upload-s3:
-          requires:
-            - dev-build
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only push dev builds from non forks
-      - nomad-integration-master:
-          requires:
-            - dev-build
-      - nomad-integration-0_8:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.8.0:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.9.1:
-          requires:
-            - dev-build
+  # build-distros:
+  #   jobs:
+  #     - go-fmt-and-vet
+  #     - build-386: &require-go-fmt-vet
+  #         requires:
+  #           - go-fmt-and-vet
+  #     - build-amd64: *require-go-fmt-vet
+  #     - build-arm-arm64: *require-go-fmt-vet
+  # test-integrations:
+  #   jobs:
+  #     - dev-build
+  #     - dev-upload-s3:
+  #         requires:
+  #           - dev-build
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only push dev builds from non forks
+  #     - nomad-integration-master:
+  #         requires:
+  #           - dev-build
+  #     - nomad-integration-0_8:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.8.0:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.9.1:
+  #         requires:
+  #           - dev-build
   website:
     jobs:
       - build-website
-      - docs-link-checker:
+      - html-validation:
           requires:
             - build-website
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only run link checker on non forks
-      - deploy-website:
-          requires:
-            - docs-link-checker
-          context: static-sites
-          filters:
-            branches:
-              only: stable-website
-  frontend:
-    jobs:
-      - frontend-cache
-      - ember-build:
-          requires:
-            - frontend-cache
-      - ember-test:
-          requires:
-            - ember-build
+  #     - docs-link-checker:
+  #         requires:
+  #           - build-website
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only run link checker on non forks
+  #     - deploy-website:
+  #         requires:
+  #           - docs-link-checker
+  #         context: static-sites
+  #         filters:
+  #           branches:
+  #             only: stable-website
+  # frontend:
+  #   jobs:
+  #     - frontend-cache
+  #     - ember-build:
+  #         requires:
+  #           - frontend-cache
+  #     - ember-test:
+  #         requires:
+  #           - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,9 +229,7 @@ jobs:
       - attach_workspace:
           at: ~/project/website
 
-      # restores gem cache
-      - restore_cache:
-          key: *RUBYGEM_CACHE_KEY
+
       # rerun build with 'ENV=production' to add analytics
       - run:
           name: install gems
@@ -252,11 +250,19 @@ jobs:
       - image: circleci/ruby:latest
     working_directory: ~/project/website
     steps:
-      - run: gem install html-proofer
+      # restores gem cache
+      - restore_cache:
+          key: *RUBYGEM_CACHE_KEY
+
+      - run:
+          name: install gems
+          command: bundle check || bundle install --path vendor/bundle --retry=3
+
       # attach website build directory
       - attach_workspace:
           at: ~/project/website
-      - run: htmlproofer --checks_to_ignore ImageCheck,ScriptCheck --disable-external ./build 2>&1  | tee html-validation.txt
+      # there are a bunch of anchors we need to clean up before we can use this step to fail builds so exit 0 always for now
+      - run: htmlproofer --checks_to_ignore ImageCheck,ScriptCheck --disable-external ./build 2>&1  | tee html-validation.txt || exit 0
       - store_artifacts:
           path: html-validation.txt
 

--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,7 @@
 source "https://rubygems.org"
 
 gem "middleman-hashicorp", "0.3.35"
+
+group :development do
+  gem 'html-proofer'
+end

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -6,6 +6,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     autoprefixer-rails (9.4.10)
       execjs
     bootstrap-sass (3.4.1)
@@ -23,6 +25,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    colorize (0.8.1)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -39,6 +42,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.5)
     execjs (2.7.0)
     ffi (1.9.25)
@@ -48,6 +53,15 @@ GEM
     hike (1.2.3)
     hooks (0.4.1)
       uber (~> 0.0.14)
+    html-proofer (3.10.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.9)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (2.1.0)
@@ -55,6 +69,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
     middleman (3.4.1)
       coffee-script (~> 2.2)
       compass (>= 1.0.0, < 2.0.0)
@@ -112,6 +127,8 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.12.9)
       activesupport (>= 3.1)
+    parallel (1.17.0)
+    public_suffix (3.0.3)
     rack (1.6.11)
     rack-livereload (0.3.17)
       rack
@@ -144,6 +161,8 @@ GEM
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uber (0.0.15)
@@ -152,12 +171,14 @@ GEM
       json (>= 1.8.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
+    yell (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   middleman-hashicorp (= 0.3.35)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
This might be noise but hopefully, it helps @kaitlincarter-hc find broken anchors. We have a bunch that the normal `wget` link checking doesn't find because it isn't an actual _broken link_. 

This runs the [linkcheck](https://github.com/gjtorikian/html-proofer#links) in https://github.com/gjtorikian/html-proofer against the local website `./build` directory.

It just `exit 0` because we have a bunch of broken anchors that would fail that step. I just wanted to run this to see what results we would get and if we ever wanted to go back and comb through the broken anchors, we can actually fail on this step. 