### PR TITLE
ui: Reconcile ember-data store when records are deleted via blocking

### DIFF
--- a/ui-v2/app/models/coordinate.js
+++ b/ui-v2/app/models/coordinate.js
@@ -10,4 +10,5 @@ export default Model.extend({
   Coord: attr(),
   Segment: attr('string'),
   Datacenter: attr('string'),
+  SyncTime: attr('number'),
 });

--- a/ui-v2/app/models/node.js
+++ b/ui-v2/app/models/node.js
@@ -21,6 +21,7 @@ export default Model.extend({
   Datacenter: attr('string'),
   Segment: attr(),
   Coord: attr(),
+  SyncTime: attr('number'),
   meta: attr(),
   hasStatus: function(status) {
     return hasStatus(get(this, 'Checks'), status);

--- a/ui-v2/app/models/proxy.js
+++ b/ui-v2/app/models/proxy.js
@@ -9,4 +9,5 @@ export default Model.extend({
   ServiceName: attr('string'),
   ServiceID: attr('string'),
   ServiceProxy: attr(),
+  SyncTime: attr('number'),
 });

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -30,6 +30,7 @@ export default Model.extend({
   Node: attr(),
   Service: attr(),
   Checks: attr(),
+  SyncTime: attr('number'),
   meta: attr(),
   passing: computed('ChecksPassing', 'Checks', function() {
     let num = 0;

--- a/ui-v2/app/models/session.js
+++ b/ui-v2/app/models/session.js
@@ -20,4 +20,5 @@ export default Model.extend({
     },
   }),
   Datacenter: attr('string'),
+  SyncTime: attr('number'),
 });

--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -1,6 +1,6 @@
 import Serializer from 'ember-data/serializers/rest';
 
-import { get, set } from '@ember/object';
+import { set } from '@ember/object';
 import {
   HEADERS_SYMBOL as HTTP_HEADERS_SYMBOL,
   HEADERS_INDEX as HTTP_HEADERS_INDEX,
@@ -44,12 +44,15 @@ export default Serializer.extend({
       requestType
     );
   },
+  timestamp: function() {
+    return new Date().getTime();
+  },
   normalizeMeta: function(store, primaryModelClass, headers, payload, id, requestType) {
     const meta = {
       cursor: headers[HTTP_HEADERS_INDEX],
     };
     if (requestType === 'query') {
-      meta.date = new Date().getTime();
+      meta.date = this.timestamp();
       payload.forEach(function(item) {
         set(item, 'SyncTime', meta.date);
       });

--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -1,6 +1,6 @@
 import Serializer from 'ember-data/serializers/rest';
 
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import {
   HEADERS_SYMBOL as HTTP_HEADERS_SYMBOL,
   HEADERS_INDEX as HTTP_HEADERS_INDEX,
@@ -47,11 +47,11 @@ export default Serializer.extend({
   normalizeMeta: function(store, primaryModelClass, headers, payload, id, requestType) {
     const meta = {
       cursor: headers[HTTP_HEADERS_INDEX],
-      date: headers['date'],
     };
     if (requestType === 'query') {
-      meta.ids = payload.map(item => {
-        return get(item, this.primaryKey);
+      meta.date = new Date().getTime();
+      payload.forEach(function(item) {
+        set(item, 'SyncTime', meta.date);
       });
     }
     return meta;

--- a/ui-v2/tests/integration/services/repository/coordinate-test.js
+++ b/ui-v2/tests/integration/services/repository/coordinate-test.js
@@ -1,13 +1,18 @@
 import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { get } from '@ember/object';
 const NAME = 'coordinate';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
-  integration: true
+  integration: true,
 });
 
 const dc = 'dc-1';
+const now = new Date().getTime();
 test('findAllByDatacenter returns the correct data for list endpoint', function(assert) {
+  get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
+    return now;
+  };
   return repo(
     'Coordinate',
     'findAllByDatacenter',
@@ -26,6 +31,7 @@ test('findAllByDatacenter returns the correct data for list endpoint', function(
         expected(function(payload) {
           return payload.map(item =>
             Object.assign({}, item, {
+              SyncTime: now,
               Datacenter: dc,
               uid: `["${dc}","${item.Node}"]`,
             })

--- a/ui-v2/tests/integration/services/repository/node-test.js
+++ b/ui-v2/tests/integration/services/repository/node-test.js
@@ -1,5 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { get } from '@ember/object';
 const NAME = 'node';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
@@ -8,7 +9,11 @@ moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
 
 const dc = 'dc-1';
 const id = 'token-name';
+const now = new Date().getTime();
 test('findByDatacenter returns the correct data for list endpoint', function(assert) {
+  get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
+    return now;
+  };
   return repo(
     'Node',
     'findAllByDatacenter',
@@ -27,6 +32,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
         expected(function(payload) {
           return payload.map(item =>
             Object.assign({}, item, {
+              SyncTime: now,
               Datacenter: dc,
               uid: `["${dc}","${item.ID}"]`,
             })
@@ -56,7 +62,6 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
             Datacenter: dc,
             uid: `["${dc}","${item.ID}"]`,
             meta: {
-              date: undefined,
               cursor: undefined,
             },
           });

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -1,6 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
 import { skip } from 'qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { get } from '@ember/object';
 const NAME = 'service';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
@@ -8,7 +9,11 @@ moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
 });
 const dc = 'dc-1';
 const id = 'token-name';
+const now = new Date().getTime();
 test('findByDatacenter returns the correct data for list endpoint', function(assert) {
+  get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
+    return now;
+  };
   return repo(
     'Service',
     'findAllByDatacenter',
@@ -27,6 +32,7 @@ test('findByDatacenter returns the correct data for list endpoint', function(ass
         expected(function(payload) {
           return payload.map(item =>
             Object.assign({}, item, {
+              SyncTime: now,
               Datacenter: dc,
               uid: `["${dc}","${item.Name}"]`,
             })
@@ -69,7 +75,6 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
           service.Nodes = nodes;
           service.Tags = payload.Nodes[0].Service.Tags;
           service.meta = {
-            date: undefined,
             cursor: undefined,
           };
 

--- a/ui-v2/tests/integration/services/repository/session-test.js
+++ b/ui-v2/tests/integration/services/repository/session-test.js
@@ -1,5 +1,6 @@
 import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { get } from '@ember/object';
 const NAME = 'session';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   // Specify the other units that are required for this test.
@@ -8,7 +9,11 @@ moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
 
 const dc = 'dc-1';
 const id = 'node-name';
+const now = new Date().getTime();
 test('findByNode returns the correct data for list endpoint', function(assert) {
+  get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
+    return now;
+  };
   return repo(
     'Session',
     'findByNode',
@@ -27,6 +32,7 @@ test('findByNode returns the correct data for list endpoint', function(assert) {
         expected(function(payload) {
           return payload.map(item =>
             Object.assign({}, item, {
+              SyncTime: now,
               Datacenter: dc,
               uid: `["${dc}","${item.ID}"]`,
             })


### PR DESCRIPTION
Currently we are barely using the ember-data store/cache, but it will
still cache records in the store even though technically we aren't using
it.

This adds a SyncTime to every record that uses blocking queries so we
can delete older records from the ember-data cache to prevent them
building up.

We decided against using the server time here, and are using a client timestamp instead. We also removed keeping track of id's of records in the meta data as using a SyncTime covers the usecase that keeping track of these id's was for.