### PR TITLE
ui: fix 'make ui' again

### DIFF
--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -114,8 +114,8 @@ function build_ui {
    if test ${ret} -eq 0
    then
       rm -rf ${1}/pkg/web_ui
-      mkdir -p ${1}/pkg/web_ui
-      cp -r ${1}/ui-v2/dist/ ${1}/pkg/web_ui
+      mkdir -p ${1}/pkg
+      cp -r ${1}/ui-v2/dist ${1}/pkg/web_ui
    fi
 
    popd > /dev/null


### PR DESCRIPTION
When the v1 ui was removed the ui build incorrectly copied everything
into a /dist/ subdirectory instead of directly into the top level.