### PR TITLE
Updates the snapshot agent docs to include a list of the ACLs required for operation

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -589,6 +589,14 @@ func (s *HTTPServer) AgentRegisterCheck(resp http.ResponseWriter, req *http.Requ
 		return nil, nil
 	}
 
+	if health.ServiceID != "" {
+		// fixup the service name so that vetCheckRegister requires the right ACLs
+		service := s.agent.State.Service(health.ServiceID)
+		if service != nil {
+			health.ServiceName = service.Service
+		}
+	}
+
 	// Get the provided token, if any, and vet against any ACL policies.
 	var token string
 	s.parseToken(req, &token)

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -398,3 +398,18 @@ func TestACLConfig() string {
 		acl_enforce_version_8 = true
 	`
 }
+
+func TestACLConfigNew() string {
+	return `
+		primary_datacenter = "dc1"
+		acl {
+			enabled = true
+			default_policy = "deny"
+			tokens {
+				master = "root"
+				agent = "root"
+				agent_master = "towel"
+			}
+		}
+	`
+}

--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -59,7 +59,6 @@ If ACLs are enabled the following privileges are required:
 | `key`     | `<lock key>`     | `write`    | The lock key (which defaults to `consul-snapshot/lock`) is used during snapshot agent leader election. |
 | `session` | `<agent name>`   | `write`    | The session used for locking during leader election is created against the agent name of the Consul agent that the Snapshot agent is registering itself with. |
 | `service` | `<service name>` | `write`    | The Snapshot agent registers itself with the local Consul agent and must have write privileges on it's service name which is configured with `-service`. |
-| `node`    | `<agent name>`   | `write`    | Write is required on the local Consul agents name in order to register health checks for the Snapshot agent. |
 
 ## Usage
 

--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -51,8 +51,15 @@ Snapshots can be restored using the
 [`consul snapshot restore`](/docs/commands/snapshot/restore.html) command, or
 the [HTTP API](/api/snapshot.html).
 
-If ACLs are enabled, a management token must be supplied in order to perform
-snapshot operations.
+If ACLs are enabled the following privileges are required:
+
+| Resource  | Segment          | Permission | Explanation |
+| --------- | ---------------- | ---------- | ----------- |
+| `acl`     | N/A              | `write`    | All snapshotting operations require this privilege due to snapshots containing ACL tokens including unredacted secrets. |
+| `key`     | `<lock key>`     | `write`    | The lock key (which defaults to `consul-snapshot/lock`) is used during snapshot agent leader election. |
+| `session` | `<agent name>`   | `write`    | The session used for locking during leader election is created against the agent name of the Consul agent that the Snapshot agent is registering itself with. |
+| `service` | `<service name>` | `write`    | The Snapshot agent registers itself with the local Consul agent and must have write privileges on it's service name which is configured with `-service`. |
+| `node`    | `<agent name>`   | `write`    | Write is required on the local Consul agents name in order to register health checks for the Snapshot agent. |
 
 ## Usage
 

--- a/website/source/docs/commands/snapshot/agent.html.markdown.erb
+++ b/website/source/docs/commands/snapshot/agent.html.markdown.erb
@@ -58,7 +58,7 @@ If ACLs are enabled the following privileges are required:
 | `acl`     | N/A              | `write`    | All snapshotting operations require this privilege due to snapshots containing ACL tokens including unredacted secrets. |
 | `key`     | `<lock key>`     | `write`    | The lock key (which defaults to `consul-snapshot/lock`) is used during snapshot agent leader election. |
 | `session` | `<agent name>`   | `write`    | The session used for locking during leader election is created against the agent name of the Consul agent that the Snapshot agent is registering itself with. |
-| `service` | `<service name>` | `write`    | The Snapshot agent registers itself with the local Consul agent and must have write privileges on it's service name which is configured with `-service`. |
+| `service` | `<service name>` | `write`    | The Snapshot agent registers itself with the local Consul agent and must have write privileges on its service name which is configured with `-service`. |
 
 ## Usage
 


### PR DESCRIPTION
This also fixes a bug in `vetCheckRegister` that was causing us to look for the wrong permission: `node:write` on the agent instead of `service:write` on the service associated with the check.

Fixes #5705 