### PR TITLE
Update to use a consulent build tag instead of just ent

### DIFF
--- a/agent/config/default_oss.go
+++ b/agent/config/default_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package config
 

--- a/agent/config/segment_oss.go
+++ b/agent/config/segment_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package config
 

--- a/agent/config/segment_oss_test.go
+++ b/agent/config/segment_oss_test.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package config
 

--- a/agent/consul/autopilot_oss.go
+++ b/agent/consul/autopilot_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package consul
 

--- a/agent/consul/enterprise_client_oss.go
+++ b/agent/consul/enterprise_client_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package consul
 

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package consul
 

--- a/agent/consul/leader_oss.go
+++ b/agent/consul/leader_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package consul
 

--- a/agent/consul/segment_oss.go
+++ b/agent/consul/segment_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package consul
 

--- a/agent/enterprise_delegate_oss.go
+++ b/agent/enterprise_delegate_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package agent
 

--- a/agent/structs/sanitize_oss.go
+++ b/agent/structs/sanitize_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package structs
 

--- a/sentinel/sentinel_oss.go
+++ b/sentinel/sentinel_oss.go
@@ -1,4 +1,4 @@
-// +build !ent
+// +build !consulent
 
 package sentinel
 


### PR DESCRIPTION
This will help to fix the issues using vault in the ent repo where we have conflicting build tags.