### PR TITLE
Do not trigger update check when in dev mode

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -232,7 +232,7 @@ func (c *cmd) run(args []string) int {
 	defer agent.ShutdownEndpoints()
 	defer agent.ShutdownAgent()
 
-	if !config.DisableUpdateCheck {
+	if !config.DisableUpdateCheck && !config.DevMode {
 		c.startupUpdateCheck(config)
 	}
 


### PR DESCRIPTION
Often when an agent is in dev mode, consul was built off of master.