### PR TITLE
Fix panic in Resolving service config when proxy-defaults is nil

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -256,11 +256,11 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 				if !ok {
 					return fmt.Errorf("invalid proxy config type %T", proxyEntry)
 				}
+				// Apply the proxy defaults to the sidecar's proxy config
+				reply.ProxyConfig = proxyConf.Config
 			}
 
 			reply.Index = index
-			// Apply the proxy defaults to the sidecar's proxy config
-			reply.ProxyConfig = proxyConf.Config
 
 			if serviceConf != nil && serviceConf.Protocol != "" {
 				if reply.ProxyConfig == nil {

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -707,6 +707,45 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 	require.Equal(expected, out)
 }
 
+func TestConfigEntry_ResolveServiceConfigNoConfig(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	// Don't create any config and make sure we don't nil panic (spoiler alert -
+	// we did in first RC)
+	args := structs.ServiceConfigRequest{
+		Name:       "foo",
+		Datacenter: s1.config.Datacenter,
+		Upstreams:  []string{"bar", "baz"},
+	}
+	var out structs.ServiceConfigResponse
+	require.NoError(msgpackrpc.CallWithCodec(codec, "ConfigEntry.ResolveServiceConfig", &args, &out))
+	// Hack to fix up the string encoding in the map[string]interface{}.
+	// msgpackRPC's codec doesn't use RawToString.
+	var err error
+	out.ProxyConfig, err = lib.MapWalk(out.ProxyConfig)
+	require.NoError(err)
+	for k := range out.UpstreamConfigs {
+		out.UpstreamConfigs[k], err = lib.MapWalk(out.UpstreamConfigs[k])
+		require.NoError(err)
+	}
+
+	expected := structs.ServiceConfigResponse{
+		ProxyConfig:     nil,
+		UpstreamConfigs: nil,
+		// Don't know what this is deterministically
+		QueryMeta: out.QueryMeta,
+	}
+	require.Equal(expected, out)
+}
+
 func TestConfigEntry_ResolveServiceConfig_ACLDeny(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Simple bug from merged PR yesterday - I assigned `proxyConf` blindly thinking "if it's nil then it's safe" only later realised due to compile error that I needed `proxyConf.Config` which I just added!

This adds a test that caused same panic @eveld saw when testing for real and fixes it.