### PR TITLE
ui: Allow text selection of clickable elements and their contents

### DIFF
--- a/ui-v2/app/instance-initializers/selection.js
+++ b/ui-v2/app/instance-initializers/selection.js
@@ -1,3 +1,5 @@
+import env from 'consul-ui/env';
+
 const SECONDARY_BUTTON = 2;
 const isSelecting = function(win = window) {
   const selection = win.getSelection();
@@ -12,6 +14,9 @@ const isSelecting = function(win = window) {
 export default {
   name: 'selection',
   initialize(container) {
+    if (env('CONSUL_UI_DISABLE_ANCHOR_SELECTION')) {
+      return;
+    }
     const dom = container.lookup('service:dom');
     const findAnchor = function(el) {
       return el.tagName === 'A' ? el : dom.closest('a', el);

--- a/ui-v2/app/instance-initializers/selection.js
+++ b/ui-v2/app/instance-initializers/selection.js
@@ -1,0 +1,49 @@
+const isSelecting = function(win = window) {
+  const selection = win.getSelection();
+  let selecting = false;
+  try {
+    selecting = 'isCollapsed' in selection && !selection.isCollapsed;
+  } catch (e) {
+    // passthrough
+  }
+  return selecting;
+};
+export default {
+  name: 'selection',
+  initialize(container) {
+    const dom = container.lookup('service:dom');
+    const findAnchor = function(el) {
+      return el.tagName === 'A' ? el : dom.closest('a', el);
+    };
+    const mousedown = function(e) {
+      const $a = findAnchor(e.target);
+      if ($a) {
+        const href = $a.getAttribute('href');
+        if (href) {
+          $a.dataset.href = href;
+          $a.removeAttribute('href');
+        }
+      }
+    };
+    const mouseup = function(e) {
+      const $a = findAnchor(e.target);
+      if ($a) {
+        const href = $a.dataset.href;
+        if (!isSelecting() && href) {
+          $a.setAttribute('href', href);
+        }
+      }
+    };
+
+    document.body.addEventListener('mousedown', mousedown);
+    document.body.addEventListener('mouseup', mouseup);
+
+    container.reopen({
+      willDestroy: function() {
+        document.body.removeEventListener('mousedown', mousedown);
+        document.body.removeEventListener('mouseup', mouseup);
+        return this._super(...arguments);
+      },
+    });
+  },
+};

--- a/ui-v2/app/instance-initializers/selection.js
+++ b/ui-v2/app/instance-initializers/selection.js
@@ -1,3 +1,4 @@
+const SECONDARY_BUTTON = 2;
 const isSelecting = function(win = window) {
   const selection = win.getSelection();
   let selecting = false;
@@ -18,6 +19,13 @@ export default {
     const mousedown = function(e) {
       const $a = findAnchor(e.target);
       if ($a) {
+        if (typeof e.button !== 'undefined' && e.button === SECONDARY_BUTTON) {
+          const dataHref = $a.dataset.href;
+          if (dataHref) {
+            $a.setAttribute('href', dataHref);
+          }
+          return;
+        }
         const href = $a.getAttribute('href');
         if (href) {
           $a.dataset.href = href;

--- a/ui-v2/app/utils/dom/click-first-anchor.js
+++ b/ui-v2/app/utils/dom/click-first-anchor.js
@@ -1,9 +1,15 @@
-const clickEvent = function() {
-  return new MouseEvent('click', {
-    bubbles: true,
-    cancelable: true,
-    view: window,
-  });
+const clickEvent = function($el) {
+  ['mousedown', 'mouseup', 'click']
+    .map(function(type) {
+      return new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+    })
+    .forEach(function(event) {
+      $el.dispatchEvent(event);
+    });
 };
 export default function(closest, click = clickEvent) {
   // TODO: Decide whether we should use `e` for ease
@@ -24,7 +30,7 @@ export default function(closest, click = clickEvent) {
     // closest should probably be relaced with a finder function
     const $a = closest('tr', e.target).querySelector('a');
     if ($a) {
-      $a.dispatchEvent(click());
+      click($a);
     }
   };
 }

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -29,7 +29,10 @@ module.exports = function(environment) {
   };
   // TODO: These should probably go onto APP
   ENV = Object.assign({}, ENV, {
+    // TODO: Let people alter this, as with anchor selection
     CONSUL_UI_DISABLE_REALTIME: false,
+    CONSUL_UI_DISABLE_ANCHOR_SELECTION:
+      typeof process.env.CONSUL_UI_DISABLE_ANCHOR_SELECTION !== 'undefined',
     CONSUL_GIT_SHA: (function() {
       if (process.env.CONSUL_GIT_SHA) {
         return process.env.CONSUL_GIT_SHA;

--- a/ui-v2/tests/unit/utils/dom/click-first-anchor-test.js
+++ b/ui-v2/tests/unit/utils/dom/click-first-anchor-test.js
@@ -39,16 +39,16 @@ test("it does nothing if an anchor isn't found", function(assert) {
   });
   assert.equal(actual, expected);
 });
-test('it dispatches the result of `click` if an anchor is found', function(assert) {
-  assert.expect(1);
-  const expected = 'click';
+test('it dispatches the result of `mouseup`, `mousedown`, `click` if an anchor is found', function(assert) {
+  assert.expect(3);
+  const expected = ['mousedown', 'mouseup', 'click'];
   const closest = function() {
     return {
       querySelector: function() {
         return {
           dispatchEvent: function(ev) {
             const actual = ev.type;
-            assert.equal(actual, expected);
+            assert.equal(actual, expected.shift());
           },
         };
       },


### PR DESCRIPTION
Since a good while ago we've been purposefully using Consul along with a bit of an overkill setup for what we are doing for our javascript development environment (`ember serve` runs in containers that we can get to via Consul Connect etc). The thinking being if we are using the Consul UI all day/everyday during development, and using as many features as we can, we are more likely to spot, find and/or become frustrated by details of the UI that we wouldn't necessarily realize if we weren't using it for day-to-day work (as opposed to 'just' building it).

This is the first result of that.

Previously the there are certain pieces of text that you often need to select and/or copy/paste. Some of these pieces of text are inside clickable elements, most notably the rows of our tabular data views. When selecting these, releasing the mouse acts as a click, which therefore navigates you away from the page you are looking at. As well as noticing this ourselves I'd specifically seen others encounter this, such as in user tests and in demos from people like @eveld 

Before:

![before](https://user-images.githubusercontent.com/554604/57077394-dd702100-6ce3-11e9-95da-dcc7d963ab6d.gif)

This commit disables a click on mousedown by removing the `href`
attribute and moving it to a `data-href` attribute. Then, on mouseup, it will
_only_ move it back if there is no selection. This means that an anchor
will only be followed on click _if_ there is no selection.

This fixes the fact that whenever you select some copy within a
clickable element it immediately throws you into the linked page when
you release your mouse.

After:

![after](https://user-images.githubusercontent.com/554604/57077422-ec56d380-6ce3-11e9-8cee-ace62bf4551c.gif)

Previous to this, we had jumped through some CSS hoops to make certain pieces of text selectable, but in the long term this isn't that scalable. As a TODO following this PR, this CSS hoop jumping in other areas can be removed.

Further notes:

We use the `isCollapsed` property here which 'seems' to be classed as
'experimental' in one place where I researched it:

https://developer.mozilla.org/en-US/docs/Web/API/Selection/isCollapsed

Although in others it makes no mention of this 'experimental' e.g:

- https://webplatform.github.io/docs/dom/Selection/isCollapsed/
- https://w3c.github.io/selection-api/#dom-selection-iscollapsed

It seems to be supported from IE9 upwards, and of course other modern browsers.

I may have gone a little overboard in feature detection for this, but I
conscious of that fact that if `isCollapsed` doesn't exist at some point
in the future (something that seems unlikely), the code here will have
no effect on the UI. But I'd specifically like a second pair of eyes on
that.