### PR TITLE
acl: a role binding rule for a role that does not exist should be ignored

### DIFF
--- a/agent/consul/acl_authmethod.go
+++ b/agent/consul/acl_authmethod.go
@@ -136,9 +136,16 @@ func (s *Server) evaluateRoleBindings(
 			})
 
 		case structs.BindingRuleBindTypeRole:
-			roleLinks = append(roleLinks, structs.ACLTokenRoleLink{
-				Name: bindName,
-			})
+			_, role, err := s.fsm.State().ACLRoleGetByName(nil, bindName)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if role != nil {
+				roleLinks = append(roleLinks, structs.ACLTokenRoleLink{
+					ID: role.ID,
+				})
+			}
 
 		default:
 			// skip unknown bind type; don't grant privileges

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -391,7 +391,7 @@ func (c *FSM) applyACLTokenSetOperation(buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSinceWithLabels([]string{"fsm", "acl", "token"}, time.Now(),
 		[]metrics.Label{{Name: "op", Value: "upsert"}})
 
-	return c.state.ACLTokenBatchSet(index, req.Tokens, req.CAS, req.AllowMissingLinks)
+	return c.state.ACLTokenBatchSet(index, req.Tokens, req.CAS, req.AllowMissingLinks, req.ProhibitUnprivileged)
 }
 
 func (c *FSM) applyACLTokenDeleteOperation(buf []byte, index uint64) interface{} {

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -619,7 +619,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, true, false))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, true, false, false))
 
 		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
 		require.NoError(t, err)
@@ -640,7 +640,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(5, tokens, true, false))
+		require.NoError(t, s.ACLTokenBatchSet(5, tokens, true, false, false))
 
 		updated := structs.ACLTokens{
 			&structs.ACLToken{
@@ -651,7 +651,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(6, updated, true, false))
+		require.NoError(t, s.ACLTokenBatchSet(6, updated, true, false, false))
 
 		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
 		require.NoError(t, err)
@@ -670,7 +670,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(5, tokens, true, false))
+		require.NoError(t, s.ACLTokenBatchSet(5, tokens, true, false, false))
 
 		updated := structs.ACLTokens{
 			&structs.ACLToken{
@@ -680,7 +680,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(6, updated, true, false))
+		require.NoError(t, s.ACLTokenBatchSet(6, updated, true, false, false))
 
 		_, token, err := s.ACLTokenGetByAccessor(nil, tokens[0].AccessorID)
 		require.NoError(t, err)
@@ -703,7 +703,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
@@ -734,7 +734,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
 		updates := structs.ACLTokens{
 			&structs.ACLToken{
@@ -759,7 +759,7 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(3, updates, false, false))
+		require.NoError(t, s.ACLTokenBatchSet(3, updates, false, false, false))
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
@@ -806,9 +806,9 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.Error(t, s.ACLTokenBatchSet(2, tokens, false, false))
+		require.Error(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, true))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, true, false))
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
@@ -845,9 +845,9 @@ func TestStateStore_ACLTokens_UpsertBatchRead(t *testing.T) {
 			},
 		}
 
-		require.Error(t, s.ACLTokenBatchSet(2, tokens, false, false))
+		require.Error(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, true))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, true, false))
 
 		idx, rtokens, err := s.ACLTokenBatchGet(nil, []string{
 			"a4f68bd6-3af5-4f56-b764-3c6f20247879",
@@ -951,7 +951,7 @@ func TestStateStore_ACLTokens_ListUpgradeable(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.ACLTokenBatchSet(7, updates, false, false))
+	require.NoError(t, s.ACLTokenBatchSet(7, updates, false, false, false))
 
 	tokens, _, err = s.ACLTokenListUpgradeable(10)
 	require.NoError(t, err)
@@ -1042,7 +1042,7 @@ func TestStateStore_ACLToken_List(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false))
+	require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
 	type testCase struct {
 		name       string
@@ -1563,7 +1563,7 @@ func TestStateStore_ACLToken_Delete(t *testing.T) {
 			},
 		}
 
-		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false))
+		require.NoError(t, s.ACLTokenBatchSet(2, tokens, false, false, false))
 
 		_, rtoken, err := s.ACLTokenGetByAccessor(nil, "f1093997-b6c7-496d-bfb8-6b1b1895641b")
 		require.NoError(t, err)
@@ -3110,7 +3110,7 @@ func TestStateStore_ACLAuthMethod_Delete_RuleAndTokenCascade(t *testing.T) {
 			AuthMethod:  "test-2",
 		},
 	}
-	require.NoError(t, s.ACLTokenBatchSet(4, tokens, false, false))
+	require.NoError(t, s.ACLTokenBatchSet(4, tokens, false, false, false))
 
 	// Delete one method.
 	require.NoError(t, s.ACLAuthMethodDeleteByName(4, "test-1"))
@@ -3568,7 +3568,7 @@ func TestStateStore_ACLTokens_Snapshot_Restore(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, s.ACLTokenBatchSet(4, tokens, false, false))
+	require.NoError(t, s.ACLTokenBatchSet(4, tokens, false, false, false))
 
 	// Snapshot the ACLs.
 	snap := s.Snapshot()

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -29,6 +29,11 @@ var (
 	// token with an empty AccessorID.
 	ErrMissingACLTokenAccessor = errors.New("Missing ACL Token AccessorID")
 
+	// ErrTokenHasNoPrivileges is returned when a token set is called on a
+	// token with no policies, roles, or service identities and the caller
+	// requires at least one to be set.
+	ErrTokenHasNoPrivileges = errors.New("Token has no privileges")
+
 	// ErrMissingACLPolicyID is returned when a policy set is called on a
 	// policy with an empty ID.
 	ErrMissingACLPolicyID = errors.New("Missing ACL Policy ID")

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1077,9 +1077,10 @@ func (r *ACLTokenBatchGetRequest) RequestDatacenter() string {
 // This is particularly useful during token replication and during
 // automatic legacy token upgrades.
 type ACLTokenBatchSetRequest struct {
-	Tokens            ACLTokens
-	CAS               bool
-	AllowMissingLinks bool
+	Tokens               ACLTokens
+	CAS                  bool
+	AllowMissingLinks    bool
+	ProhibitUnprivileged bool
 }
 
 // ACLTokenBatchDeleteRequest is used only at the Raft layer


### PR DESCRIPTION
I wrote the docs under this assumption but completely forgot to actually
enforce it.