### PR TITLE
ui: Don't look for isDescriptor on null (related to null proxies)

### DIFF
--- a/ui-v2/app/mixins/with-event-source.js
+++ b/ui-v2/app/mixins/with-event-source.js
@@ -7,18 +7,18 @@ const PREFIX = '_';
 export default Mixin.create(WithListeners, {
   setProperties: function(model) {
     const _model = {};
-    Object.keys(model).forEach(key => {
+    Object.keys(model).forEach(prop => {
       // here (see comment below on deleting)
-      if (typeof this[key] !== 'undefined' && this[key].isDescriptor) {
-        _model[`${PREFIX}${key}`] = model[key];
-        const meta = this.constructor.metaForProperty(key) || {};
+      if (this[prop] && this[prop].isDescriptor) {
+        _model[`${PREFIX}${prop}`] = model[prop];
+        const meta = this.constructor.metaForProperty(prop) || {};
         if (typeof meta.catch === 'function') {
-          if (typeof _model[`${PREFIX}${key}`].addEventListener === 'function') {
-            this.listen(_model[`_${key}`], 'error', meta.catch.bind(this));
+          if (typeof _model[`${PREFIX}${prop}`].addEventListener === 'function') {
+            this.listen(_model[`_${prop}`], 'error', meta.catch.bind(this));
           }
         }
       } else {
-        _model[key] = model[key];
+        _model[prop] = model[prop];
       }
     });
     return this._super(_model);


### PR DESCRIPTION
Firstly, I took the opportunity here to make the variable names exactly the same as the similar method below this that you won't see in the changeset, it basically renames where I'd used the word `key` to use the word `prop`. But please note, this isn't the objective of the PR.

The main reason behind this PR is that in one single area we set a property on the model of the Controller/View to `null`, see point 1. in this PR https://github.com/hashicorp/consul/pull/5487 for the reasoning behind that.

Previous to the above PR the `undefined` check we where using was ok. But once we introduced the above PR it meant that in this area we would be checking `.isDescriptor` on `null`.

We fixed this bug in https://github.com/hashicorp/consul/pull/5745 thinking it was a result of the other work in that PR. This PR takes the fix from there and applies it on its own here.

It would be nice to add before/after acceptance tests here to prevent regressions however likely/unlikely. We may add something onto here, but waiting on those shouldn't prevent approval and we may end up adding them at a later date.
