### PR TITLE
ui: Upgrades the indirect dependency on jQuery to ^3.4.0

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -38,6 +38,9 @@
       "git add"
     ]
   },
+  "resolutions": {
+    "jquery": "^3.4.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@hashicorp/consul-api-double": "^2.0.1",

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -7242,9 +7242,10 @@ jquery-deferred@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
 
-jquery@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+jquery@^3.2.1, jquery@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.4.9"


### PR DESCRIPTION
Whilst we don't specifically use `jquery` in any of our application code, we do indirectly use it via `ember-data` and its `RESTAdapter`. As far as we are aware this is the only place we indirectly use it in the UI application code (although the `ember` generated tests also make use of it).

`jquery` is an indirect dependency of `ember` itself, so we use `resolutions` here to force things to use a newer version of `jquery` than `ember` requires. We consider this relatively low risk:

1. We're jumping 1 _backwards compatible_ version here.
2. `jquery` is very mature and well respected so the potential of something not being backwards compatible is low
3. We barely use `jquery`
4. All our tests continue to pass with this upgrade.

As a further note, once we can finish off https://github.com/hashicorp/consul/pull/5637 (which gives us the ability to inject our own HTTP client into an Adapter) we'll be able to remove our reliance jQuery altogether, yet it will still be included in the source via `ember` although I'm aware `ember` is also looking to remove `jquery` with octane.

