### PR TITLE
ui: Make the Rules readonly when creating ServiceIdentities

### DIFF
--- a/ui-v2/app/templates/components/policy-form.hbs
+++ b/ui-v2/app/templates/components/policy-form.hbs
@@ -36,7 +36,7 @@
           <strong>{{item.error.Rules.validation}}</strong>
         {{/if}}
 {{else}}
-        {{#code-editor name=(concat name '[Rules]') syntax='hcl' oninput=(action 'change' (concat name '[Rules]'))}}
+        {{#code-editor readonly=true name=(concat name '[Rules]') syntax='hcl' oninput=(action 'change' (concat name '[Rules]'))}}
           {{~component 'service-identity' name=item.Name~}}
         {{/code-editor}}
 {{/if}}

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -77,3 +77,6 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     | token     |
     | role      |
     -------------
+@ignore
+  Scenario: Make sure the Service Identity Rules are readonly
+    Then ok


### PR DESCRIPTION
Previously you could edit the text area of the templated Rules for ServiceIdentities. This wouldn't effect what is saved back to Consul, but would be misleading to the user. This makes the text area/code-editor readonly

A skipped test has been added for nagging for the moment, and will be added at a later date for regression purposes.