### PR TITLE
ui: Uses the default cursor instead of a pointer for upstream rows

### DIFF
--- a/ui-v2/app/styles/routes/dc/service/index.scss
+++ b/ui-v2/app/styles/routes/dc/service/index.scss
@@ -1,0 +1,3 @@
+html.template-instance.template-show #upstreams table tr {
+  cursor: default;
+}


### PR DESCRIPTION
The rows in the new Upstreams table on the Service Instance Detail page are not clickable, this is because some are prepared_query upstreams and therefore don't have a page to view, and other upstreams are potentially services that don't exist yet and therefore would 404.

Despite this we continued to show a pointer cursor on the table rows.

This PR very specifically sets the table rows to use the default cursor only for this table.