### PR TITLE
Copy the proxy config instead of direct assignment

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/mitchellh/copystructure"
 )
 
 // The ConfigEntry endpoint is used to query centralized config information
@@ -257,7 +258,11 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 					return fmt.Errorf("invalid proxy config type %T", proxyEntry)
 				}
 				// Apply the proxy defaults to the sidecar's proxy config
-				reply.ProxyConfig = proxyConf.Config
+				mapCopy, err := copystructure.Copy(proxyConf.Config)
+				if err != nil {
+					return fmt.Errorf("failed to copy global proxy-defaults: %v", err)
+				}
+				reply.ProxyConfig = mapCopy.(map[string]interface{})
 			}
 
 			reply.Index = index

--- a/agent/consul/config_endpoint_test.go
+++ b/agent/consul/config_endpoint_test.go
@@ -695,6 +695,13 @@ func TestConfigEntry_ResolveServiceConfig(t *testing.T) {
 		QueryMeta: out.QueryMeta,
 	}
 	require.Equal(expected, out)
+
+	_, entry, err := s1.fsm.State().ConfigEntry(nil, structs.ProxyDefaults, structs.ProxyConfigGlobal)
+	require.NoError(err)
+	require.NotNil(entry)
+	proxyConf, ok := entry.(*structs.ProxyConfigEntry)
+	require.True(ok)
+	require.Equal(map[string]interface{}{"foo": 1}, proxyConf.Config)
 }
 
 func TestConfigEntry_ResolveServiceConfigNoConfig(t *testing.T) {


### PR DESCRIPTION
This prevents modifying the data in the state store which is supposed to be immutable.