### PR TITLE
Fixes race condition in Agent Cache

### DIFF
--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -214,7 +214,9 @@ func (c *Cache) Get(t string, r Request) (interface{}, ResultMeta, error) {
 	return c.getWithIndex(t, r, r.CacheInfo().MinIndex)
 }
 
-// retrieves a cache entry and checks if it is ready to be returned given the other parameters
+// getEntryLocked retrieves a cache entry and checks if it is ready to be
+// returned given the other parameters. It reads from entries and the caller
+// has to issue a read lock if necessary.
 func (c *Cache) getEntryLocked(tEntry typeEntry, key string, maxAge time.Duration, revalidate bool, minIndex uint64) (bool, bool, cacheEntry) {
 	entry, ok := c.entries[key]
 	cacheHit := false

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -352,11 +352,17 @@ RETRY_GET:
 		timeoutCh = time.After(info.Timeout)
 	}
 
-	// At this point, we know we either don't have a value at all or the
-	// value we have is too old. We need to wait for new data.
-	waiterCh, err := c.fetch(t, key, r, true, 0)
-	if err != nil {
-		return nil, ResultMeta{Index: entry.Index}, err
+	var waiterCh <-chan struct{}
+	if ok && entry.Fetching {
+		waiterCh = entry.Waiter
+	} else {
+		var err error
+		// At this point, we know we either don't have a value at all or the
+		// value we have is too old. We need to wait for new data.
+		waiterCh, err = c.fetch(t, key, r, true, 0)
+		if err != nil {
+			return nil, ResultMeta{Index: entry.Index}, err
+		}
 	}
 
 	select {

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -412,11 +412,11 @@ func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint, min
 	// We acquire a write lock because we may have to set Fetching to true.
 	c.entriesLock.Lock()
 	defer c.entriesLock.Unlock()
-	ok, entryReady, entry := c.getEntryLocked(tEntry, key, info.MaxAge, info.MustRevalidate && !ignoreRevalidation, minIndex)
+	ok, cacheHit, entry := c.getEntryLocked(tEntry, key, info.MaxAge, info.MustRevalidate && !ignoreRevalidation, minIndex)
 
 	// This handles the case where a fetch succeeded after checking for its existence in
 	// getWithIndex. This ensures that we don't miss updates.
-	if ok && entryReady && !ignoreExisting {
+	if ok && cacheHit && !ignoreExisting {
 		ch := make(chan struct{})
 		close(ch)
 		return ch, nil

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -214,6 +214,44 @@ func (c *Cache) Get(t string, r Request) (interface{}, ResultMeta, error) {
 	return c.getWithIndex(t, r, r.CacheInfo().MinIndex)
 }
 
+// retrieves a cache entry and checks if it is ready to be returned given the other parameters
+func (c *Cache) getEntryLocked(tEntry typeEntry, key string, maxAge time.Duration, revalidate bool, minIndex uint64) (bool, bool, cacheEntry) {
+	entry, ok := c.entries[key]
+
+	if !ok {
+		return false, false, entry
+	}
+
+	// Check if we have a hit
+	cacheHit := ok && entry.Valid
+
+	supportsBlocking := tEntry.Type.SupportsBlocking()
+
+	// Check index is not specified or lower than value, or the type doesn't
+	// support blocking.
+	if cacheHit && supportsBlocking &&
+		minIndex > 0 && minIndex >= entry.Index {
+		// MinIndex was given and matches or is higher than current value so we
+		// ignore the cache and fallthrough to blocking on a new value below.
+		cacheHit = false
+	}
+
+	// Check MaxAge is not exceeded if this is not a background refreshing type
+	// and MaxAge was specified.
+	if cacheHit && !tEntry.Opts.Refresh && maxAge > 0 &&
+		!entry.FetchedAt.IsZero() && maxAge < time.Since(entry.FetchedAt) {
+		cacheHit = false
+	}
+
+	// Check if we are requested to revalidate. If so the first time round the
+	// loop is not a hit but subsequent ones should be treated normally.
+	if cacheHit && !tEntry.Opts.Refresh && revalidate {
+		cacheHit = false
+	}
+
+	return true, cacheHit, entry
+}
+
 // getWithIndex implements the main Get functionality but allows internal
 // callers (Watch) to manipulate the blocking index separately from the actual
 // request object.
@@ -249,35 +287,8 @@ RETRY_GET:
 
 	// Get the current value
 	c.entriesLock.RLock()
-	entry, ok := c.entries[key]
+	_, cacheHit, entry := c.getEntryLocked(tEntry, key, info.MaxAge, info.MustRevalidate && first, minIndex)
 	c.entriesLock.RUnlock()
-
-	// Check if we have a hit
-	cacheHit := ok && entry.Valid
-
-	supportsBlocking := tEntry.Type.SupportsBlocking()
-
-	// Check index is not specified or lower than value, or the type doesn't
-	// support blocking.
-	if cacheHit && supportsBlocking &&
-		minIndex > 0 && minIndex >= entry.Index {
-		// MinIndex was given and matches or is higher than current value so we
-		// ignore the cache and fallthrough to blocking on a new value below.
-		cacheHit = false
-	}
-
-	// Check MaxAge is not exceeded if this is not a background refreshing type
-	// and MaxAge was specified.
-	if cacheHit && !tEntry.Opts.Refresh && info.MaxAge > 0 &&
-		!entry.FetchedAt.IsZero() && info.MaxAge < time.Since(entry.FetchedAt) {
-		cacheHit = false
-	}
-
-	// Check if we are requested to revalidate. If so the first time round the
-	// loop is not a hit but subsequent ones should be treated normally.
-	if cacheHit && !tEntry.Opts.Refresh && info.MustRevalidate && first {
-		cacheHit = false
-	}
 
 	if cacheHit {
 		meta := ResultMeta{Index: entry.Index}
@@ -344,26 +355,20 @@ RETRY_GET:
 		}
 	}
 
-	// No longer our first time through
-	first = false
-
 	// Set our timeout channel if we must
 	if info.Timeout > 0 && timeoutCh == nil {
 		timeoutCh = time.After(info.Timeout)
 	}
 
-	var waiterCh <-chan struct{}
-	if ok && entry.Fetching {
-		waiterCh = entry.Waiter
-	} else {
-		var err error
-		// At this point, we know we either don't have a value at all or the
-		// value we have is too old. We need to wait for new data.
-		waiterCh, err = c.fetch(t, key, r, true, 0)
-		if err != nil {
-			return nil, ResultMeta{Index: entry.Index}, err
-		}
+	// At this point, we know we either don't have a value at all or the
+	// value we have is too old. We need to wait for new data.
+	waiterCh, err := c.fetch(t, key, r, true, 0, minIndex, false, !first)
+	if err != nil {
+		return nil, ResultMeta{Index: entry.Index}, err
 	}
+
+	// No longer our first time through
+	first = false
 
 	select {
 	case <-waiterCh:
@@ -390,7 +395,7 @@ func (c *Cache) entryKey(t string, r *RequestInfo) string {
 // If allowNew is true then the fetch should create the cache entry
 // if it doesn't exist. If this is false, then fetch will do nothing
 // if the entry doesn't exist. This latter case is to support refreshing.
-func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint) (<-chan struct{}, error) {
+func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint, minIndex uint64, ignoreExisting bool, ignoreRevalidation bool) (<-chan struct{}, error) {
 	// Get the type that we're fetching
 	c.typesLock.RLock()
 	tEntry, ok := c.types[t]
@@ -399,10 +404,20 @@ func (c *Cache) fetch(t, key string, r Request, allowNew bool, attempt uint) (<-
 		return nil, fmt.Errorf("unknown type in cache: %s", t)
 	}
 
+	info := r.CacheInfo()
+
 	// We acquire a write lock because we may have to set Fetching to true.
 	c.entriesLock.Lock()
 	defer c.entriesLock.Unlock()
-	entry, ok := c.entries[key]
+	ok, entryReady, entry := c.getEntryLocked(tEntry, key, info.MaxAge, info.MustRevalidate && !ignoreRevalidation, minIndex)
+
+	// This handles the case where a fetch succeeded after checking for its existence in
+	// getWithIndex. This ensures that we don't miss updates.
+	if ok && entryReady && !ignoreExisting {
+		ch := make(chan struct{})
+		close(ch)
+		return ch, nil
+	}
 
 	// If we aren't allowing new values and we don't have an existing value,
 	// return immediately. We return an immediately-closed channel so nothing
@@ -662,7 +677,7 @@ func (c *Cache) refresh(opts *RegisterOptions, attempt uint, t string, key strin
 	// Trigger. The "allowNew" field is false because in the time we were
 	// waiting to refresh we may have expired and got evicted. If that
 	// happened, we don't want to create a new entry.
-	c.fetch(t, key, r, false, attempt)
+	c.fetch(t, key, r, false, attempt, 0, true, true)
 }
 
 // runExpiryLoop is a blocking function that watches the expiration

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -217,13 +217,14 @@ func (c *Cache) Get(t string, r Request) (interface{}, ResultMeta, error) {
 // retrieves a cache entry and checks if it is ready to be returned given the other parameters
 func (c *Cache) getEntryLocked(tEntry typeEntry, key string, maxAge time.Duration, revalidate bool, minIndex uint64) (bool, bool, cacheEntry) {
 	entry, ok := c.entries[key]
+	cacheHit := false
 
 	if !ok {
-		return false, false, entry
+		return ok, cacheHit, entry
 	}
 
 	// Check if we have a hit
-	cacheHit := ok && entry.Valid
+	cacheHit = ok && entry.Valid
 
 	supportsBlocking := tEntry.Type.SupportsBlocking()
 
@@ -249,7 +250,7 @@ func (c *Cache) getEntryLocked(tEntry typeEntry, key string, maxAge time.Duratio
 		cacheHit = false
 	}
 
-	return true, cacheHit, entry
+	return ok, cacheHit, entry
 }
 
 // getWithIndex implements the main Get functionality but allows internal

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -1123,7 +1123,6 @@ func TestCacheGet_nonBlockingType(t *testing.T) {
 	t.Parallel()
 
 	typ := TestTypeNonBlocking(t)
-	defer typ.AssertExpectations(t)
 	c := TestCache(t)
 	c.RegisterType("t", typ, nil)
 


### PR DESCRIPTION
Fixes #5793

The final fix here required a few things:

1. We needed to pass a bunch more stuff through to the `fetch` call
2. Before actually doing a real `Fetch` request in `fetch` we need to check whats in the cache to see if an entry was created that satisfies this requests requirements.

The test file assertion was duplicated so I removed it.