### PR TITLE
Envoy integration test improvements

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -83,8 +83,10 @@ for c in ./case-*/ ; do
 
     # Wipe state
     docker-compose up wipe-volumes
-    # Note, we use explicit set of dirs so we don't delete .gitignore
-    rm -rf workdir/{consul,envoy,bats,statsd,logs}
+    # Note, we use explicit set of dirs so we don't delete .gitignore. Also,
+    # don't wipe logs between runs as they are already split and we need them to
+    # upload as artifacts later.
+    rm -rf workdir/{consul,envoy,bats,statsd}
     mkdir -p workdir/{consul,envoy,bats,statsd,logs}
 
     # Reload consul config from defaults


### PR DESCRIPTION
This ensures consul container logs are dumped for failing cases too which is useful for debugging.

It also includes a minor fix to avoid deleting the .gitignore when running locally which risks later committing local results.