### PR TITLE
ui: Make the proxy icon full size in service listings

### DIFF
--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -24,7 +24,6 @@ td .kind-proxy {
   @extend %type-icon, %with-proxy;
   text-indent: -9000px !important;
   width: 24px;
-  transform: scale(0.7);
 }
 table:not(.sessions) tbody tr {
   cursor: pointer;


### PR DESCRIPTION
After some internal user testing we realized that sometimes the small proxy icon in the Service listing page could be mistaken for a 'missing image' icon. 

This PR removes the scaling so it's 'fullsize' (similar size to the `external-source` icons)

Before:

![Screenshot 2019-05-07 at 14 35 51](https://user-images.githubusercontent.com/554604/57303531-71236200-70d5-11e9-8cb6-8b9a44b0c24d.png)

After:

<img width="958" alt="Screenshot 2019-05-07 at 14 33 43" src="https://user-images.githubusercontent.com/554604/57303543-784a7000-70d5-11e9-9084-09ac1b448cb0.png">

