### PR TITLE
Allow MapWalk to handle []interface{} elements that are []uint8

### DIFF
--- a/lib/map_walker.go
+++ b/lib/map_walker.go
@@ -34,6 +34,7 @@ func MapWalk(input interface{}) (map[string]interface{}, error) {
 }
 
 var typMapIfaceIface = reflect.TypeOf(map[interface{}]interface{}{})
+var typByteSlice = reflect.TypeOf([]byte{})
 
 // mapWalker implements interfaces for the reflectwalk package
 // (github.com/mitchellh/reflectwalk) that can be used to automatically
@@ -127,7 +128,7 @@ func (w *mapWalker) Slice(v reflect.Value) error {
 	// If we find a []byte slice, it is an HCL-string converted to []byte.
 	// Convert it back to a Go string and replace the value so that JSON
 	// doesn't base64-encode it.
-	if v.Type() == reflect.TypeOf([]byte{}) {
+	if v.Type() == typByteSlice {
 		resultVal := reflect.ValueOf(string(v.Interface().([]byte)))
 		switch w.lastLoc {
 		case reflectwalk.MapKey:
@@ -185,6 +186,8 @@ func (w *mapWalker) SliceElem(i int, elem reflect.Value) error {
 		}
 
 		elem.Set(reflect.ValueOf(target))
+	} else if inner := elem.Elem(); inner.Type() == typByteSlice {
+		elem.Set(reflect.ValueOf(string(inner.Interface().([]byte))))
 	}
 
 	return nil

--- a/lib/map_walker_test.go
+++ b/lib/map_walker_test.go
@@ -53,6 +53,22 @@ func TestMapWalk(t *testing.T) {
 				"bar": "baz",
 			},
 		},
+		"map with slice": tcase{
+			input: map[string]interface{}{
+				"foo": []uint8("bar"),
+				"bar": []interface{}{
+					[]uint8("one"),
+					[]uint8("two"),
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"bar": []interface{}{
+					"one",
+					"two",
+				},
+			},
+		},
 	}
 
 	for name, tcase := range cases {

--- a/lib/map_walker_test.go
+++ b/lib/map_walker_test.go
@@ -59,6 +59,8 @@ func TestMapWalk(t *testing.T) {
 				"bar": []interface{}{
 					[]uint8("one"),
 					[]uint8("two"),
+					3,
+					4,
 				},
 			},
 			expected: map[string]interface{}{
@@ -66,6 +68,8 @@ func TestMapWalk(t *testing.T) {
 				"bar": []interface{}{
 					"one",
 					"two",
+					3,
+					4,
 				},
 			},
 		},


### PR DESCRIPTION
Previously proxy-defaults config entries like the following would have decoding errors:

```hcl
kind = "proxy-defaults"
name = "global"

config {
   envoy_dogstatsd_url = "udp://127.0.0.1:9125"
   envoy_stats_tags = ["test","erik"]
}
```

The problem was the slice of strings which during the generic decoding got turned into a `[]interface{}{[]uint8, []uint8}`. The fix allows for the SliceElem to convert the `[]uint8` into strings before the Slice method would be called on the element.

