### PR TITLE
Update to go 1.12.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.12.1
+    go: &GOLANG_IMAGE circleci/golang:1.12.5
     middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.35
     ember: &EMBER_IMAGE circleci/node:8-browsers
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   # Please keep this in-sync with the go version we build against in
   # build-support/docker/Build-Go.dockerfile.
-  - "1.12.1"
+  - "1.12.5"
 
 branches:
   only:

--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.12.1
+ARG GOLANG_VERSION=1.12.5
 FROM golang:${GOLANG_VERSION}
 
 ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \

--- a/build-support/docker/Test-Flake.dockerfile
+++ b/build-support/docker/Test-Flake.dockerfile
@@ -1,6 +1,6 @@
 FROM travisci/ci-garnet:packer-1512502276-986baf0
 
-ENV GOLANG_VERSION 1.10.3
+ENV GOLANG_VERSION 1.12.5
 
 RUN mkdir -p /home/travis/go && chown -R travis /home/travis/go
 


### PR DESCRIPTION
This should fix a few issues regarding increased virtual memory usage since we upgraded the compiler to go 1.12.

Before this can be merged we need a few things:


- [x] Main `golang` image to be updated: https://github.com/docker-library/official-images/pull/5867
- [x] Travis to support go 1.12.5
- [ ] circleci/golang image to use 1.12.5




