### PR TITLE
ui: Ensure room for non-hidden scrollbars

### DIFF
--- a/ui-v2/app/styles/components/action-group/layout.scss
+++ b/ui-v2/app/styles/components/action-group/layout.scss
@@ -14,7 +14,7 @@
   height: 30px;
   position: absolute;
   top: 8px;
-  right: 3px;
+  right: 15px;
 }
 %action-group label {
   display: block;


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/5720 we started to add some minor updates to our overall design look and feel, but in tracing designs we omitted leaving room for a scrollbar to the right hand side of our tabular rows. This reverts https://github.com/hashicorp/consul/pull/5720/files#diff-ee23af43927655ef31fe14838b182eccR17

On macOS generally users have these hidden but on other platforms and browsers these are visible and this can obstruct the 'action buttons' if we don't allow room for them.

Before:

![Screenshot 2019-05-07 at 14 59 31](https://user-images.githubusercontent.com/554604/57309082-5c4bcc00-70df-11e9-9ce1-1fa2b7e3c95d.png)

After:

![Screenshot 2019-05-07 at 14 59 51](https://user-images.githubusercontent.com/554604/57309093-62da4380-70df-11e9-822b-ed7cc67b185b.png)

@opihana as a reminder, could we add permanent scrollbars to the designs, it will probably help us avoid mistakenly doing this again! (And/or, I think we discussed possibly tweaking the look and feel of these to take this into account?)



