### PR TITLE
[docs] Enterprise Landing Page

### DIFF
--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -48,6 +48,6 @@ the license to the leading server after bootstrapping the cluster.
 
 You can set the license via the 
 [API](/api/operator/license.html) or the [CLI](/docs/commands/license.html). When
-Consul is first started, a 30 minute temporary license is available to allow for
+you first start Consul, a 30-minute temporary license is available to allow you
 time to license the datacenter. The license should be set within ten minutes of
 starting the first Consul process to allow time for the license to propagate.

--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -38,13 +38,20 @@ enterprise.
 ### Included in the Enterprise Package
 
 If you are downloading Consul from Amazon S3, then the license is included
-and you do not need to take further action. This is the most common use 
-case.
+in the binary and you do not need to take further action. This is the 
+most common use case.
+
+In the S3 bucket you will find three Enterprise zip packages. The packages with `+pro` and
+`+prem` in the name, are the binaries that include the license. The package
+with `+ent` in the name does not include the license.
 
 ### Applied after Bootstrapping
 
-If you are downloading the enterprise binary from the [releases.hashicorp.com](https://releases.hashicorp.com/consul/), you will need to apply
-the license to the leading server after bootstrapping the cluster. 
+If you are downloading the enterprise binary from the [releases.hashicorp.com](https://releases.hashicorp.com/consul/) or the `+ent` package from Amazon S3, you will need to apply
+the license to the cluster, after completing the bootstrapping process. 
+You can set the license on any agent within the cluster and it will be 
+forwarded to the leading server via the RPC forwarding functionality. 
+Below are your two options for setting the license file. 
 
 You can set the license via the 
 [API](/api/operator/license.html) or the [CLI](/docs/commands/license.html). When

--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -49,5 +49,5 @@ the license to the leading server after bootstrapping the cluster.
 You can set the license via the 
 [API](/api/operator/license.html) or the [CLI](/docs/commands/license.html). When
 you first start Consul, a 30-minute temporary license is available to allow you
-time to license the datacenter. The license should be set within ten minutes of
+time to license the datacenter. You should set the license within ten minutes of
 starting the first Consul process to allow time for the license to propagate.

--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -46,7 +46,7 @@ case.
 If you are downloading the enterprise binary from the [releases.hashicorp.com](https://releases.hashicorp.com/consul/), you will need to apply
 the license to the leading server after bootstrapping the cluster. 
 
-The license can be set via the 
+You can set the license via the 
 [API](/api/operator/license.html) or the [CLI](/docs/commands/license.html). When
 Consul is first started, a 30 minute temporary license is available to allow for
 time to license the datacenter. The license should be set within ten minutes of

--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -10,7 +10,10 @@ description: |-
 
 Consul Enterprise simplifies operations by automating workflows. It adds support
 for microservices deployments across complex network topologies. It also
-increases both scalability and resilience. Features include:
+increases both scalability and resilience. If you have already purchased Consul Enterprise, please see the [licensing section](#licensing)
+below.
+
+Features include:
 
 - [Automated Backups](/docs/enterprise/backups/index.html)
 - [Automated Upgrades](/docs/enterprise/upgrades/index.html)
@@ -29,7 +32,21 @@ Enterprise](https://www.hashicorp.com/consul.html).
 Licensing capabilities were added to Consul Enterprise v1.1.0. The license is set
 once for a datacenter and will automatically propagate to all nodes within the
 datacenter over a period of time scaled between 1 and 20 minutes depending on the
-number of nodes in the datacenter. The license can be set via the 
+number of nodes in the datacenter. There are two methods for licensing Consul
+enterprise.
+
+### Included in the Enterprise Package
+
+If you are downloading Consul from Amazon S3, then the license is included
+and you do not need to take further action. This is the most common use 
+case.
+
+### Applied after Bootstrapping
+
+If you are downloading the enterprise binary from the [public hub](https://releases.hashicorp.com/consul/), you will need to apply
+the license to the leading server after bootstrapping the cluster. 
+
+The license can be set via the 
 [API](/api/operator/license.html) or the [CLI](/docs/commands/license.html). When
 Consul is first started, a 30 minute temporary license is available to allow for
 time to license the datacenter. The license should be set within ten minutes of

--- a/website/source/docs/enterprise/index.html.md
+++ b/website/source/docs/enterprise/index.html.md
@@ -43,7 +43,7 @@ case.
 
 ### Applied after Bootstrapping
 
-If you are downloading the enterprise binary from the [public hub](https://releases.hashicorp.com/consul/), you will need to apply
+If you are downloading the enterprise binary from the [releases.hashicorp.com](https://releases.hashicorp.com/consul/), you will need to apply
 the license to the leading server after bootstrapping the cluster. 
 
 The license can be set via the 


### PR DESCRIPTION
Updating enterprise landing page to be more clear about the licensing process. This was based on a request to the Edu team. We still need to work on a troubleshooting guide. 