### PR TITLE
ui: Remove old 'default' template keyword, we now use '' for default

### DIFF
--- a/ui-v2/app/templates/components/policy-selector.hbs
+++ b/ui-v2/app/templates/components/policy-selector.hbs
@@ -59,7 +59,7 @@
       {{#block-slot 'details'}}
           <label class="type-text">
             <span>Rules <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-            {{#if (eq item.template 'default')}}
+            {{#if (eq item.template '')}}
               {{code-editor syntax='hcl' readonly=true value=item.Rules}}
             {{else}}
               {{#code-editor syntax='hcl' readonly=true}}


### PR DESCRIPTION
Original version of the ServiceIdentity work used the word `default` to describe a Policy with no template (ServiceIdentities being the only things with templates currently). We changed this to just use an empty string a while back, but omitted doing it in this one area.

This changes `default` to use `''` instead.