### PR TITLE
ui: fix production build only empty role modal

### DIFF
--- a/ui-v2/app/services/dom-buffer.js
+++ b/ui-v2/app/services/dom-buffer.js
@@ -11,12 +11,17 @@ export default Service.extend(Evented, {
   },
   add: function(name, dom) {
     this.trigger('add', dom);
-    buffer[name] = dom;
+    if (typeof buffer[name] === 'undefined') {
+      buffer[name] = [];
+    }
+    buffer[name].push(dom);
     return dom;
   },
   remove: function(name) {
     if (typeof buffer[name] !== 'undefined') {
-      buffer[name].remove();
+      buffer[name].forEach(function(item) {
+        item.remove();
+      });
       delete buffer[name];
     }
   },

--- a/ui-v2/app/templates/components/role-selector.hbs
+++ b/ui-v2/app/templates/components/role-selector.hbs
@@ -8,7 +8,7 @@
   {{/block-slot}}
   {{#block-slot 'body'}}
 
-    <input id="{{name}}_state_role" type="radio" name="{{name}}[state]" value="role" checked={{eq state 'role'}} onchange={{action 'change'}} />
+  <input id="{{name}}_state_role" type="radio" name="{{name}}[state]" value="role" checked={{if (eq state 'role') 'checked'}} onchange={{action 'change'}} />
     {{#role-form form=form dc=dc}}
       {{#block-slot 'policy'}}
 
@@ -23,7 +23,7 @@
       {{/block-slot}}
     {{/role-form}}
 
-    <input id="{{name}}_state_policy" type="radio" name="{{name}}[state]" value="policy" checked={{eq state 'policy'}} onchange={{action 'change'}} />
+    <input id="{{name}}_state_policy" type="radio" name="{{name}}[state]" value="policy" checked={{if (eq state 'policy') 'checked'}} onchange={{action 'change'}} />
     {{policy-form data-test-policy-form name="role[policy]" form=policyForm dc=dc}}
 
   {{/block-slot}}


### PR DESCRIPTION
Only during testing in a production ember build, you could _sometimes_ run into a situation where modals would not be cleaned up.

We traced this back to buffers being left over, strangely only in a production build, even though the bugfix here should have also manifested in a development build.

This PR allows multiple components to use the same dom buffer, in this case modals. Previous to this work we only needed one modal in one page at a time.

P.S. We also noticed during debugging one different between the entire rest of the application and here is that we are using short-hand conditionals for setting `checked` we also changed this here to use long-hand conditionals like the rest of the app.