### PR TITLE
ui: Gives the minimal in-form token list use a maximum row size

### DIFF
--- a/ui-v2/app/templates/components/token-list.hbs
+++ b/ui-v2/app/templates/components/token-list.hbs
@@ -3,6 +3,7 @@
   {{#tabular-collection
       data-test-tokens
       class='token-list'
+      rows=5
       items=(sort-by 'AccessorID:asc' items) as |item index|
   }}
   {{#if caption}}


### PR DESCRIPTION
This means its more straightforwards to calculate the height of the
listing itself. This component is currently only used on the form pages for tokens and roles, should therefore be a restricted size.

Also see https://github.com/hashicorp/consul/pull/5720/commits/82da9a34add6a2097b00cd4a435510e89c73a960, part of https://github.com/hashicorp/consul/pull/5720 which adds the ability to resize tables in a saner way than previously.
