### PR TITLE
More understandable timeouts in checks when value exceeds interval, Fixes #5834

### DIFF
--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -334,8 +334,13 @@ func (c *CheckHTTP) Start() {
 		// For long (>10s) interval checks the http timeout is 10s, otherwise the
 		// timeout is the interval. This means that a check *should* return
 		// before the next check begins.
-		if c.Timeout > 0 && c.Timeout < c.Interval {
-			c.httpClient.Timeout = c.Timeout
+		if c.Timeout > 0 {
+			if c.Timeout > c.Interval {
+				c.Logger.Printf("[WARN] agent: Check Timeout (%q) > Interval (%q), using Interval for %q", c.Timeout, c.Interval, c.CheckID)
+				c.httpClient.Timeout = c.Interval
+			} else {
+				c.httpClient.Timeout = c.Timeout
+			}
 		} else if c.Interval < 10*time.Second {
 			c.httpClient.Timeout = c.Interval
 		}
@@ -471,8 +476,13 @@ func (c *CheckTCP) Start() {
 		// For long (>10s) interval checks the socket timeout is 10s, otherwise
 		// the timeout is the interval. This means that a check *should* return
 		// before the next check begins.
-		if c.Timeout > 0 && c.Timeout < c.Interval {
-			c.dialer.Timeout = c.Timeout
+		if c.Timeout > 0 {
+			if c.Timeout > c.Interval {
+				c.Logger.Printf("[WARN] agent: Check Timeout (%q) > Interval (%q), using Interval for %q", c.Timeout, c.Interval, c.CheckID)
+				c.dialer.Timeout = c.Interval
+			} else {
+				c.dialer.Timeout = c.Timeout
+			}
 		} else if c.Interval < 10*time.Second {
 			c.dialer.Timeout = c.Interval
 		}

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -478,6 +478,7 @@ func (c *CheckTCP) Start() {
 		// before the next check begins.
 		if c.Timeout > 0 {
 			if c.Timeout > c.Interval {
+
 				c.Logger.Printf("[WARN] agent: Check Timeout (%q) > Interval (%q), using Interval for %q", c.Timeout, c.Interval, c.CheckID)
 				c.dialer.Timeout = c.Interval
 			} else {
@@ -485,6 +486,8 @@ func (c *CheckTCP) Start() {
 			}
 		} else if c.Interval < 10*time.Second {
 			c.dialer.Timeout = c.Interval
+		} else {
+			c.dialer.Timeout = 10 * time.Second
 		}
 	}
 


### PR DESCRIPTION
When Timeouts were greater or equal than interval for checks,

Consul used to set timeout to 10s. Now, use the interval as upper boundary in that case.

Also outputs a warning in logs in that case.

Thus:
```
Checks: [
 {
   "http": "http://localhost:80/healthz",
   "interval": "30s",
   "timeout": "30s"
  }
]
```
Will now use a timeout of 30s and not 10s as it used to be the case