### PR TITLE
ui: [BUGFIX] Replaces destroyRecord with unloadRecord for KV 404's

### DIFF
--- a/ui-v2/app/services/repository/kv.js
+++ b/ui-v2/app/services/repository/kv.js
@@ -59,7 +59,7 @@ export default RepositoryService.extend({
           const id = JSON.stringify([dc, key]);
           const record = get(this, 'store').peekRecord(this.getModelName(), id);
           if (record) {
-            record.destroyRecord();
+            record.unloadRecord();
           }
         }
         throw e;


### PR DESCRIPTION
Just because Consul gives us a 404 this doesn't guarantee the KV doesn't
exist, it doesn't even mean we don't have access to it. The behaviour also
differs depending on whether `keys` are appended to the URL or not.

Furthermore, we should never destroyRecord's without user interaction
(therefore only via the `repo.delete` method).

This switches destroyRecord to unloadRecord which performs the
additional legwork instead to keep ember-data in sync with the actual truth.

unloadRecord unloads the record from ember-data rather than sending an API
delete request, which would have been the intent here.

~Fixes #5819~

Since https://github.com/hashicorp/consul/issues/5888 this bugfix is no longer necessary. If a KV doesn't exist a delete does nothing, if we don't have access to a KV a delete does nothing. Both do send a HTTP request though, so the change here makes everything more 'correct', and we need to ensure that we keep ember-data in sync with the actual truth.

