### PR TITLE
docs: spelling

### DIFF
--- a/website/source/docs/commands/connect/envoy.html.md.erb
+++ b/website/source/docs/commands/connect/envoy.html.md.erb
@@ -96,7 +96,7 @@ allowed to access by [Connect intentions](/docs/connect/intentions.html).
 
 ## Examples
 
-Assume a local service instance is registratered on the local agent with a
+Assume a local service instance is registered on the local agent with a
 sidecar proxy (using the [sidecar service
 registration](/docs/connect/proxies/sidecar-service.html) helper) as below.
 


### PR DESCRIPTION
Fixed typo: registratered/registered.