### PR TITLE
bump middleman-hashicorp to 0.3.40 and exclude guide rendering

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.35"
+VERSION?="0.3.40"
 
 build:
 	@echo "==> Starting build in Docker..."
@@ -7,6 +7,8 @@ build:
 		--rm \
 		--tty \
 		--volume "$(shell pwd):/website" \
+		--volume "/website/source/docs/guides" \
+		--volume "$(shell pwd)/source/docs/guides/index.html.md:/website/source/docs/guides/index.html.md" \
 		-e "ENV=production" \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
@@ -20,6 +22,8 @@ website:
 		--publish "4567:4567" \
 		--publish "35729:35729" \
 		--volume "$(shell pwd):/website" \
+		--volume "/website/source/docs/guides" \
+		--volume "$(shell pwd)/source/docs/guides/index.html.md:/website/source/docs/guides/index.html.md" \
 		hashicorp/middleman-hashicorp:${VERSION}
 
 .PHONY: build website

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,9 @@
 VERSION?="0.3.40"
 
+# The volume mounting steps are a way to exclude all the consul docs from being built
+# in the Consul site build process while still including the index.html page that points
+# users to learn.hashicorp.com
+
 build:
 	@echo "==> Starting build in Docker..."
 	@docker run \

--- a/website/Makefile
+++ b/website/Makefile
@@ -2,7 +2,7 @@ VERSION?="0.3.40"
 
 # The volume mounting steps are a way to exclude all the consul docs from being built
 # in the Consul site build process while still including the index.html page that points
-# users to learn.hashicorp.com
+# users to learn.hashicorp.com. See PR#5847.
 
 build:
 	@echo "==> Starting build in Docker..."


### PR DESCRIPTION
0.3.40 of middleman has some of the gems preinstalled into the docker image so it spins up builds faster. 

Guides now live on the learn site and have a different set of layout metadata that the consul docs site does not support. There is a hack in the Makefile to:
1) mount the website directory
2) clear out the `guides` directory
3) put back the `index.html.md` page that we still host on the Consul site

This will fix the build error seen in #5823 