### PR TITLE
UI: Test readonly ServiceIdentity rules

### DIFF
--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -94,16 +94,15 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     | token     |
     | role      |
     -------------
-@ignore:
-  Scenario: Click the cancel form
-    Then ok
-    # And I click cancel on the policyForm
+  Scenario: Try to edit the Service Identity using the code editor
+    And I click serviceIdentity on the policies.form
+    Then I can't fill in the policies.form with yaml
+    ---
+      Rules: key {}
+    ---
   Where:
     -------------
     | Model     |
     | token     |
     | role      |
     -------------
-@ignore
-  Scenario: Make sure the Service Identity Rules are readonly
-    Then ok


### PR DESCRIPTION
Whilst chasing the 1.5 release we added a fix without tests to ensure the ServiceIdentity templated rules weren't editable by the user. See https://github.com/hashicorp/consul/pull/5784. At the time we were confident this was working fine, but this adds an acceptance test around it to try to prevent regressions.

This is the first time we've used a way to negate our scenario steps easily, we've had the idea/approach around for this since https://github.com/hashicorp/consul/pull/4341, but hopefully we'll be able to take this across all the rest of our steps at some point for easy negation.

Lastly, we removed an ignored test here also, which is now mostly covered in https://github.com/hashicorp/consul/pull/5838. We could potentially add more similar tests in here, but it would be handy to have the form assertion step we wrote for https://github.com/hashicorp/consul/pull/5838 available to us before we do that.
