### PR TITLE
docs: fixed typos on a few doc pages

### DIFF
--- a/website/source/docs/agent/cloud-auto-join.html.md
+++ b/website/source/docs/agent/cloud-auto-join.html.md
@@ -319,7 +319,7 @@ $ consul agent -retry-join "provider=vsphere category_name=consul-role tag_name=
 
 ### Packet
 
-This returns the first private IP address (or the IP addresso of `address type`) of all servers with the given `project` and `auth_token`.
+This returns the first private IP address (or the IP address of `address type`) of all servers with the given `project` and `auth_token`.
 
 ```sh
 $ consul agent -retry-join "provider=packet auth_token=token project=uuid url=... address_type=..."

--- a/website/source/docs/agent/sentinel.html.markdown.erb
+++ b/website/source/docs/agent/sentinel.html.markdown.erb
@@ -75,7 +75,7 @@ EOF
 }
 ```
 
-### Restrited Update Time
+### Restricted Update Time
 
 The key "haproxy_version" can only be updated during business hours.
 

--- a/website/source/docs/commands/kv/put.html.markdown.erb
+++ b/website/source/docs/commands/kv/put.html.markdown.erb
@@ -41,7 +41,7 @@ Usage: `consul kv put [options] KEY [DATA]`
   -session flag to be set. The key must be held by the session in order to be
   unlocked. The default value is false.
 
-* `-session=<string>` - User-defined identifer for this session as a string.
+* `-session=<string>` - User-defined identifier for this session as a string.
   This is commonly used with the -acquire and -release operations to build
   robust locking, but it can be set on any key. The default value is empty (no
   session).

--- a/website/source/docs/connect/intentions.html.md
+++ b/website/source/docs/connect/intentions.html.md
@@ -104,7 +104,7 @@ Precedence cannot be manually overridden today. This is a feature that will
 be added in a later version of Consul.
 
 In the case the two precedence values match, Consul will evaluate
-intentions based on lexographical ordering of the destination then
+intentions based on lexicographical ordering of the destination then
 source name. In practice, this is a moot point since authorizing a connection
 has an exact source and destination value so its impossible for two
 valid non-wildcard intentions to match.

--- a/website/source/docs/platform/k8s/service-sync.html.md
+++ b/website/source/docs/platform/k8s/service-sync.html.md
@@ -138,7 +138,7 @@ is routable and configured by some other system.
 
 ClusterIP services are synced by default as of `consul-k8s` version 0.3.0. In 
 many Kubernetes clusters, ClusterIPs may not be accessible outside of the cluster,
-so you may end up with services registered in Consul that are not routeable. To
+so you may end up with services registered in Consul that are not routable. To
 skip syncing ClusterIP services, set [`syncClusterIPServices`](/docs/platform/k8s/helm.html#v-synccatalog-clusterip-sync)
 to `false` in the Helm chart values file.
 

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -41,7 +41,7 @@ block](/docs/agent/options.html#acl).
 
 Datacenters can be upgraded in any order although secondaries will remain in
 [Legacy ACL mode](#legacy-acl-mode) until the primary datacenter is fully
-ugraded.
+upgraded.
 
 Each datacenter should follow the [standard rolling upgrade
 procedure](/docs/upgrading.html#standard-upgrades).


### PR DESCRIPTION
Fixed a few spelling errors

/docs/upgrade-specific.html ugraded/upgraded
/docs/commands/kv/put.html identifer/identifier
/docs/agent/cloud-auto-join.html addresso/address
/docs/agent/sentinel.html Restrited/Restricted
/docs/connect/intentions.html lexographical/lexicographical
/docs/platform/k8s/service-sync.html routeable/routable