### PR TITLE
Update links to envoy docs on xDS protocol

### DIFF
--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -109,7 +109,7 @@ type ConfigManager interface {
 // server is started.
 //
 // A full description of the XDS protocol can be found at
-// https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
 type Server struct {
 	Logger       *log.Logger
 	CfgMgr       ConfigManager

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -196,7 +196,7 @@ func TestServer_StreamAggregatedResources_BasicProtocol(t *testing.T) {
 	// all the others (same version) but NACK the listener. This is the most
 	// subtle part of xDS and the server implementation so I'll elaborate. A full
 	// description of the protocol can be found at
-	// https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md.
+	// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
 	// Envoy delays making a followup request for a type until after it has
 	// processed and applied the last response. The next request then will include
 	// the nonce in the last response which acknowledges _receiving_ and handling

--- a/agent/xds/xds.go
+++ b/agent/xds/xds.go
@@ -3,7 +3,7 @@
 // Discovery Service (ADS) only as we control all config.
 //
 // A full description of the XDS protocol can be found at
-// https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md
+// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol
 //
 // xds.Server also support ext_authz network filter API to authorize incoming
 // connections to Envoy.

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -12,7 +12,7 @@ Consul Connect has first class support for using
 [Envoy](https://www.envoyproxy.io) as a proxy. Consul configures Envoy by
 optionally exposing a gRPC service on the local agent that serves [Envoy's xDS
 configuration
-API](https://github.com/envoyproxy/data-plane-api/blob/master/XDS_PROTOCOL.md).
+API](https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol).
 
 Consul can configure Envoy sidecars to proxy http/1.1, http2 or gRPC traffic at
 L7 or any other tcp-based protocol at L4. Prior to Consul 1.5.0 Envoy proxies


### PR DESCRIPTION
This just updates a few dead links to where I think they should point.