### PR TITLE
agent: fix several data races and bugs related to node-local alias checks

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -70,6 +70,9 @@ func (s *ServiceState) Clone() *ServiceState {
 // CheckState describes the state of a health check record.
 type CheckState struct {
 	// Check is the local copy of the health check record.
+	//
+	// Must Clone() the overall CheckState before mutating this. After mutation
+	// reinstall into the checks map.
 	Check *structs.HealthCheck
 
 	// Token is the ACL record to update or delete the health check
@@ -95,12 +98,15 @@ type CheckState struct {
 	Deleted bool
 }
 
-// Clone returns a shallow copy of the object. The check record and the
-// defer timer still point to the original values and must not be
-// modified.
+// Clone returns a shallow copy of the object.
+//
+// The defer timer still points to the original value and must not be modified.
 func (c *CheckState) Clone() *CheckState {
 	c2 := new(CheckState)
 	*c2 = *c
+	if c.Check != nil {
+		c2.Check = c.Check.Clone()
+	}
 	return c2
 }
 
@@ -590,6 +596,13 @@ func (l *State) UpdateCheck(id types.CheckID, status, output string) {
 		return
 	}
 
+	// Ensure we only mutate a copy of the check state and put the finalized
+	// version into the checks map when complete.
+	c = c.Clone()
+	defer func(c *CheckState) {
+		l.checks[id] = c
+	}(c)
+
 	// Defer a sync if the output has changed. This is an optimization around
 	// frequent updates of output. Instead, we update the output internally,
 	// and periodically do a write-back to the servers. If there is a status
@@ -651,9 +664,9 @@ func (l *State) Checks() map[types.CheckID]*structs.HealthCheck {
 	return m
 }
 
-// CheckState returns a shallow copy of the current health check state
-// record. The health check record and the deferred check still point to
-// the original values and must not be modified.
+// CheckState returns a shallow copy of the current health check state record.
+//
+// The defer timer still points to the original value and must not be modified.
 func (l *State) CheckState(id types.CheckID) *CheckState {
 	l.RLock()
 	defer l.RUnlock()
@@ -685,8 +698,9 @@ func (l *State) setCheckStateLocked(c *CheckState) {
 }
 
 // CheckStates returns a shallow copy of all health check state records.
-// The health check records and the deferred checks still point to
-// the original values and must not be modified.
+// The map contains a shallow copy of the current check states.
+//
+// The defer timers still point to the original values and must not be modified.
 func (l *State) CheckStates() map[types.CheckID]*CheckState {
 	l.RLock()
 	defer l.RUnlock()
@@ -703,9 +717,9 @@ func (l *State) CheckStates() map[types.CheckID]*CheckState {
 
 // CriticalCheckStates returns the locally registered checks that the
 // agent is aware of and are being kept in sync with the server.
-// The map contains a shallow copy of the current check states but
-// references to the actual check definition which must not be
-// modified.
+// The map contains a shallow copy of the current check states.
+//
+// The defer timers still point to the original values and must not be modified.
 func (l *State) CriticalCheckStates() map[types.CheckID]*CheckState {
 	l.RLock()
 	defer l.RUnlock()

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -598,6 +598,11 @@ func (l *State) UpdateCheck(id types.CheckID, status, output string) {
 
 	// Ensure we only mutate a copy of the check state and put the finalized
 	// version into the checks map when complete.
+	//
+	// Note that we are relying upon the earlier deferred mutex unlock to
+	// happen AFTER this defer. As per the Go spec this is true, but leaving
+	// this note here for the future in case of any refactorings which may not
+	// notice this relationship.
 	c = c.Clone()
 	defer func(c *CheckState) {
 		l.checks[id] = c

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1204,15 +1204,6 @@ type ACLPolicyBatchDeleteRequest struct {
 	PolicyIDs []string
 }
 
-func cloneStringSlice(s []string) []string {
-	if len(s) == 0 {
-		return nil
-	}
-	out := make([]string, len(s))
-	copy(out, s)
-	return out
-}
-
 // ACLRoleSetRequest is used at the RPC layer for creation and update requests
 type ACLRoleSetRequest struct {
 	Role       ACLRole // The role to upsert

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1204,6 +1204,15 @@ type ACLPolicyBatchDeleteRequest struct {
 	PolicyIDs []string
 }
 
+func cloneStringSlice(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
+}
+
 // ACLRoleSetRequest is used at the RPC layer for creation and update requests
 type ACLRoleSetRequest struct {
 	Role       ACLRole // The role to upsert

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -966,9 +966,11 @@ func (d *HealthCheckDefinition) Clone() *HealthCheckDefinition {
 	clone := new(HealthCheckDefinition)
 	*clone = *d
 
-	clone.Header = make(map[string][]string)
-	for k, v := range d.Header {
-		clone.Header[k] = cloneStringSlice(v)
+	if d.Header != nil {
+		clone.Header = make(map[string][]string)
+		for k, v := range d.Header {
+			clone.Header[k] = cloneStringSlice(v)
+		}
 	}
 
 	return clone

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -962,6 +962,18 @@ type HealthCheckDefinition struct {
 	DeregisterCriticalServiceAfter time.Duration       `json:",omitempty"`
 }
 
+func (d *HealthCheckDefinition) Clone() *HealthCheckDefinition {
+	clone := new(HealthCheckDefinition)
+	*clone = *d
+
+	clone.Header = make(map[string][]string)
+	for k, v := range d.Header {
+		clone.Header[k] = cloneStringSlice(v)
+	}
+
+	return clone
+}
+
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 	type Alias HealthCheckDefinition
 	exported := &struct {
@@ -1045,6 +1057,8 @@ func (c *HealthCheck) IsSame(other *HealthCheck) bool {
 func (c *HealthCheck) Clone() *HealthCheck {
 	clone := new(HealthCheck)
 	*clone = *c
+	clone.ServiceTags = cloneStringSlice(c.ServiceTags)
+	clone.Definition = *c.Definition.Clone()
 	return clone
 }
 
@@ -1608,4 +1622,13 @@ func (r *KeyringResponses) Add(v interface{}) {
 
 func (r *KeyringResponses) New() interface{} {
 	return new(KeyringResponses)
+}
+
+func cloneStringSlice(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	return out
 }

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -962,20 +962,6 @@ type HealthCheckDefinition struct {
 	DeregisterCriticalServiceAfter time.Duration       `json:",omitempty"`
 }
 
-func (d *HealthCheckDefinition) Clone() *HealthCheckDefinition {
-	clone := new(HealthCheckDefinition)
-	*clone = *d
-
-	if d.Header != nil {
-		clone.Header = make(map[string][]string)
-		for k, v := range d.Header {
-			clone.Header[k] = cloneStringSlice(v)
-		}
-	}
-
-	return clone
-}
-
 func (d *HealthCheckDefinition) MarshalJSON() ([]byte, error) {
 	type Alias HealthCheckDefinition
 	exported := &struct {
@@ -1055,12 +1041,11 @@ func (c *HealthCheck) IsSame(other *HealthCheck) bool {
 	return true
 }
 
-// Clone returns a distinct clone of the HealthCheck.
+// Clone returns a distinct clone of the HealthCheck. Note that the
+// "ServiceTags" and "Definition.Header" field are not deep copied.
 func (c *HealthCheck) Clone() *HealthCheck {
 	clone := new(HealthCheck)
 	*clone = *c
-	clone.ServiceTags = cloneStringSlice(c.ServiceTags)
-	clone.Definition = *c.Definition.Clone()
 	return clone
 }
 
@@ -1624,13 +1609,4 @@ func (r *KeyringResponses) Add(v interface{}) {
 
 func (r *KeyringResponses) New() interface{} {
 	return new(KeyringResponses)
-}
-
-func cloneStringSlice(s []string) []string {
-	if len(s) == 0 {
-		return nil
-	}
-	out := make([]string, len(s))
-	copy(out, s)
-	return out
 }

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -126,14 +126,15 @@ func (a *TestAgent) Start(t *testing.T) *TestAgent {
 		require.NoError(err, fmt.Sprintf("Error creating data dir %s: %s", filepath.Join(TempDir, name), err))
 		hclDataDir = `data_dir = "` + d + `"`
 	}
-	id := NodeID()
 
+	var id string
 	for i := 10; i >= 0; i-- {
 		a.Config = TestConfig(
 			randomPortsSource(a.UseTLS),
 			config.Source{Name: a.Name, Format: "hcl", Data: a.HCL},
 			config.Source{Name: a.Name + ".data_dir", Format: "hcl", Data: hclDataDir},
 		)
+		id = string(a.Config.NodeID)
 
 		// write the keyring
 		if a.Key != "" {


### PR DESCRIPTION
The observed bug was that a full restart of a consul datacenter (servers and clients) in conjunction with a restart of a connect-flavored application with bring-your-own-service-registration logic would very frequently cause the envoy sidecar service check to never reflect the aliased service.

Over the course of investigation several bugs and unfortunate interactions were corrected:

## (1) data races

`local.CheckState` objects were only shallow copied, but the key piece of data that gets read and updated is one of the things not copied (the underlying Check with a Status field). When the stock code was run with the race detector enabled this high-relevant-to-the-test-scenario field
was found to be racy.

### Changes

* Update the existing Clone method to include the Check field.
* Use copy-on-write when those fields need to change rather than incrementally updating them in place.

This made the observed behavior occur slightly less often.

## (2) control loop corrections

If anything about how the `runLocal()` method for node-local alias check logic was ever flawed, there was no fallback option. Those checks are purely edge-triggered and failure to properly notice a single edge transition would leave the alias check incorrect until the next flap of the aliased check.

### Change

The change was to introduce a fallback timer to act as a control loop to double check the alias check matches the aliased check every minute (borrowing the duration from the non-local alias check logic body).

This made the observed behavior eventually go away when it did occur.

## (3) overlapping alias check lifetimes

Originally I thought there were two main actions involved in the data race:

**(A)** The act of adding the original check (from disk recovery) and its first health evaluation.

**(B)** The act of the HTTP API requests coming in and resetting the local state when re-registering the same services and checks.

It took awhile for me to realize that there's a third action at work:

**(C)** The goroutines associated with the original check and the later checks.

The actual sequence of actions that was causing the bad behavior was that the API actions result in the original check to be removed and re-added _without waiting for the original goroutine to terminate_. This means for brief windows of time during check definition edits there are
two goroutines that can be sending updates for the alias check status.

In extremely unlikely scenarios the original goroutine sees the aliased check start up in `critical` before being removed but does not get the notification about the nearly immediate update of that check to
`passing`.

This is interlaced with the new goroutine coming up, initializing its base case to `passing` from the current state and then listening for new notifications of edge triggers.

If the original goroutine "finishes" its update, it then commits one more write into the local state of `critical` and exits leaving the alias check no longer reflecting the underlying check.

### Change

The correction here is to enforce that the old goroutines must terminate before spawning the new one for alias checks using `sync.WaitGroup`