### PR TITLE
Stop running TestLeader_ChangeServerID in parallel

### DIFF
--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -875,7 +875,6 @@ func TestLeader_RollRaftServer(t *testing.T) {
 }
 
 func TestLeader_ChangeServerID(t *testing.T) {
-	t.Parallel()
 	conf := func(c *Config) {
 		c.Bootstrap = false
 		c.BootstrapExpect = 3


### PR DESCRIPTION
This test has failed in CI multiple times:
https://circleci.com/gh/hashicorp/consul/20675#tests/containers/1
https://circleci.com/gh/hashicorp/consul/20619#tests/containers/1

Removing the parallel flag from this test because:
- Flakiness is timing related
- The block that is failing already has a retry (with an up to 7 sec wait)
- The test spins up 3 Consul servers