### PR TITLE
exclude agent/proxyprocess tests since it will be removed in 1.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
-          for pkg in $(go list ./... | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
+          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess |circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
             reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
             gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/$reportname.xml -- -tags=$GOTAGS $pkg
           done


### PR DESCRIPTION
This excludes the `agent/proxyprocess` tests since this code will be removed soon anyway. It has shown up the most often (~85/100) failed test runs in CI.