### PR TITLE
add dev docker image upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,24 @@ jobs:
               exit 1
             fi
 
+  # upload dev docker image
+  dev-upload-docker:
+    docker:
+      - image: circleci/golang:latest # use a circleci image so the attach_workspace step works (has ca-certs installed)
+    environment:
+      <<: *ENVIRONMENT
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - consul-modcache-v1-{{ checksum "go.mod" }}
+      # get consul binary
+      - attach_workspace:
+          at: bin/
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: make ci.dev-docker
+
   # Nomad 0.8 builds on go0.10
   # Run integration tests on nomad/v0.8.7
   nomad-integration-0_8:
@@ -457,13 +475,16 @@ workflows:
   test-integrations:
     jobs:
       - dev-build
-      - dev-upload-s3:
+      - dev-upload-s3: &dev-upload
           requires:
             - dev-build
           filters:
             branches:
               ignore:
                 - /^pull\/.*$/ # only push dev builds from non forks
+      - dev-upload-docker:
+          <<: *dev-upload
+          context: consul-ci
       - nomad-integration-master:
           requires:
             - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,6 @@ jobs:
       <<: *ENVIRONMENT
     steps:
       - checkout
-      - restore_cache:
-          keys:
-          - consul-modcache-v1-{{ checksum "go.mod" }}
       # get consul binary
       - attach_workspace:
           at: bin/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -151,7 +151,7 @@ ci.dev-docker:
 	--label PULL_REQUEST=$(CIRCLE_PULL_REQUEST) \
 	--label CIRCLE_BUILD_URL=$(CIRCLE_BUILD_URL) \
 	$(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/build-support/docker/Consul-Dev.dockerfile
-	@docker login -u="$(DOCKER_LOGIN)" -p="$(DOCKER_PASS)"
+	@echo $(DOCKER_PASS) | docker login -u="$(DOCKER_LOGIN)" --password-stdin
 	@echo "Pushing dev image to: https://cloud.docker.com/u/hashicorpdev/repository/docker/hashicorpdev/consul"
 	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
 ifeq ($(CIRCLE_BRANCH), master)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,6 +47,14 @@ UI_BUILD_TAG?=consul-build-ui
 BUILD_CONTAINER_NAME?=consul-builder
 CONSUL_IMAGE_VERSION?=latest
 
+################
+# CI Variables #
+################
+CI_DEV_DOCKER_NAMESPACE?=hashicorpdev
+CI_DEV_DOCKER_IMAGE_NAME?=consul
+CI_DEV_DOCKER_WORKDIR?=bin/
+################
+
 DIST_TAG?=1
 DIST_BUILD?=1
 DIST_SIGN?=1
@@ -130,6 +138,19 @@ dev-docker: linux
 	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
 	@echo "Building Consul Development container - $(CONSUL_DEV_IMAGE)"
 	@docker build $(NOCACHE) $(QUIET) -t '$(CONSUL_DEV_IMAGE)' --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) $(CURDIR)/pkg/bin/linux_amd64 -f $(CURDIR)/build-support/docker/Consul-Dev.dockerfile
+
+ci.dev-docker:
+	@echo "Pulling consul container image - $(CONSUL_IMAGE_VERSION)"
+	@docker pull consul:$(CONSUL_IMAGE_VERSION) >/dev/null
+	@echo "Building Consul Development container - $(CI_DEV_DOCKER_IMAGE_NAME)"
+	@docker build $(NOCACHE) $(QUIET) -t '$(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)' --build-arg CONSUL_IMAGE_VERSION=$(CONSUL_IMAGE_VERSION) $(CI_DEV_DOCKER_WORKDIR) -f $(CURDIR)/build-support/docker/Consul-Dev.dockerfile
+	@docker login -u="$(DOCKER_LOGIN)" -p="$(DOCKER_PASS)"
+	@echo "Pushing dev image to: https://cloud.docker.com/u/hashicorpdev/repository/docker/hashicorpdev/consul"
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT)
+ifeq ($(CIRCLE_BRANCH), master)
+	@docker tag $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):$(GIT_COMMIT) $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+	@docker push $(CI_DEV_DOCKER_NAMESPACE)/$(CI_DEV_DOCKER_IMAGE_NAME):latest
+endif
 
 changelogfmt:
 	@echo "--> Making [GH-xxxx] references clickable..."


### PR DESCRIPTION
This PR pushes Docker images for every commit on a branch excluding those from a forked branch. 
The images will be pushed to: https://cloud.docker.com/u/hashicorpdev/repository/docker/hashicorpdev/consul where the tags are the result of `git rev-parse --short HEAD`. The only exception is I thought it might be useful to check if the `CIRCLE_BRANCH` variable was master, then it would set the `latest` tag to the latest master commit (in addition to pushing the ref of the latest master commit itself). This may not be super useful but let's try it and see.