### PR TITLE
Change log line used for verification

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -4166,6 +4166,7 @@ func TestAgent_Monitor(t *testing.T) {
 		Name:      t.Name(),
 		LogWriter: logWriter,
 		LogOutput: io.MultiWriter(os.Stderr, logWriter),
+		HCL:       `node_name = "invalid!"`,
 	}
 	a.Start(t)
 	defer a.Shutdown()
@@ -4201,7 +4202,7 @@ func TestAgent_Monitor(t *testing.T) {
 		<-done
 
 		got := resp.Body.Bytes()
-		want := []byte("raft: Initial configuration (index=1)")
+		want := []byte(`[WARN] agent: Node name "invalid!" will not be discoverable via DNS`)
 		if !bytes.Contains(got, want) {
 			r.Fatalf("got %q and did not find %q", got, want)
 		}


### PR DESCRIPTION
This test has failed in CI multiple times:
https://circleci.com/gh/hashicorp/consul/20591
https://circleci.com/gh/hashicorp/consul/20773

TestAgent_Monitor is looking for a line in the debug log output from raft, to make sure the `monitor` endpoint is working. 

In CI the output is hanging before it gets to that line, despite the retries. However, one log that is showing up consistently is the one about invalid characters for DNS lookup.

This PR changes that to be the log line we check against. 

With this change the test has passed through 3 retries in CI.