### PR TITLE
Docs: Fix the example of "consul operator raft" usage

### DIFF
--- a/website/source/docs/guides/outage.html.md
+++ b/website/source/docs/guides/outage.html.md
@@ -89,7 +89,7 @@ In Consul 0.7 and later, you can use the [`consul operator`](/docs/commands/oper
 command to inspect the Raft configuration:
 
 ```
-$ consul operator raft list-peers
+$ consul operator raft -list-peers
 Node     ID              Address         State     Voter RaftProtocol
 alice    10.0.1.8:8300   10.0.1.8:8300   follower  true  3
 bob      10.0.1.6:8300   10.0.1.6:8300   leader    true  3


### PR DESCRIPTION
`list-peers` must be used with a dash

Update: I'm not going to go through all of the checks and sigh CLA since this is my secondary account, so just copy the change somewhere and apply. Thank you.