### PR TITLE
KV: do not trigger watches when setting the same value

### DIFF
--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1333,6 +1333,14 @@ func (d *DirEntry) Clone() *DirEntry {
 	}
 }
 
+func (d *DirEntry) Equal(o *DirEntry) bool {
+	return d.LockIndex == o.LockIndex &&
+		d.Key == o.Key &&
+		d.Flags == o.Flags &&
+		bytes.Equal(d.Value, o.Value) &&
+		d.Session == o.Session
+}
+
 type DirEntries []*DirEntry
 
 // KVSRequest is used to operate on the Key-Value store

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -480,6 +480,7 @@ func TestAPI_LockMonitorRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
+	pair.Value = []byte{1}
 	if _, err := raw.KV().Put(pair, &WriteOptions{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -496,6 +497,7 @@ func TestAPI_LockMonitorRetry(t *testing.T) {
 	mutex.Lock()
 	errors = 10
 	mutex.Unlock()
+	pair.Value = []byte{2}
 	if _, err := raw.KV().Put(pair, &WriteOptions{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
If a KVSet is performed but does not update the entry, do not trigger
watches for this key.
This avoids releasing blocking queries for KV values that did not
actually change.