### PR TITLE
Run TestServer_Expect on its own

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -647,7 +647,6 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 }
 
 func TestServer_Expect(t *testing.T) {
-	t.Parallel()
 	// All test servers should be in expect=3 mode, except for the 3rd one,
 	// but one with expect=0 can cause a bootstrap to occur from the other
 	// servers as currently implemented.


### PR DESCRIPTION
This test has been flaky in CI: https://circleci.com/gh/hashicorp/consul/20603#tests/containers/1 

Removing `t.Parallel()` so that it runs in isolation to improve test reliability.

The failure was related to a heartbeat timeout the leader server, which triggered a new election and failed the test. When running the test in isolation this timeout should not occur.