### PR TITLE
Flaky test: ACLReplication_Tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,14 +424,14 @@ jobs:
 
 workflows:
   version: 2
-  build-distros:
-    jobs:
-      - go-fmt-and-vet
-      - build-386: &require-go-fmt-vet
-          requires:
-            - go-fmt-and-vet
-      - build-amd64: *require-go-fmt-vet
-      - build-arm-arm64: *require-go-fmt-vet
+  # build-distros:
+  #   jobs:
+  #     - go-fmt-and-vet
+  #     - build-386: &require-go-fmt-vet
+  #         requires:
+  #           - go-fmt-and-vet
+  #     - build-amd64: *require-go-fmt-vet
+  #     - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
     jobs:
       - dev-build
@@ -443,48 +443,48 @@ workflows:
               only:
                 - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
       - go-test-api: *go-test
-      - dev-upload-s3:
-          requires:
-            - dev-build
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only push dev builds from non forks
-      - nomad-integration-master:
-          requires:
-            - dev-build
-      - nomad-integration-0_8:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.8.0:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.9.1:
-          requires:
-            - dev-build
-  website:
-    jobs:
-      - build-website
-      - docs-link-checker:
-          requires:
-            - build-website
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only run link checker on non forks
-      - deploy-website:
-          requires:
-            - docs-link-checker
-          context: static-sites
-          filters:
-            branches:
-              only: stable-website
-  frontend:
-    jobs:
-      - frontend-cache
-      - ember-build:
-          requires:
-            - frontend-cache
-      - ember-test:
-          requires:
-            - ember-build
+  #     - dev-upload-s3:
+  #         requires:
+  #           - dev-build
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only push dev builds from non forks
+  #     - nomad-integration-master:
+  #         requires:
+  #           - dev-build
+  #     - nomad-integration-0_8:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.8.0:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.9.1:
+  #         requires:
+  #           - dev-build
+  # website:
+  #   jobs:
+  #     - build-website
+  #     - docs-link-checker:
+  #         requires:
+  #           - build-website
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only run link checker on non forks
+  #     - deploy-website:
+  #         requires:
+  #           - docs-link-checker
+  #         context: static-sites
+  #         filters:
+  #           branches:
+  #             only: stable-website
+  # frontend:
+  #   jobs:
+  #     - frontend-cache
+  #     - ember-build:
+  #         requires:
+  #           - frontend-cache
+  #     - ember-test:
+  #         requires:
+  #           - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,14 +424,14 @@ jobs:
 
 workflows:
   version: 2
-  # build-distros:
-  #   jobs:
-  #     - go-fmt-and-vet
-  #     - build-386: &require-go-fmt-vet
-  #         requires:
-  #           - go-fmt-and-vet
-  #     - build-amd64: *require-go-fmt-vet
-  #     - build-arm-arm64: *require-go-fmt-vet
+  build-distros:
+    jobs:
+      - go-fmt-and-vet
+      - build-386: &require-go-fmt-vet
+          requires:
+            - go-fmt-and-vet
+      - build-amd64: *require-go-fmt-vet
+      - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
     jobs:
       - dev-build
@@ -443,48 +443,48 @@ workflows:
               only:
                 - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
       - go-test-api: *go-test
-  #     - dev-upload-s3:
-  #         requires:
-  #           - dev-build
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only push dev builds from non forks
-  #     - nomad-integration-master:
-  #         requires:
-  #           - dev-build
-  #     - nomad-integration-0_8:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.8.0:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.9.1:
-  #         requires:
-  #           - dev-build
-  # website:
-  #   jobs:
-  #     - build-website
-  #     - docs-link-checker:
-  #         requires:
-  #           - build-website
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only run link checker on non forks
-  #     - deploy-website:
-  #         requires:
-  #           - docs-link-checker
-  #         context: static-sites
-  #         filters:
-  #           branches:
-  #             only: stable-website
-  # frontend:
-  #   jobs:
-  #     - frontend-cache
-  #     - ember-build:
-  #         requires:
-  #           - frontend-cache
-  #     - ember-test:
-  #         requires:
-  #           - ember-build
+      - dev-upload-s3:
+          requires:
+            - dev-build
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only push dev builds from non forks
+      - nomad-integration-master:
+          requires:
+            - dev-build
+      - nomad-integration-0_8:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.8.0:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.9.1:
+          requires:
+            - dev-build
+  website:
+    jobs:
+      - build-website
+      - docs-link-checker:
+          requires:
+            - build-website
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only run link checker on non forks
+      - deploy-website:
+          requires:
+            - docs-link-checker
+          context: static-sites
+          filters:
+            branches:
+              only: stable-website
+  frontend:
+    jobs:
+      - frontend-cache
+      - ember-build:
+          requires:
+            - frontend-cache
+      - ember-test:
+          requires:
+            - ember-build

--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -376,6 +376,13 @@ func TestACLReplication_Tokens(t *testing.T) {
 		checkSame(r)
 	})
 
+	// Wait for s2 global-management policy
+	retry.Run(t, func(r *retry.R) {
+		_, policy, err := s2.fsm.State().ACLPolicyGetByID(nil, structs.ACLPolicyGlobalManagementID)
+		require.NoError(r, err)
+		require.NotNil(t, policy)
+	})
+
 	// add some local tokens to the secondary DC
 	// these shouldn't be deleted by replication
 	for i := 0; i < 50; i++ {


### PR DESCRIPTION
We're seeing several failures from this ACL replication test:
https://circleci.com/gh/hashicorp/consul/20664#tests/containers/1
https://circleci.com/gh/hashicorp/consul/20612
https://circleci.com/gh/hashicorp/consul/20589#tests/containers/1

The issue seems to only be creeping up in this line:
https://github.com/hashicorp/consul/blob/4daa1585b0d6839ae8fd926b08558e240ee58dbb/agent/consul/acl_replication_test.go#L396

When adding local tokens to dc2 we get the error: No such policy with ID: 00000000-0000-0000-0000-000000000001

Oddly this isn't failing when we add tokens to dc1 a few lines above.

This PR adds a wait for the global-management token.