### PR TITLE
Improve startup message to avoid confusing users when no error occurs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1602,7 +1602,11 @@ func (a *Agent) JoinWAN(addrs []string) (n int, err error) {
 	} else {
 		err = fmt.Errorf("Must be a server to join WAN cluster")
 	}
-	a.logger.Printf("[INFO] agent: (WAN) joined: %d Err: %v", n, err)
+	if err == nil {
+		a.logger.Printf("[INFO] agent: (WAN) joined: %d", n)
+	} else {
+		a.logger.Printf("[WARN] agent: (WAN) couldn't join: %d Err: %v", n, err)
+	}
 	return
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1589,7 +1589,7 @@ func (a *Agent) JoinLAN(addrs []string) (n int, err error) {
 			}
 		}
 	} else {
-		a.logger.Printf("[WARN] agent: (LAN) joined: %d Err: %v", n, err)
+		a.logger.Printf("[WARN] agent: (LAN) couldn't join: %d Err: %v", n, err)
 	}
 	return
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1581,11 +1581,15 @@ func (a *Agent) ShutdownCh() <-chan struct{} {
 func (a *Agent) JoinLAN(addrs []string) (n int, err error) {
 	a.logger.Printf("[INFO] agent: (LAN) joining: %v", addrs)
 	n, err = a.delegate.JoinLAN(addrs)
-	a.logger.Printf("[INFO] agent: (LAN) joined: %d Err: %v", n, err)
-	if err == nil && a.joinLANNotifier != nil {
-		if notifErr := a.joinLANNotifier.Notify(systemd.Ready); notifErr != nil {
-			a.logger.Printf("[DEBUG] agent: systemd notify failed: %v", notifErr)
+	if err == nil {
+		a.logger.Printf("[INFO] agent: (LAN) joined: %d", n)
+		if a.joinLANNotifier != nil {
+			if notifErr := a.joinLANNotifier.Notify(systemd.Ready); notifErr != nil {
+				a.logger.Printf("[DEBUG] agent: systemd notify failed: %v", notifErr)
+			}
 		}
+	} else {
+		a.logger.Printf("[WARN] agent: (LAN) joined: %d Err: %v", n, err)
 	}
 	return
 }


### PR DESCRIPTION
Several times, some users not very familiar with Consul get confused
by error message at startup:

  `[INFO] agent: (LAN) joined: 1 Err: <nil>`

Having `Err: <nil>` seems weird to many users, I propose to have the
following instead:

* Success: `[INFO] agent: (LAN) joined: 1`
* Error:   `[WARN] agent: (LAN) joined: %d Err: ERROR`