### PR TITLE
bug: Consul lock does not receive signals if lock not acquired

### DIFF
--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -188,7 +188,7 @@ func init() {
 	Register("kv import", func(ui cli.Ui) (cli.Command, error) { return kvimp.New(ui), nil })
 	Register("kv put", func(ui cli.Ui) (cli.Command, error) { return kvput.New(ui), nil })
 	Register("leave", func(ui cli.Ui) (cli.Command, error) { return leave.New(ui), nil })
-	Register("lock", func(ui cli.Ui) (cli.Command, error) { return lock.New(ui), nil })
+	Register("lock", func(ui cli.Ui) (cli.Command, error) { return lock.New(ui, MakeShutdownCh()), nil })
 	Register("login", func(ui cli.Ui) (cli.Command, error) { return login.New(ui), nil })
 	Register("logout", func(ui cli.Ui) (cli.Command, error) { return logout.New(ui), nil })
 	Register("maint", func(ui cli.Ui) (cli.Command, error) { return maint.New(ui), nil })

--- a/command/lock/lock.go
+++ b/command/lock/lock.go
@@ -61,8 +61,8 @@ type cmd struct {
 	timeout            time.Duration
 }
 
-func New(ui cli.Ui) *cmd {
-	c := &cmd{UI: ui}
+func New(ui cli.Ui, shutdownCh <-chan struct{}) *cmd {
+	c := &cmd{UI: ui, ShutdownCh: shutdownCh}
 	c.init()
 	return c
 }

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -15,7 +15,7 @@ import (
 
 func argFail(t *testing.T, args []string, expected string) {
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 	c.flags.SetOutput(ui.ErrorWriter)
 	if code := c.Run(args); code != 1 {
 		t.Fatalf("expected return code 1, got %d", code)
@@ -28,7 +28,7 @@ func argFail(t *testing.T, args []string, expected string) {
 
 func TestLockCommand_noTabs(t *testing.T) {
 	t.Parallel()
-	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+	if strings.ContainsRune(New(cli.NewMockUi(), nil).Help(), '\t') {
 		t.Fatal("help has tabs")
 	}
 }
@@ -48,7 +48,7 @@ func TestLockCommand(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "test/prefix", "touch", filePath}
@@ -73,7 +73,7 @@ func TestLockCommand_NoShell(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-shell=false", "test/prefix", "touch", filePath}
@@ -98,7 +98,7 @@ func TestLockCommand_TryLock(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-try=10s", "test/prefix", "touch", filePath}
@@ -132,7 +132,7 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-n=3", "-try=10s", "test/prefix", "touch", filePath}
@@ -166,7 +166,7 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "test/prefix", "touch", filePath}
@@ -201,7 +201,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-n=3", "test/prefix", "touch", filePath}
@@ -236,7 +236,7 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-monitor-retry=9", "test/prefix", "touch", filePath}
@@ -271,7 +271,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	ui := cli.NewMockUi()
-	c := New(ui)
+	c := New(ui, nil)
 
 	filePath := filepath.Join(a.Config.DataDir, "test_touch")
 	args := []string{"-http-addr=" + a.HTTPAddr(), "-n=3", "-monitor-retry=9", "test/prefix", "touch", filePath}
@@ -330,7 +330,7 @@ func TestLockCommand_ChildExitCode(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			c := New(ui)
+			c := New(ui, nil)
 
 			if got := c.Run(tc.args); got != tc.want {
 				t.Fatalf("got %d want %d", got, tc.want)


### PR DESCRIPTION
Fix for https://github.com/hashicorp/consul/issues/4439, where consul lock does not receive signal if lock has not been acquired. The struct for `cmd` in `command/lock/lock.go` has a `shutdownCh` channel that is not populated on creation. This passes in that channel so it can receive/handle them 

cc @slackpad @preetapan 