### PR TITLE
Avoid agent in devMode to join a running cluster

### DIFF
--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -34,6 +34,10 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 	segment string, listener net.Listener) (*serf.Serf, error) {
 	conf.Init()
 
+	if s.config.DevMode {
+		conf.Tags["dev_mode"] = "true"
+	}
+
 	if wan {
 		conf.NodeName = fmt.Sprintf("%s.%s", s.config.NodeName, s.config.Datacenter)
 	} else {

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -77,6 +77,10 @@ func IsConsulServer(m serf.Member) (bool, *Server) {
 	segment := m.Tags["segment"]
 	_, bootstrap := m.Tags["bootstrap"]
 	_, useTLS := m.Tags["use_tls"]
+	_, devMode := m.Tags["dev_mode"]
+	if devMode {
+		return false, nil
+	}
 
 	expect := 0
 	expectStr, ok := m.Tags["expect"]


### PR DESCRIPTION
When using the command `consul join` on a consul agent started in dev mode, it creates lots of troubles in a real cluster.
This patch prevent this by setting a specific flag when running in dev mode and by denying access to cluster to machines in dev mode