### PR TITLE
ui: Upgrade js-yaml

### DIFF
--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -7303,8 +7303,9 @@ js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.8.4:
     esprima "^4.0.0"
 
 js-yaml@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Upgrades a compile time dependency for a security issue (js-yaml 3.12.0 > 3.13.1)

See https://github.com/nodeca/js-yaml/issues/475

