### PR TITLE
website: fix Sentinel time-of-day policy

### DIFF
--- a/website/source/docs/agent/sentinel.html.markdown.erb
+++ b/website/source/docs/agent/sentinel.html.markdown.erb
@@ -85,7 +85,7 @@ key "haproxy_version" {
     sentinel {
         code = <<EOF
 import "time"
-main = rule { time.hour > 8 and time.hour < 17 }
+main = rule { time.now.hour > 8 and time.now.hour < 17 }
 EOF
     }
 }


### PR DESCRIPTION
The policy in the time-of-day Sentinel example incorrectly references
the top-level time.hour constant. This is actually the same as the
time.Hour Go value, so in other words, 3600000000000 (the int64 value
representing the time in nanoseconds).

This is corrected by just using time.now.hour instead.