### PR TITLE
ui: Ensure Service Instance pages account for nodes

### DIFF
--- a/ui-v2/app/models/proxy.js
+++ b/ui-v2/app/models/proxy.js
@@ -8,5 +8,6 @@ export default Model.extend({
   [SLUG_KEY]: attr('string'),
   ServiceName: attr('string'),
   ServiceID: attr('string'),
+  Node: attr('string'),
   ServiceProxy: attr(),
 });

--- a/ui-v2/app/router.js
+++ b/ui-v2/app/router.js
@@ -19,7 +19,7 @@ export const routes = {
         _options: { path: '/:name' },
       },
       instance: {
-        _options: { path: '/:name/:id' },
+        _options: { path: '/:name/:node/:id' },
       },
     },
     // Nodes represent a consul node

--- a/ui-v2/app/routes/dc/services/instance.js
+++ b/ui-v2/app/routes/dc/services/instance.js
@@ -11,7 +11,7 @@ export default Route.extend({
     const proxyRepo = get(this, 'proxyRepo');
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      item: repo.findInstanceBySlug(params.id, params.name, dc),
+      item: repo.findInstanceBySlug(params.id, params.node, params.name, dc),
     }).then(function(model) {
       // this will not be run in a blocking loop, but this is ok as
       // its highly unlikely that a service will suddenly change to being a
@@ -20,7 +20,7 @@ export default Route.extend({
         proxy:
           get(model.item, 'Kind') === 'connect-proxy'
             ? null
-            : proxyRepo.findInstanceBySlug(params.id, params.name, dc),
+            : proxyRepo.findInstanceBySlug(params.id, params.node, params.name, dc),
         ...model,
       });
     });

--- a/ui-v2/app/services/repository/proxy.js
+++ b/ui-v2/app/services/repository/proxy.js
@@ -19,7 +19,7 @@ export default RepositoryService.extend({
     }
     return this.get('store').query(this.getModelName(), query);
   },
-  findInstanceBySlug: function(id, slug, dc, configuration) {
+  findInstanceBySlug: function(id, node, slug, dc, configuration) {
     return this.findAllBySlug(slug, dc, configuration).then(function(items) {
       let res = {};
       if (get(items, 'length') > 0) {

--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -32,10 +32,13 @@ export default RepositoryService.extend({
       return service;
     });
   },
-  findInstanceBySlug: function(id, slug, dc, configuration) {
+  findInstanceBySlug: function(id, node, slug, dc, configuration) {
     return this.findBySlug(slug, dc, configuration).then(function(item) {
+      // Loop through all the service instances and pick out the one
+      // that has the same service id AND node name
+      // node names are unique per datacenter
       const i = item.Nodes.findIndex(function(item) {
-        return item.Service.ID === id;
+        return item.Service.ID === id && item.Node.Node === node;
       });
       if (i !== -1) {
         const service = item.Nodes[i].Service;

--- a/ui-v2/app/templates/dc/services/-instances.hbs
+++ b/ui-v2/app/templates/dc/services/-instances.hbs
@@ -19,7 +19,7 @@
           {{/block-slot}}
           {{#block-slot 'row'}}
             <td data-test-id="{{item.Service.ID}}">
-              <a href={{href-to 'dc.services.instance' item.Service.Service (or item.Service.ID item.Service.Service )}}>
+              <a href={{href-to 'dc.services.instance' item.Service.Service item.Node.Node (or item.Service.ID item.Service.Service )}}>
                 <span data-test-external-source="{{service/external-source item.Service}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item.Service) '-color-svg') 'none')}}}></span>
                 {{ or item.Service.ID item.Service.Service }}
               </a>

--- a/ui-v2/tests/acceptance/dc/services/instances/error.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/error.feature
@@ -7,9 +7,10 @@ Feature: dc / services / instances / error: Visit Service Instance what doesn't 
     ---
       dc: dc1
       service: service-0
+      node: node-0
       id: id-that-doesnt-exist
     ---
-    Then the url should be /dc1/services/service-0/id-that-doesnt-exist
+    Then the url should be /dc1/services/service-0/node-0/id-that-doesnt-exist
     And I see the text "404 (Unable to find instance)" in "[data-test-error]"
 
 

--- a/ui-v2/tests/acceptance/dc/services/instances/proxy.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/proxy.feature
@@ -24,9 +24,10 @@ Feature: dc / services / instances / proxy: Show Proxy Service Instance
     ---
       dc: dc1
       service: service-0-proxy
+      node: node-0
       id: service-0-proxy-with-id
     ---
-    Then the url should be /dc1/services/service-0-proxy/service-0-proxy-with-id
+    Then the url should be /dc1/services/service-0-proxy/node-0/service-0-proxy-with-id
     And I see destination on the proxy like "service"
 
     And I see serviceChecksIsSelected on the tabs

--- a/ui-v2/tests/acceptance/dc/services/instances/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/show.feature
@@ -6,9 +6,17 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
     - Service:
         ID: service-0-with-id
+        Meta:
+          external-source: consul
+      Node:
+        Node: node-0
+    - Service:
+        ID: service-0-with-id
         Tags: ['Tag1', 'Tag2']
         Meta:
           external-source: nomad
+      Node:
+        Node: node-1
       Checks:
         - Name: Service check
           ServiceID: service-0
@@ -46,9 +54,10 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
       dc: dc1
       service: service-0
+      node: node-1
       id: service-0-with-id
     ---
-    Then the url should be /dc1/services/service-0/service-0-with-id
+    Then the url should be /dc1/services/service-0/node-1/service-0-with-id
     Then I don't see type on the proxy
     Then I see externalSource like "nomad"
 
@@ -77,9 +86,10 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
       dc: dc1
       service: service-0
+      node: node-0
       id: service-0-with-id
     ---
-    Then the url should be /dc1/services/service-0/service-0-with-id
+    Then the url should be /dc1/services/service-0/node-0/service-0-with-id
     And an external edit results in 0 instance models
     And pause until I see the text "deregistered" in "[data-notification]"
   @ignore

--- a/ui-v2/tests/acceptance/dc/services/instances/sidecar-proxy.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/sidecar-proxy.feature
@@ -16,9 +16,10 @@ Feature: dc / services / instances / sidecar-proxy: Show Sidecar Proxy Service I
     ---
       dc: dc1
       service: service-0-sidecar-proxy
+      node: node-0
       id: service-0-sidecar-proxy-with-id
     ---
-    Then the url should be /dc1/services/service-0-sidecar-proxy/service-0-sidecar-proxy-with-id
+    Then the url should be /dc1/services/service-0-sidecar-proxy/node-0/service-0-sidecar-proxy-with-id
     And I see destination on the proxy like "instance"
 
     And I see serviceChecksIsSelected on the tabs

--- a/ui-v2/tests/acceptance/dc/services/instances/with-proxy.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/with-proxy.feature
@@ -11,9 +11,10 @@ Feature: dc / services / instances / with-proxy: Show Service Instance with a pr
     ---
       dc: dc1
       service: service-0
+      node: node-0
       id: service-0-with-id
     ---
-    Then the url should be /dc1/services/service-0/service-0-with-id
+    Then the url should be /dc1/services/service-0/node-0/service-0-with-id
     And I see type on the proxy like "proxy"
 
     And I see serviceChecksIsSelected on the tabs

--- a/ui-v2/tests/acceptance/dc/services/instances/with-sidecar.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/with-sidecar.feature
@@ -11,9 +11,10 @@ Feature: dc / services / instances / with-sidecar: Show Service Instance with a 
     ---
       dc: dc1
       service: service-0
+      node: node-0
       id: service-0-with-id
     ---
-    Then the url should be /dc1/services/service-0/service-0-with-id
+    Then the url should be /dc1/services/service-0/node-0/service-0-with-id
     And I see type on the proxy like "sidecar-proxy"
 
     And I see serviceChecksIsSelected on the tabs

--- a/ui-v2/tests/pages/dc/services/instance.js
+++ b/ui-v2/tests/pages/dc/services/instance.js
@@ -1,6 +1,6 @@
 export default function(visitable, attribute, collection, text, radiogroup) {
   return {
-    visit: visitable('/:dc/services/:service/:id'),
+    visit: visitable('/:dc/services/:service/:node/:id'),
     externalSource: attribute('data-test-external-source', 'h1 span'),
     tabs: radiogroup('tab', ['service-checks', 'node-checks', 'upstreams', 'tags']),
     serviceChecks: collection('#service-checks [data-test-healthchecks] li', {}),


### PR DESCRIPTION
Previously we were using ServiceIds as a unique identifier/slug for linking to Service Instance Detail pages (`/:dc/services/:servicename/:serviceid`). ServiceIds are not unique per datacenter, only per Node.

This PR includes the node name into the unique identifier/slug (`/:dc/services/:servicename/:nodename/:serviceid`) and then instead of just looking for the first piece of data in the API response that has a matching ServiceId, we also check for a matching Node name.

This means we then show the correct information on the Service Detail page

Fixes #5853 

There is similar work to come that applies a similar fix when linking to Sidecar Proxies (but not 'normal' proxies)
