### PR TITLE
Fix consul connect token env variable doc

### DIFF
--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -344,7 +344,7 @@ Usage: consul connect envoy [options]
   arguments using -bootstrap.
 
   The proxy requires service:write permissions for the service it represents.
-  The token may be passed via the CLI or the CONSUL_TOKEN environment
+  The token may be passed via the CLI or the CONSUL_HTTP_TOKEN environment
   variable.
 
   The example below shows how to start a local proxy as a sidecar to a "web"

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -382,7 +382,7 @@ Usage: consul connect proxy [options]
   a non-Connect-aware application to use Connect.
 
   The proxy requires service:write permissions for the service it represents.
-  The token may be passed via the CLI or the CONSUL_TOKEN environment
+  The token may be passed via the CLI or the CONSUL_HTTP_TOKEN environment
   variable.
 
   Consul can automatically start and manage this proxy by specifying the


### PR DESCRIPTION
The cli documentation for consul connect commands incorrectly indicated
to use CONSUL_TOKEN instead of CONSUL_HTTP_TOKEN env var.