### PR TITLE
ui: Normal proxies link to services, sidecars to instances

### DIFF
--- a/ui-v2/app/services/repository/proxy.js
+++ b/ui-v2/app/services/repository/proxy.js
@@ -23,7 +23,7 @@ export default RepositoryService.extend({
     return this.findAllBySlug(slug, dc, configuration).then(function(items) {
       let res = {};
       if (get(items, 'length') > 0) {
-        let instance = items.findBy('ServiceProxy.DestinationServiceID', id);
+        let instance = items.filterBy('ServiceProxy.DestinationServiceID', id).findBy('Node', node);
         if (instance) {
           res = instance;
         } else {

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -33,15 +33,20 @@
       </dl>
 {{#if proxy.ServiceName}}
       <dl>
-        <dt data-test-proxy-type="{{if proxy.ServiceProxy.DestinationServiceID "sidecar-proxy" "proxy"}}">{{if proxy.ServiceProxy.DestinationServiceID "Sidecar " ""}}Proxy</dt>
-        <dd><a href="{{href-to 'dc.services.instance' proxy.ServiceName proxy.ServiceID}}">{{proxy.ServiceID}}</a></dd>
+{{#if proxy.ServiceProxy.DestinationServiceID}}
+        <dt data-test-proxy-type="sidecar-proxy">Sidecar Proxy</dt>
+        <dd><a href="{{href-to 'dc.services.instance' proxy.ServiceName proxy.Node proxy.ServiceID}}">{{proxy.ServiceID}}</a></dd>
+{{else}}
+        <dt data-test-proxy-type="proxy">Proxy</dt>
+        <dd><a href="{{href-to 'dc.services.show' proxy.ServiceName}}">{{proxy.ServiceName}}</a></dd>
+{{/if}}
       </dl>
 {{/if}}
 {{#if (eq item.Kind 'connect-proxy')}}
   {{#if item.Proxy.DestinationServiceID}}
       <dl>
         <dt data-test-proxy-destination="instance">Dest. Service Instance</dt>
-        <dd><a href="{{href-to 'dc.services.instance' item.Proxy.DestinationServiceName item.Proxy.DestinationServiceID}}">{{item.Proxy.DestinationServiceID}}</a></dd>
+        <dd><a href="{{href-to 'dc.services.instance' item.Proxy.DestinationServiceName item.Node.Node item.Proxy.DestinationServiceID}}">{{item.Proxy.DestinationServiceID}}</a></dd>
       </dl>
       <dl>
         <dt>Local Service Address</dt>

--- a/ui-v2/tests/acceptance/dc/services/instances/error.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/error.feature
@@ -2,7 +2,7 @@
 Feature: dc / services / instances / error: Visit Service Instance what doesn't exist
   Scenario: No instance can be found in the API response
     Given 1 datacenter model with the value "dc1"
-    And 1 service model
+    And 1 instance model
     When I visit the instance page for yaml
     ---
       dc: dc1

--- a/ui-v2/tests/acceptance/dc/services/instances/proxy.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/proxy.feature
@@ -2,7 +2,7 @@
 Feature: dc / services / instances / proxy: Show Proxy Service Instance
   Scenario: A Proxy Service instance
     Given 1 datacenter model with the value "dc1"
-    And 1 service model from yaml
+    And 1 instance model from yaml
     ---
     - Service:
         Kind: connect-proxy

--- a/ui-v2/tests/acceptance/dc/services/instances/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/show.feature
@@ -2,7 +2,7 @@
 Feature: dc / services / instances / show: Show Service Instance
   Background:
     Given 1 datacenter model with the value "dc1"
-    And 1 service model from yaml
+    And 2 instance models from yaml
     ---
     - Service:
         ID: service-0-with-id
@@ -16,7 +16,7 @@ Feature: dc / services / instances / show: Show Service Instance
         Meta:
           external-source: nomad
       Node:
-        Node: node-1
+        Node: another-node
       Checks:
         - Name: Service check
           ServiceID: service-0
@@ -54,10 +54,10 @@ Feature: dc / services / instances / show: Show Service Instance
     ---
       dc: dc1
       service: service-0
-      node: node-1
+      node: another-node
       id: service-0-with-id
     ---
-    Then the url should be /dc1/services/service-0/node-1/service-0-with-id
+    Then the url should be /dc1/services/service-0/another-node/service-0-with-id
     Then I don't see type on the proxy
     Then I see externalSource like "nomad"
 

--- a/ui-v2/tests/acceptance/dc/services/instances/with-sidecar.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/with-sidecar.feature
@@ -4,8 +4,10 @@ Feature: dc / services / instances / with-sidecar: Show Service Instance with a 
     Given 1 datacenter model with the value "dc1"
     And 1 proxy model from yaml
     ---
-    - ServiceProxy:
-        DestinationServiceID: service-1
+    - Node: node-0
+      ServiceProxy:
+        DestinationServiceID: service-0-with-id
+        DestinationServiceName: ~
     ---
     When I visit the instance page for yaml
     ---
@@ -16,8 +18,25 @@ Feature: dc / services / instances / with-sidecar: Show Service Instance with a 
     ---
     Then the url should be /dc1/services/service-0/node-0/service-0-with-id
     And I see type on the proxy like "sidecar-proxy"
-
     And I see serviceChecksIsSelected on the tabs
     And I don't see upstreams on the tabs
+  Scenario: A Service instance has no Sidecar Proxy (a DestinationServiceID) on the same node
+    Given 1 datacenter model with the value "dc1"
+    And 1 proxy model from yaml
+    ---
+    - Node: node-1
+      ServiceProxy:
+        DestinationServiceID: service-0-with-id
+        DestinationServiceName: ~
+    ---
+    When I visit the instance page for yaml
+    ---
+      dc: dc1
+      service: service-0
+      node: node-0
+      id: service-0-with-id
+    ---
+    Then the url should be /dc1/services/service-0/node-0/service-0-with-id
+    Then I don't see type on the proxy
 
 


### PR DESCRIPTION
Following on from https://github.com/hashicorp/consul/pull/5933 we
noticed that 'normal' proxies should link to the service, rather than
the service instance. Additionally sidecar proxy 'searching' within the
repository should take into account the name of the node that the
originating service is on (sidecar proxies are generally co-located)

Added an additional test here to prove that a sidecar-proxy with the
same service id but on a different node does not show the sidecar proxy
link.