### PR TITLE
build: Loosen up the regex for retrieving the CONSUL_VERSION

### DIFF
--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -974,7 +974,7 @@ function ui_version {
       return 1
    fi
 
-   local ui_version="$(grep '<!-- CONSUL_VERSION: .* -->$' "$1" | sed 's/^<!-- CONSUL_VERSION: \(.*\) -->$/\1/')" || return 1
+   local ui_version="$(grep '<!-- CONSUL_VERSION: .* -->' "$1" | sed 's/<!-- CONSUL_VERSION: \(.*\) -->/\1/' | xargs)" || return 1
    echo "$ui_version"
    return 0
 }

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -2,7 +2,13 @@ ROOT:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 all: build
 
-deps: node_modules
+deps: node_modules clean
+
+clean:
+	rm -rf ./tmp
+
+build-ci: deps
+	yarn run build-ci --output-path=dist
 
 build: deps
 	yarn run build
@@ -19,6 +25,9 @@ test: deps
 test-view: deps
 	yarn run test:view
 
+test-parallel: deps
+	yarn test-parallel
+
 lint: deps
 	yarn run lint:js
 
@@ -31,4 +40,4 @@ steps:
 node_modules: yarn.lock package.json
 	yarn install
 
-.PHONY: all deps build start test test-view lint format
+.PHONY: all deps build start test test-view lint format clean

--- a/ui-v2/lib/startup/index.js
+++ b/ui-v2/lib/startup/index.js
@@ -6,7 +6,7 @@ module.exports = {
     const vars = {
       appName: config.modulePrefix,
       environment: config.environment,
-      rootURL: config.environment === 'production' ? '{{.ContentPath}}' : rootURL,
+      rootURL: config.environment === 'production' ? '{{.ContentPath}}' : config.rootURL,
       config: config,
     };
     switch (type) {


### PR DESCRIPTION
1. Previously the `sed` replacement was searching for the CONSUL_VERSION
comment at the start of a line, it no longer does this to allow for
indentation.
2. Both `grep` and `sed` where looking for the comment at the end of the
line. We've removed this restriction here. We don't need to remove it
right now, but if we ever put the comment followed by something here the
searching would break.
3. Added `xargs` for trimming the resulting version string. We aren't
using this already in the rest of the scripts, but we are pretty sure
this is available on most systems.