### PR TITLE
Add a redirect for the K8s reference arch guide

### DIFF
--- a/website/source/redirects.txt
+++ b/website/source/redirects.txt
@@ -82,6 +82,7 @@
 /docs/guides/semaphore.html                    https://learn.hashicorp.com/consul/developer-configuration/semaphore
 /docs/guides/windows-guide.html                https://learn.hashicorp.com/consul/datacenter-deploy/windows
 /docs/guides/consul-containers.html            https://hub.docker.com/_/consul
+/docs/guides/kubernetes-reference.html         https://learn.hashicorp.com/consul/day-1-operations/kubernetes-reference
 
 # NOTE: Do not use this redirects file for intro doc links.
 #       A custom VCL (Varnish) configuration in the Fastly web admin has been


### PR DESCRIPTION
Reported in Asana:

judith@hashicorp.com Kait Carter should this link (https://www.consul.io/docs/guides/kubernetes-reference.html#infrastructure-requirements) still be accessible or have all the guides been moved to learn?

The main docs are here https://www.consul.io/docs/platform/k8s/run.html
And you can't access the guide anymore if you just click on it in the sidebar so I'm not sure if we should fix this or delete that page/redirect it to our other docs