### PR TITLE
[docs] Internals

### DIFF
--- a/website/source/docs/internals/architecture.html.md
+++ b/website/source/docs/internals/architecture.html.md
@@ -39,9 +39,7 @@ participating in the Raft quorum, maintaining cluster state, responding to RPC q
 exchanging WAN gossip with other datacenters, and forwarding queries to leaders or
 remote datacenters.
 
-* Datacenter - While the definition of a datacenter seems obvious, there are subtle details
-that must be considered. For example, in EC2, are multiple availability zones considered
-to comprise a single datacenter? We define a datacenter to be a networking environment that is
+* Datacenter - We define a datacenter to be a networking environment that is
 private, low latency, and high bandwidth. This excludes communication that would traverse
 the public internet, but for our purposes multiple availability zones within a single EC2
 region would be considered part of a single datacenter.

--- a/website/source/docs/internals/consensus.html.md
+++ b/website/source/docs/internals/consensus.html.md
@@ -30,8 +30,8 @@ There are a few key terms to know when discussing Raft:
 
 * Log - The primary unit of work in a Raft system is a log entry. The problem
 of consistency can be decomposed into a *replicated log*. A log is an ordered
-sequence of entries. We consider the log consistent if all members agree on
-the entries and their order.
+sequence of entries. Entries includes any cluster change; adding nodes, adding services, new key-value pairs, etc. We consider the log consistent
+if all members agree on the entries and their order.
 
 * FSM - [Finite State Machine](https://en.wikipedia.org/wiki/Finite-state_machine).
 An FSM is a collection of finite states with transitions between them. As new logs

--- a/website/source/docs/internals/consensus.html.md
+++ b/website/source/docs/internals/consensus.html.md
@@ -30,7 +30,7 @@ There are a few key terms to know when discussing Raft:
 
 * Log - The primary unit of work in a Raft system is a log entry. The problem
 of consistency can be decomposed into a *replicated log*. A log is an ordered
-sequence of entries. Entries includes any cluster change; adding nodes, adding services, new key-value pairs, etc. We consider the log consistent
+sequence of entries. Entries includes any cluster change: adding nodes, adding services, new key-value pairs, etc. We consider the log consistent
 if all members agree on the entries and their order.
 
 * FSM - [Finite State Machine](https://en.wikipedia.org/wiki/Finite-state_machine).

--- a/website/source/docs/internals/gossip.html.md
+++ b/website/source/docs/internals/gossip.html.md
@@ -29,7 +29,7 @@ used for a few purposes. Membership information allows clients to automatically 
 servers, reducing the amount of configuration needed. The distributed failure detection
 allows the work of failure detection to be shared by the entire cluster instead of
 concentrated on a few servers. Lastly, the gossip pool allows for reliable and fast
-event broadcasts for events like leader election.
+event broadcasts.
 
 The WAN pool is globally unique, as all servers should participate in the WAN pool
 regardless of datacenter. Membership information provided by the WAN pool allows


### PR DESCRIPTION
Updating internals docs for clarity.
- Consensus: Added example log entries.
- Gossip: Remove the note about event broadcasting example is leader election. We could replace with a better example. 
- Architecture: Removed the note about "datacenter" term being obvious since it didn't add to the definition. 