### PR TITLE
add release branch to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
 branches:
   only:
     - master
+    - release/1-6
 
 matrix:
   include:


### PR DESCRIPTION
Since we have a long running release branch we should just enable travis on it to see what we get.