### PR TITLE
Update some tests to fix ContentHash broken by the tagged service addresses

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -318,7 +318,7 @@ func TestAgent_Service(t *testing.T) {
 		Service:     "web-sidecar-proxy",
 		Port:        8000,
 		Proxy:       expectProxy.ToAPI(),
-		ContentHash: "3442362e971c43d1",
+		ContentHash: "ab93d2418205fe0d",
 		Weights: api.AgentWeights{
 			Passing: 1,
 			Warning: 1,
@@ -328,14 +328,14 @@ func TestAgent_Service(t *testing.T) {
 	// Copy and modify
 	updatedResponse := *expectedResponse
 	updatedResponse.Port = 9999
-	updatedResponse.ContentHash = "90b5c19bf0f5073"
+	updatedResponse.ContentHash = "96dab876aa16edaf"
 
 	// Simple response for non-proxy service registered in TestAgent config
 	expectWebResponse := &api.AgentService{
 		ID:          "web",
 		Service:     "web",
 		Port:        8181,
-		ContentHash: "69351c1ac865b034",
+		ContentHash: "f6e4f875dd7c0de8",
 		Weights: api.AgentWeights{
 			Passing: 1,
 			Warning: 1,

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -779,7 +779,7 @@ func TestAPI_AgentService(t *testing.T) {
 		ID:          "foo",
 		Service:     "foo",
 		Tags:        []string{"bar", "baz"},
-		ContentHash: "ad8c7a278470d1e8",
+		ContentHash: "325d9e4891696c34",
 		Port:        8000,
 		Weights: AgentWeights{
 			Passing: 1,


### PR DESCRIPTION
It turns out that hardcoding expected hashes of datastructures means that if you add any new fields to them you must also update the hard coded hashes.

This fixes the problems for now but maybe we want to take a golden file approach in the future for things like this so we can just update the hashes in one go as opposed to copy/pasting output from test failures.