### PR TITLE
Override cla check and add slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,6 @@ jobs:
               | jq --raw-output '.[] | select(.outcome!="success") | "\(.workflows.job_name): \(.build_url)"')"
             if [[ -n "${unsuccessful_builds}" ]]; then
               printf "master merge CI pipeline jobs failed:\n${unsuccessful_builds}\n"
-              git push --delete origin "${git_merge_branch}"
               curl -X POST -H 'Content-type: application/json' \
               --data \
               "{ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,6 +489,20 @@ jobs:
               exit 1
             fi
 
+            current_ref=$(git rev-parse HEAD)
+            # Set CLA check  to pass
+            echo "Setting CLA check"
+            curl -u "${HASHICORP_CI_GITHUB_TOKEN}:" -X POST \
+              --header "Accept: application/json" \
+              --show-error \
+              --silent \
+              --fail \
+              --output /dev/null \
+              -d "{ \"state\": \"success\", \
+                    \"target_url\": \"https://cla.hashicorp.com/hashicorp/consul\", \
+                    \"description\": \"Contributor License Agreement is signed.\", \
+                    \"context\": \"license/cla\"}" https://api.github.com/repos/hashicorp/consul/statuses/${current_ref}
+
             # CircleCI jobs passed, merging to release branch
             echo "master merge CI pipeline passed successfully so merging to ${CIRCLE_BRANCH}!"
             git checkout "${CIRCLE_BRANCH}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -486,11 +486,24 @@ jobs:
             if [[ -n "${unsuccessful_builds}" ]]; then
               printf "master merge CI pipeline jobs failed:\n${unsuccessful_builds}\n"
               git push --delete origin "${git_merge_branch}"
+              curl -X POST -H 'Content-type: application/json' \
+              --data \
+              "{ \
+                \"attachments\": [ \
+                  { \
+                    \"fallback\": \"Nightly Master Merge Failed!\", \
+                    \"text\": \"Nightly *master* merge into *release/1-6* failed!\n\nBuild Log: ${CIRCLE_BUILD_URL}\n\nAttempted merge from: https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/${git_merge_branch}\n\nThere may be a merge conflict to resolve.\", \
+                    \"footer\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\", \
+                    \"ts\": \"$(date +%s)\", \
+                    \"color\": \"danger\" \
+                  } \
+                ] \
+              }" ${CONSUL_SLACK_WEBHOOK_URL}
               exit 1
             fi
 
             current_ref=$(git rev-parse HEAD)
-            # Set CLA check  to pass
+            # Set CLA check to pass
             echo "Setting CLA check"
             curl -u "${HASHICORP_CI_GITHUB_TOKEN}:" -X POST \
               --header "Accept: application/json" \
@@ -509,6 +522,19 @@ jobs:
             git merge "${git_merge_branch}"
             git push origin "${CIRCLE_BRANCH}"
             git push --delete origin "${git_merge_branch}"
+            curl -X POST -H 'Content-type: application/json' \
+              --data \
+              "{ \
+                \"attachments\": [ \
+                  { \
+                    \"fallback\": \"Nightly master merge success!\", \
+                    \"text\": \"Nightly *master* merge into *release/1-6* succeeded!\", \
+                    \"footer\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\", \
+                    \"ts\": \"$(date +%s)\", \
+                    \"color\": \"good\" \
+                  } \
+                ] \
+              }" ${CONSUL_SLACK_WEBHOOK_URL}
 
 workflows:
   version: 2


### PR DESCRIPTION
This fixes an issue with pushing a merged branch of `master` into `release/1-6`. There is a requirement for the CLA check status to return but CLA checks are not kicked off on non-PRs. We fake this status check so that automation can complete the merge via a GitHub Status API update. 

There are also slack notifications added for notifications to Slack to notify us when the release merge is completed or when there is an issue. These notifications look like this:

Failure:
![image](https://user-images.githubusercontent.com/17609145/59946133-ab538380-9437-11e9-9332-3514c1509fab.png)

Success:
![image](https://user-images.githubusercontent.com/17609145/59946159-c0c8ad80-9437-11e9-9cf0-25aa39cd29d2.png)

It's a bit sloppy to keep this much logic in the CircleCI config but since we are removing it after the release we can find a better home for similar work elsewhere in the future. 