### PR TITLE
remove skip-checks on git merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,8 +467,6 @@ jobs:
             git_merge_branch="ci/master-merge-$(date +%Y%m%d%H%M%S)"
             git checkout -b "${git_merge_branch}"
             latest_oss_commit="$(git rev-parse origin/master)"
-            # adding two merge messages will add them into different paragraphs which will achieve what is in
-            # https://help.github.com/en/articles/about-status-checks#skipping-and-requesting-checks-for-individual-commits
             git merge -m "Merge Consul OSS branch 'master' at commit ${latest_oss_commit}" "${latest_oss_commit}"
             git push origin "${git_merge_branch}"
             sleep 15  # Wait for merge branch to start CircleCI pipeline

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,7 +469,7 @@ jobs:
             latest_oss_commit="$(git rev-parse origin/master)"
             # adding two merge messages will add them into different paragraphs which will achieve what is in
             # https://help.github.com/en/articles/about-status-checks#skipping-and-requesting-checks-for-individual-commits
-            git merge -m "Merge Consul OSS branch 'master' at commit ${latest_oss_commit}" -m "skip-checks: true" "${latest_oss_commit}"
+            git merge -m "Merge Consul OSS branch 'master' at commit ${latest_oss_commit}" "${latest_oss_commit}"
             git push origin "${git_merge_branch}"
             sleep 15  # Wait for merge branch to start CircleCI pipeline
 


### PR DESCRIPTION
This is a small fix to the git merge commit message on the nightly merge job. I forgot to remove the `skip-checks` line as it doesn't have any effect. In more detail for future reference, the CLA check I was trying to bypass with this option is not a [GitHub Check](https://developer.github.com/v3/checks/) but rather a [GitHub Status](https://developer.github.com/v3/repos/statuses/). This is why `skip-checks` has no effect. 