### PR TITLE
ui: Add an additional 'more than 1 char' check for selection

### DIFF
--- a/ui-v2/app/instance-initializers/selection.js
+++ b/ui-v2/app/instance-initializers/selection.js
@@ -5,7 +5,8 @@ const isSelecting = function(win = window) {
   const selection = win.getSelection();
   let selecting = false;
   try {
-    selecting = 'isCollapsed' in selection && !selection.isCollapsed;
+    selecting =
+      'isCollapsed' in selection && !selection.isCollapsed && selection.toString().length > 1;
   } catch (e) {
     // passthrough
   }


### PR DESCRIPTION
We'd rather 'play it safe' for our selection detection (which avoids
following links if you have some text selected). This commit adds an
additional check of 'more than 1 character' to the 'isSelected' check.
This is based on the fact that it's far quicker to type the character so
why would a user select on character? This therefore caters for any
fairly large (in the scheme of things) incidental mouse moves whilst
clicking a link.

Overall this is probably overkill, but worthwhile for 'playing it safe'