### PR TITLE
ui: Be more exact with intent for table truncation

### DIFF
--- a/ui-v2/app/styles/base/components/table/layout.scss
+++ b/ui-v2/app/styles/base/components/table/layout.scss
@@ -27,10 +27,14 @@
   display: block;
 }
 %table td:not(.actions),
+%table td:not(.actions) > *:only-child {
+  overflow-x: hidden;
+}
 %table td:not(.actions) > * {
   white-space: nowrap;
+}
+%table td:not(.actions) > *:only-child {
   text-overflow: ellipsis;
-  overflow-x: hidden;
 }
 %table td {
   height: 50px;


### PR DESCRIPTION
Truncation should only happen currently on table content if the tag
within the td is the only child.

Please note although the branch is bugfix, the bug is not in `master`

Before:

![Screenshot 2019-06-26 at 13 43 23](https://user-images.githubusercontent.com/554604/60180633-66a16100-9818-11e9-853a-4e23a1c4e7dc.png)

After:

![Screenshot 2019-06-26 at 13 42 51](https://user-images.githubusercontent.com/554604/60180596-538e9100-9818-11e9-8e63-a3a19e70b40f.png)
