### PR TITLE
Remove failed nodes from serfWAN

### DIFF
--- a/agent/consul/autopilot.go
+++ b/agent/consul/autopilot.go
@@ -77,6 +77,10 @@ func (d *AutopilotDelegate) Raft() *raft.Raft {
 	return d.server.raft
 }
 
-func (d *AutopilotDelegate) Serf() *serf.Serf {
+func (d *AutopilotDelegate) SerfLAN() *serf.Serf {
 	return d.server.serfLAN
+}
+
+func (d *AutopilotDelegate) SerfWAN() *serf.Serf {
+	return d.server.serfWAN
 }

--- a/agent/consul/autopilot/autopilot.go
+++ b/agent/consul/autopilot/autopilot.go
@@ -215,7 +215,9 @@ func (a *Autopilot) pruneDeadServers() error {
 				if found && s.Suffrage == raft.Nonvoter {
 					a.logger.Printf("[INFO] autopilot: Attempting removal of failed server node %q", member.Name)
 					go serfLAN.RemoveFailedNode(member.Name)
-					go serfWAN.RemoveFailedNode(member.Name)
+					if serfWAN != nil {
+						go serfWAN.RemoveFailedNode(member.Name)
+					}
 				} else {
 					failed = append(failed, member)
 

--- a/agent/consul/autopilot/autopilot.go
+++ b/agent/consul/autopilot/autopilot.go
@@ -176,7 +176,6 @@ func (a *Autopilot) RemoveDeadServers() {
 
 // pruneDeadServers removes up to numPeers/2 failed servers
 func (a *Autopilot) pruneDeadServers() error {
-	fmt.Printf("Hi from pruneDeadServers!")
 	conf := a.delegate.AutopilotConfig()
 	if conf == nil || !conf.CleanupDeadServers {
 		return nil
@@ -240,13 +239,8 @@ func (a *Autopilot) pruneDeadServers() error {
 		}
 		// If SerfLAN was removing servers, WAN should too.
 		// Check serfWAN for any failed servers
-		serfWAN := a.delegate.SerfLAN()
+		serfWAN := a.delegate.SerfWAN()
 		for _, member := range serfWAN.Members() {
-			_, err := a.delegate.IsServer(member)
-			if err != nil {
-				a.logger.Printf("[INFO] autopilot: Error parsing server info for %q: %s", member.Name, err)
-				continue
-			}
 			if member.Status == serf.StatusFailed {
 				a.logger.Printf("[INFO] autopilot: Attempting removal of failed server node %q", member.Name)
 				go serfWAN.RemoveFailedNode(member.Name)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -957,6 +958,10 @@ func (s *Server) WANMembers() []serf.Member {
 func (s *Server) RemoveFailedNode(node string) error {
 	if err := s.serfLAN.RemoveFailedNode(node); err != nil {
 		return err
+	}
+	//If node is not nodename.datacenter, make it so
+	if !strings.HasSuffix(node, "."+s.config.Datacenter) {
+		node = node + "." + s.config.Datacenter
 	}
 	if s.serfWAN != nil {
 		if err := s.serfWAN.RemoveFailedNode(node); err != nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -959,7 +959,8 @@ func (s *Server) RemoveFailedNode(node string) error {
 	if err := s.serfLAN.RemoveFailedNode(node); err != nil {
 		return err
 	}
-	//If node is not nodename.datacenter, make it so
+	// The Serf WAN pool stors members as node.datacenter
+	// so the dc is appended if not present
 	if !strings.HasSuffix(node, "."+s.config.Datacenter) {
 		node = node + "." + s.config.Datacenter
 	}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -959,7 +959,7 @@ func (s *Server) RemoveFailedNode(node string) error {
 	if err := s.serfLAN.RemoveFailedNode(node); err != nil {
 		return err
 	}
-	// The Serf WAN pool stors members as node.datacenter
+	// The Serf WAN pool stores members as node.datacenter
 	// so the dc is appended if not present
 	if !strings.HasSuffix(node, "."+s.config.Datacenter) {
 		node = node + "." + s.config.Datacenter


### PR DESCRIPTION
Autopilot primarily focuses on serfLAN and places failed servers into a left state in that gossip pool, but does not do this for serfWAN. 
Whenever serfWAN is in use, we should be removing any failed node from the gossip pool to create consistency between serfWAN and serfLAN.

In the `force-leave` command it is important to check if when passing nodenames to serfWAN it is formatted in the proper way (nodename.datacenter) or it will not properly be removed. 

Fixes #3361 