### PR TITLE
Display nicely Networks (CIDR) in runtime configuration

### DIFF
--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1651,7 +1651,6 @@ func cleanRetryJoin(a string) string {
 func sanitize(name string, v reflect.Value) reflect.Value {
 	typ := v.Type()
 	switch {
-
 	// check before isStruct and isPtr
 	case isNetAddr(typ):
 		if v.IsNil() {
@@ -1666,6 +1665,8 @@ func sanitize(name string, v reflect.Value) reflect.Value {
 			return reflect.ValueOf("unix://" + x.String())
 		case *net.IPAddr:
 			return reflect.ValueOf(x.IP.String())
+		case *net.IPNet:
+			return reflect.ValueOf(x.String())
 		default:
 			return v
 		}

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5051,6 +5051,14 @@ func TestConfigDecodeBytes(t *testing.T) {
 	}
 }
 
+func parseCIDR(t *testing.T, cidr string) *net.IPNet {
+	_, x, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("CIDRParse: %v", err)
+	}
+	return x
+}
+
 func TestSanitize(t *testing.T) {
 	rt := RuntimeConfig{
 		BindAddr:             &net.IPAddr{IP: net.ParseIP("127.0.0.1")},
@@ -5061,6 +5069,10 @@ func TestSanitize(t *testing.T) {
 			&net.UDPAddr{IP: net.ParseIP("1.2.3.4"), Port: 5678},
 		},
 		DNSSOA: RuntimeSOAConfig{Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 0},
+		AllowWriteHTTPFrom: []*net.IPNet{
+			parseCIDR(t, "127.0.0.0/8"),
+			parseCIDR(t, "::1/128"),
+		},
 		HTTPAddrs: []net.Addr{
 			&net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 5678},
 			&net.UnixAddr{Name: "/var/run/foo"},
@@ -5395,7 +5407,10 @@ func TestSanitize(t *testing.T) {
 		"Version": "",
 		"VersionPrerelease": "",
 		"Watches": [],
-		"AllowWriteHTTPFrom": []
+		"AllowWriteHTTPFrom": [
+			"127.0.0.0/8",
+			"::1/128"
+		]
 	}`
 	b, err := json.MarshalIndent(rt.Sanitized(), "", "    ")
 	if err != nil {


### PR DESCRIPTION
CIDR mask is displayed in binary in configuration.
This add support for nicely displaying CIDR in runtime configuration.

Currently, if a configuration contains the following lines:
```json
  "http_config": {
    "allow_write_http_from": [
      "127.0.0.0/8",
      "::1/128"
    ]
  }
```

A call to `/v1/agent/self?pretty` would display
```json
  "AllowWriteHTTPFrom": [
            {
                "IP": "127.0.0.0",
                "Mask": "/wAAAA=="
            },
            {
                "IP": "::1",
                "Mask": "/////////////////////w=="
            }
  ]
```
This PR fixes it and it will now display:
```json
   "AllowWriteHTTPFrom": [ "127.0.0.0/8", "::1/128" ]
```