### PR TITLE
Fix TestManager_BasicLifecycle to have less issues in travis

### DIFF
--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -215,7 +215,7 @@ func assertWatchChanRecvs(t *testing.T, ch <-chan *ConfigSnapshot, expect *Confi
 		if expect == nil {
 			require.False(t, ok, "watch chan should be closed")
 		}
-	case <-time.After(50*time.Millisecond + coalesceTimeout):
+	case <-time.After(100*time.Millisecond + coalesceTimeout):
 		t.Fatal("recv timeout")
 	}
 }


### PR DESCRIPTION
As seen in https://travis-ci.org/hashicorp/consul/jobs/551056889

The test fails quite often on Travis due to poor performance:

```
--- FAIL: TestManager_BasicLifecycle (1.33s)
    manager_test.go:179: recv timeout
FAIL
```

This PR increase timeout to avoid this test to restart the whole testing.

This should speed up tests and increase reliability