### PR TITLE
Fix unstable test TestRetryJoin in travis

### DIFF
--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -120,7 +120,7 @@ func TestRetryJoin(t *testing.T) {
 		}
 	}()
 
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
 		if got, want := len(a.LANMembers()), 2; got != want {
 			r.Fatalf("got %d LAN members want %d", got, want)
 		}


### PR DESCRIPTION
As seen in https://travis-ci.org/hashicorp/consul/jobs/551065657

Try solving this issue that cause failures and delays while testing in travis:

--- FAIL: TestRetryJoin (7.26s)
    retry.go:121: agent_test.go:125: got 1 LAN members want 2