### PR TITLE
Fix zombie consul process while invoking TestServer.Stop() method in sdk/testutil in Windows

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"runtime"
 
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -323,8 +324,14 @@ func (s *TestServer) Stop() error {
 	}
 
 	if s.cmd.Process != nil {
-		if err := s.cmd.Process.Signal(os.Interrupt); err != nil {
-			return errors.Wrap(err, "failed to kill consul server")
+		if runtime.GOOS == "windows" {
+			if err := s.cmd.Process.Kill(); err != nil { 
+				return errors.Wrap(err, "failed to kill consul server")
+			}
+		} else { // interrupt is not support in windows
+			if err := s.cmd.Process.Signal(os.Interrupt); err != nil { 
+				return errors.Wrap(err, "failed to kill consul server")
+			}
 		}
 	}
 

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -328,7 +328,7 @@ func (s *TestServer) Stop() error {
 			if err := s.cmd.Process.Kill(); err != nil { 
 				return errors.Wrap(err, "failed to kill consul server")
 			}
-		} else { // interrupt is not support in windows
+		} else { // interrupt is not supported in windows
 			if err := s.cmd.Process.Signal(os.Interrupt); err != nil { 
 				return errors.Wrap(err, "failed to kill consul server")
 			}


### PR DESCRIPTION
Windows doesn't support Interrupt signal, thus while stop it on Windows platform
it would fail and left zombie consul process