### PR TITLE
ui: Adds a `sort-control` component for asc/desc sorting of columns etc

### DIFF
--- a/ui-v2/app/components/sort-control.js
+++ b/ui-v2/app/components/sort-control.js
@@ -4,10 +4,6 @@ export default Component.extend({
   classNames: ['sort-control'],
   direction: 'asc',
   onchange: function() {},
-  init: function() {
-    this._super(...arguments);
-    this.guid = this.elementId;
-  },
   actions: {
     change: function(e) {
       if (e.target.type === 'checkbox') {

--- a/ui-v2/app/components/sort-control.js
+++ b/ui-v2/app/components/sort-control.js
@@ -1,0 +1,19 @@
+import Component from '@ember/component';
+import { get, set } from '@ember/object';
+export default Component.extend({
+  classNames: ['sort-control'],
+  direction: 'asc',
+  onchange: function() {},
+  init: function() {
+    this._super(...arguments);
+    this.guid = this.elementId;
+  },
+  actions: {
+    change: function(e) {
+      if (e.target.type === 'checkbox') {
+        set(this, 'direction', e.target.checked ? 'desc' : 'asc');
+      }
+      this.onchange({ target: { value: `${get(this, 'value')}:${get(this, 'direction')}` } });
+    },
+  },
+});

--- a/ui-v2/app/helpers/starts-with.js
+++ b/ui-v2/app/helpers/starts-with.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function startsWith([needle, haystack = ''] /*, hash*/) {
+  return haystack.startsWith(needle);
+}
+
+export default helper(startsWith);

--- a/ui-v2/app/styles/base/components/sort-control/index.scss
+++ b/ui-v2/app/styles/base/components/sort-control/index.scss
@@ -1,0 +1,1 @@
+@import './skin';

--- a/ui-v2/app/styles/base/components/sort-control/skin.scss
+++ b/ui-v2/app/styles/base/components/sort-control/skin.scss
@@ -1,0 +1,17 @@
+%sort-control input {
+  display: none;
+}
+%sort-control label {
+  @extend %user-select-none;
+  cursor: pointer;
+}
+%sort-control input[type='checkbox'] + label::after {
+  @extend %as-pseudo;
+  opacity: 0.7;
+}
+%sort-control input[type='checkbox'] + label::after {
+  @extend %with-arrow-down-icon;
+}
+%sort-control input[type='checkbox']:checked + label::after {
+  @extend %with-arrow-up-icon;
+}

--- a/ui-v2/app/styles/components/index.scss
+++ b/ui-v2/app/styles/components/index.scss
@@ -31,3 +31,4 @@
 @import './modal-dialog';
 @import './notice';
 @import './tooltip';
+@import './sort-control';

--- a/ui-v2/app/styles/components/sort-control.scss
+++ b/ui-v2/app/styles/components/sort-control.scss
@@ -1,0 +1,4 @@
+@import '../base/components/sort-control/index';
+.sort-control {
+  @extend %sort-control;
+}

--- a/ui-v2/app/templates/components/sort-control.hbs
+++ b/ui-v2/app/templates/components/sort-control.hbs
@@ -1,0 +1,7 @@
+<input id={{concat 'sort-control-value-' elementId}} type="radio" value="Name" name={{concat 'sort-control-' name}} onchange={{action 'change'}} />
+{{#if checked}}
+<input id={{concat 'sort-control-direction-' elementId}} type="checkbox" onchange={{action 'change'}} />
+{{/if}}
+<label for={{if checked (concat 'sort-control-direction-' elementId) (concat 'sort-control-value-' elementId)}}>
+  {{yield}}
+</label>

--- a/ui-v2/tests/integration/components/sort-control-test.js
+++ b/ui-v2/tests/integration/components/sort-control-test.js
@@ -1,0 +1,34 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('sort-control', 'Integration | Component | sort control', {
+  integration: true,
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{sort-control}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    ''
+  );
+
+  // Template block usage:
+  this.render(hbs`
+    {{#sort-control}}
+      template block text
+    {{/sort-control}}
+  `);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    'template block text'
+  );
+});

--- a/ui-v2/tests/integration/components/sort-control-test.js
+++ b/ui-v2/tests/integration/components/sort-control-test.js
@@ -32,3 +32,19 @@ test('it renders', function(assert) {
     'template block text'
   );
 });
+test('it changes direction and calls onchange when clicked/activated', function(assert) {
+  assert.expect(2);
+  let count = 0;
+  this.on('change', e => {
+    if (count === 0) {
+      assert.equal(e.target.value, 'sort:desc');
+    } else {
+      assert.equal(e.target.value, 'sort:asc');
+    }
+    count++;
+  });
+  this.render(hbs`{{sort-control checked=true value='sort' onchange=(action 'change')}}`);
+  const $label = this.$('label');
+  $label.trigger('click');
+  $label.trigger('click');
+});

--- a/ui-v2/tests/integration/helpers/starts-with-test.js
+++ b/ui-v2/tests/integration/helpers/starts-with-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('starts-with', 'helper:starts-with', {
+  integration: true,
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{starts-with inputValue}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    'false'
+  );
+});


### PR DESCRIPTION
This commit adds the component but doesn't yet use it anywhere. No tests
are added here as there isn't an awful lot to test.

The helper wraps `startWith`, state is managed via HTML, CSS uses the HTML state, the only logic is for testing whether the thing that fires the change event is a checkbox or not.

Acceptance tests will be added when we come to use this.

~(I think the tests may fail here due to the switch from `ember-browserify` to `ember-auto-import` on an earlier branch. There'll be a PR coming for that shortly)~ done!