### PR TITLE
ui: Ensure event sources are closed to the correct state when connecting

### DIFF
--- a/ui-v2/app/utils/dom/event-source/callable.js
+++ b/ui-v2/app/utils/dom/event-source/callable.js
@@ -68,10 +68,12 @@ export default function(
     close() {
       // additional readyState 3 = CLOSING
       switch (this.readyState) {
+        case 0: // CONNECTING
         case 2: // CLOSED
-          // it's already CLOSED , do nothing
+          this.readyState = 2;
           break;
         default:
+          // OPEN
           this.readyState = 3; // CLOSING
       }
       // non-standard

--- a/ui-v2/tests/integration/utils/dom/event-source/callable-test.js
+++ b/ui-v2/tests/integration/utils/dom/event-source/callable-test.js
@@ -82,10 +82,11 @@ module('Integration | Utility | dom/event-source/callable', function(hooks) {
     });
   });
   test("it can be closed before the first tick, and therefore doesn't run", function(assert) {
-    assert.expect(3);
+    assert.expect(4);
     const EventSource = domEventSourceCallable(EventTarget);
     const listener = this.stub();
     const source = new EventSource();
+    assert.equal(source.readyState, 0);
     source.close();
     assert.equal(source.readyState, 2);
     source.addEventListener('open', function(e) {


### PR DESCRIPTION
This fails the tests, but wouldn't produce an actual bug as the source
is still set to closing, just 1 tick later.

We also added an extra assertion here, just to make the test easier to understand the order of the `readyState` setting

Tests will fail, awaiting https://github.com/hashicorp/consul/pull/6035