### PR TITLE
digest the proxy-defaults protocol into the graph

### DIFF
--- a/agent/consul/discoverychain/compile.go
+++ b/agent/consul/discoverychain/compile.go
@@ -536,8 +536,9 @@ RESOLVE_AGAIN:
 	// Digest mesh gateway settings.
 	if serviceDefault := c.entries.GetService(resolver.Name); serviceDefault != nil {
 		groupResolver.MeshGateway = serviceDefault.MeshGateway
+	} else if c.entries.GlobalProxy != nil {
+		groupResolver.MeshGateway = c.entries.GlobalProxy.MeshGateway
 	}
-	// TODO(rb): thread proxy-defaults version through here as well
 
 	// Retain this target even if we may not retain the group resolver.
 	c.targets[target] = struct{}{}

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -838,10 +838,11 @@ func canWriteDiscoveryChain(entry discoveryChainConfigEntry, rule acl.Authorizer
 // DiscoveryChainConfigEntries wraps just the raw cross-referenced config
 // entries. None of these are defaulted.
 type DiscoveryChainConfigEntries struct {
-	Routers   map[string]*ServiceRouterConfigEntry
-	Splitters map[string]*ServiceSplitterConfigEntry
-	Resolvers map[string]*ServiceResolverConfigEntry
-	Services  map[string]*ServiceConfigEntry
+	Routers     map[string]*ServiceRouterConfigEntry
+	Splitters   map[string]*ServiceSplitterConfigEntry
+	Resolvers   map[string]*ServiceResolverConfigEntry
+	Services    map[string]*ServiceConfigEntry
+	GlobalProxy *ProxyConfigEntry
 }
 
 func (e *DiscoveryChainConfigEntries) GetRouter(name string) *ServiceRouterConfigEntry {
@@ -913,7 +914,7 @@ func (e *DiscoveryChainConfigEntries) AddServices(entries ...*ServiceConfigEntry
 }
 
 func (e *DiscoveryChainConfigEntries) IsEmpty() bool {
-	return e.IsChainEmpty() && len(e.Services) == 0
+	return e.IsChainEmpty() && len(e.Services) == 0 && e.GlobalProxy == nil
 }
 
 func (e *DiscoveryChainConfigEntries) IsChainEmpty() bool {


### PR DESCRIPTION
I'd completely ignored compiling `proxy-defaults` into the config entry graph. This PR corrects that omission.

The default global proxy config is always read as part of a chain lookup and the protocol encoded within is compiled in as the protocol to use for a service like:

1. `Protocol` from `service-defaults:SERVICE`
2. `Config.protocol` from `proxy-defaults:global`
3. `tcp`
