### PR TITLE
Gateways and resolvers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3954,6 +3954,15 @@ func (a *Agent) registerCache() {
 		RefreshTimer:   0 * time.Second,
 		RefreshTimeout: 10 * time.Minute,
 	})
+
+	a.cache.RegisterType(cachetype.ConfigEntriesName, &cachetype.ConfigEntries{
+		RPC: a,
+	}, &cache.RegisterOptions{
+		// Maintain a blocking query, retry dropped connections quickly
+		Refresh:        true,
+		RefreshTimer:   0 * time.Second,
+		RefreshTimeout: 10 * time.Minute,
+	})
 }
 
 // defaultProxyCommand returns the default Connect managed proxy command.

--- a/agent/cache-types/config_entry.go
+++ b/agent/cache-types/config_entry.go
@@ -1,0 +1,51 @@
+package cachetype
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// Recommended name for registration.
+const ConfigEntriesName = "config-entries"
+
+// ConfigEntries supports fetching discovering configuration entries
+type ConfigEntries struct {
+	RPC RPC
+}
+
+func (c *ConfigEntries) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
+	var result cache.FetchResult
+
+	// The request should be a ConfigEntryQuery.
+	reqReal, ok := req.(*structs.ConfigEntryQuery)
+	if !ok {
+		return result, fmt.Errorf(
+			"Internal cache failure: request wrong type: %T", req)
+	}
+
+	// Set the minimum query index to our current index so we block
+	reqReal.QueryOptions.MinQueryIndex = opts.MinIndex
+	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
+
+	// Always allow stale - there's no point in hitting leader if the request is
+	// going to be served from cache and endup arbitrarily stale anyway. This
+	// allows cached service-discover to automatically read scale across all
+	// servers too.
+	reqReal.AllowStale = true
+
+	// Fetch
+	var reply structs.IndexedConfigEntries
+	if err := c.RPC.RPC("ConfigEntry.List", reqReal, &reply); err != nil {
+		return result, err
+	}
+
+	result.Value = &reply
+	result.Index = reply.QueryMeta.Index
+	return result, nil
+}
+
+func (c *ConfigEntries) SupportsBlocking() bool {
+	return true
+}

--- a/agent/cache-types/config_entry_test.go
+++ b/agent/cache-types/config_entry_test.go
@@ -1,0 +1,66 @@
+package cachetype
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigEntries(t *testing.T) {
+	rpc := TestRPC(t)
+	typ := &ConfigEntries{RPC: rpc}
+
+	// Expect the proper RPC call. This also sets the expected value
+	// since that is return-by-pointer in the arguments.
+	var resp *structs.IndexedConfigEntries
+	rpc.On("RPC", "ConfigEntry.List", mock.Anything, mock.Anything).Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.ConfigEntryQuery)
+			require.Equal(t, uint64(24), req.QueryOptions.MinQueryIndex)
+			require.Equal(t, 1*time.Second, req.QueryOptions.MaxQueryTime)
+			require.True(t, req.AllowStale)
+			require.Equal(t, structs.ServiceResolver, req.Kind)
+			require.Equal(t, "", req.Name)
+
+			reply := args.Get(2).(*structs.IndexedConfigEntries)
+			reply.Kind = structs.ServiceResolver
+			reply.Entries = []structs.ConfigEntry{
+				&structs.ServiceResolverConfigEntry{Kind: structs.ServiceResolver, Name: "foo"},
+				&structs.ServiceResolverConfigEntry{Kind: structs.ServiceResolver, Name: "bar"},
+			}
+			reply.QueryMeta.Index = 48
+			resp = reply
+		})
+
+	// Fetch
+	resultA, err := typ.Fetch(cache.FetchOptions{
+		MinIndex: 24,
+		Timeout:  1 * time.Second,
+	}, &structs.ConfigEntryQuery{
+		Datacenter: "dc1",
+		Kind:       structs.ServiceResolver,
+	})
+	require.NoError(t, err)
+	require.Equal(t, cache.FetchResult{
+		Value: resp,
+		Index: 48,
+	}, resultA)
+
+	rpc.AssertExpectations(t)
+}
+
+func TestConfigEntries_badReqType(t *testing.T) {
+	rpc := TestRPC(t)
+	typ := &ConfigEntries{RPC: rpc}
+
+	// Fetch
+	_, err := typ.Fetch(cache.FetchOptions{}, cache.TestRequest(
+		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong type")
+	rpc.AssertExpectations(t)
+}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -19,6 +19,7 @@ type configSnapshotMeshGateway struct {
 	WatchedServices    map[string]context.CancelFunc
 	WatchedDatacenters map[string]context.CancelFunc
 	ServiceGroups      map[string]structs.CheckServiceNodes
+	ServiceResolvers   map[string]*structs.ServiceResolverConfigEntry
 	GatewayGroups      map[string]structs.CheckServiceNodes
 }
 

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -183,7 +183,75 @@ func TestGatewayNodesDC2(t testing.T) structs.CheckServiceNodes {
 	}
 }
 
-func TestGatewayServicesDC1(t testing.T) structs.CheckServiceNodes {
+func TestGatewayServiceGroupBarDC1(t testing.T) structs.CheckServiceNodes {
+	return structs.CheckServiceNodes{
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "bar-node-1",
+				Node:       "bar-node-1",
+				Address:    "10.1.1.4",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "bar-sidecar-proxy",
+				Address: "172.16.1.6",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "1",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "bar",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+		},
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "bar-node-2",
+				Node:       "bar-node-2",
+				Address:    "10.1.1.5",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "bar-sidecar-proxy",
+				Address: "172.16.1.7",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "1",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "bar",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+		},
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "bar-node-3",
+				Node:       "bar-node-3",
+				Address:    "10.1.1.6",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "bar-sidecar-proxy",
+				Address: "172.16.1.8",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "2",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "bar",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+		},
+	}
+}
+
+func TestGatewayServiceGroupFooDC1(t testing.T) structs.CheckServiceNodes {
 	return structs.CheckServiceNodes{
 		structs.CheckServiceNode{
 			Node: &structs.Node{
@@ -192,7 +260,19 @@ func TestGatewayServicesDC1(t testing.T) structs.CheckServiceNodes {
 				Address:    "10.1.1.1",
 				Datacenter: "dc1",
 			},
-			Service: structs.TestNodeServiceProxy(t),
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "foo-sidecar-proxy",
+				Address: "172.16.1.3",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "1",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
 		},
 		structs.CheckServiceNode{
 			Node: &structs.Node{
@@ -201,7 +281,69 @@ func TestGatewayServicesDC1(t testing.T) structs.CheckServiceNodes {
 				Address:    "10.1.1.2",
 				Datacenter: "dc1",
 			},
-			Service: structs.TestNodeServiceProxy(t),
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "foo-sidecar-proxy",
+				Address: "172.16.1.4",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "1",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+		},
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "foo-node-3",
+				Node:       "foo-node-3",
+				Address:    "10.1.1.3",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "foo-sidecar-proxy",
+				Address: "172.16.1.5",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "2",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+		},
+		structs.CheckServiceNode{
+			Node: &structs.Node{
+				ID:         "foo-node-4",
+				Node:       "foo-node-4",
+				Address:    "10.1.1.7",
+				Datacenter: "dc1",
+			},
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindConnectProxy,
+				Service: "foo-sidecar-proxy",
+				Address: "172.16.1.9",
+				Port:    2222,
+				Meta: map[string]string{
+					"version": "2",
+				},
+				Proxy: structs.ConnectProxyConfig{
+					DestinationServiceName: "foo",
+					Upstreams:              structs.TestUpstreams(t),
+				},
+			},
+			Checks: structs.HealthChecks{
+				&structs.HealthCheck{
+					Node:        "foo-node-4",
+					ServiceName: "foo-sidecar-proxy",
+					Name:        "proxy-alive",
+					Status:      "warning",
+				},
+			},
 		},
 	}
 }
@@ -268,7 +410,8 @@ func TestConfigSnapshotMeshGateway(t testing.T) *ConfigSnapshot {
 				"dc2": nil,
 			},
 			ServiceGroups: map[string]structs.CheckServiceNodes{
-				"foo": TestGatewayServicesDC1(t),
+				"foo": TestGatewayServiceGroupFooDC1(t),
+				"bar": TestGatewayServiceGroupBarDC1(t),
 			},
 			GatewayGroups: map[string]structs.CheckServiceNodes{
 				"dc2": TestGatewayNodesDC2(t),

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -2,6 +2,7 @@ package proxycfg
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,7 +86,7 @@ func TestCerts(t testing.T) (*structs.IndexedCARoots, *structs.IssuedCert) {
 	ca := connect.TestCA(t, nil)
 	roots := &structs.IndexedCARoots{
 		ActiveRootID: ca.ID,
-		TrustDomain:  connect.TestClusterID,
+		TrustDomain:  fmt.Sprintf("%s.consul", connect.TestClusterID),
 		Roots:        []*structs.CARoot{ca},
 	}
 	return roots, TestLeafForCA(t, ca)

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -387,6 +387,31 @@ func (c *ConfigEntryQuery) RequestDatacenter() string {
 	return c.Datacenter
 }
 
+func (r *ConfigEntryQuery) CacheInfo() cache.RequestInfo {
+	info := cache.RequestInfo{
+		Token:          r.Token,
+		Datacenter:     r.Datacenter,
+		MinIndex:       r.MinQueryIndex,
+		Timeout:        r.MaxQueryTime,
+		MaxAge:         r.MaxAge,
+		MustRevalidate: r.MustRevalidate,
+	}
+
+	v, err := hashstructure.Hash([]interface{}{
+		r.Kind,
+		r.Name,
+		r.Filter,
+	}, nil)
+	if err == nil {
+		// If there is an error, we don't set the key. A blank key forces
+		// no cache for this request so the request is forwarded directly
+		// to the server.
+		info.Key = strconv.FormatUint(v, 10)
+	}
+
+	return info
+}
+
 // ServiceConfigRequest is used when requesting the resolved configuration
 // for a service.
 type ServiceConfigRequest struct {

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/hashicorp/consul/agent/proxycfg"
+	"github.com/hashicorp/consul/agent/structs"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -101,6 +102,27 @@ func TestClustersFromSnapshot(t *testing.T) {
 			name:   "mesh-gateway",
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 			setup:  nil,
+		},
+		{
+			name:   "mesh-gateway-service-subsets",
+			create: proxycfg.TestConfigSnapshotMeshGateway,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.MeshGateway.ServiceResolvers = map[string]*structs.ServiceResolverConfigEntry{
+					"bar": &structs.ServiceResolverConfigEntry{
+						Kind: structs.ServiceResolver,
+						Name: "bar",
+						Subsets: map[string]structs.ServiceResolverSubset{
+							"v1": structs.ServiceResolverSubset{
+								Filter: "Service.Meta.Version == 1",
+							},
+							"v2": structs.ServiceResolverSubset{
+								Filter:      "Service.Meta.Version == 2",
+								OnlyPassing: true,
+							},
+						},
+					},
+				}
+			},
 		},
 	}
 

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -212,7 +212,7 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 
 				},
 				"connectTimeout": "1s",
-				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap, "db.default.dc1.internal.11111111-2222-3333-4444-555555555555") + `
+				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap, "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul") + `
 			}`,
 		"prepared_query:geo-cache": `
 			{
@@ -230,7 +230,7 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 
 				},
 				"connectTimeout": "5s",
-				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap, "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555") + `
+				"tlsContext": ` + expectedUpstreamTLSContextJSON(t, snap, "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul") + `
 			}`,
 	}
 }

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -233,6 +233,40 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 			setup:  nil,
 		},
+		{
+			name:   "mesh-gateway-service-subsets",
+			create: proxycfg.TestConfigSnapshotMeshGateway,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.MeshGateway.ServiceResolvers = map[string]*structs.ServiceResolverConfigEntry{
+					"bar": &structs.ServiceResolverConfigEntry{
+						Kind: structs.ServiceResolver,
+						Name: "bar",
+						Subsets: map[string]structs.ServiceResolverSubset{
+							"v1": structs.ServiceResolverSubset{
+								Filter: "Service.Meta.version == 1",
+							},
+							"v2": structs.ServiceResolverSubset{
+								Filter:      "Service.Meta.version == 2",
+								OnlyPassing: true,
+							},
+						},
+					},
+					"foo": &structs.ServiceResolverConfigEntry{
+						Kind: structs.ServiceResolver,
+						Name: "foo",
+						Subsets: map[string]structs.ServiceResolverSubset{
+							"v1": structs.ServiceResolverSubset{
+								Filter: "Service.Meta.version == 1",
+							},
+							"v2": structs.ServiceResolverSubset{
+								Filter:      "Service.Meta.version == 2",
+								OnlyPassing: true,
+							},
+						},
+					},
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/agent/xds/sni.go
+++ b/agent/xds/sni.go
@@ -10,7 +10,10 @@ func DatacenterSNI(dc string, cfgSnap *proxycfg.ConfigSnapshot) string {
 	return fmt.Sprintf("%s.internal.%s", dc, cfgSnap.Roots.TrustDomain)
 }
 
-func ServiceSNI(service string, namespace string, datacenter string, cfgSnap *proxycfg.ConfigSnapshot) string {
-	// TODO (mesh-gateway) - support service subsets here too
-	return fmt.Sprintf("%s.%s.%s.internal.%s", service, namespace, datacenter, cfgSnap.Roots.TrustDomain)
+func ServiceSNI(service string, subset string, namespace string, datacenter string, cfgSnap *proxycfg.ConfigSnapshot) string {
+	if subset == "" {
+		return fmt.Sprintf("%s.%s.%s.internal.%s", service, namespace, datacenter, cfgSnap.Roots.TrustDomain)
+	} else {
+		return fmt.Sprintf("%s.%s.%s.%s.internal.%s", subset, service, namespace, datacenter, cfgSnap.Roots.TrustDomain)
+	}
 }

--- a/agent/xds/testdata/clusters/custom-local-app.golden
+++ b/agent/xds/testdata/clusters/custom-local-app.golden
@@ -47,7 +47,7 @@
             }
           }
         },
-        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 
@@ -86,7 +86,7 @@
             }
           }
         },
-        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 

--- a/agent/xds/testdata/clusters/custom-timeouts.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.golden
@@ -59,7 +59,7 @@
             }
           }
         },
-        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 
@@ -98,7 +98,7 @@
             }
           }
         },
-        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 

--- a/agent/xds/testdata/clusters/custom-upstream.golden
+++ b/agent/xds/testdata/clusters/custom-upstream.golden
@@ -59,7 +59,7 @@
             }
           }
         },
-        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       }
     },
     {
@@ -95,7 +95,7 @@
             }
           }
         },
-        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 

--- a/agent/xds/testdata/clusters/defaults.golden
+++ b/agent/xds/testdata/clusters/defaults.golden
@@ -59,7 +59,7 @@
             }
           }
         },
-        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 
@@ -98,7 +98,7 @@
             }
           }
         },
-        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555"
+        "sni": "geo-cache.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
       },
       "outlierDetection": {
 

--- a/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
@@ -48,6 +48,38 @@
       "outlierDetection": {
 
       }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      }
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",

--- a/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "dc2.internal.11111111-2222-3333-4444-555555555555",
+      "name": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -19,7 +19,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -35,7 +35,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -51,7 +51,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -67,7 +67,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/clusters/mesh-gateway.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "dc2.internal.11111111-2222-3333-4444-555555555555",
+      "name": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -19,7 +19,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {
@@ -35,7 +35,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
@@ -37,6 +37,52 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
       "endpoints": [
         {
@@ -95,7 +141,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -122,12 +168,78 @@
               },
               "healthStatus": "HEALTHY",
               "loadBalancingWeight": 1
-            },
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "endpoints": [
+        {
+          "lbEndpoints": [
             {
               "endpoint": {
                 "address": {
                   "socketAddress": {
                     "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "v1.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.3",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.4",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "v2.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.5",
                     "portValue": 2222
                   }
                 }

--- a/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -37,53 +37,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.6",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.7",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.8",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -141,7 +95,53 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -175,7 +175,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -197,7 +197,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "v1.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "v1.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -231,7 +231,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "v2.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "v2.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [

--- a/agent/xds/testdata/endpoints/mesh-gateway.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -37,7 +37,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [
@@ -95,7 +95,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
           "lbEndpoints": [

--- a/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-custom-addresses.golden
@@ -14,14 +14,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_bar_dc2_tcp"
                 }
             }
@@ -61,14 +61,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_baz_dc2_tcp"
                 }
             }
@@ -108,14 +108,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
                 }
             }
@@ -155,14 +155,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_foo_dc2_tcp"
                 }
             }

--- a/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-tagged-addresses.golden
@@ -14,14 +14,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_lan_dc2_tcp"
                 }
             }
@@ -61,14 +61,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_wan_dc2_tcp"
                 }
             }

--- a/agent/xds/testdata/listeners/mesh-gateway.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway.golden
@@ -14,14 +14,14 @@
         {
           "filterChainMatch": {
             "serverNames": [
-              "*.dc2.internal.11111111-2222-3333-4444-555555555555"
+              "*.dc2.internal.11111111-2222-3333-4444-555555555555.consul"
             ]
           },
           "filters": [
             {
               "name": "envoy.tcp_proxy",
               "config": {
-                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555",
+                  "cluster": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
                   "stat_prefix": "mesh_gateway_remote_default_dc2_tcp"
                 }
             }


### PR DESCRIPTION
This was branched from the #6024 and has quite a bit of changes from that, once that PR is merged this one will look much smaller.

It is two commits besides from the parent branch.

First implements a cache type to support watching config entry lists.
The second commit is the changes necessary to the proxycfg and xds packages to support watching service resolvers and then generating clusters with the proper endpoints.