### PR TITLE
Prevents recursive hex encoding of keys

### DIFF
--- a/agent/connect/generate.go
+++ b/agent/connect/generate.go
@@ -6,30 +6,90 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
+	"strings"
+
+	//"crypto/ecdsa"
+	//"crypto/elliptic"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 )
 
-// GeneratePrivateKey generates a new Private key
-func GeneratePrivateKey() (crypto.Signer, string, error) {
-	var pk *ecdsa.PrivateKey
+func pemEncodeKey(key []byte, blockType string) (string, error) {
+	var buf bytes.Buffer
 
-	pk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err := pem.Encode(&buf, &pem.Block{Type: blockType, Bytes: key}); err != nil {
+		return "", fmt.Errorf("error encoding private key: %s", err)
+	}
+	return buf.String(), nil
+}
+
+func generateRSAKey(keyBits int) (crypto.Signer, string, error) {
+	var pk *rsa.PrivateKey
+
+	pk, err := rsa.GenerateKey(rand.Reader, keyBits)
 	if err != nil {
-		return nil, "", fmt.Errorf("error generating private key: %s", err)
+		return nil, "", fmt.Errorf("error generating RSA private key: %s", err)
+	}
+
+	bs := x509.MarshalPKCS1PrivateKey(pk)
+	pemBlock, err := pemEncodeKey(bs, "RSA PRIVATE KEY")
+	if err != nil {
+		return nil, "", err
+	}
+
+	return pk, pemBlock, nil
+}
+
+func generateECDSAKey(keyBits int) (crypto.Signer, string, error) {
+	var pk *ecdsa.PrivateKey
+	var curve elliptic.Curve
+
+	switch keyBits {
+	case 224:
+		curve = elliptic.P224()
+	case 256:
+		curve = elliptic.P256()
+	case 384:
+		curve = elliptic.P384()
+	case 521:
+		curve = elliptic.P521()
+	default:
+		return nil, "", fmt.Errorf("error generating ECDSA private key: unknown curve length %d", keyBits)
+	}
+
+	pk, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, "", fmt.Errorf("error generating ECDSA private key: %s", err)
 	}
 
 	bs, err := x509.MarshalECPrivateKey(pk)
 	if err != nil {
-		return nil, "", fmt.Errorf("error generating private key: %s", err)
+		return nil, "", fmt.Errorf("error marshaling ECDSA private key: %s", err)
 	}
 
-	var buf bytes.Buffer
-	err = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: bs})
+	pemBlock, err := pemEncodeKey(bs, "EC PRIVATE KEY")
 	if err != nil {
-		return nil, "", fmt.Errorf("error encoding private key: %s", err)
+		return nil, "", err
 	}
 
-	return pk, buf.String(), nil
+	return pk, pemBlock, nil
+}
+
+// GeneratePrivateKey generates a new Private key
+func GeneratePrivateKeyWithConfig(keyType string, keyBits int) (crypto.Signer, string, error) {
+	switch strings.ToLower(keyType) {
+	case "rsa":
+		return generateRSAKey(keyBits)
+	case "ecdsa":
+		return generateECDSAKey(keyBits)
+	default:
+		return nil, "", fmt.Errorf("unknown private key type requested: %s", keyType)
+	}
+}
+
+func GeneratePrivateKey() (crypto.Signer, string, error) {
+	// TODO: make configurable (e.g. "private_key_type" and "private_key_bits")
+	return GeneratePrivateKeyWithConfig("ecdsa", 256)
 }

--- a/agent/connect/generate.go
+++ b/agent/connect/generate.go
@@ -7,13 +7,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
-	"strings"
-
-	//"crypto/ecdsa"
-	//"crypto/elliptic"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 )
 
 func pemEncodeKey(key []byte, blockType string) (string, error) {

--- a/agent/connect/parsing.go
+++ b/agent/connect/parsing.go
@@ -116,6 +116,12 @@ func KeyId(raw interface{}) ([]byte, error) {
 
 // HexString returns a standard colon-separated hex value for the input
 // byte slice. This should be used with cert serial numbers and so on.
+// Also checks to make sure the input is not already a hex string. If so,
+// it is returned unchanged.
 func HexString(input []byte) string {
+	if len(input) >= 3 && string(input)[2] == ':' {
+		// input is already a hex string
+		return string(input)
+	}
 	return strings.Replace(fmt.Sprintf("% x", input), " ", ":", -1)
 }


### PR DESCRIPTION
When comparing the signing keys on CA certs, Consul converts the bytes to a hex string. Unfortunately it appears that in some circumstances the string is double encoded.

For example, the following output was observed from the `/v1/connect/ca/roots` endpoint:

```
33:37:3a:61:34:3a:63:33:3a:65:34:3a:38:35:3a:63:30:3a:61:30:3a:34:34:3a:64:63:3a:35:65:3a:61:66:3a:65:30:3a:61:37:3a:61:35:3a:38:32:3a:34:36:3a:31:66:3a:36:39:3a:65:32:3a:30:63:3a:39:30:3a:62:62:3a:62:38:3a:64:62:3a:37:66:3a:33:37:3a:34:30:3a:34:61:3a:62:66:3a:30:39:3a:37:61:3a:64:35
```

Decoding this string reveals:

```
37:a4:c3:e4:85:c0:a0:44:dc:5e:af:e0:a7:a5:82:46:1f:69:e2:0c:90:bb:b8:db:7f:37:40:4a:bf:09:7a:d5
```

So the key was encoded more than once. This PR stops that by checking to see if the input is already a hex string before encoding it again.