### PR TITLE
[docs] Fixing Ambassador Consul Connect Integration guide

### DIFF
--- a/website/source/docs/platform/k8s/connect.html.md
+++ b/website/source/docs/platform/k8s/connect.html.md
@@ -50,6 +50,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: static-server
+  labels:
+    app: static-server
   annotations:
     "consul.hashicorp.com/connect-inject": "true"
 spec:


### PR DESCRIPTION
The Ambassador Consul Connect Integration guide contained a couple of errors.

- Old URLs ending up in 404s
- Improperly formatted Kubernetes config YAMLs
- Missing/wrong label in the static-server and static-service YAMLs

All of those should be fixed and the guide actually can be used to set up a working integration which wasn't the case before.