### PR TITLE
Change the gating for when gateways release the config to envoy

### DIFF
--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -53,8 +53,9 @@ func (s *ConfigSnapshot) Valid() bool {
 		// TODO(rb): sanity check discovery chain things here?
 		return s.Roots != nil && s.ConnectProxy.Leaf != nil
 	case structs.ServiceKindMeshGateway:
-		// TODO (mesh-gateway) - what happens if all the connect services go away
-		return s.Roots != nil && len(s.MeshGateway.ServiceGroups) > 0
+		// Even if we have no services or datacenters we can still configure
+		// all the listeners and then populate everything else later.
+		return s.Roots != nil && len(s.Roots.Roots) > 0
 	default:
 		return false
 	}


### PR DESCRIPTION
Instead of waiting for any connect services (which can cause health checks of the gateway to fail for a long time - and potentially cause deregistering the service) this allows the config to be released and sent to envoy once we have the CA roots