### PR TITLE
xds message ordering

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -40,7 +40,7 @@ func (s *Server) clustersFromSnapshot(cfgSnap *proxycfg.ConfigSnapshot, token st
 // (upstreams) in the snapshot.
 func (s *Server) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnapshot, token string) ([]proto.Message, error) {
 	// TODO(rb): this sizing is a low bound.
-	clusters := make([]proto.Message, len(cfgSnap.Proxy.Upstreams)+1)
+	clusters := make([]proto.Message, 0, len(cfgSnap.Proxy.Upstreams)+1)
 
 	// Include the "app" cluster for the public listener
 	appCluster, err := s.makeAppCluster(cfgSnap)

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -5,9 +5,11 @@ import (
 	"log"
 	"os"
 	"path"
+	"sort"
 	"testing"
 	"text/template"
 
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
 	testinf "github.com/mitchellh/go-testing-interface"
@@ -153,6 +155,9 @@ func TestClustersFromSnapshot(t *testing.T) {
 
 			clusters, err := s.clustersFromSnapshot(snap, "my-token")
 			require.NoError(err)
+			sort.Slice(clusters, func(i, j int) bool {
+				return clusters[i].(*envoy.Cluster).Name < clusters[j].(*envoy.Cluster).Name
+			})
 			r, err := createResponse(ClusterType, "00000001", "00000001", clusters)
 			require.NoError(err)
 

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"sort"
 	"testing"
 
 	"github.com/mitchellh/copystructure"
@@ -295,6 +296,9 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			s := Server{Logger: log.New(os.Stderr, "", log.LstdFlags)}
 
 			endpoints, err := s.endpointsFromSnapshot(snap, "my-token")
+			sort.Slice(endpoints, func(i, j int) bool {
+				return endpoints[i].(*envoy.ClusterLoadAssignment).ClusterName < endpoints[j].(*envoy.ClusterLoadAssignment).ClusterName
+			})
 			require.NoError(err)
 			r, err := createResponse(EndpointType, "00000001", "00000001", endpoints)
 			require.NoError(err)

--- a/agent/xds/testdata/clusters/custom-local-app.golden
+++ b/agent/xds/testdata/clusters/custom-local-app.golden
@@ -3,19 +3,6 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "mylocal",
-      "connectTimeout": "5s",
-      "hosts": [
-        {
-          "socketAddress": {
-            "address": "127.0.0.1",
-            "portValue": 8080
-          }
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "db",
       "type": "EDS",
       "edsClusterConfig": {
@@ -52,6 +39,19 @@
       "outlierDetection": {
 
       }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "mylocal",
+      "connectTimeout": "5s",
+      "hosts": [
+        {
+          "socketAddress": {
+            "address": "127.0.0.1",
+            "portValue": 8080
+          }
+        }
+      ]
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",

--- a/agent/xds/testdata/clusters/custom-timeouts.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.golden
@@ -3,31 +3,6 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "local_app",
-      "type": "STATIC",
-      "connectTimeout": "1.234s",
-      "loadAssignment": {
-        "clusterName": "local_app",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "127.0.0.1",
-                      "portValue": 8080
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "db",
       "type": "EDS",
       "edsClusterConfig": {
@@ -63,6 +38,31 @@
       },
       "outlierDetection": {
 
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "1.234s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/agent/xds/testdata/clusters/defaults.golden
+++ b/agent/xds/testdata/clusters/defaults.golden
@@ -3,31 +3,6 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "local_app",
-      "type": "STATIC",
-      "connectTimeout": "5s",
-      "loadAssignment": {
-        "clusterName": "local_app",
-        "endpoints": [
-          {
-            "lbEndpoints": [
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "127.0.0.1",
-                      "portValue": 8080
-                    }
-                  }
-                }
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "db",
       "type": "EDS",
       "edsClusterConfig": {
@@ -63,6 +38,31 @@
       },
       "outlierDetection": {
 
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
@@ -3,6 +3,22 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
@@ -20,22 +36,6 @@
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "ads": {
-
-          }
-        }
-      },
-      "connectTimeout": "5s",
-      "outlierDetection": {
-
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/clusters/mesh-gateway.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway.golden
@@ -3,6 +3,22 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
@@ -20,22 +36,6 @@
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "type": "EDS",
-      "edsClusterConfig": {
-        "edsConfig": {
-          "ads": {
-
-          }
-        }
-      },
-      "connectTimeout": "5s",
-      "outlierDetection": {
-
-      }
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
@@ -3,6 +3,52 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
@@ -95,52 +141,6 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.6",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.7",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.8",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "v1.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
@@ -175,28 +175,6 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.8",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "v1.foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
@@ -218,6 +196,28 @@
                 "address": {
                   "socketAddress": {
                     "address": "172.16.1.4",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "v2.bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
                     "portValue": 2222
                   }
                 }

--- a/agent/xds/testdata/endpoints/mesh-gateway.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway.golden
@@ -3,6 +3,52 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.6",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.7",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.8",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
       "clusterName": "dc2.internal.11111111-2222-3333-4444-555555555555.consul",
       "endpoints": [
         {
@@ -82,52 +128,6 @@
                 "address": {
                   "socketAddress": {
                     "address": "172.16.1.9",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
-      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "endpoints": [
-        {
-          "lbEndpoints": [
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.6",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.7",
-                    "portValue": 2222
-                  }
-                }
-              },
-              "healthStatus": "HEALTHY",
-              "loadBalancingWeight": 1
-            },
-            {
-              "endpoint": {
-                "address": {
-                  "socketAddress": {
-                    "address": "172.16.1.8",
                     "portValue": 2222
                   }
                 }


### PR DESCRIPTION
The clusters/endpoints test were still relying on deterministic ordering of clusters/endpoints which cannot be relied upon due to golang purposefully not providing any guarantee about consistent interation ordering of maps.

Also fixed a small bug in the connect proxy cluster generation that was causing the clusters slice to be double the size it needed to with the first half being all nil pointers.

We could fix this in the non-test code to generate the key list, sort it and then loop over that. However, Envoy doesn't really care about the ordering its getting these so there is no reason to burden the real production code to do this. If we ever cared we could just move the sort.Slice from the test code into the non-test code to have deterministic ordering.