### PR TITLE
envoy: support unix sockets for grpc in bootstrap

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -27,6 +27,11 @@ type BootstrapTplArgs struct {
 	// TLS is enabled.
 	AgentCAFile string
 
+	// AgentSocket is the path to a Unix Socket for communicating with the
+	// local agent's gRPC endpoint. Disabled if the empty (the default),
+	// but overrides AgentAddress and AgentPort if set.
+	AgentSocket string
+
 	// AdminAccessLogPath The path to write the access log for the
 	// administration server. If no access log is desired specify
 	// "/dev/null". By default it will use "/dev/null".
@@ -122,12 +127,20 @@ const bootstrapTemplate = `{
         {{- end }}
         "http2_protocol_options": {},
         "hosts": [
+	  {{- if .AgentSocket -}}
+          {
+            "pipe": {
+              "path": "{{ .AgentSocket }}"
+            }
+          }
+	  {{- else -}}
           {
             "socket_address": {
               "address": "{{ .AgentAddress }}",
               "port_value": {{ .AgentPort }}
             }
           }
+	  {{- end -}}
         ]
       }
       {{- if .StaticClustersJSON -}}

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -207,6 +207,21 @@ func TestGenerateConfig(t *testing.T) {
 			},
 		},
 		{
+			Name: "grpc-addr-unix",
+			Flags: []string{"-proxy-id", "test-proxy",
+				"-grpc-addr", "unix:///var/run/consul.sock"},
+			Env: []string{},
+			WantArgs: BootstrapTplArgs{
+				ProxyCluster:          "test-proxy",
+				ProxyID:               "test-proxy",
+				AgentSocket:           "/var/run/consul.sock",
+				AdminAccessLogPath:    "/dev/null",
+				AdminBindAddress:      "127.0.0.1",
+				AdminBindPort:         "19000",
+				LocalAgentClusterName: xds.LocalAgentClusterName,
+			},
+		},
+		{
 			Name:  "access-log-path",
 			Flags: []string{"-proxy-id", "test-proxy", "-admin-access-log-path", "/some/path/access.log"},
 			Env:   []string{},

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -1,0 +1,59 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy"
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "pipe": {
+              "path": "/var/run/consul.sock"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+			"stats_tags": [
+				{
+			"tag_name": "local_cluster",
+			"fixed_value": "test-proxy"
+		}
+			],
+			"use_all_default_tags": true
+		},
+  "dynamic_resources": {
+    "lds_config": { "ads": {} },
+    "cds_config": { "ads": {} },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": ""
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add AgentSocket BootstrapTplArgs which if set overrides the AgentAddress
and AgentPort to generate a bootstrap which points Envoy to a unix
socket file instead of an ip:port.

Needed when running Envoy in a network namespace and Consul on the host.