### PR TITLE
ui: Gateway Addresses

### DIFF
--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -57,7 +57,7 @@ export default Controller.extend(WithEventSource, WithSearching, {
     // take that off 50% (100% / number of fluid columns)
     // also we added a Type column which we've currently fixed to 100px
     // so again divide that by 2 and take it off each fluid column
-    return htmlSafe(`width: calc(50% - 50px - ${Math.round(get(this, 'maxWidth') / 2)}px)`);
+    return htmlSafe(`width: calc(50% - ${Math.round(get(this, 'maxWidth') / 2)}px)`);
   }),
   maxPassing: computed('items.[]', function() {
     return max(get(this, 'items'), 'ChecksPassing');

--- a/ui-v2/app/helpers/object-entries.js
+++ b/ui-v2/app/helpers/object-entries.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function objectEntries([obj = {}] /*, hash*/) {
+  return Object.entries(obj);
+}
+
+export default helper(objectEntries);

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -17,6 +17,7 @@ export default Model.extend({
   ExternalSources: attr(),
   Meta: attr(),
   Address: attr('string'),
+  TaggedAddresses: attr(),
   Port: attr('number'),
   EnableTagOverride: attr('boolean'),
   CreateIndex: attr('number'),

--- a/ui-v2/app/routes/dc/services/instance.js
+++ b/ui-v2/app/routes/dc/services/instance.js
@@ -18,7 +18,8 @@ export default Route.extend({
       // connect-proxy or vice versa so leave as is for now
       return hash({
         proxy:
-          get(model.item, 'Kind') === 'connect-proxy'
+          // proxies and mesh-gateways can't have proxies themselves so don't even look
+          ['connect-proxy', 'mesh-gateway'].includes(get(model.item, 'Kind'))
             ? null
             : proxyRepo.findInstanceBySlug(params.id, params.node, params.name, dc),
         ...model,

--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -1,7 +1,6 @@
 @import './app-view/index';
 @import './filter-bar/index';
 @import './buttons/index';
-@import './type-icon/index';
 main {
   @extend %app-view;
 }
@@ -24,7 +23,11 @@ main {
   margin-top: 20px;
 }
 %app-view h1 span.kind-proxy {
-  @extend %type-icon, %with-proxy;
+  @extend %frame-gray-900;
+  @extend %pill;
+}
+%app-view h1 span.kind-proxy::before {
+  width: 0.3em !important;
 }
 %app-view h1 em {
   color: $gray-600;

--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -1,6 +1,5 @@
 @import './icons/index';
 @import './table/index';
-@import './type-icon/index';
 
 html.template-service.template-list td:first-child a span,
 html.template-node.template-show #services td:first-child a span,
@@ -19,11 +18,6 @@ html.template-service.template-list main th:first-child {
 
 td.folder {
   @extend %with-folder;
-}
-td .kind-proxy {
-  @extend %type-icon, %with-proxy;
-  text-indent: -9000px !important;
-  width: 24px;
 }
 table:not(.sessions) tbody tr {
   cursor: pointer;

--- a/ui-v2/app/styles/components/type-icon/index.scss
+++ b/ui-v2/app/styles/components/type-icon/index.scss
@@ -1,2 +1,0 @@
-@import './skin';
-@import './layout';

--- a/ui-v2/app/styles/components/type-icon/layout.scss
+++ b/ui-v2/app/styles/components/type-icon/layout.scss
@@ -1,5 +1,0 @@
-%type-icon {
-  display: inline-block;
-  text-indent: 20px;
-  padding: 3px;
-}

--- a/ui-v2/app/styles/components/type-icon/skin.scss
+++ b/ui-v2/app/styles/components/type-icon/skin.scss
@@ -1,6 +1,0 @@
-%type-icon {
-  border-radius: 4px;
-
-  background: $gray-100;
-  color: $gray-400;
-}

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -65,8 +65,7 @@ td strong,
 %breadcrumbs li > *,
 %action-group-action,
 %tab-nav,
-%tooltip-bubble,
-%type-icon {
+%tooltip-bubble {
   font-weight: $typo-weight-medium;
 }
 
@@ -113,7 +112,7 @@ caption,
 %tooltip-bubble,
 %healthchecked-resource strong,
 %footer,
-%type-icon {
+%app-view h1 span.kind-proxy {
   font-size: $typo-size-700;
 }
 %toggle label span {

--- a/ui-v2/app/styles/routes/dc/service/index.scss
+++ b/ui-v2/app/styles/routes/dc/service/index.scss
@@ -1,3 +1,4 @@
+html.template-instance.template-show #addresses table tr,
 html.template-instance.template-show #upstreams table tr {
   cursor: default;
 }

--- a/ui-v2/app/templates/dc/services/-addresses.hbs
+++ b/ui-v2/app/templates/dc/services/-addresses.hbs
@@ -1,0 +1,25 @@
+{{#if item.TaggedAddresses }}
+{{#tabular-collection
+    data-test-addresses
+    items=(object-entries item.TaggedAddresses) as |taggedAddress index|
+}}
+    {{#block-slot 'header'}}
+      <th>Tag</th>
+      <th>Address</th>
+    {{/block-slot}}
+    {{#block-slot 'row'}}
+{{#with (object-at 1 taggedAddress) as |address|}}
+      <td>
+        {{object-at 0 taggedAddress}}{{#if (eq address.Address item.Address)}}&nbsp;<em data-test-address-default>(default)</em>{{/if}}
+      </td>
+      <td data-test-address>
+        {{address.Address}}:{{address.Port}}
+      </td>
+{{/with}}
+    {{/block-slot}}
+{{/tabular-collection}}
+{{else}}
+  <p>
+    There are no additional addresses.
+  </p>
+{{/if}}

--- a/ui-v2/app/templates/dc/services/-addresses.hbs
+++ b/ui-v2/app/templates/dc/services/-addresses.hbs
@@ -10,7 +10,7 @@
     {{#block-slot 'row'}}
 {{#with (object-at 1 taggedAddress) as |address|}}
       <td>
-        {{object-at 0 taggedAddress}}{{#if (eq address.Address item.Address)}}&nbsp;<em data-test-address-default>(default)</em>{{/if}}
+        {{object-at 0 taggedAddress}}{{#if (and (eq address.Address item.Address) (eq address.Port item.Port))}}&nbsp;<em data-test-address-default>(default)</em>{{/if}}
       </td>
       <td data-test-address>
         {{address.Address}}:{{address.Port}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -23,7 +23,6 @@
             }}
                 {{#block-slot 'header'}}
                     <th style={{remainingWidth}}>Service</th>
-                    <th>Type</th>
                     <th style={{totalWidth}}>Health Checks<span><em>The number of health checks for the service on all nodes</em></span></th>
                     <th style={{remainingWidth}}>Tags</th>
                 {{/block-slot}}
@@ -33,13 +32,6 @@
                         <span data-test-external-source="{{service/external-source item}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
                         {{item.Name}}
                       </a>
-                    </td>
-                    <td>
-{{#if (eq item.Kind 'connect-proxy')}}
-                        <span class="kind-proxy">Proxy</span>
-{{else}}
-                        &nbsp;
-{{/if}}
                     </td>
                     <td style={{totalWidth}}>
                       {{healthcheck-info

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -21,6 +21,8 @@
 {{/with}}
 {{#if (eq item.Kind 'connect-proxy')}}
         <span class="kind-proxy">Proxy</span>
+{{else if item.Proxy.MeshGateway}}
+        <span class="kind-proxy">Mesh Gateway</span>
 {{/if}}
       </h1>
       <dl>
@@ -64,10 +66,17 @@
         {{tab-nav
             items=(compact
               (array
-                                    'Service Checks'
-                                    'Node Checks'
-(if (eq item.Kind 'connect-proxy')  'Upstreams' '')
-                                    'Tags'
+                'Service Checks'
+                'Node Checks'
+(if
+  (or (eq item.Kind 'connect-proxy') item.Proxy.MeshGateway)
+                    'Upstreams' ''
+)
+(if
+  item.Proxy.MeshGateway
+                'Addresses' ''
+)
+                'Tags'
               )
             )
             selected=selectedTab
@@ -75,10 +84,17 @@
         {{#each
             (compact
                 (array
-                                    (hash id=(slugify 'Service Checks') partial='dc/services/servicechecks')
-                                    (hash id=(slugify 'Node Checks') partial='dc/services/nodechecks')
-(if (eq item.Kind 'connect-proxy')  (hash id=(slugify 'Upstreams') partial='dc/services/upstreams') '')
-                                    (hash id=(slugify 'Tags') partial='dc/services/tags')
+                    (hash id=(slugify 'Service Checks') partial='dc/services/servicechecks')
+                    (hash id=(slugify 'Node Checks') partial='dc/services/nodechecks')
+(if
+  (or (eq item.Kind 'connect-proxy') item.Proxy.MeshGateway)
+                    (hash id=(slugify 'Upstreams') partial='dc/services/upstreams') ''
+)
+(if
+  item.Proxy.MeshGateway
+                    (hash id=(slugify 'Addresses') partial='dc/services/addresses') ''
+)
+                    (hash id=(slugify 'Tags') partial='dc/services/tags')
                 )
             ) as |panel|
         }}

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -21,7 +21,7 @@
 {{/with}}
 {{#if (eq item.Kind 'connect-proxy')}}
         <span class="kind-proxy">Proxy</span>
-{{else if item.Proxy.MeshGateway}}
+{{else if (eq item.Kind 'mesh-gateway')}}
         <span class="kind-proxy">Mesh Gateway</span>
 {{/if}}
       </h1>
@@ -69,11 +69,11 @@
                 'Service Checks'
                 'Node Checks'
 (if
-  (or (eq item.Kind 'connect-proxy') item.Proxy.MeshGateway)
-                    'Upstreams' ''
+  (eq item.Kind 'connect-proxy')
+                'Upstreams' ''
 )
 (if
-  item.Proxy.MeshGateway
+  (eq item.Kind 'mesh-gateway')
                 'Addresses' ''
 )
                 'Tags'
@@ -87,11 +87,11 @@
                     (hash id=(slugify 'Service Checks') partial='dc/services/servicechecks')
                     (hash id=(slugify 'Node Checks') partial='dc/services/nodechecks')
 (if
-  (or (eq item.Kind 'connect-proxy') item.Proxy.MeshGateway)
+  (eq item.Kind 'connect-proxy')
                     (hash id=(slugify 'Upstreams') partial='dc/services/upstreams') ''
 )
 (if
-  item.Proxy.MeshGateway
+  (eq item.Kind 'mesh-gateway')
                     (hash id=(slugify 'Addresses') partial='dc/services/addresses') ''
 )
                     (hash id=(slugify 'Tags') partial='dc/services/tags')

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -19,6 +19,8 @@
 {{/with}}
 {{#if (eq item.Service.Kind 'connect-proxy')}}
         <span class="kind-proxy">Proxy</span>
+{{else if item.Service.Proxy.MeshGateway}}
+        <span class="kind-proxy">Mesh Gateway</span>
 {{/if}}
       </h1>
       <label for="toolbar-toggle"></label>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -19,7 +19,7 @@
 {{/with}}
 {{#if (eq item.Service.Kind 'connect-proxy')}}
         <span class="kind-proxy">Proxy</span>
-{{else if item.Service.Proxy.MeshGateway}}
+{{else if (eq item.Service.Kind 'mesh-gateway')}}
         <span class="kind-proxy">Mesh Gateway</span>
 {{/if}}
       </h1>

--- a/ui-v2/tests/acceptance/dc/services/instances/gateway.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/gateway.feature
@@ -5,6 +5,7 @@ Feature: dc / services / instances / gateway: Show Gateway Service Instance
     And 1 instance model from yaml
     ---
     - Service:
+        Kind: mesh-gateway
         Name: gateway
         ID: gateway-with-id
         TaggedAddresses:
@@ -14,17 +15,6 @@ Feature: dc / services / instances / gateway: Show Gateway Service Instance
           wan:
             Address: 92.68.0.0
             Port: 8081
-        Proxy:
-          MeshGateway: {}
-          Upstreams:
-            - DestinationType: service
-              DestinationName: service-1
-              LocalBindAddress: 127.0.0.1
-              LocalBindPort: 1111
-            - DestinationType: prepared_query
-              DestinationName: service-group
-              LocalBindAddress: 127.0.0.1
-              LocalBindPort: 1112
     ---
     When I visit the instance page for yaml
     ---
@@ -45,19 +35,3 @@ Feature: dc / services / instances / gateway: Show Gateway Service Instance
     - 127.0.0.1:8080
     - 92.68.0.0:8081
     ---
-
-    When I click upstreams on the tabs
-    And I see upstreamsIsSelected on the tabs
-    And I see 2 of the upstreams object
-    And I see name on the upstreams like yaml
-    ---
-    - service-1
-    - service-group
-    ---
-    And I see type on the upstreams like yaml
-    ---
-    - service
-    - prepared_query
-    ---
-
-

--- a/ui-v2/tests/acceptance/dc/services/instances/gateway.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/gateway.feature
@@ -1,0 +1,63 @@
+@setupApplicationTest
+Feature: dc / services / instances / gateway: Show Gateway Service Instance
+  Scenario: A Gateway Service instance
+    Given 1 datacenter model with the value "dc1"
+    And 1 instance model from yaml
+    ---
+    - Service:
+        Name: gateway
+        ID: gateway-with-id
+        TaggedAddresses:
+          lan:
+            Address: 127.0.0.1
+            Port: 8080
+          wan:
+            Address: 92.68.0.0
+            Port: 8081
+        Proxy:
+          MeshGateway: {}
+          Upstreams:
+            - DestinationType: service
+              DestinationName: service-1
+              LocalBindAddress: 127.0.0.1
+              LocalBindPort: 1111
+            - DestinationType: prepared_query
+              DestinationName: service-group
+              LocalBindAddress: 127.0.0.1
+              LocalBindPort: 1112
+    ---
+    When I visit the instance page for yaml
+    ---
+      dc: dc1
+      service: gateway
+      node: node-0
+      id: gateway-with-id
+    ---
+    Then the url should be /dc1/services/gateway/node-0/gateway-with-id
+
+    And I see serviceChecksIsSelected on the tabs
+
+    When I click addresses on the tabs
+    And I see addressesIsSelected on the tabs
+    And I see 2 of the addresses object
+    And I see address on the addresses like yaml
+    ---
+    - 127.0.0.1:8080
+    - 92.68.0.0:8081
+    ---
+
+    When I click upstreams on the tabs
+    And I see upstreamsIsSelected on the tabs
+    And I see 2 of the upstreams object
+    And I see name on the upstreams like yaml
+    ---
+    - service-1
+    - service-group
+    ---
+    And I see type on the upstreams like yaml
+    ---
+    - service
+    - prepared_query
+    ---
+
+

--- a/ui-v2/tests/acceptance/steps/dc/services/instances/gateway-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/services/instances/gateway-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/integration/helpers/object-entries-test.js
+++ b/ui-v2/tests/integration/helpers/object-entries-test.js
@@ -1,0 +1,20 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('object-entries', 'helper:object-entries', {
+  integration: true,
+});
+
+// Replace this with your real tests.
+test('it renders', function(assert) {
+  this.set('inputValue', '1234');
+
+  this.render(hbs`{{object-entries inputValue}}`);
+
+  assert.equal(
+    this.$()
+      .text()
+      .trim(),
+    Object.entries('1234').toString()
+  );
+});

--- a/ui-v2/tests/pages/dc/services/instance.js
+++ b/ui-v2/tests/pages/dc/services/instance.js
@@ -2,7 +2,7 @@ export default function(visitable, attribute, collection, text, radiogroup) {
   return {
     visit: visitable('/:dc/services/:service/:node/:id'),
     externalSource: attribute('data-test-external-source', 'h1 span'),
-    tabs: radiogroup('tab', ['service-checks', 'node-checks', 'upstreams', 'tags']),
+    tabs: radiogroup('tab', ['service-checks', 'node-checks', 'addresses', 'upstreams', 'tags']),
     serviceChecks: collection('#service-checks [data-test-healthchecks] li', {}),
     nodeChecks: collection('#node-checks [data-test-healthchecks] li', {}),
     upstreams: collection('#upstreams [data-test-tabular-row]', {
@@ -10,6 +10,9 @@ export default function(visitable, attribute, collection, text, radiogroup) {
       datacenter: text('[data-test-destination-datacenter]'),
       type: text('[data-test-destination-type]'),
       address: text('[data-test-local-bind-address]'),
+    }),
+    addresses: collection('#addresses [data-test-tabular-row]', {
+      address: text('[data-test-address]'),
     }),
     proxy: {
       type: attribute('data-test-proxy-type', '[data-test-proxy-type]'),


### PR DESCRIPTION
This adds a 'Mesh Gateway' type label to service and service instance
pages, plus a new 'Addresses' tab if the service is a Mesh Gateway
showing a table of addresses for the service - plus tests.

Proxy icons where also removed here, and the column in the service listing that housed them.

Most of the 'is this a gateway?' logic is looking for existence of `Kind: "mesh-gateway"` ~`Proxy.MeshGateway` (although I'm not entirely sure this is 100% reliable?)~ . ~We also maintain the [Upstreams] tab for MeshGateways as we've assumed its possible for MeshGateways to have these (??)~

<img width="512" alt="Screenshot 2019-07-04 at 13 38 01" src="https://user-images.githubusercontent.com/554604/60667266-038b7c00-9e61-11e9-9406-e2addcb315bf.png">


