### PR TITLE
Prevent recursive hex encoding of keys

### DIFF
--- a/agent/connect/parsing.go
+++ b/agent/connect/parsing.go
@@ -116,6 +116,11 @@ func KeyId(raw interface{}) ([]byte, error) {
 
 // HexString returns a standard colon-separated hex value for the input
 // byte slice. This should be used with cert serial numbers and so on.
+// If the input already appears to be a hex string, we leave it alone.
 func HexString(input []byte) string {
+	if len(input) >= 3 && input[2] == ':' {
+		// input is already a hex string
+		return string(input)
+	}
 	return strings.Replace(fmt.Sprintf("% x", input), " ", ":", -1)
 }


### PR DESCRIPTION
When comparing the signing keys on CA certs, Consul converts the bytes to a hex string. Unfortunately it appears that in some circumstances the string is double encoded.

For example, the following output was observed from the `/v1/connect/ca/roots` endpoint:

```
33:37:3a:61:34:3a:63:33:3a:65:34:3a:38:35:3a:63:30:3a:61:30:3a:34:34:3a:64:63:3a:35:65:3a:61:66:3a:65:30:3a:61:37:3a:61:35:3a:38:32:3a:34:36:3a:31:66:3a:36:39:3a:65:32:3a:30:63:3a:39:30:3a:62:62:3a:62:38:3a:64:62:3a:37:66:3a:33:37:3a:34:30:3a:34:61:3a:62:66:3a:30:39:3a:37:61:3a:64:35
```

Decoding this string reveals:

```
37:a4:c3:e4:85:c0:a0:44:dc:5e:af:e0:a7:a5:82:46:1f:69:e2:0c:90:bb:b8:db:7f:37:40:4a:bf:09:7a:d5
```

So the key was encoded more than once. This PR stops that by checking to see if the input is already a hex string before encoding it again.