### PR TITLE
Update TestServer creation in sdk/testutil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
   go-test:
     docker:
       - image: *GOLANG_IMAGE
-    parallelism: 4
+    parallelism: 8
     environment:
       <<: *ENVIRONMENT
       GOTAGS: '' # No tags for OSS but there are for enterprise
@@ -75,7 +75,7 @@ jobs:
 
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
-          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess |circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
+          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
             reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
             gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/$reportname.xml -- -tags=$GOTAGS $pkg
           done
@@ -434,24 +434,27 @@ jobs:
       ENVOY_VERSIONS: "1.9.1"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
-  envoy-integration-test-1.10.0:
-    docker:
-      - image: *GOLANG_IMAGE
-    environment:
-      ENVOY_VERSIONS: "1.10.0"
-    steps: *ENVOY_INTEGRATION_TEST_STEPS
-
 workflows:
   version: 2
-  build-distros:
-    jobs:
-      - go-fmt-and-vet
-      - build-386: &require-go-fmt-vet
-          requires:
-            - go-fmt-and-vet
-      - build-amd64: *require-go-fmt-vet
-      - build-arm-arm64: *require-go-fmt-vet
+  # build-distros:
+  #   jobs:
+  #     - go-fmt-and-vet
+  #     - build-386: &require-go-fmt-vet
+  #         requires:
+  #           - go-fmt-and-vet
+  #     - build-amd64: *require-go-fmt-vet
+  #     - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
+    triggers:
+      - schedule:
+          # every 10 mins from 12am-12pm GMT (outside US work hours)
+          # CircleCI doesn't support some cron syntax so it has to look janky
+          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
+          cron: "0,10,20,30,40,50 0-12 * * *"
+          filters:
+            branches:
+              only:
+                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
     jobs:
       - dev-build
       - go-test: &go-test
@@ -462,51 +465,48 @@ workflows:
               only:
                 - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
       - go-test-api: *go-test
-      - dev-upload-s3:
-          requires:
-            - dev-build
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only push dev builds from non forks
-      - nomad-integration-master:
-          requires:
-            - dev-build
-      - nomad-integration-0_8:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.8.0:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.9.1:
-          requires:
-            - dev-build
-      - envoy-integration-test-1.10.0:
-          requires:
-            - dev-build
-  website:
-    jobs:
-      - build-website
-      - docs-link-checker:
-          requires:
-            - build-website
-          filters:
-            branches:
-              ignore:
-                - /^pull\/.*$/ # only run link checker on non forks
-      - deploy-website:
-          requires:
-            - docs-link-checker
-          context: static-sites
-          filters:
-            branches:
-              only: stable-website
-  frontend:
-    jobs:
-      - frontend-cache
-      - ember-build:
-          requires:
-            - frontend-cache
-      - ember-test:
-          requires:
-            - ember-build
+  #     - dev-upload-s3:
+  #         requires:
+  #           - dev-build
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only push dev builds from non forks
+  #     - nomad-integration-master:
+  #         requires:
+  #           - dev-build
+  #     - nomad-integration-0_8:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.8.0:
+  #         requires:
+  #           - dev-build
+  #     - envoy-integration-test-1.9.1:
+  #         requires:
+  #           - dev-build
+  # website:
+  #   jobs:
+  #     - build-website
+  #     - docs-link-checker:
+  #         requires:
+  #           - build-website
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - /^pull\/.*$/ # only run link checker on non forks
+  #     - deploy-website:
+  #         requires:
+  #           - docs-link-checker
+  #         context: static-sites
+  #         filters:
+  #           branches:
+  #             only: stable-website
+  # frontend:
+  #   jobs:
+  #     - frontend-cache
+  #     - ember-build:
+  #         requires:
+  #           - frontend-cache
+  #     - ember-test:
+  #         requires:
+  #           - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - consul-modcache-v1-{{ checksum "go.mod" }}
+            - consul-modcache-v1-{{ checksum "go.mod" }}
       - run:
           command: go mod download
       - save_cache:
           key: consul-modcache-v1-{{ checksum "go.mod" }}
           paths:
-          - /go/pkg/mod
+            - /go/pkg/mod
       - run:
           name: check go fmt
           command: |
@@ -55,7 +55,7 @@ jobs:
   go-test:
     docker:
       - image: *GOLANG_IMAGE
-    parallelism: 8
+    parallelism: 4
     environment:
       <<: *ENVIRONMENT
       GOTAGS: '' # No tags for OSS but there are for enterprise
@@ -63,7 +63,7 @@ jobs:
       - checkout
       - restore_cache: # restore cache from dev-build job
           keys:
-          - consul-modcache-v1-{{ checksum "go.mod" }}
+            - consul-modcache-v1-{{ checksum "go.mod" }}
       - attach_workspace:
           at: /go/bin
       - run: mkdir -p $TEST_RESULTS_DIR
@@ -75,7 +75,7 @@ jobs:
 
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
-          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
+          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess |circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
             reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
             gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/$reportname.xml -- -tags=$GOTAGS $pkg
           done
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - restore_cache: # restore cache from dev-build job
           keys:
-          - consul-modcache-v1-{{ checksum "go.mod" }}
+            - consul-modcache-v1-{{ checksum "go.mod" }}
       - attach_workspace:
           at: /go/bin
       - run: mkdir -p $TEST_RESULTS_DIR
@@ -165,13 +165,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-          - consul-modcache-v1-{{ checksum "go.mod" }}
+            - consul-modcache-v1-{{ checksum "go.mod" }}
       - run:
           command: make dev
       - save_cache:
           key: consul-modcache-v1-{{ checksum "go.mod" }}
           paths:
-          - /go/pkg/mod
+            - /go/pkg/mod
 
       # save dev build to pass to downstream jobs
       - persist_to_workspace:
@@ -434,27 +434,24 @@ jobs:
       ENVOY_VERSIONS: "1.9.1"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
+  envoy-integration-test-1.10.0:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      ENVOY_VERSIONS: "1.10.0"
+    steps: *ENVOY_INTEGRATION_TEST_STEPS
+
 workflows:
   version: 2
-  # build-distros:
-  #   jobs:
-  #     - go-fmt-and-vet
-  #     - build-386: &require-go-fmt-vet
-  #         requires:
-  #           - go-fmt-and-vet
-  #     - build-amd64: *require-go-fmt-vet
-  #     - build-arm-arm64: *require-go-fmt-vet
+  build-distros:
+    jobs:
+      - go-fmt-and-vet
+      - build-386: &require-go-fmt-vet
+          requires:
+            - go-fmt-and-vet
+      - build-amd64: *require-go-fmt-vet
+      - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
-#    triggers:
-#      - schedule:
-#          # every 10 mins from 12am-12pm GMT (outside US work hours)
-#          # CircleCI doesn't support some cron syntax so it has to look janky
-#          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
-#          cron: "0,10,20,30,40,50 0-12 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
     jobs:
       - dev-build
       - go-test: &go-test
@@ -465,48 +462,51 @@ workflows:
               only:
                 - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
       - go-test-api: *go-test
-  #     - dev-upload-s3:
-  #         requires:
-  #           - dev-build
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only push dev builds from non forks
-  #     - nomad-integration-master:
-  #         requires:
-  #           - dev-build
-  #     - nomad-integration-0_8:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.8.0:
-  #         requires:
-  #           - dev-build
-  #     - envoy-integration-test-1.9.1:
-  #         requires:
-  #           - dev-build
-  # website:
-  #   jobs:
-  #     - build-website
-  #     - docs-link-checker:
-  #         requires:
-  #           - build-website
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - /^pull\/.*$/ # only run link checker on non forks
-  #     - deploy-website:
-  #         requires:
-  #           - docs-link-checker
-  #         context: static-sites
-  #         filters:
-  #           branches:
-  #             only: stable-website
-  # frontend:
-  #   jobs:
-  #     - frontend-cache
-  #     - ember-build:
-  #         requires:
-  #           - frontend-cache
-  #     - ember-test:
-  #         requires:
-  #           - ember-build
+      - dev-upload-s3:
+          requires:
+            - dev-build
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only push dev builds from non forks
+      - nomad-integration-master:
+          requires:
+            - dev-build
+      - nomad-integration-0_8:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.8.0:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.9.1:
+          requires:
+            - dev-build
+      - envoy-integration-test-1.10.0:
+          requires:
+            - dev-build
+  website:
+    jobs:
+      - build-website
+      - docs-link-checker:
+          requires:
+            - build-website
+          filters:
+            branches:
+              ignore:
+                - /^pull\/.*$/ # only run link checker on non forks
+      - deploy-website:
+          requires:
+            - docs-link-checker
+          context: static-sites
+          filters:
+            branches:
+              only: stable-website
+  frontend:
+    jobs:
+      - frontend-cache
+      - ember-build:
+          requires:
+            - frontend-cache
+      - ember-test:
+          requires:
+            - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,16 +445,16 @@ workflows:
   #     - build-amd64: *require-go-fmt-vet
   #     - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
-#    triggers:
-#      - schedule:
-#          # every 10 mins from 12am-12pm GMT (outside US work hours)
-#          # CircleCI doesn't support some cron syntax so it has to look janky
-#          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
-#          cron: "0,10,20,30,40,50 0-12 * * *"
-#          filters:
-#            branches:
-#              only:
-#                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
+    triggers:
+      - schedule:
+          # every 10 mins from 12am-12pm GMT (outside US work hours)
+          # CircleCI doesn't support some cron syntax so it has to look janky
+          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
+          cron: "0,10,20,30,40,50 0-12 * * *"
+          filters:
+            branches:
+              only:
+                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
     jobs:
       - dev-build
       - go-test: &go-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,16 +445,16 @@ workflows:
   #     - build-amd64: *require-go-fmt-vet
   #     - build-arm-arm64: *require-go-fmt-vet
   test-integrations:
-    triggers:
-      - schedule:
-          # every 10 mins from 12am-12pm GMT (outside US work hours)
-          # CircleCI doesn't support some cron syntax so it has to look janky
-          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
-          cron: "0,10,20,30,40,50 0-12 * * *"
-          filters:
-            branches:
-              only:
-                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
+#    triggers:
+#      - schedule:
+#          # every 10 mins from 12am-12pm GMT (outside US work hours)
+#          # CircleCI doesn't support some cron syntax so it has to look janky
+#          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
+#          cron: "0,10,20,30,40,50 0-12 * * *"
+#          filters:
+#            branches:
+#              only:
+#                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
     jobs:
       - dev-build
       - go-test: &go-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - consul-modcache-v1-{{ checksum "go.mod" }}
+          - consul-modcache-v1-{{ checksum "go.mod" }}
       - run:
           command: go mod download
       - save_cache:
           key: consul-modcache-v1-{{ checksum "go.mod" }}
           paths:
-            - /go/pkg/mod
+          - /go/pkg/mod
       - run:
           name: check go fmt
           command: |
@@ -63,7 +63,7 @@ jobs:
       - checkout
       - restore_cache: # restore cache from dev-build job
           keys:
-            - consul-modcache-v1-{{ checksum "go.mod" }}
+          - consul-modcache-v1-{{ checksum "go.mod" }}
       - attach_workspace:
           at: /go/bin
       - run: mkdir -p $TEST_RESULTS_DIR
@@ -96,7 +96,7 @@ jobs:
       - checkout
       - restore_cache: # restore cache from dev-build job
           keys:
-            - consul-modcache-v1-{{ checksum "go.mod" }}
+          - consul-modcache-v1-{{ checksum "go.mod" }}
       - attach_workspace:
           at: /go/bin
       - run: mkdir -p $TEST_RESULTS_DIR
@@ -165,13 +165,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - consul-modcache-v1-{{ checksum "go.mod" }}
+          - consul-modcache-v1-{{ checksum "go.mod" }}
       - run:
           command: make dev
       - save_cache:
           key: consul-modcache-v1-{{ checksum "go.mod" }}
           paths:
-            - /go/pkg/mod
+          - /go/pkg/mod
 
       # save dev build to pass to downstream jobs
       - persist_to_workspace:

--- a/agent/consul/config.json
+++ b/agent/consul/config.json
@@ -1,0 +1,6 @@
+{
+  "recursors": [
+    "10.0.4.9"
+  ],
+  "datacenter": "dc1"
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,10 +54,18 @@ func makeClientWithConfig(
 		cb1(conf)
 	}
 	// Create server
-	server, err := testutil.NewTestServerConfigT(t, cb2)
-	if err != nil {
-		t.Fatal(err)
+	var server *testutil.TestServer
+	var err error
+	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
+		server, err = testutil.NewTestServerConfigT(t, cb2)
+		if err != nil {
+			r.Fatal(err)
+		}
+	})
+	if server.Config.Bootstrap {
+		server.WaitForLeader(t)
 	}
+
 	conf.Address = server.HTTPAddr
 
 	// Create client

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -34,7 +34,7 @@ func TestAPI_CatalogNodes(t *testing.T) {
 
 	s.WaitForSerfCheck(t)
 	catalog := c.Catalog()
-	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
+	retry.Run(t, func(r *retry.R) {
 		nodes, meta, err := catalog.Nodes(nil)
 		// We're not concerned about the createIndex of an agent
 		// Hence we're setting it to the default value

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -421,6 +421,8 @@ func TestAPI_HealthService_NodeMetaFilter(t *testing.T) {
 	})
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	health := c.Health()
 	retry.Run(t, func(r *retry.R) {
 		// consul service should always exist...

--- a/api/txn_test.go
+++ b/api/txn_test.go
@@ -17,6 +17,8 @@ func TestAPI_ClientTxn(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	session := c.Session()
 	txn := c.Txn()
 

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -330,13 +330,6 @@ func (s *TestServer) Stop() error {
 	return s.cmd.Wait()
 }
 
-type failer struct {
-	failed bool
-}
-
-func (f *failer) Log(args ...interface{}) { fmt.Println(args...) }
-func (f *failer) FailNow()                { f.failed = true }
-
 // waitForAPI waits for only the agent HTTP endpoint to start
 // responding. This is an indication that the agent has started,
 // but will likely return before a leader is elected.

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -345,8 +345,11 @@ func (s *TestServer) Stop() error {
 // but will likely return before a leader is elected.
 func (s *TestServer) waitForAPI() error {
 	var failed bool
-	timer := retry.TwoSeconds()
 
+	// This retry replicates the logic of retry.Run to allow for nested retries.
+	// By returning an error we can wrap TestServer creation with retry.Run
+	// in makeClientWithConfig.
+	timer := retry.TwoSeconds()
 	deadline := time.Now().Add(timer.Timeout)
 	for !time.Now().After(deadline) {
 		time.Sleep(timer.Wait)

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -236,7 +236,16 @@ func newTestServerConfigT(t *testing.T, cb ServerConfigCallback) (*TestServer, e
 			"consul or skip this test")
 	}
 
-	tmpdir := TempDir(t, "consul")
+	prefix := "consul"
+	if t != nil {
+		// Use test name for tmpdir if available
+		prefix = strings.Replace(t.Name(), "/", "_", -1)
+	}
+	tmpdir, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create tempdir")
+	}
+
 	cfg := defaultServerConfig()
 	cfg.DataDir = filepath.Join(tmpdir, "data")
 	if cb != nil {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -355,8 +355,7 @@ func (s *TestServer) waitForAPI(t *testing.T) {
 
 // waitForLeader waits for the Consul server's HTTP API to become
 // available, and then waits for a known leader and an index of
-// 1 or more to be observed to confirm leader election is done.
-// It then waits to ensure the anti-entropy sync has completed.
+// 2 or more to be observed to confirm leader election is done.
 func (s *TestServer) waitForLeader(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		// Query the API and check the status code.

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -358,13 +358,12 @@ func (s *TestServer) waitForAPI(t *testing.T) {
 // 1 or more to be observed to confirm leader election is done.
 // It then waits to ensure the anti-entropy sync has completed.
 func (s *TestServer) waitForLeader(t *testing.T) {
-	var index int64
 	retry.Run(t, func(r *retry.R) {
 		// Query the API and check the status code.
-		url := s.url(fmt.Sprintf("/v1/catalog/nodes?index=%d", index))
+		url := s.url("/v1/catalog/nodes")
 		resp, err := s.HTTPClient.Get(url)
 		if err != nil {
-			r.Fatal("failed http get", err)
+			r.Fatalf("failed http get '%s': %v", url, err)
 		}
 		defer resp.Body.Close()
 		if err := s.requireOK(resp); err != nil {
@@ -375,7 +374,7 @@ func (s *TestServer) waitForLeader(t *testing.T) {
 		if leader := resp.Header.Get("X-Consul-KnownLeader"); leader != "true" {
 			r.Fatalf("Consul leader status: %#v", leader)
 		}
-		index, err = strconv.ParseInt(resp.Header.Get("X-Consul-Index"), 10, 64)
+		index, err := strconv.ParseInt(resp.Header.Get("X-Consul-Index"), 10, 64)
 		if err != nil {
 			r.Fatal("bad consul index", err)
 		}


### PR DESCRIPTION
This is a refactor of how test servers are created in the sdk package.

We have been seeing several failures in circle in the api pkg during the creation of test servers. We are seeing: timeouts while waiting for a leader, or connections refused when waiting for the API.

This PR:
- Retries the creation of the test server three times.
- Reduces the retry timeout for the API wait to 2 seconds, opting to fail faster and start over.
- Removes wait for leader from server creation. This wait can be added on a test by test basis now that the function is being exported.
- Removes wait for anti-entropy sync. This is built into the existing WaitForSerfCheck func, so that can be used if the anti-entropy wait is needed

Errors waiting for leader:
https://circleci.com/gh/hashicorp/consul/29731
https://circleci.com/gh/hashicorp/consul/28677

Connection refused to v1/catalog/nodes:
https://circleci.com/gh/hashicorp/consul/30689
https://circleci.com/gh/hashicorp/consul/30639
