### PR TITLE
Clean up StatsFetcher work when context is exceeded

### DIFF
--- a/agent/consul/stats_fetcher.go
+++ b/agent/consul/stats_fetcher.go
@@ -107,6 +107,10 @@ func (f *StatsFetcher) Fetch(ctx context.Context, members []serf.Member) map[str
 		case <-ctx.Done():
 			f.logger.Printf("[WARN] consul: error getting server health from %q: %v",
 				workItem.server.Name, ctx.Err())
+
+			f.inflightLock.Lock()
+			delete(f.inflight, workItem.server.ID)
+			f.inflightLock.Unlock()
 		}
 	}
 	return replies


### PR DESCRIPTION
In TestLeader_ChangeServerID we have been seeing an issue where:

1. The context is being exceeded when fetching stats from a new member.
2. Autopilot's following calls to update the cluster's health do not issue new requests to that member because the work is still saved as inflight. The RPC in [fetch](https://github.com/hashicorp/consul/blob/master/agent/consul/stats_fetcher.go#L43) is not returning, so the inflight was never deleted.
3. The new member is never added to raft because of it.

This PR cleans up the work item from the StatsFetcher if the context is exceeded before a reply comes in. The next call to Fetch will attempt a new request.

This solution allows the new server to join but does not resolve the issue of the fetch RPC not timing out after 1s.

Test logs:
https://circleci.com/gh/hashicorp/consul/26585#tests/containers/1
https://circleci.com/gh/hashicorp/consul/26539#tests/containers/1
https://circleci.com/gh/hashicorp/consul/26465