### PR TITLE
Filter proxy destination by tags

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -865,6 +865,7 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 			"exec_mode": "ExecMode",
 			// Proxy Upstreams
 			"destination_name":      "DestinationName",
+			"destination_tags":      "DestinationTags",
 			"destination_type":      "DestinationType",
 			"destination_namespace": "DestinationNamespace",
 			"local_bind_port":       "LocalBindPort",

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -317,7 +317,7 @@ func TestAgent_Service(t *testing.T) {
 		Service:     "web-sidecar-proxy",
 		Port:        8000,
 		Proxy:       expectProxy.ToAPI(),
-		ContentHash: "3442362e971c43d1",
+		ContentHash: "90ef6e538c2c2e0",
 		Weights: api.AgentWeights{
 			Passing: 1,
 			Warning: 1,
@@ -327,7 +327,7 @@ func TestAgent_Service(t *testing.T) {
 	// Copy and modify
 	updatedResponse := *expectedResponse
 	updatedResponse.Port = 9999
-	updatedResponse.ContentHash = "90b5c19bf0f5073"
+	updatedResponse.ContentHash = "34479cd210d1d142"
 
 	// Simple response for non-proxy service registered in TestAgent config
 	expectWebResponse := &api.AgentService{
@@ -624,7 +624,7 @@ func TestAgent_Service_DeprecatedManagedProxy(t *testing.T) {
 		Service:     "web-proxy",
 		Port:        9999,
 		Address:     "10.10.10.10",
-		ContentHash: "e24f099e42e88317",
+		ContentHash: "53323ea517449367",
 		Proxy: &api.AgentServiceConnectProxyConfig{
 			DestinationServiceID:   "web",
 			DestinationServiceName: "web",
@@ -2524,8 +2524,8 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 					"destination_type": "service",
 					"destination_namespace": "default",
 					"destination_name": "db",
-		      "local_bind_address": "` + tt.ip + `",
-		      "local_bind_port": 1234,
+					"local_bind_address": "` + tt.ip + `",
+					"local_bind_port": 1234,
 					"config": {
 						"destination_type": "proxy.upstreams.config is 'opaque' so should not get translated"
 					}
@@ -2570,6 +2570,7 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 							"destination_type": "service",
 							"destination_namespace": "default",
 							"destination_name": "db",
+							"destination_tags": ["b_tag","c_tag","a_tag"],
 							"local_bind_address": "` + tt.ip + `",
 							"local_bind_port": 1234,
 							"config": {
@@ -2674,6 +2675,7 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 						{
 							DestinationType:      structs.UpstreamDestTypeService,
 							DestinationName:      "db",
+							DestinationTags:      []string{"b_tag", "c_tag", "a_tag"},
 							DestinationNamespace: "default",
 							LocalBindAddress:     tt.ip,
 							LocalBindPort:        1234,
@@ -5157,7 +5159,7 @@ func TestAgentConnectProxyConfig_Blocking(t *testing.T) {
 		ProxyServiceID:    "test-proxy",
 		TargetServiceID:   "test",
 		TargetServiceName: "test",
-		ContentHash:       "a7c93585b6d70445",
+		ContentHash:       "896cd70a98fef705",
 		ExecMode:          "daemon",
 		Command:           []string{"tubes.sh"},
 		Config: map[string]interface{}{
@@ -5178,7 +5180,7 @@ func TestAgentConnectProxyConfig_Blocking(t *testing.T) {
 	ur, err := copystructure.Copy(expectedResponse)
 	require.NoError(t, err)
 	updatedResponse := ur.(*api.ConnectProxyConfig)
-	updatedResponse.ContentHash = "aedc0ca0f3f7794e"
+	updatedResponse.ContentHash = "2ddc07d62b35360b"
 	updatedResponse.Upstreams = append(updatedResponse.Upstreams, api.Upstream{
 		DestinationType: "service",
 		DestinationName: "cache",

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1306,6 +1306,7 @@ func (b *Builder) upstreamsVal(v []Upstream) structs.Upstreams {
 			DestinationType:      b.stringVal(u.DestinationType),
 			DestinationNamespace: b.stringVal(u.DestinationNamespace),
 			DestinationName:      b.stringVal(u.DestinationName),
+			DestinationTags:      u.DestinationTags,
 			Datacenter:           b.stringVal(u.Datacenter),
 			LocalBindAddress:     b.stringVal(u.LocalBindAddress),
 			LocalBindPort:        b.intVal(u.LocalBindPort),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -482,9 +482,10 @@ type Upstream struct {
 	// DestinationType would be better as an int constant but even with custom
 	// JSON marshallers it causes havoc with all the mapstructure mangling we do
 	// on service definitions in various places.
-	DestinationType      *string `json:"destination_type,omitempty" hcl:"destination_type" mapstructure:"destination_type"`
-	DestinationNamespace *string `json:"destination_namespace,omitempty" hcl:"destination_namespace" mapstructure:"destination_namespace"`
-	DestinationName      *string `json:"destination_name,omitempty" hcl:"destination_name" mapstructure:"destination_name"`
+	DestinationType      *string  `json:"destination_type,omitempty" hcl:"destination_type" mapstructure:"destination_type"`
+	DestinationNamespace *string  `json:"destination_namespace,omitempty" hcl:"destination_namespace" mapstructure:"destination_namespace"`
+	DestinationName      *string  `json:"destination_name,omitempty" hcl:"destination_name" mapstructure:"destination_name"`
+	DestinationTags      []string `json:"destination_tags,omitempty" hcl:"destination_tags" mapstructure:"destination_tags"`
 
 	// Datacenter that the service discovery request should be run against. Note
 	// for prepared queries, the actual results might be from a different

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -3534,7 +3534,7 @@ func TestStateStore_CheckServiceTagNodes(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", []string{"master"})
+	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", false, []string{"master"})
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -179,6 +179,8 @@ func (s *state) initWatches() error {
 				QueryOptions: structs.QueryOptions{Token: s.token},
 				ServiceName:  u.DestinationName,
 				Connect:      true,
+				ServiceTags:  u.DestinationTags,
+				TagFilter:    len(u.DestinationTags) > 0,
 				// Note that Identifier doesn't type-prefix for service any more as it's
 				// the default and makes metrics and other things much cleaner. It's
 				// simpler for us if we have the type to make things unambiguous.

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -38,6 +38,13 @@ func TestConnectProxyConfig_ToAPI(t *testing.T) {
 						LocalBindPort:    2345,
 						LocalBindAddress: "127.10.10.10",
 					},
+					{
+						DestinationType: UpstreamDestTypeService,
+						DestinationName: "foo",
+						DestinationTags: []string{"tagone", "tagtwo"},
+						Datacenter:      "dc1",
+						LocalBindPort:   3456,
+					},
 				},
 			},
 			want: &api.AgentServiceConnectProxyConfig{
@@ -61,6 +68,13 @@ func TestConnectProxyConfig_ToAPI(t *testing.T) {
 						Datacenter:       "dc1",
 						LocalBindPort:    2345,
 						LocalBindAddress: "127.10.10.10",
+					},
+					{
+						DestinationType: UpstreamDestTypeService,
+						DestinationName: "foo",
+						DestinationTags: []string{"tagone", "tagtwo"},
+						Datacenter:      "dc1",
+						LocalBindPort:   3456,
 					},
 				},
 			},
@@ -91,6 +105,7 @@ func TestUpstream_MarshalJSON(t *testing.T) {
 			want: `{
 				"DestinationType": "service",
 				"DestinationName": "foo",
+				"DestinationTags": null,
 				"Datacenter": "dc1",
 				"LocalBindPort": 1234,
 				"Config": null
@@ -108,6 +123,8 @@ func TestUpstream_MarshalJSON(t *testing.T) {
 			want: `{
 				"DestinationType": "prepared_query",
 				"DestinationName": "foo",
+				"DestinationTags": null,
+				"Datacenter": "dc1",
 				"Datacenter": "dc1",
 				"LocalBindPort": 1234,
 				"Config": null

--- a/agent/structs/structs_filtering_test.go
+++ b/agent/structs/structs_filtering_test.go
@@ -43,6 +43,11 @@ var expectedFieldConfigUpstreams bexpr.FieldConfigurations = bexpr.FieldConfigur
 		CoerceFn:            bexpr.CoerceString,
 		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
 	},
+	"DestinationTags": &bexpr.FieldConfiguration{
+		StructFieldName:     "DestinationTags",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchIsEmpty, bexpr.MatchIsNotEmpty, bexpr.MatchIn, bexpr.MatchNotIn},
+	},
 	"Datacenter": &bexpr.FieldConfiguration{
 		StructFieldName:     "Datacenter",
 		CoerceFn:            bexpr.CoerceString,

--- a/api/agent.go
+++ b/api/agent.go
@@ -289,6 +289,7 @@ type Upstream struct {
 	DestinationType      UpstreamDestType `json:",omitempty"`
 	DestinationNamespace string           `json:",omitempty"`
 	DestinationName      string
+	DestinationTags      []string
 	Datacenter           string                 `json:",omitempty"`
 	LocalBindAddress     string                 `json:",omitempty"`
 	LocalBindPort        int                    `json:",omitempty"`

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1550,7 +1550,7 @@ func TestAPI_AgentConnectProxyConfig(t *testing.T) {
 		ProxyServiceID:    "foo-proxy",
 		TargetServiceID:   "foo",
 		TargetServiceName: "foo",
-		ContentHash:       "acdf5eb6f5794a14",
+		ContentHash:       "a35dc8b113ab6d00",
 		ExecMode:          "daemon",
 		Command:           []string{"consul", "connect", "proxy"},
 		Config: map[string]interface{}{

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -474,6 +474,7 @@ func testUpstreams(t *testing.T) []Upstream {
 		{
 			DestinationType: UpstreamDestTypePreparedQuery,
 			DestinationName: "geo-cache",
+			DestinationTags: []string{"tagone", "tagtwo"},
 			LocalBindPort:   8181,
 		},
 	}


### PR DESCRIPTION
In continuation of discussion #5208, I've implemented behavior which allows retrieving and filtering `service` with `connect` support by multiple tags as a proxy destination.