### PR TITLE
Envoy CLI bind addresses

### DIFF
--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -1,9 +1,11 @@
 package structs
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib"
 )
 
 type MeshGatewayMode string
@@ -79,6 +81,19 @@ type ConnectProxyConfig struct {
 
 	// MeshGateway defines the mesh gateway configuration for this upstream
 	MeshGateway MeshGatewayConfig `json:",omitempty"`
+}
+
+func (c *ConnectProxyConfig) MarshalJSON() ([]byte, error) {
+	type typeCopy ConnectProxyConfig
+	copy := typeCopy(*c)
+
+	proxyConfig, err := lib.MapWalk(copy.Config)
+	if err != nil {
+		return nil, err
+	}
+	copy.Config = proxyConfig
+
+	return json.Marshal(&copy)
 }
 
 // ToAPI returns the api struct with the same fields. We have duplicates to

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/types"
 )
 
@@ -679,6 +680,19 @@ type ServiceNode struct {
 	RaftIndex `bexpr:"-"`
 }
 
+func (sn *ServiceNode) MarshalJSON() ([]byte, error) {
+	type typeCopy ServiceNode
+	copy := typeCopy(*sn)
+
+	proxyConfig, err := lib.MapWalk(copy.ServiceProxy.Config)
+	if err != nil {
+		return nil, err
+	}
+	copy.ServiceProxy.Config = proxyConfig
+
+	return json.Marshal(&copy)
+}
+
 // PartialClone() returns a clone of the given service node, minus the node-
 // related fields that get filled in later, Address and TaggedAddresses.
 func (s *ServiceNode) PartialClone() *ServiceNode {
@@ -865,6 +879,19 @@ type NodeService struct {
 	LocallyRegisteredAsSidecar bool `json:"-" bexpr:"-"`
 
 	RaftIndex `bexpr:"-"`
+}
+
+func (ns *NodeService) MarshalJSON() ([]byte, error) {
+	type typeCopy NodeService
+	copy := typeCopy(*ns)
+
+	proxyConfig, err := lib.MapWalk(copy.Proxy.Config)
+	if err != nil {
+		return nil, err
+	}
+	copy.Proxy.Config = proxyConfig
+
+	return json.Marshal(&copy)
 }
 
 func (ns *NodeService) BestAddress(wan bool) (string, int) {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/types"
 )
 
@@ -680,19 +679,6 @@ type ServiceNode struct {
 	RaftIndex `bexpr:"-"`
 }
 
-func (sn *ServiceNode) MarshalJSON() ([]byte, error) {
-	type typeCopy ServiceNode
-	copy := typeCopy(*sn)
-
-	proxyConfig, err := lib.MapWalk(copy.ServiceProxy.Config)
-	if err != nil {
-		return nil, err
-	}
-	copy.ServiceProxy.Config = proxyConfig
-
-	return json.Marshal(&copy)
-}
-
 // PartialClone() returns a clone of the given service node, minus the node-
 // related fields that get filled in later, Address and TaggedAddresses.
 func (s *ServiceNode) PartialClone() *ServiceNode {
@@ -879,19 +865,6 @@ type NodeService struct {
 	LocallyRegisteredAsSidecar bool `json:"-" bexpr:"-"`
 
 	RaftIndex `bexpr:"-"`
-}
-
-func (ns *NodeService) MarshalJSON() ([]byte, error) {
-	type typeCopy NodeService
-	copy := typeCopy(*ns)
-
-	proxyConfig, err := lib.MapWalk(copy.Proxy.Config)
-	if err != nil {
-		return nil, err
-	}
-	copy.Proxy.Config = proxyConfig
-
-	return json.Marshal(&copy)
 }
 
 func (ns *NodeService) BestAddress(wan bool) (string, int) {

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1535,3 +1535,48 @@ func TestCheckServiceNode_BestAddress(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeService_JSON_Marshal(t *testing.T) {
+	ns := &NodeService{
+		Service: "foo",
+		Proxy: ConnectProxyConfig{
+			Config: map[string]interface{}{
+				"bind_addresses": map[string]interface{}{
+					"default": map[string]interface{}{
+						"Address": "0.0.0.0",
+						"Port":    "443",
+					},
+				},
+			},
+		},
+	}
+	buf, err := json.Marshal(ns)
+	require.NoError(t, err)
+
+	var out NodeService
+	require.NoError(t, json.Unmarshal(buf, &out))
+	require.Equal(t, *ns, out)
+}
+
+func TestServiceNode_JSON_Marshal(t *testing.T) {
+	sn := &ServiceNode{
+		Node:        "foo",
+		ServiceName: "foo",
+		ServiceProxy: ConnectProxyConfig{
+			Config: map[string]interface{}{
+				"bind_addresses": map[string]interface{}{
+					"default": map[string]interface{}{
+						"Address": "0.0.0.0",
+						"Port":    "443",
+					},
+				},
+			},
+		},
+	}
+	buf, err := json.Marshal(sn)
+	require.NoError(t, err)
+
+	var out ServiceNode
+	require.NoError(t, json.Unmarshal(buf, &out))
+	require.Equal(t, *sn, out)
+}

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -175,13 +175,13 @@ func canBind(addr string) bool {
 		return false
 	}
 
-	if_addrs, err := net.InterfaceAddrs()
+	ifAddrs, err := net.InterfaceAddrs()
 
 	if err != nil {
 		return false
 	}
 
-	for _, addr := range if_addrs {
+	for _, addr := range ifAddrs {
 		if addr.String() == ip.String() {
 			return true
 		}

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -119,7 +119,7 @@ func (c *cmd) init() {
 		"WAN address to advertise in the Mesh Gateway service registration")
 
 	c.flags.Var((*flags.FlagMapValue)(&c.bindAddresses), "bind-address", "Bind "+
-		"addresses to use instead of the default binding rules given as `<name>=<ip>:<port>` "+
+		"address to use instead of the default binding rules given as `<name>=<ip>:<port>` "+
 		"pairs. This flag may be specified multiple times to add multiple bind addresses.")
 
 	c.flags.StringVar(&c.meshGatewaySvcName, "service", "mesh-gateway",

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -294,6 +294,9 @@ func (c *cmd) Run(args []string) int {
 					"envoy_mesh_gateway_bind_tagged_addresses": true,
 				},
 			}
+		} else if !canBind(lanAddr) && lanAddr != "" {
+			c.UI.Error(fmt.Sprintf("The LAN address %q will not be bindable. Either set a bindable address or override the bind addresses with -bind-address", lanAddr))
+			return 1
 		}
 
 		svc := api.AgentServiceRegistration{

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -61,6 +61,7 @@ type cmd struct {
 	address            string
 	wanAddress         string
 	deregAfterCritical string
+	bindAddresses      map[string]string
 
 	meshGatewaySvcName string
 }
@@ -117,6 +118,10 @@ func (c *cmd) init() {
 	c.flags.StringVar(&c.wanAddress, "wan-address", "",
 		"WAN address to advertise in the Mesh Gateway service registration")
 
+	c.flags.Var((*flags.FlagMapValue)(&c.bindAddresses), "bind-address", "Bind "+
+		"addresses to use instead of the default binding rules given as `<name>=<ip>:<port>` "+
+		"pairs. This flag may be specified multiple times to add multiple bind addresses.")
+
 	c.flags.StringVar(&c.meshGatewaySvcName, "service", "mesh-gateway",
 		"Service name to use for the registration")
 
@@ -158,6 +163,31 @@ func parseAddress(addrStr string) (string, int, error) {
 	}
 
 	return addr, port, nil
+}
+
+func canBind(addr string) bool {
+	if addr == "" {
+		return false
+	}
+
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return false
+	}
+
+	if_addrs, err := net.InterfaceAddrs()
+
+	if err != nil {
+		return false
+	}
+
+	for _, addr := range if_addrs {
+		if addr.String() == ip.String() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (c *cmd) Run(args []string) int {
@@ -215,8 +245,10 @@ func (c *cmd) Run(args []string) int {
 			taggedAddrs["lan"] = api.ServiceAddress{Address: lanAddr, Port: lanPort}
 		}
 
+		wanAddr := ""
+		wanPort := lanPort
 		if c.wanAddress != "" {
-			wanAddr, wanPort, err := parseAddress(c.wanAddress)
+			wanAddr, wanPort, err = parseAddress(c.wanAddress)
 			if err != nil {
 				c.UI.Error(fmt.Sprintf("Failed to parse the -wan-address parameter: %v", err))
 				return 1
@@ -233,7 +265,29 @@ func (c *cmd) Run(args []string) int {
 
 		var proxyConf *api.AgentServiceConnectProxyConfig
 
-		if lanAddr != "" {
+		if len(c.bindAddresses) > 0 {
+			// override all default binding rules and just bind to the user-supplied addresses
+			bindAddresses := make(map[string]api.ServiceAddress)
+
+			for addrName, addrStr := range c.bindAddresses {
+				addr, port, err := parseAddress(addrStr)
+				if err != nil {
+					c.UI.Error(fmt.Sprintf("Failed to parse the bind address: %s=%s: %v", addrName, addrStr, err))
+					return 1
+				}
+
+				bindAddresses[addrName] = api.ServiceAddress{Address: addr, Port: port}
+			}
+
+			proxyConf = &api.AgentServiceConnectProxyConfig{
+				Config: map[string]interface{}{
+					"envoy_mesh_gateway_no_default_bind": true,
+					"envoy_mesh_gateway_bind_addresses":  bindAddresses,
+				},
+			}
+		} else if canBind(lanAddr) && canBind(wanAddr) {
+			// when both addresses are bindable then we bind to the tagged addresses
+			// for creating the envoy listeners
 			proxyConf = &api.AgentServiceConnectProxyConfig{
 				Config: map[string]interface{}{
 					"envoy_mesh_gateway_no_default_bind":       true,


### PR DESCRIPTION
Previously if the lan address was non-empty we would add the option to bind to the tagged addresses. Now that is only done if both the lan and wan addr are valid addresses of one of the hosts interfaces.

Additionally a new cli option `-bind-address` can be used (multiple times) to create a mapping of the desired bind addresses to use instead of the default rules or tagged addresses. Therefore you can now advertise a service address (lan / wan) that are not necessarily real addresses of the container/system/etc. and then override the bind behavior.

This is particularly useful for k8s to be able to use a load balancer where the IP is not known prior to registration and its not an address attached to one of the containers NICs.

In testing this I also found that some of our API responses were blowing up due to not being able to encode the proxy config with a nested map. So I added JSON serializer for the `ConnectProxyConfig` struct to ensure that the opaque config is JSON serializable.