### PR TITLE
test: for envoy integration tests, wait until 's2' is healthy in consul before interrogating envoy

### DIFF
--- a/test/integration/connect/envoy/case-badauthz/verify.bats
+++ b/test/integration/connect/envoy/case-badauthz/verify.bats
@@ -18,6 +18,10 @@ load helpers
   assert_proxy_presents_cert_uri localhost:21001 s2
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should NOT be able to connect to s2" {
   run retry_default must_fail_tcp_connection localhost:5000
 

--- a/test/integration/connect/envoy/case-basic/verify.bats
+++ b/test/integration/connect/envoy/case-basic/verify.bats
@@ -22,6 +22,10 @@ load helpers
   assert_proxy_presents_cert_uri localhost:21001 s2
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should be able to connect to s2" {
   run retry_default curl -s -f -d hello localhost:5000
   [ "$status" -eq 0 ]

--- a/test/integration/connect/envoy/case-centralconf/verify.bats
+++ b/test/integration/connect/envoy/case-centralconf/verify.bats
@@ -12,11 +12,14 @@ load helpers
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
-
 }
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
 }
 
 @test "s1 upstream should be able to connect to s2 with http/1.1" {

--- a/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
@@ -10,6 +10,10 @@ load helpers
   retry_default curl -f -s localhost:19001/stats -o /dev/null
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should be able to connect to s2" {
   run retry_default curl -s -f -d hello localhost:5000
 

--- a/test/integration/connect/envoy/case-grpc/verify.bats
+++ b/test/integration/connect/envoy/case-grpc/verify.bats
@@ -10,6 +10,10 @@ load helpers
   retry_default curl -f -s localhost:19001/stats -o /dev/null
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should be able to connect to s2 via grpc" {
   run fortio grpcping localhost:5000
 

--- a/test/integration/connect/envoy/case-http-badauthz/verify.bats
+++ b/test/integration/connect/envoy/case-http-badauthz/verify.bats
@@ -18,6 +18,10 @@ load helpers
   assert_proxy_presents_cert_uri localhost:21001 s2
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should NOT be able to connect to s2" {
   run retry_default must_fail_http_connection localhost:5000
 

--- a/test/integration/connect/envoy/case-http/verify.bats
+++ b/test/integration/connect/envoy/case-http/verify.bats
@@ -12,11 +12,14 @@ load helpers
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
-
 }
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
 }
 
 @test "s1 upstream should be able to connect to s2 with http/1.1" {

--- a/test/integration/connect/envoy/case-http2/verify.bats
+++ b/test/integration/connect/envoy/case-http2/verify.bats
@@ -12,11 +12,14 @@ load helpers
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
-
 }
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
 }
 
 @test "s1 upstream should be able to connect to s2 via http2" {

--- a/test/integration/connect/envoy/case-prometheus/verify.bats
+++ b/test/integration/connect/envoy/case-prometheus/verify.bats
@@ -12,11 +12,14 @@ load helpers
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
-
 }
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
 }
 
 @test "s1 upstream should be able to connect to s2 with http/1.1" {

--- a/test/integration/connect/envoy/case-statsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-statsd-udp/verify.bats
@@ -10,6 +10,10 @@ load helpers
   retry_default curl -f -s localhost:19001/stats -o /dev/null
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
 @test "s1 upstream should be able to connect to s2" {
   run retry_default curl -s -f -d hello localhost:5000
   [ "$status" == 0 ]

--- a/test/integration/connect/envoy/case-zipkin/verify.bats
+++ b/test/integration/connect/envoy/case-zipkin/verify.bats
@@ -12,11 +12,14 @@ load helpers
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
-
 }
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
 }
 
 @test "s1 upstream should be able to connect to s2" {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -131,7 +131,7 @@ function health_service_count_matches {
   local SERVICE_NAME=$1
   local EXPECT_COUNT=$2
 
-  GOT_COUNT=$(retry_default get_healthy_service_count $SERVICE_NAME)
+  GOT_COUNT=$(get_healthy_service_count $SERVICE_NAME)
 
   [ "$GOT_COUNT" -eq $EXPECT_COUNT ]
 }
@@ -140,7 +140,7 @@ function assert_service_has_healthy_instances {
   local SERVICE_NAME=$1
   local EXPECT_COUNT=$2
 
-  run retry_default health_service_count_matches $SERVICE_NAME $EXPECT_COUNT
+  run retry 10 2 health_service_count_matches $SERVICE_NAME $EXPECT_COUNT
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
When the envoy healthy panic threshold was explicitly disabled as part
of L7 traffic management it changed how envoy decided to load balance to
endpoints in a cluster. This only matters when envoy is in "panic mode"
aka "when you have a bunch of unhealthy endpoints". Panic mode sends
traffic to unhealthy instances in certain circumstances.

Note: Prior to explicitly disabling the healthy panic threshold, the
default value is 50%.

What was happening is that the test harness was bringing up consul the
sidecars, and the service instances all at once and sometimes the
proxies wouldn't have time to be checked by consul to be labeled as
'passing' in the catalog before a round of EDS happened.

The xDS server in consul effectively queries /v1/health/connect/s2 and
gets 1 result, but that one result has a 'critical' check so the xDS
server sends back that endpoint labeled as UNHEALTHY.

Envoy sees that 100% of the endpoints in the cluster are unhealthy and
would enter panic mode and still send traffic to s2. This is why the
test suites PRIOR to disabling the healthy panic threshold worked. They
were _incorrectly_ passing.

When the healthy panic threshol is disabled, envoy never enters panic
mode in this situation and thus the cluster has zero healthy endpoints
so load balancing goes nowhere and the tests fail.

Why does this only affect the test suites for envoy 1.8.0? My guess is
that https://github.com/envoyproxy/envoy/pull/4442 was merged into the
1.9.x series and somehow that plays a role.

This PR modifies the bats scripts to explicitly wait until the upstream
sidecar is healthy as measured by /v1/health/connect/s2?passing BEFORE
trying to interrogate envoy which should make the tests less racy.