### PR TITLE
test: for envoy integration tests bump the time to wait for the upstream to be healthy

### DIFF
--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -140,7 +140,7 @@ function assert_service_has_healthy_instances {
   local SERVICE_NAME=$1
   local EXPECT_COUNT=$2
 
-  run retry 10 2 health_service_count_matches $SERVICE_NAME $EXPECT_COUNT
+  run retry 30 2 health_service_count_matches $SERVICE_NAME $EXPECT_COUNT
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Apparently the successes I saw in #6108 were fleeting. Bump the overall time to wait for the services to be healthy up to 30 seconds.