### PR TITLE
Move ctx and cancel func setup into the Replicator.Start function

### DIFF
--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -61,7 +61,6 @@ func NewReplicator(config *ReplicatorConfig) (*Replicator, error) {
 	if config.Logger == nil {
 		config.Logger = log.New(os.Stderr, "", log.LstdFlags)
 	}
-	ctx, cancel := context.WithCancel(context.Background())
 	limiter := rate.NewLimiter(rate.Limit(config.Rate), config.Burst)
 
 	maxWait := config.MaxRetryWait
@@ -77,8 +76,6 @@ func NewReplicator(config *ReplicatorConfig) (*Replicator, error) {
 	return &Replicator{
 		name:      config.Name,
 		running:   false,
-		cancel:    cancel,
-		ctx:       ctx,
 		limiter:   limiter,
 		waiter:    waiter,
 		replicate: config.ReplicateFn,
@@ -93,6 +90,8 @@ func (r *Replicator) Start() {
 	if r.running {
 		return
 	}
+
+	r.ctx, r.cancel = context.WithCancel(context.Background())
 
 	go r.run()
 

--- a/agent/consul/replication_test.go
+++ b/agent/consul/replication_test.go
@@ -1,0 +1,28 @@
+package consul
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicationRestart(t *testing.T) {
+	config := ReplicatorConfig{
+		Name: "mock",
+		ReplicateFn: func(ctx context.Context, lastRemoteIndex uint64) (uint64, bool, error) {
+			return 1, false, nil
+		},
+		Rate:  1,
+		Burst: 1,
+	}
+
+	repl, err := NewReplicator(&config)
+	require.NoError(t, err)
+
+	repl.Start()
+	repl.Stop()
+	repl.Start()
+	// Previously this would have segfaulted
+	repl.Stop()
+}


### PR DESCRIPTION
Fixes #6104 	

Previously a sequence of events like:

Start
Stop
Start
Stop

would segfault on the second stop because the original ctx and cancel func were only initialized during the constructor and not during Start.