### PR TITLE
fix flaky test `TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,6 +484,18 @@ workflows:
       - envoy-integration-test-1.10.0:
           requires:
             - dev-build
+
+    triggers:
+      - schedule:
+          # every 10 mins from 12am-12pm GMT (outside US work hours)
+          # CircleCI doesn't support some cron syntax so it has to look janky
+          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
+          cron: "0,10,20,30,40,50 0-12 * * *"
+          filters:
+            branches:
+              only:
+                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
+
   website:
     jobs:
       - build-website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,18 +484,6 @@ workflows:
       - envoy-integration-test-1.10.0:
           requires:
             - dev-build
-
-    triggers:
-      - schedule:
-          # every 10 mins from 12am-12pm GMT (outside US work hours)
-          # CircleCI doesn't support some cron syntax so it has to look janky
-          # https://circleci.com/docs/2.0/workflows/#specifying-a-valid-schedule
-          cron: "0,10,20,30,40,50 0-12 * * *"
-          filters:
-            branches:
-              only:
-                - /^bug\/flaky-test-.*$/ # only run go tests on bug/flaky-test-* for now since we are fixing tests
-
   website:
     jobs:
       - build-website

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -4339,20 +4339,14 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 		}
 		resp := structs.ACLToken{}
 
-		require.NoError(t, acl.Login(&req, &resp))
+		require.NoError(t, acl2.Login(&req, &resp))
 		remoteToken = &resp
 
-		var resp2 *structs.ACLTokenResponse
-		var err error
-
-		// Flaky test! Need to retry/wait until !acl.srv.UseLegacyACLs() before continuing.
-		retry.Run(t, func(r *retry.R) {
-			// present in dc2
-			resp2, err = retrieveTestToken(codec2, "root", "dc2", remoteToken.AccessorID)
-			if err != nil {
-				r.Fatalf("expected no error, got %v", err)
-			}
-		})
+		// present in dc2
+		resp2, err := retrieveTestToken(codec2, "root", "dc2", remoteToken.AccessorID)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
 		require.NotNil(t, resp2.Token)
 		require.Len(t, resp2.Token.ServiceIdentities, 1)
 		require.Equal(t, "web2", resp2.Token.ServiceIdentities[0].ServiceName)

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -4344,9 +4344,7 @@ func TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData(t *testing.T) {
 
 		// present in dc2
 		resp2, err := retrieveTestToken(codec2, "root", "dc2", remoteToken.AccessorID)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+		require.NoError(t, err)
 		require.NotNil(t, resp2.Token)
 		require.Len(t, resp2.Token.ServiceIdentities, 1)
 		require.Equal(t, "web2", resp2.Token.ServiceIdentities[0].ServiceName)


### PR DESCRIPTION
#### Methodology for debugging this:

Test consistently flakes starting with this:

```
--- FAIL: TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData/login_in_remote (0.00s)
        require.go:794: 
            	Error Trace:	acl_endpoint_test.go:4347
            	Error:      	Received unexpected error:
            	            	ACL not found
            	Test:       	TestACLEndpoint_SecureIntroEndpoints_OnlyCreateLocalData/login_in_remote
```

I found this line consistently in failure logs, and never in passing logs:
> The ACL system is currently in legacy mode.

The above line is generated from (down the call stack) this function `retrieveTestToken` which calls `msgpackrpc.CallWithCodec(codec, "ACL.TokenRead", &arg, &out)`. `retrieveTestToken` is called for the first time in the test in the `login_in_remote` subtest (the one that always fails first in a flake).

Then I saw these lines in the test setup, which seem to essentially wait until server says "we're not in legacy mode" (plus one other check):
```
waitForNewACLs(t, s1)
waitForNewACLs(t, s2)
```

So this flake seemed like a race condition that would happen after we call `retrieveTestToken` for the first time where the server (wherever that is) still thinks we're in legacy mode, and we don't wait for that to change like we do in the above `waitForNewACLs(t, s1)...`.

So I added a retry around that first call to `retrieveTestToken`. Seems to have fixed the flake (see the many runs via cron here: https://circleci.com/gh/hashicorp/consul/tree/bug%2Fflaky-test-ACLEndpointLocalData)

Cheers!

**P.S.**: found an error in the way the `retry` pkg is being used in a different test and fixed that in this PR too.