### PR TITLE
Fix bug in service-resolver redirects if the destination uses a default resolver.

### DIFF
--- a/agent/consul/discoverychain/compile_test.go
+++ b/agent/consul/discoverychain/compile_test.go
@@ -129,12 +129,7 @@ func TestCompile(t *testing.T) {
 				}
 
 				require.Equal(t, tc.expect, res)
-
-				if tc.expectIsDefault {
-					require.True(t, res.IsDefault())
-				} else {
-					require.False(t, res.IsDefault())
-				}
+				require.Equal(t, tc.expectIsDefault, res.IsDefault())
 			}
 		})
 	}

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -88,6 +88,7 @@ func init() {
 	registerEndpoint("/v1/health/state/", []string{"GET"}, (*HTTPServer).HealthChecksInState)
 	registerEndpoint("/v1/health/service/", []string{"GET"}, (*HTTPServer).HealthServiceNodes)
 	registerEndpoint("/v1/health/connect/", []string{"GET"}, (*HTTPServer).HealthConnectServiceNodes)
+	registerEndpoint("/v1/internal/discovery-chain/", []string{"GET"}, (*HTTPServer).InternalDiscoveryChain)
 	registerEndpoint("/v1/internal/ui/nodes", []string{"GET"}, (*HTTPServer).UINodes)
 	registerEndpoint("/v1/internal/ui/node/", []string{"GET"}, (*HTTPServer).UINodeInfo)
 	registerEndpoint("/v1/internal/ui/services", []string{"GET"}, (*HTTPServer).UIServices)

--- a/agent/internal_endpoint.go
+++ b/agent/internal_endpoint.go
@@ -36,10 +36,5 @@ func (s *HTTPServer) InternalDiscoveryChain(resp http.ResponseWriter, req *http.
 		return nil, nil
 	}
 
-	// wipe before replying
-	// out.Chain.GroupResolverNodes = nil
-	// out.Chain.Resolvers = nil
-	// out.Chain.Targets = nil
-
 	return out.Chain, nil
 }

--- a/agent/internal_endpoint.go
+++ b/agent/internal_endpoint.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// InternalDiscoveryChain is helpful for debugging. Eventually we should expose
+// this data officially somehow.
+func (s *HTTPServer) InternalDiscoveryChain(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	var args structs.DiscoveryChainRequest
+	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
+		return nil, nil
+	}
+
+	args.Name = strings.TrimPrefix(req.URL.Path, "/v1/internal/discovery-chain/")
+	if args.Name == "" {
+		resp.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(resp, "Missing chain name")
+		return nil, nil
+	}
+
+	// Make the RPC request
+	var out structs.DiscoveryChainResponse
+	defer setMeta(resp, &out.QueryMeta)
+
+	if err := s.agent.RPC("ConfigEntry.ReadDiscoveryChain", &args, &out); err != nil {
+		return nil, err
+	}
+
+	if out.Chain == nil {
+		resp.WriteHeader(http.StatusNotFound)
+		return nil, nil
+	}
+
+	// wipe before replying
+	// out.Chain.GroupResolverNodes = nil
+	// out.Chain.Resolvers = nil
+	// out.Chain.Targets = nil
+
+	return out.Chain, nil
+}

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -40,11 +40,18 @@ type CompiledDiscoveryChain struct {
 	Targets   []DiscoveryTarget                      `json:",omitempty"`
 }
 
+// IsDefault returns true if the compiled chain represents no routing, no
+// splitting, and only the default resolution.  We have to be careful here to
+// avoid returning "yep this is default" when the only resolver action being
+// applied is redirection to another resolver that is default, so we double
+// check the resolver matches the requested resolver.
 func (c *CompiledDiscoveryChain) IsDefault() bool {
 	if c.Node == nil {
 		return true
 	}
-	return c.Node.Type == DiscoveryGraphNodeTypeGroupResolver && c.Node.GroupResolver.Default
+	return c.Node.Name == c.ServiceName &&
+		c.Node.Type == DiscoveryGraphNodeTypeGroupResolver &&
+		c.Node.GroupResolver.Default
 }
 
 const (

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/config_entries.hcl
@@ -1,1 +1,21 @@
 enable_central_service_config = true
+
+config_entries {
+  bootstrap {
+    kind = "proxy-defaults"
+    name = "global"
+
+    config {
+      protocol = "http"
+    }
+  }
+
+  bootstrap {
+    kind = "service-resolver"
+    name = "s2"
+
+    redirect {
+      service = "s3"
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/config_entries.hcl
@@ -1,0 +1,1 @@
+enable_central_service_config = true

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/s3.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/s3.hcl
@@ -1,0 +1,5 @@
+services {
+  name = "s3"
+  port = 8282
+  connect { sidecar_service {} }
+}

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
@@ -12,22 +12,6 @@ config {
 ' | docker_consul config write -
 
 echo '
-kind = "service-defaults"
-name = "s1"
-protocol = "http"
-' | docker_consul config write -
-echo '
-kind = "service-defaults"
-name = "s2"
-protocol = "http"
-' | docker_consul config write -
-echo '
-kind = "service-defaults"
-name = "s3"
-protocol = "http"
-' | docker_consul config write -
-
-echo '
 kind = "service-resolver"
 name = "s2"
 redirect {

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
@@ -2,23 +2,6 @@
 
 set -euo pipefail
 
-# manually setup config entries
-echo '
-kind = "proxy-defaults"
-name = "global"
-config {
-  protocol = "http"
-}
-' | docker_consul config write -
-
-echo '
-kind = "service-resolver"
-name = "s2"
-redirect {
-  service = "s3"
-}
-' | docker_consul config write -
-
 # retry because resolving the central config might race
 retry_default gen_envoy_bootstrap s1 19000
 retry_default gen_envoy_bootstrap s2 19001

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# manually setup config entries
+echo '
+kind = "proxy-defaults"
+name = "global"
+config {
+  protocol = "http"
+}
+' | docker_consul config write -
+
+echo '
+kind = "service-defaults"
+name = "s1"
+protocol = "http"
+' | docker_consul config write -
+echo '
+kind = "service-defaults"
+name = "s2"
+protocol = "http"
+' | docker_consul config write -
+echo '
+kind = "service-defaults"
+name = "s3"
+protocol = "http"
+' | docker_consul config write -
+
+echo '
+kind = "service-resolver"
+name = "s2"
+redirect {
+  service = "s3"
+}
+' | docker_consul config write -
+
+# retry because resolving the central config might race
+retry_default gen_envoy_bootstrap s1 19000
+retry_default gen_envoy_bootstrap s2 19001
+retry_default gen_envoy_bootstrap s3 19002
+
+export REQUIRED_SERVICES="s1 s1-sidecar-proxy s2 s2-sidecar-proxy s3 s3-sidecar-proxy"

--- a/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-svc-redirect/verify.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s3 proxy admin is up on :19002" {
+  retry_default curl -f -s localhost:19002/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s3 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21002 s3
+}
+
+@test "s3 proxy should be healthy" {
+  assert_service_has_healthy_instances s3 1
+}
+
+@test "s1 upstream should have healthy endpoints for s3" {
+  assert_upstream_has_healthy_endpoints 127.0.0.1:19000 s3 1
+}
+
+@test "s1 upstream should be able to connect to its upstream simply" {
+  run retry_default curl -s -f -d hello localhost:5000
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+
+@test "s1 upstream should be able to connect to s3 via upstream s2" {
+  assert_expected_fortio_name s3
+}
+

--- a/test/integration/connect/envoy/docker-compose.yml
+++ b/test/integration/connect/envoy/docker-compose.yml
@@ -46,24 +46,48 @@ services:
     depends_on:
       - consul
     image: "fortio/fortio"
+    environment:
+      - "FORTIO_NAME=s1"
     command:
      - "server"
      - "-http-port"
      - ":8080"
      - "-grpc-port"
      - ":8079"
+     - "-redirect-port"
+     - "disabled"
     network_mode: service:consul
 
   s2:
     depends_on:
       - consul
     image: "fortio/fortio"
+    environment:
+      - "FORTIO_NAME=s2"
     command:
      - "server"
      - "-http-port"
      - ":8181"
      - "-grpc-port"
      - ":8179"
+     - "-redirect-port"
+     - "disabled"
+    network_mode: service:consul
+
+  s3:
+    depends_on:
+      - consul
+    image: "fortio/fortio"
+    environment:
+      - "FORTIO_NAME=s3"
+    command:
+     - "server"
+     - "-http-port"
+     - ":8282"
+     - "-grpc-port"
+     - ":8279"
+     - "-redirect-port"
+     - "disabled"
     network_mode: service:consul
 
   s1-sidecar-proxy:
@@ -95,6 +119,27 @@ services:
      - "envoy"
      - "-c"
      - "/workdir/envoy/s2-bootstrap.json"
+     - "-l"
+     - "debug"
+     # Hot restart breaks since both envoys seem to interact with each other
+     # despite separate containers that don't share IPC namespace. Not quite
+     # sure how this happens but may be due to unix socket being in some shared
+     # location?
+     - "--disable-hot-restart"
+     - "--drain-time-s"
+     - "1"
+    volumes:
+      - *workdir-volume
+    network_mode: service:consul
+
+  s3-sidecar-proxy:
+    depends_on:
+      - consul
+    image: "envoyproxy/envoy:v${ENVOY_VERSION:-1.8.0}"
+    command:
+     - "envoy"
+     - "-c"
+     - "/workdir/envoy/s3-bootstrap.json"
      - "-l"
      - "debug"
      # Hot restart breaks since both envoys seem to interact with each other

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -176,7 +176,7 @@ function assert_service_has_healthy_instances {
 }
 
 function docker_consul {
-  docker run -i --rm --network container:envoy_consul_1 consul-dev $@
+  docker run -ti --rm --network container:envoy_consul_1 consul-dev $@
 }
 
 function docker_wget {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -176,7 +176,7 @@ function assert_service_has_healthy_instances {
 }
 
 function docker_consul {
-  docker run -ti --rm --network container:envoy_consul_1 consul-dev $@
+  docker run -i --rm --network container:envoy_consul_1 consul-dev $@
 }
 
 function docker_wget {
@@ -252,4 +252,19 @@ function gen_envoy_bootstrap {
     echo "$output"
     return $status
   fi
+}
+
+function get_upstream_fortio_name {
+  run retry_default curl -v -s -f localhost:5000/debug?env=dump
+  [ "$status" == 0 ]
+  echo "$output" | grep -E "^FORTIO_NAME="
+}
+
+function assert_expected_fortio_name {
+  local EXPECT_NAME=$1
+
+  GOT=$(get_upstream_fortio_name)
+  echo "GOT $GOT"
+
+  [ "$GOT" == "FORTIO_NAME=${EXPECT_NAME}" ]
 }


### PR DESCRIPTION
Also:
- add back an internal http endpoint to dump a compiled discovery chain for debugging purposes

Before the `CompiledDiscoveryChain.IsDefault()` method would test:

- is this chain just one resolver step?
- is that resolver step just the default?

But what I forgot to test:

- is that resolver step for the same service that the chain represents?

This last point is important because if you configured just one config
entry:

    kind = "service-resolver"
    name = "web"
    redirect {
      service = "other"
    }

and requested the chain for "web" you'd get back a **default** resolver
for "other".  In the xDS code the IsDefault() method is used to
determine if this chain is "empty". If it is then we use the
pre-discovery-chain logic that just uses data embedded in the Upstream
object (and still lets the escape hatches function).

In the example above that means certain parts of the xDS code were going
to try referencing a cluster named "web..." despite the other parts of
the xDS code maintaining clusters named "other...".