### PR TITLE
Document multiple services config in hcl

### DIFF
--- a/website/source/docs/agent/services.html.md
+++ b/website/source/docs/agent/services.html.md
@@ -235,7 +235,7 @@ Multiple services definitions can be provided at once using the plural
         {
           "args": ["/bin/check_redis", "-p", "6000"],
           "interval": "5s",
-          "ttl": "20s"
+          "timeout": "20s"
         }
       ]
     },
@@ -252,11 +252,49 @@ Multiple services definitions can be provided at once using the plural
         {
           "args": ["/bin/check_redis", "-p", "7000"],
           "interval": "30s",
-          "ttl": "60s"
+          "timeout": "60s"
         }
       ]
     },
     ...
+  ]
+}
+```
+
+In HCL you can specify the plural `services` key (although not `service`) multiple times:
+
+```hcl
+services {
+  id = "red0"
+  name = "redis"
+  tags = [
+    "primary"
+  ]
+  address = ""
+  port = 6000
+  checks = [
+    {
+      args = ["/bin/check_redis", "-p", "6000"]
+      interval = "5s"
+      timeout = "20s"
+    }
+  ]
+}
+services {
+  id = "red1"
+  name = "redis"
+  tags = [
+    "delayed",
+    "secondary"
+  ]
+  address = ""
+  port = 7000
+  checks = [
+    {
+      args = ["/bin/check_redis", "-p", "7000"]
+      interval = "30s"
+      timeout = "60s"
+    }
   ]
 }
 ```


### PR DESCRIPTION
Also change ttl => timeout since ttl doesn't work anymore.

When I was writing a config in HCL it wasn't clear how to specify multiple services. I didn't know if HCL supported objects inside an array, i.e. `[{}, {}]`. Would be nice to document that it does to save users time.