### PR TITLE
agent: avoid reverting any check updates that occur while a service is being added or the config is reloaded

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -3359,12 +3359,9 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig, snap map[types.CheckID]*s
 		health := check.HealthCheck(conf.NodeName)
 
 		// Restore the fields from the snapshot.
-		if snap != nil {
-			prev, ok := snap[health.CheckID]
-			if ok {
-				health.Output = prev.Output
-				health.Status = prev.Status
-			}
+		if prev, ok := snap[health.CheckID]; ok {
+			health.Output = prev.Output
+			health.Status = prev.Status
 		}
 
 		chkType := check.CheckType()
@@ -3424,12 +3421,9 @@ func (a *Agent) loadChecks(conf *config.RuntimeConfig, snap map[types.CheckID]*s
 			p.Check.Status = api.HealthCritical
 
 			// Restore the fields from the snapshot.
-			if snap != nil {
-				prev, ok := snap[p.Check.CheckID]
-				if ok {
-					p.Check.Output = prev.Output
-					p.Check.Status = prev.Status
-				}
+			if prev, ok := snap[p.Check.CheckID]; ok {
+				p.Check.Output = prev.Output
+				p.Check.Status = prev.Status
 			}
 
 			if err := a.addCheckLocked(p.Check, p.ChkType, false, p.Token, ConfigSourceLocal); err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -500,6 +500,59 @@ func TestAgent_AddService(t *testing.T) {
 	}
 }
 
+func TestAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t, t.Name(), `
+		node_name = "node1"
+	`)
+	defer a.Shutdown()
+
+	// It's tricky to get an UpdateCheck call to be timed properly so it lands
+	// right in the middle of an addServiceInternal call so we cheat a bit and
+	// rely upon alias checks to do that work for us.  We add enough services
+	// that probabilistically one of them is going to end up properly in the
+	// critical section.
+	const numServices = 10
+
+	services := make([]*structs.ServiceDefinition, numServices)
+	checkIDs := make([]types.CheckID, numServices)
+	for i := 0; i < numServices; i++ {
+		name := fmt.Sprintf("web-%d", i)
+
+		services[i] = &structs.ServiceDefinition{
+			ID:   name,
+			Name: name,
+			Port: 8080 + i,
+			Checks: []*structs.CheckType{
+				&structs.CheckType{
+					Name:         "alias-for-fake-service",
+					AliasService: "fake",
+				},
+			},
+		}
+
+		checkIDs[i] = types.CheckID("service:" + name)
+	}
+
+	// Add all of the services quickly as you might do from config file snippets.
+	for _, service := range services {
+		ns := service.NodeService()
+
+		chkTypes, err := service.CheckTypes()
+		require.NoError(t, err)
+
+		require.NoError(t, a.AddService(ns, chkTypes, false, service.Token, ConfigSourceLocal))
+	}
+
+	retry.Run(t, func(r *retry.R) {
+		gotChecks := a.State.Checks()
+		for id, check := range gotChecks {
+			require.Equal(r, "passing", check.Status, "check %q is wrong", id)
+			require.Equal(r, "No checks found.", check.Output, "check %q is wrong", id)
+		}
+	})
+}
+
 func TestAgent_AddServiceNoExec(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), `
@@ -2965,13 +3018,10 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Reload the checks
-	if err := a.loadChecks(a.Config); err != nil {
+	// Reload the checks and restore the snapshot.
+	if err := a.loadChecks(a.Config, snap); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-
-	// Restore the state
-	a.restoreCheckState(snap)
 
 	// Search for the check
 	out, ok := a.State.Checks()[check1.CheckID]
@@ -3010,7 +3060,7 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 	}
 
 	// Try loading the checks from the persisted files
-	if err := a.loadChecks(a.Config); err != nil {
+	if err := a.loadChecks(a.Config, nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -512,6 +512,9 @@ func TestAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T) {
 	// rely upon alias checks to do that work for us.  We add enough services
 	// that probabilistically one of them is going to end up properly in the
 	// critical section.
+	//
+	// The first number I picked here (10) surprisingly failed every time prior
+	// to PR #6144 solving the underlying problem.
 	const numServices = 10
 
 	services := make([]*structs.ServiceDefinition, numServices)


### PR DESCRIPTION
An Agent has two confusingly named locks:
* the outer lock `Agent.stateLock`
* and the inner `Agent.State` embedded lock

Operations like `Agent.addServiceInternal` will grab the outer lock and then briefly acquire the inner lock to clone the current state of all of the checks registered on the agent. This is so that when a service is re-registered any checks re-added can have their statuses carried over.

Unfortunately there is a logical data race (rather than a `-race` race) whereby the individual check goroutines (like for an alias check) are independently sending updated statuses into the `Agent.State` and only acquiring the inner lock to do so.

Example situation:

1. (goroutine 1) User registers service `"foo"`.
2. (goroutine 1) `addServiceInternal` locks the outer lock
3. (goroutine 1) `snapshotCheckState` locks the inner lock, copies the check states, and unlocks the inner lock
4. (goroutine 2) A checker determines the health of a check `"bar"` has changed and calls `State.UpdateCheck` to change from `critical -> passing`.
5. (goroutine 2) The inner lock is locked, the status for `"bar"` is flipped to `passing`, and the inner lock is unlocked.
6. (goroutine 1) The `"foo"` service finishes being added and the `defer restoreCheckState` call walks the captured check snapshot from (3).
7. (goroutine 1) The previous value of the `"bar"` check is reverted back to `critical` as it was in step (3).

The fix here is to only use the snapshot to seed the value of the check initially inserted/updated, rather than letting the check be inserted/updated at the default unmeasured state of `critical`.