### PR TITLE
More flaky test fixes

### DIFF
--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -68,13 +68,15 @@ func TestLeader_RegisterMember(t *testing.T) {
 	}
 
 	// Server should be registered
-	_, node, err := state.GetNode(s1.config.NodeName)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if node == nil {
-		t.Fatalf("server not registered")
-	}
+	retry.Run(t, func(r *retry.R) {
+		_, node, err := state.GetNode(s1.config.NodeName)
+		if err != nil {
+			r.Fatalf("err: %v", err)
+		}
+		if node == nil {
+			r.Fatalf("server not registered")
+		}
+	})
 
 	// Service should be registered
 	_, services, err := state.NodeServices(nil, s1.config.NodeName)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -4331,6 +4331,7 @@ func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType
 }
 
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		aRecordLimit        int
@@ -4398,6 +4399,7 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 		}
 		// No limits but the size of records for SRV records, since not subject to randomization issues
 		t.Run("SRV lookup limitARecord", func(t *testing.T) {
+			t.Parallel()
 			err := checkDNSService(t, test.expectedSRVResults, test.aRecordLimit, dns.TypeSRV, test.numNodesTotal, test.udpSize, test.udpAnswerLimit)
 			if err != nil {
 				t.Fatalf("Expected service SRV lookup %s to pass: %v", test.name, err)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -4331,7 +4331,6 @@ func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType
 }
 
 func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name                string
 		aRecordLimit        int
@@ -4399,7 +4398,6 @@ func TestDNS_ServiceLookup_ARecordLimits(t *testing.T) {
 		}
 		// No limits but the size of records for SRV records, since not subject to randomization issues
 		t.Run("SRV lookup limitARecord", func(t *testing.T) {
-			t.Parallel()
 			err := checkDNSService(t, test.expectedSRVResults, test.aRecordLimit, dns.TypeSRV, test.numNodesTotal, test.udpSize, test.udpAnswerLimit)
 			if err != nil {
 				t.Fatalf("Expected service SRV lookup %s to pass: %v", test.name, err)

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -715,7 +715,7 @@ func TestConnectRootsWatch(t *testing.T) {
 			return // ignore
 		}
 		v, ok := raw.(*api.CARootList)
-		if !ok || v == nil {
+		if !ok || v == nil || len(v.Roots) == 0 {
 			return // ignore
 		}
 		// Only 1 CA is the bootstrapped state (i.e. first response). Ignore this


### PR DESCRIPTION
- Added retries to: `TestLeader_RegisterMember`, `TestAPI_ClientTxn`
- Bumped down parallelization in `TestDNS_ServiceLookup_ARecordLimits`
- Accounted for case where watch initially returns empty result in `TestConnectRootsWatch`