### PR TITLE
Run go test packages in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
           PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname)
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 2 $PACKAGE_NAMES
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 3 $PACKAGE_NAMES
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,6 @@ jobs:
       - run: mkdir -p $TEST_RESULTS_DIR
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
-      # Use CircleCI test splitting by classname. Since there are no classes in go,
-      # we fake it by taking everything after github.com/hashicorp/consul/ and setting
-      # it as the classname.
-
-      # This loop writes go test results to <reportname>.xml per go package
       - run: |
           PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname)
           gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 3 $PACKAGE_NAMES
@@ -106,11 +101,6 @@ jobs:
       - attach_workspace:
           at: /go/bin
       - run: mkdir -p $TEST_RESULTS_DIR
-      # Use CircleCI test splitting by classname. Since there are no classes in go,
-      # we fake it by taking everything after github.com/hashicorp/consul/ and setting
-      # it as the classname.
-
-      # This loop writes go test results to <reportname>.xml per go package
       - run:
           working_directory: api
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,10 +83,8 @@ jobs:
 
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
-          for pkg in $(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess |circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
-            reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
-            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/$reportname.xml -- -tags=$GOTAGS $pkg
-          done
+          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' ')
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 1 $PACKAGE_NAMES
 
       - store_test_results:
           path: /tmp/test-results
@@ -116,10 +114,8 @@ jobs:
       - run:
           working_directory: api
           command: |
-            for pkg in $(go list ./... | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' '); do
-              reportname=$(echo $pkg | cut -d '/' -f3- | sed "s#/#_#g")
-              gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/$reportname.xml -- -tags=$GOTAGS $pkg
-            done
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS $PACKAGE_NAMES
 
       - store_test_results:
           path: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,8 @@ jobs:
 
       # This loop writes go test results to <reportname>.xml per go package
       - run: |
-          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname | tr '\n' ' ')
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 1 $PACKAGE_NAMES
+          PACKAGE_NAMES=$(go list ./... | grep -v github.com/hashicorp/consul/agent/proxyprocess | circleci tests split --split-by=timings --timings-type=classname)
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 2 $PACKAGE_NAMES
 
       - store_test_results:
           path: /tmp/test-results


### PR DESCRIPTION
Previously, the go tests were running in a for loop per package to generate per package result files so that they could be properly bubbled up into CircleCI. `gotestsum` has been updated to support the generation of 'classnames' as go package names so we no longer have to hack this (yay). 

I refactored the go test command and am now running with `-p 3` reducing the times from 6-7 mins to  2-3 minutes 🎉. I would rather tune this value down in favor of more go test stability but `-p 3` seems to work fairly well so far so lets try it. `-p 3` was also what was set in Travis previously. 