### PR TITLE
ui: [Bugfix] - Sticky KV Sessions

### DIFF
--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -17,6 +17,7 @@ export default Route.extend(WithKvActions, {
       isLoading: false,
       parent: repo.findBySlug(ascend(key, 1) || '/', dc),
       item: repo.findBySlug(key, dc),
+      session: null,
     }).then(model => {
       // TODO: Consider loading this after initial page load
       const session = get(model.item, 'Session');

--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -1,73 +1,77 @@
 {{#app-view class="kv edit" loading=isLoading}}
-    {{#block-slot 'notification' as |status type|}}
-      {{partial 'dc/kv/notifications'}}
-    {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
-        <ol>
-            <li><a data-test-back href={{href-to 'dc.kv.index'}}>Key / Values</a></li>
-{{#if (not-eq parent.Key '/') }}
-{{#each (slice 0 -1 (split parent.Key '/')) as |breadcrumb index|}}
-            <li><a href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
-{{/each}}
+  {{#block-slot 'notification' as |status type|}}
+    {{partial 'dc/kv/notifications'}}
+  {{/block-slot}}
+  {{#block-slot 'breadcrumbs'}}
+    <ol>
+        <li><a data-test-back href={{href-to 'dc.kv.index'}}>Key / Values</a></li>
+{{#if (not-eq parent.Key '/')}}
+  {{#each (slice 0 -1 (split parent.Key '/')) as |breadcrumb index|}}
+        <li><a href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
+  {{/each}}
 {{/if}}
-        </ol>
-    {{/block-slot}}
-    {{#block-slot 'header'}}
-        <h1>
-{{#if item.Key }}
-            {{left-trim item.Key parent.Key }}
+    </ol>
+  {{/block-slot}}
+  {{#block-slot 'header'}}
+      <h1>
+{{#if item.Key}}
+        {{left-trim item.Key parent.Key}}
 {{else}}
-            New Key / Value
+        New Key / Value
 {{/if}}
-        </h1>
-    {{/block-slot}}
-    {{#block-slot 'content'}}
-        {{#if session}}
-            <p class="notice warning"><strong>Warning.</strong> This KV has a lock session. You can edit KV's with lock sessions, but we recommend doing so with care, or not doing so at all. It may negatively impact the active node it's associated with. See below for more details on the Lock Session and see <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/internals/sessions.html" target="_blank" rel="noopener noreferrer">our documentation</a> for more information.</p>
-        {{/if}}
-        {{partial 'dc/kv/form'}}
-        {{#if session}}
-        <div data-test-session={{session.ID}}>
-                <h2><a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/internals/sessions.html#session-design" rel="help noopener noreferrer" target="_blank">Lock Session</a></h2>
-                <dl>
-                    <dt>Name</dt>
-                    <dd>{{session.Name}}</dd>
-                    <dt>Agent</dt>
-                    <dd>
-                        <a href={{href-to 'dc.nodes.show' session.Node }}>{{session.Node}}</a>
-                    </dd>
-                    <dt>ID</dt>
-                    <dd>{{session.ID}}</dd>
-                    <dt>Behavior</dt>
-                    <dd>{{session.Behavior}}</dd>
+      </h1>
+  {{/block-slot}}
+  {{#block-slot 'content'}}
+    {{#if session}}
+      <p class="notice warning">
+        <strong>Warning.</strong> This KV has a lock session. You can edit KV's with lock sessions, but we recommend doing so with care, or not doing so at all. It may negatively impact the active node it's associated with. See below for more details on the Lock Session and see <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/internals/sessions.html" target="_blank" rel="noopener noreferrer">our documentation</a> for more information.
+      </p>
+    {{/if}}
+    {{partial 'dc/kv/form'}}
+    {{#if session}}
+      <div data-test-session={{session.ID}}>
+        <h2>
+          <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/internals/sessions.html#session-design" rel="help noopener noreferrer" target="_blank">Lock Session</a>
+        </h2>
+        <dl>
+          <dt>Name</dt>
+          <dd>{{session.Name}}</dd>
+          <dt>Agent</dt>
+          <dd>
+              <a href={{href-to 'dc.nodes.show' session.Node}}>{{session.Node}}</a>
+          </dd>
+          <dt>ID</dt>
+          <dd>{{session.ID}}</dd>
+          <dt>Behavior</dt>
+          <dd>{{session.Behavior}}</dd>
 {{#if session.Delay }}
-                    <dt>Delay</dt>
-                    <dd>{{session.LockDelay}}</dd>
+          <dt>Delay</dt>
+          <dd>{{session.LockDelay}}</dd>
 {{/if}}
 {{#if session.TTL }}
-                    <dt>TTL</dt>
-                    <dd>{{session.TTL}}</dd>
+          <dt>TTL</dt>
+          <dd>{{session.TTL}}</dd>
 {{/if}}
 {{#if (gt session.Checks.length 0)}}
-                    <dt>Health Checks</dt>
-                    <dd>
-                        {{ join ', ' session.Checks}}
-                    </dd>
+          <dt>Health Checks</dt>
+          <dd>
+              {{ join ', ' session.Checks}}
+          </dd>
 {{/if}}
-                </dl>
-                {{#confirmation-dialog message='Are you sure you want to invalidate this session?'}}
-                    {{#block-slot 'action' as |confirm|}}
-                        <button type="button" data-test-delete class="type-delete" {{ action confirm "invalidateSession" session }}>Invalidate Session</button>
-                    {{/block-slot}}
-                    {{#block-slot 'dialog' as |execute cancel message|}}
-                        <p>
-                            {{message}}
-                        </p>
-                        <button type="button" class="type-delete" {{action execute}}>Confirm Invalidation</button>
-                        <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
-                    {{/block-slot}}
-                {{/confirmation-dialog}}
-            </div>
-        {{/if}}
-    {{/block-slot}}
+        </dl>
+        {{#confirmation-dialog message='Are you sure you want to invalidate this session?'}}
+          {{#block-slot 'action' as |confirm|}}
+            <button type="button" data-test-delete class="type-delete" {{action confirm "invalidateSession" session}}>Invalidate Session</button>
+          {{/block-slot}}
+          {{#block-slot 'dialog' as |execute cancel message|}}
+            <p>
+              {{message}}
+            </p>
+            <button type="button" class="type-delete" {{action execute}}>Confirm Invalidation</button>
+            <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
+          {{/block-slot}}
+        {{/confirmation-dialog}}
+      </div>
+    {{/if}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -27,7 +27,7 @@
         {{/if}}
         {{partial 'dc/kv/form'}}
         {{#if session}}
-            <div data-test-session>
+        <div data-test-session={{session.ID}}>
                 <h2><a href="{{env 'CONSUL_DOCUMENTATION_URL'}}/internals/sessions.html#session-design" rel="help noopener noreferrer" target="_blank">Lock Session</a></h2>
                 <dl>
                     <dt>Name</dt>

--- a/ui-v2/tests/acceptance/dc/kvs/edit.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/edit.feature
@@ -1,0 +1,27 @@
+@setupApplicationTest
+Feature: dc / kvs / edit: KV Viewing
+  Scenario:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
+    ---
+      Key: key
+      Session: session-id
+    ---
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+      kv: key
+    ---
+    Then the url should be /datacenter/kv/key/edit
+    And I see ID on the session like "session-id"
+    Given 1 kv model from yaml
+    ---
+      Key: another-key
+      Session: ~
+    ---
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+      kv: another-key
+    ---
+    Then I don't see ID on the session

--- a/ui-v2/tests/acceptance/steps/dc/kvs/edit-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/kvs/edit-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -63,7 +63,7 @@ export default {
   nodes: create(nodes(visitable, clickable, attribute, collection, catalogFilter)),
   node: create(node(visitable, deletable, clickable, attribute, collection, radiogroup)),
   kvs: create(kvs(visitable, deletable, creatable, clickable, attribute, collection)),
-  kv: create(kv(visitable, submitable, deletable, cancelable, clickable)),
+  kv: create(kv(visitable, attribute, submitable, deletable, cancelable, clickable)),
   acls: create(acls(visitable, deletable, creatable, clickable, attribute, collection, aclFilter)),
   acl: create(acl(visitable, submitable, deletable, cancelable, clickable)),
   policies: create(

--- a/ui-v2/tests/pages/dc/kv/edit.js
+++ b/ui-v2/tests/pages/dc/kv/edit.js
@@ -1,17 +1,19 @@
-export default function(visitable, submitable, deletable, cancelable) {
-  return submitable(
-    cancelable(
-      deletable({
-        visit: visitable(['/:dc/kv/:kv/edit', '/:dc/kv/create'], function(str) {
-          // this will encode the parts of the key path but means you can no longer
-          // visit with path parts containing slashes
-          return str
-            .split('/')
-            .map(encodeURIComponent)
-            .join('/');
-        }),
-        session: deletable({}, '[data-test-session]'),
-      })
-    )
-  );
+export default function(visitable, attribute, submitable, deletable, cancelable) {
+  return {
+    visit: visitable(['/:dc/kv/:kv/edit', '/:dc/kv/create'], function(str) {
+      // this will encode the parts of the key path but means you can no longer
+      // visit with path parts containing slashes
+      return str
+        .split('/')
+        .map(encodeURIComponent)
+        .join('/');
+    }),
+    ...submitable(),
+    ...cancelable(),
+    ...deletable(),
+    session: {
+      ID: attribute('data-test-session', '[data-test-session]'),
+      ...deletable({}, '[data-test-session]'),
+    },
+  };
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/6097

This essentially resets `session` to `null` every time you visit a KV page (then potentially loads another one in)

Please note, we took the opportunity in the last commit here to neaten up the whitespace in the template, so changes to `kv/edit.hbs` are almost all whitespace changes. The only thing we actually added to `kv/edit.hbs` was to fill in a `session.ID` value for `data-test-session` (line 32)

(cc @tryan225 @ChipV223 )