### PR TITLE
ui: Show the correct message when a session has been removed from a KV

### DIFF
--- a/ui-v2/app/mixins/kv/with-actions.js
+++ b/ui-v2/app/mixins/kv/with-actions.js
@@ -29,7 +29,7 @@ export default Mixin.create(WithBlockingActions, {
           delete item.Session;
           set(controller, 'session', null);
         });
-      }, 'delete');
+      }, 'deletesession');
     },
   },
 });

--- a/ui-v2/app/templates/dc/kv/-notifications.hbs
+++ b/ui-v2/app/templates/dc/kv/-notifications.hbs
@@ -16,5 +16,11 @@
   {{else}}
     There was an error deleting your key.
   {{/if}}
+{{ else if (eq type 'deletesession')}}
+  {{#if (eq status 'success') }}
+    Your session was invalidated.
+  {{else}}
+    There was an error invalidating your session.
+  {{/if}}
 {{/if}}
 

--- a/ui-v2/tests/acceptance/dc/kvs/sessions/invalidate.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/sessions/invalidate.feature
@@ -21,12 +21,12 @@ Feature: dc / kvs / sessions / invalidate: Invalidate Lock Sessions
     And I click confirmDelete on the session
     Then the last PUT request was made to "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter"
     Then the url should be /datacenter/kv/key/edit
-    And "[data-notification]" has the "notification-delete" class
+    And "[data-notification]" has the "notification-deletesession" class
     And "[data-notification]" has the "success" class
   Scenario: Invalidating a lock session and receiving an error
     Given the url "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter" responds with a 500 status
     And I click delete on the session
     And I click confirmDelete on the session
     Then the url should be /datacenter/kv/key/edit
-    And "[data-notification]" has the "notification-delete" class
+    And "[data-notification]" has the "notification-deletesession" class
     And "[data-notification]" has the "error" class


### PR DESCRIPTION
When you invalidate a session from a KV page previously you would see this message:

![Screenshot 2019-07-18 at 11 35 04](https://user-images.githubusercontent.com/554604/61450966-30a35880-a950-11e9-9b55-f663c9fb83e8.png)

This PR corrects the message:

![Screenshot 2019-07-18 at 11 34 19](https://user-images.githubusercontent.com/554604/61450986-40bb3800-a950-11e9-8d92-423fdc8e269c.png)

The tests check for a class on the message, not the message itself (incase we change the text of the message in future)
