### PR TITLE
connect: rework how the service resolver subset OnlyPassing flag works

### DIFF
--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -32,7 +32,7 @@ type CompiledDiscoveryChain struct {
 	// GroupResolverNodes respresents all unique service instance groups that
 	// need to be represented. For envoy these render as Clusters.
 	//
-	// Omitted from JSON because DiscoveryTarget is not a encoding.TextMarshaler.
+	// Omitted from JSON because these already show up under the Node field.
 	GroupResolverNodes map[DiscoveryTarget]*DiscoveryGraphNode `json:"-"`
 
 	// TODO(rb): not sure if these two fields are actually necessary but I'll know when I get into xDS
@@ -52,6 +52,22 @@ func (c *CompiledDiscoveryChain) IsDefault() bool {
 	return c.Node.Name == c.ServiceName &&
 		c.Node.Type == DiscoveryGraphNodeTypeGroupResolver &&
 		c.Node.GroupResolver.Default
+}
+
+// SubsetDefinitionForTarget is a convenience function to fetch the subset
+// definition for the service subset defined by the provided target. If the
+// subset is not defined an empty definition is returned.
+func (c *CompiledDiscoveryChain) SubsetDefinitionForTarget(t DiscoveryTarget) ServiceResolverSubset {
+	if t.ServiceSubset == "" {
+		return ServiceResolverSubset{}
+	}
+
+	resolver, ok := c.Resolvers[t.Service]
+	if !ok {
+		return ServiceResolverSubset{}
+	}
+
+	return resolver.Subsets[t.ServiceSubset]
 }
 
 const (

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -94,18 +94,19 @@ func Test_makeLoadAssignment(t *testing.T) {
 	testWarningCheckServiceNodes[0].Checks[0].Status = "warning"
 	testWarningCheckServiceNodes[1].Checks[0].Status = "warning"
 
+	// TODO(rb): test onlypassing
 	tests := []struct {
 		name                   string
 		clusterName            string
 		overprovisioningFactor int
-		endpoints              []structs.CheckServiceNodes
+		endpoints              []loadAssignmentEndpointGroup
 		want                   *envoy.ClusterLoadAssignment
 	}{
 		{
 			name:        "no instances",
 			clusterName: "service:test",
-			endpoints: []structs.CheckServiceNodes{
-				{},
+			endpoints: []loadAssignmentEndpointGroup{
+				{Endpoints: nil},
 			},
 			want: &envoy.ClusterLoadAssignment{
 				ClusterName: "service:test",
@@ -117,8 +118,8 @@ func Test_makeLoadAssignment(t *testing.T) {
 		{
 			name:        "instances, no weights",
 			clusterName: "service:test",
-			endpoints: []structs.CheckServiceNodes{
-				testCheckServiceNodes,
+			endpoints: []loadAssignmentEndpointGroup{
+				{Endpoints: testCheckServiceNodes},
 			},
 			want: &envoy.ClusterLoadAssignment{
 				ClusterName: "service:test",
@@ -147,8 +148,8 @@ func Test_makeLoadAssignment(t *testing.T) {
 		{
 			name:        "instances, healthy weights",
 			clusterName: "service:test",
-			endpoints: []structs.CheckServiceNodes{
-				testWeightedCheckServiceNodes,
+			endpoints: []loadAssignmentEndpointGroup{
+				{Endpoints: testWeightedCheckServiceNodes},
 			},
 			want: &envoy.ClusterLoadAssignment{
 				ClusterName: "service:test",
@@ -177,8 +178,8 @@ func Test_makeLoadAssignment(t *testing.T) {
 		{
 			name:        "instances, warning weights",
 			clusterName: "service:test",
-			endpoints: []structs.CheckServiceNodes{
-				testWarningCheckServiceNodes,
+			endpoints: []loadAssignmentEndpointGroup{
+				{Endpoints: testWarningCheckServiceNodes},
 			},
 			want: &envoy.ClusterLoadAssignment{
 				ClusterName: "service:test",
@@ -207,7 +208,12 @@ func Test_makeLoadAssignment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := makeLoadAssignment(tt.clusterName, tt.overprovisioningFactor, tt.endpoints, "dc1")
+			got := makeLoadAssignment(
+				tt.clusterName,
+				tt.overprovisioningFactor,
+				tt.endpoints,
+				"dc1",
+			)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-service-subsets.golden
@@ -246,6 +246,18 @@
               },
               "healthStatus": "HEALTHY",
               "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "172.16.1.9",
+                    "portValue": 2222
+                  }
+                }
+              },
+              "healthStatus": "UNHEALTHY",
+              "loadBalancingWeight": 1
             }
           ]
         }

--- a/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/config_entries.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/config_entries.hcl
@@ -1,0 +1,25 @@
+enable_central_service_config = true
+
+config_entries {
+  bootstrap {
+    kind = "proxy-defaults"
+    name = "global"
+
+    config {
+      protocol = "http"
+    }
+  }
+
+  bootstrap {
+    kind = "service-resolver"
+    name = "s2"
+
+    default_subset = "test"
+
+    subsets = {
+      "test" = {
+        only_passing = true
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/s2-v1.hcl
+++ b/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/s2-v1.hcl
@@ -1,0 +1,22 @@
+services {
+  id   = "s2-v1"
+  name = "s2"
+  port = 8182
+
+  meta {
+    version = "v1"
+  }
+
+  checks = [
+    {
+      name = "main"
+      ttl  = "30m"
+    },
+  ]
+
+  connect {
+    sidecar_service {
+      port = 21011
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/setup.sh
+++ b/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# wait for service registration
+wait_for_agent_service_register s1
+wait_for_agent_service_register s2
+wait_for_agent_service_register s2-v1
+
+# force s2-v1 into a warning state
+set_ttl_check_state service:s2-v1 warn
+
+# wait for bootstrap to apply config entries
+wait_for_config_entry proxy-defaults global
+wait_for_config_entry service-resolver s2
+
+gen_envoy_bootstrap s1 19000
+gen_envoy_bootstrap s2 19001
+gen_envoy_bootstrap s2-v1 19002
+
+export REQUIRED_SERVICES="
+s1 s1-sidecar-proxy
+s2 s2-sidecar-proxy
+s2-v1 s2-v1-sidecar-proxy
+"

--- a/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-subset-onlypassing/verify.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s2-v1 proxy admin is up on :19002" {
+  retry_default curl -f -s localhost:19002/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2-v1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21011 s2
+}
+
+###########################
+## with onlypassing=true
+
+@test "only one s2 proxy is healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
+@test "s1 upstream should have 1 healthy endpoint for test.s2" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 test.s2 HEALTHY 1
+}
+
+@test "s1 upstream should have 1 unhealthy endpoints for test.s2" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 test.s2 UNHEALTHY 1
+}
+
+@test "s1 upstream should be able to connect to s2" {
+  assert_expected_fortio_name s2
+}
+
+###########################
+## with onlypassing=false
+
+@test "switch back to OnlyPassing=false by deleting the config" {
+  delete_config_entry service-resolver s2
+}
+
+@test "only one s2 proxy is healthy (OnlyPassing=false)" {
+  assert_service_has_healthy_instances s2 1
+}
+
+@test "s1 upstream should have 2 healthy endpoints for test.s2 (OnlyPassing=false)" {
+  # NOTE: the subset is erased, so we use the bare name now
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2 HEALTHY 2
+}
+
+@test "s1 upstream should have 0 unhealthy endpoints for test.s2 (OnlyPassing=false)" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2 UNHEALTHY 0
+}

--- a/website/source/docs/agent/config-entries/service-resolver.html.md
+++ b/website/source/docs/agent/config-entries/service-resolver.html.md
@@ -94,10 +94,10 @@ name = "web"
     returned.
 
   - `OnlyPassing` `(bool: false)` - Specifies the behavior of the resolver's
-    health check filtering. If this is set to false, the results will include
-    instances with checks in the passing as well as the warning states. If this
-    is set to true, only instances with checks in the passing state will be
-    returned.
+    health check interpretation. If this is set to false, instances with checks
+    in the passing as well as the warning states will be considered healthy. If
+    this is set to true, only instances with checks in the passing state will
+    be considered healthy.
 
 - `Redirect` `(ServiceResolverRedirect: <optional>)` - When configured, all
   attempts to resolve the service this resolver defines will be substituted for


### PR DESCRIPTION
The main change is that we no longer filter service instances by health,
preferring instead to render all results down into EDS endpoints in
envoy and merely label the endpoints as HEALTHY or UNHEALTHY.

When OnlyPassing is set to true we will force consul checks in a
'warning' state to render as UNHEALTHY in envoy.

Fixes #6171