### PR TITLE
Avoid unnecessary conversions

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -135,7 +135,7 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 			}
 			netKVSize += size
 
-			verb := api.KVOp(in.KV.Verb)
+			verb := in.KV.Verb
 			if isWrite(verb) {
 				writes++
 			}

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -165,7 +165,7 @@ func TestKVPutCommand_Base64(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !bytes.Equal(data.Value, []byte(expected)) {
+	if !bytes.Equal(data.Value, expected) {
 		t.Errorf("bad: %#v, %s", data.Value, data.Value)
 	}
 }


### PR DESCRIPTION
Those values already have the right type.