### PR TITLE
Fixed nil check for token

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -602,7 +602,7 @@ func (a *ACL) tokenSetInternal(args *structs.ACLTokenSetRequest, reply *structs.
 	}
 
 	// Don't check expiration times here as it doesn't really matter.
-	if _, updatedToken, err := a.srv.fsm.State().ACLTokenGetByAccessor(nil, token.AccessorID); err == nil && token != nil {
+	if _, updatedToken, err := a.srv.fsm.State().ACLTokenGetByAccessor(nil, token.AccessorID); err == nil && updatedToken != nil {
 		*reply = *updatedToken
 	} else {
 		return fmt.Errorf("Failed to retrieve the token after insertion")


### PR DESCRIPTION
I can only assume we want to check for the retrieved `updatedToken` to not be
nil, before accessing it below.

`token` can't possibly be nil at this point, as we accessed `token.AccessorID`
just before.