### PR TITLE
Use the replication token when checking the health of a primary DC during CA replication

### DIFF
--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -505,6 +505,7 @@ func (s *Server) datacentersMeetMinVersion(minVersion *version.Version) (bool, e
 
 	args := structs.DCSpecificRequest{
 		Datacenter: s.config.PrimaryDatacenter,
+		QueryOptions: structs.QueryOptions{Token: s.tokens.ReplicationToken()},
 	}
 	var reply autopilot.OperatorHealthReply
 	if err := s.forwardDC("Operator.ServerHealth", s.config.PrimaryDatacenter, &args, &reply); err != nil {


### PR DESCRIPTION
this should fix #6192