### PR TITLE
ui: Enable blocking queries by default

### DIFF
--- a/ui-v2/app/controllers/settings.js
+++ b/ui-v2/app/controllers/settings.js
@@ -34,9 +34,6 @@ export default Controller.extend({
       const blocking = get(this, 'item.client.blocking');
       switch (target.name) {
         case 'client[blocking]':
-          if (typeof blocking === 'undefined') {
-            set(this, 'item.client', {});
-          }
           set(this, 'item.client.blocking', !blocking);
           this.send('update', get(this, 'item'));
           break;

--- a/ui-v2/app/routes/settings.js
+++ b/ui-v2/app/routes/settings.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 
 export default Route.extend({
   client: service('client/http'),
@@ -12,6 +12,9 @@ export default Route.extend({
       item: get(this, 'repo').findAll(),
       dcs: get(this, 'dcRepo').findAll(),
     }).then(model => {
+      if (typeof get(model.item, 'client.blocking') === 'undefined') {
+        set(model, 'item.client', { blocking: true });
+      }
       return hash({
         ...model,
         ...{

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -65,7 +65,7 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
         key: key,
         type: BlockingEventSource,
         settings: {
-          enabled: settings.blocking,
+          enabled: typeof settings.blocking === 'undefined' || settings.blocking,
         },
         createEvent: createEvent,
       }

--- a/ui-v2/tests/acceptance/dc/list-blocking.feature
+++ b/ui-v2/tests/acceptance/dc/list-blocking.feature
@@ -5,11 +5,6 @@ Feature: dc / list-blocking
   I want to see changes if I change consul externally
   Background:
     Given 1 datacenter model with the value "dc-1"
-    And settings from yaml
-    ---
-    consul:client:
-      blocking: 1
-    ---
   Scenario: Viewing the listing pages
     Given 3 [Model] models
     And a network latency of 100

--- a/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
@@ -25,7 +25,7 @@ Feature: dc / nodes / sessions / invalidate: Invalidate Lock Sessions
   Scenario: Invalidating the lock session
     And I click delete on the sessions
     And I click confirmDelete on the sessions
-    Then a PUT request is made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1"
+    Then the last PUT request was made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1"
     Then the url should be /dc1/nodes/node-0
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class


### PR DESCRIPTION
This enables blocking queries by default. They can still be turned off via the settings page, and if anyone has turned off blocking queries in previous versions of the UI and have that preference stored in localStorage still, it will continue to respect that setting.