### PR TITLE
Allow forwarding of some status RPCs

### DIFF
--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -287,7 +287,7 @@ func (s *Server) maybeBootstrap() {
 		// Retry with exponential backoff to get peer status from this server
 		for attempt := uint(0); attempt < maxPeerRetries; attempt++ {
 			if err := s.connPool.RPC(s.config.Datacenter, server.Addr, server.Version,
-				"Status.Peers", server.UseTLS, &struct{}{}, &peers); err != nil {
+				"Status.Peers", server.UseTLS, &structs.DCSpecificRequest{Datacenter: s.config.Datacenter}, &peers); err != nil {
 				nextRetry := time.Duration((1 << attempt) * peerRetryBase)
 				s.logger.Printf("[ERR] consul: Failed to confirm peer status for %s: %v. Retrying in "+
 					"%v...", server.Name, err, nextRetry.String())

--- a/agent/consul/status_endpoint.go
+++ b/agent/consul/status_endpoint.go
@@ -20,6 +20,9 @@ func (s *Status) Ping(args struct{}, reply *struct{}) error {
 
 // Leader is used to get the address of the leader
 func (s *Status) Leader(args *structs.DCSpecificRequest, reply *string) error {
+	// not using the regular forward function as it does a bunch of stuff we
+	// dont want like verifying consistency etc. We just want to enable DC
+	// forwarding
 	if args.Datacenter != "" && args.Datacenter != s.server.config.Datacenter {
 		return s.server.forwardDC("Status.Leader", args.Datacenter, args, reply)
 	}
@@ -35,6 +38,9 @@ func (s *Status) Leader(args *structs.DCSpecificRequest, reply *string) error {
 
 // Peers is used to get all the Raft peers
 func (s *Status) Peers(args *structs.DCSpecificRequest, reply *[]string) error {
+	// not using the regular forward function as it does a bunch of stuff we
+	// dont want like verifying consistency etc. We just want to enable DC
+	// forwarding
 	if args.Datacenter != "" && args.Datacenter != s.server.config.Datacenter {
 		return s.server.forwardDC("Status.Peers", args.Datacenter, args, reply)
 	}

--- a/agent/status_endpoint.go
+++ b/agent/status_endpoint.go
@@ -2,19 +2,31 @@ package agent
 
 import (
 	"net/http"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func (s *HTTPServer) StatusLeader(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	args := structs.DCSpecificRequest{}
+	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
+		return nil, nil
+	}
+
 	var out string
-	if err := s.agent.RPC("Status.Leader", struct{}{}, &out); err != nil {
+	if err := s.agent.RPC("Status.Leader", &args, &out); err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
 func (s *HTTPServer) StatusPeers(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	args := structs.DCSpecificRequest{}
+	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
+		return nil, nil
+	}
+
 	var out []string
-	if err := s.agent.RPC("Status.Peers", struct{}{}, &out); err != nil {
+	if err := s.agent.RPC("Status.Peers", &args, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/agent/status_endpoint_test.go
+++ b/agent/status_endpoint_test.go
@@ -1,10 +1,13 @@
 package agent
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStatusLeader(t *testing.T) {
@@ -24,6 +27,42 @@ func TestStatusLeader(t *testing.T) {
 	}
 }
 
+func TestStatusLeaderSecondary(t *testing.T) {
+	t.Parallel()
+	a1 := NewTestAgent(t, t.Name(), "datacenter = \"primary\"")
+	defer a1.Shutdown()
+	a2 := NewTestAgent(t, t.Name(), "datacenter = \"secondary\"")
+	defer a2.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a1.RPC, "primary")
+	testrpc.WaitForTestAgent(t, a2.RPC, "secondary")
+
+	a1SerfAddr := fmt.Sprintf("127.0.0.1:%d", a1.Config.SerfPortWAN)
+	a1Addr := fmt.Sprintf("127.0.0.1:%d", a1.Config.ServerPort)
+	a2Addr := fmt.Sprintf("127.0.0.1:%d", a2.Config.ServerPort)
+	_, err := a2.JoinWAN([]string{a1SerfAddr})
+	require.NoError(t, err)
+
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, a1.WANMembers(), 2)
+		require.Len(r, a2.WANMembers(), 2)
+	})
+
+	req, _ := http.NewRequest("GET", "/v1/status/leader?dc=secondary", nil)
+	obj, err := a1.srv.StatusLeader(nil, req)
+	require.NoError(t, err)
+	leader, ok := obj.(string)
+	require.True(t, ok)
+	require.Equal(t, a2Addr, leader)
+
+	req, _ = http.NewRequest("GET", "/v1/status/leader?dc=primary", nil)
+	obj, err = a2.srv.StatusLeader(nil, req)
+	require.NoError(t, err)
+	leader, ok = obj.(string)
+	require.True(t, ok)
+	require.Equal(t, a1Addr, leader)
+}
+
 func TestStatusPeers(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
@@ -39,4 +78,40 @@ func TestStatusPeers(t *testing.T) {
 	if len(peers) != 1 {
 		t.Fatalf("bad peers: %v", peers)
 	}
+}
+
+func TestStatusPeersSecondary(t *testing.T) {
+	t.Parallel()
+	a1 := NewTestAgent(t, t.Name(), "datacenter = \"primary\"")
+	defer a1.Shutdown()
+	a2 := NewTestAgent(t, t.Name(), "datacenter = \"secondary\"")
+	defer a2.Shutdown()
+
+	testrpc.WaitForTestAgent(t, a1.RPC, "primary")
+	testrpc.WaitForTestAgent(t, a2.RPC, "secondary")
+
+	a1SerfAddr := fmt.Sprintf("127.0.0.1:%d", a1.Config.SerfPortWAN)
+	a1Addr := fmt.Sprintf("127.0.0.1:%d", a1.Config.ServerPort)
+	a2Addr := fmt.Sprintf("127.0.0.1:%d", a2.Config.ServerPort)
+	_, err := a2.JoinWAN([]string{a1SerfAddr})
+	require.NoError(t, err)
+
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, a1.WANMembers(), 2)
+		require.Len(r, a2.WANMembers(), 2)
+	})
+
+	req, _ := http.NewRequest("GET", "/v1/status/peers?dc=secondary", nil)
+	obj, err := a1.srv.StatusPeers(nil, req)
+	require.NoError(t, err)
+	peers, ok := obj.([]string)
+	require.True(t, ok)
+	require.Equal(t, []string{a2Addr}, peers)
+
+	req, _ = http.NewRequest("GET", "/v1/status/peers?dc=primary", nil)
+	obj, err = a2.srv.StatusPeers(nil, req)
+	require.NoError(t, err)
+	peers, ok = obj.([]string)
+	require.True(t, ok)
+	require.Equal(t, []string{a1Addr}, peers)
 }

--- a/website/source/api/status.html.md
+++ b/website/source/api/status.html.md
@@ -33,6 +33,12 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
 
+### Parameters
+
+- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
+  the datacenter of the agent being queried. This is specified as part of the
+  URL as a query parameter.
+
 ### Sample Request
 
 ```text
@@ -64,6 +70,12 @@ The table below shows this endpoint's support for
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `none`       |
+
+### Parameters
+
+- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
+  the datacenter of the agent being queried. This is specified as part of the
+  URL as a query parameter.
 
 ### Sample Request
 


### PR DESCRIPTION
The `v1/status/leader` and `v1/status/peers` can now be supplied with a `dc=<datacenter` query param to control getting the leader/peers for a different datacenter.