### PR TITLE
Restore Notify to avoid panic in newServer retry

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -183,6 +183,10 @@ func newServer(c *Config) (*Server, error) {
 			oldNotify()
 		}
 	}
+	// Restore old notify to guard against re-closing `up` on a retry
+	defer func() {
+		c.NotifyListen = oldNotify
+	}()
 
 	// start server
 	w := c.LogOutput


### PR DESCRIPTION
Addresses panic seen in CI:
https://circleci.com/gh/hashicorp/consul/55476#tests/containers/1

`NotifyListen()` can be called twice if we retry since the Config is being modified directly.