### PR TITLE
Fix CA Replication when ACLs are enabled

### DIFF
--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -6,7 +6,14 @@ import (
 	"net"
 
 	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
+)
+
+var (
+	// minMultiDCConnectVersion is the minimum version in order to support multi-DC Connect
+	// features.
+	minMultiDCConnectVersion = version.Must(version.NewVersion("1.6.0"))
 )
 
 type EnterpriseServer struct{}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/connect"
-	ca "github.com/hashicorp/consul/agent/connect/ca"
 	"github.com/hashicorp/consul/agent/consul/autopilot"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
@@ -329,8 +326,6 @@ func (s *Server) establishLeadership() error {
 
 	s.startConnectLeader()
 
-	s.startCARootPruning()
-
 	s.setConsistentReadReady()
 	return nil
 }
@@ -348,8 +343,6 @@ func (s *Server) revokeLeadership() {
 	s.stopConfigReplication()
 
 	s.stopConnectLeader()
-
-	s.stopCARootPruning()
 
 	s.setCAProvider(nil, nil)
 
@@ -966,272 +959,6 @@ func (s *Server) bootstrapConfigEntries(entries []structs.ConfigEntry) error {
 		}
 	}
 	return nil
-}
-
-// initializeCAConfig is used to initialize the CA config if necessary
-// when setting up the CA during establishLeadership
-func (s *Server) initializeCAConfig() (*structs.CAConfiguration, error) {
-	state := s.fsm.State()
-	_, config, err := state.CAConfig()
-	if err != nil {
-		return nil, err
-	}
-	if config != nil {
-		return config, nil
-	}
-
-	config = s.config.CAConfig
-	if config.ClusterID == "" {
-		id, err := uuid.GenerateUUID()
-		if err != nil {
-			return nil, err
-		}
-		config.ClusterID = id
-	}
-
-	req := structs.CARequest{
-		Op:     structs.CAOpSetConfig,
-		Config: config,
-	}
-	if _, err = s.raftApply(structs.ConnectCARequestType, req); err != nil {
-		return nil, err
-	}
-
-	return config, nil
-}
-
-// initializeRootCA runs the initialization logic for a root CA.
-func (s *Server) initializeRootCA(provider ca.Provider, conf *structs.CAConfiguration) error {
-	if err := provider.Configure(conf.ClusterID, true, conf.Config); err != nil {
-		return fmt.Errorf("error configuring provider: %v", err)
-	}
-	if err := provider.GenerateRoot(); err != nil {
-		return fmt.Errorf("error generating CA root certificate: %v", err)
-	}
-
-	// Get the active root cert from the CA
-	rootPEM, err := provider.ActiveRoot()
-	if err != nil {
-		return fmt.Errorf("error getting root cert: %v", err)
-	}
-
-	rootCA, err := parseCARoot(rootPEM, conf.Provider, conf.ClusterID)
-	if err != nil {
-		return err
-	}
-
-	// Check if the CA root is already initialized and exit if it is,
-	// adding on any existing intermediate certs since they aren't directly
-	// tied to the provider.
-	// Every change to the CA after this initial bootstrapping should
-	// be done through the rotation process.
-	state := s.fsm.State()
-	_, activeRoot, err := state.CARootActive(nil)
-	if err != nil {
-		return err
-	}
-	if activeRoot != nil {
-		// This state shouldn't be possible to get into because we update the root and
-		// CA config in the same FSM operation.
-		if activeRoot.ID != rootCA.ID {
-			return fmt.Errorf("stored CA root %q is not the active root (%s)", rootCA.ID, activeRoot.ID)
-		}
-
-		rootCA.IntermediateCerts = activeRoot.IntermediateCerts
-		s.setCAProvider(provider, rootCA)
-
-		return nil
-	}
-
-	// Get the highest index
-	idx, _, err := state.CARoots(nil)
-	if err != nil {
-		return err
-	}
-
-	// Store the root cert in raft
-	resp, err := s.raftApply(structs.ConnectCARequestType, &structs.CARequest{
-		Op:    structs.CAOpSetRoots,
-		Index: idx,
-		Roots: []*structs.CARoot{rootCA},
-	})
-	if err != nil {
-		s.logger.Printf("[ERR] connect: Apply failed %v", err)
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	s.setCAProvider(provider, rootCA)
-
-	s.logger.Printf("[INFO] connect: initialized primary datacenter CA with provider %q", conf.Provider)
-
-	return nil
-}
-
-// parseCARoot returns a filled-in structs.CARoot from a raw PEM value.
-func parseCARoot(pemValue, provider, clusterID string) (*structs.CARoot, error) {
-	id, err := connect.CalculateCertFingerprint(pemValue)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing root fingerprint: %v", err)
-	}
-	rootCert, err := connect.ParseCert(pemValue)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing root cert: %v", err)
-	}
-	return &structs.CARoot{
-		ID:                  id,
-		Name:                fmt.Sprintf("%s CA Root Cert", strings.Title(provider)),
-		SerialNumber:        rootCert.SerialNumber.Uint64(),
-		SigningKeyID:        connect.HexString(rootCert.SubjectKeyId),
-		ExternalTrustDomain: clusterID,
-		NotBefore:           rootCert.NotBefore,
-		NotAfter:            rootCert.NotAfter,
-		RootCert:            pemValue,
-		Active:              true,
-	}, nil
-}
-
-// createProvider returns a connect CA provider from the given config.
-func (s *Server) createCAProvider(conf *structs.CAConfiguration) (ca.Provider, error) {
-	switch conf.Provider {
-	case structs.ConsulCAProvider:
-		return &ca.ConsulProvider{Delegate: &consulCADelegate{s}}, nil
-	case structs.VaultCAProvider:
-		return &ca.VaultProvider{}, nil
-	default:
-		return nil, fmt.Errorf("unknown CA provider %q", conf.Provider)
-	}
-}
-
-func (s *Server) getCAProvider() (ca.Provider, *structs.CARoot) {
-	retries := 0
-	var result ca.Provider
-	var resultRoot *structs.CARoot
-	for result == nil {
-		s.caProviderLock.RLock()
-		result = s.caProvider
-		resultRoot = s.caProviderRoot
-		s.caProviderLock.RUnlock()
-
-		// In cases where an agent is started with managed proxies, we may ask
-		// for the provider before establishLeadership completes. If we're the
-		// leader, then wait and get the provider again
-		if result == nil && s.IsLeader() && retries < 10 {
-			retries++
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-
-		break
-	}
-
-	return result, resultRoot
-}
-
-func (s *Server) setCAProvider(newProvider ca.Provider, root *structs.CARoot) {
-	s.caProviderLock.Lock()
-	defer s.caProviderLock.Unlock()
-	s.caProvider = newProvider
-	s.caProviderRoot = root
-}
-
-// startCARootPruning starts a goroutine that looks for stale CARoots
-// and removes them from the state store.
-func (s *Server) startCARootPruning() {
-	s.caPruningLock.Lock()
-	defer s.caPruningLock.Unlock()
-
-	if s.caPruningEnabled {
-		return
-	}
-
-	s.caPruningCh = make(chan struct{})
-
-	go func() {
-		ticker := time.NewTicker(caRootPruneInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-s.caPruningCh:
-				return
-			case <-ticker.C:
-				if err := s.pruneCARoots(); err != nil {
-					s.logger.Printf("[ERR] connect: error pruning CA roots: %v", err)
-				}
-			}
-		}
-	}()
-
-	s.caPruningEnabled = true
-}
-
-// pruneCARoots looks for any CARoots that have been rotated out and expired.
-func (s *Server) pruneCARoots() error {
-	if !s.config.ConnectEnabled {
-		return nil
-	}
-
-	state := s.fsm.State()
-	idx, roots, err := state.CARoots(nil)
-	if err != nil {
-		return err
-	}
-
-	_, caConf, err := state.CAConfig()
-	if err != nil {
-		return err
-	}
-
-	common, err := caConf.GetCommonConfig()
-	if err != nil {
-		return err
-	}
-
-	var newRoots structs.CARoots
-	for _, r := range roots {
-		if !r.Active && !r.RotatedOutAt.IsZero() && time.Since(r.RotatedOutAt) > common.LeafCertTTL*2 {
-			s.logger.Printf("[INFO] connect: pruning old unused root CA (ID: %s)", r.ID)
-			continue
-		}
-		newRoot := *r
-		newRoots = append(newRoots, &newRoot)
-	}
-
-	// Return early if there's nothing to remove.
-	if len(newRoots) == len(roots) {
-		return nil
-	}
-
-	// Commit the new root state.
-	var args structs.CARequest
-	args.Op = structs.CAOpSetRoots
-	args.Index = idx
-	args.Roots = newRoots
-	resp, err := s.raftApply(structs.ConnectCARequestType, args)
-	if err != nil {
-		return err
-	}
-	if respErr, ok := resp.(error); ok {
-		return respErr
-	}
-
-	return nil
-}
-
-// stopCARootPruning stops the CARoot pruning process.
-func (s *Server) stopCARootPruning() {
-	s.caPruningLock.Lock()
-	defer s.caPruningLock.Unlock()
-
-	if !s.caPruningEnabled {
-		return
-	}
-
-	close(s.caPruningCh)
-	s.caPruningEnabled = false
 }
 
 // reconcileReaped is used to reconcile nodes that have failed and been reaped

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -522,6 +522,10 @@ func (s *Server) secondaryCARootWatch(stopCh <-chan struct{}) {
 		// Check to see if the primary has been upgraded in case we're waiting to switch to
 		// secondary mode.
 		provider, _ := s.getCAProvider()
+		if provider == nil {
+			// this happens when leadership is being revoked and this go routine will be stopped
+			return nil
+		}
 		if !s.configuredSecondaryCA() {
 			versionOk, primaryFound := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)
 			if !primaryFound {

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"crypto/x509"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	uuid "github.com/hashicorp/go-uuid"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -370,22 +372,27 @@ func TestLeader_SecondaryCA_UpgradeBeforePrimary(t *testing.T) {
 	joinWAN(t, s2, s1)
 	testrpc.WaitForLeader(t, s2.RPC, "dc2")
 
-	// Verify the root lists are different in each DC's state store.
-	var oldSecondaryRootID string
-	{
+	// ensure all the CA initialization stuff would have already been done
+	// this is necessary to ensure that not only has a leader been elected
+	// but that it has also finished its establishLeadership call
+	retry.Run(t, func(r *retry.R) {
+		require.True(r, s1.isReadyForConsistentReads())
+		require.True(r, s2.isReadyForConsistentReads())
+	})
+
+	// Verify the primary has a root (we faked its version too low but since its the primary it ignores any version checks)
+	retry.Run(t, func(r *retry.R) {
 		state1 := s1.fsm.State()
 		_, roots1, err := state1.CARoots(nil)
-		require.NoError(t, err)
+		require.NoError(r, err)
+		require.Len(r, roots1, 1)
+	})
 
-		state2 := s2.fsm.State()
-		_, roots2, err := state2.CARoots(nil)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(roots1))
-		require.Equal(t, 1, len(roots2))
-		require.NotEqual(t, roots1[0].ID, roots2[0].ID)
-		require.NotEqual(t, roots1[0].RootCert, roots2[0].RootCert)
-		oldSecondaryRootID = roots2[0].ID
-	}
+	// Verify the secondary does not have a root - defers initialization until the primary has been upgraded.
+	state2 := s2.fsm.State()
+	_, roots2, err := state2.CARoots(nil)
+	require.NoError(t, err)
+	require.Empty(t, roots2)
 
 	// Update the version on the fly so s2 kicks off the secondary DC transition.
 	tags := s1.config.SerfWANConfig.Tags
@@ -396,38 +403,24 @@ func TestLeader_SecondaryCA_UpgradeBeforePrimary(t *testing.T) {
 	// has both roots present.
 	secondaryProvider, _ := s2.getCAProvider()
 	retry.Run(t, func(r *retry.R) {
-		state := s2.fsm.State()
-		_, roots, err := state.CARoots(nil)
-		require.NoError(r, err)
-		require.Len(r, roots, 2)
-		inter, err := secondaryProvider.ActiveIntermediate()
-		require.NoError(r, err)
-		require.NotEqual(r, "", inter, "should have valid intermediate")
-	})
-	{
 		state1 := s1.fsm.State()
 		_, roots1, err := state1.CARoots(nil)
-		require.NoError(t, err)
+		require.NoError(r, err)
+		require.Len(r, roots1, 1)
 
 		state2 := s2.fsm.State()
 		_, roots2, err := state2.CARoots(nil)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(roots1))
-		require.Equal(t, 2, len(roots2))
-		var oldSecondaryRoot *structs.CARoot
-		var newSecondaryRoot *structs.CARoot
-		if roots2[0].ID == oldSecondaryRootID {
-			oldSecondaryRoot = roots2[0]
-			newSecondaryRoot = roots2[1]
-		} else {
-			oldSecondaryRoot = roots2[1]
-			newSecondaryRoot = roots2[0]
-		}
-		require.Equal(t, roots1[0].ID, newSecondaryRoot.ID)
-		require.Equal(t, roots1[0].RootCert, newSecondaryRoot.RootCert)
-		require.NotEqual(t, newSecondaryRoot.ID, oldSecondaryRoot.ID)
-		require.NotEqual(t, newSecondaryRoot.RootCert, oldSecondaryRoot.RootCert)
-	}
+		require.NoError(r, err)
+		require.Len(r, roots2, 1)
+
+		// ensure the roots are the same
+		require.Equal(r, roots1[0].ID, roots2[0].ID)
+		require.Equal(r, roots1[0].RootCert, roots2[0].RootCert)
+
+		inter, err := secondaryProvider.ActiveIntermediate()
+		require.NoError(r, err)
+		require.NotEmpty(r, inter, "should have valid intermediate")
+	})
 
 	_, caRoot := s1.getCAProvider()
 	intermediatePEM, err := secondaryProvider.ActiveIntermediate()
@@ -847,4 +840,190 @@ func TestLeader_GenerateCASignRequest(t *testing.T) {
 	s := Server{config: &Config{PrimaryDatacenter: "east"}, tokens: new(token.Store)}
 	req := s.generateCASignRequest(csr)
 	assert.Equal(t, "east", req.RequestDatacenter())
+}
+
+func TestLeader_CARootPruning(t *testing.T) {
+	t.Parallel()
+
+	caRootPruneInterval = 200 * time.Millisecond
+
+	require := require.New(t)
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
+
+	// Get the current root
+	rootReq := &structs.DCSpecificRequest{
+		Datacenter: "dc1",
+	}
+	var rootList structs.IndexedCARoots
+	require.Nil(msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.Len(rootList.Roots, 1)
+	oldRoot := rootList.Roots[0]
+
+	// Update the provider config to use a new private key, which should
+	// cause a rotation.
+	_, newKey, err := connect.GeneratePrivateKey()
+	require.NoError(err)
+	newConfig := &structs.CAConfiguration{
+		Provider: "consul",
+		Config: map[string]interface{}{
+			"LeafCertTTL":    "500ms",
+			"PrivateKey":     newKey,
+			"RootCert":       "",
+			"RotationPeriod": "2160h",
+			"SkipValidate":   true,
+		},
+	}
+	{
+		args := &structs.CARequest{
+			Datacenter: "dc1",
+			Config:     newConfig,
+		}
+		var reply interface{}
+
+		require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", args, &reply))
+	}
+
+	// Should have 2 roots now.
+	_, roots, err := s1.fsm.State().CARoots(nil)
+	require.NoError(err)
+	require.Len(roots, 2)
+
+	time.Sleep(2 * time.Second)
+
+	// Now the old root should be pruned.
+	_, roots, err = s1.fsm.State().CARoots(nil)
+	require.NoError(err)
+	require.Len(roots, 1)
+	require.True(roots[0].Active)
+	require.NotEqual(roots[0].ID, oldRoot.ID)
+}
+
+func TestLeader_PersistIntermediateCAs(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	dir1, s1 := testServer(t)
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+
+	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
+	defer os.RemoveAll(dir3)
+	defer s3.Shutdown()
+
+	joinLAN(t, s2, s1)
+	joinLAN(t, s3, s1)
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// Get the current root
+	rootReq := &structs.DCSpecificRequest{
+		Datacenter: "dc1",
+	}
+	var rootList structs.IndexedCARoots
+	require.Nil(msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
+	require.Len(rootList.Roots, 1)
+
+	// Update the provider config to use a new private key, which should
+	// cause a rotation.
+	_, newKey, err := connect.GeneratePrivateKey()
+	require.NoError(err)
+	newConfig := &structs.CAConfiguration{
+		Provider: "consul",
+		Config: map[string]interface{}{
+			"PrivateKey":     newKey,
+			"RootCert":       "",
+			"RotationPeriod": 90 * 24 * time.Hour,
+		},
+	}
+	{
+		args := &structs.CARequest{
+			Datacenter: "dc1",
+			Config:     newConfig,
+		}
+		var reply interface{}
+
+		require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", args, &reply))
+	}
+
+	// Get the active root before leader change.
+	_, root := s1.getCAProvider()
+	require.Len(root.IntermediateCerts, 1)
+
+	// Force a leader change and make sure the root CA values are preserved.
+	s1.Leave()
+	s1.Shutdown()
+
+	retry.Run(t, func(r *retry.R) {
+		var leader *Server
+		for _, s := range []*Server{s2, s3} {
+			if s.IsLeader() {
+				leader = s
+				break
+			}
+		}
+		if leader == nil {
+			r.Fatal("no leader")
+		}
+
+		_, newLeaderRoot := leader.getCAProvider()
+		if !reflect.DeepEqual(newLeaderRoot, root) {
+			r.Fatalf("got %v, want %v", newLeaderRoot, root)
+		}
+	})
+}
+
+func TestLeader_ParseCARoot(t *testing.T) {
+	type test struct {
+		pem           string
+		expectedError bool
+	}
+	tests := []test{
+		{"", true},
+		{`-----BEGIN CERTIFICATE-----
+MIIDHDCCAsKgAwIBAgIQS+meruRVzrmVwEhXNrtk9jAKBggqhkjOPQQDAjCBuTEL
+MAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2Nv
+MRowGAYDVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAV
+BgNVBAoTDkhhc2hpQ29ycCBJbmMuMUAwPgYDVQQDEzdDb25zdWwgQWdlbnQgQ0Eg
+MTkzNzYxNzQwMjcxNzUxOTkyMzAyMzE1NDkxNjUzODYyMzAwNzE3MB4XDTE5MDQx
+MjA5MTg0NVoXDTIwMDQxMTA5MTg0NVowHDEaMBgGA1UEAxMRY2xpZW50LmRjMS5j
+b25zdWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS2UroGUh5k7eR//iPsn9ne
+CMCVsERnjqQnK6eDWnM5kTXgXcPPe5pcAS9xs0g8BZ+oVsJSc7sH6RYvX+gw6bCl
+o4IBRjCCAUIwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
+BgEFBQcDATAMBgNVHRMBAf8EAjAAMGgGA1UdDgRhBF84NDphNDplZjoxYTpjODo1
+MzoxMDo1YTpjNTplYTpjZTphYTowZDo2ZjpjOTozODozZDphZjo0NTphZTo5OTo4
+YzpiYjoyNzpiYzpiMzpmYTpmMDozMToxNDo4ZTozNDBqBgNVHSMEYzBhgF8yYTox
+MjpjYTo0Mzo0NzowODpiZjoxYTo0Yjo4MTpkNDo2MzowNTo1ODowZToxYzo3Zjoy
+NTo0ZjozNDpmNDozYjpmYzo5YTpkNzo4Mjo2YjpkYzpmODo3YjphMTo5ZDAtBgNV
+HREEJjAkghFjbGllbnQuZGMxLmNvbnN1bIIJbG9jYWxob3N0hwR/AAABMAoGCCqG
+SM49BAMCA0gAMEUCIHcLS74KSQ7RA+edwOprmkPTh1nolwXz9/y9CJ5nMVqEAiEA
+h1IHCbxWsUT3AiARwj5/D/CUppy6BHIFkvcpOCQoVyo=
+-----END CERTIFICATE-----`, false},
+	}
+	for _, test := range tests {
+		root, err := parseCARoot(test.pem, "consul", "cluster")
+		if err == nil && test.expectedError {
+			require.Error(t, err)
+		}
+		if test.pem != "" {
+			rootCert, err := connect.ParseCert(test.pem)
+			require.NoError(t, err)
+
+			// just to make sure these two are not the same
+			require.NotEqual(t, rootCert.AuthorityKeyId, rootCert.SubjectKeyId)
+
+			require.Equal(t, connect.HexString(rootCert.SubjectKeyId), root.SigningKeyID)
+		}
+	}
 }

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -2,11 +2,9 @@ package consul
 
 import (
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -1066,148 +1064,6 @@ func TestLeader_ACL_Initialization(t *testing.T) {
 	}
 }
 
-func TestLeader_CARootPruning(t *testing.T) {
-	t.Parallel()
-
-	caRootPruneInterval = 200 * time.Millisecond
-
-	require := require.New(t)
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
-
-	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
-
-	// Get the current root
-	rootReq := &structs.DCSpecificRequest{
-		Datacenter: "dc1",
-	}
-	var rootList structs.IndexedCARoots
-	require.Nil(msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
-	require.Len(rootList.Roots, 1)
-	oldRoot := rootList.Roots[0]
-
-	// Update the provider config to use a new private key, which should
-	// cause a rotation.
-	_, newKey, err := connect.GeneratePrivateKey()
-	require.NoError(err)
-	newConfig := &structs.CAConfiguration{
-		Provider: "consul",
-		Config: map[string]interface{}{
-			"LeafCertTTL":    "500ms",
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": "2160h",
-			"SkipValidate":   true,
-		},
-	}
-	{
-		args := &structs.CARequest{
-			Datacenter: "dc1",
-			Config:     newConfig,
-		}
-		var reply interface{}
-
-		require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", args, &reply))
-	}
-
-	// Should have 2 roots now.
-	_, roots, err := s1.fsm.State().CARoots(nil)
-	require.NoError(err)
-	require.Len(roots, 2)
-
-	time.Sleep(2 * time.Second)
-
-	// Now the old root should be pruned.
-	_, roots, err = s1.fsm.State().CARoots(nil)
-	require.NoError(err)
-	require.Len(roots, 1)
-	require.True(roots[0].Active)
-	require.NotEqual(roots[0].ID, oldRoot.ID)
-}
-
-func TestLeader_PersistIntermediateCAs(t *testing.T) {
-	t.Parallel()
-
-	require := require.New(t)
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
-
-	dir2, s2 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
-
-	dir3, s3 := testServerDCBootstrap(t, "dc1", false)
-	defer os.RemoveAll(dir3)
-	defer s3.Shutdown()
-
-	joinLAN(t, s2, s1)
-	joinLAN(t, s3, s1)
-
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
-
-	// Get the current root
-	rootReq := &structs.DCSpecificRequest{
-		Datacenter: "dc1",
-	}
-	var rootList structs.IndexedCARoots
-	require.Nil(msgpackrpc.CallWithCodec(codec, "ConnectCA.Roots", rootReq, &rootList))
-	require.Len(rootList.Roots, 1)
-
-	// Update the provider config to use a new private key, which should
-	// cause a rotation.
-	_, newKey, err := connect.GeneratePrivateKey()
-	require.NoError(err)
-	newConfig := &structs.CAConfiguration{
-		Provider: "consul",
-		Config: map[string]interface{}{
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": 90 * 24 * time.Hour,
-		},
-	}
-	{
-		args := &structs.CARequest{
-			Datacenter: "dc1",
-			Config:     newConfig,
-		}
-		var reply interface{}
-
-		require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.ConfigurationSet", args, &reply))
-	}
-
-	// Get the active root before leader change.
-	_, root := s1.getCAProvider()
-	require.Len(root.IntermediateCerts, 1)
-
-	// Force a leader change and make sure the root CA values are preserved.
-	s1.Leave()
-	s1.Shutdown()
-
-	retry.Run(t, func(r *retry.R) {
-		var leader *Server
-		for _, s := range []*Server{s2, s3} {
-			if s.IsLeader() {
-				leader = s
-				break
-			}
-		}
-		if leader == nil {
-			r.Fatal("no leader")
-		}
-
-		_, newLeaderRoot := leader.getCAProvider()
-		if !reflect.DeepEqual(newLeaderRoot, root) {
-			r.Fatalf("got %v, want %v", newLeaderRoot, root)
-		}
-	})
-}
-
 func TestLeader_ACLUpgrade(t *testing.T) {
 	t.Parallel()
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -1301,48 +1157,4 @@ func TestLeader_ConfigEntryBootstrap(t *testing.T) {
 		require.Equal(t, global_entry_init.Name, global.Name)
 		require.Equal(t, global_entry_init.Config, global.Config)
 	})
-}
-
-func TestLeader_ParseCARoot(t *testing.T) {
-	type test struct {
-		pem           string
-		expectedError bool
-	}
-	tests := []test{
-		{"", true},
-		{`-----BEGIN CERTIFICATE-----
-MIIDHDCCAsKgAwIBAgIQS+meruRVzrmVwEhXNrtk9jAKBggqhkjOPQQDAjCBuTEL
-MAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2Nv
-MRowGAYDVQQJExExMDEgU2Vjb25kIFN0cmVldDEOMAwGA1UEERMFOTQxMDUxFzAV
-BgNVBAoTDkhhc2hpQ29ycCBJbmMuMUAwPgYDVQQDEzdDb25zdWwgQWdlbnQgQ0Eg
-MTkzNzYxNzQwMjcxNzUxOTkyMzAyMzE1NDkxNjUzODYyMzAwNzE3MB4XDTE5MDQx
-MjA5MTg0NVoXDTIwMDQxMTA5MTg0NVowHDEaMBgGA1UEAxMRY2xpZW50LmRjMS5j
-b25zdWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS2UroGUh5k7eR//iPsn9ne
-CMCVsERnjqQnK6eDWnM5kTXgXcPPe5pcAS9xs0g8BZ+oVsJSc7sH6RYvX+gw6bCl
-o4IBRjCCAUIwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggr
-BgEFBQcDATAMBgNVHRMBAf8EAjAAMGgGA1UdDgRhBF84NDphNDplZjoxYTpjODo1
-MzoxMDo1YTpjNTplYTpjZTphYTowZDo2ZjpjOTozODozZDphZjo0NTphZTo5OTo4
-YzpiYjoyNzpiYzpiMzpmYTpmMDozMToxNDo4ZTozNDBqBgNVHSMEYzBhgF8yYTox
-MjpjYTo0Mzo0NzowODpiZjoxYTo0Yjo4MTpkNDo2MzowNTo1ODowZToxYzo3Zjoy
-NTo0ZjozNDpmNDozYjpmYzo5YTpkNzo4Mjo2YjpkYzpmODo3YjphMTo5ZDAtBgNV
-HREEJjAkghFjbGllbnQuZGMxLmNvbnN1bIIJbG9jYWxob3N0hwR/AAABMAoGCCqG
-SM49BAMCA0gAMEUCIHcLS74KSQ7RA+edwOprmkPTh1nolwXz9/y9CJ5nMVqEAiEA
-h1IHCbxWsUT3AiARwj5/D/CUppy6BHIFkvcpOCQoVyo=
------END CERTIFICATE-----`, false},
-	}
-	for _, test := range tests {
-		root, err := parseCARoot(test.pem, "consul", "cluster")
-		if err == nil && test.expectedError {
-			require.Error(t, err)
-		}
-		if test.pem != "" {
-			rootCert, err := connect.ParseCert(test.pem)
-			require.NoError(t, err)
-
-			// just to make sure these two are not the same
-			require.NotEqual(t, rootCert.AuthorityKeyId, rootCert.SubjectKeyId)
-
-			require.Equal(t, connect.HexString(rootCert.SubjectKeyId), root.SigningKeyID)
-		}
-	}
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -142,12 +142,6 @@ type Server struct {
 	caProviderRoot *structs.CARoot
 	caProviderLock sync.RWMutex
 
-	// caPruningCh is used to shut down the CA root pruning goroutine when we
-	// lose leadership.
-	caPruningCh      chan struct{}
-	caPruningLock    sync.RWMutex
-	caPruningEnabled bool
-
 	// Consul configuration
 	config *Config
 

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -276,9 +276,25 @@ func runtimeStats() map[string]string {
 // ServersMeetMinimumVersion returns whether the given alive servers are at least on the
 // given Consul version
 func ServersMeetMinimumVersion(members []serf.Member, minVersion *version.Version) bool {
+	return ServersMeetRequirements(members, func(srv *metadata.Server) bool {
+		return srv.Status != serf.StatusAlive || !srv.Build.LessThan(minVersion)
+	})
+}
+
+// ServersMeetMinimumVersion returns whether the given alive servers from a particular
+// datacenter are at least on the given Consul version
+func ServersInDCMeetMinimumVersion(members []serf.Member, datacenter string, minVersion *version.Version) bool {
+	return ServersMeetRequirements(members, func(srv *metadata.Server) bool {
+		return srv.Status != serf.StatusAlive || srv.Datacenter != datacenter || !srv.Build.LessThan(minVersion)
+	})
+}
+
+// ServersMeetRequirements returns whether the given server members meet the requirements as defined by the
+// callback function
+func ServersMeetRequirements(members []serf.Member, meetsRequirements func(*metadata.Server) bool) bool {
 	for _, member := range members {
-		if valid, parts := metadata.IsConsulServer(member); valid && parts.Status == serf.StatusAlive {
-			if parts.Build.LessThan(minVersion) {
+		if valid, parts := metadata.IsConsulServer(member); valid {
+			if !meetsRequirements(parts) {
 				return false
 			}
 		}

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -283,7 +283,7 @@ func ServersMeetMinimumVersion(members []serf.Member, minVersion *version.Versio
 
 // ServersMeetMinimumVersion returns whether the given alive servers from a particular
 // datacenter are at least on the given Consul version. This requires at least 1 alive server in the DC
-func ServersInDCMeetMinimumVersion(members []serf.Member, datacenter string, minVersion *version.Version) bool {
+func ServersInDCMeetMinimumVersion(members []serf.Member, datacenter string, minVersion *version.Version) (bool, bool) {
 	found := false
 	ok := ServersMeetRequirements(members, func(srv *metadata.Server) bool {
 		if srv.Status != serf.StatusAlive || srv.Datacenter != datacenter {
@@ -294,7 +294,7 @@ func ServersInDCMeetMinimumVersion(members []serf.Member, datacenter string, min
 		return !srv.Build.LessThan(minVersion)
 	})
 
-	return found && ok
+	return ok, found
 }
 
 // ServersMeetRequirements returns whether the given server members meet the requirements as defined by the

--- a/agent/consul/util_test.go
+++ b/agent/consul/util_test.go
@@ -427,9 +427,10 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 	}
 
 	cases := []struct {
-		members  []serf.Member
-		ver      *version.Version
-		expected bool
+		members       []serf.Member
+		ver           *version.Version
+		expected      bool
+		expectedFound bool
 	}{
 		// One server, meets reqs
 		{
@@ -437,8 +438,9 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 				makeMember("0.7.5", "primary"),
 				makeMember("0.7.3", "secondary"),
 			},
-			ver:      version.Must(version.NewVersion("0.7.5")),
-			expected: true,
+			ver:           version.Must(version.NewVersion("0.7.5")),
+			expected:      true,
+			expectedFound: true,
 		},
 		// One server, doesn't meet reqs
 		{
@@ -446,8 +448,9 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 				makeMember("0.7.5", "primary"),
 				makeMember("0.8.1", "secondary"),
 			},
-			ver:      version.Must(version.NewVersion("0.8.0")),
-			expected: false,
+			ver:           version.Must(version.NewVersion("0.8.0")),
+			expected:      false,
+			expectedFound: true,
 		},
 		// Multiple servers, meets req version
 		{
@@ -456,8 +459,9 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 				makeMember("0.8.0", "primary"),
 				makeMember("0.7.0", "secondary"),
 			},
-			ver:      version.Must(version.NewVersion("0.7.5")),
-			expected: true,
+			ver:           version.Must(version.NewVersion("0.7.5")),
+			expected:      true,
+			expectedFound: true,
 		},
 		// Multiple servers, doesn't meet req version
 		{
@@ -466,16 +470,26 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 				makeMember("0.8.0", "primary"),
 				makeMember("0.9.1", "secondary"),
 			},
-			ver:      version.Must(version.NewVersion("0.8.0")),
-			expected: false,
+			ver:           version.Must(version.NewVersion("0.8.0")),
+			expected:      false,
+			expectedFound: true,
+		},
+		{
+			members: []serf.Member{
+				makeMember("0.7.5", "secondary"),
+				makeMember("0.8.0", "secondary"),
+				makeMember("0.9.1", "secondary"),
+			},
+			ver:           version.Must(version.NewVersion("0.7.0")),
+			expected:      true,
+			expectedFound: false,
 		},
 	}
 
 	for _, tc := range cases {
-		result := ServersInDCMeetMinimumVersion(tc.members, "primary", tc.ver)
-		if result != tc.expected {
-			t.Fatalf("bad: %v, %v, %v", result, tc.ver.String(), tc)
-		}
+		result, found := ServersInDCMeetMinimumVersion(tc.members, "primary", tc.ver)
+		require.Equal(t, tc.expected, result)
+		require.Equal(t, tc.expectedFound, found)
 	}
 }
 


### PR DESCRIPTION
Fixes #6192 

Essentially this stops using autopilot + RPCs to determine server versions. Instead it just uses the local serf metadata.

This fixes the linked issue by no longer performing the RPCs that would otherwise require a special ACL token. We could have just used the replication token there but really these places already have all the information in the serf metadata so we can just use that instead of making cross-dc requests.