### PR TITLE
Set --max-obj-name-len 256 when execing Envoy

### DIFF
--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -29,6 +29,8 @@ func TestExecEnvoy(t *testing.T) {
 				"--config-path",
 				"{{ got.ConfigPath }}",
 				"--disable-hot-restart",
+				"--max-obj-name-len",
+				"256",
 				"--fake-envoy-arg",
 			},
 		},
@@ -42,6 +44,8 @@ func TestExecEnvoy(t *testing.T) {
 				// that value further below.
 				"{{ got.ConfigPath }}",
 				// No --disable-hot-restart
+				"--max-obj-name-len",
+				"256",
 				"--fake-envoy-arg",
 				"--restart-epoch",
 				"1",
@@ -57,6 +61,8 @@ func TestExecEnvoy(t *testing.T) {
 				// that value further below.
 				"{{ got.ConfigPath }}",
 				// No --disable-hot-restart
+				"--max-obj-name-len",
+				"256",
 				"--fake-envoy-arg",
 				// Restart epoch defaults to 0 if not given and not disabled.
 				"--drain-time-s",
@@ -73,6 +79,8 @@ func TestExecEnvoy(t *testing.T) {
 				// that value further below.
 				"{{ got.ConfigPath }}",
 				// No --disable-hot-restart
+				"--max-obj-name-len",
+				"256",
 				"--fake-envoy-arg",
 				// Restart epoch defaults to 0 if not given and not disabled.
 				"--parent-shutdown-time-s",
@@ -89,6 +97,8 @@ func TestExecEnvoy(t *testing.T) {
 				// that value further below.
 				"{{ got.ConfigPath }}",
 				// No --disable-hot-restart
+				"--max-obj-name-len",
+				"256",
 				"--fake-envoy-arg",
 				// Restart epoch defaults to 0 if not given and not disabled.
 				"--hot-restart-version",

--- a/command/connect/envoy/exec_unix.go
+++ b/command/connect/envoy/exec_unix.go
@@ -49,6 +49,17 @@ func hasHotRestartOption(argSets ...[]string) bool {
 	return false
 }
 
+func hasMaxObjNameLenOption(argSets ...[]string) bool {
+	for _, args := range argSets {
+		for _, opt := range args {
+			if opt == "--max-obj-name-len" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func makeBootstrapPipe(bootstrapJSON []byte) (string, error) {
 	pipeFile := filepath.Join(os.TempDir(),
 		fmt.Sprintf("envoy-%x-bootstrap.json", time.Now().UnixNano()+int64(os.Getpid())))
@@ -129,6 +140,9 @@ func execEnvoy(binary string, prefixArgs, suffixArgs []string, bootstrapJSON []b
 	envoyArgs = append(envoyArgs, "--config-path", pipeFile)
 	if disableHotRestart {
 		envoyArgs = append(envoyArgs, "--disable-hot-restart")
+	}
+	if !hasMaxObjNameLenOption(prefixArgs, suffixArgs) {
+		envoyArgs = append(envoyArgs, "--max-obj-name-len", "256")
 	}
 	envoyArgs = append(envoyArgs, suffixArgs...)
 

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -26,6 +26,9 @@ As an interim solution, you can add [custom Envoy configuration](#custom-configu
 in the [proxy service definition](/docs/connect/registration/service-registration.html) allowing
 you to use the more powerful features of Envoy.
 
+~> **Note:** When using Envoy with Consul and not using the [`consul connect envoy` command](/docs/commands/connect/envoy.html)
+   Envoy must be run with the `--max-obj-name-len` option set to `256` or greater.
+
 ## Supported Versions
 
 Consul's Envoy support was added in version 1.3.0. The following table shows


### PR DESCRIPTION
Things seemed to work before but I think that was due to envoy truncating things.

