### PR TITLE
docs: add TCP half-close broken pipe to common errors

### DIFF
--- a/website/source/docs/common-errors.html.md
+++ b/website/source/docs/common-errors.html.md
@@ -79,6 +79,14 @@ On a busy cluster, the operating system may not provide enough file descriptors 
 
 Or, if you are starting Consul from `systemd`, you could add `LimitNOFILE=65536` to the unit file for Consul. You can see our example unit file [here][systemd].
 
+## Snapshot close error
+
+Our RPC protocol requires support for a TCP half-close in order to signal the other side that they are done reading the stream, since we don't know the size in advance. This saves us from having to buffer just to calculate the size.
+
+If a host does not properly implement half-close you may see an error message `[ERR] consul: Failed to close snapshot: write tcp <source>-><destination>: write: broken pipe` when saving snapshots. This should not affect saving and restoring snapshots.
+
+This has been a [known issue](https://github.com/docker/libnetwork/issues/1204) in Docker, but may manifest in other environments as well.
+
 ## ACL Not Found
 
 ```


### PR DESCRIPTION
Adds an entry to [common-errors.html.md](https://github.com/hashicorp/consul/blob/master/website/source/docs/common-errors.html.md) describing the context for a broken pipe error when attempting to close a snapshot RPC connection.

This was previously noted in relation to Docker support in [consul-containers.html.md](https://github.com/hashicorp/consul/blob/master/website/source/docs/guides/consul-containers.html.md#known-issues), but that page is no longer accessible in the public website documentation.

https://github.com/hashicorp/consul/blob/d86efb83e53d29d0993912b8e85bd086190932ae/agent/consul/snapshot_endpoint.go#L224-L234

**Questions**
- Should this note be more specific about this behavior occurring during RPC calls from a non-RAFT-leader snapshot leader to the RAFT leader?
- Should this note mention using `tcpdump` or Wireshark for further insight into the actual TCP messages sent and received?