### PR TITLE
Make new config when retrying testServer creation

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -154,16 +154,17 @@ func testServerDCExpectNonVoter(t *testing.T, dc string, expect int) (string, *S
 }
 
 func testServerWithConfig(t *testing.T, cb func(*Config)) (string, *Server) {
-	dir, config := testServerConfig(t)
-	if cb != nil {
-		cb(config)
-	}
-
+	var dir string
 	var srv *Server
 	var err error
 
 	// Retry added to avoid cases where bind addr is already in use
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
+		dir, config := testServerConfig(t)
+		if cb != nil {
+			cb(config)
+		}
+
 		srv, err = newServer(config)
 		if err != nil {
 			os.RemoveAll(dir)
@@ -183,10 +184,6 @@ func newServer(c *Config) (*Server, error) {
 			oldNotify()
 		}
 	}
-	// Restore old notify to guard against re-closing `up` on a retry
-	defer func() {
-		c.NotifyListen = oldNotify
-	}()
 
 	// start server
 	w := c.LogOutput

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -155,12 +155,13 @@ func testServerDCExpectNonVoter(t *testing.T, dc string, expect int) (string, *S
 
 func testServerWithConfig(t *testing.T, cb func(*Config)) (string, *Server) {
 	var dir string
+	var config *Config
 	var srv *Server
 	var err error
 
 	// Retry added to avoid cases where bind addr is already in use
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
-		dir, config := testServerConfig(t)
+		dir, config = testServerConfig(t)
 		if cb != nil {
 			cb(config)
 		}


### PR DESCRIPTION
Generate new config (with new ports) when retrying testServerWithConfig.

Addresses issue where bind addr is already in use:
https://circleci.com/gh/hashicorp/consul/56536#tests/containers/1

This PR also removes the reset of `c.NotifyListen()` in `newServer` since we are no longer using a single config across retries (#6200).