### PR TITLE
config: correct limit to limits in config example

### DIFF
--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -833,7 +833,7 @@ type RuntimeConfig struct {
 	// KVMaxValueSize controls the max allowed value size. If not set defaults
 	// to raft's suggested max value size.
 	//
-	// hcl: limit { kv_max_value_size = uint64 }
+	// hcl: limits { kv_max_value_size = uint64 }
 	KVMaxValueSize uint64
 
 	// LeaveDrainTime is used to wait after a server has left the LAN Serf


### PR DESCRIPTION
This isn't yet documented on the website, but wanted to update this to add the missing s.