### PR TITLE
connect: reconcile how upstream configuration works with discovery chains

### DIFF
--- a/agent/cache-types/discovery_chain_test.go
+++ b/agent/cache-types/discovery_chain_test.go
@@ -17,7 +17,7 @@ func TestCompiledDiscoveryChain(t *testing.T) {
 
 	// just do the default chain
 	entries := structs.NewDiscoveryChainConfigEntries()
-	chain := discoverychain.TestCompileConfigEntries(t, "web", "default", "dc1")
+	chain := discoverychain.TestCompileConfigEntries(t, "web", "default", "dc1", nil)
 
 	// Expect the proper RPC call. This also sets the expected value
 	// since that is return-by-pointer in the arguments.

--- a/agent/consul/discoverychain/testing.go
+++ b/agent/consul/discoverychain/testing.go
@@ -11,19 +11,25 @@ func TestCompileConfigEntries(
 	serviceName string,
 	currentNamespace string,
 	currentDatacenter string,
+	setup func(req *CompileRequest),
 	entries ...structs.ConfigEntry,
 ) *structs.CompiledDiscoveryChain {
 	set := structs.NewDiscoveryChainConfigEntries()
 
 	set.AddEntries(entries...)
 
-	chain, err := Compile(CompileRequest{
+	req := CompileRequest{
 		ServiceName:       serviceName,
 		CurrentNamespace:  currentNamespace,
 		CurrentDatacenter: currentDatacenter,
 		InferDefaults:     true,
 		Entries:           set,
-	})
+	}
+	if setup != nil {
+		setup(&req)
+	}
+
+	chain, err := Compile(req)
 	require.NoError(t, err)
 	return chain
 }

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -64,6 +64,11 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	}
 	dbDefaultChain := func() *structs.CompiledDiscoveryChain {
 		return discoverychain.TestCompileConfigEntries(t, "db", "default", "dc1",
+			func(req *discoverychain.CompileRequest) {
+				// This is because structs.TestUpstreams uses an opaque config
+				// to override connect timeouts.
+				req.OverrideConnectTimeout = 1 * time.Second
+			},
 			&structs.ServiceResolverConfigEntry{
 				Kind: structs.ServiceResolver,
 				Name: "db",
@@ -72,6 +77,11 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	}
 	dbSplitChain := func() *structs.CompiledDiscoveryChain {
 		return discoverychain.TestCompileConfigEntries(t, "db", "default", "dc1",
+			func(req *discoverychain.CompileRequest) {
+				// This is because structs.TestUpstreams uses an opaque config
+				// to override connect timeouts.
+				req.OverrideConnectTimeout = 1 * time.Second
+			},
 			&structs.ProxyConfigEntry{
 				Kind: structs.ProxyDefaults,
 				Name: structs.ProxyConfigGlobal,
@@ -142,9 +152,14 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	})
 
 	dbChainCacheKey := testGenCacheKey(&structs.DiscoveryChainRequest{
-		Datacenter:   "dc1",
-		QueryOptions: structs.QueryOptions{Token: "my-token"},
-		Name:         "db",
+		Name:                 "db",
+		EvaluateInDatacenter: "dc1",
+		EvaluateInNamespace:  "default",
+		// This is because structs.TestUpstreams uses an opaque config
+		// to override connect timeouts.
+		OverrideConnectTimeout: 1 * time.Second,
+		Datacenter:             "dc1",
+		QueryOptions:           structs.QueryOptions{Token: "my-token"},
 	})
 
 	dbHealthCacheKey := testGenCacheKey(&structs.ServiceSpecificRequest{

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -433,6 +433,10 @@ func TestConfigSnapshotDiscoveryChain(t testing.T) *ConfigSnapshot {
 	return testConfigSnapshotDiscoveryChain(t, "simple")
 }
 
+func TestConfigSnapshotDiscoveryChainWithOverrides(t testing.T) *ConfigSnapshot {
+	return testConfigSnapshotDiscoveryChain(t, "simple-with-overrides")
+}
+
 func TestConfigSnapshotDiscoveryChainWithFailover(t testing.T) *ConfigSnapshot {
 	return testConfigSnapshotDiscoveryChain(t, "failover")
 }
@@ -449,8 +453,18 @@ func testConfigSnapshotDiscoveryChain(t testing.T, variation string, additionalE
 	roots, leaf := TestCerts(t)
 
 	// Compile a chain.
-	var entries []structs.ConfigEntry
+	var (
+		entries      []structs.ConfigEntry
+		compileSetup func(req *discoverychain.CompileRequest)
+	)
 	switch variation {
+	case "simple-with-overrides":
+		compileSetup = func(req *discoverychain.CompileRequest) {
+			req.OverrideMeshGateway.Mode = structs.MeshGatewayModeLocal
+			req.OverrideProtocol = "grpc"
+			req.OverrideConnectTimeout = 66 * time.Second
+		}
+		fallthrough
 	case "simple":
 		entries = append(entries,
 			&structs.ServiceResolverConfigEntry{
@@ -529,7 +543,7 @@ func testConfigSnapshotDiscoveryChain(t testing.T, variation string, additionalE
 		entries = append(entries, additionalEntries...)
 	}
 
-	dbChain := discoverychain.TestCompileConfigEntries(t, "db", "default", "dc1", entries...)
+	dbChain := discoverychain.TestCompileConfigEntries(t, "db", "default", "dc1", compileSetup, entries...)
 
 	dbTarget := structs.DiscoveryTarget{
 		Service:    "db",
@@ -574,6 +588,7 @@ func testConfigSnapshotDiscoveryChain(t testing.T, variation string, additionalE
 	}
 
 	switch variation {
+	case "simple-with-overrides":
 	case "simple":
 	case "failover":
 		snap.ConnectProxy.WatchedUpstreamEndpoints["db"][failTarget] =

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -986,10 +986,29 @@ func (e *DiscoveryChainConfigEntries) IsChainEmpty() bool {
 // DiscoveryChainRequest is used when requesting the discovery chain for a
 // service.
 type DiscoveryChainRequest struct {
-	Name       string
-	Datacenter string
-	// Source      QuerySource
+	Name                 string
+	EvaluateInDatacenter string
+	EvaluateInNamespace  string
 
+	// OverrideMeshGateway allows for the mesh gateway setting to be overridden
+	// for any resolver in the compiled chain.
+	OverrideMeshGateway MeshGatewayConfig
+
+	// OverrideProtocol allows for the final protocol for the chain to be
+	// altered.
+	//
+	// - If the chain ordinarily would be TCP and an L7 protocol is passed here
+	// the chain will not include Routers or Splitters.
+	//
+	// - If the chain ordinarily would be L7 and TCP is passed here the chain
+	// will not include Routers or Splitters.
+	OverrideProtocol string
+
+	// OverrideConnectTimeout allows for the ConnectTimeout setting to be
+	// overridden for any resolver in the compiled chain.
+	OverrideConnectTimeout time.Duration
+
+	Datacenter string // where to route the RPC
 	QueryOptions
 }
 
@@ -1008,9 +1027,19 @@ func (r *DiscoveryChainRequest) CacheInfo() cache.RequestInfo {
 	}
 
 	v, err := hashstructure.Hash(struct {
-		Name string
+		Name                   string
+		EvaluateInDatacenter   string
+		EvaluateInNamespace    string
+		OverrideMeshGateway    MeshGatewayConfig
+		OverrideProtocol       string
+		OverrideConnectTimeout time.Duration
 	}{
-		Name: r.Name,
+		Name:                   r.Name,
+		EvaluateInDatacenter:   r.EvaluateInDatacenter,
+		EvaluateInNamespace:    r.EvaluateInNamespace,
+		OverrideMeshGateway:    r.OverrideMeshGateway,
+		OverrideProtocol:       r.OverrideProtocol,
+		OverrideConnectTimeout: r.OverrideConnectTimeout,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -37,6 +37,19 @@ type MeshGatewayConfig struct {
 	Mode MeshGatewayMode `json:",omitempty"`
 }
 
+func (c *MeshGatewayConfig) IsZero() bool {
+	zeroVal := MeshGatewayConfig{}
+	return *c == zeroVal
+}
+
+func (base *MeshGatewayConfig) OverlayWith(overlay MeshGatewayConfig) MeshGatewayConfig {
+	out := *base
+	if overlay.Mode != MeshGatewayModeDefault {
+		out.Mode = overlay.Mode
+	}
+	return out
+}
+
 func ValidateMeshGatewayMode(mode string) (MeshGatewayMode, error) {
 	switch MeshGatewayMode(mode) {
 	case MeshGatewayModeNone:

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -18,7 +18,17 @@ type CompiledDiscoveryChain struct {
 	Namespace   string // the namespace that the chain was compiled within
 	Datacenter  string // the datacenter that the chain was compiled within
 
-	Protocol string // overall protocol shared by everything in the chain
+	// CustomizationHash is a unique hash of any data that affects the
+	// compilation of the discovery chain other than config entries or the
+	// name/namespace/datacenter evaluation criteria.
+	//
+	// If set, this value should be used to prefix/suffix any generated load
+	// balancer data plane objects to avoid sharing customized and
+	// non-customized versions.
+	CustomizationHash string
+
+	// Protocol is the overall protocol shared by everything in the chain.
+	Protocol string
 
 	// Node is the top node in the chain.
 	//
@@ -49,6 +59,7 @@ func (c *CompiledDiscoveryChain) IsDefault() bool {
 	if c.Node == nil {
 		return true
 	}
+	// TODO(rb): include CustomizationHash here?
 	return c.Node.Name == c.ServiceName &&
 		c.Node.Type == DiscoveryGraphNodeTypeGroupResolver &&
 		c.Node.GroupResolver.Default

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -58,7 +58,6 @@ func (s *Server) clustersFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnapsh
 		}
 
 		if chain == nil {
-			// Either old-school upstream or prepared query.
 			upstreamCluster, err := s.makeUpstreamCluster(u, cfgSnap)
 			if err != nil {
 				return nil, err
@@ -255,10 +254,12 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 		groupResolver := node.GroupResolver
 
 		sni := TargetSNI(target, cfgSnap)
-		s.Logger.Printf("[DEBUG] xds.clusters - generating cluster for %s", sni)
+		clusterName := CustomizeClusterName(sni, chain)
+
+		s.Logger.Printf("[DEBUG] xds.clusters - generating cluster for %s", clusterName)
 		c := &envoy.Cluster{
-			Name:                 sni,
-			AltStatName:          sni, // TODO(rb): change this?
+			Name:                 clusterName,
+			AltStatName:          sni,
 			ConnectTimeout:       groupResolver.ConnectTimeout,
 			ClusterDiscoveryType: &envoy.Cluster_Type{Type: envoy.Cluster_EDS},
 			CommonLbConfig: &envoy.Cluster_CommonLbConfig{

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -259,7 +259,7 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 		s.Logger.Printf("[DEBUG] xds.clusters - generating cluster for %s", clusterName)
 		c := &envoy.Cluster{
 			Name:                 clusterName,
-			AltStatName:          sni,
+			AltStatName:          clusterName,
 			ConnectTimeout:       groupResolver.ConnectTimeout,
 			ClusterDiscoveryType: &envoy.Cluster_Type{Type: envoy.Cluster_EDS},
 			CommonLbConfig: &envoy.Cluster_CommonLbConfig{

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -106,6 +106,11 @@ func TestClustersFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "connect-proxy-with-chain-and-overrides",
+			create: proxycfg.TestConfigSnapshotDiscoveryChainWithOverrides,
+			setup:  nil,
+		},
+		{
 			name:   "connect-proxy-with-chain-and-failover",
 			create: proxycfg.TestConfigSnapshotDiscoveryChainWithFailover,
 			setup:  nil,

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -51,11 +51,11 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 		if chain == nil {
 			// We ONLY want this branch for prepared queries.
 
-			sni := UpstreamSNI(&u, "", cfgSnap)
+			clusterName := UpstreamSNI(&u, "", cfgSnap)
 			endpoints, ok := cfgSnap.ConnectProxy.UpstreamEndpoints[id]
 			if ok {
 				la := makeLoadAssignment(
-					sni,
+					clusterName,
 					0,
 					[]loadAssignmentEndpointGroup{
 						{Endpoints: endpoints},
@@ -122,9 +122,10 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 				}
 
 				sni := TargetSNI(target, cfgSnap)
+				clusterName := CustomizeClusterName(sni, chain)
 
 				la := makeLoadAssignment(
-					sni,
+					clusterName,
 					overprovisioningFactor,
 					endpointGroups,
 					cfgSnap.Datacenter,

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -246,6 +246,11 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "connect-proxy-with-chain-and-overrides",
+			create: proxycfg.TestConfigSnapshotDiscoveryChainWithOverrides,
+			setup:  nil,
+		},
+		{
 			name:   "connect-proxy-with-chain-and-failover",
 			create: proxycfg.TestConfigSnapshotDiscoveryChainWithFailover,
 			setup:  nil,

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -185,6 +185,11 @@ func TestListenersFromSnapshot(t *testing.T) {
 			setup: nil,
 		},
 		{
+			name:   "connect-proxy-with-chain-and-overrides",
+			create: proxycfg.TestConfigSnapshotDiscoveryChainWithOverrides,
+			setup:  nil,
+		},
+		{
 			name:   "mesh-gateway",
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 		},

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -51,6 +51,11 @@ func TestRoutesFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "connect-proxy-with-chain-and-overrides",
+			create: proxycfg.TestConfigSnapshotDiscoveryChainWithOverrides,
+			setup:  nil,
+		},
+		{
 			name:   "splitter-with-resolver-redirect",
 			create: proxycfg.TestConfigSnapshotDiscoveryChain_SplitterWithResolverRedirectMultiDC,
 			setup:  nil,

--- a/agent/xds/sni.go
+++ b/agent/xds/sni.go
@@ -45,3 +45,12 @@ func QuerySNI(service string, datacenter string, cfgSnap *proxycfg.ConfigSnapsho
 func TargetSNI(target structs.DiscoveryTarget, cfgSnap *proxycfg.ConfigSnapshot) string {
 	return ServiceSNI(target.Service, target.ServiceSubset, target.Namespace, target.Datacenter, cfgSnap)
 }
+
+func CustomizeClusterName(sni string, chain *structs.CompiledDiscoveryChain) string {
+	if chain == nil || chain.CustomizationHash == "" {
+		return sni
+	}
+	// Use a colon to delimit this prefix instead of a dot to avoid a
+	// theoretical collision problem with subsets.
+	return fmt.Sprintf("%s:%s", chain.CustomizationHash, sni)
+}

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
@@ -4,7 +4,7 @@
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
       "name": "78ebd528:db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "78ebd528:db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
       "type": "EDS",
       "edsClusterConfig": {
         "edsConfig": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
@@ -1,0 +1,119 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "78ebd528:db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "66s",
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "http2ProtocolOptions": {
+
+      },
+      "outlierDetection": {
+
+      },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {
+
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-chain-and-overrides.golden
@@ -1,0 +1,41 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "78ebd528:db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.golden
@@ -1,0 +1,139 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "db:127.0.0.1:9191",
+      "address": {
+        "socketAddress": {
+          "address": "127.0.0.1",
+          "portValue": 9191
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http2_protocol_options": {
+                      },
+                  "http_filters": [
+                        {
+                              "config": {
+                                  },
+                              "name": "envoy.grpc_http1_bridge"
+                            },
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "rds": {
+                        "config_source": {
+                              "ads": {
+                                  }
+                            },
+                        "route_config_name": "db"
+                      },
+                  "stat_prefix": "upstream_db_grpc",
+                  "tracing": {
+                        "operation_name": "EGRESS",
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "prepared_query:geo-cache:127.10.10.10:8181",
+      "address": {
+        "socketAddress": {
+          "address": "127.10.10.10",
+          "portValue": 8181
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+                  "stat_prefix": "upstream_prepared_query_geo-cache_tcp"
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "public_listener:0.0.0.0:9999",
+      "address": {
+        "socketAddress": {
+          "address": "0.0.0.0",
+          "portValue": 9999
+        }
+      },
+      "filterChains": [
+        {
+          "tlsContext": {
+            "commonTlsContext": {
+              "tlsParams": {
+
+              },
+              "tlsCertificates": [
+                {
+                  "certificateChain": {
+                    "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+                  },
+                  "privateKey": {
+                    "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+                  }
+                }
+              ],
+              "validationContext": {
+                "trustedCa": {
+                  "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+                }
+              }
+            },
+            "requireClientCertificate": true
+          },
+          "filters": [
+            {
+              "name": "envoy.ext_authz",
+              "config": {
+                  "grpc_service": {
+                        "envoy_grpc": {
+                              "cluster_name": "local_agent"
+                            },
+                        "initial_metadata": [
+                              {
+                                    "key": "x-consul-token",
+                                    "value": "my-token"
+                                  }
+                            ]
+                      },
+                  "stat_prefix": "connect_authz"
+                }
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "local_app",
+                  "stat_prefix": "public_listener_tcp"
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.golden
@@ -1,0 +1,30 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+      "name": "db",
+      "virtualHosts": [
+        {
+          "name": "db",
+          "domains": [
+            "*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "78ebd528:db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+  "nonce": "00000001"
+}

--- a/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
@@ -15,7 +15,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2" {

--- a/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-dogstatsd-udp/verify.bats
@@ -48,7 +48,7 @@ load helpers
 }
 
 @test "s1 proxy should be adding cluster name as a tag" {
-  run retry_default must_match_in_statsd_logs '[#,]envoy.cluster_name:s2(,|$)' primary
+  run retry_default must_match_in_statsd_logs '[#,]envoy.cluster_name:1a47f6e1_s2(,|$)' primary
 
   echo "OUTPUT: $output"
 

--- a/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
@@ -34,7 +34,7 @@ load helpers
 }
 
 @test "s1 upstream made 1 connection" {
-  assert_envoy_metric 127.0.0.1:19000 "cluster.s2.default.secondary.*cx_total" 1
+  assert_envoy_metric 127.0.0.1:19000 "cluster.c225dc1c_s2.default.secondary.*cx_total" 1
 }
 
 @test "gateway-primary is used for the upstream connection" {

--- a/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
@@ -19,7 +19,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.secondary HEALTHY 1
+  # mesh gateway mode is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 c225dc1c:s2.default.secondary HEALTHY 1
 }
 
 @test "gateway-primary should have healthy endpoints for secondary" {

--- a/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
@@ -15,7 +15,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.secondary HEALTHY 1
+  # mesh gateway mode is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 dd412229:s2.default.secondary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2" {

--- a/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
@@ -26,5 +26,5 @@ load helpers
 }
 
 @test "s1 upstream made 1 connection" {
-  assert_envoy_metric 127.0.0.1:19000 "cluster.s2.default.secondary.*cx_total" 1
+  assert_envoy_metric 127.0.0.1:19000 "cluster.dd412229_s2.default.secondary.*cx_total" 1
 }

--- a/test/integration/connect/envoy/case-grpc/verify.bats
+++ b/test/integration/connect/envoy/case-grpc/verify.bats
@@ -15,7 +15,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 ef15b5b5:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2 via grpc" {

--- a/test/integration/connect/envoy/case-http-badauthz/verify.bats
+++ b/test/integration/connect/envoy/case-http-badauthz/verify.bats
@@ -23,7 +23,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should NOT be able to connect to s2" {

--- a/test/integration/connect/envoy/case-http/verify.bats
+++ b/test/integration/connect/envoy/case-http/verify.bats
@@ -23,7 +23,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2 with http/1.1" {

--- a/test/integration/connect/envoy/case-http2/verify.bats
+++ b/test/integration/connect/envoy/case-http2/verify.bats
@@ -23,7 +23,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 49c19fe6:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2 via http2" {

--- a/test/integration/connect/envoy/case-prometheus/verify.bats
+++ b/test/integration/connect/envoy/case-prometheus/verify.bats
@@ -23,7 +23,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2 with http/1.1" {

--- a/test/integration/connect/envoy/case-statsd-udp/verify.bats
+++ b/test/integration/connect/envoy/case-statsd-udp/verify.bats
@@ -15,7 +15,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2" {

--- a/test/integration/connect/envoy/case-zipkin/verify.bats
+++ b/test/integration/connect/envoy/case-zipkin/verify.bats
@@ -23,7 +23,8 @@ load helpers
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {
-  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+  # protocol is configured in an upstream override so the cluster name is customized here
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 1a47f6e1:s2.default.primary HEALTHY 1
 }
 
 @test "s1 upstream should be able to connect to s2" {

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -90,10 +90,10 @@ function init_workdir {
   cp consul-base-cfg/* workdir/${DC}/consul/
 
   # Add any overrides if there are any (no op if not)
-  find ${CASE_DIR} -name '*.hcl' -maxdepth 1 -type f -exec cp -f {} workdir/${DC}/consul \;
+  find ${CASE_DIR} -maxdepth 1 -name '*.hcl' -type f -exec cp -f {} workdir/${DC}/consul \;
 
   # Copy all the test files
-  find ${CASE_DIR} -name '*.bats' -maxdepth 1 -type f -exec cp -f {} workdir/${DC}/bats \;
+  find ${CASE_DIR} -maxdepth 1 -name '*.bats' -type f -exec cp -f {} workdir/${DC}/bats \;
   # Copy DC specific bats
   cp helpers.bash workdir/${DC}/bats
 


### PR DESCRIPTION
The following upstream config fields for connect sidecars sanely
integrate into discovery chain resolution:

- Destination Namespace/Datacenter: Compilation occurs locally but using
different default values for namespaces and datacenters. The xDS
clusters that are created are named as they normally would be.

- Mesh Gateway Mode (single upstream): If set this value overrides any
value computed for any resolver for the entire discovery chain. The xDS
clusters that are created may be named differently (see below).

- Mesh Gateway Mode (whole sidecar): If set this value overrides any
value computed for any resolver for the entire discovery chain. If this
is specifically overridden for a single upstream this value is ignored
in that case. The xDS clusters that are created may be named differently
(see below).

- Protocol (in opaque config): If set this value overrides the value
computed when evaluating the entire discovery chain. If the normal chain
would be TCP or if this override is set to TCP then the result is that
we explicitly disable L7 Routing and Splitting. The xDS clusters that
are created may be named differently (see below).

- Connect Timeout (in opaque config): If set this value overrides the
value for any resolver in the entire discovery chain. The xDS clusters
that are created may be named differently (see below).

If any of the above overrides affect the actual result of compiling the
discovery chain (i.e. "tcp" becomes "grpc" instead of being a no-op
override to "tcp") then the relevant parameters are hashed and provided
to the xDS layer as a prefix for use in naming the Clusters. This is to
ensure that if one Upstream discovery chain has no overrides and
tangentially needs a cluster named `"api.default.XXX"`, and another
Upstream does have overrides for `"api.default.XXX"` that they won't
cross-pollinate against the operator's wishes.

Fixes #6159