### PR TITLE
fix(connect/proxy): remove h2 from NextProtos

### DIFF
--- a/connect/proxy/config.go
+++ b/connect/proxy/config.go
@@ -46,7 +46,7 @@ type Config struct {
 
 // Service returns the *connect.Service structure represented by this config.
 func (c *Config) Service(client *api.Client, logger *log.Logger) (*connect.Service, error) {
-	return connect.NewServiceWithLogger(c.ProxiedServiceName, client, logger)
+	return connect.NewServiceWithoutH2(c.ProxiedServiceName, client, logger)
 }
 
 // PublicListenerConfig contains the parameters needed for the incoming mTLS


### PR DESCRIPTION
So far, the proxy used to announce that it supports http/2, which is not really
the case. Especially it made the native SDK think that the upstream app also
supports it, which broke support for every http/1.1 or older apps.

This has been solved adding a function to the SDK to obtain a Service without `http/2` enabled.
The proxy switches to this from now, **disabling `http/2` support**. This is not configurable, because I was unable to find a place to put this, without mixing L4 and L7 handling.

Feedback welcome :)

Fixes #4466