### PR TITLE
Fix prepared query upstream endpoint generation

### DIFF
--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -420,7 +420,8 @@ func TestConfigSnapshot(t testing.T) *ConfigSnapshot {
 		ConnectProxy: configSnapshotConnectProxy{
 			Leaf: leaf,
 			UpstreamEndpoints: map[string]structs.CheckServiceNodes{
-				"db": TestUpstreamNodes(t),
+				"db":                       TestUpstreamNodes(t),
+				"prepared_query:geo-cache": TestUpstreamNodes(t),
 			},
 		},
 		Datacenter: "dc1",

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -51,7 +51,7 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 		if chain == nil {
 			// We ONLY want this branch for prepared queries.
 
-			sni := ServiceSNI(u.DestinationName, "", u.DestinationNamespace, u.Datacenter, cfgSnap)
+			sni := UpstreamSNI(&u, "", cfgSnap)
 			endpoints, ok := cfgSnap.ConnectProxy.UpstreamEndpoints[id]
 			if ok {
 				la := makeLoadAssignment(

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -267,6 +267,40 @@ func expectEndpointsJSON(t *testing.T, snap *proxycfg.ConfigSnapshot, token stri
 						]
 					}
 				]
+			},
+			{
+				"@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+				"clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+				"endpoints": [
+					{
+						"lbEndpoints": [
+							{
+								"endpoint": {
+									"address": {
+										"socketAddress": {
+											"address": "10.10.1.1",
+											"portValue": 8080
+										}
+									}
+								},
+								"healthStatus": "HEALTHY",
+								"loadBalancingWeight": 1
+							},
+							{
+								"endpoint": {
+									"address": {
+										"socketAddress": {
+											"address": "10.10.1.2",
+											"portValue": 8080
+										}
+									}
+								},
+								"healthStatus": "HEALTHY",
+								"loadBalancingWeight": 1
+							}
+						]
+					}
+				]
 			}
 		],
 		"typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",

--- a/agent/xds/testdata/endpoints/defaults.golden
+++ b/agent/xds/testdata/endpoints/defaults.golden
@@ -34,6 +34,40 @@
           ]
         }
       ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",


### PR DESCRIPTION
The cluster name (which is an SNI value) is slightly different for prepared queries so we must use the right function to generate it.