### PR TITLE
connect: simplify the compiled discovery chain data structures

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -361,7 +361,6 @@ func (c *ConfigEntry) ReadDiscoveryChain(args *structs.DiscoveryChainRequest, re
 				OverrideMeshGateway:    args.OverrideMeshGateway,
 				OverrideProtocol:       args.OverrideProtocol,
 				OverrideConnectTimeout: args.OverrideConnectTimeout,
-				InferDefaults:          true,
 				Entries:                entries,
 			})
 			if err != nil {

--- a/agent/consul/discoverychain/testing.go
+++ b/agent/consul/discoverychain/testing.go
@@ -22,7 +22,6 @@ func TestCompileConfigEntries(
 		ServiceName:       serviceName,
 		CurrentNamespace:  currentNamespace,
 		CurrentDatacenter: currentDatacenter,
-		InferDefaults:     true,
 		Entries:           set,
 	}
 	if setup != nil {

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -5,7 +5,6 @@ import (
 	"encoding"
 	"fmt"
 	"net/url"
-	"sort"
 	"strings"
 	"time"
 )
@@ -30,24 +29,19 @@ type CompiledDiscoveryChain struct {
 	// Protocol is the overall protocol shared by everything in the chain.
 	Protocol string
 
-	// Node is the top node in the chain.
-	//
-	// If this is a router or splitter then in envoy this renders as an http
-	// route object.
-	//
-	// If this is a group resolver then in envoy this renders as a default
-	// wildcard http route object.
-	Node *DiscoveryGraphNode `json:",omitempty"`
+	// StartNode is the first key into the Nodes map that should be followed
+	// when walking the discovery chain.
+	StartNode string `json:",omitempty"`
 
-	// GroupResolverNodes respresents all unique service instance groups that
-	// need to be represented. For envoy these render as Clusters.
+	// Nodes contains all nodes available for traversal in the chain keyed by a
+	// unique name.  You can walk this by starting with StartNode.
 	//
-	// Omitted from JSON because these already show up under the Node field.
-	GroupResolverNodes map[DiscoveryTarget]*DiscoveryGraphNode `json:"-"`
+	// NOTE: The names should be treated as opaque values and are only
+	// guaranteed to be consistent within a single compilation.
+	Nodes map[string]*DiscoveryGraphNode `json:",omitempty"`
 
-	// TODO(rb): not sure if these two fields are actually necessary but I'll know when I get into xDS
-	Resolvers map[string]*ServiceResolverConfigEntry `json:",omitempty"`
-	Targets   []DiscoveryTarget                      `json:",omitempty"`
+	// Targets is a list of all targets and configuration related just to targets.
+	Targets map[DiscoveryTarget]DiscoveryTargetConfig `json:",omitempty"`
 }
 
 // IsDefault returns true if the compiled chain represents no routing, no
@@ -56,41 +50,31 @@ type CompiledDiscoveryChain struct {
 // applied is redirection to another resolver that is default, so we double
 // check the resolver matches the requested resolver.
 func (c *CompiledDiscoveryChain) IsDefault() bool {
-	if c.Node == nil {
+	if c.StartNode == "" || len(c.Nodes) == 0 {
 		return true
 	}
+
+	node := c.Nodes[c.StartNode]
+	if node == nil {
+		panic("not possible: missing node named '" + c.StartNode + "' in chain '" + c.ServiceName + "'")
+	}
+
 	// TODO(rb): include CustomizationHash here?
-	return c.Node.Name == c.ServiceName &&
-		c.Node.Type == DiscoveryGraphNodeTypeGroupResolver &&
-		c.Node.GroupResolver.Default
-}
-
-// SubsetDefinitionForTarget is a convenience function to fetch the subset
-// definition for the service subset defined by the provided target. If the
-// subset is not defined an empty definition is returned.
-func (c *CompiledDiscoveryChain) SubsetDefinitionForTarget(t DiscoveryTarget) ServiceResolverSubset {
-	if t.ServiceSubset == "" {
-		return ServiceResolverSubset{}
-	}
-
-	resolver, ok := c.Resolvers[t.Service]
-	if !ok {
-		return ServiceResolverSubset{}
-	}
-
-	return resolver.Subsets[t.ServiceSubset]
+	return node.Type == DiscoveryGraphNodeTypeResolver &&
+		node.Resolver.Default &&
+		node.Resolver.Target.Service == c.ServiceName
 }
 
 const (
-	DiscoveryGraphNodeTypeRouter        = "router"
-	DiscoveryGraphNodeTypeSplitter      = "splitter"
-	DiscoveryGraphNodeTypeGroupResolver = "group-resolver"
+	DiscoveryGraphNodeTypeRouter   = "router"
+	DiscoveryGraphNodeTypeSplitter = "splitter"
+	DiscoveryGraphNodeTypeResolver = "resolver"
 )
 
-// DiscoveryGraphNode is a single node of the compiled discovery chain.
+// DiscoveryGraphNode is a single node in the compiled discovery chain.
 type DiscoveryGraphNode struct {
 	Type string
-	Name string // default chain/service name at this spot
+	Name string // this is NOT necessarily a service
 
 	// fields for Type==router
 	Routes []*DiscoveryRoute `json:",omitempty"`
@@ -98,34 +82,48 @@ type DiscoveryGraphNode struct {
 	// fields for Type==splitter
 	Splits []*DiscoverySplit `json:",omitempty"`
 
-	// fields for Type==group-resolver
-	GroupResolver *DiscoveryGroupResolver `json:",omitempty"`
+	// fields for Type==resolver
+	Resolver *DiscoveryResolver `json:",omitempty"`
 }
 
-// compiled form of ServiceResolverConfigEntry but customized per non-failover target
-type DiscoveryGroupResolver struct {
+func (s *DiscoveryGraphNode) ServiceName() string {
+	if s.Type == DiscoveryGraphNodeTypeResolver {
+		return s.Resolver.Target.Service
+	}
+	return s.Name
+}
+
+func (s *DiscoveryGraphNode) MapKey() string {
+	return fmt.Sprintf("%s:%s", s.Type, s.Name)
+}
+
+// compiled form of ServiceResolverConfigEntry
+type DiscoveryResolver struct {
 	Definition     *ServiceResolverConfigEntry `json:",omitempty"`
 	Default        bool                        `json:",omitempty"`
 	ConnectTimeout time.Duration               `json:",omitempty"`
-	MeshGateway    MeshGatewayConfig           `json:",omitempty"`
 	Target         DiscoveryTarget             `json:",omitempty"`
 	Failover       *DiscoveryFailover          `json:",omitempty"`
 }
 
+type DiscoveryTargetConfig struct {
+	MeshGateway MeshGatewayConfig     `json:",omitempty"`
+	Subset      ServiceResolverSubset `json:",omitempty"`
+}
+
 // compiled form of ServiceRoute
 type DiscoveryRoute struct {
-	Definition      *ServiceRoute       `json:",omitempty"`
-	DestinationNode *DiscoveryGraphNode `json:",omitempty"`
+	Definition *ServiceRoute `json:",omitempty"`
+	NextNode   string        `json:",omitempty"`
 }
 
 // compiled form of ServiceSplit
 type DiscoverySplit struct {
-	Weight float32             `json:",omitempty"`
-	Node   *DiscoveryGraphNode `json:",omitempty"`
+	Weight   float32 `json:",omitempty"`
+	NextNode string  `json:",omitempty"`
 }
 
 // compiled form of ServiceResolverFailover
-// TODO(rb): figure out how to get mesh gateways in here
 type DiscoveryFailover struct {
 	Definition *ServiceResolverFailover `json:",omitempty"`
 	Targets    []DiscoveryTarget        `json:",omitempty"`
@@ -183,17 +181,21 @@ var _ encoding.TextUnmarshaler = (*DiscoveryTarget)(nil)
 //
 // This should NOT return any errors.
 func (t DiscoveryTarget) MarshalText() (text []byte, err error) {
+	return []byte(t.Identifier()), nil
+}
+
+func (t DiscoveryTarget) Identifier() string {
 	var buf bytes.Buffer
 	buf.WriteString(url.QueryEscape(t.Service))
 	buf.WriteRune(',')
-	buf.WriteString(url.QueryEscape(t.ServiceSubset))
+	buf.WriteString(url.QueryEscape(t.ServiceSubset)) // TODO(rb): move this first so the scoping flows from small->large?
 	buf.WriteRune(',')
 	if t.Namespace != "default" {
 		buf.WriteString(url.QueryEscape(t.Namespace))
 	}
 	buf.WriteRune(',')
 	buf.WriteString(url.QueryEscape(t.Datacenter))
-	return buf.Bytes(), nil
+	return buf.String()
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
@@ -255,30 +257,4 @@ func (t DiscoveryTarget) String() string {
 	b.WriteString(t.Datacenter)
 
 	return b.String()
-}
-
-type DiscoveryTargets []DiscoveryTarget
-
-func (targets DiscoveryTargets) Sort() {
-	sort.Slice(targets, func(i, j int) bool {
-		if targets[i].Service < targets[j].Service {
-			return true
-		} else if targets[i].Service > targets[j].Service {
-			return false
-		}
-
-		if targets[i].ServiceSubset < targets[j].ServiceSubset {
-			return true
-		} else if targets[i].ServiceSubset > targets[j].ServiceSubset {
-			return false
-		}
-
-		if targets[i].Namespace < targets[j].Namespace {
-			return true
-		} else if targets[i].Namespace > targets[j].Namespace {
-			return false
-		}
-
-		return targets[i].Datacenter < targets[j].Datacenter
-	})
 }

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -73,14 +73,20 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 				continue // skip the upstream (should not happen)
 			}
 
-			for target, node := range chain.GroupResolverNodes {
-				groupResolver := node.GroupResolver
-				failover := groupResolver.Failover
+			// Find all resolver nodes.
+			for _, node := range chain.Nodes {
+				if node.Type != structs.DiscoveryGraphNodeTypeResolver {
+					continue
+				}
+				failover := node.Resolver.Failover
+				target := node.Resolver.Target
 
 				endpoints, ok := chainEndpointMap[target]
 				if !ok {
 					continue // skip the cluster (should not happen)
 				}
+
+				targetConfig := chain.Targets[target]
 
 				var (
 					endpointGroups         []loadAssignmentEndpointGroup
@@ -89,7 +95,7 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 
 				primaryGroup := loadAssignmentEndpointGroup{
 					Endpoints:   endpoints,
-					OnlyPassing: chain.SubsetDefinitionForTarget(target).OnlyPassing,
+					OnlyPassing: targetConfig.Subset.OnlyPassing,
 				}
 
 				if failover != nil && len(failover.Targets) > 0 {
@@ -112,9 +118,11 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 							continue // skip the failover target (should not happen)
 						}
 
+						failTargetConfig := chain.Targets[failTarget]
+
 						endpointGroups = append(endpointGroups, loadAssignmentEndpointGroup{
 							Endpoints:   failEndpoints,
-							OnlyPassing: chain.SubsetDefinitionForTarget(failTarget).OnlyPassing,
+							OnlyPassing: failTargetConfig.Subset.OnlyPassing,
 						})
 					}
 				} else {

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -266,11 +266,11 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 					Namespace:  "default",
 					Datacenter: "dc1",
 				}
-				dbResolverNode := chain.GroupResolverNodes[dbTarget]
+				dbResolverNode := chain.Nodes["resolver:"+dbTarget.Identifier()]
 
-				groupResolverFailover := dbResolverNode.GroupResolver.Failover
+				failover := dbResolverNode.Resolver.Failover
 
-				groupResolverFailover.Definition.OverprovisioningFactor = 160
+				failover.Definition.OverprovisioningFactor = 160
 			},
 		},
 		{

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -73,11 +73,16 @@ func makeUpstreamRouteForDiscoveryChain(
 
 	var routes []envoyroute.Route
 
-	switch chain.Node.Type {
-	case structs.DiscoveryGraphNodeTypeRouter:
-		routes = make([]envoyroute.Route, 0, len(chain.Node.Routes))
+	startNode := chain.Nodes[chain.StartNode]
+	if startNode == nil {
+		panic("missing first node in compiled discovery chain for: " + chain.ServiceName)
+	}
 
-		for _, discoveryRoute := range chain.Node.Routes {
+	switch startNode.Type {
+	case structs.DiscoveryGraphNodeTypeRouter:
+		routes = make([]envoyroute.Route, 0, len(startNode.Routes))
+
+		for _, discoveryRoute := range startNode.Routes {
 			routeMatch := makeRouteMatchForDiscoveryRoute(discoveryRoute, chain.Protocol)
 
 			var (
@@ -85,19 +90,19 @@ func makeUpstreamRouteForDiscoveryChain(
 				err         error
 			)
 
-			next := discoveryRoute.DestinationNode
-			if next.Type == structs.DiscoveryGraphNodeTypeSplitter {
-				routeAction, err = makeRouteActionForSplitter(next.Splits, chain, cfgSnap)
+			nextNode := chain.Nodes[discoveryRoute.NextNode]
+			switch nextNode.Type {
+			case structs.DiscoveryGraphNodeTypeSplitter:
+				routeAction, err = makeRouteActionForSplitter(nextNode.Splits, chain, cfgSnap)
 				if err != nil {
 					return nil, err
 				}
 
-			} else if next.Type == structs.DiscoveryGraphNodeTypeGroupResolver {
-				groupResolver := next.GroupResolver
-				routeAction = makeRouteActionForSingleCluster(groupResolver.Target, chain, cfgSnap)
+			case structs.DiscoveryGraphNodeTypeResolver:
+				routeAction = makeRouteActionForSingleCluster(nextNode.Resolver.Target, chain, cfgSnap)
 
-			} else {
-				return nil, fmt.Errorf("unexpected graph node after route %q", next.Type)
+			default:
+				return nil, fmt.Errorf("unexpected graph node after route %q", nextNode.Type)
 			}
 
 			// TODO(rb): Better help handle the envoy case where you need (prefix=/foo/,rewrite=/) and (exact=/foo,rewrite=/) to do a full rewrite
@@ -142,7 +147,7 @@ func makeUpstreamRouteForDiscoveryChain(
 		}
 
 	case structs.DiscoveryGraphNodeTypeSplitter:
-		routeAction, err := makeRouteActionForSplitter(chain.Node.Splits, chain, cfgSnap)
+		routeAction, err := makeRouteActionForSplitter(startNode.Splits, chain, cfgSnap)
 		if err != nil {
 			return nil, err
 		}
@@ -154,10 +159,8 @@ func makeUpstreamRouteForDiscoveryChain(
 
 		routes = []envoyroute.Route{defaultRoute}
 
-	case structs.DiscoveryGraphNodeTypeGroupResolver:
-		groupResolver := chain.Node.GroupResolver
-
-		routeAction := makeRouteActionForSingleCluster(groupResolver.Target, chain, cfgSnap)
+	case structs.DiscoveryGraphNodeTypeResolver:
+		routeAction := makeRouteActionForSingleCluster(startNode.Resolver.Target, chain, cfgSnap)
 
 		defaultRoute := envoyroute.Route{
 			Match:  makeDefaultRouteMatch(),
@@ -167,7 +170,7 @@ func makeUpstreamRouteForDiscoveryChain(
 		routes = []envoyroute.Route{defaultRoute}
 
 	default:
-		panic("unknown top node in discovery chain of type: " + chain.Node.Type)
+		panic("unknown first node in discovery chain of type: " + startNode.Type)
 	}
 
 	return &envoy.RouteConfiguration{
@@ -320,11 +323,12 @@ func makeRouteActionForSingleCluster(target structs.DiscoveryTarget, chain *stru
 func makeRouteActionForSplitter(splits []*structs.DiscoverySplit, chain *structs.CompiledDiscoveryChain, cfgSnap *proxycfg.ConfigSnapshot) (*envoyroute.Route_Route, error) {
 	clusters := make([]*envoyroute.WeightedCluster_ClusterWeight, 0, len(splits))
 	for _, split := range splits {
-		if split.Node.Type != structs.DiscoveryGraphNodeTypeGroupResolver {
-			return nil, fmt.Errorf("unexpected splitter destination node type: %s", split.Node.Type)
+		nextNode := chain.Nodes[split.NextNode]
+
+		if nextNode.Type != structs.DiscoveryGraphNodeTypeResolver {
+			return nil, fmt.Errorf("unexpected splitter destination node type: %s", nextNode.Type)
 		}
-		groupResolver := split.Node.GroupResolver
-		target := groupResolver.Target
+		target := nextNode.Resolver.Target
 
 		sni := TargetSNI(target, cfgSnap)
 		clusterName := CustomizeClusterName(sni, chain)


### PR DESCRIPTION
This should make them better for sending over RPC or the API.

Instead of a chain implemented explicitly like a linked list (nodes
holding pointers to other nodes) instead switch to a flat map of named
nodes with nodes linking other other nodes by name. The shipped
structure is just a map and a string to indicate which key to start
from.

Other changes:

* inline the compiler option InferDefaults as true

* introduce compiled target config to avoid needing to send back
  additional maps of Resolvers; future target-specific compiled state
  can go here

* move compiled MeshGateway out of the Resolver and into the
  TargetConfig where it makes more sense.