### PR TITLE
Rename SpiffeIDService to SpiffeIDConsulService

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -5993,7 +5993,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        target,
-		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+		ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 	}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 	resp := httptest.NewRecorder()
@@ -6090,7 +6090,7 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        target,
-		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+		ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 	}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 	resp := httptest.NewRecorder()
@@ -6204,7 +6204,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 	{
 		args := &structs.ConnectAuthorizeRequest{
 			Target:        target,
-			ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+			ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 		}
 		req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 		resp := httptest.NewRecorder()
@@ -6221,7 +6221,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 	{
 		args := &structs.ConnectAuthorizeRequest{
 			Target:        target,
-			ClientCertURI: connect.TestSpiffeIDService(t, "api").URI().String(),
+			ClientCertURI: connect.TestSpiffeIDConsulService(t, "api").URI().String(),
 		}
 		req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize", jsonReader(args))
 		resp := httptest.NewRecorder()
@@ -6264,7 +6264,7 @@ func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "foo",
-		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+		ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 	}
 	req, _ := http.NewRequest("POST",
 		"/v1/agent/connect/authorize?token="+token, jsonReader(args))
@@ -6284,7 +6284,7 @@ func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "foo",
-		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+		ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 	}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize?token=root", jsonReader(args))
 	resp := httptest.NewRecorder()
@@ -6316,7 +6316,7 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 
 	args := &structs.ConnectAuthorizeRequest{
 		Target:        "foo",
-		ClientCertURI: connect.TestSpiffeIDService(t, "web").URI().String(),
+		ClientCertURI: connect.TestSpiffeIDConsulService(t, "web").URI().String(),
 	}
 	req, _ := http.NewRequest("POST", "/v1/agent/connect/authorize?token=root", jsonReader(args))
 	resp := httptest.NewRecorder()

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -504,7 +504,7 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 	// Build the cert uri
 	var id connect.CertURI
 	if req.Service != "" {
-		id = &connect.SpiffeIDService{
+		id = &connect.SpiffeIDConsulService{
 			Host:       roots.TrustDomain,
 			Datacenter: req.Datacenter,
 			Namespace:  "default",

--- a/agent/connect/ca/plugin/plugin_test.go
+++ b/agent/connect/ca/plugin/plugin_test.go
@@ -166,7 +166,7 @@ func TestProvider_Sign(t *testing.T) {
 		require := require.New(t)
 
 		// Create a CSR
-		csrPEM, _ := connect.TestCSR(t, connect.TestSpiffeIDService(t, "web"))
+		csrPEM, _ := connect.TestCSR(t, connect.TestSpiffeIDConsulService(t, "web"))
 		block, _ := pem.Decode([]byte(csrPEM))
 		csr, err := x509.ParseCertificateRequest(block.Bytes)
 		require.NoError(err)
@@ -197,7 +197,7 @@ func TestProvider_SignIntermediate(t *testing.T) {
 		require := require.New(t)
 
 		// Create a CSR
-		csrPEM, _ := connect.TestCSR(t, connect.TestSpiffeIDService(t, "web"))
+		csrPEM, _ := connect.TestCSR(t, connect.TestSpiffeIDConsulService(t, "web"))
 		block, _ := pem.Decode([]byte(csrPEM))
 		csr, err := x509.ParseCertificateRequest(block.Bytes)
 		require.NoError(err)

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -352,7 +352,7 @@ func (c *ConsulProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 
 	subject := ""
 	switch id := spiffeId.(type) {
-	case *connect.SpiffeIDService:
+	case *connect.SpiffeIDConsulService:
 		subject = id.Service
 	case *connect.SpiffeIDAgent:
 		subject = id.Agent

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -130,7 +130,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
-	spiffeService := &connect.SpiffeIDService{
+	spiffeService := &connect.SpiffeIDConsulService{
 		Host:       "node1",
 		Namespace:  "default",
 		Datacenter: "dc1",
@@ -268,7 +268,7 @@ func testCrossSignProviders(t *testing.T, provider1, provider2 Provider) {
 	require.Equal(oldRoot.Issuer.CommonName, xc.Issuer.CommonName)
 
 	// Get a leaf cert so we can verify against the cross-signed cert.
-	spiffeService := &connect.SpiffeIDService{
+	spiffeService := &connect.SpiffeIDConsulService{
 		Host:       "node1",
 		Namespace:  "default",
 		Datacenter: "dc1",
@@ -341,7 +341,7 @@ func testSignIntermediateCrossDC(t *testing.T, provider1, provider2 Provider) {
 	require.NoError(provider2.SetIntermediate(intermediatePEM, rootPEM))
 
 	// Have provider2 sign a leaf cert and make sure the chain is correct.
-	spiffeService := &connect.SpiffeIDService{
+	spiffeService := &connect.SpiffeIDConsulService{
 		Host:       "node1",
 		Namespace:  "default",
 		Datacenter: "dc1",

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -139,7 +139,7 @@ func TestVaultCAProvider_SignLeaf(t *testing.T) {
 	require.NoError(err)
 	client.SetToken(provider.config.Token)
 
-	spiffeService := &connect.SpiffeIDService{
+	spiffeService := &connect.SpiffeIDConsulService{
 		Host:       "node1",
 		Namespace:  "default",
 		Datacenter: "dc1",

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -145,7 +145,7 @@ func TestLeaf(t testing.T, service string, root *structs.CARoot) (string, string
 	}
 
 	// Build the SPIFFE ID
-	spiffeId := &SpiffeIDService{
+	spiffeId := &SpiffeIDConsulService{
 		Host:       fmt.Sprintf("%s.consul", TestClusterID),
 		Namespace:  "default",
 		Datacenter: "dc1",

--- a/agent/connect/testing_spiffe.go
+++ b/agent/connect/testing_spiffe.go
@@ -4,15 +4,15 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 )
 
-// TestSpiffeIDService returns a SPIFFE ID representing a service.
-func TestSpiffeIDService(t testing.T, service string) *SpiffeIDService {
-	return TestSpiffeIDServiceWithHost(t, service, TestClusterID+".consul")
+// TestSpiffeIDConsulService returns a SPIFFE ID representing a service.
+func TestSpiffeIDConsulService(t testing.T, service string) *SpiffeIDConsulService {
+	return TestSpiffeIDConsulServiceWithHost(t, service, TestClusterID+".consul")
 }
 
-// TestSpiffeIDServiceWithHost returns a SPIFFE ID representing a service with
+// TestSpiffeIDConsulServiceWithHost returns a SPIFFE ID representing a service with
 // the specified trust domain.
-func TestSpiffeIDServiceWithHost(t testing.T, service, host string) *SpiffeIDService {
-	return &SpiffeIDService{
+func TestSpiffeIDConsulServiceWithHost(t testing.T, service, host string) *SpiffeIDConsulService {
+	return &SpiffeIDConsulService{
 		Host:       host,
 		Namespace:  "default",
 		Datacenter: "dc1",

--- a/agent/connect/uri.go
+++ b/agent/connect/uri.go
@@ -81,7 +81,7 @@ func ParseCertURI(input *url.URL) (CertURI, error) {
 			}
 		}
 
-		return &SpiffeIDService{
+		return &SpiffeIDConsulService{
 			Host:       input.Host,
 			Namespace:  ns,
 			Datacenter: dc,

--- a/agent/connect/uri_agent.go
+++ b/agent/connect/uri_agent.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-// SpiffeIDService is the structure to represent the SPIFFE ID for an agent.
+// SpiffeIDAgent is the structure to represent the SPIFFE ID for an agent.
 type SpiffeIDAgent struct {
 	Host       string
 	Datacenter string

--- a/agent/connect/uri_service.go
+++ b/agent/connect/uri_service.go
@@ -7,8 +7,9 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 )
 
-// SpiffeIDService is the structure to represent the SPIFFE ID for a service.
-type SpiffeIDService struct {
+// SpiffeIDConsulService is the structure to represent the SPIFFE ID for a
+// Consul service (in contrast to the ID for an external service).
+type SpiffeIDConsulService struct {
 	Host       string
 	Namespace  string
 	Datacenter string
@@ -16,7 +17,7 @@ type SpiffeIDService struct {
 }
 
 // URI returns the *url.URL for this SPIFFE ID.
-func (id *SpiffeIDService) URI() *url.URL {
+func (id *SpiffeIDConsulService) URI() *url.URL {
 	var result url.URL
 	result.Scheme = "spiffe"
 	result.Host = id.Host
@@ -26,7 +27,7 @@ func (id *SpiffeIDService) URI() *url.URL {
 }
 
 // CertURI impl.
-func (id *SpiffeIDService) Authorize(ixn *structs.Intention) (bool, bool) {
+func (id *SpiffeIDConsulService) Authorize(ixn *structs.Intention) (bool, bool) {
 	if ixn.SourceNS != structs.IntentionWildcard && ixn.SourceNS != id.Namespace {
 		// Non-matching namespace
 		return false, false

--- a/agent/connect/uri_service_test.go
+++ b/agent/connect/uri_service_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSpiffeIDServiceAuthorize(t *testing.T) {
 	ns := structs.IntentionDefaultNamespace
-	serviceWeb := &SpiffeIDService{
+	serviceWeb := &SpiffeIDConsulService{
 		Host:       "1234.consul",
 		Namespace:  structs.IntentionDefaultNamespace,
 		Datacenter: "dc01",
@@ -18,7 +18,7 @@ func TestSpiffeIDServiceAuthorize(t *testing.T) {
 
 	cases := []struct {
 		Name  string
-		URI   *SpiffeIDService
+		URI   *SpiffeIDConsulService
 		Ixn   *structs.Intention
 		Auth  bool
 		Match bool

--- a/agent/connect/uri_signing.go
+++ b/agent/connect/uri_signing.go
@@ -50,7 +50,7 @@ func (id *SpiffeIDSigning) CanSign(cu CertURI) bool {
 		// federation of roots and cross-signing external roots that have different
 		// URI structure but it's simpler to start off restrictive.
 		return id.URI().String() == other.URI().String()
-	case *SpiffeIDService:
+	case *SpiffeIDConsulService:
 		// The host component of the service must be an exact match for now under
 		// ascii case folding (since hostnames are case-insensitive). Later we might
 		// worry about Unicode domains if we start allowing customisation beyond the

--- a/agent/connect/uri_signing_test.go
+++ b/agent/connect/uri_signing_test.go
@@ -91,25 +91,25 @@ func TestSpiffeIDSigning_CanSign(t *testing.T) {
 		{
 			name:  "service - good",
 			id:    testSigning,
-			input: &SpiffeIDService{TestClusterID + ".consul", "default", "dc1", "web"},
+			input: &SpiffeIDConsulService{TestClusterID + ".consul", "default", "dc1", "web"},
 			want:  true,
 		},
 		{
 			name:  "service - good midex case",
 			id:    testSigning,
-			input: &SpiffeIDService{strings.ToUpper(TestClusterID) + ".CONsuL", "defAUlt", "dc1", "WEB"},
+			input: &SpiffeIDConsulService{strings.ToUpper(TestClusterID) + ".CONsuL", "defAUlt", "dc1", "WEB"},
 			want:  true,
 		},
 		{
 			name:  "service - different cluster",
 			id:    testSigning,
-			input: &SpiffeIDService{"55555555-4444-3333-2222-111111111111.consul", "default", "dc1", "web"},
+			input: &SpiffeIDConsulService{"55555555-4444-3333-2222-111111111111.consul", "default", "dc1", "web"},
 			want:  false,
 		},
 		{
 			name:  "service - different TLD",
 			id:    testSigning,
-			input: &SpiffeIDService{TestClusterID + ".fake", "default", "dc1", "web"},
+			input: &SpiffeIDConsulService{TestClusterID + ".fake", "default", "dc1", "web"},
 			want:  false,
 		},
 	}

--- a/agent/connect/uri_test.go
+++ b/agent/connect/uri_test.go
@@ -24,7 +24,7 @@ var testCertURICases = []struct {
 	{
 		"basic service ID",
 		"spiffe://1234.consul/ns/default/dc/dc01/svc/web",
-		&SpiffeIDService{
+		&SpiffeIDConsulService{
 			Host:       "1234.consul",
 			Namespace:  "default",
 			Datacenter: "dc01",
@@ -47,7 +47,7 @@ var testCertURICases = []struct {
 	{
 		"service with URL-encoded values",
 		"spiffe://1234.consul/ns/foo%2Fbar/dc/bar%2Fbaz/svc/baz%2Fqux",
-		&SpiffeIDService{
+		&SpiffeIDConsulService{
 			Host:       "1234.consul",
 			Namespace:  "foo/bar",
 			Datacenter: "bar/baz",

--- a/agent/connect_auth.go
+++ b/agent/connect_auth.go
@@ -45,7 +45,7 @@ func (a *Agent) ConnectAuthorize(token string,
 		return returnErr(BadRequestError{"ClientCertURI not a valid Connect identifier"})
 	}
 
-	uriService, ok := uri.(*connect.SpiffeIDService)
+	uriService, ok := uri.(*connect.SpiffeIDConsulService)
 	if !ok {
 		return returnErr(BadRequestError{"ClientCertURI not a valid Service identifier"})
 	}

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -423,7 +423,7 @@ func (s *ConnectCA) Sign(
 		return err
 	}
 	signingID := connect.SpiffeIDSigningForCluster(config)
-	serviceID, isService := spiffeID.(*connect.SpiffeIDService)
+	serviceID, isService := spiffeID.(*connect.SpiffeIDConsulService)
 	agentID, isAgent := spiffeID.(*connect.SpiffeIDAgent)
 	if !isService && !isAgent {
 		return fmt.Errorf("SPIFFE ID in CSR must be a service or agent ID")

--- a/agent/consul/connect_ca_endpoint_test.go
+++ b/agent/consul/connect_ca_endpoint_test.go
@@ -245,7 +245,7 @@ func TestConnectCAConfig_TriggerRotation(t *testing.T) {
 	// Verify that new leaf certs get the cross-signed intermediate bundled
 	{
 		// Generate a CSR and request signing
-		spiffeId := connect.TestSpiffeIDService(t, "web")
+		spiffeId := connect.TestSpiffeIDConsulService(t, "web")
 		csr, _ := connect.TestCSR(t, spiffeId)
 		args := &structs.CASignRequest{
 			Datacenter: "dc1",
@@ -308,7 +308,7 @@ func TestConnectCASign(t *testing.T) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Generate a CSR and request signing
-	spiffeId := connect.TestSpiffeIDService(t, "web")
+	spiffeId := connect.TestSpiffeIDConsulService(t, "web")
 	csr, _ := connect.TestCSR(t, spiffeId)
 	args := &structs.CASignRequest{
 		Datacenter: "dc1",
@@ -318,7 +318,7 @@ func TestConnectCASign(t *testing.T) {
 	require.NoError(msgpackrpc.CallWithCodec(codec, "ConnectCA.Sign", args, &reply))
 
 	// Generate a second CSR and request signing
-	spiffeId2 := connect.TestSpiffeIDService(t, "web2")
+	spiffeId2 := connect.TestSpiffeIDConsulService(t, "web2")
 	csr, _ = connect.TestCSR(t, spiffeId2)
 	args = &structs.CASignRequest{
 		Datacenter: "dc1",
@@ -365,7 +365,7 @@ func BenchmarkConnectCASign(b *testing.B) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Generate a CSR and request signing
-	spiffeID := connect.TestSpiffeIDService(b, "web")
+	spiffeID := connect.TestSpiffeIDConsulService(b, "web")
 	csr, _ := connect.TestCSR(b, spiffeID)
 	args := &structs.CASignRequest{
 		Datacenter: "dc1",
@@ -405,7 +405,7 @@ func TestConnectCASign_rateLimit(t *testing.T) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Generate a CSR and request signing a few times in a loop.
-	spiffeID := connect.TestSpiffeIDService(t, "web")
+	spiffeID := connect.TestSpiffeIDConsulService(t, "web")
 	csr, _ := connect.TestCSR(t, spiffeID)
 	args := &structs.CASignRequest{
 		Datacenter: "dc1",
@@ -459,7 +459,7 @@ func TestConnectCASign_concurrencyLimit(t *testing.T) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Generate a CSR and request signing a few times in a loop.
-	spiffeID := connect.TestSpiffeIDService(t, "web")
+	spiffeID := connect.TestSpiffeIDConsulService(t, "web")
 	csr, _ := connect.TestCSR(t, spiffeID)
 	args := &structs.CASignRequest{
 		Datacenter: "dc1",
@@ -579,7 +579,7 @@ func TestConnectCASignValidation(t *testing.T) {
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "ACL.Apply", &arg, &webToken))
 	}
 
-	testWebID := connect.TestSpiffeIDService(t, "web")
+	testWebID := connect.TestSpiffeIDConsulService(t, "web")
 
 	tests := []struct {
 		name    string
@@ -588,7 +588,7 @@ func TestConnectCASignValidation(t *testing.T) {
 	}{
 		{
 			name: "different cluster",
-			id: &connect.SpiffeIDService{
+			id: &connect.SpiffeIDConsulService{
 				Host:       "55555555-4444-3333-2222-111111111111.consul",
 				Namespace:  testWebID.Namespace,
 				Datacenter: testWebID.Datacenter,
@@ -603,7 +603,7 @@ func TestConnectCASignValidation(t *testing.T) {
 		},
 		{
 			name: "same cluster, CSR for a different DC should NOT validate",
-			id: &connect.SpiffeIDService{
+			id: &connect.SpiffeIDConsulService{
 				Host:       testWebID.Host,
 				Namespace:  testWebID.Namespace,
 				Datacenter: "dc2",
@@ -613,7 +613,7 @@ func TestConnectCASignValidation(t *testing.T) {
 		},
 		{
 			name: "same cluster and DC, different service should not have perms",
-			id: &connect.SpiffeIDService{
+			id: &connect.SpiffeIDConsulService{
 				Host:       testWebID.Host,
 				Namespace:  testWebID.Namespace,
 				Datacenter: testWebID.Datacenter,

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -287,7 +287,7 @@ func (s *Intention) Check(
 	var uri connect.CertURI
 	switch query.SourceType {
 	case structs.IntentionSourceConsul:
-		uri = &connect.SpiffeIDService{
+		uri = &connect.SpiffeIDConsulService{
 			Namespace: query.SourceNS,
 			Service:   query.SourceName,
 		}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -449,7 +449,7 @@ func (s *Server) Check(ctx context.Context, r *envoyauthz.CheckRequest) (*envoya
 		return deniedResponse("Destination Principal is not a valid Connect identity")
 	}
 
-	destID, ok := dest.(*connect.SpiffeIDService)
+	destID, ok := dest.(*connect.SpiffeIDConsulService)
 	if !ok {
 		s.Logger.Printf("[DEBUG] grpc: Connect AuthZ DENIED: bad destination service ID: src=%s dest=%s",
 			r.Attributes.Source.Principal, r.Attributes.Destination.Principal)

--- a/agent/xds/testing.go
+++ b/agent/xds/testing.go
@@ -168,7 +168,7 @@ func TestCheckRequest(t testing.T, source, dest string) *envoyauth.CheckRequest 
 }
 
 func makeAttributeContextPeer(t testing.T, svc string) *envoyauth.AttributeContext_Peer {
-	spiffeID := connect.TestSpiffeIDService(t, svc)
+	spiffeID := connect.TestSpiffeIDConsulService(t, svc)
 	return &envoyauth.AttributeContext_Peer{
 		// We don't care about IP for now might later though
 		Address: makeAddressPtr("10.0.0.1", 1234),

--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -141,7 +141,7 @@ func TestPublicListener(t *testing.T) {
 	// cert for now.
 	conn, err := svc.Dial(context.Background(), &connect.StaticResolver{
 		Addr:    TestLocalAddr(ports[0]),
-		CertURI: agConnect.TestSpiffeIDService(t, "db"),
+		CertURI: agConnect.TestSpiffeIDConsulService(t, "db"),
 	})
 	require.NoError(t, err)
 
@@ -190,7 +190,7 @@ func TestUpstreamListener(t *testing.T) {
 	// Setup with a statuc resolver instead
 	rf := TestStaticUpstreamResolverFunc(&connect.StaticResolver{
 		Addr:    testSvr.Addr,
-		CertURI: agConnect.TestSpiffeIDService(t, "db"),
+		CertURI: agConnect.TestSpiffeIDConsulService(t, "db"),
 	})
 	l := newUpstreamListenerWithResolver(svc, cfg, rf, log.New(os.Stderr, "", log.LstdFlags))
 

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -66,7 +66,7 @@ func TestProxy_public(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		conn, err = svc.Dial(context.Background(), &connect.StaticResolver{
 			Addr:    TestLocalAddr(ports[0]),
-			CertURI: agConnect.TestSpiffeIDService(t, "echo"),
+			CertURI: agConnect.TestSpiffeIDConsulService(t, "echo"),
 		})
 		if err != nil {
 			r.Fatalf("err: %s", err)

--- a/connect/resolver.go
+++ b/connect/resolver.go
@@ -149,7 +149,7 @@ func (cr *ConsulResolver) resolveServiceEntry(entry *api.ServiceEntry) (string, 
 	}
 
 	// Generate the expected CertURI
-	certURI := &connect.SpiffeIDService{
+	certURI := &connect.SpiffeIDConsulService{
 		// No host since we don't validate trust domain here (we rely on x509 to
 		// prove trust).
 		Namespace:  "default",

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -22,7 +22,7 @@ func TestStaticResolver_Resolve(t *testing.T) {
 	}{
 		{
 			name:   "simples",
-			fields: fields{"1.2.3.4:80", connect.TestSpiffeIDService(t, "foo")},
+			fields: fields{"1.2.3.4:80", connect.TestSpiffeIDConsulService(t, "foo")},
 		},
 	}
 	for _, tt := range tests {
@@ -126,7 +126,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 			},
 			// Want empty host since we don't enforce trust domain outside of TLS and
 			// don't need to load the current one this way.
-			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
+			wantCertURI: connect.TestSpiffeIDConsulServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},
@@ -139,7 +139,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 			},
 			// Want empty host since we don't enforce trust domain outside of TLS and
 			// don't need to load the current one this way.
-			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "db", ""),
+			wantCertURI: connect.TestSpiffeIDConsulServiceWithHost(t, "db", ""),
 			wantErr:     false,
 		},
 		{
@@ -178,7 +178,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 			},
 			// Want empty host since we don't enforce trust domain outside of TLS and
 			// don't need to load the current one this way.
-			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
+			wantCertURI: connect.TestSpiffeIDConsulServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},
@@ -190,7 +190,7 @@ func TestConsulResolver_Resolve(t *testing.T) {
 			},
 			// Want empty host since we don't enforce trust domain outside of TLS and
 			// don't need to load the current one this way.
-			wantCertURI: connect.TestSpiffeIDServiceWithHost(t, "web", ""),
+			wantCertURI: connect.TestSpiffeIDConsulServiceWithHost(t, "web", ""),
 			wantErr:     false,
 			addrs:       proxyAddrs,
 		},

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -96,7 +96,7 @@ func TestService_Dial(t *testing.T) {
 			// Always expect to be connecting to a "DB"
 			resolver := &StaticResolver{
 				Addr:    testSvr.Addr,
-				CertURI: connect.TestSpiffeIDService(t, "db"),
+				CertURI: connect.TestSpiffeIDConsulService(t, "db"),
 			}
 
 			// All test runs should complete in under 500ms due to the timeout about.
@@ -233,7 +233,7 @@ func TestService_HTTPClient(t *testing.T) {
 			//require.Equal("https://backend.service.consul:443", addr)
 			return &StaticResolver{
 				Addr:    testSvr.Addr,
-				CertURI: connect.TestSpiffeIDService(t, "backend"),
+				CertURI: connect.TestSpiffeIDConsulService(t, "backend"),
 			}, nil
 		}
 

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -26,7 +26,7 @@ func Test_verifyServerCertMatchesURI(t *testing.T) {
 		{
 			name:     "simple match",
 			certs:    TestPeerCertificates(t, "web", ca1),
-			expected: connect.TestSpiffeIDService(t, "web"),
+			expected: connect.TestSpiffeIDConsulService(t, "web"),
 			wantErr:  false,
 		},
 		{
@@ -34,25 +34,25 @@ func Test_verifyServerCertMatchesURI(t *testing.T) {
 			// validity is enforced with x509 name constraints where needed.
 			name:     "different trust-domain allowed",
 			certs:    TestPeerCertificates(t, "web", ca1),
-			expected: connect.TestSpiffeIDServiceWithHost(t, "web", "other.consul"),
+			expected: connect.TestSpiffeIDConsulServiceWithHost(t, "web", "other.consul"),
 			wantErr:  false,
 		},
 		{
 			name:     "mismatch",
 			certs:    TestPeerCertificates(t, "web", ca1),
-			expected: connect.TestSpiffeIDService(t, "db"),
+			expected: connect.TestSpiffeIDConsulService(t, "db"),
 			wantErr:  true,
 		},
 		{
 			name:     "no certs",
 			certs:    []*x509.Certificate{},
-			expected: connect.TestSpiffeIDService(t, "db"),
+			expected: connect.TestSpiffeIDConsulService(t, "db"),
 			wantErr:  true,
 		},
 		{
 			name:     "nil certs",
 			certs:    nil,
-			expected: connect.TestSpiffeIDService(t, "db"),
+			expected: connect.TestSpiffeIDConsulService(t, "db"),
 			wantErr:  true,
 		},
 	}


### PR DESCRIPTION
This change is needed because we are adding a new struct
`SpiffeIDExternalService` to respresent an external service. By renaming
this struct it will be clearer what the difference between the two is.