### PR TITLE
Add arm builds

### DIFF
--- a/.circleci/bash_env.sh
+++ b/.circleci/bash_env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export GIT_COMMIT=$(git rev-parse --short HEAD)
+export GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+export GIT_DESCRIBE=$(git describe --tags --always --match "v*")
+export GIT_IMPORT=github.com/hashicorp/consul/version
+export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
             GOARM: 6
             CC: arm-linux-gnueabihf-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/armhf/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armhf/consul  -ldflags="${GOLDFLAGS}"
       - run:
           environment:
             CC: aarch64-linux-gnu-gcc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ references:
     GIT_AUTHOR_NAME: circleci-consul
     GIT_COMMITTER_NAME: circleci-consul
     S3_ARTIFACT_BUCKET:  consul-dev-artifacts
+    BASH_ENV: .circleci/bash_env.sh
 
 jobs:
   # lint consul tests
@@ -140,6 +141,7 @@ jobs:
     docker:
       - image: *GOLANG_IMAGE
     environment: &build-env
+      <<: *ENVIRONMENT
       GOXPARALLEL: 2 # CircleCI containers are 2 CPU x 4GB RAM
     steps:
       - checkout
@@ -167,17 +169,42 @@ jobs:
       XC_ARCH: "amd64"
 
   # build all arm/arm64 architecture supported OS binaries
-  build-arm-arm64:
-    <<: *build-distros
+  build-arm:
+    docker:
+      - image: *GOLANG_IMAGE
     environment:
-      <<: *build-env
-      XC_OS: linux
-      XC_ARCH: "arm arm64"
+      <<: *ENVIRONMENT
+      CGO_ENABLED: 1
+      GOOS: linux
+    steps:
+      - checkout
+      - run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+      - run:
+          environment:
+            GOARM: 5
+            CC: arm-linux-gnueabi-gcc
+            GOARCH: arm
+          command: go build -o ./pkg/bin/armel/consul  -ldflags="${GOLDFLAGS}"
+      - run:
+          environment:
+            GOARM: 6
+            CC: arm-linux-gnueabihf-gcc
+            GOARCH: arm
+          command: go build -o ./pkg/bin/armhf/consul  -ldflags="${GOLDFLAGS}"
+      - run:
+          environment:
+            CC: aarch64-linux-gnu-gcc
+            GOARCH: arm64
+          command: go build -o ./pkg/bin/aarch64/consul  -ldflags="${GOLDFLAGS}"
+      - store_artifacts:
+          path: ./pkg/bin
 
   # create a development build
   dev-build:
     docker:
       - image: *GOLANG_IMAGE
+    environment:
+      <<: *ENVIRONMENT
     steps:
       - checkout
       - restore_cache:
@@ -493,7 +520,7 @@ workflows:
     jobs:
       - build-386
       - build-amd64
-      - build-arm-arm64
+      - build-arm
   test-integrations:
     jobs:
       - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
             GOARM: 5
             CC: arm-linux-gnueabi-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/armel/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armel/consul  -ldflags="${GOLDFLAGS}"
       - run:
           environment:
             GOARM: 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,7 @@ jobs:
           environment:
             CC: aarch64-linux-gnu-gcc
             GOARCH: arm64
-          command: go build -o ./pkg/bin/aarch64/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_aarch64/consul  -ldflags="${GOLDFLAGS}"
       - store_artifacts:
           path: ./pkg/bin
 


### PR DESCRIPTION
This adds ARM builds to the CI pipeline so we can test ARM builds are successful per commit just like the other OS/ARCH. It also adds GOLDFLAGS to the build process as I left that out previously, by sourcing `.circleci/bash_env.sh`