### PR TITLE
ui: Leader icon for node listing view

### DIFF
--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -20,6 +20,38 @@ export default Adapter.extend({
     }
     return this.appendURL('internal/ui/node', [query.id], this.cleanQuery(query));
   },
+  urlForRequest: function({ type, snapshot, requestType }) {
+    switch (requestType) {
+      case 'queryLeader':
+        return this.urlForQueryLeader(snapshot, type.modelName);
+    }
+    return this._super(...arguments);
+  },
+  urlForQueryLeader: function(query, modelName) {
+    // https://www.consul.io/api/status.html#get-raft-leader
+    return this.appendURL('status/leader', [], this.cleanQuery(query));
+  },
+  isQueryLeader: function(url, method) {
+    return url.pathname === this.parseURL(this.urlForQueryLeader({})).pathname;
+  },
+  queryLeader: function(store, modelClass, id, snapshot) {
+    const params = {
+      store: store,
+      type: modelClass,
+      id: id,
+      snapshot: snapshot,
+      requestType: 'queryLeader',
+    };
+    // _requestFor is private... but these methods aren't, until they disappear..
+    const request = {
+      method: this.methodForRequest(params),
+      url: this.urlForRequest(params),
+      headers: this.headersForRequest(params),
+      data: this.dataForRequest(params),
+    };
+    // TODO: private..
+    return this._makeRequest(request);
+  },
   handleBatchResponse: function(url, response, primary, slug) {
     const dc = url.searchParams.get(API_DATACENTER_KEY) || '';
     return response.map((item, i, arr) => {
@@ -41,7 +73,21 @@ export default Adapter.extend({
     const method = requestData.method;
     if (status === HTTP_OK) {
       const url = this.parseURL(requestData.url);
+      let temp, port, address;
       switch (true) {
+        case this.isQueryLeader(url, method):
+          // This response is just an ip:port like `"10.0.0.1:8000"`
+          // split it and make it look like a `C`onsul.`R`esponse
+          // popping off the end for ports should cover us for IPv6 addresses
+          // as we should always get a `address:port` or `[a:dd:re:ss]:port` combo
+          temp = response.split(':');
+          port = temp.pop();
+          address = temp.join(':');
+          response = {
+            Address: address,
+            Port: port,
+          };
+          break;
         case this.isQueryRecord(url, method):
           response = this.handleSingleResponse(url, fillSlug(response), PRIMARY_KEY, SLUG_KEY);
           break;

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -12,8 +12,10 @@ export default Route.extend({
     },
   },
   model: function(params) {
+    const dc = this.modelFor('dc').dc.Name;
     return hash({
-      items: get(this, 'repo').findAllByDatacenter(this.modelFor('dc').dc.Name),
+      items: get(this, 'repo').findAllByDatacenter(dc),
+      leader: get(this, 'repo').findByLeader(dc),
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/services/repository/node.js
+++ b/ui-v2/app/services/repository/node.js
@@ -1,9 +1,17 @@
 import RepositoryService from 'consul-ui/services/repository';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
+
 const modelName = 'node';
 export default RepositoryService.extend({
   coordinates: service('repository/coordinate'),
   getModelName: function() {
     return modelName;
+  },
+  findByLeader: function(dc) {
+    const query = {
+      dc: dc,
+    };
+    return get(this, 'store').queryLeader(this.getModelName(), query);
   },
 });

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -14,7 +14,7 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
       type: 'message',
       data: result,
     };
-    const meta = get(event.data || {}, 'meta');
+    const meta = get(event.data || {}, 'meta') || {};
     if (typeof meta.date !== 'undefined') {
       // unload anything older than our current sync date/time
       store.peekAll(repo.getModelName()).forEach(function(item) {

--- a/ui-v2/app/services/store.js
+++ b/ui-v2/app/services/store.js
@@ -23,4 +23,9 @@ export default Store.extend({
     const adapter = this.adapterFor(modelName);
     return adapter.self(this, { modelName: modelName }, token);
   },
+  queryLeader: function(modelName, query) {
+    // TODO: no normalization, type it properly for the moment
+    const adapter = this.adapterFor(modelName);
+    return adapter.queryLeader(this, { modelName: modelName }, null, query);
+  },
 });

--- a/ui-v2/app/styles/components/healthchecked-resource.scss
+++ b/ui-v2/app/styles/components/healthchecked-resource.scss
@@ -2,7 +2,6 @@
 .healthchecked-resource > div {
   @extend %stats-card;
 }
-
 %tooltip-below::after {
   top: calc(100% - 8px);
   bottom: auto;
@@ -12,6 +11,8 @@
 %tooltip-below::before {
   top: calc(100% + 4px);
   bottom: auto;
+  /*TODO: This should probably go into base*/
+  line-height: 1em;
 }
 %tooltip-left::before {
   right: 0;
@@ -21,8 +22,6 @@
 }
 %stats-card-icon {
   @extend %tooltip-below;
-  /*TODO: This should probably go into base*/
-  line-height: 1em;
 }
 %stats-card-icon:first-child::before {
   right: 0;

--- a/ui-v2/app/templates/components/healthchecked-resource.hbs
+++ b/ui-v2/app/templates/components/healthchecked-resource.hbs
@@ -1,5 +1,5 @@
 {{#stats-card}}
-  {{#block-slot 'icon'}}{{#if false}}<span data-tooltip="Leader">Leader</span>{{/if}}{{/block-slot}}
+  {{#block-slot 'icon'}}{{yield}}{{/block-slot}}
   {{#block-slot 'mini-stat'}}
     {{#if (eq checks.length 0)}}
       <span class="zero" data-tooltip="This node has no registered healthchecks">{{checks.length}}</span>

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -20,7 +20,7 @@
                   {{#changeable-set dispatcher=searchableUnhealthy}}
                     {{#block-slot 'set' as |unhealthy|}}
                       {{#each unhealthy as |item|}}
-                          {{healthchecked-resource
+                          {{#healthchecked-resource
                               tagName='li'
                               data-test-node=item.Node
                               href=(href-to 'dc.nodes.show' item.Node)
@@ -28,6 +28,12 @@
                               address=item.Address
                               checks=item.Checks
                           }}
+                            {{#block-slot 'icon'}}
+                              {{#if (eq item.Address leader.Address)}}
+                                <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                              {{/if}}
+                            {{/block-slot}}
+                          {{/healthchecked-resource}}
                       {{/each}}
                     {{/block-slot}}
                     {{#block-slot 'empty'}}
@@ -46,13 +52,19 @@
             {{#changeable-set dispatcher=searchableHealthy}}
               {{#block-slot 'set' as |healthy|}}
                 {{#list-collection cellHeight=92 items=healthy as |item index|}}
-                    {{healthchecked-resource
+                    {{#healthchecked-resource
                         data-test-node=item.Node
                         href=(href-to 'dc.nodes.show' item.Node)
                         name=item.Node
                         address=item.Address
                         checks=item.Checks
                     }}
+                      {{#block-slot 'icon'}}
+                        {{#if (eq item.Address leader.Address)}}
+                          <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                        {{/if}}
+                      {{/block-slot}}
+                    {{/healthchecked-resource}}
                 {{/list-collection}}
               {{/block-slot}}
               {{#block-slot 'empty'}}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,84 +1,84 @@
 {{#app-view class="node list"}}
-    {{#block-slot 'header'}}
-        <h1>
-            Nodes <em>{{format-number items.length}} total</em>
-        </h1>
-        <label for="toolbar-toggle"></label>
-    {{/block-slot}}
-    {{#block-slot 'toolbar'}}
+  {{#block-slot 'header'}}
+    <h1>
+      Nodes <em>{{format-number items.length}} total</em>
+    </h1>
+    <label for="toolbar-toggle"></label>
+  {{/block-slot}}
+  {{#block-slot 'toolbar'}}
 {{#if (gt items.length 0) }}
-        {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
+    {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
 {{/if}}
-    {{/block-slot}}
-    {{#block-slot 'content'}}
+  {{/block-slot}}
+  {{#block-slot 'content'}}
 {{#if (gt unhealthy.length 0) }}
-        <div class="unhealthy">
-            <h2>Unhealthy Nodes</h2>
-            <div>
-                {{! think about 2 differing views here }}
-                <ul>
-                  {{#changeable-set dispatcher=searchableUnhealthy}}
-                    {{#block-slot 'set' as |unhealthy|}}
-                      {{#each unhealthy as |item|}}
-                          {{#healthchecked-resource
-                              tagName='li'
-                              data-test-node=item.Node
-                              href=(href-to 'dc.nodes.show' item.Node)
-                              name=item.Node
-                              address=item.Address
-                              checks=item.Checks
-                          }}
-                            {{#block-slot 'icon'}}
-                              {{#if (eq item.Address leader.Address)}}
-                                <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                              {{/if}}
-                            {{/block-slot}}
-                          {{/healthchecked-resource}}
-                      {{/each}}
+      <div class="unhealthy">
+        <h2>Unhealthy Nodes</h2>
+        <div>
+          {{! think about 2 differing views here }}
+          <ul>
+            {{#changeable-set dispatcher=searchableUnhealthy}}
+              {{#block-slot 'set' as |unhealthy|}}
+                {{#each unhealthy as |item|}}
+                  {{#healthchecked-resource
+                      tagName='li'
+                      data-test-node=item.Node
+                      href=(href-to 'dc.nodes.show' item.Node)
+                      name=item.Node
+                      address=item.Address
+                      checks=item.Checks
+                  }}
+                    {{#block-slot 'icon'}}
+                      {{#if (eq item.Address leader.Address)}}
+                        <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                      {{/if}}
                     {{/block-slot}}
-                    {{#block-slot 'empty'}}
-                      <p>
-                        There are no unhealthy nodes for that search.
-                      </p>
-                    {{/block-slot}}
-                  {{/changeable-set}}
-                </ul>
-            </div>
-        </div>
-{{/if}}
-{{#if (gt healthy.length 0) }}
-        <div class="healthy">
-            <h2>Healthy Nodes</h2>
-            {{#changeable-set dispatcher=searchableHealthy}}
-              {{#block-slot 'set' as |healthy|}}
-                {{#list-collection cellHeight=92 items=healthy as |item index|}}
-                    {{#healthchecked-resource
-                        data-test-node=item.Node
-                        href=(href-to 'dc.nodes.show' item.Node)
-                        name=item.Node
-                        address=item.Address
-                        checks=item.Checks
-                    }}
-                      {{#block-slot 'icon'}}
-                        {{#if (eq item.Address leader.Address)}}
-                          <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                        {{/if}}
-                      {{/block-slot}}
-                    {{/healthchecked-resource}}
-                {{/list-collection}}
+                  {{/healthchecked-resource}}
+                {{/each}}
               {{/block-slot}}
               {{#block-slot 'empty'}}
                 <p>
-                  There are no healthy nodes for that search.
+                  There are no unhealthy nodes for that search.
                 </p>
               {{/block-slot}}
             {{/changeable-set}}
+          </ul>
         </div>
+      </div>
+{{/if}}
+{{#if (gt healthy.length 0) }}
+      <div class="healthy">
+        <h2>Healthy Nodes</h2>
+        {{#changeable-set dispatcher=searchableHealthy}}
+          {{#block-slot 'set' as |healthy|}}
+            {{#list-collection cellHeight=92 items=healthy as |item index|}}
+              {{#healthchecked-resource
+                  data-test-node=item.Node
+                  href=(href-to 'dc.nodes.show' item.Node)
+                  name=item.Node
+                  address=item.Address
+                  checks=item.Checks
+              }}
+                {{#block-slot 'icon'}}
+                  {{#if (eq item.Address leader.Address)}}
+                    <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                  {{/if}}
+                {{/block-slot}}
+              {{/healthchecked-resource}}
+            {{/list-collection}}
+          {{/block-slot}}
+          {{#block-slot 'empty'}}
+            <p>
+              There are no healthy nodes for that search.
+            </p>
+          {{/block-slot}}
+        {{/changeable-set}}
+      </div>
 {{/if}}
 {{#if (and (eq healthy.length 0) (eq unhealthy.length 0)) }}
-    <p>
-        There are no nodes.
-    </p>
+      <p>
+          There are no nodes.
+      </p>
 {{/if}}
-    {{/block-slot}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -52,6 +52,7 @@
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^2.4.5",
     "chalk": "^2.4.2",
+    "clipboard": "^2.0.4",
     "dart-sass": "^1.14.1",
     "ember-ajax": "^3.0.0",
     "ember-auto-import": "^1.4.0",
@@ -103,8 +104,7 @@
     "node-sass": "^4.9.3",
     "prettier": "^1.10.2",
     "svgo": "^1.0.5",
-    "text-encoding": "^0.6.4",
-    "clipboard": "^2.0.4"
+    "text-encoding": "^0.6.4"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/ui-v2/tests/acceptance/dc/nodes/index.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/index.feature
@@ -1,11 +1,51 @@
 @setupApplicationTest
-Feature: Nodes
-  Scenario:
+Feature: dc / nodes / index
+  Background:
     Given 1 datacenter model with the value "dc-1"
-    And 3 node models
+    And the url "/v1/status/leader" responds with from yaml
+    ---
+    body: |
+      "211.245.86.75:8500"
+    ---
+  Scenario: Viewing nodes in the listing
+    Given 3 node models
     When I visit the nodes page for yaml
     ---
       dc: dc-1
     ---
     Then the url should be /dc-1/nodes
     Then I see 3 node models
+  Scenario: Seeing the leader in unhealthy listing
+    Given 3 node models from yaml
+    ---
+      - Address: 211.245.86.75
+        Checks:
+          - Status: warning
+            Name: Warning check
+      - Address: 10.0.0.1
+      - Address: 10.0.0.3
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see 3 node models
+    And I see leader on the unHealthyNodes
+  Scenario: Seeing the leader in healthy listing
+    Given 3 node models from yaml
+    ---
+      - Address: 211.245.86.75
+        Checks:
+          - Status: passing
+            Name: Passing check
+      - Address: 10.0.0.1
+      - Address: 10.0.0.3
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see 3 node models
+    And I see leader on the healthyNodes

--- a/ui-v2/tests/acceptance/dc/nodes/no-leader.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/no-leader.feature
@@ -1,0 +1,18 @@
+@setupApplicationTest
+Feature: dc / nodes / no-leader
+  Scenario: Leader hasn't been elected
+    Given 1 datacenter model with the value "dc-1"
+    And 3 node models
+    And the url "/v1/status/leader" responds with from yaml
+    ---
+    body: |
+      ""
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/nodes
+    Then I see 3 node models
+    And I don't see leader on the nodes
+

--- a/ui-v2/tests/acceptance/page-navigation.feature
+++ b/ui-v2/tests/acceptance/page-navigation.feature
@@ -23,7 +23,7 @@ Feature: Page Navigation
   Where:
     -----------------------------------------------------------------------
     | Link       | URL               | Endpoint                           |
-    | nodes      | /dc-1/nodes       | /v1/internal/ui/nodes?dc=dc-1      |
+    | nodes      | /dc-1/nodes       | /v1/status/leader?dc=dc-1          |
     | kvs        | /dc-1/kv          | /v1/kv/?keys&dc=dc-1&separator=%2F |
     | acls       | /dc-1/acls/tokens | /v1/acl/tokens?dc=dc-1             |
     | intentions | /dc-1/intentions  | /v1/connect/intentions?dc=dc-1     |

--- a/ui-v2/tests/acceptance/steps/dc/nodes/no-leader-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nodes/no-leader-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages/dc/nodes/index.js
+++ b/ui-v2/tests/pages/dc/nodes/index.js
@@ -1,10 +1,14 @@
 export default function(visitable, clickable, attribute, collection, filter) {
+  const node = {
+    name: attribute('data-test-node'),
+    leader: attribute('data-test-leader', '[data-test-leader]'),
+    node: clickable('header a'),
+  };
   return {
     visit: visitable('/:dc/nodes'),
-    nodes: collection('[data-test-node]', {
-      name: attribute('data-test-node'),
-      node: clickable('header a'),
-    }),
+    nodes: collection('[data-test-node]', node),
+    healthyNodes: collection('.healthy [data-test-node]', node),
+    unHealthyNodes: collection('.unhealthy [data-test-node]', node),
     filter: filter,
   };
 }

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -880,9 +880,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^2.0.1":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.3.0.tgz#1163f6dacb29d43d8dac4d1473263c257321682a"
-  integrity sha512-wbaOyOoA1X5Ur7Gj4VSZkor1zuJ2+GTbavPJGtpZZXd6CtL3RXC4HaldruBIF79j3lBXVgS/Y9ETMfGLdoAYgA==
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.5.0.tgz#d9540a38ee652d55ed90956850c9e5cbcde89454"
+  integrity sha512-RZcVIPQ4M4TZzFe2mWm7M5w28yOIpVgiYZI5ax+JG0Yr5TVbhJPMxhdb1es73cILuqIi9Fr+73OJ5IAospgPBw==
 
 "@hashicorp/ember-cli-api-double@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This builds upon the leader icons that where added here https://github.com/hashicorp/consul/pull/6021 but just `if`ed out temporarily.

It addresses one part of https://github.com/hashicorp/consul/issues/5073 by showing the leader in the node listing using a star icon and tooltip for further clarification.

To note:

The endpoint we are using doesn't support blocking queries we had 3 choices here:

1. Everytime a blocking query for nodes resolves, immediately request the leader information again
2. Make a 'fake' blocking query for the `status/leader` endpoint on the frontend, by hardcoding a 'cursor' for this endpoint, and essentially make it poll.
3. Only request the leader information when the user enters the node listing page.

After talking to other in the team a while ago we went with point 3 here. On the basis that the leader doesn't update too often (potentially why the endpoint doesn't support blocking queries).

~Potentially there is still a little work to do here, in that we may need to add something to cope with the state of consul when waiting for leader election. I thought it best to get eyes on this as soon as possible, and we can add any extra for this case ontop of here (either more commits or a PR ontop of this)~

<img width="802" alt="Screenshot 2019-08-02 at 16 04 02" src="https://user-images.githubusercontent.com/554604/62375730-30ee4700-b53f-11e9-9043-d19ae1bd709a.png">



