### PR TITLE
ui: Change signature of request/respond methods to take serialized and unserialized data

### DIFF
--- a/ui-v2/app/adapters/acl.js
+++ b/ui-v2/app/adapters/acl.js
@@ -1,5 +1,4 @@
 import Adapter, { DATACENTER_QUERY_PARAM as API_DATACENTER_KEY } from './application';
-import { get } from '@ember/object';
 import { SLUG_KEY } from 'consul-ui/models/acl';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 
@@ -53,12 +52,15 @@ export default Adapter.extend({
     `;
   },
   clone: function(store, type, id, snapshot) {
-    const serializer = store.serializerFor(type.modelName);
-    const unserialized = this.snapshotToJSON(snapshot, type);
-    const serialized = serializer.serialize(snapshot, {});
-    return get(this, 'client')
-      .request(request => this.requestForClone(request, serialized, unserialized))
-      .catch(e => adapter.error(e))
-      .then(respond => serializer.respondForQueryRecord(respond, serialized, unserialized));
+    return this.request(
+      function(adapter, request, serialized, unserialized) {
+        return adapter.requestForCloneRecord(request, serialized, unserialized);
+      },
+      function(serializer, response, serialized, unserialized) {
+        return serializer.respondForCreateRecord(response, serialized, unserialized);
+      },
+      snapshot,
+      type.modelName
+    );
   },
 });

--- a/ui-v2/app/adapters/acl.js
+++ b/ui-v2/app/adapters/acl.js
@@ -32,7 +32,7 @@ export default Adapter.extend({
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
-    // the id is in the data, don't add it in here
+    // the id is in the data, don't add it into the URL
     // https://www.consul.io/api/acl.html#update-acl-token
     return request`
       PUT /v1/acl/update?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
@@ -58,6 +58,7 @@ export default Adapter.extend({
     const serialized = serializer.serialize(snapshot, {});
     return get(this, 'client')
       .request(request => this.requestForClone(request, serialized, unserialized))
-      .then(respond => serializer.respondForQueryRecord(respond, unserialized));
+      .catch(e => adapter.error(e))
+      .then(respond => serializer.respondForQueryRecord(respond, serialized, unserialized));
   },
 });

--- a/ui-v2/app/adapters/acl.js
+++ b/ui-v2/app/adapters/acl.js
@@ -1,9 +1,7 @@
 import Adapter, { DATACENTER_QUERY_PARAM as API_DATACENTER_KEY } from './application';
 import { get } from '@ember/object';
-import EmberError from '@ember/error';
-import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/acl';
+import { SLUG_KEY } from 'consul-ui/models/acl';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
-import { OK as HTTP_OK, UNAUTHORIZED as HTTP_UNAUTHORIZED } from 'consul-ui/utils/http/status';
 
 export default Adapter.extend({
   requestForQuery: function(request, { dc, index }) {
@@ -25,26 +23,30 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
     // https://www.consul.io/api/acl.html#create-acl-token
     return request`
       PUT /v1/acl/create?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
+  requestForUpdateRecord: function(request, serialized, data) {
     // the id is in the data, don't add it in here
     // https://www.consul.io/api/acl.html#update-acl-token
     return request`
       PUT /v1/acl/update?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     // https://www.consul.io/api/acl.html#delete-acl-token
     return request`
       PUT /v1/acl/destroy/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;
   },
-  requestForCloneRecord: function(request, data) {
+  requestForCloneRecord: function(request, serialized, data) {
     // https://www.consul.io/api/acl.html#clone-acl-token
     return request`
       PUT /v1/acl/clone/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
@@ -55,35 +57,7 @@ export default Adapter.extend({
     const unserialized = this.snapshotToJSON(snapshot, type);
     const serialized = serializer.serialize(snapshot, {});
     return get(this, 'client')
-      .request(request => this.requestForClone(request, unserialized), serialized)
+      .request(request => this.requestForClone(request, serialized, unserialized))
       .then(respond => serializer.respondForQueryRecord(respond, unserialized));
-  },
-  handleResponse: function(status, headers, payload, requestData) {
-    let response = payload;
-    const method = requestData.method;
-    if (status === HTTP_OK) {
-      const url = this.parseURL(requestData.url);
-      switch (true) {
-        case response === true:
-          response = this.handleBooleanResponse(url, response, PRIMARY_KEY, SLUG_KEY);
-          break;
-        case this.isQueryRecord(url):
-          response = this.handleSingleResponse(url, response[0], PRIMARY_KEY, SLUG_KEY);
-          break;
-        case this.isUpdateRecord(url, method):
-        case this.isCreateRecord(url, method):
-        case this.isCloneRecord(url, method):
-          response = this.handleSingleResponse(url, response, PRIMARY_KEY, SLUG_KEY);
-          break;
-        default:
-          response = this.handleBatchResponse(url, response, PRIMARY_KEY, SLUG_KEY);
-      }
-    } else if (status === HTTP_UNAUTHORIZED) {
-      const e = new EmberError();
-      e.code = status;
-      e.message = payload;
-      throw e;
-    }
-    return this._super(status, headers, response, requestData);
   },
 });

--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -1,8 +1,46 @@
 import Adapter from './http';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export const DATACENTER_QUERY_PARAM = 'dc';
 export default Adapter.extend({
   repo: service('settings'),
   client: service('client/http'),
+  // TODO: kinda protected for the moment
+  // decide where this should go either read/write from http
+  // should somehow use this or vice versa
+  request: function(req, resp, obj, modelName) {
+    const client = get(this, 'client');
+    const store = get(this, 'store');
+    const adapter = this;
+
+    let unserialized, serialized;
+    const serializer = store.serializerFor(modelName);
+    // workable way to decide whether this is a snapshot
+    // essentially 'is attributable'.
+    // Snapshot is private so we can't do instanceof here
+    if (typeof obj.attributes === 'function') {
+      unserialized = obj.attributes();
+      serialized = serializer.serialize(obj, {});
+    } else {
+      unserialized = obj;
+      serialized = unserialized;
+    }
+
+    return client
+      .request(function(request) {
+        return req(adapter, request, serialized, unserialized);
+      })
+      .catch(function(e) {
+        return adapter.error(e);
+      })
+      .then(function(response) {
+        // TODO: When HTTPAdapter:responder changes, this will also need to change
+        return resp(serializer, response, serialized, unserialized);
+      });
+    // TODO: Potentially add specific serializer errors here
+    // .catch(function(e) {
+    //   return Promise.reject(e);
+    // });
+  },
 });

--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -1,7 +1,6 @@
 import Adapter from './http';
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
-
 export const DATACENTER_QUERY_PARAM = 'dc';
 export default Adapter.extend({
   repo: service('settings'),
@@ -17,9 +16,8 @@ export default Adapter.extend({
     let unserialized, serialized;
     const serializer = store.serializerFor(modelName);
     // workable way to decide whether this is a snapshot
-    // essentially 'is attributable'.
     // Snapshot is private so we can't do instanceof here
-    if (typeof obj.attributes === 'function') {
+    if (obj.constructor.name === 'Snapshot') {
       unserialized = obj.attributes();
       serialized = serializer.serialize(obj, {});
     } else {

--- a/ui-v2/app/adapters/intention.js
+++ b/ui-v2/app/adapters/intention.js
@@ -19,18 +19,22 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
     // TODO: need to make sure we remove dc
     return request`
       POST /v1/connect/intentions?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
+  requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/connect/intentions/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     return request`
       DELETE /v1/connect/intentions/${data[SLUG_KEY]}?${{
       [API_DATACENTER_KEY]: data[DATACENTER_KEY],

--- a/ui-v2/app/adapters/kv.js
+++ b/ui-v2/app/adapters/kv.js
@@ -28,19 +28,23 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
+    return request`
+      PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+      Content-Type: text/plain; charset=utf-8
+
+      ${serialized}
+    `;
+  },
+  requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
       Content-Type: application/x-www-form-urlencoded
+
+      ${serialized}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
-    return request`
-      PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
-      Content-Type: application/x-www-form-urlencoded
-    `;
-  },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     let recurse;
     if (isFolder(data[SLUG_KEY])) {
       recurse = null;

--- a/ui-v2/app/adapters/kv.js
+++ b/ui-v2/app/adapters/kv.js
@@ -28,6 +28,8 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
+  // TODO: Why are we using 2 different headers here for
+  // create and update?
   requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}

--- a/ui-v2/app/adapters/kv.js
+++ b/ui-v2/app/adapters/kv.js
@@ -28,8 +28,8 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  // TODO: Why are we using 2 different headers here for
-  // create and update?
+  // TODO: Should we replace text/plain here with x-www-form-encoded?
+  // See https://github.com/hashicorp/consul/issues/3804
   requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
@@ -41,7 +41,7 @@ export default Adapter.extend({
   requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/kv/${keyToArray(data[SLUG_KEY])}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
-      Content-Type: application/x-www-form-urlencoded
+      Content-Type: text/plain; charset=utf-8
 
       ${serialized}
     `;

--- a/ui-v2/app/adapters/policy.js
+++ b/ui-v2/app/adapters/policy.js
@@ -21,17 +21,21 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/policy?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
+  requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/policy/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     return request`
       DELETE /v1/acl/policy/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;

--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -21,17 +21,21 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/role?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
+  requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/role/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     return request`
       DELETE /v1/acl/role/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;

--- a/ui-v2/app/adapters/session.js
+++ b/ui-v2/app/adapters/session.js
@@ -23,7 +23,7 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     return request`
       PUT /v1/session/destroy/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -24,30 +24,31 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  requestForCreateRecord: function(request, data) {
+  requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/token?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;
   },
-  requestForUpdateRecord: function(request, data) {
-    // TODO: Serializer - Pretty sure this can go now
+  requestForUpdateRecord: function(request, serialized, data) {
+    // TODO: here we check data['Rules'] not serialized['Rules']
+    // data.Rules is not undefined, and serialized.Rules is not null
+    // revisit this at some point we should probably use serialized here
     // If a token has Rules, use the old API
     if (typeof data['Rules'] !== 'undefined') {
-      // TODO: need to clean up vars sent
-      data['ID'] = data['SecretID'];
-      data['Name'] = data['Description'];
+      // https://www.consul.io/api/acl/legacy.html#update-acl-token
       return request`
         PUT /v1/acl/update?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+        ${serialized}
       `;
-    }
-    if (typeof data['SecretID'] !== 'undefined') {
-      delete data['SecretID'];
     }
     return request`
       PUT /v1/acl/token/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${serialized}
     `;
   },
-  requestForDeleteRecord: function(request, data) {
+  requestForDeleteRecord: function(request, serialized, data) {
     return request`
       DELETE /v1/acl/token/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
     `;

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -63,7 +63,6 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  // TODO: We should probably call this requestForCloneRecord
   requestForCloneRecord: function(request, serialized, unserialized) {
     // this uses snapshots
     const id = unserialized[SLUG_KEY];

--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -37,7 +37,7 @@ export default Serializer.extend({
       attachHeaders(headers, this.fingerprint(this.primaryKey, this.slugKey, query.dc)(body))
     );
   },
-  respondForCreateRecord: function(respond, data) {
+  respondForCreateRecord: function(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
     return respond((headers, body) => {
@@ -49,7 +49,7 @@ export default Serializer.extend({
       return this.fingerprint(primaryKey, slugKey, data[DATACENTER_KEY])(body);
     });
   },
-  respondForUpdateRecord: function(respond, data) {
+  respondForUpdateRecord: function(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
     return respond((headers, body) => {
@@ -60,7 +60,7 @@ export default Serializer.extend({
       return this.fingerprint(primaryKey, slugKey, data[DATACENTER_KEY])(body);
     });
   },
-  respondForDeleteRecord: function(respond, data) {
+  respondForDeleteRecord: function(respond, serialized, data) {
     const slugKey = this.slugKey;
     const primaryKey = this.primaryKey;
     return respond((headers, body) => {

--- a/ui-v2/app/serializers/token.js
+++ b/ui-v2/app/serializers/token.js
@@ -10,21 +10,25 @@ export default Serializer.extend(WithPolicies, WithRoles, {
   slugKey: SLUG_KEY,
   attrs: ATTRS,
   serialize: function(snapshot, options) {
-    const data = this._super(...arguments);
-    // TODO: Check this as it used to be only on update
-    // Pretty sure Rules will only ever be on update as you can't
-    // create legacy tokens here
-    if (typeof data['Rules'] !== 'undefined') {
-      data['ID'] = data['SecretID'];
-      data['Name'] = data['Description'];
+    let data = this._super(...arguments);
+    // If a token has Rules, use the old API shape
+    // notice we use a null check here (not an undefined check)
+    // as we are dealing with the serialized model not raw user data
+    if (data['Rules'] !== null) {
+      data = {
+        ID: data.SecretID,
+        Name: data.Description,
+        Type: data.Type,
+        Rules: data.Rules,
+      };
     }
     // make sure we never send the SecretID
-    if (data && typeof data['SecretID'] !== 'undefined') {
+    if (data) {
       delete data['SecretID'];
     }
     return data;
   },
-  respondForUpdateRecord: function(respond, query) {
+  respondForUpdateRecord: function(respond, serialized, data) {
     return this._super(
       cb =>
         respond((headers, body) => {
@@ -44,7 +48,8 @@ export default Serializer.extend(WithPolicies, WithRoles, {
           }
           return cb(headers, body);
         }),
-      query
+      serialized,
+      data
     );
   },
 });

--- a/ui-v2/app/serializers/token.js
+++ b/ui-v2/app/serializers/token.js
@@ -23,6 +23,10 @@ export default Serializer.extend(WithPolicies, WithRoles, {
       };
     }
     // make sure we never send the SecretID
+    // TODO: If we selectively format the request payload in the adapter
+    // we won't have to do this here
+    // see side note in https://github.com/hashicorp/consul/pull/6285
+    // which will mean most if not all of this method can go
     if (data) {
       delete data['SecretID'];
     }

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -185,6 +185,8 @@ export default Service.extend({
         // temporarily reset the headers/content-type so it works the same
         // as previously, should be able to remove this once the data layer
         // rewrite is over and we can assert sending via form-encoded is fine
+        // also see adapters/kv content-types in requestForCreate/UpdateRecord
+        // also see https://github.com/hashicorp/consul/issues/3804
         options.contentType = 'application/json; charset=utf-8';
         headers['Content-Type'] = options.contentType;
         //

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -30,6 +30,11 @@ const dispose = function(request) {
   }
   return request;
 };
+// TODO: Potentially url should check if any of the params
+// passed to it are undefined (null is fine). We could then get rid of the
+// multitude of checks we do throughout the adapters
+// right now createURL converts undefined to '' so we need to check thats not needed
+// anywhere (todo written here for visibility)
 const url = createURL(encodeURIComponent);
 export default Service.extend({
   dom: service('dom'),

--- a/ui-v2/app/services/store.js
+++ b/ui-v2/app/services/store.js
@@ -21,6 +21,6 @@ export default Store.extend({
   self: function(modelName, token) {
     // TODO: no normalization, type it properly for the moment
     const adapter = this.adapterFor(modelName);
-    return adapter.self(this, { modelName: modelName }, token);
+    return adapter.self(this, { modelName: modelName }, token.secret, token);
   },
 });

--- a/ui-v2/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/edit.hbs
@@ -43,7 +43,7 @@
       {{/confirmation-dialog}}
   {{/if}}
   {{#if (not (token/is-legacy item))}}
-      <button type="button" {{ action "clone" item }}>Duplicate</button>
+      <button data-test-clone type="button" {{ action "clone" item }}>Duplicate</button>
   {{/if}}
 {{/if}}
     {{/block-slot}}

--- a/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
@@ -1,0 +1,29 @@
+@setupApplicationTest
+Feature: dc / acls / tokens / clone: Cloning an ACL token
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 token model from yaml
+    ---
+      AccessorID: token
+      SecretID: ee52203d-989f-4f7a-ab5a-2bef004164ca
+    ---
+  Scenario: Cloning an ACL token from the listing page
+    When I visit the tokens page for yaml
+    ---
+      dc: datacenter
+    ---
+    And I click actions on the tokens
+    And I click clone on the tokens
+    Then a PUT request is made to "/v1/acl/token/token/clone?dc=datacenter"
+    Then "[data-notification]" has the "notification-clone" class
+    And "[data-notification]" has the "success" class
+  Scenario: Using an ACL token from the detail page
+    When I visit the token page for yaml
+    ---
+      dc: datacenter
+      token: token
+    ---
+    And I click clone
+    Then the url should be /datacenter/acls/tokens
+    Then "[data-notification]" has the "notification-clone" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/steps/dc/acls/tokens/clone-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/acls/tokens/clone-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/integration/adapters/acl-test.js
+++ b/ui-v2/tests/integration/adapters/acl-test.js
@@ -37,10 +37,14 @@ module('Integration | Adapter | acl', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/create?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -49,10 +53,14 @@ module('Integration | Adapter | acl', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/update?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -61,10 +69,14 @@ module('Integration | Adapter | acl', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/destroy/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('/n')[0];
     assert.equal(actual, expected);
   });
@@ -73,10 +85,14 @@ module('Integration | Adapter | acl', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/clone/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForCloneRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForCloneRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/intention-test.js
+++ b/ui-v2/tests/integration/adapters/intention-test.js
@@ -37,10 +37,14 @@ module('Integration | Adapter | intention', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `POST /v1/connect/intentions?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -49,10 +53,14 @@ module('Integration | Adapter | intention', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/connect/intentions/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -61,10 +69,14 @@ module('Integration | Adapter | intention', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `DELETE /v1/connect/intentions/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/kv-test.js
+++ b/ui-v2/tests/integration/adapters/kv-test.js
@@ -47,11 +47,15 @@ module('Integration | Adapter | kv', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/kv/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-        Key: id,
-        Value: '',
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          Key: id,
+          Value: '',
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -60,11 +64,15 @@ module('Integration | Adapter | kv', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/kv/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        Key: id,
-        Value: '',
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          Key: id,
+          Value: '',
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -72,10 +80,14 @@ module('Integration | Adapter | kv', function(hooks) {
     const adapter = this.owner.lookup('adapter:kv');
     const client = this.owner.lookup('service:client/http');
     const expected = `DELETE /v1/kv/${id}?dc=${dc}`;
-    const actual = adapter.requestForDeleteRecord(client.url, {
-      Datacenter: dc,
-      Key: id,
-    });
+    const actual = adapter.requestForDeleteRecord(
+      client.url,
+      {},
+      {
+        Datacenter: dc,
+        Key: id,
+      }
+    );
     assert.equal(actual, expected);
   });
   test('requestForDeleteRecord returns the correct url/method for folders', function(assert) {
@@ -83,10 +95,14 @@ module('Integration | Adapter | kv', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const folder = `${id}/`;
     const expected = `DELETE /v1/kv/${folder}?dc=${dc}&recurse`;
-    const actual = adapter.requestForDeleteRecord(client.url, {
-      Datacenter: dc,
-      Key: folder,
-    });
+    const actual = adapter.requestForDeleteRecord(
+      client.url,
+      {},
+      {
+        Datacenter: dc,
+        Key: folder,
+      }
+    );
     assert.equal(actual, expected);
   });
 });

--- a/ui-v2/tests/integration/adapters/policy-test.js
+++ b/ui-v2/tests/integration/adapters/policy-test.js
@@ -37,9 +37,13 @@ module('Integration | Adapter | policy', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/policy?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -48,10 +52,14 @@ module('Integration | Adapter | policy', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/policy/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -60,10 +68,14 @@ module('Integration | Adapter | policy', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `DELETE /v1/acl/policy/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/role-test.js
+++ b/ui-v2/tests/integration/adapters/role-test.js
@@ -37,9 +37,13 @@ module('Integration | Adapter | role', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/role?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -48,10 +52,14 @@ module('Integration | Adapter | role', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/role/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -60,10 +68,14 @@ module('Integration | Adapter | role', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `DELETE /v1/acl/role/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/session-test.js
+++ b/ui-v2/tests/integration/adapters/session-test.js
@@ -48,10 +48,14 @@ module('Integration | Adapter | session', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/session/destroy/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        ID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          ID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/token-test.js
+++ b/ui-v2/tests/integration/adapters/token-test.js
@@ -57,9 +57,13 @@ module('Integration | Adapter | token', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/token?dc=${dc}`;
     const actual = adapter
-      .requestForCreateRecord(client.url, {
-        Datacenter: dc,
-      })
+      .requestForCreateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -68,10 +72,14 @@ module('Integration | Adapter | token', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/token/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Datacenter: dc,
-        AccessorID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          AccessorID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -80,11 +88,15 @@ module('Integration | Adapter | token', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/update?dc=${dc}`;
     const actual = adapter
-      .requestForUpdateRecord(client.url, {
-        Rules: 'key {}',
-        Datacenter: dc,
-        AccessorID: id,
-      })
+      .requestForUpdateRecord(
+        client.url,
+        {},
+        {
+          Rules: 'key {}',
+          Datacenter: dc,
+          AccessorID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });
@@ -93,10 +105,14 @@ module('Integration | Adapter | token', function(hooks) {
     const client = this.owner.lookup('service:client/http');
     const expected = `DELETE /v1/acl/token/${id}?dc=${dc}`;
     const actual = adapter
-      .requestForDeleteRecord(client.url, {
-        Datacenter: dc,
-        AccessorID: id,
-      })
+      .requestForDeleteRecord(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          AccessorID: id,
+        }
+      )
       .split('\n')[0];
     assert.equal(actual, expected);
   });

--- a/ui-v2/tests/integration/adapters/token-test.js
+++ b/ui-v2/tests/integration/adapters/token-test.js
@@ -116,12 +116,12 @@ module('Integration | Adapter | token', function(hooks) {
       .split('\n')[0];
     assert.equal(actual, expected);
   });
-  test('requestForClone returns the correct url', function(assert) {
+  test('requestForCloneRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:token');
     const client = this.owner.lookup('service:client/http');
     const expected = `PUT /v1/acl/token/${id}/clone?dc=${dc}`;
     const actual = adapter
-      .requestForClone(
+      .requestForCloneRecord(
         client.url,
         {},
         {

--- a/ui-v2/tests/integration/adapters/token-test.js
+++ b/ui-v2/tests/integration/adapters/token-test.js
@@ -116,4 +116,53 @@ module('Integration | Adapter | token', function(hooks) {
       .split('\n')[0];
     assert.equal(actual, expected);
   });
+  test('requestForClone returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:token');
+    const client = this.owner.lookup('service:client/http');
+    const expected = `PUT /v1/acl/token/${id}/clone?dc=${dc}`;
+    const actual = adapter
+      .requestForClone(
+        client.url,
+        {},
+        {
+          Datacenter: dc,
+          AccessorID: id,
+        }
+      )
+      .split('\n')[0];
+    assert.equal(actual, expected);
+  });
+  test('requestForSelf returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:token');
+    const client = this.owner.lookup('service:client/http');
+    const expected = `GET /v1/acl/token/self?dc=${dc}`;
+    const actual = adapter
+      .requestForSelf(
+        client.url,
+        {},
+        {
+          dc: dc,
+        }
+      )
+      .split('\n')[0];
+    assert.equal(actual, expected);
+  });
+  test('requestForSelf sets a token header using a secret', function(assert) {
+    const adapter = this.owner.lookup('adapter:token');
+    const client = this.owner.lookup('service:client/http');
+    const secret = 'sssh';
+    const expected = `X-Consul-Token: ${secret}`;
+    const actual = adapter
+      .requestForSelf(
+        client.url,
+        {},
+        {
+          dc: dc,
+          secret: secret,
+        }
+      )
+      .split('\n')[1]
+      .trim();
+    assert.equal(actual, expected);
+  });
 });

--- a/ui-v2/tests/pages/dc/acls/tokens/edit.js
+++ b/ui-v2/tests/pages/dc/acls/tokens/edit.js
@@ -14,6 +14,7 @@ export default function(
     ...deletable({}, 'form > div'),
     use: clickable('[data-test-use]'),
     confirmUse: clickable('button.type-delete'),
+    clone: clickable('[data-test-clone]'),
     policies: policySelector(),
     roles: roleSelector(),
   };

--- a/ui-v2/tests/pages/dc/acls/tokens/index.js
+++ b/ui-v2/tests/pages/dc/acls/tokens/index.js
@@ -25,6 +25,7 @@ export default function(
           actions: clickable('label'),
           use: clickable('[data-test-use]'),
           confirmUse: clickable('button.type-delete'),
+          clone: clickable('[data-test-clone]'),
         })
       ),
       filter: filter,

--- a/ui-v2/tests/unit/serializers/application-test.js
+++ b/ui-v2/tests/unit/serializers/application-test.js
@@ -37,7 +37,7 @@ module('Unit | Serializer | application', function(hooks) {
     const expected = {
       'primary-key-name': 'name',
     };
-    const actual = serializer.respondForDeleteRecord(respond, { Name: 'name', dc: 'dc-1' });
+    const actual = serializer.respondForDeleteRecord(respond, {}, { Name: 'name', dc: 'dc-1' });
     assert.deepEqual(actual, expected);
     // assert.ok(adapter.uidForURL.calledOnce);
   });

--- a/ui-v2/tests/unit/serializers/kv-test.js
+++ b/ui-v2/tests/unit/serializers/kv-test.js
@@ -43,6 +43,7 @@ module('Unit | Serializer | kv', function(hooks) {
           const body = true;
           return cb(headers, body);
         },
+        {},
         {
           Key: uid,
           Datacenter: dc,
@@ -72,6 +73,7 @@ module('Unit | Serializer | kv', function(hooks) {
           };
           return cb(headers, body);
         },
+        {},
         {
           Key: uid,
           Datacenter: dc,


### PR DESCRIPTION
This is part of https://github.com/hashicorp/consul/pull/5637

> We'd like to slightly tweak the API so that unserialized and unserialized data is available to the requestFor... methods, currently only unserialized is.

Both `requestFor` and `respondFor` methods now take both serialized data
and unserialized data.

We also leave it up to the adapter author to add (or omit) the serialized
data from the request payload, instead of it being automatically added
within the http client.

Included here is a small refactor to dry out the http adapter slightly.

Tests where changed only slightly to follow the new method signature.

As a side note here we are very tempted to write the requests like:

```javascript
// https://www.consul.io/api/acl/legacy.html#update-acl-token
return request`
  PUT /v1/acl/update?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}

  ${
    {
      ID: serialized.SecretID,
      Name: serialized.Description,
      Type: serialized.Type,
      Rules: serialized.Rules
    }
   }
`;
```

instead of:

```javascript
// https://www.consul.io/api/acl/legacy.html#update-acl-token
return request`
  PUT /v1/acl/update?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}

  ${serialized}
`;

```

and then the 'serialization' happening elsewhere in the app (in the Serializer).

Doing the former in our mind make every request easier to read, its  easier to see what is happening in one place, and it also looks exactly like the documentation https://www.consul.io/api/acl/legacy.html#update-acl-token

Right now, as part of this refactor is about moving serialization to the app Serializers where folks expect them, we've left it as the latter. But we are considering (in the more distant future), moving everything to the former example. If data values need transforming (as is the case with KV values and base64-ness), that would be done in the Serializers still, although the final structure of the JSON/request payload would be done in the Adapter. Which, actually as I write this, feels like it actually makes more sense, with the idea that _the request payload should be structured like so_ to be done in the Adapter layer.

For now this will be left as is, the above is more to communicate future ideas more than anything.

Lastly, again this is going down onto out http-adapter refactor branch, not `master` or `ui-staging` - there is still some decisions to be made/cleanup to be done once the entire refactor is over.