### PR TITLE
Add external intention source types

### DIFF
--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -34,6 +34,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 	// Build a valid intention
 	ixn := &structs.Intention{
 		ID:              testUUID(),
+		SourceType:      structs.IntentionSourceConsul,
 		SourceNS:        "default",
 		SourceName:      "*",
 		DestinationNS:   "default",
@@ -51,6 +52,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 	// Read it back out and verify it.
 	expected := &structs.Intention{
 		ID:              ixn.ID,
+		SourceType:      structs.IntentionSourceConsul,
 		SourceNS:        "default",
 		SourceName:      "*",
 		DestinationNS:   "default",
@@ -95,6 +97,7 @@ func TestStore_IntentionSetGet_basic(t *testing.T) {
 	// Attempt to insert another intention with duplicate 4-tuple
 	ixn = &structs.Intention{
 		ID:              testUUID(),
+		SourceType:      structs.IntentionSourceConsul,
 		SourceNS:        "default",
 		SourceName:      "*",
 		DestinationNS:   "default",
@@ -388,6 +391,7 @@ func TestStore_IntentionMatch_table(t *testing.T) {
 					ixn.SourceName = v[3]
 				}
 			case structs.IntentionMatchSource:
+				ixn.SourceType = structs.IntentionSourceConsul
 				ixn.SourceNS = v[0]
 				ixn.SourceName = v[1]
 				if len(v) == 4 {
@@ -402,7 +406,7 @@ func TestStore_IntentionMatch_table(t *testing.T) {
 		}
 
 		// Build the arguments
-		args := &structs.IntentionQueryMatch{Type: typ}
+		args := &structs.IntentionQueryMatch{Type: typ, SourceType: structs.IntentionSourceConsul}
 		for _, q := range tc.Query {
 			args.Entries = append(args.Entries, structs.IntentionMatchEntry{
 				Namespace: q[0],

--- a/agent/structs/intention_test.go
+++ b/agent/structs/intention_test.go
@@ -134,13 +134,25 @@ func TestIntentionValidate(t *testing.T) {
 		{
 			"SourceType is not set",
 			func(x *Intention) { x.SourceType = "" },
-			"SourceType must",
+			"SourceType must be set to 'consul'",
 		},
 
 		{
 			"SourceType is other",
 			func(x *Intention) { x.SourceType = IntentionSourceType("other") },
-			"SourceType must",
+			"SourceType must be set to 'consul'",
+		},
+
+		{
+			"SourceType is external-trust-domain",
+			func(x *Intention) { x.SourceType = IntentionSourceType("external-trust-domain") },
+			"SourceTypes 'external-trust-domain' and 'external-uri' are only supported in Consul Enterprise",
+		},
+
+		{
+			"SourceType is external-uri",
+			func(x *Intention) { x.SourceType = IntentionSourceType("external-uri") },
+			"SourceTypes 'external-trust-domain' and 'external-uri' are only supported in Consul Enterprise",
 		},
 	}
 

--- a/command/intention/check/check_test.go
+++ b/command/intention/check/check_test.go
@@ -41,6 +41,11 @@ func TestCommand_Validation(t *testing.T) {
 			[]string{"a", "b", "c"},
 			"requires exactly two",
 		},
+
+		"invalid source type": {
+			[]string{"-source-type", "invalid", "a", "b"},
+			"-source-type \"invalid\" is not supported: must be set to consul, external-trust-domain or external-uri",
+		},
 	}
 
 	for name, tc := range cases {

--- a/command/intention/delete/delete.go
+++ b/command/intention/delete/delete.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"flag"
 	"fmt"
+	"github.com/hashicorp/consul/command/intention"
 	"io"
 
 	"github.com/hashicorp/consul/command/flags"
@@ -22,12 +23,18 @@ type cmd struct {
 	http  *flags.HTTPFlags
 	help  string
 
+	// flags
+	flagSourceType string
+
 	// testStdin is the input for testing.
 	testStdin io.Reader
 }
 
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagSourceType, intention.SourceTypeFlagName, "consul",
+		intention.SourceTypeUsageAbbrev)
+
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
 	flags.Merge(c.flags, c.http.ServerFlags())
@@ -36,6 +43,12 @@ func (c *cmd) init() {
 
 func (c *cmd) Run(args []string) int {
 	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	sourceType, err := intention.ValidateSourceTypeFlag(c.flagSourceType)
+	if err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
 
@@ -48,7 +61,7 @@ func (c *cmd) Run(args []string) int {
 
 	// Get the intention ID to load
 	f := &finder.Finder{Client: client}
-	id, err := f.IDFromArgs(c.flags.Args())
+	id, err := f.IDFromArgs(sourceType, c.flags.Args())
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error: %s", err))
 		return 1

--- a/command/intention/delete/delete_test.go
+++ b/command/intention/delete/delete_test.go
@@ -36,6 +36,11 @@ func TestCommand_Validation(t *testing.T) {
 			[]string{"a", "b", "c"},
 			"requires exactly 1 or 2",
 		},
+
+		"invalid source type": {
+			[]string{"-source-type", "invalid", "a", "b"},
+			"-source-type \"invalid\" is not supported: must be set to consul, external-trust-domain or external-uri",
+		},
 	}
 
 	for name, tc := range cases {
@@ -96,4 +101,61 @@ func TestCommand(t *testing.T) {
 		require.NoError(err)
 		require.Len(ixns, 0)
 	}
+}
+
+// Test that the Source Type matters for deletion.
+func TestCommand_DeleteSourceType(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	a := agent.NewTestAgent(t, t.Name(), ``)
+	defer a.Shutdown()
+	client := a.Client()
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	// Create the intention
+	_, _, err := client.Connect().IntentionCreate(&api.Intention{
+		SourceName:      "web",
+		DestinationName: "db",
+		Action:          api.IntentionActionDeny,
+	}, nil)
+	require.NoError(err)
+
+	// Delete the wrong source type (external-uri)
+	args := []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-source-type=external-uri",
+		"web", "db",
+	}
+	require.Equal(1, c.Run(args), ui.ErrorWriter.String())
+	require.Contains(ui.ErrorWriter.String(), "Error: Intention with source \"web\", source type \"external-uri\" and destination \"db\" not found.")
+
+	// Delete the wrong source type (external-trust-domain)
+	args = []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-source-type=external-trust-domain",
+		"web", "db",
+	}
+	require.Equal(1, c.Run(args), ui.ErrorWriter.String())
+	require.Contains(ui.ErrorWriter.String(), "Error: Intention with source \"web\", source type \"external-trust-domain\" and destination \"db\" not found.")
+
+	// Find it (should still be there)
+	ixns, _, err := client.Connect().Intentions(nil)
+	require.NoError(err)
+	require.Len(ixns, 1)
+
+	// Now delete it with the source-type=consul
+	args = []string{
+		"-http-addr=" + a.HTTPAddr(),
+		"-source-type=consul",
+		"web", "db",
+	}
+	require.Equal(0, c.Run(args), ui.ErrorWriter.String())
+	require.Contains(ui.OutputWriter.String(), "deleted")
+
+	// Find it (it should be gone)
+	ixns, _, err = client.Connect().Intentions(nil)
+	require.NoError(err)
+	require.Len(ixns, 0)
 }

--- a/command/intention/finder/finder.go
+++ b/command/intention/finder/finder.go
@@ -16,7 +16,7 @@ import (
 //
 // The Finder will only download the intentions one time. This struct is
 // not expected to be used over a long period of time. Though it may be
-// reused multile times, the intentions list is only downloaded once.
+// reused multiple times, the intentions list is only downloaded once.
 type Finder struct {
 	// Client is the API client to use for any requests.
 	Client *api.Client
@@ -25,22 +25,24 @@ type Finder struct {
 	ixns []*api.Intention // cached list of intentions
 }
 
-// ID returns the intention ID for the given CLI args. An error is returned
-// if args is not 1 or 2 elements.
-func (f *Finder) IDFromArgs(args []string) (string, error) {
+// ID returns the intention ID for the given srcType and CLI args.
+// An error is returned if args is not 1 or 2 elements.
+// If there is only one arg then srcType is ignored since it's assumed to
+// be an ID.
+func (f *Finder) IDFromArgs(srcType api.IntentionSourceType, args []string) (string, error) {
 	switch len(args) {
 	case 1:
 		return args[0], nil
 
 	case 2:
-		ixn, err := f.Find(args[0], args[1])
+		ixn, err := f.Find(srcType, args[0], args[1])
 		if err != nil {
 			return "", err
 		}
 		if ixn == nil {
 			return "", fmt.Errorf(
-				"Intention with source %q and destination %q not found.",
-				args[0], args[1])
+				"Intention with source %q, source type %q and destination %q not found.",
+				args[0], srcType, args[1])
 		}
 
 		return ixn.ID, nil
@@ -52,9 +54,11 @@ func (f *Finder) IDFromArgs(args []string) (string, error) {
 
 // Find finds the intention that matches the given src and dst. This will
 // return nil when the result is not found.
-func (f *Finder) Find(src, dst string) (*api.Intention, error) {
-	src = StripDefaultNS(src)
-	dst = StripDefaultNS(dst)
+func (f *Finder) Find(srcType api.IntentionSourceType, src, dst string) (*api.Intention, error) {
+	if srcType == api.IntentionSourceConsul {
+		src = StripDefaultNS(src)
+		dst = StripDefaultNS(dst)
+	}
 
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -71,7 +75,7 @@ func (f *Finder) Find(src, dst string) (*api.Intention, error) {
 
 	// Go through the intentions and find an exact match
 	for _, ixn := range f.ixns {
-		if ixn.SourceString() == src && ixn.DestinationString() == dst {
+		if ixn.SourceType == srcType && ixn.SourceString() == src && ixn.DestinationString() == dst {
 			return ixn, nil
 		}
 	}

--- a/command/intention/finder/finder_test.go
+++ b/command/intention/finder/finder_test.go
@@ -39,11 +39,19 @@ func TestFinder(t *testing.T) {
 	}
 
 	finder := &Finder{Client: client}
-	ixn, err := finder.Find("a/b", "c/d")
+	ixn, err := finder.Find(api.IntentionSourceConsul, "a/b", "c/d")
 	require.NoError(err)
 	require.Equal(ids[0], ixn.ID)
 
-	ixn, err = finder.Find("a/c", "c/d")
+	ixn, err = finder.Find(api.IntentionSourceConsul, "a/c", "c/d")
+	require.NoError(err)
+	require.Nil(ixn)
+
+	// If SourceType is different, shouldn't match.
+	ixn, err = finder.Find(api.IntentionSourceExternalTrustDomain, "a/b", "c/d")
+	require.NoError(err)
+	require.Nil(ixn)
+	ixn, err = finder.Find(api.IntentionSourceExternalURI, "a/b", "c/d")
 	require.NoError(err)
 	require.Nil(ixn)
 }

--- a/command/intention/get/get.go
+++ b/command/intention/get/get.go
@@ -3,6 +3,7 @@ package get
 import (
 	"flag"
 	"fmt"
+	"github.com/hashicorp/consul/command/intention"
 	"io"
 	"sort"
 	"time"
@@ -25,12 +26,18 @@ type cmd struct {
 	http  *flags.HTTPFlags
 	help  string
 
+	// flags
+	flagSourceType string
+
 	// testStdin is the input for testing.
 	testStdin io.Reader
 }
 
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.StringVar(&c.flagSourceType, intention.SourceTypeFlagName, "consul",
+		intention.SourceTypeUsageAbbrev+" Ignored if ID is set.")
+
 	c.http = &flags.HTTPFlags{}
 	flags.Merge(c.flags, c.http.ClientFlags())
 	flags.Merge(c.flags, c.http.ServerFlags())
@@ -39,6 +46,12 @@ func (c *cmd) init() {
 
 func (c *cmd) Run(args []string) int {
 	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	sourceType, err := intention.ValidateSourceTypeFlag(c.flagSourceType)
+	if err != nil {
+		c.UI.Error(err.Error())
 		return 1
 	}
 
@@ -51,7 +64,7 @@ func (c *cmd) Run(args []string) int {
 
 	// Get the intention ID to load
 	f := &finder.Finder{Client: client}
-	id, err := f.IDFromArgs(c.flags.Args())
+	id, err := f.IDFromArgs(sourceType, c.flags.Args())
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error: %s", err))
 		return 1

--- a/command/intention/intention.go
+++ b/command/intention/intention.go
@@ -1,6 +1,8 @@
 package intention
 
 import (
+	"fmt"
+	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/mitchellh/cli"
 )
@@ -46,3 +48,30 @@ Usage: consul intention <subcommand> [options] [args]
 
   For more examples, ask for subcommand help or view the documentation.
 `
+
+// SourceTypeUsageAbbrev is the usage of the -source-type flag in all commands except
+// for intention create which has a more detailed usage.
+const SourceTypeUsageAbbrev = "Type of SRC. One of consul (default)," +
+	" external-trust-domain or external-uri."
+
+// SourceTypeFlagName is the name of the source type flag.
+const SourceTypeFlagName = "source-type"
+
+// ValidateSourceTypeFlag returns an error if srcType is not a valid type.
+// If valid it returns the corresponding enum value.
+func ValidateSourceTypeFlag(srcType string) (api.IntentionSourceType, error) {
+	ist := api.IntentionSourceType(srcType)
+	switch ist {
+	case api.IntentionSourceConsul,
+		api.IntentionSourceExternalTrustDomain,
+		api.IntentionSourceExternalURI:
+		return ist, nil
+	default:
+		return ist, fmt.Errorf("-%s %q is not supported: must be set to %s, %s or %s",
+			SourceTypeFlagName,
+			srcType,
+			api.IntentionSourceConsul,
+			api.IntentionSourceExternalTrustDomain,
+			api.IntentionSourceExternalURI)
+	}
+}

--- a/command/intention/match/match_test.go
+++ b/command/intention/match/match_test.go
@@ -41,6 +41,11 @@ func TestCommand_Validation(t *testing.T) {
 			[]string{"-source", "-destination", "foo"},
 			"only one of -source",
 		},
+
+		"invalid -source-type": {
+			[]string{"-source-type", "invalid", "-source", "foo"},
+			"-source-type \"invalid\" is not supported: must be set to consul, external-trust-domain or external-uri",
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
* SourceType was already a field in the Intention struct.
* Added new types to the SourceType enum: external-trust-domain and
external-uri.
* Add new flag -source-type to consul intention subcommands.
* Support for source types external-trust-domain and external-uri will be
implemented in Consul Enterprise.