### PR TITLE
ui: Make sure filtering tokens by roles works (as well as policies)

### DIFF
--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -7,9 +7,9 @@ import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 export default Adapter.extend({
   store: service('store'),
 
-  requestForQuery: function(request, { dc, index, policy }) {
+  requestForQuery: function(request, { dc, index, role, policy }) {
     return request`
-      GET /v1/acl/tokens?${{ policy, dc }}
+      GET /v1/acl/tokens?${{ role, policy, dc }}
 
       ${{ index }}
     `;

--- a/ui-v2/tests/integration/adapters/token-test.js
+++ b/ui-v2/tests/integration/adapters/token-test.js
@@ -13,6 +13,26 @@ module('Integration | Adapter | token', function(hooks) {
     });
     assert.equal(actual, expected);
   });
+  test('requestForQuery returns the correct url when a policy is specified', function(assert) {
+    const adapter = this.owner.lookup('adapter:token');
+    const client = this.owner.lookup('service:client/http');
+    const expected = `GET /v1/acl/tokens?policy=${id}&dc=${dc}`;
+    const actual = adapter.requestForQuery(client.url, {
+      dc: dc,
+      policy: id,
+    });
+    assert.equal(actual, expected);
+  });
+  test('requestForQuery returns the correct url when a role is specified', function(assert) {
+    const adapter = this.owner.lookup('adapter:token');
+    const client = this.owner.lookup('service:client/http');
+    const expected = `GET /v1/acl/tokens?role=${id}&dc=${dc}`;
+    const actual = adapter.requestForQuery(client.url, {
+      dc: dc,
+      role: id,
+    });
+    assert.equal(actual, expected);
+  });
   test('urlForQueryRecord returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:token');
     const client = this.owner.lookup('service:client/http');


### PR DESCRIPTION
Also adds an integration test for both roles and policies to make sure the adapter returns the correct URL.

Please note this is part of ember-data data layer refactor - https://github.com/hashicorp/consul/pull/5637 