### PR TITLE
Fix 404

### DIFF
--- a/website/source/discovery.html.erb
+++ b/website/source/discovery.html.erb
@@ -211,7 +211,7 @@ $ curl http://localhost:8500/v1/catalog/nodes?<code class='keyword'>dc=dc2</code
             <h3>Health Checks</h3>
             <p>Pairing service discovery with health checking prevents routing requests to unhealthy hosts and enables services to easily provide circuit breakers.</p>
             <p>
-              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/checks">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
+              <a class="learn-more" href="https://learn.hashicorp.com/consul/getting-started/services">Learn more<svg xmlns="http://www.w3.org/2000/svg" width="6" height="10" viewBox="0 0 6 10"><g fill="none" fill-rule="evenodd" transform="translate(-6 -3)"><mask id="a" fill="#fff"><path d="M7.138 3.529a.666.666 0 1 0-.942.942l3.528 3.53-3.529 3.528a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z"/></mask><g fill="#1563FF" mask="url(#a)"><path d="M0 0h16v16H0z"/></g></g></svg></a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
On page: https://www.consul.io/discovery.html

If you click the link for Health Checks -> Learn More the underlying resource is:

https://learn.hashicorp.com/consul/getting-started/checks

This page for me is a 404. I think you've bundled it together in the following page:

Register a Service and Health Check - Service Discovery

Located at: https://learn.hashicorp.com/consul/getting-started/services

Thanks for Consul, it's really awesome.