### PR TITLE
agent: blocking central config RPCs iterations should not interfere with each other

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -231,6 +231,8 @@ func (c *ConfigEntry) ResolveServiceConfig(args *structs.ServiceConfigRequest, r
 		&args.QueryOptions,
 		&reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
+			reply.Reset()
+
 			reply.MeshGateway.Mode = structs.MeshGatewayModeDefault
 			// Pass the WatchSet to both the service and proxy config lookups. If either is updated
 			// during the blocking query, this function will be rerun and these state store lookups

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -538,6 +538,12 @@ type ServiceConfigResponse struct {
 	QueryMeta
 }
 
+func (r *ServiceConfigResponse) Reset() {
+	r.ProxyConfig = nil
+	r.UpstreamConfigs = nil
+	r.MeshGateway = MeshGatewayConfig{}
+}
+
 // MarshalBinary writes ServiceConfigResponse as msgpack encoded. It's only here
 // because we need custom decoding of the raw interface{} values.
 func (r *ServiceConfigResponse) MarshalBinary() (data []byte, err error) {


### PR DESCRIPTION
The response variable from the ResolveServiceConfig RPC is mutated while various state store operations are performed.

This means that when a blocking query necessitates re-executing the body of the query (due to something like deleting `proxy-defaults/global`) some information from the previous speculative query bleeds over by way of the shared response variable.

The easy fix here is to reset the state of the response variable at the stop of the query.