### PR TITLE
Store primaries root in secondary after intermediate signature

### DIFF
--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -78,6 +78,8 @@ func TestLeader_SecondaryCA_Initialize(t *testing.T) {
 	require.Equal(roots1[0].RootCert, roots2[0].RootCert)
 	require.Equal(1, len(roots1))
 	require.Equal(len(roots1), len(roots2))
+	require.Empty(roots1[0].IntermediateCerts)
+	require.NotEmpty(roots2[0].IntermediateCerts)
 
 	// Have secondary sign a leaf cert and make sure the chain is correct.
 	spiffeService := &connect.SpiffeIDService{


### PR DESCRIPTION
This ensures that the intermediate exists within the CA root stored in raft and not just in the CA provider state. This has the very nice benefit of actually outputting the intermediate cert within the ca roots HTTP/RPC endpoints.

This change means that if signing the intermediate fails it will not set the root within raft. So far I have not come up with a reason why that is bad. The secondary CA roots watch will pull the root again and go through all the motions. So as soon as getting an intermediate CA works the root will get set.