### PR TITLE
connect: updating a service-defaults config entry should leave an unset protocol alone

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -79,11 +79,7 @@ func (e *ServiceConfigEntry) Normalize() error {
 	}
 
 	e.Kind = ServiceDefaults
-	if e.Protocol == "" {
-		e.Protocol = DefaultServiceProtocol
-	} else {
-		e.Protocol = strings.ToLower(e.Protocol)
-	}
+	e.Protocol = strings.ToLower(e.Protocol)
 
 	return nil
 }


### PR DESCRIPTION
If the entry is updated for reasons other than protocol it is surprising
that the value is explicitly persisted as 'tcp' rather than leaving it
empty and letting it fall back dynamically on the proxy-defaults value.