### PR TITLE
Turned on Envoy 1.11.1 integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,6 +501,13 @@ jobs:
       ENVOY_VERSIONS: "1.10.0"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
+  envoy-integration-test-1.11.1:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      ENVOY_VERSIONS: "1.11.1"
+    steps: *ENVOY_INTEGRATION_TEST_STEPS
+
   # This job merges master into the 'current' branch (${CIRCLE_BRANCH}) specified
   # in the branch filtering of the workflow
   merge-master:

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -17,7 +17,7 @@ FILTER_TESTS=${FILTER_TESTS:-}
 STOP_ON_FAIL=${STOP_ON_FAIL:-}
 
 # ENVOY_VERSIONS is the list of envoy versions to run each test against
-ENVOY_VERSIONS=${ENVOY_VERSIONS:-"1.10.0 1.9.1 1.8.0"}
+ENVOY_VERSIONS=${ENVOY_VERSIONS:-"1.10.0 1.9.1 1.8.0 1.11.1"}
 
 if [ ! -z "$DEBUG" ] ; then
   set -x

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -36,7 +36,7 @@ compatible Envoy versions.
 
 | Consul Version | Compatible Envoy Versions |
 |---|---|
-| 1.5.2 and higher | 1.10.0, 1.9.1, 1.8.0† |
+| 1.5.2 and higher | 1.11.1 1.10.0, 1.9.1, 1.8.0† |
 | 1.5.0, 1.5.1 | 1.9.1, 1.8.0† |
 | 1.3.x, 1.4.x | 1.9.1, 1.8.0†, 1.7.0† |
 


### PR DESCRIPTION
Fixes #6329 

I also ran the integration tests against 1.5.2 so the docs update claiming compatibility for the past version should still be accurate.

