### PR TITLE
docs: remove beta references; leave version notation

### DIFF
--- a/website/source/api/discovery-chain.html.md
+++ b/website/source/api/discovery-chain.html.md
@@ -6,7 +6,9 @@ description: |-
   The /discovery-chain endpoints are for interacting with the discovery chain.
 ---
 
-# Discovery Chain HTTP Endpoint <sup>beta</sup>
+-> **1.6.0+:**  The discovery chain API is available in Consul versions 1.6.0 and newer.
+
+# Discovery Chain HTTP Endpoint
 
 ~> This is a low-level API primarily targeted at developers building external
 [Connect proxy integrations](/docs/connect/proxies/integrate.html). Future

--- a/website/source/docs/agent/config-entries/proxy-defaults.html.md
+++ b/website/source/docs/agent/config-entries/proxy-defaults.html.md
@@ -49,9 +49,9 @@ config {
   * [Envoy](/docs/connect/proxies/envoy.html#bootstrap-configuration)
   * [Consul's built-in proxy](/docs/connect/proxies/built-in.html)
 
-- `MeshGateway` <sup>(beta)</sup> `(MeshGatewayConfig: <optional>)` - Controls the default
+- `MeshGateway` `(MeshGatewayConfig: <optional>)` - Controls the default
   [mesh gateway configuration](/docs/connect/mesh_gateway.html#connect-proxy-configuration)
-  for all proxies.
+  for all proxies. Added in v1.6.0.
 
   - `Mode` `(string: "")` - One of `none`, `local`, or `remote`.
 

--- a/website/source/docs/agent/config-entries/service-defaults.html.md
+++ b/website/source/docs/agent/config-entries/service-defaults.html.md
@@ -29,22 +29,20 @@ Protocol = "http"
 
 - `Protocol` `(string: "tcp")` - Sets the protocol of the service. This is used
   by Connect proxies for things like observability features and to unlock usage
-  of the [`service-splitter`
-  <sup>(beta)</sup>](/docs/agent/config-entries/service-splitter.html) and
-  [`service-router`
-  <sup>(beta)</sup>](/docs/agent/config-entries/service-router.html) config
+  of the [`service-splitter`](/docs/agent/config-entries/service-splitter.html) and
+  [`service-router`](/docs/agent/config-entries/service-router.html) config
   entries for a service.
 
-- `MeshGateway` <sup>(beta)</sup> `(MeshGatewayConfig: <optional>)` - Controls the default
+- `MeshGateway` `(MeshGatewayConfig: <optional>)` - Controls the default
   [mesh gateway configuration](/docs/connect/mesh_gateway.html#connect-proxy-configuration)
-  for this service.
+  for this service. Added in v1.6.0.
 
   - `Mode` `(string: "")` - One of `none`, `local`, or `remote`.
 
-- `ExternalSNI` <sup>(beta)</sup> `(string: "")` - This is an optional setting
-  that allows for the TLS
-  [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) value to be
-  changed to a non-connect value when federating with an external system.
+- `ExternalSNI` `(string: "")` - This is an optional setting that allows for
+  the TLS [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) value to
+  be changed to a non-connect value when federating with an external system.
+  Added in v1.6.0.
 
 ## ACLs
 

--- a/website/source/docs/agent/config-entries/service-resolver.html.md
+++ b/website/source/docs/agent/config-entries/service-resolver.html.md
@@ -1,12 +1,14 @@
 ---
 layout: "docs"
-page_title: "Configuration Entry Kind: Service Resolver (beta)"
+page_title: "Configuration Entry Kind: Service Resolver"
 sidebar_current: "docs-agent-cfg_entries-service_resolver"
 description: |-
   The `service-resolver` config entry kind controls which service instances should satisfy Connect upstream discovery requests for a given service name.
 ---
 
-# Service Resolver <sup>(beta)</sup>
+-> **1.6.0+:**  This config entry is available in Consul versions 1.6.0 and newer.
+
+# Service Resolver
 
 The `service-resolver` config entry kind controls which service instances
 should satisfy Connect upstream discovery requests for a given service name.

--- a/website/source/docs/agent/config-entries/service-router.html.md
+++ b/website/source/docs/agent/config-entries/service-router.html.md
@@ -1,12 +1,14 @@
 ---
 layout: "docs"
-page_title: "Configuration Entry Kind: Service Router (beta)"
+page_title: "Configuration Entry Kind: Service Router"
 sidebar_current: "docs-agent-cfg_entries-service_router"
 description: |-
   The service-router config entry kind controls Connect traffic routing and manipulation at networking layer 7 (e.g. HTTP).
 ---
 
-# Service Router <sup>(beta)</sup>
+-> **1.6.0+:**  This config entry is available in Consul versions 1.6.0 and newer.
+
+# Service Router
 
 The `service-router` config entry kind controls Connect traffic routing and
 manipulation at networking layer 7 (e.g. HTTP).

--- a/website/source/docs/agent/config-entries/service-splitter.html.md
+++ b/website/source/docs/agent/config-entries/service-splitter.html.md
@@ -1,12 +1,14 @@
 ---
 layout: "docs"
-page_title: "Configuration Entry Kind: Service Splitter (beta)"
+page_title: "Configuration Entry Kind: Service Splitter"
 sidebar_current: "docs-agent-cfg_entries-service_splitter"
 description: |-
   The service-splitter config entry kind controls how to split incoming Connect requests across different subsets of a single service (like during staged canary rollouts), or perhaps across different services (like during a v2 rewrite or other type of codebase migration).
 ---
 
-# Service Splitter <sup>(beta)</sup>
+-> **1.6.0+:**  This config entry is available in Consul versions 1.6.0 and newer.
+
+# Service Splitter
 
 The `service-splitter` config entry kind controls how to split incoming Connect
 requests across different subsets of a single service (like during staged

--- a/website/source/docs/agent/config_entries.html.md
+++ b/website/source/docs/agent/config_entries.html.md
@@ -24,13 +24,13 @@ Name = "<name of entry>"
 
 The supported `Kind` names for configuration entries are:
 
-* [`service-router` <sup>(beta)</sup>](/docs/agent/config-entries/service-router.html) - defines
+* [`service-router`](/docs/agent/config-entries/service-router.html) - defines
 where to send layer 7 traffic based on the HTTP route
 
-* [`service-splitter` <sup>(beta)</sup>](/docs/agent/config-entries/service-splitter.html) - defines
+* [`service-splitter`](/docs/agent/config-entries/service-splitter.html) - defines
 how to divide requests for a single HTTP route based on percentages
 
-* [`service-resolver` <sup>(beta)</sup>](/docs/agent/config-entries/service-resolver.html) - matches
+* [`service-resolver`](/docs/agent/config-entries/service-resolver.html) - matches
 service instances with a specific Connect upstream discovery requests
 
 * [`service-defaults`](/docs/agent/config-entries/service-defaults.html) - configures

--- a/website/source/docs/agent/services.html.md
+++ b/website/source/docs/agent/services.html.md
@@ -144,7 +144,7 @@ deprecated and has been removed as of Consul 1.1.
 
 The `kind` field is used to optionally identify the service as a [Connect
 proxy](/docs/connect/proxies.html) instance with the value `connect-proxy` or
-a [Mesh Gateway<sup>(beta)</sup>](/docs/connect/mesh_gateway.html) instance with the value `mesh-gateway`. For
+a [Mesh Gateway](/docs/connect/mesh_gateway.html) instance with the value `mesh-gateway`. For
 typical non-proxy instances the `kind` field must be omitted. The `proxy` field
 is also required for Connect proxy registrations and is only valid if `kind` is
 `connect-proxy`. The only required `proxy` field is `destination_service_name`.

--- a/website/source/docs/connect/l7-traffic-management.html.md
+++ b/website/source/docs/connect/l7-traffic-management.html.md
@@ -1,17 +1,14 @@
 ---
 layout: "docs"
-page_title: "Connect - L7 Traffic Management (beta)"
+page_title: "Connect - L7 Traffic Management"
 sidebar_current: "docs-connect-l7_traffic_management"
 description: |-
   Layer 7 traffic management allows operators to divide L7 traffic between different subsets of service instances when using Connect.
 ---
 
-# L7 Traffic Management <sup>(beta)</sup>
+-> **1.6.0+:**  This feature is available in Consul versions 1.6.0 and newer.
 
--> **Note:** This feature is not compatible with the 
-[built-in proxy](/docs/connect/proxies/built-in.html),
-[native proxies](/docs/connect/native.html),
-and some [Envoy proxy escape hatches](/docs/connect/proxies/envoy.html#escape-hatch-overrides).
+# L7 Traffic Management
 
 Layer 7 traffic management allows operators to divide L7 traffic between
 different
@@ -24,6 +21,11 @@ Canary testing, A/B tests, blue/green deploys, and soft multi-tenancy
 (prod/qa/staging sharing compute resources) all require some mechanism of
 carving out portions of the Consul catalog smaller than the level of a single
 service and configuring when that subset should receive traffic.
+
+-> **Note:** This feature is not compatible with the 
+[built-in proxy](/docs/connect/proxies/built-in.html),
+[native proxies](/docs/connect/native.html),
+and some [Envoy proxy escape hatches](/docs/connect/proxies/envoy.html#escape-hatch-overrides).
 
 ## Stages
 

--- a/website/source/docs/connect/mesh_gateway.html.md
+++ b/website/source/docs/connect/mesh_gateway.html.md
@@ -1,12 +1,14 @@
 ---
 layout: "docs"
-page_title: "Connect - Mesh Gateways (beta)"
+page_title: "Connect - Mesh Gateways"
 sidebar_current: "docs-connect-meshgateways"
 description: |-
   A Mesh Gateway enables better routing of a Connect service's data to upstreams in other datacenters. This section details how to use Envoy and describes how you can plug in a gateway of your choice.
 ---
 
-# Mesh Gateways <sup>(beta)</sup>
+-> **1.6.0+:**  This feature is available in Consul versions 1.6.0 and newer.
+
+# Mesh Gateways
 
 Mesh gateways enable routing of Connect traffic between different Consul datacenters. Those datacenters
 can reside in different clouds or runtime environments where general interconnectivity between all services

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -252,7 +252,7 @@ definition](/docs/connect/registration/service-registration.html) or
     proxy upstream config will override any values defined in config entries.
     It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
 
-### Mesh Gateway Options <sup>(beta)</sup>
+### Mesh Gateway Options
 
 These fields may also be overridden explicitly in the [proxy service
 definition](/docs/connect/registration/service-registration.html), or defined in

--- a/website/source/docs/connect/registration/service-registration.html.md
+++ b/website/source/docs/connect/registration/service-registration.html.md
@@ -187,7 +187,7 @@ followed by documentation for each attribute.
    for this proxy. The format is defined in the [Mesh Gateway Configuration Reference](#mesh-gateway-configuration-reference).
 
 
-### Mesh Gateway Configuration Reference <sup>(beta)</sup>
+### Mesh Gateway Configuration Reference
 
 The following examples show all possible mesh gateway configurations.
 

--- a/website/source/docs/internals/discovery-chain.html.md
+++ b/website/source/docs/internals/discovery-chain.html.md
@@ -6,7 +6,9 @@ description: |-
   The service discovery process can be modeled as a "discovery chain" which passes through three distinct stages: routing, splitting, and resolution. Each of these stages is controlled by a set of configuration entries.
 ---
 
-# Discovery Chain <sup>beta</sup>
+-> **1.6.0+:**  This feature is available in Consul versions 1.6.0 and newer.
+
+# Discovery Chain
 
 ~> This topic is part of a [low-level API](/api/discovery-chain.html)
 primarily targeted at developers building external [Connect proxy

--- a/website/source/docs/internals/index.html.md
+++ b/website/source/docs/internals/index.html.md
@@ -20,7 +20,7 @@ Please review the following documentation to understand how Consul works.
 * [Sessions](/docs/internals/sessions.html)
 * [Anti-Entropy](/docs/internals/anti-entropy.html)
 * [Security Model](/docs/internals/security.html)
-* [Discovery Chain <sup>beta</sup>](/docs/internals/discovery-chain.html)
+* [Discovery Chain](/docs/internals/discovery-chain.html)
 
 You should also be familiar with [Jepsen testing](/docs/internals/jepsen.html), before deploying 
 a production datacenter. 

--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -8,13 +8,6 @@ description: |-
 
 <h1>Download Consul</h1>
 
-
-<div class="alert alert-info" id="rc-1-4" role="alert">
-  <p><strong>1.6.0 beta Available:</strong> Read more about the new features coming in 1.6.0 in the
-  <a href="https://www.hashicorp.com/blog/hashicorp-consul-1-6">announcement post</a>. Binaries can be accessed on <a href="https://releases.hashicorp.com/consul/">releases.hashicorp.com</a>. View the <a href="https://github.com/hashicorp/consul/blob/v1.6.0-beta1/CHANGELOG.md">changelog</a> for details.
-  </p>
-</div>
-
 <section class="downloads">
   <div class="description row">
     <div class="col-md-12">

--- a/website/source/layouts/api.erb
+++ b/website/source/layouts/api.erb
@@ -82,7 +82,7 @@
         <a href="/api/coordinate.html">Coordinates</a>
       </li>
       <li<%= sidebar_current("api-discovery-chain") %>>
-        <a href="/api/discovery-chain.html">Discovery Chain <sup>(beta)</sup></a>
+        <a href="/api/discovery-chain.html">Discovery Chain</a>
       </li>
       <li<%= sidebar_current("api-event") %>>
         <a href="/api/event.html">Events</a>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -63,7 +63,7 @@
             <a href="/docs/internals/jepsen.html">Jepsen Testing</a>
           </li>
           <li<%= sidebar_current("docs-internals-discovery-chain") %>>
-            <a href="/docs/internals/discovery-chain.html">Discovery Chain <sup>beta</sup></a>
+            <a href="/docs/internals/discovery-chain.html">Discovery Chain</a>
           </li>
         </ul>
       </li>
@@ -419,13 +419,13 @@
             <a href="/docs/agent/config_entries.html">Configuration Entries</a>
             <ul class="nav">
               <li<%= sidebar_current("docs-agent-cfg_entries-service_router") %>>
-                <a href="/docs/agent/config-entries/service-router.html">service-router <sup>(beta)</sup></a>
+                <a href="/docs/agent/config-entries/service-router.html">service-router</a>
               </li>
               <li<%= sidebar_current("docs-agent-cfg_entries-service_splitter") %>>
-                <a href="/docs/agent/config-entries/service-splitter.html">service-splitter <sup>(beta)</sup></a>
+                <a href="/docs/agent/config-entries/service-splitter.html">service-splitter</a>
               </li>
               <li<%= sidebar_current("docs-agent-cfg_entries-service_resolver") %>>
-                <a href="/docs/agent/config-entries/service-resolver.html">service-resolver <sup>(beta)</sup></a>
+                <a href="/docs/agent/config-entries/service-resolver.html">service-resolver</a>
               </li>
               <li<%= sidebar_current("docs-agent-cfg_entries-service_defaults") %>>
                 <a href="/docs/agent/config-entries/service-defaults.html">service-defaults</a>
@@ -498,7 +498,7 @@
             <a href="/docs/connect/observability.html">Observability</a>
           </li>
           <li<%= sidebar_current("docs-connect-l7_traffic_management") %>>
-            <a href="/docs/connect/l7-traffic-management.html">L7 Traffic Management <sup>(beta)</sup></a>
+            <a href="/docs/connect/l7-traffic-management.html">L7 Traffic Management</a>
           </li>
           <li<%= sidebar_current("docs-connect-intentions") %>>
             <a href="/docs/connect/intentions.html">Intentions - Security Policies</a>
@@ -521,7 +521,7 @@
             </ul>
           </li>
           <li<%= sidebar_current("docs-connect-meshgateways") %>>
-             <a href="/docs/connect/mesh_gateway.html">Mesh Gateways <sup>(beta)</sup></a>
+             <a href="/docs/connect/mesh_gateway.html">Mesh Gateways</a>
           </li>
           <li<%= sidebar_current("docs-connect-registration") %>>
             <a href="/docs/connect/registration.html">Registering Proxies</a>


### PR DESCRIPTION
Fixes #6349 