### PR TITLE
Only require verify_incoming_rpc for auto_encrypt.allow_tls

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1114,8 +1114,8 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 	}
 
 	if rt.AutoEncryptAllowTLS {
-		if !rt.VerifyIncoming {
-			return fmt.Errorf("if auto_encrypt.allow_tls is turned on, TLS must be configured in order to work properly.")
+		if !rt.VerifyIncoming && !rt.VerifyIncomingRPC {
+			return fmt.Errorf("if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc must be enabled.")
 		}
 	}
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2714,6 +2714,79 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
+			desc: "auto_encrypt.allow works implies connect",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "verify_incoming": true,
+			  "auto_encrypt": { "allow_tls": true }
+			}`},
+			hcl: []string{`
+			  verify_incoming = true
+			  auto_encrypt { allow_tls = true }
+			`},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.VerifyIncoming = true
+				rt.AutoEncryptAllowTLS = true
+				rt.ConnectEnabled = true
+			},
+		},
+		{
+			desc: "auto_encrypt.allow works with verify_incoming",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "verify_incoming": true,
+			  "auto_encrypt": { "allow_tls": true }
+			}`},
+			hcl: []string{`
+			  verify_incoming = true
+			  auto_encrypt { allow_tls = true }
+			`},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.VerifyIncoming = true
+				rt.AutoEncryptAllowTLS = true
+				rt.ConnectEnabled = true
+			},
+		},
+		{
+			desc: "auto_encrypt.allow works with verify_incoming_rpc",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "verify_incoming_rpc": true,
+			  "auto_encrypt": { "allow_tls": true }
+			}`},
+			hcl: []string{`
+			  verify_incoming_rpc = true
+			  auto_encrypt { allow_tls = true }
+			`},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.VerifyIncomingRPC = true
+				rt.AutoEncryptAllowTLS = true
+				rt.ConnectEnabled = true
+			},
+		},
+		{
+			desc: "auto_encrypt.allow fails without verify_incoming or verify_incoming_rpc",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			json: []string{`{
+			  "auto_encrypt": { "allow_tls": true }
+			}`},
+			hcl: []string{`
+			  auto_encrypt { allow_tls = true }
+			`},
+			err: "if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc must be enabled.",
+		},
+		{
 			desc: "test connect vault provider configuration",
 			args: []string{
 				`-data-dir=` + dataDir,


### PR DESCRIPTION
Otherwise it is impossible to host the UI on a server node while using `auto_encrypt`. Fixes #6338.