### PR TITLE
Secondary CA `establishLeadership` fix

### DIFF
--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -484,10 +484,10 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 	s1.tokens.UpdateAgentToken("root", tokenStore.TokenSourceConfig)
 
 	// create some tokens
-	replToken1, err := upsertTestTokenWithPolicyRules(codec, "root", "dc1", `acl = "read"`)
+	replToken1, err := upsertTestTokenWithPolicyRules(codec, "root", "dc1", `acl = "read" operator = "write"`)
 	require.NoError(err)
 
-	replToken2, err := upsertTestTokenWithPolicyRules(codec, "root", "dc1", `acl = "read"`)
+	replToken2, err := upsertTestTokenWithPolicyRules(codec, "root", "dc1", `acl = "read" operator = "write"`)
 	require.NoError(err)
 
 	// dc2 as a secondary DC

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -471,6 +471,8 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
+		// set the build to ensure all the version checks pass and enable all the connect features that operate cross-dc
+		c.Build = "1.6.0"
 	})
 	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
@@ -496,6 +498,7 @@ func TestLeader_ReplicateIntentions(t *testing.T) {
 		c.ACLsEnabled = true
 		c.ACLDefaultPolicy = "deny"
 		c.ACLTokenReplication = false
+		c.Build = "1.6.0"
 	})
 	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()


### PR DESCRIPTION
Previously if the primary errored trying to sign our CA certificate during `establishLeadership` it would propagate all the way back and cause a leadership transfer.

This is particularly nasty because any current users of ACLs probably don't have their replication tokens with `operator:write` privileges as it wasn't needed in OSS before. So by enabling connect in a secondary datacenter without making the policy updates it could cripple your secondary DC and prevent leader establishment from ever finishing.

I did this PR in 3 commits:

1. Update the build version used so that the offending test we saw failing with enterprise now failed the same in oss (the versions where CA replication can be used were different in enterprise/oss because it was introduce in enterprise back in 1.4.0.

2. Update the secondary CA initialization code to just emit warning logs when the primary datacenter wont sign its intermediate. I also updated another error returned to give more context why something may have failed.

3. Add the "correct" ACL permissions to the policies in use in the `TestLeader_ReplicationIntentions` test to get rid of any errors that the servers would be emitting.