### PR TITLE
ui: HTTPAdapter queryLeader refactor

### DIFF
--- a/ui-v2/app/adapters/acl.js
+++ b/ui-v2/app/adapters/acl.js
@@ -56,8 +56,8 @@ export default Adapter.extend({
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForCloneRecord(request, serialized, unserialized);
       },
-      function(serializer, response, serialized, unserialized) {
-        return serializer.respondForCreateRecord(response, serialized, unserialized);
+      function(serializer, respond, serialized, unserialized) {
+        return serializer.respondForCreateRecord(respond, serialized, unserialized);
       },
       snapshot,
       type.modelName

--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -32,9 +32,9 @@ export default Adapter.extend({
       .catch(function(e) {
         return adapter.error(e);
       })
-      .then(function(response) {
+      .then(function(respond) {
         // TODO: When HTTPAdapter:responder changes, this will also need to change
-        return resp(serializer, response, serialized, unserialized);
+        return resp(serializer, respond, serialized, unserialized);
       });
     // TODO: Potentially add specific serializer errors here
     // .catch(function(e) {

--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -27,8 +27,8 @@ export default Adapter.extend({
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForQueryLeader(request, serialized, unserialized);
       },
-      function(serializer, response, serialized, unserialized) {
-        return serializer.respondForQueryLeader(response, serialized, unserialized);
+      function(serializer, respond, serialized, unserialized) {
+        return serializer.respondForQueryLeader(respond, serialized, unserialized);
       },
       snapshot,
       type.modelName

--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -17,115 +17,21 @@ export default Adapter.extend({
       ${{ index }}
     `;
   },
-  // keep the none queryLeader bits in here ready to be refactored
-  // they will all be noops until these are added to the refactor
-  urlForRequest: function({ type, snapshot, requestType }) {
-    switch (requestType) {
-      case 'queryLeader':
-        return this.urlForQueryLeader(snapshot, type.modelName);
-    }
-    return this._super(...arguments);
+  requestForQueryLeader: function(request, { dc }) {
+    return request`
+      GET /v1/status/leader?${{ dc }}
+    `;
   },
-  urlForQueryLeader: function(query, modelName) {
-    // https://www.consul.io/api/status.html#get-raft-leader
-    return this.appendURL('status/leader', [], this.cleanQuery(query));
-  },
-  isQueryLeader: function(url, method) {
-    return url.pathname === this.parseURL(this.urlForQueryLeader({})).pathname;
-  },
-  queryLeader: function(store, modelClass, id, snapshot) {
-    const params = {
-      store: store,
-      type: modelClass,
-      id: id,
-      snapshot: snapshot,
-      requestType: 'queryLeader',
-    };
-    // _requestFor is private... but these methods aren't, until they disappear..
-    const request = {
-      method: this.methodForRequest(params),
-      url: this.urlForRequest(params),
-      headers: this.headersForRequest(params),
-      data: this.dataForRequest(params),
-    };
-    // TODO: private..
-    return this._makeRequest(request);
-  },
-  urlForRequest: function({ type, snapshot, requestType }) {
-    switch (requestType) {
-      case 'queryLeader':
-        return this.urlForQueryLeader(snapshot, type.modelName);
-    }
-    return this._super(...arguments);
-  },
-  urlForQueryLeader: function(query, modelName) {
-    // https://www.consul.io/api/status.html#get-raft-leader
-    return this.appendURL('status/leader', [], this.cleanQuery(query));
-  },
-  isQueryLeader: function(url, method) {
-    return url.pathname === this.parseURL(this.urlForQueryLeader({})).pathname;
-  },
-  queryLeader: function(store, modelClass, id, snapshot) {
-    const params = {
-      store: store,
-      type: modelClass,
-      id: id,
-      snapshot: snapshot,
-      requestType: 'queryLeader',
-    };
-    // _requestFor is private... but these methods aren't, until they disappear..
-    const request = {
-      method: this.methodForRequest(params),
-      url: this.urlForRequest(params),
-      headers: this.headersForRequest(params),
-      data: this.dataForRequest(params),
-    };
-    // TODO: private..
-    return this._makeRequest(request);
-  },
-  handleBatchResponse: function(url, response, primary, slug) {
-    const dc = url.searchParams.get(API_DATACENTER_KEY) || '';
-    return response.map((item, i, arr) => {
-      // this can go in the serializer
-      item = fillSlug(item);
-      // this could be replaced by handleSingleResponse
-      // maybe perf test first although even polyfilled searchParams should be super fast
-      return {
-        ...item,
-        ...{
-          [DATACENTER_KEY]: dc,
-          [PRIMARY_KEY]: this.uidForURL(url, item[SLUG_KEY]),
-        },
-      };
-    });
-  },
-  handleResponse: function(status, headers, payload, requestData) {
-    let response = payload;
-    const method = requestData.method;
-    if (status === HTTP_OK) {
-      const url = this.parseURL(requestData.url);
-      let temp, port, address;
-      switch (true) {
-        case this.isQueryLeader(url, method):
-          // This response is just an ip:port like `"10.0.0.1:8000"`
-          // split it and make it look like a `C`onsul.`R`esponse
-          // popping off the end for ports should cover us for IPv6 addresses
-          // as we should always get a `address:port` or `[a:dd:re:ss]:port` combo
-          temp = response.split(':');
-          port = temp.pop();
-          address = temp.join(':');
-          response = {
-            Address: address,
-            Port: port,
-          };
-          break;
-        case this.isQueryRecord(url, method):
-          response = this.handleSingleResponse(url, fillSlug(response), PRIMARY_KEY, SLUG_KEY);
-          break;
-        default:
-          response = this.handleBatchResponse(url, response, PRIMARY_KEY, SLUG_KEY);
-      }
-    }
-    return this._super(status, headers, response, requestData);
+  queryLeader: function(store, type, id, snapshot) {
+    return this.request(
+      function(adapter, request, serialized, unserialized) {
+        return adapter.requestForQueryLeader(request, serialized, unserialized);
+      },
+      function(serializer, response, serialized, unserialized) {
+        return serializer.respondForQueryLeader(response, serialized, unserialized);
+      },
+      snapshot,
+      type.modelName
+    );
   },
 });

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -83,8 +83,8 @@ export default Adapter.extend({
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForSelf(request, serialized, unserialized);
       },
-      function(serializer, response, serialized, unserialized) {
-        return serializer.respondForQueryRecord(response, serialized, unserialized);
+      function(serializer, respond, serialized, unserialized) {
+        return serializer.respondForQueryRecord(respond, serialized, unserialized);
       },
       unserialized,
       type.modelName
@@ -95,11 +95,11 @@ export default Adapter.extend({
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForCloneRecord(request, serialized, unserialized);
       },
-      function(serializer, response, serialized, unserialized) {
+      function(serializer, respond, serialized, unserialized) {
         // here we just have to pass through the dc (like when querying)
         // eventually the id is created with this dc value and the id talen from the
         // json response of `acls/token/*/clone`
-        return serializer.respondForQueryRecord(response, {
+        return serializer.respondForQueryRecord(respond, {
           [API_DATACENTER_KEY]: unserialized[SLUG_KEY],
         });
       },

--- a/ui-v2/app/serializers/node.js
+++ b/ui-v2/app/serializers/node.js
@@ -29,13 +29,14 @@ export default Serializer.extend({
     // don't call super here we don't care about
     // ids/fingerprinting
     return respond(function(headers, body) {
-      // This response is just an ip:port like `"10.0.0.1:8000"`
+      // This response/body is just an ip:port like `"10.0.0.1:8500"`
       // split it and make it look like a `C`onsul.`R`esponse
       // popping off the end for ports should cover us for IPv6 addresses
       // as we should always get a `address:port` or `[a:dd:re:ss]:port` combo
       const temp = body.split(':');
       const port = temp.pop();
       const address = temp.join(':');
+      // The string input `10.0.0.1:8500` would be transformed to...
       return {
         Address: address,
         Port: port,

--- a/ui-v2/app/serializers/node.js
+++ b/ui-v2/app/serializers/node.js
@@ -25,4 +25,21 @@ export default Serializer.extend({
       query
     );
   },
+  respondForQueryLeader: function(respond, query) {
+    // don't call super here we don't care about
+    // ids/fingerprinting
+    return respond(function(headers, body) {
+      // This response is just an ip:port like `"10.0.0.1:8000"`
+      // split it and make it look like a `C`onsul.`R`esponse
+      // popping off the end for ports should cover us for IPv6 addresses
+      // as we should always get a `address:port` or `[a:dd:re:ss]:port` combo
+      const temp = body.split(':');
+      const port = temp.pop();
+      const address = temp.join(':');
+      return {
+        Address: address,
+        Port: port,
+      };
+    });
+  },
 });

--- a/ui-v2/app/services/store.js
+++ b/ui-v2/app/services/store.js
@@ -31,9 +31,4 @@ export default Store.extend({
     const adapter = this.adapterFor(modelName);
     return adapter.queryLeader(this, { modelName: modelName }, null, query);
   },
-  queryLeader: function(modelName, query) {
-    // TODO: no normalization, type it properly for the moment
-    const adapter = this.adapterFor(modelName);
-    return adapter.queryLeader(this, { modelName: modelName }, null, query);
-  },
 });

--- a/ui-v2/app/services/store.js
+++ b/ui-v2/app/services/store.js
@@ -1,8 +1,8 @@
 import Store from 'ember-data/store';
 
-// TODO: These only exist for ACLs, should probably make sure they fail
-// nicely if you aren't on ACLs for good DX
 export default Store.extend({
+  // TODO: These only exist for ACLs, should probably make sure they fail
+  // nicely if you aren't on ACLs for good DX
   // cloning immediately refreshes the view
   clone: function(modelName, id) {
     // TODO: no normalization, type it properly for the moment
@@ -23,6 +23,9 @@ export default Store.extend({
     const adapter = this.adapterFor(modelName);
     return adapter.self(this, { modelName: modelName }, token.secret, token);
   },
+  //
+  // TODO: This one is only for nodes, should fail nicely if you call it
+  // for anything other than nodes for good DX
   queryLeader: function(modelName, query) {
     // TODO: no normalization, type it properly for the moment
     const adapter = this.adapterFor(modelName);

--- a/ui-v2/tests/acceptance/dc/services/instances/show.feature
+++ b/ui-v2/tests/acceptance/dc/services/instances/show.feature
@@ -14,7 +14,9 @@ Feature: dc / services / instances / show: Show Service Instance
         ID: service-0-with-id
         Tags: ['Tag1', 'Tag2']
         Meta:
+          consul-dashboard-url: http://url.com
           external-source: nomad
+          test-meta: test-meta-value
       Node:
         Node: another-node
       Checks:
@@ -77,7 +79,7 @@ Feature: dc / services / instances / show: Show Service Instance
 
     When I click metaData on the tabs
     And I see metaDataIsSelected on the tabs
-    And I see 1 of the metaData object
+    And I see 3 of the metaData object
 
   Scenario: A Service instance warns when deregistered whilst blocking
     Given settings from yaml

--- a/ui-v2/tests/helpers/set-cookies.js
+++ b/ui-v2/tests/helpers/set-cookies.js
@@ -14,6 +14,9 @@ export default function(type, value) {
       case 'instance':
         key = 'CONSUL_NODE_COUNT';
         break;
+      case 'proxy':
+        key = 'CONSUL_PROXY_COUNT';
+        break;
       case 'kv':
         key = 'CONSUL_KV_COUNT';
         break;

--- a/ui-v2/tests/integration/adapters/node-test.js
+++ b/ui-v2/tests/integration/adapters/node-test.js
@@ -32,4 +32,13 @@ module('Integration | Adapter | node', function(hooks) {
       });
     });
   });
+  test('requestForQueryLeader returns the correct url', function(assert) {
+    const adapter = this.owner.lookup('adapter:node');
+    const client = this.owner.lookup('service:client/http');
+    const expected = `GET /v1/status/leader?dc=${dc}`;
+    const actual = adapter.requestForQueryLeader(client.url, {
+      dc: dc,
+    });
+    assert.equal(actual, expected);
+  });
 });

--- a/ui-v2/tests/integration/serializers/node-test.js
+++ b/ui-v2/tests/integration/serializers/node-test.js
@@ -56,4 +56,28 @@ module('Integration | Serializer | node', function(hooks) {
       assert.deepEqual(actual, expected);
     });
   });
+  test('respondForQueryLeader returns the correct data', function(assert) {
+    const serializer = this.owner.lookup('serializer:node');
+    const dc = 'dc-1';
+    const request = {
+      url: `/v1/status/leader?dc=${dc}`,
+    };
+    return get(request.url).then(function(payload) {
+      const expected = {
+        Address: '211.245.86.75',
+        Port: '8500',
+      };
+      const actual = serializer.respondForQueryLeader(
+        function(cb) {
+          const headers = {};
+          const body = payload;
+          return cb(headers, body);
+        },
+        {
+          dc: dc,
+        }
+      );
+      assert.deepEqual(actual, expected);
+    });
+  });
 });


### PR DESCRIPTION
As the HTTPAdapter work (see https://github.com/hashicorp/consul/pull/5637) has been long running, we've since added functionality to figure out the leader of the consul datacenter, which uses the status API (see https://github.com/hashicorp/consul/pull/6265).

This PR migrates this work over to the new HTTPAdapter, we also add a couple of extra tests here.

The related changes commit also happen elsewhere, and are 'incidental' changes to pretty much tie up all the loose ends of this run of work whilst keeping the ember upgrade as a separate PR.

As a side note: You can really see the difference in this diff in complication with adding a new API call here between the old way and the new way 🎉 