### PR TITLE
Bump eventmachine to 1.2.7 in Gemfile.lock

### DIFF
--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
-    eventmachine (1.2.5)
+    eventmachine (1.2.7)
     execjs (2.7.0)
     ffi (1.9.25)
     haml (5.0.4)


### PR DESCRIPTION
Needed to resolve an issue present in `eventmachine@1.2.5` where it will fail to compile when building with a newer version of LLVM with C++17 support.

Refs https://github.com/eventmachine/eventmachine/pull/831