### PR TITLE
make sure auto_encrypt has private key type and bits

### DIFF
--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -51,6 +51,13 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 		return errFn(err)
 	}
 
+	if conf.PrivateKeyType == "" {
+		conf.PrivateKeyType = connect.DefaultPrivateKeyType
+	}
+	if conf.PrivateKeyBits == 0 {
+		conf.PrivateKeyBits = connect.DefaultPrivateKeyBits
+	}
+
 	// Create a new private key
 	pk, pkPEM, err := connect.GeneratePrivateKeyWithConfig(conf.PrivateKeyType, conf.PrivateKeyBits)
 	if err != nil {


### PR DESCRIPTION
`PrivateKeyType` and `PrivateKeyBits` is empty when loading `c.config.CAConfig.GetCommonConfig()` which causes an error. This PR makes sure it has at least the defaults and also adds a test that would've caught this problem.

Fixes #6391 