### PR TITLE
Rephrase bind docs

### DIFF
--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -88,15 +88,16 @@ The options below are all specified on the command-line.
   for internal cluster communications.
   This is an IP address that should be reachable by all other nodes in the cluster.
   By default, this is "0.0.0.0", meaning Consul will bind to all addresses on
-the local machine and will [advertise](/docs/agent/options.html#_advertise)
-the first available private IPv4 address to the rest of the cluster. If there
-are **multiple private IPv4 addresses** available, Consul will exit with an error
-at startup. If you specify "[::]", Consul will
-[advertise](/docs/agent/options.html#_advertise) the first available public
-IPv6 address. If there are **multiple public IPv6 addresses** available, Consul
-will exit with an error at startup.
-  Consul uses both TCP and UDP and the same port for both. If you
-  have any firewalls, be sure to allow both protocols. **In Consul 1.0 and later this can be set to a [go-sockaddr](https://godoc.org/github.com/hashicorp/go-sockaddr/template) template that needs to resolve to a single address.** Some example templates:
+  the local machine and will [advertise](/docs/agent/options.html#_advertise)
+  the private IPv4 address to the rest of the cluster. If there
+  are multiple private IPv4 addresses available, Consul will exit with an error
+  at startup. If you specify "[::]", Consul will [advertise](/docs/agent/options.html#_advertise) 
+  the public IPv6 address. 
+  If there are multiple public IPv6 addresses available, Consul will exit with an error at startup.
+  Consul uses both TCP and UDP and the same port for both. If you have any firewalls, 
+  be sure to allow both protocols. In Consul 1.0 and later this can be set to a 
+  [go-sockaddr](https://godoc.org/github.com/hashicorp/go-sockaddr/template) 
+  template that needs to resolve to a single address. Some example templates:
 
     ```sh
     # Using address within a specific CIDR


### PR DESCRIPTION
Currently the documentation for `bind_address` makes it seem like Consul will advertise the first private IPv4 address if there are multiple. However, if multiple are available then Consul will instead return an error.