### PR TITLE
test: don't leak agent goroutines in TestAgent_sidecarServiceFromNodeService

### DIFF
--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -322,6 +322,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 
 			require := require.New(t)
 			a := NewTestAgent(t, "jones", hcl)
+			defer a.Shutdown()
 
 			if tt.preRegister != nil {
 				err := a.AddService(tt.preRegister.NodeService(), nil, false, "", ConfigSourceLocal)


### PR DESCRIPTION
A goroutine dump using runtime.Stack() before/after shows a drop from 121 => 4.