### PR TITLE
Distinguish errors between DC not existing and not available

### DIFF
--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -315,7 +315,7 @@ func (s *Server) getLeader() (bool, *metadata.Server) {
 func (s *Server) forwardDC(method, dc string, args interface{}, reply interface{}) error {
 	manager, server, ok := s.router.FindRoute(dc)
 	if !ok {
-		if s.router.IsDatacenterDefined(dc) {
+		if s.router.HasDatacenter(dc) {
 			s.logger.Printf("[WARN] consul.rpc: RPC request for DC %q temporary failure", dc)
 			return structs.ErrDCNotAvailable
 		}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -316,7 +316,7 @@ func (s *Server) forwardDC(method, dc string, args interface{}, reply interface{
 	manager, server, ok := s.router.FindRoute(dc)
 	if !ok {
 		if s.router.HasDatacenter(dc) {
-			s.logger.Printf("[WARN] consul.rpc: RPC request for DC %q temporary failure", dc)
+			s.logger.Printf("[WARN] consul.rpc: RPC request to DC %q is currently failing as no server can be reached", dc)
 			return structs.ErrDCNotAvailable
 		}
 		s.logger.Printf("[WARN] consul.rpc: RPC request for unkown DC %q", dc)

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -315,7 +315,11 @@ func (s *Server) getLeader() (bool, *metadata.Server) {
 func (s *Server) forwardDC(method, dc string, args interface{}, reply interface{}) error {
 	manager, server, ok := s.router.FindRoute(dc)
 	if !ok {
-		s.logger.Printf("[WARN] consul.rpc: RPC request for DC %q, no path found", dc)
+		if s.router.IsDatacenterDefined(dc) {
+			s.logger.Printf("[WARN] consul.rpc: RPC request for DC %q temporary failure", dc)
+			return structs.ErrDCNotAvailable
+		}
+		s.logger.Printf("[DEBUG] consul.rpc: RPC request for DC %q, no such DC", dc)
 		return structs.ErrNoDCPath
 	}
 

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -319,7 +319,7 @@ func (s *Server) forwardDC(method, dc string, args interface{}, reply interface{
 			s.logger.Printf("[WARN] consul.rpc: RPC request for DC %q temporary failure", dc)
 			return structs.ErrDCNotAvailable
 		}
-		s.logger.Printf("[DEBUG] consul.rpc: RPC request for DC %q, no such DC", dc)
+		s.logger.Printf("[WARN] consul.rpc: RPC request for unkown DC %q", dc)
 		return structs.ErrNoDCPath
 	}
 

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -356,8 +356,8 @@ func (r *Router) GetDatacenters() []string {
 	return dcs
 }
 
-// IsDatacenterDefined checks whether dc is defined in WAN
-func (r *Router) IsDatacenterDefined(dc string) bool {
+// HasDatacenter checks whether dc is defined in WAN
+func (r *Router) HasDatacenter(dc string) bool {
 	r.RLock()
 	defer r.RUnlock()
 	_, ok := r.managers[dc]

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -356,6 +356,14 @@ func (r *Router) GetDatacenters() []string {
 	return dcs
 }
 
+// IsDatacenterDefined checks whether dc is defined in WAN
+func (r *Router) IsDatacenterDefined(dc string) bool {
+	r.RLock()
+	defer r.RUnlock()
+	_, ok := r.managers[dc]
+	return ok
+}
+
 // datacenterSorter takes a list of DC names and a parallel vector of distances
 // and implements sort.Interface, keeping both structures coherent and sorting
 // by distance.

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -8,6 +8,7 @@ import (
 const (
 	errNoLeader                   = "No cluster leader"
 	errNoDCPath                   = "No path to datacenter"
+	errDCNotAvailable             = "Remote DC is temporary unavailable"
 	errNoServers                  = "No known Consul servers"
 	errNotReadyForConsistentReads = "Not ready to serve consistent reads"
 	errSegmentsNotSupported       = "Network segments are not supported in this version of Consul"
@@ -22,6 +23,7 @@ var (
 	ErrNotReadyForConsistentReads = errors.New(errNotReadyForConsistentReads)
 	ErrSegmentsNotSupported       = errors.New(errSegmentsNotSupported)
 	ErrRPCRateExceeded            = errors.New(errRPCRateExceeded)
+	ErrDCNotAvailable             = errors.New(errDCNotAvailable)
 )
 
 func IsErrNoLeader(err error) bool {

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -8,7 +8,7 @@ import (
 const (
 	errNoLeader                   = "No cluster leader"
 	errNoDCPath                   = "No path to datacenter"
-	errDCNotAvailable             = "Remote DC is temporary unavailable"
+	errDCNotAvailable             = "Remote DC has no server currently reachable"
 	errNoServers                  = "No known Consul servers"
 	errNotReadyForConsistentReads = "Not ready to serve consistent reads"
 	errSegmentsNotSupported       = "Network segments are not supported in this version of Consul"


### PR DESCRIPTION
Following Discussion in https://github.com/hashicorp/consul-template/issues/1250 and https://github.com/hashicorp/consul/issues/5881 this PR want to give the ability to clients to distinguish Datacenter not existing at all from not currently available (because of downtime of the DC or temp link unavailability).

This cause some issues for instance in templates such as consul-template or [consul-templaterb](https://github.com/criteo/consul-templaterb/) where it is difficult for the client to choose correct behavior (retry or fail).

This PR allow to diagnose whether the datacenter requested is temporary non-available or if the DC does not exists.