### PR TITLE
Verify service name for the successful dns resolution

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -334,11 +334,11 @@ func (a *Agent) Start() error {
 	c := a.config
 
 	// Warn if the node name is incompatible with DNS
-	if InvalidDnsRe.MatchString(a.config.NodeName) {
+	if config.InvalidDNSRe.MatchString(a.config.NodeName) {
 		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", a.config.NodeName)
-	} else if len(a.config.NodeName) > MaxDNSLabelLength {
+	} else if len(a.config.NodeName) > config.MaxDNSLabelLength {
 		a.logger.Printf("[WARN] agent: Node name %q will not be discoverable "+
 			"via DNS due to it being too long. Valid lengths are between "+
 			"1 and 63 bytes.", a.config.NodeName)
@@ -2125,11 +2125,11 @@ func (a *Agent) validateService(service *structs.NodeService, chkTypes []*struct
 	}
 
 	// Warn if the service name is incompatible with DNS
-	if InvalidDnsRe.MatchString(service.Service) {
+	if config.InvalidDNSRe.MatchString(service.Service) {
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to invalid characters. Valid characters include "+
 			"all alpha-numerics and dashes.", service.Service)
-	} else if len(service.Service) > MaxDNSLabelLength {
+	} else if len(service.Service) > config.MaxDNSLabelLength {
 		a.logger.Printf("[WARN] agent: Service name %q will not be discoverable "+
 			"via DNS due to it being too long. Valid lengths are between "+
 			"1 and 63 bytes.", service.Service)
@@ -2137,11 +2137,11 @@ func (a *Agent) validateService(service *structs.NodeService, chkTypes []*struct
 
 	// Warn if any tags are incompatible with DNS
 	for _, tag := range service.Tags {
-		if InvalidDnsRe.MatchString(tag) {
+		if config.InvalidDNSRe.MatchString(tag) {
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to invalid characters. Valid characters include "+
 				"all alpha-numerics and dashes.", tag)
-		} else if len(tag) > MaxDNSLabelLength {
+		} else if len(tag) > config.MaxDNSLabelLength {
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to it being too long. Valid lengths are between "+
 				"1 and 63 bytes.", tag)

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure"
 
-	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/acl"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
+	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/debug"
 	"github.com/hashicorp/consul/agent/structs"
 	token_store "github.com/hashicorp/consul/agent/token"
@@ -828,8 +828,8 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 	if s.agent.config.VerifyServiceName {
 		if config.InvalidDNSRe.MatchString(args.Name) {
 			return nil, fmt.Errorf("service name %q will not be discoverable "+
-			"via DNS due to invalid characters. Valid characters include "+
-			"all alpha-numerics and dashes.", args.Name)
+				"via DNS due to invalid characters. Valid characters include "+
+				"all alpha-numerics and dashes.", args.Name)
 		}
 	}
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure"
 
+	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/acl"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/debug"
@@ -822,6 +823,14 @@ func (s *HTTPServer) AgentRegisterService(resp http.ResponseWriter, req *http.Re
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing service name")
 		return nil, nil
+	}
+
+	if s.agent.config.VerifyServiceName {
+		if config.InvalidDNSRe.MatchString(args.Name) {
+			return nil, fmt.Errorf("service name %q will not be discoverable "+
+			"via DNS due to invalid characters. Valid characters include "+
+			"all alpha-numerics and dashes.", args.Name)
+		}
 	}
 
 	// Check the service address here and in the catalog RPC endpoint

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3463,7 +3463,7 @@ func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
 		}
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
 
-		_, err := a.srv.AgentRegisterService(nil, req)
+		_, err := a2.srv.AgentRegisterService(nil, req)
 		require.NoError(t, err)
 	}
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3463,7 +3463,7 @@ func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
 		}
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
 
-		obj, err := a.srv.AgentRegisterService(nil, req)
+		_, err := a.srv.AgentRegisterService(nil, req)
 		require.NoError(t, err)
 	}
 }

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3437,14 +3437,22 @@ func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	args := &structs.ServiceDefinition{
-		Name: "docker|build",
+	invalidNames := []string{
+		"docker|build",
+		"docker.build",
+		"docker_build",
 	}
-	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
 
-	_, err := a.srv.AgentRegisterService(nil, req)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "will not be discoverable via DNS due to invalid characters")
+	for _, in := range invalidNames {
+		args := &structs.ServiceDefinition{
+			Name: in,
+		}
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+	
+		_, err := a.srv.AgentRegisterService(nil, req)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "will not be discoverable via DNS due to invalid characters")
+	}
 }
 
 func TestAgent_DeregisterService(t *testing.T) {

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3448,7 +3448,7 @@ func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
 			Name: in,
 		}
 		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
-	
+
 		_, err := a.srv.AgentRegisterService(nil, req)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "will not be discoverable via DNS due to invalid characters")

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3431,6 +3431,22 @@ func TestAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T) {
 	}
 }
 
+func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t, t.Name(), "verify_service_name = true")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	args := &structs.ServiceDefinition{
+		Name: "docker|build",
+	}
+	req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+
+	_, err := a.srv.AgentRegisterService(nil, req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "will not be discoverable via DNS due to invalid characters")
+}
+
 func TestAgent_DeregisterService(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3453,6 +3453,19 @@ func TestAgent_RegisterService_InvalidServiceName(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "will not be discoverable via DNS due to invalid characters")
 	}
+
+	a2 := NewTestAgent(t, t.Name(), "")
+	defer a2.Shutdown()
+	testrpc.WaitForTestAgent(t, a2.RPC, "dc1")
+	for _, in := range invalidNames {
+		args := &structs.ServiceDefinition{
+			Name: in,
+		}
+		req, _ := http.NewRequest("PUT", "/v1/agent/service/register", jsonReader(args))
+
+		obj, err := a.srv.AgentRegisterService(nil, req)
+		require.NoError(t, err)
+	}
 }
 
 func TestAgent_DeregisterService(t *testing.T) {

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -894,6 +894,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		VerifyIncomingRPC:                b.boolVal(c.VerifyIncomingRPC),
 		VerifyOutgoing:                   verifyOutgoing,
 		VerifyServerHostname:             verifyServerName,
+		VerifyServiceName:                b.boolVal(c.VerifyServiceName),
 		Watches:                          c.Watches,
 	}
 
@@ -1024,6 +1025,16 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 			keyfileWAN := filepath.Join(rt.DataDir, SerfWANKeyring)
 			if _, err := os.Stat(keyfileWAN); err == nil {
 				b.warn("WARNING: WAN keyring exists but -encrypt given, using keyring")
+			}
+		}
+	}
+
+	if rt.VerifyServiceName {
+		rule := `^[a-zA-Z0-9\-\.]$`
+		r := regexp.MustCompile(rule)
+		for _, s := range rt.Services {
+			if !r.MatchString(s.Name) {
+				return fmt.Errorf("service name %v is not valid, use hostname that matches with %v for successful dns resolution", s.Name, rule)
 			}
 		}
 	}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1030,7 +1030,7 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 	}
 
 	if rt.VerifyServiceName {
-		rule := `^[a-zA-Z0-9\-\.]$`
+		rule := `^[a-zA-Z0-9-.]+$`
 		r := regexp.MustCompile(rule)
 		for _, s := range rt.Services {
 			if !r.MatchString(s.Name) {

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -29,7 +29,7 @@ import (
 
 // InvalidDNSRe matches with names which will not be discoverable via DNS.
 var InvalidDNSRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
-	
+
 // MaxDNSLabelLength is the max length of discoverable name.
 const MaxDNSLabelLength = 63
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -278,6 +278,7 @@ type Config struct {
 	VerifyIncomingRPC                *bool                    `json:"verify_incoming_rpc,omitempty" hcl:"verify_incoming_rpc" mapstructure:"verify_incoming_rpc"`
 	VerifyOutgoing                   *bool                    `json:"verify_outgoing,omitempty" hcl:"verify_outgoing" mapstructure:"verify_outgoing"`
 	VerifyServerHostname             *bool                    `json:"verify_server_hostname,omitempty" hcl:"verify_server_hostname" mapstructure:"verify_server_hostname"`
+	VerifyServiceName                *bool                    `json:"verify_service_name,omitempty" hcl:"verify_service_name" mapstructure:"verify_service_name"`
 	Watches                          []map[string]interface{} `json:"watches,omitempty" hcl:"watches" mapstructure:"watches"`
 
 	// This isn't used by Consul but we've documented a feature where users

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -111,4 +111,5 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.UIContentPath, "ui-content-path", "Sets the external UI path to a string. Defaults to: /ui/ ")
 	add(&f.Config.UIDir, "ui-dir", "Path to directory containing the web UI resources.")
 	add(&f.HCL, "hcl", "hcl config fragment. Can be specified multiple times.")
+	add(&f.Config.VerifyServiceName, "verify-service-name", "When given, verify service name if it meets the condition of RFC-952 and RFC-1123 for successful dns resolution.")
 }

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -111,5 +111,5 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.UIContentPath, "ui-content-path", "Sets the external UI path to a string. Defaults to: /ui/ ")
 	add(&f.Config.UIDir, "ui-dir", "Path to directory containing the web UI resources.")
 	add(&f.HCL, "hcl", "hcl config fragment. Can be specified multiple times.")
-	add(&f.Config.VerifyServiceName, "verify-service-name", "When given, verify service name if it meets the condition of RFC-952 and RFC-1123 for successful dns resolution.")
+	add(&f.Config.VerifyServiceName, "verify-service-name", "When given, verify service name if it is discoverable via DNS.")
 }

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1451,6 +1451,11 @@ type RuntimeConfig struct {
 	// hcl: verify_server_hostname = (true|false)
 	VerifyServerHostname bool
 
+	// VerifyServiceName is used to enable verification of service name.
+	// This ensures that the service name, which used for dns resolution later
+	// meets the condition of RFC-952 and RFC-1123.
+	VerifyServiceName bool
+
 	// Watches are used to monitor various endpoints and to invoke a
 	// handler to act appropriately. These are managed entirely in the
 	// agent layer using the standard APIs.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1454,6 +1454,7 @@ type RuntimeConfig struct {
 	// VerifyServiceName is used to enable verification of service name.
 	// This ensures that the service name, which used for dns resolution later
 	// meets the condition of RFC-952 and RFC-1123.
+	// When given, verify service name if it is discoverable via DNS.
 	VerifyServiceName bool
 
 	// Watches are used to monitor various endpoints and to invoke a

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -5762,6 +5762,7 @@ func TestSanitize(t *testing.T) {
 		"VerifyIncomingRPC": false,
 		"VerifyOutgoing": false,
 		"VerifyServerHostname": false,
+		"VerifyServiceName": false,
 		"Version": "",
 		"VersionPrerelease": "",
 		"Watches": [],

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -37,11 +37,7 @@ const (
 	staleCounterThreshold = 5 * time.Second
 
 	defaultMaxUDPSize = 512
-
-	MaxDNSLabelLength = 63
 )
-
-var InvalidDnsRe = regexp.MustCompile(`[^A-Za-z0-9\\-]+`)
 
 type dnsSOAConfig struct {
 	Refresh uint32 // 3600 by default
@@ -487,7 +483,7 @@ func (d *DNSServer) nameservers(cfg *dnsConfig, edns bool, maxRecursionLevel int
 	for _, o := range out.Nodes {
 		name, addr, dc := o.Node.Node, o.Node.Address, o.Node.Datacenter
 
-		if InvalidDnsRe.MatchString(name) {
+		if config.InvalidDNSRe.MatchString(name) {
 			d.logger.Printf("[WARN] dns: Skipping invalid node %q for NS records", name)
 			continue
 		}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6519,7 +6519,7 @@ func TestDNSInvalidRegex(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			if got, want := InvalidDnsRe.MatchString(test.in), test.invalid; got != want {
+			if got, want := config.InvalidDNSRe.MatchString(test.in), test.invalid; got != want {
 				t.Fatalf("Expected %v to return %v", test.in, want)
 			}
 		})

--- a/command/validate/validate.go
+++ b/command/validate/validate.go
@@ -54,14 +54,10 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	var tv bool
-	if c.checkServiceName {
-		tv = true
-	}
 	b, err := config.NewBuilder(config.Flags{
 		ConfigFiles:  configFiles,
 		ConfigFormat: &c.configFormat,
-		Config:       config.Config{VerifyServiceName: &tv},
+		Config:       config.Config{VerifyServiceName: & c.checkServiceName},
 	})
 
 	if err != nil {

--- a/command/validate/validate.go
+++ b/command/validate/validate.go
@@ -57,7 +57,7 @@ func (c *cmd) Run(args []string) int {
 	b, err := config.NewBuilder(config.Flags{
 		ConfigFiles:  configFiles,
 		ConfigFormat: &c.configFormat,
-		Config:       config.Config{VerifyServiceName: & c.checkServiceName},
+		Config:       config.Config{VerifyServiceName: &c.checkServiceName},
 	})
 
 	if err != nil {

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -147,23 +147,28 @@ func TestValidateCommand_Quiet(t *testing.T) {
 func TestValidateCommand_VerifyServiceName(t *testing.T) {
 	t.Parallel()
 
-	serviceName := "docker|build"
-	errorMessage := `Config validation failed: service name "` + serviceName +
-		`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
-
 	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)
-
 	fp := filepath.Join(td, "config.json")
-	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "services": [{"name":"`+serviceName+`"}], "data_dir":"`+td+`"}`), 0644)
 
-	require.Nilf(t, err, "err: %s", err)
+	invalidNames := []string{
+		"docker|build",
+		"docker.build",
+		"docker_build",
+	}
 
-	ui := cli.NewMockUi()
-	cmd := New(ui)
-	args := []string{"-verify-service-name", td}
+	for _, in := range invalidNames {
+		err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "services": [{"name":"`+in+`"}], "data_dir":"`+td+`"}`), 0644)
+		require.Nilf(t, err, "err: %s", err)
 
-	code := cmd.Run(args)
-	require.Equal(t, 1, code, errorMessage, ui.ErrorWriter.String())
-	require.Equal(t, "", ui.OutputWriter.String())
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+		args := []string{"-verify-service-name", td}
+
+		errorMessage := `Config validation failed: service name "` + in +
+		`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
+		code := cmd.Run(args)
+		require.Equal(t, 1, code, errorMessage, ui.ErrorWriter.String())
+		require.Equal(t, "", ui.OutputWriter.String())
+	}
 }

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -166,7 +166,7 @@ func TestValidateCommand_VerifyServiceName(t *testing.T) {
 		args := []string{"-verify-service-name", td}
 
 		errorMessage := `Config validation failed: service name "` + in +
-		`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
+			`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
 		code := cmd.Run(args)
 		require.Equal(t, 1, code, errorMessage, ui.ErrorWriter.String())
 		require.Equal(t, "", ui.OutputWriter.String())

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -148,8 +148,8 @@ func TestValidateCommand_VerifyServiceName(t *testing.T) {
 	t.Parallel()
 
 	serviceName := "docker|build"
-	errorMessage := `Config validation failed: service name "`+serviceName+
-	`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
+	errorMessage := `Config validation failed: service name "` + serviceName +
+		`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
 
 	td := testutil.TempDir(t, "consul")
 	defer os.RemoveAll(td)

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -163,12 +163,19 @@ func TestValidateCommand_VerifyServiceName(t *testing.T) {
 
 		ui := cli.NewMockUi()
 		cmd := New(ui)
-		args := []string{"-verify-service-name", td}
 
+		args := []string{"-verify-service-name", td}
 		errorMessage := `Config validation failed: service name "` + in +
 			`" will not be discoverable via DNS due to invalid characters. Valid characters include all alpha-numerics and dashes.`
 		code := cmd.Run(args)
 		require.Equal(t, 1, code, errorMessage, ui.ErrorWriter.String())
 		require.Equal(t, "", ui.OutputWriter.String())
+
+		ui = cli.NewMockUi()
+		cmd = New(ui)
+		args = []string{td}
+		code = cmd.Run(args)
+		require.Equal(t, 0, code)
+		t.Log(ui.ErrorWriter.String())
 	}
 }


### PR DESCRIPTION
#6335 

```
{
  "services": [{
    "name": "docker|build"
  }],
  "bind_addr": "{{GetInterfaceIP \"en0\"}}",
  "data_dir": "~/consul-data/"
}
```

The configuration above can cause dns resolution failure for the service name is not valid as hostname. So this PR added a flag `verify-service-name` to check if the service name is valid as hostname.

Sample usage is as follows.

```
$ consul agent -config-dir ~/conf.d -verify-service-name
==> service name docker|build is not valid, use hostname that matches with ^[a-zA-Z0-9\-\.]$ for successful dns resolution
```

```
$ consul validate -verify-service-name ~/conf.d/config.json
Config validation failed: service name docker|build is not valid, use hostname that matches with ^[a-zA-Z0-9\-\.]$ for successful dns resolution
```

If the flag is not specified, the validation will be skipped.

```
$ consul validate ~/conf.d/config.json
Configuration is valid!
```