### PR TITLE
test: add additional http status code assertions in coordinate HTTP API tests

### DIFF
--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -92,7 +92,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 		}
 
 		if resp.Code != http.StatusOK {
-			t.Fatalf("bad: %v", resp.Code)
+			r.Fatalf("bad: %v", resp.Code)
 		}
 
 		// Check that coordinates are empty before registering a node
@@ -153,7 +153,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 		}
 
 		if resp.Code != http.StatusOK {
-			t.Fatalf("bad: %v", resp.Code)
+			r.Fatalf("bad: %v", resp.Code)
 		}
 
 		coordinates, ok := obj.(structs.Coordinates)
@@ -176,7 +176,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 		}
 
 		if resp.Code != http.StatusOK {
-			t.Fatalf("bad: %v", resp.Code)
+			r.Fatalf("bad: %v", resp.Code)
 		}
 
 		coordinates, ok := obj.(structs.Coordinates)
@@ -197,7 +197,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 		}
 
 		if resp.Code != http.StatusOK {
-			t.Fatalf("bad: %v", resp.Code)
+			r.Fatalf("bad: %v", resp.Code)
 		}
 
 		coordinates, ok := obj.(structs.Coordinates)


### PR DESCRIPTION
When these tests flake sometimes this happens:

    --- FAIL: TestCoordinate_Node (1.69s)
    panic: interface conversion: interface {} is nil, not structs.Coordinates [recovered]
    FAIL    github.com/hashicorp/consul/agent       19.999s
    Exit code: 1
    panic: interface conversion: interface {} is nil, not structs.Coordinates [recovered]
            panic: interface conversion: interface {} is nil, not structs.Coordinates

There is definitely a bug lurking, but the code seems to imply this can
only return nil on 404. The tests previously were not checking the
status code.

The underlying cause of the flake is unknown, but this should turn the
failure into a more normal test failure.