### PR TITLE
Do not surface left servers

### DIFF
--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -64,10 +64,6 @@ func (s *Server) String() string {
 	return fmt.Sprintf("%s (Addr: %s/%s) (DC: %s)", s.Name, networkStr, addrStr, s.Datacenter)
 }
 
-func (s *Server) HasLeft() bool {
-	return s.Status == serf.StatusLeft
-}
-
 var versionFormat = regexp.MustCompile(`\d+\.\d+\.\d+`)
 
 // IsConsulServer returns true if a serf member is a consul server

--- a/agent/metadata/server.go
+++ b/agent/metadata/server.go
@@ -64,6 +64,10 @@ func (s *Server) String() string {
 	return fmt.Sprintf("%s (Addr: %s/%s) (DC: %s)", s.Name, networkStr, addrStr, s.Datacenter)
 }
 
+func (s *Server) HasLeft() bool {
+	return s.Status == serf.StatusLeft
+}
+
 var versionFormat = regexp.MustCompile(`\d+\.\d+\.\d+`)
 
 // IsConsulServer returns true if a serf member is a consul server

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -473,6 +473,12 @@ func (r *Router) GetDatacenterMaps() ([]structs.DatacenterMap, error) {
 				continue
 			}
 
+			if m.Status == serf.StatusLeft {
+				r.logger.Printf("[DEBUG]: consul: server %q in area %q left, skipping",
+					m.Name, areaID)
+				continue
+			}
+
 			coord, ok := info.cluster.GetCachedCoordinate(parts.Name)
 			if ok {
 				entry := &structs.Coordinate{

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -406,7 +406,7 @@ func (r *Router) GetDatacentersByDistance() ([]string, error) {
 				continue
 			}
 
-			if parts.HasLeft() {
+			if m.Status == serf.StatusLeft {
 				r.logger.Printf("[DEBUG]: consul: server %q in area %q left, skipping",
 					m.Name, areaID)
 				continue

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -406,6 +406,12 @@ func (r *Router) GetDatacentersByDistance() ([]string, error) {
 				continue
 			}
 
+			if parts.HasLeft() {
+				r.logger.Printf("[DEBUG]: consul: server %q in area %q left, skipping",
+					m.Name, areaID)
+				continue
+			}
+
 			existing := index[parts.Datacenter]
 			if parts.Datacenter == r.localDatacenter {
 				// Everything in the local datacenter looks like zero RTT.


### PR DESCRIPTION
Left servers will never come back so there is no reason to surface them in `GetDatacentersByDistance`. One of the results is that dcs with only left servers will no longer show up in `v1/catalog/datacenters`, which is the right thing to do since this dc is not reachable.