### PR TITLE
test: ensure the node name is a valid dns name

### DIFF
--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -348,7 +348,7 @@ func TestConfig(sources ...config.Source) *config.RuntimeConfig {
 			bootstrap = true
 			server = true
 			node_id = "` + nodeID + `"
-			node_name = "Node ` + nodeID + `"
+			node_name = "Node-` + nodeID + `"
 			connect {
 				enabled = true
 				ca_config {


### PR DESCRIPTION
The space in the node name was making every test emit a useless warning.