### PR TITLE
Fix check registration in 'services register' command

### DIFF
--- a/command/services/config.go
+++ b/command/services/config.go
@@ -66,10 +66,10 @@ func serviceToAgentService(svc *structs.ServiceDefinition) (*api.AgentServiceReg
 	// The structs version has non-pointer checks and the destination
 	// has pointers, so we need to set the destination to nil if there
 	// is no check ID set.
-	if result.Check != nil && result.Check.CheckID == "" {
+	if result.Check != nil && (result.Check.CheckID == "" && result.Check.Name == "") {
 		result.Check = nil
 	}
-	if len(result.Checks) == 1 && result.Checks[0].CheckID == "" {
+	if len(result.Checks) == 1 && (result.Checks[0].CheckID == "" && result.Checks[0].Name == "") {
 		result.Checks = nil
 	}
 

--- a/command/services/config.go
+++ b/command/services/config.go
@@ -66,10 +66,10 @@ func serviceToAgentService(svc *structs.ServiceDefinition) (*api.AgentServiceReg
 	// The structs version has non-pointer checks and the destination
 	// has pointers, so we need to set the destination to nil if there
 	// is no check ID set.
-	if result.Check != nil && result.Check.Name == "" {
+	if result.Check != nil && result.Check.CheckID == "" {
 		result.Check = nil
 	}
-	if len(result.Checks) == 1 && result.Checks[0].Name == "" {
+	if len(result.Checks) == 1 && result.Checks[0].CheckID == "" {
 		result.Checks = nil
 	}
 

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -49,7 +49,7 @@ func TestStructsToAgentService(t *testing.T) {
 			},
 		},
 		{
-			"Service with a check",
+			"Service has a check with name but no id",
 			&structs.ServiceDefinition{
 				Name: "web",
 				Check: structs.CheckType{
@@ -64,7 +64,7 @@ func TestStructsToAgentService(t *testing.T) {
 			},
 		},
 		{
-			"Service with a check id",
+			"Service has a check with id but no name",
 			&structs.ServiceDefinition{
 				Name: "web",
 				Check: structs.CheckType{

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -64,6 +64,21 @@ func TestStructsToAgentService(t *testing.T) {
 			},
 		},
 		{
+			"Service with a check id",
+			&structs.ServiceDefinition{
+				Name: "web",
+				Check: structs.CheckType{
+					CheckID: "ping",
+				},
+			},
+			&api.AgentServiceRegistration{
+				Name: "web",
+				Check: &api.AgentServiceCheck{
+					CheckID: "ping",
+				},
+			},
+		},
+		{
 			"Service with checks",
 			&structs.ServiceDefinition{
 				Name: "web",

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -70,7 +70,7 @@ func TestCommand_File(t *testing.T) {
 	ui := cli.NewMockUi()
 	c := New(ui)
 
-	contents := `{ "Service": { "Name": "web" } }`
+	contents := `{ "Service": { "Name": "web", "Check": {"id": "web-check", "tcp": "localhost:80", "interval": "1s"}} }`
 	f := testFile(t, "json")
 	defer os.Remove(f.Name())
 	if _, err := f.WriteString(contents); err != nil {
@@ -90,6 +90,11 @@ func TestCommand_File(t *testing.T) {
 
 	svc := svcs["web"]
 	require.NotNil(svc)
+
+	checks, err := client.Agent().Checks()
+	require.NoError(err)
+	require.Len(checks, 1)
+	require.NotNil(checks["web-check"])
 }
 
 func TestCommand_Flags(t *testing.T) {


### PR DESCRIPTION
Currently the CLI drops checks from service definitions if they don't have a name.

The name isn't required since we create one downstream if it's missing, so this PR modifies the check to look for an ID.