### PR TITLE
ui: re-remove the `Type` header on the service listing page

### DIFF
--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -28,7 +28,6 @@
             }}
                 {{#block-slot 'header'}}
                     <th style={{remainingWidth}}>Service</th>
-                    <th>Type</th>
                     <th style={{totalWidth}}>Health Checks<span><em role="tooltip">The number of health checks for the service on all nodes</em></span></th>
                     <th style={{remainingWidth}}>Tags</th>
                 {{/block-slot}}


### PR DESCRIPTION
The `Type` column used for giving details on what type of a service each
item is was removed in https://github.com/hashicorp/consul/pull/6075.

As a result of keeping long running branches in sync, this change was
partly reverted in an earlier PR https://github.com/hashicorp/consul/pull/5913 following a rebase (the `Type` header was re-added).

This commit re-removes the `Type` table header (the `<th>`)

Interestingly the PR itself doesn't add the type header, which can be seen here:

https://github.com/hashicorp/consul/pull/5913/files#diff-3ca4410a4305457e04008a6f3d6f28fa

Yet the squashed PR commit in the `ui-staging` release does:

https://github.com/hashicorp/consul/pull/6437/commits/06b6aff8d0178978543cf2a99a9016ec844e0d5e#diff-3ca4410a4305457e04008a6f3d6f28fa

Screengrab of problem (note the unwanted `Type` header):

![Screenshot 2019-09-04 at 11 00 15](https://user-images.githubusercontent.com/554604/64245658-3efb0300-cf03-11e9-91aa-e76fc6295377.png)
