### PR TITLE
Introduce flag to let consul ignore bad check files instead of not starting

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -226,6 +226,7 @@ type Config struct {
 	GossipLAN                        GossipLANConfig          `json:"gossip_lan,omitempty" hcl:"gossip_lan" mapstructure:"gossip_lan"`
 	GossipWAN                        GossipWANConfig          `json:"gossip_wan,omitempty" hcl:"gossip_wan" mapstructure:"gossip_wan"`
 	HTTPConfig                       HTTPConfig               `json:"http_config,omitempty" hcl:"http_config" mapstructure:"http_config"`
+	IgnoreInvalidCheckFiles          *bool                    `json:"ignore_invalid_check_files,omitempty" hcl:"ignore_invalid_check_files" mapstructure:"ignore_invalid_check_files"`
 	KeyFile                          *string                  `json:"key_file,omitempty" hcl:"key_file" mapstructure:"key_file"`
 	LeaveOnTerm                      *bool                    `json:"leave_on_terminate,omitempty" hcl:"leave_on_terminate" mapstructure:"leave_on_terminate"`
 	Limits                           Limits                   `json:"limits,omitempty" hcl:"limits" mapstructure:"limits"`

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -75,6 +75,7 @@ func AddFlags(fs *flag.FlagSet, f *Flags) {
 	add(&f.Config.EnableScriptChecks, "enable-script-checks", "Enables health check scripts.")
 	add(&f.Config.EnableLocalScriptChecks, "enable-local-script-checks", "Enables health check scripts from configuration file.")
 	add(&f.Config.HTTPConfig.AllowWriteHTTPFrom, "allow-write-http-from", "Only allow write endpoint calls from given network. CIDR format, can be specified multiple times.")
+	add(&f.Config.IgnoreInvalidCheckFiles, "ignore-invalid-check-files", "Ignores/skips bad check files instead of failing the agent.")
 	add(&f.Config.EncryptKey, "encrypt", "Provides the gossip encryption key.")
 	add(&f.Config.Ports.GRPC, "grpc-port", "Sets the gRPC API port to listen on (currently needed for Envoy xDS only).")
 	add(&f.Config.Ports.HTTP, "http-port", "Sets the HTTP API port to listen on.")

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -793,6 +793,10 @@ type RuntimeConfig struct {
 	// hcl: ports { https = int }
 	HTTPSPort int
 
+	// IgnoreInvalidCheckFiles is the flag used to specify if Consul should ignore badly formatted checks or checks with
+	// invalid params
+	IgnoreInvalidCheckFiles bool
+
 	// KeyFile is used to provide a TLS key that is used for serving TLS
 	// connections. Must be provided to serve TLS connections.
 	//

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3287,6 +3287,27 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				}
 			},
 		},
+		{
+			desc: "-ignore-invalid-check-files passed in CLI",
+			args: []string{
+				`-ignore-invalid-check-files`,
+				`-data-dir=` + dataDir,
+			},
+			patch: func(rt *RuntimeConfig) {
+				rt.IgnoreInvalidCheckFiles = true
+				rt.DataDir = dataDir
+			},
+		},
+		{
+			desc: "-ignore-invalid-check-files not passed in CLI",
+			args: []string{
+				`-data-dir=` + dataDir,
+			},
+			patch: func(rt *RuntimeConfig) {
+				rt.IgnoreInvalidCheckFiles = false
+				rt.DataDir = dataDir
+			},
+		},
 	}
 
 	testConfig(t, tests, dataDir)
@@ -3696,6 +3717,7 @@ func TestFullConfig(t *testing.T) {
 					"JRCrHZed": "rl0mTx81"
 				}
 			},
+			"ignore_invalid_check_files": true,
 			"key_file": "IEkkwgIA",
 			"leave_on_terminate": true,
 			"limits": {
@@ -4295,6 +4317,7 @@ func TestFullConfig(t *testing.T) {
 					"JRCrHZed" = "rl0mTx81"
 				}
 			}
+			ignore_invalid_check_files = true
 			key_file = "IEkkwgIA"
 			leave_on_terminate = true
 			limits {
@@ -4983,6 +5006,7 @@ func TestFullConfig(t *testing.T) {
 		HTTPResponseHeaders:              map[string]string{"M6TKa9NP": "xjuxjOzQ", "JRCrHZed": "rl0mTx81"},
 		HTTPSAddrs:                       []net.Addr{tcpAddr("95.17.17.19:15127")},
 		HTTPSPort:                        15127,
+		IgnoreInvalidCheckFiles:          true,
 		KeyFile:                          "IEkkwgIA",
 		KVMaxValueSize:                   1234567800000000,
 		LeaveDrainTime:                   8265 * time.Second,
@@ -5839,6 +5863,7 @@ func TestSanitize(t *testing.T) {
 		"HTTPResponseHeaders": {},
 		"HTTPSAddrs": [],
 		"HTTPSPort": 0,
+		"IgnoreInvalidCheckFiles": false,
 		"KeyFile": "hidden",
 		"KVMaxValueSize": 1234567800000000,
 		"LeaveDrainTime": "0s",

--- a/agent/structs/service_definition.go
+++ b/agent/structs/service_definition.go
@@ -128,3 +128,10 @@ func (s *ServiceDefinition) CheckTypes() (checks CheckTypes, err error) {
 	}
 	return checks, nil
 }
+
+func (s *ServiceDefinition) String() string {
+	if s == nil {
+		return "UNKNOWN"
+	}
+	return "(" + s.ID + ":" + s.Name + ")"
+}


### PR DESCRIPTION
* Introduce flag to let consul ignore bad check files instead of not starting
* Skipping all bad services or files that would otherwise cause consul agent to fail
* Cleaning up logs and added comments

https://github.com/hashicorp/consul/issues/6444