### PR TITLE
verify_incoming requires only CA

### DIFF
--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -321,13 +321,10 @@ func (c *Configurator) check(config Config, pool *x509.CertPool, cert *tls.Certi
 		return fmt.Errorf("VerifyOutgoing set, and no CA certificate provided!")
 	}
 
-	// Ensure we have a CA and cert if VerifyIncoming is set
+	// Ensure we have a CA if VerifyIncoming is set
 	if config.anyVerifyIncoming() {
 		if pool == nil {
 			return fmt.Errorf("VerifyIncoming set, and no CA certificate provided!")
-		}
-		if cert == nil || cert.Certificate == nil {
-			return fmt.Errorf("VerifyIncoming set, and no Cert/Key pair provided!")
 		}
 	}
 	return nil

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -390,8 +390,8 @@ func TestConfigurator_ErrorPropagation(t *testing.T) {
 			true, false}, // 15
 		{Config{VerifyIncomingHTTPS: true, CAFile: "", CAPath: ""},
 			true, false}, // 16
-		{Config{VerifyIncoming: true, CAFile: cafile, CAPath: ""}, true, false}, // 17
-		{Config{VerifyIncoming: true, CAFile: "", CAPath: capath}, true, false}, // 18
+		{Config{VerifyIncoming: true, CAFile: cafile, CAPath: ""}, false, false}, // 17
+		{Config{VerifyIncoming: true, CAFile: "", CAPath: capath}, false, false}, // 18
 		{Config{VerifyIncoming: true, CAFile: "", CAPath: capath,
 			CertFile: certfile, KeyFile: keyfile}, false, false}, // 19
 		{Config{CertFile: "bogus", KeyFile: "bogus"}, true, true}, // 20
@@ -704,8 +704,7 @@ func TestConfigurator_UpdateChecks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.Update(Config{}))
 	require.Error(t, c.Update(Config{VerifyOutgoing: true}))
-	require.Error(t, c.Update(Config{VerifyIncoming: true,
-		CAFile: "../test/ca/root.cer"}))
+	require.Error(t, c.Update(Config{VerifyIncoming: true}))
 	require.False(t, c.base.VerifyIncoming)
 	require.False(t, c.base.VerifyOutgoing)
 	require.Equal(t, c.version, 2)


### PR DESCRIPTION
Fixes #6398

I don't know why `verify_incoming` required a client cert before. From the docs:

> If set to true, Consul requires that all incoming connections make use of TLS and that the client provides a certificate signed by a Certificate Authority from the ca_file or ca_path.

There is no reason to have a cert as well, so lets fix that.