### PR TITLE
ci: inject missing tar binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,6 +349,10 @@ jobs:
           name: middleman build
           command: bundle exec middleman build
 
+      - run:
+          name: add missing tar binary
+          command: apk update && apk add tar
+
       # saves website build directory
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
Recently CircleCI changed something so that the `persist_to_workspace` command in a job cannot function with the busybox flavor of `tar`. It fails with:

```
Persisting to Workspace00:00

tar utility is not present in this image but it is required. Please install it to have workflow workspace capability.
```

This is causing the `build-website` job to fail. Adding the standard `tar` package fixes the issue.