### PR TITLE
ui: Add data-source component and related services

### DIFF
--- a/ui-v2/app/components/data-source.js
+++ b/ui-v2/app/components/data-source.js
@@ -1,0 +1,121 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { set } from '@ember/object';
+
+import WithListeners from 'consul-ui/mixins/with-listeners';
+
+// Utility function to set, but actually replace if we should replace
+// then call a function on the thing to be replaced (usually a clean up function)
+const replace = function(
+  obj,
+  prop,
+  value,
+  destroy = (prev = null, value) => (typeof prev === 'function' ? prev() : null)
+) {
+  const prev = obj[prop];
+  if (prev !== value) {
+    destroy(prev, value);
+  }
+  return set(obj, prop, value);
+};
+
+/**
+ * @module DataSource
+ *
+ * The DataSource component manages opening and closing data sources via an injectable data service.
+ * Data sources are only opened only if the component is visible in the viewport (using IntersectionObserver).
+ *
+ * Sources returned by the data service should follow an EventTarget/EventSource API.
+ * Management of the caching/usage/counting etc of sources should be done in the data service,
+ * not the component.
+ *
+ * @example ```js
+ *   {{data-source
+ *      src="/dc-1/services/*"
+ *      onchange={{action (mut items) value='data'}}
+ *      onerror={{action (mut error) value='error'}}
+ *   /}}```
+ *
+ * @param src {String} - An identitier used to determine the source of the data. This is passed
+ *                       to the data service for it to determine how to fetch the data.
+ * @param onchange=null {Func} - An action called when the data changes.
+ * @param onerror=null {Func} - An action called on error
+ *
+ */
+export default Component.extend(WithListeners, {
+  tagName: 'span',
+
+  // TODO: can be injected with a simpler non-blocking
+  // data service if we turn off blocking queries completely at runtime
+  data: service('blocking'),
+
+  onchange: function() {},
+  onerror: function() {},
+
+  didInsertElement: function() {
+    this._super(...arguments);
+    const options = {
+      rootMargin: '0px',
+      threshold: 1.0,
+    };
+
+    const observer = new IntersectionObserver((entries, observer) => {
+      entries.map(item => {
+        set(this, 'isIntersecting', item.isIntersecting);
+        if (!item.isIntersecting) {
+          this.actions.close.bind(this)();
+        } else {
+          this.actions.open.bind(this)();
+        }
+      });
+    }, options);
+    observer.observe(this.element); // eslint-disable-line ember/no-observers
+    this.listen(() => {
+      this.actions.close.bind(this)();
+      observer.disconnect(); // eslint-disable-line ember/no-observers
+    });
+  },
+  didReceiveAttrs: function() {
+    this._super(...arguments);
+    if (this.element && this.isIntersecting) {
+      this.actions.open.bind(this)();
+    }
+  },
+  actions: {
+    // keep this argumentless
+    open: function() {
+      const src = this.src;
+      const filter = this.filter;
+
+      // get a new source and replace the old one, cleaning up as we go
+      const source = replace(
+        this,
+        'source',
+        this.data.open(`${src}${filter ? `?filter=${filter}` : ``}`, this),
+        (prev, source) => {
+          // Makes sure any previous source (if different) is ALWAYS closed
+          this.data.close(prev, this);
+        }
+      );
+      // set up the listeners (which auto cleanup on component destruction)
+      const remove = this.listen(source, {
+        message: e => this.onchange(e),
+        error: e => this.onerror(e),
+      });
+      replace(this, '_remove', remove);
+      // dispatch the current data of the source if we have any
+      if (typeof source.getCurrentEvent === 'function') {
+        const currentEvent = source.getCurrentEvent();
+        if (currentEvent) {
+          this.onchange(currentEvent);
+        }
+      }
+    },
+    // keep this argumentless
+    close: function() {
+      this.data.close(this.source, this);
+      replace(this, '_remove', null);
+      set(this, 'source', undefined);
+    },
+  },
+});

--- a/ui-v2/app/services/blocking.js
+++ b/ui-v2/app/services/blocking.js
@@ -1,0 +1,91 @@
+import Service, { inject as service } from '@ember/service';
+
+import MultiMap from 'mnemonist/multi-map';
+
+import { BlockingEventSource as EventSource } from 'consul-ui/utils/dom/event-source';
+// utility functions to make the below code easier to read:
+import { ifNotBlocking } from 'consul-ui/services/settings';
+import { restartWhenAvailable } from 'consul-ui/services/client/http';
+import maybeCall from 'consul-ui/utils/maybe-call';
+
+// TODO: Expose sizes of things via env vars
+
+// caches cursors and previous events when the EventSources are destroyed
+const cache = new Map();
+// keeps a record of currently in use EventSources
+const sources = new Map();
+// keeps a count of currently in use EventSources
+const usage = new MultiMap(Set);
+
+export default Service.extend({
+  client: service('client/http'),
+  settings: service('settings'),
+
+  finder: service('repository/manager'),
+
+  open: function(uri, ref) {
+    let source;
+    // Check the cache for an EventSource that is already being used
+    // for this uri. If we don't have one, set one up.
+    if (!sources.has(uri)) {
+      // Setting up involves finding the correct repository method to call
+      // based on the uri, we use the eventually injectable finder for this.
+      const repo = this.finder.fromURI(...uri.split('?filter='));
+      // We then check the to see if this we have previously cached information
+      // for the URI. This data comes from caching this data when the EventSource
+      // is closed and destroyed. We recreate the EventSource from the data from the cache
+      // if so. The data is currently the cursor position and the last received data.
+      let configuration = {};
+      if (cache.has(uri)) {
+        configuration = cache.get(uri);
+      }
+      // tag on the custom createEvent for ember-data
+      configuration.createEvent = repo.reconcile;
+
+      // We create the EventSource, checking to make sure whether we should close the
+      // EventSource on first response (depending on the user setting) and reopening
+      // the EventSource if it has been paused by the user navigating to another tab
+      source = new EventSource((configuration, source) => {
+        const close = source.close.bind(source);
+        const deleteCursor = () => (configuration.cursor = undefined);
+        //
+        return maybeCall(deleteCursor, ifNotBlocking(this.settings))().then(() => {
+          return repo
+            .find(configuration)
+            .then(maybeCall(close, ifNotBlocking(this.settings)))
+            .catch(restartWhenAvailable(this.client));
+        });
+      }, configuration);
+      // Lastly, when the EventSource is no longer needed, cache its information
+      // for when we next need it again (see above re: data cache)
+      source.addEventListener('close', function close(e) {
+        const source = e.target;
+        source.removeEventListener('close', close);
+        cache.set(uri, {
+          currentEvent: e.target.getCurrentEvent(),
+          cursor: e.target.configuration.cursor,
+        });
+        // the data is cached delete the EventSource
+        sources.delete(uri);
+      });
+      sources.set(uri, source);
+    } else {
+      source = sources.get(uri);
+    }
+    // set/increase the usage counter
+    usage.set(source, ref);
+    source.open();
+    return source;
+  },
+  close: function(source, ref) {
+    if (source) {
+      // decrease the usage counter
+      usage.remove(source, ref);
+      // if the EventSource is no longer being used
+      // close it (data caching is dealt with by the above 'close' event listener)
+      if (!usage.has(source)) {
+        source.close();
+      }
+    }
+  },
+});

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -7,6 +7,21 @@ import getObjectPool from 'consul-ui/utils/get-object-pool';
 import Request from 'consul-ui/utils/http/request';
 import createURL from 'consul-ui/utils/createURL';
 
+// reopen EventSources if a user changes tab
+export const restartWhenAvailable = function(client) {
+  return function(e) {
+    // setup the aborted connection restarting
+    // this should happen here to avoid cache deletion
+    const status = get(e, 'errors.firstObject.status');
+    if (status === '0') {
+      // Any '0' errors (abort) should possibly try again, depending upon the circumstances
+      // whenAvailable returns a Promise that resolves when the client is available
+      // again
+      return client.whenAvailable(e);
+    }
+    throw e;
+  };
+};
 class HTTPError extends Error {
   constructor(statusCode, message) {
     super(message);

--- a/ui-v2/app/services/promised.js
+++ b/ui-v2/app/services/promised.js
@@ -1,0 +1,23 @@
+import Service, { inject as service } from '@ember/service';
+
+import { CallableEventSource as EventSource } from 'consul-ui/utils/dom/event-source';
+
+export default Service.extend({
+  finder: service('repository/manager'),
+
+  open: function(uri, ref) {
+    const repo = this.finder.fromURI(...uri.split('?filter='));
+    const source = new EventSource(function(configuration, source) {
+      return repo.find(configuration).then(function(res) {
+        source.dispatchEvent({ type: 'message', data: res });
+        source.close();
+      });
+    }, {});
+    return source;
+  },
+  close: function(source, ref) {
+    if (source) {
+      source.close();
+    }
+  },
+});

--- a/ui-v2/app/services/repository.js
+++ b/ui-v2/app/services/repository.js
@@ -13,6 +13,17 @@ export default Service.extend({
   },
   //
   store: service('store'),
+  reconcile: function(meta = {}) {
+    // unload anything older than our current sync date/time
+    if (typeof meta.date !== 'undefined') {
+      this.store.peekAll(this.getModelName()).forEach(item => {
+        const date = item.SyncTime;
+        if (typeof date !== 'undefined' && date != meta.date) {
+          this.store.unloadRecord(item);
+        }
+      });
+    }
+  },
   findAllByDatacenter: function(dc, configuration = {}) {
     const query = {
       dc: dc,

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -1,0 +1,80 @@
+import Service, { inject as service } from '@ember/service';
+
+export default Service.extend({
+  // TODO: Temporary repo list here
+  service: service('repository/service'),
+  node: service('repository/node'),
+  session: service('repository/session'),
+  proxy: service('repository/proxy'),
+
+  fromURI: function(src, filter) {
+    let temp = src.split('/');
+    temp.shift();
+    const dc = temp.shift();
+    const model = temp.shift();
+    const repo = this[model];
+    let slug = temp.join('/');
+
+    // TODO: if something is filtered we shouldn't reconcile things
+    // custom createEvent, here used to reconcile the ember-data store for each tick
+    // ideally we wouldn't do this here, but we handily have access to the repo here
+    const obj = {
+      reconcile: function(result = {}, configuration) {
+        const event = {
+          type: 'message',
+          data: result,
+        };
+        // const meta = get(event.data || {}, 'meta') || {};
+        repo.reconcile(event.data.meta);
+        return event;
+      },
+    };
+    let id, node;
+    switch (slug) {
+      case '*':
+        switch (model) {
+          default:
+            obj.find = function(configuration) {
+              return repo.findAllByDatacenter(dc, configuration);
+            };
+        }
+        break;
+      default:
+        switch (model) {
+          case 'session':
+            obj.find = function(configuration) {
+              return repo.findByNode(slug, dc, configuration);
+            };
+            break;
+          case 'service-instance':
+            temp = slug.split('/');
+            id = temp[0];
+            node = temp[1];
+            slug = temp[2];
+            obj.find = function(configuration) {
+              return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+            };
+            break;
+          case 'service':
+            obj.find = function(configuration) {
+              return repo.findBySlug(slug, dc, configuration);
+            };
+            break;
+          case 'proxy':
+            temp = slug.split('/');
+            id = temp[0];
+            node = temp[1];
+            slug = temp[2];
+            obj.find = function(configuration) {
+              return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+            };
+            break;
+          default:
+            obj.find = function(configuration) {
+              return repo.findBySlug(slug, dc, configuration);
+            };
+        }
+    }
+    return obj;
+  },
+});

--- a/ui-v2/app/services/settings.js
+++ b/ui-v2/app/services/settings.js
@@ -3,6 +3,12 @@ import { Promise } from 'rsvp';
 import getStorage from 'consul-ui/utils/storage/local-storage';
 const SCHEME = 'consul';
 const storage = getStorage(SCHEME);
+// promise aware assertion
+export const ifNotBlocking = function(repo) {
+  return repo.findBySlug('client').then(function(settings) {
+    return typeof settings.blocking !== 'undefined' && !settings.blocking;
+  });
+};
 export default Service.extend({
   storage: storage,
   findHeaders: function() {

--- a/ui-v2/app/utils/maybe-call.js
+++ b/ui-v2/app/utils/maybe-call.js
@@ -1,0 +1,17 @@
+/**
+ * Promise aware conditional function call
+ *
+ * @param {function} cb - The function to possibily call
+ * @param {function} [what] - A function returning a boolean resolving promise
+ * @returns {function} - function when called returns a Promise that resolves the argument it is called with
+ */
+export default function(cb, what) {
+  return function(res) {
+    return what.then(function(bool) {
+      if (bool) {
+        cb();
+      }
+      return res;
+    });
+  };
+}

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -101,6 +101,7 @@
     "jsonlint": "^1.6.3",
     "lint-staged": "^9.2.5",
     "loader.js": "^4.7.0",
+    "mnemonist": "^0.30.0",
     "node-sass": "^4.9.3",
     "prettier": "^1.10.2",
     "qunit-dom": "^0.9.0",

--- a/ui-v2/tests/integration/components/data-source-test.js
+++ b/ui-v2/tests/integration/components/data-source-test.js
@@ -1,6 +1,6 @@
 import { module } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { clearRender, render, settled, waitUntil } from '@ember/test-helpers';
+import { clearRender, render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 import test from 'ember-sinon-qunit/test-support/test';

--- a/ui-v2/tests/integration/components/data-source-test.js
+++ b/ui-v2/tests/integration/components/data-source-test.js
@@ -1,0 +1,119 @@
+import { module } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { clearRender, render, settled, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+import test from 'ember-sinon-qunit/test-support/test';
+import Service from '@ember/service';
+
+import { BlockingEventSource as RealEventSource } from 'consul-ui/utils/dom/event-source';
+
+const createFakeBlockingEventSource = function() {
+  const EventSource = function(cb) {
+    this.readyState = 1;
+    this.source = cb;
+  };
+  const o = EventSource.prototype;
+  [
+    'addEventListener',
+    'removeEventListener',
+    'dispatchEvent',
+    'close',
+    'open',
+    'getCurrentEvent',
+  ].forEach(function(item) {
+    o[item] = function() {};
+  });
+  return EventSource;
+};
+const BlockingEventSource = createFakeBlockingEventSource();
+module('Integration | Component | data-source', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
+  test('open and closed are called correctly when the src is changed', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+    assert.expect(9);
+    const close = this.stub();
+    const open = this.stub();
+    const addEventListener = this.stub();
+    const removeEventListener = this.stub();
+    let count = 0;
+    const blockingStub = Service.extend({
+      open: function(uri, obj) {
+        open(uri);
+        const source = new BlockingEventSource();
+        source.getCurrentEvent = function() {
+          return { data: uri };
+        };
+        source.addEventListener = addEventListener;
+        source.removeEventListener = removeEventListener;
+        return source;
+      },
+      close: close,
+    });
+    this.owner.register('service:blocking', blockingStub);
+    this.actions.change = data => {
+      count++;
+      switch (count) {
+        case 1:
+          assert.equal(data, 'a', 'change was called first with "a"');
+          this.set('src', 'b');
+          break;
+        case 2:
+          assert.equal(data, 'b', 'change was called second with "b"');
+          break;
+      }
+    };
+
+    this.set('src', 'a');
+    await render(hbs`{{data-source src=src onchange=(action 'change' value="data")}}`);
+    assert.equal(this.element.textContent.trim(), '');
+    await waitUntil(() => {
+      return close.calledTwice;
+    });
+    assert.ok(open.calledTwice, 'open is called when src is set');
+    assert.ok(close.calledTwice, 'close is called as open is called');
+    await clearRender();
+    await waitUntil(() => {
+      return close.calledThrice;
+    });
+    assert.ok(open.calledTwice, 'open is _still_ only called when src is set');
+    assert.ok(close.calledThrice, 'close is called an extra time as the component is destroyed');
+    assert.equal(addEventListener.callCount, 4, 'all event listeners were added');
+    assert.equal(removeEventListener.callCount, 4, 'all event listeners were removed');
+  });
+  test('error actions are triggered when errors are dispatched', async function(assert) {
+    const source = new RealEventSource();
+    const error = this.stub();
+    const close = this.stub();
+    const blockingStub = Service.extend({
+      open: function(uri, obj) {
+        source.getCurrentEvent = function() {
+          return {};
+        };
+        return source;
+      },
+      close: close,
+    });
+    this.owner.register('service:blocking', blockingStub);
+    this.actions.change = data => {
+      source.dispatchEvent({ type: 'error', error: {} });
+    };
+    this.actions.error = error;
+    await render(
+      hbs`{{data-source src="" onchange=(action 'change' value="data") onerror=(action 'error' value="error")}}`
+    );
+    await waitUntil(() => {
+      return error.calledOnce;
+    });
+    assert.ok(error.calledOnce, 'error action was called');
+    assert.ok(close.calledOnce, 'close was called before the open');
+    await clearRender();
+    assert.ok(close.calledTwice, 'close was also called when the component is destroyed');
+  });
+});

--- a/ui-v2/tests/unit/services/blocking-test.js
+++ b/ui-v2/tests/unit/services/blocking-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | blocking', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:blocking');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/services/promised-test.js
+++ b/ui-v2/tests/unit/services/promised-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | promised', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:promised');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/services/repository/manager-test.js
+++ b/ui-v2/tests/unit/services/repository/manager-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | repository/manager', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:repository/manager');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/utils/maybe-call-test.js
+++ b/ui-v2/tests/unit/utils/maybe-call-test.js
@@ -1,0 +1,18 @@
+import maybeCall from 'consul-ui/utils/maybe-call';
+import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
+
+module('Unit | Utility | maybe-call', function() {
+  test('it calls a function when the resolved value is true', function(assert) {
+    assert.expect(1);
+    return maybeCall(() => {
+      assert.ok(true);
+    }, Promise.resolve(true))();
+  });
+  test("it doesn't call a function when the resolved value is false", function(assert) {
+    assert.expect(0);
+    return maybeCall(() => {
+      assert.ok(true);
+    }, Promise.resolve(false))();
+  });
+});

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -8302,6 +8302,13 @@ mktemp@~0.4.0:
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha1-bQUVYRyKjITkhKogABKbmOmB/ws=
 
+mnemonist@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.30.0.tgz#c8c37f4425b8abcf7aa04a34199af254b398a90f"
+  integrity sha512-g9rbX4ug7am8oW3jnM7adaFaj5vv5PeOaMPNUwjKQQaTyY+qPQHTmUF59/ZOfQdtTknkjA7+7RhtmL2C0mtwPA==
+  dependencies:
+    obliterator "^1.5.0"
+
 morgan@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -8751,6 +8758,11 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+obliterator@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.5.0.tgz#f3535e5be192473ef59efb2d30396738f7c645c6"
+  integrity sha512-dENe0UviDf8/auXn0bIBKwCcUr49khvSBWDLlszv/ZB2qz1VxWDmkNKFqO2nfmve7hQb/QIDY7+rc7K3LdJimQ==
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This PR is the beginning of a series of PRs to migrate to (and use moving forwards) a componentized approach to data rather than Routes to retrieve data.

The base branch for the PR here is kept up to date with `ui-staging` until we can merge this into it, at which point we'll continue using `feature/ui-data-source` as a base branch for PRs related to this series of work.

This PR includes:

1. DataSource component
2. Repository manager for retrieving repositories base on URIs
3. Blocking data service for injection to the data-source component to
support blocking query types of data sources
4. 'Once' promise based data service for injection for potential
fallback to old style promise based data (would need to be injected via
an initial runtime variable)
5. Several utility functions taken from elsewhere
  - maybeCall - a replication of code from elsewhere for condition
  calling a function based on the result of a promise
  - restartWhenAvailable - used for restarting blocking queries when a
  tab is brought to the front
  - ifNotBlocking - to check if blocking is NOT enabled (yuk I know, but it reads nice when you read the code)

Some notes:

The utility functions have been mainly refactored out of this file:

https://github.com/hashicorp/consul/blob/593a587f4d03c36247366208db769d77c7089fc1/ui-v2/app/services/repository/type/event-source.js#L34-L63

We do not want to _replace_ those lines as we want to keep the current functionality _exactly the same_ until we have finishing migrating. Once the entire catalog is migrated, we can remove most of the files concerned with our Route based approach to blocking queries.

We are not entirely happy with where we have moved these functions, but it's mostly makes sense and I can't think of anywhere else I'd be happier with right now. This might change in future.

The remaining files in this PR are relatively straightforwards and use the functionality it we already had, with just moved it elsewhere. One thing we have changed slightly here is how we are doing our caching - we've decided to use `mnemonist` for the data structures we use for caching (along with standard `Map` and `Set`). We chose to use `mnemonist` for the moment as there maybe other functionality contained there that we use can for other work. If we decide against this in future we can switch out for something else.

We use `IntersectionObserver` here so we can control whether the component loads data based on other things apart from JS, such as CSS. Please note we have not included a polyfill here for IE11.

There is a reasonable amount of in-code based documentation, plus JSDoc comments. We plan to expand on this a little more moving forwards. If anyone has any recommendations for producing documentation from these, please shout.

We are usually quite light in the Consul UI on integration tests. The fact we have a good coverage of acceptance tests and unit tests and most of our components are glorified partials generally means we prioritize acceptance and unit above integration. In this case we plan to use this component quite a lot so we've added a more detailed component integration test than we usually would.

We've included enough 'finding' functionality here to fill out the Services section of the Consul UI using this new approach, we plan to implement that, and then move onto Nodes, before using this approach to ensure the entire UI uses live updating/blocking queries.







