### PR TITLE
Periodically clean orphan proxies

### DIFF
--- a/agent/sidecar_service.go
+++ b/agent/sidecar_service.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/consul/ipaddr"
@@ -11,6 +12,10 @@ import (
 
 func (a *Agent) sidecarServiceID(serviceID string) string {
 	return serviceID + "-sidecar-proxy"
+}
+
+func (a *Agent) sidecarTargetServiceID(serviceID string) string {
+	return strings.TrimSuffix(serviceID, "-sidecar-proxy")
 }
 
 // sidecarServiceFromNodeService returns a *structs.NodeService representing a


### PR DESCRIPTION
Sidecar are sometimes left registered when their target service is
deregistered. This adds a periodic (every 5 minutes) cleanup task that
deregisters any sidecar service that does not have a "main" service
registered.