### PR TITLE
Take Prometheus MIME-type header into account

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -88,7 +88,8 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 
 // enablePrometheusOutput will look for Prometheus mime-type or format Query parameter the same way as Nomad
 func enablePrometheusOutput(req *http.Request) bool {
-	if format := req.URL.Query().Get("format"); format == "prometheus" {
+	if format := req.URL.Query().Get("format"); format == "prometheus" ||
+		strings.HasPrefix(req.Header.Get("Accept"), "application/openmetrics-text;") {
 		return true
 	}
 	return false


### PR DESCRIPTION
Agent code comment already claims the requested MIME type would be respected. This commit actually does so.

With this change, no `?format=prometheus` GET header has to be provided any more, which is especially helpful if discovering Consul instances in Prometheus' Kubernetes service discovery.

```
curl -H 'Accept: application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1' localhost:8500/v1/agent/metrics | head
consul_client_rpc 7
consul_http_GET_v1_agent_metrics{quantile="0.5"} NaN
consul_http_GET_v1_agent_metrics{quantile="0.9"} NaN
consul_http_GET_v1_agent_metrics{quantile="0.99"} NaN
consul_http_GET_v1_agent_metrics_sum 0.8030069768428802
consul_http_GET_v1_agent_metrics_count 2
```