### PR TITLE
Nil checks in the testWriter to prevent using a bad testing.TB

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -225,12 +225,12 @@ func NewTestServerConfig(cb ServerConfigCallback) (*TestServer, error) {
 // callback function to modify the configuration. If there is an error
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
-func NewTestServerConfigT(t *testing.T, cb ServerConfigCallback) (*TestServer, error) {
+func NewTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, error) {
 	return newTestServerConfigT(t, cb)
 }
 
 // newTestServerConfigT is the internal helper for NewTestServerConfigT.
-func newTestServerConfigT(t *testing.T, cb ServerConfigCallback) (*TestServer, error) {
+func newTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, error) {
 	path, err := exec.LookPath("consul")
 	if err != nil || path == "" {
 		return nil, fmt.Errorf("consul not found on $PATH - download and install " +
@@ -263,7 +263,7 @@ func newTestServerConfigT(t *testing.T, cb ServerConfigCallback) (*TestServer, e
 		os.RemoveAll(tmpdir)
 		return nil, errors.Wrap(err, "failed marshaling json")
 	}
-	
+
 	if t != nil {
 		// if you really want this output ensure to pass a valid t
 		t.Logf("CONFIG JSON: %s", string(b))

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -32,8 +32,10 @@ type testWriter struct {
 }
 
 func (tw *testWriter) Write(p []byte) (n int, err error) {
-	tw.t.Helper()
-	if sendTestLogsToStdout {
+	if tw.t != nil {
+		tw.t.Helper()
+	}
+	if sendTestLogsToStdout || tw.t == nil {
 		fmt.Fprint(os.Stdout, strings.TrimSpace(string(p))+"\n")
 	} else {
 		tw.t.Log(strings.TrimSpace(string(p)))


### PR DESCRIPTION
Also needed to update some funcs that were taking a *testing.T to use a testing.TB. This prevents passing a nil pointer as a non-nil interface value
and thus making it impossible to detect nil before using the interfaces functions.