### PR TITLE
ci: ensure build-distros uses the same go.mod file as normal builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,10 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run: make tools
+      - run: |
+          make tools
+          # restore any go.{mod,sum} files that were updated indirectly
+          git reset --hard HEAD
       - run: ./build-support/scripts/build-local.sh
 
       # save dev build to CircleCI


### PR DESCRIPTION
When running `make tools` the go command indirectly edits both the
`go.mod` and `go.sum` files in ways that can cause the later build of consul
itself to build with slightly different dependencies than it normally
would.