### PR TITLE
Allow for enterprise only leader routines

### DIFF
--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -41,3 +41,11 @@ func (s *Server) handleEnterpriseLeave() {
 func (s *Server) enterpriseStats() map[string]map[string]string {
 	return nil
 }
+
+func (s *Server) establishEnterpriseLeadership() error {
+	return nil
+}
+
+func (s *Server) revokeEnterpriseLeadership() error {
+	return nil
+}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -309,6 +309,10 @@ func (s *Server) establishLeadership() error {
 		return err
 	}
 
+	if err := s.establishEnterpriseLeadership(); err != nil {
+		return err
+	}
+
 	// attempt to bootstrap config entries
 	if err := s.bootstrapConfigEntries(s.config.ConfigEntryBootstrap); err != nil {
 		return err
@@ -339,6 +343,8 @@ func (s *Server) revokeLeadership() {
 	// Clear the session timers on either shutdown or step down, since we
 	// are no longer responsible for session expirations.
 	s.clearAllSessionTimers()
+
+	s.revokeEnterpriseLeadership()
 
 	s.stopConfigReplication()
 


### PR DESCRIPTION
Eventually I am thinking we may need a way to register these at different priority levels but for now sticking this here will be fine.