### PR TITLE
ui: Make sure addresses when truncated use a `...`

### DIFF
--- a/ui-v2/app/templates/dc/services/-instances.hbs
+++ b/ui-v2/app/templates/dc/services/-instances.hbs
@@ -28,7 +28,7 @@
               <a href={{href-to 'dc.nodes.show' item.Node.Node}}>{{item.Node.Node}}</a>
             </td>
             <td data-test-address>
-                {{item.Service.Address}}:{{item.Service.Port}}
+              <span>{{item.Service.Address}}:{{item.Service.Port}}</span>
             </td>
             <td>
               {{#with (reject-by 'ServiceID' '' item.Checks) as |checks|}}


### PR DESCRIPTION
Most td's are using a flex layout and therefore clash with normal
truncation. Therefore we wrap addresses in a span element to ensure that
when they get truncated property with a `...`

We don't have any visual testing as yet, so no tests.

Also see https://github.com/hashicorp/consul/issues/6529

![Screenshot 2019-09-24 at 15 41 36](https://user-images.githubusercontent.com/554604/65521926-e0adb880-dee1-11e9-9456-a854a22921c6.png)

