### PR TITLE
api/watch: try to avoid more flakes in this package

### DIFF
--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -32,6 +32,8 @@ func makeClient(t *testing.T) (*api.Client, *testutil.TestServer) {
 	require.NoError(t, err)
 	conf.Address = server.HTTPAddr
 
+	server.WaitForLeader(t)
+
 	// Create client
 	client, err := api.NewClient(conf)
 	if err != nil {
@@ -369,6 +371,8 @@ func TestNodesWatch(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t) // wait for AE to sync
 
 	var (
 		wakeups  [][]*api.Node


### PR DESCRIPTION
Prior to this patch, running on a resource constrained CI platform or locally with `stress-ng -c 200` running would cause `TestNodesWatch` to expose a timing dependent behavior on anti-entropy syncs.