### PR TITLE
Add Namespace as an api query option

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -75,6 +75,10 @@ const (
 
 // QueryOptions are used to parameterize a query
 type QueryOptions struct {
+	// Namespace overrides the `default` namespace
+	// Note: Namespaces are available only in Consul Enterprise
+	Namespace string
+
 	// Providing a datacenter overwrites the DC provided
 	// by the Config
 	Datacenter string
@@ -623,6 +627,9 @@ type request struct {
 func (r *request) setQueryOptions(q *QueryOptions) {
 	if q == nil {
 		return
+	}
+	if q.Namespace != "" {
+		r.params.Set("ns", q.Namespace)
 	}
 	if q.Datacenter != "" {
 		r.params.Set("dc", q.Datacenter)

--- a/api/api.go
+++ b/api/api.go
@@ -182,6 +182,10 @@ func (o *QueryOptions) WithContext(ctx context.Context) *QueryOptions {
 
 // WriteOptions are used to parameterize a write
 type WriteOptions struct {
+	// Namespace overrides the `default` namespace
+	// Note: Namespaces are available only in Consul Enterprise
+	Namespace string
+
 	// Providing a datacenter overwrites the DC provided
 	// by the Config
 	Datacenter string
@@ -728,6 +732,9 @@ func IsRetryableError(err error) bool {
 func (r *request) setWriteOptions(q *WriteOptions) {
 	if q == nil {
 		return
+	}
+	if q.Namespace != "" {
+		r.params.Set("ns", q.Namespace)
 	}
 	if q.Datacenter != "" {
 		r.params.Set("dc", q.Datacenter)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -695,6 +695,7 @@ func TestAPI_SetQueryOptions(t *testing.T) {
 
 	r := c.newRequest("GET", "/v1/kv/foo")
 	q := &QueryOptions{
+		Namespace:         "operator",
 		Datacenter:        "foo",
 		AllowStale:        true,
 		RequireConsistent: true,
@@ -706,6 +707,9 @@ func TestAPI_SetQueryOptions(t *testing.T) {
 	}
 	r.setQueryOptions(q)
 
+	if r.params.Get("ns") != "operator" {
+		t.Fatalf("bad: %v", r.params)
+	}
 	if r.params.Get("dc") != "foo" {
 		t.Fatalf("bad: %v", r.params)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -756,11 +756,14 @@ func TestAPI_SetWriteOptions(t *testing.T) {
 
 	r := c.newRequest("GET", "/v1/kv/foo")
 	q := &WriteOptions{
+		Namespace:  "operator",
 		Datacenter: "foo",
 		Token:      "23456",
 	}
 	r.setWriteOptions(q)
-
+	if r.params.Get("ns") != "operator" {
+		t.Fatalf("bad: %v", r.params)
+	}
 	if r.params.Get("dc") != "foo" {
 		t.Fatalf("bad: %v", r.params)
 	}


### PR DESCRIPTION
This PR adds Namespace as a QueryOption and a WriteOption in the Go API.

- QueryOptions are used in read operations like `KV.Get()`
- WriteOptions are used in write operations like `KV.Put()`