### PR TITLE
connect: Implement NeedsLogger interface for CA providers

### DIFF
--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"crypto/x509"
+	"log"
 )
 
 //go:generate mockery -name Provider -inpkg
@@ -73,4 +74,11 @@ type Provider interface {
 	// is shut down permanently, such as removing a temporary PKI backend in Vault
 	// created for an intermediate CA.
 	Cleanup() error
+}
+
+// NeedsLogger is an optional interface that allows a CA provider to use the
+// Consul logger to output diagnostic messages.
+type NeedsLogger interface {
+	// SetLogger will pass a configured Logger to the provider.
+	SetLogger(logger *log.Logger)
 }

--- a/agent/connect/ca/provider.go
+++ b/agent/connect/ca/provider.go
@@ -80,5 +80,6 @@ type Provider interface {
 // Consul logger to output diagnostic messages.
 type NeedsLogger interface {
 	// SetLogger will pass a configured Logger to the provider.
+	// TODO(hclog) convert this to an hclog.Logger.
 	SetLogger(logger *log.Logger)
 }

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
 	"math/big"
 	"net/url"
 	"sync"
@@ -29,6 +30,7 @@ type ConsulProvider struct {
 	clusterID string
 	isRoot    bool
 	spiffeID  *connect.SpiffeIDSigning
+	logger    *log.Logger
 
 	sync.RWMutex
 }
@@ -542,8 +544,8 @@ func (c *ConsulProvider) CrossSignCA(cert *x509.Certificate) (string, error) {
 // getState returns the current provider state from the state delegate, and returns
 // ErrNotInitialized if no entry is found.
 func (c *ConsulProvider) getState() (uint64, *structs.CAConsulProviderState, error) {
-	state := c.Delegate.State()
-	idx, providerState, err := state.CAProviderState(c.id)
+	stateStore := c.Delegate.State()
+	idx, providerState, err := stateStore.CAProviderState(c.id)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -572,8 +574,8 @@ func (c *ConsulProvider) incrementProviderIndex(providerState *structs.CAConsulP
 
 // generateCA makes a new root CA using the current private key
 func (c *ConsulProvider) generateCA(privateKey string, sn uint64) (string, error) {
-	state := c.Delegate.State()
-	_, config, err := state.CAConfig(nil)
+	stateStore := c.Delegate.State()
+	_, config, err := stateStore.CAConfig(nil)
 	if err != nil {
 		return "", err
 	}
@@ -623,4 +625,9 @@ func (c *ConsulProvider) generateCA(privateKey string, sn uint64) (string, error
 	}
 
 	return buf.String(), nil
+}
+
+// SetLogger implements the NeedsLogger interface so the provider can log important messages.
+func (c *ConsulProvider) SetLogger(logger *log.Logger) {
+	c.logger = logger
 }

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -108,6 +108,9 @@ func (c *ConsulProvider) Configure(clusterID string, isRoot bool, rawConfig map[
 		return err
 	}
 
+	c.logger.Printf("[DEBUG] consul CA provider configured ID=%s isRoot=%v",
+		c.id, c.isRoot)
+
 	return nil
 }
 

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -3,8 +3,6 @@ package ca
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
@@ -85,8 +83,7 @@ func TestConsulCAProvider_Bootstrap(t *testing.T) {
 	conf := testConsulCAConfig()
 	delegate := newMockDelegate(t, conf)
 
-	provider := &ConsulProvider{Delegate: delegate}
-	provider.SetLogger(log.New(ioutil.Discard, "", 0))
+	provider := TestConsulProvider(t, delegate)
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
@@ -119,7 +116,7 @@ func TestConsulCAProvider_Bootstrap_WithCert(t *testing.T) {
 	}
 	delegate := newMockDelegate(t, conf)
 
-	provider := &ConsulProvider{Delegate: delegate}
+	provider := TestConsulProvider(t, delegate)
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 
@@ -141,7 +138,7 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 			conf.Config["PrivateKeyBits"] = tc.KeyBits
 			delegate := newMockDelegate(t, conf)
 
-			provider := &ConsulProvider{Delegate: delegate}
+			provider := TestConsulProvider(t, delegate)
 			require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 			require.NoError(provider.GenerateRoot())
 
@@ -245,7 +242,7 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 
 			conf1 := testConsulCAConfig()
 			delegate1 := newMockDelegate(t, conf1)
-			provider1 := &ConsulProvider{Delegate: delegate1}
+			provider1 := TestConsulProvider(t, delegate1)
 			conf1.Config["PrivateKeyType"] = tc.SigningKeyType
 			conf1.Config["PrivateKeyBits"] = tc.SigningKeyBits
 			require.NoError(provider1.Configure(conf1.ClusterID, true, conf1.Config))
@@ -254,7 +251,7 @@ func TestConsulCAProvider_CrossSignCA(t *testing.T) {
 			conf2 := testConsulCAConfig()
 			conf2.CreateIndex = 10
 			delegate2 := newMockDelegate(t, conf2)
-			provider2 := &ConsulProvider{Delegate: delegate2}
+			provider2 := TestConsulProvider(t, delegate2)
 			conf2.Config["PrivateKeyType"] = tc.CSRKeyType
 			conf2.Config["PrivateKeyBits"] = tc.CSRKeyBits
 			require.NoError(provider2.Configure(conf2.ClusterID, true, conf2.Config))
@@ -359,7 +356,7 @@ func TestConsulProvider_SignIntermediate(t *testing.T) {
 
 			conf1 := testConsulCAConfig()
 			delegate1 := newMockDelegate(t, conf1)
-			provider1 := &ConsulProvider{Delegate: delegate1}
+			provider1 := TestConsulProvider(t, delegate1)
 			conf1.Config["PrivateKeyType"] = tc.SigningKeyType
 			conf1.Config["PrivateKeyBits"] = tc.SigningKeyBits
 			require.NoError(provider1.Configure(conf1.ClusterID, true, conf1.Config))
@@ -368,7 +365,7 @@ func TestConsulProvider_SignIntermediate(t *testing.T) {
 			conf2 := testConsulCAConfig()
 			conf2.CreateIndex = 10
 			delegate2 := newMockDelegate(t, conf2)
-			provider2 := &ConsulProvider{Delegate: delegate2}
+			provider2 := TestConsulProvider(t, delegate2)
 			conf2.Config["PrivateKeyType"] = tc.CSRKeyType
 			conf2.Config["PrivateKeyBits"] = tc.CSRKeyBits
 			require.NoError(provider2.Configure(conf2.ClusterID, false, conf2.Config))
@@ -450,7 +447,7 @@ func TestConsulCAProvider_MigrateOldID(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(providerState)
 
-	provider := &ConsulProvider{Delegate: delegate}
+	provider := TestConsulProvider(t, delegate)
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -3,6 +3,8 @@ package ca
 import (
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"testing"
 	"time"
 
@@ -84,6 +86,7 @@ func TestConsulCAProvider_Bootstrap(t *testing.T) {
 	delegate := newMockDelegate(t, conf)
 
 	provider := &ConsulProvider{Delegate: delegate}
+	provider.SetLogger(log.New(ioutil.Discard, "", 0))
 	require.NoError(provider.Configure(conf.ClusterID, true, conf.Config))
 	require.NoError(provider.GenerateRoot())
 

--- a/agent/connect/ca/provider_vault_test.go
+++ b/agent/connect/ca/provider_vault_test.go
@@ -288,7 +288,7 @@ func TestVaultProvider_SignIntermediateConsul(t *testing.T) {
 
 		conf := testConsulCAConfig()
 		delegate := newMockDelegate(t, conf)
-		provider2 := &ConsulProvider{Delegate: delegate}
+		provider2 := TestConsulProvider(t, delegate)
 		require.NoError(t, provider2.Configure(conf.ClusterID, false, conf.Config))
 
 		testSignIntermediateCrossDC(t, provider1, provider2)
@@ -298,7 +298,7 @@ func TestVaultProvider_SignIntermediateConsul(t *testing.T) {
 	t.Run("pri=consul,sec=vault", func(t *testing.T) {
 		conf := testConsulCAConfig()
 		delegate := newMockDelegate(t, conf)
-		provider1 := &ConsulProvider{Delegate: delegate}
+		provider1 := TestConsulProvider(t, delegate)
 		require.NoError(t, provider1.Configure(conf.ClusterID, true, conf.Config))
 		require.NoError(t, provider1.GenerateRoot())
 

--- a/agent/connect/ca/testing.go
+++ b/agent/connect/ca/testing.go
@@ -2,8 +2,11 @@ package ca
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 
 	"github.com/hashicorp/consul/agent/connect"
+	"github.com/mitchellh/go-testing-interface"
 )
 
 // KeyTestCases is a list of the important CA key types that we should test
@@ -60,4 +63,13 @@ func CASigningKeyTypeCases() []CASigningKeyTypes {
 		}
 	}
 	return cases
+}
+
+// TestConsulProvider creates a new ConsulProvider, taking care to stub out it's
+// Logger so that logging calls don't panic. If logging output is important
+// SetLogger can be called again with another logger to capture logs.
+func TestConsulProvider(t testing.T, d ConsulProviderStateDelegate) *ConsulProvider {
+	provider := &ConsulProvider{Delegate: d}
+	provider.SetLogger(log.New(ioutil.Discard, "", 0))
+	return provider
 }

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -102,14 +102,22 @@ func parseCARoot(pemValue, provider, clusterID string) (*structs.CARoot, error) 
 
 // createProvider returns a connect CA provider from the given config.
 func (s *Server) createCAProvider(conf *structs.CAConfiguration) (ca.Provider, error) {
+	var p ca.Provider
 	switch conf.Provider {
 	case structs.ConsulCAProvider:
-		return &ca.ConsulProvider{Delegate: &consulCADelegate{s}}, nil
+		p = &ca.ConsulProvider{Delegate: &consulCADelegate{s}}
 	case structs.VaultCAProvider:
-		return &ca.VaultProvider{}, nil
+		p = &ca.VaultProvider{}
 	default:
 		return nil, fmt.Errorf("unknown CA provider %q", conf.Provider)
 	}
+
+	// If the provider implements NeedsLogger, we give it our logger.
+	if needsLogger, ok := p.(ca.NeedsLogger); ok {
+		needsLogger.SetLogger(s.logger)
+	}
+
+	return p, nil
 }
 
 func (s *Server) getCAProvider() (ca.Provider, *structs.CARoot) {
@@ -163,11 +171,6 @@ func (s *Server) initializeCA() error {
 		return err
 	}
 	s.setCAProvider(provider, nil)
-
-	// If the provider implements NeedsLogger, we give it our logger.
-	if needsLogger, ok := provider.(ca.NeedsLogger); ok {
-		needsLogger.SetLogger(s.logger)
-	}
 
 	// If this isn't the primary DC, run the secondary DC routine if the primary has already been upgraded to at least 1.6.0
 	if s.config.PrimaryDatacenter != s.config.Datacenter {

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -164,6 +164,11 @@ func (s *Server) initializeCA() error {
 	}
 	s.setCAProvider(provider, nil)
 
+	// If the provider implements NeedsLogger, we give it our logger.
+	if needsLogger, ok := provider.(ca.NeedsLogger); ok {
+		needsLogger.SetLogger(s.logger)
+	}
+
 	// If this isn't the primary DC, run the secondary DC routine if the primary has already been upgraded to at least 1.6.0
 	if s.config.PrimaryDatacenter != s.config.Datacenter {
 		versionOk, foundPrimary := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -130,10 +130,6 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	return dir, config
 }
 
-func MakeMeATestServer(t *testing.T) (string, *Server) {
-	return testServer(t)
-}
-
 func testServer(t *testing.T) (string, *Server) {
 	return testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "dc1"

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -2,9 +2,11 @@ package consul
 
 import (
 	"fmt"
+	"github.com/hashicorp/consul/agent/connect/ca"
 	"log"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -126,6 +128,10 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.NotifyShutdown = returnPortsFn
 
 	return dir, config
+}
+
+func MakeMeATestServer(t *testing.T) (string, *Server) {
+	return testServer(t)
 }
 
 func testServer(t *testing.T) (string, *Server) {
@@ -1118,4 +1124,25 @@ func TestServer_RPC_RateLimit(t *testing.T) {
 			r.Fatalf("err: %v", err)
 		}
 	})
+}
+
+func TestServer_CALogging(t *testing.T) {
+	t.Parallel()
+	dir1, conf1 := testServerConfig(t)
+	s1, err := NewServer(conf1)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	if _, ok := s1.caProvider.(ca.NeedsLogger); !ok {
+		t.Fatalf("provider does not implement NeedsLogger")
+	}
+
+	v := reflect.ValueOf(s1.caProvider).Elem().FieldByName("logger")
+	if v.IsNil() {
+		t.Fatalf("provider logger is nil")
+	}
 }


### PR DESCRIPTION
This PR adds an interface called `NeedsLogger` to Connect CA providers. If a provider needs to log messages to the Consul log, it should implement `NeedsLogger`. Consul will then pass a preconfigured logger immediately after creating the provider, but before calling `Configure()`.