### PR TITLE
command: Fix Dropped Errors

### DIFF
--- a/command/acl/policy/update/policy_update.go
+++ b/command/acl/policy/update/policy_update.go
@@ -101,7 +101,10 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	rules, err := helpers.LoadDataSource(c.rules, c.testStdin)
-
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error loading data source: %v", err))
+		return 1
+	}
 	var updated *api.ACLPolicy
 	if c.noMerge {
 		updated = &api.ACLPolicy{

--- a/command/config/delete/config_delete_test.go
+++ b/command/config/delete/config_delete_test.go
@@ -30,6 +30,7 @@ func TestConfigDelete(t *testing.T) {
 		Name:     "web",
 		Protocol: "tcp",
 	}, nil)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),

--- a/command/config/read/config_read_test.go
+++ b/command/config/read/config_read_test.go
@@ -30,6 +30,7 @@ func TestConfigRead(t *testing.T) {
 		Name:     "web",
 		Protocol: "tcp",
 	}, nil)
+	require.NoError(t, err)
 
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),


### PR DESCRIPTION
This PR fixes some dropped errors within the `command` package.