### PR TITLE
Add EnterpriseConfig stubs

### DIFF
--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -424,6 +424,9 @@ type Config struct {
 	// AutoEncryptAllowTLS is whether to enable the server responding to
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool
+
+	// Embedded Consul Enterprise specific configuration
+	*EnterpriseConfig
 }
 
 // ToTLSUtilConfig is only used by tests, usually the config is being passed
@@ -543,6 +546,7 @@ func DefaultConfig() *Config {
 
 		ServerHealthInterval: 2 * time.Second,
 		AutopilotInterval:    10 * time.Second,
+		EnterpriseConfig:     DefaultEnterpriseConfig(),
 	}
 
 	// Increase our reap interval to 3 days instead of 24h.

--- a/agent/consul/enterprise_config_oss.go
+++ b/agent/consul/enterprise_config_oss.go
@@ -1,0 +1,9 @@
+// +build !consulent
+
+package consul
+
+type EnterpriseConfig struct{}
+
+func DefaultEnterpriseConfig() *EnterpriseConfig {
+	return nil
+}


### PR DESCRIPTION
This stubs out an embedded struct in the `agent.consul.Config` struct to hold Enterprise specific configuration.