### PR TITLE
check for go binary in ci builds

### DIFF
--- a/build-support/functions/00-vars.sh
+++ b/build-support/functions/00-vars.sh
@@ -9,13 +9,15 @@ GO_BUILD_CONTAINER_DEFAULT="consul-build-go"
 COLORIZE=${COLORIZE-1}
 
 # determine GOPATH and the first GOPATH to use for intalling binaries
-GOPATH=${GOPATH:-$(go env GOPATH)}
-case $(uname) in
-    CYGWIN*)
-        GOPATH="$(cygpath $GOPATH)"
-        ;;
-esac
-MAIN_GOPATH=$(cut -d: -f1 <<< "${GOPATH}")
+if command -v go >/dev/null; then
+   GOPATH=${GOPATH:-$(go env GOPATH)}
+   case $(uname) in
+         CYGWIN*)
+            GOPATH="$(cygpath $GOPATH)"
+            ;;
+   esac
+   MAIN_GOPATH=$(cut -d: -f1 <<< "${GOPATH}")
+fi
 
 # Build debugging output is off by default
 BUILD_DEBUG=${BUILD_DEBUG-0}


### PR DESCRIPTION
In the build process, all the functions are sourced regardless of what the current build step needs. There is a case where we are sourcing all the functions in a node container for the javascript build but this container does no have go which makes the GOPATH check fail. 