### PR TITLE
[docs] gRPC Health Checking specific service

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -159,7 +159,7 @@ The table below shows this endpoint's support for
 - `GRPC` `(string: "")` - Specifies a `gRPC` check's endpoint that supports the standard
   [gRPC health checking protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
   The state of the check will be updated at the given `Interval` by probing the configured
-  endpoint.
+  endpoint. Add the service identifier after the `gRPC` check's endpoint in the following format to check for a specific service instead of the whole gRPC server `/:service_identifier`.
 
 - `GRPCUseTLS` `(bool: false)` - Specifies whether to use TLS for this `gRPC` health check.
   If TLS is enabled, then by default, a valid TLS certificate is expected. Certificate

--- a/website/source/docs/agent/checks.html.md
+++ b/website/source/docs/agent/checks.html.md
@@ -116,6 +116,7 @@ There are several different kinds of checks:
   setting `grpc_use_tls` in the check definition. If TLS is enabled, then by default, a valid
   TLS certificate is expected. Certificate verification can be turned off by setting the
   `tls_skip_verify` field to `true` in the check definition.
+  To check on a specific service instead of the whole gRPC server, add the service identifier after the `gRPC` check's endpoint in the following format `/:service_identifier`.
 
 * <a name="alias"></a>Alias - These checks alias the health state of another registered
   node or service. The state of the check will be updated asynchronously,
@@ -203,7 +204,7 @@ A Docker check:
 }
 ```
 
-A gRPC check:
+A gRPC check for the whole application:
 
 ```javascript
 {
@@ -211,6 +212,20 @@ A gRPC check:
     "id": "mem-util",
     "name": "Service health status",
     "grpc": "127.0.0.1:12345",
+    "grpc_use_tls": true,
+    "interval": "10s"
+  }
+}
+```
+
+A gRPC check for the specific `my_service` service:
+
+```javascript
+{
+  "check": {
+    "id": "mem-util",
+    "name": "Service health status",
+    "grpc": "127.0.0.1:12345/my_service",
     "grpc_use_tls": true,
     "interval": "10s"
   }


### PR DESCRIPTION
Added more documentation about heath checking a specific gRPC service instead of the whole gRPC server.

Edit:
This is based on code from [here](https://github.com/hashicorp/consul/blob/master/agent/checks/grpc.go#L28)