### PR TITLE
agent: allow mesh gateways to initialize even if there are no connect services registered yet

### DIFF
--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -83,7 +83,7 @@ func (s *ConfigSnapshot) Valid() bool {
 	case structs.ServiceKindConnectProxy:
 		return s.Roots != nil && s.ConnectProxy.Leaf != nil
 	case structs.ServiceKindMeshGateway:
-		return s.Roots != nil && s.MeshGateway.WatchedServicesSet
+		return s.Roots != nil && (s.MeshGateway.WatchedServicesSet || len(s.MeshGateway.WatchedServices) > 0)
 	default:
 		return false
 	}

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -14,17 +14,44 @@ type configSnapshotConnectProxy struct {
 	WatchedUpstreamEndpoints map[string]map[string]structs.CheckServiceNodes
 	WatchedGateways          map[string]map[string]context.CancelFunc
 	WatchedGatewayEndpoints  map[string]map[string]structs.CheckServiceNodes
-	WatchedServiceChecks     map[string][]structs.CheckType
+	WatchedServiceChecks     map[string][]structs.CheckType // TODO: missing garbage collection
 
 	UpstreamEndpoints map[string]structs.CheckServiceNodes // DEPRECATED:see:WatchedUpstreamEndpoints
 }
 
+func (c *configSnapshotConnectProxy) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return c.Leaf == nil &&
+		len(c.DiscoveryChain) == 0 &&
+		len(c.WatchedUpstreams) == 0 &&
+		len(c.WatchedUpstreamEndpoints) == 0 &&
+		len(c.WatchedGateways) == 0 &&
+		len(c.WatchedGatewayEndpoints) == 0 &&
+		len(c.WatchedServiceChecks) == 0 &&
+		len(c.UpstreamEndpoints) == 0
+}
+
 type configSnapshotMeshGateway struct {
 	WatchedServices    map[string]context.CancelFunc
+	WatchedServicesSet bool
 	WatchedDatacenters map[string]context.CancelFunc
 	ServiceGroups      map[string]structs.CheckServiceNodes
 	ServiceResolvers   map[string]*structs.ServiceResolverConfigEntry
 	GatewayGroups      map[string]structs.CheckServiceNodes
+}
+
+func (c *configSnapshotMeshGateway) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return len(c.WatchedServices) == 0 &&
+		!c.WatchedServicesSet &&
+		len(c.WatchedDatacenters) == 0 &&
+		len(c.ServiceGroups) == 0 &&
+		len(c.ServiceResolvers) == 0 &&
+		len(c.GatewayGroups) == 0
 }
 
 // ConfigSnapshot captures all the resulting config needed for a proxy instance.
@@ -54,11 +81,9 @@ type ConfigSnapshot struct {
 func (s *ConfigSnapshot) Valid() bool {
 	switch s.Kind {
 	case structs.ServiceKindConnectProxy:
-		// TODO(rb): sanity check discovery chain things here?
 		return s.Roots != nil && s.ConnectProxy.Leaf != nil
 	case structs.ServiceKindMeshGateway:
-		// TODO (mesh-gateway) - what happens if all the connect services go away
-		return s.Roots != nil && len(s.MeshGateway.ServiceGroups) > 0
+		return s.Roots != nil && s.MeshGateway.WatchedServicesSet
 	default:
 		return false
 	}

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -726,6 +726,8 @@ func (s *state) handleUpdateMeshGateway(u cache.UpdateEvent, snap *ConfigSnapsho
 				cancelFn()
 			}
 		}
+
+		snap.MeshGateway.WatchedServicesSet = true
 	case datacentersWatchID:
 		datacentersRaw, ok := u.Result.(*[]string)
 		if !ok {

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -967,8 +967,16 @@ func testConfigSnapshotDiscoveryChain(t testing.T, variation string, additionalE
 }
 
 func TestConfigSnapshotMeshGateway(t testing.T) *ConfigSnapshot {
+	return testConfigSnapshotMeshGateway(t, true)
+}
+
+func TestConfigSnapshotMeshGatewayNoServices(t testing.T) *ConfigSnapshot {
+	return testConfigSnapshotMeshGateway(t, false)
+}
+
+func testConfigSnapshotMeshGateway(t testing.T, populateServices bool) *ConfigSnapshot {
 	roots, _ := TestCerts(t)
-	return &ConfigSnapshot{
+	snap := &ConfigSnapshot{
 		Kind:    structs.ServiceKindMeshGateway,
 		Service: "mesh-gateway",
 		ProxyID: "mesh-gateway",
@@ -990,10 +998,17 @@ func TestConfigSnapshotMeshGateway(t testing.T) *ConfigSnapshot {
 		Roots:      roots,
 		Datacenter: "dc1",
 		MeshGateway: configSnapshotMeshGateway{
+			WatchedServicesSet: true,
+		},
+	}
+
+	if populateServices {
+		snap.MeshGateway = configSnapshotMeshGateway{
 			WatchedServices: map[string]context.CancelFunc{
 				"foo": nil,
 				"bar": nil,
 			},
+			WatchedServicesSet: true,
 			WatchedDatacenters: map[string]context.CancelFunc{
 				"dc2": nil,
 			},
@@ -1004,8 +1019,10 @@ func TestConfigSnapshotMeshGateway(t testing.T) *ConfigSnapshot {
 			GatewayGroups: map[string]structs.CheckServiceNodes{
 				"dc2": TestGatewayNodesDC2(t),
 			},
-		},
+		}
 	}
+
+	return snap
 }
 
 func TestConfigSnapshotExposeConfig(t testing.T) *ConfigSnapshot {

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -198,6 +198,11 @@ func TestClustersFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "mesh-gateway-no-services",
+			create: proxycfg.TestConfigSnapshotMeshGatewayNoServices,
+			setup:  nil,
+		},
+		{
 			name:   "mesh-gateway-service-subsets",
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -239,6 +239,10 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "mesh-gateway-no-services",
+			create: proxycfg.TestConfigSnapshotMeshGatewayNoServices,
+		},
+		{
 			name:   "connect-proxy-with-chain",
 			create: proxycfg.TestConfigSnapshotDiscoveryChain,
 			setup:  nil,

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -225,6 +225,10 @@ func TestListenersFromSnapshot(t *testing.T) {
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 		},
 		{
+			name:   "mesh-gateway-no-services",
+			create: proxycfg.TestConfigSnapshotMeshGatewayNoServices,
+		},
+		{
 			name:   "mesh-gateway-tagged-addresses",
 			create: proxycfg.TestConfigSnapshotMeshGateway,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/testdata/clusters/mesh-gateway-no-services.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-no-services.golden
@@ -1,0 +1,7 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/endpoints/mesh-gateway-no-services.golden
+++ b/agent/xds/testdata/endpoints/mesh-gateway-no-services.golden
@@ -1,0 +1,7 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/mesh-gateway-no-services.golden
+++ b/agent/xds/testdata/listeners/mesh-gateway-no-services.golden
@@ -1,0 +1,38 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "default:1.2.3.4:8443",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8443
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.filters.network.sni_cluster"
+            },
+            {
+              "name": "envoy.tcp_proxy",
+              "config": {
+                  "cluster": "",
+                  "stat_prefix": "mesh_gateway_local_default_tcp"
+                }
+            }
+          ]
+        }
+      ],
+      "listenerFilters": [
+        {
+          "name": "envoy.listener.tls_inspector"
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
Fixes #6543

Also improved some of the proxycfg tests to cover snapshot validity better.