### PR TITLE
Fix typo, "ENDS" should be "EDNS" for "Near: _ip"

### DIFF
--- a/website/source/api/query.html.md
+++ b/website/source/api/query.html.md
@@ -223,7 +223,7 @@ The table below shows this endpoint's support for
          where the query was executed from. For HTTP the source IP is the remote
          peer's IP address or the value of the X-Forwarded-For header with the
          header taking precedence. For DNS the source IP is the remote peer's IP
-         address or the value of the ENDS client IP with the EDNS client IP
+         address or the value of the EDNS client IP with the EDNS client IP
          taking precedence.
 
 


### PR DESCRIPTION
"ENDS" should be "EDNS", in the API parameter description of:
 * Create Prepared Query / Parameters / Service / Near / _ip

(The sentence had one incorrect and one correct occurrence.)