### PR TITLE
ui: Add missed calls to `_super`

### DIFF
--- a/ui-v2/app/mixins/creating-route.js
+++ b/ui-v2/app/mixins/creating-route.js
@@ -10,9 +10,11 @@ import { get } from '@ember/object';
  */
 export default Mixin.create({
   beforeModel: function() {
+    this._super(...arguments);
     this.repo.invalidate();
   },
   deactivate: function() {
+    this._super(...arguments);
     // TODO: This is dependent on ember-changeset
     // Change changeset to support ember-data props
     const item = get(this.controller, 'item.data');


### PR DESCRIPTION
Spotted these whilst working on UI namespace support, thought I'd PR it separately. Doesn't seem to have affected anything up until now.