### PR TITLE
ui: Remove `$radius-small` in favour of the `$decor-*` ones in `base`

### DIFF
--- a/ui-v2/app/styles/components/filter-bar/skin.scss
+++ b/ui-v2/app/styles/components/filter-bar/skin.scss
@@ -1,7 +1,7 @@
 // decoration/color
 %filter-bar > * {
   border: $decor-border-100;
-  border-radius: $radius-small;
+  border-radius: $decor-radius-100;
 }
 // TODO: Move this elsewhere
 @media #{$--horizontal-selects} {

--- a/ui-v2/app/styles/variables/index.scss
+++ b/ui-v2/app/styles/variables/index.scss
@@ -6,5 +6,4 @@ $magenta-800-no-hash: 5a1434;
 
 // decoration
 // undecided
-$radius-small: $decor-radius-100;
 $radius: $decor-radius-200;


### PR DESCRIPTION
Replaces `$radius-small` with `$decor-radius-100`. Spotted whilst working on namespace support. The final old style `$radius` will be removed as part of the PR for namespace support.