### PR TITLE
Add support of acceptance of datacenter as a param for force-leave from WAN pool

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -127,7 +127,7 @@ func (a *TestACLAgent) LocalMember() serf.Member {
 func (a *TestACLAgent) JoinLAN(addrs []string) (n int, err error) {
 	return 0, fmt.Errorf("Unimplemented")
 }
-func (a *TestACLAgent) RemoveFailedNode(node string, prune bool) error {
+func (a *TestACLAgent) RemoveFailedNode(node, datacenter string, prune bool) error {
 	return fmt.Errorf("Unimplemented")
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -134,7 +134,7 @@ type delegate interface {
 	LANSegmentMembers(segment string) ([]serf.Member, error)
 	LocalMember() serf.Member
 	JoinLAN(addrs []string) (n int, err error)
-	RemoveFailedNode(node string, prune bool) error
+	RemoveFailedNode(node, datacenter string, prune bool) error
 	ResolveToken(secretID string) (acl.Authorizer, error)
 	RPC(method string, args interface{}, reply interface{}) error
 	ACLsEnabled() bool
@@ -1779,9 +1779,9 @@ func (a *Agent) JoinWAN(addrs []string) (n int, err error) {
 }
 
 // ForceLeave is used to remove a failed node from the cluster
-func (a *Agent) ForceLeave(node string, prune bool) (err error) {
+func (a *Agent) ForceLeave(node, datacenter string, prune bool) (err error) {
 	a.logger.Printf("[INFO] agent: Force leaving node: %v", node)
-	err = a.delegate.RemoveFailedNode(node, prune)
+	err = a.delegate.RemoveFailedNode(node, datacenter, prune)
 	if err != nil {
 		a.logger.Printf("[WARN] agent: Failed to remove node: %v", err)
 	}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -438,11 +438,15 @@ func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request
 		return nil, acl.ErrPermissionDenied
 	}
 
-	//Check the value of the prune query
-	_, prune := req.URL.Query()["prune"]
+	//Check the value of the prune and datacenter query
+	datacenter := req.URL.Query().Get("datacenter")
+	prune, err := strconv.ParseBool(req.URL.Query().Get("prune"))
+	if err != nil {
+		prune = false
+	}
 
 	addr := strings.TrimPrefix(req.URL.Path, "/v1/agent/force-leave/")
-	return nil, s.agent.ForceLeave(addr, prune)
+	return nil, s.agent.ForceLeave(addr, datacenter, prune)
 }
 
 // syncChanges is a helper function which wraps a blocking call to sync

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -263,7 +263,10 @@ func (c *Client) LANSegmentMembers(segment string) ([]serf.Member, error) {
 }
 
 // RemoveFailedNode is used to remove a failed node from the cluster
-func (c *Client) RemoveFailedNode(node string, prune bool) error {
+func (c *Client) RemoveFailedNode(node, datacenter string, prune bool) error {
+	if datacenter != "" {
+		node = node + "." + datacenter
+	}
 	if prune {
 		c.serf.RemoveFailedNodePrune(node)
 	}

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -264,9 +264,6 @@ func (c *Client) LANSegmentMembers(segment string) ([]serf.Member, error) {
 
 // RemoveFailedNode is used to remove a failed node from the cluster
 func (c *Client) RemoveFailedNode(node, datacenter string, prune bool) error {
-	if datacenter != "" {
-		node = node + "." + datacenter
-	}
 	if prune {
 		c.serf.RemoveFailedNodePrune(node)
 	}

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -549,7 +549,7 @@ func TestLeader_LeftServer(t *testing.T) {
 	servers[0].Shutdown()
 
 	// Force remove the non-leader (transition to left state)
-	if err := servers[1].RemoveFailedNode(servers[0].config.NodeName, false); err != nil {
+	if err := servers[1].RemoveFailedNode(servers[0].config.NodeName, servers[0].config.Datacenter, false); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1008,7 +1008,7 @@ func (s *Server) WANMembers() []serf.Member {
 }
 
 // RemoveFailedNode is used to remove a failed node from the cluster
-func (s *Server) RemoveFailedNode(node string, prune bool) error {
+func (s *Server) RemoveFailedNode(node, datacenter string, prune bool) error {
 	var removeFn func(*serf.Serf, string) error
 	if prune {
 		removeFn = (*serf.Serf).RemoveFailedNodePrune
@@ -1021,7 +1021,9 @@ func (s *Server) RemoveFailedNode(node string, prune bool) error {
 	}
 	// The Serf WAN pool stores members as node.datacenter
 	// so the dc is appended if not present
-	if !strings.HasSuffix(node, "."+s.config.Datacenter) {
+	if datacenter != "" {
+		node = node + "." + datacenter
+	} else if !strings.HasSuffix(node, "."+s.config.Datacenter) {
 		node = node + "." + s.config.Datacenter
 	}
 	if s.serfWAN != nil {

--- a/api/agent.go
+++ b/api/agent.go
@@ -730,11 +730,13 @@ func (a *Agent) ForceLeave(node string) error {
 	return nil
 }
 
-//ForceLeavePrune is used to have an a failed agent removed
-//from the list of members
-func (a *Agent) ForceLeavePrune(node string) error {
+//ForceLeaveWithOpts is used to have an a failed agent removed
+//from the list of members with specified additional arguments
+func (a *Agent) ForceLeaveWithOpts(node string, q *QueryOptions) error {
 	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+node)
-	r.params.Set("prune", "1")
+
+	r.setQueryOptions(q)
+
 	_, resp, err := requireOK(a.c.doRequest(r))
 	if err != nil {
 		return err

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1070,7 +1070,7 @@ func TestAPI_AgentForceLeave(t *testing.T) {
 	}
 }
 
-func TestAPI_AgentForceLeavePrune(t *testing.T) {
+func TestAPI_AgentForceLeaveWithOpts(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
@@ -1078,7 +1078,8 @@ func TestAPI_AgentForceLeavePrune(t *testing.T) {
 	agent := c.Agent()
 
 	// Eject somebody
-	err := agent.ForceLeavePrune("foo")
+	q := &QueryOptions{Datacenter: "", Prune: true}
+	err := agent.ForceLeaveWithOpts("foo", q)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -155,6 +155,10 @@ type QueryOptions struct {
 	// services. This currently affects prepared query execution.
 	Connect bool
 
+	// Prune is used in force leave command to remove agent completely
+	// from list of members
+	Prune bool
+
 	// ctx is an optional context pass through to the underlying HTTP
 	// request layer. Use Context() and WithContext() to manage this.
 	ctx context.Context
@@ -675,6 +679,9 @@ func (r *request) setQueryOptions(q *QueryOptions) {
 	}
 	if q.Connect {
 		r.params.Set("connect", "true")
+	}
+	if q.Prune {
+		r.params.Set("prune", "true")
 	}
 	if q.UseCache && !q.RequireConsistent {
 		r.params.Set("cached", "")


### PR DESCRIPTION
I hope I did everything the proper way, waiting for review.
Also need some help with writing tests for `-datacenter` arg, need to know how to create fake node in another datacenter in [forceleave_test.go](https://github.com/hashicorp/consul/blob/master/command/forceleave/forceleave_test.go)

Resolves #6582 