### PR TITLE
Add PolicyReadByName for API

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -217,7 +217,7 @@ func (s *HTTPServer) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request) 
 
 	switch req.Method {
 	case "GET":
-		fn = s.ACLPolicyRead
+		fn = s.ACLPolicyReadByID
 
 	case "PUT":
 		fn = s.ACLPolicyWrite
@@ -237,10 +237,11 @@ func (s *HTTPServer) ACLPolicyCRUD(resp http.ResponseWriter, req *http.Request) 
 	return fn(resp, req, policyID)
 }
 
-func (s *HTTPServer) ACLPolicyRead(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error) {
+func (s *HTTPServer) ACLPolicyRead(resp http.ResponseWriter, req *http.Request, policyID, policyName string) (interface{}, error) {
 	args := structs.ACLPolicyGetRequest{
 		Datacenter: s.agent.config.Datacenter,
 		PolicyID:   policyID,
+		PolicyName: policyName,
 	}
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
@@ -274,6 +275,23 @@ func (s *HTTPServer) ACLPolicyCreate(resp http.ResponseWriter, req *http.Request
 	}
 
 	return s.aclPolicyWriteInternal(resp, req, "", true)
+}
+
+func (s *HTTPServer) ACLPolicyReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if s.checkACLDisabled(resp, req) {
+		return nil, nil
+	}
+
+	policyName := strings.TrimPrefix(req.URL.Path, "/v1/acl/policy/name/")
+	if policyName == "" {
+		return nil, BadRequestError{Reason: "Missing policy Name"}
+	}
+
+	return s.ACLPolicyRead(resp, req, "", policyName)
+}
+
+func (s *HTTPServer) ACLPolicyReadByID(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error) {
+	return s.ACLPolicyRead(resp, req, policyID, "")
 }
 
 func (s *HTTPServer) ACLPolicyWrite(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error) {

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -269,14 +269,6 @@ func (s *HTTPServer) ACLPolicyRead(resp http.ResponseWriter, req *http.Request, 
 	return out.Policy, nil
 }
 
-func (s *HTTPServer) ACLPolicyCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
-	if s.checkACLDisabled(resp, req) {
-		return nil, nil
-	}
-
-	return s.aclPolicyWriteInternal(resp, req, "", true)
-}
-
 func (s *HTTPServer) ACLPolicyReadByName(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
 	if s.checkACLDisabled(resp, req) {
 		return nil, nil
@@ -292,6 +284,14 @@ func (s *HTTPServer) ACLPolicyReadByName(resp http.ResponseWriter, req *http.Req
 
 func (s *HTTPServer) ACLPolicyReadByID(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error) {
 	return s.ACLPolicyRead(resp, req, policyID, "")
+}
+
+func (s *HTTPServer) ACLPolicyCreate(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if s.checkACLDisabled(resp, req) {
+		return nil, nil
+	}
+
+	return s.aclPolicyWriteInternal(resp, req, "", true)
 }
 
 func (s *HTTPServer) ACLPolicyWrite(resp http.ResponseWriter, req *http.Request, policyID string) (interface{}, error) {

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -376,14 +376,14 @@ func TestACL_HTTP(t *testing.T) {
 		})
 
 		t.Run("Read Name", func(t *testing.T) {
-			policyName := "policy-read-all-nodes"
+			policyName := "read-all-nodes"
 			req, _ := http.NewRequest("GET", "/v1/acl/policy/name/"+policyName+"?token=root", nil)
 			resp := httptest.NewRecorder()
-			raw, err := a.srv.ACLPolicyCRUD(resp, req)
+			raw, err := a.srv.ACLPolicyReadByName(resp, req)
 			require.NoError(t, err)
 			policy, ok := raw.(*structs.ACLPolicy)
 			require.True(t, ok)
-			require.Equal(t, policyMap[idMap[policyName]], policy)
+			require.Equal(t, policyMap[idMap["policy-"+policyName]], policy)
 		})
 	})
 

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -374,6 +374,17 @@ func TestACL_HTTP(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, policyMap[idMap["policy-read-all-nodes"]], policy)
 		})
+
+		t.Run("Read Name", func(t *testing.T) {
+			policyName := "policy-read-all-nodes"
+			req, _ := http.NewRequest("GET", "/v1/acl/policy/name/"+policyName+"?token=root", nil)
+			resp := httptest.NewRecorder()
+			raw, err := a.srv.ACLPolicyCRUD(resp, req)
+			require.NoError(t, err)
+			policy, ok := raw.(*structs.ACLPolicy)
+			require.True(t, ok)
+			require.Equal(t, policyMap[idMap[policyName]], policy)
+		})
 	})
 
 	t.Run("Role", func(t *testing.T) {

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -951,7 +951,16 @@ func (a *ACL) PolicyRead(args *structs.ACLPolicyGetRequest, reply *structs.ACLPo
 
 	return a.srv.blockingQuery(&args.QueryOptions, &reply.QueryMeta,
 		func(ws memdb.WatchSet, state *state.Store) error {
-			index, policy, err := state.ACLPolicyGetByID(ws, args.PolicyID, &args.EnterpriseMeta)
+			var (
+				index  uint64
+				policy *structs.ACLPolicy
+				err    error
+			)
+			if args.PolicyID != "" {
+				index, policy, err = state.ACLPolicyGetByID(ws, args.PolicyID, &args.EnterpriseMeta)
+			} else {
+				index, policy, err = state.ACLPolicyGetByName(ws, args.PolicyName, &args.EnterpriseMeta)
+			}
 
 			if err != nil {
 				return err

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -14,6 +14,7 @@ func init() {
 	registerEndpoint("/v1/acl/policies", []string{"GET"}, (*HTTPServer).ACLPolicyList)
 	registerEndpoint("/v1/acl/policy", []string{"PUT"}, (*HTTPServer).ACLPolicyCreate)
 	registerEndpoint("/v1/acl/policy/", []string{"GET", "PUT", "DELETE"}, (*HTTPServer).ACLPolicyCRUD)
+	registerEndpoint("/v1/acl/policy/name/", []string{"GET"}, (*HTTPServer).ACLPolicyReadByName)
 	registerEndpoint("/v1/acl/roles", []string{"GET"}, (*HTTPServer).ACLRoleList)
 	registerEndpoint("/v1/acl/role", []string{"PUT"}, (*HTTPServer).ACLRoleCreate)
 	registerEndpoint("/v1/acl/role/name/", []string{"GET"}, (*HTTPServer).ACLRoleReadByName)

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1238,7 +1238,8 @@ func (r *ACLPolicyDeleteRequest) RequestDatacenter() string {
 
 // ACLPolicyGetRequest is used at the RPC layer to perform policy read operations
 type ACLPolicyGetRequest struct {
-	PolicyID   string // id used for the policy lookup
+	PolicyID   string // id used for the policy lookup (one of PolicyID or PolicyName is allowed)
+	PolicyName string // name used for the policy lookup (one of PolicyID or PolicyName is allowed)
 	Datacenter string // The datacenter to perform the request within
 	EnterpriseMeta
 	QueryOptions


### PR DESCRIPTION
While writing an update to the python library consulate for Consul's ACL https://github.com/gmr/consulate/pull/123, I noticed that Consul's API was missing the PolicyReadByName API function. Seeing as how it's fairly simple fix, here's a small patch I made to the API to add the ability. Covers at the read by name issue on #5962 brought up. 

Let me know if there's any error or modification I should do here. 