### PR TITLE
sdk: ignore panics due to stray goroutines logging after a test completes

### DIFF
--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -38,6 +38,19 @@ func (tw *testWriter) Write(p []byte) (n int, err error) {
 	if sendTestLogsToStdout || tw.t == nil {
 		fmt.Fprint(os.Stdout, strings.TrimSpace(string(p))+"\n")
 	} else {
+		defer func() {
+			if r := recover(); r != nil {
+				if sr, ok := r.(string); ok {
+					if strings.HasPrefix(sr, "Log in goroutine after ") {
+						// These sorts of panics are undesirable, but requires
+						// total control over goroutine lifetimes to correct.
+						fmt.Fprint(os.Stdout, "SUPPRESSED PANIC: "+sr+"\n")
+						return
+					}
+				}
+				panic(r)
+			}
+		}()
 		tw.t.Log(strings.TrimSpace(string(p)))
 	}
 	return len(p), nil


### PR DESCRIPTION
If there is imperfect goroutine lifespan tracking if we pipe our logs
through testing.T.Logf there is a chance of a stray goroutine attempting
to log after the test that spawned it completes.

This results in a panic of:

    panic: Log in goroutine after TestLeader_SecondaryCA_Initialize has completed...

This isn't great and should be fixed, but quickly runs into situations
around externally cancelling blocking queries which isn't terribly
possible at the moment. The concession here is to ignore these specific
panics for now.

This can be triggered easily when running some tests with a high
`-count=YYY` value.