### PR TITLE
Add support for dual stack IPv4/IPv6 network

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2256,6 +2256,26 @@ func (a *Agent) addServiceInternal(req *addServiceRequest) error {
 	a.PauseSync()
 	defer a.ResumeSync()
 
+	// Set default tagged addresses
+	serviceIP := net.ParseIP(service.Address)
+	serviceAddressIs4 := serviceIP != nil && serviceIP.To4() != nil
+	serviceAddressIs6 := serviceIP != nil && serviceIP.To4() == nil
+	if service.TaggedAddresses == nil {
+		service.TaggedAddresses = map[string]structs.ServiceAddress{}
+	}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv4]; !ok && serviceAddressIs4 {
+		service.TaggedAddresses[structs.TaggedAddressLANIPv4] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv4]; !ok && serviceAddressIs4 {
+		service.TaggedAddresses[structs.TaggedAddressWANIPv4] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv6]; !ok && serviceAddressIs6 {
+		service.TaggedAddresses[structs.TaggedAddressLANIPv6] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv6]; !ok && serviceAddressIs6 {
+		service.TaggedAddresses[structs.TaggedAddressWANIPv6] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	}
+
 	// Take a snapshot of the current state of checks (if any), and when adding
 	// a check that already existed carry over the state before resuming
 	// anti-entropy.
@@ -2448,6 +2468,34 @@ func (a *Agent) validateService(service *structs.NodeService, chkTypes []*struct
 			a.logger.Printf("[DEBUG] agent: Service tag %q will not be discoverable "+
 				"via DNS due to it being too long. Valid lengths are between "+
 				"1 and 63 bytes.", tag)
+		}
+	}
+
+	// Check IPv4/IPv6 tagged addresses
+	if service.TaggedAddresses != nil {
+		if sa, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv4]; ok {
+			ip := net.ParseIP(sa.Address)
+			if ip == nil || ip.To4() == nil {
+				return fmt.Errorf("Service tagged address %q must be a valid ipv4 address", structs.TaggedAddressLANIPv4)
+			}
+		}
+		if sa, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv4]; ok {
+			ip := net.ParseIP(sa.Address)
+			if ip == nil || ip.To4() == nil {
+				return fmt.Errorf("Service tagged address %q must be a valid ipv4 address", structs.TaggedAddressWANIPv4)
+			}
+		}
+		if sa, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv6]; ok {
+			ip := net.ParseIP(sa.Address)
+			if ip == nil || ip.To4() != nil {
+				return fmt.Errorf("Service tagged address %q must be a valid ipv6 address", structs.TaggedAddressLANIPv6)
+			}
+		}
+		if sa, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv6]; ok {
+			ip := net.ParseIP(sa.Address)
+			if ip == nil || ip.To4() != nil {
+				return fmt.Errorf("Service tagged address %q must be a valid ipv6 address", structs.TaggedAddressLANIPv6)
+			}
 		}
 	}
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3018,10 +3018,11 @@ func testAgent_RegisterService_UnmanagedConnectProxy(t *testing.T, extraHCL stri
 
 func testDefaultSidecar(svc string, port int, fns ...func(*structs.NodeService)) *structs.NodeService {
 	ns := &structs.NodeService{
-		ID:      svc + "-sidecar-proxy",
-		Kind:    structs.ServiceKindConnectProxy,
-		Service: svc + "-sidecar-proxy",
-		Port:    2222,
+		ID:              svc + "-sidecar-proxy",
+		Kind:            structs.ServiceKindConnectProxy,
+		Service:         svc + "-sidecar-proxy",
+		Port:            2222,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Weights: &structs.Weights{
 			Passing: 1,
 			Warning: 1,
@@ -3383,9 +3384,10 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 			// Note here that although the registration here didn't register it, we
 			// should still see the NodeService we pre-registered here.
 			wantNS: &structs.NodeService{
-				ID:      "web-sidecar-proxy",
-				Service: "fake-sidecar",
-				Port:    9999,
+				ID:              "web-sidecar-proxy",
+				Service:         "fake-sidecar",
+				Port:            9999,
+				TaggedAddresses: map[string]structs.ServiceAddress{},
 				Weights: &structs.Weights{
 					Passing: 1,
 					Warning: 1,
@@ -3426,6 +3428,7 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 				Service:                    "web-sidecar-proxy",
 				LocallyRegisteredAsSidecar: true,
 				Port:                       6666,
+				TaggedAddresses:            map[string]structs.ServiceAddress{},
 				Weights: &structs.Weights{
 					Passing: 1,
 					Warning: 1,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -735,7 +735,7 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
-	ns := a.State.Service("my_service_id")
+	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
 
 	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
@@ -764,7 +764,7 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
-	ns := a.State.Service("my_service_id")
+	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
 
 	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
@@ -799,7 +799,7 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
-	ns := a.State.Service("my_service_id")
+	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
 
 	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
@@ -834,7 +834,7 @@ func TestAddServiceIPv6TaggedSet(t *testing.T) {
 	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
 	require.Nil(t, err)
 
-	ns := a.State.Service("my_service_id")
+	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
 	require.NotNil(t, ns)
 
 	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -718,6 +718,134 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 	}
 }
 
+func TestAddServiceIPv4TaggedDefault(t *testing.T) {
+	t.Helper()
+
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	srv := &structs.NodeService{
+		Service: "my_service",
+		ID:      "my_service_id",
+		Port:    8100,
+		Address: "10.0.1.2",
+	}
+
+	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	require.Nil(t, err)
+
+	ns := a.State.Service("my_service_id")
+	require.NotNil(t, ns)
+
+	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv4])
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressWANIPv4])
+	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv6]
+	require.False(t, ok)
+	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv6]
+	require.False(t, ok)
+}
+
+func TestAddServiceIPv6TaggedDefault(t *testing.T) {
+	t.Helper()
+
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	srv := &structs.NodeService{
+		Service: "my_service",
+		ID:      "my_service_id",
+		Port:    8100,
+		Address: "::5",
+	}
+
+	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	require.Nil(t, err)
+
+	ns := a.State.Service("my_service_id")
+	require.NotNil(t, ns)
+
+	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv6])
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressWANIPv6])
+	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv4]
+	require.False(t, ok)
+	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv4]
+	require.False(t, ok)
+}
+
+func TestAddServiceIPv4TaggedSet(t *testing.T) {
+	t.Helper()
+
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	srv := &structs.NodeService{
+		Service: "my_service",
+		ID:      "my_service_id",
+		Port:    8100,
+		Address: "10.0.1.2",
+		TaggedAddresses: map[string]structs.ServiceAddress{
+			structs.TaggedAddressWANIPv4: {
+				Address: "10.100.200.5",
+				Port:    8100,
+			},
+		},
+	}
+
+	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	require.Nil(t, err)
+
+	ns := a.State.Service("my_service_id")
+	require.NotNil(t, ns)
+
+	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv4])
+	require.Equal(t, structs.ServiceAddress{Address: "10.100.200.5", Port: 8100}, ns.TaggedAddresses[structs.TaggedAddressWANIPv4])
+	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv6]
+	require.False(t, ok)
+	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv6]
+	require.False(t, ok)
+}
+
+func TestAddServiceIPv6TaggedSet(t *testing.T) {
+	t.Helper()
+
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+
+	srv := &structs.NodeService{
+		Service: "my_service",
+		ID:      "my_service_id",
+		Port:    8100,
+		Address: "::5",
+		TaggedAddresses: map[string]structs.ServiceAddress{
+			structs.TaggedAddressWANIPv6: {
+				Address: "::6",
+				Port:    8100,
+			},
+		},
+	}
+
+	err := a.AddService(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
+	require.Nil(t, err)
+
+	ns := a.State.Service("my_service_id")
+	require.NotNil(t, ns)
+
+	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
+	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv6])
+	require.Equal(t, structs.ServiceAddress{Address: "::6", Port: 8100}, ns.TaggedAddresses[structs.TaggedAddressWANIPv6])
+	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv4]
+	require.False(t, ok)
+	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv4]
+	require.False(t, ok)
+}
+
 func TestAgent_RemoveService(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
@@ -1876,12 +2004,13 @@ func testAgent_persistedService_compat(t *testing.T, extraHCL string) {
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
-		ID:             "redis",
-		Service:        "redis",
-		Tags:           []string{"foo"},
-		Port:           8000,
-		Weights:        &structs.Weights{Passing: 1, Warning: 1},
-		EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+		ID:              "redis",
+		Service:         "redis",
+		Tags:            []string{"foo"},
+		Port:            8000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
+		Weights:         &structs.Weights{Passing: 1, Warning: 1},
+		EnterpriseMeta:  *structs.DefaultEnterpriseMeta(),
 	}
 
 	// Encode the NodeService directly. This is what previous versions

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -138,7 +138,7 @@ RETRY_ONCE:
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 
-	s.agent.TranslateAddresses(args.Datacenter, out.Nodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {
@@ -284,7 +284,7 @@ func (s *HTTPServer) catalogServiceNodes(resp http.ResponseWriter, req *http.Req
 	}
 
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
-	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.ServiceNodes, TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.ServiceNodes == nil {
@@ -340,7 +340,7 @@ RETRY_ONCE:
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 	if out.NodeServices != nil {
-		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices)
+		s.agent.TranslateAddresses(args.Datacenter, out.NodeServices, TranslateAddressAcceptAny)
 	}
 
 	// TODO: The NodeServices object in IndexedNodeServices is a pointer to

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -415,6 +415,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 
 	bindAddr := bindAddrs[0].(*net.IPAddr)
 	advertiseAddr := b.makeIPAddr(b.expandFirstIP("advertise_addr", c.AdvertiseAddrLAN), bindAddr)
+
 	if ipaddr.IsAny(advertiseAddr) {
 
 		var addrtyp string
@@ -460,7 +461,39 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 
 	// derive other advertise addresses from the advertise address
 	advertiseAddrLAN := b.makeIPAddr(b.expandFirstIP("advertise_addr", c.AdvertiseAddrLAN), advertiseAddr)
+	advertiseAddrIsV6 := advertiseAddr.IP.To4() == nil
+	var advertiseAddrV4, advertiseAddrV6 *net.IPAddr
+	if !advertiseAddrIsV6 {
+		advertiseAddrV4 = advertiseAddr
+	} else {
+		advertiseAddrV6 = advertiseAddr
+	}
+	advertiseAddrLANIPv4 := b.makeIPAddr(b.expandFirstIP("advertise_addr_ipv4", c.AdvertiseAddrLANIPv4), advertiseAddrV4)
+	if advertiseAddrLANIPv4 != nil && advertiseAddrLANIPv4.IP.To4() == nil {
+		return RuntimeConfig{}, fmt.Errorf("advertise_addr_ipv4 must be an ipv4 address")
+	}
+	advertiseAddrLANIPv6 := b.makeIPAddr(b.expandFirstIP("advertise_addr_ipv6", c.AdvertiseAddrLANIPv6), advertiseAddrV6)
+	if advertiseAddrLANIPv6 != nil && advertiseAddrLANIPv6.IP.To4() != nil {
+		return RuntimeConfig{}, fmt.Errorf("advertise_addr_ipv6 must be an ipv6 address")
+	}
+
 	advertiseAddrWAN := b.makeIPAddr(b.expandFirstIP("advertise_addr_wan", c.AdvertiseAddrWAN), advertiseAddrLAN)
+	advertiseAddrWANIsV6 := advertiseAddrWAN.IP.To4() == nil
+	var advertiseAddrWANv4, advertiseAddrWANv6 *net.IPAddr
+	if !advertiseAddrWANIsV6 {
+		advertiseAddrWANv4 = advertiseAddrWAN
+	} else {
+		advertiseAddrWANv6 = advertiseAddrWAN
+	}
+	advertiseAddrWANIPv4 := b.makeIPAddr(b.expandFirstIP("advertise_addr_wan_ipv4", c.AdvertiseAddrWANIPv4), advertiseAddrWANv4)
+	if advertiseAddrWANIPv4 != nil && advertiseAddrWANIPv4.IP.To4() == nil {
+		return RuntimeConfig{}, fmt.Errorf("advertise_addr_wan_ipv4 must be an ipv4 address")
+	}
+	advertiseAddrWANIPv6 := b.makeIPAddr(b.expandFirstIP("advertise_addr_wan_ipv6", c.AdvertiseAddrWANIPv6), advertiseAddrWANv6)
+	if advertiseAddrWANIPv6 != nil && advertiseAddrWANIPv6.IP.To4() != nil {
+		return RuntimeConfig{}, fmt.Errorf("advertise_addr_wan_ipv6 must be an ipv6 address")
+	}
+
 	rpcAdvertiseAddr := &net.TCPAddr{IP: advertiseAddrLAN.IP, Port: serverPort}
 	serfAdvertiseAddrLAN := &net.TCPAddr{IP: advertiseAddrLAN.IP, Port: serfPortLAN}
 	// Only initialize serf WAN advertise address when its enabled
@@ -509,8 +542,22 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	if c.TaggedAddresses == nil {
 		c.TaggedAddresses = make(map[string]string)
 	}
+
 	c.TaggedAddresses[structs.TaggedAddressLAN] = advertiseAddrLAN.IP.String()
+	if advertiseAddrLANIPv4 != nil {
+		c.TaggedAddresses[structs.TaggedAddressLANIPv4] = advertiseAddrLANIPv4.IP.String()
+	}
+	if advertiseAddrLANIPv6 != nil {
+		c.TaggedAddresses[structs.TaggedAddressLANIPv6] = advertiseAddrLANIPv6.IP.String()
+	}
+
 	c.TaggedAddresses[structs.TaggedAddressWAN] = advertiseAddrWAN.IP.String()
+	if advertiseAddrWANIPv4 != nil {
+		c.TaggedAddresses[structs.TaggedAddressWANIPv4] = advertiseAddrWANIPv4.IP.String()
+	}
+	if advertiseAddrWANIPv6 != nil {
+		c.TaggedAddresses[structs.TaggedAddressWANIPv6] = advertiseAddrWANIPv6.IP.String()
+	}
 
 	// segments
 	var segments []structs.NetworkSegment

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -509,8 +509,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	if c.TaggedAddresses == nil {
 		c.TaggedAddresses = make(map[string]string)
 	}
-	c.TaggedAddresses["lan"] = advertiseAddrLAN.IP.String()
-	c.TaggedAddresses["wan"] = advertiseAddrWAN.IP.String()
+	c.TaggedAddresses[structs.TaggedAddressLAN] = advertiseAddrLAN.IP.String()
+	c.TaggedAddresses[structs.TaggedAddressWAN] = advertiseAddrWAN.IP.String()
 
 	// segments
 	var segments []structs.NetworkSegment

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -182,7 +182,11 @@ type Config struct {
 	ACL                              ACL                      `json:"acl,omitempty" hcl:"acl" mapstructure:"acl"`
 	Addresses                        Addresses                `json:"addresses,omitempty" hcl:"addresses" mapstructure:"addresses"`
 	AdvertiseAddrLAN                 *string                  `json:"advertise_addr,omitempty" hcl:"advertise_addr" mapstructure:"advertise_addr"`
+	AdvertiseAddrLANIPv4             *string                  `json:"advertise_addr_ipv4,omitempty" hcl:"advertise_addr_ipv4" mapstructure:"advertise_addr_ipv4"`
+	AdvertiseAddrLANIPv6             *string                  `json:"advertise_addr_ipv6,omitempty" hcl:"advertise_addr_ipv6" mapstructure:"advertise_addr_ipv6"`
 	AdvertiseAddrWAN                 *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
+	AdvertiseAddrWANIPv4             *string                  `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
+	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
 	Autopilot                        Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                         *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
 	Bootstrap                        *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -70,8 +70,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfAdvertiseAddrLAN = tcpAddr("1.2.3.4:8301")
 				rt.SerfAdvertiseAddrWAN = tcpAddr("1.2.3.4:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "1.2.3.4",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -86,8 +88,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.AdvertiseAddrWAN = ipAddr("1.2.3.4")
 				rt.SerfAdvertiseAddrWAN = tcpAddr("1.2.3.4:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "10.0.0.1",
-					"wan": "1.2.3.4",
+					"lan":      "10.0.0.1",
+					"lan_ipv4": "10.0.0.1",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -106,8 +110,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfAdvertiseAddrLAN = tcpAddr("1.2.3.4:8301")
 				rt.SerfAdvertiseAddrWAN = tcpAddr("5.6.7.8:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "5.6.7.8",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "5.6.7.8",
+					"wan_ipv4": "5.6.7.8",
 				}
 				rt.DataDir = dataDir
 			},
@@ -129,8 +135,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrLAN = tcpAddr("1.2.3.4:8301")
 				rt.SerfBindAddrWAN = tcpAddr("1.2.3.4:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "1.2.3.4",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -282,7 +290,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrWAN = tcpAddr("127.0.0.1:8302")
 				rt.ServerMode = true
 				rt.SkipLeaveOnInt = true
-				rt.TaggedAddresses = map[string]string{"lan": "127.0.0.1", "wan": "127.0.0.1"}
+				rt.TaggedAddresses = map[string]string{
+					"lan":      "127.0.0.1",
+					"lan_ipv4": "127.0.0.1",
+					"wan":      "127.0.0.1",
+					"wan_ipv4": "127.0.0.1",
+				}
 				rt.ConsulCoordinateUpdatePeriod = 100 * time.Millisecond
 				rt.ConsulRaftElectionTimeout = 52 * time.Millisecond
 				rt.ConsulRaftHeartbeatTimeout = 35 * time.Millisecond
@@ -836,8 +849,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrLAN = tcpAddr("0.0.0.0:8301")
 				rt.SerfBindAddrWAN = tcpAddr("0.0.0.0:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "10.0.0.1",
-					"wan": "10.0.0.1",
+					"lan":      "10.0.0.1",
+					"lan_ipv4": "10.0.0.1",
+					"wan":      "10.0.0.1",
+					"wan_ipv4": "10.0.0.1",
 				}
 				rt.DataDir = dataDir
 			},
@@ -858,8 +873,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrLAN = tcpAddr("[::]:8301")
 				rt.SerfBindAddrWAN = tcpAddr("[::]:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "dead:beef::1",
-					"wan": "dead:beef::1",
+					"lan":      "dead:beef::1",
+					"lan_ipv6": "dead:beef::1",
+					"wan":      "dead:beef::1",
+					"wan_ipv6": "dead:beef::1",
 				}
 				rt.DataDir = dataDir
 			},
@@ -883,8 +900,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrLAN = tcpAddr("0.0.0.0:8301")
 				rt.SerfBindAddrWAN = tcpAddr("0.0.0.0:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "1.2.3.4",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -1101,8 +1120,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfAdvertiseAddrLAN = tcpAddr("1.2.3.4:8301")
 				rt.SerfAdvertiseAddrWAN = tcpAddr("1.2.3.4:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "1.2.3.4",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -1116,8 +1137,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.AdvertiseAddrWAN = ipAddr("1.2.3.4")
 				rt.SerfAdvertiseAddrWAN = tcpAddr("1.2.3.4:8302")
 				rt.TaggedAddresses = map[string]string{
-					"lan": "10.0.0.1",
-					"wan": "1.2.3.4",
+					"lan":      "10.0.0.1",
+					"lan_ipv4": "10.0.0.1",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -1154,8 +1177,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfPortWAN = 3000
 				rt.ServerPort = 1000
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.2.3.4",
-					"wan": "1.2.3.4",
+					"lan":      "1.2.3.4",
+					"lan_ipv4": "1.2.3.4",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -1192,8 +1217,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfPortWAN = 3000
 				rt.ServerPort = 1000
 				rt.TaggedAddresses = map[string]string{
-					"lan": "10.0.0.1",
-					"wan": "1.2.3.4",
+					"lan":      "10.0.0.1",
+					"lan_ipv4": "10.0.0.1",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 			},
@@ -1218,8 +1245,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfAdvertiseAddrWAN = nil
 				rt.SerfBindAddrWAN = nil
 				rt.TaggedAddresses = map[string]string{
-					"lan": "10.0.0.1",
-					"wan": "1.2.3.4",
+					"lan":      "10.0.0.1",
+					"lan_ipv4": "10.0.0.1",
+					"wan":      "1.2.3.4",
+					"wan_ipv4": "1.2.3.4",
 				}
 				rt.DataDir = dataDir
 				rt.SerfPortWAN = -1
@@ -1430,8 +1459,10 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				rt.SerfBindAddrWAN = tcpAddr("4.4.4.4:8302")
 				rt.StartJoinAddrsLAN = []string{"c", "d", "a", "b"}
 				rt.TaggedAddresses = map[string]string{
-					"lan": "1.1.1.1",
-					"wan": "2.2.2.2",
+					"lan":      "1.1.1.1",
+					"lan_ipv4": "1.1.1.1",
+					"wan":      "2.2.2.2",
+					"wan_ipv4": "2.2.2.2",
 				}
 				rt.DataDir = dataDir
 			},
@@ -5458,7 +5489,9 @@ func TestFullConfig(t *testing.T) {
 			"7MYgHrYH": "dALJAhLD",
 			"h6DdBy6K": "ebrr9zZ8",
 			"lan":      "17.99.29.16",
+			"lan_ipv4": "17.99.29.16",
 			"wan":      "78.63.37.19",
+			"wan_ipv4": "78.63.37.19",
 		},
 		TranslateWANAddrs:    true,
 		UIContentPath:        "/consul/",

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -247,7 +247,7 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	}
 
 	// Translate addresses after filtering so we don't waste effort.
-	s.agent.TranslateAddresses(args.Datacenter, out.Nodes)
+	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil
 	if out.Nodes == nil {

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -163,7 +163,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 	// a query can fail over to a different DC than where the execute request
 	// was sent to. That's why we use the reply's DC and not the one from
 	// the args.
-	s.agent.TranslateAddresses(reply.Datacenter, reply.Nodes)
+	s.agent.TranslateAddresses(reply.Datacenter, reply.Nodes, TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil.
 	if reply.Nodes == nil {

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -986,11 +986,11 @@ func testConfigSnapshotMeshGateway(t testing.T, populateServices bool) *ConfigSn
 			Config: map[string]interface{}{},
 		},
 		TaggedAddresses: map[string]structs.ServiceAddress{
-			"lan": structs.ServiceAddress{
+			structs.TaggedAddressLAN: structs.ServiceAddress{
 				Address: "1.2.3.4",
 				Port:    8443,
 			},
-			"wan": structs.ServiceAddress{
+			structs.TaggedAddressWAN: structs.ServiceAddress{
 				Address: "198.18.0.1",
 				Port:    443,
 			},

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -50,9 +50,10 @@ func TestServiceManager_RegisterService(t *testing.T) {
 	redisService := a.State.Service(structs.NewServiceID("redis", nil))
 	require.NotNil(redisService)
 	require.Equal(&structs.NodeService{
-		ID:      "redis",
-		Service: "redis",
-		Port:    8000,
+		ID:              "redis",
+		Service:         "redis",
+		Port:            8000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Weights: &structs.Weights{
 			Passing: 1,
 			Warning: 1,
@@ -116,10 +117,11 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))
 	require.NotNil(sidecarService)
 	require.Equal(&structs.NodeService{
-		Kind:    structs.ServiceKindConnectProxy,
-		ID:      "web-sidecar-proxy",
-		Service: "web-sidecar-proxy",
-		Port:    21000,
+		Kind:            structs.ServiceKindConnectProxy,
+		ID:              "web-sidecar-proxy",
+		Service:         "web-sidecar-proxy",
+		Port:            21000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "web",
 			DestinationServiceID:   "web",
@@ -184,10 +186,11 @@ func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 	gateway := a.State.Service(structs.NewServiceID("mesh-gateway", nil))
 	require.NotNil(gateway)
 	require.Equal(&structs.NodeService{
-		Kind:    structs.ServiceKindMeshGateway,
-		ID:      "mesh-gateway",
-		Service: "mesh-gateway",
-		Port:    443,
+		Kind:            structs.ServiceKindMeshGateway,
+		ID:              "mesh-gateway",
+		Service:         "mesh-gateway",
+		Port:            443,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Proxy: structs.ConnectProxyConfig{
 			Config: map[string]interface{}{
 				"foo":      int64(1),
@@ -276,10 +279,11 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	}
 
 	expectState := &structs.NodeService{
-		Kind:    structs.ServiceKindConnectProxy,
-		ID:      "web-sidecar-proxy",
-		Service: "web-sidecar-proxy",
-		Port:    21000,
+		Kind:            structs.ServiceKindConnectProxy,
+		ID:              "web-sidecar-proxy",
+		Service:         "web-sidecar-proxy",
+		Port:            21000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "web",
 			DestinationServiceID:   "web",
@@ -487,10 +491,11 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	svcID := "web-sidecar-proxy"
 
 	expectState := &structs.NodeService{
-		Kind:    structs.ServiceKindConnectProxy,
-		ID:      "web-sidecar-proxy",
-		Service: "web-sidecar-proxy",
-		Port:    21000,
+		Kind:            structs.ServiceKindConnectProxy,
+		ID:              "web-sidecar-proxy",
+		Service:         "web-sidecar-proxy",
+		Port:            21000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "web",
 			DestinationServiceID:   "web",
@@ -637,10 +642,11 @@ func TestServiceManager_Disabled(t *testing.T) {
 	sidecarService := a.State.Service(structs.NewServiceID("web-sidecar-proxy", nil))
 	require.NotNil(sidecarService)
 	require.Equal(&structs.NodeService{
-		Kind:    structs.ServiceKindConnectProxy,
-		ID:      "web-sidecar-proxy",
-		Service: "web-sidecar-proxy",
-		Port:    21000,
+		Kind:            structs.ServiceKindConnectProxy,
+		ID:              "web-sidecar-proxy",
+		Service:         "web-sidecar-proxy",
+		Port:            21000,
+		TaggedAddresses: map[string]structs.ServiceAddress{},
 		Proxy: structs.ConnectProxyConfig{
 			DestinationServiceName: "web",
 			DestinationServiceID:   "web",

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -115,6 +115,11 @@ var (
 	NodeMaintCheckID = NewCheckID(NodeMaint, nil)
 )
 
+const (
+	TaggedAddressWAN = "wan"
+	TaggedAddressLAN = "lan"
+)
+
 // metaKeyFormat checks if a metadata key string is valid
 var metaKeyFormat = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`).MatchString
 
@@ -608,7 +613,7 @@ type Node struct {
 
 func (n *Node) BestAddress(wan bool) string {
 	if wan {
-		if addr, ok := n.TaggedAddresses["wan"]; ok {
+		if addr, ok := n.TaggedAddresses[TaggedAddressWAN]; ok {
 			return addr
 		}
 	}
@@ -915,7 +920,7 @@ func (ns *NodeService) BestAddress(wan bool) (string, int) {
 	port := ns.Port
 
 	if wan {
-		if wan, ok := ns.TaggedAddresses["wan"]; ok {
+		if wan, ok := ns.TaggedAddresses[TaggedAddressWAN]; ok {
 			addr = wan.Address
 			if wan.Port != 0 {
 				port = wan.Port

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -116,8 +116,12 @@ var (
 )
 
 const (
-	TaggedAddressWAN = "wan"
-	TaggedAddressLAN = "lan"
+	TaggedAddressWAN     = "wan"
+	TaggedAddressWANIPv4 = "wan_ipv4"
+	TaggedAddressWANIPv6 = "wan_ipv6"
+	TaggedAddressLAN     = "lan"
+	TaggedAddressLANIPv4 = "lan_ipv4"
+	TaggedAddressLANIPv6 = "lan_ipv6"
 )
 
 // metaKeyFormat checks if a metadata key string is valid

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -97,8 +97,8 @@ func TestNodeServiceMeshGatewayWithAddrs(t testing.T, address string, port int, 
 			},
 		},
 		TaggedAddresses: map[string]ServiceAddress{
-			"lan": lanAddr,
-			"wan": wanAddr,
+			TaggedAddressLAN: lanAddr,
+			TaggedAddressWAN: wanAddr,
 		},
 	}
 }

--- a/agent/translate_addr.go
+++ b/agent/translate_addr.go
@@ -11,7 +11,7 @@ import (
 // parameter is the dc the datacenter this node is from.
 func (a *Agent) TranslateServicePort(dc string, port int, taggedAddresses map[string]structs.ServiceAddress) int {
 	if a.config.TranslateWANAddrs && (a.config.Datacenter != dc) {
-		if wanAddr, ok := taggedAddresses["wan"]; ok && wanAddr.Port != 0 {
+		if wanAddr, ok := taggedAddresses[structs.TaggedAddressWAN]; ok && wanAddr.Port != 0 {
 			return wanAddr.Port
 		}
 	}
@@ -23,7 +23,7 @@ func (a *Agent) TranslateServicePort(dc string, port int, taggedAddresses map[st
 // parameter is the dc the datacenter this node is from.
 func (a *Agent) TranslateServiceAddress(dc string, addr string, taggedAddresses map[string]structs.ServiceAddress) string {
 	if a.config.TranslateWANAddrs && (a.config.Datacenter != dc) {
-		if wanAddr, ok := taggedAddresses["wan"]; ok && wanAddr.Address != "" {
+		if wanAddr, ok := taggedAddresses[structs.TaggedAddressWAN]; ok && wanAddr.Address != "" {
 			return wanAddr.Address
 		}
 	}
@@ -35,7 +35,7 @@ func (a *Agent) TranslateServiceAddress(dc string, addr string, taggedAddresses 
 // parameter is the dc the datacenter this node is from.
 func (a *Agent) TranslateAddress(dc string, addr string, taggedAddresses map[string]string) string {
 	if a.config.TranslateWANAddrs && (a.config.Datacenter != dc) {
-		wanAddr := taggedAddresses["wan"]
+		wanAddr := taggedAddresses[structs.TaggedAddressWAN]
 		if wanAddr != "" {
 			addr = wanAddr
 		}

--- a/agent/translate_addr.go
+++ b/agent/translate_addr.go
@@ -2,8 +2,19 @@ package agent
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/hashicorp/consul/agent/structs"
+)
+
+type TranslateAddressAccept int
+
+const (
+	TranslateAddressAcceptDomain TranslateAddressAccept = 1 << iota
+	TranslateAddressAcceptIPv4
+	TranslateAddressAcceptIPv6
+
+	TranslateAddressAcceptAny TranslateAddressAccept = ^0
 )
 
 // TranslateServicePort is used to provide the final, translated port for a service,
@@ -21,32 +32,78 @@ func (a *Agent) TranslateServicePort(dc string, port int, taggedAddresses map[st
 // TranslateServiceAddress is used to provide the final, translated address for a node,
 // depending on how the agent and the other node are configured. The dc
 // parameter is the dc the datacenter this node is from.
-func (a *Agent) TranslateServiceAddress(dc string, addr string, taggedAddresses map[string]structs.ServiceAddress) string {
-	if a.config.TranslateWANAddrs && (a.config.Datacenter != dc) {
-		if wanAddr, ok := taggedAddresses[structs.TaggedAddressWAN]; ok && wanAddr.Address != "" {
-			return wanAddr.Address
+func (a *Agent) TranslateServiceAddress(dc string, addr string, taggedAddresses map[string]structs.ServiceAddress, accept TranslateAddressAccept) string {
+	def := addr
+	v4 := taggedAddresses[structs.TaggedAddressLANIPv4].Address
+	v6 := taggedAddresses[structs.TaggedAddressLANIPv6].Address
+
+	shouldUseWan := a.config.TranslateWANAddrs && (a.config.Datacenter != dc)
+	if shouldUseWan {
+		if v, ok := taggedAddresses[structs.TaggedAddressWAN]; ok {
+			def = v.Address
+		}
+		if v, ok := taggedAddresses[structs.TaggedAddressWANIPv4]; ok {
+			v4 = v.Address
+		}
+		if v, ok := taggedAddresses[structs.TaggedAddressWANIPv6]; ok {
+			v6 = v.Address
 		}
 	}
-	return addr
+
+	return translateAddressAccept(accept, def, v4, v6)
 }
 
 // TranslateAddress is used to provide the final, translated address for a node,
 // depending on how the agent and the other node are configured. The dc
 // parameter is the dc the datacenter this node is from.
-func (a *Agent) TranslateAddress(dc string, addr string, taggedAddresses map[string]string) string {
-	if a.config.TranslateWANAddrs && (a.config.Datacenter != dc) {
-		wanAddr := taggedAddresses[structs.TaggedAddressWAN]
-		if wanAddr != "" {
-			addr = wanAddr
+func (a *Agent) TranslateAddress(dc string, addr string, taggedAddresses map[string]string, accept TranslateAddressAccept) string {
+	def := addr
+	v4 := taggedAddresses[structs.TaggedAddressLANIPv4]
+	v6 := taggedAddresses[structs.TaggedAddressLANIPv6]
+
+	shouldUseWan := a.config.TranslateWANAddrs && (a.config.Datacenter != dc)
+	if shouldUseWan {
+		if v, ok := taggedAddresses[structs.TaggedAddressWAN]; ok {
+			def = v
+		}
+		if v, ok := taggedAddresses[structs.TaggedAddressWANIPv4]; ok {
+			v4 = v
+		}
+		if v, ok := taggedAddresses[structs.TaggedAddressWANIPv6]; ok {
+			v6 = v
 		}
 	}
-	return addr
+
+	return translateAddressAccept(accept, def, v4, v6)
+}
+
+func translateAddressAccept(accept TranslateAddressAccept, def, v4, v6 string) string {
+	switch {
+	case accept&TranslateAddressAcceptIPv6 > 0 && v6 != "":
+		return v6
+	case accept&TranslateAddressAcceptIPv4 > 0 && v4 != "":
+		return v4
+	case accept&TranslateAddressAcceptAny > 0 && def != "":
+		return def
+	default:
+		defIP := net.ParseIP(def)
+		switch {
+		case defIP != nil && defIP.To4() != nil && accept&TranslateAddressAcceptIPv4 > 0:
+			return def
+		case defIP != nil && defIP.To4() == nil && accept&TranslateAddressAcceptIPv6 > 0:
+			return def
+		case defIP == nil && accept&TranslateAddressAcceptDomain > 0:
+			return def
+		}
+	}
+
+	return ""
 }
 
 // TranslateAddresses translates addresses in the given structure into the
 // final, translated address, depending on how the agent and the other node are
 // configured. The dc parameter is the datacenter this structure is from.
-func (a *Agent) TranslateAddresses(dc string, subj interface{}) {
+func (a *Agent) TranslateAddresses(dc string, subj interface{}, accept TranslateAddressAccept) {
 	// CAUTION - SUBTLE! An agent running on a server can, in some cases,
 	// return pointers directly into the immutable state store for
 	// performance (it's via the in-memory RPC mechanism). It's never safe
@@ -68,28 +125,28 @@ func (a *Agent) TranslateAddresses(dc string, subj interface{}) {
 	switch v := subj.(type) {
 	case structs.CheckServiceNodes:
 		for _, entry := range v {
-			entry.Node.Address = a.TranslateAddress(dc, entry.Node.Address, entry.Node.TaggedAddresses)
-			entry.Service.Address = a.TranslateServiceAddress(dc, entry.Service.Address, entry.Service.TaggedAddresses)
+			entry.Node.Address = a.TranslateAddress(dc, entry.Node.Address, entry.Node.TaggedAddresses, accept)
+			entry.Service.Address = a.TranslateServiceAddress(dc, entry.Service.Address, entry.Service.TaggedAddresses, accept)
 			entry.Service.Port = a.TranslateServicePort(dc, entry.Service.Port, entry.Service.TaggedAddresses)
 		}
 	case *structs.Node:
-		v.Address = a.TranslateAddress(dc, v.Address, v.TaggedAddresses)
+		v.Address = a.TranslateAddress(dc, v.Address, v.TaggedAddresses, accept)
 	case structs.Nodes:
 		for _, node := range v {
-			node.Address = a.TranslateAddress(dc, node.Address, node.TaggedAddresses)
+			node.Address = a.TranslateAddress(dc, node.Address, node.TaggedAddresses, accept)
 		}
 	case structs.ServiceNodes:
 		for _, entry := range v {
-			entry.Address = a.TranslateAddress(dc, entry.Address, entry.TaggedAddresses)
-			entry.ServiceAddress = a.TranslateServiceAddress(dc, entry.ServiceAddress, entry.ServiceTaggedAddresses)
+			entry.Address = a.TranslateAddress(dc, entry.Address, entry.TaggedAddresses, accept)
+			entry.ServiceAddress = a.TranslateServiceAddress(dc, entry.ServiceAddress, entry.ServiceTaggedAddresses, accept)
 			entry.ServicePort = a.TranslateServicePort(dc, entry.ServicePort, entry.ServiceTaggedAddresses)
 		}
 	case *structs.NodeServices:
 		if v.Node != nil {
-			v.Node.Address = a.TranslateAddress(dc, v.Node.Address, v.Node.TaggedAddresses)
+			v.Node.Address = a.TranslateAddress(dc, v.Node.Address, v.Node.TaggedAddresses, accept)
 		}
 		for _, entry := range v.Services {
-			entry.Address = a.TranslateServiceAddress(dc, entry.Address, entry.TaggedAddresses)
+			entry.Address = a.TranslateServiceAddress(dc, entry.Address, entry.TaggedAddresses, accept)
 			entry.Port = a.TranslateServicePort(dc, entry.Port, entry.TaggedAddresses)
 		}
 	default:

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -52,8 +52,10 @@ func TestAPI_CatalogNodes(t *testing.T) {
 				Address:    "127.0.0.1",
 				Datacenter: "dc1",
 				TaggedAddresses: map[string]string{
-					"lan": "127.0.0.1",
-					"wan": "127.0.0.1",
+					"lan":      "127.0.0.1",
+					"lan_ipv4": "127.0.0.1",
+					"wan":      "127.0.0.1",
+					"wan_ipv4": "127.0.0.1",
 				},
 				Meta: map[string]string{
 					"consul-network-segment": "",

--- a/api/txn_test.go
+++ b/api/txn_test.go
@@ -269,8 +269,10 @@ func TestAPI_ClientTxn(t *testing.T) {
 					Address:    "127.0.0.1",
 					Datacenter: "dc1",
 					TaggedAddresses: map[string]string{
-						"lan": s.Config.Bind,
-						"wan": s.Config.Bind,
+						"lan":      s.Config.Bind,
+						"lan_ipv4": s.Config.Bind,
+						"wan":      s.Config.Bind,
+						"wan_ipv4": s.Config.Bind,
 					},
 					Meta:        map[string]string{"consul-network-segment": ""},
 					CreateIndex: ret.Results[1].Node.CreateIndex,

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/xds"
 	"github.com/hashicorp/consul/api"
 	proxyCmd "github.com/hashicorp/consul/command/connect/proxy"
@@ -244,7 +245,7 @@ func (c *cmd) Run(args []string) int {
 		taggedAddrs := make(map[string]api.ServiceAddress)
 
 		if lanAddr != "" {
-			taggedAddrs["lan"] = api.ServiceAddress{Address: lanAddr, Port: lanPort}
+			taggedAddrs[structs.TaggedAddressLAN] = api.ServiceAddress{Address: lanAddr, Port: lanPort}
 		}
 
 		wanAddr := ""
@@ -255,7 +256,7 @@ func (c *cmd) Run(args []string) int {
 				c.UI.Error(fmt.Sprintf("Failed to parse the -wan-address parameter: %v", err))
 				return 1
 			}
-			taggedAddrs["wan"] = api.ServiceAddress{Address: wanAddr, Port: wanPort}
+			taggedAddrs[structs.TaggedAddressWAN] = api.ServiceAddress{Address: wanAddr, Port: wanPort}
 		}
 
 		tcpCheckAddr := lanAddr


### PR DESCRIPTION
Implementation for https://github.com/hashicorp/consul/issues/6531

As described in the issue, we can only set one address for a service or a node. In cases were the network is dual stack IPv4/IPv6 we would like to specify addresses for both protocols.

We add config options for node :
* `advertise_addr_ipv4`
* `advertise_addr_ipv6`
* `advertise_addr_wan_ipv4`
* `advertise_addr_wan_ipv6`

These addresses are set in the TaggedAddress map and available in HTTP endpoints

For services, TaggedAddresses can be set directly when registering the service.

The keys for TaggedAddress entries are defined in the `structs` package : 
```
	TaggedAddressWAN     = "wan"
	TaggedAddressWANIPv4 = "wan_ipv4"
	TaggedAddressWANIPv6 = "wan_ipv6"
	TaggedAddressLAN     = "lan"
	TaggedAddressLANIPv4 = "lan_ipv4"
	TaggedAddressLANIPv6 = "lan_ipv6"
```

For both nodes and services, tagged addresses take default from the "address" field when compatible. For example, running an agent with `advertise_addr = "1.2.3.4"` will automatically set `lan_ipv4` and `wan_ipv4`, unless they are explicitly specified. For services the "Address" field is used. 

Left to do : 
* [ ] DNS support (waiting for https://github.com/hashicorp/consul/pull/6283)
* [ ] xDS support