### PR TITLE
chore: Add probot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,7 +19,7 @@ staleLabel: "waiting-reply"
 markComment: |
   Hey there,
   We wanted to check in on this request since it has been inactive for at least 60 days.
-  If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/compare/)
+  If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md)
   or [its documentation](https://www.consul.io/docs) please reply with a comment here to let us know and we'll keep it open for investigation.
   If there is still no activity on this issue for 30 more days, we will go ahead and close it.
 

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -33,7 +33,7 @@ unmarkComment: false
 closeComment: >
   Hey there,
   This issue has been automatically closed because there hasn't been any activity for at least 90 days. 
-  If you are still experiencing problems feel free to [open a new one](https://github.com/hashicorp/consul/issues/new), or if you have questions, visit our [community forum](https://discuss.hashicorp.com/c/consul) :+1:
+  If you are still experiencing problems, or still have questions, feel free to [open a new one](https://github.com/hashicorp/consul/issues/new) :+1:
 
 # Limit to only `issues`
 only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,11 +19,12 @@ staleLabel: "waiting-reply"
 markComment: |
   Hey there,
   We wanted to check in on this request since it has been inactive for at least 60 days.
-  Have you reviewed the [community form](https://discuss.hashicorp.com/c/consul)? 
-  If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/compare/) or 
-  [its documentation](https://www.consul.io/docs) please feel let us know and we'll keep it open for investigation.
-  If there is still no activity on this request in 30 days, we will go ahead and close it.
-  Thank you!
+  If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/compare/)
+  or [its documentation](https://www.consul.io/docs) please reply with a comment here to let us know and we'll keep it open for investigation.
+  If there is still no activity on this issue for 30 more days, we will go ahead and close it.
+
+ Feel free to check out the [community forum](https://discuss.hashicorp.com/c/consul) as well!
+ Thank you!
 
 # Comment to post when removing the stale label. Set to `false` to disable
 unmarkComment: false
@@ -31,8 +32,8 @@ unmarkComment: false
 # Comment to post when closing a stale Issue. Set to `false` to disable
 closeComment: >
   Hey there,
-  This issue has been automatically closed because there hasn't been any activity for a while. 
-  If you are still experiencing problems, or still have questions, feel free to [open a new one](https://github.com/hashicorp/consul/issues/new) :+1
+  This issue has been automatically closed because there hasn't been any activity for at least 90 days. 
+  If you are still experiencing problems, or still have questions, feel free to [open a new one](https://github.com/hashicorp/consul/issues/new) :+1:
 
 # Limit to only `issues`
 only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,7 +20,7 @@ markComment: |
   Hey there,
   We wanted to check in on this request since it has been inactive for at least 60 days.
   If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/blob/master/CHANGELOG.md)
-  or [its documentation](https://www.consul.io/docs) please reply with a comment here to let us know and we'll keep it open for investigation.
+  or [its documentation](https://www.consul.io/docs) please reply with a comment here which will cause it to stay open for investigation.
   If there is still no activity on this issue for 30 more days, we will go ahead and close it.
 
  Feel free to check out the [community forum](https://discuss.hashicorp.com/c/consul) as well!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,39 @@
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 30
+
+# Issues with these labels will never be considered stale. Set to `[]` to disable
+# We don't close any issue that is an enhancement or confirmed bug, but issues
+# waiting for reproduction cases and questions tend to get outdated.
+exemptLabels:
+  - "enhancement"
+  - "bug"
+  - "thinking"
+  - "docs"
+
+# Label to use when marking as stale
+staleLabel: "waiting-reply"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: |
+  Hey there,
+  We wanted to check in on this request since it has been inactive for at least 60 days.
+  Have you reviewed the [community form](https://discuss.hashicorp.com/c/consul)? 
+  If you think this is still an important issue in the latest version of [Consul](https://github.com/hashicorp/consul/compare/) or 
+  [its documentation](https://www.consul.io/docs) please feel let us know and we'll keep it open for investigation.
+  If there is still no activity on this request in 30 days, we will go ahead and close it.
+  Thank you!
+
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: false
+
+# Comment to post when closing a stale Issue. Set to `false` to disable
+closeComment: >
+  Hey there,
+  This issue has been automatically closed because there hasn't been any activity for a while. 
+  If you are still experiencing problems, or still have questions, feel free to [open a new one](https://github.com/hashicorp/consul/issues/new) :+1
+
+# Limit to only `issues`
+only: issues
+


### PR DESCRIPTION
This is a first draft at a GitHub Probot configuration for managing those issues
with a long enough cycle time that it shouldn't catch cases where there is
active discussion, and it'll ignore anything we've explicitly called out an
enhancement, bug, or docs change, but will prompt people for a response if
we're waiting-reply etc.

I'm especially looking for feedback on the language usage, because I think the
thresholds are about correct for the volume on this repo.

By default, the bot reviews 30 issues per hour. This variable is configurable. 

For comparison, here is [Raft's](https://github.com/hashicorp/raft/pull/327) bot configuration and [Nomad's ](https://github.com/hashicorp/nomad/pull/5375/files)

Link to source/docs: https://github.com/probot/stale