### PR TITLE
Decode number without unmarshalling as float64

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -583,6 +583,7 @@ func decodeBody(req *http.Request, out interface{}, cb func(interface{}) error) 
 
 	var raw interface{}
 	dec := json.NewDecoder(req.Body)
+	dec.UseNumber()
 	if err := dec.Decode(&raw); err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes issue #6655. encoding/json unmarshals integers as float64 by default, which results in the loss of precision when they are casted back as integers. 

Do not merge this PR as it is. The cleanest way to resolve the issue requires an addition to the mitchellh/mapstructure library and I have opened a PR to do that (https://github.com/mitchellh/mapstructure/pull/174). Once that is done, the vendored changes can be removed from this PR. 