### PR TITLE
docs: Unnecessary fix for links to learn.hashicorp.com

### DIFF
--- a/website/source/docs/platform/k8s/index.html.md
+++ b/website/source/docs/platform/k8s/index.html.md
@@ -47,15 +47,12 @@ Kubernetes can choose to leverage Consul.
 
 There are several ways to try Consul with Kubernetes in different environments.
 
- - The [Consul and minikube guide](https://learn.hashicorp.com/consul/
-   getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs) is a quick walk through of how to deploy Consul with the official Helm chart on a local instance of Minikube. 
+ - The [Consul and minikube guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs) is a quick walk through of how to deploy Consul with the official Helm chart on a local instance of Minikube.
 
- - The [Deploying Consul with Kubernetes guide](https://learn.hashicorp.com/
-   consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs)
+ - The [Deploying Consul with Kubernetes guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs)
    walks you through deploying Consul on Kubernetes with the official Helm chart and can be applied to any Kubernetes installation type.
 
- - The [Kubernetes on Azure guide](https://learn.hashicorp.com/consul/
-   getting-started-k8s/azure-k8s?utm_source=consul.io&utm_medium=docs) is a complete walk through on how to deploy Consul on AKS.
+ - The [Kubernetes on Azure guide](https://learn.hashicorp.com/consul/getting-started-k8s/azure-k8s?utm_source=consul.io&utm_medium=docs) is a complete walk through on how to deploy Consul on AKS.
 
  - The [Consul and Kubernetes Reference Architecture](
    https://learn.hashicorp.com/consul/day-1-operations/kubernetes-reference?utm_source=consul.io&utm_medium=docs) guide provides recommended practices for production. 


### PR DESCRIPTION
This "fix" is intended to remove new line break in few links at the page
https://www.consul.io/docs/platform/k8s/index.html , its not necessary since
Chrome and Safari are ignoring new lines, but it allows to keep links
in order and respect to standards.