### PR TITLE
modify netlify-cli installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 references:
   images:
     go: &GOLANG_IMAGE circleci/golang:1.12.8
-    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.35
+    middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.40
     ember: &EMBER_IMAGE circleci/node:8-browsers
 
   paths:

--- a/website/scripts/link-check.sh
+++ b/website/scripts/link-check.sh
@@ -2,7 +2,10 @@
 set -xe
 
 # Install netlify-cli
-sudo npm install netlify-cli -g
+npm install netlify-cli
+
+# set path to grab the netlify binary
+export PATH=$PATH:$(npm bin)
 
 # Deploy site to netlify
 # Assumes NETLIFY_SITE_ID and NETLIFY_AUTH_TOKEN env variables are set


### PR DESCRIPTION
This prevents a global installation of the `netlify-cli` NPM package that was causing errors in builds when trying to write to `/root/.npm`.