### PR TITLE
add code coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,13 @@ jobs:
           rm -rf /tmp/vault*
       - run: |
           PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 3 $PACKAGE_NAMES
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 3 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
+
+      # save coverage report parts
+      - persist_to_workspace:
+          root: .
+          paths:
+            - cov_*.part
 
       - store_test_results:
           path: /tmp/test-results
@@ -134,10 +140,37 @@ jobs:
           working_directory: api
           command: |
             PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS $PACKAGE_NAMES
+            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -cover -coverprofile=cov_api.part $PACKAGE_NAMES
+
+      # save coverage report parts
+      - persist_to_workspace:
+          root: ./api
+          paths:
+            - cov_*.part
 
       - store_test_results:
           path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+
+  # combine code coverage results from the parallel circleci executors
+  coverage-merge:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      <<: *ENVIRONMENT
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: mkdir -p $TEST_RESULTS_DIR
+      - run:
+          name: merge coverage reports
+          command: |
+            echo "mode: set" > coverage.out
+            grep -h -v "mode: set" cov_*.part >> coverage.out
+            go tool cover -html=coverage.out -o /tmp/test-results/coverage.html
+
       - store_artifacts:
           path: /tmp/test-results
 
@@ -540,6 +573,10 @@ workflows:
           requires:
             - dev-build
       - go-test-api: *go-test
+      - coverage-merge:
+          requires:
+            - go-test
+            - go-test-api
   build-distros:
     jobs:
       - check-vendor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,9 @@ jobs:
             echo "mode: set" > coverage.out
             grep -h -v "mode: set" cov_*.part >> coverage.out
             go tool cover -html=coverage.out -o /tmp/test-results/coverage.html
-
+      - run:
+          name: codecov upload
+          command: bash <(curl -s https://codecov.io/bash)
       - store_artifacts:
           path: /tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             go tool cover -html=coverage.out -o /tmp/test-results/coverage.html
       - run:
           name: codecov upload
-          command: bash <(curl -s https://codecov.io/bash)
+          command: bash <(curl -s https://codecov.io/bash) -C $CIRCLE_SHA1
       - store_artifacts:
           path: /tmp/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             go tool cover -html=coverage.out -o /tmp/test-results/coverage.html
       - run:
           name: codecov upload
-          command: bash <(curl -s https://codecov.io/bash) -C $CIRCLE_SHA1
+          command: bash <(curl -s https://codecov.io/bash) -C $CIRCLE_SHA1 -f '!agent/bindata_assetfs.go'
       - store_artifacts:
           path: /tmp/test-results
 


### PR DESCRIPTION
I am not sure how useful this will be especially with all the golang `if err != nil` checks that gets flagged as not covered but I thought it might be useful to at least run and look into it for any signals.

I generate a coverage `cov_*.part` file out of each of the [parallel test executors](https://circleci.com/gh/hashicorp/consul/86260) which I then pick up in a [subsequent job](https://circleci.com/gh/hashicorp/consul/86262) to merge all together. This takes < 3 mins so it's + 3 min time to the `go-test` workflow. It should still finish under the envoy tests though.

An example of the HTML coverage report can be found in the Artifacts in the `coverage-merge` job or directly linked here: https://86262-14125254-gh.circle-artifacts.com/0/tmp/test-results/coverage.html