### PR TITLE
Update the ACL Resolver to allow for Consul Enterprise specific hooks.

### DIFF
--- a/acl/chained_authorizer.go
+++ b/acl/chained_authorizer.go
@@ -19,6 +19,10 @@ func NewChainedAuthorizer(chain []Authorizer) *ChainedAuthorizer {
 	}
 }
 
+func (c *ChainedAuthorizer) AuthorizerChain() []Authorizer {
+	return c.chain
+}
+
 func (c *ChainedAuthorizer) executeChain(enforce func(authz Authorizer) EnforcementDecision) EnforcementDecision {
 	for _, authz := range c.chain {
 		decision := enforce(authz)

--- a/agent/consul/acl_oss.go
+++ b/agent/consul/acl_oss.go
@@ -6,8 +6,16 @@ import (
 	"log"
 
 	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
 )
+
+// EnterpriseACLResolverDelegate stub
+type EnterpriseACLResolverDelegate interface{}
 
 func newEnterpriseACLConfig(*log.Logger) *acl.EnterpriseACLConfig {
 	return nil
+}
+
+func (r *ACLResolver) resolveEnterpriseDefaultsForIdentity(identity structs.ACLIdentity) (acl.Authorizer, error) {
+	return nil, nil
 }

--- a/agent/consul/acl_oss_test.go
+++ b/agent/consul/acl_oss_test.go
@@ -1,0 +1,28 @@
+// +build !consulent
+
+package consul
+
+import (
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+func testIdentityForTokenEnterprise(string) (bool, structs.ACLIdentity, error) {
+	return true, nil, acl.ErrNotFound
+}
+
+func testPolicyForIDEnterprise(string) (bool, *structs.ACLPolicy, error) {
+	return true, nil, acl.ErrNotFound
+}
+
+func testRoleForIDEnterprise(string) (bool, *structs.ACLRole, error) {
+	return true, nil, acl.ErrNotFound
+}
+
+// EnterpriseACLResolverTestDelegate stub
+type EnterpriseACLResolverTestDelegate struct{}
+
+// RPC stub for the EnterpriseACLResolverTestDelegate
+func (d *EnterpriseACLResolverTestDelegate) RPC(string, interface{}, interface{}) (bool, error) {
+	return false, nil
+}

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -169,7 +169,6 @@ func (s *ACLServiceIdentity) EstimateSize() int {
 func (s *ACLServiceIdentity) SyntheticPolicy(entMeta *EnterpriseMeta) *ACLPolicy {
 	// Given that we validate this string name before persisting, we do not
 	// have to escape it before doing the following interpolation.
-	// TODO (namespaces) include namespace
 	rules := aclServiceIdentityRules(s.ServiceName, entMeta)
 
 	hasher := fnv.New128a()
@@ -673,7 +672,7 @@ func (policies ACLPolicies) resolveWithCache(cache *ACLCaches, entConf *acl.Ente
 	return parsed, nil
 }
 
-func (policies ACLPolicies) Compile(parent acl.Authorizer, cache *ACLCaches, entConf *acl.EnterpriseACLConfig) (acl.Authorizer, error) {
+func (policies ACLPolicies) Compile(cache *ACLCaches, entConf *acl.EnterpriseACLConfig) (acl.Authorizer, error) {
 	// Determine the cache key
 	cacheKey := policies.HashKey()
 	entry := cache.GetAuthorizer(cacheKey)
@@ -688,7 +687,7 @@ func (policies ACLPolicies) Compile(parent acl.Authorizer, cache *ACLCaches, ent
 	}
 
 	// Create the ACL object
-	authorizer, err := acl.NewPolicyAuthorizerWithDefaults(parent, parsed, entConf)
+	authorizer, err := acl.NewPolicyAuthorizer(parsed, entConf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct ACL Authorizer: %v", err)
 	}
@@ -1083,8 +1082,6 @@ type ACLTokenListResponse struct {
 type ACLTokenBatchGetRequest struct {
 	AccessorIDs []string // List of accessor ids to fetch
 	Datacenter  string   // The datacenter to perform the request within
-	// TODO (namespaces) should this use enterprise meta? - it would be hard to
-	// update in a backwards compatible manner an accessor ids should be unique
 	QueryOptions
 }
 
@@ -1111,7 +1108,6 @@ type ACLTokenBatchSetRequest struct {
 // multiple tokens need to be removed from the local DCs state.
 type ACLTokenBatchDeleteRequest struct {
 	TokenIDs []string // Tokens to delete
-	// TODO (namespaces) should we update with ent meta?
 }
 
 // ACLTokenBootstrapRequest is used only at the Raft layer
@@ -1496,8 +1492,6 @@ func (r *ACLLoginRequest) RequestDatacenter() string {
 
 type ACLLogoutRequest struct {
 	Datacenter string // The datacenter to perform the request within
-	// TODO (namespaces) do we need the ent meta here? tokens are again
-	// unique across namespaces so its likely we don't need it.
 	WriteRequest
 }
 

--- a/agent/structs/acl_test.go
+++ b/agent/structs/acl_test.go
@@ -661,7 +661,7 @@ func TestStructs_ACLPolicies_Compile(t *testing.T) {
 	}
 
 	t.Run("Cache Miss", func(t *testing.T) {
-		authz, err := testPolicies.Compile(acl.DenyAll(), cache, nil)
+		authz, err := testPolicies.Compile(cache, nil)
 		require.NoError(t, err)
 		require.NotNil(t, authz)
 
@@ -669,7 +669,7 @@ func TestStructs_ACLPolicies_Compile(t *testing.T) {
 		require.Equal(t, acl.Allow, authz.AgentRead("foo", nil))
 		require.Equal(t, acl.Allow, authz.KeyRead("foo", nil))
 		require.Equal(t, acl.Allow, authz.ServiceRead("foo", nil))
-		require.Equal(t, acl.Deny, authz.ACLRead(nil))
+		require.Equal(t, acl.Default, authz.ACLRead(nil))
 	})
 
 	t.Run("Check Cache", func(t *testing.T) {
@@ -682,18 +682,18 @@ func TestStructs_ACLPolicies_Compile(t *testing.T) {
 		require.Equal(t, acl.Allow, authz.AgentRead("foo", nil))
 		require.Equal(t, acl.Allow, authz.KeyRead("foo", nil))
 		require.Equal(t, acl.Allow, authz.ServiceRead("foo", nil))
-		require.Equal(t, acl.Deny, authz.ACLRead(nil))
+		require.Equal(t, acl.Default, authz.ACLRead(nil))
 
 		// setup the cache for the next test
 		cache.PutAuthorizer(testPolicies.HashKey(), acl.DenyAll())
 	})
 
 	t.Run("Cache Hit", func(t *testing.T) {
-		authz, err := testPolicies.Compile(acl.DenyAll(), cache, nil)
+		authz, err := testPolicies.Compile(cache, nil)
 		require.NoError(t, err)
 		require.NotNil(t, authz)
 
-		// we reset the Authorizer in the cache so now everything should be denied
+		// we reset the Authorizer in the cache so now everything should be defaulted
 		require.Equal(t, acl.Deny, authz.NodeRead("foo", nil))
 		require.Equal(t, acl.Deny, authz.AgentRead("foo", nil))
 		require.Equal(t, acl.Deny, authz.KeyRead("foo", nil))


### PR DESCRIPTION
This PR is the OSS side of things to make the ACLResolver interfaces play nicely with Consul Enterprise specific functionality.

The two big changes here are that we added an extra method on the resolver to handle creating the defaults authorizer and that we no longer create the authorizer in one fell swoop but rather build up the authorizer chain.

The fall out of this is that a bunch of our pointer equality tests no longer are valid. Instead I had to replace them with validating the authorizers in the chain by pointer equality.

I also fixed a few flaky tests that were relying on timings completely outside of the tests control. Mainly we were trying to assert some ACL resource was still in the cache when the go routine that could have blown it away may or may not have finished.