### PR TITLE
Ensure that cache entries for tokens are prefixed “token-secret…

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -634,7 +634,7 @@ func (a *ACL) tokenSetInternal(args *structs.ACLTokenSetRequest, reply *structs.
 	}
 
 	// Purge the identity from the cache to prevent using the previous definition of the identity
-	a.srv.acls.cache.RemoveIdentity(token.SecretID)
+	a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(token.SecretID))
 
 	if respErr, ok := resp.(error); ok {
 		return respErr
@@ -776,7 +776,7 @@ func (a *ACL) TokenDelete(args *structs.ACLTokenDeleteRequest, reply *string) er
 	}
 
 	// Purge the identity from the cache to prevent using the previous definition of the identity
-	a.srv.acls.cache.RemoveIdentity(token.SecretID)
+	a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(token.SecretID))
 
 	if respErr, ok := resp.(error); ok {
 		return respErr
@@ -2249,7 +2249,7 @@ func (a *ACL) Logout(args *structs.ACLLogoutRequest, reply *bool) error {
 
 	// Purge the identity from the cache to prevent using the previous definition of the identity
 	if token != nil {
-		a.srv.acls.cache.RemoveIdentity(token.SecretID)
+		a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(token.SecretID))
 	}
 
 	if respErr, ok := resp.(error); ok {

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -186,7 +186,7 @@ func (a *ACL) Apply(args *structs.ACLRequest, reply *string) error {
 
 	// Clear the cache if applicable
 	if args.ACL.ID != "" {
-		a.srv.acls.cache.RemoveIdentity(args.ACL.ID)
+		a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(args.ACL.ID))
 	}
 
 	return nil

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -106,7 +106,7 @@ func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
 
 	// Purge the identities from the cache
 	for _, secretID := range secretIDs {
-		s.acls.cache.RemoveIdentity(secretID)
+		s.acls.cache.RemoveIdentity(tokenSecretCacheID(secretID))
 	}
 
 	if respErr, ok := resp.(error); ok {


### PR DESCRIPTION
Originally the only thing stored in the Identity cache were token secrets. However once we store other types of identities it will be important to prevent name collisions and therefore we need to prefix every cache ID with the type. This wouldn't be so bad if all our token secrets were uuids but since for backwards compatibility sake we allow free form secrets we cannot rely on them being unique even when all other types are prefixes appropriately.