### PR TITLE
[CI] fix: insufficient memory for go-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,7 @@ jobs:
   go-test:
     docker:
       - image: *GOLANG_IMAGE
+    resource_class: medium+
     parallelism: 8
     environment:
       <<: *ENVIRONMENT


### PR DESCRIPTION
`go-test` often fails due to `cannot allocate memory`.

* https://circleci.com/gh/hashicorp/consul/82209#tests/containers/4
* https://circleci.com/gh/hashicorp/consul/84694#tests/containers/7
* https://circleci.com/gh/hashicorp/consul/86642#tests/containers/5

```
/usr/local/go/pkg/tool/linux_amd64/link: flushing $WORK/b705/bootstrap.test: write $WORK/b705/bootstrap.test: cannot allocate memory
```

This PR increases memory to 6GM (4GB by default)
https://circleci.com/docs/2.0/configuration-reference/#resource_class