### PR TITLE
[Metrics] Add server raft.{last,applied}_index gauges

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -523,7 +523,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 	}
 
 	// Start the metrics handlers.
-	go s.sessionStats()
+	go s.updateMetrics()
 
 	return s, nil
 }

--- a/agent/consul/session_ttl.go
+++ b/agent/consul/session_ttl.go
@@ -126,14 +126,16 @@ func (s *Server) clearAllSessionTimers() {
 	s.sessionTimers.StopAll()
 }
 
-// sessionStats is a long running routine used to capture
-// the number of active sessions being tracked
-func (s *Server) sessionStats() {
+// updateMetrics is a long running routine used to uddate a
+// number of server periodic metrics
+func (s *Server) updateMetrics() {
 	for {
 		select {
-		case <-time.After(5 * time.Second):
+		case <-time.After(time.Second):
 			metrics.SetGauge([]string{"session_ttl", "active"}, float32(s.sessionTimers.Len()))
 
+			metrics.SetGauge([]string{"raft", "applied_index"}, float32(s.raft.AppliedIndex()))
+			metrics.SetGauge([]string{"raft", "last_index"}, float32(s.raft.LastIndex()))
 		case <-s.shutdownCh:
 			return
 		}


### PR DESCRIPTION
These metrics are useful for :
* Tracking te rate of update to the db
* Allow to have a rough idea of when an index originated