### PR TITLE
keep catalog tags if tag override is enabled

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -321,7 +321,11 @@ func (s *Store) ensureRegistrationTxn(tx *memdb.Txn, idx uint64, req *structs.Re
 		if err != nil {
 			return fmt.Errorf("failed service lookup: %s", err)
 		}
+
 		if existing == nil || !(existing.(*structs.ServiceNode).ToNodeService()).IsSame(req.Service) {
+			if existing != nil && req.Service.EnableTagOverride && req.FromAgent {
+				copy(req.Service.Tags, (existing.(*structs.ServiceNode).ToNodeService()).Tags)
+			}
 			if err := s.ensureServiceTxn(tx, idx, req.Node, req.Service); err != nil {
 				return fmt.Errorf("failed inserting service: %s", err)
 

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1378,6 +1378,7 @@ func (l *State) syncService(id string) error {
 		NodeMeta:        l.metadata,
 		Service:         l.services[id].Service,
 		WriteRequest:    structs.WriteRequest{Token: l.serviceToken(id)},
+		FromAgent:       true,
 	}
 
 	// Backwards-compatibility for Consul < 0.5
@@ -1431,6 +1432,7 @@ func (l *State) syncCheck(id types.CheckID) error {
 		NodeMeta:        l.metadata,
 		Check:           c.Check,
 		WriteRequest:    structs.WriteRequest{Token: l.checkToken(id)},
+		FromAgent:       true,
 	}
 
 	// Pull in the associated service if any
@@ -1473,6 +1475,7 @@ func (l *State) syncNodeInfo() error {
 		TaggedAddresses: l.config.TaggedAddresses,
 		NodeMeta:        l.metadata,
 		WriteRequest:    structs.WriteRequest{Token: l.tokens.AgentToken()},
+		FromAgent:       true,
 	}
 	var out struct{}
 	err := l.Delegate.RPC("Catalog.Register", &req, &out)

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -262,6 +262,9 @@ type RegisterRequest struct {
 	// node portion of this update will not apply.
 	SkipNodeUpdate bool
 
+	// Check whether the request created from client agent
+	FromAgent bool
+
 	WriteRequest
 }
 


### PR DESCRIPTION
Not sure whether it is proper approach.
But it works in our case.

> We got same issue.
To keep service tags which updated in catalog. We applied below patch.
It makes distinct between request from client agent and request from server agent.
And ignores client agents tags which not override yet.

https://github.com/hashicorp/consul/issues/2174