### PR TITLE
Build all ARM variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,13 +190,31 @@ jobs:
             GOARM: 5
             CC: arm-linux-gnueabi-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/linux_armel/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armel/v${GOARM}/consul  -ldflags="${GOLDFLAGS}"
+      - run:
+          environment:
+            GOARM: 6
+            CC: arm-linux-gnueabi-gcc
+            GOARCH: arm
+          command: go build -o ./pkg/bin/linux_armel/v${GOARM}/consul  -ldflags="${GOLDFLAGS}"
+      - run:
+          environment:
+            GOARM: 7
+            CC: arm-linux-gnueabi-gcc
+            GOARCH: arm
+          command: go build -o ./pkg/bin/linux_armel/v${GOARM}/consul  -ldflags="${GOLDFLAGS}"
       - run:
           environment:
             GOARM: 6
             CC: arm-linux-gnueabihf-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/linux_armhf/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armhf/v${GOARM}/consul  -ldflags="${GOLDFLAGS}"
+      - run:
+          environment:
+            GOARM: 7
+            CC: arm-linux-gnueabihf-gcc
+            GOARCH: arm
+          command: go build -o ./pkg/bin/linux_armhf/v${GOARM}/consul  -ldflags="${GOLDFLAGS}"
       - run:
           environment:
             CC: aarch64-linux-gnu-gcc


### PR DESCRIPTION
Previously there was already an ARM build job to handle armel v5, armhf v6 and arm64. This is to add a few combinations missed:

- armelv6
- armelv7
- armhfv7