### PR TITLE
Backport: Update mediums on main community page (#6699)

### DIFF
--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -2,22 +2,18 @@
 layout: "inner"
 page_title: "Community"
 description: |-
-  Consul is a large project with a growing community. These are pointers
+  Consul is a large project with a growing community. There are
   active, dedicated users willing to help you through various mediums.
 ---
 
 <h1>Community</h1>
 
 <p>
-  Consul is a large project with a growing community. These are pointers
+  Consul is a large project with a growing community. There are
   active, dedicated users willing to help you through various mediums.
 </p>
 <p>
-  <strong>Chat:</strong> <a href="https://gitter.im/hashicorp-consul/Lobby">Consul on Gitter</a>
-</p>
-<p>
-  <strong>Mailing list:</strong>
-  <a href="https://groups.google.com/group/consul-tool">Consul Google Group</a>
+  <strong>Community Forum:</strong> <a href="https://discuss.hashicorp.com/c/consul">Consul Community Forum</a>
 </p>
 <p>
   <strong>Bug Tracker:</strong>


### PR DESCRIPTION
Updating all .io Community sites to direct practitioners to the Forum as the first medium for communicating with other users and HashiCorp employees. Deleted Gitter link and Google Group link, as these will be phased out over the next few months. Updated what appeared to be a typo on the page description. Chatted with Nic Jackson before submitting PR.

*This has already been merged to master and the stable-website branch.*