### PR TITLE
update CONTRIBUTING.md to build consul with 1.12+

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ issue. Stale issues will be closed.
 ## Building Consul
 
 If you wish to work on Consul itself, you'll first need [Go](https://golang.org)
-installed (version 1.10+ is _required_). Make sure you have Go properly installed,
+installed (version 1.12+ is _required_). Make sure you have Go properly installed,
 including setting up your [GOPATH](https://golang.org/doc/code.html#GOPATH).
 
 Next, clone this repository into `$GOPATH/src/github.com/hashicorp/consul` and 


### PR DESCRIPTION
Closes #6717. `CONTRIBUTING.md` stated that Consul could be built with 1.10+ but we are using `string.ReplaceAll` which was added in Go 1.12. 

ref: https://golang.org/pkg/strings/#ReplaceAll