### PR TITLE
Implement stub method on the DirEntry

### DIFF
--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -36,4 +36,4 @@ func (m *EnterpriseMeta) InitDefault() {}
 func (m *EnterpriseMeta) FillAuthzContext(*acl.EnterpriseAuthorizerContext) {}
 
 // FillAuthzContext stub
-func (d *DirEntry) FillAuthzContext(*acl.EnterpriseAuthorizercontext) {}
+func (d *DirEntry) FillAuthzContext(*acl.EnterpriseAuthorizerContext) {}


### PR DESCRIPTION
This is so we can put Sentinel policy back in place for KV entries.

Note that I accidentally committed the first part directly to master a few minutes ago: https://github.com/hashicorp/consul/commit/825e19bc5f8402662d904c397b38171a7ae20bf3

That commit only added the single line, I would revert but then its even more commits.