### PR TITLE
ui: Add optional name="" attribute to slots so you can name the slots using it (as opposed to positional params)

### DIFF
--- a/ui-v2/lib/block-slots/addon/components/yield-slot.js
+++ b/ui-v2/lib/block-slots/addon/components/yield-slot.js
@@ -5,6 +5,12 @@ import Slots from '../mixins/slots';
 const YieldSlotComponent = Component.extend({
   layout,
   tagName: '',
+  _name: computed('__name', 'name', function() {
+    return this.name || this.__name;
+  }),
+  _blockParams: computed('__blockParams', 'params', function() {
+    return this.params || this.__blockParams;
+  }),
   _parentView: computed(function() {
     return this.nearestOfType(Slots);
   }),
@@ -14,7 +20,7 @@ const YieldSlotComponent = Component.extend({
 });
 
 YieldSlotComponent.reopenClass({
-  positionalParams: ['_name', '_blockParams'],
+  positionalParams: ['__name', '__blockParams'],
 });
 
 export default YieldSlotComponent;


### PR DESCRIPTION
Pretty soon we would like to move to XML/Angle Bracket style
components. As they are XML-y it means you can't use positional
parameters anymore (every 'argument' for the component requires it to
use an XML-like attribute).

This adds a `name=""` attribute to both block-slot and yield-slot
components so we can use attributes to specify the name. We prefer using
attributes from now on, whilst the positional parameter is still
available yet deprecated so we can move over at whatever speed fits.

We also did the same with the block params positional parameter.

As a final note this entire in repo addon is a fork of
`ember-block-slots`

We've specifically not used `or` here for the same reasons as jQuery `trigger` vs `click`, `hover`, `keyup` etc etc. The ember team seem to be going through a similar reduction of API lately so we would like to follow that approach. If anyone feels strongly I'd happily switch in `or` instead.

There is no implementation right now, we'll either do this as we go along, or we'll do a few separate PRs when time allows/bit-by-bit.