### PR TITLE
ui: Adds some express middleware, removes need to run api dev server

### DIFF
--- a/ui-v2/.ember-cli
+++ b/ui-v2/.ember-cli
@@ -4,10 +4,6 @@
     anonymous, but there are times when you might want to disable this behavior.
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
-
-    Uncomment the proxy setting to point ember-cli to a locally running consul
-    instance.
   */
-  // "proxy": "http://localhost:8500",
   "disableAnalytics": false
 }

--- a/ui-v2/.ember-cli
+++ b/ui-v2/.ember-cli
@@ -4,7 +4,10 @@
     anonymous, but there are times when you might want to disable this behavior.
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
+
+    Uncomment the proxy setting to point ember-cli to a locally running consul
+    instance.
   */
-  "disableAnalytics": false,
-  "proxy": "http://localhost:3000"
+  // "proxy": "http://localhost:8500",
+  "disableAnalytics": false
 }

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -29,6 +29,9 @@ build: deps
 start: deps
 	yarn run start
 
+start-consul: deps
+	yarn run start:consul
+
 start-api: deps
 	yarn run start:api
 

--- a/ui-v2/README.md
+++ b/ui-v2/README.md
@@ -51,6 +51,17 @@ See `./node_modules/@hashicorp/consul-api-double` for more details.
 If you wish to run the UI code against a running consul instance, uncomment the `proxy`
 line in `.ember-cli` to point ember-cli to your consul instance.
 
+You can also run the UI against a normal Consul installation.
+
+`make start-consul` or `yarn run start:consul` will use the `CONSUL_HTTP_ADDR`
+environment variable to locate the Consul installation. If that it not set
+`start-consul` will use `http://localhost:8500`.
+
+Example usage:
+
+```
+CONSUL_HTTP_ADDR=http://10.0.0.1:8500 make start-consul
+```
 
 ### Code Generators
 

--- a/ui-v2/README.md
+++ b/ui-v2/README.md
@@ -21,14 +21,11 @@ All tooling scripts below primarily use `make` which in turn call node package s
 
 ## Running / Development
 
-The source code comes with a small server that runs enough of the consul API
+The source code comes with a small development mode that runs enough of the consul API
 as a set of mocks/fixtures to be able to run the UI without having to run
 consul.
 
-* `make start-api` or `yarn start:api` (this starts a Consul API double running
-on http://localhost:3000)
-* `make start` or `yarn start` to start the ember app that connects to the
-above API double
+* `make start` or `yarn start` to start the ember app
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 
 To enable ACLs using the mock API, use Web Inspector to set a cookie as follows:
@@ -50,6 +47,9 @@ CONSUL_NODE_CODE=1000
 ```
 
 See `./node_modules/@hashicorp/consul-api-double` for more details.
+
+If you wish to run the UI code against a running consul instance, uncomment the `proxy`
+line in `.ember-cli` to point ember-cli to your consul instance.
 
 
 ### Code Generators

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -19,6 +19,7 @@
     "format:css": "prettier --write \"app/styles/**/*.*\"",
     "start": "ember serve --port=${EMBER_SERVE_PORT:-4200} --live-reload-port=${EMBER_LIVE_RELOAD_PORT:-7020}",
     "start:staging": "ember serve --port=${EMBER_SERVE_PORT:-4200} --live-reload-port=${EMBER_LIVE_RELOAD_PORT:-7020} --environment staging",
+    "start:consul": "ember serve --proxy=${CONSUL_HTTP_ADDR:-http://localhost:8500} --port=${EMBER_SERVE_PORT:-4200} --live-reload-port=${EMBER_LIVE_RELOAD_PORT:-7020}",
     "start:api": "api-double --dir ./node_modules/@hashicorp/consul-api-double",
     "test": "ember test --test-port=${EMBER_TEST_PORT:-7357}",
     "test:parallel": "EMBER_EXAM_PARALLEL=true ember exam --split=4 --parallel",


### PR DESCRIPTION
The effect of this PR means that instead of having to develop by running `make start-api` followed by `make start`, you just run the single `make start`. We've amended the README here also, but kept the additional/no longer required make target incase there is a need to run a separate server at any point.

This PR uses the code from here https://github.com/hashicorp/api-double/blob/379074cb16144357c0e491f1920d4156ae5f32d2/bin/index.js#L35-L44 to run the API server using ember's express process rather than a separate one.

More details:

`@hashicorp/api-double` comes with a basic express based server to run the
API double. This uses the express based server that ember-cli includes
and uses to run your app instead.

Eventually this will be moved to the `@hashicorp/ember-cli-api-double`
addon instead.

Ideally this would all use a centralized path in set in a single config file in your project, we'll have to figure out how to get to this from ember's `serverMiddleware` hook before moving it over to `@hashicorp/ember-cli-api-double`



