### PR TITLE
docs: Rename TTL to Timeout in Script/TCP checks

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -224,7 +224,7 @@ The table below shows this endpoint's support for
   "Header": {"x-foo":["bar", "baz"]},
   "TCP": "example.com:22",
   "Interval": "10s",
-  "TTL": "15s",
+  "Timeout": "5s",
   "TLSSkipVerify": true
 }
 ```

--- a/website/source/api/agent/service.html.md
+++ b/website/source/api/agent/service.html.md
@@ -610,9 +610,8 @@ For the `Connect` field, the parameters are:
   "Check": {
     "DeregisterCriticalServiceAfter": "90m",
     "Args": ["/usr/local/bin/check_redis.py"],
-    "HTTP": "http://localhost:5000/health",
     "Interval": "10s",
-    "TTL": "15s"
+    "Timeout": "5s"
   },
   "Weights": {
     "Passing": 10,


### PR DESCRIPTION
TTL and Interval options were made mutually exclusive in https://github.com/hashicorp/consul/pull/3560.
    
Change to Timeout, which is a correct parameter for HTTP, Script, and TCP checks.
    
Resolves #6343

This PR supersedes https://github.com/hashicorp/consul/pull/4274.