### PR TITLE
website - add -moz-osx-font-smoothing for smooth firefox osx fonts

### DIFF
--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -6,6 +6,7 @@ html {
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   color: $body-font-color;
   background-color: $white;


### PR DESCRIPTION
Adding `-moz-osx-font-smoothing: grayscale;` to `<body>`  in `global-styles` to smooth out fonts in Firefox on OSX.

Note that we are already using `-webkit-font-smoothing: antialiased;`.

#### Before

![Screen Shot 2019-11-07 at 12 08 59 PM](https://user-images.githubusercontent.com/5368111/68419415-68c8e400-0157-11ea-865f-eed77ee4eab1.png)

---

### After

![Screen Shot 2019-11-07 at 12 08 52 PM](https://user-images.githubusercontent.com/5368111/68419413-68c8e400-0157-11ea-992f-5ae0e06793de.png)

