### PR TITLE
Fix a couple of timing problems in the agent tests

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -2366,8 +2366,8 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	_, err := a2.JoinWAN([]string{addr})
 	require.NoError(t, err)
 	retry.Run(t, func(r *retry.R) {
-		require.Len(t, a1.WANMembers(), 2)
-		require.Len(t, a2.WANMembers(), 2)
+		require.Len(r, a1.WANMembers(), 2)
+		require.Len(r, a2.WANMembers(), 2)
 	})
 
 	// Register an equivalent prepared query.

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -740,7 +740,7 @@ func TestHealthServiceNodes_Filter(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/health/service/consul?dc=dc1&filter="+url.QueryEscape("Node.Node == `test-health-node`"), nil)
 	resp := httptest.NewRecorder()
@@ -792,7 +792,7 @@ func TestHealthServiceNodes_Filter(t *testing.T) {
 
 	assertIndex(t, resp)
 
-	// Should be a non-nil empty list for checks
+	// Should be a list of checks with 1 element
 	nodes = obj.(structs.CheckServiceNodes)
 	require.Len(t, nodes, 1)
 	require.Len(t, nodes[0].Checks, 1)
@@ -978,7 +978,7 @@ func TestHealthServiceNodes_CheckType(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")
 	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	req, _ := http.NewRequest("GET", "/v1/health/service/consul?dc=dc1", nil)
 	resp := httptest.NewRecorder()


### PR DESCRIPTION
These all failed consistently when run using `make test-flake FLAKE_PKG=agent FLAKE_TEST=$TEST_NAME`