### PR TITLE
sdk: add NewTestServerT, deprecate NewTestServer

### DIFF
--- a/sdk/testutil/README.md
+++ b/sdk/testutil/README.md
@@ -27,7 +27,7 @@ import (
 
 func TestFoo_bar(t *testing.T) {
 	// Create a test Consul server
-	srv1, err := testutil.NewTestServer()
+	srv1, err := testutil.NewTestServerT(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestFoo_bar(t *testing.T) {
 
 	// Create a secondary server, passing in configuration
 	// to avoid bootstrapping as we are forming a cluster.
-	srv2, err := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+	srv2, err := testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.Bootstrap = false
 	})
 	if err != nil {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -219,6 +219,9 @@ func NewTestServer() (*TestServer, error) {
 // NewTestServerT is an easy helper method to create a new Consul
 // test server with the most basic configuration.
 func NewTestServerT(t *testing.T) (*TestServer, error) {
+	if t == nil {
+		return nil, errors.New("testutil: a non-nil *testing.T is required")
+	}
 	return NewTestServerConfigT(t, nil)
 }
 

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -211,10 +211,15 @@ type TestServer struct {
 	tmpdir string
 }
 
-// NewTestServer is an easy helper method to create a new Consul
-// test server with the most basic configuration.
+// Deprecated: Use NewTestServerT instead.
 func NewTestServer() (*TestServer, error) {
 	return NewTestServerConfigT(nil, nil)
+}
+
+// NewTestServerT is an easy helper method to create a new Consul
+// test server with the most basic configuration.
+func NewTestServerT(t *testing.T) (*TestServer, error) {
+	return NewTestServerConfigT(t, nil)
 }
 
 func NewTestServerConfig(cb ServerConfigCallback) (*TestServer, error) {


### PR DESCRIPTION
To prevent nil pointer deref from `t.Logf` usage.

Looks like this had been worked around previously by adding a nil check in https://github.com/hashicorp/consul/commit/6d4930da93cadc4e3e61f997758a5c16899506e7, but this formally deprecates the problematic method.