### PR TITLE
Switch Logger to HcLog with Standard Logger Wrapper

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
 
 	"github.com/stretchr/testify/require"
@@ -76,7 +77,16 @@ func NewTestACLAgent(name string, hcl string, resolveFn func(string) (acl.Author
 	}
 	agent.LogOutput = logOutput
 	agent.LogWriter = a.LogWriter
-	agent.logger = log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
+
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   a.Name,
+		Level:  log.LstdFlags | log.Lmicroseconds,
+		Output: logOutput,
+	})
+	agent.logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
+
 	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
 
 	a.Agent.delegate = a

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -3,14 +3,13 @@ package ae
 import (
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -392,7 +391,12 @@ func (m *mock) SyncChanges() error {
 }
 
 func testSyncer() *StateSyncer {
-	logger := log.New(os.Stderr, "", 0)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: 0,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	l := NewStateSyncer(nil, time.Second, nil, logger)
 	l.stagger = func(d time.Duration) time.Duration { return d }
 	l.ClusterSize = func() int { return 1 }

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 )
@@ -85,7 +86,7 @@ func TestAE_staggerDependsOnClusterSize(t *testing.T) {
 	libRandomStagger = func(d time.Duration) time.Duration { return d }
 	defer func() { libRandomStagger = lib.RandomStagger }()
 
-	l := testSyncer()
+	l := testSyncer(t)
 	if got, want := l.staggerFn(10*time.Millisecond), 10*time.Millisecond; got != want {
 		t.Fatalf("got %v want %v", got, want)
 	}
@@ -105,7 +106,7 @@ func TestAE_Run_SyncFullBeforeChanges(t *testing.T) {
 	}
 
 	// indicate that we have partial changes before starting Run
-	l := testSyncer()
+	l := testSyncer(t)
 	l.State = state
 	l.ShutdownCh = shutdownCh
 	l.SyncChanges.Trigger()
@@ -131,7 +132,7 @@ func TestAE_Run_Quit(t *testing.T) {
 				t.Fatal("Run should panic")
 			}
 		}()
-		l := testSyncer()
+		l := testSyncer(t)
 		l.ClusterSize = nil
 		l.Run()
 	})
@@ -139,7 +140,7 @@ func TestAE_Run_Quit(t *testing.T) {
 		// start timer which explodes if runFSM does not quit
 		tm := time.AfterFunc(time.Second, func() { panic("timeout") })
 
-		l := testSyncer()
+		l := testSyncer(t)
 		l.runFSM(fullSyncState, func(fsmState) fsmState { return doneState })
 		// should just quit
 		tm.Stop()
@@ -149,7 +150,7 @@ func TestAE_Run_Quit(t *testing.T) {
 func TestAE_FSM(t *testing.T) {
 	t.Run("fullSyncState", func(t *testing.T) {
 		t.Run("Paused -> retryFullSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.Pause()
 			fs := l.nextFSMState(fullSyncState)
 			if got, want := fs, retryFullSyncState; got != want {
@@ -157,7 +158,7 @@ func TestAE_FSM(t *testing.T) {
 			}
 		})
 		t.Run("SyncFull() error -> retryFullSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.State = &mock{syncFull: func() error { return errors.New("boom") }}
 			fs := l.nextFSMState(fullSyncState)
 			if got, want := fs, retryFullSyncState; got != want {
@@ -165,7 +166,7 @@ func TestAE_FSM(t *testing.T) {
 			}
 		})
 		t.Run("SyncFull() OK -> partialSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.State = &mock{}
 			fs := l.nextFSMState(fullSyncState)
 			if got, want := fs, partialSyncState; got != want {
@@ -177,7 +178,7 @@ func TestAE_FSM(t *testing.T) {
 	t.Run("retryFullSyncState", func(t *testing.T) {
 		// helper for testing state transitions from retrySyncFullState
 		test := func(ev event, to fsmState) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.retrySyncFullEvent = func() event { return ev }
 			fs := l.nextFSMState(retryFullSyncState)
 			if got, want := fs, to; got != want {
@@ -207,7 +208,7 @@ func TestAE_FSM(t *testing.T) {
 	t.Run("partialSyncState", func(t *testing.T) {
 		// helper for testing state transitions from partialSyncState
 		test := func(ev event, to fsmState) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.syncChangesEvent = func() event { return ev }
 			fs := l.nextFSMState(partialSyncState)
 			if got, want := fs, to; got != want {
@@ -224,7 +225,7 @@ func TestAE_FSM(t *testing.T) {
 			test(syncFullTimerEvent, fullSyncState)
 		})
 		t.Run("syncChangesEvent+Paused -> partialSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.Pause()
 			l.syncChangesEvent = func() event { return syncChangesNotifEvent }
 			fs := l.nextFSMState(partialSyncState)
@@ -233,7 +234,7 @@ func TestAE_FSM(t *testing.T) {
 			}
 		})
 		t.Run("syncChangesEvent+SyncChanges() error -> partialSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.State = &mock{syncChanges: func() error { return errors.New("boom") }}
 			l.syncChangesEvent = func() event { return syncChangesNotifEvent }
 			fs := l.nextFSMState(partialSyncState)
@@ -242,7 +243,7 @@ func TestAE_FSM(t *testing.T) {
 			}
 		})
 		t.Run("syncChangesEvent+SyncChanges() OK -> partialSyncState", func(t *testing.T) {
-			l := testSyncer()
+			l := testSyncer(t)
 			l.State = &mock{}
 			l.syncChangesEvent = func() event { return syncChangesNotifEvent }
 			fs := l.nextFSMState(partialSyncState)
@@ -267,14 +268,14 @@ func TestAE_FSM(t *testing.T) {
 				t.Fatal("invalid state should panic")
 			}
 		}()
-		l := testSyncer()
+		l := testSyncer(t)
 		l.nextFSMState(fsmState("invalid"))
 	})
 }
 
 func TestAE_RetrySyncFullEvent(t *testing.T) {
 	t.Run("trigger shutdownEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})
 		evch := make(chan event)
 		go func() { evch <- l.retrySyncFullEvent() }()
@@ -284,7 +285,7 @@ func TestAE_RetrySyncFullEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger shutdownEvent during FullNotif", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})
 		evch := make(chan event)
 		go func() { evch <- l.retrySyncFullEvent() }()
@@ -296,7 +297,7 @@ func TestAE_RetrySyncFullEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger syncFullNotifEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.serverUpInterval = 10 * time.Millisecond
 		evch := make(chan event)
 		go func() { evch <- l.retrySyncFullEvent() }()
@@ -306,7 +307,7 @@ func TestAE_RetrySyncFullEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger syncFullTimerEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.retryFailInterval = 10 * time.Millisecond
 		evch := make(chan event)
 		go func() { evch <- l.retrySyncFullEvent() }()
@@ -318,7 +319,7 @@ func TestAE_RetrySyncFullEvent(t *testing.T) {
 
 func TestAE_SyncChangesEvent(t *testing.T) {
 	t.Run("trigger shutdownEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})
 		evch := make(chan event)
 		go func() { evch <- l.syncChangesEvent() }()
@@ -328,7 +329,7 @@ func TestAE_SyncChangesEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger shutdownEvent during FullNotif", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.ShutdownCh = make(chan struct{})
 		evch := make(chan event)
 		go func() { evch <- l.syncChangesEvent() }()
@@ -340,7 +341,7 @@ func TestAE_SyncChangesEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger syncFullNotifEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.serverUpInterval = 10 * time.Millisecond
 		evch := make(chan event)
 		go func() { evch <- l.syncChangesEvent() }()
@@ -350,7 +351,7 @@ func TestAE_SyncChangesEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger syncFullTimerEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		l.Interval = 10 * time.Millisecond
 		evch := make(chan event)
 		go func() { evch <- l.syncChangesEvent() }()
@@ -359,7 +360,7 @@ func TestAE_SyncChangesEvent(t *testing.T) {
 		}
 	})
 	t.Run("trigger syncChangesNotifEvent", func(t *testing.T) {
-		l := testSyncer()
+		l := testSyncer(t)
 		evch := make(chan event)
 		go func() { evch <- l.syncChangesEvent() }()
 		l.SyncChanges.Trigger()
@@ -390,13 +391,15 @@ func (m *mock) SyncChanges() error {
 	return nil
 }
 
-func testSyncer() *StateSyncer {
+func testSyncer(t *testing.T) *StateSyncer {
 	consulLogger := hclog.New(&hclog.LoggerOptions{
-		Level: 0,
+		Level:  0,
+		Output: testutil.TestWriter(t),
 	})
 	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 		InferLevels: true,
 	})
+
 	l := NewStateSyncer(nil, time.Second, nil, logger)
 	l.stagger = func(d time.Duration) time.Duration { return d }
 	l.ClusterSize = func() int { return 1 }

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -15,7 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/consul/sdk/testutil"
 
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul/agent/exec"
@@ -578,13 +577,7 @@ func (c *CheckDocker) Start() {
 	}
 
 	if c.Logger == nil {
-		consulLogger := hclog.New(&hclog.LoggerOptions{
-			Level:  0,
-			Output: ioutil.Discard,
-		})
-		c.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
-			InferLevels: true,
-		})
+		c.Logger = testutil.NewDiscardLogger()
 	}
 
 	if c.Shell == "" {

--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul/agent/exec"
@@ -577,7 +578,13 @@ func (c *CheckDocker) Start() {
 	}
 
 	if c.Logger == nil {
-		c.Logger = log.New(ioutil.Discard, "", 0)
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level:  0,
+			Output: ioutil.Discard,
+		})
+		c.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 
 	if c.Shell == "" {

--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -3,8 +3,6 @@ package checks
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +15,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/mock"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-uuid"
@@ -44,7 +43,7 @@ func TestCheckMonitor_Script(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
 			notif := mock.NewNotify()
-			logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+			logger := testutil.TestHcLog("")
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 			check := &CheckMonitor{
@@ -84,7 +83,7 @@ func TestCheckMonitor_Args(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
 			notif := mock.NewNotify()
-			logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+			logger := testutil.TestHcLog("")
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 			check := &CheckMonitor{
 				Notify:        notif,
@@ -112,7 +111,7 @@ func TestCheckMonitor_Args(t *testing.T) {
 func TestCheckMonitor_Timeout(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckMonitor{
@@ -142,7 +141,8 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 func TestCheckMonitor_RandomStagger(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
+
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckMonitor{
 		Notify:        notif,
@@ -171,7 +171,7 @@ func TestCheckMonitor_RandomStagger(t *testing.T) {
 func TestCheckMonitor_LimitOutput(t *testing.T) {
 	t.Parallel()
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckMonitor{
 		Notify:        notif,
@@ -196,11 +196,13 @@ func TestCheckMonitor_LimitOutput(t *testing.T) {
 func TestCheckTTL(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
+
+	logger := testutil.TestHcLog("")
 	check := &CheckTTL{
 		Notify:  notif,
 		CheckID: types.CheckID("foo"),
 		TTL:     200 * time.Millisecond,
-		Logger:  log.New(ioutil.Discard, uniqueID(), log.LstdFlags),
+		Logger:  logger,
 	}
 	check.Start()
 	defer check.Stop()
@@ -317,7 +319,7 @@ func TestCheckHTTP(t *testing.T) {
 			defer server.Close()
 
 			notif := mock.NewNotify()
-			logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+			logger := testutil.TestHcLog("")
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 			check := &CheckHTTP{
@@ -357,7 +359,8 @@ func TestCheckHTTP_Proxied(t *testing.T) {
 	defer proxy.Close()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -392,7 +395,7 @@ func TestCheckHTTP_NotProxied(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -506,7 +509,7 @@ func TestCheckMaxOutputSize(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	maxOutputSize := 32
 	check := &CheckHTTP{
 		CheckID:       types.CheckID("bar"),
@@ -542,7 +545,7 @@ func TestCheckHTTPTimeout(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -569,7 +572,7 @@ func TestCheckHTTPTimeout(t *testing.T) {
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
 	t.Parallel()
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	check := &CheckHTTP{
 		CheckID:       types.CheckID("foo"),
 		HTTP:          "http://foo.bar/baz",
@@ -609,7 +612,7 @@ func TestCheckHTTP_TLS_SkipVerify(t *testing.T) {
 	}
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -646,7 +649,7 @@ func TestCheckHTTP_TLS_BadVerify(t *testing.T) {
 	}
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckHTTP{
 		CheckID:         types.CheckID("skipverify_false"),
@@ -696,7 +699,7 @@ func mockTCPServer(network string) net.Listener {
 
 func expectTCPStatus(t *testing.T, tcp string, status string) {
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckTCP{
 		CheckID:       types.CheckID("foo"),
@@ -721,7 +724,7 @@ func TestStatusHandlerUpdateStatusAfterConsecutiveChecksThresholdIsReached(t *te
 	t.Parallel()
 	checkID := types.CheckID("foo")
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 2, 3)
 
 	// Set the initial status to passing after a single success
@@ -763,7 +766,7 @@ func TestStatusHandlerResetCountersOnNonIdenticalsConsecutiveChecks(t *testing.T
 	t.Parallel()
 	checkID := types.CheckID("foo")
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	statusHandler := NewStatusHandler(notif, logger, 2, 3)
 
 	// Set the initial status to passing after a single success
@@ -1103,7 +1106,8 @@ func TestCheck_Docker(t *testing.T) {
 			}
 
 			notif, upd := mock.NewNotifyChan()
-			statusHandler := NewStatusHandler(notif, log.New(ioutil.Discard, uniqueID(), log.LstdFlags), 0, 0)
+			logger := testutil.TestHcLog("")
+			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 			id := types.CheckID("chk")
 			check := &CheckDocker{
 				CheckID:           id,

--- a/agent/checks/check_test.go
+++ b/agent/checks/check_test.go
@@ -43,7 +43,7 @@ func TestCheckMonitor_Script(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
 			notif := mock.NewNotify()
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 			check := &CheckMonitor{
@@ -83,7 +83,7 @@ func TestCheckMonitor_Args(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
 			notif := mock.NewNotify()
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 			check := &CheckMonitor{
 				Notify:        notif,
@@ -111,7 +111,7 @@ func TestCheckMonitor_Args(t *testing.T) {
 func TestCheckMonitor_Timeout(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckMonitor{
@@ -141,7 +141,7 @@ func TestCheckMonitor_Timeout(t *testing.T) {
 func TestCheckMonitor_RandomStagger(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckMonitor{
@@ -171,7 +171,7 @@ func TestCheckMonitor_RandomStagger(t *testing.T) {
 func TestCheckMonitor_LimitOutput(t *testing.T) {
 	t.Parallel()
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckMonitor{
 		Notify:        notif,
@@ -197,7 +197,7 @@ func TestCheckTTL(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	notif := mock.NewNotify()
 
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	check := &CheckTTL{
 		Notify:  notif,
 		CheckID: types.CheckID("foo"),
@@ -319,7 +319,7 @@ func TestCheckHTTP(t *testing.T) {
 			defer server.Close()
 
 			notif := mock.NewNotify()
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 			check := &CheckHTTP{
@@ -360,7 +360,7 @@ func TestCheckHTTP_Proxied(t *testing.T) {
 
 	notif := mock.NewNotify()
 
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -395,7 +395,7 @@ func TestCheckHTTP_NotProxied(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -509,7 +509,7 @@ func TestCheckMaxOutputSize(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	maxOutputSize := 32
 	check := &CheckHTTP{
 		CheckID:       types.CheckID("bar"),
@@ -545,7 +545,7 @@ func TestCheckHTTPTimeout(t *testing.T) {
 	defer server.Close()
 
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -572,7 +572,7 @@ func TestCheckHTTPTimeout(t *testing.T) {
 func TestCheckHTTP_disablesKeepAlives(t *testing.T) {
 	t.Parallel()
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	check := &CheckHTTP{
 		CheckID:       types.CheckID("foo"),
 		HTTP:          "http://foo.bar/baz",
@@ -612,7 +612,7 @@ func TestCheckHTTP_TLS_SkipVerify(t *testing.T) {
 	}
 
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 
 	check := &CheckHTTP{
@@ -649,7 +649,7 @@ func TestCheckHTTP_TLS_BadVerify(t *testing.T) {
 	}
 
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckHTTP{
 		CheckID:         types.CheckID("skipverify_false"),
@@ -699,7 +699,7 @@ func mockTCPServer(network string) net.Listener {
 
 func expectTCPStatus(t *testing.T, tcp string, status string) {
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckTCP{
 		CheckID:       types.CheckID("foo"),
@@ -724,7 +724,7 @@ func TestStatusHandlerUpdateStatusAfterConsecutiveChecksThresholdIsReached(t *te
 	t.Parallel()
 	checkID := types.CheckID("foo")
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 2, 3)
 
 	// Set the initial status to passing after a single success
@@ -766,7 +766,7 @@ func TestStatusHandlerResetCountersOnNonIdenticalsConsecutiveChecks(t *testing.T
 	t.Parallel()
 	checkID := types.CheckID("foo")
 	notif := mock.NewNotify()
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	statusHandler := NewStatusHandler(notif, logger, 2, 3)
 
 	// Set the initial status to passing after a single success
@@ -1106,7 +1106,7 @@ func TestCheck_Docker(t *testing.T) {
 			}
 
 			notif, upd := mock.NewNotifyChan()
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			statusHandler := NewStatusHandler(notif, logger, 0, 0)
 			id := types.CheckID("chk")
 			check := &CheckDocker{

--- a/agent/checks/grpc_test.go
+++ b/agent/checks/grpc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/types"
+	"github.com/hashicorp/go-hclog"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -107,7 +108,14 @@ func TestGRPC_Proxied(t *testing.T) {
 	t.Parallel()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   uniqueID(),
+		Level:  log.LstdFlags,
+		Output: ioutil.Discard,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckGRPC{
 		CheckID:       types.CheckID("foo"),
@@ -135,7 +143,14 @@ func TestGRPC_NotProxied(t *testing.T) {
 	t.Parallel()
 
 	notif := mock.NewNotify()
-	logger := log.New(ioutil.Discard, uniqueID(), log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   uniqueID(),
+		Level:  log.LstdFlags,
+		Output: ioutil.Discard,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	statusHandler := NewStatusHandler(notif, logger, 0, 0)
 	check := &CheckGRPC{
 		CheckID:       types.CheckID("foo"),

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 	"log"
-	"os"
 	"sort"
 	"sync"
 	"time"
@@ -11,6 +10,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/sync/singleflight"
 	"golang.org/x/time/rate"
 )
@@ -192,7 +192,11 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 	}
 
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		config.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
+
 	}
 
 	cache, err := structs.NewACLCaches(config.CacheConfig)
@@ -1078,7 +1082,10 @@ type aclFilter struct {
 // newACLFilter constructs a new aclFilter.
 func newACLFilter(authorizer acl.Authorizer, logger *log.Logger, enforceVersion8 bool) *aclFilter {
 	if logger == nil {
-		logger = log.New(os.Stderr, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 	return &aclFilter{
 		authorizer:      authorizer,

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"fmt"
 	"log"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -192,7 +193,7 @@ func NewACLResolver(config *ACLResolverConfig) (*ACLResolver, error) {
 	}
 
 	if config.Logger == nil {
-		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		consulLogger := hclog.New(&hclog.LoggerOptions{Output: os.Stderr})
 		config.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,
 		})
@@ -1082,7 +1083,9 @@ type aclFilter struct {
 // newACLFilter constructs a new aclFilter.
 func newACLFilter(authorizer acl.Authorizer, logger *log.Logger, enforceVersion8 bool) *aclFilter {
 	if logger == nil {
-		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level:  log.LstdFlags,
+			Output: os.Stderr})
 		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,
 		})

--- a/agent/consul/auto_encrypt_test.go
+++ b/agent/consul/auto_encrypt_test.go
@@ -16,7 +16,7 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 		rawHost string
 		logger  *log.Logger
 	}
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 
 	tests := []struct {
 		name    string

--- a/agent/consul/auto_encrypt_test.go
+++ b/agent/consul/auto_encrypt_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,6 +16,8 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 		rawHost string
 		logger  *log.Logger
 	}
+	logger := testutil.TestHcLog("")
+
 	tests := []struct {
 		name    string
 		args    args
@@ -25,7 +28,7 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 			name: "host without port",
 			args: args{
 				"127.0.0.1",
-				log.New(os.Stderr, "", log.LstdFlags),
+				logger,
 			},
 			ips:     []net.IP{net.IPv4(127, 0, 0, 1)},
 			wantErr: false,
@@ -34,7 +37,7 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 			name: "host with port",
 			args: args{
 				"127.0.0.1:1234",
-				log.New(os.Stderr, "", log.LstdFlags),
+				logger,
 			},
 			ips:     []net.IP{net.IPv4(127, 0, 0, 1)},
 			wantErr: false,
@@ -43,7 +46,7 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 			name: "host with broken port",
 			args: args{
 				"127.0.0.1:xyz",
-				log.New(os.Stderr, "", log.LstdFlags),
+				logger,
 			},
 			ips:     []net.IP{net.IPv4(127, 0, 0, 1)},
 			wantErr: false,
@@ -52,7 +55,7 @@ func TestAutoEncrypt_resolveAddr(t *testing.T) {
 			name: "not an address",
 			args: args{
 				"abc",
-				log.New(os.Stderr, "", log.LstdFlags),
+				logger,
 			},
 			ips:     nil,
 			wantErr: true,

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -125,8 +125,8 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 	// Create a logger
 	if logger == nil {
 		consulLogger := hclog.New(&hclog.LoggerOptions{
-			Output: config.LogOutput,
 			Level:  log.LstdFlags,
+			Output: config.LogOutput,
 		})
 		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
 	"golang.org/x/time/rate"
 )
@@ -123,7 +124,10 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 
 	// Create a logger
 	if logger == nil {
-		logger = log.New(config.LogOutput, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 
 	connPool := &pool.ConnPool{

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -124,7 +124,10 @@ func NewClientLogger(config *Config, logger *log.Logger, tlsConfigurator *tlsuti
 
 	// Create a logger
 	if logger == nil {
-		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Output: config.LogOutput,
+			Level:  log.LstdFlags,
+		})
 		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,
 		})

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-raftchunking"
 	"github.com/hashicorp/raft"
@@ -72,12 +73,19 @@ func New(gc *state.TombstoneGC, logOutput io.Writer) (*FSM, error) {
 		return nil, err
 	}
 
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: logOutput,
+	})
+
 	fsm := &FSM{
 		logOutput: logOutput,
-		logger:    log.New(logOutput, "", log.LstdFlags),
-		apply:     make(map[structs.MessageType]command),
-		state:     stateNew,
-		gc:        gc,
+		logger: consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		}),
+		apply: make(map[structs.MessageType]command),
+		state: stateNew,
+		gc:    gc,
 	}
 
 	// Build out the apply dispatch table based on the registered commands.

--- a/agent/consul/leader_routine_manager.go
+++ b/agent/consul/leader_routine_manager.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"sync"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 type LeaderRoutine func(ctx context.Context) error
@@ -23,7 +25,13 @@ type LeaderRoutineManager struct {
 
 func NewLeaderRoutineManager(logger *log.Logger) *LeaderRoutineManager {
 	if logger == nil {
-		logger = log.New(os.Stderr, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level:  log.LstdFlags,
+			Output: os.Stderr,
+		})
+		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 
 	return &LeaderRoutineManager{

--- a/agent/consul/leader_routine_manager_test.go
+++ b/agent/consul/leader_routine_manager_test.go
@@ -16,7 +16,7 @@ func TestLeaderRoutineManager(t *testing.T) {
 	var running uint32
 	// tlog := testutil.NewCancellableTestLogger(t)
 	// defer tlog.Cancel()
-	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t.Name()))
+	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t))
 
 	run := func(ctx context.Context) error {
 		atomic.StoreUint32(&running, 1)

--- a/agent/consul/leader_routine_manager_test.go
+++ b/agent/consul/leader_routine_manager_test.go
@@ -16,7 +16,7 @@ func TestLeaderRoutineManager(t *testing.T) {
 	var running uint32
 	// tlog := testutil.NewCancellableTestLogger(t)
 	// defer tlog.Cancel()
-	mgr := NewLeaderRoutineManager(testutil.TestLogger(t))
+	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t.Name()))
 
 	run := func(ctx context.Context) error {
 		atomic.StoreUint32(&running, 1)

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -18,7 +18,8 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/net-rpc-msgpackrpc"
+	"github.com/hashicorp/go-hclog"
+	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/stretchr/testify/require"
 )
@@ -2998,7 +2999,14 @@ func (m *mockQueryServer) JoinQueryLog() string {
 func (m *mockQueryServer) GetLogger() *log.Logger {
 	if m.Logger == nil {
 		m.LogBuffer = new(bytes.Buffer)
-		m.Logger = log.New(m.LogBuffer, "", 0)
+
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level:  0,
+			Output: m.LogBuffer,
+		})
+		m.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 	return m.Logger
 }

--- a/agent/consul/replication.go
+++ b/agent/consul/replication.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 	"sync/atomic"
 	"time"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/time/rate"
 )
 
@@ -59,7 +59,12 @@ func NewReplicator(config *ReplicatorConfig) (*Replicator, error) {
 		return nil, fmt.Errorf("Cannot create the Replicator without a Delegate set in the config")
 	}
 	if config.Logger == nil {
-		config.Logger = log.New(os.Stderr, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level: log.LstdFlags,
+		})
+		config.Logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 	limiter := rate.NewLimiter(rate.Limit(config.Rate), config.Burst)
 

--- a/agent/consul/replication_test.go
+++ b/agent/consul/replication_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestReplicationRestart(t *testing.T) {
-	mgr := NewLeaderRoutineManager(testutil.TestLogger(t))
+	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t.Name()))
 
 	config := ReplicatorConfig{
 		Name: "mock",
@@ -86,7 +86,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(0)).Return(0, nil, uint64(0), fmt.Errorf("induced error"))
@@ -105,7 +105,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(1), nil)
@@ -125,7 +125,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(1), nil)
@@ -147,7 +147,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -167,7 +167,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -189,7 +189,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -210,7 +210,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -232,7 +232,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -253,7 +253,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestLogger(t),
+			Logger:   testutil.TestHcLog(t.Name()),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(3, "bcd", uint64(4), nil)

--- a/agent/consul/replication_test.go
+++ b/agent/consul/replication_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestReplicationRestart(t *testing.T) {
-	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t.Name()))
+	mgr := NewLeaderRoutineManager(testutil.TestHcLog(t))
 
 	config := ReplicatorConfig{
 		Name: "mock",
@@ -86,7 +86,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(0)).Return(0, nil, uint64(0), fmt.Errorf("induced error"))
@@ -105,7 +105,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(1), nil)
@@ -125,7 +125,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(1), nil)
@@ -147,7 +147,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -167,7 +167,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -189,7 +189,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -210,7 +210,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -232,7 +232,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(1, nil, uint64(4), nil)
@@ -253,7 +253,7 @@ func TestIndexReplicator(t *testing.T) {
 
 		replicator := IndexReplicator{
 			Delegate: delegate,
-			Logger:   testutil.TestHcLog(t.Name()),
+			Logger:   testutil.TestHcLog(t),
 		}
 
 		delegate.On("FetchRemote", uint64(3)).Return(3, "bcd", uint64(4), nil)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -310,7 +310,9 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		config.LogOutput = os.Stderr
 	}
 	if logger == nil {
-		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		consulLogger := hclog.New(&hclog.LoggerOptions{
+			Level:  log.LstdFlags,
+			Output: config.LogOutput})
 		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: true,
 		})

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -310,7 +310,10 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		config.LogOutput = os.Stderr
 	}
 	if logger == nil {
-		logger = log.New(config.LogOutput, "", log.LstdFlags)
+		consulLogger := hclog.New(&hclog.LoggerOptions{})
+		logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+			InferLevels: true,
+		})
 	}
 
 	// Check if TLS is enabled

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"golang.org/x/time/rate"
 
@@ -205,7 +206,14 @@ func newServer(c *Config) (*Server, error) {
 	if w == nil {
 		w = os.Stderr
 	}
-	logger := log.New(w, c.NodeName+" - ", log.LstdFlags|log.Lmicroseconds)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   c.NodeName,
+		Level:  log.LstdFlags | log.Lmicroseconds,
+		Output: w,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	tlsConf, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), logger)
 	if err != nil {
 		return nil, err

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -1917,7 +1918,8 @@ func TestState_Notify(t *testing.T) {
 	t.Parallel()
 
 	consulLogger := hclog.New(&hclog.LoggerOptions{
-		Level: log.LstdFlags,
+		Level:  log.LstdFlags,
+		Output: os.Stderr,
 	})
 	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 		InferLevels: true,

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/config"
@@ -1916,8 +1916,15 @@ func checksInSync(state *local.State, wantChecks int) error {
 func TestState_Notify(t *testing.T) {
 	t.Parallel()
 
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: log.LstdFlags,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
+
 	state := local.NewState(local.Config{},
-		log.New(os.Stderr, "", log.LstdFlags), &token.Store{})
+		logger, &token.Store{})
 
 	// Stub state syncing
 	state.TriggerSyncChanges = func() {}

--- a/agent/local/testing.go
+++ b/agent/local/testing.go
@@ -2,15 +2,21 @@ package local
 
 import (
 	"log"
-	"os"
 
 	"github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/go-testing-interface"
 )
 
 // TestState returns a configured *State for testing.
 func TestState(t testing.T) *State {
-	result := NewState(Config{}, log.New(os.Stderr, "", log.LstdFlags), &token.Store{})
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: log.LstdFlags,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
+	result := NewState(Config{}, logger, &token.Store{})
 	result.TriggerSyncChanges = func() {}
 	return result
 }

--- a/agent/local/testing.go
+++ b/agent/local/testing.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"log"
+	"os"
 
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/go-hclog"
@@ -11,7 +12,8 @@ import (
 // TestState returns a configured *State for testing.
 func TestState(t testing.T) *State {
 	consulLogger := hclog.New(&hclog.LoggerOptions{
-		Level: log.LstdFlags,
+		Level:  log.LstdFlags,
+		Output: os.Stderr,
 	})
 	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 		InferLevels: true,

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -309,7 +309,7 @@ func testManager_BasicLifecycle(
 
 	require := require.New(t)
 
-	logger := testutil.TestHcLog(t.Name())
+	logger := testutil.TestHcLog(t)
 	state := local.NewState(local.Config{}, logger, &token.Store{})
 	source := &structs.QuerySource{
 		Node:       "node1",
@@ -446,7 +446,7 @@ func assertWatchChanRecvs(t *testing.T, ch <-chan *ConfigSnapshot, expect *Confi
 
 func TestManager_deliverLatest(t *testing.T) {
 	// None of these need to do anything to test this method just be valid
-	logger := testutil.TestHcLog(t.Name())
+	logger := testutil.TestHcLog(t)
 	cfg := ManagerConfig{
 		Cache: cache.New(nil),
 		State: local.NewState(local.Config{}, logger, &token.Store{}),

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -1,8 +1,6 @@
 package proxycfg
 
 import (
-	"log"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -17,6 +15,7 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 // assertLastReqArgs verifies that each request type had the correct source
@@ -310,7 +309,7 @@ func testManager_BasicLifecycle(
 
 	require := require.New(t)
 
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog(t.Name())
 	state := local.NewState(local.Config{}, logger, &token.Store{})
 	source := &structs.QuerySource{
 		Node:       "node1",
@@ -447,7 +446,7 @@ func assertWatchChanRecvs(t *testing.T, ch <-chan *ConfigSnapshot, expect *Confi
 
 func TestManager_deliverLatest(t *testing.T) {
 	// None of these need to do anything to test this method just be valid
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog(t.Name())
 	cfg := ManagerConfig{
 		Cache: cache.New(nil),
 		State: local.NewState(local.Config{}, logger, &token.Store{}),

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -622,7 +622,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 			require.NotNil(t, state)
 
 			// setup the test logger to use the t.Log
-			state.logger = testutil.TestHcLog(t.Name())
+			state.logger = testutil.TestHcLog(t)
 
 			// setup a new testing cache notifier
 			cn := newTestCacheNotifier()

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -622,7 +622,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 			require.NotNil(t, state)
 
 			// setup the test logger to use the t.Log
-			state.logger = testutil.TestLogger(t)
+			state.logger = testutil.TestHcLog(t.Name())
 
 			// setup a new testing cache notifier
 			cn := newTestCacheNotifier()

--- a/agent/retry_join_test.go
+++ b/agent/retry_join_test.go
@@ -45,6 +45,8 @@ func TestAgentRetryJoinAddrs(t *testing.T) {
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var buf bytes.Buffer
+
+			//TODO: s-christoff implement logger without failing test
 			logger := log.New(&buf, "logger: ", log.Lshortfile)
 			require.Equal(t, test.expected, retryJoinAddrs(d, "LAN", test.input, logger), buf.String())
 			if i == 4 {

--- a/agent/router/manager_test.go
+++ b/agent/router/manager_test.go
@@ -2,15 +2,14 @@ package router_test
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"net"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/router"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 type fauxAddr struct {
@@ -56,21 +55,21 @@ func (s *fauxSerf) NumNodes() int {
 }
 
 func testManager() (m *router.Manager) {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{})
 	return m
 }
 
 func testManagerFailProb(failPct float64) (m *router.Manager) {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{failPct: failPct})
 	return m
 }
 
 func testManagerFailAddr(failAddr net.Addr) (m *router.Manager) {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{failAddr: failAddr})
 	return m
@@ -195,7 +194,7 @@ func TestServers_FindServer(t *testing.T) {
 
 // func New(logger *log.Logger, shutdownCh chan struct{}) (m *Manager) {
 func TestServers_New(t *testing.T) {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	shutdownCh := make(chan struct{})
 	m := router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{})
 	if m == nil {

--- a/agent/router/manager_test.go
+++ b/agent/router/manager_test.go
@@ -54,22 +54,22 @@ func (s *fauxSerf) NumNodes() int {
 	return 16384
 }
 
-func testManager() (m *router.Manager) {
-	logger := testutil.TestHcLog("")
+func testManager(t testing.TB) (m *router.Manager) {
+	logger := testutil.TestHcLog(t)
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{})
 	return m
 }
 
-func testManagerFailProb(failPct float64) (m *router.Manager) {
-	logger := testutil.TestHcLog("")
+func testManagerFailProb(t testing.TB, failPct float64) (m *router.Manager) {
+	logger := testutil.TestHcLog(t)
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{failPct: failPct})
 	return m
 }
 
-func testManagerFailAddr(failAddr net.Addr) (m *router.Manager) {
-	logger := testutil.TestHcLog("")
+func testManagerFailAddr(t testing.TB, failAddr net.Addr) (m *router.Manager) {
+	logger := testutil.TestHcLog(t)
 	shutdownCh := make(chan struct{})
 	m = router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{failAddr: failAddr})
 	return m
@@ -77,7 +77,7 @@ func testManagerFailAddr(failAddr net.Addr) (m *router.Manager) {
 
 // func (m *Manager) AddServer(server *metadata.Server) {
 func TestServers_AddServer(t *testing.T) {
-	m := testManager()
+	m := testManager(t)
 	var num int
 	num = m.NumServers()
 	if num != 0 {
@@ -107,7 +107,7 @@ func TestServers_AddServer(t *testing.T) {
 
 // func (m *Manager) IsOffline() bool {
 func TestServers_IsOffline(t *testing.T) {
-	m := testManager()
+	m := testManager(t)
 	if !m.IsOffline() {
 		t.Fatalf("bad")
 	}
@@ -128,7 +128,7 @@ func TestServers_IsOffline(t *testing.T) {
 	}
 
 	const failPct = 0.5
-	m = testManagerFailProb(failPct)
+	m = testManagerFailProb(t, failPct)
 	m.AddServer(s1)
 	var on, off int
 	for i := 0; i < 100; i++ {
@@ -146,7 +146,7 @@ func TestServers_IsOffline(t *testing.T) {
 
 // func (m *Manager) FindServer() (server *metadata.Server) {
 func TestServers_FindServer(t *testing.T) {
-	m := testManager()
+	m := testManager(t)
 
 	if m.FindServer() != nil {
 		t.Fatalf("Expected nil return")
@@ -194,7 +194,7 @@ func TestServers_FindServer(t *testing.T) {
 
 // func New(logger *log.Logger, shutdownCh chan struct{}) (m *Manager) {
 func TestServers_New(t *testing.T) {
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	shutdownCh := make(chan struct{})
 	m := router.New(logger, shutdownCh, &fauxSerf{}, &fauxConnPool{})
 	if m == nil {
@@ -204,7 +204,7 @@ func TestServers_New(t *testing.T) {
 
 // func (m *Manager) NotifyFailedServer(server *metadata.Server) {
 func TestServers_NotifyFailedServer(t *testing.T) {
-	m := testManager()
+	m := testManager(t)
 
 	if m.NumServers() != 0 {
 		t.Fatalf("Expected zero servers to start")
@@ -257,7 +257,7 @@ func TestServers_NotifyFailedServer(t *testing.T) {
 
 // func (m *Manager) NumServers() (numServers int) {
 func TestServers_NumServers(t *testing.T) {
-	m := testManager()
+	m := testManager(t)
 	var num int
 	num = m.NumServers()
 	if num != 0 {
@@ -275,7 +275,7 @@ func TestServers_NumServers(t *testing.T) {
 // func (m *Manager) RebalanceServers() {
 func TestServers_RebalanceServers(t *testing.T) {
 	const failPct = 0.5
-	m := testManagerFailProb(failPct)
+	m := testManagerFailProb(t, failPct)
 	const maxServers = 100
 	const numShuffleTests = 100
 	const uniquePassRate = 0.5
@@ -322,7 +322,7 @@ func TestServers_RebalanceServers_AvoidFailed(t *testing.T) {
 		&metadata.Server{Name: "s3", Addr: &fauxAddr{"s3"}},
 	}
 	for i := 0; i < 100; i++ {
-		m := testManagerFailAddr(&fauxAddr{"s2"})
+		m := testManagerFailAddr(t, &fauxAddr{"s2"})
 		for _, s := range servers {
 			m.AddServer(s)
 		}
@@ -337,7 +337,7 @@ func TestServers_RebalanceServers_AvoidFailed(t *testing.T) {
 // func (m *Manager) RemoveServer(server *metadata.Server) {
 func TestManager_RemoveServer(t *testing.T) {
 	const nodeNameFmt = "s%02d"
-	m := testManager()
+	m := testManager(t)
 
 	if m.NumServers() != 0 {
 		t.Fatalf("Expected zero servers to start")

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -83,6 +83,7 @@ type areaInfo struct {
 
 // NewRouter returns a new Router with the given configuration.
 func NewRouter(logger *log.Logger, localDatacenter string) *Router {
+
 	router := &Router{
 		logger:          logger,
 		localDatacenter: localDatacenter,

--- a/agent/router/router_test.go
+++ b/agent/router/router_test.go
@@ -2,9 +2,7 @@ package router
 
 import (
 	"fmt"
-	"log"
 	"net"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -13,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/hashicorp/serf/serf"
@@ -95,7 +94,7 @@ func testCluster(self string) *mockCluster {
 }
 
 func testRouter(dc string) *Router {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	return NewRouter(logger, dc)
 }
 

--- a/agent/router/router_test.go
+++ b/agent/router/router_test.go
@@ -93,13 +93,13 @@ func testCluster(self string) *mockCluster {
 	return c
 }
 
-func testRouter(dc string) *Router {
-	logger := testutil.TestHcLog("")
+func testRouter(t testing.TB, dc string) *Router {
+	logger := testutil.TestHcLog(t)
 	return NewRouter(logger, dc)
 }
 
 func TestRouter_Shutdown(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	// Create a WAN-looking area.
 	self := "node0.dc0"
@@ -135,7 +135,7 @@ func TestRouter_Shutdown(t *testing.T) {
 }
 
 func TestRouter_Routing(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	// Create a WAN-looking area.
 	self := "node0.dc0"
@@ -269,7 +269,7 @@ func TestRouter_Routing(t *testing.T) {
 }
 
 func TestRouter_Routing_Offline(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	// Create a WAN-looking area.
 	self := "node0.dc0"
@@ -349,7 +349,7 @@ func TestRouter_Routing_Offline(t *testing.T) {
 }
 
 func TestRouter_GetDatacenters(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	self := "node0.dc0"
 	wan := testCluster(self)
@@ -380,7 +380,7 @@ func TestRouter_distanceSorter(t *testing.T) {
 }
 
 func TestRouter_GetDatacentersByDistance(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	// Start with just the WAN area described in the diagram above.
 	self := "node0.dc0"
@@ -418,7 +418,7 @@ func TestRouter_GetDatacentersByDistance(t *testing.T) {
 }
 
 func TestRouter_GetDatacenterMaps(t *testing.T) {
-	r := testRouter("dc0")
+	r := testRouter(t, "dc0")
 
 	self := "node0.dc0"
 	wan := testCluster(self)

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
-	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/agent/config"
@@ -196,15 +195,8 @@ func (a *TestAgent) Start() (err error) {
 	if logOutput == nil {
 		logOutput = os.Stderr
 	}
-	consulLogger := hclog.New(&hclog.LoggerOptions{
-		Name:   a.Name,
-		Level:  log.LstdFlags | log.Lmicroseconds,
-		Output: logOutput,
-	})
 
-	agentLogger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
-		InferLevels: true,
-	})
+	agentLogger := log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
 
 	agent, err := New(a.Config, agentLogger)
 	if err != nil {

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	metrics "github.com/armon/go-metrics"
+	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
 
 	"github.com/hashicorp/consul/agent/config"
@@ -195,7 +196,15 @@ func (a *TestAgent) Start() (err error) {
 	if logOutput == nil {
 		logOutput = os.Stderr
 	}
-	agentLogger := log.New(logOutput, a.Name+" - ", log.LstdFlags|log.Lmicroseconds)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   a.Name,
+		Level:  log.LstdFlags | log.Lmicroseconds,
+		Output: logOutput,
+	})
+
+	agentLogger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 
 	agent, err := New(a.Config, agentLogger)
 	if err != nil {

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/consul/agent/exec"
 	"github.com/hashicorp/consul/api/watch"
 	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/net/context"
 )
 
@@ -41,7 +42,13 @@ func makeWatchHandler(logOutput io.Writer, handler interface{}) watch.HandlerFun
 		panic(fmt.Errorf("unknown handler type %T", handler))
 	}
 
-	logger := log.New(logOutput, "", log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: logOutput,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	fn := func(idx uint64, data interface{}) {
 		// Create the command
 		var cmd *osexec.Cmd
@@ -94,7 +101,13 @@ func makeWatchHandler(logOutput io.Writer, handler interface{}) watch.HandlerFun
 }
 
 func makeHTTPWatchHandler(logOutput io.Writer, config *watch.HttpHandlerConfig) watch.HandlerFunc {
-	logger := log.New(logOutput, "", log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: logOutput,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 
 	fn := func(idx uint64, data interface{}) {
 		trans := cleanhttp.DefaultTransport()

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -247,7 +247,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: testutil.TestHcLog("")}
+			s := Server{Logger: testutil.TestHcLog(t)}
 
 			clusters, err := s.clustersFromSnapshot(snap, "my-token")
 			require.NoError(err)

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -2,8 +2,6 @@ package xds
 
 import (
 	"bytes"
-	"log"
-	"os"
 	"path"
 	"sort"
 	"testing"
@@ -12,6 +10,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -248,7 +247,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: log.New(os.Stderr, "", log.LstdFlags)}
+			s := Server{Logger: testutil.TestHcLog("")}
 
 			clusters, err := s.clustersFromSnapshot(snap, "my-token")
 			require.NoError(err)

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -1,8 +1,6 @@
 package xds
 
 import (
-	"log"
-	"os"
 	"path"
 	"sort"
 	"testing"
@@ -16,6 +14,7 @@ import (
 	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 )
 
@@ -366,7 +365,7 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: log.New(os.Stderr, "", log.LstdFlags)}
+			s := Server{Logger: testutil.TestHcLog("")}
 
 			endpoints, err := s.endpointsFromSnapshot(snap, "my-token")
 			sort.Slice(endpoints, func(i, j int) bool {

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -365,7 +365,7 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: testutil.TestHcLog("")}
+			s := Server{Logger: testutil.TestHcLog(t)}
 
 			endpoints, err := s.endpointsFromSnapshot(snap, "my-token")
 			sort.Slice(endpoints, func(i, j int) bool {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -284,7 +284,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: testutil.TestHcLog("")}
+			s := Server{Logger: testutil.TestHcLog(t)}
 
 			listeners, err := s.listenersFromSnapshot(snap, "my-token")
 			sort.Slice(listeners, func(i, j int) bool {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -3,8 +3,6 @@ package xds
 import (
 	"bytes"
 	"fmt"
-	"log"
-	"os"
 	"path"
 	"sort"
 	"testing"
@@ -13,6 +11,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -285,7 +284,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 			}
 
 			// Need server just for logger dependency
-			s := Server{Logger: log.New(os.Stderr, "", log.LstdFlags)}
+			s := Server{Logger: testutil.TestHcLog("")}
 
 			listeners, err := s.listenersFromSnapshot(snap, "my-token")
 			sort.Slice(listeners, func(i, j int) bool {

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -3,8 +3,6 @@ package xds
 import (
 	"context"
 	"errors"
-	"log"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -21,6 +19,7 @@ import (
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 // testManager is a mock of proxycfg.Manager that's simpler to control for
@@ -103,7 +102,7 @@ func (m *testManager) ConnectAuthorize(token string, req *structs.ConnectAuthori
 }
 
 func TestServer_StreamAggregatedResources_BasicProtocol(t *testing.T) {
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		// Allow all
@@ -434,7 +433,7 @@ func TestServer_StreamAggregatedResources_ACLEnforcement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := log.New(os.Stderr, "", log.LstdFlags)
+			logger := testutil.TestHcLog("")
 			mgr := newTestManager(t)
 			aclResolve := func(id string) (acl.Authorizer, error) {
 				if !tt.defaultDeny {
@@ -514,7 +513,7 @@ func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedDuring
 	var validToken atomic.Value
 	validToken.Store(token)
 
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		if token := validToken.Load(); token == nil || id != token.(string) {
@@ -605,7 +604,7 @@ func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedInBack
 	var validToken atomic.Value
 	validToken.Store(token)
 
-	logger := log.New(os.Stderr, "", log.LstdFlags)
+	logger := testutil.TestHcLog("")
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		if token := validToken.Load(); token == nil || id != token.(string) {
@@ -778,7 +777,7 @@ func TestServer_Check(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := "my-real-acl-token"
-			logger := log.New(os.Stderr, "", log.LstdFlags)
+			logger := testutil.TestHcLog("")
 			mgr := newTestManager(t)
 
 			// Setup expected auth result against that token no lock as no other

--- a/agent/xds/server_test.go
+++ b/agent/xds/server_test.go
@@ -102,7 +102,7 @@ func (m *testManager) ConnectAuthorize(token string, req *structs.ConnectAuthori
 }
 
 func TestServer_StreamAggregatedResources_BasicProtocol(t *testing.T) {
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		// Allow all
@@ -433,7 +433,7 @@ func TestServer_StreamAggregatedResources_ACLEnforcement(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			mgr := newTestManager(t)
 			aclResolve := func(id string) (acl.Authorizer, error) {
 				if !tt.defaultDeny {
@@ -513,7 +513,7 @@ func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedDuring
 	var validToken atomic.Value
 	validToken.Store(token)
 
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		if token := validToken.Load(); token == nil || id != token.(string) {
@@ -604,7 +604,7 @@ func TestServer_StreamAggregatedResources_ACLTokenDeleted_StreamTerminatedInBack
 	var validToken atomic.Value
 	validToken.Store(token)
 
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	mgr := newTestManager(t)
 	aclResolve := func(id string) (acl.Authorizer, error) {
 		if token := validToken.Load(); token == nil || id != token.(string) {
@@ -777,7 +777,7 @@ func TestServer_Check(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := "my-real-acl-token"
-			logger := testutil.TestHcLog("")
+			logger := testutil.TestHcLog(t)
 			mgr := newTestManager(t)
 
 			// Setup expected auth result against that token no lock as no other

--- a/api/watch/plan.go
+++ b/api/watch/plan.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
 )
 
 const (
@@ -44,7 +45,13 @@ func (p *Plan) RunWithConfig(address string, conf *consulapi.Config) error {
 	if output == nil {
 		output = os.Stderr
 	}
-	logger := log.New(output, "", log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: output,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 
 	return p.RunWithClientAndLogger(client, logger)
 }

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/consul/service_os"
 	"github.com/hashicorp/go-checkpoint"
+	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/logutils"
 	"github.com/mitchellh/cli"
@@ -202,7 +203,13 @@ func (c *cmd) run(args []string) int {
 	}
 	c.logFilter = logFilter
 	c.logOutput = logOutput
-	c.logger = log.New(logOutput, "", log.LstdFlags)
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: logOutput,
+	})
+	c.logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 
 	// Setup gRPC logger to use the same output/filtering
 	grpclog.SetLoggerV2(logger.NewGRPCLogger(logConfig, c.logger))

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"
 	proxyImpl "github.com/hashicorp/consul/connect/proxy"
+	"github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/consul/logger"
 	"github.com/hashicorp/logutils"
@@ -139,7 +140,14 @@ func (c *cmd) Run(args []string) int {
 	}
 	c.logFilter = logFilter
 	c.logOutput = logOutput
-	c.logger = log.New(logOutput, "", log.LstdFlags)
+
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  log.LstdFlags,
+		Output: logOutput,
+	})
+	c.logger = consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 
 	// Enable Pprof if needed
 	if c.pprofAddr != "" {

--- a/command/connect/proxy/register.go
+++ b/command/connect/proxy/register.go
@@ -3,12 +3,12 @@ package proxy
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
 )
 
 const (
@@ -89,8 +89,15 @@ const (
 // execute Run in a goroutine.
 func NewRegisterMonitor() *RegisterMonitor {
 	var lock sync.Mutex
+
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: log.LstdFlags,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	return &RegisterMonitor{
-		Logger:          log.New(os.Stderr, "", log.LstdFlags), // default logger
+		Logger:          logger, // default logger
 		ReconcilePeriod: RegisterReconcilePeriod,
 		TTLPeriod:       RegisterTTLPeriod,
 		lock:            &lock,

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -111,7 +111,7 @@ func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 	require.NoError(t, err)
 
 	w, err := NewAgentConfigWatcher(client, "web-sidecar-proxy",
-		testutil.TestHcLog(""))
+		testutil.TestHcLog(t))
 	require.NoError(t, err)
 
 	cfg := testGetConfigValTimeout(t, w, 500*time.Millisecond)

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"log"
-	"os"
 	"testing"
 	"time"
 
@@ -11,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/connect"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,7 +111,7 @@ func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 	require.NoError(t, err)
 
 	w, err := NewAgentConfigWatcher(client, "web-sidecar-proxy",
-		log.New(os.Stderr, "", log.LstdFlags))
+		testutil.TestHcLog(""))
 	require.NoError(t, err)
 
 	cfg := testGetConfigValTimeout(t, w, 500*time.Millisecond)

--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -128,7 +128,7 @@ func TestPublicListener(t *testing.T) {
 	sink := testSetupMetrics(t)
 
 	svc := connect.TestService(t, "db", ca)
-	l := NewPublicListener(svc, cfg, testutil.TestHcLog(""))
+	l := NewPublicListener(svc, cfg, testutil.TestHcLog(t))
 
 	// Run proxy
 	go func() {
@@ -194,7 +194,7 @@ func TestUpstreamListener(t *testing.T) {
 		Addr:    testSvr.Addr,
 		CertURI: agConnect.TestSpiffeIDService(t, "db"),
 	})
-	l := newUpstreamListenerWithResolver(svc, cfg, rf, testutil.TestHcLog(""))
+	l := newUpstreamListenerWithResolver(svc, cfg, rf, testutil.TestHcLog(t))
 
 	// Run proxy
 	go func() {

--- a/connect/proxy/listener_test.go
+++ b/connect/proxy/listener_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -19,6 +17,7 @@ import (
 	agConnect "github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
 )
 
 func testSetupMetrics(t *testing.T) *metrics.InmemSink {
@@ -129,7 +128,7 @@ func TestPublicListener(t *testing.T) {
 	sink := testSetupMetrics(t)
 
 	svc := connect.TestService(t, "db", ca)
-	l := NewPublicListener(svc, cfg, log.New(os.Stderr, "", log.LstdFlags))
+	l := NewPublicListener(svc, cfg, testutil.TestHcLog(""))
 
 	// Run proxy
 	go func() {
@@ -195,7 +194,7 @@ func TestUpstreamListener(t *testing.T) {
 		Addr:    testSvr.Addr,
 		CertURI: agConnect.TestSpiffeIDService(t, "db"),
 	})
-	l := newUpstreamListenerWithResolver(svc, cfg, rf, log.New(os.Stderr, "", log.LstdFlags))
+	l := newUpstreamListenerWithResolver(svc, cfg, rf, testutil.TestHcLog(""))
 
 	// Run proxy
 	go func() {

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -80,5 +80,5 @@ func TestProxy_public(t *testing.T) {
 }
 
 func testLogger(t *testing.T) *log.Logger {
-	return testutil.TestHcLog("")
+	return testutil.TestHcLog(t)
 }

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 	"net"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/consul/testrpc"
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/connect"
 	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/stretchr/testify/require"
 )
@@ -80,5 +80,5 @@ func TestProxy_public(t *testing.T) {
 }
 
 func testLogger(t *testing.T) *log.Logger {
-	return log.New(os.Stderr, "", log.LstdFlags)
+	return testutil.TestHcLog("")
 }

--- a/connect/service.go
+++ b/connect/service.go
@@ -8,11 +8,11 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/api/watch"
+	"github.com/hashicorp/go-hclog"
 	"golang.org/x/net/http2"
 )
 
@@ -61,8 +61,14 @@ type Service struct {
 // Consul agent, and with an ACL token that has `service:write` privileges for
 // the service specified.
 func NewService(serviceName string, client *api.Client) (*Service, error) {
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: log.LstdFlags,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	return NewServiceWithLogger(serviceName, client,
-		log.New(os.Stderr, "", log.LstdFlags))
+		logger)
 }
 
 // NewServiceWithLogger starts the service with a specified log.Logger.

--- a/connect/testing.go
+++ b/connect/testing.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/freeport"
-	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/go-hclog"
 	testing "github.com/mitchellh/go-testing-interface"
 )
 
@@ -22,7 +22,12 @@ func TestService(t testing.T, service string, ca *structs.CARoot) *Service {
 	t.Helper()
 
 	// Don't need to talk to client since we are setting TLSConfig locally
-	logger := testutil.TestHcLog("")
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level: log.LstdFlags,
+	})
+	logger := consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 	svc, err := NewDevServiceWithTLSConfig(service,
 		logger, TestTLSConfig(t, service, ca))
 	if err != nil {

--- a/connect/testing.go
+++ b/connect/testing.go
@@ -8,12 +8,12 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"os"
 	"sync/atomic"
 
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/freeport"
+	"github.com/hashicorp/consul/sdk/testutil"
 	testing "github.com/mitchellh/go-testing-interface"
 )
 
@@ -22,8 +22,9 @@ func TestService(t testing.T, service string, ca *structs.CARoot) *Service {
 	t.Helper()
 
 	// Don't need to talk to client since we are setting TLSConfig locally
+	logger := testutil.TestHcLog("")
 	svc, err := NewDevServiceWithTLSConfig(service,
-		log.New(os.Stderr, "", log.LstdFlags), TestTLSConfig(t, service, ca))
+		logger, TestTLSConfig(t, service, ca))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -21,6 +22,16 @@ func TestHcLog(name string) *log.Logger {
 	consulLogger := hclog.New(&hclog.LoggerOptions{
 		Name:  name,
 		Level: log.LstdFlags,
+	})
+	return consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
+}
+
+func NewDiscardLogger() *log.Logger {
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Level:  0,
+		Output: ioutil.Discard,
 	})
 	return consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 		InferLevels: true,

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -7,12 +7,24 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 var sendTestLogsToStdout bool
 
 func init() {
 	sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
+}
+
+func TestHcLog(name string) *log.Logger {
+	consulLogger := hclog.New(&hclog.LoggerOptions{
+		Name:  name,
+		Level: log.LstdFlags,
+	})
+	return consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
+		InferLevels: true,
+	})
 }
 
 func TestLogger(t testing.TB) *log.Logger {

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -18,10 +18,10 @@ func init() {
 	sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
 }
 
-func TestHcLog(name string) *log.Logger {
+func TestHcLog(t testing.TB) *log.Logger {
 	consulLogger := hclog.New(&hclog.LoggerOptions{
-		Name:  name,
-		Level: log.LstdFlags,
+		Name:   t.Name(),
+		Output: TestWriter(t),
 	})
 	return consulLogger.StandardLogger(&hclog.StandardLoggerOptions{
 		InferLevels: true,

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -150,7 +149,7 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	// Take a snapshot.
-	logger := log.New(os.Stdout, "", 0)
+	logger := testutil.TestHcLog("")
 	snap, err := New(logger, before)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -253,7 +252,7 @@ func TestSnapshot_BadRestore(t *testing.T) {
 	}
 
 	// Take a snapshot.
-	logger := log.New(os.Stdout, "", 0)
+	logger := testutil.TestHcLog("")
 	snap, err := New(logger, before)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -149,7 +149,7 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	// Take a snapshot.
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	snap, err := New(logger, before)
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -252,7 +252,7 @@ func TestSnapshot_BadRestore(t *testing.T) {
 	}
 
 	// Take a snapshot.
-	logger := testutil.TestHcLog("")
+	logger := testutil.TestHcLog(t)
 	snap, err := New(logger, before)
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -341,7 +341,7 @@ func TestConfig_SpecifyDC(t *testing.T) {
 }
 
 func TestConfigurator_NewConfigurator(t *testing.T) {
-	logger := testutil.TestHcLog("logger :")
+	logger := testutil.TestHcLog(t)
 	c, err := NewConfigurator(Config{}, logger)
 	require.NoError(t, err)
 	require.NotNil(t, c)

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -1,18 +1,17 @@
 package tlsutil
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/yamux"
 	"github.com/stretchr/testify/require"
 )
@@ -342,8 +341,7 @@ func TestConfig_SpecifyDC(t *testing.T) {
 }
 
 func TestConfigurator_NewConfigurator(t *testing.T) {
-	buf := bytes.Buffer{}
-	logger := log.New(&buf, "logger: ", log.Lshortfile)
+	logger := testutil.TestHcLog("logger :")
 	c, err := NewConfigurator(Config{}, logger)
 	require.NoError(t, err)
 	require.NotNil(t, c)


### PR DESCRIPTION
This is a multiple phase process to moving Consul to using HcLog. 
Phase one is to implement HcLog with the Standard Logger wrapper so function signatures that rely on the standard logger do not need to be changed, as well as all the logging print statements. 

Curious on if I should make another test logging function for custom HcLog's to be defined or is it fine how it is? There were a handful that needed buffered loggers.
