### PR TITLE
Update connection for the openstack provider in documentation

### DIFF
--- a/website/source/docs/agent/cloud-auto-join.html.md
+++ b/website/source/docs/agent/cloud-auto-join.html.md
@@ -242,8 +242,11 @@ $ consul agent -retry-join "provider=os tag_key=consul tag_value=server username
 - `provider` (required) - the name of the provider ("os" in this case).
 - `tag_key` (required) - the key of the tag to auto-join on.
 - `tag_value` (required) - the value of the tag to auto-join on.
+- `domain_name` (optional) - the name of the domain.
+- `domain_id` (optional) - the id of the domain.
 - `project_id` (optional) - the id of the project (tenant id).
-- `username` (optional) - the username to use for auth.
+- `region` (optional) - the name of the region.
+- `user_name` (optional) - the username to use for auth.
 - `password` (optional) - the password to use for auth.
 - `token` (optional) - the token to use for auth.
 - `auth_url` (optional) - the identity endpoint to use for auth.


### PR DESCRIPTION
The option `username` does not work. Need to use user_name with underscore
```bash
[ERR] agent: Cannot discover LAN provider=os tag_key=consul tag_value=server auth_url=https://api.selvpc.ru/identity/v3 password=**** username=user_cli project_id=6828dcb9d453424bbd6c99e43893a7b8 : discover-os: Authentication failed: Exactly one of Username and UserID must be provided for password authentication
```
The option `user_name` works, however, it's need to use `region`, `domain_name` in additional. 
https://github.com/hashicorp/go-discover/blob/master/provider/os/os_discover.go#L121