### PR TITLE
docs: Improve session API documentation

### DIFF
--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -8,7 +8,9 @@ description: |-
 
 # Session HTTP Endpoint
 
-The `/session` endpoints create, destroy, and query sessions in Consul.
+The `/session` endpoints create, destroy, and query sessions in Consul. A
+conceptual overview of sessions is found at the
+[Session Internals](/docs/internals/sessions.html) page.
 
 ## Create Session
 
@@ -35,8 +37,7 @@ The table below shows this endpoint's support for
   the datacenter of the agent being queried. This is specified as part of the
   URL as a query parameter. Using this across datacenters is not recommended.
 
-- `LockDelay` `(string: "15s")` - Specifies the duration for the lock delay. This
-  must be greater than `0`.
+- `LockDelay` `(string: "15s")` - Specifies the duration for the lock delay.
 
 - `Node` `(string: "<agent>")` - Specifies the name of the node. This must refer
   to a node that is already registered.


### PR DESCRIPTION
In investigating #4508, I found that the API currently does allow `LockDelay` to be set to `0` and correctly releases the lock immediately. There is still a question of how the issue manifested itself for the user, but we should remove the incorrect statement in our API documentation.

I also put a link to the Session Internals page at the top, to direct people to a more in-depth overview of why/how they should use the Sessions API.

Deploy preview is at: https://deploy-preview-6777--consul-docs-preview.netlify.com/api/session.html