### PR TITLE
ui: Adds `href-mut` helper for modifying current URLs

### DIFF
--- a/ui-v2/app/helpers/href-mut.js
+++ b/ui-v2/app/helpers/href-mut.js
@@ -1,0 +1,27 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { hrefTo } from 'consul-ui/helpers/href-to';
+
+const getRouteParams = function(route, params = {}) {
+  return route.paramNames.map(function(item) {
+    if (typeof params[item] !== 'undefined') {
+      return params[item];
+    }
+    return route.params[item];
+  });
+};
+export default Helper.extend({
+  router: service('router'),
+  compute([params], hash) {
+    let current = this.router.currentRoute;
+    let parent;
+    let atts = getRouteParams(current, params);
+    // walk up the entire route/s replacing any instances
+    // of the specified params with the values specified
+    while ((parent = current.parent)) {
+      atts = atts.concat(getRouteParams(parent, params));
+      current = parent;
+    }
+    return hrefTo(this, this.router, [this.router.currentRoute.name, ...atts.reverse()], hash);
+  },
+});

--- a/ui-v2/app/helpers/href-to.js
+++ b/ui-v2/app/helpers/href-to.js
@@ -3,37 +3,40 @@
 // (dynamic or wildcard) and encode or not depending on the type
 import { inject as service } from '@ember/service';
 import Helper from '@ember/component/helper';
-import { hrefTo } from 'ember-href-to/helpers/href-to';
+import { hrefTo as _hrefTo } from 'ember-href-to/helpers/href-to';
 
 import wildcard from 'consul-ui/utils/routing/wildcard';
 
 import { routes } from 'consul-ui/router';
 
 const isWildcard = wildcard(routes);
+export const hrefTo = function(owned, router, [targetRouteName, ...rest], namedArgs) {
+  if (isWildcard(targetRouteName)) {
+    rest = rest.map(function(item, i) {
+      return item
+        .split('/')
+        .map(encodeURIComponent)
+        .join('/');
+    });
+  }
+  if (namedArgs.params) {
+    return _hrefTo(owned, namedArgs.params);
+  } else {
+    // we don't check to see if nspaces are enabled here as routes
+    // with beginning with 'nspace' only exist if nspaces are enabled
+
+    // this globally converts non-nspaced href-to's to nspace aware
+    // href-to's only if you are within a namespace
+    if (router.currentRouteName.startsWith('nspace.') && targetRouteName.startsWith('dc.')) {
+      targetRouteName = `nspace.${targetRouteName}`;
+    }
+    return _hrefTo(owned, [targetRouteName, ...rest]);
+  }
+};
 
 export default Helper.extend({
   router: service('router'),
-  compute([targetRouteName, ...rest], namedArgs) {
-    if (isWildcard(targetRouteName)) {
-      rest = rest.map(function(item, i) {
-        return item
-          .split('/')
-          .map(encodeURIComponent)
-          .join('/');
-      });
-    }
-    if (namedArgs.params) {
-      return hrefTo(this, namedArgs.params);
-    } else {
-      // we don't check to see if nspaces are enabled here as routes
-      // with beginning with 'nspace' only exist if nspaces are enabled
-
-      // this globally converts non-nspaced href-to's to nspace aware
-      // href-to's only if you are within a namespace
-      if (this.router.currentRouteName.startsWith('nspace.') && targetRouteName.startsWith('dc.')) {
-        targetRouteName = `nspace.${targetRouteName}`;
-      }
-      return hrefTo(this, [targetRouteName, ...rest]);
-    }
+  compute(params, hash) {
+    return hrefTo(this, this.router, params, hash);
   },
 });

--- a/ui-v2/tests/integration/helpers/href-mut-test.js
+++ b/ui-v2/tests/integration/helpers/href-mut-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | href-mut', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{href-mut inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});

--- a/ui-v2/tests/integration/helpers/href-mut-test.js
+++ b/ui-v2/tests/integration/helpers/href-mut-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -7,11 +7,9 @@ module('Integration | Helper | href-mut', function(hooks) {
   setupRenderingTest(hooks);
 
   // Replace this with your real tests.
-  test('it renders', async function(assert) {
-    this.set('inputValue', '1234');
+  skip('it renders', async function(assert) {
+    await render(hbs`{{href-mut (hash dc=dc-1)}}`);
 
-    await render(hbs`{{href-mut inputValue}}`);
-
-    assert.equal(this.element.textContent.trim(), '1234');
+    assert.equal(this.element.textContent.trim(), '');
   });
 });


### PR DESCRIPTION
Sometimes you just need to link to your current route, but alter one of
the parameters of the route. In our case the datacenter menu is a good
example. When you change the datacenter from the node listing page we
want the user to be taken to the node listing page on the newly selected
datacenter, not a different route.

This PR uses the router service to walk up the current route and
replace parameters in the route that you specify as an argument to the
helper. This then uses the newly mutated arguments and the existing
routeName to pass through to the already existing `hrefTo` helper.

Usage is:

```hbs
{{href-mut (hash dc='dc-10')}}
```

Currently WIP as this includes the ember generated helper tests that possibly need tweaking once I've had 👀 on this.

Please note this is being merged down to https://github.com/hashicorp/consul/pull/6639 which is where we will use this first for both the DC menu and the nspace menu.