### PR TITLE
bug: Allow services register command to register an unnamed check

### DIFF
--- a/command/services/config.go
+++ b/command/services/config.go
@@ -65,12 +65,9 @@ func serviceToAgentService(svc *structs.ServiceDefinition) (*api.AgentServiceReg
 
 	// The structs version has non-pointer checks and the destination
 	// has pointers, so we need to set the destination to nil if there
-	// is no check ID set.
-	if result.Check != nil && result.Check.Name == "" {
+	// is a zero-value Check field.
+	if result.Check != nil && reflect.DeepEqual(*result.Check, api.AgentServiceCheck{}) {
 		result.Check = nil
-	}
-	if len(result.Checks) == 1 && result.Checks[0].Name == "" {
-		result.Checks = nil
 	}
 
 	return &result, nil

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
@@ -61,6 +62,32 @@ func TestStructsToAgentService(t *testing.T) {
 				Check: &api.AgentServiceCheck{
 					Name: "ping",
 				},
+			},
+		},
+		{
+			"Service with an unnamed check",
+			&structs.ServiceDefinition{
+				Name: "web",
+				Check: structs.CheckType{
+					TTL: 5 * time.Second,
+				},
+			},
+			&api.AgentServiceRegistration{
+				Name: "web",
+				Check: &api.AgentServiceCheck{
+					TTL: "5s",
+				},
+			},
+		},
+		{
+			"Service with a zero-value check",
+			&structs.ServiceDefinition{
+				Name:  "web",
+				Check: structs.CheckType{},
+			},
+			&api.AgentServiceRegistration{
+				Name:  "web",
+				Check: nil,
 			},
 		},
 		{


### PR DESCRIPTION
The logic in parsing data files and converting them to data structures
accidentally removed healthchecks with no Name field, even though we
explicitly state in API documentation that is allowed.

We remove the check for "len(results.Checks) == 1" because if the length
of the array is more than 0, we know that it is not a zero value array.
This allows us to register a singular, unnamed check via the CLI.

Fixes #6796