### PR TITLE
website: alert for kubecon

### DIFF
--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -10,6 +10,9 @@ description: |-
       <div>
         <div>
           <div>
+          <a class='notification' href='https://learn.hashicorp.com/consul?track=kubernetes&utm_source=TODO&utm_medium=banner&utm_term=track#kubernetes'>
+            <span>KUBECON</span> Learn how to deploy Consul on Kubernetes <span><svg xmlns='http://www.w3.org/2000/svg' width='6' height='10' viewBox='0 0 6 10'><path fill='#650D34' d='M1.138.529a.666.666 0 1 0-.942.943L3.724 5 .195 8.53a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z'/></svg><span>
+          </a>
             <h1 class='g-type-display-1'>Secure Service Networking</h1>
             <p  class='g-type-body-large'>Consul is a service networking solution to connect and secure services across any runtime platform and public or private cloud</p>
             <a href='/downloads.html' class='button download'>

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -10,7 +10,7 @@ description: |-
       <div>
         <div>
           <div>
-          <a class='notification' href='https://learn.hashicorp.com/consul?track=kubernetes&utm_source=TODO&utm_medium=banner&utm_term=track#kubernetes'>
+          <a class='notification' href='https://learn.hashicorp.com/consul?track=kubernetes&utm_source=consul.io&utm_medium=banner&utm_term=track#kubernetes'>
             <span>KUBECON</span> Learn how to deploy Consul on Kubernetes <span><svg xmlns='http://www.w3.org/2000/svg' width='6' height='10' viewBox='0 0 6 10'><path fill='#650D34' d='M1.138.529a.666.666 0 1 0-.942.943L3.724 5 .195 8.53a.666.666 0 1 0 .943.943l4-4a.666.666 0 0 0 0-.943l-4-4z'/></svg><span>
           </a>
             <h1 class='g-type-display-1'>Secure Service Networking</h1>


### PR DESCRIPTION
This is a little notification for attendees of [KubeCon](https://events19.linuxfoundation.org/events/kubecon-cloudnativecon-north-america-2019/) to jump straight into our learn track for Kubernetes if they visit consul.io.

![image](https://user-images.githubusercontent.com/846194/68984557-99e38d00-07c5-11ea-813e-7b512075a53d.png)

The intended text

> Deploy Consul on Kubernetes for service discovery and service mesh

didn't quite fit, so shortened it a bit. The `utm_source` I left as `TODO` as I'm not sure what that should be.