### PR TITLE
auto_encrypt and verify_incoming

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1113,7 +1113,7 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 
 	if rt.AutoEncryptAllowTLS {
 		if !rt.VerifyIncoming && !rt.VerifyIncomingRPC {
-			return fmt.Errorf("if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc must be enabled.")
+			b.warn("if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc should be enabled. It is necessary to turn it off during a migration to TLS, but it should definitely be turned on afterwards.")
 		}
 	}
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2684,7 +2684,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
-			desc: "auto_encrypt.allow fails without verify_incoming or verify_incoming_rpc",
+			desc: "auto_encrypt.allow warns without verify_incoming or verify_incoming_rpc",
 			args: []string{
 				`-data-dir=` + dataDir,
 			},
@@ -2694,7 +2694,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			hcl: []string{`
 			  auto_encrypt { allow_tls = true }
 			`},
-			err: "if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc must be enabled.",
+			warns: []string{"if auto_encrypt.allow_tls is turned on, either verify_incoming or verify_incoming_rpc should be enabled. It is necessary to turn it off during a migration to TLS, but it should definitely be turned on afterwards."},
+			patch: func(rt *RuntimeConfig) {
+				rt.DataDir = dataDir
+				rt.AutoEncryptAllowTLS = true
+				rt.ConnectEnabled = true
+			},
 		},
 		{
 			desc: "test connect vault provider configuration",

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -323,11 +323,20 @@ func (c *Configurator) check(config Config, pool *x509.CertPool, cert *tls.Certi
 
 	// Ensure we have a CA and cert if VerifyIncoming is set
 	if config.anyVerifyIncoming() {
+		autoEncryptMsg := " AutoEncrypt only secures the connection between client and server and doesn't affect incoming connections on the client."
 		if pool == nil {
-			return fmt.Errorf("VerifyIncoming set, and no CA certificate provided!")
+			errMsg := "VerifyIncoming set, and no CA certificate provided!"
+			if config.AutoEncryptTLS {
+				errMsg += autoEncryptMsg
+			}
+			return fmt.Errorf(errMsg)
 		}
 		if cert == nil {
-			return fmt.Errorf("VerifyIncoming set, and no Cert/Key pair provided!")
+			errMsg := "VerifyIncoming set, and no Cert/Key pair provided!"
+			if config.AutoEncryptTLS {
+				errMsg += autoEncryptMsg
+			}
+			return fmt.Errorf(errMsg)
 		}
 	}
 	return nil

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1729,12 +1729,17 @@ to the old fragment -->
       currently only supports numeric IDs.
     - `mode` - The permission bits to set on the file.
 
-* <a name="verify_incoming"></a><a href="#verify_incoming">`verify_incoming`</a> - If
-  set to true, Consul requires that all incoming
-  connections make use of TLS and that the client provides a certificate signed
-  by a Certificate Authority from the [`ca_file`](#ca_file) or [`ca_path`](#ca_path).
-  This applies to both server RPC and to the HTTPS API. By default, this is false, and
-  Consul will not enforce the use of TLS or verify a client's authenticity.
+* <a name="verify_incoming"></a><a href="#verify_incoming">`verify_incoming`</a> 
+  - If set to true, Consul requires that all incoming connections make use of TLS
+  and that the client provides a certificate signed by a Certificate Authority
+  from the [`ca_file`](#ca_file) or [`ca_path`](#ca_path).  This applies to
+  both server RPC and to the HTTPS API. By default, this is false, and Consul
+  will not enforce the use of TLS or verify a client's authenticity. Turning
+  on `verify_incoming` on consul clients protects the HTTPS endpoint, by ensuring
+  that the certificate that is presented by a 3rd party tool to the HTTPS
+  endpoint was created by the CA that the consul client was setup with. If the
+  UI is served, the same checks are performed.
+
 
 * <a name="verify_incoming_rpc"></a><a href="#verify_incoming_rpc">`verify_incoming_rpc`</a> - If
   set to true, Consul requires that all incoming RPC


### PR DESCRIPTION
After some discussion around auto_encrypt in combination with `verify_incoming`, we decided to do the following:

* relax requirement to enable `verify_incoming` on the server, so that migration is possible
* improve log output to explain better why `verify_incoming` on clients still need manual CA and cert setup even together with auto_encrypt
* explain verify_incoming on Consul clients in docs
* [x] fix learn docs https://github.com/hashicorp/learn/pull/848

Fixes https://github.com/hashicorp/consul/issues/6398, https://github.com/hashicorp/consul/issues/6127.