### PR TITLE
5652 - Adds "consul intention list" command

### DIFF
--- a/command/commands_oss.go
+++ b/command/commands_oss.go
@@ -63,6 +63,7 @@ import (
 	ixncreate "github.com/hashicorp/consul/command/intention/create"
 	ixndelete "github.com/hashicorp/consul/command/intention/delete"
 	ixnget "github.com/hashicorp/consul/command/intention/get"
+	ixnlist "github.com/hashicorp/consul/command/intention/list"
 	ixnmatch "github.com/hashicorp/consul/command/intention/match"
 	"github.com/hashicorp/consul/command/join"
 	"github.com/hashicorp/consul/command/keygen"
@@ -179,6 +180,7 @@ func init() {
 	Register("intention create", func(ui cli.Ui) (cli.Command, error) { return ixncreate.New(ui), nil })
 	Register("intention delete", func(ui cli.Ui) (cli.Command, error) { return ixndelete.New(ui), nil })
 	Register("intention get", func(ui cli.Ui) (cli.Command, error) { return ixnget.New(ui), nil })
+	Register("intention list", func(ui cli.Ui) (cli.Command, error) { return ixnlist.New(ui), nil })
 	Register("intention match", func(ui cli.Ui) (cli.Command, error) { return ixnmatch.New(ui), nil })
 	Register("join", func(ui cli.Ui) (cli.Command, error) { return join.New(ui), nil })
 	Register("keygen", func(ui cli.Ui) (cli.Command, error) { return keygen.New(ui), nil })

--- a/command/intention/intention.go
+++ b/command/intention/intention.go
@@ -40,6 +40,10 @@ Usage: consul intention <subcommand> [options] [args]
 
       $ consul intention check web db
 
+  List all intentions:
+
+      $ consul intention list
+
   Find all intentions for communicating to the "db" service:
 
       $ consul intention match db

--- a/command/intention/list/intention_list.go
+++ b/command/intention/list/intention_list.go
@@ -1,0 +1,84 @@
+package list
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/hashicorp/consul/command/flags"
+	"github.com/mitchellh/cli"
+	"github.com/ryanuber/columnize"
+)
+
+func New(ui cli.Ui) *cmd {
+	c := &cmd{UI: ui}
+	c.init()
+	return c
+}
+
+type cmd struct {
+	UI    cli.Ui
+	flags *flag.FlagSet
+	http  *flags.HTTPFlags
+	help  string
+}
+
+func (c *cmd) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+
+	c.http = &flags.HTTPFlags{}
+	flags.Merge(c.flags, c.http.ClientFlags())
+	flags.Merge(c.flags, c.http.ServerFlags())
+	c.help = flags.Usage(help, c.flags)
+}
+
+func (c *cmd) Run(args []string) int {
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	client, err := c.http.APIClient()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		return 1
+	}
+
+	ixns, _, err := client.Connect().Intentions(nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to retrieve the intentions list: %s", err))
+		return 1
+	}
+
+	if len(ixns) == 0 {
+		c.UI.Error(fmt.Sprintf("There are no intentions."))
+		return 2
+	}
+
+	result := make([]string, 0, len(ixns))
+	header := "ID|Source|Action|Destination|Precedence"
+	result = append(result, header)
+	for _, ixn := range ixns {
+		line := fmt.Sprintf("%s|%s|%s|%s|%d",
+			ixn.ID, ixn.SourceName, ixn.Action, ixn.DestinationName, ixn.Precedence)
+		result = append(result, line)
+	}
+
+	output := columnize.SimpleFormat(result)
+	c.UI.Output(output)
+
+	return 0
+}
+
+func (c *cmd) Synopsis() string {
+	return synopsis
+}
+
+func (c *cmd) Help() string {
+	return c.help
+}
+
+const synopsis = "List connect intentions"
+const help = `
+Usage: consul intention list
+
+  List all consul connect intentions.
+`

--- a/command/intention/list/intention_list_test.go
+++ b/command/intention/list/intention_list_test.go
@@ -1,0 +1,46 @@
+package list
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/api"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntentionListCommand_noTabs(t *testing.T) {
+	t.Parallel()
+	if strings.ContainsRune(New(cli.NewMockUi()).Help(), '\t') {
+		t.Fatal("help has tabs")
+	}
+}
+
+func TestIntentionListCommand(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	a := agent.NewTestAgent(t, t.Name(), ``)
+	defer a.Shutdown()
+	client := a.Client()
+
+	// Create the intention
+	var id string
+	{
+                var err error
+                id, _, err = client.Connect().IntentionCreate(&api.Intention{
+                        SourceName:      "web",
+                        DestinationName: "db",
+                        Action:          api.IntentionActionAllow,
+                }, nil)
+                require.NoError(err)
+        }
+
+	// List all intentions
+	ui := cli.NewMockUi()
+	cmd := New(ui)
+	args := []string{"-http-addr=" + a.HTTPAddr()}
+
+	require.Equal(0, cmd.Run(args), ui.ErrorWriter.String())
+        require.Contains(ui.OutputWriter.String(), id)
+}

--- a/command/intention/list/intention_list_test.go
+++ b/command/intention/list/intention_list_test.go
@@ -27,14 +27,14 @@ func TestIntentionListCommand(t *testing.T) {
 	// Create the intention
 	var id string
 	{
-                var err error
-                id, _, err = client.Connect().IntentionCreate(&api.Intention{
-                        SourceName:      "web",
-                        DestinationName: "db",
-                        Action:          api.IntentionActionAllow,
-                }, nil)
-                require.NoError(err)
-        }
+		var err error
+		id, _, err = client.Connect().IntentionCreate(&api.Intention{
+			SourceName:      "web",
+			DestinationName: "db",
+			Action:          api.IntentionActionAllow,
+		}, nil)
+		require.NoError(err)
+	}
 
 	// List all intentions
 	ui := cli.NewMockUi()
@@ -42,5 +42,5 @@ func TestIntentionListCommand(t *testing.T) {
 	args := []string{"-http-addr=" + a.HTTPAddr()}
 
 	require.Equal(0, cmd.Run(args), ui.ErrorWriter.String())
-        require.Contains(ui.OutputWriter.String(), id)
+	require.Contains(ui.OutputWriter.String(), id)
 }

--- a/website/source/docs/commands/intention.html.md
+++ b/website/source/docs/commands/intention.html.md
@@ -32,6 +32,7 @@ Subcommands:
     create    Create intentions for service connections.
     delete    Delete an intention.
     get       Show information about an intention.
+    list      Show all intentions
     match     Show intentions that match a source or destination.
 ```
 
@@ -47,6 +48,10 @@ Create an intention to allow "web" to talk to "db":
 Test whether a "web" is allowed to connect to "db":
 
     $ consul intention check web db
+
+List all intentions:
+
+    $ consul intention list
 
 Find all intentions for communicating to the "db" service:
 

--- a/website/source/docs/commands/intention/list.html.md.erb
+++ b/website/source/docs/commands/intention/list.html.md.erb
@@ -1,0 +1,19 @@
+---
+layout: "docs"
+page_title: "Commands: Intention List"
+sidebar_current: "docs-commands-intention-list"
+---
+
+# Consul Intention List
+
+Command: `consul intention list`
+
+The `intention list` command shows all intentions including ID and precedence.
+
+## Usage
+
+Usage: `consul intention list`
+
+#### API Options
+
+<%= partial "docs/commands/http_api_options_client" %>


### PR DESCRIPTION
This allows you to see a view similar to what is in the UI while also providing the user with the IDs.

Let me know if a different format is preferred over columns.

Resolves #5652