### PR TITLE
Allow configuration of upstream connection limits in Envoy

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -473,8 +473,8 @@ func makeThresholdsIfNeeded(limits UpstreamLimits) []*envoycluster.CircuitBreake
 	if limits.MaxPendingRequests != 0 {
 		threshold.MaxPendingRequests = makeUint32Value(limits.MaxPendingRequests)
 	}
-	if limits.MaxRequests != 0 {
-		threshold.MaxRequests = makeUint32Value(limits.MaxRequests)
+	if limits.MaxConcurrentRequests != 0 {
+		threshold.MaxRequests = makeUint32Value(limits.MaxConcurrentRequests)
 	}
 
 	return []*envoycluster.CircuitBreakers_Thresholds{threshold}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -467,14 +467,14 @@ func makeThresholdsIfNeeded(limits UpstreamLimits) []*envoycluster.CircuitBreake
 	threshold := &envoycluster.CircuitBreakers_Thresholds{}
 	// Likewise, make sure to not set any threshold values on the zero-value in
 	// order to rely on Envoy defaults
-	if limits.MaxConnections != 0 {
-		threshold.MaxConnections = makeUint32Value(limits.MaxConnections)
+	if limits.MaxConnections != nil {
+		threshold.MaxConnections = makeUint32Value(*limits.MaxConnections)
 	}
-	if limits.MaxPendingRequests != 0 {
-		threshold.MaxPendingRequests = makeUint32Value(limits.MaxPendingRequests)
+	if limits.MaxPendingRequests != nil {
+		threshold.MaxPendingRequests = makeUint32Value(*limits.MaxPendingRequests)
 	}
-	if limits.MaxConcurrentRequests != 0 {
-		threshold.MaxRequests = makeUint32Value(limits.MaxConcurrentRequests)
+	if limits.MaxConcurrentRequests != nil {
+		threshold.MaxRequests = makeUint32Value(*limits.MaxConcurrentRequests)
 	}
 
 	return []*envoycluster.CircuitBreakers_Thresholds{threshold}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -234,6 +234,9 @@ func (s *Server) makeUpstreamClusterForPreparedQuery(upstream structs.Upstream, 
 					},
 				},
 			},
+			CircuitBreakers: &envoycluster.CircuitBreakers{
+				Thresholds: makeThresholdsIfNeeded(cfg.Limits),
+			},
 			// Having an empty config enables outlier detection with default config.
 			OutlierDetection: &envoycluster.OutlierDetection{},
 		}
@@ -338,6 +341,9 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 						Ads: &envoycore.AggregatedConfigSource{},
 					},
 				},
+			},
+			CircuitBreakers: &envoycluster.CircuitBreakers{
+				Thresholds: makeThresholdsIfNeeded(cfg.Limits),
 			},
 			// Having an empty config enables outlier detection with default config.
 			OutlierDetection: &envoycluster.OutlierDetection{},
@@ -448,4 +454,28 @@ func (s *Server) makeMeshGatewayCluster(clusterName string, cfgSnap *proxycfg.Co
 		// Having an empty config enables outlier detection with default config.
 		OutlierDetection: &envoycluster.OutlierDetection{},
 	}, nil
+}
+
+func makeThresholdsIfNeeded(limits UpstreamLimits) []*envoycluster.CircuitBreakers_Thresholds {
+	var empty UpstreamLimits
+	// Make sure to not create any thresholds when passed the zero-value in order
+	// to rely on Envoy defaults
+	if limits == empty {
+		return nil
+	}
+
+	threshold := &envoycluster.CircuitBreakers_Thresholds{}
+	// Likewise, make sure to not set any threshold values on the zero-value in
+	// order to rely on Envoy defaults
+	if limits.MaxConnections != 0 {
+		threshold.MaxConnections = makeUint32Value(limits.MaxConnections)
+	}
+	if limits.MaxPendingRequests != 0 {
+		threshold.MaxPendingRequests = makeUint32Value(limits.MaxPendingRequests)
+	}
+	if limits.MaxRequests != 0 {
+		threshold.MaxRequests = makeUint32Value(limits.MaxRequests)
+	}
+
+	return []*envoycluster.CircuitBreakers_Thresholds{threshold}
 }

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -112,6 +112,42 @@ func TestClustersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name:   "custom-limits-max-connections-only",
+			create: proxycfg.TestConfigSnapshot,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				for i := range snap.Proxy.Upstreams {
+					// We check if Config is nil because the prepared_query upstream is
+					// initialized without a Config map. Use Upstreams[i] syntax to
+					// modify the actual ConfigSnapshot instead of copying the Upstream
+					// in the range.
+					if snap.Proxy.Upstreams[i].Config == nil {
+						snap.Proxy.Upstreams[i].Config = map[string]interface{}{}
+					}
+
+					snap.Proxy.Upstreams[i].Config["limits"] = map[string]interface{}{
+						"max_connections": 500,
+					}
+				}
+			},
+		},
+		{
+			name:   "custom-limits",
+			create: proxycfg.TestConfigSnapshot,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				for i := range snap.Proxy.Upstreams {
+					if snap.Proxy.Upstreams[i].Config == nil {
+						snap.Proxy.Upstreams[i].Config = map[string]interface{}{}
+					}
+
+					snap.Proxy.Upstreams[i].Config["limits"] = map[string]interface{}{
+						"max_connections":      500,
+						"max_pending_requests": 600,
+						"max_requests":         700,
+					}
+				}
+			},
+		},
+		{
 			name:   "connect-proxy-with-chain",
 			create: proxycfg.TestConfigSnapshotDiscoveryChain,
 			setup:  nil,
@@ -313,6 +349,9 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 				"outlierDetection": {
 
 				},
+				"circuitBreakers": {
+
+				},
 				"altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
 				"commonLbConfig": {
 					"healthyPanicThreshold": {}
@@ -333,6 +372,9 @@ func expectClustersJSONResources(t *testing.T, snap *proxycfg.ConfigSnapshot, to
 					}
 				},
 				"outlierDetection": {
+
+				},
+				"circuitBreakers": {
 
 				},
 				"connectTimeout": "5s",

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -140,9 +140,9 @@ func TestClustersFromSnapshot(t *testing.T) {
 					}
 
 					snap.Proxy.Upstreams[i].Config["limits"] = map[string]interface{}{
-						"max_connections":      500,
-						"max_pending_requests": 600,
-						"max_requests":         700,
+						"max_connections":         500,
+						"max_pending_requests":    600,
+						"max_concurrent_requests": 700,
 					}
 				}
 			},

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -131,6 +131,23 @@ func TestClustersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name:   "custom-limits-set-to-zero",
+			create: proxycfg.TestConfigSnapshot,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				for i := range snap.Proxy.Upstreams {
+					if snap.Proxy.Upstreams[i].Config == nil {
+						snap.Proxy.Upstreams[i].Config = map[string]interface{}{}
+					}
+
+					snap.Proxy.Upstreams[i].Config["limits"] = map[string]interface{}{
+						"max_connections":         0,
+						"max_pending_requests":    0,
+						"max_concurrent_requests": 0,
+					}
+				}
+			},
+		},
+		{
 			name:   "custom-limits",
 			create: proxycfg.TestConfigSnapshot,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -104,6 +104,25 @@ func ParseMeshGatewayConfig(m map[string]interface{}) (MeshGatewayConfig, error)
 	return cfg, err
 }
 
+// UpstreamLimits describes the limits that are associated with a specific
+// upstream of a service instance.
+type UpstreamLimits struct {
+	// MaxConnections is the maximum number of connections the local proxy can
+	// make to the upstream service.
+	MaxConnections int `mapstructure:"max_connections"`
+
+	// MaxPendingRequests is the maximum number of requests that will be queued
+	// waiting for an available connection. This is mostly applicable to HTTP/1.1
+	// clusters since all HTTP/2 requests are streamed over a single
+	// connection.
+	MaxPendingRequests int `mapstructure:"max_pending_requests"`
+
+	// MaxRequests is the maximum number of in-flight requests that will be allowed
+	// to the upstream cluster at a point in time. This is mostly applicable to HTTP/2
+	// clusters since all HTTP/1.1 requests are limited by MaxConnections.
+	MaxRequests int `mapstructure:"max_requests"`
+}
+
 // UpstreamConfig describes the keys we understand from
 // Connect.Proxy.Upstream[*].Config.
 type UpstreamConfig struct {
@@ -131,6 +150,10 @@ type UpstreamConfig struct {
 	// ConnectTimeoutMs is the number of milliseconds to timeout making a new
 	// connection to this upstream. Defaults to 5000 (5 seconds) if not set.
 	ConnectTimeoutMs int `mapstructure:"connect_timeout_ms"`
+
+	// Limits are the set of limits that are applied to the proxy for a specific upstream of a
+	// service instance.
+	Limits UpstreamLimits `mapstructure:"limits"`
 }
 
 func ParseUpstreamConfigNoDefaults(m map[string]interface{}) (UpstreamConfig, error) {

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -117,10 +117,10 @@ type UpstreamLimits struct {
 	// connection.
 	MaxPendingRequests int `mapstructure:"max_pending_requests"`
 
-	// MaxRequests is the maximum number of in-flight requests that will be allowed
+	// MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed
 	// to the upstream cluster at a point in time. This is mostly applicable to HTTP/2
 	// clusters since all HTTP/1.1 requests are limited by MaxConnections.
-	MaxRequests int `mapstructure:"max_requests"`
+	MaxConcurrentRequests int `mapstructure:"max_concurrent_requests"`
 }
 
 // UpstreamConfig describes the keys we understand from

--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -109,18 +109,18 @@ func ParseMeshGatewayConfig(m map[string]interface{}) (MeshGatewayConfig, error)
 type UpstreamLimits struct {
 	// MaxConnections is the maximum number of connections the local proxy can
 	// make to the upstream service.
-	MaxConnections int `mapstructure:"max_connections"`
+	MaxConnections *int `mapstructure:"max_connections"`
 
 	// MaxPendingRequests is the maximum number of requests that will be queued
 	// waiting for an available connection. This is mostly applicable to HTTP/1.1
 	// clusters since all HTTP/2 requests are streamed over a single
 	// connection.
-	MaxPendingRequests int `mapstructure:"max_pending_requests"`
+	MaxPendingRequests *int `mapstructure:"max_pending_requests"`
 
 	// MaxConcurrentRequests is the maximum number of in-flight requests that will be allowed
 	// to the upstream cluster at a point in time. This is mostly applicable to HTTP/2
 	// clusters since all HTTP/1.1 requests are limited by MaxConnections.
-	MaxConcurrentRequests int `mapstructure:"max_concurrent_requests"`
+	MaxConcurrentRequests *int `mapstructure:"max_concurrent_requests"`
 }
 
 // UpstreamConfig describes the keys we understand from

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -205,6 +205,25 @@ func TestParseUpstreamConfig(t *testing.T) {
 				Protocol:         "tcp",
 			},
 		},
+		{
+			name: "connect limits map",
+			input: map[string]interface{}{
+				"limits": map[string]interface{}{
+					"max_connections":      50,
+					"max_pending_requests": 60,
+					"max_requests":         70,
+				},
+			},
+			want: UpstreamConfig{
+				ConnectTimeoutMs: 5000,
+				Protocol:         "tcp",
+				Limits: UpstreamLimits{
+					MaxConnections:     50,
+					MaxPendingRequests: 60,
+					MaxRequests:        70,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -218,9 +218,28 @@ func TestParseUpstreamConfig(t *testing.T) {
 				ConnectTimeoutMs: 5000,
 				Protocol:         "tcp",
 				Limits: UpstreamLimits{
-					MaxConnections:        50,
-					MaxPendingRequests:    60,
-					MaxConcurrentRequests: 70,
+					MaxConnections:        intPointer(50),
+					MaxPendingRequests:    intPointer(60),
+					MaxConcurrentRequests: intPointer(70),
+				},
+			},
+		},
+		{
+			name: "connect limits map zero",
+			input: map[string]interface{}{
+				"limits": map[string]interface{}{
+					"max_connections":         0,
+					"max_pending_requests":    0,
+					"max_concurrent_requests": 0,
+				},
+			},
+			want: UpstreamConfig{
+				ConnectTimeoutMs: 5000,
+				Protocol:         "tcp",
+				Limits: UpstreamLimits{
+					MaxConnections:        intPointer(0),
+					MaxPendingRequests:    intPointer(0),
+					MaxConcurrentRequests: intPointer(0),
 				},
 			},
 		},
@@ -232,4 +251,8 @@ func TestParseUpstreamConfig(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func intPointer(i int) *int {
+	return &i
 }

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -209,18 +209,18 @@ func TestParseUpstreamConfig(t *testing.T) {
 			name: "connect limits map",
 			input: map[string]interface{}{
 				"limits": map[string]interface{}{
-					"max_connections":      50,
-					"max_pending_requests": 60,
-					"max_requests":         70,
+					"max_connections":         50,
+					"max_pending_requests":    60,
+					"max_concurrent_requests": 70,
 				},
 			},
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 5000,
 				Protocol:         "tcp",
 				Limits: UpstreamLimits{
-					MaxConnections:     50,
-					MaxPendingRequests: 60,
-					MaxRequests:        70,
+					MaxConnections:        50,
+					MaxPendingRequests:    60,
+					MaxConcurrentRequests: 70,
 				},
 			},
 		},

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-failover.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-and-overrides.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "66s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -61,6 +64,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain-external-sni.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-chain.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-chain.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway-triggered.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-local-gateway.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway-triggered.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-double-failover-through-remote-gateway.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway-triggered.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-local-gateway.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway-triggered.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.golden
+++ b/agent/xds/testdata/clusters/connect-proxy-with-tcp-chain-failover-through-remote-gateway.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "33s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/custom-limits-max-connections-only.golden
+++ b/agent/xds/testdata/clusters/custom-limits-max-connections-only.golden
@@ -15,7 +15,11 @@
       },
       "connectTimeout": "5s",
       "circuitBreakers": {
-
+        "thresholds": [
+          {
+            "maxConnections": 500
+          }
+        ]
       },
       "tlsContext": {
         "commonTlsContext": {
@@ -62,7 +66,11 @@
       },
       "connectTimeout": "5s",
       "circuitBreakers": {
-
+        "thresholds": [
+          {
+            "maxConnections": 500
+          }
+        ]
       },
       "tlsContext": {
         "commonTlsContext": {
@@ -93,16 +101,28 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "mylocal",
-      "connectTimeout": "15s",
-      "hosts": [
-        {
-          "socketAddress": {
-            "address": "127.0.0.1",
-            "portValue": 8080
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
           }
-        }
-      ]
+        ]
+      }
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",

--- a/agent/xds/testdata/clusters/custom-limits-set-to-zero.golden
+++ b/agent/xds/testdata/clusters/custom-limits-set-to-zero.golden
@@ -1,0 +1,134 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "circuitBreakers": {
+        "thresholds": [
+          {
+            "maxConnections": 0,
+            "maxPendingRequests": 0,
+            "maxRequests": 0
+          }
+        ]
+      },
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "outlierDetection": {
+
+      },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {
+
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "circuitBreakers": {
+        "thresholds": [
+          {
+            "maxConnections": 0,
+            "maxPendingRequests": 0,
+            "maxRequests": 0
+          }
+        ]
+      },
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "geo-cache.default.dc1.query.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "outlierDetection": {
+
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/clusters/custom-limits.golden
+++ b/agent/xds/testdata/clusters/custom-limits.golden
@@ -15,7 +15,13 @@
       },
       "connectTimeout": "5s",
       "circuitBreakers": {
-
+        "thresholds": [
+          {
+            "maxConnections": 500,
+            "maxPendingRequests": 600,
+            "maxRequests": 700
+          }
+        ]
       },
       "tlsContext": {
         "commonTlsContext": {
@@ -62,7 +68,13 @@
       },
       "connectTimeout": "5s",
       "circuitBreakers": {
-
+        "thresholds": [
+          {
+            "maxConnections": 500,
+            "maxPendingRequests": 600,
+            "maxRequests": 700
+          }
+        ]
       },
       "tlsContext": {
         "commonTlsContext": {
@@ -93,16 +105,28 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.Cluster",
-      "name": "mylocal",
-      "connectTimeout": "15s",
-      "hosts": [
-        {
-          "socketAddress": {
-            "address": "127.0.0.1",
-            "portValue": 8080
+      "name": "local_app",
+      "type": "STATIC",
+      "connectTimeout": "5s",
+      "loadAssignment": {
+        "clusterName": "local_app",
+        "endpoints": [
+          {
+            "lbEndpoints": [
+              {
+                "endpoint": {
+                  "address": {
+                    "socketAddress": {
+                      "address": "127.0.0.1",
+                      "portValue": 8080
+                    }
+                  }
+                }
+              }
+            ]
           }
-        }
-      ]
+        ]
+      }
     }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",

--- a/agent/xds/testdata/clusters/custom-timeouts.golden
+++ b/agent/xds/testdata/clusters/custom-timeouts.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/custom-upstream-default-chain.golden
+++ b/agent/xds/testdata/clusters/custom-upstream-default-chain.golden
@@ -13,6 +13,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/custom-upstream.golden
+++ b/agent/xds/testdata/clusters/custom-upstream.golden
@@ -13,6 +13,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/defaults.golden
+++ b/agent/xds/testdata/clusters/defaults.golden
@@ -14,6 +14,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -58,6 +61,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/agent/xds/testdata/clusters/splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/clusters/splitter-with-resolver-redirect.golden
@@ -13,6 +13,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -78,6 +81,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {
@@ -123,6 +129,9 @@
         }
       },
       "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
       "tlsContext": {
         "commonTlsContext": {
           "tlsParams": {

--- a/test/integration/connect/envoy/case-upstream-connection-limits/s1.hcl
+++ b/test/integration/connect/envoy/case-upstream-connection-limits/s1.hcl
@@ -12,7 +12,7 @@ services {
               limits {
                 max_connections = 3
                 max_pending_requests = 4
-                max_requests = 5
+                max_concurrent_requests = 5
               }
             }
           }

--- a/test/integration/connect/envoy/case-upstream-connection-limits/s1.hcl
+++ b/test/integration/connect/envoy/case-upstream-connection-limits/s1.hcl
@@ -1,0 +1,23 @@
+services {
+  name = "s1"
+  port = 8080
+  connect {
+    sidecar_service {
+      proxy {
+        upstreams = [
+          {
+            destination_name = "s2"
+            local_bind_port = 5000
+            config {
+              limits {
+                max_connections = 3
+                max_pending_requests = 4
+                max_requests = 5
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/integration/connect/envoy/case-upstream-connection-limits/s2.hcl
+++ b/test/integration/connect/envoy/case-upstream-connection-limits/s2.hcl
@@ -1,0 +1,5 @@
+services {
+  name = "s2"
+  port = 8181
+  connect { sidecar_service {} }
+}

--- a/test/integration/connect/envoy/case-upstream-connection-limits/setup.sh
+++ b/test/integration/connect/envoy/case-upstream-connection-limits/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
+gen_envoy_bootstrap s1 19000 primary
+gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-upstream-connection-limits/verify.bats
+++ b/test/integration/connect/envoy/case-upstream-connection-limits/verify.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1
+}
+
+@test "s1 upstream should have healthy endpoints for s2" {
+  assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1
+}
+
+@test "s1 proxy should have been configured with max_connections on the cluster" {
+  CLUSTER_THRESHOLD=$(get_envoy_cluster_threshold localhost:19000 s2.default.primary)
+  echo $CLUSTER_THRESHOLD
+
+  MAX_CONNS=$(echo $CLUSTER_THRESHOLD | jq  --raw-output '.max_connections')
+  MAX_PENDING_REQS=$(echo $CLUSTER_THRESHOLD | jq  --raw-output '.max_pending_requests')
+  MAX_REQS=$(echo $CLUSTER_THRESHOLD | jq  --raw-output '.max_requests')
+
+  echo "MAX_CONNS = $MAX_CONNS"
+  echo "MAX_PENDING_REQS = $MAX_PENDING_REQS"
+  echo "MAX_REQS = $MAX_REQS"
+
+  [ "$MAX_CONNS" = "3" ]
+  [ "$MAX_PENDING_REQS" = "4" ]
+  [ "$MAX_REQS" = "5" ]
+}

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -256,6 +256,19 @@ definition](/docs/connect/registration/service-registration.html) or
     proxy upstream config will override any values defined in config entries.
     It is supported here for backwards compatibility with Consul versions prior to 1.6.0.
 
+- `limits` - A set of limits to apply when connecting to the upstream service.
+  These limits are applied on a per-service-instance basis.  The following
+  limits are respected:
+
+  - `max_connections` - The maximum number of connections a service instance
+    will be allowed to establish against the given upstream.
+  - `max_pending_requests` - The maximum number of requests that will be queued
+    while waiting for a connection to be established. For this configuration to
+    be respected, a L7 protocol must be defined in the `protocol` field.
+  - `max_concurrent_requests` - The maximum number of concurrent requests that
+    will be allowed at a single point in time. For this configuration to be
+    respected, a L7 protocol must be defined in the `protocol` field.
+
 ### Mesh Gateway Options
 
 These fields may also be overridden explicitly in the [proxy service

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -261,12 +261,14 @@ definition](/docs/connect/registration/service-registration.html) or
   limits are respected:
 
   - `max_connections` - The maximum number of connections a service instance
-    will be allowed to establish against the given upstream.
+    will be allowed to establish against the given upstream. Use this to limit
+    HTTP/1.1 traffic, since HTTP/1.1 has a request per connection.
   - `max_pending_requests` - The maximum number of requests that will be queued
     while waiting for a connection to be established. For this configuration to
     be respected, a L7 protocol must be defined in the `protocol` field.
   - `max_concurrent_requests` - The maximum number of concurrent requests that
-    will be allowed at a single point in time. For this configuration to be
+    will be allowed at a single point in time. Use this to limit HTTP/2 traffic,
+    since HTTP/2 has many requests per connection. For this configuration to be
     respected, a L7 protocol must be defined in the `protocol` field.
 
 ### Mesh Gateway Options

--- a/website/source/docs/connect/registration/service-registration.html.md
+++ b/website/source/docs/connect/registration/service-registration.html.md
@@ -184,10 +184,10 @@ followed by documentation for each attribute.
   any valid JSON object. This might be used to configure proxy-specific features
   like timeouts or retries for the given upstream. See the [built-in proxy
   configuration
-  reference](/docs/connect/configuration.html#built-in-proxy-options) for
+  reference](/docs/connect/proxies/built-in.html#proxy-upstream-config-key-reference) for
   options available when using the built-in proxy. If using Envoy as a proxy,
   see [Envoy configuration
-  reference](/docs/connect/configuration.html#envoy-options)
+  reference](/docs/connect/proxies/envoy.html#proxy-upstream-config-options)
 * `mesh_gateway` `(object: {})` - Specifies the mesh gateway configuration
    for this proxy. The format is defined in the [Mesh Gateway Configuration Reference](#mesh-gateway-configuration-reference).
 * `expose` `(object: {})` - Specifies the configuration to expose HTTP paths through this proxy. 


### PR DESCRIPTION
Fixes #6359 

This PR adds a `limits` field to the upstream configuration of a connect envoy proxy. This `limits` field is intended to contain configuration regarding connections/requests of the given service to the specified upstream, such as `max_connections`, `max_pending_requests`, and `max_requests`.

This is currently only allowed on the `proxy.upstreams[*].config` part of the service definition, a future improvement would be to allow these upstream configurations to be set in a service's `service-defaults` central config.

Example:
```
services {
  name = "s1"
  port = 8080
  connect {
    sidecar_service {
      proxy {
        upstreams = [
          {
            destination_name = "s2"
            local_bind_port = 5000
            config {
              limits {
                max_connections = 3
                max_pending_requests = 4
                max_requests = 5
              }
            }
          }
        ]
      }
    }
  }
}
```

## UX

Some relevant UX decisions I made, looking for feedback on this.

### Limits Block

I chose to scope this section under a `limits` block in order to more concretely define them as related, as well as simplify the implementation. This should be a natural place to add more related configuration if necessary as well.

I considered naming this something to the effect of `connection_limits`, but felt that was a little too wordy when typing.

### max_* Naming

After looking into the big three proxy configuration (Envoy, Nginx, HAProxy), I eventually settled on keeping the naming that Envoy uses for these values.

For `max_connections` and `max_pending_requests`, all three had similar configuration values, although they varied in whether those values were set on a per-server or per-{cluster,frontend} basis.

For `max_requests`, this represents the max allowed in-flight requests to an upstream cluster by Envoy. This is mostly useful in a HTTP/2 context, since HTTP/1.1 requests are mostly bounded by the max_connections parameter. I was not able to find an equivalent configuration option in HAProxy or Nginx.

I also considered changing `max_requests` to `max_inflight_requests` or `max_concurrent_requests` to be more specific in naming, but decided it was better to keep 100% consistent with Envoy than to change a single name.

## TODO

- [x] Update all related documentation with this new configuration value.
- [x] Decide whether to support `service-defaults` in this PR or future one.