### PR TITLE
docs: Fix links to Sentinel docs for Consul

### DIFF
--- a/website/source/docs/acl/acl-legacy.html.md
+++ b/website/source/docs/acl/acl-legacy.html.md
@@ -804,7 +804,7 @@ A token with `write` access on a prefix also has `list` access. A token with `li
 #### Sentinel Integration
 
 Consul Enterprise supports additional optional fields for key write policies for
-[Sentinel](https://docs.hashicorp.com/sentinel/app/consul/) integration. An example key rule with a
+[Sentinel](https://docs.hashicorp.com/sentinel/consul/) integration. An example key rule with a
 Sentinel code policy looks like this:
 
 ```hcl

--- a/website/source/docs/acl/acl-rules.html.md
+++ b/website/source/docs/acl/acl-rules.html.md
@@ -263,7 +263,7 @@ A token with `write` access on a prefix also has `list` access. A token with `li
 #### Sentinel Integration
 
 Consul Enterprise supports additional optional fields for key write policies for
-[Sentinel](https://docs.hashicorp.com/sentinel/app/consul/) integration. An example key rule with a
+[Sentinel](https://docs.hashicorp.com/sentinel/consul/) integration. An example key rule with a
 Sentinel code policy looks like this:
 
 ```hcl

--- a/website/source/docs/enterprise/sentinel/index.html.markdown.erb
+++ b/website/source/docs/enterprise/sentinel/index.html.markdown.erb
@@ -12,7 +12,7 @@ and "deny" policies to support full conditional logic and integration with
 external systems. [Learn more about Sentinel here.](https://docs.hashicorp.com/sentinel/concepts/).
 
 To get started with Sentinel in Consul,
-[read the general documentation](https://docs.hashicorp.com/sentinel/app/consul/) or
+[read the general documentation](https://docs.hashicorp.com/sentinel/consul/) or
 [Consul documentation](/docs/agent/sentinel.html).
 
 

--- a/website/source/docs/guides/acl-legacy.html.md
+++ b/website/source/docs/guides/acl-legacy.html.md
@@ -791,7 +791,7 @@ A token with `write` access on a prefix also has `list` access. A token with `li
 #### Sentinel Integration
 
 Consul Enterprise supports additional optional fields for key write policies for
-[Sentinel](https://docs.hashicorp.com/sentinel/app/consul/) integration. An example key rule with a
+[Sentinel](https://docs.hashicorp.com/sentinel/consul/) integration. An example key rule with a
 Sentinel code policy looks like this:
 
 ```text


### PR DESCRIPTION
Current URL returns a 404 error. Correct links to point to the proper URL.