### PR TITLE
[docs] fix: the links to l7-observability-k8s are broken

### DIFF
--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -56,7 +56,7 @@ There are several ways to try Connect in different environments.
    chart, and using intentions. You can run the guide on Minikube or an existing
    Kubernetes cluster.
 
- - The [observability guide](https://learn.hashicorp.com/consul/getting-started-k8s/l7-observability-k8s)
+ - The [observability guide](https://learn.hashicorp.com/consul/kubernetes/l7-observability-k8s)
    shows how to deploy a basic metrics collection and visualization pipeline on
    a Minikube or Kubernetes cluster using the official Helm charts for Consul,
    Prometheus, and Grafana.

--- a/website/source/docs/connect/observability.html.md
+++ b/website/source/docs/connect/observability.html.md
@@ -27,7 +27,7 @@ configuration](/docs/agent/options.html#enable_central_service_config).
 If you
 are using Kubernetes, the Helm chart can simplify much of the necessary
 configuration, which you can learn about in the [observability
-guide](https://learn.hashicorp.com/consul/getting-started-k8s/l7-observability-k8s).
+guide](https://learn.hashicorp.com/consul/kubernetes/l7-observability-k8s).
 
 ### Metrics Destination
 


### PR DESCRIPTION
`observability guild` link leads to result in 404.
I guess redirection is wrong. 
```
$ curl https://learn.hashicorp.com/consul/getting-started-k8s/l7-observability-k8s
Redirecting to /consul/developer-mesh/l7-observability-k8s
```
This PR fixes with the original URL.