### PR TITLE
Check if intermediate cert needs to be renewed.

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -621,9 +621,10 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	if connectCAConfig != nil {
 		lib.TranslateKeys(connectCAConfig, map[string]string{
 			// Consul CA config
-			"private_key":     "PrivateKey",
-			"root_cert":       "RootCert",
-			"rotation_period": "RotationPeriod",
+			"private_key":           "PrivateKey",
+			"root_cert":             "RootCert",
+			"rotation_period":       "RotationPeriod",
+			"intermediate_cert_ttl": "IntermediateCertTTL",
 
 			// Vault CA config
 			"address":               "Address",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3764,6 +3764,7 @@ func TestFullConfig(t *testing.T) {
 				"ca_provider": "consul",
 				"ca_config": {
 					"rotation_period": "90h",
+					"intermediate_cert_ttl": "8760h",
 					"leaf_cert_ttl": "1h",
 					"csr_max_per_second": 100,
 					"csr_max_concurrent": 2
@@ -4363,6 +4364,7 @@ func TestFullConfig(t *testing.T) {
 				ca_provider = "consul"
 				ca_config {
 					rotation_period = "90h"
+					intermediate_cert_ttl = "8760h"
 					leaf_cert_ttl = "1h"
 					# hack float since json parses numbers as float and we have to
 					# assert against the same thing
@@ -5073,10 +5075,11 @@ func TestFullConfig(t *testing.T) {
 		ExposeMaxPort:         2222,
 		ConnectCAProvider:     "consul",
 		ConnectCAConfig: map[string]interface{}{
-			"RotationPeriod":   "90h",
-			"LeafCertTTL":      "1h",
-			"CSRMaxPerSecond":  float64(100),
-			"CSRMaxConcurrent": float64(2),
+			"RotationPeriod":      "90h",
+			"IntermediateCertTTL": "8760h",
+			"LeafCertTTL":         "1h",
+			"CSRMaxPerSecond":     float64(100),
+			"CSRMaxConcurrent":    float64(2),
 		},
 		DNSAddrs:                         []net.Addr{tcpAddr("93.95.95.81:7001"), udpAddr("93.95.95.81:7001")},
 		DNSARecordLimit:                  29907,

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -463,8 +463,7 @@ func (c *ConsulProvider) SignIntermediate(csr *x509.CertificateRequest) (string,
 	// Sign the certificate valid from 1 minute in the past, this helps it be
 	// accepted right away even when nodes are not in close time sync across the
 	// cluster. A minute is more than enough for typical DC clock drift.
-	extra := time.Minute
-	effectiveNow := time.Now().Add(-1 * extra)
+	effectiveNow := time.Now().Add(-1 * time.Minute)
 	template := x509.Certificate{
 		SerialNumber:          sn,
 		Subject:               csr.Subject,
@@ -479,7 +478,7 @@ func (c *ConsulProvider) SignIntermediate(csr *x509.CertificateRequest) (string,
 			x509.KeyUsageDigitalSignature,
 		IsCA:           true,
 		MaxPathLenZero: true,
-		NotAfter:       effectiveNow.Add(c.config.IntermediateCertTTL + extra),
+		NotAfter:       effectiveNow.Add(c.config.IntermediateCertTTL),
 		NotBefore:      effectiveNow,
 		SubjectKeyId:   subjectKeyID,
 	}

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -463,7 +463,8 @@ func (c *ConsulProvider) SignIntermediate(csr *x509.CertificateRequest) (string,
 	// Sign the certificate valid from 1 minute in the past, this helps it be
 	// accepted right away even when nodes are not in close time sync across the
 	// cluster. A minute is more than enough for typical DC clock drift.
-	effectiveNow := time.Now().Add(-1 * time.Minute)
+	extra := time.Minute
+	effectiveNow := time.Now().Add(-1 * extra)
 	template := x509.Certificate{
 		SerialNumber:          sn,
 		Subject:               csr.Subject,
@@ -478,7 +479,7 @@ func (c *ConsulProvider) SignIntermediate(csr *x509.CertificateRequest) (string,
 			x509.KeyUsageDigitalSignature,
 		IsCA:           true,
 		MaxPathLenZero: true,
-		NotAfter:       effectiveNow.Add(c.config.IntermediateCertTTL),
+		NotAfter:       effectiveNow.Add(c.config.IntermediateCertTTL + extra),
 		NotBefore:      effectiveNow,
 		SubjectKeyId:   subjectKeyID,
 	}

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -478,7 +478,7 @@ func (c *ConsulProvider) SignIntermediate(csr *x509.CertificateRequest) (string,
 			x509.KeyUsageDigitalSignature,
 		IsCA:           true,
 		MaxPathLenZero: true,
-		NotAfter:       effectiveNow.AddDate(1, 0, 0),
+		NotAfter:       effectiveNow.Add(c.config.IntermediateCertTTL),
 		NotBefore:      effectiveNow,
 		SubjectKeyId:   subjectKeyID,
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -68,7 +68,8 @@ func testConsulCAConfig() *structs.CAConfiguration {
 		Provider:  "consul",
 		Config: map[string]interface{}{
 			// Tests duration parsing after msgpack type mangling during raft apply.
-			"LeafCertTTL": []uint8("72h"),
+			"LeafCertTTL":         []uint8("72h"),
+			"IntermediateCertTTL": []uint8("72h"),
 		},
 	}
 }

--- a/agent/connect/testing_ca.go
+++ b/agent/connect/testing_ca.go
@@ -361,9 +361,10 @@ func testCAConfigSet(t testing.T, a TestAgentRPC,
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     ca.SigningKey,
-			"RootCert":       ca.RootCert,
-			"RotationPeriod": 180 * 24 * time.Hour,
+			"PrivateKey":          ca.SigningKey,
+			"RootCert":            ca.RootCert,
+			"RotationPeriod":      180 * 24 * time.Hour,
+			"IntermediateCertTTL": 72 * time.Hour,
 		},
 	}
 	args := &structs.CARequest{

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -90,6 +90,28 @@ func TestConnectCAConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "basic with IntermediateCertTTL",
+			body: `
+			{
+				"Provider": "consul",
+				"Config": {
+					"LeafCertTTL": "72h",
+					"RotationPeriod": "1h",
+					"IntermediateCertTTL": "2h"
+				}
+			}`,
+			wantErr: false,
+			wantCfg: structs.CAConfiguration{
+				Provider:  "consul",
+				ClusterID: connect.TestClusterID,
+				Config: map[string]interface{}{
+					"LeafCertTTL":         "72h",
+					"RotationPeriod":      "1h",
+					"IntermediateCertTTL": "2h",
+				},
+			},
+		},
+		{
 			name: "force without cross sign CamelCase",
 			body: `
 			{
@@ -211,7 +233,6 @@ func TestConnectCAConfig(t *testing.T) {
 				}
 				require.NoError(err)
 			}
-
 			// The config should be updated now.
 			{
 				req, _ := http.NewRequest("GET", "/v1/connect/ca/configuration", nil)

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -549,8 +549,9 @@ func DefaultConfig() *Config {
 		CAConfig: &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"RotationPeriod": "2160h",
-				"LeafCertTTL":    "72h",
+				"RotationPeriod":      "2160h",
+				"LeafCertTTL":         "72h",
+				"IntermediateCertTTL": "8760h", // 365 * 24h
 			},
 		},
 

--- a/agent/consul/fsm/commands_oss_test.go
+++ b/agent/consul/fsm/commands_oss_test.go
@@ -1280,9 +1280,10 @@ func TestFSM_CAConfig(t *testing.T) {
 		Config: &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"PrivateKey":     "asdf",
-				"RootCert":       "qwer",
-				"RotationPeriod": 90 * 24 * time.Hour,
+				"PrivateKey":          "asdf",
+				"RootCert":            "qwer",
+				"RotationPeriod":      90 * 24 * time.Hour,
+				"IntermediateCertTTL": 365 * 24 * time.Hour,
 			},
 		},
 	}
@@ -1312,6 +1313,9 @@ func TestFSM_CAConfig(t *testing.T) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 	if got, want := conf.RotationPeriod, 90*24*time.Hour; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if got, want := conf.IntermediateCertTTL, 365*24*time.Hour; got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}
 

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -344,7 +344,7 @@ func (s *Server) initializeSecondaryCA(provider ca.Provider, primaryRoots struct
 
 		storedRootID, err = connect.CalculateCertFingerprint(storedRoot)
 		if err != nil {
-			return fmt.Errorf("error parsing root fingerprint: %v, %#v", err, primaryRoots)
+			return fmt.Errorf("error parsing root fingerprint: %v, %#v", err, storedRoot)
 		}
 
 		intermediateCert, err := connect.ParseCert(activeIntermediate)

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -162,6 +162,134 @@ func TestLeader_SecondaryCA_Initialize(t *testing.T) {
 	}
 }
 
+func waitForActiveCARoot(t *testing.T, srv *Server, expect *structs.CARoot) {
+	retry.Run(t, func(r *retry.R) {
+		_, root := srv.getCAProvider()
+		if root == nil {
+			r.Fatal("no root")
+		}
+		if root.ID != expect.ID {
+			r.Fatalf("current active root is %s; waiting for %s", root.ID, expect.ID)
+		}
+	})
+}
+
+func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
+	t.Parallel()
+
+	certRenewalTimeout = 1 * time.Millisecond
+	require := require.New(t)
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.Build = "1.6.0"
+		c.CAConfig = &structs.CAConfiguration{
+			Provider: "consul",
+			Config: map[string]interface{}{
+				"PrivateKey":     "",
+				"RootCert":       "",
+				"RotationPeriod": "2160h",
+				"LeafCertTTL":    "72h",
+				// The retry loop only retries for 7sec max and
+				// the ttl needs to be below so that it
+				// triggers definitely.
+				"IntermediateCertTTL": 5 * time.Second,
+			},
+		}
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	// dc2 as a secondary DC
+	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.PrimaryDatacenter = "dc1"
+		c.Build = "1.6.0"
+	})
+	defer os.RemoveAll(dir2)
+	defer s2.Shutdown()
+
+	// Create the WAN link
+	joinWAN(t, s2, s1)
+	testrpc.WaitForLeader(t, s2.RPC, "dc2")
+
+	// Get the original intermediate
+	secondaryProvider, _ := s2.getCAProvider()
+	intermediatePEM, err := secondaryProvider.ActiveIntermediate()
+	require.NoError(err)
+	cert, err := connect.ParseCert(intermediatePEM)
+	require.NoError(err)
+	currentCertSerialNumber := cert.SerialNumber
+	currentCertAuthorityKeyId := cert.AuthorityKeyId
+
+	// Capture the current root
+	var originalRoot *structs.CARoot
+	{
+		rootList, activeRoot, err := getTestRoots(s1, "dc1")
+		require.NoError(err)
+		require.Len(rootList.Roots, 1)
+		originalRoot = activeRoot
+	}
+
+	waitForActiveCARoot(t, s1, originalRoot)
+	waitForActiveCARoot(t, s2, originalRoot)
+
+	// Wait for dc2's intermediate to be refreshed.
+	// It is possible that test fails when the blocking query doesn't return.
+	// When https://github.com/hashicorp/consul/pull/3777 is merged
+	// however, defaultQueryTime will be configurable and we con lower it
+	// so that it returns for sure.
+	retry.Run(t, func(r *retry.R) {
+		secondaryProvider, _ := s2.getCAProvider()
+		intermediatePEM, err = secondaryProvider.ActiveIntermediate()
+		r.Check(err)
+		cert, err := connect.ParseCert(intermediatePEM)
+		r.Check(err)
+		if cert.SerialNumber.Cmp(currentCertSerialNumber) == 0 || !reflect.DeepEqual(cert.AuthorityKeyId, currentCertAuthorityKeyId) {
+			currentCertSerialNumber = cert.SerialNumber
+			currentCertAuthorityKeyId = cert.AuthorityKeyId
+			r.Fatal("not a renewed intermediate")
+		}
+	})
+	require.NoError(err)
+
+	// Get the new root from dc1 and validate a chain of:
+	// dc2 leaf -> dc2 intermediate -> dc1 root
+	_, caRoot := s1.getCAProvider()
+
+	// Have dc2 sign a leaf cert and make sure the chain is correct.
+	spiffeService := &connect.SpiffeIDService{
+		Host:       "node1",
+		Namespace:  "default",
+		Datacenter: "dc1",
+		Service:    "foo",
+	}
+	raw, _ := connect.TestCSR(t, spiffeService)
+
+	leafCsr, err := connect.ParseCSR(raw)
+	require.NoError(err)
+
+	leafPEM, err := secondaryProvider.Sign(leafCsr)
+	require.NoError(err)
+
+	cert, err = connect.ParseCert(leafPEM)
+	require.NoError(err)
+
+	// Check that the leaf signed by the new intermediate can be verified using the
+	// returned cert chain (signed intermediate + remote root).
+	intermediatePool := x509.NewCertPool()
+	intermediatePool.AppendCertsFromPEM([]byte(intermediatePEM))
+	rootPool := x509.NewCertPool()
+	rootPool.AppendCertsFromPEM([]byte(caRoot.RootCert))
+
+	_, err = cert.Verify(x509.VerifyOptions{
+		Intermediates: intermediatePool,
+		Roots:         rootPool,
+	})
+	require.NoError(err)
+}
+
 func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	t.Parallel()
 
@@ -214,9 +342,10 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 	newConfig := &structs.CAConfiguration{
 		Provider: "consul",
 		Config: map[string]interface{}{
-			"PrivateKey":     newKey,
-			"RootCert":       "",
-			"RotationPeriod": 90 * 24 * time.Hour,
+			"PrivateKey":          newKey,
+			"RootCert":            "",
+			"RotationPeriod":      90 * 24 * time.Hour,
+			"IntermediateCertTTL": 72 * 24 * time.Hour,
 		},
 	}
 	{
@@ -1291,4 +1420,14 @@ func readTestData(t *testing.T, name string) string {
 		t.Fatalf("failed reading fixture file %s: %s", name, err)
 	}
 	return string(bs)
+}
+
+func TestLeader_lessThanHalfTimePassed(t *testing.T) {
+	now := time.Now()
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(-5*time.Second)))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(5*time.Second)))
+	require.False(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(10*time.Second)))
+
+	require.True(t, lessThanHalfTimePassed(now, now.Add(-10*time.Second), now.Add(20*time.Second)))
 }

--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -177,7 +177,7 @@ func waitForActiveCARoot(t *testing.T, srv *Server, expect *structs.CARoot) {
 func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 	t.Parallel()
 
-	certRenewalTimeout = 1 * time.Millisecond
+	intermediateCertRenewInterval = time.Millisecond
 	require := require.New(t)
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -192,7 +192,11 @@ func TestLeader_SecondaryCA_IntermediateRenew(t *testing.T) {
 				// The retry loop only retries for 7sec max and
 				// the ttl needs to be below so that it
 				// triggers definitely.
-				"IntermediateCertTTL": 5 * time.Second,
+				// Since certs are created so that they are
+				// valid from 1minute in the past, we need to
+				// account for that, otherwise it will be
+				// expired immediately.
+				"IntermediateCertTTL": time.Minute + (5 * time.Second),
 			},
 		}
 	})

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -127,6 +127,8 @@ type Server struct {
 	// autopilotWaitGroup is used to block until Autopilot shuts down.
 	autopilotWaitGroup sync.WaitGroup
 
+	// caProviderReconfigurationLock guards the provider reconfiguration.
+	caProviderReconfigurationLock sync.Mutex
 	// caProvider is the current CA provider in use for Connect. This is
 	// only non-nil when we are the leader.
 	caProvider ca.Provider

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -89,16 +89,17 @@ const (
 )
 
 const (
-	legacyACLReplicationRoutineName = "legacy ACL replication"
-	aclPolicyReplicationRoutineName = "ACL policy replication"
-	aclRoleReplicationRoutineName   = "ACL role replication"
-	aclTokenReplicationRoutineName  = "ACL token replication"
-	aclTokenReapingRoutineName      = "acl token reaping"
-	aclUpgradeRoutineName           = "legacy ACL token upgrade"
-	caRootPruningRoutineName        = "CA root pruning"
-	configReplicationRoutineName    = "config entry replication"
-	intentionReplicationRoutineName = "intention replication"
-	secondaryCARootWatchRoutineName = "secondary CA roots watch"
+	legacyACLReplicationRoutineName    = "legacy ACL replication"
+	aclPolicyReplicationRoutineName    = "ACL policy replication"
+	aclRoleReplicationRoutineName      = "ACL role replication"
+	aclTokenReplicationRoutineName     = "ACL token replication"
+	aclTokenReapingRoutineName         = "acl token reaping"
+	aclUpgradeRoutineName              = "legacy ACL token upgrade"
+	caRootPruningRoutineName           = "CA root pruning"
+	configReplicationRoutineName       = "config entry replication"
+	intentionReplicationRoutineName    = "intention replication"
+	secondaryCARootWatchRoutineName    = "secondary CA roots watch"
+	secondaryCertRenewWatchRoutineName = "secondary cert renew watch"
 )
 
 var (

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -155,10 +155,11 @@ func testServerConfig(t *testing.T) (string, *Config) {
 		ClusterID: connect.TestClusterID,
 		Provider:  structs.ConsulCAProvider,
 		Config: map[string]interface{}{
-			"PrivateKey":     "",
-			"RootCert":       "",
-			"RotationPeriod": "2160h",
-			"LeafCertTTL":    "72h",
+			"PrivateKey":          "",
+			"RootCert":            "",
+			"RotationPeriod":      "2160h",
+			"LeafCertTTL":         "72h",
+			"IntermediateCertTTL": "72h",
 		},
 	}
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -424,9 +424,10 @@ func (c CommonCAProviderConfig) Validate() error {
 type ConsulCAProviderConfig struct {
 	CommonCAProviderConfig `mapstructure:",squash"`
 
-	PrivateKey     string
-	RootCert       string
-	RotationPeriod time.Duration
+	PrivateKey          string
+	RootCert            string
+	RotationPeriod      time.Duration
+	IntermediateCertTTL time.Duration
 
 	// DisableCrossSigning is really only useful in test code to use the built in
 	// provider while exercising logic that depends on the CA provider ability to

--- a/api/connect_ca.go
+++ b/api/connect_ca.go
@@ -39,9 +39,10 @@ type CommonCAProviderConfig struct {
 type ConsulCAProviderConfig struct {
 	CommonCAProviderConfig `mapstructure:",squash"`
 
-	PrivateKey     string
-	RootCert       string
-	RotationPeriod time.Duration
+	PrivateKey          string
+	RootCert            string
+	RotationPeriod      time.Duration
+	IntermediateCertTTL time.Duration
 }
 
 // ParseConsulCAConfig takes a raw config map and returns a parsed

--- a/api/connect_ca_test.go
+++ b/api/connect_ca_test.go
@@ -62,7 +62,8 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 
 	s.WaitForSerfCheck(t)
 	expected := &ConsulCAProviderConfig{
-		RotationPeriod: 90 * 24 * time.Hour,
+		RotationPeriod:      90 * 24 * time.Hour,
+		IntermediateCertTTL: 365 * 24 * time.Hour,
 	}
 	expected.LeafCertTTL = 72 * time.Hour
 
@@ -83,15 +84,19 @@ func TestAPI_ConnectCAConfig_get_set(t *testing.T) {
 		// Change a config value and update
 		conf.Config["PrivateKey"] = ""
 		conf.Config["RotationPeriod"] = 120 * 24 * time.Hour
+		conf.Config["IntermediateCertTTL"] = 300 * 24 * time.Hour
+
 		// Pass through some state as if the provider stored it so we can make sure
 		// we can read it again.
 		conf.Config["test_state"] = map[string]string{"foo": "bar"}
+
 		_, err = connect.CASetConfig(conf, nil)
 		r.Check(err)
 
 		updated, _, err := connect.CAGetConfig(nil)
 		r.Check(err)
 		expected.RotationPeriod = 120 * 24 * time.Hour
+		expected.IntermediateCertTTL = 300 * 24 * time.Hour
 		parsed, err = ParseConsulCAConfig(updated.Config)
 		r.Check(err)
 		require.Equal(r, expected, parsed)

--- a/command/connect/ca/set/connect_ca_set_test.go
+++ b/command/connect/ca/set/connect_ca_set_test.go
@@ -50,4 +50,5 @@ func TestConnectCASetConfigCommand(t *testing.T) {
 	parsed, err := ca.ParseConsulCAConfig(reply.Config)
 	require.NoError(err)
 	require.Equal(24*time.Hour, parsed.RotationPeriod)
+	require.Equal(36*time.Hour, parsed.IntermediateCertTTL)
 }

--- a/command/connect/ca/set/test-fixtures/ca_config.json
+++ b/command/connect/ca/set/test-fixtures/ca_config.json
@@ -3,6 +3,7 @@
 	"Config": {
 		"PrivateKey": "",
 		"RootCert": "",
-		"RotationPeriod": "24h"
+		"RotationPeriod": "24h",
+		"IntermediateCertTTL": "36h"
 	}
 }

--- a/sdk/freeport/freeport_test.go
+++ b/sdk/freeport/freeport_test.go
@@ -185,10 +185,10 @@ func TestTakeReturn(t *testing.T) {
 				c.Close()
 			}
 		}()
-		for _, port := range allPorts {
+		for i, port := range allPorts {
 			ln, err := net.ListenTCP("tcp", tcpAddr("127.0.0.1", port))
 			if err != nil {
-				t.Fatalf("err: %v", err)
+				t.Fatalf("%d err: %v", i, err)
 			}
 			leaked = append(leaked, ln)
 		}

--- a/sdk/freeport/systemlimit.go
+++ b/sdk/freeport/systemlimit.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package freeport
+
+import "golang.org/x/sys/unix"
+
+func systemLimit() (int, error) {
+	var limit unix.Rlimit
+	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit)
+	return int(limit.Cur), err
+}

--- a/sdk/freeport/systemlimit_windows.go
+++ b/sdk/freeport/systemlimit_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package freeport
+
+func systemLimit() (int, error) {
+	return 0, nil
+}

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -24,7 +24,7 @@ func WaitForLeader(t *testing.T, rpc rpcFn, dc string) {
 			r.Fatalf("No leader")
 		}
 		if out.Index < 2 {
-			r.Fatalf("Consul index should be at least 2")
+			r.Fatalf("Consul index should be at least 2 in %s", dc)
 		}
 	})
 }

--- a/website/source/api/connect/ca.html.md
+++ b/website/source/api/connect/ca.html.md
@@ -97,7 +97,8 @@ $ curl \
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "RotationPeriod": "2160h"
+        "RotationPeriod": "2160h",
+        "IntermediateCertTTL": "8760h"
     },
     "CreateIndex": 5,
     "ModifyIndex": 5
@@ -148,7 +149,8 @@ providers, see [Provider Config](/docs/connect/ca.html).
         "LeafCertTTL": "72h",
         "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----...",
         "RootCert": "-----BEGIN CERTIFICATE-----...",
-        "RotationPeriod": "2160h"
+        "RotationPeriod": "2160h",
+        "IntermediateCertTTL": "8760h"
     },
     "ForceWithoutCrossSigning": false
 }

--- a/website/source/docs/connect/ca.html.md
+++ b/website/source/docs/connect/ca.html.md
@@ -92,7 +92,8 @@ $ curl http://localhost:8500/v1/connect/ca/configuration
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "RotationPeriod": "2160h"
+        "RotationPeriod": "2160h",
+        "IntermediateCertTTL": "8760h"
     },
     "CreateIndex": 5,
     "ModifyIndex": 5

--- a/website/source/docs/connect/ca/consul.html.md
+++ b/website/source/docs/connect/ca/consul.html.md
@@ -73,7 +73,8 @@ $ curl localhost:8500/v1/connect/ca/configuration
     "Provider": "consul",
     "Config": {
         "LeafCertTTL": "72h",
-        "RotationPeriod": "2160h"
+        "RotationPeriod": "2160h",
+        "IntermediateCertTTL": "8760h"
     },
     "CreateIndex": 5,
     "ModifyIndex": 5
@@ -106,7 +107,8 @@ $ jq -n --arg key "$(cat root.key)"  --arg cert "$(cat root.crt)" '
         "LeafCertTTL": "72h",
         "PrivateKey": $key,
         "RootCert": $cert,
-        "RotationPeriod": "2160h"
+        "RotationPeriod": "2160h",
+        "IntermediateCertTTL": "8760h"
     }
 }' > ca_config.json
 ```
@@ -121,7 +123,8 @@ $ cat ca_config.json
     "LeafCertTTL": "72h",
     "PrivateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEArqiy1c3pbT3cSkjdEM1APALUareU...",
     "RootCert": "-----BEGIN CERTIFICATE-----\nMIIDijCCAnKgAwIBAgIJAOFZ66em1qC7MA0GCSqGSIb3...",
-    "RotationPeriod": "2160h"
+    "RotationPeriod": "2160h",
+    "IntermediateCertTTL": "8760h"
   }
 }
 


### PR DESCRIPTION
Fixes #6542.

Currently when using the built-in CA provider for Connect, root certificates are valid for 10 years, however secondary DCs get intermediates that are valid for only 1 year. There is no mechanism currently short of rotating the root in the primary that will cause the secondary DCs to renew their intermediates.
This PR adds a check that renews the cert if it is half way through its validity period.

In order to be able to test these changes, a new configuration option was added: `IntermediateCertTTL` which is set extremely low in the tests.

The commits for this PR are done so that you could read them one by one and get a better overview. It contains some bugfixes and refactorings. Only the last commit has the new feature!