### PR TITLE
ui: Ensure AbortErrors have a zero status

### DIFF
--- a/ui-v2/app/adapters/http.js
+++ b/ui-v2/app/adapters/http.js
@@ -65,6 +65,7 @@ export default Adapter.extend({
       switch (err.statusCode) {
         case 0:
           error = new AbortError();
+          error.errors[0].status = '0';
           break;
         case 401:
           error = new UnauthorizedError(errors, detailedMessage);


### PR DESCRIPTION
`AbortError`s should have the `status` for their first error set to 0 (see https://github.com/hashicorp/consul/pull/5048)

When we did our data layer refactor (https://github.com/hashicorp/consul/pull/5637) this additional assignment was removed (https://github.com/hashicorp/consul/pull/5637/files#diff-c83fd603b9ef4d08d0937ca10bf3f187L46) but we didn't put it back anywhere.

As a consequence of this, when switching to a different tab and back again, any blocking queries that were aborted as a result of the tab change do not get started back up again.

This fixes the issue.

I had a reasonably large go at an acceptance test for this, and whilst I got far enough to be able to inject/mock a fake document so we could set `document.hidden = true`, once I realized that we would also have to start lots of work to more closely replicate/inject/mock the `AbortError`s etc we decided to leave that as a future task, so no tests here unfortunately.

(P.S. whilst this bug is on `master` it did not make it into any released version of the UI 🎉 )
