### PR TITLE
ui: Ensure %app-content > %app-view-content rename is complete

### DIFF
--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -37,7 +37,7 @@ main {
 %app-view-header .actions button {
   @extend %button-compact;
 }
-%app-content div > dl {
+%app-view-content div > dl {
   @extend %form-row;
 }
 [role='tabpanel'] > p:only-child,

--- a/ui-v2/app/styles/components/app-view/skin.scss
+++ b/ui-v2/app/styles/components/app-view/skin.scss
@@ -29,12 +29,12 @@
     border-top: 0 !important;
   }
 }
-%app-content div > dl > dd {
+%app-view-content div > dl > dd {
   color: $gray-400;
 }
 [role='tabpanel'] > p:only-child,
 .template-error > div,
-%app-content > p:only-child,
+%app-view-content > p:only-child,
 %app-view > div.disabled > div {
   @extend %frame-gray-500;
 }

--- a/ui-v2/app/styles/components/form-elements.scss
+++ b/ui-v2/app/styles/components/form-elements.scss
@@ -12,7 +12,7 @@ label span {
   @extend %form-element-error;
 }
 %modal-dialog .type-text,
-%app-content .type-text {
+%app-view-content .type-text {
   @extend %form-element;
 }
 .type-toggle {
@@ -22,10 +22,10 @@ label span {
 %radio-group,
 %checkbox-group,
 form table,
-%app-content form dl {
+%app-view-content form dl {
   @extend %form-row;
 }
-%app-content form:not(.filter-bar) [role='radiogroup'],
+%app-view-content form:not(.filter-bar) [role='radiogroup'],
 %modal-window [role='radiogroup'] {
   @extend %radio-group;
 }

--- a/ui-v2/app/styles/core/layout.scss
+++ b/ui-v2/app/styles/core/layout.scss
@@ -3,7 +3,7 @@
 // TODO: This shouldn't be done here, decide the best way to do this
 // %main-decoration ? %main-skin ? %content-skin ?
 // it includes layouts of components, but not layout of itself?
-// %main-components? What about %app-content
+// %main-components? What about %app-view-content
 main,
 %modal-window {
   @extend %main-content;

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -32,7 +32,7 @@ h3,
 }
 /* Weighting */
 h1,
-%app-content div > dt,
+%app-view-content div > dt,
 %header-drop-nav .is-active {
   font-weight: $typo-weight-bold;
 }
@@ -43,7 +43,7 @@ caption,
 %header-nav,
 %healthcheck-output dt,
 %copy-button,
-%app-content div > dl > dt,
+%app-view-content div > dl > dt,
 %tbody-th,
 %form-element > span,
 %toggle label span {
@@ -121,7 +121,7 @@ fieldset > p,
 .template-error > div,
 [role='tabpanel'] > p:only-child,
 .with-confirmation p,
-%app-content > p:only-child,
+%app-view-content > p:only-child,
 %app-view > div.disabled > div,
 %button,
 %form-element > em,


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/6575 we changed the name of
%app-content to %app-view-content, but missed a few places that needed
renaming, this corrects that.