### PR TITLE
Reorg helm chart docs

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -1,107 +1,17 @@
 ---
 layout: "docs"
-page_title: "Helm - Kubernetes"
+page_title: "Helm Chart Reference - Kubernetes"
 sidebar_current: "docs-platform-k8s-helm"
 description: |-
-  The Consul Helm chart is the recommended way to install and configure Consul on Kubernetes. In addition to running Consul itself, the Helm chart is the primary method for installing and configuring Consul integrations with Kubernetes such as catalog syncing, Connect injection, and more.
+  Reference for the Consul Helm chart.
 ---
 
-# Helm Chart
-
-The [Consul Helm chart](https://github.com/hashicorp/consul-helm)
-is the recommended way to install and configure Consul on Kubernetes.
-In addition to running Consul itself, the Helm chart is the primary
-method for installing and configuring Consul integrations with
-Kubernetes such as catalog syncing, Connect injection, and more.
-
-A step-by-step beginner tutorial and accompanying video can be found at the [Minikube with Consul guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs).
-
-This page assumes general knowledge of [Helm](https://helm.sh/) and
-how to use it. Using Helm to install Consul will require that Helm is
-properly installed and configured with your Kubernetes cluster.
-
--> **Important:** The Helm chart is new and
-may still change significantly over time. Please always run Helm with
-`--dry-run` before any install or upgrade to verify changes.
-
-~> **Security Warning:** By default, the chart will install an insecure
-configuration of Consul. This provides a less complicated out-of-box experience
-for new users, but is not appropriate for a production setup. Make sure that
-your Kubernetes cluster is properly secured to prevent unwanted access to
-Consul, or that you understand and enable the
-[recommended Consul security features](/docs/internals/security.html).
-Currently, some of these features are not supported in the Helm chart and
-require additional manual configuration.
-
-
-## Using the Helm Chart
-
-To install Consul using the Helm chart you must first install Helm onto
-your Kubernetes cluster. See the
-[Helm Install Guide](https://helm.sh/docs/using_helm/#installing-helm) for more information.
-
-Once Helm is installed, determine the latest version of the Consul Helm chart
-by visiting [https://github.com/hashicorp/consul-helm/releases](https://github.com/hashicorp/consul-helm/releases).
-
-Clone the chart at that version, for example if the latest version is
-`v0.8.1` you would run:
-
-```bash
-$ git clone --single-branch --branch v0.8.1 https://github.com/hashicorp/consul-helm.git
-Cloning into 'consul-helm'...
-...
-You are in 'detached HEAD' state...
-```
-
-Ensure you've checked out the correct version with `helm inspect`:
-
-```bash
-$ helm inspect chart ./consul-helm
-apiVersion: v1
-description: Install and configure Consul on Kubernetes.
-home: https://www.consul.io
-name: consul
-sources:
-- https://github.com/hashicorp/consul
-- https://github.com/hashicorp/consul-helm
-- https://github.com/hashicorp/consul-k8s
-version: 0.8.1
-```
-
-Now you're ready to install Consul! To install Consul with the default
-configuration run:
-
-```sh
-$ helm install --name consul ./consul-helm
-NAME:   consul
-...
-Your release is named consul. To learn more about the release, try:
-
-  $ helm status consul
-  $ helm get consul
-```
-
-If you want to customize the installation,
-create a `values.yaml` file to override the default settings.
-You can learn what settings are available by running `helm inspect values ./consul-helm`
-or by reading the below [Configuration](#configuration-values) section.
-
-Once you've created your `values.yaml` file, run `helm install` with the `-f` flag:
-
-```bash
-$ helm install --name consul -f ./values.yaml ./consul-helm
-```
-
-~> **Warning:** By default, the chart will install _everything_: a
-Consul server cluster, client agents on all nodes, feature components, etc.
-This provides a nice out-of-box experience for new users, but may not be
-appropriate for a production setup. Consider setting the `global.enabled`
-value to `false` and opt-in to the various components.
+# Helm Chart Reference
 
 ## Configuration (Values)
 
 The chart is highly customizable using
-[Helm configuration values](https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing).
+[Helm configuration values](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
 Each value has a sane default tuned for an optimal getting started experience
 with Consul. Before going into production, please review the parameters below
 and consider if they're appropriate for your deployment.
@@ -432,9 +342,10 @@ kubectl create secret generic consul-ent-license --from-literal="key=${secret}"
 
 -> **Note:** If you cannot find your `.hclic` file, please contact your sales team or Technical Account Manager.
 
-In your `values.yaml`, change the value of `global.image` to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/consul-enterprise/tags).
+In your `config.yaml`, change the value of `global.image` to one of the enterprise [release tags](https://hub.docker.com/r/hashicorp/consul-enterprise/tags).
 
 ```yaml
+# config.yaml
 global:
   image: "hashicorp/consul-enterprise:1.4.3-ent"
 ```
@@ -442,6 +353,9 @@ global:
 Add the name of the secret you just created to `server.enterpriseLicense`.
 
 ```yaml
+# config.yaml
+global:
+  image: "hashicorp/consul-enterprise:1.4.3-ent"
 server:
   enterpriseLicense:
     secretName: "consul-ent-license"
@@ -451,7 +365,7 @@ server:
 Now run `helm install`:
 
 ```bash
-$ helm install --wait --name consul -f ./values.yaml ./consul-helm
+$ helm install --wait hashicorp ./consul-helm -f config.yaml
 ```
 
 Once the cluster is up, you can verify the nodes are running Consul Enterprise by
@@ -461,7 +375,7 @@ First, forward your local port 8500 to the Consul servers so you can run `consul
 commands locally against the Consul servers in Kubernetes:
 
 ```bash
-$ kubectl port-forward service/consul-consul-server -n default 8500
+$ kubectl port-forward service/hashicorp-consul-server 8500:8500
 ```
 
 In a separate tab, run the `consul license get` command (if using ACLs see below):
@@ -483,9 +397,9 @@ Licensed Features:
         Advanced Network Federation
 $ consul members
 Node                                       Address           Status  Type    Build      Protocol  DC   Segment
-consul-consul-server-0                     10.60.0.187:8301  alive   server  1.4.3+ent  2         dc1  <all>
-consul-consul-server-1                     10.60.1.229:8301  alive   server  1.4.3+ent  2         dc1  <all>
-consul-consul-server-2                     10.60.2.197:8301  alive   server  1.4.3+ent  2         dc1  <all>
+hashicorp-consul-server-0                  10.60.0.187:8301  alive   server  1.4.3+ent  2         dc1  <all>
+hashicorp-consul-server-1                  10.60.1.229:8301  alive   server  1.4.3+ent  2         dc1  <all>
+hashicorp-consul-server-2                  10.60.2.197:8301  alive   server  1.4.3+ent  2         dc1  <all>
 ```
 
 If you get an error:
@@ -498,7 +412,7 @@ Then you have likely enabled ACLs. You need to specify your ACL token when
 running the `license get` command. First, get the ACL token:
 
 ```bash
-$ kubectl get secrets/consul-consul-bootstrap-acl-token --template={{.data.token}} | base64 -D
+$ kubectl get secrets/hashicorp-consul-bootstrap-acl-token --template={{.data.token}} | base64 -D
 4dae8373-b4d7-8009-9880-a796850caef9%
 ```
 
@@ -523,12 +437,10 @@ Licensed Features:
 
 ## Helm Chart Examples
 
-The below `values.yaml` results in a single server Consul cluster with a `LoadBalancer` to allow external access to the UI and API.
+The below `config.yaml` results in a single server Consul cluster with a `LoadBalancer` to allow external access to the UI and API.
 
 ```yaml
-global:
-  enabled: true
-
+# config.yaml
 server:
   replicas: 1
   bootstrapExpect: 1
@@ -538,14 +450,14 @@ ui:
     type: LoadBalancer
 ```
 
-The below `values.yaml` results in a three server Consul Enterprise cluster with 100GB of storage and automatic Connect injection.
+The below `config.yaml` results in a three server Consul Enterprise cluster with 100GB of storage and automatic Connect injection.
 
 Note, this would require a secret that contains the enterprise license key.
 
 ```yaml
+# config.yaml
 global:
   image: "hashicorp/consul-enterprise:1.4.2-ent"
-  datacenter: dc1
 
 server:
   replicas: 3

--- a/website/source/docs/platform/k8s/index.html.md
+++ b/website/source/docs/platform/k8s/index.html.md
@@ -47,6 +47,8 @@ Kubernetes can choose to leverage Consul.
 
 There are several ways to try Consul with Kubernetes in different environments.
 
+Guides
+
  - The [Consul and minikube guide](https://learn.hashicorp.com/consul/
    getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs) is a quick walk through of how to deploy Consul with the official Helm chart on a local instance of Minikube. 
 
@@ -63,17 +65,7 @@ There are several ways to try Consul with Kubernetes in different environments.
  - The [Consul and Kubernetes Deployment](
    https://learn.hashicorp.com/consul/day-1-operations/kubernetes-deployment-guide?utm_source=consul.io&utm_medium=docs) guide covers the necessary steps to install and configure a new Consul cluster on Kubernetes in production.
 
-## "consul-k8s" Project
-
-The dedicated [consul-k8s project](https://github.com/hashicorp/consul-k8s)
-contains the integration functionality between Consul and Kubernetes.
-You generally will not need to invoke this project directly since the
-[Helm chart](/docs/platform/k8s/helm.html) automates the installation and
-configuration of the project when necessary.
-
-We may integrate this functionality directly into Consul in the future,
-but the separate project allows us to iterate and version the Kubernetes
-functionality separately. Additionally, a lot of the functionality works
-across multiple Consul versions, so you're able to update and resolve any
-Kubernetes integration issues without also upgrading Consul itself which
-can be more difficult.
+Documentation
+  
+  - [Installing Consul](/docs/platform/k8s/run.html) covers how to install Consul using the Helm chart.
+  - [Helm Chart Reference](/docs/platform/k8s/run.html) describes the different options for configuring the Helm chart.

--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "docs"
-page_title: "Running Consul - Kubernetes"
+page_title: "Installing Consul on Kubernetes - Kubernetes"
 sidebar_current: "docs-platform-k8s-run"
 description: |-
   Consul can run directly on Kubernetes, both in server or client mode. For pure-Kubernetes workloads, this enables Consul to also exist purely within Kubernetes. For heterogeneous workloads, Consul agents can join a server running inside or outside of Kubernetes.
 ---
 
-# Running Consul on Kubernetes
+# Installing Consul on Kubernetes
 
 Consul can run directly on Kubernetes, both in server or client mode.
 For pure-Kubernetes workloads, this enables Consul to also exist purely
@@ -17,13 +17,16 @@ This page starts with a large how-to section for various specific tasks.
 To learn more about the general architecture of Consul on Kubernetes, scroll
 down to the [architecture](/docs/platform/k8s/run.html#architecture) section. If you would like to get hands-on experience testing Consul on Kubernetes, try the step-by-step beginner tutorial with an accompanying video in the [Minikube with Consul guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs)
 
-## Helm Chart
+## Helm Chart Installation
 
 The recommended way to run Consul on Kubernetes is via the
 [Helm chart](/docs/platform/k8s/helm.html). This will install and configure
 all the necessary components to run Consul. The configuration enables you
 to run just a server cluster, just a client cluster, or both. Using the Helm
-chart, you can have a full Consul deployment up and running in seconds.
+chart, you can have a full Consul deployment up and running in minutes.
+
+A step-by-step beginner tutorial and accompanying video can be found at the
+[Minikube with Consul guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs).
 
 While the Helm chart exposes dozens of useful configurations and automatically
 sets up complex resources, it **does not automatically operate Consul.**
@@ -43,59 +46,127 @@ the [recommended security features](/docs/internals/security.html). Currently,
 some of these features are not supported in the Helm chart and require additional
 manual configuration.
 
-## How-To
+### Prerequisites
+
+The Consul Helm chart works with Helm 2 and Helm 3. If using Helm 2, you will
+need to install Tiller by following the
+[Helm 2 Installation Guide](https://v2.helm.sh/docs/using_helm/#quickstart-guide).
 
 ### Installing Consul
 
-To install Consul, clone the consul-helm repository, checkout the latest release, and install
-Consul. You can run `helm install` with the `--dry-run` flag to see the
-resources it would configure. In a production environment, you should always
-use the `--dry-run` flag prior to making any changes to the Consul cluster
-via Helm.
+Determine the latest version of the Consul Helm chart
+by visiting [https://github.com/hashicorp/consul-helm/releases](https://github.com/hashicorp/consul-helm/releases).
+
+Clone the chart at that version. For example, if the latest version is
+`v0.8.1`, you would run:
+
+```bash
+$ git clone --single-branch --branch v0.8.1 https://github.com/hashicorp/consul-helm.git
+Cloning into 'consul-helm'...
+...
+You are in 'detached HEAD' state...
+```
+
+Ensure you've checked out the correct version with `helm inspect chart`:
+
+```bash
+$ helm inspect chart ./consul-helm
+apiVersion: v1
+description: Install and configure Consul on Kubernetes.
+home: https://www.consul.io
+name: consul
+sources:
+- https://github.com/hashicorp/consul
+- https://github.com/hashicorp/consul-helm
+- https://github.com/hashicorp/consul-k8s
+version: 0.8.1
+```
+
+Now you're ready to install Consul! To install Consul with the default
+configuration using Helm 3 run:
 
 ```sh
-# Clone the chart repo
-$ git clone https://github.com/hashicorp/consul-helm.git
-$ cd consul-helm
-
-# Checkout a tagged version
-$ git checkout v0.1.0
-
-# Run Helm
-$ helm install --name consul ./
+$ helm install hashicorp ./consul-helm
+NAME: hashicorp
 ...
 ```
+
+-> If using Helm 2, run: `helm install --name hashicorp ./consul-helm`
 
 _That's it._ The Helm chart does everything to setup a recommended
 Consul-on-Kubernetes deployment.
 In a couple minutes, a Consul cluster will be formed and a leader
 elected and every node will have a running Consul agent.
 
-The defaults will install both server and client agents. To install
-only one or the other, see the
-[chart configuration values](/docs/platform/k8s/helm.html#configuration-values-).
+### Customizing Your Installation
+If you want to customize your installation,
+create a `config.yaml` file to override the default settings.
+You can learn what settings are available by running `helm inspect values ./consul-helm`
+or by reading the [Helm Chart Reference](/docs/platform/k8s/helm.html).
 
-### Viewing the Consul UI
+Once you've created your `config.yaml` file, run `helm install` with the `-f` flag:
+
+```bash
+$ helm install hashicorp ./consul-helm -f config.yaml
+```
+
+If you've already installed Consul and want to make changes, you'll need to run
+`helm upgrade`. See the [Upgrading Consul on Kubernetes](/docs/platform/k8s/run.html#upgrading-consul-on-kubernetes)
+section for more details.
+
+## Uninstalling Consul
+Consul can be uninstalled via the `helm delete` command:
+
+```bash
+$ helm delete hashicorp
+release "hashicorp" uninstalled
+```
+
+-> If using Helm 2, run `helm delete --purge hashicorp`
+
+After deleting the Helm release, you need to delete the `PersistentVolumeClaim`'s
+for the persistent volumes that store Consul's data. These are not deleted by Helm due to a [bug](https://github.com/helm/helm/issues/5156).
+To delete, run:
+
+```bash
+$ kubectl get pvc -l chart=consul-helm
+NAME                                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-default-hashicorp-consul-server-0   Bound    pvc-32cb296b-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+data-default-hashicorp-consul-server-1   Bound    pvc-32d79919-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+data-default-hashicorp-consul-server-2   Bound    pvc-331581ea-1213-11ea-b6f0-42010a8001db   10Gi       RWO            standard       17m
+
+$ kubectl delete pvc -l chart=consul-helm
+persistentvolumeclaim "data-default-hashicorp-consul-server-0" deleted
+persistentvolumeclaim "data-default-hashicorp-consul-server-1" deleted
+persistentvolumeclaim "data-default-hashicorp-consul-server-2" deleted
+```
+
+## Viewing the Consul UI
 
 The Consul UI is enabled by default when using the Helm chart.
-For security reasons, it isn't exposed via a Service by default so you must
-use `kubectl port-forward` to visit the UI. Once the port is forwarded as
-shown below, navigate your browser to `http://localhost:8500`.
+For security reasons, it isn't exposed via a `LoadBalancer` Service by default so you must
+use `kubectl port-forward` to visit the UI: 
 
 ```
-$ kubectl port-forward consul-server-0 8500:8500
+$ kubectl port-forward service/hashicorp-consul-server 8500:8500
 ...
 ```
 
-The UI can also be exposed via a Kubernetes Service. To do this, configure
-the [`ui.service` chart values](/docs/platform/k8s/helm.html#v-ui-service).
+Once the port is forwarded navigate to [http://localhost:8500](http://localhost:8500).
 
-### Joining an Existing Consul Cluster
+If you want to expose the UI via a Kubernetes Service, configure
+the [`ui.service` chart values](/docs/platform/k8s/helm.html#v-ui-service).
+This service will allow requests to the Consul servers so it should
+not be open to the world.
+
+
+## Joining an Existing Consul Cluster
 
 If you have a Consul cluster already running, you can configure your
 Kubernetes nodes to join this existing cluster.
 
 ```yaml
+# config.yaml
 global:
   enabled: false
 
@@ -105,7 +176,7 @@ client:
     - "provider=my-cloud config=val ..."
 ```
 
-The `values.yaml` file to configure the Helm chart sets the proper
+The `config.yaml` file to configure the Helm chart sets the proper
 configuration to join an existing cluster.
 
 The `global.enabled` value first disables all chart components by default
@@ -126,7 +197,7 @@ If this isn't possible, consider running the Kubernetes agents as a separate
 DC or adopting Enterprise for
 [network segments](/docs/enterprise/network-segments/index.html).
 
-### Accessing the Consul HTTP API
+## Accessing the Consul HTTP API
 
 The Consul HTTP API should be accessed by communicating to the local agent
 running on the same node. While technically any listening agent (client or
@@ -200,7 +271,7 @@ spec:
                 consul kv put hello world
 ```
 
-### Upgrading Consul on Kubernetes
+## Upgrading Consul on Kubernetes
 
 To upgrade Consul on Kubernetes, we follow the same pattern as
 [generally upgrading Consul](/docs/upgrading.html), except we can use
@@ -212,7 +283,7 @@ Upgrading Consul on Kubernetes will follow the same pattern: each server
 will be updated one-by-one. After that is successful, the clients will
 be updated in batches.
 
-#### Upgrading Consul Servers
+### Upgrading Consul Servers
 
 To initiate the upgrade, change the `server.image` value to the
 desired Consul version. For illustrative purposes, the example below will
@@ -249,7 +320,7 @@ then decrease `updatePartition` and upgrade again. Continue until
 `updatePartition` is `0`. At this point, you may remove the
 `updatePartition` configuration. Your server upgrade is complete.
 
-#### Upgrading Consul Clients
+### Upgrading Consul Clients
 
 With the servers upgraded, it is time to upgrade the clients. To upgrade
 the clients, set the `client.image` value to the desired Consul version.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -575,7 +575,7 @@
         <a href="/docs/platform/k8s/index.html">Kubernetes</a>
         <ul class="nav">
           <li<%= sidebar_current("docs-platform-k8s-run") %>>
-            <a href="/docs/platform/k8s/run.html">Running Consul</a>
+            <a href="/docs/platform/k8s/run.html">Installing Consul</a>
             <ul class="nav">
               <li<%= sidebar_current("docs-platform-k8s-run-aks") %>>
                 <a href="/docs/platform/k8s/aks.html">Consul on Azure Cloud</a>
@@ -589,7 +589,7 @@
             </ul>
           </li>
           <li<%= sidebar_current("docs-platform-k8s-helm") %>>
-            <a href="/docs/platform/k8s/helm.html">Helm Chart</a>
+            <a href="/docs/platform/k8s/helm.html">Helm Chart Reference</a>
           </li>
           <li<%= sidebar_current("docs-platform-k8s-ooc-nodes") %>>
             <a href="/docs/platform/k8s/out-of-cluster-nodes.html">Out-of-Cluster Nodes</a>


### PR DESCRIPTION
- Remove duplicate install instructions from the Helm Chart page and
kept them in Running Consul
- Renamed Helm Chart to Helm Chart Reference because that's mostly what
it contains (along with some examples)
- Renamed Running Consul to Installing Consul
- Changed instructions to be for installing using Helm 3 and added
  notes if using Helm 2
- Used release name "hashicorp" so subsequent instructions can be more
concise and pastable, e.g. "port forward to svc/hashicorp-consul-server" vs. "port
forward to svc/<your release name>-consul-server"
 - Use config.yaml as the name for the override values file since it
    differentiates from the default values.yaml file and its the name of the
    file used in the helm docs
    (https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing)