### PR TITLE
ui: Slight refactor 'name deciding' for `request` > `rpc`

### DIFF
--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -18,40 +18,9 @@ export default Adapter.extend({
       [DATACENTER_QUERY_PARAM]: dc,
     };
   },
-  // TODO: kinda protected for the moment
-  // decide where this should go either read/write from http
-  // should somehow use this or vice versa
+  // TODO: Deprecated, remove `request` usage from everywhere and replace with
+  // `HTTPAdapter.rpc`
   request: function(req, resp, obj, modelName) {
-    const client = this.client;
-    const store = this.store;
-    const adapter = this;
-
-    let unserialized, serialized;
-    const serializer = store.serializerFor(modelName);
-    // workable way to decide whether this is a snapshot
-    // Snapshot is private so we can't do instanceof here
-    if (obj.constructor.name === 'Snapshot') {
-      unserialized = obj.attributes();
-      serialized = serializer.serialize(obj, {});
-    } else {
-      unserialized = obj;
-      serialized = unserialized;
-    }
-
-    return client
-      .request(function(request) {
-        return req(adapter, request, serialized, unserialized);
-      })
-      .catch(function(e) {
-        return adapter.error(e);
-      })
-      .then(function(respond) {
-        // TODO: When HTTPAdapter:responder changes, this will also need to change
-        return resp(serializer, respond, serialized, unserialized);
-      });
-    // TODO: Potentially add specific serializer errors here
-    // .catch(function(e) {
-    //   return Promise.reject(e);
-    // });
+    return this.rpc(...arguments);
   },
 });


### PR DESCRIPTION
During the refactor of the data layer (https://github.com/hashicorp/consul/pull/5637) we had a method that you can use
to do a request/response call i.e. adapter.request > serializer.respond

We weren't sure what to name this but eventually wanted it to live on
the HTTPAdapter itself (see removed comments in the changeset)

We've decided `rpc` is a good name and we've moved this to where we want
it. We've deprecated the old `request` method name but not removed it as
yet. There's also opportunity now to reduce the 'read/write' functions
further as they essentially do the same thing. Again we've left this for
the moment, but we are hoping to get the code for our custom Adapter down
to less than 100 LoC.