### PR TITLE
Increase raft notify buffer.

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -722,7 +722,7 @@ func (s *Server) setupRaft() error {
 	}
 
 	// Set up a channel for reliable leader notifications.
-	raftNotifyCh := make(chan bool, 1)
+	raftNotifyCh := make(chan bool, 1000)
 	s.config.RaftConfig.NotifyCh = raftNotifyCh
 	s.raftNotifyCh = raftNotifyCh
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -722,7 +722,7 @@ func (s *Server) setupRaft() error {
 	}
 
 	// Set up a channel for reliable leader notifications.
-	raftNotifyCh := make(chan bool, 1000)
+	raftNotifyCh := make(chan bool, 10)
 	s.config.RaftConfig.NotifyCh = raftNotifyCh
 	s.raftNotifyCh = raftNotifyCh
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/6852.

Increasing the buffer helps recovering from leader flapping. It lowers
the chances of the flapping leader to get into a deadlock situation like
described in #6852.