### PR TITLE
Fixes for streaming issues identified in #6730

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -445,13 +445,15 @@ func (a *Agent) Start() error {
 	a.State.Delegate = a.delegate
 	a.State.TriggerSyncChanges = a.sync.SyncChanges.Trigger
 
-	// Set up the gRPC client for the cache.
-	conn, err := a.delegate.GRPCConn()
-	if err != nil {
-		return err
-	}
+	if a.config.EnableBackendStreaming {
+		// Set up the gRPC client for the cache.
+		conn, err := a.delegate.GRPCConn()
+		if err != nil {
+			return err
+		}
 
-	a.streamClient = stream.NewConsulClient(conn)
+		a.streamClient = stream.NewConsulClient(conn)
+	}
 
 	// Register the cache. We do this much later so the delegate is
 	// populated from above.
@@ -1332,6 +1334,8 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	}
 
 	base.ConfigEntryBootstrap = a.config.ConfigEntryBootstrap
+
+	base.GRPCEnabled = a.config.EnableBackendStreaming
 
 	return base, nil
 }

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -2446,13 +2446,17 @@ func testACLFilterServer(t *testing.T) (string, string, *Server, rpc.ClientCodec
 }
 
 func testACLFilterServerV8(t *testing.T, enforceVersion8 bool) (dir, token string, srv *Server, codec rpc.ClientCodec) {
-	dir, srv = testServerWithConfig(t, func(c *Config) {
+	return testACLFilterServerWithConfigFn(t, func(c *Config) {
 		c.ACLDatacenter = "dc1"
 		c.ACLsEnabled = true
 		c.ACLMasterToken = "root"
 		c.ACLDefaultPolicy = "deny"
 		c.ACLEnforceVersion8 = enforceVersion8
 	})
+}
+
+func testACLFilterServerWithConfigFn(t *testing.T, fn func(*Config)) (dir, token string, srv *Server, codec rpc.ClientCodec) {
+	dir, srv = testServerWithConfig(t, fn)
 
 	codec = rpcClient(t, srv)
 	testrpc.WaitForLeader(t, srv.RPC, "dc1")

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -425,6 +425,10 @@ type Config struct {
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool
 
+	// GRPCEnabled controls whether servers will listen for gRPC streams or RPC
+	// calls and whether clients will start gRPC clients.
+	GRPCEnabled bool
+
 	// GRPCResolverScheme is the gRPC resolver scheme to use. This is only used for
 	// tests running in parallel to avoid overwriting each other.
 	GRPCResolverScheme string

--- a/agent/consul/grpc_client.go
+++ b/agent/consul/grpc_client.go
@@ -1,22 +1,35 @@
 package consul
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
 	"sync"
-	"time"
+	"sync/atomic"
 
+	"google.golang.org/grpc"
+	grpcStats "google.golang.org/grpc/stats"
+
+	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/pool"
 
 	"github.com/hashicorp/consul/tlsutil"
-	"google.golang.org/grpc"
 )
 
 const (
 	grpcBasePath = "/consul"
 )
+
+// grpcStatsHandler is the global stats handler instance. Yes I know global is
+// horrible but go-metrics started it. Now we need to be global to make
+// connection count gauge useful.
+var grpcStatsHandler *GRPCStatsHandler
+
+func init() {
+	grpcStatsHandler = &GRPCStatsHandler{}
+}
 
 type ServerProvider interface {
 	Servers() []*metadata.Server
@@ -50,11 +63,12 @@ func (c *GRPCClient) GRPCConn(datacenter string) (*grpc.ClientConn, error) {
 
 	dialer := newDialer(c.serverProvider, c.tlsConfigurator.OutgoingRPCWrapper())
 	conn, err := grpc.Dial(fmt.Sprintf("%s:///server.%s", c.scheme, datacenter),
-		// use WithInsecure mode here because we handle the TLS wrapping in the custom dialer
-		// based on logic around whether the server has TLS enabled.
+		// use WithInsecure mode here because we handle the TLS wrapping in the
+		// custom dialer based on logic around whether the server has TLS enabled.
 		grpc.WithInsecure(),
-		grpc.WithDialer(dialer),
+		grpc.WithContextDialer(dialer),
 		grpc.WithDisableRetry(),
+		grpc.WithStatsHandler(grpcStatsHandler),
 		grpc.WithBalancerName("pick_first"))
 	if err != nil {
 		return nil, err
@@ -65,11 +79,59 @@ func (c *GRPCClient) GRPCConn(datacenter string) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
+// GRPCStatsHandler is a grpc/stats.StatsHandler which emits stats to
+// go-metrics.
+type GRPCStatsHandler struct {
+	activeConns uint64 // must be 8-byte aligned for atomic access
+}
+
+// TagRPC implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) TagRPC(ctx context.Context, i *grpcStats.RPCTagInfo) context.Context {
+	// No-op
+	return ctx
+}
+
+// HandleRPC implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) HandleRPC(ctx context.Context, s grpcStats.RPCStats) {
+	label := "server"
+	if s.IsClient() {
+		label = "client"
+	}
+	switch s.(type) {
+	case *grpcStats.InHeader:
+		metrics.IncrCounter([]string{"grpc", label, "request"}, 1)
+	}
+}
+
+// TagConn implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) TagConn(ctx context.Context, i *grpcStats.ConnTagInfo) context.Context {
+	// No-op
+	return ctx
+}
+
+// HandleConn implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) HandleConn(ctx context.Context, s grpcStats.ConnStats) {
+	label := "server"
+	if s.IsClient() {
+		label = "client"
+	}
+	var new uint64
+	switch s.(type) {
+	case *grpcStats.ConnBegin:
+		new = atomic.AddUint64(&c.activeConns, 1)
+	case *grpcStats.ConnEnd:
+		// Decrement!
+		new = atomic.AddUint64(&c.activeConns, ^uint64(0))
+	}
+	metrics.SetGauge([]string{"grpc", label, "active_conns"}, float32(new))
+}
+
 // newDialer returns a gRPC dialer function that conditionally wraps the connection
 // with TLS depending on the given useTLS value.
-func newDialer(serverProvider ServerProvider, wrapper tlsutil.DCWrapper) func(string, time.Duration) (net.Conn, error) {
-	return func(addr string, _ time.Duration) (net.Conn, error) {
-		conn, err := net.Dial("tcp", addr)
+func newDialer(serverProvider ServerProvider, wrapper tlsutil.DCWrapper) func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		d := net.Dialer{}
+		conn, err := d.DialContext(ctx, "tcp", addr)
 		if err != nil {
 			return nil, err
 		}

--- a/agent/consul/grpc_resolver_test.go
+++ b/agent/consul/grpc_resolver_test.go
@@ -74,19 +74,33 @@ func TestGRPCResolver_Failover_LocalDC(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	dir1, server1 := testServer(t)
+	dir1, server1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir1)
 	defer server1.Shutdown()
 
-	dir2, server2 := testServerDCBootstrap(t, "dc1", false)
+	dir2, server2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir2)
 	defer server2.Shutdown()
 
-	dir3, server3 := testServerDCBootstrap(t, "dc1", false)
+	dir3, server3 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir3)
 	defer server3.Shutdown()
 
-	dir4, client := testClient(t)
+	dir4, client := testClientWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.NodeName = uniqueNodeName(t.Name())
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir4)
 	defer client.Shutdown()
 
@@ -134,25 +148,48 @@ func TestGRPCResolver_Failover_MultiDC(t *testing.T) {
 
 	// Create a single server in dc1.
 	require := require.New(t)
-	dir1, server1 := testServer(t)
+	dir1, server1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir1)
 	defer server1.Shutdown()
 
 	// Create a client in dc1.
-	cDir, client := testClient(t)
+	cDir, client := testClientWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.NodeName = uniqueNodeName(t.Name())
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(cDir)
 	defer client.Shutdown()
 
 	// Create 3 servers in dc2.
-	dir2, server2 := testServerDCExpect(t, "dc2", 3)
+	dir2, server2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.Bootstrap = false
+		c.BootstrapExpect = 3
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir2)
 	defer server2.Shutdown()
 
-	dir3, server3 := testServerDCExpect(t, "dc2", 3)
+	dir3, server3 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.Bootstrap = false
+		c.BootstrapExpect = 3
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir3)
 	defer server3.Shutdown()
 
-	dir4, server4 := testServerDCExpect(t, "dc2", 3)
+	dir4, server4 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc2"
+		c.Bootstrap = false
+		c.BootstrapExpect = 3
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir4)
 	defer server4.Shutdown()
 

--- a/agent/consul/grpc_resolver_test.go
+++ b/agent/consul/grpc_resolver_test.go
@@ -16,19 +16,35 @@ func TestGRPCResolver_Rebalance(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	dir1, server1 := testServer(t)
+	dir1, server1 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = true
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir1)
 	defer server1.Shutdown()
 
-	dir2, server2 := testServerDCBootstrap(t, "dc1", false)
+	dir2, server2 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = false
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir2)
 	defer server2.Shutdown()
 
-	dir3, server3 := testServerDCBootstrap(t, "dc1", false)
+	dir3, server3 := testServerWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.Bootstrap = false
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir3)
 	defer server3.Shutdown()
 
-	dir4, client := testClient(t)
+	dir4, client := testClientWithConfig(t, func(c *Config) {
+		c.Datacenter = "dc1"
+		c.NodeName = uniqueNodeName(t.Name())
+		c.GRPCEnabled = true
+	})
 	defer os.RemoveAll(dir4)
 	defer client.Shutdown()
 

--- a/agent/consul/grpc_stats.go
+++ b/agent/consul/grpc_stats.go
@@ -1,0 +1,90 @@
+package consul
+
+import (
+	"context"
+	"sync/atomic"
+
+	metrics "github.com/armon/go-metrics"
+	"google.golang.org/grpc"
+	grpcStats "google.golang.org/grpc/stats"
+)
+
+var (
+	// grpcStatsHandler is the global stats handler instance. Yes I know global is
+	// horrible but go-metrics started it. Now we need to be global to make
+	// connection count gauge useful.
+	grpcStatsHandler *GRPCStatsHandler
+
+	// grpcActiveStreams is used to keep track of the number of open streaming
+	// RPCs on a server. It is accessed atomically, See notes above on global
+	// sadness.
+	grpcActiveStreams uint64
+)
+
+func init() {
+	grpcStatsHandler = &GRPCStatsHandler{}
+}
+
+// GRPCStatsHandler is a grpc/stats.StatsHandler which emits stats to
+// go-metrics.
+type GRPCStatsHandler struct {
+	activeConns uint64 // must be 8-byte aligned for atomic access
+}
+
+// TagRPC implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) TagRPC(ctx context.Context, i *grpcStats.RPCTagInfo) context.Context {
+	// No-op
+	return ctx
+}
+
+// HandleRPC implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) HandleRPC(ctx context.Context, s grpcStats.RPCStats) {
+	label := "server"
+	if s.IsClient() {
+		label = "client"
+	}
+	switch s.(type) {
+	case *grpcStats.InHeader:
+		metrics.IncrCounter([]string{"grpc", label, "request"}, 1)
+	}
+}
+
+// TagConn implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) TagConn(ctx context.Context, i *grpcStats.ConnTagInfo) context.Context {
+	// No-op
+	return ctx
+}
+
+// HandleConn implements grpcStats.StatsHandler
+func (c *GRPCStatsHandler) HandleConn(ctx context.Context, s grpcStats.ConnStats) {
+	label := "server"
+	if s.IsClient() {
+		label = "client"
+	}
+	var new uint64
+	switch s.(type) {
+	case *grpcStats.ConnBegin:
+		new = atomic.AddUint64(&c.activeConns, 1)
+	case *grpcStats.ConnEnd:
+		// Decrement!
+		new = atomic.AddUint64(&c.activeConns, ^uint64(0))
+	}
+	metrics.SetGauge([]string{"grpc", label, "active_conns"}, float32(new))
+}
+
+// GRPCCountingStreamInterceptor is a grpc.ServerStreamInterceptor that just
+// tracks open streaming calls to the server and emits metrics on how many are
+// open.
+func GRPCCountingStreamInterceptor(srv interface{}, ss grpc.ServerStream,
+	info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+
+	// Count the stream
+	new := atomic.AddUint64(&grpcActiveStreams, 1)
+	metrics.SetGauge([]string{"grpc", "server", "active_streams"}, float32(new))
+	defer func() {
+		new := atomic.AddUint64(&grpcActiveStreams, ^uint64(0))
+		metrics.SetGauge([]string{"grpc", "server", "active_streams"}, float32(new))
+	}()
+
+	return handler(srv, ss)
+}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -142,8 +142,12 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 		s.handleInsecureConn(conn)
 
 	case pool.RPCGRPC:
-		s.handleGRPCConn(conn)
-
+		if !s.config.GRPCEnabled {
+			s.logger.Printf("[ERR] consul.rpc: GRPC conn opened but GRPC is not enabled, closing")
+			conn.Close()
+		} else {
+			s.handleGRPCConn(conn)
+		}
 	default:
 		if !s.handleEnterpriseRPCConn(typ, conn, isTLS) {
 			s.logger.Printf("[ERR] consul.rpc: unrecognized RPC byte: %v %s", typ, logConn(conn))

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -838,7 +838,10 @@ func (s *Server) setupGRPC() error {
 
 	// We don't need to pass tls.Config to the server since it's multiplexed
 	// behind the RPC listener, which already has TLS configured.
-	srv := grpc.NewServer(grpc.StatsHandler(grpcStatsHandler))
+	srv := grpc.NewServer(
+		grpc.StatsHandler(grpcStatsHandler),
+		grpc.StreamInterceptor(GRPCCountingStreamInterceptor),
+	)
 	stream.RegisterConsulServer(srv, &ConsulGRPCAdapter{Health{s}})
 
 	go srv.Serve(lis)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -838,7 +838,7 @@ func (s *Server) setupGRPC() error {
 
 	// We don't need to pass tls.Config to the server since it's multiplexed
 	// behind the RPC listener, which already has TLS configured.
-	srv := grpc.NewServer()
+	srv := grpc.NewServer(grpc.StatsHandler(grpcStatsHandler))
 	stream.RegisterConsulServer(srv, &ConsulGRPCAdapter{Health{s}})
 
 	go srv.Serve(lis)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -356,8 +356,16 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		ForceTLS:        config.VerifyOutgoing,
 	}
 
-	// Register the gRPC resolver used for connection balancing.
-	grpcResolverBuilder := registerResolverBuilder(config.GRPCResolverScheme, config.Datacenter, shutdownCh)
+	var tracker router.ServerTracker
+	var grpcResolverBuilder *ServerResolverBuilder
+
+	if config.GRPCEnabled {
+		// Register the gRPC resolver used for connection balancing.
+		grpcResolverBuilder = registerResolverBuilder(config.GRPCResolverScheme, config.Datacenter, shutdownCh)
+		tracker = grpcResolverBuilder
+	} else {
+		tracker = &router.NoOpServerTracker{}
+	}
 
 	// Create server.
 	s := &Server{
@@ -369,7 +377,7 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 		logger:                  logger,
 		leaveCh:                 make(chan struct{}),
 		reconcileCh:             make(chan serf.Member, reconcileChSize),
-		router:                  router.NewRouter(logger, config.Datacenter, grpcResolverBuilder),
+		router:                  router.NewRouter(logger, config.Datacenter, tracker),
 		rpcServer:               rpc.NewServer(),
 		insecureRPCServer:       rpc.NewServer(),
 		tlsConfigurator:         tlsConfigurator,
@@ -489,17 +497,19 @@ func NewServerLogger(config *Config, logger *log.Logger, tokens *token.Store, tl
 	}
 	go s.lanEventHandler()
 
-	// Start the gRPC server shuffling using the LAN serf for node count.
-	go grpcResolverBuilder.periodicServerRebalance(s.serfLAN)
+	if s.config.GRPCEnabled {
+		// Start the gRPC server shuffling using the LAN serf for node count.
+		go grpcResolverBuilder.periodicServerRebalance(s.serfLAN)
 
-	// Initialize the GRPC listener.
-	if err := s.setupGRPC(); err != nil {
-		s.Shutdown()
-		return nil, fmt.Errorf("Failed to start GRPC layer: %v", err)
+		// Initialize the GRPC listener.
+		if err := s.setupGRPC(); err != nil {
+			s.Shutdown()
+			return nil, fmt.Errorf("Failed to start GRPC layer: %v", err)
+		}
+
+		// Start the GRPC client.
+		s.grpcClient = NewGRPCClient(s.logger, grpcResolverBuilder, tlsConfigurator, config.GRPCResolverScheme)
 	}
-
-	// Start the GRPC client.
-	s.grpcClient = NewGRPCClient(s.logger, grpcResolverBuilder, tlsConfigurator, config.GRPCResolverScheme)
 
 	// Start the flooders after the LAN event handler is wired up.
 	s.floodSegments(config)
@@ -836,7 +846,12 @@ func (s *Server) setupGRPC() error {
 
 	// Set up a gRPC client connection to the above listener.
 	dialer := newDialer(s.serverLookup, s.tlsConfigurator.OutgoingRPCWrapper())
-	conn, err := grpc.Dial(lis.Addr().String(), grpc.WithInsecure(), grpc.WithDialer(dialer), grpc.WithDisableRetry())
+	conn, err := grpc.Dial(lis.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(dialer),
+		grpc.WithDisableRetry(),
+		grpc.WithStatsHandler(grpcStatsHandler),
+		grpc.WithBalancerName("pick_first"))
 	if err != nil {
 		return err
 	}
@@ -1234,6 +1249,9 @@ func (s *Server) SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io
 
 // GRPCConn returns a gRPC connection to a server.
 func (s *Server) GRPCConn() (*grpc.ClientConn, error) {
+	if !s.config.GRPCEnabled {
+		return nil, fmt.Errorf("GRPC not enabled")
+	}
 	return s.grpcConn, nil
 }
 

--- a/agent/consul/streaming_endpoint.go
+++ b/agent/consul/streaming_endpoint.go
@@ -9,6 +9,7 @@ import (
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/consul/stream"
 	bexpr "github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-uuid"
 )
 
 type ConsulGRPCAdapter struct {
@@ -18,7 +19,16 @@ type ConsulGRPCAdapter struct {
 // Subscribe opens a long-lived gRPC stream which sends an initial snapshot
 // of state for the requested topic, then only sends updates.
 func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server stream.Consul_SubscribeServer) error {
-	metrics.IncrCounter([]string{"subscribe", strings.ToLower(req.Topic.String())}, 1)
+	metrics.IncrCounter([]string{"rpc", "subscribe", strings.ToLower(req.Topic.String())}, 1)
+
+	// streamID is just used for message correlation in trace logs. Ideally we'd
+	// only execute this code while trace logs are enabled but it's not that
+	// expensive and theres not a very clean way to do that right now and
+	// impending logging changes so I think this makes sense for now.
+	streamID, err := uuid.GenerateUUID()
+	if err != nil {
+		return err
+	}
 
 	// Forward the request to a remote DC if applicable.
 	if req.Datacenter != "" && req.Datacenter != h.srv.config.Datacenter {
@@ -26,6 +36,15 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 		if err != nil {
 			return err
 		}
+
+		h.srv.logger.Printf("[DEBUG] consul: subscribe forward to dc=%s topic=%q key=%q "+
+			"index=%d streamID=%s", req.Datacenter, req.Topic.String(), req.Key,
+			req.Index, streamID)
+
+		defer func() {
+			h.srv.logger.Printf("[DEBUG] consul: subscribe forwarded stream complete "+
+				"streamID=%s", streamID)
+		}()
 
 		// Open a Subscribe call to the remote DC.
 		client := stream.NewConsulClient(conn)
@@ -46,7 +65,13 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 		}
 	}
 
-	h.srv.logger.Printf("consul: stream starting in %s", h.srv.config.Datacenter)
+	h.srv.logger.Printf("[DEBUG] consul: subscribe start topic=%q key=%q "+
+		"index=%d streamID=%s", req.Topic.String(), req.Key, req.Index, streamID)
+
+	defer func() {
+		h.srv.logger.Printf("[DEBUG] consul: subscribe stream closed streamID=%s",
+			streamID)
+	}()
 
 	// Resolve the token and create the ACL filter.
 	rule, err := h.srv.ResolveToken(req.Token)
@@ -68,6 +93,7 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 	// is lower than the last sent index of the topic.
 	state := h.srv.fsm.State()
 	lastSentIndex := state.LastTopicIndex(req.Topic)
+	var snapshotIndex, nSnapEvents uint64
 	sent := make(map[uint32]struct{})
 	if req.Index < lastSentIndex || lastSentIndex == 0 {
 		snapshotCh := make(chan stream.Event, 32)
@@ -79,7 +105,13 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 			if err := sendEvent(event, aclFilter, eval, sent, server); err != nil {
 				return err
 			}
+			if event.GetEndOfSnapshot() {
+				snapshotIndex = event.Index
+			} else {
+				nSnapEvents++
+			}
 		}
+
 	} else {
 		// If there wasn't a snapshot, just send an end of snapshot message
 		// so the client knows not to wait for one.
@@ -88,10 +120,14 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 			Index:   lastSentIndex,
 			Payload: &stream.Event_EndOfSnapshot{EndOfSnapshot: true},
 		}
+		snapshotIndex = lastSentIndex
 		if err := server.Send(&endSnapshotEvent); err != nil {
 			return err
 		}
 	}
+
+	h.srv.logger.Printf("[DEBUG] consul: subscribe snapshot complete snapIndex=%d "+
+		"nEvents=%d streamID=%s", snapshotIndex, nSnapEvents, streamID)
 
 	// Register a subscription on this topic/key with the FSM.
 	eventCh, err := state.Subscribe(req)
@@ -100,6 +136,7 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 	}
 	defer state.Unsubscribe(req)
 
+	var sentEvents uint64
 	for {
 		select {
 		case <-server.Context().Done():
@@ -123,6 +160,10 @@ func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server strea
 			if err := sendEvent(event, aclFilter, eval, sent, server); err != nil {
 				return err
 			}
+			sentEvents++
+
+			h.srv.logger.Printf("[DEBUG] consul: subscribe sent event eventIndex=%d "+
+				"streamID=%s", event.Index, streamID)
 		}
 	}
 }
@@ -153,13 +194,13 @@ func sendEvent(event stream.Event, aclFilter *aclFilter, eval *bexpr.Evaluator,
 		}
 	}
 
-	// Get the unique identifier for the object the event pertains to, and
-	// hash it to save space. This is only used to determine if an object has been
-	// removed and needs to be deleted from the client's cache. In other words, if we hit a
-	// hash collision, it only results in a redundant message being sent without affecting
-	// correctness. 32 bits means there is only a 1% chance of collision with ~9000 items in this map.
-	// For current uses that seems reasonable but when we add KV streaming we may want
-	// to revisit this.
+	// Get the unique identifier for the object the event pertains to, and hash it
+	// to save space. This is only used to determine if an object has been removed
+	// and needs to be deleted from the client's cache. In other words, if we hit
+	// a hash collision, it only results in a redundant message being sent without
+	// affecting correctness. 32 bits means there is only a 1% chance of collision
+	// with ~9000 items in this map. For current uses that seems reasonable but
+	// when we add KV streaming we may want to revisit this.
 	rawId := event.ContentID()
 	hash := fnv.New32a()
 	hash.Write([]byte(rawId))

--- a/agent/consul/streaming_endpoint.go
+++ b/agent/consul/streaming_endpoint.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
-	"strings"
 
-	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/agent/consul/stream"
 	bexpr "github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-uuid"
@@ -19,8 +17,6 @@ type ConsulGRPCAdapter struct {
 // Subscribe opens a long-lived gRPC stream which sends an initial snapshot
 // of state for the requested topic, then only sends updates.
 func (h *ConsulGRPCAdapter) Subscribe(req *stream.SubscribeRequest, server stream.Consul_SubscribeServer) error {
-	metrics.IncrCounter([]string{"rpc", "subscribe", strings.ToLower(req.Topic.String())}, 1)
-
 	// streamID is just used for message correlation in trace logs. Ideally we'd
 	// only execute this code while trace logs are enabled but it's not that
 	// expensive and theres not a very clean way to do that right now and

--- a/agent/consul/streaming_endpoint_test.go
+++ b/agent/consul/streaming_endpoint_test.go
@@ -973,7 +973,8 @@ service "foo" {
 		select {
 		case event := <-eventCh:
 			require.True(event.GetReloadStream())
-		case <-time.After(500 * time.Millisecond):
+			// 500 ms was not enough in CI apparently...
+		case <-time.After(2 * time.Second):
 			t.Fatalf("did not receive reload event")
 		}
 	}

--- a/agent/router/manager.go
+++ b/agent/router/manager.go
@@ -70,6 +70,16 @@ type ServerTracker interface {
 	RemoveServer(*metadata.Server)
 }
 
+// NoOpServerTracker is a ServerTracker that does nothing. Used when gRPC is not
+// enabled.
+type NoOpServerTracker struct{}
+
+// AddServer implements ServerTracker
+func (t *NoOpServerTracker) AddServer(*metadata.Server) {}
+
+// RemoveServer implements ServerTracker
+func (t *NoOpServerTracker) RemoveServer(*metadata.Server) {}
+
 // serverList is a local copy of the struct used to maintain the list of
 // Consul servers used by Manager.
 //

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -464,9 +464,10 @@ google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/grpc
 google.golang.org/grpc/credentials
 google.golang.org/grpc/health/grpc_health_v1
+google.golang.org/grpc/resolver
+google.golang.org/grpc/stats
 google.golang.org/grpc/codes
 google.golang.org/grpc/status
-google.golang.org/grpc/resolver
 google.golang.org/grpc/metadata
 google.golang.org/grpc/grpclog
 google.golang.org/grpc/balancer
@@ -489,7 +490,6 @@ google.golang.org/grpc/peer
 google.golang.org/grpc/resolver/dns
 google.golang.org/grpc/resolver/passthrough
 google.golang.org/grpc/serviceconfig
-google.golang.org/grpc/stats
 google.golang.org/grpc/tap
 google.golang.org/grpc/credentials/internal
 google.golang.org/grpc/health

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -608,12 +608,6 @@ These metrics are used to monitor the health of the Consul servers.
     <td>timer</td>
   </tr>
   <tr>
-    <td>`consul.rpc.accept_conn`</td>
-    <td>This increments when a server accepts an RPC connection.</td>
-    <td>connections</td>
-    <td>counter</td>
-  </tr>
-  <tr>
     <td>`consul.catalog.register`</td>
     <td>This measures the time it takes to complete a catalog register operation.</td>
     <td>ms</td>
@@ -692,6 +686,36 @@ These metrics are used to monitor the health of the Consul servers.
     <td>timer</td>
   </tr>
   <tr>
+    <td>`consul.grpc.client.active_conns`</td>
+    <td>This shows how many outbound gRPC connections the client has open to one or more servers.</td>
+    <td>connections</td>
+    <td>gauge</td>
+  </tr>
+  <tr>
+    <td>`consul.grpc.client.requests`</td>
+    <td>This increments each time a client makes an outbound gRPC request to a Consul server.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
+    <td>`consul.grpc.server.active_conns`</td>
+    <td>This shows how many inbound gRPC connections the server is currently serving.</td>
+    <td>connections</td>
+    <td>gauge</td>
+  </tr>
+  <tr>
+    <td>`consul.grpc.server.active_streams`</td>
+    <td>This shows how many active streaming RPC queries the server is currently serving.</td>
+    <td>streams</td>
+    <td>gauge</td>
+  </tr>
+  <tr>
+    <td>`consul.grpc.server.requests`</td>
+    <td>This increments each time a server receives an inbound gRPC request (including streaming requests) from a client.</td>
+    <td>requests</td>
+    <td>counter</td>
+  </tr>
+  <tr>
     <td>`consul.kvs.apply`</td>
     <td>This measures the time it takes to complete an update to the KV store.</td>
     <td>ms</td>
@@ -746,6 +770,12 @@ These metrics are used to monitor the health of the Consul servers.
     <td>timer</td>
   </tr>
   <tr>
+    <td>`consul.rpc.accept_conn`</td>
+    <td>This increments when a server accepts an RPC connection.</td>
+    <td>connections</td>
+    <td>counter</td>
+  </tr>
+  <tr>
     <td>`consul.rpc.raft_handoff`</td>
     <td>This increments when a server accepts a Raft-related RPC connection.</td>
     <td>connections</td>
@@ -759,13 +789,13 @@ These metrics are used to monitor the health of the Consul servers.
   </tr>
   <tr>
     <td>`consul.rpc.request`</td>
-    <td>This increments when a server receives a Consul-related RPC request.</td>
+    <td>This increments when a server receives a Consul-related RPC request. This includes blocking RPC requests.</td>
     <td>requests</td>
     <td>counter</td>
   </tr>
   <tr>
     <td>`consul.rpc.query`</td>
-    <td>This increments when a server sends a (potentially blocking) RPC query.</td>
+    <td>This increments when a server starts handling a (potentially blocking) RPC query. Since it only increments at the start of a blocking RPC it only gives the rate of new blocking calls not the total number currently open.</td>
     <td>queries</td>
     <td>counter</td>
   </tr>


### PR DESCRIPTION
This PR fixes several issues identified during testing and noted in #6730 

They are all in one PR as the code change was small and I worked on fixing them as I found them during testing.

Issues are:

 - `enable_backend_streaming` now actually controls all the gRPC components instead of just controlling wiring in client cache. This is important because otherwise all users would get gRPC server exposed and all agents would actually open gRPC connections to the servers even though nothing is using gRPC yet. This makes sure we actually don't change behaviour for clients or servers unless explicitly enabled for now.
 - Wires up the `grpc.StatsHandler` so that grpc metrics are exposed.
 - Replace verbose, un-leveled log output with debug-only useful output.
 - Fixes a resource leak if the client drops the connection or some other error occurs during snapshot sending.
 - Fixes GRPCConn caching for cases where multiple clients are in the same process (needed for benchmark and testing but probably also saves us from being surprised by this in the future too.


## TODO

 - [x] end-to-end test the new grpc Metrics and check they are sane and useful