### PR TITLE
test: wait for Serf check in TestServicesWatch

### DIFF
--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -449,6 +449,8 @@ func TestServiceWatch(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	var (
 		wakeups  [][]*api.ServiceEntry
 		notifyCh = make(chan struct{})
@@ -516,6 +518,8 @@ func TestServiceMultipleTagsWatch(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	var (
 		wakeups  [][]*api.ServiceEntry
@@ -608,6 +612,8 @@ func TestChecksWatch_State(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	var (
 		wakeups  [][]*api.HealthCheck
 		notifyCh = make(chan struct{})
@@ -681,6 +687,8 @@ func TestChecksWatch_Service(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	var (
 		wakeups  [][]*api.HealthCheck
@@ -886,6 +894,8 @@ func TestConnectLeafWatch(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	// Register a web service to get certs for
 	{
 		agent := c.Agent()
@@ -967,6 +977,8 @@ func TestAgentServiceWatch(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
 
 	var (
 		wakeups  []*api.AgentService

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -300,6 +300,8 @@ func TestServicesWatch(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	s.WaitForSerfCheck(t)
+
 	var (
 		wakeups  []map[string][]string
 		notifyCh = make(chan struct{})


### PR DESCRIPTION
Following example from `TestNodesWatch` https://github.com/hashicorp/consul/blob/aed5cb76690aee5a77a15a1cf3992c517ab5fd17/api/watch/funcs_test.go#L375

I don't think this fixes the underlying potential race condition, but running `FLAKE_PKG=api/watch FLAKE_TEST=TestServicesWatch make test-flake` it seems to make it far less likely to occur...

Refs prior discussion in https://github.com/hashicorp/consul/pull/6503#pullrequestreview-290184650 and https://github.com/hashicorp/consul/pull/5876#issuecomment-495397811