### PR TITLE
docs: Fix expose path HTTP listener ports

### DIFF
--- a/website/source/docs/connect/registration/service-registration.html.md
+++ b/website/source/docs/connect/registration/service-registration.html.md
@@ -267,7 +267,7 @@ registrations](/docs/agent/services.html#service-definition-parameter-case).
 }
 ```
 
-#### Expose an HTTP listener in Envoy at port 2150 that routes to an HTTP server listening at port 8080
+#### Expose an HTTP listener in Envoy at port 21500 that routes to an HTTP server listening at port 8080
 
 ```json
 {
@@ -293,7 +293,7 @@ registrations](/docs/agent/services.html#service-definition-parameter-case).
         "path": "/grpc.health.v1.Health/Check",
         "protocol": "http2",
         "local_path_port": 9090,
-        "listener_port": 21500
+        "listener_port": 21501
       }
     ]
   } 


### PR DESCRIPTION
The listener ports specified in the headings for the HTTP and HTTP2 examples do not match the ports in the corresponding service registration configurations.

This commit changes the port specified in the heading for the HTTP listener to match the port used in the service registration example.

In addition, the listener_port specified for the HTTP2 listener is modified to match the port number specified in the heading.