### PR TITLE
website: embed yt videos on intro pages

### DIFF
--- a/website/source/assets/stylesheets/_inner.scss
+++ b/website/source/assets/stylesheets/_inner.scss
@@ -157,4 +157,9 @@
     @extend .table;
     @extend .table-striped;
   }
+
+  iframe {
+    width: 100%;
+    max-width: 560px;
+  }
 }

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -18,6 +18,8 @@ with Connect](/docs/connect/native.html) for optimal performance and security.
 Connect can help you secure your services and provide data about service-to-service
 communications.
 
+Review the video below to learn more about Consul Connect from HashiCorp's co-founder Armon. 
+
 <iframe src="https://www.youtube.com/embed/8T8t4-hQY74" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
 
 ## Application Security

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -18,6 +18,8 @@ with Connect](/docs/connect/native.html) for optimal performance and security.
 Connect can help you secure your services and provide data about service-to-service
 communications.
 
+<iframe src="https://www.youtube.com/embed/8T8t4-hQY74" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
+
 ## Application Security
 
 Connect enables secure deployment best-practices with automatic

--- a/website/source/intro/index.html.md
+++ b/website/source/intro/index.html.md
@@ -24,6 +24,8 @@ supports both a proxy and native integration model. Consul ships with a
 simple built-in proxy so that everything works out of the box, but also
 supports 3rd party proxy integrations such as Envoy.
 
+<iframe src="https://www.youtube.com/embed/mxeMdl0KvBI" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
+
 The key features of Consul are:
 
 * **Service Discovery**: Clients of Consul can register a service, such as

--- a/website/source/intro/index.html.md
+++ b/website/source/intro/index.html.md
@@ -24,6 +24,8 @@ supports both a proxy and native integration model. Consul ships with a
 simple built-in proxy so that everything works out of the box, but also
 supports 3rd party proxy integrations such as Envoy.
 
+Review the video below to learn more about Consul from HashiCorp's co-founder Armon. 
+
 <iframe src="https://www.youtube.com/embed/mxeMdl0KvBI" frameborder="0" allowfullscreen="true"  width="560" height="315" ></iframe>
 
 The key features of Consul are:


### PR DESCRIPTION
🔗 https://deploy-preview-6871--consul-docs-preview.netlify.com/intro
🔗 https://deploy-preview-6871--consul-docs-preview.netlify.com/docs/connect/

- for /docs/connect
- for /intro
- css to handle iframe responding at smaller viewports

context: the impetus for adding this video comes from a request from Armon Dadgar...

> I do think it would be worth getting some of them onto the IO sites as well, like quick "what is TF" type videos - armon

### intro page
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/49507/70065538-4c369500-15b9-11ea-8adb-5ca4cd644eed.png">


### consul connect
<img width="991" alt="image" src="https://user-images.githubusercontent.com/49507/70065492-3923c500-15b9-11ea-927c-491c409c87c8.png">
