### PR TITLE
coverage: add initial .codecov.yml config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,35 @@
+# https://docs.codecov.io/docs/commit-status
+coverage:
+  status:
+    # only measure diff changes, not unexpected project changes from flakiness
+    project: no
+    patch: yes
+      # default:
+        # https://docs.codecov.io/docs/commit-status#section-threshold
+        # TODO: consider setting instead of using existing coverage as baseline
+        # target: 
+        # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
+        # TODO: should any paths be excluded from coverage metrics?
+        # paths:
+    # https://docs.codecov.io/docs/commit-status#section-changes-status
+    # TODO: enable after eliminating current unexpected coverage changes
+    changes: no
+
+# https://docs.codecov.io/docs/codecov-yaml#section-default-yaml
+# TODO: experiment with changing these values?
+# parsers:
+#   gcov:
+#     branch_detection:
+#       conditional: yes
+#       loop: yes
+#       method: no
+#       macro: no
+
+# https://docs.codecov.io/docs/pull-request-comments#section-layout
+# TODO: any need to tweak the layout here?
+# comment:
+  # layout: "reach,diff,flags,tree"
+
+# https://docs.codecov.io/docs/flags
+# TODO: split out test coverage for API, SDK, UI, website?
+# flags:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,17 +1,12 @@
-# FIXME: remove before merging
-codecov:
-  branch: codecov-yml
-
 # https://docs.codecov.io/docs/commit-status
 coverage:
   status:
     # only measure diff changes, not unexpected project changes from flakiness
     project: no
-    patch: yes
-      # default:
+    patch:
+      default:
         # https://docs.codecov.io/docs/commit-status#section-threshold
-        # TODO: consider setting instead of using existing coverage as baseline
-        # target: 
+        target: 70
         # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
         # TODO: should any paths be excluded from coverage metrics?
         # paths:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+# FIXME: remove before merging
+codecov:
+  branch: codecov-yml
+
 # https://docs.codecov.io/docs/commit-status
 coverage:
   status:
@@ -26,9 +30,8 @@ coverage:
 #       macro: no
 
 # https://docs.codecov.io/docs/pull-request-comments#section-layout
-# TODO: any need to tweak the layout here?
-# comment:
-  # layout: "reach,diff,flags,tree"
+comment:
+  layout: "diff,flags,tree"
 
 # https://docs.codecov.io/docs/flags
 # TODO: split out test coverage for API, SDK, UI, website?


### PR DESCRIPTION
Adds a skeleton CodeCov config file, only change from [defaults](https://docs.codecov.io/docs/codecov-yaml#section-default-yaml) is disabling the `project` status check (visible in the screenshot below), as we want to initially just focus on diff coverage. Includes comments indicating future config where we may want to experiment.

<img width="805" alt="Screen Shot 2019-12-03 at 4 11 13 PM" src="https://user-images.githubusercontent.com/1149913/70183874-a2d4c980-16b4-11ea-95b8-aafedeb9c087.png">