### PR TITLE
Adding Proper error message for using snake_case instead of CamelCase and testcase. 

### DIFF
--- a/lib/patch_hcl.go
+++ b/lib/patch_hcl.go
@@ -42,7 +42,7 @@ func patchValue(name string, v interface{}, skip []string, skipTree []string) in
 			return x
 		}
 		if len(x) > 1 {
-			panic(fmt.Sprintf("%s: []map[string]interface{} with more than one element not supported: %s", name, v))
+			panic(fmt.Sprintf("%s: []map[string]interface{} with more than one element not supported: %s. Make sure you are using snake_case instead of CamelCase.", name, v))
 		}
 		return patchValue(name, x[0], skip, skipTree)
 

--- a/lib/patch_hcl_test.go
+++ b/lib/patch_hcl_test.go
@@ -121,3 +121,50 @@ func TestPatchSliceOfMaps(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchSliceOfMapsFailure(t *testing.T) {
+	tests := []struct {
+		in, out  string
+		skip     []string
+		skipTree []string
+	}{
+		{
+			// To check failure of conversion in case of CamelCase
+			in: `{
+				"services": [
+					{
+						"Checks": [
+							{
+								"header": [
+									{"a":"b"}
+								]
+							}
+						]
+					}
+				]
+			}`,
+			out: `{
+				"services": [
+					{
+						"Checks": [
+							{
+								"header": {"a":"b"}
+							}
+						]
+					}
+				]
+			}`,
+			skip: []string{"services", "services.checks"},
+		},
+	}
+
+	for i, tt := range tests {
+		desc := fmt.Sprintf("%02d: %s -> %s skip: %v", i, tt.in, tt.out, tt.skip)
+		t.Run(desc, func(t *testing.T) {
+			out := PatchSliceOfMaps(parse(tt.in), tt.skip, tt.skipTree)
+			if got, want := out, parse(tt.out); reflect.DeepEqual(got, want) {
+				t.Fatalf("\ngot  %#v\nwant %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
What? 
1. Adding proper error message for using snake_case instead of CamelCase in HCL or json as mentioned in this https://github.com/hashicorp/consul/issues/6870

2. Adding test case for failure of patchValue function when CamelCase is supplied. 