### PR TITLE
Fix the TestLeader_SecondaryCA_IntermediateRefresh test flakine…

### DIFF
--- a/agent/consul/leader_connect_test.go
+++ b/agent/consul/leader_connect_test.go
@@ -237,6 +237,9 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		updatedRoot = activeRoot
 	}
 
+	testrpc.WaitForActiveCARoot(t, s1.RPC, "dc1", updatedRoot)
+	testrpc.WaitForActiveCARoot(t, s2.RPC, "dc2", updatedRoot)
+
 	// Wait for dc2's intermediate to be refreshed.
 	var intermediatePEM string
 	retry.Run(t, func(r *retry.R) {
@@ -247,9 +250,6 @@ func TestLeader_SecondaryCA_IntermediateRefresh(t *testing.T) {
 		}
 	})
 	require.NoError(err)
-
-	testrpc.WaitForActiveCARoot(t, s1.RPC, "dc1", updatedRoot)
-	testrpc.WaitForActiveCARoot(t, s2.RPC, "dc2", updatedRoot)
 
 	// Verify the root lists have been rotated in each DC's state store.
 	state1 := s1.fsm.State()


### PR DESCRIPTION
Before the fix: `go test -count 10 ./agent/consul -run TestLeader_SecondaryCA_IntermediateRefresh` would fail 9/10 times. After the fix, I ran it with `-count 100` and it passed every time.

The real question here is whether needing to move these up is indicative of an actual issue.

cc: @banks 

What I believe was happening was that the intermediate was being changed between when we got the updated intermediate from the secondary CA provider and when we actually signed the cert. Therefore, the leaf cert couldn't be verified because we were setting up the cert pool with the old intermediate.

I added some debug logging to the Consul CA provider so I could see when it was setting new intermediates and it did happen 3 times.

https://gist.github.com/mkeeler/c4a8a7f429f788641d1562a63bbe7251