### PR TITLE
agent: fewer file local differences between enterprise and oss (#6820)

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -410,6 +410,8 @@ func (a *Agent) Start() error {
 	// waiting to discover a consul server
 	consulCfg.ServerUp = a.sync.SyncFull.Trigger
 
+	a.initEnterprise(consulCfg)
+
 	tlsConfigurator, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), a.logger)
 	if err != nil {
 		return err

--- a/agent/agent_oss.go
+++ b/agent/agent_oss.go
@@ -1,0 +1,8 @@
+// +build !consulent
+
+package agent
+
+import "github.com/hashicorp/consul/agent/consul"
+
+func (a *Agent) initEnterprise(consulCfg *consul.Config) {
+}

--- a/agent/consul/fsm/fsm_test.go
+++ b/agent/consul/fsm/fsm_test.go
@@ -47,7 +47,7 @@ func TestFSM_IgnoreUnknown(t *testing.T) {
 		Foo string
 	}
 	req := UnknownRequest{Foo: "bar"}
-	msgType := structs.IgnoreUnknownTypeFlag | 64
+	msgType := structs.IgnoreUnknownTypeFlag | 75
 	buf, err := structs.Encode(msgType, req)
 	assert.Nil(t, err)
 

--- a/lib/serf.go
+++ b/lib/serf.go
@@ -1,8 +1,9 @@
 package lib
 
 import (
-	"github.com/hashicorp/serf/serf"
 	"time"
+
+	"github.com/hashicorp/serf/serf"
 )
 
 // SerfDefaultConfig returns a Consul-flavored Serf default configuration,


### PR DESCRIPTION
* Increase number to test ignore. Consul Enterprise has more flags and since we are trying to reduce the differences between both code bases, we are increasing the number in oss. The semantics don't change, it is just a cosmetic thing.
* Introduce agent.initEnterprise for enterprise related hooks.
* Sync test with ent version.
* Fix import order.
* revert error wording.