### PR TITLE
fix: Destroying a session that doesn't exist returns status code 500 …

### DIFF
--- a/agent/consul/session_endpoint.go
+++ b/agent/consul/session_endpoint.go
@@ -58,7 +58,7 @@ func (s *Session) Apply(args *structs.SessionRequest, reply *string) error {
 				return fmt.Errorf("Session lookup failed: %v", err)
 			}
 			if existing == nil {
-				return fmt.Errorf("Unknown session %q", args.Session.ID)
+				return nil
 			}
 			if rule.SessionWrite(existing.Node, &entCtx) != acl.Allow {
 				return acl.ErrPermissionDenied


### PR DESCRIPTION
…if ACLs are enabled

fix #6840