### PR TITLE
ci: set GOMAXPROCS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
     environment:
       <<: *ENVIRONMENT
       GOTAGS: "" # No tags for OSS but there are for enterprise
+      GOMAXPROCS: 2 # medium (default) boxes are 2 vCPUs, 4GB RAM https://circleci.com/docs/2.0/configuration-reference/#docker-executor
     steps:
       - checkout
       - restore_cache: # restore cache from earlier job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
     environment:
       <<: *ENVIRONMENT
       GOTAGS: "" # No tags for OSS but there are for enterprise
+      # GOMAXPROCS defaults to number of cores on underlying hardware, set explicitly to avoid OOM issues https://support.circleci.com/hc/en-us/articles/360034684273-common-GoLang-memory-issues
       GOMAXPROCS: 2 # medium (default) boxes are 2 vCPUs, 4GB RAM https://circleci.com/docs/2.0/configuration-reference/#docker-executor
     steps:
       - checkout


### PR DESCRIPTION
Refs https://circleci.com/docs/2.0/configuration-reference/#docker-executor

Sets `GOMAXPROCS` to `2` until we can upgrade the `resource_class` in our CircleCI plan.