### PR TITLE
Small improvements to Connect docs

### DIFF
--- a/website/source/docs/connect/connect-internals.html.md
+++ b/website/source/docs/connect/connect-internals.html.md
@@ -36,7 +36,7 @@ The destination service verifies the client certificate
 against the [public CA bundle](/api/connect/ca.html#list-ca-root-certificates).
 After verifying the certificate, it must also call the
 [authorization API](/api/agent/connect.html#authorize) to authorize
-the connection against the configured set of Consul intentions.
+the connection against the configured set of Consul [intentions](/docs/connect/intentions.html).
 If the authorization API responds successfully, the connection is established.
 Otherwise, the connection is rejected.
 
@@ -46,7 +46,7 @@ also ships with built-in support for [Vault](/docs/connect/ca/vault.html). The P
 and can be extended to support any system by adding additional CA providers.
 
 All APIs required for Connect typically respond in microseconds and impose
-minimal overhead to existing services. This is because the Connect-related APIs
+minimal overhead to existing services. Ensuring this, Connect-related APIs calls
 are all made to the local Consul agent over a loopback interface, and all [agent
 Connect endpoints](/api/agent/connect.html) implement local caching, background
 updating, and support blocking queries. Most API calls operate on purely local

--- a/website/source/docs/connect/connect-internals.html.md
+++ b/website/source/docs/connect/connect-internals.html.md
@@ -46,7 +46,7 @@ also ships with built-in support for [Vault](/docs/connect/ca/vault.html). The P
 and can be extended to support any system by adding additional CA providers.
 
 All APIs required for Connect typically respond in microseconds and impose
-minimal overhead to existing services. Ensuring this, Connect-related APIs calls
+minimal overhead to existing services. To ensure this, Connect-related API calls
 are all made to the local Consul agent over a loopback interface, and all [agent
 Connect endpoints](/api/agent/connect.html) implement local caching, background
 updating, and support blocking queries. Most API calls operate on purely local

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -37,7 +37,7 @@ programming languages and frameworks. When you configure Consul Connect to use
 sidecar proxies, those proxies "see" all service-to-service traffic and can
 collect data about it. Consul Connect can configure Envoy proxies to collect
 layer 7 metrics and export them to tools like Prometheus. Correctly instrumented
-application can also send open tracing data through Envoy.
+applications can also send open tracing data through Envoy.
 
 ## Getting Started With Connect
 


### PR DESCRIPTION
I was reading through the connect docs and wanted to make a few changes while I was there. I added a link to the intentions docs and adjusted some phrasing in the "Connect internals" page. And I fixed a small typo on the Connect index page.

I probably ought to squash this down to 1 commit on merge. Thanks for reading!