### PR TITLE
website: add 1.7.0 Beta announcement to Downloads page

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -8,9 +8,9 @@ description: |-
 
 <h1>Download Consul</h1>
 
-<div class="alert alert-info" id="rc-1-4" role="alert">
+<div class="alert alert-info" id="beta-1-7" role="alert">
   <p><strong>1.7.0 Beta Available:</strong> Read more about the new features coming in 1.7.0 in the
-  <a href="#">announcement post</a>. Binaries can be accessed on <a href="https://releases.hashicorp.com/consul/">releases.hashicorp.com</a>.
+  <a href="https://www.hashicorp.com/blog/announcing-hashicorp-consul-1-7/">announcement post</a>. Binaries can be accessed on <a href="https://releases.hashicorp.com/consul/">releases.hashicorp.com</a>.
   </p>
 </div>
 

--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -8,6 +8,12 @@ description: |-
 
 <h1>Download Consul</h1>
 
+<div class="alert alert-info" id="rc-1-4" role="alert">
+  <p><strong>1.7.0 Beta Available:</strong> Read more about the new features coming in 1.7.0 in the
+  <a href="#">announcement post</a>. Binaries can be accessed on <a href="https://releases.hashicorp.com/consul/">releases.hashicorp.com</a>.
+  </p>
+</div>
+
 <section class="downloads">
   <div class="description row">
     <div class="col-md-12">


### PR DESCRIPTION
**FIXME:** update announcement post link before merging

@alvin-huang will the release process pull the current non-beta version (i.e. v1.6.2), or does a commit like https://github.com/hashicorp/consul/commit/1200f25eabc75368484a78698e75f1e61b6ed010 need to be merged back to `master` from `stable-website`? Right now the Netlify preview is showing v1.6.1