### PR TITLE
ui: [Bugfix] Fix DC switching when blocking queries enabled (1.7-beta)

### DIFF
--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -38,7 +38,8 @@ export default Serializer.extend({
     return respond((headers, body) =>
       attachHeaders(
         headers,
-        map(body, this.fingerprint(this.primaryKey, this.slugKey, query.dc), query)
+        map(body, this.fingerprint(this.primaryKey, this.slugKey, query.dc)),
+        query
       )
     );
   },
@@ -46,7 +47,8 @@ export default Serializer.extend({
     return respond((headers, body) =>
       attachHeaders(
         headers,
-        map(body, this.fingerprint(this.primaryKey, this.slugKey, query.dc), query)
+        map(body, this.fingerprint(this.primaryKey, this.slugKey, query.dc)),
+        query
       )
     );
   },

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -18,9 +18,12 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
     if (typeof meta.date !== 'undefined') {
       // unload anything older than our current sync date/time
       store.peekAll(repo.getModelName()).forEach(function(item) {
-        const date = get(item, 'SyncTime');
-        if (typeof date !== 'undefined' && date != meta.date) {
-          store.unloadRecord(item);
+        const dc = get(item, 'Datacenter');
+        if (dc === meta.dc) {
+          const date = get(item, 'SyncTime');
+          if (typeof date !== 'undefined' && date != meta.date) {
+            store.unloadRecord(item);
+          }
         }
       });
     }

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -17,7 +17,7 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
     const meta = get(event.data || {}, 'meta') || {};
     if (typeof meta.date !== 'undefined') {
       // unload anything older than our current sync date/time
-      store.peekAll(repo.getModelName()).forEach(function(item) {
+      store.peekAll(repo.getModelName()).forEach(function(item, i) {
         const dc = get(item, 'Datacenter');
         if (dc === meta.dc) {
           const date = get(item, 'SyncTime');

--- a/ui-v2/app/utils/http/consul.js
+++ b/ui-v2/app/utils/http/consul.js
@@ -1,3 +1,4 @@
 export const HEADERS_SYMBOL = '__consul_ui_http_headers__';
+export const HEADERS_DATACENTER = 'x-consul-datacenter';
 export const HEADERS_INDEX = 'x-consul-index';
 export const HEADERS_DIGEST = 'x-consul-contenthash';

--- a/ui-v2/tests/acceptance/dc/services/dc-switch.feature
+++ b/ui-v2/tests/acceptance/dc/services/dc-switch.feature
@@ -1,0 +1,27 @@
+@setupApplicationTest
+Feature: dc / services / dc-switch : Switching Datacenters
+  Scenario: Seeing all services when switching datacenters
+    Given 2 datacenter models from yaml
+    ---
+      - dc-1
+      - dc-2
+    ---
+    And 6 service models
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    Then I see 6 service models
+    When I click dc on the navigation
+    And I click dcs.1.name
+    Then the url should be /dc-2/services
+    Then I see 6 service models
+    When I click dc on the navigation
+    And I click dcs.0.name
+    Then the url should be /dc-1/services
+    Then I see 6 service models
+    When I click dc on the navigation
+    And I click dcs.1.name
+    Then the url should be /dc-2/services
+    Then I see 6 service models

--- a/ui-v2/tests/acceptance/steps/dc/services/dc-switch-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/services/dc-switch-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/integration/serializers/acl-test.js
+++ b/ui-v2/tests/integration/serializers/acl-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | acl', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -39,7 +39,9 @@ module('Integration | Serializer | acl', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/intention-test.js
+++ b/ui-v2/tests/integration/serializers/intention-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | intention', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -41,7 +41,9 @@ module('Integration | Serializer | intention', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/kv-test.js
+++ b/ui-v2/tests/integration/serializers/kv-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | kv', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -45,7 +45,9 @@ module('Integration | Serializer | kv', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/node-test.js
+++ b/ui-v2/tests/integration/serializers/node-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | node', function(hooks) {
   setupTest(hooks);
   test('respondForQuery returns the correct data for list endpoint', function(assert) {
@@ -40,7 +40,9 @@ module('Integration | Serializer | node', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/policy-test.js
+++ b/ui-v2/tests/integration/serializers/policy-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | policy', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -39,7 +39,9 @@ module('Integration | Serializer | policy', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/role-test.js
+++ b/ui-v2/tests/integration/serializers/role-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 import { createPolicies } from 'consul-ui/tests/helpers/normalizers';
 
 module('Integration | Serializer | role', function(hooks) {
@@ -43,7 +43,9 @@ module('Integration | Serializer | role', function(hooks) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
         Policies: createPolicies(payload),
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/service-test.js
+++ b/ui-v2/tests/integration/serializers/service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Serializer | service', function(hooks) {
   setupTest(hooks);
   test('respondForQuery returns the correct data for list endpoint', function(assert) {
@@ -40,7 +40,9 @@ module('Integration | Serializer | service', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
         Name: id,
         Nodes: payload,

--- a/ui-v2/tests/integration/serializers/session-test.js
+++ b/ui-v2/tests/integration/serializers/session-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 module('Integration | Adapter | session | response', function(hooks) {
   setupTest(hooks);
   const dc = 'dc-1';
@@ -40,7 +40,9 @@ module('Integration | Adapter | session | response', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload[0], {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
       });
       const actual = serializer.respondForQueryRecord(

--- a/ui-v2/tests/integration/serializers/token-test.js
+++ b/ui-v2/tests/integration/serializers/token-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
-import { HEADERS_SYMBOL as META } from 'consul-ui/utils/http/consul';
+import { HEADERS_SYMBOL as META, HEADERS_DATACENTER as DC } from 'consul-ui/utils/http/consul';
 
 import { createPolicies } from 'consul-ui/tests/helpers/normalizers';
 
@@ -43,7 +43,9 @@ module('Integration | Serializer | token', function(hooks) {
     return get(request.url).then(function(payload) {
       const expected = Object.assign({}, payload, {
         Datacenter: dc,
-        [META]: {},
+        [META]: {
+          [DC]: dc,
+        },
         uid: `["${dc}","${id}"]`,
         Policies: createPolicies(payload),
       });

--- a/ui-v2/tests/integration/services/repository/node-test.js
+++ b/ui-v2/tests/integration/services/repository/node-test.js
@@ -63,7 +63,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
             uid: `["${dc}","${item.ID}"]`,
             meta: {
               cursor: undefined,
-              dc: undefined,
+              dc: dc,
             },
           });
         })

--- a/ui-v2/tests/integration/services/repository/node-test.js
+++ b/ui-v2/tests/integration/services/repository/node-test.js
@@ -63,6 +63,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
             uid: `["${dc}","${item.ID}"]`,
             meta: {
               cursor: undefined,
+              dc: undefined,
             },
           });
         })

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -76,6 +76,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
           service.Tags = payload.Nodes[0].Service.Tags;
           service.meta = {
             cursor: undefined,
+            dc: undefined,
           };
 
           return service;

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -76,7 +76,7 @@ test('findBySlug returns the correct data for item endpoint', function(assert) {
           service.Tags = payload.Nodes[0].Service.Tags;
           service.meta = {
             cursor: undefined,
-            dc: undefined,
+            dc: dc,
           };
 
           return service;

--- a/ui-v2/tests/pages/components/page.js
+++ b/ui-v2/tests/pages/components/page.js
@@ -1,5 +1,5 @@
 import { clickable } from 'ember-cli-page-object';
-export default {
+const page = {
   navigation: ['services', 'nodes', 'kvs', 'acls', 'intentions', 'docs', 'settings'].reduce(
     function(prev, item, i, arr) {
       const key = item;
@@ -23,3 +23,5 @@ export default {
     }
   ),
 };
+page.navigation.dc = clickable('[data-test-datacenter-selected]');
+export default page;

--- a/ui-v2/tests/pages/dc/services/index.js
+++ b/ui-v2/tests/pages/dc/services/index.js
@@ -6,7 +6,9 @@ export default function(visitable, clickable, attribute, collection, page, filte
       service: clickable('a'),
       externalSource: attribute('data-test-external-source', 'a span'),
     }),
-    dcs: collection('[data-test-datacenter-picker]'),
+    dcs: collection('[data-test-datacenter-picker]', {
+      name: clickable('a'),
+    }),
     navigation: page.navigation,
     filter: filter,
   };

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -46,7 +46,7 @@ export default function(assert, library, pages, utils) {
           if (isNaN(parseInt(prop))) {
             return (obj = obj[prop]);
           } else {
-            return (obj = obj.objectAt(prop));
+            return (obj = obj.objectAt(parseInt(prop)));
           }
         }) && obj
       );

--- a/ui-v2/tests/unit/serializers/application-test.js
+++ b/ui-v2/tests/unit/serializers/application-test.js
@@ -60,7 +60,9 @@ module('Unit | Serializer | application', function(hooks) {
     const expected = {
       Datacenter: 'dc-1',
       Name: 'name',
-      __consul_ui_http_headers__: {},
+      __consul_ui_http_headers__: {
+        'x-consul-datacenter': 'dc-1',
+      },
       'primary-key-name': 'name',
     };
     const respond = function(cb) {


### PR DESCRIPTION
This bug has already been fixed for 1.6.x (https://github.com/hashicorp/consul/pull/6555).

This PR adds a fix for 1.7, but without the specific change to include namespace support (this bug was also fixed in https://github.com/hashicorp/consul/pull/6808).

See descriptions in the above PRs