### PR TITLE
ui: Explicitly remove properties that shouldn't be sent when saving

### DIFF
--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -25,14 +25,26 @@ export default Adapter.extend({
     return request`
       PUT /v1/acl/role?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
 
-      ${serialized}
+      ${{
+        Name: serialized.Name,
+        Description: serialized.Description,
+        Namespace: serialized.Namespace,
+        Policies: serialized.Policies,
+        ServiceIdentities: serialized.ServiceIdentities,
+      }}
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/role/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
 
-      ${serialized}
+      ${{
+        Name: serialized.Name,
+        Description: serialized.Description,
+        Namespace: serialized.Namespace,
+        Policies: serialized.Policies,
+        ServiceIdentities: serialized.ServiceIdentities,
+      }}
     `;
   },
   requestForDeleteRecord: function(request, serialized, data) {

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -26,6 +26,14 @@ export default Adapter.extend({
   requestForCreateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/token?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
+
+      ${{
+        Description: serialized.Description,
+        Policies: serialized.Policies,
+        Roles: serialized.Roles,
+        ServiceIdentities: serialized.ServiceIdentities,
+        Local: serialized.Local,
+      }}
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
@@ -45,7 +53,13 @@ export default Adapter.extend({
     return request`
       PUT /v1/acl/token/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
 
-      ${serialized}
+      ${{
+        Description: serialized.Description,
+        Policies: serialized.Policies,
+        Roles: serialized.Roles,
+        ServiceIdentities: serialized.ServiceIdentities,
+        Local: serialized.Local,
+      }}
     `;
   },
   requestForDeleteRecord: function(request, serialized, data) {


### PR DESCRIPTION
This PR removes properties that shouldn't be sent when saving objects back to the API. Previously Consul would allow this but a recent change disallowed it (https://github.com/hashicorp/consul/pull/6874)