### PR TITLE
Namespaces docs updates

### DIFF
--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -78,9 +78,8 @@ func (f *HTTPFlags) NamespaceFlags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	// TODO (namespaces) Do we want to allow setting via an env var? CONSUL_NAMESPACE
 	fs.Var(&f.namespace, "ns",
-		"Specifies the namespace to query. If not provided, the namespace will be inferred +"+
-			"from the request's ACL token, or will default to the `default` namespace. "+
-			"Namespaces is a Consul Enterprise feature.")
+		"Specifies the namespace to query. If not provided, the namespace will"+
+			"default to the `default` namespace. Namespaces is a Consul Enterprise feature.")
 	return fs
 }
 

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -308,8 +308,8 @@ replication enabled.
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the Auth Method to use for Login. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inferred from the request's ACL 
-  token, or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 

--- a/website/source/api/acl/auth-methods.html.md
+++ b/website/source/api/acl/auth-methods.html.md
@@ -57,8 +57,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the auth method within. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -128,12 +128,12 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the auth method within. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.
 
 ### Sample Request
 
 ```sh
+
 $ curl -X GET http://127.0.0.1:8500/v1/acl/auth-method/minikube
 ```
 
@@ -194,8 +194,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the auth method to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -269,12 +269,12 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   Auth Method to delete. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
-
+  the namespace will default to the `default` namespace. Added in Consul 1.7.
+ 
 ### Sample Request
 
 ```sh
+
 $ curl -X DELETE \
     http://127.0.0.1:8500/v1/acl/auth-method/minikube
 ```
@@ -308,10 +308,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the auth methods for. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. The namespace may be specified as '*' and then
-  results will be returned for all namespaces. Added in Consul 1.7.0.
-
+  the namespace will default to the `default` namespace. The namespace may be 
+  specified as '*' and then results will be returned for all namespaces. 
+  Added in Consul 1.7.0.
 
 ## Sample Request
 

--- a/website/source/api/acl/binding-rules.html.md
+++ b/website/source/api/acl/binding-rules.html.md
@@ -91,8 +91,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the binding rule. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -157,9 +157,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the binding rule. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
-
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -261,8 +259,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the binding rule to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -327,8 +325,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   binding rule to delete. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -368,9 +365,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the binding rules for. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. The namespace may be specified as '*' and then
-  results will be returned for all namespaces. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. 
+  The namespace may be specified as '*' and then results will be returned for all namespaces. 
+  Added in Consul 1.7.0.
 
 ## Sample Request
 

--- a/website/source/api/acl/binding-rules.html.md
+++ b/website/source/api/acl/binding-rules.html.md
@@ -156,7 +156,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the binding rule. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -324,7 +324,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   binding rule to delete. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -364,7 +364,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the binding rules for. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. 
   The namespace may be specified as '*' and then results will be returned for all namespaces. 
   Added in Consul 1.7.0.

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -53,8 +53,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the policy. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -119,8 +119,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the policy. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -185,8 +184,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the policy to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -250,8 +249,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   policy to delete. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -288,8 +286,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the Policies for. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -118,7 +118,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the policy. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -248,7 +248,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   policy to delete. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -285,7 +285,7 @@ The table below shows this endpoint's support for
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the Policies for. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 

--- a/website/source/api/acl/roles.html.md
+++ b/website/source/api/acl/roles.html.md
@@ -162,7 +162,7 @@ The table below shows this endpoint's support for
    
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -227,7 +227,7 @@ The table below shows this endpoint's support for
    
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -392,7 +392,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   role to delete. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -434,7 +434,7 @@ The table below shows this endpoint's support for
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the roles for. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 

--- a/website/source/api/acl/roles.html.md
+++ b/website/source/api/acl/roles.html.md
@@ -67,8 +67,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the role. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -163,8 +163,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -229,8 +228,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -313,8 +311,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the role to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -395,8 +393,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   role to delete. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -438,8 +435,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the roles for. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -172,7 +172,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the token. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -507,7 +507,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   token to delete. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -553,7 +553,7 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the tokens for. This value can be specified as the `ns` URL query 
-  parameter orthe `X-Consul-Namespace` header. If not provided by either,
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
   the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -93,8 +93,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the token. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -173,8 +173,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the token. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -344,8 +343,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the token to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -432,8 +431,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the token to be cloned. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -509,8 +508,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   token to delete. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -556,8 +554,7 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the tokens for. This value can be specified as the `ns` URL query 
   parameter orthe `X-Consul-Namespace` header. If not provided by either,
-  the namespace will be inherited from the request's ACL token or will default
-  to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -91,8 +91,7 @@ The table below shows this endpoint's support for
   `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
   the namespace may be provided within the `Service` or `Check` fields but if
   present in multiple places, they must all be the same. If not provided at all, 
-  the namespace will be inherited from the request's ACL token or will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
 
 
 It is important to note that `Check` does not have to be provided with `Service`
@@ -206,8 +205,8 @@ The behavior of the endpoint depends on what keys are provided.
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
   service and checks will be deregistered.  If not provided in the JSON body, the value of
   the `ns` URL query parameter or the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will be inherited from the request's ACL 
-  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  If not provided at all, the namespace will default to the `default` namespace. 
+  Added in Consul 1.7.0.
 
 ### Sample Payloads
 
@@ -407,8 +406,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list services. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
+  the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -479,8 +478,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to use for the
   query. This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
+  the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -685,8 +684,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list services. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
+  the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/health.html.md
+++ b/website/source/api/health.html.md
@@ -47,8 +47,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list checks. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. To view
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
+  to the `default` namespace. To view
   checks for multiple namespaces the `*` wildcard namespace may be used. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -152,8 +152,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the service.
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -252,8 +252,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the service. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL  token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
+  the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -447,8 +447,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
-  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -69,7 +69,9 @@ The table below shows this endpoint's support for
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
   If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  This is specified as part of the URL as a query parameter. 
+  For recursive lookups, the namespace may be specified as '*' and then results 
+  will be returned for all namespaces. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -68,9 +68,8 @@ The table below shows this endpoint's support for
   This is specified as part of the URL as a query parameter.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -207,9 +206,8 @@ The table below shows this endpoint's support for
   of the key. The key must be held by this session to be unlocked.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -268,9 +266,8 @@ The table below shows this endpoint's support for
   deleted if the index matches the `ModifyIndex` of that key.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -32,9 +32,8 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried. This is specified as part of the
@@ -132,9 +131,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -178,9 +176,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -239,9 +236,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -295,9 +291,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -355,9 +350,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will be inferred from the request's ACL token,
-  or will default to the `default` namespace. This is specified as part of the
-  URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will default to the `default` namespace. 
+  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -237,7 +237,9 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
   If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  This is specified as part of the URL as a query parameter. 
+  The namespace may be specified as '*' and then results will be returned for all namespaces.
+  Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -292,7 +294,9 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
   If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  This is specified as part of the URL as a query parameter. 
+  The namespace may be specified as '*' and then results will be returned for all namespaces.
+  Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/docs/commands/_http_api_namespace_options.html.md
+++ b/website/source/docs/commands/_http_api_namespace_options.html.md
@@ -1,3 +1,2 @@
 * `-ns=<string>` - Specifies the namespace to query. If not provided, the namespace
-  will be inferred from the request's ACL token, or will default to
-  the `default` namespace. Namespaces is a Consul Enterprise feature added in v1.7.0.
+  will default to the `default` namespace. Namespaces is a Consul Enterprise feature added in v1.7.0.


### PR DESCRIPTION
1. Inferring a namespace from the ACL token has not been implemented, so that is being removed from the docs in one commit.
2. KV and session endpoints that support the wildcard namespace now have docs that point that out.