### PR TITLE
correct website download version to 1.6.2

### DIFF
--- a/website/config.rb
+++ b/website/config.rb
@@ -2,7 +2,7 @@ set :base_url, "https://www.consul.io/"
 
 activate :hashicorp do |h|
   h.name        = "consul"
-  h.version     = "1.6.1"
+  h.version     = "1.6.2"
   h.github_slug = "hashicorp/consul"
 end
 


### PR DESCRIPTION
This commit: https://github.com/hashicorp/consul/commit/1200f25eabc75368484a78698e75f1e61b6ed010

Should've been cherry-picked over to master after the 1.6.2 release. The changelog changes were copied over the website version was not. Since 1.7.0 is a beta right now, the current website version was not updated to 1.7.0-beta1 and needs to be updated from 1.6.1 to 1.6.2.