### PR TITLE
Update CONTRIBUTING.md w/ stipulation that go 1.13 is not yet supported

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ issue. Stale issues will be closed.
 ## Building Consul
 
 If you wish to work on Consul itself, you'll first need [Go](https://golang.org)
-installed (version 1.12+ is _required_). Make sure you have Go properly installed,
+installed (version 1.12 is _required_, [go 1.13 is not yet supported](https://github.com/hashicorp/consul/issues/6879)). Make sure you have Go properly installed,
 including setting up your [GOPATH](https://golang.org/doc/code.html#GOPATH).
 
 Next, clone this repository into `$GOPATH/src/github.com/hashicorp/consul` and 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ issue. Stale issues will be closed.
 ## Building Consul
 
 If you wish to work on Consul itself, you'll first need [Go](https://golang.org)
-installed (version 1.12 is _required_, [go 1.13 is not yet supported](https://github.com/hashicorp/consul/issues/6879)). Make sure you have Go properly installed,
+installed (version 1.12 is _required_, and [version 1.13 is not yet supported](https://github.com/hashicorp/consul/issues/6879)). Make sure you have Go properly installed,
 including setting up your [GOPATH](https://golang.org/doc/code.html#GOPATH).
 
 Next, clone this repository into `$GOPATH/src/github.com/hashicorp/consul` and 
@@ -135,4 +135,3 @@ Consul currently uses Go Modules for vendoring.
 
 Please only apply the minimal vendor changes to get your PR to work. 
 Consul does not attempt to track the latest version for each dependency.
-


### PR DESCRIPTION
Updating the version specified in CONTRIBUTING.md to take #6879 into account. This content should be removed/adjusted when Go version 1.13 is supported. 