### PR TITLE
ui: Remove `writable` usage from policy and use the request instead

### DIFF
--- a/ui-v2/app/adapters/policy.js
+++ b/ui-v2/app/adapters/policy.js
@@ -25,14 +25,24 @@ export default Adapter.extend({
     return request`
       PUT /v1/acl/policy?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
 
-      ${serialized}
+      ${{
+        Name: serialized.Name,
+        Description: serialized.Description,
+        Rules: serialized.Rules,
+        Datacenters: serialized.Datacenters,
+      }}
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
     return request`
       PUT /v1/acl/policy/${data[SLUG_KEY]}?${{ [API_DATACENTER_KEY]: data[DATACENTER_KEY] }}
 
-      ${serialized}
+      ${{
+        Name: serialized.Name,
+        Description: serialized.Description,
+        Rules: serialized.Rules,
+        Datacenters: serialized.Datacenters,
+      }}
     `;
   },
   requestForDeleteRecord: function(request, serialized, data) {

--- a/ui-v2/app/models/policy.js
+++ b/ui-v2/app/models/policy.js
@@ -1,11 +1,10 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import writable from 'consul-ui/utils/model/writable';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'ID';
 
-const model = Model.extend({
+export default Model.extend({
   [PRIMARY_KEY]: attr('string'),
   [SLUG_KEY]: attr('string'),
   Name: attr('string', {
@@ -29,6 +28,3 @@ const model = Model.extend({
     defaultValue: '',
   }),
 });
-// TODO: Remove this in favour of just specifying it in the Adapter
-export const ATTRS = writable(model, ['Name', 'Description', 'Rules', 'Datacenters']);
-export default model;

--- a/ui-v2/app/models/token.js
+++ b/ui-v2/app/models/token.js
@@ -1,11 +1,10 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import writable from 'consul-ui/utils/model/writable';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'AccessorID';
 
-const model = Model.extend({
+export default Model.extend({
   [PRIMARY_KEY]: attr('string'),
   [SLUG_KEY]: attr('string'),
   IDPName: attr('string'),
@@ -43,19 +42,3 @@ const model = Model.extend({
   CreateIndex: attr('number'),
   ModifyIndex: attr('number'),
 });
-// TODO: Remove this in favour of just specifying it in the Adapter
-// Name and Rules is only for legacy tokens
-export const ATTRS = writable(model, [
-  'Name',
-  'Rules',
-  'Type',
-  'Local',
-  'Description',
-  'Policies',
-  'Roles',
-  // SecretID isn't writable but we need it to identify an
-  // update via the old API, see TokenAdapter dataForRequest
-  'SecretID',
-  'AccessorID',
-]);
-export default model;

--- a/ui-v2/app/serializers/policy.js
+++ b/ui-v2/app/serializers/policy.js
@@ -1,8 +1,7 @@
 import Serializer from './application';
-import { PRIMARY_KEY, SLUG_KEY, ATTRS } from 'consul-ui/models/policy';
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/policy';
 
 export default Serializer.extend({
   primaryKey: PRIMARY_KEY,
   slugKey: SLUG_KEY,
-  attrs: ATTRS,
 });

--- a/ui-v2/app/serializers/token.js
+++ b/ui-v2/app/serializers/token.js
@@ -1,6 +1,6 @@
 import Serializer from './application';
 import { get } from '@ember/object';
-import { PRIMARY_KEY, SLUG_KEY, ATTRS } from 'consul-ui/models/token';
+import { PRIMARY_KEY, SLUG_KEY } from 'consul-ui/models/token';
 
 import WithPolicies from 'consul-ui/mixins/policy/as-many';
 import WithRoles from 'consul-ui/mixins/role/as-many';
@@ -8,7 +8,6 @@ import WithRoles from 'consul-ui/mixins/role/as-many';
 export default Serializer.extend(WithPolicies, WithRoles, {
   primaryKey: PRIMARY_KEY,
   slugKey: SLUG_KEY,
-  attrs: ATTRS,
   serialize: function(snapshot, options) {
     let data = this._super(...arguments);
     // If a token has Rules, use the old API shape


### PR DESCRIPTION
A recent change to the backend (https://github.com/hashicorp/consul/pull/6874) meant that if you sent any data in the HTTP body that wasn't needed the backend would return an error.

In https://github.com/hashicorp/consul/pull/6917 we changed the HTTP requests that weren't already using our `writable` functionality to remove data from the HTTP request that wasn't needed.

`writable` was used before we rewrite our data to achieve this, but our new data layer makes it much easier to see what is being sent to the server as it doesn't spread the information for the HTTP request over multiple files.

This PR remove `writable` usage from `policy` and continues to clean up `token` and moves them to use our new data layer approach.

We can't quite delete `writable` yet as in this branch `intentions` still use it, but in https://github.com/hashicorp/consul/pull/6639 we switched intentions to use our new approach also while we were there. Once https://github.com/hashicorp/consul/pull/6639 and this PR are merged we can add another PR to completely remove `writable` 😁 
