### PR TITLE
ui: Fixes styling of 'duplicate intention' error message

### DIFF
--- a/ui-v2/app/styles/components/flash-message.scss
+++ b/ui-v2/app/styles/components/flash-message.scss
@@ -5,3 +5,13 @@
 %flash-message.exiting {
   @extend %blink-in-fade-out;
 }
+/* This is for the flash message that appears */
+/* when you save an intention that already exists */
+/* once we have refactored app-view with data-source with nicer */
+/* flash message usage we should be able to remove this */
+%flash-message p.exists strong::before {
+  @extend %with-cancel-square-fill-color-icon;
+}
+%flash-message p.exists {
+  @extend %frame-red-500;
+}


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/5033 tweaked the possible classes for our notifications. The where all either `success` or `error`, apart from one, which we didn't realize for when you try to save an intention that already exists.

This makes 'exists' notifications like error ones.

Previous:

![Screenshot 2019-12-11 at 15 00 33](https://user-images.githubusercontent.com/554604/70632660-28152c80-1c27-11ea-8ea9-f06517ca0da2.png)

Fixed:

![Screenshot 2019-12-11 at 15 01 51](https://user-images.githubusercontent.com/554604/70632710-411ddd80-1c27-11ea-8444-9f7f5357ab59.png)

At some point after our `data-source` work lands we are likely to re-visit this as less of the UI will use a `Route.model` blocking page load approach, so we added some comments here to that effect.
