### PR TITLE
build: fix makefile and CI 'fmt' and 'vet' tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,17 @@ jobs:
       - run:
           name: check go fmt
           command: |
-            files=$(go fmt ./...)
+            files="$(go fmt ./... ; (cd api && go fmt ./... | sed 's@^@api/@') ; (cd sdk && go fmt ./... | sed 's@^@sdk/@'))"
             if [ -n "$files" ]; then
-              echo "The following file(s) do not conform to go fmt:"
-              echo "$files"
-              exit 1
+                echo "The following file(s) do not conform to go fmt:"
+                echo "$files"
+                exit 1
             fi
       - run:
-          command: go vet ./...
+          command: |
+            go vet ./... && \
+              (cd api && go vet ./...) && \
+              (cd sdk && go vet ./...)
     environment:
       <<: *ENVIRONMENT
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -307,11 +307,15 @@ cover:
 
 format:
 	@echo "--> Running go fmt"
-	@go fmt $(GOFILES)
+	@go fmt ./...
+	@cd api && go fmt ./... | sed 's@^@api/@'
+	@cd sdk && go fmt ./... | sed 's@^@sdk/@'
 
 vet:
 	@echo "--> Running go vet"
-	@go vet -tags '$(GOTAGS)' $(GOFILES); if [ $$? -eq 1 ]; then \
+	@go vet -tags '$(GOTAGS)' ./... && \
+		(cd api && go vet -tags '$(GOTAGS)' ./...) && \
+		(cd sdk && go vet -tags '$(GOTAGS)' ./...); if [ $$? -ne 0 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \

--- a/api/kv.go
+++ b/api/kv.go
@@ -43,7 +43,7 @@ type KVPair struct {
 
 	// Namespace is the namespace the KVPair is associated with
 	// Namespacing is a Consul Enterprise feature.
-	Namespace string `json: ",omitempty"`
+	Namespace string `json:",omitempty"`
 }
 
 // KVPairs is a list of KVPair objects

--- a/api/session.go
+++ b/api/session.go
@@ -28,19 +28,19 @@ type SessionEntry struct {
 	LockDelay   time.Duration
 	Behavior    string
 	TTL         string
-  Namespace   string `json:",omitempty"`
+	Namespace   string `json:",omitempty"`
 
 	// Deprecated for Consul Enterprise in v1.7.0.
-	Checks      []string
+	Checks []string
 
 	// NodeChecks and ServiceChecks are new in Consul 1.7.0.
 	// When associating checks with sessions, namespaces can be specified for service checks.
-	NodeChecks []string
+	NodeChecks    []string
 	ServiceChecks []ServiceCheck
 }
 
 type ServiceCheck struct {
-	ID string
+	ID        string
 	Namespace string
 }
 

--- a/api/txn.go
+++ b/api/txn.go
@@ -97,12 +97,12 @@ type KVTxnResponse struct {
 type SessionOp string
 
 const (
-	SessionDelete    SessionOp = "delete"
+	SessionDelete SessionOp = "delete"
 )
 
 // SessionTxnOp defines a single operation inside a transaction.
 type SessionTxnOp struct {
-	Verb  SessionOp
+	Verb    SessionOp
 	Session Session
 }
 


### PR DESCRIPTION
Will subsume https://github.com/hashicorp/consul/pull/6929 when complete.

Somewhat related to https://github.com/hashicorp/consul/issues/6879 as these usages of `./...` get even more broken in go `1.13+`.