### PR TITLE
Auto encrypt k8s

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -592,6 +592,8 @@ func (a *Agent) setupClientAutoEncryptCache(reply *structs.SignedResponse) (*str
 		Datacenter: a.config.Datacenter,
 		Token:      a.tokens.AgentToken(),
 		Agent:      a.config.NodeName,
+		DNSSAN:     a.config.AutoEncryptDNSSAN,
+		IPSAN:      a.config.AutoEncryptIPSAN,
 	}
 
 	// prepolutate leaf cache

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -508,6 +509,8 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 	// Build the cert uri
 	var id connect.CertURI
 	var commonName string
+	var dnsNames []string
+	var ipAddresses []net.IP
 	if req.Service != "" {
 		id = &connect.SpiffeIDService{
 			Host:       roots.TrustDomain,
@@ -523,6 +526,8 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 			Agent:      req.Agent,
 		}
 		commonName = connect.ServiceCN(req.Agent, roots.TrustDomain)
+		dnsNames = []string{"localhost"}
+		ipAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::")}
 	} else {
 		return result, errors.New("URI must be either service or agent")
 	}
@@ -545,7 +550,7 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 	}
 
 	// Create a CSR.
-	csr, err := connect.CreateCSR(id, commonName, pk)
+	csr, err := connect.CreateCSRWithSAN(id, commonName, pk, dnsNames, ipAddresses)
 	if err != nil {
 		return result, err
 	}

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -526,8 +526,8 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 			Agent:      req.Agent,
 		}
 		commonName = connect.ServiceCN(req.Agent, roots.TrustDomain)
-		dnsNames = []string{"localhost"}
-		ipAddresses = []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::")}
+		dnsNames = append([]string{"localhost"}, req.DNSSAN...)
+		ipAddresses = append([]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::")}, req.IPSAN...)
 	} else {
 		return result, errors.New("URI must be either service or agent")
 	}
@@ -641,6 +641,8 @@ type ConnectCALeafRequest struct {
 	Datacenter    string
 	Service       string // Service name, not ID
 	Agent         string // Agent name, not ID
+	DNSSAN        []string
+	IPSAN         []net.IP
 	MinQueryIndex uint64
 	MaxQueryTime  time.Duration
 }

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -550,7 +550,7 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 	}
 
 	// Create a CSR.
-	csr, err := connect.CreateCSRWithSAN(id, commonName, pk, dnsNames, ipAddresses)
+	csr, err := connect.CreateCSR(id, commonName, pk, dnsNames, ipAddresses)
 	if err != nil {
 		return result, err
 	}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -604,6 +604,20 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	}
 
 	autoEncryptTLS := b.boolVal(c.AutoEncrypt.TLS)
+	autoEncryptDNSSAN := []string{}
+	for _, d := range c.AutoEncrypt.DNSSAN {
+		autoEncryptDNSSAN = append(autoEncryptDNSSAN, d)
+	}
+	autoEncryptIPSAN := []net.IP{}
+	for _, i := range c.AutoEncrypt.IPSAN {
+		ip := net.ParseIP(i)
+		if ip == nil {
+			b.warn(fmt.Sprintf("Cannot parse ip %q from AutoEncrypt.IPSAN", i))
+			continue
+		}
+		autoEncryptIPSAN = append(autoEncryptIPSAN, ip)
+
+	}
 	autoEncryptAllowTLS := b.boolVal(c.AutoEncrypt.AllowTLS)
 
 	if autoEncryptAllowTLS {
@@ -809,6 +823,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		ClientAddrs:                      clientAddrs,
 		ConfigEntryBootstrap:             configEntries,
 		AutoEncryptTLS:                   autoEncryptTLS,
+		AutoEncryptDNSSAN:                autoEncryptDNSSAN,
+		AutoEncryptIPSAN:                 autoEncryptIPSAN,
 		AutoEncryptAllowTLS:              autoEncryptAllowTLS,
 		ConnectEnabled:                   connectEnabled,
 		ConnectCAProvider:                connectCAProvider,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -562,6 +562,12 @@ type AutoEncrypt struct {
 	// TLS enables receiving certificates for clients from servers
 	TLS *bool `json:"tls,omitempty" hcl:"tls" mapstructure:"tls"`
 
+	// Additional DNS SAN entries that clients request for their certificates.
+	DNSSAN []string `json:"dns_san,omitempty" hcl:"dns_san" mapstructure:"dns_san"`
+
+	// Additional IP SAN entries that clients request for their certificates.
+	IPSAN []string `json:"ip_san,omitempty" hcl:"ip_san" mapstructure:"ip_san"`
+
 	// AllowTLS enables the RPC endpoint on the server to answer
 	// AutoEncrypt.Sign requests.
 	AllowTLS *bool `json:"allow_tls,omitempty" hcl:"allow_tls" mapstructure:"allow_tls"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -529,6 +529,14 @@ type RuntimeConfig struct {
 	// servers.
 	AutoEncryptTLS bool
 
+	// Additional DNS SAN entries that clients request during auto_encrypt
+	// flow for their certificates.
+	AutoEncryptDNSSAN []string
+
+	// Additional IP SAN entries that clients request during auto_encrypt
+	// flow for their certificates.
+	AutoEncryptIPSAN []net.IP
+
 	// AutoEncryptAllowTLS enables the server to respond to
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3727,6 +3727,8 @@ func TestFullConfig(t *testing.T) {
                         },
 			"auto_encrypt": {
 				"tls": true,
+				"dns_san": ["a.com", "b.com"],
+				"ip_san": ["192.168.4.139", "192.168.4.140"],
 				"allow_tls": true
 			},
 			"connect": {
@@ -4324,6 +4326,8 @@ func TestFullConfig(t *testing.T) {
 			}
 			auto_encrypt = {
 				tls = true
+				dns_san = ["a.com", "b.com"]
+				ip_san = ["192.168.4.139", "192.168.4.140"]
 				allow_tls = true
 			}
 			connect {
@@ -5030,6 +5034,8 @@ func TestFullConfig(t *testing.T) {
 			},
 		},
 		AutoEncryptTLS:        true,
+		AutoEncryptDNSSAN:     []string{"a.com", "b.com"},
+		AutoEncryptIPSAN:      []net.IP{net.ParseIP("192.168.4.139"), net.ParseIP("192.168.4.140")},
 		AutoEncryptAllowTLS:   true,
 		ConnectEnabled:        true,
 		ConnectSidecarMinPort: 8888,
@@ -5868,6 +5874,8 @@ func TestSanitize(t *testing.T) {
 		"ClientAddrs": [],
 		"ConfigEntryBootstrap": [],
 		"AutoEncryptTLS": false,
+		"AutoEncryptDNSSAN": [],
+		"AutoEncryptIPSAN": [],
 		"AutoEncryptAllowTLS": false,
 		"ConnectCAConfig": {},
 		"ConnectCAProvider": "",

--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -403,6 +403,8 @@ func (c *ConsulProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 		NotBefore:      effectiveNow,
 		AuthorityKeyId: keyId,
 		SubjectKeyId:   keyId,
+		DNSNames:       csr.DNSNames,
+		IPAddresses:    csr.IPAddresses,
 	}
 
 	// Create the certificate, PEM encode it and return that value.

--- a/agent/connect/csr.go
+++ b/agent/connect/csr.go
@@ -42,9 +42,9 @@ func SigAlgoForKeyType(keyType string) x509.SignatureAlgorithm {
 	}
 }
 
-// CreateCSRWithSAN returns a CSR to sign the given service with SAN entries
+// CreateCSR returns a CSR to sign the given service with SAN entries
 // along with the PEM-encoded private key for this certificate.
-func CreateCSRWithSAN(uri CertURI, commonName string, privateKey crypto.Signer,
+func CreateCSR(uri CertURI, commonName string, privateKey crypto.Signer,
 	dnsNames []string, ipAddresses []net.IP, extensions ...pkix.Extension) (string, error) {
 	template := &x509.CertificateRequest{
 		URIs:               []*url.URL{uri.URI()},
@@ -70,13 +70,6 @@ func CreateCSRWithSAN(uri CertURI, commonName string, privateKey crypto.Signer,
 	return csrBuf.String(), nil
 }
 
-// CreateCSR returns a CSR to sign the given service along with the PEM-encoded
-// private key for this certificate.
-func CreateCSR(uri CertURI, commonName string, privateKey crypto.Signer,
-	extensions ...pkix.Extension) (string, error) {
-	return CreateCSRWithSAN(uri, commonName, privateKey, nil, nil, extensions...)
-}
-
 // CreateCSR returns a CA CSR to sign the given service along with the PEM-encoded
 // private key for this certificate.
 func CreateCACSR(uri CertURI, commonName string, privateKey crypto.Signer) (string, error) {
@@ -85,7 +78,7 @@ func CreateCACSR(uri CertURI, commonName string, privateKey crypto.Signer) (stri
 		return "", err
 	}
 
-	return CreateCSR(uri, commonName, privateKey, ext)
+	return CreateCSR(uri, commonName, privateKey, nil, nil, ext)
 }
 
 // CreateCAExtension creates a pkix.Extension for the x509 Basic Constraints

--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -64,12 +64,15 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 		return errFn(err)
 	}
 
+	dnsNames := []string{"localhost"}
+	ipAddresses := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::")}
+
 	// Create a CSR.
 	//
 	// The Common Name includes the dummy trust domain for now but Server will
 	// override this when it is signed anyway so it's OK.
 	cn := connect.AgentCN(string(c.config.NodeName), dummyTrustDomain)
-	csr, err := connect.CreateCSR(id, cn, pk)
+	csr, err := connect.CreateCSRWithSAN(id, cn, pk, dnsNames, ipAddresses)
 	if err != nil {
 		return errFn(err)
 	}

--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -72,7 +72,7 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 	// The Common Name includes the dummy trust domain for now but Server will
 	// override this when it is signed anyway so it's OK.
 	cn := connect.AgentCN(string(c.config.NodeName), dummyTrustDomain)
-	csr, err := connect.CreateCSRWithSAN(id, cn, pk, dnsNames, ipAddresses)
+	csr, err := connect.CreateCSR(id, cn, pk, dnsNames, ipAddresses)
 	if err != nil {
 		return errFn(err)
 	}

--- a/agent/consul/auto_encrypt_endpoint_test.go
+++ b/agent/consul/auto_encrypt_endpoint_test.go
@@ -80,7 +80,7 @@ func TestAutoEncryptSign(t *testing.T) {
 			require.NoError(t, err)
 			dnsNames := []string{"localhost"}
 			ipAddresses := []net.IP{net.ParseIP("127.0.0.1")}
-			csr, err := connect.CreateCSRWithSAN(id, cn, pk, dnsNames, ipAddresses)
+			csr, err := connect.CreateCSR(id, cn, pk, dnsNames, ipAddresses)
 			require.NoError(t, err, info)
 			require.NotEmpty(t, csr, info)
 			args := &structs.CASignRequest{

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -826,6 +826,10 @@ default will automatically work with some tooling.
 
     * <a name="tls"></a><a href="#tls">`tls`</a> (Defaults to `false`) Allows the client to request the Connect CA and certificates from the servers, for encrypting RPC communication. The client will make the request to any servers listed in the `-join` or `-retry-join` option. This requires that every server to have `auto_encrypt.allow_tls` enabled. When both `auto_encrypt` options are used, it allows clients to receive certificates that are generated on the servers. If the `-server-port` is not the default one, it has to be provided to the client as well. Usually this is discovered through LAN gossip, but `auto_encrypt` provision happens before the information can be distributed through gossip. The most secure `auto_encrypt` setup is when the client is provided with the built-in CA, `verify_server_hostname` is turned on, and when an ACL token with `node.write` permissions is setup. It is also possible to use `auto_encrypt` with a CA and ACL, but without `verify_server_hostname`, or only with a ACL enabled, or only with CA and `verify_server_hostname`, or only with a CA, or finally without a CA and without ACL enabled. In any case, the communication to the `auto_encrypt` endpoint is always TLS encrypted.
 
+    * <a name="dns_san"></a><a href="#dns_san">`dns_san`</a> (Defaults to `[]`) When this option is being used, the certificates requested by `auto_encrypt` from the server have these `dns_san` set as DNS SAN.
+
+    * <a name="ip_san"></a><a href="#ip_san">`ip_san`</a> (Defaults to `[]`) When this option is being used, the certificates requested by `auto_encrypt` from the server have these `ip_san` set as IP SAN.
+
 * <a name="bootstrap"></a><a href="#bootstrap">`bootstrap`</a> Equivalent to the
   [`-bootstrap` command-line flag](#_bootstrap).
 


### PR DESCRIPTION
Since auto_encrypt certs are being used to serve HTTPS (https://github.com/hashicorp/consul/pull/6489) they should have sensible `Subject Alternative Name` set instead of only providing the spiffe id. And there is a way to configure additional DNSSAN and IPSAN which will be used by the agent when requesting auto_encrypt certs. Note the following cert, which has `consul.io` and  `192.168.1.1` set.

```
$ echo | \
                       openssl s_client -connect localhost:8501 2>/dev/null | \
                       openssl x509 -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 11 (0xb)
    Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN=pri-9ioo0o5x.consul.ca.c1ce7653.consul
        Validity
            Not Before: Jan 16 10:50:46 2020 GMT
            Not After : Jan 19 10:50:46 2020 GMT
        Subject: CN=c1.agnt.c1ce7653.consul
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:48:da:ae:28:fc:b5:2e:f6:63:d3:0b:58:29:e6:
                    71:d4:1f:ab:f9:df:e5:bc:e6:79:be:6a:05:97:92:
                    95:34:c0:0f:d6:91:79:bc:67:e8:db:7b:bb:0a:1c:
                    1e:a9:e8:c8:de:2a:b6:ed:66:64:40:3d:38:c2:3f:
                    d0:63:6b:c9:b9
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment, Data Encipherment, Key Agreement
            X509v3 Extended Key Usage:
                TLS Web Client Authentication, TLS Web Server Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Subject Key Identifier:
                F3:A0:08:64:C7:4F:FC:D6:64:33:92:93:C8:6E:65:A9:C0:B0:D7:74:3D:95:D0:1C:1E:50:18:FB:9A:BE:B3:F9
            X509v3 Authority Key Identifier:
                keyid:F3:A0:08:64:C7:4F:FC:D6:64:33:92:93:C8:6E:65:A9:C0:B0:D7:74:3D:95:D0:1C:1E:50:18:FB:9A:BE:B3:F9

            X509v3 Subject Alternative Name:
                DNS:localhost, DNS:consul.io, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:0, IP Address:192.168.1.1, URI:spiffe://c1ce7653-457a-7942-f7a3-fedb029b7fc2.consul/agent/client/dc/dc1/id/c1
    Signature Algorithm: ecdsa-with-SHA256
         30:45:02:21:00:b6:11:b7:96:ef:98:ca:55:f1:73:f7:1d:a1:
         ad:07:ba:d8:2c:41:c9:67:9c:0f:ca:88:15:40:e7:ee:93:23:
         72:02:20:09:f5:27:f0:df:f9:fc:02:a8:40:ef:06:e6:28:b5:
         35:b3:22:1d:50:27:75:a0:6b:c4:36:30:bc:de:bc:bb:00
```

Todo:

* [x] make additional SAN configurable
* [ ] check if the vault and aws pca correctly assigns SAN