### PR TITLE
Add CI test-integrations job for connect Vault CA provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,6 +557,20 @@ jobs:
       ENVOY_VERSIONS: "1.11.1"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
+  # run tests on vault ca provider integration tests
+  vault-ca-provider:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      # FIXME Ensure all deps are installed properly on CI
+      # Install vault
+      - run: |
+          wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
+          sudo unzip -d /usr/local/bin /tmp/vault.zip
+          rm -rf /tmp/vault*
+      # Run go tests
+      - run: make test-vault-ca-provider
+
 workflows:
   version: 2
   go-tests:
@@ -628,6 +642,9 @@ workflows:
       - envoy-integration-test-1.11.1:
           requires:
             - dev-build
+      - vault-ca-provider:
+          requires:
+          - dev-build
   website:
     jobs:
       - build-website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,11 +104,6 @@ jobs:
       - run: mkdir -p $TEST_RESULTS_DIR
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
-        # TODO Can we remove the vault dependency in go-test now that we have the vault-ca-provider job?
-      - run: |
-          wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
-          sudo unzip -d /usr/local/bin /tmp/vault.zip
-          rm -rf /tmp/vault*
       - run: |
           PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
           gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,6 +561,8 @@ jobs:
   vault-ca-provider:
     docker:
       - image: *GOLANG_IMAGE
+    environment:
+      <<: *ENVIRONMENT
     steps:
       # FIXME Ensure all deps are installed properly on CI
       # Install vault

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,6 +572,8 @@ jobs:
             - consul-modcache-v1-{{ checksum "go.mod" }}
       # Run go tests
       - run: make test-vault-ca-provider
+      - store_test_results:
+          path: /tmp/test-results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - run: mkdir -p $TEST_RESULTS_DIR
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
+        # TODO Can we remove the vault dependency in go-test now that we have the vault-ca-provider job?
       - run: |
           wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
           sudo unzip -d /usr/local/bin /tmp/vault.zip
@@ -564,12 +565,13 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
-      # FIXME Ensure all deps are installed properly on CI
       # Install vault
       - run: |
           wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
           sudo unzip -d /usr/local/bin /tmp/vault.zip
           rm -rf /tmp/vault*
+      # Gather deps to run go tests
+      - checkout
       # Run go tests
       - run: make test-vault-ca-provider
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -567,6 +567,9 @@ jobs:
           rm -rf /tmp/vault*
       # Gather deps to run go tests
       - checkout
+      - restore_cache: # restore cache from dev-build job
+          keys:
+            - consul-modcache-v1-{{ checksum "go.mod" }}
       # Run go tests
       - run: make test-vault-ca-provider
 
@@ -643,7 +646,7 @@ workflows:
             - dev-build
       - vault-ca-provider:
           requires:
-          - dev-build
+            - dev-build
   website:
     jobs:
       - build-website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -565,9 +565,11 @@ jobs:
           wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
           sudo unzip -d /usr/local/bin /tmp/vault.zip
           rm -rf /tmp/vault*
+      # Create directory to store test results
+      - run: mkdir -p $TEST_RESULTS_DIR
       # Gather deps to run go tests
       - checkout
-      - restore_cache: # restore cache from dev-build job
+      - restore_cache:
           keys:
             - consul-modcache-v1-{{ checksum "go.mod" }}
       # Run go tests

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -369,6 +369,10 @@ ui-docker: ui-build-image
 test-envoy-integ: $(ENVOY_INTEG_DEPS)
 	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
 
+test-vault-ca-provider:
+	@echo "Running /agent/connect/ca TestVaultCAProvider tests in verbose mode"
+	@go test $(CURDIR)/agent/connect/ca/* -run TestVaultCAProvider -v
+
 proto-delete:
 	@echo "Removing $(PROTOGOFILES)"
 	-@rm $(PROTOGOFILES)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -379,7 +379,6 @@ else
 	@go test $(CURDIR)/agent/connect/ca/* -run TestVaultCAProvider -v
 endif
 
-
 proto-delete:
 	@echo "Removing $(PROTOGOFILES)"
 	-@rm $(PROTOGOFILES)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -370,8 +370,15 @@ test-envoy-integ: $(ENVOY_INTEG_DEPS)
 	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
 
 test-vault-ca-provider:
+ifeq ("$(CIRCLECI)","true")
+# Run in CI
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- $(CURDIR)/agent/connect/ca/* -run TestVaultCAProvider
+else
+# Run locally
 	@echo "Running /agent/connect/ca TestVaultCAProvider tests in verbose mode"
 	@go test $(CURDIR)/agent/connect/ca/* -run TestVaultCAProvider -v
+endif
+
 
 proto-delete:
 	@echo "Removing $(PROTOGOFILES)"


### PR DESCRIPTION
First pass on #6535 and will finish the issue when complete. This PR is not quite ready to merge because I'm not able to run this in CI yet to verify the deps are installed correctly. It may need to depend on more of the [go-test env setup or run steps](https://github.com/hashicorp/consul/blob/master/.circleci/config.yml#L95).

Here's the local `make test-vault-ca-provider` behavior with and without a vault bin available:

<img width="1440" alt="Screen Shot 2019-12-13 at 4 11 16 PM" src="https://user-images.githubusercontent.com/938395/70840178-6b0d0680-1dc5-11ea-83d6-b9e59efa4c11.png">
