### PR TITLE
ui: Implement data-source for Service Listing page, plus acceptance tests steps amends

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,6 +524,23 @@ jobs:
           command: make test-ci
       - store_test_results:
           path: ui-v2/test-results
+  # run ember frontend unit tests to produce coverage report
+  ember-coverage:
+    docker:
+      - image: *EMBER_IMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: *YARN_CACHE_KEY
+      - attach_workspace:
+          at: ui-v2
+      - run:
+          working_directory: ui-v2
+          command: make test-coverage
+      - run:
+          name: codecov ui upload
+          working_directory: ui-v2
+          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui
 
   # Envoy integration tests. Require docker dev binary to be built already
   envoy-integration-test-1.8.0:
@@ -702,5 +719,8 @@ workflows:
           requires:
             - ember-build
       - ember-test-ent:
+          requires:
+            - ember-build
+      - ember-coverage:
           requires:
             - ember-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,6 +496,9 @@ jobs:
       - image: *EMBER_IMAGE
     environment:
       EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+      CONSUL_NSPACES_ENABLED: 0
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:
@@ -504,7 +507,7 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-oss-ci
+          command: node_modules/ember-cli/bin/ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --path dist --silent -r xunit
       - store_test_results:
           path: ui-v2/test-results
   # run ember frontend tests
@@ -513,6 +516,8 @@ jobs:
       - image: *EMBER_IMAGE
     environment:
       EMBER_TEST_REPORT: test-results/report-ent.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:
@@ -521,7 +526,7 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-ci
+          command: node_modules/ember-cli/bin/ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --path dist --silent -r xunit
       - store_test_results:
           path: ui-v2/test-results
   # run ember frontend unit tests to produce coverage report

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,8 @@ coverage:
         # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
         # TODO: should any paths be excluded from coverage metrics?
         # paths:
+      ui:
+        informational: true
     # https://docs.codecov.io/docs/commit-status#section-changes-status
     # TODO: enable after eliminating current unexpected coverage changes?
     changes: off
@@ -29,4 +31,6 @@ comment: false
 
 # https://docs.codecov.io/docs/flags
 # TODO: split out test coverage for API, SDK, UI, website?
-# flags:
+flags:
+  ui:
+    paths: /ui-v2/

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -65,6 +65,17 @@ test-oss-ci: deps test-node
 test-node:
 	yarn run test:node
 
+# This seems to be the only way to only include a subset of files for coverage
+# Right now we only want the /app/utils/ folder to be included for coverage
+specify-coverage:
+	sed -i "s/exclude, include/include: ['consul-ui\/utils\/**\/*','consul-ui\/search\/**\/*']/g" ./node_modules/ember-cli-code-coverage/index.js
+
+test-coverage: deps specify-coverage
+	yarn run test:coverage
+
+test-view-coverage: deps specify-coverage
+	yarn run test:view:coverage
+
 test-parallel: deps
 	yarn run test:parallel
 

--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -18,40 +18,9 @@ export default Adapter.extend({
       [DATACENTER_QUERY_PARAM]: dc,
     };
   },
-  // TODO: kinda protected for the moment
-  // decide where this should go either read/write from http
-  // should somehow use this or vice versa
+  // TODO: Deprecated, remove `request` usage from everywhere and replace with
+  // `HTTPAdapter.rpc`
   request: function(req, resp, obj, modelName) {
-    const client = this.client;
-    const store = this.store;
-    const adapter = this;
-
-    let unserialized, serialized;
-    const serializer = store.serializerFor(modelName);
-    // workable way to decide whether this is a snapshot
-    // Snapshot is private so we can't do instanceof here
-    if (obj.constructor.name === 'Snapshot') {
-      unserialized = obj.attributes();
-      serialized = serializer.serialize(obj, {});
-    } else {
-      unserialized = obj;
-      serialized = unserialized;
-    }
-
-    return client
-      .request(function(request) {
-        return req(adapter, request, serialized, unserialized);
-      })
-      .catch(function(e) {
-        return adapter.error(e);
-      })
-      .then(function(respond) {
-        // TODO: When HTTPAdapter:responder changes, this will also need to change
-        return resp(serializer, respond, serialized, unserialized);
-      });
-    // TODO: Potentially add specific serializer errors here
-    // .catch(function(e) {
-    //   return Promise.reject(e);
-    // });
+    return this.rpc(...arguments);
   },
 });

--- a/ui-v2/app/components/app-error.js
+++ b/ui-v2/app/components/app-error.js
@@ -1,0 +1,3 @@
+import Component from '@ember/component';
+
+export default Component.extend({});

--- a/ui-v2/app/components/consul-service-list.js
+++ b/ui-v2/app/components/consul-service-list.js
@@ -1,0 +1,65 @@
+import Component from '@ember/component';
+import { get, computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+
+const max = function(arr, prop) {
+  return arr.reduce(function(prev, item) {
+    return Math.max(prev, get(item, prop));
+  }, 0);
+};
+const chunk = function(str, size) {
+  const num = Math.ceil(str.length / size);
+  const chunks = new Array(num);
+  for (let i = 0, o = 0; i < num; ++i, o += size) {
+    chunks[i] = str.substr(o, size);
+  }
+  return chunks;
+};
+const width = function(num) {
+  const str = num.toString();
+  const len = str.length;
+  const commas = chunk(str, 3).length - 1;
+  return commas * 4 + len * 10;
+};
+const widthDeclaration = function(num) {
+  return htmlSafe(`width: ${num}px`);
+};
+export default Component.extend({
+  tagName: '',
+  onchange: function() {},
+  maxWidth: computed('{maxPassing,maxWarning,maxCritical}', function() {
+    const PADDING = 32 * 3 + 13;
+    return ['maxPassing', 'maxWarning', 'maxCritical'].reduce((prev, item) => {
+      return prev + width(get(this, item));
+    }, PADDING);
+  }),
+  totalWidth: computed('maxWidth', function() {
+    return widthDeclaration(get(this, 'maxWidth'));
+  }),
+  remainingWidth: computed('maxWidth', function() {
+    // maxWidth is the maximum width of the healthchecks column
+    // there are currently 2 other columns so divide it by 2 and
+    // take that off 50% (100% / number of fluid columns)
+    // also we added a Type column which we've currently fixed to 100px
+    // so again divide that by 2 and take it off each fluid column
+    return htmlSafe(`width: calc(50% - 50px - ${Math.round(get(this, 'maxWidth') / 2)}px)`);
+  }),
+  maxPassing: computed('items.[]', function() {
+    return max(get(this, 'items'), 'ChecksPassing');
+  }),
+  maxWarning: computed('items.[]', function() {
+    return max(get(this, 'items'), 'ChecksWarning');
+  }),
+  maxCritical: computed('items.[]', function() {
+    return max(get(this, 'items'), 'ChecksCritical');
+  }),
+  passingWidth: computed('maxPassing', function() {
+    return widthDeclaration(width(get(this, 'maxPassing')));
+  }),
+  warningWidth: computed('maxWarning', function() {
+    return widthDeclaration(width(get(this, 'maxWarning')));
+  }),
+  criticalWidth: computed('maxCritical', function() {
+    return widthDeclaration(width(get(this, 'maxCritical')));
+  }),
+});

--- a/ui-v2/app/components/data-source.js
+++ b/ui-v2/app/components/data-source.js
@@ -1,0 +1,121 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { set } from '@ember/object';
+
+import WithListeners from 'consul-ui/mixins/with-listeners';
+
+// Utility function to set, but actually replace if we should replace
+// then call a function on the thing to be replaced (usually a clean up function)
+const replace = function(
+  obj,
+  prop,
+  value,
+  destroy = (prev = null, value) => (typeof prev === 'function' ? prev() : null)
+) {
+  const prev = obj[prop];
+  if (prev !== value) {
+    destroy(prev, value);
+  }
+  return set(obj, prop, value);
+};
+
+/**
+ * @module DataSource
+ *
+ * The DataSource component manages opening and closing data sources via an injectable data service.
+ * Data sources are only opened only if the component is visible in the viewport (using IntersectionObserver).
+ *
+ * Sources returned by the data service should follow an EventTarget/EventSource API.
+ * Management of the caching/usage/counting etc of sources should be done in the data service,
+ * not the component.
+ *
+ * @example ```js
+ *   {{data-source
+ *      src="/dc-1/services/*"
+ *      onchange={{action (mut items) value='data'}}
+ *      onerror={{action (mut error) value='error'}}
+ *   /}}```
+ *
+ * @param src {String} - An identitier used to determine the source of the data. This is passed
+ *                       to the data service for it to determine how to fetch the data.
+ * @param onchange=null {Func} - An action called when the data changes.
+ * @param onerror=null {Func} - An action called on error
+ *
+ */
+export default Component.extend(WithListeners, {
+  tagName: 'span',
+
+  // TODO: can be injected with a simpler non-blocking
+  // data service if we turn off blocking queries completely at runtime
+  data: service('blocking'),
+
+  onchange: function() {},
+  onerror: function() {},
+
+  didInsertElement: function() {
+    this._super(...arguments);
+    const options = {
+      rootMargin: '0px',
+      threshold: 1.0,
+    };
+
+    const observer = new IntersectionObserver((entries, observer) => {
+      entries.map(item => {
+        set(this, 'isIntersecting', item.isIntersecting);
+        if (!item.isIntersecting) {
+          this.actions.close.bind(this)();
+        } else {
+          this.actions.open.bind(this)();
+        }
+      });
+    }, options);
+    observer.observe(this.element); // eslint-disable-line ember/no-observers
+    this.listen(() => {
+      this.actions.close.bind(this)();
+      observer.disconnect(); // eslint-disable-line ember/no-observers
+    });
+  },
+  didReceiveAttrs: function() {
+    this._super(...arguments);
+    if (this.element && this.isIntersecting) {
+      this.actions.open.bind(this)();
+    }
+  },
+  actions: {
+    // keep this argumentless
+    open: function() {
+      const src = this.src;
+      const filter = this.filter;
+
+      // get a new source and replace the old one, cleaning up as we go
+      const source = replace(
+        this,
+        'source',
+        this.data.open(`${src}${filter ? `?filter=${filter}` : ``}`, this),
+        (prev, source) => {
+          // Makes sure any previous source (if different) is ALWAYS closed
+          this.data.close(prev, this);
+        }
+      );
+      // set up the listeners (which auto cleanup on component destruction)
+      const remove = this.listen(source, {
+        message: e => this.onchange(e),
+        error: e => this.onerror(e),
+      });
+      replace(this, '_remove', remove);
+      // dispatch the current data of the source if we have any
+      if (typeof source.getCurrentEvent === 'function') {
+        const currentEvent = source.getCurrentEvent();
+        if (currentEvent) {
+          this.onchange(currentEvent);
+        }
+      }
+    },
+    // keep this argumentless
+    close: function() {
+      this.data.close(this.source, this);
+      replace(this, '_remove', null);
+      set(this, 'source', undefined);
+    },
+  },
+});

--- a/ui-v2/app/components/data-source.js
+++ b/ui-v2/app/components/data-source.js
@@ -3,9 +3,16 @@ import { inject as service } from '@ember/service';
 import { set } from '@ember/object';
 
 import WithListeners from 'consul-ui/mixins/with-listeners';
-
-// Utility function to set, but actually replace if we should replace
-// then call a function on the thing to be replaced (usually a clean up function)
+import Ember from 'ember';
+/**
+ * Utility function to set, but actually replace if we should replace
+ * then call a function on the thing to be replaced (usually a clean up function)
+ *
+ * @param obj - target object with the property to replace
+ * @param prop {string} - property to replace on the target object
+ * @param value - value to use for replacement
+ * @param destroy {(prev: any, value: any) => any} - teardown function
+ */
 const replace = function(
   obj,
   prop,
@@ -29,17 +36,17 @@ const replace = function(
  * Management of the caching/usage/counting etc of sources should be done in the data service,
  * not the component.
  *
- * @example ```js
+ * @example ```javascript
  *   {{data-source
  *      src="/dc-1/services/*"
  *      onchange={{action (mut items) value='data'}}
  *      onerror={{action (mut error) value='error'}}
  *   /}}```
  *
- * @param src {String} - An identitier used to determine the source of the data. This is passed
+ * @param src {string} - An identifier used to determine the source of the data. This is passed
  *                       to the data service for it to determine how to fetch the data.
- * @param onchange=null {Func} - An action called when the data changes.
- * @param onerror=null {Func} - An action called on error
+ * @param onchange {function=} - An action called when the data changes.
+ * @param onerror {function=} - An action called on error
  *
  */
 export default Component.extend(WithListeners, {
@@ -52,6 +59,8 @@ export default Component.extend(WithListeners, {
   onchange: function() {},
   onerror: function() {},
 
+  isIntersecting: false,
+
   didInsertElement: function() {
     this._super(...arguments);
     const options = {
@@ -61,8 +70,8 @@ export default Component.extend(WithListeners, {
 
     const observer = new IntersectionObserver((entries, observer) => {
       entries.map(item => {
-        set(this, 'isIntersecting', item.isIntersecting);
-        if (!item.isIntersecting) {
+        set(this, 'isIntersecting', item.isIntersecting || Ember.testing);
+        if (!this.isIntersecting) {
           this.actions.close.bind(this)();
         } else {
           this.actions.open.bind(this)();
@@ -114,7 +123,7 @@ export default Component.extend(WithListeners, {
     // keep this argumentless
     close: function() {
       this.data.close(this.source, this);
-      replace(this, '_remove', null);
+      replace(this, '_remove', undefined);
       set(this, 'source', undefined);
     },
   },

--- a/ui-v2/app/controllers/dc/nodes/index.js
+++ b/ui-v2/app/controllers/dc/nodes/index.js
@@ -1,10 +1,9 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
-import WithEventSource from 'consul-ui/mixins/with-event-source';
+import { get, computed } from '@ember/object';
 import WithHealthFiltering from 'consul-ui/mixins/with-health-filtering';
 import WithSearching from 'consul-ui/mixins/with-searching';
-import { get } from '@ember/object';
-export default Controller.extend(WithEventSource, WithSearching, WithHealthFiltering, {
+
+export default Controller.extend(WithSearching, WithHealthFiltering, {
   init: function() {
     this.searchParams = {
       healthyNode: 's',

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { get, computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
-import WithEventSource from 'consul-ui/mixins/with-event-source';
 import WithSearching from 'consul-ui/mixins/with-searching';
 const max = function(arr, prop) {
   return arr.reduce(function(prev, item) {
@@ -25,7 +24,7 @@ const width = function(num) {
 const widthDeclaration = function(num) {
   return htmlSafe(`width: ${num}px`);
 };
-export default Controller.extend(WithEventSource, WithSearching, {
+export default Controller.extend(WithSearching, {
   queryParams: {
     s: {
       as: 'filter',

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -1,29 +1,6 @@
 import Controller from '@ember/controller';
 import { get, computed } from '@ember/object';
-import { htmlSafe } from '@ember/string';
 import WithSearching from 'consul-ui/mixins/with-searching';
-const max = function(arr, prop) {
-  return arr.reduce(function(prev, item) {
-    return Math.max(prev, get(item, prop));
-  }, 0);
-};
-const chunk = function(str, size) {
-  const num = Math.ceil(str.length / size);
-  const chunks = new Array(num);
-  for (let i = 0, o = 0; i < num; ++i, o += size) {
-    chunks[i] = str.substr(o, size);
-  }
-  return chunks;
-};
-const width = function(num) {
-  const str = num.toString();
-  const len = str.length;
-  const commas = chunk(str, 3).length - 1;
-  return commas * 4 + len * 10;
-};
-const widthDeclaration = function(num) {
-  return htmlSafe(`width: ${num}px`);
-};
 export default Controller.extend(WithSearching, {
   queryParams: {
     s: {
@@ -40,40 +17,5 @@ export default Controller.extend(WithSearching, {
     return get(this, 'searchables.service')
       .add(this.items)
       .search(this.terms);
-  }),
-  maxWidth: computed('{maxPassing,maxWarning,maxCritical}', function() {
-    const PADDING = 32 * 3 + 13;
-    return ['maxPassing', 'maxWarning', 'maxCritical'].reduce((prev, item) => {
-      return prev + width(get(this, item));
-    }, PADDING);
-  }),
-  totalWidth: computed('maxWidth', function() {
-    return widthDeclaration(this.maxWidth);
-  }),
-  remainingWidth: computed('maxWidth', function() {
-    // maxWidth is the maximum width of the healthchecks column
-    // there are currently 2 other columns so divide it by 2 and
-    // take that off 50% (100% / number of fluid columns)
-    // also we added a Type column which we've currently fixed to 100px
-    // so again divide that by 2 and take it off each fluid column
-    return htmlSafe(`width: calc(50% - ${Math.round(this.maxWidth / 2)}px)`);
-  }),
-  maxPassing: computed('items.[]', function() {
-    return max(this.items, 'ChecksPassing');
-  }),
-  maxWarning: computed('items.[]', function() {
-    return max(this.items, 'ChecksWarning');
-  }),
-  maxCritical: computed('items.[]', function() {
-    return max(this.items, 'ChecksCritical');
-  }),
-  passingWidth: computed('maxPassing', function() {
-    return widthDeclaration(width(this.maxPassing));
-  }),
-  warningWidth: computed('maxWarning', function() {
-    return widthDeclaration(width(this.maxWarning));
-  }),
-  criticalWidth: computed('maxCritical', function() {
-    return widthDeclaration(width(this.maxCritical));
   }),
 });

--- a/ui-v2/app/helpers/href-to.js
+++ b/ui-v2/app/helpers/href-to.js
@@ -27,7 +27,11 @@ export const hrefTo = function(owned, router, [targetRouteName, ...rest], namedA
 
     // this globally converts non-nspaced href-to's to nspace aware
     // href-to's only if you are within a namespace
-    if (router.currentRouteName.startsWith('nspace.') && targetRouteName.startsWith('dc.')) {
+    if (
+      router.currentRouteName !== null &&
+      router.currentRouteName.startsWith('nspace.') &&
+      targetRouteName.startsWith('dc.')
+    ) {
       targetRouteName = `nspace.${targetRouteName}`;
     }
     return _hrefTo(owned, [targetRouteName, ...rest]);

--- a/ui-v2/app/helpers/is-undefined.js
+++ b/ui-v2/app/helpers/is-undefined.js
@@ -1,0 +1,10 @@
+import { helper } from '@ember/component/helper';
+
+export function isUndefined([value, type], hash) {
+  // we have to check is destroyed here as .content is set to null
+  // rather than undefined when a if/when a destryed ember value/object
+  // is passed through
+  return typeof value === 'undefined' || value.isDestroyed;
+}
+
+export default helper(isUndefined);

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -13,7 +13,10 @@ export default Route.extend({
   model: function(params) {
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      items: this.repo.findAllByDatacenter(dc, this.modelFor('nspace').nspace.substr(1)),
+      dc: dc,
+      nspace: this.modelFor('nspace').nspace.substr(1),
+      items: undefined,
+      error: undefined,
       leader: this.repo.findByLeader(dc),
     });
   },

--- a/ui-v2/app/routes/dc/services/index.js
+++ b/ui-v2/app/routes/dc/services/index.js
@@ -28,11 +28,9 @@ export default Route.extend({
     }
     return {
       terms: terms !== '' ? terms.split('\n') : [],
-      items: this.repo.findAllByDatacenter(
-        this.modelFor('dc').dc.Name,
-        this.modelFor('nspace').nspace.substr(1)
-      ),
-    });
+      dc: this.modelFor('dc').dc.Name,
+      nspace: this.modelFor('nspace').nspace.substr(1),
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/index.js
+++ b/ui-v2/app/routes/dc/services/index.js
@@ -30,6 +30,11 @@ export default Route.extend({
       terms: terms !== '' ? terms.split('\n') : [],
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1),
+      // TODO: Find out a less manual way of resetting these
+      // that are set via data-source and therefore kept around
+      // between transitions
+      items: undefined,
+      error: undefined,
     };
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc/services/index.js
+++ b/ui-v2/app/routes/dc/services/index.js
@@ -1,9 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-import { hash } from 'rsvp';
 
 export default Route.extend({
-  repo: service('repository/service'),
   queryParams: {
     s: {
       as: 'filter',
@@ -29,7 +26,7 @@ export default Route.extend({
           .trim();
       }
     }
-    return hash({
+    return {
       terms: terms !== '' ? terms.split('\n') : [],
       items: this.repo.findAllByDatacenter(
         this.modelFor('dc').dc.Name,

--- a/ui-v2/app/services/blocking.js
+++ b/ui-v2/app/services/blocking.js
@@ -1,0 +1,91 @@
+import Service, { inject as service } from '@ember/service';
+
+import MultiMap from 'mnemonist/multi-map';
+
+import { BlockingEventSource as EventSource } from 'consul-ui/utils/dom/event-source';
+// utility functions to make the below code easier to read:
+import { ifNotBlocking } from 'consul-ui/services/settings';
+import { restartWhenAvailable } from 'consul-ui/services/client/http';
+import maybeCall from 'consul-ui/utils/maybe-call';
+
+// TODO: Expose sizes of things via env vars
+
+// caches cursors and previous events when the EventSources are destroyed
+const cache = new Map();
+// keeps a record of currently in use EventSources
+const sources = new Map();
+// keeps a count of currently in use EventSources
+const usage = new MultiMap(Set);
+
+export default Service.extend({
+  client: service('client/http'),
+  settings: service('settings'),
+
+  finder: service('repository/manager'),
+
+  open: function(uri, ref) {
+    let source;
+    // Check the cache for an EventSource that is already being used
+    // for this uri. If we don't have one, set one up.
+    if (!sources.has(uri)) {
+      // Setting up involves finding the correct repository method to call
+      // based on the uri, we use the eventually injectable finder for this.
+      const repo = this.finder.fromURI(...uri.split('?filter='));
+      // We then check the to see if this we have previously cached information
+      // for the URI. This data comes from caching this data when the EventSource
+      // is closed and destroyed. We recreate the EventSource from the data from the cache
+      // if so. The data is currently the cursor position and the last received data.
+      let configuration = {};
+      if (cache.has(uri)) {
+        configuration = cache.get(uri);
+      }
+      // tag on the custom createEvent for ember-data
+      configuration.createEvent = repo.reconcile;
+
+      // We create the EventSource, checking to make sure whether we should close the
+      // EventSource on first response (depending on the user setting) and reopening
+      // the EventSource if it has been paused by the user navigating to another tab
+      source = new EventSource((configuration, source) => {
+        const close = source.close.bind(source);
+        const deleteCursor = () => (configuration.cursor = undefined);
+        //
+        return maybeCall(deleteCursor, ifNotBlocking(this.settings))().then(() => {
+          return repo
+            .find(configuration)
+            .then(maybeCall(close, ifNotBlocking(this.settings)))
+            .catch(restartWhenAvailable(this.client));
+        });
+      }, configuration);
+      // Lastly, when the EventSource is no longer needed, cache its information
+      // for when we next need it again (see above re: data cache)
+      source.addEventListener('close', function close(e) {
+        const source = e.target;
+        source.removeEventListener('close', close);
+        cache.set(uri, {
+          currentEvent: e.target.getCurrentEvent(),
+          cursor: e.target.configuration.cursor,
+        });
+        // the data is cached delete the EventSource
+        sources.delete(uri);
+      });
+      sources.set(uri, source);
+    } else {
+      source = sources.get(uri);
+    }
+    // set/increase the usage counter
+    usage.set(source, ref);
+    source.open();
+    return source;
+  },
+  close: function(source, ref) {
+    if (source) {
+      // decrease the usage counter
+      usage.remove(source, ref);
+      // if the EventSource is no longer being used
+      // close it (data caching is dealt with by the above 'close' event listener)
+      if (!usage.has(source)) {
+        source.close();
+      }
+    }
+  },
+});

--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -8,6 +8,21 @@ import getObjectPool from 'consul-ui/utils/get-object-pool';
 import Request from 'consul-ui/utils/http/request';
 import createURL from 'consul-ui/utils/createURL';
 
+// reopen EventSources if a user changes tab
+export const restartWhenAvailable = function(client) {
+  return function(e) {
+    // setup the aborted connection restarting
+    // this should happen here to avoid cache deletion
+    const status = get(e, 'errors.firstObject.status');
+    if (status === '0') {
+      // Any '0' errors (abort) should possibly try again, depending upon the circumstances
+      // whenAvailable returns a Promise that resolves when the client is available
+      // again
+      return client.whenAvailable(e);
+    }
+    throw e;
+  };
+};
 class HTTPError extends Error {
   constructor(statusCode, message) {
     super(message);

--- a/ui-v2/app/services/promised.js
+++ b/ui-v2/app/services/promised.js
@@ -1,0 +1,23 @@
+import Service, { inject as service } from '@ember/service';
+
+import { CallableEventSource as EventSource } from 'consul-ui/utils/dom/event-source';
+
+export default Service.extend({
+  finder: service('repository/manager'),
+
+  open: function(uri, ref) {
+    const repo = this.finder.fromURI(...uri.split('?filter='));
+    const source = new EventSource(function(configuration, source) {
+      return repo.find(configuration).then(function(res) {
+        source.dispatchEvent({ type: 'message', data: res });
+        source.close();
+      });
+    }, {});
+    return source;
+  },
+  close: function(source, ref) {
+    if (source) {
+      source.close();
+    }
+  },
+});

--- a/ui-v2/app/services/repository.js
+++ b/ui-v2/app/services/repository.js
@@ -13,6 +13,18 @@ export default Service.extend({
   },
   //
   store: service('store'),
+  reconcile: function(meta = {}) {
+    // unload anything older than our current sync date/time
+    // FIXME: This needs fixing once again to take nspaces into account
+    if (typeof meta.date !== 'undefined') {
+      this.store.peekAll(this.getModelName()).forEach(item => {
+        const date = item.SyncTime;
+        if (typeof date !== 'undefined' && date != meta.date) {
+          this.store.unloadRecord(item);
+        }
+      });
+    }
+  },
   findAllByDatacenter: function(dc, nspace, configuration = {}) {
     const query = {
       dc: dc,

--- a/ui-v2/app/services/repository.js
+++ b/ui-v2/app/services/repository.js
@@ -1,4 +1,5 @@
 import Service, { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
 export default Service.extend({
@@ -15,12 +16,21 @@ export default Service.extend({
   store: service('store'),
   reconcile: function(meta = {}) {
     // unload anything older than our current sync date/time
-    // FIXME: This needs fixing once again to take nspaces into account
     if (typeof meta.date !== 'undefined') {
+      const checkNspace = meta.nspace !== '';
       this.store.peekAll(this.getModelName()).forEach(item => {
-        const date = item.SyncTime;
-        if (typeof date !== 'undefined' && date != meta.date) {
-          this.store.unloadRecord(item);
+        const dc = get(item, 'Datacenter');
+        if (dc === meta.dc) {
+          if (checkNspace) {
+            const nspace = get(item, 'Namespace');
+            if (nspace !== meta.namespace) {
+              return;
+            }
+          }
+          const date = get(item, 'SyncTime');
+          if (typeof date !== 'undefined' && date != meta.date) {
+            this.store.unloadRecord(item);
+          }
         }
       });
     }

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -1,0 +1,80 @@
+import Service, { inject as service } from '@ember/service';
+
+export default Service.extend({
+  // TODO: Temporary repo list here
+  service: service('repository/service'),
+  node: service('repository/node'),
+  session: service('repository/session'),
+  proxy: service('repository/proxy'),
+
+  fromURI: function(src, filter) {
+    let temp = src.split('/');
+    temp.shift();
+    const dc = temp.shift();
+    const model = temp.shift();
+    const repo = this[model];
+    let slug = temp.join('/');
+
+    // TODO: if something is filtered we shouldn't reconcile things
+    // custom createEvent, here used to reconcile the ember-data store for each tick
+    // ideally we wouldn't do this here, but we handily have access to the repo here
+    const obj = {
+      reconcile: function(result = {}, configuration) {
+        const event = {
+          type: 'message',
+          data: result,
+        };
+        // const meta = get(event.data || {}, 'meta') || {};
+        repo.reconcile(event.data.meta);
+        return event;
+      },
+    };
+    let id, node;
+    switch (slug) {
+      case '*':
+        switch (model) {
+          default:
+            obj.find = function(configuration) {
+              return repo.findAllByDatacenter(dc, configuration);
+            };
+        }
+        break;
+      default:
+        switch (model) {
+          case 'session':
+            obj.find = function(configuration) {
+              return repo.findByNode(slug, dc, configuration);
+            };
+            break;
+          case 'service-instance':
+            temp = slug.split('/');
+            id = temp[0];
+            node = temp[1];
+            slug = temp[2];
+            obj.find = function(configuration) {
+              return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+            };
+            break;
+          case 'service':
+            obj.find = function(configuration) {
+              return repo.findBySlug(slug, dc, configuration);
+            };
+            break;
+          case 'proxy':
+            temp = slug.split('/');
+            id = temp[0];
+            node = temp[1];
+            slug = temp[2];
+            obj.find = function(configuration) {
+              return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+            };
+            break;
+          default:
+            obj.find = function(configuration) {
+              return repo.findBySlug(slug, dc, configuration);
+            };
+        }
+    }
+    return obj;
+  },
+});

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -12,6 +12,7 @@ export default Service.extend({
   fromURI: function(src, filter) {
     let temp = src.split('/');
     temp.shift();
+    const nspace = temp.shift();
     const dc = temp.shift();
     const model = temp.shift();
     const repo = this[model];
@@ -37,7 +38,7 @@ export default Service.extend({
       case 'services':
       case 'nodes':
         obj.find = function(configuration) {
-          return repo.findAllByDatacenter(dc, configuration);
+          return repo.findAllByDatacenter(dc, nspace, configuration);
         };
         break;
       // weirder ones
@@ -47,7 +48,7 @@ export default Service.extend({
         node = temp[1];
         slug = temp[2];
         obj.find = function(configuration) {
-          return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+          return repo.findInstanceBySlug(id, node, slug, dc, nspace, configuration);
         };
         break;
       case 'proxy':
@@ -56,13 +57,13 @@ export default Service.extend({
         node = temp[1];
         slug = temp[2];
         obj.find = function(configuration) {
-          return repo.findInstanceBySlug(id, node, slug, dc, configuration);
+          return repo.findInstanceBySlug(id, node, slug, dc, nspace, configuration);
         };
         break;
       // commoner slugs
       default:
         obj.find = function(configuration) {
-          return repo.findBySlug(slug, dc, configuration);
+          return repo.findBySlug(slug, dc, nspace, configuration);
         };
     }
     return obj;

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -41,7 +41,11 @@ export default Service.extend({
           return repo.findAllByDatacenter(dc, nspace, configuration);
         };
         break;
-      // weirder ones
+      case 'session':
+        obj.find = function(configuration) {
+          return repo.findByNode(slug, dc, nspace, configuration);
+        };
+        break;
       case 'service-instance':
         temp = slug.split('/');
         id = temp[0];

--- a/ui-v2/app/services/settings.js
+++ b/ui-v2/app/services/settings.js
@@ -3,6 +3,12 @@ import { Promise } from 'rsvp';
 import getStorage from 'consul-ui/utils/storage/local-storage';
 const SCHEME = 'consul';
 const storage = getStorage(SCHEME);
+// promise aware assertion
+export const ifNotBlocking = function(repo) {
+  return repo.findBySlug('client').then(function(settings) {
+    return typeof settings.blocking !== 'undefined' && !settings.blocking;
+  });
+};
 export default Service.extend({
   storage: storage,
   findHeaders: function() {

--- a/ui-v2/app/templates/components/app-error.hbs
+++ b/ui-v2/app/templates/components/app-error.hbs
@@ -1,0 +1,19 @@
+{{#app-view class="error show"}}
+  {{#block-slot 'header'}}
+    <h1 data-test-error>
+{{#if error.status }}
+      {{error.status}} ({{error.title}})
+{{else}}
+      {{error.title}}
+{{/if}}
+    </h1>
+  {{/block-slot}}
+  {{#block-slot 'content'}}
+    <p>
+        Consul returned an error.
+        You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.<br />
+        Try looking in our <a href="{{env 'CONSUL_DOCUMENTATION_URL'}}" target="_blank">documentation</a>
+    </p>
+    <a rel="home" href={{href-to 'index'}}>Go back to root</a>
+  {{/block-slot}}
+{{/app-view}}

--- a/ui-v2/app/templates/components/app-error.hbs
+++ b/ui-v2/app/templates/components/app-error.hbs
@@ -1,5 +1,5 @@
 {{#app-view class="error show"}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <h1 data-test-error>
 {{#if error.status }}
       {{error.status}} ({{error.title}})
@@ -8,7 +8,7 @@
 {{/if}}
     </h1>
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
     <p>
         Consul returned an error.
         You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.<br />

--- a/ui-v2/app/templates/components/consul-service-list.hbs
+++ b/ui-v2/app/templates/components/consul-service-list.hbs
@@ -1,6 +1,6 @@
 {{#if (gt items.length 0)}}
   {{#tabular-collection items=items as |item index|}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <th style={{remainingWidth}}>Service</th>
       <th style={{totalWidth}}>
         Health Checks
@@ -10,7 +10,7 @@
       </th>
       <th style={{remainingWidth}}>Tags</th>
     {{/block-slot}}
-    {{#block-slot 'row'}}
+    {{#block-slot name='row'}}
       <td data-test-service={{item.Name}} style={{remainingWidth}}>
         <a href={{href-to routeName item.Name}}>
           <span data-test-external-source={{service/external-source item}} style={{{concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>

--- a/ui-v2/app/templates/components/consul-service-list.hbs
+++ b/ui-v2/app/templates/components/consul-service-list.hbs
@@ -1,0 +1,31 @@
+{{#if (gt items.length 0)}}
+  {{#tabular-collection items=items as |item index|}}
+    {{#block-slot 'header'}}
+      <th style={{remainingWidth}}>Service</th>
+      <th style={{totalWidth}}>
+        Health Checks
+        <span>
+          <em role="tooltip">The number of health checks for the service on all nodes</em>
+        </span>
+      </th>
+      <th style={{remainingWidth}}>Tags</th>
+    {{/block-slot}}
+    {{#block-slot 'row'}}
+      <td data-test-service={{item.Name}} style={{remainingWidth}}>
+        <a href={{href-to routeName item.Name}}>
+          <span data-test-external-source={{service/external-source item}} style={{{concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
+          {{item.Name}}
+        </a>
+      </td>
+      <td style={{totalWidth}}>
+        {{healthcheck-info
+          passing=item.ChecksPassing warning=item.ChecksWarning critical=item.ChecksCritical
+          passingWidth=passingWidth warningWidth=warningWidth criticalWidth=criticalWidth
+        }}
+      </td>
+      <td style={{remainingWidth}}>
+        {{tag-list items=item.Tags}}
+      </td>
+    {{/block-slot}}
+  {{/tabular-collection}}
+{{/if}}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,85 +1,96 @@
 {{title 'Nodes'}}
-{{#app-view class="node list"}}
-  {{#block-slot name='header'}}
-    <h1>
-      Nodes <em>{{format-number items.length}} total</em>
-    </h1>
-    <label for="toolbar-toggle"></label>
-  {{/block-slot}}
-  {{#block-slot name='toolbar'}}
+{{data-source
+  src=(concat '/' nspace '/' dc '/nodes')
+  onchange=(action (mut items) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if
+    (not (is-undefined error))
+}}
+  {{app-error error=error.errors.firstObject}}
+{{else}}
+  {{#app-view class="node list" loading=(is-undefined items)}}
+    {{#block-slot name='header'}}
+      <h1>
+        Nodes <em>{{format-number items.length}} total</em>
+      </h1>
+      <label for="toolbar-toggle"></label>
+    {{/block-slot}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
-    {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
+      {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
 {{/if}}
-  {{/block-slot}}
-  {{#block-slot name='content'}}
+    {{/block-slot}}
+    {{#block-slot name='content'}}
 {{#if (gt unhealthy.length 0) }}
-      <div class="unhealthy">
-        <h2>Unhealthy Nodes</h2>
-        <div>
-          {{! think about 2 differing views here }}
-          <ul>
-            {{#changeable-set dispatcher=searchableUnhealthy}}
-              {{#block-slot name='set' as |unhealthy|}}
-                {{#each unhealthy as |item|}}
-                  {{#healthchecked-resource
-                      tagName='li'
-                      data-test-node=item.Node
-                      href=(href-to 'dc.nodes.show' item.Node)
-                      name=item.Node
-                      address=item.Address
-                      checks=item.Checks
-                  }}
-                    {{#block-slot name='icon'}}
-                      {{#if (eq item.Address leader.Address)}}
-                        <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                      {{/if}}
-                    {{/block-slot}}
-                  {{/healthchecked-resource}}
-                {{/each}}
-              {{/block-slot}}
-              {{#block-slot name='empty'}}
-                <p>
-                  There are no unhealthy nodes for that search.
-                </p>
-              {{/block-slot}}
-            {{/changeable-set}}
-          </ul>
+        <div class="unhealthy">
+          <h2>Unhealthy Nodes</h2>
+          <div>
+            {{! think about 2 differing views here }}
+            <ul>
+              {{#changeable-set dispatcher=searchableUnhealthy}}
+                {{#block-slot name='set' as |unhealthy|}}
+                  {{#each unhealthy as |item|}}
+                    {{#healthchecked-resource
+                        tagName='li'
+                        data-test-node=item.Node
+                        href=(href-to 'dc.nodes.show' item.Node)
+                        name=item.Node
+                        address=item.Address
+                        checks=item.Checks
+                    }}
+                      {{#block-slot name='icon'}}
+                        {{#if (eq item.Address leader.Address)}}
+                          <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                        {{/if}}
+                      {{/block-slot}}
+                    {{/healthchecked-resource}}
+                  {{/each}}
+                {{/block-slot}}
+                {{#block-slot name='empty'}}
+                  <p>
+                    There are no unhealthy nodes for that search.
+                  </p>
+                {{/block-slot}}
+              {{/changeable-set}}
+            </ul>
+          </div>
         </div>
-      </div>
 {{/if}}
 {{#if (gt healthy.length 0) }}
-      <div class="healthy">
-        <h2>Healthy Nodes</h2>
-        {{#changeable-set dispatcher=searchableHealthy}}
-          {{#block-slot name='set' as |healthy|}}
-            {{#list-collection cellHeight=92 items=healthy as |item index|}}
-              {{#healthchecked-resource
-                  data-test-node=item.Node
-                  href=(href-to 'dc.nodes.show' item.Node)
-                  name=item.Node
-                  address=item.Address
-                  checks=item.Checks
-              }}
-                {{#block-slot name='icon'}}
-                  {{#if (eq item.Address leader.Address)}}
-                    <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                  {{/if}}
-                {{/block-slot}}
-              {{/healthchecked-resource}}
-            {{/list-collection}}
-          {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no healthy nodes for that search.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
-      </div>
+        <div class="healthy">
+          <h2>Healthy Nodes</h2>
+          {{#changeable-set dispatcher=searchableHealthy}}
+            {{#block-slot name='set' as |healthy|}}
+              {{#list-collection cellHeight=92 items=healthy as |item index|}}
+                {{#healthchecked-resource
+                    data-test-node=item.Node
+                    href=(href-to 'dc.nodes.show' item.Node)
+                    name=item.Node
+                    address=item.Address
+                    checks=item.Checks
+                }}
+                  {{#block-slot name='icon'}}
+                    {{#if (eq item.Address leader.Address)}}
+                      <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                    {{/if}}
+                  {{/block-slot}}
+                {{/healthchecked-resource}}
+              {{/list-collection}}
+            {{/block-slot}}
+            {{#block-slot name='empty'}}
+              <p>
+                There are no healthy nodes for that search.
+              </p>
+            {{/block-slot}}
+          {{/changeable-set}}
+        </div>
 {{/if}}
 {{#if (and (eq healthy.length 0) (eq unhealthy.length 0)) }}
-      <p>
-          There are no nodes.
-      </p>
+        <p>
+            There are no nodes.
+        </p>
 {{/if}}
-  {{/block-slot}}
-{{/app-view}}
+    {{/block-slot}}
+  {{/app-view}}
+{{/if}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -1,6 +1,6 @@
 {{title 'Services'}}
 {{data-source
-  src=(concat '/' dc '/services')
+  src=(concat '/' nspace '/' dc '/services')
   onchange=(action (mut items) value='data')
   onerror=(action (mut error) value='error')
 }}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -1,5 +1,15 @@
 {{title 'Services'}}
-{{#app-view class="service list"}}
+{{data-source
+  src=(concat '/' dc '/services')
+  onchange=(action (mut items) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if
+    (not (is-undefined error))
+}}
+  {{app-error error=error.errors.firstObject}}
+{{else}}
+  {{#app-view class="service list" loading=(is-undefined items)}}
     {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/services/notifications'}}
     {{/block-slot}}
@@ -58,5 +68,6 @@
           {{/block-slot}}
         {{/changeable-set}}
     {{/block-slot}}
-{{/app-view}}
+  {{/app-view}}
+{{/if}}
 

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -14,10 +14,10 @@
       {{partial 'dc/services/notifications'}}
     {{/block-slot}}
     {{#block-slot name='header'}}
-        <h1>
-            Services <em>{{format-number items.length}} total</em>
-        </h1>
-        <label for="toolbar-toggle"></label>
+      <h1>
+        Services <em>{{format-number items.length}} total</em>
+      </h1>
+      <label for="toolbar-toggle"></label>
     {{/block-slot}}
     {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
@@ -30,43 +30,16 @@
 {{/if}}
     {{/block-slot}}
     {{#block-slot name='content'}}
-        {{#changeable-set dispatcher=searchable}}
-          {{#block-slot name='set' as |filtered|}}
-            {{#tabular-collection
-                route='dc.services.show'
-                key='Name'
-                items=filtered as |item index|
-            }}
-                {{#block-slot name='header'}}
-                    <th style={{remainingWidth}}>Service</th>
-                    <th style={{totalWidth}}>Health Checks<span><em role="tooltip">The number of health checks for the service on all nodes</em></span></th>
-                    <th style={{remainingWidth}}>Tags</th>
-                {{/block-slot}}
-                {{#block-slot name='row'}}
-                    <td data-test-service="{{item.Name}}" style={{remainingWidth}}>
-                      <a href={{href-to 'dc.services.show' item.Name}}>
-                        <span data-test-external-source="{{service/external-source item}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
-                        {{item.Name}}
-                      </a>
-                    </td>
-                    <td style={{totalWidth}}>
-                      {{healthcheck-info
-                        passing=item.ChecksPassing warning=item.ChecksWarning critical=item.ChecksCritical
-                        passingWidth=passingWidth warningWidth=warningWidth criticalWidth=criticalWidth
-                      }}
-                    </td>
-                    <td style={{remainingWidth}}>
-                      {{tag-list items=item.Tags}}
-                    </td>
-                {{/block-slot}}
-            {{/tabular-collection}}
-          {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no services.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
+      {{#changeable-set dispatcher=searchable}}
+        {{#block-slot name='set' as |filtered|}}
+          {{consul-service-list routeName="dc.services.show" items=filtered}}
+        {{/block-slot}}
+        {{#block-slot name='empty'}}
+          <p>
+            There are no services.
+          </p>
+        {{/block-slot}}
+      {{/changeable-set}}
     {{/block-slot}}
   {{/app-view}}
 {{/if}}

--- a/ui-v2/app/utils/maybe-call.js
+++ b/ui-v2/app/utils/maybe-call.js
@@ -1,0 +1,17 @@
+/**
+ * Promise aware conditional function call
+ *
+ * @param {function} cb - The function to possibily call
+ * @param {function} [what] - A function returning a boolean resolving promise
+ * @returns {function} - function when called returns a Promise that resolves the argument it is called with
+ */
+export default function(cb, what) {
+  return function(res) {
+    return what.then(function(bool) {
+      if (bool) {
+        cb();
+      }
+      return res;
+    });
+  };
+}

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -90,7 +90,9 @@ module.exports = function(environment, $ = process.env) {
         '@hashicorp/ember-cli-api-double': {
           'auto-import': false,
           enabled: true,
-          endpoints: ['/node_modules/@hashicorp/consul-api-double/v1'],
+          endpoints: {
+            '/v1': '/node_modules/@hashicorp/consul-api-double/v1',
+          },
         },
         APP: Object.assign({}, ENV.APP, {
           LOG_ACTIVE_GENERATION: false,
@@ -106,7 +108,9 @@ module.exports = function(environment, $ = process.env) {
         CONSUL_NSPACES_ENABLED: true,
         '@hashicorp/ember-cli-api-double': {
           enabled: true,
-          endpoints: ['/node_modules/@hashicorp/consul-api-double/v1'],
+          endpoints: {
+            '/v1': '/node_modules/@hashicorp/consul-api-double/v1',
+          },
         },
       });
       break;

--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -48,7 +48,7 @@ module.exports = function(defaults) {
       },
     },
     'sassOptions': {
-      implementation: require('node-sass'),
+      implementation: require('dart-sass'),
       sourceMapEmbed: sourcemaps,
     },
     'autoprefixer': {

--- a/ui-v2/lib/startup/index.js
+++ b/ui-v2/lib/startup/index.js
@@ -11,10 +11,15 @@ const apiDouble = require('@hashicorp/api-double');
 const apiDoubleHeaders = require('@hashicorp/api-double/lib/headers');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
+
+const express = require('express');
 //
 module.exports = {
   name: 'startup',
   serverMiddleware: function(server) {
+    // Serve the coverage folder for easy viewing during development
+    server.app.use('/coverage', express.static('coverage'));
+
     // TODO: This should all be moved out into ember-cli-api-double
     // and we should figure out a way to get to the settings here for
     // so we can set this path name centrally in config

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -111,6 +111,7 @@
     "lint-staged": "^9.2.5",
     "loader.js": "^4.7.0",
     "ngraph.graph": "^18.0.3",
+    "mnemonist": "^0.30.0",
     "node-sass": "^4.9.3",
     "pretender": "^3.2.0",
     "prettier": "^1.10.2",

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -29,8 +29,8 @@
     "test:view": "ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:oss:view": "CONSUL_NSPACES_ENABLED=0 ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:node": "tape ./node-tests/**/*.js",
-    "test:coverage": "COVERAGE=true ember test --test-port=${EMBER_TEST_PORT:-7357}",
-    "test:view:coverage": "COVERAGE=true ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
+    "test:coverage": "COVERAGE=true ember test --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
+    "test:view:coverage": "COVERAGE=true ember test --server --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
     "steps:list": "node ./lib/commands/bin/list.js"
   },
   "husky": {
@@ -54,7 +54,7 @@
     "@ember/jquery": "^0.6.0",
     "@ember/optional-features": "^0.7.0",
     "@hashicorp/consul-api-double": "^2.6.2",
-    "@hashicorp/ember-cli-api-double": "^2.0.0",
+    "@hashicorp/ember-cli-api-double": "^3.0.0",
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^3.0.0",
     "chalk": "^2.4.2",
@@ -111,6 +111,7 @@
     "loader.js": "^4.7.0",
     "ngraph.graph": "^18.0.3",
     "node-sass": "^4.9.3",
+    "pretender": "^3.2.0",
     "prettier": "^1.10.2",
     "qunit-dom": "^0.9.0",
     "tape": "^4.13.0",

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -60,6 +60,7 @@
     "chalk": "^2.4.2",
     "clipboard": "^2.0.4",
     "css.escape": "^1.5.1",
+    "dart-sass": "^1.25.0",
     "ember-auto-import": "^1.4.0",
     "ember-changeset-validations": "^2.1.0",
     "ember-cli": "~3.12.0",

--- a/ui-v2/tests/helpers/api.js
+++ b/ui-v2/tests/helpers/api.js
@@ -5,10 +5,7 @@ import setCookies from 'consul-ui/tests/helpers/set-cookies';
 import typeToURL from 'consul-ui/tests/helpers/type-to-url';
 
 const addon = config['@hashicorp/ember-cli-api-double'];
-const temp = addon.endpoints[0].split('/');
-temp.pop();
-const path = temp.join('/');
-const api = apiDouble(path, setCookies, typeToURL);
+const api = apiDouble(addon, setCookies, typeToURL);
 export const get = function(_url, options = { headers: { cookie: {} } }) {
   const url = new URL(_url, 'http://localhost');
   return new Promise(function(resolve) {

--- a/ui-v2/tests/integration/components/app-error-test.js
+++ b/ui-v2/tests/integration/components/app-error-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | app-error', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{app-error}}`);
+
+    assert.equal([...this.element.querySelectorAll('[data-test-error]')].length, 1);
+
+    // Template block usage:
+    await render(hbs`
+      {{#app-error}}{{/app-error}}
+    `);
+
+    assert.equal([...this.element.querySelectorAll('[data-test-error]')].length, 1);
+  });
+});

--- a/ui-v2/tests/integration/components/consul-service-list-test.js
+++ b/ui-v2/tests/integration/components/consul-service-list-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | consul-service-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{consul-service-list}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#consul-service-list}}
+      {{/consul-service-list}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});

--- a/ui-v2/tests/integration/components/data-source-test.js
+++ b/ui-v2/tests/integration/components/data-source-test.js
@@ -1,0 +1,119 @@
+import { module } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { clearRender, render, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+import test from 'ember-sinon-qunit/test-support/test';
+import Service from '@ember/service';
+
+import { BlockingEventSource as RealEventSource } from 'consul-ui/utils/dom/event-source';
+
+const createFakeBlockingEventSource = function() {
+  const EventSource = function(cb) {
+    this.readyState = 1;
+    this.source = cb;
+  };
+  const o = EventSource.prototype;
+  [
+    'addEventListener',
+    'removeEventListener',
+    'dispatchEvent',
+    'close',
+    'open',
+    'getCurrentEvent',
+  ].forEach(function(item) {
+    o[item] = function() {};
+  });
+  return EventSource;
+};
+const BlockingEventSource = createFakeBlockingEventSource();
+module('Integration | Component | data-source', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.actions = {};
+    this.send = (actionName, ...args) => this.actions[actionName].apply(this, args);
+  });
+  test('open and closed are called correctly when the src is changed', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+    assert.expect(9);
+    const close = this.stub();
+    const open = this.stub();
+    const addEventListener = this.stub();
+    const removeEventListener = this.stub();
+    let count = 0;
+    const blockingStub = Service.extend({
+      open: function(uri, obj) {
+        open(uri);
+        const source = new BlockingEventSource();
+        source.getCurrentEvent = function() {
+          return { data: uri };
+        };
+        source.addEventListener = addEventListener;
+        source.removeEventListener = removeEventListener;
+        return source;
+      },
+      close: close,
+    });
+    this.owner.register('service:blocking', blockingStub);
+    this.actions.change = data => {
+      count++;
+      switch (count) {
+        case 1:
+          assert.equal(data, 'a', 'change was called first with "a"');
+          this.set('src', 'b');
+          break;
+        case 2:
+          assert.equal(data, 'b', 'change was called second with "b"');
+          break;
+      }
+    };
+
+    this.set('src', 'a');
+    await render(hbs`{{data-source src=src onchange=(action 'change' value="data")}}`);
+    assert.equal(this.element.textContent.trim(), '');
+    await waitUntil(() => {
+      return close.calledTwice;
+    });
+    assert.ok(open.calledTwice, 'open is called when src is set');
+    assert.ok(close.calledTwice, 'close is called as open is called');
+    await clearRender();
+    await waitUntil(() => {
+      return close.calledThrice;
+    });
+    assert.ok(open.calledTwice, 'open is _still_ only called when src is set');
+    assert.ok(close.calledThrice, 'close is called an extra time as the component is destroyed');
+    assert.equal(addEventListener.callCount, 4, 'all event listeners were added');
+    assert.equal(removeEventListener.callCount, 4, 'all event listeners were removed');
+  });
+  test('error actions are triggered when errors are dispatched', async function(assert) {
+    const source = new RealEventSource();
+    const error = this.stub();
+    const close = this.stub();
+    const blockingStub = Service.extend({
+      open: function(uri, obj) {
+        source.getCurrentEvent = function() {
+          return {};
+        };
+        return source;
+      },
+      close: close,
+    });
+    this.owner.register('service:blocking', blockingStub);
+    this.actions.change = data => {
+      source.dispatchEvent({ type: 'error', error: {} });
+    };
+    this.actions.error = error;
+    await render(
+      hbs`{{data-source src="" onchange=(action 'change' value="data") onerror=(action 'error' value="error")}}`
+    );
+    await waitUntil(() => {
+      return error.calledOnce;
+    });
+    assert.ok(error.calledOnce, 'error action was called');
+    assert.ok(close.calledOnce, 'close was called before the open');
+    await clearRender();
+    assert.ok(close.calledTwice, 'close was also called when the component is destroyed');
+  });
+});

--- a/ui-v2/tests/integration/helpers/is-undefined-test.js
+++ b/ui-v2/tests/integration/helpers/is-undefined-test.js
@@ -1,0 +1,17 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | is-undefined', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  skip('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{is-undefined inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'false');
+  });
+});

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -122,7 +122,7 @@ export default function(assert, library) {
   click(library, pauseUntil, find, utils.click);
   form(library, find, utils.fillIn, utils.triggerKeyEvent, getCurrentPage);
   debug(library, assert, utils.currentURL);
-  assertHttp(library, assert, pauseUntil, utils.lastNthRequest);
+  assertHttp(library, assert, pauseUntil, lastNthRequest);
   assertModel(library, assert, find, getCurrentPage, pauseUntil, pluralize);
   assertPage(library, assert, find, getCurrentPage);
   assertDom(library, assert, pauseUntil, utils.find, utils.currentURL, clipboard);

--- a/ui-v2/tests/steps/assertions/dom.js
+++ b/ui-v2/tests/steps/assertions/dom.js
@@ -1,24 +1,26 @@
 export default function(scenario, assert, pauseUntil, find, currentURL, clipboard) {
   scenario
-    .then('pause until I see the text "$text" in "$selector"', function(text, selector) {
-      return pauseUntil(function(resolve) {
-        const $el = find(selector);
-        if ($el) {
-          const hasText = $el.textContent.indexOf(text) !== -1;
-          if (hasText) {
-            assert.ok(hasText, `Expected to see "${text}" in "${selector}"`);
-            resolve();
+    .then(
+      [
+        'I see the text "$text" in "$selector"',
+        'pause until I see the text "$text" in "$selector"',
+      ],
+      function(text, selector) {
+        return pauseUntil(function(resolve, reject) {
+          const $el = find(selector);
+          if ($el) {
+            const hasText = $el.textContent.indexOf(text) !== -1;
+            if (hasText) {
+              assert.ok(hasText, `Expected to see "${text}" in "${selector}"`);
+              resolve();
+            } else {
+              reject(`Expected to see "${text}" in "${selector}"`);
+            }
           }
-        }
-      });
-    })
-    .then(['I see the text "$text" in "$selector"'], function(text, selector) {
-      const textContent = find(selector).textContent;
-      assert.ok(
-        textContent.indexOf(text) !== -1,
-        `Expected to see "${text}" in "${selector}", was "${textContent}"`
-      );
-    })
+          return Promise.resolve();
+        });
+      }
+    )
     .then(['I copied "$text"'], function(text) {
       const copied = clipboard();
       assert.ok(
@@ -35,10 +37,19 @@ export default function(scenario, assert, pauseUntil, find, currentURL, clipboar
     // TODO: Think of better language
     // TODO: These should be mergeable
     .then(['"$selector" has the "$class" class'], function(selector, cls) {
-      // because `find` doesn't work, guessing its sandboxed to ember's container
-      assert
-        .dom(document.querySelector(selector))
-        .hasClass(cls, `Expected [class] to contain ${cls} on ${selector}`);
+      return pauseUntil(function(resolve, reject) {
+        // because `find` doesn't work, guessing its sandboxed to ember's container
+        const $el = document.querySelector(selector);
+        if ($el) {
+          if ($el.classList.contains(cls)) {
+            assert.ok(true, `Expected [class] to contain ${cls} on ${selector}`);
+            resolve();
+          } else {
+            reject(`Expected [class] to contain ${cls} on ${selector}`);
+          }
+        }
+        return Promise.resolve();
+      });
     })
     .then([`I don't see the "$selector" element`], function(selector) {
       assert.equal(document.querySelector(selector), null, `Expected not to see ${selector}`);
@@ -63,12 +74,18 @@ export default function(scenario, assert, pauseUntil, find, currentURL, clipboar
       });
     })
     .then('the url should be $url', function(url) {
-      // TODO: nice! $url should be wrapped in ""
-      if (url === "''") {
-        url = '';
-      }
-      const current = currentURL() || '';
-      assert.equal(current, url, `Expected the url to be ${url} was ${current}`);
+      return pauseUntil(function(resolve, reject) {
+        // TODO: nice! $url should be wrapped in ""
+        if (url === "''") {
+          url = '';
+        }
+        const current = currentURL() || '';
+        if (current === url) {
+          assert.equal(current, url, `Expected the url to be ${url} was ${current}`);
+          resolve();
+        }
+        return Promise.resolve();
+      });
     })
     .then(['the title should be "$title"'], function(title) {
       assert.equal(document.title, title, `Expected the document.title to equal "${title}"`);

--- a/ui-v2/tests/steps/assertions/http.js
+++ b/ui-v2/tests/steps/assertions/http.js
@@ -1,4 +1,4 @@
-export default function(scenario, assert, lastNthRequest) {
+export default function(scenario, assert, pauseUntil, lastNthRequest) {
   // lastNthRequest should return a
   // {
   //   method: '',
@@ -22,11 +22,17 @@ export default function(scenario, assert, lastNthRequest) {
       assert.equal(diff.size, 0, `Expected requests "${[...diff].join(', ')}"`);
     })
     .then('a $method request was made to "$endpoint"', function(method, url) {
-      const requests = lastNthRequest(null, method);
-      const request = requests.find(function(item) {
-        return method === item.method && url === item.url;
+      return pauseUntil(function(resolve, reject) {
+        const requests = lastNthRequest(null, method);
+        const request = requests.find(function(item) {
+          return method === item.method && url === item.url;
+        });
+        if (request) {
+          assert.ok(request, `Expected a ${method} request url to ${url}`);
+          resolve();
+        }
+        return Promise.resolve();
       });
-      assert.ok(request, `Expected a ${method} request url to ${url}`);
     })
     .then('a $method request was made to "$endpoint" with no body', function(method, url) {
       const requests = lastNthRequest(null, method);

--- a/ui-v2/tests/steps/assertions/model.js
+++ b/ui-v2/tests/steps/assertions/model.js
@@ -1,23 +1,20 @@
 export default function(scenario, assert, find, currentPage, pauseUntil, pluralize) {
   scenario
-    .then('pause until I see $number $model model[s]?', function(num, model) {
-      return pauseUntil(function(resolve) {
-        const len = currentPage()[pluralize(model)].filter(function(item) {
-          return item.isVisible;
-        }).length;
-        if (len === num) {
-          assert.equal(len, num, `Expected ${num} ${model}s, saw ${len}`);
-          resolve();
-        }
-      });
-    })
-    .then(['I see $num $model model[s]?'], function(num, model) {
-      const len = currentPage()[pluralize(model)].filter(function(item) {
-        return item.isVisible;
-      }).length;
-
-      assert.equal(len, num, `Expected ${num} ${pluralize(model)}, saw ${len}`);
-    })
+    .then(
+      ['I see $number $model model[s]?', 'pause until I see $number $model model[s]?'],
+      function(num, model) {
+        return pauseUntil(function(resolve) {
+          const len = currentPage()[pluralize(model)].filter(function(item) {
+            return item.isVisible;
+          }).length;
+          if (len === num) {
+            assert.equal(len, num, `Expected ${num} ${model}s, saw ${len}`);
+            resolve();
+          }
+          return Promise.resolve();
+        });
+      }
+    )
     .then(['I see $num $model model[s]? on the $component component'], function(
       num,
       model,

--- a/ui-v2/tests/steps/interactions/click.js
+++ b/ui-v2/tests/steps/interactions/click.js
@@ -1,21 +1,29 @@
-export default function(scenario, find, click) {
+export default function(scenario, pauseUntil, find, click) {
   scenario
     .when('I click "$selector"', function(selector) {
-      return click(selector);
+      return pauseUntil(function(resolve, reject) {
+        const $el = document.querySelector(selector);
+        if ($el) {
+          return click(selector).then(resolve);
+        }
+        return Promise.resolve();
+      });
     })
     // TODO: Probably nicer to think of better vocab than having the 'without " rule'
     .when(['I click (?!")$property(?!")', 'I click $property on the $component'], function(
       property,
-      component,
-      next
+      component
     ) {
-      try {
-        if (typeof component === 'string') {
-          property = `${component}.${property}`;
-        }
-        return find(property)();
-      } catch (e) {
-        throw e;
+      let prop = property;
+      if (typeof component === 'string') {
+        prop = `${component}.${property}`;
       }
+      return pauseUntil(function(resolve, reject) {
+        try {
+          return find(prop)().then(resolve);
+        } catch (e) {
+          return Promise.resolve();
+        }
+      });
     });
 }

--- a/ui-v2/tests/test-helper.js
+++ b/ui-v2/tests/test-helper.js
@@ -1,11 +1,9 @@
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
-import { start } from 'ember-qunit';
 import './helpers/flash-message';
-import loadEmberExam from 'ember-exam/test-support/load';
+import start from 'ember-exam/test-support/start';
 
-loadEmberExam();
 const application = Application.create(config.APP);
 application.inject('component:copy-button', 'clipboard', 'service:clipboard/local-storage');
 setApplication(application);

--- a/ui-v2/tests/unit/services/blocking-test.js
+++ b/ui-v2/tests/unit/services/blocking-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | blocking', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:blocking');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/services/promised-test.js
+++ b/ui-v2/tests/unit/services/promised-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | promised', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:promised');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/services/repository/manager-test.js
+++ b/ui-v2/tests/unit/services/repository/manager-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | repository/manager', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:repository/manager');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/utils/maybe-call-test.js
+++ b/ui-v2/tests/unit/utils/maybe-call-test.js
@@ -1,0 +1,18 @@
+import maybeCall from 'consul-ui/utils/maybe-call';
+import { module, test } from 'qunit';
+import { Promise } from 'rsvp';
+
+module('Unit | Utility | maybe-call', function() {
+  test('it calls a function when the resolved value is true', function(assert) {
+    assert.expect(1);
+    return maybeCall(() => {
+      assert.ok(true);
+    }, Promise.resolve(true))();
+  });
+  test("it doesn't call a function when the resolved value is false", function(assert) {
+    assert.expect(0);
+    return maybeCall(() => {
+      assert.ok(true);
+    }, Promise.resolve(false))();
+  });
+});

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -8567,6 +8567,13 @@ mktemp@~0.4.0:
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
   integrity sha1-bQUVYRyKjITkhKogABKbmOmB/ws=
 
+mnemonist@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/mnemonist/-/mnemonist-0.30.0.tgz#c8c37f4425b8abcf7aa04a34199af254b398a90f"
+  integrity sha512-g9rbX4ug7am8oW3jnM7adaFaj5vv5PeOaMPNUwjKQQaTyY+qPQHTmUF59/ZOfQdtTknkjA7+7RhtmL2C0mtwPA==
+  dependencies:
+    obliterator "^1.5.0"
+
 morgan@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -9038,6 +9045,11 @@ object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
+
+obliterator@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.5.0.tgz#f3535e5be192473ef59efb2d30396738f7c645c6"
+  integrity sha512-dENe0UviDf8/auXn0bIBKwCcUr49khvSBWDLlszv/ZB2qz1VxWDmkNKFqO2nfmve7hQb/QIDY7+rc7K3LdJimQ==
 
 on-finished@~2.3.0:
   version "2.3.0"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -978,7 +978,7 @@
     "@glimmer/interfaces" "^0.42.0"
     "@glimmer/util" "^0.42.0"
 
-"@hashicorp/api-double@^1.3.0":
+"@hashicorp/api-double@^1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@hashicorp/api-double/-/api-double-1.6.1.tgz#67c4c4c5cbf9f51f3b8bc992ab2df21acf63b318"
   integrity sha512-JkQZIsH/2B9T2oK5SQNDakvqlHjxQHu0I9ftmmrxqkxYvYoLN+Whp7dzQ8HswOp1vIJyqbvUhSw06XfH/eimZA==
@@ -996,19 +996,19 @@
   resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.12.0.tgz#725078f770bbd0ef75a5f2498968c5c8891f90a2"
   integrity sha512-8OcgesUjWQ8AjaXzbz3tGJQn1kM0sN6pLidGM7isNPUyYmIjIEXQzaeUQYzsfv0N2Ko9ZuOXYUsaBl8IK1KGow==
 
-"@hashicorp/ember-cli-api-double@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/ember-cli-api-double/-/ember-cli-api-double-2.0.0.tgz#259b13c89150b852f2ebe3b7c182dd16d3ee4c42"
-  integrity sha512-ZQ+0exG43jnuxEg5dkPkdsaRPX3je5AU+0KQUOmIug6KQ21nSw3KXmMj9+z6dGymdYBaiXaMY2WNTtj+r1Ajuw==
+"@hashicorp/ember-cli-api-double@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/ember-cli-api-double/-/ember-cli-api-double-3.0.0.tgz#2a9e8e475c8ac9780221f46584297640870f9f1c"
+  integrity sha512-3jpkkB0jsVWbpI3ySsBJ5jmSb1bPkJu8nZTh9YvIiQDhH76zqHY7AXi35oSV4M83f5qYtBLJjDSdwrf0zJ9Dlg==
   dependencies:
-    "@hashicorp/api-double" "^1.3.0"
+    "@hashicorp/api-double" "^1.6.1"
     array-range "^1.0.1"
     broccoli-file-creator "^2.1.1"
     broccoli-merge-trees "^3.0.2"
-    ember-auto-import "^1.4.0"
+    ember-auto-import "^1.5.3"
     ember-cli-babel "^6.6.0"
     merge-options "^1.0.1"
-    pretender "^2.0.0"
+    pretender "^3.2.0"
     recursive-readdir-sync "^1.0.6"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
@@ -1272,11 +1272,6 @@
     "@webassemblyjs/ast" "1.7.11"
     "@webassemblyjs/wast-parser" "1.7.11"
     "@xtuc/long" "4.2.1"
-
-"@xg-wang/whatwg-fetch@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@xg-wang/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#f7b222c012a238e7d6e89ed3d72a1e0edb58453d"
-  integrity sha512-ULtqA6L75RLzTNW68IiOja0XYv4Ebc3OGMzfia1xxSEMpD0mk/pMvkQX0vbCFyQmKc5xGp80Ms2WiSlXLh8hbA==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -4390,6 +4385,40 @@ ember-auto-import@^1.2.13, ember-auto-import@^1.4.0:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
+ember-auto-import@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.5.3.tgz#b32936f874d1ed7057ad2ed3f6116357820be44b"
+  integrity sha512-7JfdunM1BmLy/lyUXu7uEoi0Gi4+dxkGM23FgIEyW5g7z4MidhP53Fc61t49oPSnq7+J4lLpbH1f6C+mDMgb4A==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/traverse" "^7.1.6"
+    "@babel/types" "^7.1.6"
+    "@embroider/core" "^0.4.3"
+    babel-core "^6.26.3"
+    babel-loader "^8.0.6"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-template "^6.26.0"
+    babylon "^6.18.0"
+    broccoli-debug "^0.6.4"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
+    enhanced-resolve "^4.0.0"
+    fs-extra "^6.0.1"
+    fs-tree-diff "^1.0.0"
+    handlebars "^4.3.1"
+    js-string-escape "^1.0.1"
+    lodash "^4.17.10"
+    mkdirp "^0.5.1"
+    pkg-up "^2.0.0"
+    resolve "^1.7.1"
+    rimraf "^2.6.2"
+    symlink-or-copy "^1.2.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^0.3.3"
+    webpack "~4.28"
+
 ember-basic-dropdown@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-1.1.3.tgz#0506045ccc60db4972fc78b963c1324f6415818a"
@@ -5781,10 +5810,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fake-xml-http-request@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.0.1.tgz#e4a7f256af055d8059deb23c9d7ae721d28cf078"
-  integrity sha512-KzT+G4aLM1Btg25QRGxB6yGLGOVZXXzrH8I4OG3KHwsdoqFclyW3alieqh5NaYGcmbQvNOn/ldGO1rGKf7CNdA==
+fake-xml-http-request@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz#279fdac235840d7a4dff77d98ec44bce9fc690a6"
+  integrity sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==
 
 faker@^4.1.0:
   version "4.1.0"
@@ -6522,6 +6551,17 @@ handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
   integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.3.1:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.2.tgz#01127b3840156a0927058779482031afe0e730d7"
+  integrity sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -9447,14 +9487,14 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-pretender@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.2.tgz#02d7c0a3f18cb0ce376dfc4fb0043ca288f50316"
-  integrity sha512-5Jx7kBalWDn8oEKfw6nAcx2KK4GkDSQXG3WhgaPsDtak6Rv6nTeQjOdvOM9PEvauS+9Ur+DLfZTDWBtqK6lFVA==
+pretender@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-3.2.0.tgz#3e653009462f737c1184ca8b7b8d2f03cf47421b"
+  integrity sha512-YnqYFZ9JKcpseQnYE5iR1y1gBATtJTXzI/SXtTFt4mvXabg6U4AIzvNzJok9IhxP5lIyQ9OeWCsg2DkjhQJSKg==
   dependencies:
-    "@xg-wang/whatwg-fetch" "^3.0.0"
-    fake-xml-http-request "~2.0.0"
+    fake-xml-http-request "^2.1.1"
     route-recognizer "^0.3.3"
+    whatwg-fetch "^3.0.0"
 
 prettier@^1.10.2:
   version "1.18.2"
@@ -11804,6 +11844,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.2.0:
   version "2.3.0"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1466,6 +1466,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aot-test-generators@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/aot-test-generators/-/aot-test-generators-0.1.0.tgz#43f0f615f97cb298d7919c1b0b4e6b7310b03cd0"
@@ -2413,6 +2421,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
 "binaryextensions@1 || 2":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.2.0.tgz#e7c6ba82d4f5f5758c26078fe8eea28881233311"
@@ -2511,7 +2524,7 @@ braces@^2.3.1, braces@^2.3.2:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -3415,6 +3428,21 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
+"chokidar@>=2.0.0 <4.0.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.3.1.tgz#c84e5b3d18d9a4d77558fef466b1bf16bbeb3450"
+  integrity sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.3.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.0.2:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -4000,6 +4028,13 @@ dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
   integrity sha1-lxS0ct6CoYQ94vuptodpOMq0TGg=
+
+dart-sass@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/dart-sass/-/dart-sass-1.25.0.tgz#e00c0348118916e9d81cb485297184c131af1dad"
+  integrity sha512-syNOAstJXAmvD3RifcDk3fiPMyYE2fY8so6w9gf2/wNlKpG0zyH+oiXubEYVOy1WAWkzOc72pbAxwx+3OU4JJA==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -6266,6 +6301,11 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
+fsevents@~2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
+  integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
 fstream@^1.0.0, fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
@@ -6395,6 +6435,13 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -6411,10 +6458,10 @@ glob@^5.0.10:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.2, glob@^7.1.4, glob@~7.1.1:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+glob@^7.0.0, glob@^7.1.3, glob@~7.1.1, glob@~7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -6423,10 +6470,10 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.2, glob@^7.1.4, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3, glob@~7.1.6:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@^7.0.3, glob@^7.0.4, glob@^7.1.2, glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -6494,9 +6541,9 @@ globby@^9.0.0:
     slash "^2.0.0"
 
 globule@^1.0.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.1.tgz#5dffb1b191f22d20797a9369b49eab4e9839696d"
-  integrity sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.3.0.tgz#41d0e9fb44afd4b80d93a23263714f90b3dec904"
+  integrity sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==
   dependencies:
     glob "~7.1.1"
     lodash "~4.17.10"
@@ -7106,6 +7153,13 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -7223,7 +7277,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -8746,9 +8800,9 @@ node-releases@^1.1.29:
     semver "^5.3.0"
 
 node-sass@^4.9.3:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
-  integrity sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -8757,7 +8811,7 @@ node-sass@^4.9.3:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.13.2"
@@ -8813,7 +8867,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -9384,6 +9438,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.0.4, picomatch@^2.0.7:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
+  integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
 picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
@@ -9823,6 +9882,13 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+readdirp@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.3.0.tgz#984458d13a1e42e2e9f5841b129e162f369aff17"
+  integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
+  dependencies:
+    picomatch "^2.0.7"
 
 recast@^0.11.3:
   version "0.11.23"


### PR DESCRIPTION
This PR is part of https://github.com/hashicorp/consul/pull/6821 and is to be merged onto that PR.

This implements data-source for the service listing.

Notes:

1. New app-error component now that API errors aren't coming from the Route
2. New is-undefined helper as ember has a special type of undefined in
templates - isDestroyed. Usually we'd shy away from this negative
'undefined' and use `is-defined` instead but this fits better with
javascript.
3. Code required for cleaning up tests in-between test case runs. During
testing the entire environment can't be cleaned up between test cases,
so we ensure we tear down event listeners and overwrite caches using
`init` and `willDestroy`. These additions are only required during
testing.
4. ember tests rely on the Route.model hook in order to know when to
wait for an API response. As we are moving away from this to a
componentized approach to data, tests can no longer rely on this ember
Route.model specific behaviour. Therefore we being to change out gherkin
steps to use a spinner/waiter in order to wait for API responses. This
will gradually be spread out over other steps and we'll be able to
remove our 'pause until' steps as they will be identical to the steps
without 'pause until'.

P.S. We also changed our mind slightly here on how you ask for multiple data objects as opposed to single ones (`/service/service-name` vs `/services`). We'd originally thought of using a `*`, and even though for our usecase here this is pretty safe to use. It could complicate matters for other data objects. We also considered just an empty `/service` to mean 'multiple' but we'd also like to use `data-source`s to request empty objects via `repo.create()` ready for object creation.

P.P.S.

Our next step here was to split the service listing out into a first iteration of its own component, we decided that we may aswell add that to the end of this PR. See 54df634 for more details.