### PR TITLE
ui: %form-element-textarea > %form-element-text-input typo

### DIFF
--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -1,5 +1,5 @@
 body,
-%form-element-textarea {
+%form-element-text-input {
   @extend %typo-body;
 }
 h1 {


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/6881 we made a typo and used `%form-element-textarea` (a placeholder that doesn't exist) instead of `%form-element-text-input`.

This fixes that.

Please note, whilst this is a bugfix, this bug has not yet reached `master`

Before:

<img width="245" alt="Screenshot 2019-12-16 at 13 40 26" src="https://user-images.githubusercontent.com/554604/70911378-b6175b80-2009-11ea-9f09-23f0126d133f.png">

After:

<img width="306" alt="Screenshot 2019-12-16 at 13 40 37" src="https://user-images.githubusercontent.com/554604/70911383-b9aae280-2009-11ea-8bc5-ca699df05a2f.png">
