### PR TITLE
OSS changes to allow for parsing the enterprise DNS config prop…

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -99,7 +99,7 @@ func NewBuilder(flags Flags) (*Builder, error) {
 
 	b := &Builder{
 		Flags: flags,
-		Head:  []Source{DefaultSource()},
+		Head:  []Source{DefaultSource(), DefaultEnterpriseSource()},
 	}
 
 	if b.boolVal(b.Flags.DevMode) {
@@ -128,7 +128,7 @@ func NewBuilder(flags Flags) (*Builder, error) {
 			Data:   s,
 		})
 	}
-	b.Tail = append(b.Tail, NonUserSource(), DefaultConsulSource(), DefaultEnterpriseSource(), DefaultVersionSource())
+	b.Tail = append(b.Tail, NonUserSource(), DefaultConsulSource(), OverrideEnterpriseSource(), DefaultVersionSource())
 	if b.boolVal(b.Flags.DevMode) {
 		b.Tail = append(b.Tail, DevConsulSource())
 	}

--- a/agent/config/default_oss.go
+++ b/agent/config/default_oss.go
@@ -2,11 +2,22 @@
 
 package config
 
-// DefaultEnterpriseSource returns the consul agent configuration for the enterprise mode.
-// This should be merged in the tail after the DefaultConsulSource.
+// DefaultEnterpriseSource returns the consul agent configuration for enterprise mode.
+// These can be overridden by the user and therefore this source should be merged in the
+// head and processed before user configuration.
 func DefaultEnterpriseSource() Source {
 	return Source{
-		Name:   "enterprise",
+		Name:   "enterprise-defaults",
+		Format: "hcl",
+		Data:   ``,
+	}
+}
+
+// OverrideEnterpriseSource returns the consul agent configuration for the enterprise mode.
+// This should be merged in the tail after the DefaultConsulSource.
+func OverrideEnterpriseSource() Source {
+	return Source{
+		Name:   "enterprise-overrides",
 		Format: "hcl",
 		Data:   ``,
 	}

--- a/agent/config/runtime_oss_test.go
+++ b/agent/config/runtime_oss_test.go
@@ -5,3 +5,9 @@ package config
 var entMetaJSON = `{}`
 
 var entRuntimeConfigSanitize = `{}`
+
+var entFullDNSJSONConfig = ``
+
+var entFullDNSHCLConfig = ``
+
+var entFullRuntimeConfig = EnterpriseRuntimeConfig{}

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3782,7 +3782,7 @@ func TestFullConfig(t *testing.T) {
 				},
 				"udp_answer_limit": 29909,
 				"use_cache": true,
-				"cache_max_age": "5m"
+				"cache_max_age": "5m"` + entFullDNSJSONConfig + `
 			},
 			"enable_acl_replication": true,
 			"enable_agent_tls_for_checks": true,
@@ -4382,6 +4382,7 @@ func TestFullConfig(t *testing.T) {
 				udp_answer_limit = 29909
 				use_cache = true
 				cache_max_age = "5m"
+				` + entFullDNSHCLConfig + `
 			}
 			enable_acl_replication = true
 			enable_agent_tls_for_checks = true
@@ -5484,6 +5485,7 @@ func TestFullConfig(t *testing.T) {
 				"args":       []interface{}{"dltjDJ2a", "flEa7C2d"},
 			},
 		},
+		EnterpriseRuntimeConfig: entFullRuntimeConfig,
 	}
 
 	warns := []string{


### PR DESCRIPTION
This PR fixes the config handling a bit.

In particular for default enterprise config I changed it so that true defaults that are user-overridable can be gotten from the `DefaultEnterpriseSource` function where override for non-user modifiable values are in `OverrideEnterpriseSource`. 