### PR TITLE
coverage: add UI test coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
             go tool cover -html=coverage.out -o /tmp/test-results/coverage.html
       - run:
           name: codecov upload
-          command: bash <(curl -s https://codecov.io/bash) -v -C $CIRCLE_SHA1 -f '!agent/bindata_assetfs.go'
+          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -f '!agent/bindata_assetfs.go'
       - store_artifacts:
           path: /tmp/test-results
 
@@ -513,7 +513,7 @@ jobs:
       - run:
           working_directory: ui-v2
           name: codecov upload
-          command: bash <(curl -s https://codecov.io/bash) -v -C $CIRCLE_SHA1 -F ui
+          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui
       - store_test_results:
           path: ui-v2/test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,6 +497,7 @@ jobs:
     docker:
       - image: *EMBER_IMAGE
     environment:
+      COVERAGE: true
       EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
       EMBER_TEST_REPORT: test-results/report.xml #outputs test report for CircleCI test summary
     parallelism: 4
@@ -509,6 +510,10 @@ jobs:
       - run:
           working_directory: ui-v2
           command: node_modules/ember-cli/bin/ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --path dist --silent -r xunit
+      - run:
+          working_directory: ui-v2
+          name: codecov upload
+          command: bash <(curl -s https://codecov.io/bash) -v -C $CIRCLE_SHA1 -F ui
       - store_test_results:
           path: ui-v2/test-results
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,9 +7,9 @@ coverage:
       default:
         # https://docs.codecov.io/docs/commit-status#section-informational
         informational: true
-        # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
-        # TODO: should any paths be excluded from coverage metrics?
-        # paths:
+      ui:
+        flags: ui
+        informational: true
     # https://docs.codecov.io/docs/commit-status#section-changes-status
     # TODO: enable after eliminating current unexpected coverage changes?
     changes: off
@@ -28,5 +28,8 @@ coverage:
 comment: false
 
 # https://docs.codecov.io/docs/flags
-# TODO: split out test coverage for API, SDK, UI, website?
-# flags:
+# TODO: split out test coverage for API, SDK, website?
+flags:
+  ui:
+    paths:
+      - ui-v2

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,11 @@
 coverage:
   status:
     # only measure diff changes, not unexpected project changes from flakiness
-    project: off
+    project:
+      default: off
+      ui:
+        flags: ui
+        informational: true
     patch:
       default:
         # https://docs.codecov.io/docs/commit-status#section-informational


### PR DESCRIPTION
This is an experiment in adding separate UI test coverage reporting using CodeCov [flags](https://docs.codecov.io/docs/flags) functionality - it looks like the underlying infrastructure is [already set up](https://github.com/hashicorp/consul/blob/master/ui-v2/package.json#L26), just need to get it reporting in CI...