### PR TITLE
connect: add new internal flag to retain more details during discovery chain compilation to aid in visualizations

### DIFF
--- a/agent/consul/discovery_chain_endpoint.go
+++ b/agent/consul/discovery_chain_endpoint.go
@@ -89,6 +89,7 @@ func (c *DiscoveryChain) Get(args *structs.DiscoveryChainRequest, reply *structs
 				OverrideMeshGateway:    args.OverrideMeshGateway,
 				OverrideProtocol:       args.OverrideProtocol,
 				OverrideConnectTimeout: args.OverrideConnectTimeout,
+				InternalRetainDetails:  args.InternalRetainDetails,
 				Entries:                entries,
 			})
 			if err != nil {

--- a/agent/discovery_chain_endpoint.go
+++ b/agent/discovery_chain_endpoint.go
@@ -13,12 +13,25 @@ import (
 )
 
 func (s *HTTPServer) DiscoveryChainRead(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	return s.discoveryChainRead(resp, req, false)
+}
+
+func (s *HTTPServer) UIDiscoveryChainRead(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	return s.discoveryChainRead(resp, req, true)
+}
+
+func (s *HTTPServer) discoveryChainRead(resp http.ResponseWriter, req *http.Request, ui bool) (interface{}, error) {
 	var args structs.DiscoveryChainRequest
 	if done := s.parse(resp, req, &args.Datacenter, &args.QueryOptions); done {
 		return nil, nil
 	}
+	args.InternalRetainDetails = ui
 
-	args.Name = strings.TrimPrefix(req.URL.Path, "/v1/discovery-chain/")
+	if ui {
+		args.Name = strings.TrimPrefix(req.URL.Path, "/v1/internal/discovery-chain/")
+	} else {
+		args.Name = strings.TrimPrefix(req.URL.Path, "/v1/discovery-chain/")
+	}
 	if args.Name == "" {
 		return nil, BadRequestError{Reason: "Missing chain name"}
 	}

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -90,6 +90,7 @@ func init() {
 	registerEndpoint("/v1/internal/ui/node/", []string{"GET"}, (*HTTPServer).UINodeInfo)
 	registerEndpoint("/v1/internal/ui/services", []string{"GET"}, (*HTTPServer).UIServices)
 	registerEndpoint("/v1/internal/acl/authorize", []string{"POST"}, (*HTTPServer).ACLAuthorize)
+	registerEndpoint("/v1/internal/discovery-chain/", []string{"GET", "POST"}, (*HTTPServer).UIDiscoveryChainRead)
 	registerEndpoint("/v1/kv/", []string{"GET", "PUT", "DELETE"}, (*HTTPServer).KVSEndpoint)
 	registerEndpoint("/v1/operator/raft/configuration", []string{"GET"}, (*HTTPServer).OperatorRaftConfiguration)
 	registerEndpoint("/v1/operator/raft/peer", []string{"DELETE"}, (*HTTPServer).OperatorRaftPeer)

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -1061,6 +1061,8 @@ type DiscoveryChainRequest struct {
 	// overridden for any resolver in the compiled chain.
 	OverrideConnectTimeout time.Duration
 
+	InternalRetainDetails bool `json:"-"`
+
 	Datacenter string // where to route the RPC
 	QueryOptions
 }
@@ -1086,6 +1088,7 @@ func (r *DiscoveryChainRequest) CacheInfo() cache.RequestInfo {
 		OverrideMeshGateway    MeshGatewayConfig
 		OverrideProtocol       string
 		OverrideConnectTimeout time.Duration
+		InternalRetainDetails  bool
 	}{
 		Name:                   r.Name,
 		EvaluateInDatacenter:   r.EvaluateInDatacenter,
@@ -1093,6 +1096,7 @@ func (r *DiscoveryChainRequest) CacheInfo() cache.RequestInfo {
 		OverrideMeshGateway:    r.OverrideMeshGateway,
 		OverrideProtocol:       r.OverrideProtocol,
 		OverrideConnectTimeout: r.OverrideConnectTimeout,
+		InternalRetainDetails:  r.InternalRetainDetails,
 	}, nil)
 	if err == nil {
 		// If there is an error, we don't set the key. A blank key forces


### PR DESCRIPTION
This is activated using /v1/internal/discovery-chain instead of /v1/discovery-chain

Fixes #6809 

Sample usage:
```
============================================================
CREATE CONFIG ENTRIES
{
    "Kind": "proxy-defaults",
    "Name": "global",
    "Config": {
        "protocol": "http"
    },
    "MeshGateway": {},
    "Expose": {},
    "CreateIndex": 29,
    "ModifyIndex": 114
}
{
    "Kind": "service-resolver",
    "Name": "web",
    "Redirect": {
        "Service": "other"
    },
    "CreateIndex": 12,
    "ModifyIndex": 115
}
{
    "Kind": "service-resolver",
    "Name": "fail",
    "Failover": {
        "*": {
            "Service": "web",
            "Datacenters": [
                "dc9",
                "dc42"
            ]
        }
    },
    "CreateIndex": 20,
    "ModifyIndex": 116
}
{
    "Kind": "service-splitter",
    "Name": "main",
    "Splits": [
        {
            "Weight": 50,
            "Service": "left"
        },
        {
            "Weight": 50,
            "Service": "right"
        }
    ],
    "CreateIndex": 30,
    "ModifyIndex": 117
}
{
    "Kind": "service-splitter",
    "Name": "left",
    "Splits": [
        {
            "Weight": 50,
            "Service": "left-left"
        },
        {
            "Weight": 50,
            "Service": "right"
        }
    ],
    "CreateIndex": 34,
    "ModifyIndex": 118
}

============================================================
diff between /v1/discovery-chain/web and /v1/internal/discovery-chain/web
{								{
    "Chain": {							    "Chain": {
        "ServiceName": "web",					        "ServiceName": "web",
        "Namespace": "default",					        "Namespace": "default",
        "Datacenter": "dc1",					        "Datacenter": "dc1",
        "Protocol": "http",					        "Protocol": "http",
        "StartNode": "resolver:other.default.dc1",	      |	        "StartNode": "redirect:web.default.dc1",
        "Nodes": {						        "Nodes": {
							      >	            "redirect:web.default.dc1": {
							      >	                "Type": "redirect",
							      >	                "Name": "web.default.dc1",
							      >	                "Redirect": {
							      >	                    "Mechanism": "explicit",
							      >	                    "NextNode": "resolver:other.default.dc1"
							      >	                }
							      >	            },
            "resolver:other.default.dc1": {			            "resolver:other.default.dc1": {
                "Type": "resolver",				                "Type": "resolver",
                "Name": "other.default.dc1",			                "Name": "other.default.dc1",
                "Resolver": {					                "Resolver": {
                    "ConnectTimeout": "5s",			                    "ConnectTimeout": "5s",
                    "Default": true,				                    "Default": true,
                    "Target": "other.default.dc1"		                    "Target": "other.default.dc1"
                }						                }
            }							            }
        },							        },
        "Targets": {						        "Targets": {
            "other.default.dc1": {				            "other.default.dc1": {
                "ID": "other.default.dc1",			                "ID": "other.default.dc1",
                "Service": "other",				                "Service": "other",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc1",				                "Datacenter": "dc1",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "other.default.dc1.internal.d1ab25f4-f	                "SNI": "other.default.dc1.internal.d1ab25f4-f
                "Name": "other.default.dc1.internal.d1ab25f4-	                "Name": "other.default.dc1.internal.d1ab25f4-
            }							            }
        }							        }
    }								    }
}								}

============================================================
diff between /v1/discovery-chain/fail and /v1/internal/discovery-chain/fail
{								{
    "Chain": {							    "Chain": {
        "ServiceName": "fail",					        "ServiceName": "fail",
        "Namespace": "default",					        "Namespace": "default",
        "Datacenter": "dc1",					        "Datacenter": "dc1",
        "Protocol": "http",					        "Protocol": "http",
        "StartNode": "resolver:fail.default.dc1",		        "StartNode": "resolver:fail.default.dc1",
        "Nodes": {						        "Nodes": {
            "resolver:fail.default.dc1": {			            "resolver:fail.default.dc1": {
                "Type": "resolver",				                "Type": "resolver",
                "Name": "fail.default.dc1",			                "Name": "fail.default.dc1",
                "Resolver": {					                "Resolver": {
                    "ConnectTimeout": "5s",			                    "ConnectTimeout": "5s",
                    "Target": "fail.default.dc1",		                    "Target": "fail.default.dc1",
                    "Failover": {				                    "Failover": {
                        "Targets": [				                        "Targets": [
                            "other.default.dc9",		                            "other.default.dc9",
                            "other.default.dc42"		                            "other.default.dc42"
							      >	                        ],
							      >	                        "InternalTargets": [
							      >	                            [
							      >	                                {
							      >	                                    "RedirectMechanism": "exp
							      >	                                    "Name": "web.default.dc9"
							      >	                                },
							      >	                                {
							      >	                                    "Name": "other.default.dc
							      >	                                }
							      >	                            ],
							      >	                            [
							      >	                                {
							      >	                                    "RedirectMechanism": "exp
							      >	                                    "Name": "web.default.dc42
							      >	                                },
							      >	                                {
							      >	                                    "Name": "other.default.dc
							      >	                                }
							      >	                            ]
                        ]					                        ]
                    }						                    }
                }						                }
            }							            }
        },							        },
        "Targets": {						        "Targets": {
            "fail.default.dc1": {				            "fail.default.dc1": {
                "ID": "fail.default.dc1",			                "ID": "fail.default.dc1",
                "Service": "fail",				                "Service": "fail",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc1",				                "Datacenter": "dc1",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "fail.default.dc1.internal.d1ab25f4-f6	                "SNI": "fail.default.dc1.internal.d1ab25f4-f6
                "Name": "fail.default.dc1.internal.d1ab25f4-f	                "Name": "fail.default.dc1.internal.d1ab25f4-f
            },							            },
            "other.default.dc42": {				            "other.default.dc42": {
                "ID": "other.default.dc42",			                "ID": "other.default.dc42",
                "Service": "other",				                "Service": "other",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc42",				                "Datacenter": "dc42",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "other.default.dc42.internal.d1ab25f4-	                "SNI": "other.default.dc42.internal.d1ab25f4-
                "Name": "other.default.dc42.internal.d1ab25f4	                "Name": "other.default.dc42.internal.d1ab25f4
            },							            },
            "other.default.dc9": {				            "other.default.dc9": {
                "ID": "other.default.dc9",			                "ID": "other.default.dc9",
                "Service": "other",				                "Service": "other",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc9",				                "Datacenter": "dc9",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "other.default.dc9.internal.d1ab25f4-f	                "SNI": "other.default.dc9.internal.d1ab25f4-f
                "Name": "other.default.dc9.internal.d1ab25f4-	                "Name": "other.default.dc9.internal.d1ab25f4-
            }							            }
        }							        }
    }								    }
}								}

============================================================
diff between /v1/discovery-chain/main and /v1/internal/discovery-chain/main
{								{
    "Chain": {							    "Chain": {
        "ServiceName": "main",					        "ServiceName": "main",
        "Namespace": "default",					        "Namespace": "default",
        "Datacenter": "dc1",					        "Datacenter": "dc1",
        "Protocol": "http",					        "Protocol": "http",
        "StartNode": "splitter:main",				        "StartNode": "splitter:main",
        "Nodes": {						        "Nodes": {
            "resolver:left-left.default.dc1": {			            "resolver:left-left.default.dc1": {
                "Type": "resolver",				                "Type": "resolver",
                "Name": "left-left.default.dc1",		                "Name": "left-left.default.dc1",
                "Resolver": {					                "Resolver": {
                    "ConnectTimeout": "5s",			                    "ConnectTimeout": "5s",
                    "Default": true,				                    "Default": true,
                    "Target": "left-left.default.dc1"		                    "Target": "left-left.default.dc1"
                }						                }
            },							            },
            "resolver:right.default.dc1": {			            "resolver:right.default.dc1": {
                "Type": "resolver",				                "Type": "resolver",
                "Name": "right.default.dc1",			                "Name": "right.default.dc1",
                "Resolver": {					                "Resolver": {
                    "ConnectTimeout": "5s",			                    "ConnectTimeout": "5s",
                    "Default": true,				                    "Default": true,
                    "Target": "right.default.dc1"		                    "Target": "right.default.dc1"
                }						                }
            },							            },
            "splitter:main": {				      |	            "splitter:left": {
                "Type": "splitter",				                "Type": "splitter",
                "Name": "main",				      |	                "Name": "left",
                "Splits": [					                "Splits": [
                    {						                    {
                        "Weight": 25,			      |	                        "Weight": 50,
                        "NextNode": "resolver:left-left.defau	                        "NextNode": "resolver:left-left.defau
                    },						                    },
                    {						                    {
                        "Weight": 25,			      |	                        "Weight": 50,
                        "NextNode": "resolver:right.default.d	                        "NextNode": "resolver:right.default.d
							      >	                    }
							      >	                ]
							      >	            },
							      >	            "splitter:main": {
							      >	                "Type": "splitter",
							      >	                "Name": "main",
							      >	                "Splits": [
							      >	                    {
							      >	                        "Weight": 50,
							      >	                        "NextNode": "splitter:left"
                    },						                    },
                    {						                    {
                        "Weight": 50,				                        "Weight": 50,
                        "NextNode": "resolver:right.default.d	                        "NextNode": "resolver:right.default.d
                    }						                    }
                ]						                ]
            }							            }
        },							        },
        "Targets": {						        "Targets": {
            "left-left.default.dc1": {				            "left-left.default.dc1": {
                "ID": "left-left.default.dc1",			                "ID": "left-left.default.dc1",
                "Service": "left-left",				                "Service": "left-left",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc1",				                "Datacenter": "dc1",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "left-left.default.dc1.internal.d1ab25	                "SNI": "left-left.default.dc1.internal.d1ab25
                "Name": "left-left.default.dc1.internal.d1ab2	                "Name": "left-left.default.dc1.internal.d1ab2
            },							            },
            "right.default.dc1": {				            "right.default.dc1": {
                "ID": "right.default.dc1",			                "ID": "right.default.dc1",
                "Service": "right",				                "Service": "right",
                "Namespace": "default",				                "Namespace": "default",
                "Datacenter": "dc1",				                "Datacenter": "dc1",
                "MeshGateway": {},				                "MeshGateway": {},
                "Subset": {},					                "Subset": {},
                "SNI": "right.default.dc1.internal.d1ab25f4-f	                "SNI": "right.default.dc1.internal.d1ab25f4-f
                "Name": "right.default.dc1.internal.d1ab25f4-	                "Name": "right.default.dc1.internal.d1ab25f4-
            }							            }
        }							        }
    }								    }
}								}
```