### PR TITLE
ui: debug ACL tokens with namespaces

### DIFF
--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -7,14 +7,16 @@ export const NSPACE_QUERY_PARAM = 'ns';
 export default Adapter.extend({
   repo: service('settings'),
   client: service('client/http'),
-  formatNspace: function(nspace) {
+  formatNspace: function(queryParamKeys) {
     if (config.CONSUL_NSPACES_ENABLED) {
-      return nspace !== '' ? { [NSPACE_QUERY_PARAM]: nspace } : undefined;
+      return {
+        [NSPACE_QUERY_PARAM]: queryParamKeys,
+      };
     }
   },
-  formatDatacenter: function(dc) {
+  formatDatacenter: function(queryParamKeys) {
     return {
-      [DATACENTER_QUERY_PARAM]: dc,
+      [DATACENTER_QUERY_PARAM]: queryParamKeys,
     };
   },
   // TODO: kinda protected for the moment

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -20,6 +20,8 @@ export default Adapter.extend({
     `;
   },
   requestForQueryRecord: function(request, { dc, ns, index, id }) {
+    // FIXME: Why is `ns` undefined here, but passed correctly to requestForQuery?
+
     if (typeof id === 'undefined') {
       throw new Error('You must specify an id');
     }


### PR DESCRIPTION
Got `make start-consul` running locally against a backend with namespaces enabled, and started stepping through this with @mkeeler, narrowed down the issue slightly but not quite sure how to fix it, just pushing this up to hand off any clues that might help point in the right direction.

The issue seems to be that the params object passed to `requestForQuery` during the pageload has the `ns` key set as expected, but it's undefined when `requestForQueryRecord` is called from clicking the `Use` button for a token.