### PR TITLE
ui: Make sure that the namespace is passed when impersonating a token

### DIFF
--- a/ui-v2/app/mixins/token/with-actions.js
+++ b/ui-v2/app/mixins/token/with-actions.js
@@ -9,13 +9,18 @@ export default Mixin.create(WithBlockingActions, {
     use: function(item) {
       return this.feedback.execute(() => {
         return this.repo
-          .findBySlug(get(item, 'AccessorID'), this.modelFor('dc').dc.Name)
+          .findBySlug(
+            get(item, 'AccessorID'),
+            this.modelFor('dc').dc.Name,
+            this.modelFor('nspace').nspace.substr(1)
+          )
           .then(item => {
             return this.settings
               .persist({
                 token: {
                   AccessorID: get(item, 'AccessorID'),
                   SecretID: get(item, 'SecretID'),
+                  Namespace: get(item, 'Namespace'),
                 },
               })
               .then(() => {


### PR DESCRIPTION
This PR adds the namespace parameter when impersonating a token, and also saves the resulting namespace to localStorage for when the user refreshes/returns to the UI. Mirroring the same functionality as logging in.