### PR TITLE
ui: Make sure that the namespace is passed when changing a token via [Use]

### DIFF
--- a/ui-v2/app/mixins/token/with-actions.js
+++ b/ui-v2/app/mixins/token/with-actions.js
@@ -9,13 +9,18 @@ export default Mixin.create(WithBlockingActions, {
     use: function(item) {
       return this.feedback.execute(() => {
         return this.repo
-          .findBySlug(get(item, 'AccessorID'), this.modelFor('dc').dc.Name)
+          .findBySlug(
+            get(item, 'AccessorID'),
+            this.modelFor('dc').dc.Name,
+            this.modelFor('nspace').nspace.substr(1)
+          )
           .then(item => {
             return this.settings
               .persist({
                 token: {
                   AccessorID: get(item, 'AccessorID'),
                   SecretID: get(item, 'SecretID'),
+                  Namespace: get(item, 'Namespace'),
                 },
               })
               .then(() => {

--- a/ui-v2/app/routes/dc.js
+++ b/ui-v2/app/routes/dc.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import { hash } from 'rsvp';
+import { hash, Promise } from 'rsvp';
 import { get } from '@ember/object';
 
 // TODO: We should potentially move all these nspace related things

--- a/ui-v2/app/routes/dc.js
+++ b/ui-v2/app/routes/dc.js
@@ -74,13 +74,28 @@ export default Route.extend({
     // https://deprecations.emberjs.com/v3.x/#toc_deprecate-router-events
     willTransition: function(transition) {
       this._super(...arguments);
-      if (typeof transition !== 'undefined' && transition.from.name.endsWith('nspaces.create')) {
+      if (
+        typeof transition !== 'undefined' &&
+        (transition.from.name.endsWith('nspaces.create') ||
+          transition.from.name.startsWith('nspace.dc.acls.tokens'))
+      ) {
         // Only when we create, reload the nspaces in the main menu to update them
         // as we don't block for those
-        this.nspacesRepo.findAll().then(items => {
+        // And also when we [Use] a token reload the nspaces that you are able to see,
+        // including your permissions for being able to manage namespaces
+        // Potentially we should just do this on every single transition
+        // but then we would need to check to see if nspaces are enabled
+        Promise.all([
+          this.nspacesRepo.findAll(),
+          this.nspacesRepo.authorize(
+            get(this.controller, 'dc.Name'),
+            get(this.controller, 'nspace.Name')
+          ),
+        ]).then(([nspaces, permissions]) => {
           if (typeof this.controller !== 'undefined') {
             this.controller.setProperties({
-              nspaces: items,
+              nspaces: nspaces,
+              permissions: permissions,
             });
           }
         });

--- a/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
@@ -24,7 +24,7 @@ Feature: dc / acls / tokens / own no delete: The your current token has no delet
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
     ---
     And I click actions on the tokens
     Then I don't see delete on the tokens

--- a/ui-v2/tests/acceptance/dc/acls/tokens/use.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/use.feature
@@ -23,7 +23,7 @@ Feature: dc / acls / tokens / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
     ---
   Scenario: Using an ACL token from the detail page
     When I visit the token page for yaml
@@ -41,5 +41,5 @@ Feature: dc / acls / tokens / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
     ---


### PR DESCRIPTION
This PR adds the namespace parameter when changing a token via [Use], and also saves the resulting namespace to localStorage for when the user refreshes/returns to the UI. Mirroring the same functionality as logging in.