### PR TITLE
Ensure ember-data ids are created correct taking into account the nspace

### DIFF
--- a/ui-v2/app/serializers/application.js
+++ b/ui-v2/app/serializers/application.js
@@ -41,7 +41,7 @@ const attachHeaders = function(headers, body, query = {}) {
 
 export default Serializer.extend({
   attachHeaders: attachHeaders,
-  fingerprint: createFingerprinter(DATACENTER_KEY, NSPACE_KEY, DEFAULT_NSPACE),
+  fingerprint: createFingerprinter(DATACENTER_KEY, NSPACE_KEY),
   respondForQuery: function(respond, query) {
     return respond((headers, body) =>
       attachHeaders(
@@ -88,9 +88,12 @@ export default Serializer.extend({
     const primaryKey = this.primaryKey;
     return respond((headers, body) => {
       // Deletes only need the primaryKey/uid returning
+      // and they need the slug key AND potential namespace in order to
+      // create the correct uid/fingerprint
       return {
         [primaryKey]: this.fingerprint(primaryKey, slugKey, data[DATACENTER_KEY])({
           [slugKey]: data[slugKey],
+          [NSPACE_KEY]: data[NSPACE_KEY],
         })[primaryKey],
       };
     });

--- a/ui-v2/app/utils/create-fingerprinter.js
+++ b/ui-v2/app/utils/create-fingerprinter.js
@@ -1,4 +1,4 @@
-export default function(foreignKey, nspaceKey, nspaceUndefinedName, hash = JSON.stringify) {
+export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
   return function(primaryKey, slugKey, foreignKeyValue) {
     if (foreignKeyValue == null || foreignKeyValue.length < 1) {
       throw new Error('Unable to create fingerprint, missing foreignKey value');
@@ -7,7 +7,7 @@ export default function(foreignKey, nspaceKey, nspaceUndefinedName, hash = JSON.
       if (item[slugKey] == null || item[slugKey].length < 1) {
         throw new Error('Unable to create fingerprint, missing slug');
       }
-      const nspaceValue = item[nspaceKey] || nspaceUndefinedName;
+      const nspaceValue = item[nspaceKey] || 'default';
       return {
         ...item,
         ...{

--- a/ui-v2/tests/unit/utils/create-fingerprinter-test.js
+++ b/ui-v2/tests/unit/utils/create-fingerprinter-test.js
@@ -5,6 +5,21 @@ module('Unit | Utility | create fingerprinter', function() {
   test("fingerprint returns a 'unique' fingerprinted object based on primary, slug and foreign keys", function(assert) {
     const obj = {
       ID: 'slug',
+      Namespace: 'namespace',
+    };
+    const expected = {
+      Datacenter: 'dc',
+      Namespace: 'namespace',
+      ID: 'slug',
+      uid: '["namespace","dc","slug"]',
+    };
+    const fingerprint = createFingerprinter('Datacenter', 'Namespace');
+    const actual = fingerprint('uid', 'ID', 'dc')(obj);
+    assert.deepEqual(actual, expected);
+  });
+  test("fingerprint returns a 'unique' fingerprinted object based on primary, slug and foreign keys, and uses default namespace if none set", function(assert) {
+    const obj = {
+      ID: 'slug',
     };
     const expected = {
       Datacenter: 'dc',
@@ -12,12 +27,12 @@ module('Unit | Utility | create fingerprinter', function() {
       ID: 'slug',
       uid: '["default","dc","slug"]',
     };
-    const fingerprint = createFingerprinter('Datacenter', 'Namespace', 'default');
+    const fingerprint = createFingerprinter('Datacenter', 'Namespace');
     const actual = fingerprint('uid', 'ID', 'dc')(obj);
     assert.deepEqual(actual, expected);
   });
   test("fingerprint throws an error if it can't find a foreignKey", function(assert) {
-    const fingerprint = createFingerprinter('Datacenter', 'Namespace', 'default');
+    const fingerprint = createFingerprinter('Datacenter', 'Namespace');
     [undefined, null].forEach(function(item) {
       assert.throws(function() {
         fingerprint('uid', 'ID', item);
@@ -25,7 +40,7 @@ module('Unit | Utility | create fingerprinter', function() {
     });
   });
   test("fingerprint throws an error if it can't find a slug", function(assert) {
-    const fingerprint = createFingerprinter('Datacenter', 'Namespace', 'default');
+    const fingerprint = createFingerprinter('Datacenter', 'Namespace');
     [
       {},
       {


### PR DESCRIPTION
This PR ensures that the correct namespace is taken into account when creating ember-data id's on deletion (used for local caching).

We also took the opportunity here to revert back to just using the plain string `'default'` as we have done in other areas of the code.