### PR TITLE
ui: Cope with the possibility of receiving no namespaces

### DIFF
--- a/ui-v2/app/templates/components/hashicorp-consul.hbs
+++ b/ui-v2/app/templates/components/hashicorp-consul.hbs
@@ -11,7 +11,7 @@
             <nav>
 {{#if dc}}
                 <ul>
-  {{#if (env 'CONSUL_NSPACES_ENABLED')}}
+  {{#if (and (env 'CONSUL_NSPACES_ENABLED') (gt nspaces.length 0))}}
                     <li>
     {{#if (and (eq nspaces.length 1) (not canManageNspaces)) }}
                         <span data-test-nspace-selected={{nspace.Name}}>{{nspace.Name}}</span>


### PR DESCRIPTION
Recently a change was added to include the possibility of the namespace API endpoint returning zero namespaces. This hides the namespace menu if that happens.