### PR TITLE
Revert "Remove docs refs to NS inference from ACL token"

### DIFF
--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -77,8 +77,9 @@ func (f *HTTPFlags) ServerFlags() *flag.FlagSet {
 func (f *HTTPFlags) NamespaceFlags() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	fs.Var(&f.namespace, "namespace",
-		"Specifies the namespace to query. If not provided, the namespace will"+
-			"default to the `default` namespace. Namespaces is a Consul Enterprise feature.")
+		"Specifies the namespace to query. If not provided, the namespace will be inferred +"+
+			"from the request's ACL token, or will default to the `default` namespace. "+
+			"Namespaces is a Consul Enterprise feature.")
 	return fs
 }
 

--- a/website/source/api/acl/acl.html.md
+++ b/website/source/api/acl/acl.html.md
@@ -308,8 +308,8 @@ replication enabled.
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the Auth Method to use for Login. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token, or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 

--- a/website/source/api/acl/auth-methods.html.md
+++ b/website/source/api/acl/auth-methods.html.md
@@ -57,8 +57,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the auth method within. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -128,12 +128,12 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the auth method within. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
 ```sh
-
 $ curl -X GET http://127.0.0.1:8500/v1/acl/auth-method/minikube
 ```
 
@@ -194,8 +194,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the auth method to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -269,12 +269,12 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   Auth Method to delete. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.
- 
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
+
 ### Sample Request
 
 ```sh
-
 $ curl -X DELETE \
     http://127.0.0.1:8500/v1/acl/auth-method/minikube
 ```
@@ -308,9 +308,10 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the auth methods for. This value can be specified as the `ns` URL query 
   parameter or in the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. The namespace may be 
-  specified as '*' and then results will be returned for all namespaces. 
-  Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. The namespace may be specified as '*' and then
+  results will be returned for all namespaces. Added in Consul 1.7.0.
+
 
 ## Sample Request
 

--- a/website/source/api/acl/binding-rules.html.md
+++ b/website/source/api/acl/binding-rules.html.md
@@ -91,8 +91,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the binding rule. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -157,7 +157,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the binding rule. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
+
 
 ### Sample Request
 
@@ -259,8 +261,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the binding rule to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -325,7 +327,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   binding rule to delete. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -365,9 +368,9 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the binding rules for. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. 
-  The namespace may be specified as '*' and then results will be returned for all namespaces. 
-  Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. The namespace may be specified as '*' and then
+  results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request
 

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -53,8 +53,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the policy. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -119,7 +119,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the policy. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -184,8 +185,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the policy to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -249,7 +250,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   policy to delete. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -286,7 +288,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the Policies for. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/acl/roles.html.md
+++ b/website/source/api/acl/roles.html.md
@@ -67,8 +67,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the role. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -163,7 +163,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -228,7 +229,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the role. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -311,8 +313,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the role to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -393,7 +395,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   role to delete. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -435,7 +438,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the roles for. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/acl/tokens.html.md
+++ b/website/source/api/acl/tokens.html.md
@@ -93,8 +93,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
   create the token. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -173,7 +173,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
   the token. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -343,8 +344,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the token to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -431,8 +432,8 @@ The table below shows this endpoint's support for
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace of
   the token to be cloned. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -508,7 +509,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the
   token to delete. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -554,7 +556,8 @@ The table below shows this endpoint's support for
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list
   the tokens for. This value can be specified as the `ns` URL query 
   parameter or the `X-Consul-Namespace` header. If not provided by either,
-  the namespace will default to the `default` namespace. The namespace may be specified as '*' and then
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. The namespace may be specified as '*' and then
   results will be returned for all namespaces. Added in Consul 1.7.0.
 
 ## Sample Request

--- a/website/source/api/catalog.html.md
+++ b/website/source/api/catalog.html.md
@@ -91,7 +91,8 @@ The table below shows this endpoint's support for
   `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
   the namespace may be provided within the `Service` or `Check` fields but if
   present in multiple places, they must all be the same. If not provided at all, 
-  the namespace will default to the `default` namespace. Added in Consul 1.7.0.
+  the namespace will be inherited from the request's ACL token or will default 
+  to the `default` namespace. Added in Consul 1.7.0.
 
 
 It is important to note that `Check` does not have to be provided with `Service`
@@ -205,8 +206,8 @@ The behavior of the endpoint depends on what keys are provided.
 - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
   service and checks will be deregistered.  If not provided in the JSON body, the value of
   the `ns` URL query parameter or the `X-Consul-Namespace` header will be used. 
-  If not provided at all, the namespace will default to the `default` namespace. 
-  Added in Consul 1.7.0.
+  If not provided at all, the namespace will be inherited from the request's ACL 
+  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Payloads
 
@@ -406,8 +407,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list services. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
-  the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -478,8 +479,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to use for the
   query. This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
-  the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -684,8 +685,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list services. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
-  the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/health.html.md
+++ b/website/source/api/health.html.md
@@ -47,8 +47,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to list checks. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
-  to the `default` namespace. To view
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. To view
   checks for multiple namespaces the `*` wildcard namespace may be used. Added in Consul 1.7.0.
 
 ### Sample Request
@@ -152,8 +152,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the service.
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -252,8 +252,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace of the service. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default to 
-  the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL  token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -447,8 +447,8 @@ The table below shows this endpoint's support for
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query. 
   This value may be provided by either the `ns` URL query parameter or in the 
-  `X-Consul-Namespace` header. If not provided at all, the namespace will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/kv.html.md
+++ b/website/source/api/kv.html.md
@@ -68,7 +68,8 @@ The table below shows this endpoint's support for
   This is specified as part of the URL as a query parameter.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
   This is specified as part of the URL as a query parameter. 
   For recursive lookups, the namespace may be specified as '*' and then results 
   will be returned for all namespaces. Added in Consul 1.7.0.
@@ -209,8 +210,9 @@ The table below shows this endpoint's support for
   of the key. The key must be held by this session to be unlocked.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Payload
 
@@ -269,8 +271,9 @@ The table below shows this endpoint's support for
   deleted if the index matches the `ModifyIndex` of that key.
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -32,8 +32,9 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 - `dc` `(string: "")` - Specifies the datacenter to query. This will default to
   the datacenter of the agent being queried. This is specified as part of the
@@ -131,8 +132,9 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -176,8 +178,9 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -236,8 +239,9 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. 
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter
   The namespace may be specified as '*' and then results will be returned for all namespaces.
   Added in Consul 1.7.0.
 
@@ -293,8 +297,8 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. 
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace.   This is specified as part of the URL as a query parameter. 
   The namespace may be specified as '*' and then results will be returned for all namespaces.
   Added in Consul 1.7.0.
 
@@ -354,8 +358,9 @@ The table below shows this endpoint's support for
   URL as a query parameter. Using this across datacenters is not recommended.
   
 - `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query.
-  If not provided, the namespace will default to the `default` namespace. 
-  This is specified as part of the URL as a query parameter. Added in Consul 1.7.0.
+  If not provided, the namespace will be inferred from the request's ACL token,
+  or will default to the `default` namespace. This is specified as part of the
+  URL as a query parameter. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/docs/commands/_http_api_namespace_options.html.md
+++ b/website/source/docs/commands/_http_api_namespace_options.html.md
@@ -1,3 +1,3 @@
-* `-namespace=<string>` - Specifies the namespace to query. If not provided, the namespace will default
-  to the value of the `CONSUL_NAMESPACE` environment variable or `default` if neither is set. Namespaces 
-  is a Consul Enterprise feature added in v1.7.0.
+* `-namespace=<string>` - Specifies the namespace to query. If not provided, the namespace  will be inferred from the request's ACL token, or will default to
+  the `default` namespace. Namespaces is a Consul Enterprise feature added in v1.7.0.
+


### PR DESCRIPTION
This reverts commit 3a8426de9c76e7d8dd2728e4ae78bc4e5e18626a.

```
# Conflicts:
#	command/flags/http.go
#	website/source/api/acl/binding-rules.html.md
#	website/source/api/acl/policies.html.md
#	website/source/api/acl/roles.html.md
#	website/source/api/acl/tokens.html.md
#	website/source/api/kv.html.md
#	website/source/api/session.html.md
#	website/source/docs/commands/_http_api_namespace_options.html.md
```

Basically we are putting back information about inferring a resources namespace from the token that was removed from the docs when this feature didn't make it in for beta1.