### PR TITLE
Add json-iterator/go as an optional json lib

### DIFF
--- a/agent/acl_endpoint_legacy_test.go
+++ b/agent/acl_endpoint_legacy_test.go
@@ -2,12 +2,13 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -2,12 +2,13 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/authmethod/testauth"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha512"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/go-memdb"
 

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1,13 +1,14 @@
 package agent
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/mitchellh/hashstructure"

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -16,6 +15,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/testrpc"
 

--- a/agent/checks/docker.go
+++ b/agent/checks/docker.go
@@ -2,13 +2,14 @@ package checks
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/armon/circbuf"
 	"github.com/docker/go-connections/sockets"

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/checks"
 	"github.com/hashicorp/consul/agent/connect/ca"

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/go-multierror"

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/checks"
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -9,6 +8,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	metrics "github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/acl"

--- a/agent/consul/authmethod/kubeauth/testing.go
+++ b/agent/consul/authmethod/kubeauth/testing.go
@@ -2,7 +2,6 @@ package kubeauth
 
 import (
 	"bytes"
-	"encoding/json"
 	"encoding/pem"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/stretchr/testify/require"
 	authv1 "k8s.io/api/authentication/v1"

--- a/agent/http.go
+++ b/agent/http.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/NYTimes/gziphandler"
 	"github.com/armon/go-metrics"

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/structs"
 	tokenStore "github.com/hashicorp/consul/agent/token"

--- a/agent/keyring.go
+++ b/agent/keyring.go
@@ -2,11 +2,12 @@ package agent
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -2,13 +2,14 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"sync/atomic"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/testrpc"
 

--- a/agent/remote_exec.go
+++ b/agent/remote_exec.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/exec"
 	"github.com/hashicorp/consul/agent/structs"

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -2,10 +2,11 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"time"
 

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -1,12 +1,13 @@
 package agent
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -2,12 +2,13 @@ package agent
 
 import (
 	"bytes"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -1,7 +1,6 @@
 package structs
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
@@ -9,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/cache"

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -1,9 +1,10 @@
 package structs
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -1,9 +1,10 @@
 package structs
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/require"

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -1,9 +1,10 @@
 package structs
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/lib"
 )

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -3,7 +3,6 @@ package structs
 import (
 	"bytes"
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1,11 +1,12 @@
 package structs
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/api"

--- a/agent/watch_handler.go
+++ b/agent/watch_handler.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -11,6 +10,8 @@ import (
 	"os"
 	osexec "os/exec"
 	"strconv"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul/agent/exec"

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -1,10 +1,11 @@
 package xds
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1,7 +1,6 @@
 package xds
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +8,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -1,9 +1,10 @@
 package acl
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"

--- a/command/config/read/config_read.go
+++ b/command/config/read/config_read.go
@@ -1,9 +1,10 @@
 package read
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/command/flags"
 	"github.com/mitchellh/cli"

--- a/command/config/write/decode_shim.go
+++ b/command/config/write/decode_shim.go
@@ -1,9 +1,10 @@
 package write
 
 import (
-	"encoding/json"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/hcl"
 )

--- a/command/connect/ca/get/connect_ca_get.go
+++ b/command/connect/ca/get/connect_ca_get.go
@@ -1,9 +1,10 @@
 package get
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/connect/ca/set/connect_ca_set.go
+++ b/command/connect/ca/set/connect_ca_set.go
@@ -1,10 +1,11 @@
 package set
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/connect/envoy/bootstrap_config.go
+++ b/command/connect/envoy/bootstrap_config.go
@@ -2,13 +2,14 @@ package envoy
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"net"
 	"net/url"
 	"os"
 	"strings"
 	"text/template"
+
+	"github.com/hashicorp/consul/internal/json"
 )
 
 // BootstrapConfig is the set of keys we care about in a Connect.Proxy.Config

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -1,7 +1,6 @@
 package envoy
 
 import (
-	"encoding/json"
 	"flag"
 	"io/ioutil"
 	"net"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/xds"

--- a/command/connect/envoy/exec_test.go
+++ b/command/connect/envoy/exec_test.go
@@ -3,7 +3,6 @@
 package envoy
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/stretchr/testify/require"
 )

--- a/command/debug/debug.go
+++ b/command/debug/debug.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"archive/tar"
 	"compress/gzip"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -14,6 +13,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/exec/exec.go
+++ b/command/exec/exec.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/flags/config_test.go
+++ b/command/flags/config_test.go
@@ -2,12 +2,13 @@ package flags
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"path"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/mitchellh/mapstructure"
 )

--- a/command/intention/create/create.go
+++ b/command/intention/create/create.go
@@ -1,11 +1,12 @@
 package create
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/kv/exp/kv_export.go
+++ b/command/kv/exp/kv_export.go
@@ -1,9 +1,10 @@
 package exp
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/kv/exp/kv_export_test.go
+++ b/command/kv/exp/kv_export_test.go
@@ -2,9 +2,10 @@ package exp
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"

--- a/command/kv/imp/kv_import.go
+++ b/command/kv/imp/kv_import.go
@@ -3,13 +3,14 @@ package imp
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/flags"

--- a/command/watch/watch.go
+++ b/command/watch/watch.go
@@ -2,13 +2,14 @@ package watch
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	osexec "os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/exec"

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 	github.com/imdario/mergo v0.3.6
+	github.com/json-iterator/go v1.1.5
 	github.com/kr/text v0.1.0
 	github.com/miekg/dns v1.1.22
 	github.com/mitchellh/cli v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,6 @@ github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59b
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3 h1:KYQXGkl6vs02hK7pK4eIbw0NpNPedieTSTEiJ//bwGs=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191106202628-ed6320f186d4 h1:PDpCLFAH/YIX0QpHPf2eO7L4rC2OOirBrKtXTLLiNTY=
@@ -398,8 +396,6 @@ golang.org/x/sys v0.0.0-20190508220229-2d0786266e9c h1:hDn6jm7snBX2O7+EeTk6Q4WXJ
 golang.org/x/sys v0.0.0-20190508220229-2d0786266e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 h1:sM3evRHxE/1RuMe1FYAL3j7C7fUfIjkbE+NiDAYUF8U=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
-golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe h1:6fAMxZRR6sl1Uq8U61gxU+kPTs2tR8uOySCbBP7BN/M=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/json/json.go
+++ b/internal/json/json.go
@@ -1,0 +1,22 @@
+// +build !jsoniter
+
+package json
+
+import "encoding/json"
+
+type RawMessage = json.RawMessage
+
+var (
+	// Marshal is the counterpart to Marshal in encoding/json.
+	Marshal = json.Marshal
+	// Unmarshal is the counterpart to Unmarshal in encoding/json.
+	Unmarshal = json.Unmarshal
+	// NewEncoder is the counterpart to NewEncoder in encoding/json.
+	NewEncoder = json.NewEncoder
+	// NewDecoder is the counterpart to NewDecoder in encoding/json.
+	NewDecoder = json.NewDecoder
+	// MarshalIndent is the counterpart to MarshalIndent in encoding/json.
+	MarshalIndent = json.MarshalIndent
+	// Indent is the counterpart to Indent in encoding/json.
+	Indent = json.Indent
+)

--- a/internal/json/jsoniter.go
+++ b/internal/json/jsoniter.go
@@ -1,0 +1,23 @@
+// +build jsoniter
+
+package json
+
+import "github.com/json-iterator/go"
+
+type RawMessage = json.RawMessage
+
+var (
+	json = jsoniter.ConfigCompatibleWithStandardLibrary
+	// Marshal is the counterpart to Marshal in github.com/json-iterator/go.
+	Marshal = json.Marshal
+	// Unmarshal is the counterpart to Unmarshal in github.com/json-iterator/go.
+	Unmarshal = json.Unmarshal
+	// NewEncoder is the counterpart to NewEncoder in github.com/json-iterator/go.
+	NewEncoder = json.NewEncoder
+	// NewDecoder is the counterpart to NewDecoder in github.com/json-iterator/go.
+	NewDecoder = json.NewDecoder
+	// MarshalIndent is the counterpart to MarshalIndent in github.com/json-iterator/go.
+	MarshalIndent = json.MarshalIndent
+	// Indent is the counterpart to Indent in github.com/json-iterator/go.
+	Indent = json.Indent
+)

--- a/lib/json.go
+++ b/lib/json.go
@@ -2,8 +2,9 @@ package lib
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
+
+	"github.com/hashicorp/consul/internal/json"
 )
 
 // DecodeJSON is a convenience function to create a JSON decoder

--- a/lib/patch_hcl_test.go
+++ b/lib/patch_hcl_test.go
@@ -1,10 +1,11 @@
 package lib
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 )
 
 func parse(s string) map[string]interface{} {

--- a/lib/translate_test.go
+++ b/lib/translate_test.go
@@ -1,8 +1,9 @@
 package lib
 
 import (
-	"encoding/json"
 	"testing"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/stretchr/testify/require"
 )

--- a/snapshot/archive.go
+++ b/snapshot/archive.go
@@ -14,12 +14,13 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"hash"
 	"io"
 	"io/ioutil"
 	"time"
+
+	"github.com/hashicorp/consul/internal/json"
 
 	"github.com/hashicorp/raft"
 )


### PR DESCRIPTION
This PR integrates a third-party json lib called `jsoniter` (it has a higher performance) into `consul` as an optional json lib, consul will still use `encoding/json` as default json package, which means this PR won't have any impact on the current codebase, on the other side, users are allowed to switch to [jsoniter](https://github.com/json-iterator/go/) by building with specified tags: jsoniter.
```
$ go build -tags=jsoniter . 
```
## Benchmark
![](https://camo.githubusercontent.com/9f07f16d9d489005278c9722c785b2595b01c59e/687474703a2f2f6a736f6e697465722e636f6d2f62656e63686d61726b732f676f2d62656e63686d61726b2e706e67)