### PR TITLE
Use default minsize of gzip handler

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -168,8 +168,7 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 			metrics.MeasureSince(key, start)
 		}
 
-		gzipWrapper, _ := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(0))
-		gzipHandler := gzipWrapper(http.HandlerFunc(wrapper))
+		gzipHandler := gziphandler.GzipHandler(http.HandlerFunc(wrapper))
 		mux.Handle(pattern, gzipHandler)
 	}
 


### PR DESCRIPTION
Fixes #6306

Use default minsize of gzip handler, avoiding memory allocation problem.