### PR TITLE
ui: Adds nspace attributes in places where they were missed

### DIFF
--- a/ui-v2/app/components/child-selector.js
+++ b/ui-v2/app/components/child-selector.js
@@ -25,7 +25,7 @@ export default Component.extend(SlotsMixin, WithListeners, {
     this._super(...arguments);
     this.searchable = this.container.searchable(this.type);
     this.form = this.formContainer.form(this.type);
-    this.form.clear({ Datacenter: this.dc });
+    this.form.clear({ Datacenter: this.dc, Namespace: this.nspace });
   },
   options: computed('selectedOptions.[]', 'allOptions.[]', function() {
     // It's not massively important here that we are defaulting `items` and
@@ -52,7 +52,7 @@ export default Component.extend(SlotsMixin, WithListeners, {
       });
     },
     reset: function() {
-      this.form.clear({ Datacenter: this.dc });
+      this.form.clear({ Datacenter: this.dc, Namespace: this.nspace });
     },
     open: function() {
       if (!get(this, 'allOptions.closed')) {

--- a/ui-v2/app/templates/components/role-form.hbs
+++ b/ui-v2/app/templates/components/role-form.hbs
@@ -21,6 +21,6 @@
   {{#yield-slot 'policy' (block-params item)}}
     {{yield}}
   {{else}}
-    {{policy-selector dc=dc items=item.Policies}}
+    {{policy-selector dc=dc nspace=nspace items=item.Policies}}
   {{/yield-slot}}
 </fieldset>

--- a/ui-v2/app/templates/components/role-selector.hbs
+++ b/ui-v2/app/templates/components/role-selector.hbs
@@ -9,10 +9,10 @@
   {{#block-slot 'body'}}
 
   <input id="{{name}}_state_role" type="radio" name="{{name}}[state]" value="role" checked={{if (eq state 'role') 'checked'}} onchange={{action 'change'}} />
-    {{#role-form form=form dc=dc}}
+    {{#role-form form=form dc=dc nspace=nspace}}
       {{#block-slot 'policy'}}
 
-        {{#policy-selector source=source dc=dc items=item.Policies}}
+        {{#policy-selector source=source dc=dc nspace=nspace items=item.Policies}}
           {{#block-slot 'trigger'}}
             <label for="{{name}}_state_policy" data-test-create-policy class="type-dialog">
               <span>Create new policy</span>

--- a/ui-v2/app/templates/dc/acls/roles/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-form.hbs
@@ -1,5 +1,5 @@
 <form>
-  {{role-form form=form item=item dc=dc}}
+  {{role-form form=form item=item dc=dc nspace=nspace}}
 {{#if (and (not create) (gt items.length 0))}}
   <h2>Where is this role used?</h2>
   <p>

--- a/ui-v2/app/templates/dc/nspaces/-form.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-form.hbs
@@ -23,14 +23,14 @@
     <p>
       By adding roles to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    {{role-selector dc=dc items=item.ACLs.RoleDefaults}}
+    {{role-selector dc=dc nspace='default' items=item.ACLs.RoleDefaults}}
   </fieldset>
   <fieldset id="policies">
     <h2>Policies</h2>
     <p>
       By adding policies to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    {{policy-selector dc=dc items=item.ACLs.PolicyDefaults}}
+    {{policy-selector dc=dc nspace='default' items=item.ACLs.PolicyDefaults}}
   </fieldset>
 {{/if}}
   <div>


### PR DESCRIPTION
We have an acceptance testing series of PRs beginning here https://github.com/hashicorp/consul/pull/6980 and this bug was noticed during working on that series. However, we felt it would be better to PR the fix separately against `master` rather than waiting for that series to be merged down, hence there are no tests here (the tests that caught this will eventually be committed to the above PR series).

We also noticed that the role and policy selectors for adding roles and policies to namespaces themselves where not scoped to a namespace ( 🐔 🥚 )

Apparently you can only assign 'default' policies and roles to namespaces themselves, so here we hardcode the 'default' namespace to the role and policy selectors when editing namespaces themselves.
