### PR TITLE
ui: Namespace acceptance testing

### DIFF
--- a/ui-v2/app/adapters/policy.js
+++ b/ui-v2/app/adapters/policy.js
@@ -4,6 +4,9 @@ import { SLUG_KEY } from 'consul-ui/models/policy';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
 
+import nonEmptySet from 'consul-ui/utils/non-empty-set';
+const Namespace = nonEmptySet('Namespace');
+
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
   requestForQuery: function(request, { dc, ns, index, id }) {
@@ -32,7 +35,6 @@ export default Adapter.extend({
   requestForCreateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/policy?${params}
@@ -42,13 +44,13 @@ export default Adapter.extend({
         Description: serialized.Description,
         Rules: serialized.Rules,
         Datacenters: serialized.Datacenters,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/policy/${data[SLUG_KEY]}?${params}
@@ -58,6 +60,7 @@ export default Adapter.extend({
         Description: serialized.Description,
         Rules: serialized.Rules,
         Datacenters: serialized.Datacenters,
+        Namespace: serialized.Namespace,
       }}
     `;
   },

--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -3,7 +3,9 @@ import Adapter from './application';
 import { SLUG_KEY } from 'consul-ui/models/role';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
+import nonEmptySet from 'consul-ui/utils/non-empty-set';
 
+const Namespace = nonEmptySet('Namespace');
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
   requestForQuery: function(request, { dc, ns, index, id }) {
@@ -32,7 +34,6 @@ export default Adapter.extend({
   requestForCreateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/role?${params}
@@ -40,16 +41,15 @@ export default Adapter.extend({
       ${{
         Name: serialized.Name,
         Description: serialized.Description,
-        Namespace: serialized.Namespace,
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },
   requestForUpdateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/role/${data[SLUG_KEY]}?${params}

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -4,7 +4,9 @@ import { inject as service } from '@ember/service';
 import { SLUG_KEY } from 'consul-ui/models/token';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
+import nonEmptySet from 'consul-ui/utils/non-empty-set';
 
+const Namespace = nonEmptySet('Namespace');
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
   store: service('store'),
@@ -35,7 +37,6 @@ export default Adapter.extend({
   requestForCreateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/token?${params}
@@ -46,6 +47,7 @@ export default Adapter.extend({
         Roles: serialized.Roles,
         ServiceIdentities: serialized.ServiceIdentities,
         Local: serialized.Local,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },
@@ -66,13 +68,13 @@ export default Adapter.extend({
     }
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
-      ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`
       PUT /v1/acl/token/${data[SLUG_KEY]}?${params}
 
       ${{
         Description: serialized.Description,
+        Namespace: serialized.Namespace,
         Policies: serialized.Policies,
         Roles: serialized.Roles,
         ServiceIdentities: serialized.ServiceIdentities,

--- a/ui-v2/app/components/child-selector.js
+++ b/ui-v2/app/components/child-selector.js
@@ -25,7 +25,7 @@ export default Component.extend(SlotsMixin, WithListeners, {
     this._super(...arguments);
     this.searchable = this.container.searchable(this.type);
     this.form = this.formContainer.form(this.type);
-    this.form.clear({ Datacenter: this.dc });
+    this.form.clear({ Datacenter: this.dc, Namespace: this.nspace });
   },
   options: computed('selectedOptions.[]', 'allOptions.[]', function() {
     // It's not massively important here that we are defaulting `items` and
@@ -52,7 +52,7 @@ export default Component.extend(SlotsMixin, WithListeners, {
       });
     },
     reset: function() {
-      this.form.clear({ Datacenter: this.dc });
+      this.form.clear({ Datacenter: this.dc, Namespace: this.nspace });
     },
     open: function() {
       if (!get(this, 'allOptions.closed')) {

--- a/ui-v2/app/mixins/acl/with-actions.js
+++ b/ui-v2/app/mixins/acl/with-actions.js
@@ -8,12 +8,14 @@ export default Mixin.create(WithBlockingActions, {
   actions: {
     use: function(item) {
       return this.feedback.execute(() => {
-        // old style legacy ACLs don't have AccessorIDs
-        // therefore set it to null, this way the frontend knows
+        // old style legacy ACLs don't have AccessorIDs or Namespaces
+        // therefore set AccessorID to null, this way the frontend knows
         // to use legacy ACLs
+        // set the Namespace to just use default
         return this.settings
           .persist({
             token: {
+              Namespace: 'default',
               AccessorID: null,
               SecretID: get(item, 'ID'),
             },

--- a/ui-v2/app/routes/dc/acls.js
+++ b/ui-v2/app/routes/dc/acls.js
@@ -16,9 +16,9 @@ export default Route.extend(WithBlockingActions, {
           return this.settings
             .persist({
               token: {
+                Namespace: get(item, 'Namespace'),
                 AccessorID: get(item, 'AccessorID'),
                 SecretID: secret,
-                Namespace: get(item, 'Namespace'),
               },
             })
             .then(item => {

--- a/ui-v2/app/routes/dc/intentions/create.js
+++ b/ui-v2/app/routes/dc/intentions/create.js
@@ -15,7 +15,7 @@ export default Route.extend(WithIntentionActions, {
   },
   model: function(params) {
     const dc = this.modelFor('dc').dc.Name;
-    const nspace = this.modelFor('nspace').nspace.substr(1);
+    const nspace = '*';
     this.item = this.repo.create({
       Datacenter: dc,
     });

--- a/ui-v2/app/templates/components/role-form.hbs
+++ b/ui-v2/app/templates/components/role-form.hbs
@@ -21,6 +21,6 @@
   {{#yield-slot 'policy' (block-params item)}}
     {{yield}}
   {{else}}
-    {{policy-selector dc=dc items=item.Policies}}
+    {{policy-selector dc=dc nspace=nspace items=item.Policies}}
   {{/yield-slot}}
 </fieldset>

--- a/ui-v2/app/templates/components/role-selector.hbs
+++ b/ui-v2/app/templates/components/role-selector.hbs
@@ -9,10 +9,10 @@
   {{#block-slot 'body'}}
 
   <input id="{{name}}_state_role" type="radio" name="{{name}}[state]" value="role" checked={{if (eq state 'role') 'checked'}} onchange={{action 'change'}} />
-    {{#role-form form=form dc=dc}}
+    {{#role-form form=form dc=dc nspace=nspace}}
       {{#block-slot 'policy'}}
 
-        {{#policy-selector source=source dc=dc items=item.Policies}}
+        {{#policy-selector source=source dc=dc nspace=nspace items=item.Policies}}
           {{#block-slot 'trigger'}}
             <label for="{{name}}_state_policy" data-test-create-policy class="type-dialog">
               <span>Create new policy</span>

--- a/ui-v2/app/templates/dc/acls/roles/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-form.hbs
@@ -1,5 +1,5 @@
 <form>
-  {{role-form form=form item=item dc=dc}}
+  {{role-form form=form item=item dc=dc nspace=nspace}}
 {{#if (and (not create) (gt items.length 0))}}
   <h2>Where is this role used?</h2>
   <p>

--- a/ui-v2/app/templates/dc/nspaces/-form.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-form.hbs
@@ -23,14 +23,14 @@
     <p>
       By adding roles to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    {{role-selector dc=dc items=item.ACLs.RoleDefaults}}
+    {{role-selector dc=dc nspace='default' items=item.ACLs.RoleDefaults}}
   </fieldset>
   <fieldset id="policies">
     <h2>Policies</h2>
     <p>
       By adding policies to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    {{policy-selector dc=dc items=item.ACLs.PolicyDefaults}}
+    {{policy-selector dc=dc nspace='default' items=item.ACLs.PolicyDefaults}}
   </fieldset>
 {{/if}}
   <div>

--- a/ui-v2/app/utils/non-empty-set.js
+++ b/ui-v2/app/utils/non-empty-set.js
@@ -1,0 +1,11 @@
+export default function(prop) {
+  return function(value) {
+    if (typeof value === 'undefined' || value === null || value === '') {
+      return {};
+    } else {
+      return {
+        [prop]: value,
+      };
+    }
+  };
+}

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -94,7 +94,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
-    ENV.CONSUL_NSPACES_TEST = false;
+    ENV.CONSUL_NSPACES_TEST = true;
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/ui-v2/tests/acceptance/components/acl-filter.feature
+++ b/ui-v2/tests/acceptance/components/acl-filter.feature
@@ -1,4 +1,5 @@
 @setupApplicationTest
+@notNamespaceable
 Feature: components / acl filter: Acl Filter
   In order to find the acl token I'm looking for easier
   As a user

--- a/ui-v2/tests/acceptance/components/intention-filter.feature
+++ b/ui-v2/tests/acceptance/components/intention-filter.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: components / intention filter: Intention Filter
+Feature: components / intention-filter: Intention Filter
   In order to find the intention I'm looking for easier
   As a user
   I should be able to filter by 'policy' (allow/deny) and freetext search tokens by source and destination

--- a/ui-v2/tests/acceptance/dc/acls/index.feature
+++ b/ui-v2/tests/acceptance/dc/acls/index.feature
@@ -1,5 +1,6 @@
 @setupApplicationTest
-Feature: acl forwarding
+@notNamespaceable
+Feature: dc / acls / index: acl forwarding
   In order to arrive at a useful page when only specifying 'acls' in the url
   As a user
   I should be redirected to the tokens page

--- a/ui-v2/tests/acceptance/dc/acls/list-order.feature
+++ b/ui-v2/tests/acceptance/dc/acls/list-order.feature
@@ -1,4 +1,5 @@
 @setupApplicationTest
+@notNamespaceable
 Feature: dc / acls / list-order
   In order to be able to find ACL tokens easier
   As a user

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -27,8 +27,9 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     And I click ".ember-power-select-option:nth-child(1)"
     And I see 2 policy models on the policies component
     And I submit
-    Then a PUT request is made to "/v1/acl/[Model]/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" with the body from yaml
     ---
+      Namespace: @namespace
       Policies:
       - ID: policy-1
         Name: Policy 1

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -22,18 +22,22 @@ Feature: dc / acls / policies / as many / add new: Add new policy
       Rules: key {}
     ---
     And I click submit on the policies.form
-    Then the last PUT request was made to "/v1/acl/policy?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
     ---
-      Name: New-Policy
-      Description: New Policy Description
-      Rules: key {}
+      body:
+        Name: New-Policy
+        Description: New Policy Description
+        Namespace: @namespace
+        Rules: key {}
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/[Model]/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
     ---
-      Policies:
-        - Name: New-Policy
-          ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+      body:
+        Namespace: @namespace
+        Policies:
+          - ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+            Name: New-Policy
     ---
     Then the url should be /datacenter/acls/[Model]s
     And "[data-notification]" has the "notification-update" class
@@ -53,10 +57,12 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     And I click serviceIdentity on the policies.form
     And I click submit on the policies.form
     And I submit
-    Then a PUT request is made to "/v1/acl/[Model]/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
     ---
-      ServiceIdentities:
-        - ServiceName: New-Service-Identity
+      body:
+        Namespace: @namespace
+        ServiceIdentities:
+          - ServiceName: New-Service-Identity
     ---
     Then the url should be /datacenter/acls/[Model]s
     And "[data-notification]" has the "notification-update" class
@@ -81,10 +87,11 @@ Feature: dc / acls / policies / as many / add new: Add new policy
       Rules: key {}
     ---
     And I click submit on the policies.form
-    Then the last PUT request was made to "/v1/acl/policy?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" with the body from yaml
     ---
       Name: New-Policy
       Description: New Policy Description
+      Namespace: @namespace
       Rules: key {}
     ---
     And I see error on the policies.form.rules like 'Invalid service policy: acl.ServicePolicy{Name:"service", Policy:"", Sentinel:acl.Sentinel{Code:"", EnforcementLevel:""}, Intentions:""}'

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/remove.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/remove.feature
@@ -17,14 +17,16 @@ Feature: dc / acls / policies / as many / remove: Remove
     Then the url should be /datacenter/acls/[Model]s/key
     And I see 1 policy model on the policies component
     And I click expand on the policies.selectedOptions
-    And the last GET request was made to "/v1/acl/policy/00000000-0000-0000-0000-000000000001?dc=datacenter"
+    And a GET request was made to "/v1/acl/policy/00000000-0000-0000-0000-000000000001?dc=datacenter&ns=@namespace"
     And I click delete on the policies.selectedOptions
     And I click confirmDelete on the policies.selectedOptions
     And I see 0 policy models on the policies component
     And I submit
-    Then a PUT request is made to "/v1/acl/[Model]/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
     ---
-      Policies: [[]]
+      body:
+        Namespace: @namespace
+        Policies: [[]]
     ---
     Then the url should be /datacenter/acls/[Model]s
   Where:

--- a/ui-v2/tests/acceptance/dc/acls/policies/delete.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/delete.feature
@@ -14,10 +14,10 @@ Feature: dc / acls / policies / delete: Policy Delete
     And I click actions on the policies
     And I click delete on the policies
     And I click confirmDelete on the policies
-    Then a DELETE request is made to "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=default"
+    Then a DELETE request was made to "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=@!namespace"
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
-    Given the url "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=default" responds with a 500 status
+    Given the url "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=@namespace" responds with a 500 status
     And I click actions on the policies
     And I click delete on the policies
     And I click confirmDelete on the policies
@@ -31,7 +31,7 @@ Feature: dc / acls / policies / delete: Policy Delete
     ---
     And I click delete
     And I click confirmDelete on the deleteModal
-    Then a DELETE request is made to "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=default"
+    Then a DELETE request was made to "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=@!namespace"
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
     When I visit the policy page for yaml
@@ -39,7 +39,7 @@ Feature: dc / acls / policies / delete: Policy Delete
       dc: datacenter
       policy: 1981f51d-301a-497b-89a0-05112ef02b4b
     ---
-    Given the url "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=default" responds with a 500 status
+    Given the url "/v1/acl/policy/1981f51d-301a-497b-89a0-05112ef02b4b?dc=datacenter&ns=@namespace" responds with a 500 status
     And I click delete
     And I click confirmDelete on the deleteModal
     And "[data-notification]" has the "notification-delete" class

--- a/ui-v2/tests/acceptance/dc/acls/policies/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/update.feature
@@ -25,13 +25,16 @@ Feature: dc / acls / policies / update: ACL Policy Update
     And I click validDatacenters
     And I click datacenter
     And I submit
-    Then a PUT request is made to "/v1/acl/policy/policy-id?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter" from yaml
     ---
-      Name: [Name]
-      Description: [Description]
-      Rules: [Rules]
-      Datacenters:
-        - datacenter
+      body:
+        Name: [Name]
+        Description: [Description]
+        Rules: [Rules]
+        Namespace: @namespace
+        Datacenters:
+          - datacenter
+
     ---
     Then the url should be /datacenter/acls/policies
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/as-many/add-existing.feature
@@ -32,14 +32,16 @@ Feature: dc / acls / roles / as many / add existing: Add existing
       Description: The Description
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: The Description
-      Roles:
-      - ID: role-1
-        Name: Role 1
-      - ID: role-2
-        Name: Role 2
+      body:
+        Namespace: @namespace
+        Description: The Description
+        Roles:
+        - ID: role-1
+          Name: Role 1
+        - ID: role-2
+          Name: Role 2
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/roles/as-many/add-new.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/as-many/add-new.feature
@@ -1,5 +1,6 @@
 @setupApplicationTest
-Feature: dc / acls / roles / as many / add new: Add new
+@notNamespaceable
+Feature: dc / acls / roles / as-many / add-new: Add new
   Background:
     Given 1 datacenter model with the value "datacenter"
     And 1 token model from yaml
@@ -29,18 +30,22 @@ Feature: dc / acls / roles / as many / add new: Add new
     ---
   Scenario: Add Policy-less Role
     And I click submit on the roles.form
-    Then the last PUT request was made to "/v1/acl/role?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
     ---
-      Name: New-Role
-      Description: New Role Description
+      body:
+        Name: New-Role
+        Namespace: @namespace
+        Description: New Role Description
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: The Description
-      Roles:
-        - Name: New-Role
-          ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+      body:
+        Description: The Description
+        Namespace: @namespace
+        Roles:
+          - Name: New-Role
+            ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class
@@ -49,21 +54,25 @@ Feature: dc / acls / roles / as many / add new: Add new
     And I click "#new-role-toggle + div .ember-power-select-trigger"
     And I click ".ember-power-select-option:first-child"
     And I click submit on the roles.form
-    Then the last PUT request was made to "/v1/acl/role?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
     ---
-      Name: New-Role
-      Description: New Role Description
-      Policies:
-        - ID: policy-1
-          Name: policy
+      body:
+        Name: New-Role
+        Description: New Role Description
+        Namespace: @namespace
+        Policies:
+          - ID: policy-1
+            Name: policy
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: The Description
-      Roles:
-        - Name: New-Role
-          ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+      body:
+        Description: The Description
+        Namespace: @namespace
+        Roles:
+          - Name: New-Role
+            ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class
@@ -78,29 +87,35 @@ Feature: dc / acls / roles / as many / add new: Add new
     ---
     # This next line is actually the popped up policyForm due to the way things currently work
     And I click submit on the roles.form
-    Then the last PUT request was made to "/v1/acl/policy?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
     ---
-      Name: New-Policy
-      Description: New Policy Description
-      Rules: key {}
+      body:
+        Name: New-Policy
+        Description: New Policy Description
+        Namespace: @namespace
+        Rules: key {}
     ---
     And I click submit on the roles.form
-    Then the last PUT request was made to "/v1/acl/role?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
     ---
-      Name: New-Role
-      Description: New Role Description
-      Policies:
-      # TODO: Ouch, we need to do deep partial comparisons here
-        - ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
-          Name: New-Policy
+      body:
+        Name: New-Role
+        Description: New Role Description
+        Namespace: @namespace
+        Policies:
+        # TODO: Ouch, we need to do deep partial comparisons here
+          - ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+            Name: New-Policy
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: The Description
-      Roles:
-        - Name: New-Role
-          ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+      body:
+        Description: The Description
+        Namespace: @namespace
+        Roles:
+          - Name: New-Role
+            ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class
@@ -115,20 +130,24 @@ Feature: dc / acls / roles / as many / add new: Add new
     # This next line is actually the popped up policyForm due to the way things currently work
     And I click submit on the roles.form
     And I click submit on the roles.form
-    Then the last PUT request was made to "/v1/acl/role?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
     ---
-      Name: New-Role
-      Description: New Role Description
-      ServiceIdentities:
-        - ServiceName: New-Service-Identity
+      body:
+        Name: New-Role
+        Description: New Role Description
+        Namespace: @namespace
+        ServiceIdentities:
+          - ServiceName: New-Service-Identity
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: The Description
-      Roles:
-        - Name: New-Role
-          ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
+      body:
+        Description: The Description
+        Namespace: @namespace
+        Roles:
+          - Name: New-Role
+            ID: ee52203d-989f-4f7a-ab5a-2bef004164ca-1
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/roles/as-many/list.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/as-many/list.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / acls / roles / as many / list: List
+Feature: dc / acls / roles / as-many / list: List
   Scenario:
     Given 1 datacenter model with the value "datacenter"
     And 1 token model from yaml

--- a/ui-v2/tests/acceptance/dc/acls/roles/as-many/remove.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/as-many/remove.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / acls / roles / as many / remove: Remove
+Feature: dc / acls / roles / as-many / remove: Remove
   Scenario:
     Given 1 datacenter model with the value "datacenter"
     And 1 token model from yaml
@@ -21,8 +21,10 @@ Feature: dc / acls / roles / as many / remove: Remove
     And I click confirmDelete on the roles.selectedOptions
     And I see 0 role models on the roles component
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Roles: []
+      body:
+        Namespace: @namespace
+        Roles: []
     ---
     Then the url should be /datacenter/acls/tokens

--- a/ui-v2/tests/acceptance/dc/acls/roles/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/update.feature
@@ -21,10 +21,12 @@ Feature: dc / acls / roles / update: ACL Role Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/role/role-id?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter" from yaml
     ---
-      Name: [Name]
-      Description: [Description]
+      body:
+        Namespace: @namespace
+        Name: [Name]
+        Description: [Description]
     ---
     Then the url should be /datacenter/acls/roles
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/tokens/anonymous-no-delete.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/anonymous-no-delete.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / acls / tokens / anonymous no delete: The anonymous token has no delete buttons
+Feature: dc / acls / tokens / anonymous-no-delete: The anonymous token has no delete buttons
   Background:
     Given 1 datacenter model with the value "dc-1"
     And 1 token model from yaml

--- a/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
@@ -14,7 +14,7 @@ Feature: dc / acls / tokens / clone: Cloning an ACL token
     ---
     And I click actions on the tokens
     And I click clone on the tokens
-    Then a PUT request is made to "/v1/acl/token/token/clone?dc=datacenter&ns=default"
+    Then a PUT request was made to "/v1/acl/token/token/clone?dc=datacenter&ns=@!namespace"
     Then "[data-notification]" has the "notification-clone" class
     And "[data-notification]" has the "success" class
   Scenario: Using an ACL token from the detail page

--- a/ui-v2/tests/acceptance/dc/acls/tokens/legacy/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/legacy/update.feature
@@ -25,12 +25,13 @@ Feature: dc / acls / tokens / legacy / update: ACL Token Update
     # TODO: Remove this when I'm 100% sure token types are gone
     # And I click "[value=[Type]]"
     And I submit
-    Then a PUT request is made to "/v1/acl/update?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/update?dc=datacenter" from yaml
     # You can no longer edit Type but make sure it gets sent
     ---
-      ID: secret
-      Name: [Name]
-      Type: client
+      body:
+        ID: secret
+        Name: [Name]
+        Type: client
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/tokens/legacy/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/legacy/update.feature
@@ -1,4 +1,5 @@
 @setupApplicationTest
+@notNamespaceable
 Feature: dc / acls / tokens / legacy / update: ACL Token Update
   Background:
     Given 1 datacenter model with the value "datacenter"

--- a/ui-v2/tests/acceptance/dc/acls/tokens/login-errors.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/login-errors.feature
@@ -1,9 +1,9 @@
 @setupApplicationTest
-Feature: dc / acls / tokens / index: ACL Login Errors
+Feature: dc / acls / tokens / login-errors: ACL Login Errors
 
   Scenario: I get any 500 error that is not the specific legacy token cluster one
     Given 1 datacenter model with the value "dc-1"
-    Given the url "/v1/acl/tokens" responds with a 500 status
+    Given the url "/v1/acl/tokens?ns=@namespace" responds with a 500 status
     When I visit the tokens page for yaml
     ---
       dc: dc-1
@@ -12,7 +12,7 @@ Feature: dc / acls / tokens / index: ACL Login Errors
     Then I see the text "500 (The backend responded with an error)" in "[data-test-error]"
   Scenario: I get a 500 error from acl/tokens that is the specific legacy one
     Given 1 datacenter model with the value "dc-1"
-    And the url "/v1/acl/tokens" responds with from yaml
+    And the url "/v1/acl/tokens?ns=@namespace" responds with from yaml
     ---
     status: 500
     body: "rpc error making call: rpc: can't find method ACL.TokenRead"
@@ -23,9 +23,10 @@ Feature: dc / acls / tokens / index: ACL Login Errors
     ---
     Then the url should be /dc-1/acls/tokens
     Then ".app-view" has the "unauthorized" class
+  @notNamespaceable
   Scenario: I get a 500 error from acl/token/self that is the specific legacy one
     Given 1 datacenter model with the value "dc-1"
-    Given the url "/v1/acl/tokens" responds with from yaml
+    Given the url "/v1/acl/tokens?ns=@namespace" responds with from yaml
     ---
     status: 500
     body: "rpc error making call: rpc: can't find method ACL.TokenRead"

--- a/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/own-no-delete.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / acls / tokens / own no delete: The your current token has no delete buttons
+Feature: dc / acls / tokens / own-no-delete: The your current token has no delete buttons
   Background:
     Given 1 datacenter model with the value "dc-1"
     And 1 token model from yaml
@@ -24,7 +24,7 @@ Feature: dc / acls / tokens / own no delete: The your current token has no delet
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"@namespace\"}"
     ---
     And I click actions on the tokens
     Then I don't see delete on the tokens

--- a/ui-v2/tests/acceptance/dc/acls/tokens/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/update.feature
@@ -19,9 +19,11 @@ Feature: dc / acls / tokens / update: ACL Token Update
       Description: [Description]
     ---
     And I submit
-    Then a PUT request is made to "/v1/acl/token/key?dc=datacenter&ns=default" with the body from yaml
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" from yaml
     ---
-      Description: [Description]
+      body:
+        Namespace: @namespace
+        Description: [Description]
     ---
     Then the url should be /datacenter/acls/tokens
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/tokens/use.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/use.feature
@@ -23,7 +23,7 @@ Feature: dc / acls / tokens / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"@namespace\"}"
     ---
   Scenario: Using an ACL token from the detail page
     When I visit the token page for yaml
@@ -41,5 +41,5 @@ Feature: dc / acls / tokens / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"default\"}"
+    consul:token: "{\"AccessorID\":\"token\",\"SecretID\":\"ee52203d-989f-4f7a-ab5a-2bef004164ca\",\"Namespace\":\"@namespace\"}"
     ---

--- a/ui-v2/tests/acceptance/dc/acls/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/update.feature
@@ -1,4 +1,5 @@
 @setupApplicationTest
+@notNamespaceable
 Feature: dc / acls / update: ACL Update
   Background:
     Given 1 datacenter model with the value "datacenter"

--- a/ui-v2/tests/acceptance/dc/acls/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/update.feature
@@ -21,10 +21,11 @@ Feature: dc / acls / update: ACL Update
     ---
     And I click "[value=[Type]]"
     And I submit
-    Then a PUT request is made to "/v1/acl/update?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/acl/update?dc=datacenter" from yaml
     ---
-      Name: [Name]
-      Type: [Type]
+      body:
+        Name: [Name]
+        Type: [Type]
     ---
     Then the url should be /datacenter/acls
     And "[data-notification]" has the "notification-update" class

--- a/ui-v2/tests/acceptance/dc/acls/use.feature
+++ b/ui-v2/tests/acceptance/dc/acls/use.feature
@@ -1,4 +1,5 @@
 @setupApplicationTest
+@notNamespaceable
 Feature: dc / acls / use: Using an ACL token
   Background:
     Given 1 datacenter model with the value "datacenter"
@@ -14,7 +15,7 @@ Feature: dc / acls / use: Using an ACL token
     ---
     Then I have settings like yaml
     ---
-    consul:token: '{"AccessorID":null,"SecretID":"id"}'
+    consul:token: '{"Namespace":"@namespace","AccessorID":null,"SecretID":"id"}'
     ---
     And I click actions on the acls
     And I click use on the acls
@@ -23,7 +24,7 @@ Feature: dc / acls / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: '{"AccessorID":null,"SecretID":"token"}'
+    consul:token: '{"Namespace":"@namespace","AccessorID":null,"SecretID":"token"}'
     ---
   Scenario: Using an ACL token from the detail page
     When I visit the acl page for yaml
@@ -33,7 +34,7 @@ Feature: dc / acls / use: Using an ACL token
     ---
     Then I have settings like yaml
     ---
-    consul:token: '{"AccessorID":null,"SecretID":"id"}'
+    consul:token: '{"Namespace":"@namespace","AccessorID":null,"SecretID":"id"}'
     ---
     And I click use
     And I click confirmUse
@@ -41,5 +42,5 @@ Feature: dc / acls / use: Using an ACL token
     And "[data-notification]" has the "success" class
     Then I have settings like yaml
     ---
-    consul:token: '{"AccessorID":null,"SecretID":"token"}'
+    consul:token: '{"Namespace":"@namespace","AccessorID":null,"SecretID":"token"}'
     ---

--- a/ui-v2/tests/acceptance/dc/forwarding.feature
+++ b/ui-v2/tests/acceptance/dc/forwarding.feature
@@ -1,8 +1,9 @@
 @setupApplicationTest
-Feature: dc forwarding
+Feature: dc / forwarding
   In order to arrive at a useful page when only specifying a dc in the url
   As a user
   I should be redirected to the services page for the dc
+  @notNamespaceable
   Scenario: Arriving at the datacenter index page with no other url info
     Given 1 datacenter model with the value "datacenter"
     When I visit the dcs page for yaml

--- a/ui-v2/tests/acceptance/dc/index.feature
+++ b/ui-v2/tests/acceptance/dc/index.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: Datacenters
+Feature: dc / index: Datacenters
 @ignore
   Scenario: Arriving at the service page
     Given 10 datacenter models

--- a/ui-v2/tests/acceptance/dc/intentions/create.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/create.feature
@@ -32,7 +32,7 @@ Feature: dc / intentions / create: Intention Create
     # Specifically set deny
     And I click "[value=deny]"
     And I submit
-    Then a POST request is made to "/v1/connect/intentions?dc=datacenter" with the body from yaml
+    Then a POST request was made to "/v1/connect/intentions?dc=datacenter" with the body from yaml
     ---
       SourceName: web
       DestinationName: db

--- a/ui-v2/tests/acceptance/dc/intentions/filtered-select.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/filtered-select.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / intentions / filtered select: Intention Service Select Dropdowns
+Feature: dc / intentions / filtered-select: Intention Service Select Dropdowns
   In order to use services as intention sources and destinations
   As a user
   I want to be able to choose see existing services in the dropdown, but not existing proxy services

--- a/ui-v2/tests/acceptance/dc/intentions/form-select.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/form-select.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / intentions / form select: Intention Service Select Dropdowns
+Feature: dc / intentions / form-select: Intention Service Select Dropdowns
   In order to set future Consul services as intention sources and destinations
   As a user
   I want to type into the autocomplete and select what I've typed to use it as the future service

--- a/ui-v2/tests/acceptance/dc/intentions/update.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/update.feature
@@ -19,7 +19,7 @@ Feature: dc / intentions / update: Intention Update
     ---
     And I click "[value=[Action]]"
     And I submit
-    Then a PUT request is made to "/v1/connect/intentions/intention-id?dc=datacenter" with the body from yaml
+    Then a PUT request was made to "/v1/connect/intentions/intention-id?dc=datacenter" with the body from yaml
     ---
       Description: [Description]
       Action: [Action]

--- a/ui-v2/tests/acceptance/dc/kvs/sessions/invalidate.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/sessions/invalidate.feature
@@ -19,12 +19,12 @@ Feature: dc / kvs / sessions / invalidate: Invalidate Lock Sessions
   Scenario: Invalidating the lock session
     And I click delete on the session
     And I click confirmDelete on the session
-    Then the last PUT request was made to "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=default"
+    Then a PUT request was made to "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=@!namespace"
     Then the url should be /datacenter/kv/key/edit
     And "[data-notification]" has the "notification-deletesession" class
     And "[data-notification]" has the "success" class
   Scenario: Invalidating a lock session and receiving an error
-    Given the url "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=default" responds with a 500 status
+    Given the url "/v1/session/destroy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter&ns=@!namespace" responds with a 500 status
     And I click delete on the session
     And I click confirmDelete on the session
     Then the url should be /datacenter/kv/key/edit

--- a/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/trailing-slash.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / kvs / trailing slash
+Feature: dc / kvs / trailing-slash
   Scenario: I have 10 folders
     Given 1 datacenter model with the value "datacenter"
     And 10 kv models from yaml
@@ -9,11 +9,11 @@ Feature: dc / kvs / trailing slash
       kv: foo/bar
     ---
     Then the url should be /datacenter/kv/foo/bar/
-    And the last GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F"
+    And a GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F&ns=@namespace"
     When I visit the kvs page for yaml
     ---
       dc: datacenter
       kv: foo/bar/
     ---
     Then the url should be /datacenter/kv/foo/bar/
-    And the last GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F"
+    And a GET request was made to "/v1/kv/foo/bar/?keys&dc=datacenter&separator=%2F&ns=@namespace"

--- a/ui-v2/tests/acceptance/dc/kvs/update.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/update.feature
@@ -20,7 +20,7 @@ Feature: dc / kvs / update: KV Update
       value: [Value]
     ---
     And I submit
-    Then a PUT request is made to "/v1/kv/[EncodedName]?dc=datacenter&ns=default" with the body "[Value]"
+    Then a PUT request was made to "/v1/kv/[EncodedName]?dc=datacenter&ns=@!namespace" with the body "[Value]"
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
   Where:
@@ -50,7 +50,7 @@ Feature: dc / kvs / update: KV Update
       value: '   '
     ---
     And I submit
-    Then a PUT request is made to "/v1/kv/key?dc=datacenter&ns=default" with the body "   "
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with the body "   "
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
@@ -72,7 +72,7 @@ Feature: dc / kvs / update: KV Update
       value: ''
     ---
     And I submit
-    Then a PUT request is made to "/v1/kv/key?dc=datacenter&ns=default" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
@@ -89,7 +89,7 @@ Feature: dc / kvs / update: KV Update
     ---
     Then the url should be /datacenter/kv/key/edit
     And I submit
-    Then a PUT request is made to "/v1/kv/key?dc=datacenter&ns=default" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/list.feature
+++ b/ui-v2/tests/acceptance/dc/list.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc > list: List Models
+Feature: dc / list: List Models
   Scenario: Listing [Model]
     Given 1 datacenter model with the value "dc-1"
     And 3 [Model] models

--- a/ui-v2/tests/acceptance/dc/nodes/empty-ids.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/empty-ids.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: Hedge for if nodes come in over the API with no ID
+Feature: dc / nodes / empty-ids: Hedge for if nodes come in over the API with no ID
   Scenario: A node list with some missing IDs
     Given 1 datacenter model with the value "dc-1"
     And 5 node models from yaml

--- a/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
@@ -25,12 +25,12 @@ Feature: dc / nodes / sessions / invalidate: Invalidate Lock Sessions
   Scenario: Invalidating the lock session
     And I click delete on the sessions
     And I click confirmDelete on the sessions
-    Then the last PUT request was made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=default"
+    Then the last PUT request was made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@!namespace"
     Then the url should be /dc1/nodes/node-0
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
   Scenario: Invalidating a lock session and receiving an error
-    Given the url "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=default" responds with a 500 status
+    Given the url "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@!namespace" responds with a 500 status
     And I click delete on the sessions
     And I click confirmDelete on the sessions
     Then the url should be /dc1/nodes/node-0

--- a/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/sessions/invalidate.feature
@@ -25,7 +25,7 @@ Feature: dc / nodes / sessions / invalidate: Invalidate Lock Sessions
   Scenario: Invalidating the lock session
     And I click delete on the sessions
     And I click confirmDelete on the sessions
-    Then the last PUT request was made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@!namespace"
+    Then a PUT request was made to "/v1/session/destroy/7bbbd8bb-fff3-4292-b6e3-cfedd788546a?dc=dc1&ns=@!namespace"
     Then the url should be /dc1/nodes/node-0
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/nspaces/index.feature
+++ b/ui-v2/tests/acceptance/dc/nspaces/index.feature
@@ -1,0 +1,31 @@
+@setupApplicationTest
+Feature: dc / nspaces / index: Nspaces List
+  Background:
+    Given settings from yaml
+    ---
+    consul:token:
+      SecretID: secret
+      AccessorID: accessor
+      Namespace: default
+    ---
+    And 1 datacenter model with the value "dc-1"
+    And 3 nspace models
+    When I visit the nspaces page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/namespaces
+  Scenario:
+    Then I see 3 nspace models
+  Scenario: Searching the nspaces
+    Then I see 3 nspace models
+    Then I fill in with yaml
+    ---
+    s: default
+    ---
+    And I see 1 nspace model
+    And I see 1 nspace model with the description "The default namespace"
+  Scenario: The default namespace can't be deleted
+    Then I see 3 nspace models
+    And I click actions on the nspaces
+    Then I don't see delete on the nspaces

--- a/ui-v2/tests/acceptance/dc/nspaces/update.feature
+++ b/ui-v2/tests/acceptance/dc/nspaces/update.feature
@@ -1,0 +1,42 @@
+@setupApplicationTest
+Feature: dc / nspaces / update: Nspace Update
+  Background:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 nspace model from yaml
+    ---
+      Name: namespace
+      Description: empty
+      PolicyDefaults: ~
+    ---
+    When I visit the nspace page for yaml
+    ---
+      dc: datacenter
+      namespace: namespace
+    ---
+    Then the url should be /datacenter/namespaces/namespace
+  Scenario: Update to [Description]
+    Then I fill in with yaml
+    ---
+      Description: [Description]
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/namespace/namespace" from yaml
+    ---
+      body:
+        Description: [Description]
+    ---
+    Then the url should be /datacenter/namespaces
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class
+    Where:
+      ---------------------------
+      | Description             |
+      | description             |
+      | description with spaces |
+      ---------------------------
+  Scenario: There was an error saving the key
+    Given the url "/v1/namespace/namespace" responds with a 500 status
+    And I submit
+    Then the url should be /datacenter/namespaces/namespace
+    Then "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "error" class

--- a/ui-v2/tests/acceptance/dc/services/error.feature
+++ b/ui-v2/tests/acceptance/dc/services/error.feature
@@ -11,6 +11,7 @@ Feature: dc / services / error
       dc: 404-datacenter
     ---
     Then I see the text "404 (Page not found)" in "[data-test-error]"
+  @notNamespaceable
   Scenario: Arriving at the service page
     Given 2 datacenter models from yaml
     ---
@@ -23,5 +24,8 @@ Feature: dc / services / error
       dc: dc-1
     ---
     Then I see the text "500 (The backend responded with an error)" in "[data-test-error]"
+    # This is the actual step that works slightly differently
+    # When running through namespaces as the dc menu says 'Error'
+    # which is still kind of ok
     When I click dc on the navigation
     And I see 2 datacenter models

--- a/ui-v2/tests/acceptance/dc/services/index.feature
+++ b/ui-v2/tests/acceptance/dc/services/index.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / services: List Services
+Feature: dc / services / index: List Services
   Scenario:
     Given 1 datacenter model with the value "dc-1"
     And 6 service models from yaml

--- a/ui-v2/tests/acceptance/deleting.feature
+++ b/ui-v2/tests/acceptance/deleting.feature
@@ -21,13 +21,14 @@ Feature: deleting: Deleting items with confirmations, success and error notifica
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
   Where:
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    | Edit     | Listing     | Method | URL                                                                            | Data                                                                 | Slug                                            |
-    # | acl      | acls       | PUT    | /v1/acl/destroy/something?dc=datacenter                                        | {"Name": "something", "ID": "something"}                             | acl: something                                  |
-    | kv        | kvs        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                    | ["key-name"]                                                         | kv: key-name                                    |
-    | intention | intentions | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter      | {"SourceName": "name", "ID": "ee52203d-989f-4f7a-ab5a-2bef004164ca"} | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
-    | token     | tokens     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=@!namespace | {"AccessorID": "001fda31-194e-4ff1-a5ec-589abf2cafd0"}               | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    | Edit     | Listing     | Method | URL                                                                             | Data                                                                 |
+    | kv        | kvs        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                    | ["key-name"]                                                         |
+    | intention | intentions | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter       | {"SourceName": "name", "ID": "ee52203d-989f-4f7a-ab5a-2bef004164ca"} |
+    | token     | tokens     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=@!namespace | {"AccessorID": "001fda31-194e-4ff1-a5ec-589abf2cafd0"}               |
+    | nspace    | nspaces    | DELETE | /v1/namespace/a-namespace                                                       | {"Name": "a-namespace"}                                              |
+    # | acl      | acls       | PUT    | /v1/acl/destroy/something?dc=datacenter                                        | {"Name": "something", "ID": "something"}                             |
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   Scenario: Deleting a [Model] from the [Model] detail page
     When I visit the [Model] page for yaml
     ---
@@ -50,13 +51,14 @@ Feature: deleting: Deleting items with confirmations, success and error notifica
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "error" class
   Where:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------
-    | Model     | Method | URL                                                                          | Slug                                            |
-    # | acl       | PUT    | /v1/acl/destroy/something?dc=datacenter                                      | acl: something                                  |
-      | kv        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                | kv: key-name                                    |
-    | intention | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter    | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------
+    | Model     | Method | URL                                                                              | Slug                                            |
+    | kv        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                     | kv: key-name                                    |
+    | intention | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter        | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
     | token     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=@!namespace  | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
-    -------------------------------------------------------------------------------------------------------------------------------------------------------
+    | nspace    | DELETE | /v1/namespace/a-namespace                                                        | namespace: a-namespace                          |
+    # | acl       | PUT    | /v1/acl/destroy/something?dc=datacenter                                      | acl: something                                  |
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------
 @ignore
   Scenario: Sort out the wide tables ^
     Then ok

--- a/ui-v2/tests/acceptance/deleting.feature
+++ b/ui-v2/tests/acceptance/deleting.feature
@@ -17,17 +17,17 @@ Feature: deleting: Deleting items with confirmations, success and error notifica
     And I click actions on the [Listing]
     And I click delete on the [Listing]
     And I click confirmDelete on the [Listing]
-    Then a [Method] request is made to "[URL]"
+    Then a [Method] request was made to "[URL]"
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
   Where:
-    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    | Edit     | Listing     | Method | URL                                                                         | Data                                                                 | Slug                                            |
-    # | acl      | acls       | PUT    | /v1/acl/destroy/something?dc=datacenter                                    | {"Name": "something", "ID": "something"}                             | acl: something                                  |
-    | kv        | kvs        | DELETE | /v1/kv/key-name?dc=datacenter&ns=default                                    | ["key-name"]                                                         | kv: key-name                                    |
-    | intention | intentions | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter   | {"SourceName": "name", "ID": "ee52203d-989f-4f7a-ab5a-2bef004164ca"} | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
-    | token     | tokens     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=default | {"AccessorID": "001fda31-194e-4ff1-a5ec-589abf2cafd0"}               | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
-    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    | Edit     | Listing     | Method | URL                                                                            | Data                                                                 | Slug                                            |
+    # | acl      | acls       | PUT    | /v1/acl/destroy/something?dc=datacenter                                        | {"Name": "something", "ID": "something"}                             | acl: something                                  |
+    | kv        | kvs        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                    | ["key-name"]                                                         | kv: key-name                                    |
+    | intention | intentions | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter      | {"SourceName": "name", "ID": "ee52203d-989f-4f7a-ab5a-2bef004164ca"} | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
+    | token     | tokens     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=@!namespace | {"AccessorID": "001fda31-194e-4ff1-a5ec-589abf2cafd0"}               | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   Scenario: Deleting a [Model] from the [Model] detail page
     When I visit the [Model] page for yaml
     ---
@@ -36,7 +36,7 @@ Feature: deleting: Deleting items with confirmations, success and error notifica
     ---
     And I click delete
     And I click confirmDelete
-    Then a [Method] request is made to "[URL]"
+    Then a [Method] request was made to "[URL]"
     And "[data-notification]" has the "notification-delete" class
     And "[data-notification]" has the "success" class
     When I visit the [Model] page for yaml
@@ -53,9 +53,9 @@ Feature: deleting: Deleting items with confirmations, success and error notifica
     -------------------------------------------------------------------------------------------------------------------------------------------------------
     | Model     | Method | URL                                                                          | Slug                                            |
     # | acl       | PUT    | /v1/acl/destroy/something?dc=datacenter                                      | acl: something                                  |
-      | kv        | DELETE | /v1/kv/key-name?dc=datacenter&ns=default                                   | kv: key-name                                    |
+      | kv        | DELETE | /v1/kv/key-name?dc=datacenter&ns=@!namespace                                | kv: key-name                                    |
     | intention | DELETE | /v1/connect/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=datacenter    | intention: ee52203d-989f-4f7a-ab5a-2bef004164ca |
-    | token     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=default  | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
+    | token     | DELETE | /v1/acl/token/001fda31-194e-4ff1-a5ec-589abf2cafd0?dc=datacenter&ns=@!namespace  | token: 001fda31-194e-4ff1-a5ec-589abf2cafd0     |
     -------------------------------------------------------------------------------------------------------------------------------------------------------
 @ignore
   Scenario: Sort out the wide tables ^

--- a/ui-v2/tests/acceptance/index-forwarding.feature
+++ b/ui-v2/tests/acceptance/index-forwarding.feature
@@ -1,5 +1,6 @@
 @setupApplicationTest
-Feature: index forwarding
+@notNamespaceable
+Feature: index-forwarding
   Scenario: Arriving at the index page when there is only one datacenter
     Given 1 datacenter model with the value "datacenter"
     When I visit the index page

--- a/ui-v2/tests/acceptance/page-navigation.feature
+++ b/ui-v2/tests/acceptance/page-navigation.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: Page Navigation
+Feature: page-navigation
   In order to view all the data in consul
   As a user
   I should be able to visit every page and view data in a HTML from the API
@@ -11,7 +11,7 @@ Feature: Page Navigation
       dc: dc-1
     ---
     Then the url should be /dc-1/services
-    Then the last GET request was made to "/v1/internal/ui/services?dc=dc-1"
+    Then a GET request was made to "/v1/internal/ui/services?dc=dc-1&ns=@namespace"
   Scenario: Clicking [Link] in the navigation takes me to [URL]
     When I visit the services page for yaml
     ---
@@ -19,16 +19,16 @@ Feature: Page Navigation
     ---
     When I click [Link] on the navigation
     Then the url should be [URL]
-    Then the last GET request was made to "[Endpoint]"
+    Then a GET request was made to "[Endpoint]"
   Where:
-    -----------------------------------------------------------------------
-    | Link       | URL               | Endpoint                           |
-    | nodes      | /dc-1/nodes       | /v1/internal/ui/nodes?dc=dc-1      |
-    | kvs        | /dc-1/kv          | /v1/kv/?keys&dc=dc-1&separator=%2F |
-    | acls       | /dc-1/acls/tokens | /v1/acl/tokens?dc=dc-1             |
-    | intentions | /dc-1/intentions  | /v1/connect/intentions?dc=dc-1     |
-    # | settings   | /settings         | /v1/catalog/datacenters            |
-    -----------------------------------------------------------------------
+    -------------------------------------------------------------------------------------
+    | Link       | URL               | Endpoint                                         |
+    | nodes      | /dc-1/nodes       | /v1/internal/ui/nodes?dc=dc-1                    |
+    | kvs        | /dc-1/kv          | /v1/kv/?keys&dc=dc-1&separator=%2F&ns=@namespace |
+    | acls       | /dc-1/acls/tokens | /v1/acl/tokens?dc=dc-1&ns=@namespace             |
+    | intentions | /dc-1/intentions  | /v1/connect/intentions?dc=dc-1                   |
+    # | settings   | /settings         | /v1/catalog/datacenters                         |
+    -------------------------------------------------------------------------------------
   Scenario: Clicking a [Item] in the [Model] listing and back again
     When I visit the [Model] page for yaml
     ---
@@ -40,16 +40,16 @@ Feature: Page Navigation
     And I click "[data-test-back]"
     Then the url should be [Back]
   Where:
-    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    | Item      | Model      | URL                                                      | Endpoint                                                           | Back                |
-    | service   | services   | /dc-1/services/service-0                                 | /v1/discovery-chain/service-0?dc=dc-1                              | /dc-1/services      |
-    | node      | nodes      | /dc-1/nodes/node-0                                       | /v1/session/node/node-0?dc=dc-1                                    | /dc-1/nodes         |
-    | kv        | kvs        | /dc-1/kv/0-key-value/edit                                | /v1/session/info/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=dc-1      | /dc-1/kv            |
-    # | acl       | acls       | /dc-1/acls/anonymous                                     | /v1/acl/info/anonymous?dc=dc-1                                    | /dc-1/acls         |
-    | intention | intentions | /dc-1/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca    | /v1/internal/ui/services?dc=dc-1&ns=*                              | /dc-1/intentions    |
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    | Item      | Model      | URL                                                      | Endpoint                                                                    | Back                |
+    | service   | services   | /dc-1/services/service-0                                 | /v1/discovery-chain/service-0?dc=dc-1&ns=@namespace                         | /dc-1/services      |
+    | node      | nodes      | /dc-1/nodes/node-0                                       | /v1/session/node/node-0?dc=dc-1&ns=@namespace                               | /dc-1/nodes         |
+    | kv        | kvs        | /dc-1/kv/0-key-value/edit                                | /v1/session/info/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=dc-1&ns=@namespace | /dc-1/kv            |
+    # | acl       | acls       | /dc-1/acls/anonymous                                     | /v1/acl/info/anonymous?dc=dc-1                                             | /dc-1/acls         |
+    | intention | intentions | /dc-1/intentions/ee52203d-989f-4f7a-ab5a-2bef004164ca    | /v1/internal/ui/services?dc=dc-1&ns=*                                       | /dc-1/intentions    |
 # These Endpoints will be datacenters due to the datacenters checkbox selectors
-    | token     | tokens     | /dc-1/acls/tokens/ee52203d-989f-4f7a-ab5a-2bef004164ca   | /v1/catalog/datacenters                                            | /dc-1/acls/tokens   |
-    | policy    | policies   | /dc-1/acls/policies/ee52203d-989f-4f7a-ab5a-2bef004164ca | /v1/catalog/datacenters                                            | /dc-1/acls/policies |
+    | token     | tokens     | /dc-1/acls/tokens/ee52203d-989f-4f7a-ab5a-2bef004164ca   | /v1/catalog/datacenters                                                     | /dc-1/acls/tokens   |
+    | policy    | policies   | /dc-1/acls/policies/ee52203d-989f-4f7a-ab5a-2bef004164ca | /v1/catalog/datacenters                                                     | /dc-1/acls/policies |
     # | token     | tokens     | /dc-1/acls/tokens/00000000-0000-0000-0000-000000000000   | /v1/acl/token/00000000-0000-0000-0000-000000000000?dc=dc-1    | /dc-1/acls/tokens |
     # | policy    | policies   | /dc-1/acls/policies/ee52203d-989f-4f7a-ab5a-2bef004164ca | /v1/acl/policy/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=dc-1   | /dc-1/acls/policies |
     --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ Feature: Page Navigation
       - /v1/namespaces
       - /v1/internal/ui/node/node-0?dc=dc-1
       - /v1/coordinate/nodes?dc=dc-1
-      - /v1/session/node/node-0?dc=dc-1
+      - /v1/session/node/node-0?dc=dc-1&ns=@namespace
     ---
   Scenario: The kv detail page calls the correct API endpoints
     When I visit the kv page for yaml
@@ -79,8 +79,8 @@ Feature: Page Navigation
     ---
       - /v1/catalog/datacenters
       - /v1/namespaces
-      - /v1/kv/keyname?dc=dc-1
-      - /v1/session/info/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=dc-1
+      - /v1/kv/keyname?dc=dc-1&ns=@namespace
+      - /v1/session/info/ee52203d-989f-4f7a-ab5a-2bef004164ca?dc=dc-1&ns=@namespace
     ---
   Scenario: The policies page/tab calls the correct API endpoints
     When I visit the policies page for yaml
@@ -92,7 +92,7 @@ Feature: Page Navigation
     ---
       - /v1/catalog/datacenters
       - /v1/namespaces
-      - /v1/acl/policies?dc=dc-1
+      - /v1/acl/policies?dc=dc-1&ns=@namespace
     ---
   Scenario: The intention detail page calls the correct API endpoints
     When I visit the intention page for yaml

--- a/ui-v2/tests/acceptance/startup.feature
+++ b/ui-v2/tests/acceptance/startup.feature
@@ -3,6 +3,7 @@ Feature: startup
   In order to give users an indication as early as possible that they are at the right place
   As a user
   I should be able to see a startup logo
+  @notNamespaceable
   Scenario: When loading the index.html file into a browser
     Given 1 datacenter model with the value "dc-1"
     Then the url should be ''

--- a/ui-v2/tests/acceptance/steps/dc/nspaces/delete-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nspaces/delete-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/steps/dc/nspaces/index-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nspaces/index-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/steps/dc/nspaces/update-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nspaces/update-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/acceptance/submit-blank.feature
+++ b/ui-v2/tests/acceptance/submit-blank.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: submit blank
+Feature: submit-blank
   In order to prevent form's being saved without values
   As a user
   I shouldn't be able to submit a blank form

--- a/ui-v2/tests/acceptance/token-header.feature
+++ b/ui-v2/tests/acceptance/token-header.feature
@@ -1,5 +1,6 @@
 @setupApplicationTest
-Feature: token headers
+@notNamespaceable
+Feature: token-header
   In order to authenticate with tokens
   As a user
   I need to be able to specify a ACL token AND/OR leave it blank to authenticate with the API
@@ -7,7 +8,7 @@ Feature: token headers
     Given 1 datacenter model with the value "datacenter"
     When I visit the index page
     Then the url should be /datacenter/services
-    And a GET request is made to "/v1/namespaces" from yaml
+    And a GET request was made to "/v1/namespaces" from yaml
     ---
     headers:
       X-Consul-Token: ''

--- a/ui-v2/tests/dictionary.js
+++ b/ui-v2/tests/dictionary.js
@@ -3,12 +3,6 @@ import Yadda from 'yadda';
 import YAML from 'js-yaml';
 export default function(nspace, dict = new Yadda.Dictionary()) {
   dict
-    .define('json', /([^\u0000]*)/, function(val, cb) {
-      cb(null, JSON.parse(val));
-    })
-    .define('yaml', /([^\u0000]*)/, function(val, cb) {
-      cb(null, YAML.safeLoad(val));
-    })
     .define('model', /(\w+)/, function(model, cb) {
       switch (model) {
         case 'datacenter':
@@ -37,7 +31,45 @@ export default function(nspace, dict = new Yadda.Dictionary()) {
       }
       cb(null, model);
     })
-    .define('number', /(\d+)/, Yadda.converters.integer);
+    .define('number', /(\d+)/, Yadda.converters.integer)
+    .define('json', /([^\u0000]*)/, function(val, cb) {
+      // replace any instance of @namespace in the string
+      val = val.replace(
+        /@namespace/g,
+        typeof nspace === 'undefined' || nspace === '' ? 'default' : nspace
+      );
+      cb(null, JSON.parse(val));
+    })
+    .define('yaml', /([^\u0000]*)/, function(val, cb) {
+      // sometimes we need to always force a namespace queryParam
+      // mainly for DELETEs
+      val = val.replace(/ns=@!namespace/g, `ns=${nspace || 'default'}`);
+      if (typeof nspace === 'undefined' || nspace === '') {
+        val = val.replace(/Namespace: @namespace/g, '').replace(/&ns=@namespace/g, '');
+      }
+      // replace any other instance of @namespace in the string
+      val = val.replace(
+        /@namespace/g,
+        typeof nspace === 'undefined' || nspace === '' ? 'default' : nspace
+      );
+      cb(null, YAML.safeLoad(val));
+    })
+    .define('endpoint', /([^\u0000]*)/, function(val, cb) {
+      // if is @namespace is !important, always replace with namespace
+      // or if its undefined or empty then use default
+      val = val.replace(/ns=@!namespace/g, `ns=${nspace || 'default'}`);
+      // for endpoints if namespace isn't specified it should
+      // never add the ns= unless its !important...
+      if (typeof nspace !== 'undefined' && nspace !== '') {
+        val = val.replace(/ns=@namespace/g, `ns=${nspace}`);
+      } else {
+        val = val
+          .replace(/&ns=@namespace/g, '')
+          .replace(/ns=@namespace&/g, '')
+          .replace(/ns=@namespace/g, '');
+      }
+      cb(null, val);
+    });
   if (typeof nspace !== 'undefined' && nspace !== '') {
     dict.define('url', /([^\u0000]*)/, function(val, cb) {
       val = `/~${nspace}${val}`;

--- a/ui-v2/tests/helpers/set-cookies.js
+++ b/ui-v2/tests/helpers/set-cookies.js
@@ -42,6 +42,9 @@ export default function(type, value) {
         key = 'CONSUL_TOKEN_COUNT';
         obj['CONSUL_ACLS_ENABLE'] = 1;
         break;
+      case 'nspace':
+        key = 'CONSUL_NSPACE_COUNT';
+        break;
     }
     if (key) {
       obj[key] = value;

--- a/ui-v2/tests/helpers/type-to-url.js
+++ b/ui-v2/tests/helpers/type-to-url.js
@@ -32,6 +32,9 @@ export default function(type) {
     case 'token':
       requests = ['/v1/acl/tokens', '/v1/acl/token/'];
       break;
+    case 'nspace':
+      requests = ['/v1/namespaces', '/v1/namespace/'];
+      break;
   }
   // TODO: An instance of URL should come in here (instead of 2 args)
   return function(url, method) {

--- a/ui-v2/tests/helpers/yadda-annotations.js
+++ b/ui-v2/tests/helpers/yadda-annotations.js
@@ -54,7 +54,9 @@ const checkAnnotations = function(annotations, isScenario) {
       });
       if (annotations.namespaceable && !annotations.notnamespaceable) {
         ['', 'default', 'team-1', undefined].forEach(function(item) {
-          test(`Scenario: ${scenario.title} with the ${item} namespace set`, function(assert) {
+          test(`Scenario: ${
+            scenario.title
+          } with the ${item === '' ? 'empty' : typeof item === 'undefined' ? 'undefined' : item} namespace set`, function(assert) {
             const libraries = library.default({
               assert: assert,
               library: Yadda.localisation.English.library(getDictionary(item)),

--- a/ui-v2/tests/integration/adapters/policy-test.js
+++ b/ui-v2/tests/integration/adapters/policy-test.js
@@ -43,9 +43,7 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/policy?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/policy?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
           client.url,
@@ -62,9 +60,7 @@ module('Integration | Adapter | policy', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:policy');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/policy/${id}?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/policy/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
           client.url,

--- a/ui-v2/tests/integration/adapters/role-test.js
+++ b/ui-v2/tests/integration/adapters/role-test.js
@@ -36,9 +36,7 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/role?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/role?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
           client.url,
@@ -55,9 +53,7 @@ module('Integration | Adapter | role', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:role');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/role/${id}?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/role/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
           client.url,

--- a/ui-v2/tests/integration/adapters/token-test.js
+++ b/ui-v2/tests/integration/adapters/token-test.js
@@ -64,9 +64,7 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForCreateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/token?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/token?dc=${dc}`;
       const actual = adapter
         .requestForCreateRecord(
           client.url,
@@ -83,9 +81,7 @@ module('Integration | Adapter | token', function(hooks) {
     test(`requestForUpdateRecord returns the correct url (without Rules it uses the v2 API) when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:token');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/acl/token/${id}?dc=${dc}${
-        typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
-      }`;
+      const expected = `PUT /v1/acl/token/${id}?dc=${dc}`;
       const actual = adapter
         .requestForUpdateRecord(
           client.url,

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -40,6 +40,8 @@ import tokens from 'consul-ui/tests/pages/dc/acls/tokens/index';
 import token from 'consul-ui/tests/pages/dc/acls/tokens/edit';
 import intentions from 'consul-ui/tests/pages/dc/intentions/index';
 import intention from 'consul-ui/tests/pages/dc/intentions/edit';
+import nspaces from 'consul-ui/tests/pages/dc/nspaces/index';
+import nspace from 'consul-ui/tests/pages/dc/nspaces/edit';
 
 const deletable = createDeletable(clickable);
 const submitable = createSubmitable(clickable, is);
@@ -104,5 +106,9 @@ export default {
     intentions(visitable, deletable, creatable, clickable, attribute, collection, intentionFilter)
   ),
   intention: create(intention(visitable, submitable, deletable, cancelable)),
+  nspaces: create(
+    nspaces(visitable, deletable, creatable, clickable, attribute, collection, text, freetextFilter)
+  ),
+  nspace: create(nspace(visitable, submitable, deletable, cancelable)),
   settings: create(settings(visitable, submitable)),
 };

--- a/ui-v2/tests/pages/dc/nspaces/edit.js
+++ b/ui-v2/tests/pages/dc/nspaces/edit.js
@@ -1,0 +1,8 @@
+export default function(visitable, submitable, deletable, cancelable) {
+  return {
+    visit: visitable(['/:dc/namespaces/:namespace', '/:dc/namespaces/create']),
+    ...submitable({}, 'form > div'),
+    ...cancelable({}, 'form > div'),
+    ...deletable({}, 'form > div'),
+  };
+}

--- a/ui-v2/tests/pages/dc/nspaces/index.js
+++ b/ui-v2/tests/pages/dc/nspaces/index.js
@@ -1,0 +1,24 @@
+export default function(
+  visitable,
+  deletable,
+  creatable,
+  clickable,
+  attribute,
+  collection,
+  text,
+  filter
+) {
+  return creatable({
+    visit: visitable('/:dc/namespaces'),
+    nspaces: collection(
+      '[data-test-tabular-row]',
+      deletable({
+        action: attribute('data-test-nspace-action', '[data-test-nspace-action]'),
+        description: text('[data-test-description]'),
+        nspace: clickable('a'),
+        actions: clickable('label'),
+      })
+    ),
+    filter: filter,
+  });
+}

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -121,6 +121,10 @@ export default function(assert, library) {
   assertForm(library, assert, find, getCurrentPage);
 
   return library.given(["I'm using a legacy token"], function(number, model, data) {
-    window.localStorage['consul:token'] = JSON.stringify({ AccessorID: null, SecretID: 'id' });
+    window.localStorage['consul:token'] = JSON.stringify({
+      Namespace: 'default',
+      AccessorID: null,
+      SecretID: 'id',
+    });
   });
 }

--- a/ui-v2/tests/steps/assertions/http.js
+++ b/ui-v2/tests/steps/assertions/http.js
@@ -1,7 +1,3 @@
-// TODO: This entire file/steps need refactoring out so that they don't depend on order
-// unless you specifically ask it to assert for order of requests
-// this should also let us simplify the entire API for these steps
-// an reword them to make more sense
 export default function(scenario, assert, lastNthRequest) {
   // lastNthRequest should return a
   // {
@@ -9,112 +5,7 @@ export default function(scenario, assert, lastNthRequest) {
   //   requestBody: '',
   //   requestHeaders: ''
   // }
-  const assertRequest = function(request, method, url) {
-    assert.equal(
-      request.method,
-      method,
-      `Expected the request method to be ${method}, was ${request.method}`
-    );
-    assert.equal(request.url, url, `Expected the request url to be ${url}, was ${request.url}`);
-  };
   scenario
-    .then('a $method request is made to "$endpoint" with the body from yaml\n$yaml', function(
-      method,
-      url,
-      data
-    ) {
-      const request = lastNthRequest(1);
-      assertRequest(request, method, url);
-      const body = JSON.parse(request.requestBody);
-      Object.keys(data).forEach(function(key, i, arr) {
-        assert.deepEqual(
-          body[key],
-          data[key],
-          `Expected the payload to contain ${key} equaling ${data[key]}, ${key} was ${body[key]}`
-        );
-      });
-    })
-    // TODO: This one can replace the above one, it covers more use cases
-    // also DRY it out a bit
-    .then('a $method request is made to "$endpoint" from yaml\n$yaml', function(method, url, yaml) {
-      const request = lastNthRequest(1);
-      assertRequest(request, method, url);
-      let data = yaml.body || {};
-      const body = JSON.parse(request.requestBody);
-      Object.keys(data).forEach(function(key, i, arr) {
-        assert.equal(
-          body[key],
-          data[key],
-          `Expected the payload to contain ${key} to equal ${body[key]}, ${key} was ${data[key]}`
-        );
-      });
-      data = yaml.headers || {};
-      const headers = request.requestHeaders;
-      Object.keys(data).forEach(function(key, i, arr) {
-        assert.equal(
-          headers[key],
-          data[key],
-          `Expected the payload to contain ${key} to equal ${headers[key]}, ${key} was ${data[key]}`
-        );
-      });
-    })
-    .then('a $method request is made to "$endpoint" with the body "$body"', function(
-      method,
-      url,
-      data
-    ) {
-      const request = lastNthRequest(1);
-      assertRequest(request, method, url);
-      assert.equal(
-        request.requestBody,
-        data,
-        `Expected the request body to be ${data}, was ${request.requestBody}`
-      );
-    })
-    .then('a $method request is made to "$endpoint" with no body', function(method, url) {
-      const request = lastNthRequest(1);
-      assertRequest(request, method, url);
-      assert.equal(
-        request.requestBody,
-        null,
-        `Expected the request body to be null, was ${request.requestBody}`
-      );
-    })
-
-    .then('a $method request is made to "$endpoint"', function(method, url) {
-      const request = lastNthRequest(1);
-      assertRequest(request, method, url);
-    })
-    .then('the last $method request was made to "$endpoint"', function(method, url) {
-      const request = lastNthRequest(0, method);
-      assertRequest(request, method, url);
-    })
-    .then(
-      'the last $method request was made to "$endpoint" with the body from yaml\n$yaml',
-      function(method, url, data) {
-        const request = lastNthRequest(0, method);
-        const body = JSON.parse(request.requestBody);
-        assert.ok(request, `Expected a ${method} request`);
-        assertRequest(request, method, url);
-        Object.keys(data).forEach(function(key, i, arr) {
-          assert.deepEqual(
-            body[key],
-            data[key],
-            `Expected the payload to contain ${key} equaling ${data[key]}, ${key} was ${body[key]}`
-          );
-        });
-      }
-    )
-    .then('the last $method requests were like yaml\n$yaml', function(method, data) {
-      const requests = lastNthRequest(null, method);
-      data.reverse().forEach(function(item, i, arr) {
-        assert.equal(
-          requests[i].url,
-          item,
-          `Expected the request url to be ${item}, was ${requests[i].url}`
-        );
-      });
-    })
     .then('the last $method requests included from yaml\n$yaml', function(method, data) {
       const requests = lastNthRequest(null, method);
       const a = new Set(data);
@@ -130,8 +21,6 @@ export default function(scenario, assert, lastNthRequest) {
       );
       assert.equal(diff.size, 0, `Expected requests "${[...diff].join(', ')}"`);
     })
-    // These 'was made to' methods should always be preferred as they don't rely
-    // on order of requests, then we should be able to deprecate most of the above
     .then('a $method request was made to "$endpoint"', function(method, url) {
       const requests = lastNthRequest(null, method);
       const request = requests.find(function(item) {

--- a/ui-v2/tests/steps/assertions/http.js
+++ b/ui-v2/tests/steps/assertions/http.js
@@ -18,7 +18,7 @@ export default function(scenario, assert, lastNthRequest) {
     assert.equal(request.url, url, `Expected the request url to be ${url}, was ${request.url}`);
   };
   scenario
-    .then('a $method request is made to "$url" with the body from yaml\n$yaml', function(
+    .then('a $method request is made to "$endpoint" with the body from yaml\n$yaml', function(
       method,
       url,
       data
@@ -36,7 +36,7 @@ export default function(scenario, assert, lastNthRequest) {
     })
     // TODO: This one can replace the above one, it covers more use cases
     // also DRY it out a bit
-    .then('a $method request is made to "$url" from yaml\n$yaml', function(method, url, yaml) {
+    .then('a $method request is made to "$endpoint" from yaml\n$yaml', function(method, url, yaml) {
       const request = lastNthRequest(1);
       assertRequest(request, method, url);
       let data = yaml.body || {};
@@ -58,7 +58,11 @@ export default function(scenario, assert, lastNthRequest) {
         );
       });
     })
-    .then('a $method request is made to "$url" with the body "$body"', function(method, url, data) {
+    .then('a $method request is made to "$endpoint" with the body "$body"', function(
+      method,
+      url,
+      data
+    ) {
       const request = lastNthRequest(1);
       assertRequest(request, method, url);
       assert.equal(
@@ -67,7 +71,7 @@ export default function(scenario, assert, lastNthRequest) {
         `Expected the request body to be ${data}, was ${request.requestBody}`
       );
     })
-    .then('a $method request is made to "$url" with no body', function(method, url) {
+    .then('a $method request is made to "$endpoint" with no body', function(method, url) {
       const request = lastNthRequest(1);
       assertRequest(request, method, url);
       assert.equal(
@@ -77,31 +81,30 @@ export default function(scenario, assert, lastNthRequest) {
       );
     })
 
-    .then('a $method request is made to "$url"', function(method, url) {
+    .then('a $method request is made to "$endpoint"', function(method, url) {
       const request = lastNthRequest(1);
       assertRequest(request, method, url);
     })
-    .then('the last $method request was made to "$url"', function(method, url) {
+    .then('the last $method request was made to "$endpoint"', function(method, url) {
       const request = lastNthRequest(0, method);
       assertRequest(request, method, url);
     })
-    .then('the last $method request was made to "$url" with the body from yaml\n$yaml', function(
-      method,
-      url,
-      data
-    ) {
-      const request = lastNthRequest(0, method);
-      const body = JSON.parse(request.requestBody);
-      assert.ok(request, `Expected a ${method} request`);
-      assertRequest(request, method, url);
-      Object.keys(data).forEach(function(key, i, arr) {
-        assert.deepEqual(
-          body[key],
-          data[key],
-          `Expected the payload to contain ${key} equaling ${data[key]}, ${key} was ${body[key]}`
-        );
-      });
-    })
+    .then(
+      'the last $method request was made to "$endpoint" with the body from yaml\n$yaml',
+      function(method, url, data) {
+        const request = lastNthRequest(0, method);
+        const body = JSON.parse(request.requestBody);
+        assert.ok(request, `Expected a ${method} request`);
+        assertRequest(request, method, url);
+        Object.keys(data).forEach(function(key, i, arr) {
+          assert.deepEqual(
+            body[key],
+            data[key],
+            `Expected the payload to contain ${key} equaling ${data[key]}, ${key} was ${body[key]}`
+          );
+        });
+      }
+    )
     .then('the last $method requests were like yaml\n$yaml', function(method, data) {
       const requests = lastNthRequest(null, method);
       data.reverse().forEach(function(item, i, arr) {
@@ -127,14 +130,42 @@ export default function(scenario, assert, lastNthRequest) {
       );
       assert.equal(diff.size, 0, `Expected requests "${[...diff].join(', ')}"`);
     })
-    .then('a $method request was made to "$url"', function(method, url) {
+    // These 'was made to' methods should always be preferred as they don't rely
+    // on order of requests, then we should be able to deprecate most of the above
+    .then('a $method request was made to "$endpoint"', function(method, url) {
       const requests = lastNthRequest(null, method);
       const request = requests.find(function(item) {
         return method === item.method && url === item.url;
       });
       assert.ok(request, `Expected a ${method} request url to ${url}`);
     })
-    .then('a $method request was made to "$url" from yaml\n$yaml', function(method, url, yaml) {
+    .then('a $method request was made to "$endpoint" with no body', function(method, url) {
+      const requests = lastNthRequest(null, method);
+      const request = requests.find(function(item) {
+        return method === item.method && url === item.url;
+      });
+      assert.equal(
+        request.requestBody,
+        null,
+        `Expected the request body to be null, was ${request.requestBody}`
+      );
+    })
+    .then('a $method request was made to "$endpoint" with the body "$body"', function(
+      method,
+      url,
+      body
+    ) {
+      const requests = lastNthRequest(null, method);
+      const request = requests.find(function(item) {
+        return method === item.method && url === item.url;
+      });
+      assert.ok(request, `Expected a ${method} request url to ${url} with the body "${body}"`);
+    })
+    .then('a $method request was made to "$endpoint" from yaml\n$yaml', function(
+      method,
+      url,
+      yaml
+    ) {
       const requests = lastNthRequest(null, method);
       const request = requests.find(function(item) {
         return method === item.method && url === item.url;
@@ -142,19 +173,23 @@ export default function(scenario, assert, lastNthRequest) {
       let data = yaml.body || {};
       const body = JSON.parse(request.requestBody);
       Object.keys(data).forEach(function(key, i, arr) {
-        assert.equal(
+        assert.deepEqual(
           body[key],
           data[key],
-          `Expected the payload to contain ${key} to equal ${body[key]}, ${key} was ${data[key]}`
+          `Expected the payload to contain ${key} equaling ${JSON.stringify(
+            data[key]
+          )}, ${key} was ${JSON.stringify(body[key])}`
         );
       });
       data = yaml.headers || {};
       const headers = request.requestHeaders;
       Object.keys(data).forEach(function(key, i, arr) {
-        assert.equal(
+        assert.deepEqual(
           headers[key],
           data[key],
-          `Expected the payload to contain ${key} to equal ${headers[key]}, ${key} was ${data[key]}`
+          `Expected the payload to contain ${key} equaling ${JSON.stringify(
+            data[key]
+          )}, ${key} was ${JSON.stringify(headers[key])}`
         );
       });
     });

--- a/ui-v2/tests/steps/doubles/http.js
+++ b/ui-v2/tests/steps/doubles/http.js
@@ -1,12 +1,12 @@
 export default function(scenario, respondWith, set) {
   // respondWith should set the url to return a certain response shape
   scenario
-    .given(['the url "$url" responds with a $status status'], function(url, status) {
+    .given(['the url "$endpoint" responds with a $status status'], function(url, status) {
       respondWith(url, {
         status: parseInt(status),
       });
     })
-    .given(['the url "$url" responds with from yaml\n$yaml'], function(url, data) {
+    .given(['the url "$endpoint" responds with from yaml\n$yaml'], function(url, data) {
       respondWith(url, data);
     })
     .given('a network latency of $number', function(number) {

--- a/ui-v2/tests/unit/mixins/acl/with-actions-test.js
+++ b/ui-v2/tests/unit/mixins/acl/with-actions-test.js
@@ -34,7 +34,7 @@ module('Unit | Mixin | acl/with actions', function(hooks) {
       })
     );
     const item = { ID: 'id' };
-    const expectedToken = { AccessorID: null, SecretID: item.ID };
+    const expectedToken = { Namespace: 'default', AccessorID: null, SecretID: item.ID };
     this.owner.register(
       'service:settings',
       Service.extend({

--- a/ui-v2/tests/unit/utils/non-empty-set-test.js
+++ b/ui-v2/tests/unit/utils/non-empty-set-test.js
@@ -1,0 +1,10 @@
+import nonEmptySet from 'consul-ui/utils/non-empty-set';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | nonEmptySet', function() {
+  // Replace this with your real tests.
+  test('it works', function(assert) {
+    let result = nonEmptySet();
+    assert.ok(result);
+  });
+});

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -979,9 +979,9 @@
     "@glimmer/util" "^0.42.0"
 
 "@hashicorp/api-double@^1.3.0":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@hashicorp/api-double/-/api-double-1.5.1.tgz#0c0d62f00622d87b4f9a99fcaa8f20cbb35d1796"
-  integrity sha512-24dsxjbjb5TtVlTdRiG9jFfRLIYqx8NkiyD2zjInzh/022n0dDMk5b1zFWTIcJulO4079Q2z08Cx3B1kDCe9mg==
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/api-double/-/api-double-1.6.0.tgz#23c48d1982b81b6c9164067354d7653320ba761f"
+  integrity sha512-U11NttTVvJUVOFH4bgS8eZ+0s6j4/4DYPz9xkJM2ciZBnG353l2G7LYeivt55QajnCl3ImevEO4vSlvvFf4I4Q==
   dependencies:
     array-range "^1.0.1"
     backtick-template "^0.2.0"
@@ -992,9 +992,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^2.6.2":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.9.0.tgz#4489920942b2a7cc8276f15db6a38e414b34dd2f"
-  integrity sha512-a2GKU2pwLjmaC7OeCbEjHUjE9uYThe79OgxoHbT/8UrTO3yYssUDrlZke5hY8MObz03L+Qq6THRzonEYw4KpiQ==
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.10.0.tgz#5d958ee3715ac7eaf8f69382575f16e50f09c835"
+  integrity sha512-NxPRqCNG9xFwcu0JT87634xdt6BL9PcKoLDlpkrij+AsFmDxjcWwiH0MkhD18CMPAwu9UCMG8escpVEIt4JxIQ==
 
 "@hashicorp/ember-cli-api-double@^2.0.0":
   version "2.0.0"
@@ -1634,9 +1634,9 @@ astral-regex@^1.0.0:
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-disk-cache@^1.2.1:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/async-disk-cache/-/async-disk-cache-1.3.4.tgz#a5c9f72f199a9933583659f57a0e11377884f816"
-  integrity sha512-qsIvGJ/XYZ5bSGf5vHt2aEQHZnyuehmk/+51rCJhpkZl4LtvOZ+STbhLbdFAJGYO+dLzUT5Bb4nLKqHBX83vhw==
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/async-disk-cache/-/async-disk-cache-1.3.5.tgz#cc6206ed79bb6982b878fc52e0505e4f52b62a02"
+  integrity sha512-VZpqfR0R7CEOJZ/0FOTgWq70lCrZyS1rkI8PXugDUkTKyyAUgZ2zQ09gLhMkEn+wN8LYeUTPxZdXtlX/kmbXKQ==
   dependencies:
     debug "^2.1.3"
     heimdalljs "^0.2.3"
@@ -2419,9 +2419,9 @@ binary-extensions@^1.0.0:
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
 "binaryextensions@1 || 2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.2.tgz#c83c3d74233ba7674e4f313cb2a2b70f54e94b7c"
-  integrity sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.2.0.tgz#e7c6ba82d4f5f5758c26078fe8eea28881233311"
+  integrity sha512-bHhs98rj/7i/RZpCSJ3uk55pLXOItjIrh2sRQZSM6OoktScX+LxJzvlU+FELp9j3TdcddTmmYArLSGptCTwjuw==
 
 blank-object@^1.0.1:
   version "1.0.2"
@@ -3339,10 +3339,15 @@ can-symlink@^1.0.0:
   dependencies:
     tmp "0.0.28"
 
-caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000989:
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000989:
   version "1.0.30000989"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz#b9193e293ccf7e4426c5245134b8f2a56c0ac4b9"
   integrity sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+
+caniuse-lite@^1.0.30000844:
+  version "1.0.30001019"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz#857e3fccaad2b2feb3f1f6d8a8f62d747ea648e1"
+  integrity sha512-6ljkLtF1KM5fQ+5ZN0wuyVvvebJxgJPTmScOMaFuQN2QuOzvRJnWSKfzQskQU5IOU4Gap3zasYPIinzwUjoj/g==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3791,10 +3796,17 @@ continuable-cache@^0.3.1:
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
   integrity sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.1:
+convert-source-map@^1.1.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
+
+convert-source-map@^1.5.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
+  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -3856,7 +3868,12 @@ core-js@2.4.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
   integrity sha1-TekR5mew6ukSTjQlS1OupvxhjT4=
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
+core-js@^2.4.0, core-js@^2.5.0:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
+core-js@^2.6.5:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -4279,10 +4296,15 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
+electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.30:
   version "1.3.252"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.252.tgz#5b6261965b564a0f4df0f1c86246487897017f52"
   integrity sha512-NWJ5TztDnjExFISZHFwpoJjMbLUifsNBnx7u2JI0gCw6SbKyQYYWWtBHasO/jPtHym69F4EZuTpRNGN11MT/jg==
+
+electron-to-chromium@^1.3.47:
+  version "1.3.327"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.327.tgz#516f28b4271727004362b4ac814494ae64d9dde7"
+  integrity sha512-DNMd91VtKt44LIkFtpICxAWu/GSGFLUMDM/kFINJ3Oe47OimSnbMvO3ChkUCdUyit+pRdhdCcM3+i5bpli5gqg==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -5684,10 +5706,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fake-xml-http-request@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.0.0.tgz#41a92f0ca539477700cb1dafd2df251d55dac8ff"
-  integrity sha512-UjNnynb6eLAB0lyh2PlTEkjRJORnNsVF1hbzU+PQv89/cyBV9GDRCy7JAcLQgeCLYT+3kaumWWZKEJvbaK74eQ==
+fake-xml-http-request@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-2.0.1.tgz#e4a7f256af055d8059deb23c9d7ae721d28cf078"
+  integrity sha512-KzT+G4aLM1Btg25QRGxB6yGLGOVZXXzrH8I4OG3KHwsdoqFclyW3alieqh5NaYGcmbQvNOn/ldGO1rGKf7CNdA==
 
 faker@^4.1.0:
   version "4.1.0"
@@ -6278,10 +6300,22 @@ glob@^5.0.10:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.1.2, glob@^7.1.4, glob@~7.1.1:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -8203,17 +8237,29 @@ mime-db@1.40.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+
 "mime-db@>= 1.40.0 < 2":
   version "1.41.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.41.0.tgz#9110408e1f6aa1b34aef51f2c9df3caddf46b6a0"
   integrity sha512-B5gxBI+2K431XW8C2rcc/lhppbuji67nf9v39eH8pkWoZDxnAL0PxdpH32KYRScniF8qDHBDlI+ipgg5WrCUYw==
 
-mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.19, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.19, mime-types@~2.1.19:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
   integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
   dependencies:
     mime-db "1.40.0"
+
+mime-types@~2.1.24:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+  dependencies:
+    mime-db "1.43.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -9288,12 +9334,12 @@ prepend-http@^2.0.0:
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 pretender@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.1.tgz#5085f0a1272c31d5b57c488386f69e6ca207cb35"
-  integrity sha512-IkidsJzaroAanw3I43tKCFm2xCpurkQr9aPXv5/jpN+LfCwDaeI8rngVWtQZTx4qqbhc5zJspnLHJ4N/25KvDQ==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-2.1.2.tgz#02d7c0a3f18cb0ce376dfc4fb0043ca288f50316"
+  integrity sha512-5Jx7kBalWDn8oEKfw6nAcx2KK4GkDSQXG3WhgaPsDtak6Rv6nTeQjOdvOM9PEvauS+9Ur+DLfZTDWBtqK6lFVA==
   dependencies:
     "@xg-wang/whatwg-fetch" "^3.0.0"
-    fake-xml-http-request "^2.0.0"
+    fake-xml-http-request "~2.0.0"
     route-recognizer "^0.3.3"
 
 prettier@^1.10.2:
@@ -9905,10 +9951,17 @@ resolve@1.9.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.3, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
+resolve@^1.1.3, resolve@^1.1.7, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.7.1, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.0, resolve@^1.3.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.1.tgz#9e018c540fcf0c427d678b9931cbf45e984bcaff"
+  integrity sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==
   dependencies:
     path-parse "^1.0.6"
 
@@ -10810,7 +10863,12 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8, symlink-or-copy@^1.2.0:
+symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.3.1.tgz#9506dd64d8e98fa21dcbf4018d1eab23e77f71fe"
+  integrity sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==
+
+symlink-or-copy@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#5d49108e2ab824a34069b68974486c290020b393"
   integrity sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg==
@@ -10968,9 +11026,9 @@ text-table@^0.2.0:
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 "textextensions@1 || 2":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.5.0.tgz#e21d3831dafa37513dd80666dff541414e314293"
-  integrity sha512-1IkVr355eHcomgK7fgj1Xsokturx6L5S2JRT5WcRdA6v5shk9sxWuO/w/VbpQexwkXJMQIa/j1dBi3oo7+HhcA==
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
+  integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
 
 through2@^2.0.0:
   version "2.0.5"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -992,9 +992,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^2.6.2":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.10.0.tgz#5d958ee3715ac7eaf8f69382575f16e50f09c835"
-  integrity sha512-NxPRqCNG9xFwcu0JT87634xdt6BL9PcKoLDlpkrij+AsFmDxjcWwiH0MkhD18CMPAwu9UCMG8escpVEIt4JxIQ==
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.10.1.tgz#50401a9394cb228fc1005239b98a63ea11dfdbcf"
+  integrity sha512-b4/8hbXabwrYyiuoIxv66ayyu3dnHgMke0b7F8d8nVh8oAA12qnbrY9uCExWAm+hddXUjb3NAliUWypUQL9ZqA==
 
 "@hashicorp/ember-cli-api-double@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This PR continues on from https://github.com/hashicorp/consul/pull/6980 and replaces https://github.com/hashicorp/consul/pull/6997 (which we eventually decided to PR altogether here)

Changes:

1. We've added a few places where we'd missed passing through the `nspace=""` attribute. `...arguments` will be great here once we move to using that.
2. We hardcode the 'default' namespace for adding roles and policies to nspaces in the nspace CRUD area.
3. We finished up our test helpers/dictionary/steps to allow us more control over nspaces during testing.
4. Tried to make our acceptance test titles a little more consistent.
5. Make some amends to our tests to account for different scenarios of nspaces
6. We also had to alter some of our integration tests now that we have decided not to pass the nspace on using the queryParam.
7. Finally enable nspace acceptance testing by default. Whilst this greatly improves of acceptance testing coverage for namespaces it also means that it takes a lot longer for them to run, so we've kept this disable-able via a cookie. The thinking here is that if you are writing tests for a new feature you can turn this off until you are complete, at which point you can turn it back on again, all via browser cookies. CI will always run with nspace testing enabled.

Once this is merged, all of our previous tests will now also be run for various scenarios of namespaces (empty, undefined, default and team-1). Moving forwards we'll potentially add more testing specifically for more namespace specific functionality.

P.S. We've added a further commit to the end of this to clean up our old deprecated HTTP assertion steps, we figured we may as well do it here instead of a further PR. Please see comments in the commit here for details d3eb17a39a099ef7d1a4872d0514032fe48771f8
