### PR TITLE
ui: Move slots to use attributes over positional params

### DIFF
--- a/ui-v2/app/templates/application.hbs
+++ b/ui-v2/app/templates/application.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{#hashicorp-consul id="wrapper" permissions=permissions dcs=dcs dc=dc nspaces=nspaces nspace=nspace}}
     {{#app-view class="loading show"}}
-      {{#block-slot 'content'}}
+      {{#block-slot name='content'}}
         {{partial 'consul-loading'}}
       {{/block-slot}}
     {{/app-view}}

--- a/ui-v2/app/templates/components/app-view.hbs
+++ b/ui-v2/app/templates/components/app-view.hbs
@@ -9,28 +9,28 @@
           <strong>
             {{component.flashType}}!
           </strong>
-          {{#yield-slot 'notification' (block-params (lowercase component.flashType) (lowercase flash.action) flash.item )}}{{yield}}{{/yield-slot}}
+          {{#yield-slot name='notification' params=(block-params (lowercase component.flashType) (lowercase flash.action) flash.item )}}{{yield}}{{/yield-slot}}
         </p>
     {{/flash-message}}
 {{/each}}
     <div>
         <div class="actions">
   {{#if authorized}}
-            {{#yield-slot 'actions'}}{{yield}}{{/yield-slot}}
+            {{#yield-slot name='actions'}}{{yield}}{{/yield-slot}}
   {{/if}}
         </div>
 
         <div>
   {{#if authorized}}
             <nav aria-label="Breadcrumb">
-                {{#yield-slot 'breadcrumbs'}}{{yield}}{{/yield-slot}}
+                {{#yield-slot name='breadcrumbs'}}{{yield}}{{/yield-slot}}
             </nav>
   {{/if}}
-            {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
+            {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
         </div>
     </div>
   {{#if authorized}}
-    {{#yield-slot 'toolbar'}}
+    {{#yield-slot name='toolbar'}}
       <input type="checkbox" id="toolbar-toggle" />
       {{yield}}
     {{/yield-slot}}
@@ -42,11 +42,11 @@
     {{partial 'consul-loading'}}
 {{else}}
     {{#if (not enabled) }}
-      {{#yield-slot 'disabled'}}{{yield}}{{/yield-slot}}
+      {{#yield-slot name='disabled'}}{{yield}}{{/yield-slot}}
     {{else if (not authorized)}}
-      {{#yield-slot 'authorization'}}{{yield}}{{/yield-slot}}
+      {{#yield-slot name='authorization'}}{{yield}}{{/yield-slot}}
     {{else}}
-      {{#yield-slot 'content'}}{{yield}}{{/yield-slot}}
+      {{#yield-slot name='content'}}{{yield}}{{/yield-slot}}
     {{/if}}
 {{/if}}
 </div>

--- a/ui-v2/app/templates/components/changeable-set.hbs
+++ b/ui-v2/app/templates/components/changeable-set.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#if (gt items.length 0)}}
-  {{#yield-slot 'set' (block-params items)}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='set' params=(block-params items)}}{{yield}}{{/yield-slot}}
 {{else}}
-  {{#yield-slot 'empty'}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='empty'}}{{yield}}{{/yield-slot}}
 {{/if}}

--- a/ui-v2/app/templates/components/child-selector.hbs
+++ b/ui-v2/app/templates/components/child-selector.hbs
@@ -1,7 +1,7 @@
 {{yield}}
-  {{#yield-slot 'create'}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='create'}}{{yield}}{{/yield-slot}}
   <label class="type-text">
-    <span>{{#yield-slot 'label'}}{{yield}}{{/yield-slot}}</span>
+    <span>{{#yield-slot name='label'}}{{yield}}{{/yield-slot}}</span>
       {{#power-select
         onopen=(action 'open')
         search=(action 'search')
@@ -11,11 +11,11 @@
         searchPlaceholder=placeholder
         onchange=(action 'change' 'items[]' items) as |item|
       }}
-        {{#yield-slot 'option' (block-params item)}}{{yield}}{{/yield-slot}}
+        {{#yield-slot name='option' params=(block-params item)}}{{yield}}{{/yield-slot}}
       {{/power-select}}
   </label>
 {{#if (gt items.length 0)}}
-  {{#yield-slot 'set'}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='set'}}{{yield}}{{/yield-slot}}
 {{else}}
 
 {{/if}}

--- a/ui-v2/app/templates/components/confirmation-dialog.hbs
+++ b/ui-v2/app/templates/components/confirmation-dialog.hbs
@@ -1,10 +1,10 @@
 {{yield}}
-{{#yield-slot 'action' (block-params confirm cancel)}}
+{{#yield-slot name='action' params=(block-params confirm cancel)}}
 {{#if (or permanent (not confirming))}}
     {{yield}}
 {{/if}}
 {{/yield-slot}}
-{{#yield-slot 'dialog' (block-params execute cancel message actionName)}}
+{{#yield-slot name='dialog' params=(block-params execute cancel message actionName)}}
 {{#if confirming }}
     {{yield}}
 {{/if}}

--- a/ui-v2/app/templates/components/copy-button-feedback.hbs
+++ b/ui-v2/app/templates/components/copy-button-feedback.hbs
@@ -1,13 +1,13 @@
 {{#feedback-dialog type='inline'}}
-  {{#block-slot 'action' as |success error|}}
+  {{#block-slot name='action' as |success error|}}
     {{#copy-button success=(action success) error=(action error) clipboardText=copy title=(concat 'Copy ' name ' to the clipboard')}}{{#if hasBlock }}{{yield}}{{else}}{{value}}{{/if}}{{/copy-button}}
   {{/block-slot}}
-  {{#block-slot 'success' as |transition|}}
+  {{#block-slot name='success' as |transition|}}
     <p class={{transition}}>
       Copied {{name}}!
     </p>
   {{/block-slot}}
-  {{#block-slot 'error' as |transition|}}
+  {{#block-slot name='error' as |transition|}}
     <p class={{transition}}>
       Sorry, something went wrong!
     </p>

--- a/ui-v2/app/templates/components/feedback-dialog.hbs
+++ b/ui-v2/app/templates/components/feedback-dialog.hbs
@@ -1,9 +1,9 @@
 {{yield}}
 {{#if (eq state 'success') }}
-    {{#yield-slot 'success' (block-params transition)}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='success' params=(block-params transition)}}{{yield}}{{/yield-slot}}
 {{else if (eq state 'error') }}
-    {{#yield-slot 'error' (block-params transition)}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='error' params=(block-params transition)}}{{yield}}{{/yield-slot}}
 {{/if}}
 {{#if (or permanent (eq state 'ready')) }}
-    {{#yield-slot 'action' (block-params success error)}}{{yield}}{{message}}{{/yield-slot}}
+    {{#yield-slot name='action' params=(block-params success error)}}{{yield}}{{message}}{{/yield-slot}}
 {{/if}}

--- a/ui-v2/app/templates/components/healthcheck-list.hbs
+++ b/ui-v2/app/templates/components/healthcheck-list.hbs
@@ -6,10 +6,10 @@
     class=item.Status
     tagName='li'
     }}
-      {{#block-slot 'header'}}
+      {{#block-slot name='header'}}
         <h3>{{item.Name}}</h3>
       {{/block-slot}}
-      {{#block-slot 'content'}}
+      {{#block-slot name='content'}}
       <dl>
         <dt>ServiceName</dt>
         <dd>{{or item.ServiceName '-'}}</dd>
@@ -37,15 +37,15 @@
         <dd>
             <pre><code>{{item.Output}}</code></pre>
     {{#feedback-dialog type='inline'}}
-      {{#block-slot 'action' as |success error|}}
+      {{#block-slot name='action' as |success error|}}
           {{copy-button success=(action success) error=(action error) clipboardText=item.Output title='copy output to clipboard'}}
       {{/block-slot}}
-      {{#block-slot 'success' as |transition|}}
+      {{#block-slot name='success' as |transition|}}
         <p class={{transition}}>
           Copied output!
         </p>
       {{/block-slot}}
-      {{#block-slot 'error' as |transition|}}
+      {{#block-slot name='error' as |transition|}}
         <p class={{transition}}>
           Sorry, something went wrong!
         </p>

--- a/ui-v2/app/templates/components/healthcheck-output.hbs
+++ b/ui-v2/app/templates/components/healthcheck-output.hbs
@@ -2,7 +2,7 @@
 {{yield}}
 <div>
   <header>
-    {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
   </header>
-  {{#yield-slot 'content'}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='content'}}{{yield}}{{/yield-slot}}
 </div>

--- a/ui-v2/app/templates/components/healthchecked-resource.hbs
+++ b/ui-v2/app/templates/components/healthchecked-resource.hbs
@@ -1,19 +1,19 @@
 {{#stats-card}}
-  {{#block-slot 'icon'}}{{yield}}{{/block-slot}}
-  {{#block-slot 'mini-stat'}}
+  {{#block-slot name='icon'}}{{yield}}{{/block-slot}}
+  {{#block-slot name='mini-stat'}}
     {{#if (eq checks.length 0)}}
       <span class="zero" data-tooltip="This node has no registered healthchecks">{{checks.length}}</span>
     {{else if (eq checks.length healthy.length)}}
       <span class="non-zero" data-tooltip={{concat 'All ' healthy.length ' ' (pluralize healthy.length 'check' without-count=true) ' passing'}}>{{healthy.length}}</span>
     {{/if}}
   {{/block-slot}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <a href={{href}}>
       <strong>{{name}}</strong>
       <span>{{address}}</span>
     </a>
   {{/block-slot}}
-  {{#block-slot 'body'}}
+  {{#block-slot name='body'}}
   {{#if (not-eq checks.length healthy.length)}}
     <ul>
   {{#each unhealthy as |item|}}

--- a/ui-v2/app/templates/components/modal-dialog.hbs
+++ b/ui-v2/app/templates/components/modal-dialog.hbs
@@ -6,13 +6,13 @@
     <div>
       <header>
         <label for="modal_close">Close</label>
-        {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
+        {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
       </header>
       <div>
-        {{#yield-slot 'body'}}{{yield}}{{/yield-slot}}
+        {{#yield-slot name='body'}}{{yield}}{{/yield-slot}}
       </div>
       <footer>
-        {{#yield-slot 'actions' (block-params (action 'close'))}}{{yield}}{{/yield-slot}}
+        {{#yield-slot name='actions' params=(block-params (action 'close'))}}{{yield}}{{/yield-slot}}
       </footer>
     </div>
   </div>

--- a/ui-v2/app/templates/components/policy-form.hbs
+++ b/ui-v2/app/templates/components/policy-form.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 <fieldset>
-  {{#yield-slot 'template'}}
+  {{#yield-slot name='template'}}
   {{else}}
     <header>
       Policy or service identity?

--- a/ui-v2/app/templates/components/policy-selector.hbs
+++ b/ui-v2/app/templates/components/policy-selector.hbs
@@ -1,10 +1,10 @@
 {{#child-selector repo=repo dc=dc nspace=nspace type="policy" placeholder="Search for policy" items=items}}
   {{yield}}
-  {{#block-slot 'label'}}
+  {{#block-slot name='label'}}
     Apply an existing policy
   {{/block-slot}}
-  {{#block-slot 'create'}}
-    {{#yield-slot 'trigger'}}
+  {{#block-slot name='create'}}
+    {{#yield-slot name='trigger'}}
       {{yield}}
     {{else}}
       <label class="type-dialog" for="new-policy-toggle">
@@ -13,13 +13,13 @@
       {{!TODO: potentially call trigger something else}}
       {{!the modal has to go here so that if you provide a slot to trigger it doesn't get rendered}}
       {{#modal-dialog data-test-policy-form onopen=(action 'open') name="new-policy-toggle"}}
-        {{#block-slot 'header'}}
+        {{#block-slot name='header'}}
           <h2>New Policy</h2>
         {{/block-slot}}
-        {{#block-slot 'body'}}
+        {{#block-slot name='body'}}
           {{policy-form form=form dc=dc}}
         {{/block-slot}}
-        {{#block-slot 'actions' as |close|}}
+        {{#block-slot name='actions' as |close|}}
           <button type="submit" {{action 'save' item items (queue (action close) (action 'reset'))}} disabled={{if (or item.isSaving item.isPristine item.isInvalid) 'disabled'}}>
             {{#if item.isSaving }}
               <div class="progress indeterminate"></div>
@@ -31,20 +31,20 @@
       {{/modal-dialog}}
     {{/yield-slot}}
   {{/block-slot}}
-  {{#block-slot 'option' as |option|}}
+  {{#block-slot name='option' as |option|}}
     {{option.Name}}
   {{/block-slot}}
-  {{#block-slot 'set'}}
+  {{#block-slot name='set'}}
     {{#tabular-details
         data-test-policies
         onchange=(action 'loadItem')
         items=(sort-by 'CreateTime:desc' 'Name:asc' items) as |item index|
     }}
-      {{#block-slot 'header'}}
+      {{#block-slot name='header'}}
         <th>Name</th>
         <th>Datacenters</th>
       {{/block-slot}}
-      {{#block-slot 'row'}}
+      {{#block-slot name='row'}}
         <td class={{policy/typeof item}}>
 {{#if item.ID }}
           <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
@@ -56,7 +56,7 @@
           {{if (not item.isSaving) (join ', ' (policy/datacenters item)) 'Saving...'}}
         </td>
       {{/block-slot}}
-      {{#block-slot 'details'}}
+      {{#block-slot name='details'}}
           <label class="type-text">
             <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
             {{#if (eq item.template '')}}
@@ -69,10 +69,10 @@
           </label>
           <div>
             {{#confirmation-dialog message='Are you sure you want to remove this policy from this token?'}}
-              {{#block-slot 'action' as |confirm|}}
+              {{#block-slot name='action' as |confirm|}}
                 <button data-test-delete type="button" class="type-delete" {{action confirm 'remove' item items}}>Remove</button>
               {{/block-slot}}
-              {{#block-slot 'dialog' as |execute cancel message|}}
+              {{#block-slot name='dialog' as |execute cancel message|}}
                 <p>
                   {{message}}
                 </p>

--- a/ui-v2/app/templates/components/role-form.hbs
+++ b/ui-v2/app/templates/components/role-form.hbs
@@ -18,7 +18,7 @@
 {{!TODO: temporary policies id, look at the inception token modals and get rid of id="policies" and use something else}}
 <fieldset id="policies" class="policies">
   <h2>Policies</h2>
-  {{#yield-slot 'policy' (block-params item)}}
+  {{#yield-slot name='policy' params=(block-params item)}}
     {{yield}}
   {{else}}
     {{policy-selector dc=dc items=item.Policies}}

--- a/ui-v2/app/templates/components/role-selector.hbs
+++ b/ui-v2/app/templates/components/role-selector.hbs
@@ -1,19 +1,19 @@
 {{#modal-dialog data-test-role-form onclose=(action (mut state) 'role') name="new-role-toggle"}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
 {{#if (eq state 'role')}}
     <h2>New Role</h2>
 {{else}}
     <h2>New Policy</h2>
 {{/if}}
   {{/block-slot}}
-  {{#block-slot 'body'}}
+  {{#block-slot name='body'}}
 
   <input id="{{name}}_state_role" type="radio" name="{{name}}[state]" value="role" checked={{if (eq state 'role') 'checked'}} onchange={{action 'change'}} />
     {{#role-form form=form dc=dc}}
-      {{#block-slot 'policy'}}
+      {{#block-slot name='policy'}}
 
         {{#policy-selector source=source dc=dc items=item.Policies}}
-          {{#block-slot 'trigger'}}
+          {{#block-slot name='trigger'}}
             <label for="{{name}}_state_policy" data-test-create-policy class="type-dialog">
               <span>Create new policy</span>
             </label>
@@ -27,7 +27,7 @@
     {{policy-form data-test-policy-form name="role[policy]" form=policyForm dc=dc}}
 
   {{/block-slot}}
-  {{#block-slot 'actions' as |close|}}
+  {{#block-slot name='actions' as |close|}}
 
 {{#if (eq state 'role')}}
     <button type="submit" {{action 'save' item items (queue (action close) (action 'reset'))}} disabled={{if (or item.isSaving item.isPristine item.isInvalid) 'disabled'}}>
@@ -51,29 +51,29 @@
 {{/modal-dialog}}
 
 {{#child-selector repo=repo dc=dc nspace=nspace type="role" placeholder="Search for role" items=items}}
-  {{#block-slot 'label'}}
+  {{#block-slot name='label'}}
     Apply an existing role
   {{/block-slot}}
-  {{#block-slot 'create'}}
+  {{#block-slot name='create'}}
     <label class="type-dialog" for="new-role-toggle">
       <span>Create new role</span>
     </label>
 
   {{/block-slot}}
-  {{#block-slot 'option' as |option|}}
+  {{#block-slot name='option' as |option|}}
     {{option.Name}}
   {{/block-slot}}
-  {{#block-slot 'set'}}
+  {{#block-slot name='set'}}
     {{#tabular-collection
         data-test-roles
         rows=5
         items=(sort-by 'CreateTime:desc' 'Name:asc' items) as |item index|
     }}
-      {{#block-slot 'header'}}
+      {{#block-slot name='header'}}
         <th>Name</th>
         <th>Description</th>
       {{/block-slot}}
-      {{#block-slot 'row'}}
+      {{#block-slot name='row'}}
         <td>
           <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
         </td>
@@ -81,9 +81,9 @@
           {{item.Description}}
         </td>
       {{/block-slot}}
-      {{#block-slot 'actions' as |index change checked|}}
+      {{#block-slot name='actions' as |index change checked|}}
         {{#confirmation-dialog confirming=false index=index message="Are you sure you want to remove this Role?"}}
-          {{#block-slot 'action' as |confirm|}}
+          {{#block-slot name='action' as |confirm|}}
               {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                   <ul>
                       <li>
@@ -95,7 +95,7 @@
                   </ul>
               {{/action-group}}
           {{/block-slot}}
-          {{#block-slot 'dialog' as |execute cancel message name|}}
+          {{#block-slot name='dialog' as |execute cancel message name|}}
             {{delete-confirmation message=message execute=execute cancel=cancel}}
           {{/block-slot}}
         {{/confirmation-dialog}}

--- a/ui-v2/app/templates/components/stats-card.hbs
+++ b/ui-v2/app/templates/components/stats-card.hbs
@@ -1,9 +1,9 @@
 {{yield}}
 <div class="stats-card">
   <header>
-    {{#yield-slot 'mini-stat'}}{{yield}}{{/yield-slot}}
-    {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
-    {{#yield-slot 'icon'}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='mini-stat'}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
+    {{#yield-slot name='icon'}}{{yield}}{{/yield-slot}}
   </header>
-  {{#yield-slot 'body'}}{{yield}}{{/yield-slot}}
+  {{#yield-slot name='body'}}{{yield}}{{/yield-slot}}
 </div>

--- a/ui-v2/app/templates/components/tabular-collection.hbs
+++ b/ui-v2/app/templates/components/tabular-collection.hbs
@@ -1,10 +1,10 @@
 {{yield}}
 {{#if hasCaption}}
-  <caption>{{#yield-slot 'caption'}}{{yield}}{{/yield-slot}}</caption>
+  <caption>{{#yield-slot name='caption'}}{{yield}}{{/yield-slot}}</caption>
 {{/if}}
   <thead>
       <tr>
-          {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
+          {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
 {{#if hasActions }}
           <th class="actions">Actions<input type="radio" name="actions" id="actions_close" onchange={{action change}} value="" /></th>
 {{/if}}
@@ -14,10 +14,10 @@
       <tr></tr>
 {{~#each _cells as |cell index|~}}
       <tr data-test-tabular-row style={{{cell.style}}} onclick={{action 'click'}}>
-        {{#yield-slot 'row'}}{{yield cell.item index}}{{/yield-slot}}
+        {{#yield-slot name='row'}}{{yield cell.item index}}{{/yield-slot}}
 {{#if hasActions }}
           <td class="actions">
-              {{#yield-slot 'actions' (block-params (concat index) change checked)}}{{yield cell.item index}}{{/yield-slot}}
+              {{#yield-slot name='actions' params=(block-params (concat index) change checked)}}{{yield cell.item index}}{{/yield-slot}}
           </td>
 {{/if}}
       </tr>

--- a/ui-v2/app/templates/components/tabular-details.hbs
+++ b/ui-v2/app/templates/components/tabular-details.hbs
@@ -2,14 +2,14 @@
 <table class="with-details has-actions">
   <thead>
     <tr>
-      {{#yield-slot 'header'}}{{yield}}{{/yield-slot}}
+      {{#yield-slot name='header'}}{{yield}}{{/yield-slot}}
       <th class="actions">Actions</th>
     </tr>
   </thead>
   <tbody>
     {{#each items as |item index|}}
       <tr data-test-tabular-row onclick={{action 'click'}}>
-          {{#yield-slot 'row'}}{{yield item index}}{{/yield-slot}}
+          {{#yield-slot name='row'}}{{yield item index}}{{/yield-slot}}
           <td class="actions">
             <label for={{concat inputId index}}><span>Show details</span></label>
           </td>
@@ -20,7 +20,7 @@
           <div>
             <label for={{concat inputId index}}><span>Hide details</span></label>
             <div>
-              {{#yield-slot 'details'}}
+              {{#yield-slot name='details'}}
                 {{yield item index}}
               {{/yield-slot}}
             </div>

--- a/ui-v2/app/templates/components/token-list.hbs
+++ b/ui-v2/app/templates/components/token-list.hbs
@@ -7,14 +7,14 @@
       items=(sort-by 'AccessorID:asc' items) as |item index|
   }}
   {{#if caption}}
-    {{#block-slot 'caption'}}{{caption}}{{/block-slot}}
+    {{#block-slot name='caption'}}{{caption}}{{/block-slot}}
   {{/if}}
-      {{#block-slot 'header'}}
+      {{#block-slot name='header'}}
           <th>AccessorID</th>
           <th>Scope</th>
           <th>Description</th>
       {{/block-slot}}
-      {{#block-slot 'row'}}
+      {{#block-slot name='row'}}
           <td data-test-token="{{item.AccessorID}}">
             <a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}} target={{or target ''}}>{{truncate item.AccessorID 8 false}}</a>
           </td>

--- a/ui-v2/app/templates/dc/acls.hbs
+++ b/ui-v2/app/templates/dc/acls.hbs
@@ -1,1 +1,1 @@
-{{ outlet }}
+{{outlet}}

--- a/ui-v2/app/templates/dc/acls/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/-form.hbs
@@ -32,11 +32,11 @@
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (not-eq item.ID 'anonymous')) }}
         {{#confirmation-dialog message='Are you sure you want to delete this ACL token?'}}
-            {{#block-slot 'action' as |confirm|}}
+            {{#block-slot name='action' as |confirm|}}
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item parent}}>Delete</button>
             {{/block-slot}}
-            {{#block-slot 'dialog' as |execute cancel message|}}
-              {{delete-confirmation message=message execute=execute cancel=cancel}}
+            {{#block-slot name='dialog' as |execute cancel message|}}
+            {{delete-confirmation message=message execute=execute cancel=cancel}}
             {{/block-slot}}
         {{/confirmation-dialog}}
 {{/if}}

--- a/ui-v2/app/templates/dc/acls/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/edit.hbs
@@ -1,13 +1,13 @@
 {{#app-view class="acl edit" loading=isLoading}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.acls'}}>All Tokens</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
 {{#if item.Name }}
             {{item.Name}}
@@ -16,20 +16,20 @@
 {{/if}}
         </h1>
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
 {{#if (not create) }}
         {{#feedback-dialog type='inline'}}
-            {{#block-slot 'action' as |success error|}}
+            {{#block-slot name='action' as |success error|}}
                 {{#copy-button success=(action success) error=(action error) clipboardText=item.ID title='copy token ID to clipboard'}}
                     Copy token ID
                 {{/copy-button}}
             {{/block-slot}}
-            {{#block-slot 'success' as |transition|}}
+            {{#block-slot name='success' as |transition|}}
                 <p class={{transition}}>
                     Copied token ID!
                 </p>
             {{/block-slot}}
-            {{#block-slot 'error' as |transition|}}
+            {{#block-slot name='error' as |transition|}}
                 <p class={{transition}}>
                     Sorry, something went wrong!
                 </p>
@@ -37,10 +37,10 @@
         {{/feedback-dialog}}
         <button type="button" {{ action "clone" item }}>Clone token</button>
         {{#confirmation-dialog message='Are you sure you want to use this ACL token?'}}
-            {{#block-slot 'action' as |confirm|}}
+            {{#block-slot name='action' as |confirm|}}
                 <button data-test-use type="button" {{ action confirm 'use' item }}>Use token</button>
             {{/block-slot}}
-            {{#block-slot 'dialog' as |execute cancel message|}}
+            {{#block-slot name='dialog' as |execute cancel message|}}
                 <p>
                     {{message}}
                 </p>
@@ -50,7 +50,7 @@
         {{/confirmation-dialog}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{ partial 'dc/acls/form'}}
     {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/acls/index.hbs
+++ b/ui-v2/app/templates/dc/acls/index.hbs
@@ -1,32 +1,32 @@
 {{#app-view class="acl list" loading=isLoading}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
             ACL Tokens <em>{{format-number items.length}} total</em>
         </h1>
         <label for="toolbar-toggle"></label>
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
         <a data-test-create href="{{href-to 'dc.acls.create'}}" class="type-create">Create</a>
     {{/block-slot}}
-    {{#block-slot 'toolbar'}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
         {{acl-filter searchable=searchable filters=typeFilters search=filters.s type=filters.type onchange=(action 'filter')}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 items=(sort-by 'Name:asc' filtered) as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th>Name</th>
                     <th>Type</th>
                 {{/block-slot}}
-                {{#block-slot 'row'}}
+                {{#block-slot name='row'}}
                     <td data-test-acl="{{item.Name}}">
                         <a href={{href-to 'dc.acls.edit' item.ID}}>{{item.Name}}</a>
                     </td>
@@ -38,9 +38,9 @@
                         {{/if}}
                     </td>
                 {{/block-slot}}
-                {{#block-slot 'actions' as |index change checked|}}
+                {{#block-slot name='actions' as |index change checked|}}
                     {{#confirmation-dialog confirming=false index=index}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                                 <ul>
                                   <li>
@@ -67,7 +67,7 @@
                               </ul>
                             {{/action-group}}
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message name|}}
+                        {{#block-slot name='dialog' as |execute cancel message name|}}
                             <p>
                                 {{#if (eq name 'delete')}}
                                     Are you sure you want to delete this ACL token?
@@ -92,7 +92,7 @@
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no ACLs.
             </p>

--- a/ui-v2/app/templates/dc/acls/policies/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/-form.hbs
@@ -1,7 +1,7 @@
 <form>
   {{#policy-form form=form item=item}}
     {{!don't show template selection here, i.e. Service Identity}}
-    {{block-slot 'template'}}
+    {{block-slot name='template'}}
   {{/policy-form}}
 {{#if (not create) }}
   {{token-list caption="Applied to the following tokens:" items=items}}
@@ -16,16 +16,16 @@
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (not create) }}
         {{#confirmation-dialog message='Are you sure you want to delete this Policy?'}}
-            {{#block-slot 'action' as |confirm|}}
+            {{#block-slot name='action' as |confirm|}}
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             {{/block-slot}}
-            {{#block-slot 'dialog' as |execute cancel message|}}
+            {{#block-slot name='dialog' as |execute cancel message|}}
     {{#if (gt items.length 0)}}
               {{#modal-dialog data-test-delete-modal onclose=(action cancel)}}
-                  {{#block-slot 'header'}}
+                  {{#block-slot name='header'}}
                       <h2>Policy in Use</h2>
                   {{/block-slot}}
-                  {{#block-slot 'body'}}
+                  {{#block-slot name='body'}}
                     <p>
                       This Policy is currently in use. If you choose to delete this Policy, it will be removed from the following <strong>{{items.length}} Tokens</strong>:
                     </p>
@@ -34,7 +34,7 @@
                       This action cannot be undone. {{message}}
                     </p>
                   {{/block-slot}}
-                  {{#block-slot 'actions' as |close|}}
+                  {{#block-slot name='actions' as |close|}}
                     <button type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
                     <button type="button" class="type-cancel" {{action close}}>Cancel</button>
                   {{/block-slot}}

--- a/ui-v2/app/templates/dc/acls/policies/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/edit.hbs
@@ -1,19 +1,19 @@
 {{#app-view class=(concat 'policy ' (if (or isAuthorized isEnabled) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/policies/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'disabled'}}
+    {{#block-slot name='disabled'}}
       {{partial 'dc/acls/disabled'}}
     {{/block-slot}}
-    {{#block-slot 'authorization'}}
+    {{#block-slot name='authorization'}}
       {{partial 'dc/acls/authorization'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.acls.policies'}}>All Policies</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
 {{#if isAuthorized }}
   {{#if create }}
@@ -30,7 +30,7 @@
 {{/if}}
         </h1>
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
 {{#if (eq (policy/typeof item) 'policy-management')}}
       {{ partial 'dc/acls/policies/view'}}
 {{else}}

--- a/ui-v2/app/templates/dc/acls/policies/index.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/index.hbs
@@ -1,8 +1,8 @@
 {{#app-view class=(concat 'policy ' (if (not isAuthorized) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/policies/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <h1>
         Access Controls
       </h1>
@@ -10,32 +10,32 @@
         {{partial 'dc/acls/nav'}}
       {{/if}}
     {{/block-slot}}
-    {{#block-slot 'disabled'}}
+    {{#block-slot name='disabled'}}
       {{partial 'dc/acls/disabled'}}
     {{/block-slot}}
-    {{#block-slot 'authorization'}}
+    {{#block-slot name='authorization'}}
       {{partial 'dc/acls/authorization'}}
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
         <a data-test-create href="{{href-to 'dc.acls.policies.create'}}" class="type-create">Create</a>
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
 {{#if (gt items.length 0) }}
         <form class="filter-bar">
           {{freetext-filter searchable=searchable value=s placeholder="Search"}}
         </form>
 {{/if}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th>Name</th>
                     <th>Datacenters</th>
                     <th>Description</th>
                 {{/block-slot}}
-                {{#block-slot 'row' }}
+                {{#block-slot name='row'}}
                     <td data-test-policy="{{item.Name}}">
                       <a href={{href-to 'dc.acls.policies.edit' item.ID}} class={{if (eq (policy/typeof item) 'policy-management') 'is-management'}}>{{item.Name}}</a>
                     </td>
@@ -46,9 +46,9 @@
                       <p>{{item.Description}}</p>
                     </td>
                 {{/block-slot}}
-                {{#block-slot 'actions' as |index change checked|}}
+                {{#block-slot name='actions' as |index change checked|}}
                     {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Policy?"}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                                 <ul>
     {{#if (eq (policy/typeof item) 'policy-management')}}
@@ -67,14 +67,14 @@
                                 </ul>
                             {{/action-group}}
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message name|}}
+                        {{#block-slot name='dialog' as |execute cancel message name|}}
                           {{delete-confirmation message=message execute=execute cancel=cancel}}
                         {{/block-slot}}
                     {{/confirmation-dialog}}
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no Policies.
             </p>

--- a/ui-v2/app/templates/dc/acls/roles/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-form.hbs
@@ -17,16 +17,16 @@
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (not create) }}
         {{#confirmation-dialog message='Are you sure you want to delete this Role?'}}
-            {{#block-slot 'action' as |confirm|}}
+            {{#block-slot name='action' as |confirm|}}
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             {{/block-slot}}
-            {{#block-slot 'dialog' as |execute cancel message|}}
+            {{#block-slot name='dialog' as |execute cancel message|}}
     {{#if (gt items.length 0)}}
               {{#modal-dialog onclose=(action cancel)}}
-                  {{#block-slot 'header'}}
+                  {{#block-slot name='header'}}
                       <h2>Role in Use</h2>
                   {{/block-slot}}
-                  {{#block-slot 'body'}}
+                  {{#block-slot name='body'}}
                     <p>
                       This Role is currently in use. If you choose to delete this Role, it will be removed from the following <strong>{{items.length}} Tokens</strong>:
                     </p>
@@ -35,7 +35,7 @@
                       This action cannot be undone. {{message}}
                     </p>
                   {{/block-slot}}
-                  {{#block-slot 'actions' as |close|}}
+                  {{#block-slot name='actions' as |close|}}
                     <button type="button" class="type-delete" {{action execute}}>Yes, Delete</button>
                     <button type="button" class="type-cancel" {{action close}}>Cancel</button>
                   {{/block-slot}}

--- a/ui-v2/app/templates/dc/acls/roles/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/edit.hbs
@@ -1,19 +1,19 @@
 {{#app-view class=(concat 'role ' (if (or isAuthorized isEnabled) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/roles/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'disabled'}}
+    {{#block-slot name='disabled'}}
       {{partial 'dc/acls/disabled'}}
     {{/block-slot}}
-    {{#block-slot 'authorization'}}
+    {{#block-slot name='authorization'}}
       {{partial 'dc/acls/authorization'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.acls.roles'}}>All Roles</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
 {{#if isAuthorized }}
   {{#if create }}
@@ -26,7 +26,7 @@
 {{/if}}
         </h1>
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
       {{ partial 'dc/acls/roles/form'}}
     {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/acls/roles/index.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/index.hbs
@@ -1,8 +1,8 @@
 {{#app-view class=(concat 'role ' (if (not isAuthorized) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/roles/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <h1>
         Access Controls
       </h1>
@@ -10,32 +10,32 @@
         {{partial 'dc/acls/nav'}}
       {{/if}}
     {{/block-slot}}
-    {{#block-slot 'disabled'}}
+    {{#block-slot name='disabled'}}
       {{partial 'dc/acls/disabled'}}
     {{/block-slot}}
-    {{#block-slot 'authorization'}}
+    {{#block-slot name='authorization'}}
       {{partial 'dc/acls/authorization'}}
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
         <a data-test-create href="{{href-to 'dc.acls.roles.create'}}" class="type-create">Create</a>
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
 {{#if (gt items.length 0) }}
         <form class="filter-bar">
           {{freetext-filter searchable=searchable value=s placeholder="Search"}}
         </form>
 {{/if}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th>Name</th>
                     <th>Description</th>
                     <th>Policies</th>
                 {{/block-slot}}
-                {{#block-slot 'row' }}
+                {{#block-slot name='row'}}
                     <td data-test-role="{{item.Name}}">
                       <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
                     </td>
@@ -48,9 +48,9 @@
                       {{/each}}
                     </td>
                 {{/block-slot}}
-                {{#block-slot 'actions' as |index change checked|}}
+                {{#block-slot name='actions' as |index change checked|}}
                     {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Role?"}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                                 <ul>
                                     <li>
@@ -62,14 +62,14 @@
                                 </ul>
                             {{/action-group}}
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message name|}}
+                        {{#block-slot name='dialog' as |execute cancel message name|}}
                           {{delete-confirmation message=message execute=execute cancel=cancel}}
                         {{/block-slot}}
                     {{/confirmation-dialog}}
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no Roles.
             </p>

--- a/ui-v2/app/templates/dc/acls/tokens/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-form.hbs
@@ -15,10 +15,10 @@
         <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (not (token/is-anonymous item)) (not-eq item.AccessorID token.AccessorID) ) }}
         {{#confirmation-dialog message='Are you sure you want to delete this Token?'}}
-            {{#block-slot 'action' as |confirm|}}
+            {{#block-slot name='action' as |confirm|}}
                 <button type="button" data-test-delete class="type-delete" {{action confirm 'delete' item}}>Delete</button>
             {{/block-slot}}
-            {{#block-slot 'dialog' as |execute cancel message|}}
+            {{#block-slot name='dialog' as |execute cancel message|}}
               {{delete-confirmation message=message execute=execute cancel=cancel}}
             {{/block-slot}}
         {{/confirmation-dialog}}

--- a/ui-v2/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/edit.hbs
@@ -1,19 +1,19 @@
 {{#app-view class=(concat 'token ' (if (or isAuthorized isEnabled) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/acls/tokens/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'disabled'}}
+    {{#block-slot name='disabled'}}
       {{partial 'dc/acls/disabled'}}
     {{/block-slot}}
-    {{#block-slot 'authorization'}}
+    {{#block-slot name='authorization'}}
       {{partial 'dc/acls/authorization'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.acls.tokens'}}>All Tokens</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
 {{#if isAuthorized }}
   {{#if create }}
@@ -26,14 +26,14 @@
 {{/if}}
         </h1>
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
 {{#if (not create)}}
   {{#if (not-eq item.AccessorID token.AccessorID)}}
       {{#confirmation-dialog message='Are you sure you want to use this ACL token?'}}
-        {{#block-slot 'action' as |confirm|}}
+        {{#block-slot name='action' as |confirm|}}
             <button data-test-use type="button" {{ action confirm 'use' item }}>Use</button>
         {{/block-slot}}
-        {{#block-slot 'dialog' as |execute cancel message|}}
+        {{#block-slot name='dialog' as |execute cancel message|}}
           <p>
               {{message}}
           </p>
@@ -47,7 +47,7 @@
   {{/if}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#if (token/is-legacy item)}}
             <p class="notice info"><strong>Update.</strong> We have upgraded our ACL system by allowing you to create reusable policies which you can then apply to tokens. Don't worry, even though this token was written in the old style, it is still valid. However, we do recommend upgrading your old tokens to the new style. Learn how in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl-migrate-tokens.html" target="_blank" rel="noopener noreferrer">documentation</a>.</p>
         {{/if}}

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -1,8 +1,8 @@
 {{#app-view class=(concat 'token ' (if (and isEnabled (not isAuthorized)) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-  {{#block-slot 'notification' as |status type subject|}}
+  {{#block-slot name='notification' as |status type subject|}}
     {{partial 'dc/acls/tokens/notifications'}}
   {{/block-slot}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <h1>
       Access Controls
     </h1>
@@ -10,16 +10,16 @@
     {{partial 'dc/acls/nav'}}
 {{/if}}
   {{/block-slot}}
-  {{#block-slot 'disabled'}}
+  {{#block-slot name='disabled'}}
     {{partial 'dc/acls/disabled'}}
   {{/block-slot}}
-  {{#block-slot 'authorization'}}
+  {{#block-slot name='authorization'}}
     {{partial 'dc/acls/authorization'}}
   {{/block-slot}}
-  {{#block-slot 'actions'}}
+  {{#block-slot name='actions'}}
       <a data-test-create href="{{href-to 'dc.acls.tokens.create'}}" class="type-create">Create</a>
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
 {{#if (gt items.length 0) }}
     <form class="filter-bar">
       {{freetext-filter searchable=searchable value=s placeholder="Search"}}
@@ -29,18 +29,18 @@
     <p data-test-notification-update class="notice info"><strong>Update.</strong> We have upgraded our ACL System to allow the creation of reusable policies that can be applied to tokens. Read more about the changes and how to upgrade legacy tokens in our <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl-migrate-tokens.html" target="_blank" rel="noopener noreferrer">documentation</a>.</p>
 {{/if}}
     {{#changeable-set dispatcher=searchable}}
-      {{#block-slot 'set' as |filtered|}}
+      {{#block-slot name='set' as |filtered|}}
         {{#tabular-collection
             items=(sort-by 'CreateTime:desc' filtered) as |item index|
         }}
-          {{#block-slot 'header'}}
+          {{#block-slot name='header'}}
               <th>Accessor ID</th>
               <th>Scope</th>
               <th>Description</th>
               <th>Roles &amp; Policies</th>
               <th>&nbsp;</th>
           {{/block-slot}}
-          {{#block-slot 'row'}}
+          {{#block-slot name='row'}}
               <td data-test-token="{{item.AccessorID}}" class={{if (eq item.AccessorID token.AccessorID) 'me' }}>
                   <a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>{{truncate item.AccessorID 8 false}}</a>
               </td>
@@ -63,9 +63,9 @@
               <td>Your token</td>
 {{/if}}
           {{/block-slot}}
-          {{#block-slot 'actions' as |index change checked|}}
+          {{#block-slot name='actions' as |index change checked|}}
             {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Token?"}}
-              {{#block-slot 'action' as |confirm|}}
+              {{#block-slot name='action' as |confirm|}}
                 {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                   <ul>
 {{#if false}}
@@ -99,7 +99,7 @@
                   </ul>
                 {{/action-group}}
               {{/block-slot}}
-              {{#block-slot 'dialog' as |execute cancel message name|}}
+              {{#block-slot name='dialog' as |execute cancel message name|}}
                   <p>
                       {{#if (eq name 'delete')}}
                         {{message}}
@@ -127,7 +127,7 @@
           {{/block-slot}}
         {{/tabular-collection}}
       {{/block-slot}}
-      {{#block-slot 'empty'}}
+      {{#block-slot name='empty'}}
         <p>
           There are no Tokens.
         </p>

--- a/ui-v2/app/templates/dc/intentions/-form.hbs
+++ b/ui-v2/app/templates/dc/intentions/-form.hbs
@@ -114,10 +114,10 @@
     <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and item.ID (not-eq item.ID 'anonymous')) }}
     {{#confirmation-dialog message='Are you sure you want to delete this Intention?'}}
-      {{#block-slot 'action' as |confirm|}}
+      {{#block-slot name='action' as |confirm|}}
         <button data-test-delete type="button" class="type-delete" {{action confirm 'delete' item parent}}>Delete</button>
       {{/block-slot}}
-      {{#block-slot 'dialog' as |execute cancel message|}}
+      {{#block-slot name='dialog' as |execute cancel message|}}
         {{delete-confirmation message=message execute=execute cancel=cancel}}
       {{/block-slot}}
     {{/confirmation-dialog}}

--- a/ui-v2/app/templates/dc/intentions/edit.hbs
+++ b/ui-v2/app/templates/dc/intentions/edit.hbs
@@ -1,13 +1,13 @@
 {{#app-view class="intention edit" loading=isLoading}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/intentions/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.intentions'}}>All Intentions</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
 {{#if item.ID }}
             Edit Intention
@@ -16,20 +16,20 @@
 {{/if}}
         </h1>
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
 {{#if (not create) }}
         {{#feedback-dialog type='inline'}}
-            {{#block-slot 'action' as |success error|}}
+            {{#block-slot name='action' as |success error|}}
                 {{#copy-button success=(action success) error=(action error) clipboardText=item.ID title='copy UUID to clipboard'}}
                     Copy UUID
                 {{/copy-button}}
             {{/block-slot}}
-            {{#block-slot 'success' as |transition|}}
+            {{#block-slot name='success' as |transition|}}
                 <p class={{transition}}>
                     Copied UUID!
                 </p>
             {{/block-slot}}
-            {{#block-slot 'error' as |transition|}}
+            {{#block-slot name='error' as |transition|}}
                 <p class={{transition}}>
                     Sorry, something went wrong!
                 </p>
@@ -37,7 +37,7 @@
         {{/feedback-dialog}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{ partial 'dc/intentions/form'}}
     {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/intentions/index.hbs
+++ b/ui-v2/app/templates/dc/intentions/index.hbs
@@ -1,36 +1,36 @@
 {{#app-view class="intention list"}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/intentions/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
             Intentions <em>{{format-number items.length}} total</em>
         </h1>
         <label for="toolbar-toggle"></label>
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
         <a data-test-create href="{{href-to 'dc.intentions.create'}}" class="type-create">Create</a>
     {{/block-slot}}
-    {{#block-slot 'toolbar'}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
         {{intention-filter searchable=searchable filters=actionFilters search=filters.s type=filters.action onchange=(action 'filter')}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 route='dc.intentions.edit'
                 key='SourceName'
                 items=filtered as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th>Source</th>
                     <th>&nbsp;</th>
                     <th>Destination</th>
                     <th>Precedence</th>
                 {{/block-slot}}
-                {{#block-slot 'row'}}
+                {{#block-slot name='row'}}
                     <td class="source" data-test-intention="{{item.ID}}">
                       <a href={{href-to 'dc.intentions.edit' item.ID}} data-test-intention-source="{{item.SourceName}}">
                         {{#if (eq item.SourceName '*') }}
@@ -60,9 +60,9 @@
                         {{item.Precedence}}
                     </td>
                 {{/block-slot}}
-                {{#block-slot 'actions' as |index change checked|}}
+                {{#block-slot name='actions' as |index change checked|}}
                     {{#confirmation-dialog confirming=false index=index message='Are you sure you want to delete this intention?'}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                                 <ul>
                                     <li>
@@ -74,14 +74,14 @@
                                 </ul>
                             {{/action-group}}
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message|}}
+                        {{#block-slot name='dialog' as |execute cancel message|}}
                           {{delete-confirmation message=message execute=execute cancel=cancel}}
                         {{/block-slot}}
                     {{/confirmation-dialog}}
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no intentions.
             </p>

--- a/ui-v2/app/templates/dc/kv/-form.hbs
+++ b/ui-v2/app/templates/dc/kv/-form.hbs
@@ -34,10 +34,10 @@
     <button type="submit" {{ action "update" item parent}} disabled={{if item.isInvalid 'disabled'}}>Save</button>
     <button type="reset" {{ action "cancel" item parent}}>Cancel changes</button>
     {{#confirmation-dialog message='Are you sure you want to delete this key?'}}
-        {{#block-slot 'action' as |confirm|}}
+        {{#block-slot name='action' as |confirm|}}
             <button data-test-delete type="button" class="type-delete" {{action confirm 'delete' item parent}}>Delete</button>
         {{/block-slot}}
-        {{#block-slot 'dialog' as |execute cancel message|}}
+        {{#block-slot name='dialog' as |execute cancel message|}}
           {{delete-confirmation message=message execute=execute cancel=cancel}}
         {{/block-slot}}
     {{/confirmation-dialog}}

--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -1,8 +1,8 @@
 {{#app-view class="kv edit" loading=isLoading}}
-  {{#block-slot 'notification' as |status type|}}
+  {{#block-slot name='notification' as |status type|}}
     {{partial 'dc/kv/notifications'}}
   {{/block-slot}}
-  {{#block-slot 'breadcrumbs'}}
+  {{#block-slot name='breadcrumbs'}}
     <ol>
         <li><a data-test-back href={{href-to 'dc.kv.index'}}>Key / Values</a></li>
 {{#if (not-eq parent.Key '/')}}
@@ -12,7 +12,7 @@
 {{/if}}
     </ol>
   {{/block-slot}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
       <h1>
 {{#if item.Key}}
         {{left-trim item.Key parent.Key}}
@@ -21,7 +21,7 @@
 {{/if}}
       </h1>
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
     {{#if session}}
       <p class="notice warning">
         <strong>Warning.</strong> This KV has a lock session. You can edit KV's with lock sessions, but we recommend doing so with care, or not doing so at all. It may negatively impact the active node it's associated with. See below for more details on the Lock Session and see <a href="{{env 'CONSUL_DOCS_URL'}}/internals/sessions.html" target="_blank" rel="noopener noreferrer">our documentation</a> for more information.
@@ -60,10 +60,10 @@
 {{/if}}
         </dl>
         {{#confirmation-dialog message='Are you sure you want to invalidate this session?'}}
-          {{#block-slot 'action' as |confirm|}}
+          {{#block-slot name='action' as |confirm|}}
             <button type="button" data-test-delete class="type-delete" {{action confirm "invalidateSession" session}}>Invalidate Session</button>
           {{/block-slot}}
-          {{#block-slot 'dialog' as |execute cancel message|}}
+          {{#block-slot name='dialog' as |execute cancel message|}}
             <p>
               {{message}}
             </p>

--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -1,8 +1,8 @@
 {{#app-view class="kv list" loading=isLoading}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/kv/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
 {{#if (not-eq parent.Key '/') }}
             <li><a href={{href-to 'dc.kv'}}>Key / Values</a></li>
@@ -12,7 +12,7 @@
 {{/each}}
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
             {{#if (eq parent.Key '/') }}
                 Key / Value
@@ -22,37 +22,37 @@
         </h1>
         <label for="toolbar-toggle"></label>
     {{/block-slot}}
-    {{#block-slot 'toolbar'}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
       <form class="filter-bar">
         {{freetext-filter searchable=searchable value=s placeholder="Search by name"}}
       </form>
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
 {{#if (not-eq parent.Key '/') }}
         <a data-test-create href="{{href-to 'dc.kv.create' parent.Key}}" class="type-create">Create</a>
 {{else}}
         <a data-test-create href="{{href-to 'dc.kv.root-create'}}" class="type-create">Create</a>
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 items=(sort-by 'isFolder:desc' 'Key:asc' filtered) as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th>Name</th>
                 {{/block-slot}}
-                {{#block-slot 'row'}}
+                {{#block-slot name='row'}}
                     <td data-test-kv="{{item.Key}}" class={{if item.isFolder 'folder' 'file' }}>
                         <a href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{right-trim (left-trim item.Key parent.Key) '/'}}</a>
                     </td>
                 {{/block-slot}}
-                {{#block-slot 'actions' as |index change checked|}}
+                {{#block-slot name='actions' as |index change checked|}}
                     {{#confirmation-dialog confirming=false index=index message='Are you sure you want to delete this key?'}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                                 <ul>
                                     <li>
@@ -64,14 +64,14 @@
                                 </ul>
                             {{/action-group}}
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message|}}
+                        {{#block-slot name='dialog' as |execute cancel message|}}
                           {{delete-confirmation message=message execute=execute cancel=cancel}}
                         {{/block-slot}}
                     {{/confirmation-dialog}}
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no Key / Value pairs.
             </p>

--- a/ui-v2/app/templates/dc/nodes/-services.hbs
+++ b/ui-v2/app/templates/dc/nodes/-services.hbs
@@ -5,17 +5,17 @@
   </form>
 {{/if}}
   {{#changeable-set dispatcher=searchable}}
-    {{#block-slot 'set' as |filtered|}}
+    {{#block-slot name='set' as |filtered|}}
       {{#tabular-collection
           data-test-services
           items=filtered as |item index|
       }}
-          {{#block-slot 'header'}}
+          {{#block-slot name='header'}}
               <th>Service</th>
               <th>Port</th>
               <th>Tags</th>
           {{/block-slot}}
-          {{#block-slot 'row'}}
+          {{#block-slot name='row'}}
               <td data-test-service-name="{{item.Service}}">
                 <a href={{href-to 'dc.services.show' item.Service}}>
                   <span data-test-external-source="{{service/external-source item}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
@@ -31,7 +31,7 @@
           {{/block-slot}}
       {{/tabular-collection}}
     {{/block-slot}}
-    {{#block-slot 'empty'}}
+    {{#block-slot name='empty'}}
       <p>
         There are no services.
       </p>

--- a/ui-v2/app/templates/dc/nodes/-sessions.hbs
+++ b/ui-v2/app/templates/dc/nodes/-sessions.hbs
@@ -4,7 +4,7 @@
         class="sessions"
         items=sessions as |item index|
     }}
-        {{#block-slot 'header'}}
+        {{#block-slot name='header'}}
             <th>Name</th>
             <th>ID</th>
             <th>Delay</th>
@@ -13,7 +13,7 @@
             <th>Checks</th>
             <th>&nbsp;</th>
         {{/block-slot}}
-        {{#block-slot 'row'}}
+        {{#block-slot name='row'}}
                 <td>
                     {{item.Name}}
                 </td>
@@ -36,10 +36,10 @@
                 </td>
                 <td>
                     {{#confirmation-dialog message='Are you sure you want to invalidate this session?'}}
-                        {{#block-slot 'action' as |confirm|}}
+                        {{#block-slot name='action' as |confirm|}}
                             <button data-test-delete type="button" class="type-delete" {{action confirm 'invalidateSession' item}}>Invalidate</button>
                         {{/block-slot}}
-                        {{#block-slot 'dialog' as |execute cancel message|}}
+                        {{#block-slot name='dialog' as |execute cancel message|}}
                             <p>
                                 {{message}}
                             </p>

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,16 +1,16 @@
 {{#app-view class="node list"}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <h1>
       Nodes <em>{{format-number items.length}} total</em>
     </h1>
     <label for="toolbar-toggle"></label>
   {{/block-slot}}
-  {{#block-slot 'toolbar'}}
+  {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
     {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
 {{/if}}
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
 {{#if (gt unhealthy.length 0) }}
       <div class="unhealthy">
         <h2>Unhealthy Nodes</h2>
@@ -18,7 +18,7 @@
           {{! think about 2 differing views here }}
           <ul>
             {{#changeable-set dispatcher=searchableUnhealthy}}
-              {{#block-slot 'set' as |unhealthy|}}
+              {{#block-slot name='set' as |unhealthy|}}
                 {{#each unhealthy as |item|}}
                   {{#healthchecked-resource
                       tagName='li'
@@ -28,7 +28,7 @@
                       address=item.Address
                       checks=item.Checks
                   }}
-                    {{#block-slot 'icon'}}
+                    {{#block-slot name='icon'}}
                       {{#if (eq item.Address leader.Address)}}
                         <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
                       {{/if}}
@@ -36,7 +36,7 @@
                   {{/healthchecked-resource}}
                 {{/each}}
               {{/block-slot}}
-              {{#block-slot 'empty'}}
+              {{#block-slot name='empty'}}
                 <p>
                   There are no unhealthy nodes for that search.
                 </p>
@@ -50,7 +50,7 @@
       <div class="healthy">
         <h2>Healthy Nodes</h2>
         {{#changeable-set dispatcher=searchableHealthy}}
-          {{#block-slot 'set' as |healthy|}}
+          {{#block-slot name='set' as |healthy|}}
             {{#list-collection cellHeight=92 items=healthy as |item index|}}
               {{#healthchecked-resource
                   data-test-node=item.Node
@@ -59,7 +59,7 @@
                   address=item.Address
                   checks=item.Checks
               }}
-                {{#block-slot 'icon'}}
+                {{#block-slot name='icon'}}
                   {{#if (eq item.Address leader.Address)}}
                     <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
                   {{/if}}
@@ -67,7 +67,7 @@
               {{/healthchecked-resource}}
             {{/list-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no healthy nodes for that search.
             </p>

--- a/ui-v2/app/templates/dc/nodes/metadata.hbs
+++ b/ui-v2/app/templates/dc/nodes/metadata.hbs
@@ -4,11 +4,11 @@
         data-test-metadata
         items=meta as |item index|
     }}
-        {{#block-slot 'header'}}
+        {{#block-slot name='header'}}
             <th>Key</th>
             <th>Value</th>
         {{/block-slot}}
-        {{#block-slot 'row'}}
+        {{#block-slot name='row'}}
             <td>
               <span>
                 {{object-at 0 item}}

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -1,14 +1,14 @@
 {{#app-view class="node show"}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{!TODO: Move sessions to its own folder within nodes }}
       {{partial 'dc/nodes/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.nodes'}}>All Nodes</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
           {{ item.Node }}
         </h1>
@@ -26,26 +26,26 @@
             selected=selectedTab
         }}
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
       {{#feedback-dialog type='inline'}}
-          {{#block-slot 'action' as |success error|}}
+          {{#block-slot name='action' as |success error|}}
               {{#copy-button success=(action success) error=(action error) clipboardText=item.Address title='copy IP address to clipboard'}}
                   {{item.Address}}
               {{/copy-button}}
           {{/block-slot}}
-          {{#block-slot 'success' as |transition|}}
+          {{#block-slot name='success' as |transition|}}
               <p class={{transition}}>
                   Copied IP Address!
               </p>
           {{/block-slot}}
-          {{#block-slot 'error' as |transition|}}
+          {{#block-slot name='error' as |transition|}}
               <p class={{transition}}>
                   Sorry, something went wrong!
               </p>
           {{/block-slot}}
       {{/feedback-dialog}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#each
             (compact
                 (array

--- a/ui-v2/app/templates/dc/nspaces/-form.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-form.hbs
@@ -42,10 +42,10 @@
       <button type="reset" {{ action "cancel" item}}>Cancel</button>
 {{# if (and (not create) (not-eq item.Name 'default')) }}
       {{#confirmation-dialog message='Are you sure you want to delete this Namespace?'}}
-          {{#block-slot 'action' as |confirm|}}
+          {{#block-slot name='action' as |confirm|}}
               <button data-test-delete type="button" class="type-delete" {{action confirm 'delete' item parent}}>Delete</button>
           {{/block-slot}}
-          {{#block-slot 'dialog' as |execute cancel message|}}
+          {{#block-slot name='dialog' as |execute cancel message|}}
             {{delete-confirmation message=message execute=execute cancel=cancel}}
           {{/block-slot}}
       {{/confirmation-dialog}}

--- a/ui-v2/app/templates/dc/nspaces/edit.hbs
+++ b/ui-v2/app/templates/dc/nspaces/edit.hbs
@@ -1,13 +1,13 @@
 {{#app-view class="nspace edit" loading=isLoading}}
-  {{#block-slot 'notification' as |status type|}}
+  {{#block-slot name='notification' as |status type|}}
     {{partial 'dc/nspaces/notifications'}}
   {{/block-slot}}
-  {{#block-slot 'breadcrumbs'}}
+  {{#block-slot name='breadcrumbs'}}
     <ol>
         <li><a data-test-back href={{href-to 'dc.nspaces'}}>All Namespaces</a></li>
     </ol>
   {{/block-slot}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <h1>
 {{#if create }}
       New Namespace
@@ -16,9 +16,9 @@
 {{/if}}
     </h1>
   {{/block-slot}}
-  {{#block-slot 'actions'}}
+  {{#block-slot name='actions'}}
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
     {{ partial 'dc/nspaces/form'}}
   {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/nspaces/index.hbs
+++ b/ui-v2/app/templates/dc/nspaces/index.hbs
@@ -1,34 +1,34 @@
 {{#app-view class="nspace list" loading=isLoading}}
-  {{#block-slot 'notification' as |status type subject|}}
+  {{#block-slot name='notification' as |status type subject|}}
     {{partial 'dc/nspaces/notifications'}}
   {{/block-slot}}
-  {{#block-slot 'header'}}
+  {{#block-slot name='header'}}
     <h1>
       Namespaces
     </h1>
   {{/block-slot}}
-  {{#block-slot 'actions'}}
+  {{#block-slot name='actions'}}
       <a data-test-create href="{{href-to 'dc.nspaces.create'}}" class="type-create">Create</a>
   {{/block-slot}}
-  {{#block-slot 'content'}}
+  {{#block-slot name='content'}}
 {{#if (gt items.length 0) }}
     <form class="filter-bar">
       {{freetext-filter searchable=searchable value=s placeholder="Search"}}
     </form>
 {{/if}}
     {{#changeable-set dispatcher=searchable}}
-      {{#block-slot 'set' as |filtered|}}
+      {{#block-slot name='set' as |filtered|}}
         {{#tabular-collection
             items=filtered as |item index|
         }}
-          {{#block-slot 'header'}}
+          {{#block-slot name='header'}}
               <th>Name</th>
               <th>Description</th>
 {{#if (env 'CONSUL_ACLS_ENABLED')}}
               <th>Roles &amp; Policies</th>
 {{/if}}
           {{/block-slot}}
-          {{#block-slot 'row'}}
+          {{#block-slot name='row'}}
 {{#if item.DeletedAt}}
               <td class="no-actions" colspan="3">
                 <p>
@@ -51,9 +51,9 @@
   {{/if}}
 {{/if}}
           {{/block-slot}}
-          {{#block-slot 'actions' as |index change checked|}}
+          {{#block-slot name='actions' as |index change checked|}}
             {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Namespace?"}}
-              {{#block-slot 'action' as |confirm|}}
+              {{#block-slot name='action' as |confirm|}}
                 {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
                   <ul>
                     <li>
@@ -67,7 +67,7 @@
                   </ul>
                 {{/action-group}}
               {{/block-slot}}
-              {{#block-slot 'dialog' as |execute cancel message name|}}
+              {{#block-slot name='dialog' as |execute cancel message name|}}
                   <p>
                     {{message}}
                   </p>
@@ -80,7 +80,7 @@
           {{/block-slot}}
         {{/tabular-collection}}
       {{/block-slot}}
-      {{#block-slot 'empty'}}
+      {{#block-slot name='empty'}}
         <p>
           There are no Namespaces.
         </p>

--- a/ui-v2/app/templates/dc/services/-addresses.hbs
+++ b/ui-v2/app/templates/dc/services/-addresses.hbs
@@ -3,11 +3,11 @@
     data-test-addresses
     items=(object-entries item.TaggedAddresses) as |taggedAddress index|
 }}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <th>Tag</th>
       <th>Address</th>
     {{/block-slot}}
-    {{#block-slot 'row'}}
+    {{#block-slot name='row'}}
 {{#with (object-at 1 taggedAddress) as |address|}}
       <td>
         {{object-at 0 taggedAddress}}{{#if (and (eq address.Address item.Address) (eq address.Port item.Port))}}&nbsp;<em data-test-address-default>(default)</em>{{/if}}

--- a/ui-v2/app/templates/dc/services/-exposedpaths.hbs
+++ b/ui-v2/app/templates/dc/services/-exposedpaths.hbs
@@ -6,14 +6,14 @@
     class="exposedpaths"
     items=item.Proxy.Expose.Paths as |path index|
 }}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <th>Path</th>
       <th>Protocol</th>
       <th>Listener port</th>
       <th>Local path port</th>
       <th>Combined address<span><em role="tooltip">Service address, listener port, and path all combined into one URL.</em></span></th>
     {{/block-slot}}
-    {{#block-slot 'row'}}
+    {{#block-slot name='row'}}
       <td>
         <span>{{path.Path}}</span>
       </td>

--- a/ui-v2/app/templates/dc/services/-instances.hbs
+++ b/ui-v2/app/templates/dc/services/-instances.hbs
@@ -5,19 +5,19 @@
   </form>
 {{/if}}
   {{#changeable-set dispatcher=searchable}}
-    {{#block-slot 'set' as |filtered|}}
+    {{#block-slot name='set' as |filtered|}}
       {{#tabular-collection
           data-test-instances
           items=filtered as |item index|
       }}
-          {{#block-slot 'header'}}
+          {{#block-slot name='header'}}
             <th>ID</th>
             <th>Node</th>
             <th>Address</th>
             <th>Node Checks</th>
             <th>Service Checks</th>
           {{/block-slot}}
-          {{#block-slot 'row'}}
+          {{#block-slot name='row'}}
             <td data-test-id="{{item.Service.ID}}">
               <a href={{href-to 'dc.services.instance' item.Service.Service item.Node.Node (or item.Service.ID item.Service.Service )}}>
                 <span data-test-external-source="{{service/external-source item.Service}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item.Service) '-color-svg') 'none')}}}></span>
@@ -47,7 +47,7 @@
           {{/block-slot}}
       {{/tabular-collection}}
     {{/block-slot}}
-    {{#block-slot 'empty'}}
+    {{#block-slot name='empty'}}
       <p>
         There are no services.
       </p>

--- a/ui-v2/app/templates/dc/services/-upstreams.hbs
+++ b/ui-v2/app/templates/dc/services/-upstreams.hbs
@@ -3,13 +3,13 @@
     data-test-upstreams
     items=item.Proxy.Upstreams as |item index|
 }}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <th>Upstream</th>
       <th>Datacenter</th>
       <th>Type</th>
       <th>Local Bind Address</th>
     {{/block-slot}}
-    {{#block-slot 'row'}}
+    {{#block-slot name='row'}}
       <td>
         <a data-test-destination-name>
           {{item.DestinationName}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -1,14 +1,14 @@
 {{#app-view class="service list"}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/services/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
         <h1>
             Services <em>{{format-number items.length}} total</em>
         </h1>
         <label for="toolbar-toggle"></label>
     {{/block-slot}}
-    {{#block-slot 'toolbar'}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
       {{phrase-editor
         placeholder='service:name tag:name status:critical search-term'
@@ -18,20 +18,20 @@
       }}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#changeable-set dispatcher=searchable}}
-          {{#block-slot 'set' as |filtered|}}
+          {{#block-slot name='set' as |filtered|}}
             {{#tabular-collection
                 route='dc.services.show'
                 key='Name'
                 items=filtered as |item index|
             }}
-                {{#block-slot 'header'}}
+                {{#block-slot name='header'}}
                     <th style={{remainingWidth}}>Service</th>
                     <th style={{totalWidth}}>Health Checks<span><em role="tooltip">The number of health checks for the service on all nodes</em></span></th>
                     <th style={{remainingWidth}}>Tags</th>
                 {{/block-slot}}
-                {{#block-slot 'row'}}
+                {{#block-slot name='row'}}
                     <td data-test-service="{{item.Name}}" style={{remainingWidth}}>
                       <a href={{href-to 'dc.services.show' item.Name}}>
                         <span data-test-external-source="{{service/external-source item}}" style={{{ concat 'background-image: ' (css-var (concat '--' (service/external-source item) '-color-svg') 'none')}}}></span>
@@ -50,7 +50,7 @@
                 {{/block-slot}}
             {{/tabular-collection}}
           {{/block-slot}}
-          {{#block-slot 'empty'}}
+          {{#block-slot name='empty'}}
             <p>
               There are no services.
             </p>

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -1,15 +1,15 @@
 {{#app-view class="instance show"}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/services/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
             <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service}})</a></li>
             <li><strong>Instance</strong></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <h1>
         {{ item.ID }}
 {{#with (service/external-source item) as |externalSource| }}
@@ -62,7 +62,7 @@
   {{/if}}
 {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{tab-nav
             items=(compact
               (array

--- a/ui-v2/app/templates/dc/services/metadata.hbs
+++ b/ui-v2/app/templates/dc/services/metadata.hbs
@@ -4,11 +4,11 @@
         data-test-metadata
         items=meta as |item index|
     }}
-        {{#block-slot 'header'}}
+        {{#block-slot name='header'}}
             <th>Key</th>
             <th>Value</th>
         {{/block-slot}}
-        {{#block-slot 'row'}}
+        {{#block-slot name='row'}}
             <td>
               <span>
                 {{object-at 0 item}}

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -1,13 +1,13 @@
 {{#app-view class="service show"}}
-    {{#block-slot 'notification' as |status type|}}
+    {{#block-slot name='notification' as |status type|}}
       {{partial 'dc/services/notifications'}}
     {{/block-slot}}
-    {{#block-slot 'breadcrumbs'}}
+    {{#block-slot name='breadcrumbs'}}
         <ol>
             <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
         </ol>
     {{/block-slot}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <h1>
         {{ item.Service.Service }}
 {{#with (service/external-source item.Service) as |externalSource| }}
@@ -35,12 +35,12 @@
           selected=selectedTab
       }}
     {{/block-slot}}
-    {{#block-slot 'actions'}}
+    {{#block-slot name='actions'}}
       {{#if urls.service}}
         {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
       {{/if}}
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
         {{#each
             (compact
                 (array

--- a/ui-v2/app/templates/error.hbs
+++ b/ui-v2/app/templates/error.hbs
@@ -1,6 +1,6 @@
 {{#hashicorp-consul id="wrapper" permissions=permissions dcs=dcs dc=dc nspaces=nspaces nspace=nspace}}
     {{#app-view class="error show"}}
-        {{#block-slot 'header'}}
+        {{#block-slot name='header'}}
             <h1 data-test-error>
 {{#if error.status }}
                 {{error.status}} ({{error.message}})
@@ -9,7 +9,7 @@
 {{/if}}
             </h1>
         {{/block-slot}}
-        {{#block-slot 'content'}}
+        {{#block-slot name='content'}}
             <p>
                 Consul returned an error.
                 You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.<br />

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -1,11 +1,11 @@
 {{#hashicorp-consul id="wrapper" permissions=permissions dcs=dcs dc=dc nspaces=nspaces nspace=nspace}}
   {{#app-view class="settings show"}}
-    {{#block-slot 'header'}}
+    {{#block-slot name='header'}}
       <h1>
           Settings
       </h1>
     {{/block-slot}}
-    {{#block-slot 'content'}}
+    {{#block-slot name='content'}}
       <div class="notice info">
         <h3>Local Storage</h3>
         <p>

--- a/ui-v2/lib/block-slots/addon/components/block-slot.js
+++ b/ui-v2/lib/block-slots/addon/components/block-slot.js
@@ -8,8 +8,8 @@ import YieldSlot from './yield-slot';
 const BlockSlot = Component.extend({
   layout,
   tagName: '',
-  _name: computed('__name', 'name', function() {
-    return this.name || this.__name;
+  _name: computed('name', function() {
+    return this.name;
   }),
   didInsertElement: function() {
     const slottedComponent = this.nearestOfType(Slots);
@@ -50,10 +50,6 @@ const BlockSlot = Component.extend({
       this.slottedComponent._deactivateSlot(this._name);
     }
   },
-});
-
-BlockSlot.reopenClass({
-  positionalParams: ['__name'],
 });
 
 export default BlockSlot;

--- a/ui-v2/lib/block-slots/addon/components/yield-slot.js
+++ b/ui-v2/lib/block-slots/addon/components/yield-slot.js
@@ -5,11 +5,11 @@ import Slots from '../mixins/slots';
 const YieldSlotComponent = Component.extend({
   layout,
   tagName: '',
-  _name: computed('__name', 'name', function() {
-    return this.name || this.__name;
+  _name: computed('name', function() {
+    return this.name;
   }),
-  _blockParams: computed('__blockParams', 'params', function() {
-    return this.params || this.__blockParams;
+  _blockParams: computed('params', function() {
+    return this.params;
   }),
   _parentView: computed(function() {
     return this.nearestOfType(Slots);
@@ -17,10 +17,6 @@ const YieldSlotComponent = Component.extend({
   isActive: computed('_parentView._slots.[]', '_name', function() {
     return get(this, '_parentView._slots').includes(get(this, '_name'));
   }),
-});
-
-YieldSlotComponent.reopenClass({
-  positionalParams: ['__name', '__blockParams'],
 });
 
 export default YieldSlotComponent;

--- a/ui-v2/tests/integration/components/feedback-dialog-test.js
+++ b/ui-v2/tests/integration/components/feedback-dialog-test.js
@@ -18,9 +18,9 @@ module('Integration | Component | feedback dialog', function(hooks) {
     // Template block usage:
     await render(hbs`
       {{#feedback-dialog}}
-        {{#block-slot 'success'}}
+        {{#block-slot name='success'}}
         {{/block-slot}}
-        {{#block-slot 'error'}}
+        {{#block-slot name='error'}}
         {{/block-slot}}
       {{/feedback-dialog}}
     `);

--- a/ui-v2/tests/integration/components/stats-card-test.js
+++ b/ui-v2/tests/integration/components/stats-card-test.js
@@ -13,10 +13,10 @@ module('Integration | Component | stats card', function(hooks) {
     // Template block usage:
     await render(hbs`
       {{#stats-card}}
-        {{#block-slot 'icon'}}icon{{/block-slot}}
-        {{#block-slot 'mini-stat'}}mini-stat{{/block-slot}}
-        {{#block-slot 'header'}}header{{/block-slot}}
-        {{#block-slot 'body'}}body{{/block-slot}}
+        {{#block-slot name='icon'}}icon{{/block-slot}}
+        {{#block-slot name='mini-stat'}}mini-stat{{/block-slot}}
+        {{#block-slot name='header'}}header{{/block-slot}}
+        {{#block-slot name='body'}}body{{/block-slot}}
       {{/stats-card}}
     `);
     ['icon', 'mini-stat', 'header'].forEach(item => {


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/6740 we added the ability for slots to be named via attributes instead of using positional parameters (similarly for block-params). This means we will be able to use XML/Angle bracket style syntax when using these components. In the above PR we only added the ability but didn't go through and change everything.

This PR goes through and changes everything.

We also removed the ability to use positional params at all here (I split that into a second commit)

This should free us up to use the angle bracket codemod so that our resulting templates all consistently use angle brackets over curly brackets.

P.S.

We ran the `ember-angle-brackets-codemod` on this and it seems to be more or less fine, but we are going to wait until we have less outstanding PRs to run and PR it - as this codemod touches every single template file its likely to cause conflicts if we don't.
