### PR TITLE
Update force-leave ACL requirement to operator:write

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -475,7 +475,7 @@ func (s *HTTPServer) AgentForceLeave(resp http.ResponseWriter, req *http.Request
 	if err != nil {
 		return nil, err
 	}
-	if rule != nil && rule.AgentWrite(s.agent.config.NodeName, nil) != acl.Allow {
+	if rule != nil && rule.OperatorWrite(nil) != acl.Allow {
 		return nil, acl.ErrPermissionDenied
 	}
 

--- a/website/source/api/agent.html.md
+++ b/website/source/api/agent.html.md
@@ -506,7 +506,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required  |
 | ---------------- | ----------------- | ------------- | ------------- |
-| `NO`             | `none`            | `none`        | `agent:write` |
+| `NO`             | `none`            | `none`        | `operator:write` |
 
 ### Parameters
 


### PR DESCRIPTION
Currently the ACL requirement for `AgentForceLeave`, is `agent:write`. This requirement doesn't really fit the endpoint given that the node that is being force left is a different node in the cluster. Whereas agent privileges are for actions an agent can take regarding its own status. 

Rather than making things significantly more complex for users by making the rule `node:write`, this PR opts for using `operator:write`, since this endpoint can remove an arbitrary number of failed nodes from the cluster.

This is a breaking change and needs to go in 1.7.0, rather than a minor release.