### PR TITLE
ui: Use {{data-source}} for the node listing page

### DIFF
--- a/ui-v2/app/controllers/dc/nodes/index.js
+++ b/ui-v2/app/controllers/dc/nodes/index.js
@@ -1,10 +1,9 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
-import WithEventSource from 'consul-ui/mixins/with-event-source';
+import { get, computed } from '@ember/object';
 import WithHealthFiltering from 'consul-ui/mixins/with-health-filtering';
 import WithSearching from 'consul-ui/mixins/with-searching';
-import { get } from '@ember/object';
-export default Controller.extend(WithEventSource, WithSearching, WithHealthFiltering, {
+
+export default Controller.extend(WithSearching, WithHealthFiltering, {
   init: function() {
     this.searchParams = {
       healthyNode: 's',

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -13,7 +13,10 @@ export default Route.extend({
   model: function(params) {
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      items: this.repo.findAllByDatacenter(dc, this.modelFor('nspace').nspace.substr(1)),
+      dc: dc,
+      nspace: this.modelFor('nspace').nspace.substr(1),
+      items: undefined,
+      error: undefined,
       leader: this.repo.findByLeader(dc),
     });
   },

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -41,7 +41,11 @@ export default Service.extend({
           return repo.findAllByDatacenter(dc, nspace, configuration);
         };
         break;
-      // weirder ones
+      case 'session':
+        obj.find = function(configuration) {
+          return repo.findByNode(slug, dc, nspace, configuration);
+        };
+        break;
       case 'service-instance':
         temp = slug.split('/');
         id = temp[0];

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,85 +1,96 @@
 {{title 'Nodes'}}
-{{#app-view class="node list"}}
-  {{#block-slot name='header'}}
-    <h1>
-      Nodes <em>{{format-number items.length}} total</em>
-    </h1>
-    <label for="toolbar-toggle"></label>
-  {{/block-slot}}
-  {{#block-slot name='toolbar'}}
+{{data-source
+  src=(concat '/' nspace '/' dc '/nodes')
+  onchange=(action (mut items) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if
+    (not (is-undefined error))
+}}
+  {{app-error error=error.errors.firstObject}}
+{{else}}
+  {{#app-view class="node list" loading=(is-undefined items)}}
+    {{#block-slot name='header'}}
+      <h1>
+        Nodes <em>{{format-number items.length}} total</em>
+      </h1>
+      <label for="toolbar-toggle"></label>
+    {{/block-slot}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
-    {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
+      {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
 {{/if}}
-  {{/block-slot}}
-  {{#block-slot name='content'}}
+    {{/block-slot}}
+    {{#block-slot name='content'}}
 {{#if (gt unhealthy.length 0) }}
-      <div class="unhealthy">
-        <h2>Unhealthy Nodes</h2>
-        <div>
-          {{! think about 2 differing views here }}
-          <ul>
-            {{#changeable-set dispatcher=searchableUnhealthy}}
-              {{#block-slot name='set' as |unhealthy|}}
-                {{#each unhealthy as |item|}}
-                  {{#healthchecked-resource
-                      tagName='li'
-                      data-test-node=item.Node
-                      href=(href-to 'dc.nodes.show' item.Node)
-                      name=item.Node
-                      address=item.Address
-                      checks=item.Checks
-                  }}
-                    {{#block-slot name='icon'}}
-                      {{#if (eq item.Address leader.Address)}}
-                        <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                      {{/if}}
-                    {{/block-slot}}
-                  {{/healthchecked-resource}}
-                {{/each}}
-              {{/block-slot}}
-              {{#block-slot name='empty'}}
-                <p>
-                  There are no unhealthy nodes for that search.
-                </p>
-              {{/block-slot}}
-            {{/changeable-set}}
-          </ul>
+        <div class="unhealthy">
+          <h2>Unhealthy Nodes</h2>
+          <div>
+            {{! think about 2 differing views here }}
+            <ul>
+              {{#changeable-set dispatcher=searchableUnhealthy}}
+                {{#block-slot name='set' as |unhealthy|}}
+                  {{#each unhealthy as |item|}}
+                    {{#healthchecked-resource
+                        tagName='li'
+                        data-test-node=item.Node
+                        href=(href-to 'dc.nodes.show' item.Node)
+                        name=item.Node
+                        address=item.Address
+                        checks=item.Checks
+                    }}
+                      {{#block-slot 'icon'}}
+                        {{#if (eq item.Address leader.Address)}}
+                          <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                        {{/if}}
+                      {{/block-slot}}
+                    {{/healthchecked-resource}}
+                  {{/each}}
+                {{/block-slot}}
+                {{#block-slot name='empty'}}
+                  <p>
+                    There are no unhealthy nodes for that search.
+                  </p>
+                {{/block-slot}}
+              {{/changeable-set}}
+            </ul>
+          </div>
         </div>
-      </div>
 {{/if}}
 {{#if (gt healthy.length 0) }}
-      <div class="healthy">
-        <h2>Healthy Nodes</h2>
-        {{#changeable-set dispatcher=searchableHealthy}}
-          {{#block-slot name='set' as |healthy|}}
-            {{#list-collection cellHeight=92 items=healthy as |item index|}}
-              {{#healthchecked-resource
-                  data-test-node=item.Node
-                  href=(href-to 'dc.nodes.show' item.Node)
-                  name=item.Node
-                  address=item.Address
-                  checks=item.Checks
-              }}
-                {{#block-slot name='icon'}}
-                  {{#if (eq item.Address leader.Address)}}
-                    <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                  {{/if}}
-                {{/block-slot}}
-              {{/healthchecked-resource}}
-            {{/list-collection}}
-          {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no healthy nodes for that search.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
-      </div>
+        <div class="healthy">
+          <h2>Healthy Nodes</h2>
+          {{#changeable-set dispatcher=searchableHealthy}}
+            {{#block-slot name='set' as |healthy|}}
+              {{#list-collection cellHeight=92 items=healthy as |item index|}}
+                {{#healthchecked-resource
+                    data-test-node=item.Node
+                    href=(href-to 'dc.nodes.show' item.Node)
+                    name=item.Node
+                    address=item.Address
+                    checks=item.Checks
+                }}
+                  {{#block-slot name='icon'}}
+                    {{#if (eq item.Address leader.Address)}}
+                      <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                    {{/if}}
+                  {{/block-slot}}
+                {{/healthchecked-resource}}
+              {{/list-collection}}
+            {{/block-slot}}
+            {{#block-slot name='empty'}}
+              <p>
+                There are no healthy nodes for that search.
+              </p>
+            {{/block-slot}}
+          {{/changeable-set}}
+        </div>
 {{/if}}
 {{#if (and (eq healthy.length 0) (eq unhealthy.length 0)) }}
-      <p>
-          There are no nodes.
-      </p>
+        <p>
+            There are no nodes.
+        </p>
 {{/if}}
-  {{/block-slot}}
-{{/app-view}}
+    {{/block-slot}}
+  {{/app-view}}
+{{/if}}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -39,7 +39,7 @@
                         address=item.Address
                         checks=item.Checks
                     }}
-                      {{#block-slot 'icon'}}
+                      {{#block-slot name='icon'}}
                         {{#if (eq item.Address leader.Address)}}
                           <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
                         {{/if}}


### PR DESCRIPTION
This PR is part of the `{{data-source}}` work https://github.com/hashicorp/consul/pull/6821.

https://github.com/hashicorp/consul/pull/6951 implements data-source for the service listing page.

This PR implements data-source for the node listing page.

2 things of note:

1. We do not currently use data-source for the leader data gathering. This will be added at a later date.
2. We did not include a `{{consul-node-list}}` component here. Our node listing uses different views (a grid view and a basic list view), as we aren't entirely sure how to split/organize this into a `{{consul-node-list}}` or whether its worthwhile to even do so, we've decided to leave that for the future.
