### PR TITLE
ui: Implement new confirmation dialogs in other list views

### DIFF
--- a/ui-v2/app/components/popover-menu.js
+++ b/ui-v2/app/components/popover-menu.js
@@ -16,7 +16,9 @@ export default Component.extend(Slotted, {
   actions: {
     change: function(e) {
       if (!e.target.checked) {
-        this.dom.element(`#popover-menu-${this.guid}`).checked = false;
+        [...this.dom.elements(`[id^=popover-menu-${this.guid}]`)].forEach(function($item) {
+          $item.checked = false;
+        });
       }
       this.onchange(e);
     },

--- a/ui-v2/app/styles/base/components/menu-panel/layout.scss
+++ b/ui-v2/app/styles/base/components/menu-panel/layout.scss
@@ -6,12 +6,14 @@
   display: none;
 }
 %menu-panel [type='checkbox'] ~ * {
-  transition: transform 150ms, min-height 150ms;
+  transition: transform 150ms, min-height 150ms, max-height 150ms;
   min-height: 0;
 }
 %menu-panel [type='checkbox']:checked ~ * {
   transform: translateX(calc(-100% - 10px));
-  min-height: 143px;
+  /* this needs to autocalculate */
+  /* or be hardcoded */
+  /* min-height: 143px; */
 }
 %menu-panel-sub-panel {
   position: absolute;
@@ -80,10 +82,5 @@
 @supports not (max-width: fit-content) {
   %menu-panel-header {
     max-width: 200px;
-  }
-}
-@media #{$--lt-horizontal-nav} {
-  %menu-panel-header {
-    text-align: left;
   }
 }

--- a/ui-v2/app/styles/base/components/popover-menu/layout.scss
+++ b/ui-v2/app/styles/base/components/popover-menu/layout.scss
@@ -4,13 +4,22 @@
 %more-popover-menu + label > * {
   @extend %toggle-button;
 }
-%more-popover-menu + label + div {
+%more-popover-menu-panel {
   @extend %menu-panel;
   width: 192px;
 }
-%more-popover-menu + label + div:not(.above) {
+%more-popover-menu + label + div {
+  @extend %more-popover-menu-panel;
+}
+%more-popover-menu-panel:not(.above) {
   top: 38px;
 }
-%more-popover-menu + label + div:not(.left) {
+%more-popover-menu-panel:not(.left) {
   right: 10px;
+}
+%more-popover-menu-panel li [role='menu'] {
+  display: none;
+}
+%more-popover-menu-panel [id$='-']:first-child:checked ~ ul label[for$='-'] + [role='menu'] {
+  display: block;
 }

--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -7,6 +7,21 @@
 %app-view-header .actions > [type='checkbox'] {
   @extend %more-popover-menu;
 }
+%more-popover-menu-panel [type='checkbox']:checked ~ * {
+  /* this needs to autocalculate */
+  min-height: 143px;
+  max-height: 143px;
+}
+%more-popover-menu-panel [id$='logout']:checked ~ * {
+  /* this needs to autocalculate */
+  min-height: 163px;
+  max-height: 163px;
+}
+%more-popover-menu-panel [id$='delete']:checked ~ ul label[for$='delete'] + [role='menu'],
+%more-popover-menu-panel [id$='logout']:checked ~ ul label[for$='logout'] + [role='menu'],
+%more-popover-menu-panel [id$='use']:checked ~ ul label[for$='use'] + [role='menu'] {
+  display: block;
+}
 %app-view-header .actions label + div {
   // We need this extra to allow tooltips to show
   overflow: visible !important;

--- a/ui-v2/app/templates/components/popover-menu.hbs
+++ b/ui-v2/app/templates/components/popover-menu.hbs
@@ -8,7 +8,10 @@
     </button>
   {{/toggle-button}}
   <div>
-    <input type="checkbox" id={{concat 'popover-menu-' guid}} />
+    <input type="checkbox" id={{concat 'popover-menu-' guid '-'}} />
+    {{#each submenus as |sub|}}
+      <input type="checkbox" id={{concat 'popover-menu-' guid '-' sub}} />
+    {{/each}}
     {{#yield-slot name='header'}}
       <div>
         {{yield}}
@@ -16,7 +19,7 @@
     {{else}}
     {{/yield-slot}}
     <ul role="menu" id={{ariaControls}} aria-labelledby={{ariaLabelledBy}} aria-expanded={{ariaExpanded}}>
-      {{#yield-slot name='menu' params=(block-params (concat 'popover-menu-' guid) send keypressClick) }}
+      {{#yield-slot name='menu' params=(block-params (concat 'popover-menu-' guid '-') send keypressClick) }}
         {{yield}}
       {{/yield-slot}}
     </ul>

--- a/ui-v2/app/templates/components/role-selector.hbs
+++ b/ui-v2/app/templates/components/role-selector.hbs
@@ -82,25 +82,40 @@
         </td>
       {{/block-slot}}
       {{#block-slot name='actions' as |index change checked|}}
-        {{#confirmation-dialog confirming=false index=index message="Are you sure you want to remove this Role?"}}
-          {{#block-slot name='action' as |confirm|}}
-              {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                  <ul>
-                      <li>
-                          <a data-test-edit href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
+        {{#popover-menu expanded=(if (eq checked index) true false) onchange=(action change index) keyboardAccess=false}}
+          {{#block-slot name='trigger'}}
+            More
+          {{/block-slot}}
+          {{#block-slot name='menu' as |confirm send keypressClick|}}
+              <li role="none">
+                <a role="menuitem" tabindex="-1" href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
+              </li>
+              <li role="none" class="dangerous">
+                <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Remove</label>
+                <div role="menu">
+                  <div class="confirmation-alert warning">
+                    <div>
+                      <header>
+                        Confirm Remove
+                      </header>
+                      <p>
+                        Are you sure you want to remove this role?
+                      </p>
+                    </div>
+                    <ul>
+                      <li class="dangerous">
+                        <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'remove' item items}}>Remove</button>
                       </li>
                       <li>
-                          <button type="button" class="type-delete" data-test-delete {{action confirm 'remove' item items}}>Remove</button>
+                        <label for={{confirm}}>Cancel</label>
                       </li>
-                  </ul>
-              {{/action-group}}
+                    </ul>
+                  </div>
+                </div>
+              </li>
           {{/block-slot}}
-          {{#block-slot name='dialog' as |execute cancel message name|}}
-            {{delete-confirmation message=message execute=execute cancel=cancel}}
-          {{/block-slot}}
-        {{/confirmation-dialog}}
+        {{/popover-menu}}
       {{/block-slot}}
     {{/tabular-collection}}
-
   {{/block-slot}}
 {{/child-selector}}

--- a/ui-v2/app/templates/dc/acls/index.hbs
+++ b/ui-v2/app/templates/dc/acls/index.hbs
@@ -1,102 +1,144 @@
 {{#app-view class="acl list" loading=isLoading}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/acls/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-        <h1>
-            ACL Tokens <em>{{format-number items.length}} total</em>
-        </h1>
-        <label for="toolbar-toggle"></label>
-    {{/block-slot}}
-    {{#block-slot name='actions'}}
-        <a data-test-create href="{{href-to 'dc.acls.create'}}" class="type-create">Create</a>
-    {{/block-slot}}
-    {{#block-slot name='toolbar'}}
+  {{#block-slot name='notification' as |status type|}}
+    {{partial 'dc/acls/notifications'}}
+  {{/block-slot}}
+  {{#block-slot name='header'}}
+    <h1>
+        ACL Tokens <em>{{format-number items.length}} total</em>
+    </h1>
+    <label for="toolbar-toggle"></label>
+  {{/block-slot}}
+  {{#block-slot name='actions'}}
+    <a data-test-create href="{{href-to 'dc.acls.create'}}" class="type-create">Create</a>
+  {{/block-slot}}
+  {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
-        {{acl-filter searchable=searchable filters=typeFilters search=filters.s type=filters.type onchange=(action 'filter')}}
+    {{acl-filter searchable=searchable filters=typeFilters search=filters.s type=filters.type onchange=(action 'filter')}}
 {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='content'}}
-        {{#changeable-set dispatcher=searchable}}
-          {{#block-slot name='set' as |filtered|}}
-            {{#tabular-collection
-                items=(sort-by 'Name:asc' filtered) as |item index|
+  {{/block-slot}}
+  {{#block-slot name='content'}}
+    {{#changeable-set dispatcher=searchable}}
+      {{#block-slot name='set' as |filtered|}}
+        {{#tabular-collection
+            items=(sort-by 'Name:asc' filtered) as |item index|
+        }}
+          {{#block-slot name='header'}}
+            <th>Name</th>
+            <th>Type</th>
+          {{/block-slot}}
+          {{#block-slot name='row'}}
+            <td data-test-acl="{{item.Name}}">
+              <a href={{href-to 'dc.acls.edit' item.ID}}>{{item.Name}}</a>
+            </td>
+            <td>
+              {{#if (eq item.Type 'management')}}
+                <strong>{{item.Type}}</strong>
+              {{else}}
+                <span>{{item.Type}}</span>
+              {{/if}}
+            </td>
+          {{/block-slot}}
+          {{#block-slot name='actions' as |index change checked|}}
+            {{#popover-menu
+              expanded=(if (eq checked index) true false)
+              onchange=(action change index)
+              keyboardAccess=false
+              submenus=(array 'logout' 'use' 'delete')
             }}
-                {{#block-slot name='header'}}
-                    <th>Name</th>
-                    <th>Type</th>
-                {{/block-slot}}
-                {{#block-slot name='row'}}
-                    <td data-test-acl="{{item.Name}}">
-                        <a href={{href-to 'dc.acls.edit' item.ID}}>{{item.Name}}</a>
-                    </td>
-                    <td>
-                        {{#if (eq item.Type 'management')}}
-                            <strong>{{item.Type}}</strong>
-                        {{else}}
-                            <span>{{item.Type}}</span>
-                        {{/if}}
-                    </td>
-                {{/block-slot}}
-                {{#block-slot name='actions' as |index change checked|}}
-                    {{#confirmation-dialog confirming=false index=index}}
-                        {{#block-slot name='action' as |confirm|}}
-                            {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                                <ul>
-                                  <li>
-                                    <a data-test-edit href={{href-to 'dc.acls.edit' item.ID}}>Edit</a>
-                                  </li>
-{{#if (eq item.ID token.SecretID) }}
-                                  <li>
-                                      <button type="button" data-test-logout {{action confirm 'logout' item}}>Stop using</button>
-                                  </li>
-{{else}}
-
-                                  <li>
-                                      <button type="button" data-test-use {{action confirm 'use' item}}>Use</button>
-                                  </li>
-{{/if}}
-                                  <li>
-                                      <button type="button" data-test-clone {{action 'sendClone' item}}>Clone</button>
-                                  </li>
-{{# if (not-eq item.ID 'anonymous') }}
-                                  <li>
-                                      <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                                  </li>
-{{/if}}
-                              </ul>
-                            {{/action-group}}
-                        {{/block-slot}}
-                        {{#block-slot name='dialog' as |execute cancel message name|}}
-                            <p>
-                                {{#if (eq name 'delete')}}
-                                    Are you sure you want to delete this ACL token?
-                                {{else if (eq name 'logout')}}
-                                    Are you sure you want to stop using this ACL token? This will log you out.
-                                {{ else if (eq name 'use')}}
-                                    Are you sure you want to use this ACL token?
-                                {{/if}}
-                            </p>
-                            <button type="button" class="type-delete" {{action execute}}>
-                                {{#if (eq name 'delete')}}
-                                    Confirm Delete
-                                {{else if (eq name 'logout')}}
-                                    Confirm Logout
-                                {{ else if (eq name 'use')}}
-                                    Confirm Use
-                                {{/if}}
-                            </button>
-                            <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
-                        {{/block-slot}}
-                    {{/confirmation-dialog}}
-                {{/block-slot}}
-            {{/tabular-collection}}
+              {{#block-slot name='trigger'}}
+                More
+              {{/block-slot}}
+              {{#block-slot name='menu' as |confirm send keypressClick|}}
+                  <li role="none">
+                    <a data-test-edit role="menuitem" tabindex="-1" href={{href-to 'dc.acls.edit' item.ID}}>Edit</a>
+                  </li>
+      {{#if (eq item.ID token.SecretID) }}
+                  <li role="none">
+                    <label for={{concat confirm 'logout'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-logout>Stop using</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm logout
+                          </header>
+                          <p>
+                            Are you sure you want to stop using this ACL token? This will log you out.
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" onclick={{action send 'logout' item}}>Logout</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'logout'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
+      {{else}}
+                  <li role="none">
+                    <label for={{concat confirm 'use'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-use>Use</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm use
+                          </header>
+                          <p>
+                            Are you sure you want to use this ACL token?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'use'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
+      {{/if}}
+                  <li role="none">
+                      <button role="menuitem" tabindex="-1" type="button" data-test-clone {{action 'sendClone' item}}>Duplicate</button>
+                  </li>
+      {{# if (not-eq item.ID 'anonymous') }}
+                  <li role="none" class="dangerous">
+                    <label for={{concat confirm 'delete'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm Delete
+                          </header>
+                          <p>
+                            Are you sure you want to delete this token?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'delete'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
+      {{/if}}
+              {{/block-slot}}
+            {{/popover-menu}}
           {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no ACLs.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
-    {{/block-slot}}
+        {{/tabular-collection}}
+      {{/block-slot}}
+      {{#block-slot name='empty'}}
+        <p>
+          There are no ACLs.
+        </p>
+      {{/block-slot}}
+    {{/changeable-set}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/acls/index.hbs
+++ b/ui-v2/app/templates/dc/acls/index.hbs
@@ -91,7 +91,7 @@
                         </div>
                         <ul>
                           <li class="dangerous">
-                            <button tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
+                            <button data-test-confirm-use tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
                           </li>
                           <li>
                             <label for={{concat confirm 'use'}}>Cancel</label>

--- a/ui-v2/app/templates/dc/acls/policies/index.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/index.hbs
@@ -1,84 +1,100 @@
 {{#app-view class=(concat 'policy ' (if (not isAuthorized) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/acls/policies/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-      <h1>
-        Access Controls
-      </h1>
-      {{#if isAuthorized }}
-        {{partial 'dc/acls/nav'}}
-      {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='disabled'}}
-      {{partial 'dc/acls/disabled'}}
-    {{/block-slot}}
-    {{#block-slot name='authorization'}}
-      {{partial 'dc/acls/authorization'}}
-    {{/block-slot}}
-    {{#block-slot name='actions'}}
-        <a data-test-create href="{{href-to 'dc.acls.policies.create'}}" class="type-create">Create</a>
-    {{/block-slot}}
-    {{#block-slot name='content'}}
-{{#if (gt items.length 0) }}
-        <form class="filter-bar">
-          {{freetext-filter searchable=searchable value=s placeholder="Search"}}
-        </form>
-{{/if}}
-        {{#changeable-set dispatcher=searchable}}
-          {{#block-slot name='set' as |filtered|}}
-            {{#tabular-collection
-                items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
-            }}
-                {{#block-slot name='header'}}
-                    <th>Name</th>
-                    <th>Datacenters</th>
-                    <th>Description</th>
-                {{/block-slot}}
-                {{#block-slot name='row'}}
-                    <td data-test-policy="{{item.Name}}">
-                      <a href={{href-to 'dc.acls.policies.edit' item.ID}} class={{if (eq (policy/typeof item) 'policy-management') 'is-management'}}>{{item.Name}}</a>
-                    </td>
-                    <td>
-                      {{join ', ' (policy/datacenters item)}}
-                    </td>
-                    <td data-test-description>
-                      <p>{{item.Description}}</p>
-                    </td>
-                {{/block-slot}}
-                {{#block-slot name='actions' as |index change checked|}}
-                    {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Policy?"}}
-                        {{#block-slot name='action' as |confirm|}}
-                            {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                                <ul>
-    {{#if (eq (policy/typeof item) 'policy-management')}}
-                                    <li>
-                                        <a data-test-edit href={{href-to 'dc.acls.policies.edit' item.ID}}>View</a>
-                                    </li>
-    {{else}}
-
-                                    <li>
-                                        <a data-test-edit href={{href-to 'dc.acls.policies.edit' item.ID}}>Edit</a>
-                                    </li>
-                                    <li>
-                                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                                    </li>
+  {{#block-slot name='notification' as |status type|}}
+    {{partial 'dc/acls/policies/notifications'}}
+  {{/block-slot}}
+  {{#block-slot name='header'}}
+    <h1>
+      Access Controls
+    </h1>
+    {{#if isAuthorized }}
+      {{partial 'dc/acls/nav'}}
     {{/if}}
-                                </ul>
-                            {{/action-group}}
-                        {{/block-slot}}
-                        {{#block-slot name='dialog' as |execute cancel message name|}}
-                          {{delete-confirmation message=message execute=execute cancel=cancel}}
-                        {{/block-slot}}
-                    {{/confirmation-dialog}}
-                {{/block-slot}}
-            {{/tabular-collection}}
+  {{/block-slot}}
+  {{#block-slot name='disabled'}}
+    {{partial 'dc/acls/disabled'}}
+  {{/block-slot}}
+  {{#block-slot name='authorization'}}
+    {{partial 'dc/acls/authorization'}}
+  {{/block-slot}}
+  {{#block-slot name='actions'}}
+      <a data-test-create href="{{href-to 'dc.acls.policies.create'}}" class="type-create">Create</a>
+  {{/block-slot}}
+  {{#block-slot name='content'}}
+{{#if (gt items.length 0) }}
+      <form class="filter-bar">
+        {{freetext-filter searchable=searchable value=s placeholder="Search"}}
+      </form>
+{{/if}}
+    {{#changeable-set dispatcher=searchable}}
+      {{#block-slot name='set' as |filtered|}}
+        {{#tabular-collection
+            items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
+        }}
+          {{#block-slot name='header'}}
+            <th>Name</th>
+            <th>Datacenters</th>
+            <th>Description</th>
           {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no Policies.
-            </p>
+          {{#block-slot name='row'}}
+            <td data-test-policy="{{item.Name}}">
+              <a href={{href-to 'dc.acls.policies.edit' item.ID}} class={{if (eq (policy/typeof item) 'policy-management') 'is-management'}}>{{item.Name}}</a>
+            </td>
+            <td>
+              {{join ', ' (policy/datacenters item)}}
+            </td>
+            <td data-test-description>
+              <p>{{item.Description}}</p>
+            </td>
           {{/block-slot}}
-        {{/changeable-set}}
-    {{/block-slot}}
+          {{#block-slot name='actions' as |index change checked|}}
+            {{#popover-menu expanded=(if (eq checked index) true false) onchange=(action change index) keyboardAccess=false}}
+              {{#block-slot name='trigger'}}
+                More
+              {{/block-slot}}
+              {{#block-slot name='menu' as |confirm send keypressClick|}}
+{{#if (eq (policy/typeof item) 'policy-management')}}
+                <li role="none">
+                    <a role="menuitem" tabindex="-1" data-test-edit href={{href-to 'dc.acls.policies.edit' item.ID}}>View</a>
+                </li>
+{{else}}
+
+                <li role="none">
+                    <a role="menuitem" tabindex="-1" data-test-edit href={{href-to 'dc.acls.policies.edit' item.ID}}>Edit</a>
+                </li>
+                <li role="none" class="dangerous">
+                  <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                  <div role="menu">
+                    <div class="confirmation-alert warning">
+                      <div>
+                        <header>
+                          Confirm Delete
+                        </header>
+                        <p>
+                          Are you sure you want to delete this policy?
+                        </p>
+                      </div>
+                      <ul>
+                        <li class="dangerous">
+                          <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                        </li>
+                        <li>
+                          <label for={{confirm}}>Cancel</label>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </li>
+{{/if}}
+              {{/block-slot}}
+            {{/popover-menu}}
+          {{/block-slot}}
+        {{/tabular-collection}}
+      {{/block-slot}}
+      {{#block-slot name='empty'}}
+        <p>
+          There are no Policies.
+        </p>
+      {{/block-slot}}
+    {{/changeable-set}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/acls/roles/index.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/index.hbs
@@ -1,79 +1,95 @@
 {{#app-view class=(concat 'role ' (if (not isAuthorized) 'edit' 'list')) loading=isLoading authorized=isAuthorized enabled=isEnabled}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/acls/roles/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-      <h1>
-        Access Controls
-      </h1>
-      {{#if isAuthorized }}
-        {{partial 'dc/acls/nav'}}
-      {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='disabled'}}
-      {{partial 'dc/acls/disabled'}}
-    {{/block-slot}}
-    {{#block-slot name='authorization'}}
-      {{partial 'dc/acls/authorization'}}
-    {{/block-slot}}
-    {{#block-slot name='actions'}}
-        <a data-test-create href="{{href-to 'dc.acls.roles.create'}}" class="type-create">Create</a>
-    {{/block-slot}}
-    {{#block-slot name='content'}}
+  {{#block-slot name='notification' as |status type|}}
+    {{partial 'dc/acls/roles/notifications'}}
+  {{/block-slot}}
+  {{#block-slot name='header'}}
+    <h1>
+      Access Controls
+    </h1>
+    {{#if isAuthorized }}
+      {{partial 'dc/acls/nav'}}
+    {{/if}}
+  {{/block-slot}}
+  {{#block-slot name='disabled'}}
+    {{partial 'dc/acls/disabled'}}
+  {{/block-slot}}
+  {{#block-slot name='authorization'}}
+    {{partial 'dc/acls/authorization'}}
+  {{/block-slot}}
+  {{#block-slot name='actions'}}
+    <a data-test-create href="{{href-to 'dc.acls.roles.create'}}" class="type-create">Create</a>
+  {{/block-slot}}
+  {{#block-slot name='content'}}
 {{#if (gt items.length 0) }}
-        <form class="filter-bar">
-          {{freetext-filter searchable=searchable value=s placeholder="Search"}}
-        </form>
+    <form class="filter-bar">
+      {{freetext-filter searchable=searchable value=s placeholder="Search"}}
+    </form>
 {{/if}}
-        {{#changeable-set dispatcher=searchable}}
-          {{#block-slot name='set' as |filtered|}}
-            {{#tabular-collection
-                items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
-            }}
-                {{#block-slot name='header'}}
-                    <th>Name</th>
-                    <th>Description</th>
-                    <th>Policies</th>
+    {{#changeable-set dispatcher=searchable}}
+      {{#block-slot name='set' as |filtered|}}
+        {{#tabular-collection
+            items=(sort-by 'CreateIndex:desc' 'Name:asc' filtered) as |item index|
+        }}
+            {{#block-slot name='header'}}
+              <th>Name</th>
+              <th>Description</th>
+              <th>Policies</th>
+            {{/block-slot}}
+            {{#block-slot name='row'}}
+              <td data-test-role="{{item.Name}}">
+                <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
+              </td>
+              <td data-test-description>
+                <p>{{item.Description}}</p>
+              </td>
+              <td>
+                {{#each item.Policies as |item|}}
+                  <strong data-test-policy class={{policy/typeof item}}>{{item.Name}}</strong>
+                {{/each}}
+              </td>
+            {{/block-slot}}
+            {{#block-slot name='actions' as |index change checked|}}
+              {{#popover-menu expanded=(if (eq checked index) true false) onchange=(action change index) keyboardAccess=false}}
+                {{#block-slot name='trigger'}}
+                  More
                 {{/block-slot}}
-                {{#block-slot name='row'}}
-                    <td data-test-role="{{item.Name}}">
-                      <a href={{href-to 'dc.acls.roles.edit' item.ID}}>{{item.Name}}</a>
-                    </td>
-                    <td data-test-description>
-                      <p>{{item.Description}}</p>
-                    </td>
-                    <td>
-                      {{#each item.Policies as |item|}}
-                        <strong data-test-policy class={{policy/typeof item}}>{{item.Name}}</strong>
-                      {{/each}}
-                    </td>
+                {{#block-slot name='menu' as |confirm send keypressClick|}}
+                    <li role="none">
+                      <a role="menuitem" tabindex="-1" href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
+                    </li>
+                    <li role="none" class="dangerous">
+                      <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                      <div role="menu">
+                        <div class="confirmation-alert warning">
+                          <div>
+                            <header>
+                              Confirm Delete
+                            </header>
+                            <p>
+                              Are you sure you want to delete this role?
+                            </p>
+                          </div>
+                          <ul>
+                            <li class="dangerous">
+                              <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                            </li>
+                            <li>
+                              <label for={{confirm}}>Cancel</label>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
                 {{/block-slot}}
-                {{#block-slot name='actions' as |index change checked|}}
-                    {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Role?"}}
-                        {{#block-slot name='action' as |confirm|}}
-                            {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                                <ul>
-                                    <li>
-                                        <a data-test-edit href={{href-to 'dc.acls.roles.edit' item.ID}}>Edit</a>
-                                    </li>
-                                    <li>
-                                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                                    </li>
-                                </ul>
-                            {{/action-group}}
-                        {{/block-slot}}
-                        {{#block-slot name='dialog' as |execute cancel message name|}}
-                          {{delete-confirmation message=message execute=execute cancel=cancel}}
-                        {{/block-slot}}
-                    {{/confirmation-dialog}}
-                {{/block-slot}}
-            {{/tabular-collection}}
-          {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no Roles.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
-    {{/block-slot}}
+              {{/popover-menu}}
+            {{/block-slot}}
+        {{/tabular-collection}}
+      {{/block-slot}}
+      {{#block-slot name='empty'}}
+        <p>
+          There are no Roles.
+        </p>
+      {{/block-slot}}
+    {{/changeable-set}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -121,7 +121,7 @@
                         </div>
                         <ul>
                           <li class="dangerous">
-                            <button tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
+                            <button data-test-confirm-use tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
                           </li>
                           <li>
                             <label for={{concat confirm 'use'}}>Cancel</label>

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -64,66 +64,100 @@
 {{/if}}
           {{/block-slot}}
           {{#block-slot name='actions' as |index change checked|}}
-            {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Token?"}}
-              {{#block-slot name='action' as |confirm|}}
-                {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                  <ul>
-{{#if false}}
-                    <li>
-                      {{#copy-button-feedback title="Copy AccessorID to the clipboard" copy=item.AccessorID name="AccessorID"}}Copy AccessorID{{/copy-button-feedback}}
-                    </li>
-{{/if}}
-                    <li>
-                        <a data-test-edit href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>Edit</a>
-                    </li>
+            {{#popover-menu
+              expanded=(if (eq checked index) true false)
+              onchange=(action change index)
+              keyboardAccess=false
+              submenus=(array 'logout' 'use' 'delete')
+            }}
+              {{#block-slot name='trigger'}}
+                More
+              {{/block-slot}}
+              {{#block-slot name='menu' as |confirm send keypressClick|}}
+                  <li role="none">
+                    <a data-test-edit role="menuitem" tabindex="-1" href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>Edit</a>
+                  </li>
 {{#if (not (token/is-legacy item))}}
-                    <li>
-                        <button type="button" data-test-clone {{action 'sendClone' item}}>Duplicate</button>
-                    </li>
+                  <li role="none">
+                      <button role="menuitem" tabindex="-1" type="button" data-test-clone {{action 'sendClone' item}}>Duplicate</button>
+                  </li>
 {{/if}}
 {{#if (eq item.AccessorID token.AccessorID) }}
-                    <li>
-                        <button type="button" data-test-logout {{action confirm 'logout' item}}>Stop using</button>
-                    </li>
+                  <li role="none">
+                    <label for={{concat confirm 'logout'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-logout>Stop using</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm logout
+                          </header>
+                          <p>
+                            Are you sure you want to stop using this ACL token? This will log you out.
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" onclick={{action send 'logout' item}}>Logout</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'logout'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
 {{else}}
-
-                    <li>
-                        <button type="button" data-test-use {{action confirm 'use' item}}>Use</button>
-                    </li>
+                  <li role="none">
+                    <label for={{concat confirm 'use'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-use>Use</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm use
+                          </header>
+                          <p>
+                            Are you sure you want to use this ACL token?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" onclick={{action send 'use' item}}>Use</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'use'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
 {{/if}}
 {{#unless (or (token/is-anonymous item) (eq item.AccessorID token.AccessorID)) }}
-                    <li>
-                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                    </li>
+                  <li role="none" class="dangerous">
+                    <label for={{concat confirm 'delete'}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm Delete
+                          </header>
+                          <p>
+                            Are you sure you want to delete this token?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                          </li>
+                          <li>
+                            <label for={{concat confirm 'delete'}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
 {{/unless}}
-                  </ul>
-                {{/action-group}}
               {{/block-slot}}
-              {{#block-slot name='dialog' as |execute cancel message name|}}
-                  <p>
-                      {{#if (eq name 'delete')}}
-                        {{message}}
-{{#if (eq item.AccessorID token.AccessorID)}}
-                        Warning: This is the token you are currently using!
-{{/if}}
-                      {{else if (eq name 'logout')}}
-                          Are you sure you want to stop using this ACL token? This will log you out.
-                      {{else if (eq name 'use')}}
-                          Are you sure you want to use this ACL token?
-                      {{/if}}
-                  </p>
-                  <button type="button" class="type-delete" {{action execute}}>
-                      {{#if (eq name 'delete')}}
-                          Confirm Delete
-                      {{else if (eq name 'logout')}}
-                          Confirm Logout
-                      {{ else if (eq name 'use')}}
-                          Confirm Use
-                      {{/if}}
-                  </button>
-                  <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
-              {{/block-slot}}
-            {{/confirmation-dialog}}
+            {{/popover-menu}}
           {{/block-slot}}
         {{/tabular-collection}}
       {{/block-slot}}

--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -1,81 +1,97 @@
 {{#app-view class="kv list" loading=isLoading}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/kv/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='breadcrumbs'}}
-        <ol>
+  {{#block-slot name='notification' as |status type|}}
+    {{partial 'dc/kv/notifications'}}
+  {{/block-slot}}
+  {{#block-slot name='breadcrumbs'}}
+    <ol>
 {{#if (not-eq parent.Key '/') }}
-            <li><a href={{href-to 'dc.kv'}}>Key / Values</a></li>
+      <li><a href={{href-to 'dc.kv'}}>Key / Values</a></li>
 {{/if}}
 {{#each (slice 0 -2 (split parent.Key '/')) as |breadcrumb index|}}
-            <li><a href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
+      <li><a href={{href-to 'dc.kv.folder' (join '/' (append (slice 0 (add index 1) (split parent.Key '/')) ''))}}>{{breadcrumb}}</a></li>
 {{/each}}
-        </ol>
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-        <h1>
-            {{#if (eq parent.Key '/') }}
-                Key / Value
-            {{else}}
-                {{ take 1 (drop 1 (reverse (split parent.Key '/'))) }}
-            {{/if}}
-        </h1>
-        <label for="toolbar-toggle"></label>
-    {{/block-slot}}
-    {{#block-slot name='toolbar'}}
+    </ol>
+  {{/block-slot}}
+  {{#block-slot name='header'}}
+      <h1>
+        {{#if (eq parent.Key '/')}}
+          Key / Value
+        {{else}}
+          {{take 1 (drop 1 (reverse (split parent.Key '/')))}}
+        {{/if}}
+      </h1>
+      <label for="toolbar-toggle"></label>
+  {{/block-slot}}
+  {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
-      <form class="filter-bar">
-        {{freetext-filter searchable=searchable value=s placeholder="Search by name"}}
-      </form>
+    <form class="filter-bar">
+      {{freetext-filter searchable=searchable value=s placeholder="Search by name"}}
+    </form>
 {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='actions'}}
+  {{/block-slot}}
+  {{#block-slot name='actions'}}
 {{#if (not-eq parent.Key '/') }}
-        <a data-test-create href="{{href-to 'dc.kv.create' parent.Key}}" class="type-create">Create</a>
+      <a data-test-create href="{{href-to 'dc.kv.create' parent.Key}}" class="type-create">Create</a>
 {{else}}
-        <a data-test-create href="{{href-to 'dc.kv.root-create'}}" class="type-create">Create</a>
+      <a data-test-create href="{{href-to 'dc.kv.root-create'}}" class="type-create">Create</a>
 {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='content'}}
-        {{#changeable-set dispatcher=searchable}}
-          {{#block-slot name='set' as |filtered|}}
-            {{#tabular-collection
-                items=(sort-by 'isFolder:desc' 'Key:asc' filtered) as |item index|
-            }}
-                {{#block-slot name='header'}}
-                    <th>Name</th>
-                {{/block-slot}}
-                {{#block-slot name='row'}}
-                    <td data-test-kv="{{item.Key}}" class={{if item.isFolder 'folder' 'file' }}>
-                        <a href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{right-trim (left-trim item.Key parent.Key) '/'}}</a>
-                    </td>
-                {{/block-slot}}
-                {{#block-slot name='actions' as |index change checked|}}
-                    {{#confirmation-dialog confirming=false index=index message='Are you sure you want to delete this key?'}}
-                        {{#block-slot name='action' as |confirm|}}
-                            {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                                <ul>
-                                    <li>
-                                        <a data-test-edit href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{if item.isFolder 'View' 'Edit'}}</a>
-                                    </li>
-                                    <li>
-                                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                                    </li>
-                                </ul>
-                            {{/action-group}}
-                        {{/block-slot}}
-                        {{#block-slot name='dialog' as |execute cancel message|}}
-                          {{delete-confirmation message=message execute=execute cancel=cancel}}
-                        {{/block-slot}}
-                    {{/confirmation-dialog}}
-                {{/block-slot}}
-            {{/tabular-collection}}
+  {{/block-slot}}
+  {{#block-slot name='content'}}
+    {{#changeable-set dispatcher=searchable}}
+      {{#block-slot name='set' as |filtered|}}
+        {{#tabular-collection
+            items=(sort-by 'isFolder:desc' 'Key:asc' filtered) as |item index|
+        }}
+          {{#block-slot name='header'}}
+            <th>Name</th>
           {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no Key / Value pairs.
-            </p>
+          {{#block-slot name='row'}}
+            <td data-test-kv={{item.Key}} class={{if item.isFolder 'folder' 'file' }}>
+                <a href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{right-trim (left-trim item.Key parent.Key) '/'}}</a>
+            </td>
           {{/block-slot}}
-        {{/changeable-set}}
-    {{/block-slot}}
+          {{#block-slot name='actions' as |index change checked|}}
+            {{#popover-menu expanded=(if (eq checked index) true false) onchange=(action change index) keyboardAccess=false}}
+              {{#block-slot name='trigger'}}
+                More
+              {{/block-slot}}
+              {{#block-slot name='menu' as |confirm send keypressClick|}}
+                  <li role="none">
+                    <a data-test-edit role="menuitem" tabindex="-1" href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{if item.isFolder 'View' 'Edit'}}</a>
+                  </li>
+                  <li role="none" class="dangerous">
+                    <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm Delete
+                          </header>
+                          <p>
+                            Are you sure you want to delete this key?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                          </li>
+                          <li>
+                            <label for={{confirm}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
+              {{/block-slot}}
+            {{/popover-menu}}
+          {{/block-slot}}
+        {{/tabular-collection}}
+      {{/block-slot}}
+      {{#block-slot name='empty'}}
+        <p>
+          There are no Key / Value pairs.
+        </p>
+      {{/block-slot}}
+    {{/changeable-set}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/templates/dc/nspaces/index.hbs
+++ b/ui-v2/app/templates/dc/nspaces/index.hbs
@@ -52,31 +52,39 @@
 {{/if}}
           {{/block-slot}}
           {{#block-slot name='actions' as |index change checked|}}
-            {{#confirmation-dialog confirming=false index=index message="Are you sure you want to delete this Namespace?"}}
-              {{#block-slot name='action' as |confirm|}}
-                {{#action-group index=index onchange=(action change) checked=(if (eq checked index) 'checked')}}
-                  <ul>
-                    <li>
-                        <a data-test-edit href={{href-to 'dc.nspaces.edit' item.Name}}>Edit</a>
-                    </li>
-{{#if (not-eq item.Name 'default')}}
-                    <li>
-                        <button type="button" class="type-delete" data-test-delete {{action confirm 'delete' item}}>Delete</button>
-                    </li>
-{{/if}}
-                  </ul>
-                {{/action-group}}
+            {{#popover-menu expanded=(if (eq checked index) true false) onchange=(action change index) keyboardAccess=false}}
+              {{#block-slot name='trigger'}}
+                More
               {{/block-slot}}
-              {{#block-slot name='dialog' as |execute cancel message name|}}
-                  <p>
-                    {{message}}
-                  </p>
-                  <button type="button" class="type-delete" {{action execute}}>
-                    Confirm Delete
-                  </button>
-                  <button type="button" class="type-cancel" {{action cancel}}>Cancel</button>
+              {{#block-slot name='menu' as |confirm send keypressClick|}}
+                  <li role="none">
+                    <a data-test-edit role="menuitem" tabindex="-1" href={{href-to 'dc.nspaces.edit' item.Name}}>Edit</a>
+                  </li>
+                  <li role="none" class="dangerous">
+                    <label for={{confirm}} role="menuitem" tabindex="-1" onkeypress={{keypressClick}} data-test-delete>Delete</label>
+                    <div role="menu">
+                      <div class="confirmation-alert warning">
+                        <div>
+                          <header>
+                            Confirm Delete
+                          </header>
+                          <p>
+                            Are you sure you want to delete this key?
+                          </p>
+                        </div>
+                        <ul>
+                          <li class="dangerous">
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                          </li>
+                          <li>
+                            <label for={{confirm}}>Cancel</label>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </li>
               {{/block-slot}}
-            {{/confirmation-dialog}}
+            {{/popover-menu}}
           {{/block-slot}}
         {{/tabular-collection}}
       {{/block-slot}}

--- a/ui-v2/tests/pages/dc/acls/index.js
+++ b/ui-v2/tests/pages/dc/acls/index.js
@@ -8,7 +8,7 @@ export default function(visitable, deletable, creatable, clickable, attribute, c
         acl: clickable('a'),
         actions: clickable('label'),
         use: clickable('[data-test-use]'),
-        confirmUse: clickable('button.type-delete'),
+        confirmUse: clickable('[data-test-confirm-use]'),
       })
     ),
     filter: filter,

--- a/ui-v2/tests/pages/dc/acls/tokens/index.js
+++ b/ui-v2/tests/pages/dc/acls/tokens/index.js
@@ -24,7 +24,7 @@ export default function(
           token: clickable('a'),
           actions: clickable('label'),
           use: clickable('[data-test-use]'),
-          confirmUse: clickable('button.type-delete'),
+          confirmUse: clickable('[data-test-confirm-use]'),
           clone: clickable('[data-test-clone]'),
         })
       ),


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/7007 we reused our new popover-menu component for the 'action-groups' that we use for our row delete/use etc confirmations. We also included the new style of confirmation dialogs there.

This PR mainly repeats this throughout the UI (the referenced PR only implemented this for intentions to provide an example)

One unforeseen problem that we also addressed here was being able to have multiple 'subpanels' in the popover menu, in this case required for multiple confirmations in the menu specifically for ACLs and ACL tokens.

The solution here isn't my favourite, yet it works well whilst sticking to using CSS/the browser for controlling the popover-menu state. I have further ideas for this in future, partly based on work we were doing in the discovery-chain work, and partly based on a potential usage of contextual components here.

Right now, the solution here works fine, so we are happy to PR this and revisit the innards of this at a later date.

