### PR TITLE
Use correct subject key id for leaf certs.

### DIFF
--- a/agent/connect/ca/provider_consul.go
+++ b/agent/connect/ca/provider_consul.go
@@ -343,6 +343,12 @@ func (c *ConsulProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 		return "", err
 	}
 
+	// Create the subjectKeyId for the cert from the csr public key.
+	subjectKeyID, err := connect.KeyId(csr.PublicKey)
+	if err != nil {
+		return "", err
+	}
+
 	// Parse the SPIFFE ID
 	spiffeId, err := connect.ParseCertURI(csr.URIs[0])
 	if err != nil {
@@ -402,7 +408,7 @@ func (c *ConsulProvider) Sign(csr *x509.CertificateRequest) (string, error) {
 		NotAfter:       effectiveNow.Add(c.config.LeafCertTTL),
 		NotBefore:      effectiveNow,
 		AuthorityKeyId: keyId,
-		SubjectKeyId:   keyId,
+		SubjectKeyId:   subjectKeyID,
 		DNSNames:       csr.DNSNames,
 		IPAddresses:    csr.IPAddresses,
 	}

--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -176,6 +176,9 @@ func TestConsulCAProvider_SignLeaf(t *testing.T) {
 				require.Equal(spiffeService.URI(), parsed.URIs[0])
 				require.Equal(connect.ServiceCN("foo", connect.TestClusterID), parsed.Subject.CommonName)
 				require.Equal(uint64(2), parsed.SerialNumber.Uint64())
+				subjectKeyID, err := connect.KeyId(csr.PublicKey)
+				require.NoError(err)
+				require.Equal(subjectKeyID, parsed.SubjectKeyId)
 				requireNotEncoded(t, parsed.SubjectKeyId)
 				requireNotEncoded(t, parsed.AuthorityKeyId)
 


### PR DESCRIPTION
Previously leaf certificates had the authority key id as their subject key id.

Fixes https://github.com/hashicorp/consul/issues/6771. This issue also contains everything you might want to know about this.