### PR TITLE
Fix autopilot test

### DIFF
--- a/agent/consul/autopilot_test.go
+++ b/agent/consul/autopilot_test.go
@@ -310,7 +310,10 @@ func TestAutopilot_CleanupStaleRaftServer(t *testing.T) {
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
 	// Add s4 to peers directly
-	s1.raft.AddVoter(raft.ServerID(s4.config.NodeID), raft.ServerAddress(joinAddrLAN(s4)), 0, 0)
+	addVoterFuture := s1.raft.AddVoter(raft.ServerID(s4.config.NodeID), raft.ServerAddress(joinAddrLAN(s4)), 0, 0)
+	if err := addVoterFuture.Error(); err != nil {
+		t.Fatal(err)
+	}
 
 	// Verify we have 4 peers
 	peers, err := s1.numPeers()


### PR DESCRIPTION
In theory this test was not 100% correct before, because it didn't check if `AddVoter` succeeded. But it used to work since `NumPeers` relies on `GetConfiguration` and that went through the raft leader loop as well.

But since https://github.com/hashicorp/raft/pull/379 was merged, `GetConfiguration` is instant now and is almost always faster than going through raft leader loop, which means it will report the old configuration with 3 peers, because `AddVoter` didn't made it back.