### PR TITLE
Small change to TLS connection wording

### DIFF
--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -12,10 +12,10 @@ description: |-
 Consul Connect provides service-to-service connection authorization and
 encryption using mutual Transport Layer Security (TLS). Applications can use
 [sidecar proxies](/docs/connect/proxies.html) in a service mesh configuration to
-automatically establish TLS connections for inbound and outbound connections
-without being aware of Connect at all. Applications may also [natively integrate
-with Connect](/docs/connect/native.html) for optimal performance and security.
-Connect can help you secure your services and provide data about service-to-service
+establish TLS connections for inbound and outbound connections without being aware 
+of Connect at all. Applications may also [natively integrate with Connect](/docs/connect/native.html) 
+for optimal performance and security. Connect can help you secure your services and provide data 
+about service-to-service
 communications.
 
 Review the video below to learn more about Consul Connect from HashiCorp's co-founder Armon. 


### PR DESCRIPTION
Removing automatic connection wording for applications for the time being. From @blake 
> They can automatically establish TLS connections without being aware that TLS is happening. They are aware that they’re routed through the Connect proxy, the app has to configure itself to use the local upstream port.