### PR TITLE
Add accessorID of token when ops are denied by ACL system

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -41,6 +41,21 @@ func (a *Agent) resolveTokenAndDefaultMeta(id string, entMeta *structs.Enterpris
 	return a.delegate.ResolveTokenAndDefaultMeta(id, entMeta, authzContext)
 }
 
+// ResolveIdentityFromToken is used to resolve an ACL token secret a structs.ACLIdentity.
+func (a *Agent) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
+	// ACLs are disabled
+	if !a.delegate.ACLsEnabled() {
+		return false, nil, nil
+	}
+
+	// Disable ACLs if version 8 enforcement isn't enabled.
+	if !a.config.ACLEnforceVersion8 {
+		return false, nil, nil
+	}
+
+	return a.delegate.ResolveIdentityFromToken(token)
+}
+
 func (a *Agent) initializeACLs() error {
 	// Build a policy for the agent master token.
 	// The builtin agent master policy allows reading any node information
@@ -241,6 +256,11 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 		return nil
 	}
 
+	_, tokenIdent, err := a.delegate.ResolveIdentityFromToken(token)
+	if err != nil {
+		a.logger.Printf("[DEBUG] agent: failed to acquire token identity, err=%v", err)
+	}
+
 	var authzContext acl.AuthorizerContext
 	structs.DefaultEnterpriseMeta().FillAuthzContext(&authzContext)
 	// Filter out members based on the node policy.
@@ -250,7 +270,11 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 		if rule.NodeRead(node, &authzContext) == acl.Allow {
 			continue
 		}
-		a.logger.Printf("[DEBUG] agent: dropping node %q from result due to ACLs", node)
+		var accessorID string
+		if tokenIdent != nil {
+			accessorID = tokenIdent.ID()
+		}
+		a.logger.Printf("[DEBUG] agent: dropping node from result due to ACLs, node=%q accessorID=%v", node, accessorID)
 		m = append(m[:i], m[i+1:]...)
 		i--
 	}
@@ -280,7 +304,7 @@ func (a *Agent) filterServicesWithAuthorizer(authz acl.Authorizer, services *map
 		if authz.ServiceRead(service.Service, &authzContext) == acl.Allow {
 			continue
 		}
-		a.logger.Printf("[DEBUG] agent: dropping service %q from result due to ACLs", id.String())
+		a.logger.Printf("[DEBUG] agent: dropping service from result due to ACLs, service=%q ", id.String())
 		delete(*services, id)
 	}
 	return nil
@@ -316,7 +340,7 @@ func (a *Agent) filterChecksWithAuthorizer(authz acl.Authorizer, checks *map[str
 				continue
 			}
 		}
-		a.logger.Printf("[DEBUG] agent: dropping check %q from result due to ACLs", id.String())
+		a.logger.Printf("[DEBUG] agent: dropping check from result due to ACLs, check=%q ", id.String())
 		delete(*checks, id)
 	}
 	return nil

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -41,8 +41,7 @@ func (a *Agent) resolveTokenAndDefaultMeta(id string, entMeta *structs.Enterpris
 	return a.delegate.ResolveTokenAndDefaultMeta(id, entMeta, authzContext)
 }
 
-// resolveIdentityFromToken takes an ACL token's secretID, ensures ACLs are
-// enabled, and retrieves its ACLIdentity.
+// resolveTokenAndDefaultMeta is used to resolve an ACLToken's secretID to a structs.ACLIdentity
 func (a *Agent) resolveIdentityFromToken(secretID string) (bool, structs.ACLIdentity, error) {
 	// ACLs are disabled
 	if !a.delegate.ACLsEnabled() {
@@ -55,6 +54,21 @@ func (a *Agent) resolveIdentityFromToken(secretID string) (bool, structs.ACLIden
 	}
 
 	return a.delegate.ResolveIdentityFromToken(secretID)
+}
+
+// aclAccessorID is used to convert an ACLToken's secretID to its accessorID for non-
+// critical purposes, such as logging. Therefore we interpret all errors as empty-string
+// so we can safely log it without handling non-critical errors at the usage site.
+func (a *Agent) aclAccessorID(secretID string) string {
+	_, ident, err := a.resolveIdentityFromToken(secretID)
+	if err != nil {
+		a.logger.Printf("[DEBUG] agent.acl: %v", err)
+		return ""
+	}
+	if ident == nil {
+		return ""
+	}
+	return ident.ID()
 }
 
 func (a *Agent) initializeACLs() error {
@@ -257,11 +271,6 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 		return nil
 	}
 
-	_, tokenIdent, err := a.delegate.ResolveIdentityFromToken(token)
-	if err != nil {
-		a.logger.Printf("[DEBUG] agent: failed to acquire token identity, err=%q", err)
-	}
-
 	var authzContext acl.AuthorizerContext
 	structs.DefaultEnterpriseMeta().FillAuthzContext(&authzContext)
 	// Filter out members based on the node policy.
@@ -271,10 +280,7 @@ func (a *Agent) filterMembers(token string, members *[]serf.Member) error {
 		if rule.NodeRead(node, &authzContext) == acl.Allow {
 			continue
 		}
-		var accessorID string
-		if tokenIdent != nil {
-			accessorID = tokenIdent.ID()
-		}
+		accessorID := a.aclAccessorID(token)
 		a.logger.Printf("[DEBUG] agent: dropping node from result due to ACLs, node=%q accessorID=%q", node, accessorID)
 		m = append(m[:i], m[i+1:]...)
 		i--
@@ -305,7 +311,7 @@ func (a *Agent) filterServicesWithAuthorizer(authz acl.Authorizer, services *map
 		if authz.ServiceRead(service.Service, &authzContext) == acl.Allow {
 			continue
 		}
-		a.logger.Printf("[DEBUG] agent: dropping service from result due to ACLs, service=%q ", id.String())
+		a.logger.Printf("[DEBUG] agent: dropping service from result due to ACLs, service=%q", id.String())
 		delete(*services, id)
 	}
 	return nil
@@ -341,7 +347,7 @@ func (a *Agent) filterChecksWithAuthorizer(authz acl.Authorizer, checks *map[str
 				continue
 			}
 		}
-		a.logger.Printf("[DEBUG] agent: dropping check from result due to ACLs, check=%q ", id.String())
+		a.logger.Printf("[DEBUG] agent: dropping check from result due to ACLs, check=%q", id.String())
 		delete(*checks, id)
 	}
 	return nil

--- a/agent/acl.go
+++ b/agent/acl.go
@@ -41,7 +41,7 @@ func (a *Agent) resolveTokenAndDefaultMeta(id string, entMeta *structs.Enterpris
 	return a.delegate.ResolveTokenAndDefaultMeta(id, entMeta, authzContext)
 }
 
-// resolveTokenAndDefaultMeta is used to resolve an ACLToken's secretID to a structs.ACLIdentity
+// resolveIdentityFromToken is used to resolve an ACLToken's secretID to a structs.ACLIdentity
 func (a *Agent) resolveIdentityFromToken(secretID string) (bool, structs.ACLIdentity, error) {
 	// ACLs are disabled
 	if !a.delegate.ACLsEnabled() {

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -135,8 +135,6 @@ func (a *TestACLAgent) ResolveIdentityFromToken(secretID string) (bool, structs.
 		panic("This agent is useless without providing a token resolution function")
 	}
 
-	// note(kit) This is almost certainly not useful test behavior, but I have no idea how I should be testing this x)
-	//           I've just been getting an infinite loop where i accidentally dispatch right back to the delegate
 	identity, _, err := a.resolveTokenFn(secretID)
 	if err != nil {
 		return true, nil, err

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -130,6 +130,21 @@ func (a *TestACLAgent) ResolveTokenAndDefaultMeta(secretID string, entMeta *stru
 	return authz, err
 }
 
+func (a *TestACLAgent) ResolveIdentityFromToken(secretID string) (bool, structs.ACLIdentity, error) {
+	if a.resolveTokenFn == nil {
+		panic("This agent is useless without providing a token resolution function")
+	}
+
+	// note(kit) This is almost certainly not useful test behavior, but I have no idea how I should be testing this x)
+	//           I've just been getting an infinite loop where i accidentally dispatch right back to the delegate
+	identity, _, err := a.resolveTokenFn(secretID)
+	if err != nil {
+		return true, nil, err
+	}
+
+	return true, identity, nil
+}
+
 // All of these are stubs to satisfy the interface
 func (a *TestACLAgent) Encrypted() bool {
 	return false

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -152,7 +152,7 @@ type notifier interface {
 	Notify(string) error
 }
 
-// The agent is the long running process that is run on every machine.
+// Agent is the long running process that is run on every machine.
 // It exposes an RPC interface that is used by the CLI to control the
 // agent. The agent runs the query interfaces like HTTP, DNS, and RPC.
 // However, it can run in either a client, or server mode. In server
@@ -309,6 +309,8 @@ type Agent struct {
 	persistedTokensLock sync.RWMutex
 }
 
+// New verifies the configuration given has a Datacenter and DataDir
+// configured, and maps the remaining config fields to fields on the Agent.
 func New(c *config.RuntimeConfig, logger *log.Logger) (*Agent, error) {
 	if c.Datacenter == "" {
 		return nil, fmt.Errorf("Must configure a Datacenter")
@@ -353,6 +355,7 @@ func New(c *config.RuntimeConfig, logger *log.Logger) (*Agent, error) {
 	return &a, nil
 }
 
+// LocalConfig takes a config.RuntimeConfig and maps the fields to a local.Config
 func LocalConfig(cfg *config.RuntimeConfig) local.Config {
 	lc := local.Config{
 		AdvertiseAddr:       cfg.AdvertiseAddrLAN.String(),
@@ -369,6 +372,7 @@ func LocalConfig(cfg *config.RuntimeConfig) local.Config {
 	return lc
 }
 
+// Start verifies its configuration and runs an agent's various subprocesses.
 func (a *Agent) Start() error {
 	a.stateLock.Lock()
 	defer a.stateLock.Unlock()
@@ -1877,7 +1881,7 @@ func (a *Agent) ResumeSync() {
 	}
 }
 
-// syncPausedCh returns either a channel or nil. If nil sync is not paused. If
+// SyncPausedCh returns either a channel or nil. If nil sync is not paused. If
 // non-nil, the channel will be closed when sync resumes.
 func (a *Agent) SyncPausedCh() <-chan struct{} {
 	a.syncMu.Lock()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1938,7 +1938,7 @@ OUTER:
 				//  todo(mkcp) port all of these logger calls to hclog w/ loglevel configuration
 				if err := a.RPC("Coordinate.Update", &req, &reply); err != nil {
 					if acl.IsErrPermissionDenied(err) {
-						_, tokenIdent, err2 := a.ResolveIdentityFromToken(agentToken)
+						_, tokenIdent, err2 := a.resolveIdentityFromToken(agentToken)
 						if err2 != nil {
 							a.logger.Printf("[DEBUG] agent: failed to acquire token identity, err=%v", err2)
 						}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1935,16 +1935,12 @@ OUTER:
 					WriteRequest: structs.WriteRequest{Token: agentToken},
 				}
 				var reply struct{}
-				//  todo(mkcp) port all of these logger calls to hclog w/ loglevel configuration
+				// todo(kit) port all of these logger calls to hclog w/ loglevel configuration
+				// todo(kit) handle acl.ErrNotFound cases here in the future
 				if err := a.RPC("Coordinate.Update", &req, &reply); err != nil {
 					if acl.IsErrPermissionDenied(err) {
-						_, tokenIdent, err2 := a.resolveIdentityFromToken(agentToken)
-						if err2 != nil {
-							a.logger.Printf("[DEBUG] agent: failed to acquire token identity, err=%v", err2)
-						}
-						if tokenIdent != nil {
-							a.logger.Printf("[DEBUG] agent: Coordinate update blocked by ACLs, accessorID=%v", tokenIdent.ID())
-						}
+						accessorID := a.aclAccessorID(agentToken)
+						a.logger.Printf("[DEBUG] agent: Coordinate update blocked by ACLs, accessorID=%v", accessorID)
 					} else {
 						a.logger.Printf("[ERR] agent: Coordinate update error: %v", err)
 					}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -437,7 +437,7 @@ func (r *ACLResolver) fetchAndCacheIdentityFromToken(token string, cached *struc
 	return nil, err
 }
 
-// resolveIdentityFromToken takes a token as a string and returns an ACLIdentity.
+// resolveIdentityFromToken takes a token secret as a string and returns an ACLIdentity.
 // We read the value from ACLResolver's cache if available, and if the read misses
 // we initiate an RPC for the value.
 func (r *ACLResolver) resolveIdentityFromToken(token string) (structs.ACLIdentity, error) {

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -437,10 +437,10 @@ func (r *ACLResolver) fetchAndCacheIdentityFromToken(token string, cached *struc
 	return nil, err
 }
 
-// ResolveIdentityFromToken takes a token as a string and returns an ACLIdentity.
+// resolveIdentityFromToken takes a token as a string and returns an ACLIdentity.
 // We read the value from ACLResolver's cache if available, and if the read misses
 // we initiate an RPC for the value.
-func (r *ACLResolver) ResolveIdentityFromToken(token string) (structs.ACLIdentity, error) {
+func (r *ACLResolver) resolveIdentityFromToken(token string) (structs.ACLIdentity, error) {
 	// Attempt to resolve locally first (local results are not cached)
 	if done, identity, err := r.delegate.ResolveIdentityFromToken(token); done {
 		return identity, err
@@ -782,7 +782,7 @@ func (r *ACLResolver) collectPoliciesForIdentity(identity structs.ACLIdentity, p
 			if policy != nil {
 				policies = append(policies, policy)
 			} else {
-				r.logger.Printf("[WARN] acl: policy not found for identity, policy=%q identity=%q", policyID, accessorID)
+				r.logger.Printf("[WARN] acl: policy not found for identity, policy=%q accessorID=%q", policyID, accessorID)
 			}
 
 			continue
@@ -880,7 +880,7 @@ func (r *ACLResolver) collectRolesForIdentity(identity structs.ACLIdentity, role
 				if identity != nil {
 					accessorID = identity.ID()
 				}
-				r.logger.Printf("[WARN] acl: role not found for identity, role=%q identity=%q", roleID, accessorID)
+				r.logger.Printf("[WARN] acl: role not found for identity, role=%q accessorID=%q", roleID, accessorID)
 			}
 
 			continue
@@ -958,7 +958,7 @@ func (r *ACLResolver) resolveTokenToIdentityAndPolicies(token string) (structs.A
 
 	for i := 0; i < tokenPolicyResolutionMaxRetries; i++ {
 		// Resolve the token to an ACLIdentity
-		identity, err := r.ResolveIdentityFromToken(token)
+		identity, err := r.resolveIdentityFromToken(token)
 		if err != nil {
 			return nil, nil, err
 		} else if identity == nil {
@@ -997,7 +997,7 @@ func (r *ACLResolver) resolveTokenToIdentityAndRoles(token string) (structs.ACLI
 
 	for i := 0; i < tokenRoleResolutionMaxRetries; i++ {
 		// Resolve the token to an ACLIdentity
-		identity, err := r.ResolveIdentityFromToken(token)
+		identity, err := r.resolveIdentityFromToken(token)
 		if err != nil {
 			return nil, nil, err
 		} else if identity == nil {

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2395,15 +2395,14 @@ func (a *ACL) Authorize(args *structs.RemoteACLAuthorizationRequest, reply *[]st
 
 // ResolveIdentityFromToken passes through a request from the ACL type to the ACL's srv delegate.
 func (a *ACL) ResolveIdentityFromToken(args *structs.ACLRequest, reply *structs.ACLIdentity) error {
-	// fixme(kit): do we need to do any other checks here? Maybe look into the cache or route to another endpoint file?
 	_, ident, err := a.srv.ResolveIdentityFromToken(args.WriteRequest.Token)
 	if err != nil {
 		return err
+	} else if ident == nil {
+		return fmt.Errorf("Failed to initialize identity")
 	}
 
-	// fixme(kit): what other error cases would we want to handle from ResolveIdentityFromToken?
-
 	// Set our reply and return
-	reply = &ident
+	*reply = ident
 	return nil
 }

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2392,3 +2392,18 @@ func (a *ACL) Authorize(args *structs.RemoteACLAuthorizationRequest, reply *[]st
 	*reply = responses
 	return nil
 }
+
+// ResolveIdentityFromToken passes through a request from the ACL type to the ACL's srv delegate.
+func (a *ACL) ResolveIdentityFromToken(args *structs.ACLRequest, reply *structs.ACLIdentity) error {
+	// fixme(kit): do we need to do any other checks here? Maybe look into the cache or route to another endpoint file?
+	_, ident, err := a.srv.ResolveIdentityFromToken(args.WriteRequest.Token)
+	if err != nil {
+		return err
+	}
+
+	// fixme(kit): what other error cases would we want to handle from ResolveIdentityFromToken?
+
+	// Set our reply and return
+	reply = &ident
+	return nil
+}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2392,17 +2392,3 @@ func (a *ACL) Authorize(args *structs.RemoteACLAuthorizationRequest, reply *[]st
 	*reply = responses
 	return nil
 }
-
-// ResolveIdentityFromToken passes through a request from the ACL type to the ACL's srv delegate.
-func (a *ACL) ResolveIdentityFromToken(args *structs.ACLRequest, reply *structs.ACLIdentity) error {
-	_, ident, err := a.srv.ResolveIdentityFromToken(args.WriteRequest.Token)
-	if err != nil {
-		return err
-	} else if ident == nil {
-		return fmt.Errorf("Failed to initialize identity")
-	}
-
-	// Set our reply and return
-	*reply = ident
-	return nil
-}

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -164,7 +164,7 @@ func (s *Server) ACLsEnabled() bool {
 	return s.config.ACLsEnabled
 }
 
-// ResolveIdentityFromToken retrieve's a token's full identity given its secretID.
+// ResolveIdentityFromToken retrieves a token's full identity given its secretID.
 func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// only allow remote RPC resolution when token replication is off and
 	// when not in the ACL datacenter

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -164,7 +164,7 @@ func (s *Server) ACLsEnabled() bool {
 	return s.config.ACLsEnabled
 }
 
-// fixme(kit): write a doc comment for this public function
+// ResolveIdentityFromToken retrieve's a token's full identity given its secretID.
 func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// only allow remote RPC resolution when token replication is off and
 	// when not in the ACL datacenter
@@ -218,28 +218,8 @@ func (s *Server) ResolveTokenToIdentityAndAuthorizer(token string) (structs.ACLI
 	return s.acls.ResolveTokenToIdentityAndAuthorizer(token)
 }
 
-func (s *Server) ResolveTokenAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error) {
-	identity, authz, err := s.acls.ResolveTokenToIdentityAndAuthorizer(token)
-	if err != nil {
-		return nil, err
-	}
-
-	// Default the EnterpriseMeta based on the Tokens meta or actual defaults
-	// in the case of unknown identity
-	if identity != nil {
-		entMeta.Merge(identity.EnterpriseMetadata())
-	} else {
-		entMeta.Merge(structs.DefaultEnterpriseMeta())
-	}
-
-	// Use the meta to fill in the ACL authorization context
-	entMeta.FillAuthzContext(authzContext)
-
-	return authz, err
-}
-
-// fixme(mkcp): just ResolveTokenAndDefaultMeta copied but we return the identity too. This is pretty janky, but the fn is called in ~60 places so
-// I'm not ready to refactor it just yet
+// ResolveTokenIdentityAndDefaultMeta retrieves an identity and authorizer for the caller,
+// and populates the EnterpriseMeta based on the AuthorizerContext.
 func (s *Server) ResolveTokenIdentityAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (structs.ACLIdentity, acl.Authorizer, error) {
 	identity, authz, err := s.acls.ResolveTokenToIdentityAndAuthorizer(token)
 	if err != nil {
@@ -258,6 +238,12 @@ func (s *Server) ResolveTokenIdentityAndDefaultMeta(token string, entMeta *struc
 	entMeta.FillAuthzContext(authzContext)
 
 	return identity, authz, err
+}
+
+// ResolveTokenAndDefaultMeta passes through to ResolveTokenIdentityAndDefaultMeta, eliding the identity from its response.
+func (s *Server) ResolveTokenAndDefaultMeta(token string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error) {
+	_, authz, err := s.ResolveTokenIdentityAndDefaultMeta(token, entMeta, authzContext)
+	return authz, err
 }
 
 func (s *Server) filterACL(token string, subj interface{}) error {

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -38,9 +38,13 @@ func (s *Intention) checkIntentionID(id string) (bool, error) {
 
 // prepareApplyCreate validates that the requester has permissions to create the new intention,
 // generates a new uuid for the intention and generally validates that the request is well-formed
-func (s *Intention) prepareApplyCreate(authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
+func (s *Intention) prepareApplyCreate(ident structs.ACLIdentity, authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
 	if !args.Intention.CanWrite(authz) {
-		s.srv.logger.Printf("[WARN] consul.intention: Intention creation denied due to ACLs")
+		var accessorID string
+		if ident != nil {
+			accessorID = ident.ID()
+		}
+		s.srv.logger.Printf("[WARN] consul.intention: Intention creation denied due to ACLs, accessorID=%v", accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -85,9 +89,13 @@ func (s *Intention) prepareApplyCreate(authz acl.Authorizer, entMeta *structs.En
 
 // prepareApplyUpdate validates that the requester has permissions on both the updated and existing
 // intention as well as generally validating that the request is well-formed
-func (s *Intention) prepareApplyUpdate(authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
+func (s *Intention) prepareApplyUpdate(ident structs.ACLIdentity, authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
 	if !args.Intention.CanWrite(authz) {
-		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention %q denied due to ACLs", args.Intention.ID)
+		var accessorID string
+		if ident != nil {
+			accessorID = ident.ID()
+		}
+		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -103,7 +111,11 @@ func (s *Intention) prepareApplyUpdate(authz acl.Authorizer, entMeta *structs.En
 	// which must be true to perform any rename. This is the only ACL enforcement
 	// done for deletions and a secondary enforcement for updates.
 	if !ixn.CanWrite(authz) {
-		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention %q denied due to ACLs", args.Intention.ID)
+		var accessorID string
+		if ident != nil {
+			accessorID = ident.ID()
+		}
+		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -134,7 +146,7 @@ func (s *Intention) prepareApplyUpdate(authz acl.Authorizer, entMeta *structs.En
 
 // prepareApplyDelete ensures that the intention specified by the ID in the request exists
 // and that the requester is authorized to delete it
-func (s *Intention) prepareApplyDelete(authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
+func (s *Intention) prepareApplyDelete(ident structs.ACLIdentity, authz acl.Authorizer, entMeta *structs.EnterpriseMeta, args *structs.IntentionRequest) error {
 	// If this is not a create, then we have to verify the ID.
 	state := s.srv.fsm.State()
 	_, ixn, err := state.IntentionGet(nil, args.Intention.ID)
@@ -149,7 +161,11 @@ func (s *Intention) prepareApplyDelete(authz acl.Authorizer, entMeta *structs.En
 	// which must be true to perform any rename. This is the only ACL enforcement
 	// done for deletions and a secondary enforcement for updates.
 	if !ixn.CanWrite(authz) {
-		s.srv.logger.Printf("[WARN] consul.intention: Deletion operation on intention %q denied due to ACLs", args.Intention.ID)
+		var accessorID string
+		if ident != nil {
+			accessorID = ident.ID()
+		}
+		s.srv.logger.Printf("[WARN] consul.intention: Deletion operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -179,22 +195,22 @@ func (s *Intention) Apply(
 
 	// Get the ACL token for the request for the checks below.
 	var entMeta structs.EnterpriseMeta
-	authz, err := s.srv.ResolveTokenAndDefaultMeta(args.Token, &entMeta, nil)
+	ident, authz, err := s.srv.ResolveTokenIdentityAndDefaultMeta(args.Token, &entMeta, nil)
 	if err != nil {
 		return err
 	}
 
 	switch args.Op {
 	case structs.IntentionOpCreate:
-		if err := s.prepareApplyCreate(authz, &entMeta, args); err != nil {
+		if err := s.prepareApplyCreate(ident, authz, &entMeta, args); err != nil {
 			return err
 		}
 	case structs.IntentionOpUpdate:
-		if err := s.prepareApplyUpdate(authz, &entMeta, args); err != nil {
+		if err := s.prepareApplyUpdate(ident, authz, &entMeta, args); err != nil {
 			return err
 		}
 	case structs.IntentionOpDelete:
-		if err := s.prepareApplyDelete(authz, &entMeta, args); err != nil {
+		if err := s.prepareApplyDelete(ident, authz, &entMeta, args); err != nil {
 			return err
 		}
 	default:
@@ -248,7 +264,15 @@ func (s *Intention) Get(
 
 			// If ACLs prevented any responses, error
 			if len(reply.Intentions) == 0 {
-				s.srv.logger.Printf("[WARN] consul.intention: Request to get intention '%s' denied due to ACLs", args.IntentionID)
+				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
+				if err != nil {
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+				}
+				var accessorID string
+				if ident != nil {
+					accessorID = ident.ID()
+				}
+				s.srv.logger.Printf("[WARN] consul.intention: Request to get intention denied due to ACLs, intention=%s accessorID=%v", args.IntentionID, accessorID)
 				return acl.ErrPermissionDenied
 			}
 
@@ -312,7 +336,15 @@ func (s *Intention) Match(
 		for _, entry := range args.Match.Entries {
 			entry.FillAuthzContext(&authzContext)
 			if prefix := entry.Name; prefix != "" && rule.IntentionRead(prefix, &authzContext) != acl.Allow {
-				s.srv.logger.Printf("[WARN] consul.intention: Operation on intention prefix '%s' denied due to ACLs", prefix)
+				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
+				if err != nil {
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+				}
+				var accessorID string
+				if ident != nil {
+					accessorID = ident.ID()
+				}
+				s.srv.logger.Printf("[WARN] consul.intention: Operation on intention prefix denied due to ACLs, prefix=%s accessorID=%v", prefix, accessorID)
 				return acl.ErrPermissionDenied
 			}
 		}
@@ -383,7 +415,15 @@ func (s *Intention) Check(
 		var authzContext acl.AuthorizerContext
 		query.FillAuthzContext(&authzContext)
 		if rule != nil && rule.ServiceRead(prefix, &authzContext) != acl.Allow {
-			s.srv.logger.Printf("[WARN] consul.intention: test on intention '%s' denied due to ACLs", prefix)
+			_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
+			if err != nil {
+				s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+			}
+			var accessorID string
+			if ident != nil {
+				accessorID = ident.ID()
+			}
+			s.srv.logger.Printf("[WARN] consul.intention: test on intention denied due to ACLs, intention=%s accessorID=%v", prefix, accessorID)
 			return acl.ErrPermissionDenied
 		}
 	}

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -44,7 +44,7 @@ func (s *Intention) prepareApplyCreate(ident structs.ACLIdentity, authz acl.Auth
 		if ident != nil {
 			accessorID = ident.ID()
 		}
-		s.srv.logger.Printf("[WARN] consul.intention: Intention creation denied due to ACLs, accessorID=%v", accessorID)
+		s.srv.logger.Printf("[WARN] consul.intention: Intention creation denied due to ACLs, accessorID=%q", accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -95,7 +95,7 @@ func (s *Intention) prepareApplyUpdate(ident structs.ACLIdentity, authz acl.Auth
 		if ident != nil {
 			accessorID = ident.ID()
 		}
-		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
+		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%q", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -115,7 +115,7 @@ func (s *Intention) prepareApplyUpdate(ident structs.ACLIdentity, authz acl.Auth
 		if ident != nil {
 			accessorID = ident.ID()
 		}
-		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
+		s.srv.logger.Printf("[WARN] consul.intention: Update operation on intention denied due to ACLs, intention=%q accessorID=%q", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -151,7 +151,7 @@ func (s *Intention) prepareApplyDelete(ident structs.ACLIdentity, authz acl.Auth
 	state := s.srv.fsm.State()
 	_, ixn, err := state.IntentionGet(nil, args.Intention.ID)
 	if err != nil {
-		return fmt.Errorf("Intention lookup failed: %v", err)
+		return fmt.Errorf("Intention lookup failed: %q", err)
 	}
 	if ixn == nil {
 		return fmt.Errorf("Cannot delete non-existent intention: '%s'", args.Intention.ID)
@@ -165,7 +165,7 @@ func (s *Intention) prepareApplyDelete(ident structs.ACLIdentity, authz acl.Auth
 		if ident != nil {
 			accessorID = ident.ID()
 		}
-		s.srv.logger.Printf("[WARN] consul.intention: Deletion operation on intention denied due to ACLs, intention=%q accessorID=%v", args.Intention.ID, accessorID)
+		s.srv.logger.Printf("[WARN] consul.intention: Deletion operation on intention denied due to ACLs, intention=%q accessorID=%q", args.Intention.ID, accessorID)
 		return acl.ErrPermissionDenied
 	}
 
@@ -266,13 +266,13 @@ func (s *Intention) Get(
 			if len(reply.Intentions) == 0 {
 				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 				if err != nil {
-					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%q", err)
 				}
 				var accessorID string
 				if ident != nil {
 					accessorID = ident.ID()
 				}
-				s.srv.logger.Printf("[WARN] consul.intention: Request to get intention denied due to ACLs, intention=%s accessorID=%v", args.IntentionID, accessorID)
+				s.srv.logger.Printf("[WARN] consul.intention: Request to get intention denied due to ACLs, intention=%s accessorID=%q", args.IntentionID, accessorID)
 				return acl.ErrPermissionDenied
 			}
 
@@ -338,13 +338,13 @@ func (s *Intention) Match(
 			if prefix := entry.Name; prefix != "" && rule.IntentionRead(prefix, &authzContext) != acl.Allow {
 				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 				if err != nil {
-					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%q", err)
 				}
 				var accessorID string
 				if ident != nil {
 					accessorID = ident.ID()
 				}
-				s.srv.logger.Printf("[WARN] consul.intention: Operation on intention prefix denied due to ACLs, prefix=%s accessorID=%v", prefix, accessorID)
+				s.srv.logger.Printf("[WARN] consul.intention: Operation on intention prefix denied due to ACLs, prefix=%s accessorID=%q", prefix, accessorID)
 				return acl.ErrPermissionDenied
 			}
 		}
@@ -417,13 +417,13 @@ func (s *Intention) Check(
 		if rule != nil && rule.ServiceRead(prefix, &authzContext) != acl.Allow {
 			_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 			if err != nil {
-				s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
+				s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%q", err)
 			}
 			var accessorID string
 			if ident != nil {
 				accessorID = ident.ID()
 			}
-			s.srv.logger.Printf("[WARN] consul.intention: test on intention denied due to ACLs, intention=%s accessorID=%v", prefix, accessorID)
+			s.srv.logger.Printf("[WARN] consul.intention: test on intention denied due to ACLs, intention=%s accessorID=%q", prefix, accessorID)
 			return acl.ErrPermissionDenied
 		}
 	}

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -266,7 +266,7 @@ func (s *Intention) Get(
 			if len(reply.Intentions) == 0 {
 				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 				if err != nil {
-					s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
 				}
 				var accessorID string
 				if ident != nil {
@@ -338,7 +338,7 @@ func (s *Intention) Match(
 			if prefix := entry.Name; prefix != "" && rule.IntentionRead(prefix, &authzContext) != acl.Allow {
 				_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 				if err != nil {
-					s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+					s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
 				}
 				var accessorID string
 				if ident != nil {
@@ -417,7 +417,7 @@ func (s *Intention) Check(
 		if rule != nil && rule.ServiceRead(prefix, &authzContext) != acl.Allow {
 			_, ident, err := s.srv.ResolveIdentityFromToken(args.Token)
 			if err != nil {
-				s.srv.logger.Printf("[DEBUG] consul.intention: failed to fetch ACL AccessorID, reason: %v", err)
+				s.srv.logger.Printf("[DEBUG] consul.intention: failed to failed to acquire token identity, err=%v", err)
 			}
 			var accessorID string
 			if ident != nil {

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1144,7 +1144,7 @@ func (l *State) deleteCheck(key structs.CheckID) error {
 		// todo(fs): some backoff strategy might be a better solution
 		l.checks[key].InSync = true
 		accessorID := l.ACLAccessorID(ct)
-		l.logger.Printf("[DEBUG] agent: Check deregistration blocked by ACLs, check=%q accessorID=%v", key.String(), accessorID)
+		l.logger.Printf("[DEBUG] agent: Check deregistration blocked by ACLs, check=%q accessorID=%q", key.String(), accessorID)
 		metrics.IncrCounter([]string{"acl", "blocked", "check", "deregistration"}, 1)
 		return nil
 
@@ -1283,7 +1283,7 @@ func (l *State) syncCheck(key structs.CheckID) error {
 		// todo(fs): some backoff strategy might be a better solution
 		l.checks[key].InSync = true
 		accessorID := l.ACLAccessorID(ct)
-		l.logger.Printf("[DEBUG] agent: Check registration blocked by ACLs, check=%q accessorID=%v", key, accessorID)
+		l.logger.Printf("[DEBUG] agent: Check registration blocked by ACLs, check=%q accessorID=%q", key, accessorID)
 		metrics.IncrCounter([]string{"acl", "blocked", "check", "registration"}, 1)
 		return nil
 
@@ -1317,7 +1317,7 @@ func (l *State) syncNodeInfo() error {
 		// todo(fs): some backoff strategy might be a better solution
 		l.nodeInfoInSync = true
 		accessorID := l.ACLAccessorID(at)
-		l.logger.Printf("[DEBUG] agent: Node info update blocked by ACLs, nodeID=%v accessorID=%v", l.config.NodeID, accessorID)
+		l.logger.Printf("[DEBUG] agent: Node info update blocked by ACLs, nodeID=%q accessorID=%q", l.config.NodeID, accessorID)
 		metrics.IncrCounter([]string{"acl", "blocked", "node", "registration"}, 1)
 		return nil
 
@@ -1354,7 +1354,7 @@ func (l *State) ACLAccessorID(token string) string {
 	}
 	var reply structs.ACLIdentity
 	if err := l.Delegate.RPC("ACL.ResolveIdentityFromToken", &req, &reply); err != nil {
-		l.logger.Printf("[DEBUG] agent.local: failed to acquire token identity, err=%v", err)
+		l.logger.Printf("[DEBUG] agent.local: failed to acquire token identity, err=%q", err)
 		return ""
 	}
 	if reply == nil {

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1345,8 +1345,8 @@ func (l *State) notifyIfAliased(serviceID structs.ServiceID) {
 
 // ACLAccessorID takes an ACL secret token and retrives identity metadata on the
 // token, returning just the accessorID so we can log it here. In the future we
-// may wish to return more fields from structs.ACLIdentity to log out more debug
-// info when ACLs are denied
+// may wish to return more of the fields on structs.ACLIdentity to log out more
+// debug info when ACLs are denied in state.go.
 func (l *State) ACLAccessorID(token string) string {
 	req := structs.ACLRequest{
 		Datacenter:   l.config.Datacenter,
@@ -1357,8 +1357,6 @@ func (l *State) ACLAccessorID(token string) string {
 		l.logger.Printf("[DEBUG] agent.local: failed to acquire token identity, err=%v", err)
 		return ""
 	}
-
-	// Sometimes we don't get a reply struct back?
 	if reply == nil {
 		return ""
 	}


### PR DESCRIPTION
Intended to resolve customer asks in #7010, plus wherever else I could find ACL debug logs with access to a token.

We employ a few different ways of getting the accessorID, depending on where we are in the agent.
- `agent/local/state.go` acquires it via internal RPC because local is a subcomponent of the `agent` and we don't have access to one. Adding an additional network hop in these `service` and `check` sync loops might be prohibitively expensive on a critical path, but I haven't profiled it. I would appreciate feedback on my impl here from folks w/ more Go and consul experience.
- Then various delegate and srv calls to `ResolveIdentityFromToken` so we can pull the accessorID off of it.

- Added some doc comments early on when I was still researching the problem. Can split into its own PR if needed. 

And important note is that none of this is particularly tested, because I couldn't find any place that felt like it needed unit testing (could be wrong there) and integration testing logging felt... bizarre? I also had some difficulty building up a test case to induce the logs themselves so much of what I'm submitting here is taken on faith, the type checker, and a few thousand `Test{Agent,ACL}` runs to ensure I didn't break something important.

I would appreciate that whoever review this PR get about as nitpicky as possible. Treat this code like someone with 5 years of Go experience got a little {drunk/tired from a new baby/etc.} and rushed through this. I would like to learn as much as possible from whatever I missed. Thanks! 

Will squash before merge.