### PR TITLE
ui: Remove the Service Identities selector from the Nspaces > Policy form

### DIFF
--- a/ui-v2/app/components/policy-form.js
+++ b/ui-v2/app/components/policy-form.js
@@ -7,6 +7,7 @@ export default FormComponent.extend({
   datacenterRepo: service('repository/dc/component'),
   type: 'policy',
   name: 'policy',
+  allowServiceIdentity: true,
   classNames: ['policy-form'],
 
   isScoped: false,

--- a/ui-v2/app/components/policy-selector.js
+++ b/ui-v2/app/components/policy-selector.js
@@ -12,6 +12,7 @@ export default ChildSelectorComponent.extend({
   datacenterRepo: service('repository/dc/component'),
   name: 'policy',
   type: 'policy',
+  allowServiceIdentity: true,
   classNames: ['policy-selector'],
   init: function() {
     this._super(...arguments);

--- a/ui-v2/app/templates/components/policy-form.hbs
+++ b/ui-v2/app/templates/components/policy-form.hbs
@@ -3,8 +3,9 @@
   {{#yield-slot name='template'}}
   {{else}}
     <header>
-      Policy or service identity?
+      Policy{{if allowServiceIdentity ' or service identity?' ''}}
     </header>
+  {{#if allowServiceIdentity}}
     <p>
       A Service Identity is default policy with a configurable service name. This saves you some time and effort you're using Consul for Connect features.
     </p>
@@ -13,10 +14,13 @@
         {{#each templates as |template|}}
             <label>
               <span>{{template.name}}</span>
-              <input data-test-radiobutton={{concat 'template_' template.template}} type="radio" name="{{name}}[template]" value={{template.template}} checked={{eq item.template template.template}} onchange={{action (changeset-set item 'template') value='target.value'}}/>
+              <input data-test-radiobutton={{concat 'template_' template.template}} type="radio" name={{concat name '[template]'}} value={{template.template}} checked={{eq item.template template.template}} onchange={{action (changeset-set item 'template') value='target.value'}}/>
             </label>
         {{/each}}
     </div>
+  {{else}}
+    <input type="hidden" name={{concat name '[template]'}} value="" />
+  {{/if}}
   {{/yield-slot}}
     <label class="type-text{{if (and item.error.Name (not item.isPristine)) ' has-error'}}">
         <span>Name</span>

--- a/ui-v2/app/templates/components/policy-selector.hbs
+++ b/ui-v2/app/templates/components/policy-selector.hbs
@@ -17,7 +17,7 @@
           <h2>New Policy</h2>
         {{/block-slot}}
         {{#block-slot name='body'}}
-          {{policy-form form=form dc=dc}}
+          {{policy-form form=form dc=dc allowServiceIdentity=allowServiceIdentity}}
         {{/block-slot}}
         {{#block-slot name='actions' as |close|}}
           <button type="submit" {{action 'save' item items (queue (action close) (action 'reset'))}} disabled={{if (or item.isSaving item.isPristine item.isInvalid) 'disabled'}}>

--- a/ui-v2/app/templates/dc/nspaces/-form.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-form.hbs
@@ -30,7 +30,7 @@
     <p>
       By adding policies to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    {{policy-selector dc=dc nspace='default' items=item.ACLs.PolicyDefaults}}
+    {{policy-selector dc=dc nspace='default' allowServiceIdentity=false items=item.ACLs.PolicyDefaults}}
   </fieldset>
 {{/if}}
   <div>

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/nspaces.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/nspaces.feature
@@ -1,0 +1,19 @@
+@setupApplicationTest
+Feature: dc / acls / policies / as many / nspaces: As many for nspaces
+  Scenario:
+    Given 1 datacenter model with the value "datacenter"
+    And 1 nspace model from yaml
+    ---
+      Name: key
+      ACLs:
+        PolicyDefaults: ~
+        RoleDefaults: ~
+    ---
+    When I visit the nspace page for yaml
+    ---
+      dc: datacenter
+      namespace: key
+    ---
+    Then the url should be /datacenter/namespaces/key
+    And I click policies.create
+    And I don't see the "#policies [data-test-radiobutton=template_service-identity]" element

--- a/ui-v2/tests/acceptance/steps/dc/acls/policies/as-many/nspaces-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/acls/policies/as-many/nspaces-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -109,6 +109,8 @@ export default {
   nspaces: create(
     nspaces(visitable, deletable, creatable, clickable, attribute, collection, text, freetextFilter)
   ),
-  nspace: create(nspace(visitable, submitable, deletable, cancelable)),
+  nspace: create(
+    nspace(visitable, submitable, deletable, cancelable, policySelector, roleSelector)
+  ),
   settings: create(settings(visitable, submitable)),
 };

--- a/ui-v2/tests/pages/dc/nspaces/edit.js
+++ b/ui-v2/tests/pages/dc/nspaces/edit.js
@@ -1,8 +1,17 @@
-export default function(visitable, submitable, deletable, cancelable) {
+export default function(
+  visitable,
+  submitable,
+  deletable,
+  cancelable,
+  policySelector,
+  roleSelector
+) {
   return {
     visit: visitable(['/:dc/namespaces/:namespace', '/:dc/namespaces/create']),
     ...submitable({}, 'form > div'),
     ...cancelable({}, 'form > div'),
     ...deletable({}, 'form > div'),
+    policies: policySelector(),
+    roles: roleSelector(),
   };
 }

--- a/ui-v2/tests/steps/assertions/dom.js
+++ b/ui-v2/tests/steps/assertions/dom.js
@@ -40,6 +40,9 @@ export default function(scenario, assert, pauseUntil, find, currentURL, clipboar
         .dom(document.querySelector(selector))
         .hasClass(cls, `Expected [class] to contain ${cls} on ${selector}`);
     })
+    .then([`I don't see the "$selector" element`], function(selector) {
+      assert.equal(document.querySelector(selector), null, `Expected not to see ${selector}`);
+    })
     .then(['"$selector" doesn\'t have the "$class" class'], function(selector, cls) {
       assert.ok(
         !document.querySelector(selector).classList.contains(cls),


### PR DESCRIPTION
When editing Nspaces, although you can assign policies to a nspace using
PolicyDefaults you cannot assign a Service Identity to a policy like you
can when adding a policy to a token.

This commit adds an extra attribute to our policy-form/policy-selector
component so you can disable this setting. At a later date we may change
this to have a conficgurable `<Slot />` instead.

Simple acceptance tests is included here