### PR TITLE
Remove inaccurate checks deprecation statement

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -130,11 +130,7 @@ The table below shows this endpoint's support for
   much, much longer than any expected recoverable outage for the given service.
 
 - `Args` `(array<string>)` - Specifies command arguments to run to update the
-  status of the check. Prior to Consul 1.0, checks used a single `Script` field
-  to define the command to run, and would always run in a shell. In Consul
-  1.0, the `Args` array was added so that checks can be run without a shell. The
-  `Script` field is deprecated, and you should include the shell in the `Args` to
-  run under a shell, eg. `"args": ["sh", "-c", "..."]`.
+  status of the check.
 
   -> **Note:** Consul 1.0 shipped with an issue where `Args` was erroneously named
     `ScriptArgs` in this API. Please use `ScriptArgs` with Consul 1.0 (that will


### PR DESCRIPTION
This file got missed in the doucmentation update for the below commit, and appears to have been misleading since consul v1.1.0.  This lead to us upgrading consul and having health checks fail to register, as the documentation indicated the Script fields was only deprecated, not removed.

https://github.com/hashicorp/consul/commit/b73323aa429f6edcfdff3b951774ca6f296f2bc5