### PR TITLE
Unflake the TestAPI_AgentConnectCALeaf test

### DIFF
--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1389,6 +1389,9 @@ func TestAPI_AgentConnectCALeaf(t *testing.T) {
 	c, s := makeClient(t)
 	defer s.Stop()
 
+	// ensure we don't try to sign a leaf cert before connect has been initialized
+	s.WaitForActiveCARoot(t)
+
 	agent := c.Agent()
 	// Setup service
 	reg := &AgentServiceRegistration{


### PR DESCRIPTION
Fixes: #7053 

The fix here is to wait until connect gets fully initialized before trying to sign a leaf cert. We already had a helper to do this.