### PR TITLE
ui: Fix positioning of active icon in the selected menu item

### DIFF
--- a/ui-v2/app/styles/base/components/menu-panel/layout.scss
+++ b/ui-v2/app/styles/base/components/menu-panel/layout.scss
@@ -65,6 +65,9 @@
   padding: 10px;
   padding-left: 36px;
 }
+%menu-panel .is-active {
+  position: relative;
+}
 %menu-panel .is-active > *::after {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
Before:

![Screenshot 2020-01-28 at 09 43 16](https://user-images.githubusercontent.com/554604/73252577-dc0c5000-41b2-11ea-8085-b699a87dffa0.png)

(^ notice `ca_east-6` is the current datacenter)

After:

![Screenshot 2020-01-28 at 09 45 16](https://user-images.githubusercontent.com/554604/73252624-ecbcc600-41b2-11ea-880a-86ed09ac92a1.png)
