### PR TITLE
ui: Fix wrapping service ids in the Node Detail > Services tab

### DIFF
--- a/ui-v2/app/styles/routes/dc/nodes/index.scss
+++ b/ui-v2/app/styles/routes/dc/nodes/index.scss
@@ -10,6 +10,9 @@ html.template-node.template-list .unhealthy h2 {
 html.template-node.template-show #meta-data table tr {
   cursor: default;
 }
+html.template-node.template-show #services table tbody td em {
+  display: inline-block;
+}
 .healthy > div > ul > li {
   padding-top: 16px;
 }


### PR DESCRIPTION
Before:

<img width="578" alt="Screenshot 2020-01-28 at 09 51 45" src="https://user-images.githubusercontent.com/554604/73253213-fb57ad00-41b3-11ea-8428-31d1bd2dc031.png">

After:

<img width="607" alt="Screenshot 2020-01-28 at 09 53 23" src="https://user-images.githubusercontent.com/554604/73253245-0c082300-41b4-11ea-9fb7-a0bfb94837e3.png">
