### PR TITLE
use 4 parallelism for go-test and print package names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
   go-test:
     docker:
       - image: *GOLANG_IMAGE
-    parallelism: 8
+    parallelism: 4
     environment:
       <<: *ENVIRONMENT
       GOTAGS: "" # No tags for OSS but there are for enterprise
@@ -109,6 +109,8 @@ jobs:
       - run: sudo service rsyslog start
       - run: |
           PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+          echo $PACKAGE_NAMES
           gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
 
       # save coverage report parts


### PR DESCRIPTION
To not take up 8 CircleCI executors, I bumped the parallelism down to 4. Theoretically we could use just 3 executors but the test metadata doesn't include build times and the 3rd container with ! (`agent` || `agent/consul`) packages take about 8 minutes to run having to build so many packages. With 4 containers they all finish around the same time as seen here.

4 parallelism:
![image](https://user-images.githubusercontent.com/17609145/73283296-e6354b00-41c0-11ea-84ad-c1f8e7b39b3f.png)

3 parallelism:
![image](https://user-images.githubusercontent.com/17609145/73278134-27c1f800-41b9-11ea-8047-5a38902e2755.png)
