### PR TITLE
docs: update ACL perms for the /connect/ca/roots endpoint

### DIFF
--- a/website/source/api/connect/ca.html.md
+++ b/website/source/api/connect/ca.html.md
@@ -29,7 +29,7 @@ The table below shows this endpoint's support for
 
 | Blocking Queries | Consistency Modes | Agent Caching | ACL Required     |
 | ---------------- | ----------------- | ------------- | ---------------- |
-| `YES`            | `all`             | `none`        | `operator:read`  |
+| `YES`            | `all`             | `none`        | `none`           |
 
 ### Sample Request
 


### PR DESCRIPTION
Similar to the [`/agent/connect/ca/roots`](https://www.consul.io/api/agent/connect.html#certificate-authority-ca-roots), the `/connect/ca/roots` also doesn't require an ACL token.