### PR TITLE
Output proper HTTP status codes for Txn requests that are too large

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -69,9 +69,11 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 	sizeStr := req.Header.Get("Content-Length")
 	if sizeStr != "" {
 		if size, err := strconv.Atoi(sizeStr); err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Failed to parse Content-Length: %v", err)
 			return nil, 0, false
 		} else if size > int(s.agent.config.KVMaxValueSize) {
+			resp.WriteHeader(http.StatusRequestEntityTooLarge)
 			fmt.Fprintf(resp, "Request body too large, max size: %v bytes", s.agent.config.KVMaxValueSize)
 			return nil, 0, false
 		}


### PR DESCRIPTION
Previously the plain text error message was being returned with 200 status codes.