### PR TITLE
Output proper HTTP status codes for Txn requests that are too large

### DIFF
--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -69,9 +69,11 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 	sizeStr := req.Header.Get("Content-Length")
 	if sizeStr != "" {
 		if size, err := strconv.Atoi(sizeStr); err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprintf(resp, "Failed to parse Content-Length: %v", err)
 			return nil, 0, false
 		} else if size > int(s.agent.config.KVMaxValueSize) {
+			resp.WriteHeader(http.StatusRequestEntityTooLarge)
 			fmt.Fprintf(resp, "Request body too large, max size: %v bytes", s.agent.config.KVMaxValueSize)
 			return nil, 0, false
 		}

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -41,7 +41,7 @@ func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 
 func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 	t.Parallel()
-	testIt := func(agent *TestAgent, wantPass bool) {
+	testIt := func(t *testing.T, agent *TestAgent, wantPass bool) {
 		value := strings.Repeat("X", 3*raft.SuggestedMaxDataSize)
 		value = base64.StdEncoding.EncodeToString([]byte(value))
 		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -56,6 +56,7 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
  ]
  `, value)))
 		req, _ := http.NewRequest("PUT", "/v1/txn", buf)
+		req.Header.Add("Content-Length", fmt.Sprintf("%d", buf.Len()))
 		resp := httptest.NewRecorder()
 		if _, err := agent.srv.Txn(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -70,13 +71,13 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 
 	t.Run("toobig", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "")
-		testIt(a, false)
+		testIt(t, a, false)
 		a.Shutdown()
 	})
 
 	t.Run("allowed", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
-		testIt(a, true)
+		testIt(t, a, true)
 		a.Shutdown()
 	})
 }


### PR DESCRIPTION
This is the backport of #7157