### PR TITLE
ui: Add live updates/blocking queries to the Intention listing page

### DIFF
--- a/ui-v2/app/instance-initializers/event-source.js
+++ b/ui-v2/app/instance-initializers/event-source.js
@@ -4,7 +4,7 @@ export function initialize(container) {
   if (env('CONSUL_UI_DISABLE_REALTIME')) {
     return;
   }
-  ['node', 'coordinate', 'session', 'service', 'proxy', 'discovery-chain']
+  ['node', 'coordinate', 'session', 'service', 'proxy', 'discovery-chain', 'intention']
     .concat(env('CONSUL_NSPACES_ENABLED') ? ['nspace/enabled'] : [])
     .map(function(item) {
       // create repositories that return a promise resolving to an EventSource
@@ -68,6 +68,12 @@ export function initialize(container) {
         services: {
           repo: 'repository/service/event-source',
           proxyRepo: 'repository/proxy/event-source',
+        },
+      },
+      {
+        route: 'dc/intentions/index',
+        services: {
+          repo: 'repository/intention/event-source',
         },
       },
       {

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -28,7 +28,7 @@
       {{#if (not (env 'CONSUL_UI_DISABLE_REALTIME'))}}
         <fieldset>
           <h2>Blocking Queries</h2>
-          <p>Keep catalog info up-to-date without refreshing the page. Any changes made to services and nodes would be reflected in real time.</p>
+          <p>Keep catalog info up-to-date without refreshing the page. Any changes made to services, nodes and intentions would be reflected in real time.</p>
           <div class="type-toggle">
             <label>
               <input type="checkbox" name="client[blocking]" checked={{if item.client.blocking 'checked'}} onchange={{action 'change'}} />

--- a/ui-v2/tests/acceptance/dc/list-blocking.feature
+++ b/ui-v2/tests/acceptance/dc/list-blocking.feature
@@ -5,7 +5,7 @@ Feature: dc / list-blocking
   I want to see changes if I change consul externally
   Background:
     Given 1 datacenter model with the value "dc-1"
-  Scenario: Viewing the listing pages
+  Scenario: Viewing the listing pages for [Page]
     Given 3 [Model] models
     And a network latency of 100
     When I visit the [Page] page for yaml
@@ -25,8 +25,9 @@ Feature: dc / list-blocking
     | Page       | Model       | Url               |
     | services   | service     | services          |
     | nodes      | node        | nodes             |
+    | intentions | intention   | intentions        |
     ------------------------------------------------
-  Scenario: Viewing detail pages with a listing
+  Scenario: Viewing detail pages with a listing for [Page]
     Given 3 [Model] models
     And a network latency of 100
     When I visit the [Page] page for yaml


### PR DESCRIPTION
This PR enables blocking queries/live updates for Intentions.

[Preview Link](https://deploy-preview-7161--consul-ui-staging.netlify.com/ui/ar_west-5/intentions)

If you add a cookie called `CONSUL_LATENCY` whilst visiting the above link and then hit refresh you can speed up the rate of change:

![Screenshot 2020-01-29 at 11 08 18](https://user-images.githubusercontent.com/554604/73351850-ca48ac80-4287-11ea-900e-6720a8eb4676.png)

500 means fake a change every 500 milliseconds.
