### PR TITLE
ui:  Fix sticky nspace menu

### DIFF
--- a/ui-v2/app/components/aria-menu.js
+++ b/ui-v2/app/components/aria-menu.js
@@ -39,6 +39,7 @@ const MENU_ITEMS = '[role^="menuitem"]';
 export default Component.extend({
   tagName: '',
   dom: service('dom'),
+  router: service('router'),
   guid: '',
   expanded: false,
   orientation: 'vertical',
@@ -47,6 +48,7 @@ export default Component.extend({
     this._super(...arguments);
     set(this, 'guid', this.dom.guid(this));
     this._listeners = this.dom.listeners();
+    this._routelisteners = this.dom.listeners();
   },
   didInsertElement: function() {
     // TODO: How do you detect whether the children have changed?
@@ -54,10 +56,14 @@ export default Component.extend({
     this.$menu = this.dom.element(`#${COMPONENT_ID}menu-${this.guid}`);
     const labelledBy = this.$menu.getAttribute('aria-labelledby');
     this.$trigger = this.dom.element(`#${labelledBy}`);
+    this._routelisteners.add(this.router, {
+      routeWillChange: () => this.actions.close.apply(this, [{}]),
+    });
   },
   willDestroyElement: function() {
     this._super(...arguments);
     this._listeners.remove();
+    this._routelisteners.remove();
   },
   actions: {
     keypressClick: function(e) {

--- a/ui-v2/app/templates/components/hashicorp-consul.hbs
+++ b/ui-v2/app/templates/components/hashicorp-consul.hbs
@@ -12,7 +12,7 @@
 {{#if dc}}
                 <ul>
   {{#if (and (env 'CONSUL_NSPACES_ENABLED') (gt nspaces.length 0))}}
-                    <li>
+                    <li data-test-nspace-menu>
     {{#if (and (eq nspaces.length 1) (not canManageNspaces)) }}
                         <span data-test-nspace-selected={{nspace.Name}}>{{nspace.Name}}</span>
     {{ else }}

--- a/ui-v2/app/templates/components/popover-menu.hbs
+++ b/ui-v2/app/templates/components/popover-menu.hbs
@@ -1,6 +1,6 @@
 {{yield (concat 'popover-menu-' guid)}}
 {{#aria-menu keyboardAccess=keyboardAccess as |change keypress ariaLabelledBy ariaControls ariaExpanded keypressClick|}}
-  {{#toggle-button checked=expanded onchange=(queue change (action 'change')) as |click|}}
+  {{#toggle-button checked=ariaExpanded onchange=(queue change (action 'change')) as |click|}}
     <button type="button" aria-haspopup="menu" onkeydown={{keypress}} onclick={{click}} id={{ariaLabelledBy}} aria-controls={{ariaControls}}>
       {{#yield-slot name='trigger'}}
         {{yield}}

--- a/ui-v2/tests/acceptance/dc/nspaces/manage.feature
+++ b/ui-v2/tests/acceptance/dc/nspaces/manage.feature
@@ -1,0 +1,33 @@
+@setupApplicationTest
+Feature: dc / nspaces / manage : Managing Namespaces
+  Scenario:
+    Given settings from yaml
+    ---
+    consul:token:
+      SecretID: secret
+      AccessorID: accessor
+      Namespace: default
+    ---
+    And 1 datacenter models from yaml
+    ---
+      - dc-1
+    ---
+    And 6 service models
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    Then I see 6 service models
+    # In order to test this properly you have to click around a few times
+    # between services and nspace management
+    When I click nspace on the navigation
+    And I click manageNspaces on the navigation
+    Then the url should be /dc-1/namespaces
+    And I don't see manageNspacesIsVisible on the navigation
+    When I click services on the navigation
+    Then the url should be /dc-1/services
+    When I click nspace on the navigation
+    And I click manageNspaces on the navigation
+    Then the url should be /dc-1/namespaces
+    And I don't see manageNspacesIsVisible on the navigation

--- a/ui-v2/tests/acceptance/steps/dc/nspaces/manage-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/nspaces/manage-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages/components/page.js
+++ b/ui-v2/tests/pages/components/page.js
@@ -1,4 +1,4 @@
-import { clickable } from 'ember-cli-page-object';
+import { clickable, is } from 'ember-cli-page-object';
 const page = {
   navigation: ['services', 'nodes', 'kvs', 'acls', 'intentions', 'docs', 'settings'].reduce(
     function(prev, item, i, arr) {
@@ -24,4 +24,10 @@ const page = {
   ),
 };
 page.navigation.dc = clickable('[data-test-datacenter-menu] button');
+page.navigation.nspace = clickable('[data-test-nspace-menu] button');
+page.navigation.manageNspaces = clickable('[data-test-main-nav-nspaces] a');
+page.navigation.manageNspacesIsVisible = is(
+  ':checked',
+  '[data-test-nspace-menu] > input[type="checkbox"]'
+);
 export default page;

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -71,16 +71,20 @@ export default function(scenario, assert, find, currentPage) {
       } else {
         obj = currentPage()[component];
       }
-      assert.throws(
-        function() {
-          const func = obj[property].bind(obj);
-          func();
-        },
-        function(e) {
-          return e.message.startsWith('Element not found');
-        },
-        `Expected to not see ${property} on ${component}`
-      );
+      if (typeof obj[property] === 'function') {
+        assert.throws(
+          function() {
+            const func = obj[property].bind(obj);
+            func();
+          },
+          function(e) {
+            return e.message.startsWith('Element not found');
+          },
+          `Expected to not see ${property} on ${component}`
+        );
+      } else {
+        assert.notOk(obj[property]);
+      }
     })
     .then(["I don't see $property"], function(property) {
       assert.throws(


### PR DESCRIPTION
Occasionally the nspace menu would stay open when clicked. This PR adds a route listener to the menu so we can always close the menu on route change.

Ideally I'd prefer components not to be aware of routes, so we may change this at some point in the future if we find an approach that we are happier with.

Tests included (you had to click around a bit to get it to stay open)

(see https://github.com/hashicorp/consul/pull/7187 for test problems/solutions)