### PR TITLE
various tweaks on top of the hclog work

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -61,8 +61,11 @@ func (a *Agent) resolveIdentityFromToken(secretID string) (bool, structs.ACLIden
 // so we can safely log it without handling non-critical errors at the usage site.
 func (a *Agent) aclAccessorID(secretID string) string {
 	_, ident, err := a.resolveIdentityFromToken(secretID)
+	if acl.IsErrNotFound(err) {
+		return ""
+	}
 	if err != nil {
-		a.logger.Debug("error", err)
+		a.logger.Debug("non-critical error resolving acl token accessor for logging", "error", err)
 		return ""
 	}
 	if ident == nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1982,7 +1982,7 @@ OUTER:
 				if err := a.RPC("Coordinate.Update", &req, &reply); err != nil {
 					if acl.IsErrPermissionDenied(err) {
 						accessorID := a.aclAccessorID(agentToken)
-						a.logger.Warn("Coordinate update blocked by ACLs", "accesorID", accessorID)
+						a.logger.Warn("Coordinate update blocked by ACLs", "accessorID", accessorID)
 					} else {
 						a.logger.Error("Coordinate update error", "error", err)
 					}

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -784,8 +784,8 @@ func (r *ACLResolver) collectPoliciesForIdentity(identity structs.ACLIdentity, p
 			} else {
 				r.logger.Warn("policy not found for identity",
 					"policy", policyID,
-					"identity", identity.ID(),
-					"accessorID", accessorID)
+					"accessorID", accessorID,
+				)
 			}
 
 			continue
@@ -885,7 +885,6 @@ func (r *ACLResolver) collectRolesForIdentity(identity structs.ACLIdentity, role
 				}
 				r.logger.Warn("role not found for identity",
 					"role", roleID,
-					"identity", identity.ID(),
 					"accessorID", accessorID,
 				)
 			}

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -472,8 +472,11 @@ func (s *Intention) Check(
 // so we can safely log it without handling non-critical errors at the usage site.
 func (s *Intention) aclAccessorID(secretID string) string {
 	_, ident, err := s.srv.ResolveIdentityFromToken(secretID)
+	if acl.IsErrNotFound(err) {
+		return ""
+	}
 	if err != nil {
-		s.srv.logger.Debug("error", err)
+		s.logger.Debug("non-critical error resolving acl token accessor for logging", "error", err)
 		return ""
 	}
 	if ident == nil {

--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -266,8 +266,11 @@ func (m *Internal) executeKeyringOpMgr(
 // so we can safely log it without handling non-critical errors at the usage site.
 func (m *Internal) aclAccessorID(secretID string) string {
 	_, ident, err := m.srv.ResolveIdentityFromToken(secretID)
+	if acl.IsErrNotFound(err) {
+		return ""
+	}
 	if err != nil {
-		m.srv.logger.Debug("error", err)
+		m.logger.Debug("non-critical error resolving acl token accessor for logging", "error", err)
 		return ""
 	}
 	if ident == nil {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -396,7 +396,7 @@ func NewServerLogger(config *Config, logger hclog.InterceptLogger, tokens *token
 		Delegate: &FunctionReplicator{ReplicateFn: s.replicateConfig},
 		Rate:     s.config.ConfigReplicationRate,
 		Burst:    s.config.ConfigReplicationBurst,
-		Logger:   s.loggers.Named(logging.Replication).Named(logging.ConfigEntry),
+		Logger:   s.logger,
 	}
 	s.configReplicator, err = NewReplicator(&configReplicatorConfig)
 	if err != nil {

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1361,8 +1361,11 @@ func (l *State) notifyIfAliased(serviceID structs.ServiceID) {
 // so we can safely log it without handling non-critical errors at the usage site.
 func (l *State) aclAccessorID(secretID string) string {
 	_, ident, err := l.Delegate.ResolveIdentityFromToken(secretID)
+	if acl.IsErrNotFound(err) {
+		return ""
+	}
 	if err != nil {
-		l.logger.Debug("error", err)
+		l.logger.Debug("non-critical error resolving acl token accessor for logging", "error", err)
 		return ""
 	}
 	if ident == nil {


### PR DESCRIPTION
- the various `aclAccessorID` functions were using an even number of args to `Debug` which results in a log message that includes `EXTRA_VALUE_AT_END`
- the `aclAccessorID` log message was not very exciting
- some typos
- now that `accessorID` is logged we don't want to log `identity`
- `replicateConfig` didn't use the passed in `logger`
- the config entry replicator had a logger that repeated the replication/config/replication/config part