### PR TITLE
ui: Use data-source component for service show/instance/routing views

### DIFF
--- a/ui-v2/app/controllers/dc/nodes/index.js
+++ b/ui-v2/app/controllers/dc/nodes/index.js
@@ -1,10 +1,9 @@
 import Controller from '@ember/controller';
-import { computed } from '@ember/object';
-import WithEventSource from 'consul-ui/mixins/with-event-source';
+import { get, computed } from '@ember/object';
 import WithHealthFiltering from 'consul-ui/mixins/with-health-filtering';
 import WithSearching from 'consul-ui/mixins/with-searching';
-import { get } from '@ember/object';
-export default Controller.extend(WithEventSource, WithSearching, WithHealthFiltering, {
+
+export default Controller.extend(WithSearching, WithHealthFiltering, {
   init: function() {
     this.searchParams = {
       healthyNode: 's',

--- a/ui-v2/app/controllers/dc/services/instance.js
+++ b/ui-v2/app/controllers/dc/services/instance.js
@@ -1,10 +1,7 @@
 import Controller from '@ember/controller';
-import { get, set } from '@ember/object';
-import { inject as service } from '@ember/service';
-import WithEventSource, { listen } from 'consul-ui/mixins/with-event-source';
+import { set } from '@ember/object';
 
-export default Controller.extend(WithEventSource, {
-  notify: service('flashMessages'),
+export default Controller.extend({
   setProperties: function() {
     this._super(...arguments);
     // This method is called immediately after `Route::setupController`, and done here rather than there
@@ -12,23 +9,6 @@ export default Controller.extend(WithEventSource, {
     // need this variable
     set(this, 'selectedTab', 'service-checks');
   },
-  item: listen('item').catch(function(e) {
-    if (e.target.readyState === 1) {
-      // OPEN
-      if (get(e, 'error.errors.firstObject.status') === '404') {
-        this.notify.add({
-          destroyOnClick: false,
-          sticky: true,
-          type: 'warning',
-          action: 'update',
-        });
-        const proxy = this.proxy;
-        if (proxy) {
-          proxy.close();
-        }
-      }
-    }
-  }),
   actions: {
     change: function(e) {
       set(this, 'selectedTab', e.target.value);

--- a/ui-v2/app/controllers/dc/services/show.js
+++ b/ui-v2/app/controllers/dc/services/show.js
@@ -3,10 +3,8 @@ import { get, set, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import WithSearching from 'consul-ui/mixins/with-searching';
-import WithEventSource, { listen } from 'consul-ui/mixins/with-event-source';
-export default Controller.extend(WithEventSource, WithSearching, {
+export default Controller.extend(WithSearching, {
   dom: service('dom'),
-  notify: service('flashMessages'),
   items: alias('item.Nodes'),
   init: function() {
     this.searchParams = {
@@ -22,19 +20,6 @@ export default Controller.extend(WithEventSource, WithSearching, {
 
     set(this, 'selectedTab', 'instances');
   },
-  item: listen('item').catch(function(e) {
-    if (e.target.readyState === 1) {
-      // OPEN
-      if (get(e, 'error.errors.firstObject.status') === '404') {
-        this.notify.add({
-          destroyOnClick: false,
-          sticky: true,
-          type: 'warning',
-          action: 'update',
-        });
-      }
-    }
-  }),
   searchable: computed('items', function() {
     return get(this, 'searchables.serviceInstance')
       .add(this.items)

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -13,7 +13,10 @@ export default Route.extend({
   model: function(params) {
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      items: this.repo.findAllByDatacenter(dc, this.modelFor('nspace').nspace.substr(1)),
+      dc: dc,
+      nspace: this.modelFor('nspace').nspace.substr(1),
+      items: undefined,
+      error: undefined,
       leader: this.repo.findByLeader(dc),
     });
   },

--- a/ui-v2/app/routes/dc/services/instance.js
+++ b/ui-v2/app/routes/dc/services/instance.js
@@ -1,29 +1,14 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
-import { hash } from 'rsvp';
-import { get } from '@ember/object';
 
 export default Route.extend({
-  repo: service('repository/service'),
-  proxyRepo: service('repository/proxy'),
   model: function(params) {
-    const dc = this.modelFor('dc').dc.Name;
-    const nspace = this.modelFor('nspace').nspace.substr(1);
-    return hash({
-      item: this.repo.findInstanceBySlug(params.id, params.node, params.name, dc, nspace),
-    }).then(model => {
-      // this will not be run in a blocking loop, but this is ok as
-      // its highly unlikely that a service will suddenly change to being a
-      // connect-proxy or vice versa so leave as is for now
-      return hash({
-        proxy:
-          // proxies and mesh-gateways can't have proxies themselves so don't even look
-          ['connect-proxy', 'mesh-gateway'].includes(get(model.item, 'Kind'))
-            ? null
-            : this.proxyRepo.findInstanceBySlug(params.id, params.node, params.name, dc, nspace),
-        ...model,
-      });
-    });
+    return {
+      dc: this.modelFor('dc').dc.Name,
+      nspace: this.modelFor('nspace').nspace.substr(1),
+      slug: [params.id, params.node, params.name].join('/'),
+      item: undefined,
+      proxy: undefined,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -1,11 +1,8 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
-import { get } from '@ember/object';
 
 export default Route.extend({
-  repo: service('repository/service'),
-  chainRepo: service('repository/discovery-chain'),
   settings: service('settings'),
   queryParams: {
     s: {
@@ -17,16 +14,12 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      item: this.repo.findBySlug(params.name, dc, nspace),
+      item: undefined,
+      chain: undefined,
       urls: this.settings.findBySlug('urls'),
       dc: dc,
-    }).then(model => {
-      return hash({
-        chain: ['connect-proxy', 'mesh-gateway'].includes(get(model, 'item.Service.Kind'))
-          ? null
-          : this.chainRepo.findBySlug(params.name, dc, nspace),
-        ...model,
-      });
+      nspace: nspace,
+      slug: params.name,
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -3,7 +3,9 @@ import Service, { inject as service } from '@ember/service';
 export default Service.extend({
   // TODO: Temporary repo list here
   service: service('repository/service'),
+  ['service-instance']: service('repository/service'),
   services: service('repository/service'),
+  ['discovery-chain']: service('repository/discovery-chain'),
   node: service('repository/node'),
   nodes: service('repository/node'),
   session: service('repository/session'),

--- a/ui-v2/app/services/repository/manager.js
+++ b/ui-v2/app/services/repository/manager.js
@@ -41,7 +41,11 @@ export default Service.extend({
           return repo.findAllByDatacenter(dc, nspace, configuration);
         };
         break;
-      // weirder ones
+      case 'session':
+        obj.find = function(configuration) {
+          return repo.findByNode(slug, dc, nspace, configuration);
+        };
+        break;
       case 'service-instance':
         temp = slug.split('/');
         id = temp[0];

--- a/ui-v2/app/templates/components/app-view.hbs
+++ b/ui-v2/app/templates/components/app-view.hbs
@@ -1,6 +1,9 @@
 {{yield}}
 {{#if (not loading)}}
 <header>
+  {{#yield-slot 'notification2'}}
+    {{yield}}
+  {{/yield-slot}}
 {{#each flashMessages.queue as |flash|}}
     {{#flash-message flash=flash as |component flash|}}
         {{! flashes automatically ucfirst the type }}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,85 +1,96 @@
 {{title 'Nodes'}}
-{{#app-view class="node list"}}
-  {{#block-slot name='header'}}
-    <h1>
-      Nodes <em>{{format-number items.length}} total</em>
-    </h1>
-    <label for="toolbar-toggle"></label>
-  {{/block-slot}}
-  {{#block-slot name='toolbar'}}
+{{data-source
+  src=(concat '/' nspace '/' dc '/nodes')
+  onchange=(action (mut items) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if
+    (not (is-undefined error))
+}}
+  {{app-error error=error.errors.firstObject}}
+{{else}}
+  {{#app-view class="node list" loading=(is-undefined items)}}
+    {{#block-slot name='header'}}
+      <h1>
+        Nodes <em>{{format-number items.length}} total</em>
+      </h1>
+      <label for="toolbar-toggle"></label>
+    {{/block-slot}}
+    {{#block-slot name='toolbar'}}
 {{#if (gt items.length 0) }}
-    {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
+      {{catalog-filter searchable=(array searchableHealthy searchableUnhealthy) search=s status=filters.status onchange=(action 'filter')}}
 {{/if}}
-  {{/block-slot}}
-  {{#block-slot name='content'}}
+    {{/block-slot}}
+    {{#block-slot name='content'}}
 {{#if (gt unhealthy.length 0) }}
-      <div class="unhealthy">
-        <h2>Unhealthy Nodes</h2>
-        <div>
-          {{! think about 2 differing views here }}
-          <ul>
-            {{#changeable-set dispatcher=searchableUnhealthy}}
-              {{#block-slot name='set' as |unhealthy|}}
-                {{#each unhealthy as |item|}}
-                  {{#healthchecked-resource
-                      tagName='li'
-                      data-test-node=item.Node
-                      href=(href-to 'dc.nodes.show' item.Node)
-                      name=item.Node
-                      address=item.Address
-                      checks=item.Checks
-                  }}
-                    {{#block-slot name='icon'}}
-                      {{#if (eq item.Address leader.Address)}}
-                        <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                      {{/if}}
-                    {{/block-slot}}
-                  {{/healthchecked-resource}}
-                {{/each}}
-              {{/block-slot}}
-              {{#block-slot name='empty'}}
-                <p>
-                  There are no unhealthy nodes for that search.
-                </p>
-              {{/block-slot}}
-            {{/changeable-set}}
-          </ul>
+        <div class="unhealthy">
+          <h2>Unhealthy Nodes</h2>
+          <div>
+            {{! think about 2 differing views here }}
+            <ul>
+              {{#changeable-set dispatcher=searchableUnhealthy}}
+                {{#block-slot name='set' as |unhealthy|}}
+                  {{#each unhealthy as |item|}}
+                    {{#healthchecked-resource
+                        tagName='li'
+                        data-test-node=item.Node
+                        href=(href-to 'dc.nodes.show' item.Node)
+                        name=item.Node
+                        address=item.Address
+                        checks=item.Checks
+                    }}
+                      {{#block-slot 'icon'}}
+                        {{#if (eq item.Address leader.Address)}}
+                          <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                        {{/if}}
+                      {{/block-slot}}
+                    {{/healthchecked-resource}}
+                  {{/each}}
+                {{/block-slot}}
+                {{#block-slot name='empty'}}
+                  <p>
+                    There are no unhealthy nodes for that search.
+                  </p>
+                {{/block-slot}}
+              {{/changeable-set}}
+            </ul>
+          </div>
         </div>
-      </div>
 {{/if}}
 {{#if (gt healthy.length 0) }}
-      <div class="healthy">
-        <h2>Healthy Nodes</h2>
-        {{#changeable-set dispatcher=searchableHealthy}}
-          {{#block-slot name='set' as |healthy|}}
-            {{#list-collection cellHeight=92 items=healthy as |item index|}}
-              {{#healthchecked-resource
-                  data-test-node=item.Node
-                  href=(href-to 'dc.nodes.show' item.Node)
-                  name=item.Node
-                  address=item.Address
-                  checks=item.Checks
-              }}
-                {{#block-slot name='icon'}}
-                  {{#if (eq item.Address leader.Address)}}
-                    <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
-                  {{/if}}
-                {{/block-slot}}
-              {{/healthchecked-resource}}
-            {{/list-collection}}
-          {{/block-slot}}
-          {{#block-slot name='empty'}}
-            <p>
-              There are no healthy nodes for that search.
-            </p>
-          {{/block-slot}}
-        {{/changeable-set}}
-      </div>
+        <div class="healthy">
+          <h2>Healthy Nodes</h2>
+          {{#changeable-set dispatcher=searchableHealthy}}
+            {{#block-slot name='set' as |healthy|}}
+              {{#list-collection cellHeight=92 items=healthy as |item index|}}
+                {{#healthchecked-resource
+                    data-test-node=item.Node
+                    href=(href-to 'dc.nodes.show' item.Node)
+                    name=item.Node
+                    address=item.Address
+                    checks=item.Checks
+                }}
+                  {{#block-slot name='icon'}}
+                    {{#if (eq item.Address leader.Address)}}
+                      <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
+                    {{/if}}
+                  {{/block-slot}}
+                {{/healthchecked-resource}}
+              {{/list-collection}}
+            {{/block-slot}}
+            {{#block-slot name='empty'}}
+              <p>
+                There are no healthy nodes for that search.
+              </p>
+            {{/block-slot}}
+          {{/changeable-set}}
+        </div>
 {{/if}}
 {{#if (and (eq healthy.length 0) (eq unhealthy.length 0)) }}
-      <p>
-          There are no nodes.
-      </p>
+        <p>
+            There are no nodes.
+        </p>
 {{/if}}
-  {{/block-slot}}
-{{/app-view}}
+    {{/block-slot}}
+  {{/app-view}}
+{{/if}}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -39,7 +39,7 @@
                         address=item.Address
                         checks=item.Checks
                     }}
-                      {{#block-slot 'icon'}}
+                      {{#block-slot name='icon'}}
                         {{#if (eq item.Address leader.Address)}}
                           <span data-test-leader={{leader.Address}} data-tooltip="Leader">Leader</span>
                         {{/if}}

--- a/ui-v2/app/templates/dc/services/-notifications.hbs
+++ b/ui-v2/app/templates/dc/services/-notifications.hbs
@@ -1,7 +1,0 @@
-{{#if (eq type 'update')}}
-  {{#if (eq status 'warning') }}
-    This service has been deregistered and no longer exists in the catalog.
-  {{else}}
-  {{/if}}
-{{/if}}
-

--- a/ui-v2/app/templates/dc/services/-routing.hbs
+++ b/ui-v2/app/templates/dc/services/-routing.hbs
@@ -1,1 +1,8 @@
-{{discovery-chain chain=chain.Chain}}
+{{data-source
+  src=(concat '/' nspace '/' dc '/discovery-chain/' slug)
+  onchange=(action (mut chain) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if (not (is-undefined chain))}}
+  {{discovery-chain chain=chain.Chain}}
+{{/if}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -10,9 +10,6 @@
   {{app-error error=error.errors.firstObject}}
 {{else}}
   {{#app-view class="service list" loading=(is-undefined items)}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/services/notifications'}}
-    {{/block-slot}}
     {{#block-slot name='header'}}
       <h1>
         Services <em>{{format-number items.length}} total</em>

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -1,117 +1,158 @@
 {{title item.ID}}
-{{#app-view class="instance show"}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/services/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='breadcrumbs'}}
-        <ol>
-            <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
-            <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service}})</a></li>
-            <li><strong>Instance</strong></li>
-        </ol>
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-      <h1>
-        {{ item.ID }}
-{{#with (service/external-source item) as |externalSource| }}
-  {{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg| }}
-    {{#if (not-eq bg 'none') }}
-        <span data-test-external-source="{{externalSource}}" style={{{ concat 'background-image:' bg }}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
-    {{/if}}
-  {{/with}}
-{{/with}}
-{{#if (eq item.Kind 'connect-proxy')}}
-        <span class="kind-proxy">Proxy</span>
-{{else if (eq item.Kind 'mesh-gateway')}}
-        <span class="kind-proxy">Mesh Gateway</span>
+{{data-source
+  src=(concat '/' nspace '/' dc '/service-instance/' slug)
+  onchange=(action (mut item) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if (
+  and
+    (not (is-undefined item))
+    (not (eq item.Kind 'connect-proxy'))
+    (not (eq item.Kind 'mesh-gateway'))
+  )}}
+  {{! right now we don't mind too much about proxy errors}}
+  {{data-source
+    src=(concat '/' nspace '/' dc '/proxy/' slug)
+    onchange=(action (mut proxy) value='data')
+  }}
 {{/if}}
-      </h1>
-      <dl>
-        <dt>Service Name</dt>
-        <dd><a href="{{href-to 'dc.services.show' item.Service}}">{{item.Service}}</a></dd>
-      </dl>
-      <dl>
-        <dt>Node Name</dt>
-        <dd><a href="{{href-to 'dc.nodes.show' item.Node.Node}}">{{item.Node.Node}}</a></dd>
-      </dl>
-{{#if proxy.ServiceName}}
-      <dl>
-{{#if proxy.ServiceProxy.DestinationServiceID}}
-        <dt data-test-proxy-type="sidecar-proxy">Sidecar Proxy</dt>
-        <dd><a href="{{href-to 'dc.services.instance' proxy.ServiceName proxy.Node proxy.ServiceID}}">{{proxy.ServiceID}}</a></dd>
+
+{{#if (and (is-undefined item) (eq error.errors.firstObject.status '404'))}}
+  {{app-error error=error.errors.firstObject}}
 {{else}}
-        <dt data-test-proxy-type="proxy">Proxy</dt>
-        <dd><a href="{{href-to 'dc.services.show' proxy.ServiceName}}">{{proxy.ServiceName}}</a></dd>
-{{/if}}
-      </dl>
-{{/if}}
-{{#if (eq item.Kind 'connect-proxy')}}
-  {{#if item.Proxy.DestinationServiceID}}
-      <dl>
-        <dt data-test-proxy-destination="instance">Dest. Service Instance</dt>
-        <dd><a href="{{href-to 'dc.services.instance' item.Proxy.DestinationServiceName item.Node.Node item.Proxy.DestinationServiceID}}">{{item.Proxy.DestinationServiceID}}</a></dd>
-      </dl>
-      <dl>
-        <dt>Local Service Address</dt>
-        <dd>{{item.Proxy.LocalServiceAddress}}:{{item.Proxy.LocalServicePort}}</dd>
-      </dl>
-  {{else}}
-      <dl>
-        <dt data-test-proxy-destination="service">Dest. Service</dt>
-        <dd><a href="{{href-to 'dc.services.show' item.Proxy.DestinationServiceName}}">{{item.Proxy.DestinationServiceName}}</a></dd>
-      </dl>
+  {{#app-view class="instance show" loading=(
+    not
+      (and
+        (not (is-undefined item))
+        (or
+          (eq item.Kind 'connect-proxy')
+          (eq item.Kind 'mesh-gateway')
+          (not (is-undefined proxy))
+        )
+      )
+  )}}
+      {{#block-slot 'notification2'}}
+        {{#if (eq error.errors.firstObject.status '404')}}
+          <div class="flash-message">
+            <p data-notification class="warning notification-update">
+              <strong>
+                Warning!
+              </strong>
+              This service has been deregistered and no longer exists in the catalog.
+            </p>
+          </div>
+        {{/if}}
+      {{/block-slot}}
+      {{#block-slot name='breadcrumbs'}}
+          <ol>
+              <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
+              <li><a data-test-back href={{href-to 'dc.services.show'}}>Service ({{item.Service}})</a></li>
+              <li><strong>Instance</strong></li>
+          </ol>
+      {{/block-slot}}
+      {{#block-slot name='header'}}
+        <h1>
+          {{ item.ID }}
+  {{#with (service/external-source item) as |externalSource| }}
+    {{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg| }}
+      {{#if (not-eq bg 'none') }}
+          <span data-test-external-source="{{externalSource}}" style={{{ concat 'background-image:' bg }}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
+      {{/if}}
+    {{/with}}
+  {{/with}}
+  {{#if (eq item.Kind 'connect-proxy')}}
+          <span class="kind-proxy">Proxy</span>
+  {{else if (eq item.Kind 'mesh-gateway')}}
+          <span class="kind-proxy">Mesh Gateway</span>
   {{/if}}
-{{/if}}
-    {{/block-slot}}
-    {{#block-slot name='content'}}
-        {{tab-nav
-            items=(compact
-              (array
-                'Service Checks'
-                'Node Checks'
-(if
-  (eq item.Kind 'connect-proxy')
-                'Upstreams' ''
-)
-(if
-  (and (eq item.Kind 'connect-proxy') (gt item.Proxy.Expose.Paths.length 0))
-                'Exposed Paths' ''
-)
-(if
-  (eq item.Kind 'mesh-gateway')
-                'Addresses' ''
-)
-                'Tags'
-                'Meta Data'
-              )
-            )
-            selected=selectedTab
-        }}
-        {{#each
-            (compact
+        </h1>
+        <dl>
+          <dt>Service Name</dt>
+          <dd><a href="{{href-to 'dc.services.show' item.Service}}">{{item.Service}}</a></dd>
+        </dl>
+        <dl>
+          <dt>Node Name</dt>
+          <dd><a href="{{href-to 'dc.nodes.show' item.Node.Node}}">{{item.Node.Node}}</a></dd>
+        </dl>
+  {{#if proxy.ServiceName}}
+        <dl>
+  {{#if proxy.ServiceProxy.DestinationServiceID}}
+          <dt data-test-proxy-type="sidecar-proxy">Sidecar Proxy</dt>
+          <dd><a href="{{href-to 'dc.services.instance' proxy.ServiceName proxy.Node proxy.ServiceID}}">{{proxy.ServiceID}}</a></dd>
+  {{else}}
+          <dt data-test-proxy-type="proxy">Proxy</dt>
+          <dd><a href="{{href-to 'dc.services.show' proxy.ServiceName}}">{{proxy.ServiceName}}</a></dd>
+  {{/if}}
+        </dl>
+  {{/if}}
+  {{#if (eq item.Kind 'connect-proxy')}}
+    {{#if item.Proxy.DestinationServiceID}}
+        <dl>
+          <dt data-test-proxy-destination="instance">Dest. Service Instance</dt>
+          <dd><a href="{{href-to 'dc.services.instance' item.Proxy.DestinationServiceName item.Node.Node item.Proxy.DestinationServiceID}}">{{item.Proxy.DestinationServiceID}}</a></dd>
+        </dl>
+        <dl>
+          <dt>Local Service Address</dt>
+          <dd>{{item.Proxy.LocalServiceAddress}}:{{item.Proxy.LocalServicePort}}</dd>
+        </dl>
+    {{else}}
+        <dl>
+          <dt data-test-proxy-destination="service">Dest. Service</dt>
+          <dd><a href="{{href-to 'dc.services.show' item.Proxy.DestinationServiceName}}">{{item.Proxy.DestinationServiceName}}</a></dd>
+        </dl>
+    {{/if}}
+  {{/if}}
+      {{/block-slot}}
+      {{#block-slot name='content'}}
+          {{tab-nav
+              items=(compact
                 (array
-                    (hash id=(slugify 'Service Checks') partial='dc/services/servicechecks')
-                    (hash id=(slugify 'Node Checks') partial='dc/services/nodechecks')
-(if
-  (eq item.Kind 'connect-proxy')
-                    (hash id=(slugify 'Upstreams') partial='dc/services/upstreams') ''
-)
-(if
-  (and (eq item.Kind 'connect-proxy') (gt item.Proxy.Expose.Paths.length 0))
-                    (hash id=(slugify 'Exposed Paths') partial='dc/services/exposedpaths') ''
-)
-(if
-  (eq item.Kind 'mesh-gateway')
-                    (hash id=(slugify 'Addresses') partial='dc/services/addresses') ''
-)
-                    (hash id=(slugify 'Tags') partial='dc/services/tags')
-                    (hash id=(slugify 'Meta Data') partial='dc/services/metadata')
+                  'Service Checks'
+                  'Node Checks'
+  (if
+    (eq item.Kind 'connect-proxy')
+                  'Upstreams' ''
+  )
+  (if
+    (and (eq item.Kind 'connect-proxy') (gt item.Proxy.Expose.Paths.length 0))
+                  'Exposed Paths' ''
+  )
+  (if
+    (eq item.Kind 'mesh-gateway')
+                  'Addresses' ''
+  )
+                  'Tags'
+                  'Meta Data'
                 )
-            ) as |panel|
-        }}
-            {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action "change")}}
-                {{partial panel.partial}}
-            {{/tab-section}}
-        {{/each}}
-    {{/block-slot}}
-{{/app-view}}
+              )
+              selected=selectedTab
+          }}
+          {{#each
+              (compact
+                  (array
+                      (hash id=(slugify 'Service Checks') partial='dc/services/servicechecks')
+                      (hash id=(slugify 'Node Checks') partial='dc/services/nodechecks')
+  (if
+    (eq item.Kind 'connect-proxy')
+                      (hash id=(slugify 'Upstreams') partial='dc/services/upstreams') ''
+  )
+  (if
+    (and (eq item.Kind 'connect-proxy') (gt item.Proxy.Expose.Paths.length 0))
+                      (hash id=(slugify 'Exposed Paths') partial='dc/services/exposedpaths') ''
+  )
+  (if
+    (eq item.Kind 'mesh-gateway')
+                      (hash id=(slugify 'Addresses') partial='dc/services/addresses') ''
+  )
+                      (hash id=(slugify 'Tags') partial='dc/services/tags')
+                      (hash id=(slugify 'Meta Data') partial='dc/services/metadata')
+                  )
+              ) as |panel|
+          }}
+              {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action "change")}}
+                  {{partial panel.partial}}
+              {{/tab-section}}
+          {{/each}}
+      {{/block-slot}}
+  {{/app-view}}
+{{/if}}

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -1,59 +1,93 @@
 {{title item.Service.Service}}
-{{#app-view class="service show"}}
-  {{#block-slot name='notification' as |status type|}}
-    {{partial 'dc/services/notifications'}}
-  {{/block-slot}}
-  {{#block-slot name='breadcrumbs'}}
-    <ol>
-        <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
-    </ol>
-  {{/block-slot}}
-  {{#block-slot name='header'}}
-    <h1>
-      {{item.Service.Service}}
-{{#with (service/external-source item.Service) as |externalSource|}}
-{{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg|}}
-  {{#if (not-eq bg 'none')}}
-      <span data-test-external-source={{externalSource}} style={{{concat 'background-image:' bg}}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
-  {{/if}}
-{{/with}}
-{{/with}}
-{{#if (eq item.Service.Kind 'connect-proxy')}}
-      <span class="kind-proxy">Proxy</span>
-{{else if (eq item.Service.Kind 'mesh-gateway')}}
-      <span class="kind-proxy">Mesh Gateway</span>
-{{/if}}
-    </h1>
-    <label for="toolbar-toggle"></label>
-    {{tab-nav
-      items=(compact
-        (array
-                        'Instances'
-(if (not-eq chain null) 'Routing' '')
-                        'Tags'
-        )
-      )
-      selected=selectedTab
-    }}
-  {{/block-slot}}
-  {{#block-slot name='actions'}}
-    {{#if urls.service}}
-      {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
+{{data-source
+  src=(concat '/' nspace '/' dc '/service/' slug)
+  onchange=(action (mut item) value='data')
+  onerror=(action (mut error) value='error')
+}}
+{{#if (and (is-undefined item) (eq error.errors.firstObject.status '404'))}}
+  {{app-error error=error.errors.firstObject}}
+{{else}}
+  {{#if (not (is-undefined item))}}
+    {{#app-view class="service show" loading=(is-undefined item)}}
+        {{#block-slot 'notification2'}}
+          {{#if (eq error.errors.firstObject.status '404')}}
+            <div class="flash-message">
+              <p data-notification class="warning notification-update">
+                <strong>
+                  Warning!
+                </strong>
+                This service has been deregistered and no longer exists in the catalog.
+              </p>
+            </div>
+          {{/if}}
+        {{/block-slot}}
+        {{#block-slot name='breadcrumbs'}}
+            <ol>
+                <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
+            </ol>
+        {{/block-slot}}
+        {{#block-slot name='header'}}
+          <h1>
+            {{ item.Service.Service }}
+    {{#with (service/external-source item.Service) as |externalSource| }}
+      {{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg| }}
+        {{#if (not-eq bg 'none') }}
+            <span data-test-external-source="{{externalSource}}" style={{{ concat 'background-image:' bg }}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
+        {{/if}}
+      {{/with}}
+    {{/with}}
+    {{#if (eq item.Service.Kind 'connect-proxy')}}
+            <span class="kind-proxy">Proxy</span>
+    {{else if (eq item.Service.Kind 'mesh-gateway')}}
+            <span class="kind-proxy">Mesh Gateway</span>
     {{/if}}
-  {{/block-slot}}
-  {{#block-slot name='content'}}
-    {{#each
-      (compact
-        (array
+          </h1>
+          <label for="toolbar-toggle"></label>
+          {{tab-nav
+              items=(compact
+                (array
+                                          'Instances'
+  (if
+    (and
+      (not-eq item.Service.Kind 'connect-proxy')
+      (not-eq item.Service.Kind 'mesh-gateway')
+    )
+                                          'Routing'
+    ''
+  )
+                                          'Tags'
+                )
+              )
+              selected=selectedTab
+          }}
+        {{/block-slot}}
+        {{#block-slot name='actions'}}
+          {{#if urls.service}}
+            {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
+          {{/if}}
+        {{/block-slot}}
+        {{#block-slot name='content'}}
+            {{#each
+                (compact
+                    (array
                         (hash id=(slugify 'Instances') partial='dc/services/instances')
-(if (not-eq chain null) (hash id=(slugify 'Routing') partial='dc/services/routing') '')
+  (if
+    (and
+      (not-eq item.Service.Kind 'connect-proxy')
+      (not-eq item.Service.Kind 'mesh-gateway')
+    )
+                        (hash id=(slugify 'Routing') partial='dc/services/routing')
+    ''
+    )
                         (hash id=(slugify 'Tags') partial='dc/services/tags')
-        )
-      ) as |panel|
-    }}
-        {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action 'change')}}
-          {{partial panel.partial}}
-        {{/tab-section}}
-    {{/each}}
-  {{/block-slot}}
-{{/app-view}}
+                    )
+                ) as |panel|
+            }}
+                {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action "change")}}
+                    {{partial panel.partial}}
+                {{/tab-section}}
+            {{/each}}
+        {{/block-slot}}
+    {{/app-view}}
+  {{/if}}
+{{/if}}

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -54,12 +54,17 @@ export default function(assert, library) {
     return new Promise(function(r, reject) {
       let count = 0;
       let resolved = false;
-      const resolve = function() {
+      const retry = function() {
+        return Promise.resolve();
+      };
+      const resolve = function(str = message) {
         resolved = true;
+        assert.ok(resolved, str);
         r();
+        return Promise.resolve();
       };
       (function tick() {
-        run(resolve, reject).then(function() {
+        run(resolve, reject, retry).then(function() {
           if (!resolved) {
             setTimeout(function() {
               if (++count >= 50) {
@@ -124,7 +129,7 @@ export default function(assert, library) {
   debug(library, assert, utils.currentURL);
   assertHttp(library, assert, pauseUntil, lastNthRequest);
   assertModel(library, assert, find, getCurrentPage, pauseUntil, pluralize);
-  assertPage(library, assert, find, getCurrentPage);
+  assertPage(library, assert, find, getCurrentPage, pauseUntil);
   assertDom(library, assert, pauseUntil, utils.find, utils.currentURL, clipboard);
   assertForm(library, assert, find, getCurrentPage);
 

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -25,69 +25,97 @@ const isExpectedError = function(e) {
   return [notFound, cannotDestructure, cannotReadContext].some(item => e.message.startsWith(item));
 };
 
-export default function(scenario, assert, find, currentPage) {
+export default function(scenario, assert, find, currentPage, pauseUntil) {
   scenario
     .then('I see $property on the $component like yaml\n$yaml', function(
       property,
       component,
       yaml
     ) {
-      const _component = currentPage()[component];
-      const iterator = new Array(_component.length).fill(true);
-      // this will catch if we get aren't managing to select a component
-      assert.ok(iterator.length > 0);
-      iterator.forEach(function(item, i, arr) {
-        const actual =
-          typeof _component.objectAt(i)[property] === 'undefined'
-            ? null
-            : _component.objectAt(i)[property];
+      return pauseUntil(function(resolve, reject) {
+        const _component = currentPage()[component];
+        // this will catch if we get aren't managing to select a component
+        if (_component.length === 0) {
+          return Promise.resolve();
+        }
+        const iterator = new Array(_component.length).fill(true);
 
-        // anything coming from the DOM is going to be text/strings
-        // if the yaml has numbers, cast them to strings
-        // TODO: This would get problematic for deeper objects
-        // will have to look to do this recursively
-        const expected = typeof yaml[i] === 'number' ? yaml[i].toString() : yaml[i];
+        let pass = true;
+        iterator.forEach(function(item, i, arr) {
+          const actual =
+            typeof _component.objectAt(i)[property] === 'undefined'
+              ? null
+              : _component.objectAt(i)[property];
 
-        assert.deepEqual(
-          actual,
-          expected,
-          `Expected to see ${property} on ${component}[${i}] as ${JSON.stringify(
-            expected
-          )}, was ${JSON.stringify(actual)}`
-        );
-      });
+          // anything coming from the DOM is going to be text/strings
+          // if the yaml has numbers, cast them to strings
+          // TODO: This would get problematic for deeper objects
+          // will have to look to do this recursively
+          const expected = typeof yaml[i] === 'number' ? yaml[i].toString() : yaml[i];
+          assert.deepEqual(
+            actual,
+            expected,
+            `Expected to see ${property} on ${component}[${i}] as ${JSON.stringify(
+              expected
+            )}, was ${JSON.stringify(actual)}`
+          );
+          if (actual !== expected) {
+            pass = false;
+          }
+        });
+        if (pass) {
+          return resolve();
+        } else {
+          return reject();
+        }
+      }, `Expected to see ${property} on ${component} equal to specific data`);
     })
     .then(['I see $property on the $component'], function(property, component) {
-      // TODO: Time to work on repetition
-      // Collection
-      var obj;
-      if (typeof currentPage()[component].objectAt === 'function') {
-        obj = currentPage()[component].objectAt(0);
-      } else {
-        obj = currentPage()[component];
-      }
-      let _component;
-      if (typeof obj === 'function') {
-        const func = obj[property].bind(obj);
-        try {
-          _component = func();
-        } catch (e) {
-          console.error(e);
-          throw new Error(
-            `The '${property}' property on the '${component}' page object doesn't exist`
-          );
+      return pauseUntil(function(resolve, reject) {
+        // TODO: Time to work on repetition
+        // Collection
+        let obj;
+        if (typeof currentPage()[component].objectAt === 'function') {
+          obj = currentPage()[component].objectAt(0);
+        } else {
+          obj = currentPage()[component];
         }
-      } else {
-        _component = obj;
-      }
-      assert.ok(_component[property], `Expected to see ${property} on ${component}`);
+        let _component;
+        if (typeof obj === 'function') {
+          const func = obj[property].bind(obj);
+          try {
+            _component = func();
+          } catch (e) {
+            return Promise.resolve();
+          }
+        } else {
+          _component = obj;
+        }
+        try {
+          obj = _component[property];
+        } catch (e) {
+          return Promise.resolve();
+        }
+        if (obj) {
+          return resolve();
+        } else {
+          return reject();
+        }
+      }, `Expected to see ${property} on ${component}`);
     })
     .then(['I see $num of the $component object'], function(num, component) {
-      assert.equal(
-        currentPage()[component].length,
-        num,
-        `Expected to see ${num} items in the ${component} object`
-      );
+      return pauseUntil(function(resolve, reject) {
+        let obj;
+        try {
+          obj = currentPage()[component];
+        } catch (e) {
+          return Promise.resolve();
+        }
+        if (obj.length !== parseInt(num)) {
+          return reject();
+        }
+        return resolve();
+      }, `Expected to see ${num} items in the ${component} object`);
     })
     .then(["I don't see $property on the $component"], function(property, component) {
       const message = `Expected to not see ${property} on ${component}`;
@@ -157,24 +185,38 @@ export default function(scenario, assert, find, currentPage) {
         "I see $property on the $component like '$value'",
       ],
       function(property, component, value) {
-        let target;
-        try {
+        return pauseUntil(function(resolve, reject) {
+          let prop = property;
           if (typeof component === 'string') {
-            property = `${component}.${property}`;
+            prop = `${component}.${prop}`;
           }
-          target = find(property);
-        } catch (e) {
-          throw e;
-        }
-        assert.equal(
-          target,
-          value,
-          `Expected to see ${property} on ${component} as ${value}, was ${target}`
-        );
+          let target;
+          try {
+            target = find(prop);
+          } catch (e) {
+            return Promise.resolve();
+          }
+          if (target === value) {
+            return resolve();
+          } else {
+            return reject();
+          }
+        }, `Expected to see ${property} on ${component} as ${value}`);
       }
     )
     .then(['I see $property like "$value"'], function(property, value) {
-      const target = currentPage()[property];
-      assert.equal(target, value, `Expected to see ${property} as ${value}, was ${target}`);
+      return pauseUntil(function(resolve, reject) {
+        let target;
+        try {
+          target = currentPage()[property];
+        } catch (e) {
+          return Promise.resolve();
+        }
+        if (target === value) {
+          return resolve();
+        } else {
+          return reject();
+        }
+      }, `Expected to see ${property} as ${value}`);
     });
 }


### PR DESCRIPTION
This PR is part of https://github.com/hashicorp/consul/pull/6821, and uses our data-source component for the service show/instance/routing views.

This also continues to migrate our steps over to steps that don't rely
on ember routes blocking and resolving before a test moves on i.e. uses
our pauseUntil spinner/wait function.

We also slightly improve the API of our pauseUntil function here. We
figured that there are three thing you might need to do within this
function.

1. retry (wait another few milliseconds before 'looking again')
2. resolve (a successful test)
2. reject (an unsuccessful test)

so we added a third argument here called 'retry' which just wraps
Promise.resolve which is what we are currently using. Adding a specific
'retry' function makes this easier to use. We aren't using this yet, but
we'll probably move all our pauseUntil calls to use this retry function
instead of Promise.resolve.

Oh its also worthwhile mentioning here:

1. We needed a new way to add notifications, so for the moment we've just used a `notification2` (gah!) block. We hope to gradually move our other notifications over to use the same method, but for the moment we don't want to change too much at once so we'll support both until we can get everything moved over.
2. Previously we would have to load all data in the Route even if the user never needed it - for example if the user never clicks to view the [Routing] tab, then they didn't really need to load that data. Now using our `data-source` component that only retrieves data when it becomes visible, the data for the [Routing] tab is only loaded when the user clicks on the tab (and blocking queries will pause when the user clicks away from that tab) 