### PR TITLE
Fix a couple bugs regarding intentions with namespaces

### DIFF
--- a/agent/connect/uri_service_oss.go
+++ b/agent/connect/uri_service_oss.go
@@ -1,0 +1,13 @@
+// +build !consulent
+
+package connect
+
+import (
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+// GetEnterpriseMeta will synthesize an EnterpriseMeta struct from the SpiffeIDService.
+// in OSS this just returns an empty (but never nil) struct pointer
+func (id *SpiffeIDService) GetEnterpriseMeta() *structs.EnterpriseMeta {
+	return &structs.EnterpriseMeta{}
+}

--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -288,9 +288,6 @@ func parseIntentionMatchEntry(input string) (structs.IntentionMatchEntry, error)
 	var result structs.IntentionMatchEntry
 	result.Namespace = structs.IntentionDefaultNamespace
 
-	// TODO(mitchellh): when namespaces are introduced, set the default
-	// namespace to be the namespace of the requestor.
-
 	// Get the index to the '/'. If it doesn't exist, we have just a name
 	// so just set that and return.
 	idx := strings.IndexByte(input, '/')

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -505,8 +505,9 @@ func (s *Server) Check(ctx context.Context, r *envoyauthz.CheckRequest) (*envoya
 
 	// Create an authz request
 	req := &structs.ConnectAuthorizeRequest{
-		Target:        destID.Service,
-		ClientCertURI: r.Attributes.Source.Principal,
+		Target:         destID.Service,
+		EnterpriseMeta: *destID.GetEnterpriseMeta(),
+		ClientCertURI:  r.Attributes.Source.Principal,
 		// TODO(banks): need Envoy to support sending cert serial/hash to enforce
 		// revocation later.
 	}

--- a/command/intention/finder/finder.go
+++ b/command/intention/finder/finder.go
@@ -84,7 +84,7 @@ func (f *Finder) Find(src, dst string) (*api.Intention, error) {
 func StripDefaultNS(v string) string {
 	if idx := strings.IndexByte(v, '/'); idx > 0 {
 		if v[:idx] == api.IntentionDefaultNamespace {
-			return v[:idx+1]
+			return v[idx+1:]
 		}
 	}
 


### PR DESCRIPTION
The two main bugs fixed here were that some of the intention CLI commands were incorrectly splitting the `<namespace>/<service name>` strings and the `create` command wasn't doing it at all.

The second one was that connect authorizations performed by the xDS server were not including the namespace.