### PR TITLE
Updates to the Txn API for namespaces

### DIFF
--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -68,7 +68,7 @@ func (t *Txn) preCheck(authorizer acl.Authorizer, ops structs.TxnOps) structs.Tx
 			}
 
 			service := &op.Service.Service
-			// This is intentionally nil as we will authorizer the request
+			// This is intentionally nil as we will authorize the request
 			// using vetServiceTxnOp next instead of doing it in servicePreApply
 			if err := servicePreApply(service, nil); err != nil {
 				errors = append(errors, &structs.TxnError{

--- a/agent/consul/txn_endpoint.go
+++ b/agent/consul/txn_endpoint.go
@@ -68,6 +68,8 @@ func (t *Txn) preCheck(authorizer acl.Authorizer, ops structs.TxnOps) structs.Tx
 			}
 
 			service := &op.Service.Service
+			// This is intentionally nil as we will authorizer the request
+			// using vetServiceTxnOp next instead of doing it in servicePreApply
 			if err := servicePreApply(service, nil); err != nil {
 				errors = append(errors, &structs.TxnError{
 					OpIndex: i,

--- a/agent/structs/structs_oss.go
+++ b/agent/structs/structs_oss.go
@@ -46,6 +46,10 @@ func (m *EnterpriseMeta) NamespaceOrDefault() string {
 	return "default"
 }
 
+func EnterpriseMetaInitializer(_ string) EnterpriseMeta {
+	return emptyEnterpriseMeta
+}
+
 // ReplicationEnterpriseMeta stub
 func ReplicationEnterpriseMeta() *EnterpriseMeta {
 	return &emptyEnterpriseMeta

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -125,10 +125,11 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 				KV: &structs.TxnKVOp{
 					Verb: verb,
 					DirEnt: structs.DirEntry{
-						Key:     in.KV.Key,
-						Value:   in.KV.Value,
-						Flags:   in.KV.Flags,
-						Session: in.KV.Session,
+						Key:            in.KV.Key,
+						Value:          in.KV.Value,
+						Flags:          in.KV.Flags,
+						Session:        in.KV.Session,
+						EnterpriseMeta: structs.EnterpriseMetaInitializer(in.KV.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: in.KV.Index,
 						},
@@ -188,6 +189,7 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 							Warning: svc.Weights.Warning,
 						},
 						EnableTagOverride: svc.EnableTagOverride,
+						EnterpriseMeta:    structs.EnterpriseMetaInitializer(svc.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: svc.ModifyIndex,
 						},
@@ -243,6 +245,7 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 							Timeout:                        timeout,
 							DeregisterCriticalServiceAfter: deregisterCriticalServiceAfter,
 						},
+						EnterpriseMeta: structs.EnterpriseMetaInitializer(check.Namespace),
 						RaftIndex: structs.RaftIndex{
 							ModifyIndex: check.ModifyIndex,
 						},

--- a/api/txn.go
+++ b/api/txn.go
@@ -75,12 +75,13 @@ const (
 
 // KVTxnOp defines a single operation inside a transaction.
 type KVTxnOp struct {
-	Verb    KVOp
-	Key     string
-	Value   []byte
-	Flags   uint64
-	Index   uint64
-	Session string
+	Verb      KVOp
+	Key       string
+	Value     []byte
+	Flags     uint64
+	Index     uint64
+	Session   string
+	Namespace string `json:",omitempty"`
 }
 
 // KVTxnOps defines a set of operations to be performed inside a single

--- a/website/source/api/txn.html.md
+++ b/website/source/api/txn.html.md
@@ -74,6 +74,10 @@ The table below shows this endpoint's support for
   - `Session` `(string: "")` - Specifies a session. See the table below for more
     information.
     
+  - `Namespace` `(string: "")` - **(Enterprise Only)** Specifies the namespace to 
+    create the KV data If not provided, the namespace will be inherited from the 
+    request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
+    
 - `Node` operations have the following fields:
 
   - `Verb` `(string: <required>)` - Specifies the type of operation to perform.


### PR DESCRIPTION
The two biggest changes here were for ACL enforcement and ensuring the HTTP API parses namespaces and adds them to the appropriate structure.