### PR TITLE
add 'make go-mod-tidy' to serially run tidy on all submodules in the correct order

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -219,6 +219,12 @@ test: other-consul dev-build vet test-install-deps test-internal
 test-install-deps:
 	go test -tags '$(GOTAGS)' -i $(GOTEST_PKGS)
 
+go-mod-tidy:
+	@echo "--> Running go mod tidy"
+	@cd sdk && go mod tidy
+	@cd api && go mod tidy
+	@go mod tidy
+
 update-vendor:
 	@echo "--> Running go mod vendor"
 	@go mod vendor

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -225,7 +225,7 @@ go-mod-tidy:
 	@cd api && go mod tidy
 	@go mod tidy
 
-update-vendor:
+update-vendor: go-mod-tidy
 	@echo "--> Running go mod vendor"
 	@go mod vendor
 	@echo "--> Removing vendoring of our own nested modules"


### PR DESCRIPTION
I've found this scriptlet useful while working on branch surgery so I figured others might also find it useful.