### PR TITLE
ui: Split splitter names in the discovery-chain

### DIFF
--- a/ui-v2/app/components/discovery-chain.js
+++ b/ui-v2/app/components/discovery-chain.js
@@ -99,7 +99,7 @@ export default Component.extend({
       switch (item.Type) {
         case 'splitter':
           item.Splits.forEach(splitter => {
-            graph.addLink(`splitter:${item.Name}`, splitter.NextNode);
+            graph.addLink(item.ID, splitter.NextNode);
           });
           break;
         case 'router':

--- a/ui-v2/app/utils/components/discovery-chain/index.js
+++ b/ui-v2/app/utils/components/discovery-chain/index.js
@@ -38,6 +38,14 @@ export const getSplitters = function(nodes) {
   return getNodesByType(nodes, 'splitter').map(function(item) {
     // Splitters need IDs adding so we can find them in the DOM later
     item.ID = `splitter:${item.Name}`;
+    // splitters have a service.nspace as a name
+    // do the reverse dance to ensure we don't mess up any
+    // serivice names with dots in them
+    const temp = item.Name.split('.');
+    temp.reverse();
+    temp.shift();
+    temp.reverse();
+    item.Name = temp.join('.');
     return item;
   });
 };


### PR DESCRIPTION
Previous to 1.7 splitter names didn't include the namespace name

i.e. 'service-name'

As of 1.7 they now include the namespace

i.e. 'service-name.namespace'

This PR take account of that.