### PR TITLE
ui: Actually remove CI parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -497,7 +497,6 @@ jobs:
     environment:
       EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
       EMBER_TEST_REPORT: test-results/report.xml #outputs test report for CircleCI test summary
-    parallelism: 4
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/7188 we temporarily removed ember exam for parallel builds, but we forgot to tell CI to not run this in 4 parallel runs.

This PR does that.