### PR TITLE
ACL enforcement for the agent/health/services endpoints

### DIFF
--- a/lib/patch_hcl.go
+++ b/lib/patch_hcl.go
@@ -2,14 +2,25 @@ package lib
 
 import (
 	"fmt"
+	"strings"
 )
 
 func PatchSliceOfMaps(m map[string]interface{}, skip []string, skipTree []string) map[string]interface{} {
-	return patchValue("", m, skip, skipTree).(map[string]interface{})
+	lowerSkip := make([]string, len(skip))
+	lowerSkipTree := make([]string, len(skipTree))
+
+	for i, val := range skip {
+		lowerSkip[i] = strings.ToLower(val)
+	}
+
+	for i, val := range skipTree {
+		lowerSkipTree[i] = strings.ToLower(val)
+	}
+
+	return patchValue("", m, lowerSkip, lowerSkipTree).(map[string]interface{})
 }
 
 func patchValue(name string, v interface{}, skip []string, skipTree []string) interface{} {
-	// fmt.Printf("%q: %T\n", name, v)
 	switch x := v.(type) {
 	case map[string]interface{}:
 		if len(x) == 0 {
@@ -70,8 +81,9 @@ func patchValue(name string, v interface{}, skip []string, skipTree []string) in
 }
 
 func strSliceContains(s string, v []string) bool {
+	lower := strings.ToLower(s)
 	for _, vv := range v {
-		if s == vv {
+		if lower == vv {
 			return true
 		}
 	}

--- a/lib/patch_hcl_test.go
+++ b/lib/patch_hcl_test.go
@@ -40,7 +40,7 @@ func TestPatchSliceOfMaps(t *testing.T) {
 		},
 		{
 			in: `{
-				"services": [
+				"Services": [
 					{
 						"checks": [
 							{
@@ -53,7 +53,7 @@ func TestPatchSliceOfMaps(t *testing.T) {
 				]
 			}`,
 			out: `{
-				"services": [
+				"Services": [
 					{
 						"checks": [
 							{


### PR DESCRIPTION
This was already released in v1.6.3 but the implementation needed some slight differences for master. This PR implements the same thing for master.

Additionally this PR contains a bugfix for Consul not being able to parse a config like:

```
Services {
   Name = "foo"
   Port = 80
}
```

even though the following would work

```
services {
   Name = "foo"
   Port = 80
}
```

Basically the problem was that `PatchSliceOfMaps` was doing case-sensitive comparisons to check if it should ignore some key so I made it case-insensitive.