### PR TITLE
Add missing Autopilot -min-quorum documentation

### DIFF
--- a/command/operator/autopilot/set/operator_autopilot_set.go
+++ b/command/operator/autopilot/set/operator_autopilot_set.go
@@ -42,7 +42,7 @@ func (c *cmd) init() {
 		"Controls the maximum number of log entries that a server can trail the "+
 			"leader by before being considered unhealthy.")
 	c.flags.Var(&c.minQuorum, "min-quorum",
-		"Sets the minimum number of of servers required in a cluster before autopilot "+
+		"Sets the minimum number of servers required in a cluster before autopilot "+
 			"is allowed to prune dead servers.")
 	c.flags.Var(&c.lastContactThreshold, "last-contact-threshold",
 		"Controls the maximum amount of time a server can go without contact "+

--- a/website/source/api/operator/autopilot.html.md
+++ b/website/source/api/operator/autopilot.html.md
@@ -108,7 +108,7 @@ The table below shows this endpoint's support for
 - `MaxTrailingLogs` `(int: 250)` specifies the maximum number of log entries
   that a server can trail the leader by before being considered unhealthy.
 
-- `MinQuorum` `int: 0` - specifies the minimum number of servers needed before
+- `MinQuorum` `(int: 0)` - specifies the minimum number of servers needed before
   Autopilot can prune dead servers.
 
 - `ServerStabilizationTime` `(string: "10s")` - Specifies the minimum amount of

--- a/website/source/docs/commands/operator/autopilot.html.markdown.erb
+++ b/website/source/docs/commands/operator/autopilot.html.markdown.erb
@@ -71,6 +71,9 @@ from the leader before being considered unhealthy. Must be a duration value such
 * `-max-trailing-logs` - Controls the maximum number of log entries that a server can trail
 the leader by before being considered unhealthy.
 
+* `-min-quorum` - Sets the minimum number of servers required in a cluster
+before autopilot is allowed to prune dead servers.
+
 * `-server-stabilization-time` - Controls the minimum amount of time a server must be stable in
 the 'healthy' state before being added to the cluster. Only takes effect if all servers are
 running Raft protocol version 3 or higher. Must be a duration value such as `10s`.


### PR DESCRIPTION
This PR adds the missing website documentation for the Autopilot `-min-quorum` option. In addition it fixes a small copy-pasta error in the command help description.

I've just started to read into Autopilot and I'm a bit concerned about this option. The docs (https://www.consul.io/docs/agent/options.html#min_quorum) state the following:

```
Sets the minimum number of servers necessary in a cluster before autopilot can prune dead servers. There is no default. 
```

Based on my limited Go knowledge I noticed that the `intVal` is set to `0`, so that could be understood as the default value. Meaning if left untouched and set to `0` Autopilot will **always** be allowed to prune dead servers. To my understanding this behavior is fine for most setups. Can you help me understand a bit better when it makes sense to adjust this value? I'd like to improve the documentation thus it provides a bit more guidance as the Autopilot Tutorial does not yet include more insights. :)

https://learn.hashicorp.com/consul/day-2-operations/autopilot