### PR TITLE
ui: Hides the Routing tab for a service proxy

### DIFF
--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
+import { get } from '@ember/object';
 
 export default Route.extend({
   repo: service('repository/service'),
@@ -17,9 +18,15 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
       item: this.repo.findBySlug(params.name, dc, nspace),
-      chain: this.chainRepo.findBySlug(params.name, dc, nspace),
       urls: this.settings.findBySlug('urls'),
       dc: dc,
+    }).then(model => {
+      return hash({
+        chain: ['connect-proxy', 'mesh-gateway'].includes(get(model, 'item.Service.Kind'))
+          ? null
+          : this.chainRepo.findBySlug(params.name, dc, nspace),
+        ...model,
+      });
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -29,7 +29,7 @@
           items=(compact
             (array
               'Instances'
-              'Routing'
+    (if chain 'Routing' '')
               'Tags'
             )
           )
@@ -45,9 +45,9 @@
         {{#each
             (compact
                 (array
-                    (hash id=(slugify 'Instances') partial='dc/services/instances')
-                    (hash id=(slugify 'Routing') partial='dc/services/routing')
-                    (hash id=(slugify 'Tags') partial='dc/services/tags')
+                  (hash id=(slugify 'Instances') partial='dc/services/instances')
+        (if chain (hash id=(slugify 'Routing') partial='dc/services/routing') '')
+                  (hash id=(slugify 'Tags') partial='dc/services/tags')
                 )
             ) as |panel|
         }}

--- a/ui-v2/tests/acceptance/dc/services/show-routing.feature
+++ b/ui-v2/tests/acceptance/dc/services/show-routing.feature
@@ -1,0 +1,37 @@
+@setupApplicationTest
+Feature: dc / services / Show Routing for Serivce
+Scenario: Given a service, the Routing tab should display
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: consul
+        Name: service-0
+        ID: service-0-with-id
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And the title should be "service-0 - Consul"
+    And I see routing on the tabs
+  Scenario: Given a service proxy, the Routing tab should not display
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: connect-proxy
+        Name: service-0-proxy
+        ID: service-0-proxy-with-id
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0-proxy
+    ---
+    And the title should be "service-0-proxy - Consul"
+    And I don't see routing on the tabs
+

--- a/ui-v2/tests/acceptance/steps/dc/services/show-routing-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/services/show-routing-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -67,8 +67,10 @@ const roleSelector = roleSelectorFactory(clickable, deletable, collection, alias
 export default {
   index: create(index(visitable, collection)),
   dcs: create(dcs(visitable, clickable, attribute, collection)),
-  services: create(services(visitable, clickable, attribute, collection, page, catalogFilter)),
-  service: create(service(visitable, attribute, collection, text, catalogFilter)),
+  services: create(
+    services(visitable, clickable, attribute, collection, page, catalogFilter, radiogroup)
+  ),
+  service: create(service(visitable, attribute, collection, text, catalogFilter, radiogroup)),
   instance: create(instance(visitable, attribute, collection, text, radiogroup)),
   nodes: create(nodes(visitable, clickable, attribute, collection, catalogFilter)),
   node: create(node(visitable, deletable, clickable, attribute, collection, radiogroup)),

--- a/ui-v2/tests/pages/dc/services/show.js
+++ b/ui-v2/tests/pages/dc/services/show.js
@@ -1,4 +1,4 @@
-export default function(visitable, attribute, collection, text, filter) {
+export default function(visitable, attribute, collection, text, filter, radiogroup) {
   return {
     visit: visitable('/:dc/services/:service'),
     externalSource: attribute('data-test-external-source', 'h1 span'),
@@ -8,6 +8,7 @@ export default function(visitable, attribute, collection, text, filter) {
     dashboardAnchor: {
       href: attribute('href', '[data-test-dashboard-anchor]'),
     },
+    tabs: radiogroup('tab', ['instances', 'routing', 'tags']),
     filter: filter,
   };
 }


### PR DESCRIPTION
* Adds conditional in route to not make discovery-chain request if service kind is equal to `connect-proxy` or `mesh-gateway`

* Adds conditional in template to not show Routing tab if `chain` returns as null

* Creates a new acceptance test to test the Routing tab not being displayed for a service proxy

* Adds `tabs` to the services/show page object