### PR TITLE
Increase watchLimit to 8192.

### DIFF
--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -81,9 +81,13 @@ var (
 const (
 	// watchLimit is used as a soft limit to cap how many watches we allow
 	// for a given blocking query. If this is exceeded, then we will use a
-	// higher-level watch that's less fine-grained. This isn't as bad as it
-	// seems since we have made the main culprits (nodes and services) more
-	// efficient by diffing before we update via register requests.
+	// higher-level watch that's less fine-grained.  Choosing the perfect
+	// value is impossible given how different deployments and workload
+	// are. This value was recommended by customers with many servers. We
+	// expect streaming to arrive soon and that should help a lot with
+	// blocking queries. Please see
+	// https://github.com/hashicorp/consul/pull/7200 and linked issues/prs
+	// for more context
 	watchLimit = 8192
 )
 

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -84,10 +84,7 @@ const (
 	// higher-level watch that's less fine-grained. This isn't as bad as it
 	// seems since we have made the main culprits (nodes and services) more
 	// efficient by diffing before we update via register requests.
-	//
-	// Given the current size of aFew == 32 in memdb's watch_few.go, this
-	// will allow for up to ~64 goroutines per blocking query.
-	watchLimit = 2048
+	watchLimit = 8192
 )
 
 // Store is where we store all of Consul's state, including


### PR DESCRIPTION
The previous value was too conservative and users with many instances
were having problems because of it. This change increases the limit to
8192 which reportedly fixed most of the issues with that.

Related: #4984, #4986, #5050.