### PR TITLE
ui: Add ability to search nodes listing page with IP Address

### DIFF
--- a/ui-v2/app/search/filters/node.js
+++ b/ui-v2/app/search/filters/node.js
@@ -5,6 +5,9 @@ export default function(filterable) {
     return (
       get(item, 'Node')
         .toLowerCase()
+        .indexOf(sLower) !== -1 ||
+      get(item, 'Address')
+        .toLowerCase()
         .indexOf(sLower) !== -1
     );
   });

--- a/ui-v2/app/templates/components/catalog-filter.hbs
+++ b/ui-v2/app/templates/components/catalog-filter.hbs
@@ -1,5 +1,5 @@
 {{!<form>}}
-    {{freetext-filter searchable=searchable value=search placeholder="Search by name"}}
+    {{freetext-filter searchable=searchable value=search placeholder="Search"}}
     {{radio-group keyboardAccess=true name="status" value=status items=(array
       (hash label='All (Any Status)' value='' )
       (hash label='Critical Checks' value='critical')

--- a/ui-v2/tests/acceptance/dc/nodes/index.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/index.feature
@@ -50,3 +50,30 @@ Feature: dc / nodes / index
     Then the url should be /dc-1/nodes
     Then I see 3 node models
     And I see leader on the healthyNodes
+  Scenario: Searching the nodes with name and IP address
+    Given 3 node models from yaml
+    ---
+      - Node: node-01
+        Address: 10.0.0.0
+      - Node: node-02
+        Address: 10.0.0.1
+      - Node: node-03
+        Address: 10.0.0.2
+    ---
+    When I visit the nodes page for yaml
+    ---
+      dc: dc-1
+    ---
+    And I see 3 node models
+    Then I fill in with yaml
+    ---
+    s: node-01
+    ---
+    And I see 1 node model
+    And I see 1 node model with the name "node-01"
+    Then I fill in with yaml
+    ---
+    s: 10.0.0.1
+    ---
+    And I see 1 node model
+    And I see 1 node model with the name "node-02"

--- a/ui-v2/tests/unit/search/filters/node-test.js
+++ b/ui-v2/tests/unit/search/filters/node-test.js
@@ -3,10 +3,11 @@ import { module, test } from 'qunit';
 
 module('Unit | Search | Filter | node', function() {
   const filter = getFilter(cb => cb);
-  test('items are found by properties', function(assert) {
+  test('items are found by name', function(assert) {
     [
       {
         Node: 'node-HIT',
+        Address: '10.0.0.0',
       },
     ].forEach(function(item) {
       const actual = filter(item, {
@@ -15,14 +16,41 @@ module('Unit | Search | Filter | node', function() {
       assert.ok(actual);
     });
   });
-  test('items are not found', function(assert) {
+  test('items are found by IP address', function(assert) {
+    [
+      {
+        Node: 'node-HIT',
+        Address: '10.0.0.0',
+      },
+    ].forEach(function(item) {
+      const actual = filter(item, {
+        s: '10',
+      });
+      assert.ok(actual);
+    });
+  });
+  test('items are not found by name', function(assert) {
     [
       {
         Node: 'name',
+        Address: '10.0.0.0',
       },
     ].forEach(function(item) {
       const actual = filter(item, {
         s: 'hit',
+      });
+      assert.notOk(actual);
+    });
+  });
+  test('items are not found by IP address', function(assert) {
+    [
+      {
+        Node: 'name',
+        Address: '10.0.0.0',
+      },
+    ].forEach(function(item) {
+      const actual = filter(item, {
+        s: '9',
       });
       assert.notOk(actual);
     });


### PR DESCRIPTION
* Update search field placeholder to display `Search`

* Add an acceptance test to search node listings with node name and IP Address

* Update and add unit tests for filter/search node listing with IP Address

![TBT](https://user-images.githubusercontent.com/19161242/73694946-1e4bfa80-46a7-11ea-88e6-f0b9eda47324.gif)
