### PR TITLE
agent: differentiate wan vs lan loggers in memberlist and serf

### DIFF
--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -34,13 +34,17 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 		conf.Tags["acls"] = string(structs.ACLModeDisabled)
 	}
 
+	const subLoggerName = "lan"
+
 	// We use the Intercept variant here to ensure that serf and memberlist logs
 	// can be streamed via the monitor endpoint
 	serfLogger := c.logger.
 		NamedIntercept(logging.Serf).
+		NamedIntercept(subLoggerName).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 	memberlistLogger := c.logger.
 		NamedIntercept(logging.Memberlist).
+		NamedIntercept(subLoggerName).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 
 	conf.MemberlistConfig.Logger = memberlistLogger

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -34,17 +34,15 @@ func (c *Client) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 		conf.Tags["acls"] = string(structs.ACLModeDisabled)
 	}
 
-	const subLoggerName = "lan"
-
 	// We use the Intercept variant here to ensure that serf and memberlist logs
 	// can be streamed via the monitor endpoint
 	serfLogger := c.logger.
 		NamedIntercept(logging.Serf).
-		NamedIntercept(subLoggerName).
+		NamedIntercept(logging.LAN).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 	memberlistLogger := c.logger.
 		NamedIntercept(logging.Memberlist).
-		NamedIntercept(subLoggerName).
+		NamedIntercept(logging.LAN).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 
 	conf.MemberlistConfig.Logger = memberlistLogger

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -82,9 +82,9 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 
 	var subLoggerName string
 	if wan {
-		subLoggerName = "wan"
+		subLoggerName = logging.WAN
 	} else {
-		subLoggerName = "lan"
+		subLoggerName = logging.LAN
 	}
 
 	// Wrap hclog in a standard logger wrapper for serf and memberlist

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -80,14 +80,23 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string, w
 		conf.Tags["acls"] = string(structs.ACLModeDisabled)
 	}
 
+	var subLoggerName string
+	if wan {
+		subLoggerName = "wan"
+	} else {
+		subLoggerName = "lan"
+	}
+
 	// Wrap hclog in a standard logger wrapper for serf and memberlist
 	// We use the Intercept variant here to ensure that serf and memberlist logs
 	// can be streamed via the monitor endpoint
 	serfLogger := s.logger.
 		NamedIntercept(logging.Serf).
+		NamedIntercept(subLoggerName).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 	memberlistLogger := s.logger.
 		NamedIntercept(logging.Memberlist).
+		NamedIntercept(subLoggerName).
 		StandardLoggerIntercept(&hclog.StandardLoggerOptions{InferLevels: true})
 
 	conf.MemberlistConfig.Logger = memberlistLogger

--- a/logging/names.go
+++ b/logging/names.go
@@ -23,6 +23,7 @@ const (
 	Intentions    string = "intentions"
 	Internal      string = "internal"
 	KV            string = "kvs"
+	LAN           string = "lan"
 	Leader        string = "leader"
 	Legacy        string = "legacy"
 	License       string = "license"
@@ -44,5 +45,6 @@ const (
 	Snapshot      string = "snapshot"
 	TLSUtil       string = "tlsutil"
 	Transaction   string = "txn"
+	WAN           string = "wan"
 	Watch         string = "watch"
 )


### PR DESCRIPTION
This should be a helpful change until memberlist and serf can be
properly switched to native hclog.