### PR TITLE
ui: Ensure KV flags are passed through to Consul on update

### DIFF
--- a/ui-v2/app/adapters/kv.js
+++ b/ui-v2/app/adapters/kv.js
@@ -53,6 +53,7 @@ export default Adapter.extend({
   requestForUpdateRecord: function(request, serialized, data) {
     const params = {
       ...this.formatDatacenter(data[DATACENTER_KEY]),
+      flags: data.Flags,
       ...this.formatNspace(data[NSPACE_KEY]),
     };
     return request`

--- a/ui-v2/tests/acceptance/dc/kvs/update.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/update.feature
@@ -6,6 +6,7 @@ Feature: dc / kvs / update: KV Update
     And 1 kv model from yaml
     ---
       Key: "[Name]"
+      Flags: 12
     ---
     When I visit the kv page for yaml
     ---
@@ -21,7 +22,7 @@ Feature: dc / kvs / update: KV Update
       value: [Value]
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/[EncodedName]?dc=datacenter&ns=@!namespace" with the body "[Value]"
+    Then a PUT request was made to "/v1/kv/[EncodedName]?dc=datacenter&flags=12&ns=@!namespace" with the body "[Value]"
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
   Where:
@@ -37,6 +38,7 @@ Feature: dc / kvs / update: KV Update
     And 1 kv model from yaml
     ---
       Key: key
+      Flags: 12
     ---
     When I visit the kv page for yaml
     ---
@@ -51,7 +53,7 @@ Feature: dc / kvs / update: KV Update
       value: '   '
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with the body "   "
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with the body "   "
     Then the url should be /datacenter/kv
     And the title should be "Key/Value - Consul"
     And "[data-notification]" has the "notification-update" class
@@ -60,6 +62,7 @@ Feature: dc / kvs / update: KV Update
     And 1 kv model from yaml
     ---
       Key: key
+      Flags: 12
     ---
     When I visit the kv page for yaml
     ---
@@ -74,15 +77,16 @@ Feature: dc / kvs / update: KV Update
       value: ''
     ---
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class
   Scenario: Update to a key when the value is empty
     And 1 kv model from yaml
     ---
-    Key: key
-    Value: ~
+      Key: key
+      Value: ~
+      Flags: 12
     ---
     When I visit the kv page for yaml
     ---
@@ -91,7 +95,7 @@ Feature: dc / kvs / update: KV Update
     ---
     Then the url should be /datacenter/kv/key/edit
     And I submit
-    Then a PUT request was made to "/v1/kv/key?dc=datacenter&ns=@!namespace" with no body
+    Then a PUT request was made to "/v1/kv/key?dc=datacenter&flags=12&ns=@!namespace" with no body
     Then the url should be /datacenter/kv
     And "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "success" class

--- a/ui-v2/tests/integration/adapters/kv-test.js
+++ b/ui-v2/tests/integration/adapters/kv-test.js
@@ -58,7 +58,8 @@ module('Integration | Adapter | kv', function(hooks) {
     test(`requestForUpdateRecord returns the correct url/method when nspace is ${nspace}`, function(assert) {
       const adapter = this.owner.lookup('adapter:kv');
       const client = this.owner.lookup('service:client/http');
-      const expected = `PUT /v1/kv/${id}?dc=${dc}${
+      const flags = 12;
+      const expected = `PUT /v1/kv/${id}?dc=${dc}&flags=${flags}${
         typeof nspace !== 'undefined' ? `&ns=${nspace}` : ``
       }`;
       let actual = adapter
@@ -70,6 +71,7 @@ module('Integration | Adapter | kv', function(hooks) {
             Key: id,
             Value: '',
             Namespace: nspace,
+            Flags: flags,
           }
         )
         .split('\n')


### PR DESCRIPTION
Previously we weren't passing the flags property through to Consul, which meant that any flags were being unset when you saved a KV using the UI.

This PR fixes that

Fixes https://github.com/hashicorp/consul/issues/7105