### PR TITLE
Fix disco chain graph validation for namespaces

### DIFF
--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -357,7 +357,7 @@ func (s *Store) validateProposedConfigEntryInServiceGraph(
 		// somehow omit the ones that have a default protocol configured.
 
 		for _, kind := range serviceGraphKinds {
-			_, entries, err := s.configEntriesByKindTxn(tx, nil, kind, entMeta)
+			_, entries, err := s.configEntriesByKindTxn(tx, nil, kind, structs.WildcardEnterpriseMeta())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously this happened to be validating only the chains in the default namespace. Now it will validate all chains in all namespaces when the global proxy-defaults is changed.