### PR TITLE
fix ember parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,6 +496,9 @@ jobs:
       - image: *EMBER_IMAGE
     environment:
       EMBER_TEST_REPORT: test-results/report-oss.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+      CONSUL_NSPACES_ENABLED: 0
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:
@@ -504,7 +507,7 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-oss-ci
+          command: node_modules/ember-cli/bin/ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --path dist --silent -r xunit
       - store_test_results:
           path: ui-v2/test-results
   # run ember frontend tests
@@ -513,6 +516,8 @@ jobs:
       - image: *EMBER_IMAGE
     environment:
       EMBER_TEST_REPORT: test-results/report-ent.xml #outputs test report for CircleCI test summary
+      EMBER_TEST_PARALLEL: true #enables test parallelization with ember-exam
+    parallelism: 2
     steps:
       - checkout
       - restore_cache:
@@ -521,7 +526,7 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-ci
+          command: node_modules/ember-cli/bin/ember exam --split=$CIRCLE_NODE_TOTAL --partition=`expr $CIRCLE_NODE_INDEX + 1` --path dist --silent -r xunit
       - store_test_results:
           path: ui-v2/test-results
   # run ember frontend unit tests to produce coverage report

--- a/ui-v2/tests/test-helper.js
+++ b/ui-v2/tests/test-helper.js
@@ -1,11 +1,9 @@
 import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
-import { start } from 'ember-qunit';
 import './helpers/flash-message';
-import loadEmberExam from 'ember-exam/test-support/load';
+import start from 'ember-exam/test-support/start';
 
-loadEmberExam();
 const application = Application.create(config.APP);
 application.inject('component:copy-button', 'clipboard', 'service:clipboard/local-storage');
 setApplication(application);


### PR DESCRIPTION
This PR fixes the ember test parallelization we lost in the ember upgrade. When I was debugging this I landed on this issue: https://github.com/ember-cli/ember-exam/issues/244. It looks like in the ember upgrade, ember-exam got bumped from `^2.0.1` to `^4.0.0`. Because of this, we got a bunch of ember exam upgrades including what is outlined here: https://github.com/ember-cli/ember-exam/issues/244#issuecomment-480439951. As a result, with the new version of `ember-exam` we need to call `start()` from `ember-exam/test-support/` rather than calling `start()` from `ember-qunit`