### PR TITLE
ui: Discovery chain improvements

### DIFF
--- a/ui-v2/app/components/route-card.js
+++ b/ui-v2/app/components/route-card.js
@@ -4,12 +4,6 @@ import { get, computed } from '@ember/object';
 export default Component.extend({
   tagName: '',
   path: computed('item', function() {
-    if (get(this, 'item.Default')) {
-      return {
-        type: 'Default',
-        value: '/',
-      };
-    }
     return Object.entries(get(this, 'item.Definition.Match.HTTP') || {}).reduce(
       function(prev, [key, value]) {
         if (key.toLowerCase().startsWith('path')) {

--- a/ui-v2/app/templates/components/route-card.hbs
+++ b/ui-v2/app/templates/components/route-card.hbs
@@ -12,9 +12,7 @@
       {{path.type}}
       </dt>
       <dd>
-  {{#if (not-eq path.type 'Default')}}
         {{path.value}}
-  {{/if}}
       </dd>
     </dl>
   </header>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -1,59 +1,59 @@
 {{title item.Service.Service}}
 {{#app-view class="service show"}}
-    {{#block-slot name='notification' as |status type|}}
-      {{partial 'dc/services/notifications'}}
-    {{/block-slot}}
-    {{#block-slot name='breadcrumbs'}}
-        <ol>
-            <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
-        </ol>
-    {{/block-slot}}
-    {{#block-slot name='header'}}
-      <h1>
-        {{ item.Service.Service }}
-{{#with (service/external-source item.Service) as |externalSource| }}
-  {{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg| }}
-    {{#if (not-eq bg 'none') }}
-        <span data-test-external-source="{{externalSource}}" style={{{ concat 'background-image:' bg }}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
-    {{/if}}
-  {{/with}}
+  {{#block-slot name='notification' as |status type|}}
+    {{partial 'dc/services/notifications'}}
+  {{/block-slot}}
+  {{#block-slot name='breadcrumbs'}}
+    <ol>
+        <li><a data-test-back href={{href-to 'dc.services'}}>All Services</a></li>
+    </ol>
+  {{/block-slot}}
+  {{#block-slot name='header'}}
+    <h1>
+      {{item.Service.Service}}
+{{#with (service/external-source item.Service) as |externalSource|}}
+{{#with (css-var (concat '--' externalSource '-color-svg') 'none') as |bg|}}
+  {{#if (not-eq bg 'none')}}
+      <span data-test-external-source={{externalSource}} style={{{concat 'background-image:' bg}}} data-tooltip="Registered via {{externalSource}}">Registered via {{externalSource}}</span>
+  {{/if}}
+{{/with}}
 {{/with}}
 {{#if (eq item.Service.Kind 'connect-proxy')}}
-        <span class="kind-proxy">Proxy</span>
+      <span class="kind-proxy">Proxy</span>
 {{else if (eq item.Service.Kind 'mesh-gateway')}}
-        <span class="kind-proxy">Mesh Gateway</span>
+      <span class="kind-proxy">Mesh Gateway</span>
 {{/if}}
-      </h1>
-      <label for="toolbar-toggle"></label>
-      {{tab-nav
-          items=(compact
-            (array
-              'Instances'
-    (if chain 'Routing' '')
-              'Tags'
-            )
-          )
-          selected=selectedTab
-      }}
-    {{/block-slot}}
-    {{#block-slot name='actions'}}
-      {{#if urls.service}}
-        {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
-      {{/if}}
-    {{/block-slot}}
-    {{#block-slot name='content'}}
-        {{#each
-            (compact
-                (array
-                  (hash id=(slugify 'Instances') partial='dc/services/instances')
-        (if chain (hash id=(slugify 'Routing') partial='dc/services/routing') '')
-                  (hash id=(slugify 'Tags') partial='dc/services/tags')
-                )
-            ) as |panel|
-        }}
-            {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action "change")}}
-                {{partial panel.partial}}
-            {{/tab-section}}
-        {{/each}}
-    {{/block-slot}}
+    </h1>
+    <label for="toolbar-toggle"></label>
+    {{tab-nav
+      items=(compact
+        (array
+                        'Instances'
+(if (not-eq chain null) 'Routing' '')
+                        'Tags'
+        )
+      )
+      selected=selectedTab
+    }}
+  {{/block-slot}}
+  {{#block-slot name='actions'}}
+    {{#if urls.service}}
+      {{#templated-anchor data-test-dashboard-anchor href=urls.service vars=(hash Datacenter=dc Service=(hash Name=item.Service.Service)) rel="external"}}Open Dashboard{{/templated-anchor}}
+    {{/if}}
+  {{/block-slot}}
+  {{#block-slot name='content'}}
+    {{#each
+      (compact
+        (array
+                        (hash id=(slugify 'Instances') partial='dc/services/instances')
+(if (not-eq chain null) (hash id=(slugify 'Routing') partial='dc/services/routing') '')
+                        (hash id=(slugify 'Tags') partial='dc/services/tags')
+        )
+      ) as |panel|
+    }}
+        {{#tab-section id=panel.id selected=(eq (if selectedTab selectedTab '') panel.id) onchange=(action 'change')}}
+          {{partial panel.partial}}
+        {{/tab-section}}
+    {{/each}}
+  {{/block-slot}}
 {{/app-view}}

--- a/ui-v2/app/utils/components/discovery-chain/index.js
+++ b/ui-v2/app/utils/components/discovery-chain/index.js
@@ -37,7 +37,6 @@ export const getAlternateServices = function(targets, a) {
 export const getSplitters = function(nodes) {
   return getNodesByType(nodes, 'splitter').map(function(item) {
     // Splitters need IDs adding so we can find them in the DOM later
-    item.ID = `splitter:${item.Name}`;
     // splitters have a service.nspace as a name
     // do the reverse dance to ensure we don't mess up any
     // serivice names with dots in them
@@ -45,8 +44,11 @@ export const getSplitters = function(nodes) {
     temp.reverse();
     temp.shift();
     temp.reverse();
-    item.Name = temp.join('.');
-    return item;
+    return {
+      ...item,
+      ID: `splitter:${item.Name}`,
+      Name: temp.join('.'),
+    };
   });
 };
 export const getRoutes = function(nodes, uid) {

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -992,9 +992,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^2.6.2":
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.11.0.tgz#0b833893ccc5cfb9546b1513127d5e92d30f2262"
-  integrity sha512-2MO1jiwuJyPlSGQ4AeFtLKJWmLSj0msoiaRHPtj6YPjm69ZkY/t4U4SU3cfpVn2Dx7wHzXe//9GvNHI1gRxAzg==
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.12.0.tgz#725078f770bbd0ef75a5f2498968c5c8891f90a2"
+  integrity sha512-8OcgesUjWQ8AjaXzbz3tGJQn1kM0sN6pLidGM7isNPUyYmIjIEXQzaeUQYzsfv0N2Ko9ZuOXYUsaBl8IK1KGow==
 
 "@hashicorp/ember-cli-api-double@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This PR includes several minor amends/improvement to the discovery chain visualization:

1. We decided `default` wasn't the ideal word to use for the final catch-all route/the one that sometimes is added by default - so we reverted this one back to just using `Prefix: /`
2. Various safer/defensive checks for a few things that we don't think is actually possible (the default router not being able to find a splitter/resolver, the disco-chain component firing an inViewport twice in a row with the same value etc.)
3. We found a very weird templating potential bug where the entire visualisation would flash when appearing (render twice in quick succession), it seemed to be related to the fact that we were using `if chain`,. I never completely got to the bottom of why this was happening, but found that changing it to `if (not-eq chain null)` prevented the flashing from happening.
4. As the bug in point 3 ^ _sometimes_ rendered the entire chain twice, we'd occasionally get a bug due to the fact that we were mutating the data and therefore performing the same transformation on already transformed data. So we made the data use a more immutable state where this was happening.

Also took the opportunity to clean up a bit of our whitespace in the template while I was here.