### PR TITLE
rpc: measure blocking queries

### DIFF
--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -555,9 +555,10 @@ func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta s
 	// atomic inc our gauge of blockingQueries
 	atomic.AddUint64(&s.queriesBlocking, 1)
 	// atomic dec when we return from blockingQuery()
-	defer atomic.AddUint64(&s.queriesBlocking, -1)
+	defer atomic.AddUint64(&s.queriesBlocking, ^uint64(0))
 	// set gauge directly to a float32 of our Server's queriesBlocking
-	metrics.SetGauge([]string{"rpc", "queries_blocking"}, float32(s.queriesBlocking))
+	queriesBlocking := float32(atomic.LoadUint64(&s.queriesBlocking))
+	metrics.SetGauge([]string{"rpc", "queries_blocking"}, queriesBlocking)
 
 RUN_QUERY:
 	// Setup blocking loop

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -550,7 +550,7 @@ func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta s
 	//   we only dec on the return of blockingQuery(). We'd need swap out defer for a dec on retry on L616 as well as
 	// 	 on the return at L621
 	// -> There I think it's simpler if we don't instrument the RUN_QUERY statement and continue to use the
-    // 	  end of s.blockingQuery()'s setup phase as the point of measurement.
+	// 	  end of s.blockingQuery()'s setup phase as the point of measurement.
 
 	// atomic inc our gauge of blockingQueries
 	atomic.AddUint64(&s.queriesBlocking, 1)

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -113,7 +113,7 @@ type Server struct {
 	// queriesBlocking is a counter that we incr and decr atomically in
 	// rpc calls to provide telemetry on how many blocking queries are running.
 	// We interact with queriesBlocking atomically, do not move without ensuring it is
-	// safely whole in the struct layout
+	// correctly 64-byte aligned in the struct layout
 	queriesBlocking uint64
 
 	// aclConfig is the configuration for the ACL system

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -110,6 +110,12 @@ var (
 // Server is Consul server which manages the service discovery,
 // health checking, DC forwarding, Raft, and multiple Serf pools.
 type Server struct {
+	// queriesBlocking is a counter that we incr and decr atomically in
+	// rpc calls to provide telemetry on how many blocking queries are running.
+	// We interact with queriesBlocking atomically, do not move without ensuring it is
+	// safely whole in the struct layout
+	queriesBlocking uint64
+
 	// aclConfig is the configuration for the ACL system
 	aclConfig *acl.Config
 

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -765,7 +765,7 @@ These metrics are used to monitor the health of the Consul servers.
   </tr>
   <tr>
     <td>`consul.rpc.query`</td>
-    <td>This increments when a server receives a new blocking RPC request, indicating the rate of new blocking query calls. See consul.rpc.queries_blocking for the current number of in-flight blocking RPC calls.</td>
+    <td>This increments when a server receives a new blocking RPC request, indicating the rate of new blocking query calls. See consul.rpc.queries_blocking for the current number of in-flight blocking RPC calls. This metric changed in 1.7.0 to only increment on the the start of a query. The rate of queries will appear lower, but is more accurate.</td>
     <td>queries</td>
     <td>counter</td>
   </tr>

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -771,7 +771,7 @@ These metrics are used to monitor the health of the Consul servers.
   </tr>
   <tr>
     <td>`consul.rpc.queries_blocking`</td>
-    <td>Shows the current number of (potentially blocking) active queries.</td>
+    <td>Shows the current number of blocking active queries.</td>
     <td>queries</td>
     <td>gauge</td>
   </tr>

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -771,7 +771,7 @@ These metrics are used to monitor the health of the Consul servers.
   </tr>
   <tr>
     <td>`consul.rpc.queries_blocking`</td>
-    <td>Shows the current number of blocking active queries.</td>
+    <td>This shows the current number of in-flight blocking queries the server is handling.</td>
     <td>queries</td>
     <td>gauge</td>
   </tr>

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -770,6 +770,12 @@ These metrics are used to monitor the health of the Consul servers.
     <td>counter</td>
   </tr>
   <tr>
+    <td>`consul.rpc.queries_blocking`</td>
+    <td>Shows the current number of (potentially blocking) active queries.</td>
+    <td>queries</td>
+    <td>gauge</td>
+  </tr>
+  <tr>
     <td>`consul.rpc.cross-dc`</td>
     <td>This increments when a server sends a (potentially blocking) cross datacenter RPC query.</td>
     <td>queries</td>

--- a/website/source/docs/agent/telemetry.html.md
+++ b/website/source/docs/agent/telemetry.html.md
@@ -765,7 +765,7 @@ These metrics are used to monitor the health of the Consul servers.
   </tr>
   <tr>
     <td>`consul.rpc.query`</td>
-    <td>This increments when a server sends a (potentially blocking) RPC query.</td>
+    <td>This increments when a server receives a new blocking RPC request, indicating the rate of new blocking query calls. See consul.rpc.queries_blocking for the current number of in-flight blocking RPC calls.</td>
     <td>queries</td>
     <td>counter</td>
   </tr>

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -35,6 +35,13 @@ users, both the datacenter and the services namespace will be present. For examp
 PTR record would previously have contained `web.service.consul`, it will now be `web.service.dc1.consul`
 in OSS or `web.service.ns1.dc1.consul` for Enterprise.
 
+### Telemetry: semantics of `consul.rpc.query` changed, see `consul.rpc.queries_blocking`
+
+Consul has changed the semantics of query counts in its [telemetry](/docs/agent/telemetry.html#metrics-reference).
+`consul.rpc.query` now only increments on the *start* of a query (blocking or non-blocking), whereas before it would
+measure when blocking queries polled for more data. The gauge `consul.rpc.queries_blocking` has been added for a more
+to more precisely capture the view of *active* blocking queries.
+
 ## Consul 1.6.0
 
 #### Removal of Deprecated Features


### PR DESCRIPTION
Fixes #6846 

We add an atomic counter to `agent/consul.Server.queriesBlocking` and inc/dec it in `agent/consul s.blockingQuery()` to track active blocking queries. Also added docs in telemetry.md.

I deviate from #6846 a bit in where I mark the point of query start, [review question is here](https://github.com/hashicorp/consul/pull/7224/files#diff-cefe66c3774a83b3ec294243f1550944R546-R553)

Before merge 
- [x] Remove REVIEW on `agent/consul/rpc.goL546`

Will squash before merge.