### PR TITLE
OSS Changes for various config entry namespacing bugs

### DIFF
--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2207,8 +2207,8 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			patch: func(rt *RuntimeConfig) {
 				rt.Checks = []*structs.CheckDefinition{
-					&structs.CheckDefinition{Name: "a", ScriptArgs: []string{"/bin/true"}, OutputMaxSize: checks.DefaultBufSize, EnterpriseMeta: *structs.DefaultEnterpriseMeta()},
-					&structs.CheckDefinition{Name: "b", ScriptArgs: []string{"/bin/false"}, OutputMaxSize: checks.DefaultBufSize, EnterpriseMeta: *structs.DefaultEnterpriseMeta()},
+					&structs.CheckDefinition{Name: "a", ScriptArgs: []string{"/bin/true"}, OutputMaxSize: checks.DefaultBufSize},
+					&structs.CheckDefinition{Name: "b", ScriptArgs: []string{"/bin/false"}, OutputMaxSize: checks.DefaultBufSize},
 				}
 				rt.DataDir = dataDir
 			},
@@ -2226,7 +2226,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			patch: func(rt *RuntimeConfig) {
 				rt.Checks = []*structs.CheckDefinition{
-					&structs.CheckDefinition{Name: "a", GRPC: "localhost:12345/foo", GRPCUseTLS: true, OutputMaxSize: checks.DefaultBufSize, EnterpriseMeta: *structs.DefaultEnterpriseMeta()},
+					&structs.CheckDefinition{Name: "a", GRPC: "localhost:12345/foo", GRPCUseTLS: true, OutputMaxSize: checks.DefaultBufSize},
 				}
 				rt.DataDir = dataDir
 			},
@@ -2244,7 +2244,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			patch: func(rt *RuntimeConfig) {
 				rt.Checks = []*structs.CheckDefinition{
-					&structs.CheckDefinition{Name: "a", AliasService: "foo", OutputMaxSize: checks.DefaultBufSize, EnterpriseMeta: *structs.DefaultEnterpriseMeta()},
+					&structs.CheckDefinition{Name: "a", AliasService: "foo", OutputMaxSize: checks.DefaultBufSize},
 				}
 				rt.DataDir = dataDir
 			},
@@ -2271,7 +2271,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 							Passing: 1,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 					&structs.ServiceDefinition{
 						Name: "b",
@@ -2281,7 +2280,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 							Passing: 13,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 				}
 				rt.DataDir = dataDir
@@ -2399,7 +2397,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 							Passing: 1,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 				}
 				rt.DataDir = dataDir
@@ -2540,14 +2537,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 									Passing: 1,
 									Warning: 1,
 								},
-								EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 							},
 						},
 						Weights: &structs.Weights{
 							Passing: 1,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 				}
 			},
@@ -2671,14 +2666,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 									Passing: 1,
 									Warning: 1,
 								},
-								EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 							},
 						},
 						Weights: &structs.Weights{
 							Passing: 1,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 				}
 			},
@@ -5087,7 +5080,6 @@ func TestFullConfig(t *testing.T) {
 				Timeout:                        1813 * time.Second,
 				TTL:                            21743 * time.Second,
 				DeregisterCriticalServiceAfter: 14232 * time.Second,
-				EnterpriseMeta:                 *structs.DefaultEnterpriseMeta(),
 			},
 			&structs.CheckDefinition{
 				ID:         "Cqq95BhP",
@@ -5112,7 +5104,6 @@ func TestFullConfig(t *testing.T) {
 				Timeout:                        18506 * time.Second,
 				TTL:                            31006 * time.Second,
 				DeregisterCriticalServiceAfter: 2366 * time.Second,
-				EnterpriseMeta:                 *structs.DefaultEnterpriseMeta(),
 			},
 			&structs.CheckDefinition{
 				ID:         "fZaCAXww",
@@ -5137,7 +5128,6 @@ func TestFullConfig(t *testing.T) {
 				Timeout:                        5954 * time.Second,
 				TTL:                            30044 * time.Second,
 				DeregisterCriticalServiceAfter: 13209 * time.Second,
-				EnterpriseMeta:                 *structs.DefaultEnterpriseMeta(),
 			},
 		},
 		CheckUpdateInterval: 16507 * time.Second,
@@ -5324,10 +5314,8 @@ func TestFullConfig(t *testing.T) {
 							Passing: 1,
 							Warning: 1,
 						},
-						EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					},
 				},
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 			{
 				ID:      "MRHVMZuD",
@@ -5387,8 +5375,7 @@ func TestFullConfig(t *testing.T) {
 						DeregisterCriticalServiceAfter: 68482 * time.Second,
 					},
 				},
-				Connect:        &structs.ServiceConnect{},
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+				Connect: &structs.ServiceConnect{},
 			},
 			{
 				ID:   "Kh81CPF6",
@@ -5436,7 +5423,6 @@ func TestFullConfig(t *testing.T) {
 					Passing: 1,
 					Warning: 1,
 				},
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 			{
 				ID:   "kvVqbwSE",
@@ -5452,7 +5438,6 @@ func TestFullConfig(t *testing.T) {
 					Passing: 1,
 					Warning: 1,
 				},
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 			{
 				ID:   "dLOXpSCI",
@@ -5548,7 +5533,6 @@ func TestFullConfig(t *testing.T) {
 						DeregisterCriticalServiceAfter: 68787 * time.Second,
 					},
 				},
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 		},
 		SerfAdvertiseAddrLAN: tcpAddr("17.99.29.16:8301"),

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 )
 
+func mustCopyProxyConfig(t *testing.T, ns *structs.NodeService) structs.ConnectProxyConfig {
+	cfg, err := copyProxyConfig(ns)
+	require.NoError(t, err)
+	return cfg
+}
+
 // assertLastReqArgs verifies that each request type had the correct source
 // parameters (e.g. Datacenter name) and token.
 func assertLastReqArgs(t *testing.T, types *TestCacheTypes, token string, source *structs.QuerySource) {
@@ -137,7 +143,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 	dbChainCacheKey := testGenCacheKey(&structs.DiscoveryChainRequest{
 		Name:                 "db",
 		EvaluateInDatacenter: "dc1",
-		EvaluateInNamespace:  "",
+		EvaluateInNamespace:  "default",
 		// This is because structs.TestUpstreams uses an opaque config
 		// to override connect timeouts.
 		OverrideConnectTimeout: 1 * time.Second,
@@ -190,7 +196,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 				ProxyID:         webProxy.CompoundServiceID(),
 				Address:         webProxy.Address,
 				Port:            webProxy.Port,
-				Proxy:           webProxy.Proxy,
+				Proxy:           mustCopyProxyConfig(t, webProxy),
 				TaggedAddresses: make(map[string]structs.ServiceAddress),
 				Roots:           roots,
 				ConnectProxy: configSnapshotConnectProxy{
@@ -234,7 +240,7 @@ func TestManager_BasicLifecycle(t *testing.T) {
 				ProxyID:         webProxy.CompoundServiceID(),
 				Address:         webProxy.Address,
 				Port:            webProxy.Port,
-				Proxy:           webProxy.Proxy,
+				Proxy:           mustCopyProxyConfig(t, webProxy),
 				TaggedAddresses: make(map[string]structs.ServiceAddress),
 				Roots:           roots,
 				ConnectProxy: configSnapshotConnectProxy{

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -147,7 +147,7 @@ func (cn *testCacheNotifier) getNotifierRequest(t testing.TB, correlationId stri
 	cn.lock.RLock()
 	req, ok := cn.notifiers[correlationId]
 	cn.lock.RUnlock()
-	require.True(t, ok)
+	require.True(t, ok, "Correlation ID: %s is missing", correlationId)
 	return req
 }
 
@@ -384,7 +384,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"discovery-chain:api": genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api",
 					EvaluateInDatacenter: "dc1",
-					EvaluateInNamespace:  "",
+					EvaluateInNamespace:  "default",
 					Datacenter:           "dc1",
 					OverrideMeshGateway: structs.MeshGatewayConfig{
 						Mode: meshGatewayProxyConfigValue,
@@ -393,7 +393,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"discovery-chain:api-failover-remote?dc=dc2": genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api-failover-remote",
 					EvaluateInDatacenter: "dc2",
-					EvaluateInNamespace:  "",
+					EvaluateInNamespace:  "default",
 					Datacenter:           "dc1",
 					OverrideMeshGateway: structs.MeshGatewayConfig{
 						Mode: structs.MeshGatewayModeRemote,
@@ -402,7 +402,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"discovery-chain:api-failover-local?dc=dc2": genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api-failover-local",
 					EvaluateInDatacenter: "dc2",
-					EvaluateInNamespace:  "",
+					EvaluateInNamespace:  "default",
 					Datacenter:           "dc1",
 					OverrideMeshGateway: structs.MeshGatewayConfig{
 						Mode: structs.MeshGatewayModeLocal,
@@ -411,7 +411,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"discovery-chain:api-failover-direct?dc=dc2": genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api-failover-direct",
 					EvaluateInDatacenter: "dc2",
-					EvaluateInNamespace:  "",
+					EvaluateInNamespace:  "default",
 					Datacenter:           "dc1",
 					OverrideMeshGateway: structs.MeshGatewayConfig{
 						Mode: structs.MeshGatewayModeNone,
@@ -420,7 +420,7 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				"discovery-chain:api-dc2": genVerifyDiscoveryChainWatch(&structs.DiscoveryChainRequest{
 					Name:                 "api-dc2",
 					EvaluateInDatacenter: "dc1",
-					EvaluateInNamespace:  "",
+					EvaluateInNamespace:  "default",
 					Datacenter:           "dc1",
 					OverrideMeshGateway: structs.MeshGatewayConfig{
 						Mode: meshGatewayProxyConfigValue,

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -46,6 +46,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			},
 			token: "foo",
 			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMeta(),
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
@@ -105,12 +106,13 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			},
 			token: "foo",
 			wantNS: &structs.NodeService{
-				Kind:    structs.ServiceKindConnectProxy,
-				ID:      "web1-sidecar-proxy",
-				Service: "motorbike1",
-				Port:    3333,
-				Tags:    []string{"foo", "bar"},
-				Address: "127.127.127.127",
+				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+				Kind:           structs.ServiceKindConnectProxy,
+				ID:             "web1-sidecar-proxy",
+				Service:        "motorbike1",
+				Port:           3333,
+				Tags:           []string{"foo", "bar"},
+				Address:        "127.127.127.127",
 				Meta: map[string]string{
 					"foo": "bar",
 				},
@@ -182,6 +184,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 				},
 			},
 			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMeta(),
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",
@@ -271,6 +274,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			},
 			token: "foo",
 			wantNS: &structs.NodeService{
+				EnterpriseMeta:             *structs.DefaultEnterpriseMeta(),
 				Kind:                       structs.ServiceKindConnectProxy,
 				ID:                         "web1-sidecar-proxy",
 				Service:                    "web-sidecar-proxy",

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -356,13 +356,15 @@ func (k UpstreamKey) String() string {
 // upstream in a canonical but human readable way.
 func (u *Upstream) Identifier() string {
 	name := u.DestinationName
-	if u.DestinationNamespace != "" && u.DestinationNamespace != "default" {
+	typ := u.DestinationType
+
+	if typ != UpstreamDestTypePreparedQuery && u.DestinationNamespace != "" && u.DestinationNamespace != "default" {
 		name = u.DestinationNamespace + "/" + u.DestinationName
 	}
 	if u.Datacenter != "" {
 		name += "?dc=" + u.Datacenter
 	}
-	typ := u.DestinationType
+
 	// Service is default type so never prefix it. This is more readable and long
 	// term it is the only type that matters so we can drop the prefix and have
 	// nicer naming in metrics etc.

--- a/agent/structs/discovery_chain.go
+++ b/agent/structs/discovery_chain.go
@@ -85,7 +85,7 @@ func (c *CompiledDiscoveryChain) IsDefault() bool {
 
 	target := c.Targets[node.Resolver.Target]
 
-	return target.Service == c.ServiceName
+	return target.Service == c.ServiceName && target.Namespace == c.Namespace
 }
 
 const (

--- a/agent/structs/service_definition.go
+++ b/agent/structs/service_definition.go
@@ -71,6 +71,8 @@ func (s *ServiceDefinition) NodeService() *NodeService {
 		EnableTagOverride: s.EnableTagOverride,
 		EnterpriseMeta:    s.EnterpriseMeta,
 	}
+	ns.EnterpriseMeta.Normalize()
+
 	if s.Connect != nil {
 		ns.Connect = *s.Connect
 	}


### PR DESCRIPTION
Bugs Fixed:

* The config parsing was defaulting the namespace. This caused the CLI command `consul services register` to not handle the namespace flag appropriately.
* We were not defaulting the upstream destination_namespace appropriately and therefore were inadvertently requiring an upstream to require a namespace.
* Fixed an ACL enforcement issue that would allow writes to config entries that would in some way redirect traffic to a service in another namespace..