### PR TITLE
docs: namespaces has erroneous HCL example

### DIFF
--- a/website/source/docs/enterprise/namespaces/index.html.md
+++ b/website/source/docs/enterprise/namespaces/index.html.md
@@ -53,8 +53,8 @@ JSON:
 HCL:
 
 ```hcl
-Name: "team-1"
-Description: "Namespace for Team 1"
+Name = "team-1"
+Description = "Namespace for Team 1"
 ACLs {
   PolicyDefaults = [
     {


### PR DESCRIPTION
Failed to parse namespace input: At 1:5: illegal char