### PR TITLE
Changed the return value from null to empty JSON list

### DIFF
--- a/website/source/api/session.html.md
+++ b/website/source/api/session.html.md
@@ -209,7 +209,7 @@ $ curl \
 ]
 ```
 
-If the session does not exist, `null` is returned instead of a JSON list.
+If the session does not exist, an empty JSON list `[]` is returned.
 
 ## List Sessions for Node
 


### PR DESCRIPTION
Changed the return value from _null_ to **empty JSON list**, when a session does not exist.

I observed this behavior during an integration test.

<img width="651" alt="Screenshot 2020-02-06 at 11 47 20" src="https://user-images.githubusercontent.com/55922671/73935177-de1f8e80-48d7-11ea-9de9-d11a4fc0bc12.png">
