### PR TITLE
ui: Fix for differences between uncompiled and compiled CSS

### DIFF
--- a/ui-v2/app/styles/base/components/menu-panel/layout.scss
+++ b/ui-v2/app/styles/base/components/menu-panel/layout.scss
@@ -65,8 +65,13 @@
   padding: 10px;
   padding-left: 36px;
 }
+/* here the !important is only needed for what seems to be a difference */
+/* with the CSS before and after compression */
+/* i.e. before compression this style is applied */
+/* after compression it is in the source but doesn't seem to get */
+/* applied (unless you add the !important) */
 %menu-panel .is-active {
-  position: relative;
+  position: relative !important;
 }
 %menu-panel .is-active > *::after {
   position: absolute;


### PR DESCRIPTION
We noticed that this relative positioning is not even applied when the CSS is
compiled/compressed. When looking via Web Inspector this style/selector
doesn't even appear even though it is in the CSS source.

This !important reduces the amount of selectors for this style rule,
which fixes the error, so potentially this isn't a specificity thing.

See https://github.com/hashicorp/consul/pull/7148 for the original fix that works in development mode, yet not once all the CSS is compressed in production mode.

Fixes https://github.com/hashicorp/consul/issues/7229
