### PR TITLE
agent/consul server: fix LeaderTest_ChangeNodeID 

### DIFF
--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -982,16 +982,7 @@ func TestLeader_ChangeNodeID(t *testing.T) {
 
 	// Shut down a server, freeing up its address/port
 	s3.Shutdown()
-
-	retry.Run(t, func(r *retry.R) {
-		failed := 0
-		for _, m := range s1.LANMembers() {
-			if m.Status == serf.StatusFailed {
-				failed++
-			}
-		}
-		require.Equal(r, 1, failed)
-	})
+	waitForAnyLANLeave(t, s1)
 
 	// Bring up a new server with s3's name that will get a different ID
 	dir4, s4 := testServerWithConfig(t, func(c *Config) {

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/serf/serf"
 	"net"
 	"os"
 	"strings"
@@ -74,6 +75,20 @@ func waitForLeaderEstablishment(t *testing.T, servers ...*Server) {
 			}
 		}
 		require.True(r, hasLeader, "Cluster has not elected a leader yet")
+	})
+}
+
+// waitForAnyLANLeave retries until it sees a LANMember with StatusLeft, or it gets interrupted
+// by the test runner
+func waitForAnyLANLeave(t *testing.T, server *Server) {
+	retry.Run(t, func(r *retry.R) {
+		left := 0
+		for _, m := range server.LANMembers() {
+			if m.Status == serf.StatusLeft {
+				left++
+			}
+		}
+		require.Equal(r, 1, left, "no LANMember with StatusLeft found")
 	})
 }
 

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/serf/serf"
 	"net"
 	"os"
 	"strings"
@@ -75,20 +74,6 @@ func waitForLeaderEstablishment(t *testing.T, servers ...*Server) {
 			}
 		}
 		require.True(r, hasLeader, "Cluster has not elected a leader yet")
-	})
-}
-
-// waitForAnyLANLeave retries until it sees a LANMember with StatusLeft, or it gets interrupted
-// by the test runner
-func waitForAnyLANLeave(t *testing.T, server *Server) {
-	retry.Run(t, func(r *retry.R) {
-		left := 0
-		for _, m := range server.LANMembers() {
-			if m.Status == serf.StatusLeft {
-				left++
-			}
-		}
-		require.Equal(r, 1, left, "no LANMember with StatusLeft found")
 	})
 }
 


### PR DESCRIPTION
Fixes #7043 

LeaderTest_ChangeNodeID got flaky after(?) voluntary node shutdown in memberlist broadcasted its status as `StatusLeft` rather than `StatusFailed`

I'm a bit concerned that we only failed the test 10%-30% of the time before this -- the `retry.Run` based wait seems to not be deterministic? Learned enough to make this test better, but not yet why it was only failing sometimes before.

Anyway, here's the numbers. Only ran in batches of 100 cause 1k would've taken 30 minutes and I timeboxed this one.

Running `gotestsum -- ./agent/consul -run TestLeader_ChangeNodeID --timeout 0 --count 100` on macOS:

Before this PR
<img width="1440" alt="Screen Shot 2020-02-06 at 2 44 03 PM" src="https://user-images.githubusercontent.com/938395/73985169-580f4200-48ef-11ea-9bfc-e3010e9e814f.png">

On this PR
<img width="1436" alt="Screen Shot 2020-02-06 at 2 39 01 PM" src="https://user-images.githubusercontent.com/938395/73985164-56457e80-48ef-11ea-9302-745f4b0bf47a.png">
