### PR TITLE
WIP, RFC: Add new parameters for rate limiting read and write RPCs individually

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1233,6 +1233,20 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.RPCMaxBurst = a.config.RPCMaxBurst
 	}
 
+	if a.config.ReadRPCRateLimit > 0 {
+		base.ReadRPCRate = a.config.ReadRPCRateLimit
+	}
+	if a.config.ReadRPCMaxBurst > 0 {
+		base.ReadRPCMaxBurst = a.config.ReadRPCMaxBurst
+	}
+
+	if a.config.WriteRPCRateLimit > 0 {
+		base.WriteRPCRate = a.config.WriteRPCRateLimit
+	}
+	if a.config.WriteRPCMaxBurst > 0 {
+		base.WriteRPCMaxBurst = a.config.WriteRPCMaxBurst
+	}
+
 	// RPC-related performance configs.
 	if a.config.RPCHoldTimeout > 0 {
 		base.RPCHoldTimeout = a.config.RPCHoldTimeout

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -974,6 +974,10 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		VerifyOutgoing:                   verifyOutgoing,
 		VerifyServerHostname:             verifyServerName,
 		Watches:                          c.Watches,
+		ReadRPCRateLimit:                 rate.Limit(b.float64Val(c.Limits.ReadRPCRate)),
+		ReadRPCMaxBurst:                  b.intVal(c.Limits.ReadRPCMaxBurst),
+		WriteRPCRateLimit:                rate.Limit(b.float64Val(c.Limits.WriteRPCRate)),
+		WriteRPCMaxBurst:                 b.intVal(c.Limits.WriteRPCMaxBurst),
 	}
 
 	if entCfg, err := b.BuildEnterpriseRuntimeConfig(&c); err != nil {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -677,6 +677,12 @@ type Limits struct {
 	RPCMaxBurst    *int     `json:"rpc_max_burst,omitempty" hcl:"rpc_max_burst" mapstructure:"rpc_max_burst"`
 	RPCRate        *float64 `json:"rpc_rate,omitempty" hcl:"rpc_rate" mapstructure:"rpc_rate"`
 	KVMaxValueSize *uint64  `json:"kv_max_value_size,omitempty" hcl:"kv_max_value_size" mapstructure:"kv_max_value_size"`
+
+	ReadRPCMaxBurst    *int     `json:"read_rpc_max_burst,omitempty" hcl:"read_rpc_max_burst" mapstructure:"read_rpc_max_burst"`
+	ReadRPCRate        *float64 `json:"read_rpc_rate,omitempty" hcl:"read_rpc_rate" mapstructure:"read_rpc_rate"`
+
+	WriteRPCMaxBurst    *int     `json:"write_rpc_max_burst,omitempty" hcl:"write_rpc_max_burst" mapstructure:"write_rpc_max_burst"`
+	WriteRPCRate        *float64 `json:"write_rpc_rate,omitempty" hcl:"write_rpc_rate" mapstructure:"write_rpc_rate"`
 }
 
 type Segment struct {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1504,6 +1504,12 @@ type RuntimeConfig struct {
 	//
 	Watches []map[string]interface{}
 
+	ReadRPCRateLimit rate.Limit
+	ReadRPCMaxBurst  int
+
+	WriteRPCRateLimit rate.Limit
+	WriteRPCMaxBurst  int
+
 	EnterpriseRuntimeConfig
 }
 

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -438,6 +438,12 @@ type Config struct {
 	// AutoEncrypt.Sign requests.
 	AutoEncryptAllowTLS bool
 
+	ReadRPCRate     rate.Limit
+	ReadRPCMaxBurst int
+
+	WriteRPCRate     rate.Limit
+	WriteRPCMaxBurst int
+
 	// Embedded Consul Enterprise specific configuration
 	*EnterpriseConfig
 }
@@ -562,7 +568,14 @@ func DefaultConfig() *Config {
 		AutopilotInterval:    10 * time.Second,
 		DefaultQueryTime:     300 * time.Second,
 		MaxQueryTime:         600 * time.Second,
-		EnterpriseConfig:     DefaultEnterpriseConfig(),
+
+		ReadRPCRate:     rate.Inf,
+		ReadRPCMaxBurst: 1000,
+
+		WriteRPCRate:     rate.Inf,
+		WriteRPCMaxBurst: 1000,
+
+		EnterpriseConfig: DefaultEnterpriseConfig(),
 	}
 
 	// Increase our reap interval to 3 days instead of 24h.


### PR DESCRIPTION
This is a very early draft of untested change for controlling read and write RPCs individually. I'm glad if I can have feedback from the community.

Current consul provides a way to control RPC rate from each agent (`limits.rcp_rate`). The feature is really helpful for controlling load against consul servers.

However, I think having a common rate limiter for every RPC isn't ideal because each RPC introduces different load. Generally speaking, write request (or a command which introduces side effect against state machines) is much heavier than read only request (or a command which introduce no side effect against state machines) in the context of Raft based systems.

So I'd like to propose an idea of implementing dedicated RPC limiters for read (currently `KVS.List` and `KVS.Get` only) and write (currently `KVS.Put` only) requests. It will be useful for controlling load comes from heavy write requests without sacrificing performance of read requests (in our case vast majority of requests is read, and I guess it's common for typical consul deployments).

I'm still not testing and benchmarking this change yet and planning to do that in the near future. But I want to know the idea and design are acceptable from the perspective of consul community earlier because we want to avoid to have an internal fork of consul as much as possible. If the idea and design is acceptable, I'd like to have opinions about the ideal implementation.