### PR TITLE
ui: oss don't ever POST/PUT Namespaces when writing data

### DIFF
--- a/ui-v2/app/adapters/policy.js
+++ b/ui-v2/app/adapters/policy.js
@@ -4,8 +4,15 @@ import { SLUG_KEY } from 'consul-ui/models/policy';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
 
+import { env } from 'consul-ui/env';
 import nonEmptySet from 'consul-ui/utils/non-empty-set';
-const Namespace = nonEmptySet('Namespace');
+
+let Namespace;
+if (env('CONSUL_NSPACES_ENABLED')) {
+  Namespace = nonEmptySet('Namespace');
+} else {
+  Namespace = () => ({});
+}
 
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
@@ -60,7 +67,7 @@ export default Adapter.extend({
         Description: serialized.Description,
         Rules: serialized.Rules,
         Datacenters: serialized.Datacenters,
-        Namespace: serialized.Namespace,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },

--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -3,9 +3,16 @@ import Adapter from './application';
 import { SLUG_KEY } from 'consul-ui/models/role';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
+
+import { env } from 'consul-ui/env';
 import nonEmptySet from 'consul-ui/utils/non-empty-set';
 
-const Namespace = nonEmptySet('Namespace');
+let Namespace;
+if (env('CONSUL_NSPACES_ENABLED')) {
+  Namespace = nonEmptySet('Namespace');
+} else {
+  Namespace = () => ({});
+}
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
   requestForQuery: function(request, { dc, ns, index, id }) {
@@ -57,9 +64,9 @@ export default Adapter.extend({
       ${{
         Name: serialized.Name,
         Description: serialized.Description,
-        Namespace: serialized.Namespace,
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -4,9 +4,16 @@ import { inject as service } from '@ember/service';
 import { SLUG_KEY } from 'consul-ui/models/token';
 import { FOREIGN_KEY as DATACENTER_KEY } from 'consul-ui/models/dc';
 import { NSPACE_KEY } from 'consul-ui/models/nspace';
+
+import { env } from 'consul-ui/env';
 import nonEmptySet from 'consul-ui/utils/non-empty-set';
 
-const Namespace = nonEmptySet('Namespace');
+let Namespace;
+if (env('CONSUL_NSPACES_ENABLED')) {
+  Namespace = nonEmptySet('Namespace');
+} else {
+  Namespace = () => ({});
+}
 // TODO: Update to use this.formatDatacenter()
 export default Adapter.extend({
   store: service('store'),
@@ -74,11 +81,11 @@ export default Adapter.extend({
 
       ${{
         Description: serialized.Description,
-        Namespace: serialized.Namespace,
         Policies: serialized.Policies,
         Roles: serialized.Roles,
         ServiceIdentities: serialized.ServiceIdentities,
         Local: serialized.Local,
+        ...Namespace(serialized.Namespace),
       }}
     `;
   },

--- a/ui-v2/tests/acceptance/dc/acls/policies/create.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/create.feature
@@ -1,14 +1,51 @@
 @setupApplicationTest
 Feature: dc / acls / policies / create
-  Scenario: 
+  Background:
     Given 1 datacenter model with the value "datacenter"
     When I visit the policy page for yaml
     ---
       dc: datacenter
     ---
+  Scenario: Visiting the page without error and the title is correct
     Then the url should be /datacenter/acls/policies/create
     And the title should be "New Policy - Consul"
 
-@ignore
-  Scenario: Test we can create a ACLs Policy
-  Then ok
+  Scenario: Creating a simple ACL policy with description [Description]
+    Then I fill in the policy form with yaml
+    ---
+      Name: my-policy
+      Description: [Description]
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" from yaml
+    ---
+      body:
+        Name: my-policy
+        Namespace: @namespace
+        Description: [Description]
+    ---
+    Then the url should be /datacenter/acls/policies
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class
+    Where:
+      ---------------------------
+      | Description             |
+      | description             |
+      | description with spaces |
+      ---------------------------
+
+  @notNamespaceable
+  Scenario: Creating a simple ACL policy when Namespaces are disabled does not send Namespace
+    Then I fill in the policy form with yaml
+    ---
+      Name: my-policy
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/policy?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/policies
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/acls/policies/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/update.feature
@@ -53,3 +53,18 @@ Feature: dc / acls / policies / update: ACL Policy Update
     Then the url should be /datacenter/acls/policies/policy-id
     Then "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "error" class
+
+  @notNamespaceable
+  Scenario: Updating a simple ACL policy when Namespaces are disabled does not send Namespace
+    Then I fill in the policy form with yaml
+    ---
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/policy/policy-id?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/policies
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/acls/roles/create.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/create.feature
@@ -1,14 +1,51 @@
 @setupApplicationTest
 Feature: dc / acls / roles / create
-  Scenario: 
+  Background:
     Given 1 datacenter model with the value "datacenter"
     When I visit the role page for yaml
     ---
       dc: datacenter
     ---
+
+  Scenario: Visiting the page without error and the title is correct
     Then the url should be /datacenter/acls/roles/create
     And the title should be "New Role - Consul"
+  Scenario: Creating a simple ACL role with description [Description]
+    Then I fill in the role form with yaml
+    ---
+      Name: my-role
+      Description: [Description]
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" from yaml
+    ---
+      body:
+        Namespace: @namespace
+        Name: my-role
+        Description: [Description]
+    ---
+    Then the url should be /datacenter/acls/roles
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class
+    Where:
+      ---------------------------
+      | Description             |
+      | description             |
+      | description with spaces |
+      ---------------------------
+  @notNamespaceable
+  Scenario: Creating a simple ACL role when Namespaces are disabled does not send Namespace
+    Then I fill in the role form with yaml
+    ---
+      Name: my-role
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/role?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/roles
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class
 
-@ignore
-  Scenario: Test we can create a ACLs role
-  Then ok

--- a/ui-v2/tests/acceptance/dc/acls/roles/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/roles/update.feature
@@ -45,3 +45,18 @@ Feature: dc / acls / roles / update: ACL Role Update
     Then the url should be /datacenter/acls/roles/role-id
     Then "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "error" class
+
+  @notNamespaceable
+  Scenario: Updating a simple ACL role when Namespaces are disabled does not send Namespace
+    Then I fill in the role form with yaml
+    ---
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/role/role-id?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/roles
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/acls/tokens/create.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/create.feature
@@ -1,14 +1,46 @@
 @setupApplicationTest
 Feature: dc / acls / tokens / create
-  Scenario: 
+  Background:
     Given 1 datacenter model with the value "datacenter"
     When I visit the token page for yaml
     ---
       dc: datacenter
     ---
+  Scenario: Visiting the page without error and the title is correct
     Then the url should be /datacenter/acls/tokens/create
     And the title should be "New Token - Consul"
-
-@ignore
-  Scenario: Test we can create a ACLs Token
-  Then ok
+  Scenario: Creating a simple ACL token with description [Description]
+    Then I fill in with yaml
+    ---
+      Description: [Description]
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/token?dc=datacenter" from yaml
+    ---
+      body:
+        Namespace: @namespace
+        Description: [Description]
+    ---
+    Then the url should be /datacenter/acls/tokens
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class
+    Where:
+      ---------------------------
+      | Description             |
+      | description             |
+      | description with spaces |
+      ---------------------------
+  @notNamespaceable
+  Scenario: Creating a simple ACL token when Namespaces are disabled does not send Namespace
+    Then I fill in with yaml
+    ---
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/token?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/tokens
+    And "[data-notification]" has the "notification-create" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/acceptance/dc/acls/tokens/update.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/update.feature
@@ -41,3 +41,18 @@ Feature: dc / acls / tokens / update: ACL Token Update
     Then the url should be /datacenter/acls/tokens/key
     Then "[data-notification]" has the "notification-update" class
     And "[data-notification]" has the "error" class
+
+  @notNamespaceable
+  Scenario: Updating a simple ACL token when Namespaces are disabled does not send Namespace
+    Then I fill in with yaml
+    ---
+      Description: Description
+    ---
+    And I submit
+    Then a PUT request was made to "/v1/acl/token/key?dc=datacenter" without properties from yaml
+    ---
+      - Namespace
+    ---
+    Then the url should be /datacenter/acls/tokens
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class

--- a/ui-v2/tests/steps/assertions/http.js
+++ b/ui-v2/tests/steps/assertions/http.js
@@ -81,5 +81,23 @@ export default function(scenario, assert, lastNthRequest) {
           )}, ${key} was ${JSON.stringify(headers[key])}`
         );
       });
+    })
+    .then('a $method request was made to "$endpoint" without properties from yaml\n$yaml', function(
+      method,
+      url,
+      properties
+    ) {
+      const requests = lastNthRequest(null, method);
+      const request = requests.find(function(item) {
+        return method === item.method && url === item.url;
+      });
+      const body = JSON.parse(request.requestBody);
+      properties.forEach(function(key, i, arr) {
+        assert.equal(
+          typeof body[key],
+          'undefined',
+          `Expected payload to not have a ${key} property`
+        );
+      });
     });
 }


### PR DESCRIPTION
We missed a couple of places where we use the `nonEmptySet` function, which
will only perform the set if the specified property is non-empty.

Currently we aren't certain there is a place in OSS where a `Namespace`
can make its way down via the API and end up being PUT/POSTed back out
again when saved. If this did ever happen we would assume it would be
the default namespace, but additionally we add an extra check here to ensure we never
PUT/POST the Namespace property if Namespaces are disabled.

This additional check could be removed in the future.

