### PR TITLE
Fix a bug with ACL enforcement of reads on namespaced config entries.

### DIFF
--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -85,10 +85,11 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 
 	// Create a dummy config entry to check the ACL permissions.
 	lookupEntry, err := structs.MakeConfigEntry(args.Kind, args.Name)
-	lookupEntry.GetEnterpriseMeta().Merge(&args.EnterpriseMeta)
 	if err != nil {
 		return err
 	}
+	lookupEntry.GetEnterpriseMeta().Merge(&args.EnterpriseMeta)
+	
 	if authz != nil && !lookupEntry.CanRead(authz) {
 		return acl.ErrPermissionDenied
 	}

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -89,7 +89,7 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 		return err
 	}
 	lookupEntry.GetEnterpriseMeta().Merge(&args.EnterpriseMeta)
-	
+
 	if authz != nil && !lookupEntry.CanRead(authz) {
 		return acl.ErrPermissionDenied
 	}

--- a/agent/consul/config_endpoint.go
+++ b/agent/consul/config_endpoint.go
@@ -85,6 +85,7 @@ func (c *ConfigEntry) Get(args *structs.ConfigEntryQuery, reply *structs.ConfigE
 
 	// Create a dummy config entry to check the ACL permissions.
 	lookupEntry, err := structs.MakeConfigEntry(args.Kind, args.Name)
+	lookupEntry.GetEnterpriseMeta().Merge(&args.EnterpriseMeta)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@kyhavlov Found this when writing some more tests (which live elsewhere)