### PR TITLE
Remove outdated TODO

### DIFF
--- a/agent/consul/state/session_test.go
+++ b/agent/consul/state/session_test.go
@@ -131,7 +131,6 @@ func TestStateStore_SessionCreate_SessionGet(t *testing.T) {
 		t.Fatalf("bad")
 	}
 
-	// TODO (namespaces) (freddy) This test fails if the Txn is started after registering check2, not sure why
 	tx := s.db.Txn(false)
 	defer tx.Abort()
 


### PR DESCRIPTION
OSS sync for session checks tests