### PR TITLE
Remove the 1.7.0 beta banner on downloads page

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -8,12 +8,6 @@ description: |-
 
 <h1>Download Consul</h1>
 
-<div class="alert alert-info" id="beta-1-7" role="alert">
-  <p><strong>1.7.0 Beta Available:</strong> Read more about the new features coming in 1.7.0 in the
-  <a href="https://www.hashicorp.com/blog/announcing-hashicorp-consul-1-7/">announcement post</a>. Binaries can be accessed on <a href="https://releases.hashicorp.com/consul/">releases.hashicorp.com</a>.
-  </p>
-</div>
-
 <section class="downloads">
   <div class="description row">
     <div class="col-md-12">


### PR DESCRIPTION
I think this is the only place where this matters.