### PR TITLE
fix use of hclog logger

### DIFF
--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -68,8 +68,7 @@ func (s *Server) listen(listener net.Listener) {
 
 		free, err := s.rpcConnLimiter.Accept(conn)
 		if err != nil {
-			s.rpcLogger().Error("rejecting RPC conn from %s"+
-				" rpc_max_conns_per_client exceeded", conn.RemoteAddr().String())
+			s.rpcLogger().Error("rejecting RPC conn from because rpc_max_conns_per_client exceeded", "conn", logConn(conn))
 			conn.Close()
 			continue
 		}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -137,7 +137,7 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 	case pool.RPCTLS:
 		// Don't allow malicious client to create TLS-in-TLS for ever.
 		if isTLS {
-			s.rpcLogger().Error("TLS connection attempting to establish inner TLS connection %s", logConn(conn))
+			s.rpcLogger().Error("TLS connection attempting to establish inner TLS connection", "conn", logConn(conn))
 			conn.Close()
 			return
 		}
@@ -153,7 +153,7 @@ func (s *Server) handleConn(conn net.Conn, isTLS bool) {
 	case pool.RPCTLSInsecure:
 		// Don't allow malicious client to create TLS-in-TLS for ever.
 		if isTLS {
-			s.rpcLogger().Error("TLS connection attempting to establish inner TLS connection %s", logConn(conn))
+			s.rpcLogger().Error("TLS connection attempting to establish inner TLS connection", "conn", logConn(conn))
 			conn.Close()
 			return
 		}

--- a/connect/service.go
+++ b/connect/service.go
@@ -205,7 +205,7 @@ func (s *Service) Dial(ctx context.Context, resolver Resolver) (net.Conn, error)
 		tlsConn.Close()
 		return nil, err
 	}
-	s.logger.Debug("successfully connected to service instance", addr,
+	s.logger.Debug("successfully connected to service instance",
 		"address", addr,
 		"identity", certURI.URI(),
 	)

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -40,7 +40,7 @@ func New(logger hclog.Logger, r *raft.Raft) (*Snapshot, error) {
 	}
 	defer func() {
 		if err := snap.Close(); err != nil {
-			logger.Error("Failed to close Raft snapshot: %v", err)
+			logger.Error("Failed to close Raft snapshot", "error", err)
 		}
 	}()
 


### PR DESCRIPTION
This particular log statement has an even number of args being passed to an hclog function call, which triggers `EXTRA_VALUE_AT_END`.