### PR TITLE
agent/proxycfg: Dropped Errors

### DIFF
--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -370,6 +370,9 @@ func (s *state) initWatchesMeshGateway() error {
 	err = s.cache.Notify(s.ctx, cachetype.CatalogDatacentersName, &structs.DatacentersRequest{
 		QueryOptions: structs.QueryOptions{Token: s.token, MaxAge: 30 * time.Second},
 	}, datacentersWatchID, s.ch)
+	if err != nil {
+		return err
+	}
 
 	// Once we start getting notified about the datacenters we will setup watches on the
 	// gateways within those other datacenters. We cannot do that here because we don't

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -292,6 +292,9 @@ func (s *state) initWatchesConnectProxy() error {
 				Connect:       true,
 				Source:        *s.source,
 			}, "upstream:"+u.Identifier(), s.ch)
+			if err != nil {
+				return err
+			}
 
 		case structs.UpstreamDestTypeService:
 			fallthrough


### PR DESCRIPTION
This fixes two dropped errors in the `agent/proxycfg` package.