### PR TITLE
Sensible keyring error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1631,14 +1631,14 @@ LOAD:
 				config.SerfLANConfig.MemberlistConfig.Keyring,
 				a.config.EncryptKey,
 			) {
-			a.logger.Warn("LAN" + msg)
+			a.logger.Warn(msg, "keyring", "LAN")
 		}
 		if existingWANKeyring &&
 			keyringIsMissingKey(
 				config.SerfWANConfig.MemberlistConfig.Keyring,
 				a.config.EncryptKey,
 			) {
-			a.logger.Warn("WAN" + msg)
+			a.logger.Warn(msg, "keyring", "WAN")
 		}
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha512"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1585,6 +1587,7 @@ func (a *Agent) setupBaseKeyrings(config *consul.Config) error {
 	fileLAN := filepath.Join(a.config.DataDir, SerfLANKeyring)
 	fileWAN := filepath.Join(a.config.DataDir, SerfWANKeyring)
 
+	var existingLANKeyring, existingWANKeyring bool
 	if a.config.EncryptKey == "" {
 		goto LOAD
 	}
@@ -1592,12 +1595,16 @@ func (a *Agent) setupBaseKeyrings(config *consul.Config) error {
 		if err := initKeyring(fileLAN, a.config.EncryptKey); err != nil {
 			return err
 		}
+	} else {
+		existingLANKeyring = true
 	}
 	if a.config.ServerMode && federationEnabled {
 		if _, err := os.Stat(fileWAN); err != nil {
 			if err := initKeyring(fileWAN, a.config.EncryptKey); err != nil {
 				return err
 			}
+		} else {
+			existingWANKeyring = true
 		}
 	}
 
@@ -1617,7 +1624,42 @@ LOAD:
 		}
 	}
 
+	// Only perform the following checks if there was an encrypt_key
+	// provided in the configuration.
+	if a.config.EncryptKey != "" {
+		msg := " keyring doesn't include key provided with -encrypt, using keyring"
+		if existingLANKeyring &&
+			keyringIsMissingKey(
+				config.SerfLANConfig.MemberlistConfig.Keyring,
+				a.config.EncryptKey,
+			) {
+			a.logger.Warn("LAN" + msg)
+		}
+		if existingWANKeyring &&
+			keyringIsMissingKey(
+				config.SerfWANConfig.MemberlistConfig.Keyring,
+				a.config.EncryptKey,
+			) {
+			a.logger.Warn("WAN" + msg)
+		}
+	}
+
 	return nil
+}
+
+// keyringIsMissingKey checks whether a key is part of a keyring. Returns true
+// if it is not included.
+func keyringIsMissingKey(keyring *memberlist.Keyring, key string) bool {
+	k1, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return true
+	}
+	for _, k2 := range keyring.GetKeys() {
+		if bytes.Equal(k1, k2) {
+			return false
+		}
+	}
+	return true
 }
 
 // setupKeyrings is used to initialize and load keyrings during agent startup.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,11 +1,9 @@
 package agent
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha512"
 	"crypto/tls"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -1645,21 +1643,6 @@ LOAD:
 	}
 
 	return nil
-}
-
-// keyringIsMissingKey checks whether a key is part of a keyring. Returns true
-// if it is not included.
-func keyringIsMissingKey(keyring *memberlist.Keyring, key string) bool {
-	k1, err := base64.StdEncoding.DecodeString(key)
-	if err != nil {
-		return true
-	}
-	for _, k2 := range keyring.GetKeys() {
-		if bytes.Equal(k1, k2) {
-			return false
-		}
-	}
-	return true
 }
 
 // setupKeyrings is used to initialize and load keyrings during agent startup.

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1106,16 +1106,6 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 		if _, err := decodeBytes(rt.EncryptKey); err != nil {
 			return fmt.Errorf("encrypt has invalid key: %s", err)
 		}
-		keyfileLAN := filepath.Join(rt.DataDir, SerfLANKeyring)
-		if _, err := os.Stat(keyfileLAN); err == nil {
-			b.warn("WARNING: LAN keyring exists but -encrypt given, using keyring")
-		}
-		if rt.ServerMode {
-			keyfileWAN := filepath.Join(rt.DataDir, SerfWANKeyring)
-			if _, err := os.Stat(keyfileWAN); err == nil {
-				b.warn("WARNING: WAN keyring exists but -encrypt given, using keyring")
-			}
-		}
 	}
 
 	// Check the data dir for signs of an un-migrated Consul 0.5.x or older

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -2158,41 +2158,6 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			err:  "encrypt has invalid key: illegal base64 data at input byte 4",
 		},
 		{
-			desc: "encrypt given but LAN keyring exists",
-			args: []string{
-				`-data-dir=` + dataDir,
-			},
-			json: []string{`{ "encrypt": "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=" }`},
-			hcl:  []string{` encrypt = "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=" `},
-			patch: func(rt *RuntimeConfig) {
-				rt.EncryptKey = "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s="
-				rt.DataDir = dataDir
-			},
-			pre: func() {
-				writeFile(filepath.Join(dataDir, SerfLANKeyring), []byte("pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s="))
-			},
-			warns: []string{`WARNING: LAN keyring exists but -encrypt given, using keyring`},
-		},
-		{
-			desc: "encrypt given but WAN keyring exists",
-			args: []string{
-				`-data-dir=` + dataDir,
-			},
-			json: []string{`{ "encrypt": "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=", "server": true }`},
-			hcl:  []string{` encrypt = "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s=" server = true `},
-			patch: func(rt *RuntimeConfig) {
-				rt.EncryptKey = "pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s="
-				rt.ServerMode = true
-				rt.LeaveOnTerm = false
-				rt.SkipLeaveOnInt = true
-				rt.DataDir = dataDir
-			},
-			pre: func() {
-				writeFile(filepath.Join(dataDir, SerfWANKeyring), []byte("pUqJrVyVRj5jsiYEkM/tFQYfWyJIv4s3XkvDwy7Cu5s="))
-			},
-			warns: []string{`WARNING: WAN keyring exists but -encrypt given, using keyring`},
-		},
-		{
 			desc: "multiple check files",
 			args: []string{
 				`-data-dir=` + dataDir,

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -334,3 +334,15 @@ func TestValidateLocalOnly(t *testing.T) {
 
 	require.Error(t, ValidateLocalOnly(true, false))
 }
+
+func TestAgent_KeyringIsMissingKey(t *testing.T) {
+	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
+	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
+	decoded1, err := decodeStringKey(key1)
+	require.NoError(t, err)
+	keyring, err := memberlist.NewKeyring([][]byte{}, decoded1)
+	require.NoError(t, err)
+
+	require.True(t, keyringIsMissingKey(keyring, key2))
+	require.False(t, keyringIsMissingKey(keyring, key1))
+}


### PR DESCRIPTION
Fixes #7231. Before an agent would always emit a warning when there is
an encrypt key in the configuration and an existing keyring stored,
which is happening on restart.

Now it only emits that warning when the encrypt key from the
configuration is not part of the keyring.

I feel a little bad, because `setupBaseKeyrings` is not pretty and I would like to make it better. But that would mean more changes that don't contribute to the fix at hand. Will leave that for later.