### PR TITLE
ui: Remove `next` from usage from discovery-chain component

### DIFF
--- a/ui-v2/app/components/discovery-chain.js
+++ b/ui-v2/app/components/discovery-chain.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { set, get, computed } from '@ember/object';
-import { next } from '@ember/runloop';
 
 import {
   createRoute,
@@ -147,24 +146,21 @@ export default Component.extend({
   // the developer access to the mouse event therefore we just use JS to add our events
   // revisit this post Octane
   addPathListeners: function() {
-    // TODO: Figure out if we can remove this next
-    next(() => {
-      this._listeners.remove();
-      this._listeners.add(this.dom.document(), {
-        click: e => {
-          // all route/splitter/resolver components currently
-          // have classes that end in '-card'
-          if (!this.dom.closest('[class$="-card"]', e.target)) {
-            set(this, 'active', false);
-            set(this, 'selectedId', '');
-          }
-        },
-      });
-      [...this.dom.elements('path.split', this.element)].forEach(item => {
-        this._listeners.add(item, {
-          mouseover: e => this.actions.showSplit.apply(this, [e]),
-          mouseout: e => this.actions.hideSplit.apply(this, [e]),
-        });
+    this._listeners.remove();
+    this._listeners.add(this.dom.document(), {
+      click: e => {
+        // all route/splitter/resolver components currently
+        // have classes that end in '-card'
+        if (!this.dom.closest('[class$="-card"]', e.target)) {
+          set(this, 'active', false);
+          set(this, 'selectedId', '');
+        }
+      },
+    });
+    [...this.dom.elements('path.split', this.element)].forEach(item => {
+      this._listeners.add(item, {
+        mouseover: e => this.actions.showSplit.apply(this, [e]),
+        mouseout: e => this.actions.hideSplit.apply(this, [e]),
       });
     });
     // TODO: currently don't think there is a way to listen


### PR DESCRIPTION
In a previous iteration of discovery-chain wrapping some event listeners
in a call to `next` (i.e. do this on next tick) was necessary. We added
a comment in here to see if we could get rid of it at a later date.

We've taken another look at this and it looks like this `next` is no
longer required in this later iteration. Further more there is the
tiniest chance that possibly, as we are adding listeners on next tick, that the
listeners could be added after component destruction, which means when
you click on the page we try to set a property of a destroyed object and
boom.

Removing this `next` removes this tiny possibility.