### PR TITLE
ui: Test coverage developer experience

### DIFF
--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -73,8 +73,8 @@ specify-coverage:
 test-coverage: deps specify-coverage
 	yarn run test:coverage
 
-test-view-coverage: deps specify-coverage
-	yarn run test:view:coverage
+test-coverage-view: deps specify-coverage
+	yarn run test:coverage:view
 
 test-parallel: deps
 	yarn run test:parallel

--- a/ui-v2/app/utils/components/discovery-chain/index.js
+++ b/ui-v2/app/utils/components/discovery-chain/index.js
@@ -39,7 +39,7 @@ export const getSplitters = function(nodes) {
     // Splitters need IDs adding so we can find them in the DOM later
     // splitters have a service.nspace as a name
     // do the reverse dance to ensure we don't mess up any
-    // serivice names with dots in them
+    // service names with dots in them
     const temp = item.Name.split('.');
     temp.reverse();
     temp.shift();

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -30,7 +30,7 @@
     "test:oss:view": "CONSUL_NSPACES_ENABLED=0 ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:node": "tape ./node-tests/**/*.js",
     "test:coverage": "COVERAGE=true ember test --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
-    "test:view:coverage": "COVERAGE=true ember test --server --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
+    "test:coverage:view": "COVERAGE=true ember test --server --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
     "steps:list": "node ./lib/commands/bin/list.js"
   },
   "husky": {

--- a/ui-v2/tests/unit/utils/components/discovery-chain/get-splitters-test.js
+++ b/ui-v2/tests/unit/utils/components/discovery-chain/get-splitters-test.js
@@ -1,0 +1,54 @@
+import { getSplitters } from 'consul-ui/utils/components/discovery-chain/index';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | components/discovery-chain/get-splitters', function() {
+  test('it collects and correctly parses splitter Names', function(assert) {
+    const actual = getSplitters({
+      'splitter:splitter-name.default': {
+        Type: 'splitter',
+        Name: 'splitter-name.default',
+        Splits: [
+          {
+            Weight: 50,
+            NextNode: '',
+          },
+          {
+            Weight: 50,
+            NextNode: '',
+          },
+        ],
+      },
+      'splitter:not-splitter-name.default': {
+        Type: 'not-splitter',
+        Name: 'splitter-name.default',
+        Splits: [
+          {
+            Weight: 50,
+            NextNode: '',
+          },
+          {
+            Weight: 50,
+            NextNode: '',
+          },
+        ],
+      },
+    });
+    const expected = {
+      Type: 'splitter',
+      Name: 'splitter-name',
+      ID: 'splitter:splitter-name.default',
+      Splits: [
+        {
+          Weight: 50,
+          NextNode: '',
+        },
+        {
+          Weight: 50,
+          NextNode: '',
+        },
+      ],
+    };
+    assert.equal(actual.length, 1);
+    assert.deepEqual(actual[0], expected);
+  });
+});


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/7027 we improved our test coverage system so we could add it to our CI.

The primary reason for this current PR was to test out the experience of using this as an engineer/developer. We spotted 2 things:

1. The makefile targets we had chosen to run the tests whilst viewing in a browser had a naming inconsistency (this is corrected here)
2. We added a `/coverage` endpoint so we could serve the coverage reports easily. Unfortunately it seems as though this only gets added if you are using `ember serve` not `ember test`. So this means you must have a development build of the app running in order to serve `/coverage`. It would be nice for this to be served just using embers test setup, but it wasn't immediately clear how to do this, so I left this as is.

Whilst testing out the experience of using this, we chose to add a couple of discovery chain tests to see what it was like. We've included these here also, and we are waiting to see what effect this has in CI/this PR description.