### PR TITLE
remove docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,8 +306,7 @@ jobs:
       # get consul binary
       - attach_workspace:
           at: bin/
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run: make ci.dev-docker
 
   # Nomad 0.8 builds on go0.10
@@ -537,8 +536,7 @@ jobs:
       # Get go binary from workspace
       - attach_workspace:
           at: .
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       # Build the consul-dev image from the already built binary
       - run: docker build -t consul-dev -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:


### PR DESCRIPTION
Previously, we were using [`docker_layer_caching`](https://circleci.com/docs/2.0/docker-layer-caching/) in a few places in the envoy builds. However, this really only saved us 10 seconds or so of time since the containers don't have many layers to build anyway. Now that we moved to the credit based CircleCI plan, this would cost 200 credits per job (essentially 20 minutes of runtime on a medium/default container) so I am turning it off for now.

We can add it back in the future if we do build containers where we would benefit from this.