### PR TITLE
Bump default of HTTPMaxConnsPerClient to 200

### DIFF
--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -103,7 +103,7 @@ func DefaultSource() Source {
 			recursor_timeout = "2s"
 		}
 		limits = {
-			http_max_conns_per_client = 100
+			http_max_conns_per_client = 200
 			https_handshake_timeout = "5s"
 			rpc_handshake_timeout = "5s"
 			rpc_rate = -1

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -806,7 +806,7 @@ type RuntimeConfig struct {
 	// HTTPMaxConnsPerClient limits the number of concurrent TCP connections the
 	// HTTP(S) server will accept from any single source IP address.
 	//
-	// hcl: limits{ http_max_conns_per_client = 100 }
+	// hcl: limits{ http_max_conns_per_client = 200 }
 	HTTPMaxConnsPerClient int
 
 	// HTTPSHandshakeTimeout is the time allowed for HTTPS client to complete the

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3466,7 +3466,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				// intentional.
 				rt.RPCHandshakeTimeout = 5 * time.Second
 				rt.HTTPSHandshakeTimeout = 5 * time.Second
-				rt.HTTPMaxConnsPerClient = 100
+				rt.HTTPMaxConnsPerClient = 200
 				rt.RPCMaxConnsPerClient = 100
 			},
 		},

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1397,7 +1397,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         Configures a limit of how many concurrent TCP connections a single
         client IP address is allowed to open to the agent's HTTP(S) server. This
         affects the HTTP(S) servers in both client and server agents. Default
-        value is `100`.
+        value is `200`.
     *   <a name="https_handshake_timeout"></a><a
         href="#https_handshake_timeout">`https_handshake_timeout`</a> -
         Configures the limit for how long the HTTPS server in both client and


### PR DESCRIPTION
Fixes #7284.

Todo:

* [ ] where do we call out this problem for vault with consul 1.7.0 and 1.6.3?
  * discuss.hashicorp.com?