### PR TITLE
ui: Gracefully cope with 500 errors from the disco-chain API endpoint

### DIFF
--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -24,7 +24,23 @@ export default Route.extend({
       return hash({
         chain: ['connect-proxy', 'mesh-gateway'].includes(get(model, 'item.Service.Kind'))
           ? null
-          : this.chainRepo.findBySlug(params.name, dc, nspace),
+          : this.chainRepo.findBySlug(params.name, dc, nspace).catch(function(e) {
+              const code = get(e, 'errors.firstObject.status');
+              // Currently we are specifically catching a 500, but we return null
+              // by default, so null for all errors.
+              // The extra code here is mainly for documentation purposes
+              // and for if we need to perform different actions based on the error code
+              // in the future
+              switch (code) {
+                case '500':
+                  // connect is likely to be disabled
+                  // we just return a null to hide the tab
+                  // `Connect must be enabled in order to use this endpoint`
+                  return null;
+                default:
+                  return null;
+              }
+            }),
         ...model,
       });
     });

--- a/ui-v2/tests/acceptance/dc/services/show-routing.feature
+++ b/ui-v2/tests/acceptance/dc/services/show-routing.feature
@@ -1,6 +1,6 @@
 @setupApplicationTest
-Feature: dc / services / Show Routing for Serivce
-Scenario: Given a service, the Routing tab should display
+Feature: dc / services / Show Routing for Service
+  Scenario: Given a service, the Routing tab should display
     Given 1 datacenter model with the value "dc1"
     And 1 node models
     And 1 service model from yaml
@@ -34,4 +34,27 @@ Scenario: Given a service, the Routing tab should display
     ---
     And the title should be "service-0-proxy - Consul"
     And I don't see routing on the tabs
+
+  Scenario: Given connect is disabled, the Routing tab should not display or error
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: consul
+        Name: service-0
+        ID: service-0-with-id
+    ---
+    And the url "/v1/discovery-chain/service-0?dc=dc1&ns=@namespace" responds with from yaml
+    ---
+    status: 500
+    body: "Connect must be enabled in order to use this endpoint"
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I don't see routing on the tabs
+    And I don't see the "[data-test-error]" element
 


### PR DESCRIPTION
When connect is disabled the discovery-chain endpoint returns a 500
error status, which we previously did not gracefully cope with.

This commit gracefully copes with any errors from the disco-chain
endpoint by suppressing the error and hiding the Routing tab from the
Service detail page.

Acceptance test included

Fixes https://github.com/hashicorp/consul/issues/7288