### PR TITLE
only run website workflow on docs/* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,6 +635,7 @@ workflows:
             branches:
               ignore:
                 - stable-website
+                - /^docs\/.*/
       - lint-consul-retry
       - go-fmt-and-vet:
           requires:
@@ -659,6 +660,7 @@ workflows:
             branches:
               ignore:
                 - stable-website
+                - /^docs\/.*/
       - build-386: &require-check-vendor
           requires:
             - check-vendor
@@ -671,6 +673,7 @@ workflows:
             branches:
               ignore:
                 - stable-website
+                - /^docs\/.*/
       - dev-upload-s3: &dev-upload
           requires:
             - dev-build
@@ -726,6 +729,7 @@ workflows:
             branches:
               ignore:
                 - stable-website
+                - /^docs\/.*/
       - ember-build:
           requires:
             - frontend-cache


### PR DESCRIPTION
Sometimes we have documentation only PRs and those shouldn't need to run all the tests in CI. This PR restricts any branch prefixed with `docs/*` to only run our website workflow.