### PR TITLE
increase envoy route timeout to 5mins

### DIFF
--- a/agent/xds/config.go
+++ b/agent/xds/config.go
@@ -151,6 +151,10 @@ type UpstreamConfig struct {
 	// connection to this upstream. Defaults to 5000 (5 seconds) if not set.
 	ConnectTimeoutMs int `mapstructure:"connect_timeout_ms"`
 
+	// RouteTimeMs is the number of milliseconds that Envoy will wait for the
+	// upstream to respond with a complete response. Default to 300000 (5 mins)
+	// if not set
+	RouteTimeoutMs int `mapstructure:"route_timeout_ms"`
 	// Limits are the set of limits that are applied to the proxy for a specific upstream of a
 	// service instance.
 	Limits UpstreamLimits `mapstructure:"limits"`
@@ -175,6 +179,9 @@ func ParseUpstreamConfig(m map[string]interface{}) (UpstreamConfig, error) {
 	}
 	if cfg.ConnectTimeoutMs < 1 {
 		cfg.ConnectTimeoutMs = 5000
+	}
+	if cfg.RouteTimeoutMs <= 0 {
+		cfg.RouteTimeoutMs = 300000
 	}
 	return cfg, err
 }

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -144,6 +144,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 5000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -152,6 +153,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 5000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -163,6 +165,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 5000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -173,6 +176,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 5000,
 				Protocol:         "http",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -183,6 +187,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 1000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -193,6 +198,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 1000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -203,6 +209,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 			want: UpstreamConfig{
 				ConnectTimeoutMs: 1000,
 				Protocol:         "tcp",
+				RouteTimeoutMs:   300000,
 			},
 		},
 		{
@@ -222,6 +229,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 					MaxPendingRequests:    intPointer(60),
 					MaxConcurrentRequests: intPointer(70),
 				},
+				RouteTimeoutMs: 300000,
 			},
 		},
 		{
@@ -241,6 +249,7 @@ func TestParseUpstreamConfig(t *testing.T) {
 					MaxPendingRequests:    intPointer(0),
 					MaxConcurrentRequests: intPointer(0),
 				},
+				RouteTimeoutMs: 300000,
 			},
 		},
 	}

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -3,9 +3,9 @@ package xds
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/gogo/protobuf/proto"
+	"strings"
+	"time"
 
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
@@ -317,6 +317,7 @@ func makeRouteActionForSingleCluster(targetID string, chain *structs.CompiledDis
 			ClusterSpecifier: &envoyroute.RouteAction_Cluster{
 				Cluster: clusterName,
 			},
+			Timeout: addrOfTime(5 * time.Minute),
 		},
 	}
 }
@@ -353,6 +354,7 @@ func makeRouteActionForSplitter(splits []*structs.DiscoverySplit, chain *structs
 					TotalWeight: makeUint32Value(10000), // scaled up 100%
 				},
 			},
+			Timeout: addrOfTime(5 * time.Minute),
 		},
 	}, nil
 }

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.golden
@@ -35,7 +35,8 @@
                                                       "path": "/health1"
                                                     },
                                                 "route": {
-                                                      "cluster": "local_app"
+                                                      "cluster": "local_app",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]
@@ -87,7 +88,8 @@
                                                       "path": "/health2"
                                                     },
                                                 "route": {
-                                                      "cluster": "local_app"
+                                                      "cluster": "local_app",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.golden
@@ -37,7 +37,8 @@
                                                       "path": "/grpc.health.v1.Health/Check"
                                                     },
                                                 "route": {
-                                                      "cluster": "exposed_cluster_9090"
+                                                      "cluster": "exposed_cluster_9090",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]
@@ -89,7 +90,8 @@
                                                       "path": "/health1"
                                                     },
                                                 "route": {
-                                                      "cluster": "local_app"
+                                                      "cluster": "local_app",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]

--- a/agent/xds/testdata/listeners/http-public-listener.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.golden
@@ -121,7 +121,8 @@
                                                       "prefix": "/"
                                                     },
                                                 "route": {
-                                                      "cluster": "local_app"
+                                                      "cluster": "local_app",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]

--- a/agent/xds/testdata/listeners/http-upstream.golden
+++ b/agent/xds/testdata/listeners/http-upstream.golden
@@ -35,7 +35,8 @@
                                                       "prefix": "/"
                                                     },
                                                 "route": {
-                                                      "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                                                      "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                                                      "timeout": "300s"
                                                     }
                                               }
                                         ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-overrides.golden
@@ -16,7 +16,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "a236e964~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "a236e964~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-router.golden
@@ -16,7 +16,8 @@
                 "prefix": "/prefix"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -24,7 +25,8 @@
                 "path": "/exact"
               },
               "route": {
-                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -32,7 +34,8 @@
                 "regex": "/regex"
               },
               "route": {
-                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -46,7 +49,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -61,7 +65,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-not-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -75,7 +80,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -89,7 +95,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -103,7 +110,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-suffix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -117,7 +125,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -131,7 +140,8 @@
                 ]
               },
               "route": {
-                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "just-methods.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -149,7 +159,8 @@
                 ]
               },
               "route": {
-                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "hdr-exact-with-method.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -163,7 +174,8 @@
                 ]
               },
               "route": {
-                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "prm-exact.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -178,7 +190,8 @@
                 ]
               },
               "route": {
-                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "prm-regex.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -191,7 +204,8 @@
                 ]
               },
               "route": {
-                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "prm-present.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -199,7 +213,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "nil-match.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -207,7 +222,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "empty-match-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -215,7 +231,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "empty-match-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -224,7 +241,8 @@
               },
               "route": {
                 "cluster": "prefix-rewrite-1.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "prefixRewrite": "/"
+                "prefixRewrite": "/",
+                "timeout": "300s"
               }
             },
             {
@@ -233,7 +251,8 @@
               },
               "route": {
                 "cluster": "prefix-rewrite-2.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
-                "prefixRewrite": "/nested/newlocation"
+                "prefixRewrite": "/nested/newlocation",
+                "timeout": "300s"
               }
             },
             {
@@ -251,6 +270,7 @@
               },
               "route": {
                 "cluster": "retry-connect.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s",
                 "retryPolicy": {
                   "retryOn": "connect-failure",
                   "numRetries": 15
@@ -263,6 +283,7 @@
               },
               "route": {
                 "cluster": "retry-codes.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s",
                 "retryPolicy": {
                   "retryOn": "retriable-status-codes",
                   "numRetries": 15,
@@ -280,6 +301,7 @@
               },
               "route": {
                 "cluster": "retry-both.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s",
                 "retryPolicy": {
                   "retryOn": "connect-failure,retriable-status-codes",
                   "retriableStatusCodes": [
@@ -295,6 +317,7 @@
                 "prefix": "/split-3-ways"
               },
               "route": {
+                "timeout": "300s",
                 "weightedClusters": {
                   "clusters": [
                     {
@@ -319,7 +342,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-and-splitter.golden
@@ -16,6 +16,7 @@
                 "prefix": "/"
               },
               "route": {
+                "timeout": "300s",
                 "weightedClusters": {
                   "clusters": [
                     {

--- a/agent/xds/testdata/routes/connect-proxy-with-chain-external-sni.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain-external-sni.golden
@@ -16,7 +16,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-chain.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-chain.golden
@@ -16,7 +16,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/connect-proxy-with-grpc-router.golden
+++ b/agent/xds/testdata/routes/connect-proxy-with-grpc-router.golden
@@ -16,7 +16,8 @@
                 "path": "/fgrpc.PingServer/Ping"
               },
               "route": {
-                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "prefix.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             },
             {
@@ -24,7 +25,8 @@
                 "prefix": "/"
               },
               "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+                "timeout": "300s"
               }
             }
           ]

--- a/agent/xds/testdata/routes/splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/routes/splitter-with-resolver-redirect.golden
@@ -16,6 +16,7 @@
                 "prefix": "/"
               },
               "route": {
+                "timeout": "300s",
                 "weightedClusters": {
                   "clusters": [
                     {


### PR DESCRIPTION
default envoy route timeout is 15s. It's not sufficient for request that take long time to process.
An Issue was raised here: https://github.com/hashicorp/consul/issues/6382
PR add timeout to 5mins