### PR TITLE
skip go build and tests on ui/* branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,6 +636,7 @@ workflows:
               ignore:
                 - stable-website
                 - /^docs\/.*/
+                - /^ui\/.*/
       - lint-consul-retry
       - go-fmt-and-vet:
           requires:
@@ -661,6 +662,7 @@ workflows:
               ignore:
                 - stable-website
                 - /^docs\/.*/
+                - /^ui\/.*/
       - build-386: &require-check-vendor
           requires:
             - check-vendor
@@ -674,6 +676,7 @@ workflows:
               ignore:
                 - stable-website
                 - /^docs\/.*/
+                - /^ui\/.*/
       - dev-upload-s3: &dev-upload
           requires:
             - dev-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,7 +637,13 @@ workflows:
                 - stable-website
                 - /^docs\/.*/
                 - /^ui\/.*/
-      - lint-consul-retry
+      - lint-consul-retry:
+          filters:
+            branches:
+              ignore:
+                - stable-website
+                - /^docs\/.*/
+                - /^ui\/.*/
       - go-fmt-and-vet:
           requires:
             - check-vendor


### PR DESCRIPTION
This also adds the branch filtering to the `lint-consul-retry` job because that one runs in parallel with `check-vendor` rather than having `check-vendor` be a dependency.