### PR TITLE
ui: Use options.method for keying not options.type

### DIFF
--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -207,7 +207,7 @@ export default Service.extend({
     return Promise.resolve(e);
   },
   acquire: function(options, xhr) {
-    const request = new Request(options.type, options.url, { body: options.data || {} }, xhr);
+    const request = new Request(options.method, options.url, { body: options.data || {} }, xhr);
     return this.connections.acquire(request, request.getId());
   },
   complete: function() {


### PR DESCRIPTION
Whilst looking into potentially switching out our jQuery based ajax request for fetch (unfortunately we found here we use `readyState` for a tiny feature, which `fetch` doesn't have so we can't do this without doing something more complicated than we would like), we found a tiny typo when generating IDs for requests.

Basically `options.type` is always `undefined`, we are using this to generate unique IDs for requests, so the intention would have been `options.method`.