### PR TITLE
ui: Be more specific with the display toggling checkboxes

### DIFF
--- a/ui-v2/app/styles/components/main-nav-horizontal/layout.scss
+++ b/ui-v2/app/styles/components/main-nav-horizontal/layout.scss
@@ -1,7 +1,7 @@
-%main-nav-horizontal [type='checkbox'] ~ div {
+%main-nav-horizontal > ul > li > [type='checkbox'] ~ div {
   display: none;
 }
-%main-nav-horizontal [type='checkbox']:checked ~ div {
+%main-nav-horizontal > ul > li > [type='checkbox']:checked ~ div {
   display: block;
 }
 %main-nav-horizontal [type='checkbox'] + label > * {


### PR DESCRIPTION
Ensure the nspace menu informational header shows on the Manage Namespaces page

<img width="350" alt="Screenshot 2020-02-17 at 16 43 59" src="https://user-images.githubusercontent.com/554604/74672444-32aeed80-51a5-11ea-8a49-4109ba93e7fb.png">
