### PR TITLE
ui: Use a service-proxy to test service removal notification

### DIFF
--- a/ui-v2/tests/acceptance/dc/list-blocking.feature
+++ b/ui-v2/tests/acceptance/dc/list-blocking.feature
@@ -33,7 +33,7 @@ Feature: dc / list-blocking
     When I visit the [Page] page for yaml
     ---
       dc: dc-1
-      service: service-0
+      service: service-0-proxy
     ---
     Then the url should be /dc-1/[Url]
     And pause until I see 3 [Model] models
@@ -44,7 +44,7 @@ Feature: dc / list-blocking
     And an external edit results in 0 [Model] models
     And pause until I see the text "deregistered" in "[data-notification]"
   Where:
-    -------------------------------------------------
-    | Page       | Model       | Url                |
-    | service    | instance    | services/service-0 |
-    -------------------------------------------------
+    -------------------------------------------------------
+    | Page       | Model       | Url                      |
+    | service    | instance    | services/service-0-proxy |
+    -------------------------------------------------------


### PR DESCRIPTION
This PR attempts to reduce a possible test flake for the test which asserts that we see a warning notification when a service has been removed.

We noticed that it could be down to the new [Routing] tab and contents of this tab that we have recently enabled. As the routing tab is only appears for normal services and not proxies we reduce this test down to only the test it is intended to test.

Whilst not ideal we can see if flake continue to occur or not.
