### PR TITLE
Connect: Fix endpoints clusterName when using cluster escape hatch

### DIFF
--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -78,6 +78,7 @@ func (s *Server) endpointsFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnaps
 		} else {
 			// Newfangled discovery chain plumbing.
 			es := s.endpointsFromDiscoveryChain(
+				u,
 				chain,
 				cfgSnap.Datacenter,
 				cfgSnap.ConnectProxy.WatchedUpstreamEndpoints[id],
@@ -267,6 +268,7 @@ func (s *Server) endpointsFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSna
 			}
 
 			es := s.endpointsFromDiscoveryChain(
+				u,
 				cfgSnap.IngressGateway.DiscoveryChain[id],
 				cfgSnap.Datacenter,
 				cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id],
@@ -290,6 +292,7 @@ func makeEndpoint(clusterName, host string, port int) envoyendpoint.LbEndpoint {
 }
 
 func (s *Server) endpointsFromDiscoveryChain(
+	upstream structs.Upstream,
 	chain *structs.CompiledDiscoveryChain,
 	datacenter string,
 	upstreamEndpoints, gatewayEndpoints map[string]structs.CheckServiceNodes,
@@ -298,6 +301,30 @@ func (s *Server) endpointsFromDiscoveryChain(
 
 	if chain == nil {
 		return resources
+	}
+
+	cfg, err := ParseUpstreamConfigNoDefaults(upstream.Config)
+	if err != nil {
+		// Don't hard fail on a config typo, just warn. The parse func returns
+		// default config if there is an error so it's safe to continue.
+		s.Logger.Warn("failed to parse", "upstream", upstream.Identifier(),
+			"error", err)
+	}
+
+	var escapeHatchCluster *envoy.Cluster
+	if cfg.ClusterJSON != "" {
+		if chain.IsDefault() {
+			// If you haven't done anything to setup the discovery chain, then
+			// you can use the envoy_cluster_json escape hatch.
+			escapeHatchCluster, err = makeClusterFromUserConfig(cfg.ClusterJSON)
+			if err != nil {
+				return resources
+			}
+		} else {
+			s.Logger.Warn("ignoring escape hatch setting, because a discovery chain is configued for",
+				"discovery chain", chain.ServiceName, "upstream", upstream.Identifier(),
+				"envoy_cluster_json", chain.ServiceName)
+		}
 	}
 
 	// Find all resolver nodes.
@@ -311,6 +338,10 @@ func (s *Server) endpointsFromDiscoveryChain(
 		target := chain.Targets[targetID]
 
 		clusterName := CustomizeClusterName(target.Name, chain)
+		if escapeHatchCluster != nil {
+			clusterName = escapeHatchCluster.Name
+		}
+		s.Logger.Debug("generating endpoints for", "cluster", clusterName)
 
 		// Determine if we have to generate the entire cluster differently.
 		failoverThroughMeshGateway := chain.WillFailoverThroughMeshGateway(node)

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -307,6 +307,17 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 			setup:  nil,
 		},
 		{
+			name:   "connect-proxy-with-default-chain-and-custom-cluster",
+			create: proxycfg.TestConfigSnapshotDiscoveryChainDefault,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.Proxy.Upstreams[0].Config["envoy_cluster_json"] =
+					customAppClusterJSON(t, customClusterJSONOptions{
+						Name:        "myservice",
+						IncludeType: false,
+					})
+			},
+		},
+		{
 			name:   "splitter-with-resolver-redirect",
 			create: proxycfg.TestConfigSnapshotDiscoveryChain_SplitterWithResolverRedirectMultiDC,
 			setup:  nil,

--- a/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.golden
+++ b/agent/xds/testdata/endpoints/connect-proxy-with-default-chain-and-custom-cluster.golden
@@ -1,0 +1,41 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "myservice",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+  "nonce": "00000001"
+}


### PR DESCRIPTION
Hello

I discover this using upstream envoy overrides `envoy_cluster_json` and `envoy_listener_json`.
When using a specific definition for this upstream cluster the name used by consul to generate endpoints was the default one from the discovery chain.
Consul is responding to envoy with the full sni name of my service instead of the custom name of my cluster.

An extract of my config : 
```
upstreams {
  destination_type = "service"
  destination_name = "my-service"
  local_bind_port = 8002
  config {
    envoy_cluster_json = <<EOL
      {
        "@type": "type.googleapis.com/envoy.api.v2.Cluster",
        "name": "my-custom-cluster",
        "type": "EDS",
        "eds_cluster_config": {
          "eds_config": {
            "ads": {}
          }
        },
...
      }
    EOL

    envoy_listener_json = <<EOL
      {
        "@type": "type.googleapis.com/envoy.api.v2.Listener",
        "name": "my-service:127.0.0.1:8002",
...
                            "route": {
                              "cluster": "my-custom-cluster",
```

I'm using consul 1.7.1 in a GKE Cluster. Everything is deployed with consul-helm chart.

My code is heavily inspired by the xds clusters code where the override of the upstream cluster is happening.
I dont know if my code follow your guidelines but i am open to comments/fix/whatever you want :-)

Fix #7613 