### PR TITLE
ui: Add box-shadow to table items on hover

### DIFF
--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -43,6 +43,10 @@ table:not(.sessions) tbody tr {
 table:not(.sessions) td:first-child {
   padding: 0;
 }
+
+table:not(.sessions) tbody tr:hover {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
 /* Header Tooltips/Icon*/
 th {
   overflow: visible;


### PR DESCRIPTION
[Preview Link]( https://deploy-preview-7320--consul-ui-staging.netlify.com/ui/)
<img width="481" alt="Screen Shot 2020-02-19 at 9 23 05 AM" src="https://user-images.githubusercontent.com/19161242/74846881-3b1b3b80-52ff-11ea-88c0-1a7c06182e19.png">
