### PR TITLE
Properly detect no alt domain set

### DIFF
--- a/agent/dns.go
+++ b/agent/dns.go
@@ -190,7 +190,13 @@ func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
 	d.mux = dns.NewServeMux()
 	d.mux.HandleFunc("arpa.", d.handlePtr)
 	d.mux.HandleFunc(d.domain, d.handleQuery)
-	if d.altDomain != "" {
+	// this is not an empty string check because NewDNSServer will have
+	// converted the configured alt domain into an FQDN which will ensure that
+	// the value ends with a ".". Therefore "." is the empty string equivalent
+	// for originally having no alternate domain set. If there is a reason
+	// why consul should be configured to handle the root zone I have yet
+	// to think of it.
+	if d.altDomain != "." {
 		d.mux.HandleFunc(d.altDomain, d.handleQuery)
 	}
 	d.toggleRecursorHandlerFromConfig(cfg)

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -188,6 +188,21 @@ func TestDNS_Over_TCP(t *testing.T) {
 	}
 }
 
+func TestDNS_EmptyAltDomain(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t, t.Name(), "")
+	defer a.Shutdown()
+	testrpc.WaitForLeader(t, a.RPC, "dc1")
+
+	m := new(dns.Msg)
+	m.SetQuestion("consul.service.", dns.TypeA)
+
+	c := new(dns.Client)
+	in, _, err := c.Exchange(m, a.DNSAddr())
+	require.NoError(t, err)
+	require.Empty(t, in.Answer)
+}
+
 func TestDNS_NodeLookup(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), "")


### PR DESCRIPTION
Previously when no recursors were configured, we would set up a root zone handler which allowed non-fully-qualified domain names to be processed as though they were consul queries. 

This bug has existed since 1.5.2