### PR TITLE
agent: Prune Unused Test Helper Functions

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -3156,11 +3156,11 @@ func TestAgent_RegisterService_TranslateKeys(t *testing.T) {
 
 	t.Run("normal", func(t *testing.T) {
 		t.Parallel()
-		testAgent_RegisterService_ACLDeny(t, "enable_central_service_config = false")
+		testAgent_RegisterService_TranslateKeys(t, "enable_central_service_config = false")
 	})
 	t.Run("service manager", func(t *testing.T) {
 		t.Parallel()
-		testAgent_RegisterService_ACLDeny(t, "enable_central_service_config = true")
+		testAgent_RegisterService_TranslateKeys(t, "enable_central_service_config = true")
 	})
 }
 
@@ -3329,6 +3329,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 					"some":                "meta",
 					"enable_tag_override": "sidecar_service.meta is 'opaque' so should not get translated",
 				},
+				TaggedAddresses:            map[string]structs.ServiceAddress{},
 				Port:                       8001,
 				EnableTagOverride:          true,
 				Weights:                    &structs.Weights{Passing: 1, Warning: 1},

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -36,7 +36,6 @@ import (
 	tokenStore "github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
@@ -6136,13 +6135,6 @@ func requireLeafValidUnderCA(t *testing.T, issued *structs.IssuedCert, ca *struc
 	// Verify the private key matches. tls.LoadX509Keypair does this for us!
 	_, err = tls.X509KeyPair([]byte(issued.CertPEM), []byte(issued.PrivateKeyPEM))
 	require.NoError(t, err)
-}
-
-func makeTelemetryDefaults(targetID string) lib.TelemetryConfig {
-	return lib.TelemetryConfig{
-		FilterDefault: true,
-		MetricsPrefix: "consul.proxy." + targetID,
-	}
 }
 
 func TestAgentConnectAuthorize_badBody(t *testing.T) {


### PR DESCRIPTION
This removes three unused test helper functions from the `agent` package.

`externalIP()`
`testAgent_RegisterService_TranslateKeys()`
`makeTelemetryDefaults()`