### PR TITLE
ui: Use WithEventSource mixin on intentions to ensure cleanup

### DIFF
--- a/ui-v2/app/controllers/dc/intentions/index.js
+++ b/ui-v2/app/controllers/dc/intentions/index.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { computed, get } from '@ember/object';
 import WithFiltering from 'consul-ui/mixins/with-filtering';
 import WithSearching from 'consul-ui/mixins/with-searching';
+import WithEventSource from 'consul-ui/mixins/with-event-source';
 import ucfirst from 'consul-ui/utils/ucfirst';
 // TODO: DRY out in acls at least
 const createCounter = function(prop) {
@@ -10,7 +11,7 @@ const createCounter = function(prop) {
   };
 };
 const countAction = createCounter('Action');
-export default Controller.extend(WithSearching, WithFiltering, {
+export default Controller.extend(WithSearching, WithFiltering, WithEventSource, {
   queryParams: {
     action: {
       as: 'action',


### PR DESCRIPTION
The WithEventSource mixin has a reset method when the Controller is
exited which will close any open EventSources/Blocking queries.

This adds it in for intentions