### PR TITLE
ui: Make a specific CI coverage make target ensuring use of CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,7 +572,7 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-coverage
+          command: make test-coverage-ci
       - run:
           name: codecov ui upload
           working_directory: ui-v2

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -76,6 +76,9 @@ test-coverage: deps specify-coverage
 test-coverage-view: deps specify-coverage
 	yarn run test:coverage:view
 
+test-coverage-ci: deps specify-coverage
+	yarn run test:coverage:ci
+
 test-parallel: deps
 	yarn run test:parallel
 

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -30,6 +30,7 @@
     "test:oss:view": "CONSUL_NSPACES_ENABLED=0 ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:node": "tape ./node-tests/**/*.js",
     "test:coverage": "COVERAGE=true ember test --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
+    "test:coverage:ci": "COVERAGE=true ember test --environment test --filter=Unit --path dist --test-port=${EMBER_TEST_PORT:-7357}",
     "test:coverage:view": "COVERAGE=true ember test --server --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
     "steps:list": "node ./lib/commands/bin/list.js"
   },


### PR DESCRIPTION
Our coverage tests keep running out of memory, which seemed to be related to https://github.com/hashicorp/vault/pull/8152 . Then @alvin-huang pointed out we weren't using the already created CI cache to run the coverage job.

This make a new CI specific make target to use the CI cache for the coverage job also.

