### PR TITLE
[BUGFIX] Configuration reload does not discard Check's statuses for services

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3437,6 +3437,62 @@ func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	require.Len(t, tlsConf.ClientCAs.Subjects(), 2)
 }
 
+func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
+	t.Parallel()
+	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
+	defer os.RemoveAll(dataDir)
+	waitDurationSeconds := 1
+	hcl := `
+		enable_local_script_checks=true
+		services=[{
+		  name="webserver1",
+		  check{name="check1",
+		  args=["true"],
+		  interval="` + strconv.Itoa(waitDurationSeconds) + `s"}}
+		]
+	`
+	a := NewTestAgent(t, t.Name(), hcl)
+	defer a.Shutdown()
+
+	hcl = `
+		data_dir = "` + dataDir + `"
+		verify_outgoing = true
+		ca_path = "../test/ca_path"
+		cert_file = "../test/key/ourdomain.cer"
+		key_file = "../test/key/ourdomain.key"
+		verify_server_hostname = true
+	`
+	c := TestConfig(testutil.Logger(t), config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
+	// Initially, state is critical during waitDurationSeconds seconds
+	retry.Run(t, func(r *retry.R) {
+		gotChecks := a.State.Checks(nil)
+		require.Equal(r, 1, len(gotChecks), "Should have a check registered, but had %#v", gotChecks)
+		for id, check := range gotChecks {
+			require.Equal(r, "critical", check.Status, "check %q is wrong", id)
+		}
+	})
+	time.Sleep(time.Duration(waitDurationSeconds) * time.Second)
+	// It should now be passing
+	retry.Run(t, func(r *retry.R) {
+		gotChecks := a.State.Checks(nil)
+		for id, check := range gotChecks {
+			require.Equal(r, "passing", check.Status, "check %q is wrong", id)
+		}
+	})
+
+	require.NoError(t, a.ReloadConfig(c))
+	// After reload, should be passing directly (no critical state)
+	for id, check := range a.State.Checks(nil) {
+		require.Equal(t, "passing", check.Status, "check %q is wrong", id)
+	}
+	// Ensure to take reload into account event with async stuff
+	time.Sleep(time.Duration(100) * time.Millisecond)
+	// Of course, after a sleep, should be Ok too
+	for id, check := range a.State.Checks(nil) {
+		require.Equal(t, "passing", check.Status, "check %q is wrong", id)
+	}
+}
+
 func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2030,7 +2030,7 @@ func testAgent_persistedService_compat(t *testing.T, extraHCL string) {
 	}
 
 	// Load the services
-	if err := a.loadServices(a.Config); err != nil {
+	if err := a.loadServices(a.Config, nil); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -86,7 +86,7 @@ func (s *ServiceManager) registerOnce(args *addServiceRequest) error {
 	s.agent.stateLock.Lock()
 	defer s.agent.stateLock.Unlock()
 
-	err := s.agent.addServiceInternal(args)
+	err := s.agent.addServiceInternal(args, s.agent.snapshotCheckState())
 	if err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
 	}
@@ -127,7 +127,7 @@ func (s *ServiceManager) AddService(req *addServiceRequest) error {
 		req.persistService = nil
 		req.persistDefaults = nil
 		req.persistServiceConfig = false
-		return s.agent.addServiceInternal(req)
+		return s.agent.addServiceInternal(req, s.agent.snapshotCheckState())
 	}
 
 	var (
@@ -279,7 +279,7 @@ func (w *serviceConfigWatch) RegisterAndStart(
 		token:                 w.registration.token,
 		replaceExistingChecks: w.registration.replaceExistingChecks,
 		source:                w.registration.source,
-	})
+	}, w.agent.snapshotCheckState())
 	if err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
 	}


### PR DESCRIPTION
This fixes issue #7318

Between versions 1.5.2 and 1.5.3, a regression has been introduced regarding health
of services. A patch #6144 had been issued for HealthChecks of nodes, but not for healthchecks
of services.

What happened when a reload was:

1. save all healthcheck statuses
2. cleanup everything
3. add new services with healthchecks

In step 3, the state of healthchecks was taken into account locally,
so at step 3, but since we cleaned up at step 2, state was lost.

This PR introduces the snap parameter, so step 3 can use information from step 1