### PR TITLE
WIP - Add size statistics  to `consul snapshot inspect` output

### DIFF
--- a/command/snapshot/inspect/snapshot_inspect.go
+++ b/command/snapshot/inspect/snapshot_inspect.go
@@ -62,6 +62,12 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
+	stats, err := snapshot.GetStats(f)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error getting snapshot statistics: %s", err))
+		return 1
+	}
+
 	var b bytes.Buffer
 	tw := tabwriter.NewWriter(&b, 0, 2, 6, ' ', 0)
 	fmt.Fprintf(tw, "ID\t%s\n", meta.ID)
@@ -69,6 +75,12 @@ func (c *cmd) Run(args []string) int {
 	fmt.Fprintf(tw, "Index\t%d\n", meta.Index)
 	fmt.Fprintf(tw, "Term\t%d\n", meta.Term)
 	fmt.Fprintf(tw, "Version\t%d\n", meta.Version)
+
+	fmt.Fprintf(tw, "\n%s\t%s\t%s\n", "Record Type", "Count", "TotalSize")
+	for _, s := range stats {
+		fmt.Fprintf(tw, "%s\t%d\t%s\n", s.Name, s.Count, snapshot.ByteSize(uint64(s.Sum)))
+	}
+
 	if err = tw.Flush(); err != nil {
 		c.UI.Error(fmt.Sprintf("Error rendering snapshot info: %s", err))
 		return 1


### PR DESCRIPTION
This PR closes #7106 [Improvements to consul snapshot inspect CLI command](https://github.com/hashicorp/consul/issues/7106). 

This is a WIP PR; I'll first naively copy most of the [tool's functionality](https://github.com/banks/consul-snapshot-tool) and then refactor to fit in with the rest of consul codebase. Then, I'll write the necessary tests and see if it impacts performance.

## Questions
Should the output be sorted according to the Total Size, or alphabetically? I'd think that if it's something someone might use every once in a while, sorting by Total Size might be useful; on the other hand, if it's something that might be parsed programmatically, it would make more sense to keep it alphabetically sorted.