### PR TITLE
Make /register/check docs match actuality

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -109,7 +109,7 @@ The table below shows this endpoint's support for
 
 - `Name` `(string: <required>)` - Specifies the name of the check.
 
-- `ID` `(string: "")` - Specifies a unique ID for this check on the node.
+- `CheckID` `(string: "")` - Specifies a unique ID for this check on the node.
   This defaults to the `"Name"` parameter, but it may be necessary to provide an
   ID for uniqueness.
 
@@ -214,7 +214,7 @@ The table below shows this endpoint's support for
 
 ```json
 {
-  "ID": "mem",
+  "CheckID": "mem",
   "Name": "Memory utilization",
   "Notes": "Ensure we don't oversubscribe memory",
   "DeregisterCriticalServiceAfter": "90m",


### PR DESCRIPTION
Not sure what to title this PR, but as of 1.7.1 (possibly due to #6874), we cannot register checks with `ID`, but only with `CheckID`.

With Consul 1.7.1, this fails:
```
{
    "ID": "dat_service",
    "Name": "dat_service_name",
    "Port": 2222,
    "Check": {
        "id": "dat_check",
        "name": "Check service health on port 2222",
        "http": "http://127.0.0.1:2222/healthz",
        "interval": "10s",
        "timeout": "1s",
        "deregister_critical_service_after": "1m"
    },
    "Address": "127.0.0.1"
}
```

But this succeeds (with 1.3.1):
```
{
    "ID": "dat_service",
    "Name": "dat_service_name",
    "Port": 2222,
    "Check": {
        "checkid": "dat_check",
        "name": "Check service health on port 2222",
        "http": "http://127.0.0.1:2222/healthz",
        "interval": "10s",
        "timeout": "1s",
        "deregister_critical_service_after": "1m"
    },
    "Address": "127.0.0.1"
}
```