### PR TITLE
http: use default minsize for gzip handler.

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -257,8 +257,17 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 			metrics.MeasureSince(key, start)
 		}
 
-		gzipWrapper, _ := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(0))
-		gzipHandler := gzipWrapper(http.HandlerFunc(wrapper))
+		var gzipHandler http.Handler
+		minSize := gziphandler.DefaultMinSize
+		if pattern == "/v1/agent/monitor" {
+			minSize = 0
+		}
+		gzipWrapper, err := gziphandler.GzipHandlerWithOpts(gziphandler.MinSize(minSize))
+		if err == nil {
+			gzipHandler = gzipWrapper(http.HandlerFunc(wrapper))
+		} else {
+			gzipHandler = gziphandler.GzipHandler(http.HandlerFunc(wrapper))
+		}
 		mux.Handle(pattern, gzipHandler)
 	}
 


### PR DESCRIPTION
Fixes #6306

`v1/agent/monitor` gets another minSize to avoid problems while streaming the response.