### PR TITLE
Update register check docs (closes #6635)

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -111,7 +111,7 @@ The table below shows this endpoint's support for
 
 - `ID` `(string: "")` - Specifies a unique ID for this check on the node.
   This defaults to the `"Name"` parameter, but it may be necessary to provide an
-  ID for uniqueness.
+  ID for uniqueness. This value will return in the response as `"CheckId"`
 
 - `Interval` `(string: "")` - Specifies the frequency at which to run this
   check. This is required for HTTP and TCP checks.


### PR DESCRIPTION
Update register check documentation clarify that `Id` returns as `CheckId` in the response