### PR TITLE
ui: Updates Consul blueprints to be compatible with new ED version

### DIFF
--- a/ui-v2/blueprints/adapter-test/index.js
+++ b/ui-v2/blueprints/adapter-test/index.js
@@ -1,11 +1,10 @@
-/*eslint node/no-extraneous-require: "off"*/
-'use strict';
-
-const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
 const path = require('path');
 
+const testInfo = require('ember-cli-test-info');
+const useTestFrameworkDetector = require('@ember-data/private-build-infra/src/utilities/test-framework-detector');
+
 module.exports = useTestFrameworkDetector({
-  description: 'Generates a Consul HTTP ember-data adapter unit and integration tests',
+  description: 'Generates Consul HTTP ember-data adapter unit and integration tests',
 
   root: __dirname,
 
@@ -16,7 +15,7 @@ module.exports = useTestFrameworkDetector({
       },
       __path__() {
         return '';
-      }
+      },
     };
   },
 

--- a/ui-v2/blueprints/adapter/index.js
+++ b/ui-v2/blueprints/adapter/index.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const path = require('path');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification').isModuleUnificationProject;
 module.exports = {
   description: 'Generates a Consul HTTP ember-data adapter',
 
@@ -11,19 +10,6 @@ module.exports = {
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'adapter';
-        },
-      };
-    }
   },
   locals(options) {
     // Return custom template variables here.

--- a/ui-v2/blueprints/model-test/index.js
+++ b/ui-v2/blueprints/model-test/index.js
@@ -1,11 +1,9 @@
-/*eslint node/no-extraneous-require: "off"*/
-'use strict';
-
-const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
 const path = require('path');
 
+const useTestFrameworkDetector = require('@ember-data/private-build-infra/src/utilities/test-framework-detector');
+
 module.exports = useTestFrameworkDetector({
-  description: 'Generates a Consul ember-data model unit tests',
+  description: 'Generates a Consul ember-data model unit test.',
 
   root: __dirname,
 
@@ -16,7 +14,7 @@ module.exports = useTestFrameworkDetector({
       },
       __path__() {
         return '';
-      }
+      },
     };
   },
 

--- a/ui-v2/blueprints/model/index.js
+++ b/ui-v2/blueprints/model/index.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const path = require('path');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification').isModuleUnificationProject;
 module.exports = {
   description: 'Generates a Consul HTTP ember-data model',
 
@@ -10,21 +9,6 @@ module.exports = {
 
   root: __dirname,
 
-  fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'model';
-        },
-      };
-    }
-  },
   locals(options) {
     // Return custom template variables here.
     return {

--- a/ui-v2/blueprints/repository-test/index.js
+++ b/ui-v2/blueprints/repository-test/index.js
@@ -1,11 +1,9 @@
-/*eslint node/no-extraneous-require: "off"*/
-'use strict';
-
-const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
 const path = require('path');
 
+const useTestFrameworkDetector = require('@ember-data/private-build-infra/src/utilities/test-framework-detector');
+
 module.exports = useTestFrameworkDetector({
-  description: 'Generates a Consul HTTP ember-data serializer unit and integration tests',
+  description: 'Generates Consul repository unit and integration tests',
 
   root: __dirname,
 
@@ -16,7 +14,7 @@ module.exports = useTestFrameworkDetector({
       },
       __path__() {
         return '';
-      }
+      },
     };
   },
 

--- a/ui-v2/blueprints/repository-test/qunit-files/__root__/__path__/integration/services/repository/__test__.js
+++ b/ui-v2/blueprints/repository-test/qunit-files/__root__/__path__/integration/services/repository/__test__.js
@@ -9,7 +9,7 @@ const dc = 'dc-1';
 const id = 'slug';
 const now = new Date().getTime();
 test('findByDatacenter returns the correct data for list endpoint', function(assert) {
-  get(this.subject(), 'store').serializerFor('<%= dasherizedModuleName %>').timestamp = function() {
+  this.subject().store.serializerFor('<%= dasherizedModuleName %>').timestamp = function() {
     return now;
   };
   return repo(

--- a/ui-v2/blueprints/repository-test/qunit-files/__root__/__path__/unit/services/repository/__test__.js
+++ b/ui-v2/blueprints/repository-test/qunit-files/__root__/__path__/unit/services/repository/__test__.js
@@ -6,7 +6,7 @@ module('Unit | Repository | <%= dasherizedModuleName %>', function(hooks) {
 
   // Replace this with your real tests.
   test('it exists', function(assert) {
-    let repo = this.owner.lookup('service:repository/<%= dasherizedModuleName %>');
+    const repo = this.owner.lookup('service:repository/<%= dasherizedModuleName %>');
     assert.ok(repo);
   });
 });

--- a/ui-v2/blueprints/serializer-test/index.js
+++ b/ui-v2/blueprints/serializer-test/index.js
@@ -1,11 +1,9 @@
-/*eslint node/no-extraneous-require: "off"*/
-'use strict';
-
-const useTestFrameworkDetector = require('@ember-data/-build-infra/src/utilities/test-framework-detector');
 const path = require('path');
 
+const useTestFrameworkDetector = require('@ember-data/private-build-infra/src/utilities/test-framework-detector');
+
 module.exports = useTestFrameworkDetector({
-  description: 'Generates a Consul HTTP ember-data serializer unit and integration tests',
+  description: 'Generates Consul HTTP ember-data serializer unit and integration tests.',
 
   root: __dirname,
 
@@ -16,7 +14,7 @@ module.exports = useTestFrameworkDetector({
       },
       __path__() {
         return '';
-      }
+      },
     };
   },
 

--- a/ui-v2/blueprints/serializer/index.js
+++ b/ui-v2/blueprints/serializer/index.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const path = require('path');
-const isModuleUnificationProject = require('@ember-data/-build-infra/src/utilities/module-unification').isModuleUnificationProject;
 module.exports = {
   description: 'Generates a Consul HTTP ember-data serializer',
 
@@ -11,19 +10,6 @@ module.exports = {
   root: __dirname,
 
   fileMapTokens(options) {
-    if (isModuleUnificationProject(this.project)) {
-      return {
-        __root__() {
-          return 'src';
-        },
-        __path__(options) {
-          return path.join('data', 'models', options.dasherizedModuleName);
-        },
-        __name__() {
-          return 'serializer';
-        },
-      };
-    }
   },
   locals(options) {
     // Return custom template variables here.


### PR DESCRIPTION
During some prototyping work we realized that our custom blueprints for creating an ember-data adapter/serializer/model triplet plus repository had become incompatible with the new 3.16 version of ember-data. This brings those blueprints up to date. 