### PR TITLE
Take Prometheus MIME-type header into account

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -85,12 +85,30 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 	}, nil
 }
 
+// acceptsOpenMetricsMimeType returns ntrue if mime type is Prometheus-compatible
+func acceptsOpenMetricsMimeType(acceptHeader string) bool {
+	mimeTypes := strings.Split(acceptHeader, ",")
+	for _, v := range mimeTypes {
+		mimeInfo := strings.Split(v, ";")
+		if len(mimeInfo) > 0 {
+			rawMime := strings.ToLower(strings.Trim(mimeInfo[0], " "))
+			if rawMime == "application/openmetrics-text" {
+				return true
+			}
+			if rawMime == "text/plain" && (len(mimeInfo) > 1 && strings.Trim(mimeInfo[1], " ") == "version=0.4.0") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // enablePrometheusOutput will look for Prometheus mime-type or format Query parameter the same way as Nomad
 func enablePrometheusOutput(req *http.Request) bool {
 	if format := req.URL.Query().Get("format"); format == "prometheus" {
 		return true
 	}
-	return false
+	return acceptsOpenMetricsMimeType(req.Header.Get("Accept"))
 }
 
 func (s *HTTPServer) AgentMetrics(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -85,7 +85,7 @@ func (s *HTTPServer) AgentSelf(resp http.ResponseWriter, req *http.Request) (int
 	}, nil
 }
 
-// acceptsOpenMetricsMimeType returns ntrue if mime type is Prometheus-compatible
+// acceptsOpenMetricsMimeType returns true if mime type is Prometheus-compatible
 func acceptsOpenMetricsMimeType(acceptHeader string) bool {
 	mimeTypes := strings.Split(acceptHeader, ",")
 	for _, v := range mimeTypes {

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1680,6 +1680,21 @@ func TestAgent_ForceLeave(t *testing.T) {
 
 }
 
+func TestOpenMetricsMimeTypeHeaders(t *testing.T) {
+	t.Parallel()
+	assert.False(t, acceptsOpenMetricsMimeType(""))
+	assert.False(t, acceptsOpenMetricsMimeType(";;;"))
+	assert.False(t, acceptsOpenMetricsMimeType(",,,"))
+	assert.False(t, acceptsOpenMetricsMimeType("text/plain"))
+	assert.True(t, acceptsOpenMetricsMimeType("text/plain;version=0.4.0,"))
+	assert.True(t, acceptsOpenMetricsMimeType("text/plain;version=0.4.0;q=1,*/*;q=0.1"))
+	assert.True(t, acceptsOpenMetricsMimeType("text/plain   ;   version=0.4.0"))
+	assert.True(t, acceptsOpenMetricsMimeType("*/*, application/openmetrics-text ;"))
+	assert.True(t, acceptsOpenMetricsMimeType("*/*, application/openmetrics-text ;q=1"))
+	assert.True(t, acceptsOpenMetricsMimeType("application/openmetrics-text, text/plain;version=0.4.0"))
+	assert.True(t, acceptsOpenMetricsMimeType("application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1"))
+}
+
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, t.Name(), TestACLConfig())


### PR DESCRIPTION
This will avoid adding format=prometheus in request and to parse more easily metrics using Prometheus.

This commit follows https://github.com/hashicorp/consul/pull/6514 and extends it by accepting old Prometheus mime-type.