### PR TITLE
ui: Coordinates don't require a nspace, so don't expect one in the repo

### DIFF
--- a/ui-v2/app/services/repository/coordinate.js
+++ b/ui-v2/app/services/repository/coordinate.js
@@ -10,8 +10,19 @@ export default RepositoryService.extend({
   getModelName: function() {
     return modelName;
   },
-  findAllByNode: function(node, dc, nspace, configuration) {
-    return this.findAllByDatacenter(dc, nspace, configuration).then(function(coordinates) {
+  // Coordinates don't need nspaces so we have a custom method here
+  // that doesn't accept nspaces
+  findAllByDatacenter: function(dc, configuration = {}) {
+    const query = {
+      dc: dc,
+    };
+    if (typeof configuration.cursor !== 'undefined') {
+      query.index = configuration.cursor;
+    }
+    return this.store.query(this.getModelName(), query);
+  },
+  findAllByNode: function(node, dc, configuration) {
+    return this.findAllByDatacenter(dc, configuration).then(function(coordinates) {
       let results = {};
       if (get(coordinates, 'length') > 1) {
         results = tomography(node, coordinates.map(item => get(item, 'data')));

--- a/ui-v2/tests/integration/services/repository/coordinate-test.js
+++ b/ui-v2/tests/integration/services/repository/coordinate-test.js
@@ -44,3 +44,18 @@ test('findAllByDatacenter returns the correct data for list endpoint', function(
     }
   );
 });
+test('findAllByNode calls findAllByDatacenter with the correct arguments', function(assert) {
+  assert.expect(3);
+  const datacenter = 'dc-1';
+  const conf = {
+    cursor: 1,
+  };
+  const service = this.subject();
+  service.findAllByDatacenter = function(dc, configuration) {
+    assert.equal(arguments.length, 2, 'Expected to be called with the correct number of arguments');
+    assert.equal(dc, datacenter);
+    assert.deepEqual(configuration, conf);
+    return Promise.resolve([]);
+  };
+  return service.findAllByNode('node-name', datacenter, conf);
+});


### PR DESCRIPTION
This PR ensures that the `index` blocking query parameter/cursor is maintained whilst blocking on the coordinates endpoint.