### PR TITLE
[Website] Update middleman-hashicorp to 0.3.44

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.43"
+gem "middleman-hashicorp", "0.3.44"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.43)
+    middleman-hashicorp (0.3.44)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -104,7 +104,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     multi_json (1.14.1)
-    nokogiri (1.10.7)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     padrino-helpers (0.12.9)
       i18n (~> 0.6, >= 0.6.7)
@@ -112,7 +112,7 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.12.9)
       activesupport (>= 3.1)
-    rack (1.6.12)
+    rack (1.6.13)
     rack-livereload (0.3.17)
       rack
     rack-test (1.1.0)
@@ -121,7 +121,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.0)
-    rouge (3.15.0)
+    rouge (3.16.0)
     sass (3.4.25)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -155,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.43)
+  middleman-hashicorp (= 0.3.44)
 
 BUNDLED WITH
    1.17.3

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.43"
+VERSION?="0.3.44"
 
 # The volume mounting steps are a way to exclude all the consul docs from being built
 # in the Consul site build process while still including the index.html page that points


### PR DESCRIPTION
This PR updates the website's `middleman-hashicorp` dependency to `0.3.44`.   This version intends to mitigate potential security issues by upgrading the package's jQuery to the latest 2.x stable.