### PR TITLE
agent/txn_endpoint: configure max txn request length

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -968,7 +968,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		TLSPreferServerCipherSuites:      b.boolVal(c.TLSPreferServerCipherSuites),
 		TaggedAddresses:                  c.TaggedAddresses,
 		TranslateWANAddrs:                b.boolVal(c.TranslateWANAddrs),
-		TxnMaxDataSize:                   b.uint64Val(c.Limits.TxnMaxDataSize),
+		TxnMaxReqLen:                     b.uint64Val(c.Limits.TxnMaxReqLen),
 		UIDir:                            b.stringVal(c.UIDir),
 		UIContentPath:                    UIPathBuilder(b.stringVal(c.UIContentPath)),
 		UnixSocketGroup:                  b.stringVal(c.UnixSocket.Group),

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -968,6 +968,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		TLSPreferServerCipherSuites:      b.boolVal(c.TLSPreferServerCipherSuites),
 		TaggedAddresses:                  c.TaggedAddresses,
 		TranslateWANAddrs:                b.boolVal(c.TranslateWANAddrs),
+		TxnMaxDataSize:                   b.uint64Val(c.Limits.TxnMaxDataSize),
 		UIDir:                            b.stringVal(c.UIDir),
 		UIContentPath:                    UIPathBuilder(b.stringVal(c.UIContentPath)),
 		UnixSocketGroup:                  b.stringVal(c.UnixSocket.Group),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -684,6 +684,7 @@ type Limits struct {
 	RPCMaxConnsPerClient  *int     `json:"rpc_max_conns_per_client,omitempty" hcl:"rpc_max_conns_per_client" mapstructure:"rpc_max_conns_per_client"`
 	RPCRate               *float64 `json:"rpc_rate,omitempty" hcl:"rpc_rate" mapstructure:"rpc_rate"`
 	KVMaxValueSize        *uint64  `json:"kv_max_value_size,omitempty" hcl:"kv_max_value_size" mapstructure:"kv_max_value_size"`
+	TxnMaxDataSize        *uint64  `json:"txn_max_data_size,omitempty" hcl:"txn_max_data_size" mapstructure:"txn_max_data_size"`
 }
 
 type Segment struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -684,7 +684,7 @@ type Limits struct {
 	RPCMaxConnsPerClient  *int     `json:"rpc_max_conns_per_client,omitempty" hcl:"rpc_max_conns_per_client" mapstructure:"rpc_max_conns_per_client"`
 	RPCRate               *float64 `json:"rpc_rate,omitempty" hcl:"rpc_rate" mapstructure:"rpc_rate"`
 	KVMaxValueSize        *uint64  `json:"kv_max_value_size,omitempty" hcl:"kv_max_value_size" mapstructure:"kv_max_value_size"`
-	TxnMaxDataSize        *uint64  `json:"txn_max_data_size,omitempty" hcl:"txn_max_data_size" mapstructure:"txn_max_data_size"`
+	TxnMaxReqLen          *uint64  `json:"txn_max_req_len,omitempty" hcl:"txn_max_req_len" mapstructure:"txn_max_req_len"`
 }
 
 type Segment struct {

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -110,7 +110,7 @@ func DefaultSource() Source {
 			rpc_max_burst = 1000
 			rpc_max_conns_per_client = 100
 			kv_max_value_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
-			txn_max_data_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
+			txn_max_req_len = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 		}
 		performance = {
 			leave_drain_time = "5s"

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -110,6 +110,7 @@ func DefaultSource() Source {
 			rpc_max_burst = 1000
 			rpc_max_conns_per_client = 100
 			kv_max_value_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
+			txn_max_data_size = ` + strconv.FormatInt(raft.SuggestedMaxDataSize, 10) + `
 		}
 		performance = {
 			leave_drain_time = "5s"

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1452,11 +1452,11 @@ type RuntimeConfig struct {
 	// hcl: translate_wan_addrs = (true|false)
 	TranslateWANAddrs bool
 
-	// TxnMaxDataSize configures the upper limit for the size (in bytes) of the
+	// TxnMaxReqLen configures the upper limit for the size (in bytes) of the
 	// incoming request bodies for transactions to the /txn endpoint.
 	//
-	// hcl: limits { txn_max_data_size = uint64 }
-	TxnMaxDataSize uint64
+	// hcl: limits { txn_max_req_len = uint64 }
+	TxnMaxReqLen uint64
 
 	// UIDir is the directory containing the Web UI resources.
 	// If provided, the UI endpoints will be enabled.

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1452,6 +1452,12 @@ type RuntimeConfig struct {
 	// hcl: translate_wan_addrs = (true|false)
 	TranslateWANAddrs bool
 
+	// TxnMaxDataSize configures the upper limit for the size (in bytes) of the
+	// incoming request bodies for transactions to the /txn endpoint.
+	//
+	// hcl: limits { txn_max_data_size = uint64 }
+	TxnMaxDataSize uint64
+
 	// UIDir is the directory containing the Web UI resources.
 	// If provided, the UI endpoints will be enabled.
 	//

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6217,6 +6217,7 @@ func TestSanitize(t *testing.T) {
 			"StatsiteAddr": ""
 		},
 		"TranslateWANAddrs": false,
+		"TxnMaxDataSize": 0,
 		"UIDir": "",
 		"UIContentPath": "",
 		"UnixSocketGroup": "",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3870,7 +3870,8 @@ func TestFullConfig(t *testing.T) {
 				"rpc_rate": 12029.43,
 				"rpc_max_burst": 44848,
 				"rpc_max_conns_per_client": 2954,
-				"kv_max_value_size": 1234567800000000
+				"kv_max_value_size": 1234567800000000,
+				"txn_max_data_size": 5678000000000000
 			},
 			"log_level": "k1zo9Spt",
 			"log_json": true,
@@ -4500,6 +4501,7 @@ func TestFullConfig(t *testing.T) {
 				rpc_max_burst = 44848
 				rpc_max_conns_per_client = 2954
 				kv_max_value_size = 1234567800000000
+				txn_max_data_size = 5678000000000000
 			}
 			log_level = "k1zo9Spt"
 			log_json = true
@@ -5573,6 +5575,7 @@ func TestFullConfig(t *testing.T) {
 			"wan_ipv4": "78.63.37.19",
 		},
 		TranslateWANAddrs:    true,
+		TxnMaxDataSize:       5678000000000000,
 		UIContentPath:        "/consul/",
 		UIDir:                "11IFzAUn",
 		UnixSocketUser:       "E0nB1DwA",
@@ -5908,6 +5911,7 @@ func TestSanitize(t *testing.T) {
 			},
 		},
 		KVMaxValueSize: 1234567800000000,
+		TxnMaxDataSize: 5678000000000000,
 	}
 
 	rtJSON := `{
@@ -6217,7 +6221,7 @@ func TestSanitize(t *testing.T) {
 			"StatsiteAddr": ""
 		},
 		"TranslateWANAddrs": false,
-		"TxnMaxDataSize": 0,
+		"TxnMaxDataSize": 5678000000000000,
 		"UIDir": "",
 		"UIContentPath": "",
 		"UnixSocketGroup": "",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3871,7 +3871,7 @@ func TestFullConfig(t *testing.T) {
 				"rpc_max_burst": 44848,
 				"rpc_max_conns_per_client": 2954,
 				"kv_max_value_size": 1234567800000000,
-				"txn_max_data_size": 5678000000000000
+				"txn_max_req_len": 5678000000000000
 			},
 			"log_level": "k1zo9Spt",
 			"log_json": true,
@@ -4501,7 +4501,7 @@ func TestFullConfig(t *testing.T) {
 				rpc_max_burst = 44848
 				rpc_max_conns_per_client = 2954
 				kv_max_value_size = 1234567800000000
-				txn_max_data_size = 5678000000000000
+				txn_max_req_len = 5678000000000000
 			}
 			log_level = "k1zo9Spt"
 			log_json = true
@@ -5575,7 +5575,7 @@ func TestFullConfig(t *testing.T) {
 			"wan_ipv4": "78.63.37.19",
 		},
 		TranslateWANAddrs:    true,
-		TxnMaxDataSize:       5678000000000000,
+		TxnMaxReqLen:         5678000000000000,
 		UIContentPath:        "/consul/",
 		UIDir:                "11IFzAUn",
 		UnixSocketUser:       "E0nB1DwA",
@@ -5911,7 +5911,7 @@ func TestSanitize(t *testing.T) {
 			},
 		},
 		KVMaxValueSize: 1234567800000000,
-		TxnMaxDataSize: 5678000000000000,
+		TxnMaxReqLen:   5678000000000000,
 	}
 
 	rtJSON := `{
@@ -6221,7 +6221,7 @@ func TestSanitize(t *testing.T) {
 			"StatsiteAddr": ""
 		},
 		"TranslateWANAddrs": false,
-		"TxnMaxDataSize": 5678000000000000,
+		"TxnMaxReqLen": 5678000000000000,
 		"UIDir": "",
 		"UIContentPath": "",
 		"UnixSocketGroup": "",

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -86,7 +86,7 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 	}
 
 	// Check Content-Length first before decoding to return early
-	if req.ContentLength > (maxTxnLen) {
+	if req.ContentLength > maxTxnLen {
 		resp.WriteHeader(http.StatusRequestEntityTooLarge)
 		fmt.Fprintf(resp, "Request body too large, max size: %v bytes", maxTxnLen)
 		return nil, 0, false

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -80,7 +80,7 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 	})
 
 	t.Run("exceeds default max kv value size", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_data_size = 123456789 }")
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 123456789 }")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
@@ -88,7 +88,7 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 	t.Run("allowed", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), `
 limits = {
-	txn_max_data_size = 123456789
+	txn_max_req_len = 123456789
 	kv_max_value_size = 123456789
 }`)
 		testIt(t, a, true)
@@ -153,7 +153,7 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 	})
 
 	t.Run("exceeds default max kv value size", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_data_size = 123456789 }")
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 123456789 }")
 		testIt(a, false)
 		a.Shutdown()
 	})
@@ -161,7 +161,7 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 	t.Run("allowed", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), `
 limits = {
-	txn_max_data_size = 123456789
+	txn_max_req_len = 123456789
 	kv_max_value_size = 123456789
 }`)
 		testIt(a, true)

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -54,7 +53,6 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
  ]
  `, value)))
 		req, _ := http.NewRequest("PUT", "/v1/txn", buf)
-		req.Header.Add("Content-Length", fmt.Sprintf("%d", buf.Len()))
 		resp := httptest.NewRecorder()
 		if _, err := agent.srv.Txn(resp, req); err != nil {
 			t.Fatalf("err: %v", err)
@@ -73,8 +71,8 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 		a.Shutdown()
 	})
 
-	t.Run("exceeds default max txn len", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
+	t.Run("exceeds configured max txn len", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 700000 }")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
@@ -146,8 +144,8 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 		a.Shutdown()
 	})
 
-	t.Run("exceeds default max txn len", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
+	t.Run("exceeds configured max txn len", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 700000 }")
 		testIt(a, false)
 		a.Shutdown()
 	})
@@ -164,6 +162,12 @@ limits = {
 	txn_max_req_len = 123456789
 	kv_max_value_size = 123456789
 }`)
+		testIt(a, true)
+		a.Shutdown()
+	})
+
+	t.Run("allowed kv max backward compatible", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
 		testIt(a, true)
 		a.Shutdown()
 	})
@@ -643,51 +647,4 @@ func TestTxnEndpoint_UpdateCheck(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, txnResp)
-}
-
-func TestConvertOps_ContentLength(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), "")
-	defer a.Shutdown()
-
-	jsonBody := `[
-     {
-         "KV": {
-             "Verb": "set",
-             "Key": "key1",
-             "Value": "aGVsbG8gd29ybGQ="
-         }
-     }
- ]`
-
-	tests := []struct {
-		contentLength string
-		ok            bool
-	}{
-		{"", true},
-		{strconv.Itoa(len(jsonBody)), true},
-		{strconv.Itoa(raft.SuggestedMaxDataSize), true},
-		{strconv.Itoa(raft.SuggestedMaxDataSize + 100), false},
-	}
-
-	for _, tc := range tests {
-		t.Run("contentLength: "+tc.contentLength, func(t *testing.T) {
-			resp := httptest.NewRecorder()
-			var body bytes.Buffer
-
-			// Doesn't matter what the request body size actually is, as we only
-			// check 'Content-Length' header in this test anyway.
-			body.WriteString(jsonBody)
-
-			req := httptest.NewRequest("POST", "http://foo.com", &body)
-			req.Header.Add("Content-Length", tc.contentLength)
-
-			_, _, ok := a.srv.convertOps(resp, req)
-			if ok != tc.ok {
-				t.Fatal("ok != tc.ok")
-			}
-
-		})
-
-	}
-
 }

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -67,14 +67,30 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 		}
 	}
 
-	t.Run("toobig", func(t *testing.T) {
+	t.Run("exceeds default limits", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
 
-	t.Run("allowed", func(t *testing.T) {
+	t.Run("exceeds default max txn size", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
+		testIt(t, a, false)
+		a.Shutdown()
+	})
+
+	t.Run("exceeds default max kv value size", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_data_size = 123456789 }")
+		testIt(t, a, false)
+		a.Shutdown()
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), `
+limits = {
+	txn_max_data_size = 123456789
+	kv_max_value_size = 123456789
+}`)
 		testIt(t, a, true)
 		a.Shutdown()
 	})
@@ -124,14 +140,30 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 		}
 	}
 
-	t.Run("toobig", func(t *testing.T) {
+	t.Run("exceeds default limits", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "")
 		testIt(a, false)
 		a.Shutdown()
 	})
 
-	t.Run("allowed", func(t *testing.T) {
+	t.Run("exceeds default max txn size", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
+		testIt(a, false)
+		a.Shutdown()
+	})
+
+	t.Run("exceeds default max kv value size", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), "limits = { txn_max_data_size = 123456789 }")
+		testIt(a, false)
+		a.Shutdown()
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		a := NewTestAgent(t, t.Name(), `
+limits = {
+	txn_max_data_size = 123456789
+	kv_max_value_size = 123456789
+}`)
 		testIt(a, true)
 		a.Shutdown()
 	})

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -73,7 +73,7 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 		a.Shutdown()
 	})
 
-	t.Run("exceeds default max txn size", func(t *testing.T) {
+	t.Run("exceeds default max txn len", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
 		testIt(t, a, false)
 		a.Shutdown()
@@ -146,7 +146,7 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 		a.Shutdown()
 	})
 
-	t.Run("exceeds default max txn size", func(t *testing.T) {
+	t.Run("exceeds default max txn len", func(t *testing.T) {
 		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
 		testIt(a, false)
 		a.Shutdown()

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1449,8 +1449,8 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         single RPC call to a Consul server. See
         https://en.wikipedia.org/wiki/Token_bucket for more details about how
         token bucket rate limiters operate.
-    *   <a name="txn_max_data_size"></a><a href="#txn_max_data_size">
-        `txn_max_data_size`</a> - Configures the maximum number of
+    *   <a name="txn_max_req_len"></a><a href="#txn_max_req_len">
+        `txn_max_req_len`</a> - Configures the maximum number of
         bytes for a transaction request body to the [`/v1/txn`](/api/txn.html)
         endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
         suggested max size. **Note that increasing beyond this default can

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1449,6 +1449,14 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         single RPC call to a Consul server. See
         https://en.wikipedia.org/wiki/Token_bucket for more details about how
         token bucket rate limiters operate.
+    *   <a name="txn_max_data_size"></a><a href="#txn_max_data_size">
+        `txn_max_data_size`</a> - Configures the maximum number of
+        bytes for a transaction request body to the [`/v1/txn`](/api/txn.html)
+        endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
+        suggested max size. **Note that increasing beyond this default can
+        cause Consul to fail in unexpected ways**, it may potentially affect
+        leadership stability and prevent timely heartbeat signals by
+        increasing RPC IO duration.
 
 * <a name="log_file"></a><a href="#log_file">`log_file`</a> Equivalent to the
   [`-log-file` command-line flag](#_log_file).


### PR DESCRIPTION
This PR introduces the option to configure the maximum request length for transaction requests to the `/txn` endpoint that is distinct from the KV value limit. These changes do not affect the current default behavior of the `/txn` endpoint and aims to improve clarity on the limits imposed on the transaction by narrowing the usage of the  KV value limit to only KV operations.
* `limits.txn_max_req_len`
* Defaults to the suggested raft size, currently ~500KB
* Adds more context on the difference between the two limits within a transaction
* Adds documentation on the option
* Removes the cumulative kv value limit check with preference for the the max txn size restriction.