### PR TITLE
Fix documentation registering service checks

### DIFF
--- a/website/source/api/agent/check.html.md
+++ b/website/source/api/agent/check.html.md
@@ -109,7 +109,7 @@ The table below shows this endpoint's support for
 
 - `Name` `(string: <required>)` - Specifies the name of the check.
 
-- `ID` `(string: "")` - Specifies a unique ID for this check on the node.
+- `CheckID` `(string: "")` - Specifies a unique ID for this check on the node.
   This defaults to the `"Name"` parameter, but it may be necessary to provide an
   ID for uniqueness.
 


### PR DESCRIPTION
After Consul 1.7, posted JSON is validated, thus making it vital to have accurate documentation.