### PR TITLE
1.7 upgrade note

### DIFF
--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -23,7 +23,7 @@ and [backward-incompatible Session API changes](#session-api).
 
 ### Session API
 This version introduced a backwards incompatible change to the Session API. 
-Queries to get or renew sessions from agents on earlier versions will be rejected.
+Queries to view or renew sessions from agents on earlier versions will be rejected.
 This impacts features and products including: Vault, the Enterprise snapshot agent, and locks.
 
 The issue occurs when clients are still running 1.6.4 or earlier but servers have been upgraded to 1.7.0 or 1.7.1. 

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -17,8 +17,17 @@ upgrade flow.
 
 ## Consul 1.7.0
 
-Consul 1.7.0 contains two major changes that may impact upgrades: 
-[stricter JSON decoding](#stricter-json-decoding) and [modified DNS outputs](#dns-ptr-record-output)
+Consul 1.7.0 contains three major changes that impact upgrades: 
+[stricter JSON decoding](#stricter-json-decoding), [modified DNS outputs](#dns-ptr-record-output), 
+and [backward-incompatible Session API changes](#session-api).
+
+### Session API
+This version introduced a backwards incompatible change to the Session API. 
+Queries to get or renew sessions from agents on earlier versions will be rejected.
+This impacts features and products including: Vault, the enterprise snapshot agent, and locks.
+
+The issue occurs when clients are still running 1.6.4 or earlier but servers have been upgraded to 1.7.0 or 1.7.1. 
+For this reason, we recommend you upgrade directly to 1.7.2 which will include a fix for this issue.
 
 ### Stricter JSON Decoding
 

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -24,7 +24,7 @@ and [backward-incompatible Session API changes](#session-api).
 ### Session API
 This version introduced a backwards incompatible change to the Session API. 
 Queries to get or renew sessions from agents on earlier versions will be rejected.
-This impacts features and products including: Vault, the enterprise snapshot agent, and locks.
+This impacts features and products including: Vault, the Enterprise snapshot agent, and locks.
 
 The issue occurs when clients are still running 1.6.4 or earlier but servers have been upgraded to 1.7.0 or 1.7.1. 
 For this reason, we recommend you upgrade directly to 1.7.2 which will include a fix for this issue.

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -27,7 +27,7 @@ Queries to view or renew sessions from agents on earlier versions will be reject
 This impacts features and products including: Vault, the Enterprise snapshot agent, and locks.
 
 The issue occurs when clients are still running 1.6.4 or earlier but servers have been upgraded to 1.7.0 or 1.7.1. 
-For this reason, we recommend you upgrade directly to 1.7.2 which will include a fix for this issue.
+For this reason, we recommend you upgrade directly to 1.7.2 when it is available as it will include a fix for this issue.
 
 ### Stricter JSON Decoding
 

--- a/website/source/docs/upgrade-specific.html.md
+++ b/website/source/docs/upgrade-specific.html.md
@@ -22,7 +22,7 @@ Consul 1.7.0 contains three major changes that impact upgrades:
 and [backward-incompatible Session API changes](#session-api).
 
 ### Session API
-This version introduced a backwards incompatible change to the Session API. 
+Consul 1.7.0 introduced a backwards incompatible change to the Session API. 
 Queries to view or renew sessions from agents on earlier versions will be rejected.
 This impacts features and products including: Vault, the Enterprise snapshot agent, and locks.
 


### PR DESCRIPTION
The Session API in Consul 1.7.0 and 1.7.1 is incompatible with prior versions of Consul.

This PR adds a note to our version-specific upgrade guide to guard against users upgrading before the fix in 1.7.2 is released.