### PR TITLE
Fix session backwards incompatibility with 1.6.x and earlier.

### DIFF
--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -98,6 +98,7 @@ func (s *HTTPServer) SessionRenew(resp http.ResponseWriter, req *http.Request) (
 
 	// Pull out the session id
 	args.SessionID = strings.TrimPrefix(req.URL.Path, "/v1/session/renew/")
+	args.Session = args.SessionID
 	if args.SessionID == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing session")
@@ -128,6 +129,7 @@ func (s *HTTPServer) SessionGet(resp http.ResponseWriter, req *http.Request) (in
 
 	// Pull out the session id
 	args.SessionID = strings.TrimPrefix(req.URL.Path, "/v1/session/info/")
+	args.Session = args.SessionID
 	if args.SessionID == "" {
 		resp.WriteHeader(http.StatusBadRequest)
 		fmt.Fprint(resp, "Missing session")

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -2036,6 +2036,8 @@ func (r *SessionRequest) RequestDatacenter() string {
 type SessionSpecificRequest struct {
 	Datacenter string
 	SessionID  string
+	// DEPRECATED in 1.7.0
+	Session string
 	EnterpriseMeta
 	QueryOptions
 }


### PR DESCRIPTION
Fixes #7395 

I did the following:

1. Added back the `Session` field in the `SessionSpecificRequest`
2. In the RPC api we "fixup" the request struct and copy the `Session` field to `SessionID` when `SessionID == ""`
3. In the HTTP API we set both fields to the same value so that during upgrades sessions still work. Like where a server was just upgraded and its API was used to generate the RPC but since it was a write (like renewing a session) it gets sent along to the leader which may not be upgraded.

I have tests for 1 & 2 but can't really test item 3 there is no functional difference in the unit tests and without intercepting RPCs somehow and verifying that both fields are set, it would require a multi-version consul setup to force any error to begin with.