### PR TITLE
add len, cap while initializing array on agent/consul/state/catalog.go

### DIFF
--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1785,7 +1785,7 @@ func sanitize(name string, v reflect.Value) reflect.Value {
 		return reflect.ValueOf(m)
 
 	case isArray(typ) || isSlice(typ):
-		ma := make([]interface{}, 0)
+		ma := make([]interface{}, 0, v.Len())
 		for i := 0; i < v.Len(); i++ {
 			ma = append(ma, sanitize(fmt.Sprintf("%s[%d]", name, i), v.Index(i)).Interface())
 		}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -739,7 +739,7 @@ func (s *Store) Services(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (ui
 	// Generate the output structure.
 	var results = make(structs.Services)
 	for service, tags := range unique {
-		results[service] = make([]string, 0)
+		results[service] = make([]string, 0, len(tags))
 		for tag := range tags {
 			results[service] = append(results[service], tag)
 		}
@@ -837,7 +837,7 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 	// Generate the output structure.
 	var results = make(structs.Services)
 	for service, tags := range unique {
-		results[service] = make([]string, 0)
+		results[service] = make([]string, 0, len(tags))
 		for tag := range tags {
 			results[service] = append(results[service], tag)
 		}


### PR DESCRIPTION
I've add len, cap while initializing array to avoid additional memory allocation on loop.