### PR TITLE
docs: add docs for kv_max_value_size

### DIFF
--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -197,7 +197,11 @@ func (s *HTTPServer) KVSPut(resp http.ResponseWriter, req *http.Request, args *s
 	// Check the content-length
 	if req.ContentLength > int64(s.agent.config.KVMaxValueSize) {
 		resp.WriteHeader(http.StatusRequestEntityTooLarge)
-		fmt.Fprintf(resp, "Value exceeds %d byte limit", s.agent.config.KVMaxValueSize)
+		fmt.Fprintf(resp,
+			"Request body(%d bytes) too large, max size: %d bytes. See %s.",
+			req.ContentLength, s.agent.config.KVMaxValueSize,
+			"https://www.consul.io/docs/agent/options.html#kv_max_value_size",
+		)
 		return nil, nil
 	}
 

--- a/agent/txn_endpoint.go
+++ b/agent/txn_endpoint.go
@@ -88,7 +88,11 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 	// Check Content-Length first before decoding to return early
 	if req.ContentLength > maxTxnLen {
 		resp.WriteHeader(http.StatusRequestEntityTooLarge)
-		fmt.Fprintf(resp, "Request body too large, max size: %v bytes", maxTxnLen)
+		fmt.Fprintf(resp,
+			"Request body(%d bytes) too large, max size: %d bytes. See %s.",
+			req.ContentLength, maxTxnLen,
+			"https://www.consul.io/docs/agent/options.html#txn_max_req_len",
+		)
 		return nil, 0, false
 	}
 
@@ -99,7 +103,11 @@ func (s *HTTPServer) convertOps(resp http.ResponseWriter, req *http.Request) (st
 			// The request size is also verified during decoding to double check
 			// if the Content-Length header was not set by the client.
 			resp.WriteHeader(http.StatusRequestEntityTooLarge)
-			fmt.Fprintf(resp, "Request body too large, max size: %v bytes", maxTxnLen)
+			fmt.Fprintf(resp,
+				"Request body too large, max size: %d bytes. See %s.",
+				maxTxnLen,
+				"https://www.consul.io/docs/agent/options.html#txn_max_req_len",
+			)
 		} else {
 			// Note the body is in API format, and not the RPC format. If we can't
 			// decode it, we will return a 400 since we don't have enough context to

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1454,7 +1454,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         bytes for a kv request body to the [`/v1/kv`](/api/kv.html) endpoint.
         This limit defaults to [raft's](https://github.com/hashicorp/raft)
         suggested max size(512KB). **Note that tuning these improperly can cause
-        Consul to fail in unexpected ways.**, it may potentially affect
+        Consul to fail in unexpected ways**, it may potentially affect
         leadership stability and prevent timely heartbeat signals by increasing
         RPC IO duration.
         This option affects the txn endpoint too, but Consul 1.7.2 introduced
@@ -1465,7 +1465,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         bytes for a transaction request body to the [`/v1/txn`](/api/txn.html)
         endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
         suggested max size(512KB). **Note that tuning these improperly can cause
-        Consul to fail in unexpected ways.**, it may potentially affect
+        Consul to fail in unexpected ways**, it may potentially affect
         leadership stability and prevent timely heartbeat signals by
         increasing RPC IO duration.
 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1449,6 +1449,17 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         single RPC call to a Consul server. See
         https://en.wikipedia.org/wiki/Token_bucket for more details about how
         token bucket rate limiters operate.
+    *   <a name="kv_max_value_size"></a><a href="#kv_max_value_size">
+        `kv_max_value_size`</a> - Configures the maximum number of
+        bytes for a kv request body to the [`/v1/kv`](/api/kv.html)
+        endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
+        suggested max size. **Note that increasing beyond this default can
+        cause Consul to fail in unexpected ways**, it may potentially affect
+        leadership stability and prevent timely heartbeat signals by
+        increasing RPC IO duration.
+        This option affects the txn endpoint too, but Consul 1.7.2 introduced
+        `txn_max_req_len` which is the preferred way to set the limit for the
+        txn endpoint. If both limits are set, the higher one takes precedence.
     *   <a name="txn_max_req_len"></a><a href="#txn_max_req_len">
         `txn_max_req_len`</a> - Configures the maximum number of
         bytes for a transaction request body to the [`/v1/txn`](/api/txn.html)

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1450,22 +1450,22 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
         https://en.wikipedia.org/wiki/Token_bucket for more details about how
         token bucket rate limiters operate.
     *   <a name="kv_max_value_size"></a><a href="#kv_max_value_size">
-        `kv_max_value_size`</a> - Configures the maximum number of
-        bytes for a kv request body to the [`/v1/kv`](/api/kv.html)
-        endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
-        suggested max size. **Note that increasing beyond this default can
-        cause Consul to fail in unexpected ways**, it may potentially affect
-        leadership stability and prevent timely heartbeat signals by
-        increasing RPC IO duration.
+        `kv_max_value_size`</a> - **(Advanced)** Configures the maximum number of
+        bytes for a kv request body to the [`/v1/kv`](/api/kv.html) endpoint.
+        This limit defaults to [raft's](https://github.com/hashicorp/raft)
+        suggested max size(512KB). **Note that tuning these improperly can cause
+        Consul to fail in unexpected ways.**, it may potentially affect
+        leadership stability and prevent timely heartbeat signals by increasing
+        RPC IO duration.
         This option affects the txn endpoint too, but Consul 1.7.2 introduced
         `txn_max_req_len` which is the preferred way to set the limit for the
         txn endpoint. If both limits are set, the higher one takes precedence.
     *   <a name="txn_max_req_len"></a><a href="#txn_max_req_len">
-        `txn_max_req_len`</a> - Configures the maximum number of
+        `txn_max_req_len`</a> - **(Advanced)** Configures the maximum number of
         bytes for a transaction request body to the [`/v1/txn`](/api/txn.html)
         endpoint. This limit defaults to [raft's](https://github.com/hashicorp/raft)
-        suggested max size. **Note that increasing beyond this default can
-        cause Consul to fail in unexpected ways**, it may potentially affect
+        suggested max size(512KB). **Note that tuning these improperly can cause
+        Consul to fail in unexpected ways.**, it may potentially affect
         leadership stability and prevent timely heartbeat signals by
         increasing RPC IO duration.
 


### PR DESCRIPTION
Apart from the added docs, the error messages are similar now and are pointing to the corresponding options.

Fixes #6708.