### PR TITLE
add auto cherry-picking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,17 @@ jobs:
       - store_test_results:
           path: *TEST_RESULTS_DIR
 
+  # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick
+  cherry-picker:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      - checkout
+      - add_ssh_keys: # needs a key to push cherry-picked commits back to github
+          fingerprints:
+            - "c9:04:b7:85:bf:0e:ce:93:5f:b8:0e:68:8e:16:f3:71"
+      - run: .circleci/scripts/cherry-picker.sh
+
 workflows:
   version: 2
   go-tests:
@@ -748,3 +759,11 @@ workflows:
       - ember-test-ent:
           requires:
             - ember-build
+  cherry-pick:
+    jobs:
+      - cherry-picker:
+          context: team-consul
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -47,7 +47,7 @@ for label in $labels; do
     # else if the label matches backport/*, it will attempt to cherry-pick to the release branch
     elif [[ $label =~ backport/* ]]; then
         echo "backporting to $label"
-        branch=${label/backport/release}
+        branch="${label/backport/release}.x"
         git checkout $branch || exit 1
         git cherry-pick $CIRCLE_SHA1 || exit 1
         git push origin $branch

--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -1,0 +1,55 @@
+# This script is meant to run on every new commit to master in CircleCI. If the commit comes from a PR, it will
+# check the PR associated with the commit for labels. If the label matches `docs*` it will be cherry-picked
+# to stable-website. If the label matches `backport/*`, it will be cherry-picked to the appropriate `release/*`
+# branch.
+
+# Requires $CIRCLE_PROJECT_USERNAME, $CIRCLE_PROJECT_REPONAME, and $CIRCLE_SHA1 from CircleCI
+#!/bin/bash
+
+# search for the PR labels applicable to the specified commit
+resp=$(curl -f -s "https://api.github.com/search/issues?q=repo:$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME+sha:$CIRCLE_SHA1")
+status="$?"
+if [[ "$status" -ne 0 ]]; then
+  echo "The GitHub API returned $status which means it was probably rate limited."
+  exit $status
+fi
+
+# get the count from the GitHub API to check if the commit matched a PR
+count=$(echo "$resp" | jq '.total_count')
+if [[ "$count" -eq 0 ]]; then
+  echo "This commit was not associated with a PR"
+  exit 0
+fi
+
+# If the API returned a non-zero count, we have found a PR with that commit so we find
+# the labels from the PR
+labels=$(echo "$resp" | jq --raw-output '.items[].labels[] | .name')
+status="$?"
+if [[ "$status" -ne 0 ]]; then
+  pr_url=$(echo "$resp" | jq --raw-output '.items[].pull_request.url')
+  echo "jq exited with $status when trying to find label names. Are there labels applied to the PR ($pr_url)?"
+  # This can be a valid error but usually this means we do not have any labels so it doesn't signal
+  # cherry-picking is possible. Exit 0 for now unless we run into cases where these failures are important.
+  exit 0
+fi
+
+# loop through all labels on the PR
+for label in $labels; do
+    git config --local user.email "hashicorp-ci@users.noreply.github.com"
+    git config --local user.name "hashicorp-ci"
+    echo "checking label: $label"
+    # if the label matches docs*, it will attempt to cherry-pick to stable-website
+    if [[ $label =~ docs* ]]; then
+        echo "docs"
+        git checkout stable-website
+        git cherry-pick $CIRCLE_SHA1
+        git push origin stable-website
+    # else if the label matches backport/*, it will attempt to cherry-pick to the release branch
+    elif [[ $label =~ backport/* ]]; then
+        echo "backporting to $label"
+        branch=${label/backport/release}
+        git checkout $branch
+        git cherry-pick $CIRCLE_SHA1
+        git push origin $branch
+    fi
+done

--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -41,15 +41,15 @@ for label in $labels; do
     # if the label matches docs*, it will attempt to cherry-pick to stable-website
     if [[ $label =~ docs* ]]; then
         echo "docs"
-        git checkout stable-website
-        git cherry-pick $CIRCLE_SHA1
+        git checkout stable-website || exit 1
+        git cherry-pick $CIRCLE_SHA1 || exit 1
         git push origin stable-website
     # else if the label matches backport/*, it will attempt to cherry-pick to the release branch
     elif [[ $label =~ backport/* ]]; then
         echo "backporting to $label"
         branch=${label/backport/release}
-        git checkout $branch
-        git cherry-pick $CIRCLE_SHA1
+        git checkout $branch || exit 1
+        git cherry-pick $CIRCLE_SHA1 || exit 1
         git push origin $branch
     fi
 done


### PR DESCRIPTION
This PR adds auto cherry-picking (minus merge conflict) to the CircleCI workflow. This was inspired by the [GitHub action](https://github.com/hashicorp/vault/blob/master/.github/workflows/stable-website.yaml) created by @kalafut in Vault. While this is more natively done within Actions, I wanted to explore what the workflow would look like if we sticked to CircleCI. 

**Note:** This means adding labels to PRs is important if you want them auto cherry-picked. (You can retroactively add a label to a PR and rerun the job on a commit you have already merged, though). 

I added comments to the actual script so it should be pretty easy to follow but a high level of the logic is:

The `cherry-picker` workflow runs on every commit to `master` only, and only for committers in the `team-consul` context, which contains the `consul` GitHub team as of now. This means any other HashiCorp employee who has write access to this repo will not be able to trigger this. There is a deploy key that is added to this repo to write back to the `hashicorp/consul` repo once the cherry-picking is done. 

1) check each commit to see if there is an associated PR
2) check that PR to see if there are labels
3) if there are labels, check if there are any that match `docs*` or `backport/*`
4) if there is a `docs*` label, cherry pick the commit to `stable-website`; if there is a `backport/*` commit, cherry pick the commit to the appropriate `release/` branch (ex: `backport/1.7` -> `release/1.7`) 

Future enhancements:
- currently we only merge a few commits everyday but if we do hit a GitHub rate limit, we will need to use a GitHub token
- maybe switch to this endpoint once it is out of developer preview: https://developer.github.com/v3/repos/commits/#list-pull-requests-associated-with-commit

Example runs: 
docs commit (docs label)
https://github.com/alvin-test-org/cherry-pick-test/pull/15
https://circleci.com/gh/alvin-test-org/cherry-pick-test/28

multiple commits (3 commits squashed)
https://github.com/alvin-test-org/cherry-pick-test/pull/4
https://circleci.com/gh/alvin-test-org/cherry-pick-test/29

backport commit (backport/1.7 label)
https://github.com/alvin-test-org/cherry-pick-test/pull/1
https://circleci.com/gh/alvin-test-org/cherry-pick-test/30

multiple backports(backport/1.7 and backport/1.6 label)
https://github.com/alvin-test-org/cherry-pick-test/pull/2
https://circleci.com/gh/alvin-test-org/cherry-pick-test/31

backporting from a fork (or generally, cherry picking from a fork):
https://github.com/alvin-test-org/cherry-pick-test/pull/16
https://circleci.com/gh/alvin-test-org/cherry-pick-test/32