### PR TITLE
Fix error output when agent crashes in an early stage

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -221,6 +221,7 @@ func (c *cmd) run(args []string) int {
 	memSink, err := lib.InitTelemetry(config.Telemetry)
 	if err != nil {
 		c.logger.Error(err.Error())
+		logGate.Flush()
 		return 1
 	}
 
@@ -229,6 +230,7 @@ func (c *cmd) run(args []string) int {
 	agent, err := agent.New(config, c.logger)
 	if err != nil {
 		c.logger.Error("Error creating agent", "error", err)
+		logGate.Flush()
 		return 1
 	}
 	agent.LogOutput = logOutput


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/consul/issues/7410

With this change the error message are visible to the end user:

```bash
$ docker run -ti --read-only consul-dev:latest consul agent  --data-dir='/tmp' --log-level=TRACE
==> Starting Consul agent...
    2020-03-08T19:14:57.212Z [DEBUG] agent: Using random ID as node ID: id=d015aca7-3c10-d715-29dc-a8b799e2cf82
    2020-03-08T19:14:57.212Z [ERROR] agent: Failed to setup node ID: open /tmp/node-id: read-only file system
    2020-03-08T19:14:57.213Z [INFO]  agent: Exit code: code=1
```