### PR TITLE
[Unstable Tests] Use retry_long instead of retry_default for envoy tests

### DIFF
--- a/.circleci/bash_env.sh
+++ b/.circleci/bash_env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export DEBUG=1
 export GIT_COMMIT=$(git rev-parse --short HEAD)
 export GIT_COMMIT_YEAR=$(git show -s --format=%cd --date=format:%Y HEAD)
 export GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)

--- a/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
@@ -28,7 +28,7 @@ load helpers
 }
 
 @test "s1 upstream should be able to connect to s2" {
-  run retry_default curl -s -f -d hello localhost:5000
+  run retry_long curl -s -f -d hello localhost:5000
   [ "$status" -eq 0 ]
   [ "$output" = "hello" ]
 }

--- a/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
@@ -20,7 +20,7 @@ load helpers
 }
 
 @test "s1 upstream should be able to connect to s2" {
-  run retry_default curl -s -f -d hello localhost:5000
+  run retry_long curl -s -f -d hello localhost:5000
   [ "$status" -eq 0 ]
   [ "$output" = "hello" ]
 }


### PR DESCRIPTION
This might help fixing unstable tests such as:
https://circleci.com/gh/hashicorp/consul/138559