### PR TITLE
Add information about which services are proxied to ui services endpoint

### DIFF
--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -314,6 +314,7 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
+			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -345,6 +346,7 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
+				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,
@@ -381,6 +383,7 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
+			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -401,6 +404,7 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
+				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,


### PR DESCRIPTION
Example output from the endpoint:

```json
[
    {
        "Name": "consul",
        "Tags": null,
        "Nodes": [
            "MacBook-Pro.keeler.lan"
        ],
        "InstanceCount": 1,
        "ChecksPassing": 1,
        "ChecksWarning": 0,
        "ChecksCritical": 0,
        "ExternalSources": null
    },
    {
        "Name": "web",
        "Tags": null,
        "Nodes": [
            "MacBook-Pro.keeler.lan",
            "MacBook-Pro.keeler.lan",
            "MacBook-Pro.keeler.lan"
        ],
        "InstanceCount": 3,
        "ChecksPassing": 3,
        "ChecksWarning": 0,
        "ChecksCritical": 0,
        "ExternalSources": null
    },
    {
        "Kind": "connect-proxy",
        "Name": "web-sidecar-proxy",
        "Tags": null,
        "Nodes": [
            "MacBook-Pro.keeler.lan",
            "MacBook-Pro.keeler.lan",
            "MacBook-Pro.keeler.lan"
        ],
        "InstanceCount": 3,
        "ProxyFor": [
            "web"
        ],
        "ChecksPassing": 6,
        "ChecksWarning": 0,
        "ChecksCritical": 3,
        "ExternalSources": null
    }
]
```

This will allow the UI to know without trying to name match things whether there is a proxy for a service.
