### PR TITLE
Update namespace docs for config entries

### DIFF
--- a/website/source/api/config.html.md
+++ b/website/source/api/config.html.md
@@ -52,11 +52,9 @@ The table below shows this endpoint's support for
   non-zero, the entry is only set if the current index matches the `ModifyIndex`
   of that entry.
 
-- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
-  service and checks will be registered. This value may be provided by either the
-  `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
-  the namespace may be provided within the `Service` or `Check` fields but if
-  present in multiple places, they must all be the same. If not provided at all, 
+- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace the config
+  entry will apply to. This value may be provided by either the `ns` URL query 
+  parameter or in the `X-Consul-Namespace` header. If not provided at all, 
   the namespace will be inherited from the request's ACL token or will default 
   to the `default` namespace. Added in Consul 1.7.0.
 
@@ -117,13 +115,10 @@ The table below shows this endpoint's support for
 - `name` `(string: <required>)` - Specifies the name of the entry to read. This
   is specified as part of the URL.
 
-- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
-  service and checks will be registered. This value may be provided by either the
-  `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
-  the namespace may be provided within the `Service` or `Check` fields but if
-  present in multiple places, they must all be the same. If not provided at all, 
-  the namespace will be inherited from the request's ACL token or will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query. 
+  This value may be provided by either the `ns` URL query parameter or in the 
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited from 
+  the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -179,13 +174,10 @@ The table below shows this endpoint's support for
 - `kind` `(string: <required>)` - Specifies the kind of the entry to list. This
   is specified as part of the URL.
 
-- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
-  service and checks will be registered. This value may be provided by either the
-  `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
-  the namespace may be provided within the `Service` or `Check` fields but if
-  present in multiple places, they must all be the same. If not provided at all, 
-  the namespace will be inherited from the request's ACL token or will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to query. 
+  This value may be provided by either the `ns` URL query parameter or in the 
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited from 
+  the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 
@@ -253,13 +245,10 @@ The table below shows this endpoint's support for
 - `name` `(string: <required>)` - Specifies the name of the entry to delete. This
   is specified as part of the URL.
 
-- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace in which the
-  service and checks will be registered. This value may be provided by either the
-  `ns` URL query parameter or in the `X-Consul-Namespace` header. Additionally,
-  the namespace may be provided within the `Service` or `Check` fields but if
-  present in multiple places, they must all be the same. If not provided at all, 
-  the namespace will be inherited from the request's ACL token or will default 
-  to the `default` namespace. Added in Consul 1.7.0.
+- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to delete from. 
+  This value may be provided by either the `ns` URL query parameter or in the 
+  `X-Consul-Namespace` header. If not provided at all, the namespace will be inherited
+  from the request's ACL token or will default to the `default` namespace. Added in Consul 1.7.0.
 
 ### Sample Request
 

--- a/website/source/docs/agent/config-entries/proxy-defaults.html.md
+++ b/website/source/docs/agent/config-entries/proxy-defaults.html.md
@@ -41,6 +41,8 @@ config {
 
 - `Name` - Must be set to `global`
 
+- `Namespace` **Enterprise Only** Specifies the namespace the config entry will apply to.
+
 - `Config` `(map[string]arbitrary)` - An arbitrary map of configuration values used by Connect proxies.
   The available configurations depend on the Connect proxy you use. Any values
   that your proxy allows can be configured globally here. To
@@ -59,23 +61,23 @@ config {
   [expose path configuration](/docs/connect/registration/service-registration.html#expose-paths-configuration-reference)
   for Envoy. Added in v1.6.2.
 
-  Exposing paths through Envoy enables a service to protect itself by only listening on localhost, while still allowing 
-  non-Connect-enabled applications to contact an HTTP endpoint. 
-  Some examples include: exposing a `/metrics` path for Prometheus or `/healthz` for kubelet liveness checks.
+    Exposing paths through Envoy enables a service to protect itself by only listening on localhost, while still allowing 
+    non-Connect-enabled applications to contact an HTTP endpoint. 
+    Some examples include: exposing a `/metrics` path for Prometheus or `/healthz` for kubelet liveness checks.
 
-  - `Checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
- Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's 
- [advertise address](/docs/agent/options.html#advertise). The port for these listeners are dynamically allocated from 
- [expose_min_port](/docs/agent/options.html#expose_min_port) to [expose_max_port](/docs/agent/options.html#expose_max_port). 
- This flag is useful when a Consul client cannot reach registered services over localhost. One example is when running 
- Consul on Kubernetes, and Consul agents run in their own pods.
-  - `Paths` `array<Path>: []` - A list of paths to expose through Envoy.
-    - `Path` `(string: "")` - The HTTP path to expose. The path must be prefixed by a slash. ie: `/metrics`.
-    - `LocalPathPort` `(int: 0)` - The port where the local service is listening for connections to the path.
-    - `ListenerPort` `(int: 0)` - The port where the proxy will listen for connections. This port must be  available 
-    for the listener to be set up. If the port is not free then Envoy will not expose a listener for the path, 
-    but the proxy registration will not fail. 
-    - `Protocol` `(string: "http")` - Sets the protocol of the listener. One of `http` or `http2`. For gRPC use `http2`.
+    - `Checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
+    Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's 
+    [advertise address](/docs/agent/options.html#advertise). The port for these listeners are dynamically allocated from 
+    [expose_min_port](/docs/agent/options.html#expose_min_port) to [expose_max_port](/docs/agent/options.html#expose_max_port). 
+    This flag is useful when a Consul client cannot reach registered services over localhost. One example is when running 
+    Consul on Kubernetes, and Consul agents run in their own pods.
+    - `Paths` `array<Path>: []` - A list of paths to expose through Envoy.
+      - `Path` `(string: "")` - The HTTP path to expose. The path must be prefixed by a slash. ie: `/metrics`.
+      - `LocalPathPort` `(int: 0)` - The port where the local service is listening for connections to the path.
+      - `ListenerPort` `(int: 0)` - The port where the proxy will listen for connections. This port must be  available 
+      for the listener to be set up. If the port is not free then Envoy will not expose a listener for the path, 
+      but the proxy registration will not fail. 
+      - `Protocol` `(string: "http")` - Sets the protocol of the listener. One of `http` or `http2`. For gRPC use `http2`.
 
 ## ACLs
 

--- a/website/source/docs/agent/config-entries/proxy-defaults.html.md
+++ b/website/source/docs/agent/config-entries/proxy-defaults.html.md
@@ -41,7 +41,7 @@ config {
 
 - `Name` - Must be set to `global`
 
-- `Namespace` **Enterprise Only** Specifies the namespace the config entry will apply to.
+- `Namespace` `(string: "default")` - **Enterprise Only** Specifies the namespace the config entry will apply to.
 
 - `Config` `(map[string]arbitrary)` - An arbitrary map of configuration values used by Connect proxies.
   The available configurations depend on the Connect proxy you use. Any values

--- a/website/source/docs/agent/config-entries/proxy-defaults.html.md
+++ b/website/source/docs/agent/config-entries/proxy-defaults.html.md
@@ -14,17 +14,18 @@ one global entry is supported.
 
 ## Sample Config Entries
 
-Set the default protocol for all sidecar proxies:
+Set the default protocol for all sidecar proxies in the default namespace:
 
 ```hcl
 kind = "proxy-defaults"
 name = "global"
+namespace = "default"
 config {
   protocol = "http"
 }
 ```
 
-Set proxy-specific defaults:
+Set proxy-specific defaults :
 
 ```hcl
 kind = "proxy-defaults"

--- a/website/source/docs/agent/config-entries/service-defaults.html.md
+++ b/website/source/docs/agent/config-entries/service-defaults.html.md
@@ -28,7 +28,7 @@ Protocol = "http"
 
 - `Name` `(string: <required>)` - Set to the name of the service being configured.
 
-- `Namespace` **Enterprise Only** Specifies the namespace the config entry will apply to.
+- `Namespace` `(string: "default")` - **Enterprise Only** Specifies the namespace the config entry will apply to.
 
 - `Protocol` `(string: "tcp")` - Sets the protocol of the service. This is used
   by Connect proxies for things like observability features and to unlock usage

--- a/website/source/docs/agent/config-entries/service-defaults.html.md
+++ b/website/source/docs/agent/config-entries/service-defaults.html.md
@@ -13,11 +13,12 @@ service, such as its protocol.
 
 ## Sample Config Entries
 
-Set the default protocol for a service to HTTP:
+Set the default protocol for a service in the default namespace to HTTP:
 
 ```hcl
 Kind = "service-defaults"
 Name = "web"
+Namespace = "default"
 Protocol = "http"
 ```
 
@@ -26,6 +27,8 @@ Protocol = "http"
 - `Kind` - Must be set to `service-defaults`
 
 - `Name` `(string: <required>)` - Set to the name of the service being configured.
+
+- `Namespace` **Enterprise Only** Specifies the namespace the config entry will apply to.
 
 - `Protocol` `(string: "tcp")` - Sets the protocol of the service. This is used
   by Connect proxies for things like observability features and to unlock usage
@@ -48,23 +51,23 @@ Protocol = "http"
   [expose path configuration](/docs/connect/registration/service-registration.html#expose-paths-configuration-reference)
   for Envoy. Added in v1.6.2.
 
-  Exposing paths through Envoy enables a service to protect itself by only listening on localhost, while still allowing 
-  non-Connect-enabled applications to contact an HTTP endpoint. 
-  Some examples include: exposing a `/metrics` path for Prometheus or `/healthz` for kubelet liveness checks.
+    Exposing paths through Envoy enables a service to protect itself by only listening on localhost, while still allowing 
+    non-Connect-enabled applications to contact an HTTP endpoint. 
+    Some examples include: exposing a `/metrics` path for Prometheus or `/healthz` for kubelet liveness checks.
 
-  - `Checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
-  Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's 
-  [advertise address](/docs/agent/options.html#advertise). The port for these listeners are dynamically allocated from 
-  [expose_min_port](/docs/agent/options.html#expose_min_port) to [expose_max_port](/docs/agent/options.html#expose_max_port). 
-  This flag is useful when a Consul client cannot reach registered services over localhost. One example is when running 
-  Consul on Kubernetes, and Consul agents run in their own pods.
-  - `Paths` `array<Path>: []` - A list of paths to expose through Envoy.
-    - `Path` `(string: "")` - The HTTP path to expose. The path must be prefixed by a slash. ie: `/metrics`.
-    - `LocalPathPort` `(int: 0)` - The port where the local service is listening for connections to the path.
-    - `ListenerPort` `(int: 0)` - The port where the proxy will listen for connections. This port must be  available for 
-    the listener to be set up. If the port is not free then Envoy will not expose a listener for the path, 
-    but the proxy registration will not fail. 
-    - `Protocol` `(string: "http")` - Sets the protocol of the listener. One of `http` or `http2`. For gRPC use `http2`.
+    - `Checks` `(bool: false)` - If enabled, all HTTP and gRPC checks registered with the agent are exposed through Envoy.
+    Envoy will expose listeners for these checks and will only accept connections originating from localhost or Consul's 
+    [advertise address](/docs/agent/options.html#advertise). The port for these listeners are dynamically allocated from 
+    [expose_min_port](/docs/agent/options.html#expose_min_port) to [expose_max_port](/docs/agent/options.html#expose_max_port). 
+    This flag is useful when a Consul client cannot reach registered services over localhost. One example is when running 
+    Consul on Kubernetes, and Consul agents run in their own pods.
+    - `Paths` `array<Path>: []` - A list of paths to expose through Envoy.
+      - `Path` `(string: "")` - The HTTP path to expose. The path must be prefixed by a slash. ie: `/metrics`.
+      - `LocalPathPort` `(int: 0)` - The port where the local service is listening for connections to the path.
+      - `ListenerPort` `(int: 0)` - The port where the proxy will listen for connections. This port must be  available for 
+      the listener to be set up. If the port is not free then Envoy will not expose a listener for the path, 
+      but the proxy registration will not fail. 
+      - `Protocol` `(string: "http")` - Sets the protocol of the listener. One of `http` or `http2`. For gRPC use `http2`.
 
 ## ACLs
 


### PR DESCRIPTION
- API docs for config entries referenced service/check registrations
- Expose docs for config entries were not properly indented