### PR TITLE
Fix unstable TestAgent_ReloadConfigAndKeepChecksStatus

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3459,9 +3459,6 @@ func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
 	retry.Run(t, func(r *retry.R) {
 		gotChecks := a.State.Checks(nil)
 		require.Equal(r, 1, len(gotChecks), "Should have a check registered, but had %#v", gotChecks)
-		for id, check := range gotChecks {
-			require.Equal(r, "critical", check.Status, "check %q is wrong", id)
-		}
 	})
 	c := TestConfig(testutil.Logger(t), config.Source{Name: t.Name(), Format: "hcl", Data: hcl})
 	a.ReloadConfig(c)


### PR DESCRIPTION
On my machine, with some load, TestAgent_ReloadConfigAndKeepChecksStatus is failing 1/3 of time
because interval is low (1s). Remove the first test for critical as it is tested elsewhere.

Setting the interval to 3s of interval also fixes the issue but slow down all tests

This will avoid test to be unstable and fix #7425.

test protocal on my machine to ensure it is not a bigger problem:

```shell
while true
do
  go clean -testcache
  go test -timeout 30s github.com/hashicorp/consul/agent -run '^TestAgent_ReloadConfigAndKeepChecksStatus$'
done
```

=> with 1s interval => fails 1/3 of time
=> with 3s interval => never fails
