### PR TITLE
add Authorization header in GitHub API call

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -64,7 +64,7 @@ function cherry_pick_with_slack_notification {
 }
 
 # search for the PR labels applicable to the specified commit
-resp=$(curl -f -s "https://api.github.com/search/issues?q=repo:$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME+sha:$CIRCLE_SHA1")
+resp=$(curl -f -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/search/issues?q=repo:$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME+sha:$CIRCLE_SHA1")
 ret="$?"
 if [[ "$ret" -ne 0 ]]; then
     status "The GitHub API returned $ret which means it was probably rate limited."


### PR DESCRIPTION
This adds an OAuth token to the curl call when checking the GitHub API. This is useful for us in enterprise since it cannot do anonymous auth for private repos. While initially I was thinking to use `-u "$GITHUB_TOKEN:"` such that anonymous basic auth will still work in OSS when we do not set the token and it is empty, I decided using the token for both OSS and ENT will give us the benefit of a higher rate limit on OSS anyway.  This value will be populated from the CircleCI context that is attached to the cherry picker job. 