### PR TITLE
consul/rpc: Remove some unused methods

### DIFF
--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -632,34 +632,10 @@ func (s *Server) globalRPC(method string, args interface{},
 	return nil
 }
 
-type raftEncoder func(structs.MessageType, interface{}) ([]byte, error)
-
 // raftApply is used to encode a message, run it through raft, and return
 // the FSM response along with any errors
 func (s *Server) raftApply(t structs.MessageType, msg interface{}) (interface{}, error) {
-	return s.raftApplyMsgpack(t, msg)
-}
-
-// raftApplyMsgpack will msgpack encode the request and then run it through raft,
-// then return the FSM response along with any errors.
-func (s *Server) raftApplyMsgpack(t structs.MessageType, msg interface{}) (interface{}, error) {
-	return s.raftApplyWithEncoder(t, msg, structs.Encode)
-}
-
-// raftApplyProtobuf will protobuf encode the request and then run it through raft,
-// then return the FSM response along with any errors.
-func (s *Server) raftApplyProtobuf(t structs.MessageType, msg interface{}) (interface{}, error) {
-	return s.raftApplyWithEncoder(t, msg, structs.EncodeProtoInterface)
-}
-
-// raftApplyWithEncoder is used to encode a message, run it through raft,
-// and return the FSM response along with any errors. Unlike raftApply this
-// takes the encoder to use as an argument.
-func (s *Server) raftApplyWithEncoder(t structs.MessageType, msg interface{}, encoder raftEncoder) (interface{}, error) {
-	if encoder == nil {
-		return nil, fmt.Errorf("Failed to encode request: nil encoder")
-	}
-	buf, err := encoder(t, msg)
+	buf, err := structs.Encode(t, msg)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to encode request: %v", err)
 	}


### PR DESCRIPTION
While reaading the code in this file I noticed a method that was not being used. Removing that method allowed the removal of another 2 as well as a type.