### PR TITLE
ci: Use golangci-lint for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,30 +33,30 @@ jobs:
       - checkout
       - run: go get -u github.com/hashicorp/lint-consul-retry && lint-consul-retry
 
-  # Runs go fmt and go vet
-  go-fmt-and-vet:
+  # Runs Go linters
+  lint:
     docker:
       - image: *GOLANG_IMAGE
     steps:
       - checkout
       - run:
-          command: go mod download
-      - run:
-          name: check go fmt
+          name: Install golangci-lint
           command: |
-            files="$(go fmt ./... ; (cd api && go fmt ./... | sed 's@^@api/@') ; (cd sdk && go fmt ./... | sed 's@^@sdk/@'))"
-            if [ -n "$files" ]; then
-                echo "The following file(s) do not conform to go fmt:"
-                echo "$files"
-                exit 1
-            fi
+            download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+            wget -O- -q $download | sh -s -- -b /go/bin/ v1.23.6
+      - run: go mod download
       - run:
-          command: |
-            go vet ./... && \
-              (cd api && go vet ./...) && \
-              (cd sdk && go vet ./...)
-    environment:
-      <<: *ENVIRONMENT
+          name: lint
+          command: &lintcmd |
+            golangci-lint run -v --concurrency 2
+      - run:
+          name: lint api
+          working_directory: api
+          command: *lintcmd
+      - run:
+          name: lint sdk
+          working_directory: sdk
+          command: *lintcmd
 
   # checks vendor directory is correct
   check-vendor:
@@ -619,15 +619,13 @@ workflows:
                 - stable-website
                 - /^docs\/.*/
                 - /^ui\/.*/
-      - go-fmt-and-vet:
-          requires:
-            - check-vendor
-      - dev-build:
-          requires:
-            - go-fmt-and-vet
+      - lint
+      - dev-build
       - go-test: &go-test
           requires:
             - dev-build
+            - lint
+            - check-vendor
       - go-test-api: *go-test
       - go-test-sdk: *go-test
       - coverage-merge:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - govet
+
+issues:
+  # Disable the default exclude list so that all excludes are explicitly
+  # defined in this file.
+  exclude-use-default: false
+
+linters-settings:
+  gofmt:
+    simplify: false

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,8 @@ GOTOOLS = \
 	golang.org/x/tools/cmd/stringer \
 	github.com/gogo/protobuf/protoc-gen-gofast@$(GOGOVERSION) \
 	github.com/hashicorp/protoc-gen-go-binary \
-	github.com/vektra/mockery/cmd/mockery
+	github.com/vektra/mockery/cmd/mockery \
+	github.com/golangci/golangci-lint/cmd/golangci-lint@v1.23.6
 
 GOTAGS ?=
 GOOS?=$(shell go env GOOS)

--- a/api/.golangci.yml
+++ b/api/.golangci.yml
@@ -1,0 +1,1 @@
+../.golangci.yml

--- a/sdk/.golangci.yml
+++ b/sdk/.golangci.yml
@@ -1,0 +1,1 @@
+../.golangci.yml


### PR DESCRIPTION
Using golangci-lint has a number of advantages:

- adding new linters becomes much easier, its a couple lines of yaml config
  instead of more bash scripting

- it enables whitelisting of issues using inline comments or regex

- when running multiple linters less work is done. The parsed source can be reused
  by multiple linters

- linters are run in parallel to reduce CI runtime.

This PR also changes the workflow so that more work can be done in parallel. This should reduce the overall workflow runtime by a minute or two.