### PR TITLE
cherry pick 'docs-cherrypick' label rather than 'docs' to stable-website

### DIFF
--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -95,8 +95,8 @@ for label in $labels; do
     git config --local user.email "hashicorp-ci@users.noreply.github.com"
     git config --local user.name "hashicorp-ci"
     status "checking label: $label"
-    # if the label matches docs*, it will attempt to cherry-pick to stable-website
-    if [[ $label =~ docs* ]]; then
+    # if the label matches docs-cherrypick, it will attempt to cherry-pick to stable-website
+    if [[ $label == docs-cherrypick ]]; then
         status "backporting to stable-website"
         branch="stable-website"
         cherry_pick_with_slack_notification $branch $CIRCLE_SHA1 $pr_url


### PR DESCRIPTION
I have also created the label 
![image](https://user-images.githubusercontent.com/17609145/76545180-b20ba600-645f-11ea-81a8-678ae913fa59.png)
