### PR TITLE
Fix ACL mode advertisement and detection

### DIFF
--- a/agent/consul/acl_server_oss.go
+++ b/agent/consul/acl_server_oss.go
@@ -16,6 +16,3 @@ func (s *Server) ResolveEntTokenToIdentityAndAuthorizer(token string) (structs.A
 func (s *Server) validateEnterpriseToken(identity structs.ACLIdentity) error {
 	return nil
 }
-
-// Consul-enterprise only
-func (s *Server) updateSegmentACLAdvertisements() {}

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -62,3 +62,9 @@ func (s *Server) validateEnterpriseRequest(entMeta *structs.EnterpriseMeta, writ
 func (_ *Server) addEnterpriseSerfTags(_ map[string]string) {
 	// do nothing
 }
+
+// updateEnterpriseSerfTags in enterprise will update any instances of Serf with the tag that
+// are not the normal LAN or WAN serf instances (network segments and network areas)
+func (_ *Server) updateEnterpriseSerfTags(_, _ string) {
+	// do nothing
+}

--- a/agent/consul/server_lookup.go
+++ b/agent/consul/server_lookup.go
@@ -63,3 +63,14 @@ func (sl *ServerLookup) Servers() []*metadata.Server {
 	}
 	return ret
 }
+
+func (sl *ServerLookup) CheckServers(fn func(srv *metadata.Server) bool) {
+	sl.lock.RLock()
+	defer sl.lock.RUnlock()
+
+	for _, srv := range sl.addressToServer {
+		if !fn(srv) {
+			return
+		}
+	}
+}

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -207,6 +207,7 @@ func (s *Server) lanEventHandler() {
 			case serf.EventUser:
 				s.localEvent(e.(serf.UserEvent))
 			case serf.EventMemberUpdate:
+				s.lanNodeUpdate(e.(serf.MemberEvent))
 				s.localMemberEvent(e.(serf.MemberEvent))
 			case serf.EventQuery: // Ignore
 			default:


### PR DESCRIPTION
These changes are necessary to ensure advertisement happens correctly even when datacenters are connected via network areas in Consul enterprise.

This also changes how we check if ACLs can be upgraded within the local datacenter. Previously we would iterate through all LAN members. Now we just use the ServerLookup type to iterate through all known servers in the DC.