### PR TITLE
Don’t pass `-u` to get get inside Go build image dockerfile

### DIFF
--- a/build-support/docker/Build-Go.dockerfile
+++ b/build-support/docker/Build-Go.dockerfile
@@ -8,6 +8,6 @@ ARG GOTOOLS="github.com/elazarl/go-bindata-assetfs/... \
    github.com/axw/gocov/gocov \
    gopkg.in/matm/v1/gocov-html"
 
-RUN GO111MODULE=on go get -u -v ${GOTOOLS} && mkdir -p /consul
+RUN GO111MODULE=on go get -v ${GOTOOLS} && mkdir -p /consul
 
 WORKDIR /consul


### PR DESCRIPTION
The `-u` was causing issues where it attempted to get newer versions of some modules than was linked in the tools go.mod file which no longer compiled.