### PR TITLE
website/docs: small doc improvements to CLI reference

### DIFF
--- a/website/source/docs/commands/join.html.markdown.erb
+++ b/website/source/docs/commands/join.html.markdown.erb
@@ -2,8 +2,11 @@
 layout: "docs"
 page_title: "Commands: Join"
 sidebar_current: "docs-commands-join"
-description: |-
-  The `join` command tells a Consul agent to join an existing cluster. A new Consul agent must join with at least one existing member of a cluster in order to join an existing cluster. After joining that one member, the gossip layer takes over, propagating the updated membership state across the cluster.
+description: >-
+  The `join` command tells a Consul agent to join an existing cluster.
+  A new Consul agent may join any node in the existing cluster. After joining
+  with one member, the gossip communication will propagate the updated membership
+  state across the cluster.
 ---
 
 # Consul Join
@@ -11,17 +14,12 @@ description: |-
 Command: `consul join`
 
 The `join` command tells a Consul agent to join an existing cluster.
-A new Consul agent must join with at least one existing member of a cluster
-in order to join an existing cluster. After joining that one member,
-the gossip layer takes over, propagating the updated membership state across
-the cluster.
+A new Consul agent may join any node in the existing cluster. After joining
+with one member, the gossip communication will propagate the updated membership
+state across the cluster.
 
-If you don't join an existing cluster, then that agent is part of its own
-isolated cluster. Other nodes can join it.
-
-Agents can join other agents multiple times without issue. If a node that
-is already part of a cluster joins another node, then the clusters of the
-two nodes join to become a single cluster.
+An agent which is already part of a cluster may join an agent in a different
+cluster, causing the two clusters to be merged into a single cluster.
 
 ## Usage
 

--- a/website/source/docs/commands/lock.html.markdown.erb
+++ b/website/source/docs/commands/lock.html.markdown.erb
@@ -77,7 +77,7 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 * `-timeout` - Maximum amount of time to wait to acquire the lock, specified
    as a duration like `1s` or `3h`. The default value is 0.
 
-* `-try` - Attempt to acquire the lock up to the given timeout. The timeout is a
+* `-timeout` - Attempt to acquire the lock up to the given timeout. The timeout is a
   positive decimal number, with unit suffix, such as "500ms". Valid time units
   are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 

--- a/website/source/docs/commands/operator/area.html.markdown.erb
+++ b/website/source/docs/commands/operator/area.html.markdown.erb
@@ -15,7 +15,7 @@ Command: `consul operator area`
 
 <%= enterprise_alert :consul %>
 
-Consul Enterprise version supports network areas, which are operator-defined relationships
+Consul Enterprise supports network areas, which are operator-defined relationships
 between servers in two different Consul datacenters. The operator area command is used to
 interact with Consul's network area subsystem.
 


### PR DESCRIPTION
Small improvements to the `join` docs.

The help text for `lock` says `-try` is deprecated and replaced with `-timeout`.
Update the docs to match.