### PR TITLE
ui: Adds blueprint for creating css-components

### DIFF
--- a/ui-v2/blueprints/css-component/files/__root__/__path__/__name__.scss
+++ b/ui-v2/blueprints/css-component/files/__root__/__path__/__name__.scss
@@ -1,0 +1,5 @@
+@import './<%= dasherizedModuleName %>/index';
+.<%= dasherizedModuleName %> {
+  @extend %<%= dasherizedModuleName %>;
+}
+

--- a/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/index.scss
+++ b/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/index.scss
@@ -1,0 +1,2 @@
+@import './skin';
+@import './layout';

--- a/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/layout.scss
+++ b/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/layout.scss
@@ -1,0 +1,3 @@
+%<%= dasherizedModuleName %> {
+
+}

--- a/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/skin.scss
+++ b/ui-v2/blueprints/css-component/files/__root__/__path__/__name__/skin.scss
@@ -1,0 +1,4 @@
+%<%= dasherizedModuleName %> {
+
+}
+

--- a/ui-v2/blueprints/css-component/index.js
+++ b/ui-v2/blueprints/css-component/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const path = require('path');
+module.exports = {
+  description: 'Generates a CSS component',
+
+  availableOptions: [],
+
+  root: __dirname,
+
+  fileMapTokens(options) {
+      return {
+        __path__() {
+          return path.join('styles', 'components');
+        }
+      };
+  },
+  locals(options) {
+    // Return custom template variables here.
+    return {
+    };
+  }
+
+  // afterInstall(options) {
+  //   // Perform extra work here.
+  // }
+};

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -7311,7 +7311,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.11, handlebars@^4.5.1:
+handlebars@^4.0.11, handlebars@^4.3.1, handlebars@^4.5.1:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
   integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
@@ -7326,17 +7326,6 @@ handlebars@^4.0.4, handlebars@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
   integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
-  dependencies:
-    neo-async "^2.6.0"
-    optimist "^0.6.1"
-    source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.3.1:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.2.tgz#01127b3840156a0927058779482031afe0e730d7"
-  integrity sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -7311,7 +7311,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.11, handlebars@^4.3.1, handlebars@^4.5.1:
+handlebars@^4.0.11, handlebars@^4.5.1:
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
   integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
@@ -7326,6 +7326,17 @@ handlebars@^4.0.4, handlebars@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
   integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.3.1:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.2.tgz#01127b3840156a0927058779482031afe0e730d7"
+  integrity sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
We have almost settled on a 'pseudo-standard' layout for our CSS components, and as we create quite a few of these it can be a little tedious to manually make the file structure for each of these.

Therefore we've created a blueprint to help out:

`ember generate css-component component-name`

Currently, _if_ this is of type 2. (see below), you'll still need to import the CSS component into your `./styles/component/index.scss` file.

---

CSS Components are CSS only components, which can be one of 2 types:

1. A composable CSS component that is not commonly used on its own
2. A CSS component that is commonly used along with a HTML/JS component,
potentially made up of other composable CSS components.

For type 1. you probably don't need the `./styles/component-name.scss`
file. But instead of complicating matters with options for the blueprint
right now, we just rely on the user to delete the
`./styles/component-name.scss` file if they don't need it.

We also don't automatically add this import to the
`./styles/components/index.scss` file for 2 reasons:

1. We are potentially going to be moving the
`./styles/components/index.scss` file to `./styles/components.scss`.
2. If we aren't going to provide a CLI swicth to ask whether this is of
component type 1. or component type 2. we don't want to automatically
include things that the user might not need.

Both of these 2 reasons are a little TBD and at some point in the future
we'll probably iterate on this blueprint to make it even easier to make
either type of CSS component.

Lastly, we quibbled about adding a `README.mdx` here also, and in the end decided not to as we are still discussing/investigating options around documentation for these types of things. We can always add this in here at a later date if we decide to.