### PR TITLE
Log "vew version available" message at info level

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -108,7 +108,7 @@ func (c *cmd) checkpointResults(results *checkpoint.CheckResponse, err error) {
 		return
 	}
 	if results.Outdated {
-		c.logger.Error("Newer Consul version available", "new_version", results.CurrentVersion, "current_version", c.version)
+		c.logger.Info("Newer Consul version available", "new_version", results.CurrentVersion, "current_version", c.version)
 	}
 	for _, alert := range results.Alerts {
 		switch alert.Level {


### PR DESCRIPTION
Fixes #7457

An `info` log level should be a good compromise between letting users know and not triggering automated alerts.