### PR TITLE
Make the example code for RedundancyZoneTag match description

### DIFF
--- a/website/source/docs/guides/autopilot.html.md
+++ b/website/source/docs/guides/autopilot.html.md
@@ -147,7 +147,7 @@ tag. For example, if `RedundancyZoneTag` is set to `zone`, and `-node-meta zone:
 is used when starting a server, that server's redundancy zone will be `east1a`.
 
 ```
-$ consul operator autopilot set-config -redundancy-zone-tag=uswest1
+$ consul operator autopilot set-config -redundancy-zone-tag=zone
 Configuration updated!
 
 $ consul operator autopilot get-config
@@ -155,13 +155,13 @@ CleanupDeadServers = false
 LastContactThreshold = 200ms
 MaxTrailingLogs = 250
 ServerStabilizationTime = 5s
-RedundancyZoneTag = "uswest1"
+RedundancyZoneTag = "zone"
 DisableUpgradeMigration = false
 UpgradeVersionTag = ""
 ```
 
 For our Autopilot features, we now have disabled dead server cleanup, server stabilization time to 5 seconds, and
-the redundancy zone tag is uswest1.
+the redundancy zone tag is zone.
 
 Consul will then use these values to partition the servers by redundancy zone, and will
 aim to keep one voting server per zone. Extra servers in each zone will stay as non-voters


### PR DESCRIPTION
This is a suggestion to improve the logical connection between the example code and the description for RedundancyZoneTag. With these changes, the text would read more easily, because the code fits the description from the first paragraph (before the example code).

The example code contains the `RedundancyZoneTag = "uswest1"`, whereas the description mentions that the zone tag should be set to the "key" of the "meta tag", which is "zone". I suppose that the description is correct and that the example code should include RedundancyZoneTag = "zone" instead? The description below the example code should then read "and the redundancy zone tag is zone", because "uswest1" looks more like a value for the meta tag "zone" (i.e., the actual name of the zone).