### PR TITLE
Fix #7468 : Out log error for invalid log directory

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -130,6 +130,10 @@ func Setup(config *Config, ui cli.Ui) (hclog.InterceptLogger, *GatedWriter, io.W
 			MaxBytes: logRotateBytes,
 			MaxFiles: config.LogRotateMaxFiles,
 		}
+		if err := logFile.openNew(); err != nil {
+			ui.Error(fmt.Sprintf("Failed to setup logging: %v", err))
+			return nil, nil, nil, false
+		}
 		writers = append(writers, logFile)
 	}
 


### PR DESCRIPTION
Relates to #7447

This PR will allow consul to throw log error if provided
log directory has permission issues for writing or is non existent.

Signed-off-by: Deepjyoti Mondal <djmdeveloper060796@gmail.com>