### PR TITLE
ui: Adds `selectable-key-values` helper

### DIFF
--- a/ui-v2/app/components/popover-select/index.hbs
+++ b/ui-v2/app/components/popover-select/index.hbs
@@ -1,17 +1,19 @@
-<PopoverMenu @keyboardAccess={{false}}>
-  <BlockSlot @name="trigger">
-    <span>
-      {{selected.value}}
-    </span>
-  </BlockSlot>
-  <BlockSlot @name="menu" as |confirm send keypressClick|>
-    <li role="separator">
-      {{title}}
-    </li>
-    {{#each options as |option| }}
-    <li role="none" class={{if (eq selected option) 'is-active'}}>
-      <button tabindex="-1" role="menuitem" type="button" value={{option.key}} onclick={{action 'change' option}}>{{option.value}}</button>
-    </li>
+<div class="popover-select" ...attributes>
+  <PopoverMenu @keyboardAccess={{false}}>
+    <BlockSlot @name="trigger">
+      <span>
+        {{selected.value}}
+      </span>
+    </BlockSlot>
+    <BlockSlot @name="menu">
+      <li role="separator">
+        {{title}}
+      </li>
+    {{#each options as |option|}}
+      <li role="none" class={{if (eq selected.key option.key) 'is-active'}}>
+        <button tabindex="-1" role="menuitem" type="button" value={{option.key}} onclick={{action 'change' option}}>{{option.value}}</button>
+      </li>
     {{/each}}
-  </BlockSlot>
-</PopoverMenu>
+    </BlockSlot>
+  </PopoverMenu>
+</div>

--- a/ui-v2/app/components/popover-select/index.js
+++ b/ui-v2/app/components/popover-select/index.js
@@ -1,12 +1,19 @@
 import Component from '@ember/component';
-import { set } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['popover-select'],
   actions: {
     change: function(option, e) {
-      set(this, 'selectedOption', option);
-      this.onchange({ target: this });
+      // We fake an event here, which could be a bit of a footbun if we treat
+      // it completely like an event, we should be abe to avoid doing this
+      // when we move to glimmer components (this.args.selected vs this.selected)
+      this.onchange({
+        target: {
+          selected: option,
+        },
+        // make this vaguely event like to avoid
+        // having a separate property
+        preventDefault: function(e) {},
+      });
     },
   },
 });

--- a/ui-v2/app/controllers/dc/nodes/index.js
+++ b/ui-v2/app/controllers/dc/nodes/index.js
@@ -21,14 +21,4 @@ export default Controller.extend(WithEventSource, WithSearching, {
       .add(this.items)
       .search(this.terms);
   }),
-  sortOptions: [
-    {
-      key: 'Node:asc',
-      value: 'A to Z',
-    },
-    {
-      key: 'Node:desc',
-      value: 'Z to A',
-    },
-  ],
 });

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -20,31 +20,4 @@ export default Controller.extend(WithEventSource, WithSearching, {
       .add(this.items)
       .search(this.terms);
   }),
-  services: computed('items.[]', function() {
-    return this.items.filter(function(item) {
-      return item.Kind === 'consul';
-    });
-  }),
-  proxies: computed('items.[]', function() {
-    return this.items.filter(function(item) {
-      return item.Kind === 'connect-proxy';
-    });
-  }),
-  withProxies: computed('proxies', function() {
-    const proxies = {};
-    this.proxies.forEach(item => {
-      proxies[item.Name.replace('-proxy', '')] = true;
-    });
-    return proxies;
-  }),
-  sortOptions: [
-    {
-      key: 'Name:asc',
-      value: 'A to Z',
-    },
-    {
-      key: 'Name:desc',
-      value: 'Z to A',
-    },
-  ],
 });

--- a/ui-v2/app/helpers/selectable-key-values.js
+++ b/ui-v2/app/helpers/selectable-key-values.js
@@ -1,0 +1,46 @@
+import { helper } from '@ember/component/helper';
+import { slugify } from 'consul-ui/helpers/slugify';
+export const selectableKeyValues = function(params = [], hash = {}) {
+  let selected;
+
+  const items = params.map(function(item, i) {
+    let key, value;
+    switch (typeof item) {
+      case 'string':
+        key = slugify([item]);
+        value = item;
+        break;
+      default:
+        if (item.length > 1) {
+          key = item[0];
+          value = item[1];
+        } else {
+          key = slugify([item[0]]);
+          value = item[0];
+        }
+        break;
+    }
+    const kv = {
+      key: key,
+      value: value,
+    };
+    switch (typeof hash.selected) {
+      case 'string':
+        if (hash.selected === item[0]) {
+          selected = kv;
+        }
+        break;
+      case 'number':
+        if (hash.selected === i) {
+          selected = kv;
+        }
+        break;
+    }
+    return kv;
+  });
+  return {
+    items: items,
+    selected: typeof selected === 'undefined' ? items[0] : selected,
+  };
+};
+export default helper(selectableKeyValues);

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -1,4 +1,11 @@
 {{title 'Nodes'}}
+{{#let (selectable-key-values
+    (array "Node:asc" "A to Z")
+    (array "Node:desc" "Z to A")
+      selected=sortBy
+  )
+  as |sort|
+}}
 <AppView @class="node list">
   <BlockSlot @name="header">
     <h1>
@@ -9,11 +16,11 @@
   <BlockSlot @name="toolbar">
 {{#if (gt items.length 0) }}
     <CatalogToolbar
-      @searchable={{array searchable}} 
-      @value={{search}} 
-      @selected={{if sortBy (find-by 'key' sortBy sortOptions) sortOptions.firstObject}}
-      @options={{sortOptions}} 
-      @onchange={{action (mut sortBy) value='target.selectedOption.key'}} 
+      @searchable={{array searchable}}
+      @value={{search}}
+      @selected={{sort.selected}}
+      @options={{sort.items}}
+      @onchange={{action (mut sortBy) value='target.selected.key'}}
     />
 {{/if}}
   </BlockSlot>
@@ -24,13 +31,13 @@
           <ul>
             <ChangeableSet @dispatcher={{searchable}}>
               <BlockSlot @name="set" as |items|>
-                {{#each (sort-by (if sortBy sortBy sortOptions.firstObject.key) items) as |item|}}
-                  <HealthcheckedResource 
-                    @tagName="li" 
-                    @data-test-node={{item.Node}} 
-                    @href={{href-to "dc.nodes.show" item.Node}} 
-                    @name={{item.Node}} 
-                    @address={{item.Address}} 
+                {{#each (sort-by sort.selected.key items) as |item|}}
+                  <HealthcheckedResource
+                    @tagName="li"
+                    @data-test-node={{item.Node}}
+                    @href={{href-to "dc.nodes.show" item.Node}}
+                    @name={{item.Node}}
+                    @address={{item.Address}}
                     @checks={{item.Checks}}>
                     <BlockSlot @name="icon">
                       {{#if (eq item.Address leader.Address)}}
@@ -52,3 +59,4 @@
 {{/if}}
   </BlockSlot>
 </AppView>
+{{/let}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -1,35 +1,43 @@
 {{title 'Services'}}
-<AppView @class="service list">
-    <BlockSlot @name="notification" as |status type|>
-      {{partial 'dc/services/notifications'}}
-    </BlockSlot>
-    <BlockSlot @name="header">
-        <h1>
-            Services <em>{{format-number items.length}} total</em>
-        </h1>
-        <label for="toolbar-toggle"></label>
-    </BlockSlot>
-    <BlockSlot @name="toolbar">
-      {{#if (gt items.length 0) }}
-        <CatalogToolbar
-          @searchable={{searchable}} 
-          @value={{search}} 
-          @selected={{if sortBy (find-by 'key' sortBy sortOptions) sortOptions.firstObject}}
-          @options={{sortOptions}} 
-          @onchange={{action (mut sortBy) value='target.selectedOption.key'}} 
-        />
-      {{/if}}
-    </BlockSlot>
-    <BlockSlot @name="content">
-        <ChangeableSet @dispatcher={{searchable}}>
-          <BlockSlot @name="set" as |filtered|>
-            <ConsulServiceList @routeName="dc.services.show" @items={{sort-by (if sortBy sortBy sortOptions.firstObject.key) filtered}} />
-          </BlockSlot>
-          <BlockSlot @name="empty">
-            <p>
-              There are no services.
-            </p>
-          </BlockSlot>
-        </ChangeableSet>
-    </BlockSlot>
-</AppView>
+{{#let (selectable-key-values
+    (array "Name:asc" "A to Z")
+    (array "Name:desc" "Z to A")
+      selected=sortBy
+  )
+  as |sort|
+}}
+    <AppView @class="service list">
+        <BlockSlot @name="notification" as |status type|>
+          {{partial 'dc/services/notifications'}}
+        </BlockSlot>
+        <BlockSlot @name="header">
+            <h1>
+                Services <em>{{format-number items.length}} total</em>
+            </h1>
+            <label for="toolbar-toggle"></label>
+        </BlockSlot>
+        <BlockSlot @name="toolbar">
+          {{#if (gt items.length 0) }}
+            <CatalogToolbar
+              @searchable={{searchable}}
+              @value={{search}}
+              @selected={{sort.selected}}
+              @options={{sort.items}}
+              @onchange={{action (mut sortBy) value='target.selected.key'}}
+            />
+          {{/if}}
+        </BlockSlot>
+        <BlockSlot @name="content">
+            <ChangeableSet @dispatcher={{searchable}}>
+              <BlockSlot @name="set" as |filtered|>
+                <ConsulServiceList @routeName="dc.services.show" @items={{sort-by sort.selected.key filtered}} />
+              </BlockSlot>
+              <BlockSlot @name="empty">
+                <p>
+                  There are no services.
+                </p>
+              </BlockSlot>
+            </ChangeableSet>
+        </BlockSlot>
+    </AppView>
+{{/let}}

--- a/ui-v2/tests/unit/helpers/selectable-key-values-test.js
+++ b/ui-v2/tests/unit/helpers/selectable-key-values-test.js
@@ -1,0 +1,34 @@
+import { selectableKeyValues } from 'consul-ui/helpers/selectable-key-values';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | selectable-key-values', function() {
+  test('it turns arrays into key values and selects the first item by default', function(assert) {
+    const actual = selectableKeyValues([['key-1', 'value-1'], ['key-2', 'value-2']]);
+    assert.equal(actual.items.length, 2);
+    assert.deepEqual(actual.selected, { key: 'key-1', value: 'value-1' });
+  });
+  test('it turns arrays into key values and selects the defined key', function(assert) {
+    const actual = selectableKeyValues([['key-1', 'value-1'], ['key-2', 'value-2']], {
+      selected: 'key-2',
+    });
+    assert.equal(actual.items.length, 2);
+    assert.deepEqual(actual.selected, { key: 'key-2', value: 'value-2' });
+  });
+  test('it turns arrays into key values and selects the defined index', function(assert) {
+    const actual = selectableKeyValues([['key-1', 'value-1'], ['key-2', 'value-2']], {
+      selected: 1,
+    });
+    assert.equal(actual.items.length, 2);
+    assert.deepEqual(actual.selected, { key: 'key-2', value: 'value-2' });
+  });
+  test('it turns arrays with only one element into key values and selects the defined index', function(assert) {
+    const actual = selectableKeyValues([['Value 1'], ['Value 2']], { selected: 1 });
+    assert.equal(actual.items.length, 2);
+    assert.deepEqual(actual.selected, { key: 'value-2', value: 'Value 2' });
+  });
+  test('it turns strings into key values and selects the defined index', function(assert) {
+    const actual = selectableKeyValues(['Value 1', 'Value 2'], { selected: 1 });
+    assert.equal(actual.items.length, 2);
+    assert.deepEqual(actual.selected, { key: 'value-2', value: 'Value 2' });
+  });
+});


### PR DESCRIPTION
Preferably we want all copy/text to live in the template. Whilst you can
achieve what we've done here with a combination of different helpers, as
we will be using this approach in various places it's probably best to
make a helper.

We also hit an ember bug related to using the `let` helper and trying to
access `thingThatWasLet.firstObject` (which can also be worked around
using `object-at`).

Moving everything to a helper 'sorted' everything.

Probably worthwhile noting that if the sort option themselves become
dynamic, I'm not sure if the helper here would actually react as you
would expect (I'm aware that ember helpers on react on the root
arguments, not necesarily sub properties of those arguments). If we get
to that point this helper could take the same approach as what I believe
ember-composable-helpers does to get around this, or move them to the
view controller. If we do ever moved this to the view controller, we
can still use the exported function from the new helper here to keep
using the same functionality and tests we have here.

Last note: We also did a tiny bit more cleanup here:

1. Removed a bit of code that had been copied in by accident I think?
2. Changed the component js file for popover-select to be tag-less, so its closer to a glimmer componen t.
