### PR TITLE
ci: fix cherry-pick job by using newer git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -593,8 +593,9 @@ jobs:
   # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick
   cherry-picker:
     docker:
-      - image: *GOLANG_IMAGE
+      - image: alpine:3.11
     steps:
+      - run: apk add --no-cache --no-progress git bash curl ncurses jq
       - checkout
       - add_ssh_keys: # needs a key to push cherry-picked commits back to github
           fingerprints:


### PR DESCRIPTION
https://github.com/git/git/commit/37897bfc27d3003dddf7722113e676e925fe9e21 made it possible to use the `-m` flag with cherry-pick, even when the target is not a merge commit.

This commit changes the image used to run the cherry-pick job to alpine so that we get a more recent version of git.

The alpine image will also download much faster when the CI node does not have the image cached.