### PR TITLE
Add lint to makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
   lint:
     docker:
       - image: *GOLANG_IMAGE
+    environment:
+      GOTAGS: "" # No tags for OSS but there are for enterprise
     steps:
       - checkout
       - run:
@@ -48,7 +50,7 @@ jobs:
       - run:
           name: lint
           command: &lintcmd |
-            golangci-lint run -v --concurrency 2
+            golangci-lint run --build-tags="$GOTAGS" -v --concurrency 2
       - run:
           name: lint api
           working_directory: api

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,3 +12,6 @@ issues:
 linters-settings:
   gofmt:
     simplify: false
+
+run:
+  timeout: 5m


### PR DESCRIPTION
Follow up to #7440

And support for setting build tags in CI lint job.

Removed the unused 'test-ci' target.