### PR TITLE
Enable CLI to register terminating gateways

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -210,9 +210,7 @@ func buildAgentService(s *structs.NodeService) api.AgentService {
 		as.Meta = map[string]string{}
 	}
 	// Attach Proxy config if exists
-	if s.Kind == structs.ServiceKindConnectProxy ||
-		s.Kind == structs.ServiceKindMeshGateway {
-
+	if s.Kind == structs.ServiceKindConnectProxy || s.IsGateway() {
 		as.Proxy = s.Proxy.ToAPI()
 	}
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1410,6 +1410,8 @@ func (b *Builder) serviceKindVal(v *string) structs.ServiceKind {
 		return structs.ServiceKindConnectProxy
 	case string(structs.ServiceKindMeshGateway):
 		return structs.ServiceKindMeshGateway
+	case string(structs.ServiceKindTerminatingGateway):
+		return structs.ServiceKindTerminatingGateway
 	default:
 		return structs.ServiceKindTypical
 	}

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -497,10 +497,23 @@ func registerTestCatalogEntries(t *testing.T, codec rpc.ClientCodec) {
 	registerTestCatalogEntriesMap(t, codec, registrations)
 }
 
-func registerTestCatalogEntriesMeshGateway(t *testing.T, codec rpc.ClientCodec) {
+func registerTestCatalogProxyEntries(t *testing.T, codec rpc.ClientCodec) {
 	t.Helper()
 
 	registrations := map[string]*structs.RegisterRequest{
+		"Service tg-gw": &structs.RegisterRequest{
+			Datacenter: "dc1",
+			Node:       "terminating-gateway",
+			ID:         types.NodeID("3a9d7530-20d4-443a-98d3-c10fe78f09f4"),
+			Address:    "10.1.2.2",
+			Service: &structs.NodeService{
+				Kind:    structs.ServiceKindTerminatingGateway,
+				ID:      "tg-gw-01",
+				Service: "tg-gw",
+				Port:    8443,
+				Address: "198.18.1.3",
+			},
+		},
 		"Service mg-gw": &structs.RegisterRequest{
 			Datacenter: "dc1",
 			Node:       "gateway",

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -611,7 +611,7 @@ func TestInternal_ServiceDump_Kind(t *testing.T) {
 
 	// prep the cluster with some data we can use in our filters
 	registerTestCatalogEntries(t, codec)
-	registerTestCatalogEntriesMeshGateway(t, codec)
+	registerTestCatalogProxyEntries(t, codec)
 
 	doRequest := func(t *testing.T, kind structs.ServiceKind) structs.CheckServiceNodes {
 		t.Helper()
@@ -631,6 +631,13 @@ func TestInternal_ServiceDump_Kind(t *testing.T) {
 		nodes := doRequest(t, structs.ServiceKindTypical)
 		// redis (3), web (3), critical (1), warning (1) and consul (1)
 		require.Len(t, nodes, 9)
+	})
+
+	t.Run("Terminating Gateway", func(t *testing.T) {
+		nodes := doRequest(t, structs.ServiceKindTerminatingGateway)
+		require.Len(t, nodes, 1)
+		require.Equal(t, "tg-gw", nodes[0].Service.Service)
+		require.Equal(t, "tg-gw-01", nodes[0].Service.ID)
 	})
 
 	t.Run("Mesh Gateway", func(t *testing.T) {

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -120,9 +120,9 @@ func (s *ServiceManager) AddService(req *addServiceRequest) error {
 
 	req.service.EnterpriseMeta.Normalize()
 
-	// For now only sidecar proxies have anything that can be configured
+	// For now only proxies have anything that can be configured
 	// centrally. So bypass the whole manager for regular services.
-	if !req.service.IsSidecarProxy() && !req.service.IsMeshGateway() {
+	if !req.service.IsSidecarProxy() && !req.service.IsGateway() {
 		// previousDefaults are ignored here because they are only relevant for central config.
 		req.persistService = nil
 		req.persistDefaults = nil

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1039,7 +1039,6 @@ func (s *NodeService) IsSidecarProxy() bool {
 }
 
 func (s *NodeService) IsGateway() bool {
-	// TODO (gateways) any other things to check?
 	return s.Kind == ServiceKindMeshGateway || s.Kind == ServiceKindTerminatingGateway
 }
 

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -890,21 +890,11 @@ const (
 	// service will proxy connections based off the SNI header set by other
 	// connect proxies
 	ServiceKindMeshGateway ServiceKind = "mesh-gateway"
-)
 
-func ServiceKindFromString(kind string) (ServiceKind, error) {
-	switch kind {
-	case string(ServiceKindTypical):
-		return ServiceKindTypical, nil
-	case string(ServiceKindConnectProxy):
-		return ServiceKindConnectProxy, nil
-	case string(ServiceKindMeshGateway):
-		return ServiceKindMeshGateway, nil
-	default:
-		// have to return something and it may as well be typical
-		return ServiceKindTypical, fmt.Errorf("Invalid service kind: %s", kind)
-	}
-}
+	// ServiceKindTerminatingGateway is a Terminating Gateway for the Connect
+	// feature. This service will proxy connections to services outside the mesh.
+	ServiceKindTerminatingGateway ServiceKind = "terminating-gateway"
+)
 
 // Type to hold a address and port of a service
 type ServiceAddress struct {
@@ -1048,9 +1038,9 @@ func (s *NodeService) IsSidecarProxy() bool {
 	return s.Kind == ServiceKindConnectProxy && s.Proxy.DestinationServiceID != ""
 }
 
-func (s *NodeService) IsMeshGateway() bool {
-	// TODO (mesh-gateway) any other things to check?
-	return s.Kind == ServiceKindMeshGateway
+func (s *NodeService) IsGateway() bool {
+	// TODO (gateways) any other things to check?
+	return s.Kind == ServiceKindMeshGateway || s.Kind == ServiceKindTerminatingGateway
 }
 
 // Validate validates the node service configuration.
@@ -1147,36 +1137,36 @@ func (s *NodeService) Validate() error {
 		}
 	}
 
-	// MeshGateway validation
-	if s.Kind == ServiceKindMeshGateway {
+	// Gateway validation
+	if s.IsGateway() {
 		// Gateways must have a port
 		if s.Port == 0 {
-			result = multierror.Append(result, fmt.Errorf("Port must be non-zero for a Mesh Gateway"))
+			result = multierror.Append(result, fmt.Errorf("Port must be non-zero for a %s", s.Kind))
 		}
 
 		// Gateways cannot have sidecars
 		if s.Connect.SidecarService != nil {
-			result = multierror.Append(result, fmt.Errorf("Mesh Gateways cannot have a sidecar service defined"))
+			result = multierror.Append(result, fmt.Errorf("A %s cannot have a sidecar service defined", s.Kind))
 		}
 
 		if s.Proxy.DestinationServiceName != "" {
-			result = multierror.Append(result, fmt.Errorf("The Proxy.DestinationServiceName configuration is invalid for Mesh Gateways"))
+			result = multierror.Append(result, fmt.Errorf("The Proxy.DestinationServiceName configuration is invalid for a %s", s.Kind))
 		}
 
 		if s.Proxy.DestinationServiceID != "" {
-			result = multierror.Append(result, fmt.Errorf("The Proxy.DestinationServiceID configuration is invalid for Mesh Gateways"))
+			result = multierror.Append(result, fmt.Errorf("The Proxy.DestinationServiceID configuration is invalid for a %s", s.Kind))
 		}
 
 		if s.Proxy.LocalServiceAddress != "" {
-			result = multierror.Append(result, fmt.Errorf("The Proxy.LocalServiceAddress configuration is invalid for Mesh Gateways"))
+			result = multierror.Append(result, fmt.Errorf("The Proxy.LocalServiceAddress configuration is invalid for a %s", s.Kind))
 		}
 
 		if s.Proxy.LocalServicePort != 0 {
-			result = multierror.Append(result, fmt.Errorf("The Proxy.LocalServicePort configuration is invalid for Mesh Gateways"))
+			result = multierror.Append(result, fmt.Errorf("The Proxy.LocalServicePort configuration is invalid for a %s", s.Kind))
 		}
 
 		if len(s.Proxy.Upstreams) != 0 {
-			result = multierror.Append(result, fmt.Errorf("The Proxy.Upstreams configuration is invalid for Mesh Gateways"))
+			result = multierror.Append(result, fmt.Errorf("The Proxy.Upstreams configuration is invalid for a %s", s.Kind))
 		}
 	}
 

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -85,6 +85,14 @@ func TestNodeServiceMeshGateway(t testing.T) *NodeService {
 		ServiceAddress{Address: "198.18.4.5", Port: 443})
 }
 
+func TestNodeServiceTerminatingGateway(t testing.T, address string) *NodeService {
+	return &NodeService{
+		Kind:    ServiceKindTerminatingGateway,
+		Service: "terminating-gateway",
+		Address: address,
+	}
+}
+
 func TestNodeServiceMeshGatewayWithAddrs(t testing.T, address string, port int, lanAddr, wanAddr ServiceAddress) *NodeService {
 	return &NodeService{
 		Kind:    ServiceKindMeshGateway,

--- a/agent/structs/testing_catalog.go
+++ b/agent/structs/testing_catalog.go
@@ -88,6 +88,7 @@ func TestNodeServiceMeshGateway(t testing.T) *NodeService {
 func TestNodeServiceTerminatingGateway(t testing.T, address string) *NodeService {
 	return &NodeService{
 		Kind:    ServiceKindTerminatingGateway,
+		Port:    8443,
 		Service: "terminating-gateway",
 		Address: address,
 	}

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -480,7 +480,7 @@ func (s *Server) makeMeshGatewayCluster(clusterName string, cfgSnap *proxycfg.Co
 // defaults to use the mesh gateway timeout.
 func (s *Server) makeMeshGatewayClusterWithConnectTimeout(clusterName string, cfgSnap *proxycfg.ConfigSnapshot,
 	connectTimeout time.Duration) (*envoy.Cluster, error) {
-	cfg, err := ParseMeshGatewayConfig(cfgSnap.Proxy.Config)
+	cfg, err := ParseGatewayConfig(cfgSnap.Proxy.Config)
 	if err != nil {
 		// Don't hard fail on a config typo, just warn. The parse func returns
 		// default config if there is an error so it's safe to continue.

--- a/agent/xds/config_test.go
+++ b/agent/xds/config_test.go
@@ -1,6 +1,7 @@
 package xds
 
 import (
+	"github.com/hashicorp/consul/agent/structs"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -247,6 +248,96 @@ func TestParseUpstreamConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseUpstreamConfig(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseGatewayConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  GatewayConfig
+	}{
+		{
+			name:  "defaults - nil",
+			input: nil,
+			want: GatewayConfig{
+				ConnectTimeoutMs: 5000,
+			},
+		},
+		{
+			name:  "defaults - empty",
+			input: map[string]interface{}{},
+			want: GatewayConfig{
+				ConnectTimeoutMs: 5000,
+			},
+		},
+		{
+			name: "defaults - other stuff",
+			input: map[string]interface{}{
+				"foo":       "bar",
+				"envoy_foo": "envoy_bar",
+			},
+			want: GatewayConfig{
+				ConnectTimeoutMs: 5000,
+			},
+		},
+		{
+			name: "kitchen sink",
+			input: map[string]interface{}{
+				"envoy_gateway_bind_tagged_addresses": true,
+				"envoy_gateway_bind_addresses":        map[string]structs.ServiceAddress{"foo": {Address: "127.0.0.1", Port: 80}},
+				"envoy_gateway_no_default_bind":       true,
+				"connect_timeout_ms":                  10,
+			},
+			want: GatewayConfig{
+				ConnectTimeoutMs:    10,
+				BindTaggedAddresses: true,
+				NoDefaultBind:       true,
+				BindAddresses:       map[string]structs.ServiceAddress{"foo": {Address: "127.0.0.1", Port: 80}},
+			},
+		},
+		{
+			name: "deprecated kitchen sink",
+			input: map[string]interface{}{
+				"envoy_mesh_gateway_bind_tagged_addresses": true,
+				"envoy_mesh_gateway_bind_addresses":        map[string]structs.ServiceAddress{"foo": {Address: "127.0.0.1", Port: 80}},
+				"envoy_mesh_gateway_no_default_bind":       true,
+				"connect_timeout_ms":                       10,
+			},
+			want: GatewayConfig{
+				ConnectTimeoutMs:    10,
+				BindTaggedAddresses: true,
+				NoDefaultBind:       true,
+				BindAddresses:       map[string]structs.ServiceAddress{"foo": {Address: "127.0.0.1", Port: 80}},
+			},
+		},
+		{
+			name: "new fields override deprecated ones",
+			input: map[string]interface{}{
+				// Deprecated
+				"envoy_mesh_gateway_bind_tagged_addresses": true,
+				"envoy_mesh_gateway_bind_addresses":        map[string]structs.ServiceAddress{"foo": {Address: "127.0.0.1", Port: 80}},
+				"envoy_mesh_gateway_no_default_bind":       true,
+
+				// New
+				"envoy_gateway_bind_tagged_addresses": false,
+				"envoy_gateway_bind_addresses":        map[string]structs.ServiceAddress{"bar": {Address: "127.0.0.1", Port: 8080}},
+				"envoy_gateway_no_default_bind":       false,
+			},
+			want: GatewayConfig{
+				ConnectTimeoutMs:    5000,
+				BindTaggedAddresses: false,
+				NoDefaultBind:       false,
+				BindAddresses:       map[string]structs.ServiceAddress{"bar": {Address: "127.0.0.1", Port: 8080}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGatewayConfig(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -181,7 +181,7 @@ func parseCheckPath(check structs.CheckType) (structs.ExposePath, error) {
 
 // listenersFromSnapshotMeshGateway returns the "listener" for a mesh-gateway service
 func (s *Server) listenersFromSnapshotMeshGateway(cfgSnap *proxycfg.ConfigSnapshot, token string) ([]proto.Message, error) {
-	cfg, err := ParseMeshGatewayConfig(cfgSnap.Proxy.Config)
+	cfg, err := ParseGatewayConfig(cfgSnap.Proxy.Config)
 	if err != nil {
 		// Don't hard fail on a config typo, just warn. The parse func returns
 		// default config if there is an error so it's safe to continue.

--- a/api/agent.go
+++ b/api/agent.go
@@ -28,6 +28,10 @@ const (
 	// service will proxy connections based off the SNI header set by other
 	// connect proxies
 	ServiceKindMeshGateway ServiceKind = "mesh-gateway"
+
+	// ServiceKindTerminatingGateway is a Terminating Gateway for the Connect
+	// feature. This service will proxy connections to services outside the mesh.
+	ServiceKindTerminatingGateway ServiceKind = "terminating-gateway"
 )
 
 // UpstreamDestType is the type of upstream discovery mechanism.

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1705,6 +1705,37 @@ func TestAgentService_Register_MeshGateway(t *testing.T) {
 	require.Equal(t, "bar", svc.Proxy.Config["foo"])
 }
 
+func TestAgentService_Register_TerminatingGateway(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	agent := c.Agent()
+
+	reg := AgentServiceRegistration{
+		Kind:    ServiceKindTerminatingGateway,
+		Name:    "terminating-gateway",
+		Address: "10.1.2.3",
+		Port:    8443,
+		Proxy: &AgentServiceConnectProxyConfig{
+			Config: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	}
+
+	err := agent.ServiceRegister(&reg)
+	require.NoError(t, err)
+
+	svc, _, err := agent.Service("terminating-gateway", nil)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	require.Equal(t, ServiceKindTerminatingGateway, svc.Kind)
+	require.NotNil(t, svc.Proxy)
+	require.Contains(t, svc.Proxy.Config, "foo")
+	require.Equal(t, "bar", svc.Proxy.Config["foo"])
+}
+
 func TestAgentService_ExposeChecks(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -46,6 +46,7 @@ type cmd struct {
 
 	// flags
 	meshGateway          bool
+	gateway              string
 	proxyID              string
 	sidecarFor           string
 	adminAccessLogPath   string
@@ -65,12 +66,12 @@ type cmd struct {
 	exposeServers      bool
 
 	gatewaySvcName string
-	gatewayKind    GatewayValue
+	gatewayKind    api.ServiceKind
 }
 
 const (
 	defaultEnvoyVersion = "1.13.1"
-	meshGatewayVal      = api.ServiceKindMeshGateway
+	meshGatewayVal      = "mesh"
 )
 
 var supportedGateways = map[string]api.ServiceKind{
@@ -88,7 +89,7 @@ func (c *cmd) init() {
 	c.flags.BoolVar(&c.meshGateway, "mesh-gateway", false,
 		"Configure Envoy as a Mesh Gateway.")
 
-	c.flags.Var(&c.gatewayKind, "gateway",
+	c.flags.StringVar(&c.gateway, "gateway", "",
 		"The type of gateway to register. One of: terminating or mesh")
 
 	c.flags.StringVar(&c.sidecarFor, "sidecar-for", os.Getenv("CONNECT_SIDECAR_FOR"),
@@ -209,19 +210,16 @@ func (c *cmd) Run(args []string) int {
 	c.client = client
 
 	// Fixup for deprecated mesh-gateway flag
-	if c.meshGateway && c.gatewayKind.String() != "" {
+	if c.meshGateway && c.gateway != "" {
 		c.UI.Error("The mesh-gateway flag is deprecated and cannot be used alongside the gateway flag")
 		return 1
 	}
 	if c.meshGateway {
-		if err := c.gatewayKind.Set(string(meshGatewayVal)); err != nil {
-			c.UI.Error(err.Error())
-			return 1
-		}
+		c.gateway = meshGatewayVal
 	}
 
 	if c.exposeServers {
-		if c.gatewayKind.Value() != meshGatewayVal {
+		if c.gateway != meshGatewayVal {
 			c.UI.Error("'-expose-servers' can only be used for mesh gateways")
 			return 1
 		}
@@ -232,12 +230,14 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	if c.register {
-		if c.gatewayKind.String() == "" {
+		if c.gateway == "" {
 			c.UI.Error("Auto-Registration can only be used for gateways")
 			return 1
 		}
+		c.gatewayKind = supportedGateways[c.gateway]
+
 		if c.gatewaySvcName == "" {
-			c.gatewaySvcName = c.gatewayKind.String()
+			c.gatewaySvcName = string(c.gatewayKind)
 		}
 
 		taggedAddrs := make(map[string]api.ServiceAddress)
@@ -287,7 +287,7 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		svc := api.AgentServiceRegistration{
-			Kind:            c.gatewayKind.Value(),
+			Kind:            c.gatewayKind,
 			Name:            c.gatewaySvcName,
 			Address:         lanAddr.Address,
 			Port:            lanAddr.Port,
@@ -318,8 +318,8 @@ func (c *cmd) Run(args []string) int {
 			return 1
 		}
 		c.proxyID = proxyID
-	} else if c.proxyID == "" && c.gatewayKind.String() != "" {
-		gatewaySvc, err := proxyCmd.LookupGatewayProxy(c.client, c.gatewayKind.Value())
+	} else if c.proxyID == "" && c.gateway != "" {
+		gatewaySvc, err := proxyCmd.LookupGatewayProxy(c.client, c.gatewayKind)
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 1
@@ -471,7 +471,7 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	cluster := c.proxyID
 	if c.sidecarFor != "" {
 		cluster = c.sidecarFor
-	} else if c.gatewayKind.String() != "" && c.gatewaySvcName != "" {
+	} else if c.gateway != "" && c.gatewaySvcName != "" {
 		cluster = c.gatewaySvcName
 	}
 

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -70,9 +70,8 @@ type cmd struct {
 }
 
 const (
-	defaultEnvoyVersion     = "1.13.1"
-	meshGatewayVal          = "mesh"
-	DefaultGatewayPort  int = 443
+	defaultEnvoyVersion = "1.13.1"
+	meshGatewayVal      = "mesh"
 )
 
 var supportedGateways = map[string]api.ServiceKind{
@@ -235,13 +234,7 @@ func (c *cmd) Run(args []string) int {
 			c.UI.Error("Auto-Registration can only be used for gateways")
 			return 1
 		}
-
-		kind, ok := supportedGateways[c.gateway]
-		if !ok {
-			c.UI.Error("Gateway must be one of: terminating or mesh")
-			return 1
-		}
-		c.gatewayKind = kind
+		c.gatewayKind = supportedGateways[c.gateway]
 
 		if c.gatewaySvcName == "" {
 			c.gatewaySvcName = string(c.gatewayKind)

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -70,8 +70,9 @@ type cmd struct {
 }
 
 const (
-	defaultEnvoyVersion = "1.13.1"
-	meshGatewayVal      = "mesh"
+	defaultEnvoyVersion     = "1.13.1"
+	meshGatewayVal          = "mesh"
+	DefaultGatewayPort  int = 443
 )
 
 var supportedGateways = map[string]api.ServiceKind{
@@ -234,7 +235,13 @@ func (c *cmd) Run(args []string) int {
 			c.UI.Error("Auto-Registration can only be used for gateways")
 			return 1
 		}
-		c.gatewayKind = supportedGateways[c.gateway]
+
+		kind, ok := supportedGateways[c.gateway]
+		if !ok {
+			c.UI.Error("Gateway must be one of: terminating or mesh")
+			return 1
+		}
+		c.gatewayKind = kind
 
 		if c.gatewaySvcName == "" {
 			c.gatewaySvcName = string(c.gatewayKind)

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -70,9 +70,8 @@ type cmd struct {
 }
 
 const (
-	defaultEnvoyVersion     = "1.13.1"
-	meshGatewayVal          = "mesh"
-	DefaultGatewayPort  int = 443
+	defaultEnvoyVersion = "1.13.1"
+	meshGatewayVal      = "mesh"
 )
 
 var supportedGateways = map[string]api.ServiceKind{

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -3,6 +3,12 @@ package envoy
 import (
 	"encoding/json"
 	"flag"
+	"github.com/hashicorp/consul/agent"
+	"github.com/hashicorp/consul/agent/xds"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/mitchellh/cli"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -11,13 +17,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/hashicorp/consul/agent"
-	"github.com/hashicorp/consul/agent/xds"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/mitchellh/cli"
-	"github.com/stretchr/testify/require"
 )
 
 var update = flag.Bool("update", false, "update golden files")
@@ -26,6 +25,57 @@ func TestEnvoyCommand_noTabs(t *testing.T) {
 	t.Parallel()
 	if strings.ContainsRune(New(nil).Help(), '\t') {
 		t.Fatal("help has tabs")
+	}
+}
+
+func TestEnvoyGateway_Validation(t *testing.T) {
+	t.Parallel()
+	ui := cli.NewMockUi()
+	c := New(ui)
+
+	cases := map[string]struct {
+		args   []string
+		output string
+	}{
+		"-register for non-gateway": {
+			[]string{"-register"},
+			"Auto-Registration can only be used for gateways",
+		},
+		"-mesh-gateway and -gateway cannot be combined": {
+			[]string{"-register", "-mesh-gateway", "-gateway", "mesh"},
+			"The mesh-gateway flag is deprecated and cannot be used alongside the gateway flag",
+		},
+		"unknown gateway type": {
+			[]string{"-register", "-gateway", "dne"},
+			"Gateway must be one of",
+		},
+		"no proxy registration specified nor discovered": {
+			[]string{""},
+			"No proxy ID specified",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c.init()
+			// Ensure our buffer is always clear
+			if ui.ErrorWriter != nil {
+				ui.ErrorWriter.Reset()
+			}
+			if ui.OutputWriter != nil {
+				ui.OutputWriter.Reset()
+			}
+
+			code := c.Run(tc.args)
+			if code == 0 {
+				t.Errorf("%s: expected non-zero exit", name)
+			}
+
+			output := ui.ErrorWriter.String()
+			if !strings.Contains(output, tc.output) {
+				t.Errorf("expected %q to contain %q", output, tc.output)
+			}
+		})
 	}
 }
 

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -30,38 +30,45 @@ func TestEnvoyCommand_noTabs(t *testing.T) {
 
 func TestEnvoyGateway_Validation(t *testing.T) {
 	t.Parallel()
+	ui := cli.NewMockUi()
+	c := New(ui)
 
-	cases := []struct {
-		name   string
+	cases := map[string]struct {
 		args   []string
 		output string
 	}{
-		{
-			"-register for non-gateway",
+		"-register for non-gateway": {
 			[]string{"-register"},
 			"Auto-Registration can only be used for gateways",
 		},
-		{
-			"-mesh-gateway and -gateway cannot be combined",
+		"-mesh-gateway and -gateway cannot be combined": {
 			[]string{"-register", "-mesh-gateway", "-gateway", "mesh"},
 			"The mesh-gateway flag is deprecated and cannot be used alongside the gateway flag",
 		},
-		{
-			"no proxy registration specified nor discovered",
+		"unknown gateway type": {
+			[]string{"-register", "-gateway", "dne"},
+			"Gateway must be one of",
+		},
+		"no proxy registration specified nor discovered": {
 			[]string{""},
 			"No proxy ID specified",
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			ui := cli.NewMockUi()
-			c := New(ui)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
 			c.init()
+			// Ensure our buffer is always clear
+			if ui.ErrorWriter != nil {
+				ui.ErrorWriter.Reset()
+			}
+			if ui.OutputWriter != nil {
+				ui.OutputWriter.Reset()
+			}
 
 			code := c.Run(tc.args)
 			if code == 0 {
-				t.Errorf("%s: expected non-zero exit", tc.name)
+				t.Errorf("%s: expected non-zero exit", name)
 			}
 
 			output := ui.ErrorWriter.String()

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -30,45 +30,38 @@ func TestEnvoyCommand_noTabs(t *testing.T) {
 
 func TestEnvoyGateway_Validation(t *testing.T) {
 	t.Parallel()
-	ui := cli.NewMockUi()
-	c := New(ui)
 
-	cases := map[string]struct {
+	cases := []struct {
+		name   string
 		args   []string
 		output string
 	}{
-		"-register for non-gateway": {
+		{
+			"-register for non-gateway",
 			[]string{"-register"},
 			"Auto-Registration can only be used for gateways",
 		},
-		"-mesh-gateway and -gateway cannot be combined": {
+		{
+			"-mesh-gateway and -gateway cannot be combined",
 			[]string{"-register", "-mesh-gateway", "-gateway", "mesh"},
 			"The mesh-gateway flag is deprecated and cannot be used alongside the gateway flag",
 		},
-		"unknown gateway type": {
-			[]string{"-register", "-gateway", "dne"},
-			"Gateway must be one of",
-		},
-		"no proxy registration specified nor discovered": {
+		{
+			"no proxy registration specified nor discovered",
 			[]string{""},
 			"No proxy ID specified",
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			c := New(ui)
 			c.init()
-			// Ensure our buffer is always clear
-			if ui.ErrorWriter != nil {
-				ui.ErrorWriter.Reset()
-			}
-			if ui.OutputWriter != nil {
-				ui.OutputWriter.Reset()
-			}
 
 			code := c.Run(tc.args)
 			if code == 0 {
-				t.Errorf("%s: expected non-zero exit", name)
+				t.Errorf("%s: expected non-zero exit", tc.name)
 			}
 
 			output := ui.ErrorWriter.String()

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 )
 
-const defaultMeshGatewayPort int = 443
+const defaultGatewayPort int = 443
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an
 // addr:port string into an api.ServiceAddress.
@@ -21,14 +21,14 @@ type ServiceAddressValue struct {
 
 func (s *ServiceAddressValue) String() string {
 	if s == nil {
-		return fmt.Sprintf(":%d", defaultMeshGatewayPort)
+		return fmt.Sprintf(":%d", defaultGatewayPort)
 	}
 	return fmt.Sprintf("%v:%d", s.value.Address, s.value.Port)
 }
 
 func (s *ServiceAddressValue) Value() api.ServiceAddress {
 	if s == nil || s.value.Port == 0 && s.value.Address == "" {
-		return api.ServiceAddress{Port: defaultMeshGatewayPort}
+		return api.ServiceAddress{Port: defaultGatewayPort}
 	}
 	return s.value
 }
@@ -51,7 +51,7 @@ func parseAddress(raw string) (api.ServiceAddress, error) {
 		return result, fmt.Errorf("Error parsing address %q: %v", x, err)
 	}
 
-	port := defaultMeshGatewayPort
+	port := defaultGatewayPort
 	if portStr != "" {
 		port, err = strconv.Atoi(portStr)
 		if err != nil {

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -11,7 +11,28 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 )
 
-const defaultMeshGatewayPort int = 443
+const defaultGatewayPort int = 443
+
+type GatewayValue struct {
+	value string
+}
+
+func (g *GatewayValue) String() string {
+	return g.value
+}
+
+func (g *GatewayValue) Value() string {
+	return g.value
+}
+
+func (g *GatewayValue) Set(raw string) error {
+	var err error
+	_, ok := supportedGateways[g.value]
+	if g.value != "" && !ok {
+		return fmt.Errorf("Gateway must be one of: terminating or mesh")
+	}
+	return err
+}
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an
 // addr:port string into an api.ServiceAddress.
@@ -21,14 +42,14 @@ type ServiceAddressValue struct {
 
 func (s *ServiceAddressValue) String() string {
 	if s == nil {
-		return fmt.Sprintf(":%d", defaultMeshGatewayPort)
+		return fmt.Sprintf(":%d", defaultGatewayPort)
 	}
 	return fmt.Sprintf("%v:%d", s.value.Address, s.value.Port)
 }
 
 func (s *ServiceAddressValue) Value() api.ServiceAddress {
 	if s == nil || s.value.Port == 0 && s.value.Address == "" {
-		return api.ServiceAddress{Port: defaultMeshGatewayPort}
+		return api.ServiceAddress{Port: defaultGatewayPort}
 	}
 	return s.value
 }
@@ -51,7 +72,7 @@ func parseAddress(raw string) (api.ServiceAddress, error) {
 		return result, fmt.Errorf("Error parsing address %q: %v", x, err)
 	}
 
-	port := defaultMeshGatewayPort
+	port := defaultGatewayPort
 	if portStr != "" {
 		port, err = strconv.Atoi(portStr)
 		if err != nil {

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -14,24 +14,24 @@ import (
 const defaultGatewayPort int = 443
 
 type GatewayValue struct {
-	value string
+	value api.ServiceKind
 }
 
 func (g *GatewayValue) String() string {
-	return g.value
+	return string(g.value)
 }
 
-func (g *GatewayValue) Value() string {
+func (g *GatewayValue) Value() api.ServiceKind {
 	return g.value
 }
 
 func (g *GatewayValue) Set(raw string) error {
-	var err error
-	_, ok := supportedGateways[g.value]
-	if g.value != "" && !ok {
+	kind, ok := supportedGateways[raw]
+	if !ok {
 		return fmt.Errorf("Gateway must be one of: terminating or mesh")
 	}
-	return err
+	g.value = kind
+	return nil
 }
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -11,28 +11,7 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 )
 
-const defaultGatewayPort int = 443
-
-type GatewayValue struct {
-	value string
-}
-
-func (g *GatewayValue) String() string {
-	return g.value
-}
-
-func (g *GatewayValue) Value() string {
-	return g.value
-}
-
-func (g *GatewayValue) Set(raw string) error {
-	var err error
-	_, ok := supportedGateways[g.value]
-	if g.value != "" && !ok {
-		return fmt.Errorf("Gateway must be one of: terminating or mesh")
-	}
-	return err
-}
+const defaultMeshGatewayPort int = 443
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an
 // addr:port string into an api.ServiceAddress.
@@ -42,14 +21,14 @@ type ServiceAddressValue struct {
 
 func (s *ServiceAddressValue) String() string {
 	if s == nil {
-		return fmt.Sprintf(":%d", defaultGatewayPort)
+		return fmt.Sprintf(":%d", defaultMeshGatewayPort)
 	}
 	return fmt.Sprintf("%v:%d", s.value.Address, s.value.Port)
 }
 
 func (s *ServiceAddressValue) Value() api.ServiceAddress {
 	if s == nil || s.value.Port == 0 && s.value.Address == "" {
-		return api.ServiceAddress{Port: defaultGatewayPort}
+		return api.ServiceAddress{Port: defaultMeshGatewayPort}
 	}
 	return s.value
 }
@@ -72,7 +51,7 @@ func parseAddress(raw string) (api.ServiceAddress, error) {
 		return result, fmt.Errorf("Error parsing address %q: %v", x, err)
 	}
 
-	port := defaultGatewayPort
+	port := defaultMeshGatewayPort
 	if portStr != "" {
 		port, err = strconv.Atoi(portStr)
 		if err != nil {

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -14,24 +14,24 @@ import (
 const defaultGatewayPort int = 443
 
 type GatewayValue struct {
-	value api.ServiceKind
+	value string
 }
 
 func (g *GatewayValue) String() string {
-	return string(g.value)
+	return g.value
 }
 
-func (g *GatewayValue) Value() api.ServiceKind {
+func (g *GatewayValue) Value() string {
 	return g.value
 }
 
 func (g *GatewayValue) Set(raw string) error {
-	kind, ok := supportedGateways[raw]
-	if !ok {
+	var err error
+	_, ok := supportedGateways[g.value]
+	if g.value != "" && !ok {
 		return fmt.Errorf("Gateway must be one of: terminating or mesh")
 	}
-	g.value = kind
-	return nil
+	return err
 }
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -10,12 +10,12 @@ import (
 func TestServiceAddressValue_Value(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
 	})
 
 	t.Run("set value", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestServiceAddressValue_Set(t *testing.T) {
 			input: "8.8.8.8:",
 			expectedValue: api.ServiceAddress{
 				Address: "8.8.8.8",
-				Port:    defaultMeshGatewayPort,
+				Port:    defaultGatewayPort,
 			},
 		},
 		{

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -10,12 +10,12 @@ import (
 func TestServiceAddressValue_Value(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
 	})
 
 	t.Run("set value", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestServiceAddressValue_Set(t *testing.T) {
 			input: "8.8.8.8:",
 			expectedValue: api.ServiceAddress{
 				Address: "8.8.8.8",
-				Port:    defaultMeshGatewayPort,
+				Port:    defaultGatewayPort,
 			},
 		},
 		{
@@ -75,6 +75,44 @@ func TestServiceAddressValue_Set(t *testing.T) {
 			}
 
 			require.Equal(t, addr.Value(), tc.expectedValue)
+		})
+	}
+}
+
+func TestGatewayValue_Set(t *testing.T) {
+	var testcases = []struct {
+		name          string
+		input         string
+		expectedErr   string
+		expectedValue api.ServiceKind
+	}{
+		{
+			name:          "mesh gateway",
+			input:         "mesh",
+			expectedValue: api.ServiceKindMeshGateway,
+		},
+		{
+			name:          "terminating gateway",
+			input:         "terminating",
+			expectedValue: api.ServiceKindTerminatingGateway,
+		},
+		{
+			name:        "kind does not exist",
+			input:       "dne",
+			expectedErr: "Gateway must be one of:",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := &GatewayValue{}
+			err := gw.Set(tc.input)
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+				return
+			}
+
+			require.Equal(t, gw.Value(), tc.expectedValue)
 		})
 	}
 }

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -10,12 +10,12 @@ import (
 func TestServiceAddressValue_Value(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultGatewayPort})
+		require.Equal(t, addr.Value(), api.ServiceAddress{Port: defaultMeshGatewayPort})
 	})
 
 	t.Run("set value", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestServiceAddressValue_Set(t *testing.T) {
 			input: "8.8.8.8:",
 			expectedValue: api.ServiceAddress{
 				Address: "8.8.8.8",
-				Port:    defaultGatewayPort,
+				Port:    defaultMeshGatewayPort,
 			},
 		},
 		{
@@ -75,44 +75,6 @@ func TestServiceAddressValue_Set(t *testing.T) {
 			}
 
 			require.Equal(t, addr.Value(), tc.expectedValue)
-		})
-	}
-}
-
-func TestGatewayValue_Set(t *testing.T) {
-	var testcases = []struct {
-		name          string
-		input         string
-		expectedErr   string
-		expectedValue api.ServiceKind
-	}{
-		{
-			name:          "mesh gateway",
-			input:         "mesh",
-			expectedValue: api.ServiceKindMeshGateway,
-		},
-		{
-			name:          "terminating gateway",
-			input:         "terminating",
-			expectedValue: api.ServiceKindTerminatingGateway,
-		},
-		{
-			name:        "kind does not exist",
-			input:       "dne",
-			expectedErr: "Gateway must be one of:",
-		},
-	}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			gw := &GatewayValue{}
-			err := gw.Set(tc.input)
-			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
-				return
-			}
-
-			require.Equal(t, gw.Value(), tc.expectedValue)
 		})
 	}
 }

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -248,13 +248,13 @@ func LookupProxyIDForSidecar(client *api.Client, sidecarFor string) (string, err
 	return proxyIDs[0], nil
 }
 
-// LookupGatewayProxyID finds the mesh-gateway service registered with the local
+// LookupGatewayProxyID finds the gateway service registered with the local
 // agent if any and returns its service ID. It will return an ID if and only if
-// there is exactly one registered mesh-gateway registered to the agent.
-func LookupGatewayProxy(client *api.Client) (*api.AgentService, error) {
-	svcs, err := client.Agent().ServicesWithFilter("Kind == `mesh-gateway`")
+// there is exactly one gateway of this kind registered to the agent.
+func LookupGatewayProxy(client *api.Client, kind api.ServiceKind) (*api.AgentService, error) {
+	svcs, err := client.Agent().ServicesWithFilter(fmt.Sprintf("Kind == `%s`", kind))
 	if err != nil {
-		return nil, fmt.Errorf("Failed looking up mesh-gateway instances: %v", err)
+		return nil, fmt.Errorf("Failed looking up %s instances: %v", kind, err)
 	}
 
 	var proxyIDs []string
@@ -264,14 +264,14 @@ func LookupGatewayProxy(client *api.Client) (*api.AgentService, error) {
 
 	switch len(svcs) {
 	case 0:
-		return nil, fmt.Errorf("No mesh-gateway services registered with this agent")
+		return nil, fmt.Errorf("No %s services registered with this agent", kind)
 	case 1:
 		for _, svc := range svcs {
 			return svc, nil
 		}
 		return nil, fmt.Errorf("This should be unreachable")
 	default:
-		return nil, fmt.Errorf("Cannot lookup the mesh-gateway's proxy ID because multiple are registered with the agent")
+		return nil, fmt.Errorf("Cannot lookup the %s's proxy ID because multiple are registered with the agent", kind)
 	}
 }
 

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -287,6 +287,10 @@ the  [global `proxy-defaults` configuration
 entry](/docs/agent/config_entries.html#proxy-defaults-proxy-defaults) to act as
 defaults that are inherited by all services.
 
+Prior to 1.8.0 these settings were specific to Mesh Gateways. The deprecated 
+names such as `envoy_mesh_gateway_bind_addresses` and `envoy_mesh_gateway_no_default_bind`
+will continue to be supported.
+
 - `connect_timeout_ms` - The number of milliseconds to allow when making upstream
   connections before timing out. Defaults to 5000 (5 seconds). If the upstream
   service has the configuration option
@@ -296,7 +300,7 @@ defaults that are inherited by all services.
 
 - `envoy_gateway_bind_tagged_addresses` - Indicates that the gateway
   services tagged addresses should be bound to listeners in addition to the
-  default listener address.
+  default listener address. 
 
 - `envoy_gateway_bind_addresses` - A map of additional addresses to be bound.
   This map's keys are the name of the listeners to be created and the values are

--- a/website/source/docs/connect/proxies/envoy.md
+++ b/website/source/docs/connect/proxies/envoy.md
@@ -279,7 +279,7 @@ definition](/docs/connect/registration/service-registration.html) or
     since HTTP/2 has many requests per connection. For this configuration to be
     respected, a L7 protocol must be defined in the `protocol` field.
 
-### Mesh Gateway Options
+### Gateway Options
 
 These fields may also be overridden explicitly in the [proxy service
 definition](/docs/connect/registration/service-registration.html), or defined in
@@ -292,20 +292,20 @@ defaults that are inherited by all services.
   service has the configuration option
   [`connect_timeout_ms`](/docs/agent/config-entries/service-resolver.html#connecttimeout)
   set for the `service-resolver`, that timeout value will take precedence over
-  this mesh gateway option.
+  this gateway option.
 
-- `envoy_mesh_gateway_bind_tagged_addresses` - Indicates that the mesh gateway
+- `envoy_gateway_bind_tagged_addresses` - Indicates that the gateway
   services tagged addresses should be bound to listeners in addition to the
   default listener address.
 
-- `envoy_mesh_gateway_bind_addresses` - A map of additional addresses to be bound.
+- `envoy_gateway_bind_addresses` - A map of additional addresses to be bound.
   This map's keys are the name of the listeners to be created and the values are
   a map with two keys, address and port, that combined make the address to bind the
   listener to. These are bound in addition to the default address.
 
-- `envoy_mesh_gateway_no_default_bind` - Prevents binding to the default address
-  of the mesh gateway service. This should be used with one of the other options
-  to configure the gateways bind addresses.
+- `envoy_gateway_no_default_bind` - Prevents binding to the default address
+  of the gateway service. This should be used with one of the other options
+  to configure the gateway's bind addresses.
 
 ## Advanced Configuration
 


### PR DESCRIPTION
This PR enables the CLI to register terminating gateways.