### PR TITLE
agent/rpc: unwrap the delegate.RPC call

### DIFF
--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-uuid"
+	uuid "github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1512,6 +1512,8 @@ func TestAgent_Join_WAN(t *testing.T) {
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
+
+	t.Logf("##### DEBUG %T\n", a1.delegate)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", a2.Config.SerfPortWAN)
 	req, _ := http.NewRequest("PUT", fmt.Sprintf("/v1/agent/join/%s?wan=true", addr), nil)


### PR DESCRIPTION
`Agent.RPC` wraps `Agent.delegate.RPC`, adding support for registering fake
endpoints in tests.

This type of interface wrapping can make the code more difficult to change
because every contributor needs to know that calling the delegate method
directly may not be correct. A search through git history shows this has
happened on at least one occasion.

Including test hooks in the non-test code can make the code harder to
understand by distracting the reader. In extreme cases it may also introduce
bugs that are avoided when the test-only code is kept in the test suite.

This commit moves fake endpoint registration into `TestAgent` and starts
the process of removing `Agent.RPC`. There are 800+ calls to this method,
so a lot more work will be required, but as of this commit the call is
now a clean passthrough, so it is no longer incorrect to call
`Agent.delegate.RPC`.