### PR TITLE
agent: Remove unused method Encrypted from delegate interface

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -143,9 +143,6 @@ func (a *TestACLAgent) ResolveIdentityFromToken(secretID string) (bool, structs.
 }
 
 // All of these are stubs to satisfy the interface
-func (a *TestACLAgent) Encrypted() bool {
-	return false
-}
 func (a *TestACLAgent) GetLANCoordinate() (lib.CoordinateSet, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -127,7 +127,6 @@ func ConfigSourceFromName(name string) (configSource, bool) {
 // delegate defines the interface shared by both
 // consul.Client and consul.Server.
 type delegate interface {
-	Encrypted() bool
 	GetLANCoordinate() (lib.CoordinateSet, error)
 	Leave() error
 	LANMembers() []serf.Member
@@ -3434,10 +3433,6 @@ func (a *Agent) purgeCheckState(checkID structs.CheckID) error {
 		return nil
 	}
 	return err
-}
-
-func (a *Agent) GossipEncrypted() bool {
-	return a.delegate.Encrypted()
 }
 
 // Stats is used to get various debugging state from the sub-systems

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -284,11 +284,6 @@ func (c *Client) KeyManagerLAN() *serf.KeyManager {
 	return c.serf.KeyManager()
 }
 
-// Encrypted determines if gossip is encrypted
-func (c *Client) Encrypted() bool {
-	return c.serf.EncryptionEnabled()
-}
-
 // RPC is used to forward an RPC call to a consul server, or fail if no servers
 func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	// This is subtle but we start measuring the time on the client side

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -708,27 +708,6 @@ func TestClientServer_UserEvent(t *testing.T) {
 	}
 }
 
-func TestClient_Encrypted(t *testing.T) {
-	t.Parallel()
-	dir1, c1 := testClient(t)
-	defer os.RemoveAll(dir1)
-	defer c1.Shutdown()
-
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	dir2, c2 := testClientWithConfig(t, func(c *Config) {
-		c.SerfLANConfig.MemberlistConfig.SecretKey = key
-	})
-	defer os.RemoveAll(dir2)
-	defer c2.Shutdown()
-
-	if c1.Encrypted() {
-		t.Fatalf("should not be encrypted")
-	}
-	if !c2.Encrypted() {
-		t.Fatalf("should be encrypted")
-	}
-}
-
 func TestClient_Reload(t *testing.T) {
 	t.Parallel()
 	dir1, c := testClientWithConfig(t, func(c *Config) {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1159,15 +1159,6 @@ func (s *Server) KeyManagerWAN() *serf.KeyManager {
 	return s.serfWAN.KeyManager()
 }
 
-// Encrypted determines if gossip is encrypted
-func (s *Server) Encrypted() bool {
-	LANEncrypted := s.serfLAN.EncryptionEnabled()
-	if s.serfWAN == nil {
-		return LANEncrypted
-	}
-	return LANEncrypted && s.serfWAN.EncryptionEnabled()
-}
-
 // LANSegments returns a map of LAN segments by name
 func (s *Server) LANSegments() map[string]*serf.Serf {
 	segments := make(map[string]*serf.Serf, len(s.segmentLAN)+1)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1197,28 +1197,6 @@ func TestServer_globalRPCErrors(t *testing.T) {
 	}
 }
 
-func TestServer_Encrypted(t *testing.T) {
-	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-
-	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
-		c.SerfLANConfig.MemberlistConfig.SecretKey = key
-		c.SerfWANConfig.MemberlistConfig.SecretKey = key
-	})
-	defer os.RemoveAll(dir2)
-	defer s2.Shutdown()
-
-	if s1.Encrypted() {
-		t.Fatalf("should not be encrypted")
-	}
-	if !s2.Encrypted() {
-		t.Fatalf("should be encrypted")
-	}
-}
-
 func testVerifyRPC(s1, s2 *Server, t *testing.T) (bool, error) {
 	joinLAN(t, s1, s2)
 	retry.Run(t, func(r *retry.R) {


### PR DESCRIPTION
It appears to be unused. It looks like it has been around a while, I guess at some point we stopped using this method.