### PR TITLE
add ssh package and push to branch before notifying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,7 +597,7 @@ jobs:
     docker:
       - image: alpine:3.11
     steps:
-      - run: apk add --no-cache --no-progress git bash curl ncurses jq
+      - run: apk add --no-cache --no-progress git bash curl ncurses jq openssh-client
       - checkout
       - add_ssh_keys: # needs a key to push cherry-picked commits back to github
           fingerprints:

--- a/.circleci/scripts/cherry-picker.sh
+++ b/.circleci/scripts/cherry-picker.sh
@@ -50,6 +50,8 @@ function cherry_pick_with_slack_notification {
     # Else we send a success notification
     else
         status "🍒✅ Cherry picking of PR commit ${commit:0:7} from $pr_url succeeded!"
+        # push changes to the specified branch
+        git push origin "$branch"
         curl -X POST -H 'Content-type: application/json' \
         --data \
         "{ \
@@ -103,12 +105,10 @@ for label in $labels; do
         status "backporting to stable-website"
         branch="stable-website"
         cherry_pick_with_slack_notification "$branch" "$CIRCLE_SHA1" "$pr_url"
-        git push origin stable-website
     # else if the label matches backport/*, it will attempt to cherry-pick to the release branch
     elif [[ $label =~ backport/* ]]; then
         status "backporting to $label"
         branch="${label/backport/release}.x"
         cherry_pick_with_slack_notification "$branch" "$CIRCLE_SHA1" "$pr_url"
-        git push origin "$branch"
     fi
 done


### PR DESCRIPTION
This adds the openssh package to alpine to push git branch back to GitHub as well as only send slack notifications if the `git push` succeeds along with the `git cherry-pick`