### PR TITLE
rebuild UI for master/ui-staging dev docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,8 @@ jobs:
       <<: *ENVIRONMENT
     steps:
       - checkout
+      - attach_workspace: # this normally runs as the first job and has nothing to attach; only used in master branch after rebuilding UI
+          at: .
       - run:
           command: make dev
 
@@ -490,6 +492,38 @@ jobs:
           paths:
             - dist
 
+  # rebuild UI for packaging
+  ember-build-prod:
+    docker:
+      - image: *EMBER_IMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: *YARN_CACHE_KEY
+      - run: cd ui-v2 && make
+
+      # saves the build to a workspace to be passed to a downstream job
+      - persist_to_workspace:
+          root: ui-v2
+          paths:
+            - dist
+
+  # build static-assets file
+  build-static-assets:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./pkg
+      - run: mv pkg/dist pkg/web_ui # 'make static-assets' looks for the 'pkg/web_ui' path
+      - run: make tools
+      - run: make static-assets
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./agent/bindata_assetfs.go
+
   # run ember frontend tests
   ember-test-oss:
     docker:
@@ -650,6 +684,29 @@ workflows:
             - check-vendor
       - build-amd64: *require-check-vendor
       - build-arm: *require-check-vendor
+      # every commit on ui-staging and master will have a rebuilt UI
+      - frontend-cache:
+          filters:
+            branches:
+              only:
+                - master
+                - ui-staging
+      - ember-build-prod:
+          requires:
+            - frontend-cache
+      - build-static-assets:
+          requires:
+            - ember-build-prod
+      - dev-build:
+          requires:
+            - build-static-assets
+      - dev-upload-s3:
+          requires:
+            - dev-build
+      - dev-upload-docker:
+          requires:
+            - dev-build
+          context: consul-ci
   test-integrations:
     jobs:
       - dev-build:
@@ -666,6 +723,8 @@ workflows:
             branches:
               ignore:
                 - /^pull\/.*$/ # only push dev builds from non forks
+                - master # all master dev uploads will include a UI rebuild in build-distros
+                - ui-staging # all ui-staging dev uploads will include a UI rebuild in build-distros
       - dev-upload-docker:
           <<: *dev-upload
           context: consul-ci


### PR DESCRIPTION
Previously, the [per commit dev docker images](https://hub.docker.com/r/hashicorpdev/consul) were embedding the result of `make dev` only which used the `agent/bindata_assetfs.go` file that was present in the repo on every commit. This is usually from the last release when this file was regenerated and committed. 

Now, every commit on any branch that is _not_ `master` or `ui-staging` will still be build using the `agent/bindata_assetfs.go` file as before but any commit on `master` or `ui-staging` will get a fresh UI rebuild and then a consul binary and resulting docker container is generated from that. 

This change is helpful for folks working on ecosystem projects that rely on the latest changes in `master` to pull in new Consul functionality but also want to try out new UI features that are merged in. 
