### PR TITLE
Add config entry for terminating gateways

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,8 @@ jobs:
       <<: *ENVIRONMENT
     steps:
       - checkout
+      - attach_workspace: # this normally runs as the first job and has nothing to attach; only used in master branch after rebuilding UI
+          at: .
       - run:
           command: make dev
 
@@ -490,6 +492,38 @@ jobs:
           paths:
             - dist
 
+  # rebuild UI for packaging
+  ember-build-prod:
+    docker:
+      - image: *EMBER_IMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: *YARN_CACHE_KEY
+      - run: cd ui-v2 && make
+
+      # saves the build to a workspace to be passed to a downstream job
+      - persist_to_workspace:
+          root: ui-v2
+          paths:
+            - dist
+
+  # build static-assets file
+  build-static-assets:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./pkg
+      - run: mv pkg/dist pkg/web_ui # 'make static-assets' looks for the 'pkg/web_ui' path
+      - run: make tools
+      - run: make static-assets
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./agent/bindata_assetfs.go
+
   # run ember frontend tests
   ember-test-oss:
     docker:
@@ -650,6 +684,29 @@ workflows:
             - check-vendor
       - build-amd64: *require-check-vendor
       - build-arm: *require-check-vendor
+      # every commit on ui-staging and master will have a rebuilt UI
+      - frontend-cache:
+          filters:
+            branches:
+              only:
+                - master
+                - ui-staging
+      - ember-build-prod:
+          requires:
+            - frontend-cache
+      - build-static-assets:
+          requires:
+            - ember-build-prod
+      - dev-build:
+          requires:
+            - build-static-assets
+      - dev-upload-s3:
+          requires:
+            - dev-build
+      - dev-upload-docker:
+          requires:
+            - dev-build
+          context: consul-ci
   test-integrations:
     jobs:
       - dev-build:
@@ -666,6 +723,8 @@ workflows:
             branches:
               ignore:
                 - /^pull\/.*$/ # only push dev builds from non forks
+                - master # all master dev uploads will include a UI rebuild in build-distros
+                - ui-staging # all ui-staging dev uploads will include a UI rebuild in build-distros
       - dev-upload-docker:
           <<: *dev-upload
           context: consul-ci

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -1,15 +1,12 @@
 package consul
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/serf/serf"
 )
 
 var serverACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
@@ -105,96 +102,33 @@ func (s *Server) updateACLAdvertisement() {
 	s.updateSerfTags("acls", string(structs.ACLModeEnabled))
 }
 
-type serversACLMode struct {
-	// leader is the address of the leader
-	leader string
-
-	// mode indicates the overall ACL mode of the servers
-	mode structs.ACLMode
-
-	// leaderMode is the ACL mode of the leader server
-	leaderMode structs.ACLMode
-
-	// indicates that at least one server was processed
-	found bool
-
-	//
-	server *Server
-}
-
-func (s *serversACLMode) init(leader string) {
-	s.leader = leader
-	s.mode = structs.ACLModeEnabled
-	s.leaderMode = structs.ACLModeUnknown
-	s.found = false
-}
-
-func (s *serversACLMode) update(srv *metadata.Server) bool {
-	fmt.Printf("Processing server acl mode for: %s - %s\n", srv.Name, srv.ACLs)
-	if srv.Status != serf.StatusAlive && srv.Status != serf.StatusFailed {
-		// they are left or something so regardless we treat these servers as meeting
-		// the version requirement
-		return true
-	}
-
-	// mark that we processed at least one server
-	s.found = true
-
-	if srvAddr := srv.Addr.String(); srvAddr == s.leader {
-		s.leaderMode = srv.ACLs
-	}
-
-	switch srv.ACLs {
-	case structs.ACLModeDisabled:
-		// anything disabled means we cant enable ACLs
-		s.mode = structs.ACLModeDisabled
-	case structs.ACLModeEnabled:
-		// do nothing
-	case structs.ACLModeLegacy:
-		// This covers legacy mode and older server versions that don't advertise ACL support
-		if s.mode != structs.ACLModeDisabled && s.mode != structs.ACLModeUnknown {
-			s.mode = structs.ACLModeLegacy
-		}
-	default:
-		if s.mode != structs.ACLModeDisabled {
-			s.mode = structs.ACLModeUnknown
-		}
-	}
-
-	return true
-}
-
 func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
 	if atomic.LoadInt32(&s.useNewACLs) != 0 {
 		// can't upgrade because we are already upgraded
 		return false
 	}
 
-	var state serversACLMode
 	if !s.InACLDatacenter() {
-		state.init("")
-		// use the router to check server information for non-local datacenters
-		s.router.CheckServers(s.config.ACLDatacenter, state.update)
-		if state.mode != structs.ACLModeEnabled || !state.found {
-			s.logger.Info("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "ACLDatacenter", s.config.ACLDatacenter, "mode", state.mode, "found", state.found)
+		foundServers, mode, _ := ServersGetACLMode(s, "", s.config.ACLDatacenter)
+		if mode != structs.ACLModeEnabled || !foundServers {
+			s.logger.Info("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "ACLDatacenter", s.config.ACLDatacenter, "mode", mode, "found", foundServers)
 			return false
 		}
 	}
 
-	state.init(string(s.raft.Leader()))
-	// this uses the serverLookup instead of the router as its for the local datacenter
-	s.serverLookup.CheckServers(state.update)
+	leaderAddr := string(s.raft.Leader())
+	foundServers, mode, leaderMode := ServersGetACLMode(s, leaderAddr, s.config.Datacenter)
 	if isLeader {
-		if state.mode == structs.ACLModeLegacy {
+		if mode == structs.ACLModeLegacy {
 			return true
 		}
 	} else {
-		if state.leaderMode == structs.ACLModeEnabled {
+		if leaderMode == structs.ACLModeEnabled {
 			return true
 		}
 	}
 
-	s.logger.Info("Cannot upgrade to new ACLs", "leaderMode", state.leaderMode, "mode", state.mode, "found", state.found, "leader", state.leader)
+	s.logger.Info("Cannot upgrade to new ACLs", "leaderMode", leaderMode, "mode", mode, "found", foundServers, "leader", leaderAddr)
 	return false
 }
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -444,7 +444,7 @@ func (s *Server) initializeLegacyACL() error {
 	// of state in the state store that will cause problems with older
 	// servers consuming snapshots, so we have to wait to create it.
 	var minVersion = version.Must(version.NewVersion("0.9.1"))
-	if ServersMeetMinimumVersion(s.LANMembers(), minVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minVersion); ok {
 		canBootstrap, _, err := state.CanBootstrapACLToken()
 		if err != nil {
 			return fmt.Errorf("failed looking for ACL bootstrap info: %v", err)
@@ -978,7 +978,7 @@ func (s *Server) getOrCreateAutopilotConfig() *autopilot.Config {
 		return config
 	}
 
-	if !ServersMeetMinimumVersion(s.LANMembers(), minAutopilotVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minAutopilotVersion); !ok {
 		logger.Warn("can't initialize until all servers are >= " + minAutopilotVersion.String())
 		return nil
 	}
@@ -1004,7 +1004,7 @@ func (s *Server) bootstrapConfigEntries(entries []structs.ConfigEntry) error {
 		return nil
 	}
 
-	if !ServersMeetMinimumVersion(s.LANMembers(), minCentralizedConfigVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minCentralizedConfigVersion); !ok {
 		s.loggers.
 			Named(logging.CentralConfig).
 			Warn("config: can't initialize until all servers >=" + minCentralizedConfigVersion.String())

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -193,7 +193,7 @@ func (s *Server) initializeCA() error {
 
 	// If this isn't the primary DC, run the secondary DC routine if the primary has already been upgraded to at least 1.6.0
 	if s.config.PrimaryDatacenter != s.config.Datacenter {
-		versionOk, foundPrimary := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)
+		versionOk, foundPrimary := ServersInDCMeetMinimumVersion(s, s.config.PrimaryDatacenter, minMultiDCConnectVersion)
 		if !foundPrimary {
 			connectLogger.Warn("primary datacenter is configured but unreachable - deferring initialization of the secondary datacenter CA")
 			// return nil because we will initialize the secondary CA later
@@ -738,7 +738,7 @@ func (s *Server) secondaryCARootWatch(ctx context.Context) error {
 			return nil
 		}
 		if !s.configuredSecondaryCA() {
-			versionOk, primaryFound := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)
+			versionOk, primaryFound := ServersInDCMeetMinimumVersion(s, s.config.PrimaryDatacenter, minMultiDCConnectVersion)
 			if !primaryFound {
 				return fmt.Errorf("Primary datacenter is unreachable - deferring secondary CA initialization")
 			}

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"fmt"
-
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
@@ -326,6 +325,7 @@ func (s *Store) validateProposedConfigEntryInGraph(
 	case structs.ServiceSplitter:
 	case structs.ServiceResolver:
 	case structs.IngressGateway:
+	case structs.TerminatingGateway:
 	default:
 		return fmt.Errorf("unhandled kind %q during validation of %q", kind, name)
 	}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -15,12 +15,13 @@ import (
 )
 
 const (
-	ServiceDefaults string = "service-defaults"
-	ProxyDefaults   string = "proxy-defaults"
-	ServiceRouter   string = "service-router"
-	ServiceSplitter string = "service-splitter"
-	ServiceResolver string = "service-resolver"
-	IngressGateway  string = "ingress-gateway"
+	ServiceDefaults    string = "service-defaults"
+	ProxyDefaults      string = "proxy-defaults"
+	ServiceRouter      string = "service-router"
+	ServiceSplitter    string = "service-splitter"
+	ServiceResolver    string = "service-resolver"
+	IngressGateway     string = "ingress-gateway"
+	TerminatingGateway string = "terminating-gateway"
 
 	ProxyConfigGlobal string = "global"
 
@@ -386,6 +387,15 @@ func ConfigEntryDecodeRulesForKind(kind string) (skipWhenPatching []string, tran
 			}, map[string]string{
 				"service_subset": "servicesubset",
 			}, nil
+	case TerminatingGateway:
+		return []string{
+				"services",
+				"Services",
+			}, map[string]string{
+				"ca_file":   "cafile",
+				"cert_file": "certfile",
+				"key_file":  "keyfile",
+			}, nil
 	default:
 		return nil, nil, fmt.Errorf("kind %q should be explicitly handled here", kind)
 	}
@@ -478,6 +488,8 @@ func MakeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &ServiceResolverConfigEntry{Name: name}, nil
 	case IngressGateway:
 		return &IngressGatewayConfigEntry{Name: name}, nil
+	case TerminatingGateway:
+		return &TerminatingGatewayConfigEntry{Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}
@@ -489,7 +501,7 @@ func ValidateConfigEntryKind(kind string) bool {
 		return true
 	case ServiceRouter, ServiceSplitter, ServiceResolver:
 		return true
-	case IngressGateway:
+	case IngressGateway, TerminatingGateway:
 		return true
 	default:
 		return false

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -122,3 +122,111 @@ func (e *IngressGatewayConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
 
 	return &e.EnterpriseMeta
 }
+
+// TerminatingGatewayConfigEntry manages the configuration for a terminating service
+// with the given name.
+type TerminatingGatewayConfigEntry struct {
+	Kind     string
+	Name     string
+	Services []LinkedService
+
+	EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
+	RaftIndex
+}
+
+// A LinkedService is a service represented by a terminating gateway
+type LinkedService struct {
+	// Name is the name of the service, as defined in Consul's catalog
+	Name string `json:",omitempty"`
+
+	// CAFile is the optional path to a CA certificate to use for TLS connections
+	// from the gateway to the linked service
+	CAFile string `json:",omitempty"`
+
+	// CertFile is the optional path to a client certificate to use for TLS connections
+	// from the gateway to the linked service
+	CertFile string `json:",omitempty"`
+
+	// KeyFile is the optional path to a private key to use for TLS connections
+	// from the gateway to the linked service
+	KeyFile string `json:",omitempty"`
+
+	EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
+}
+
+func (e *TerminatingGatewayConfigEntry) GetKind() string {
+	return TerminatingGateway
+}
+
+func (e *TerminatingGatewayConfigEntry) GetName() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.Name
+}
+
+func (e *TerminatingGatewayConfigEntry) Normalize() error {
+	if e == nil {
+		return fmt.Errorf("config entry is nil")
+	}
+
+	e.Kind = TerminatingGateway
+
+	for _, svc := range e.Services {
+		svc.EnterpriseMeta.Normalize()
+	}
+	e.EnterpriseMeta.Normalize()
+
+	return nil
+}
+
+func (e *TerminatingGatewayConfigEntry) Validate() error {
+	seen := make(map[string]map[string]bool)
+
+	for _, svc := range e.Services {
+		if svc.Name == "" {
+			return fmt.Errorf("Service name cannot be blank.")
+		}
+
+		ns := svc.NamespaceOrDefault()
+		if _, ok := seen[ns]; !ok {
+			seen[ns] = make(map[string]bool)
+		}
+		if ok := seen[ns][svc.Name]; ok {
+			return fmt.Errorf("Service %q was specified more than once within a namespace", svc.Name)
+		}
+		seen[ns][svc.Name] = true
+	}
+	return nil
+}
+
+func (e *TerminatingGatewayConfigEntry) CanRead(authz acl.Authorizer) bool {
+	var authzContext acl.AuthorizerContext
+	e.FillAuthzContext(&authzContext)
+
+	return authz.OperatorRead(&authzContext) == acl.Allow
+}
+
+func (e *TerminatingGatewayConfigEntry) CanWrite(authz acl.Authorizer) bool {
+	var authzContext acl.AuthorizerContext
+	e.FillAuthzContext(&authzContext)
+
+	return authz.OperatorWrite(&authzContext) == acl.Allow
+}
+
+func (e *TerminatingGatewayConfigEntry) GetRaftIndex() *RaftIndex {
+	if e == nil {
+		return &RaftIndex{}
+	}
+
+	return &e.RaftIndex
+}
+
+func (e *TerminatingGatewayConfigEntry) GetEnterpriseMeta() *EnterpriseMeta {
+	if e == nil {
+		return nil
+	}
+
+	return &e.EnterpriseMeta
+}

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -173,8 +173,8 @@ func (e *TerminatingGatewayConfigEntry) Normalize() error {
 
 	e.Kind = TerminatingGateway
 
-	for _, svc := range e.Services {
-		svc.EnterpriseMeta.Normalize()
+	for i := range e.Services {
+		e.Services[i].EnterpriseMeta.Normalize()
 	}
 	e.EnterpriseMeta.Normalize()
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -190,6 +190,9 @@ func (e *TerminatingGatewayConfigEntry) Validate() error {
 		}
 
 		ns := svc.NamespaceOrDefault()
+		if ns == WildcardSpecifier {
+			return fmt.Errorf("Wildcard namespace is not supported for terminating gateway services")
+		}
 		if _, ok := seen[ns]; !ok {
 			seen[ns] = make(map[string]bool)
 		}

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -151,3 +151,59 @@ func TestIngressConfigEntry_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestTerminatingConfigEntry_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		entry     TerminatingGatewayConfigEntry
+		expectErr string
+	}{
+		{
+			name: "service conflict",
+			entry: TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-gw-west",
+				Services: []LinkedService{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "foo",
+					},
+				},
+			},
+			expectErr: "Service \"foo\" was specified more than once",
+		},
+		{
+			name: "blank service name",
+			entry: TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-gw-west",
+				Services: []LinkedService{
+					{
+						Name: "",
+					},
+				},
+			},
+			expectErr: "Service name cannot be blank.",
+		},
+	}
+
+	for _, test := range cases {
+		// We explicitly copy the variable for the range statement so that can run
+		// tests in parallel.
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.entry.Validate()
+			if tc.expectErr != "" {
+				require.Error(t, err)
+				requireContainsLower(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -647,6 +647,63 @@ func TestDecodeConfigEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "terminating-gateway: kitchen sink",
+			snake: `
+				kind = "terminating-gateway"
+				name = "terminating-gw-west"
+				services = [
+					{
+						name = "payments",
+						ca_file = "/etc/payments/ca.pem",
+						cert_file = "/etc/payments/cert.pem",
+						key_file = "/etc/payments/tls.key",
+					},
+					{
+						name = "*",
+						ca_file = "/etc/all/ca.pem",
+						cert_file = "/etc/all/cert.pem",
+						key_file = "/etc/all/tls.key",
+					},
+				]
+			`,
+			camel: `
+				Kind = "terminating-gateway"
+				Name = "terminating-gw-west"
+				services = [
+					{
+						Name = "payments",
+						CAFile = "/etc/payments/ca.pem",
+						CertFile = "/etc/payments/cert.pem",
+						KeyFile = "/etc/payments/tls.key",
+					},
+					{
+						name = "*",
+						CAFile = "/etc/all/ca.pem",
+						CertFile = "/etc/all/cert.pem",
+						KeyFile = "/etc/all/tls.key",
+					},
+				]
+			`,
+			expect: &TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-gw-west",
+				Services: []LinkedService{
+					{
+						Name:     "payments",
+						CAFile:   "/etc/payments/ca.pem",
+						CertFile: "/etc/payments/cert.pem",
+						KeyFile:  "/etc/payments/tls.key",
+					},
+					{
+						Name:     "*",
+						CAFile:   "/etc/all/ca.pem",
+						CertFile: "/etc/all/cert.pem",
+						KeyFile:  "/etc/all/tls.key",
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -670,7 +670,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 			camel: `
 				Kind = "terminating-gateway"
 				Name = "terminating-gw-west"
-				services = [
+				Services = [
 					{
 						Name = "payments",
 						CAFile = "/etc/payments/ca.pem",
@@ -678,7 +678,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 						KeyFile = "/etc/payments/tls.key",
 					},
 					{
-						name = "*",
+						Name = "*",
 						CAFile = "/etc/all/ca.pem",
 						CertFile = "/etc/all/cert.pem",
 						KeyFile = "/etc/all/tls.key",

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -314,6 +314,7 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
+			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -345,6 +346,7 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
+				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,
@@ -381,6 +383,7 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
+			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -401,6 +404,7 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
+				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -12,12 +12,13 @@ import (
 )
 
 const (
-	ServiceDefaults string = "service-defaults"
-	ProxyDefaults   string = "proxy-defaults"
-	ServiceRouter   string = "service-router"
-	ServiceSplitter string = "service-splitter"
-	ServiceResolver string = "service-resolver"
-	IngressGateway  string = "ingress-gateway"
+	ServiceDefaults    string = "service-defaults"
+	ProxyDefaults      string = "proxy-defaults"
+	ServiceRouter      string = "service-router"
+	ServiceSplitter    string = "service-splitter"
+	ServiceResolver    string = "service-resolver"
+	IngressGateway     string = "ingress-gateway"
+	TerminatingGateway string = "terminating-gateway"
 
 	ProxyConfigGlobal string = "global"
 )
@@ -141,11 +142,6 @@ func (p *ProxyConfigEntry) GetModifyIndex() uint64 {
 	return p.ModifyIndex
 }
 
-type rawEntryListResponse struct {
-	kind    string
-	Entries []map[string]interface{}
-}
-
 func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 	switch kind {
 	case ServiceDefaults:
@@ -160,6 +156,8 @@ func makeConfigEntry(kind, name string) (ConfigEntry, error) {
 		return &ServiceResolverConfigEntry{Kind: kind, Name: name}, nil
 	case IngressGateway:
 		return &IngressGatewayConfigEntry{Kind: kind, Name: name}, nil
+	case TerminatingGateway:
+		return &TerminatingGatewayConfigEntry{Kind: kind, Name: name}, nil
 	default:
 		return nil, fmt.Errorf("invalid config entry kind: %s", kind)
 	}

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -75,7 +75,7 @@ func (i *IngressGatewayConfigEntry) GetModifyIndex() uint64 {
 	return i.ModifyIndex
 }
 
-// IngressGatewayConfigEntry manages the configuration for a terminating gateway
+// TerminatingGatewayConfigEntry manages the configuration for a terminating gateway
 // with the given name.
 type TerminatingGatewayConfigEntry struct {
 	// Kind of the config entry. This should be set to api.TerminatingGateway.

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -74,3 +74,67 @@ func (i *IngressGatewayConfigEntry) GetCreateIndex() uint64 {
 func (i *IngressGatewayConfigEntry) GetModifyIndex() uint64 {
 	return i.ModifyIndex
 }
+
+// IngressGatewayConfigEntry manages the configuration for a terminating gateway
+// with the given name.
+type TerminatingGatewayConfigEntry struct {
+	// Kind of the config entry. This should be set to api.TerminatingGateway.
+	Kind string
+
+	// Name is used to match the config entry with its associated terminating gateway
+	// service. This should match the name provided in the service definition.
+	Name string
+
+	// Services is a list of service names represented by the terminating gateway.
+	Services []LinkedService `json:",omitempty"`
+
+	// CreateIndex is the Raft index this entry was created at. This is a
+	// read-only field.
+	CreateIndex uint64
+
+	// ModifyIndex is used for the Check-And-Set operations and can also be fed
+	// back into the WaitIndex of the QueryOptions in order to perform blocking
+	// queries.
+	ModifyIndex uint64
+
+	// Namespace is the namespace the config entry is associated with
+	// Namespacing is a Consul Enterprise feature.
+	Namespace string `json:",omitempty"`
+}
+
+// A LinkedService is a service represented by a terminating gateway
+type LinkedService struct {
+	// The namespace the service is registered in
+	Namespace string `json:",omitempty"`
+
+	// Name is the name of the service, as defined in Consul's catalog
+	Name string `json:",omitempty"`
+
+	// CAFile is the optional path to a CA certificate to use for TLS connections
+	// from the gateway to the linked service
+	CAFile string `json:",omitempty"`
+
+	// CertFile is the optional path to a client certificate to use for TLS connections
+	// from the gateway to the linked service
+	CertFile string `json:",omitempty"`
+
+	// KeyFile is the optional path to a private key to use for TLS connections
+	// from the gateway to the linked service
+	KeyFile string `json:",omitempty"`
+}
+
+func (g *TerminatingGatewayConfigEntry) GetKind() string {
+	return g.Kind
+}
+
+func (g *TerminatingGatewayConfigEntry) GetName() string {
+	return g.Name
+}
+
+func (g *TerminatingGatewayConfigEntry) GetCreateIndex() uint64 {
+	return g.CreateIndex
+}
+
+func (g *TerminatingGatewayConfigEntry) GetModifyIndex() uint64 {
+	return g.ModifyIndex
+}

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -673,6 +673,50 @@ func TestDecodeConfigEntry(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "terminating-gateway",
+			body: `
+			{
+				"Kind": "terminating-gateway",
+				"Name": "terminating-west",
+				"Services": [
+					{
+						"Namespace": "foo",						
+						"Name": "web",
+						"CAFile": "/etc/ca.pem",
+						"CertFile": "/etc/cert.pem",
+						"KeyFile": "/etc/tls.key"
+					},
+					{
+						"Name": "api"
+					},
+					{
+						"Namespace": "bar",
+						"Name": "*"
+					}
+				]
+			}`,
+			expect: &TerminatingGatewayConfigEntry{
+				Kind: "terminating-gateway",
+				Name: "terminating-west",
+				Services: []LinkedService{
+					{
+						Namespace: "foo",
+						Name:      "web",
+						CAFile:    "/etc/ca.pem",
+						CertFile:  "/etc/cert.pem",
+						KeyFile:   "/etc/tls.key",
+					},
+					{
+						Name: "api",
+					},
+					{
+						Namespace: "bar",
+						Name:      "*",
+					},
+				},
+			},
+		},
 	} {
 		tc := tc
 

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -246,6 +246,121 @@ func TestParseConfigEntry(t *testing.T) {
 			},
 		},
 		{
+			name: "terminating-gateway",
+			snake: `
+				kind = "terminating-gateway"
+				name = "terminating-gw-west"
+				namespace = "default"
+				services = [
+				  {
+					name = "billing"
+					namespace = "biz"
+					ca_file = "/etc/ca.crt"
+					cert_file = "/etc/client.crt"
+					key_file = "/etc/tls.key"
+				  },
+				  {
+					name = "*"
+					namespace = "ops"
+				  }
+				]
+			`,
+			camel: `
+				Kind = "terminating-gateway"
+				Name = "terminating-gw-west"
+				Namespace = "default"
+				Services = [
+				  {
+					Name = "billing"
+					Namespace = "biz"
+					CAFile = "/etc/ca.crt"
+					CertFile = "/etc/client.crt"
+					KeyFile = "/etc/tls.key"
+				  },
+				  {
+					Name = "*"
+					Namespace = "ops"
+				  }
+				]
+			`,
+			snakeJSON: `
+			{
+				"kind": "terminating-gateway",
+				"name": "terminating-gw-west",
+				"namespace": "default",
+				"services": [
+				  {
+					"name": "billing",
+					"namespace": "biz",
+					"ca_file": "/etc/ca.crt",
+					"cert_file": "/etc/client.crt",
+					"key_file": "/etc/tls.key"
+				  },
+				  {
+					"name": "*",
+					"namespace": "ops"
+				  }
+				]
+			}
+			`,
+			camelJSON: `
+			{
+				"Kind": "terminating-gateway",
+				"Name": "terminating-gw-west",
+				"Namespace": "default",
+				"Services": [
+				  {
+					"Name": "billing",
+					"Namespace": "biz",
+					"CAFile": "/etc/ca.crt",
+					"CertFile": "/etc/client.crt",
+					"KeyFile": "/etc/tls.key"
+				  },
+				  {
+					"Name": "*",
+					"Namespace": "ops"
+				  }
+				]
+			}
+			`,
+			expect: &api.TerminatingGatewayConfigEntry{
+				Kind:      "terminating-gateway",
+				Name:      "terminating-gw-west",
+				Namespace: "default",
+				Services: []api.LinkedService{
+					{
+						Name:      "billing",
+						Namespace: "biz",
+						CAFile:    "/etc/ca.crt",
+						CertFile:  "/etc/client.crt",
+						KeyFile:   "/etc/tls.key",
+					},
+					{
+						Name:      "*",
+						Namespace: "ops",
+					},
+				},
+			},
+			expectJSON: &api.TerminatingGatewayConfigEntry{
+				Kind:      "terminating-gateway",
+				Name:      "terminating-gw-west",
+				Namespace: "default",
+				Services: []api.LinkedService{
+					{
+						Name:      "billing",
+						Namespace: "biz",
+						CAFile:    "/etc/ca.crt",
+						CertFile:  "/etc/client.crt",
+						KeyFile:   "/etc/tls.key",
+					},
+					{
+						Name:      "*",
+						Namespace: "ops",
+					},
+				},
+			},
+		},
+		{
 			name: "service-defaults",
 			snake: `
 				kind = "service-defaults"

--- a/sdk/freeport/ephemeral_darwin.go
+++ b/sdk/freeport/ephemeral_darwin.go
@@ -1,0 +1,37 @@
+//+build darwin
+
+package freeport
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+const ephemeralPortRangeSysctlFirst = "net.inet.ip.portrange.first"
+const ephemeralPortRangeSysctlLast = "net.inet.ip.portrange.last"
+
+var ephemeralPortRangePatt = regexp.MustCompile(`^\s*(\d+)\s+(\d+)\s*$`)
+
+func getEphemeralPortRange() (int, int, error) {
+	cmd := exec.Command("/usr/sbin/sysctl", "-n", ephemeralPortRangeSysctlFirst, ephemeralPortRangeSysctlLast)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	val := string(out)
+
+	m := ephemeralPortRangePatt.FindStringSubmatch(val)
+	if m != nil {
+		min, err1 := strconv.Atoi(m[1])
+		max, err2 := strconv.Atoi(m[2])
+
+		if err1 == nil && err2 == nil {
+			return min, max, nil
+		}
+	}
+
+	return 0, 0, fmt.Errorf("unexpected sysctl value %q for keys %q, %q", val, ephemeralPortRangeSysctlFirst, ephemeralPortRangeSysctlLast)
+}

--- a/sdk/freeport/ephemeral_darwin_test.go
+++ b/sdk/freeport/ephemeral_darwin_test.go
@@ -1,0 +1,18 @@
+//+build darwin
+
+package freeport
+
+import (
+	"testing"
+)
+
+func TestGetEphemeralPortRange(t *testing.T) {
+	min, max, err := getEphemeralPortRange()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if min <= 0 || max <= 0 || min > max {
+		t.Fatalf("unexpected values: min=%d, max=%d", min, max)
+	}
+	t.Logf("min=%d, max=%d", min, max)
+}

--- a/sdk/freeport/ephemeral_fallback.go
+++ b/sdk/freeport/ephemeral_fallback.go
@@ -1,4 +1,4 @@
-//+build !linux
+//+build !linux,!darwin
 
 package freeport
 

--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -35,8 +35,8 @@ export default RepositoryService.extend({
       return service;
     });
   },
-  findInstanceBySlug: function(id, node, slug, dc, configuration) {
-    return this.findBySlug(slug, dc, configuration).then(function(item) {
+  findInstanceBySlug: function(id, node, slug, dc, nspace, configuration) {
+    return this.findBySlug(slug, dc, nspace, configuration).then(function(item) {
       // TODO: Move this to the Serializer
       // Loop through all the service instances and pick out the one
       // that has the same service id AND node name

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -13,6 +13,34 @@ const id = 'token-name';
 const now = new Date().getTime();
 const undefinedNspace = 'default';
 [undefinedNspace, 'team-1', undefined].forEach(nspace => {
+  test(`findInstanceBySlug calls findBySlug with the correct arguments when nspace is ${nspace}`, function(assert) {
+    assert.expect(4);
+    const id = 'id';
+    const slug = 'slug';
+    const node = 'node-name';
+
+    const datacenter = 'dc-1';
+    const conf = {
+      cursor: 1,
+    };
+    const service = this.subject();
+    service.findBySlug = function(slug, dc, nspace, configuration) {
+      assert.equal(
+        arguments.length,
+        4,
+        'Expected to be called with the correct number of arguments'
+      );
+      assert.equal(dc, datacenter);
+      assert.deepEqual(configuration, conf);
+      return Promise.resolve({ Nodes: [] });
+    };
+    // This will throw an error as we don't resolve any services that match what was requested
+    // so a 404 is the correct error response
+    return service.findInstanceBySlug(id, slug, node, datacenter, nspace, conf).catch(function(e) {
+      assert.equal(e.errors[0].status, '404');
+    });
+  });
+
   test(`findByDatacenter returns the correct data for list endpoint when nspace is ${nspace}`, function(assert) {
     get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
       return now;

--- a/website/source/api/acl/policies.html.md
+++ b/website/source/api/acl/policies.html.md
@@ -145,6 +145,59 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/policy/e359bd81-baca-903e-7e64-1ccd9f
 }
 ```
 
+## Read a Policy by Name
+
+This endpoint reads an ACL policy with the given ID.
+
+| Method | Path                         | Produces                   |
+| ------ | ---------------------------- | -------------------------- |
+| `GET`  | `/acl/policy/name/:name`     | `application/json`         |
+
+The table below shows this endpoint's support for
+[blocking queries](/api/features/blocking.html),
+[consistency modes](/api/features/consistency.html),
+[agent caching](/api/features/caching.html), and
+[required ACLs](/api/index.html#authentication).
+
+| Blocking Queries | Consistency Modes | Agent Caching | ACL Required |
+| ---------------- | ----------------- | ------------- | ------------ |
+| `YES`            | `all`             | `none`        | `acl:read`   |
+
+### Parameters
+
+- `name` `(string: <required>)` - Specifies the name of the ACL policy to
+  read. This is required and is specified as part of the URL path.
+
+- `ns` `(string: "")` - **(Enterprise Only)** Specifies the namespace to lookup
+  the policy. This value can be specified as the `ns` URL query
+  parameter or the `X-Consul-Namespace` header. If not provided by either,
+  the namespace will be inherited from the request's ACL token or will default
+  to the `default` namespace. Added in Consul 1.7.0.
+
+
+### Sample Request
+
+```sh
+$ curl -X GET http://127.0.0.1:8500/v1/acl/policy/name/node-read
+```
+
+### Sample Response
+
+```json
+{
+    "ID": "e359bd81-baca-903e-7e64-1ccd9fdc78f5",
+    "Name": "node-read",
+    "Description": "Grants read access to all node information",
+    "Rules": "node_prefix \"\" { policy = \"read\"}",
+    "Datacenters": [
+        "dc1"
+    ],
+    "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
+    "CreateIndex": 14,
+    "ModifyIndex": 14
+}
+```
+
 ## Update a Policy
 
 This endpoint updates an existing ACL policy.


### PR DESCRIPTION
This config entry will be used to configure terminating gateways.

It accepts the name of the gateway and a list of services the gateway will represent.

For each service users will be able to specify: its name, namespace, and additional options for TLS origination.