### PR TITLE
Add link to Learn from downloads page

### DIFF
--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -29,7 +29,7 @@ description: |-
         You can also <a href="https://releases.hashicorp.com/consul/" target="_blank" rel="nofollow noopener noreferrer">download older versions of Consul</a> from the releases service.
       </p>
       <p>
-      Check out the <a href="https://github.com/hashicorp/consul/blob/v<%= latest_version %>/CHANGELOG.md">v<%= latest_version %> CHANGELOG</a> for information on the latest release.
+      Check out the <a href="https://github.com/hashicorp/consul/blob/v<%= latest_version %>/CHANGELOG.md">v<%= latest_version %> CHANGELOG</a> for information on the latest release. Continue learning with our step by step guides at <a href="https://learn.hashicorp.com/consul">HashiCorp Learn</a>.
       </p>
     </div>
   </div>

--- a/website/source/downloads_tools.html.erb
+++ b/website/source/downloads_tools.html.erb
@@ -28,7 +28,7 @@ description: |-
     <a href="https://github.com/hashicorp/consul-replicate">Consul Replicate</a> - Consul cross-DC KV replication daemon.
   </li>
   <li>
-    <a href="https://github.com/hashicorp/consul-template">Consul Template</a> - Generic template rendering and notifications with Consul
+    <a href="https://github.com/hashicorp/consul-template">Consul Template</a> - Generic template rendering and notifications with Consul. A step by step tutorial is at <a href="https://learn.hashicorp.com/consul/developer-configuration/consul-template">HashiCorp Learn</a>.
   </li>
 </ul>
 


### PR DESCRIPTION
Adds a link to Learn from the downloads page as well as a link to the Consul Template guide.

Running a step-by-step tutorial is the next step for many practitioners after installing the Consul binary. This will help them continue on their journey to proficiency with Consul.