### PR TITLE
[WIP] Try fixing integration tests being unstable

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -354,7 +354,7 @@ ui-docker: ui-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui
 
 test-envoy-integ: $(ENVOY_INTEG_DEPS)
-	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
+	$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
 
 test-vault-ca-provider:
 ifeq ("$(CIRCLECI)","true")

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -240,8 +240,8 @@ function assert_upstream_has_endpoints_in_status_once {
   then
     return 0
   else
-    echo "[ERROR] assert_upstream_has_endpoints_in_status_once $HOSTPORT $CLUSTER_NAME $HEALTH_STATUS $EXPECT_COUNT" > &2
-    cat "$output" > &2
+    echo "[ERROR] assert_upstream_has_endpoints_in_status_once $HOSTPORT $CLUSTER_NAME $HEALTH_STATUS $EXPECT_COUNT"
+    cat "$output"
     return 1
   fi
   rm $output

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -51,6 +51,10 @@ function retry_long {
   retry 30 1 "$@"
 }
 
+function retry_envoy {
+  retry 30 2 "$@"
+}
+
 function echored {
   tput setaf 1
   tput bold
@@ -212,7 +216,7 @@ function get_upstream_endpoint_in_status_count {
   local HOSTPORT=$1
   local CLUSTER_NAME=$2
   local HEALTH_STATUS=$3
-  run retry_default curl -s -f "http://${HOSTPORT}/clusters?format=json"
+  run retry_envoy curl -f "http://${HOSTPORT}/clusters?format=json"
   [ "$status" -eq 0 ]
   if [ "$4" != "" ]
   then

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -48,7 +48,7 @@ function cleanup {
     capture_logs
   fi
 
-  docker-compose down -v --remove-orphans
+  docker-compose down -v --remove-orphans --timeout 30
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
This might fix this kind of errors:

Removing network envoy_default
Removing volume envoy_workdir
⨯ FAIL
ERR: command exited with status 1
     command:   exit 1
     line:      1
     function:  main
     called at: /home/circleci/project/test/integration/connect/envoy/run-tests.sh:0
make: *** [GNUmakefile:357: test-envoy-integ] Error 1

Example: https://circleci.com/gh/hashicorp/consul/148321