### PR TITLE
ui: Ensure blocking query configuration is passed through to findInstanceBySlug

### DIFF
--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -35,8 +35,8 @@ export default RepositoryService.extend({
       return service;
     });
   },
-  findInstanceBySlug: function(id, node, slug, dc, configuration) {
-    return this.findBySlug(slug, dc, configuration).then(function(item) {
+  findInstanceBySlug: function(id, node, slug, dc, nspace, configuration) {
+    return this.findBySlug(slug, dc, nspace, configuration).then(function(item) {
       // TODO: Move this to the Serializer
       // Loop through all the service instances and pick out the one
       // that has the same service id AND node name

--- a/ui-v2/tests/integration/services/repository/service-test.js
+++ b/ui-v2/tests/integration/services/repository/service-test.js
@@ -13,6 +13,34 @@ const id = 'token-name';
 const now = new Date().getTime();
 const undefinedNspace = 'default';
 [undefinedNspace, 'team-1', undefined].forEach(nspace => {
+  test(`findInstanceBySlug calls findBySlug with the correct arguments when nspace is ${nspace}`, function(assert) {
+    assert.expect(4);
+    const id = 'id';
+    const slug = 'slug';
+    const node = 'node-name';
+
+    const datacenter = 'dc-1';
+    const conf = {
+      cursor: 1,
+    };
+    const service = this.subject();
+    service.findBySlug = function(slug, dc, nspace, configuration) {
+      assert.equal(
+        arguments.length,
+        4,
+        'Expected to be called with the correct number of arguments'
+      );
+      assert.equal(dc, datacenter);
+      assert.deepEqual(configuration, conf);
+      return Promise.resolve({ Nodes: [] });
+    };
+    // This will throw an error as we don't resolve any services that match what was requested
+    // so a 404 is the correct error response
+    return service.findInstanceBySlug(id, slug, node, datacenter, nspace, conf).catch(function(e) {
+      assert.equal(e.errors[0].status, '404');
+    });
+  });
+
   test(`findByDatacenter returns the correct data for list endpoint when nspace is ${nspace}`, function(assert) {
     get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
       return now;


### PR DESCRIPTION
Due to the addition of namespace support, this arguments passed to this
method have been increased. Whilst the nspace support continues to work
here, the configuration for blocking queries is never passed through.
This results in a 2 second poll on the service instance detail page, rather than a blocking query.

This commit fixes that.

I added a test similar to https://github.com/hashicorp/consul/pull/7378 