### PR TITLE
Fixed bat warning

### DIFF
--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
@@ -71,6 +71,6 @@ load helpers
   assert_expected_fortio_name s2-secondary
 }
 
-@test "s1 upstream made 1 connection" {
+@test "s1 upstream made 1 connection to s2" {
   assert_envoy_metric_at_least 127.0.0.1:19000 "cluster.s2.default.primary.*cx_total" 1
 }


### PR DESCRIPTION
This fixes this bat warning:

  duplicate test name(s) in /workdir/primary/bats/verify.bats: test_s1_upstream_made_1_connection

Test was already defined at line 42, rename it to avoid test name duplication