### PR TITLE
Backport of various version/requirements checking fixes

### DIFF
--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -433,3 +433,10 @@ func (c *Client) ReloadConfig(config *Config) error {
 	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))
 	return nil
 }
+
+// updateSerfTags is a helper function to propagate a key, value tag to
+// all the necessary Serf instances managed by the Client.
+func (c *Client) updateSerfTags(key, value string) {
+	// Update the LAN serf
+	lib.UpdateSerfTag(c.serf, key, value)
+}

--- a/agent/consul/enterprise_server_oss.go
+++ b/agent/consul/enterprise_server_oss.go
@@ -41,3 +41,9 @@ func (s *Server) handleEnterpriseLeave() {
 func (s *Server) enterpriseStats() map[string]map[string]string {
 	return nil
 }
+
+// updateEnterpriseSerfTags in enterprise will update any instances of Serf with the tag that
+// are not the normal LAN or WAN serf instances (network segments and network areas)
+func (_ *Server) updateEnterpriseSerfTags(_, _ string) {
+	// do nothing
+}

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -418,7 +418,7 @@ func (s *Server) initializeLegacyACL() error {
 	// of state in the state store that will cause problems with older
 	// servers consuming snapshots, so we have to wait to create it.
 	var minVersion = version.Must(version.NewVersion("0.9.1"))
-	if ServersMeetMinimumVersion(s.LANMembers(), minVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minVersion); ok {
 		canBootstrap, _, err := state.CanBootstrapACLToken()
 		if err != nil {
 			return fmt.Errorf("failed looking for ACL bootstrap info: %v", err)
@@ -628,6 +628,7 @@ func (s *Server) initializeACLs(upgrade bool) error {
 			if s.IsACLReplicationEnabled() {
 				s.startLegacyACLReplication()
 			}
+			return nil
 		}
 
 		if upgrade {
@@ -904,7 +905,7 @@ func (s *Server) getOrCreateAutopilotConfig() *autopilot.Config {
 		return config
 	}
 
-	if !ServersMeetMinimumVersion(s.LANMembers(), minAutopilotVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minAutopilotVersion); !ok {
 		s.logger.Printf("[WARN] autopilot: can't initialize until all servers are >= %s", minAutopilotVersion.String())
 		return nil
 	}
@@ -930,7 +931,7 @@ func (s *Server) bootstrapConfigEntries(entries []structs.ConfigEntry) error {
 		return nil
 	}
 
-	if !ServersMeetMinimumVersion(s.LANMembers(), minCentralizedConfigVersion) {
+	if ok, _ := ServersInDCMeetMinimumVersion(s, s.config.Datacenter, minCentralizedConfigVersion); !ok {
 		s.logger.Printf("[WARN] centralized config: can't initialize until all servers >= %s", minCentralizedConfigVersion.String())
 		return nil
 	}

--- a/agent/consul/leader_connect.go
+++ b/agent/consul/leader_connect.go
@@ -160,7 +160,7 @@ func (s *Server) initializeCA() error {
 
 	// If this isn't the primary DC, run the secondary DC routine if the primary has already been upgraded to at least 1.6.0
 	if s.config.PrimaryDatacenter != s.config.Datacenter {
-		versionOk, foundPrimary := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)
+		versionOk, foundPrimary := ServersInDCMeetMinimumVersion(s, s.config.PrimaryDatacenter, minMultiDCConnectVersion)
 		if !foundPrimary {
 			s.logger.Printf("[WARN] connect: primary datacenter is configured but unreachable - deferring initialization of the secondary datacenter CA")
 			// return nil because we will initialize the secondary CA later
@@ -603,7 +603,7 @@ func (s *Server) secondaryCARootWatch(stopCh <-chan struct{}) {
 			return nil
 		}
 		if !s.configuredSecondaryCA() {
-			versionOk, primaryFound := ServersInDCMeetMinimumVersion(s.WANMembers(), s.config.PrimaryDatacenter, minMultiDCConnectVersion)
+			versionOk, primaryFound := ServersInDCMeetMinimumVersion(s, s.config.PrimaryDatacenter, minMultiDCConnectVersion)
 			if !primaryFound {
 				return fmt.Errorf("Primary datacenter is unreachable - deferring secondary CA initialization")
 			}

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1294,6 +1294,17 @@ func (s *Server) intentionReplicationEnabled() bool {
 	return s.config.ConnectEnabled && s.config.Datacenter != s.config.PrimaryDatacenter
 }
 
+func (s *Server) updateSerfTags(key, value string) {
+	// Update the LAN serf
+	lib.UpdateSerfTag(s.serfLAN, key, value)
+
+	if s.serfWAN != nil {
+		lib.UpdateSerfTag(s.serfWAN, key, value)
+	}
+
+	s.updateEnterpriseSerfTags(key, value)
+}
+
 // peersInfoContent is used to help operators understand what happened to the
 // peers.json file. This is written to a file called peers.info in the same
 // location.

--- a/agent/consul/server_lookup.go
+++ b/agent/consul/server_lookup.go
@@ -63,3 +63,14 @@ func (sl *ServerLookup) Servers() []*metadata.Server {
 	}
 	return ret
 }
+
+func (sl *ServerLookup) CheckServers(fn func(srv *metadata.Server) bool) {
+	sl.lock.RLock()
+	defer sl.lock.RUnlock()
+
+	for _, srv := range sl.addressToServer {
+		if !fn(srv) {
+			return
+		}
+	}
+}

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -273,89 +273,172 @@ func runtimeStats() map[string]string {
 	}
 }
 
-// ServersMeetMinimumVersion returns whether the given alive servers are at least on the
-// given Consul version
-func ServersMeetMinimumVersion(members []serf.Member, minVersion *version.Version) bool {
-	return ServersMeetRequirements(members, func(srv *metadata.Server) bool {
-		return srv.Status != serf.StatusAlive || !srv.Build.LessThan(minVersion)
-	})
+// checkServersProvider exists so that we can unit tests the requirements checking functions
+// without having to spin up a whole agent/server.
+type checkServersProvider interface {
+	CheckServers(datacenter string, fn func(*metadata.Server) bool)
 }
 
-// ServersMeetMinimumVersion returns whether the given alive servers from a particular
-// datacenter are at least on the given Consul version. This requires at least 1 alive server in the DC
-func ServersInDCMeetMinimumVersion(members []serf.Member, datacenter string, minVersion *version.Version) (bool, bool) {
-	found := false
-	ok := ServersMeetRequirements(members, func(srv *metadata.Server) bool {
-		if srv.Status != serf.StatusAlive || srv.Datacenter != datacenter {
-			return true
+// serverRequirementsFn should inspect the given metadata.Server struct
+// and return two booleans. The first indicates whether the given requirements
+// are met. The second indicates whether this server should be considered filtered.
+//
+// The reason for the two booleans is so that a requirement function could "filter"
+// out the left server members if we only want to consider things which are still
+// around or likely to come back (failed state).
+type serverRequirementFn func(*metadata.Server) (ok bool, filtered bool)
+
+type serversMeetRequirementsState struct {
+	// meetsRequirements is the callback to actual check for some specific requirement
+	meetsRequirements serverRequirementFn
+
+	// ok indicates whether all unfiltered servers meet the desired requirements
+	ok bool
+
+	// found is a boolean indicating that the meetsRequirement function accepted at
+	// least one unfiltered server.
+	found bool
+}
+
+func (s *serversMeetRequirementsState) update(srv *metadata.Server) bool {
+	ok, filtered := s.meetsRequirements(srv)
+
+	if filtered {
+		// keep going but don't update any of the internal state as this server
+		// was filtered by the requirements function
+		return true
+	}
+
+	// mark that at least one server processed was not filtered
+	s.found = true
+
+	if !ok {
+		// mark that at least one server does not meet the requirements
+		s.ok = false
+
+		// prevent continuing server evaluation
+		return false
+	}
+
+	// this should already be set but this will prevent accidentally reusing
+	// the state object from causing false-negatives.
+	s.ok = true
+
+	// continue evaluating servers
+	return true
+}
+
+// ServersInDCMeetRequirements returns whether the given server members meet the requirements as defined by the
+// callback function and whether at least one server remains unfiltered by the requirements function.
+func ServersInDCMeetRequirements(provider checkServersProvider, datacenter string, meetsRequirements serverRequirementFn) (ok bool, found bool) {
+	state := serversMeetRequirementsState{meetsRequirements: meetsRequirements, found: false, ok: true}
+
+	provider.CheckServers(datacenter, state.update)
+
+	return state.ok, state.found
+}
+
+// ServersInDCMeetMinimumVersion returns whether the given alive servers from a particular
+// datacenter are at least on the given Consul version. This also returns whether any
+// alive or failed servers are known in that datacenter (ignoring left and leaving ones)
+func ServersInDCMeetMinimumVersion(provider checkServersProvider, datacenter string, minVersion *version.Version) (ok bool, found bool) {
+	return ServersInDCMeetRequirements(provider, datacenter, func(srv *metadata.Server) (bool, bool) {
+		if srv.Status != serf.StatusAlive && srv.Status != serf.StatusFailed {
+			// filter out the left servers as those should not be factored into our requirements
+			return true, true
 		}
 
-		found = true
-		return !srv.Build.LessThan(minVersion)
+		return !srv.Build.LessThan(minVersion), false
 	})
-
-	return ok, found
 }
 
-// ServersMeetRequirements returns whether the given server members meet the requirements as defined by the
-// callback function
-func ServersMeetRequirements(members []serf.Member, meetsRequirements func(*metadata.Server) bool) bool {
-	for _, member := range members {
-		if valid, parts := metadata.IsConsulServer(member); valid {
-			if !meetsRequirements(parts) {
-				return false
-			}
+// CheckServers implements the checkServersProvider interface for the Server
+func (s *Server) CheckServers(datacenter string, fn func(*metadata.Server) bool) {
+	if datacenter == s.config.Datacenter {
+		// use the ServerLookup type for the local DC
+		s.serverLookup.CheckServers(fn)
+	} else {
+		// use the router for all non-local DCs
+		s.router.CheckServers(datacenter, fn)
+	}
+}
+
+// CheckServers implements the checkServersProvider interface for the Client
+func (c *Client) CheckServers(datacenter string, fn func(*metadata.Server) bool) {
+	if datacenter != c.config.Datacenter {
+		return
+	}
+
+	c.routers.CheckServers(fn)
+}
+
+type serversACLMode struct {
+	// leader is the address of the leader
+	leader string
+
+	// mode indicates the overall ACL mode of the servers
+	mode structs.ACLMode
+
+	// leaderMode is the ACL mode of the leader server
+	leaderMode structs.ACLMode
+
+	// indicates that at least one server was processed
+	found bool
+}
+
+func (s *serversACLMode) init(leader string) {
+	s.leader = leader
+	s.mode = structs.ACLModeEnabled
+	s.leaderMode = structs.ACLModeUnknown
+	s.found = false
+}
+
+func (s *serversACLMode) update(srv *metadata.Server) bool {
+	if srv.Status != serf.StatusAlive && srv.Status != serf.StatusFailed {
+		// they are left or something so regardless we treat these servers as meeting
+		// the version requirement
+		return true
+	}
+
+	// mark that we processed at least one server
+	s.found = true
+
+	if srvAddr := srv.Addr.String(); srvAddr == s.leader {
+		s.leaderMode = srv.ACLs
+	}
+
+	switch srv.ACLs {
+	case structs.ACLModeDisabled:
+		// anything disabled means we cant enable ACLs
+		s.mode = structs.ACLModeDisabled
+	case structs.ACLModeEnabled:
+		// do nothing
+	case structs.ACLModeLegacy:
+		// This covers legacy mode and older server versions that don't advertise ACL support
+		if s.mode != structs.ACLModeDisabled && s.mode != structs.ACLModeUnknown {
+			s.mode = structs.ACLModeLegacy
+		}
+	default:
+		if s.mode != structs.ACLModeDisabled {
+			s.mode = structs.ACLModeUnknown
 		}
 	}
 
 	return true
 }
 
-func ServersGetACLMode(members []serf.Member, leader string, datacenter string) (numServers int, mode structs.ACLMode, leaderMode structs.ACLMode) {
-	numServers = 0
-	mode = structs.ACLModeEnabled
-	leaderMode = structs.ACLModeUnknown
-	for _, member := range members {
-		if valid, parts := metadata.IsConsulServer(member); valid {
+// ServersGetACLMode checks all the servers in a particular datacenter and determines
+// what the minimum ACL mode amongst them is and what the leaders ACL mode is.
+// The "found" return value indicates whether there were any servers considered in
+// this datacenter. If that is false then the other mode return values are meaningless
+// as they will be ACLModeEnabled and ACLModeUnkown respectively.
+func ServersGetACLMode(provider checkServersProvider, leaderAddr string, datacenter string) (found bool, mode structs.ACLMode, leaderMode structs.ACLMode) {
+	var state serversACLMode
+	state.init(leaderAddr)
 
-			if datacenter != "" && parts.Datacenter != datacenter {
-				continue
-			}
+	provider.CheckServers(datacenter, state.update)
 
-			if parts.Status != serf.StatusAlive && parts.Status != serf.StatusFailed {
-				// ignore any server that isn't alive or failed. We are considering failed
-				// because in this state there is a reasonable expectation that they could
-				// become stable again. Also autopilot should remove dead servers if they
-				// are truly gone.
-				continue
-			}
-
-			numServers += 1
-
-			if memberAddr := (&net.TCPAddr{IP: member.Addr, Port: parts.Port}).String(); memberAddr == leader {
-				leaderMode = parts.ACLs
-			}
-
-			switch parts.ACLs {
-			case structs.ACLModeDisabled:
-				// anything disabled means we cant enable ACLs
-				mode = structs.ACLModeDisabled
-			case structs.ACLModeEnabled:
-				// do nothing
-			case structs.ACLModeLegacy:
-				// This covers legacy mode and older server versions that don't advertise ACL support
-				if mode != structs.ACLModeDisabled && mode != structs.ACLModeUnknown {
-					mode = structs.ACLModeLegacy
-				}
-			default:
-				if mode != structs.ACLModeDisabled {
-					mode = structs.ACLModeUnknown
-				}
-			}
-		}
-	}
-
-	return
+	return state.found, state.mode, state.leaderMode
 }
 
 // InterpolateHIL processes the string as if it were HIL and interpolates only

--- a/agent/consul/util_test.go
+++ b/agent/consul/util_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/serf/serf"
@@ -336,108 +337,52 @@ func TestGetPublicIPv6(t *testing.T) {
 	}
 }
 
-func TestServersMeetMinimumVersion(t *testing.T) {
-	t.Parallel()
-	makeMember := func(version string) serf.Member {
-		return serf.Member{
-			Name: "foo",
-			Addr: net.IP([]byte{127, 0, 0, 1}),
-			Tags: map[string]string{
-				"role":          "consul",
-				"id":            "asdf",
-				"dc":            "east-aws",
-				"port":          "10000",
-				"build":         version,
-				"wan_join_port": "1234",
-				"vsn":           "1",
-				"expect":        "3",
-				"raft_vsn":      "3",
-			},
-			Status: serf.StatusAlive,
+type testServersProvider []metadata.Server
+
+func (p testServersProvider) CheckServers(datacenter string, fn func(*metadata.Server) bool) {
+	for _, srv := range p {
+		// filter these out - now I don't have to modify the tests. Originally the dc filtering
+		// happened in the ServersInDCMeetMinimumVersion, now we get a list of servers to check
+		// through the routing infrastructure or server lookup which will map a datacenter to a
+		// list of metadata.Server structs that are all in that datacenter.
+		if srv.Datacenter != datacenter {
+			continue
 		}
-	}
 
-	cases := []struct {
-		members  []serf.Member
-		ver      *version.Version
-		expected bool
-	}{
-		// One server, meets reqs
-		{
-			members: []serf.Member{
-				makeMember("0.7.5"),
-			},
-			ver:      version.Must(version.NewVersion("0.7.5")),
-			expected: true,
-		},
-		// One server, doesn't meet reqs
-		{
-			members: []serf.Member{
-				makeMember("0.7.5"),
-			},
-			ver:      version.Must(version.NewVersion("0.8.0")),
-			expected: false,
-		},
-		// Multiple servers, meets req version
-		{
-			members: []serf.Member{
-				makeMember("0.7.5"),
-				makeMember("0.8.0"),
-			},
-			ver:      version.Must(version.NewVersion("0.7.5")),
-			expected: true,
-		},
-		// Multiple servers, doesn't meet req version
-		{
-			members: []serf.Member{
-				makeMember("0.7.5"),
-				makeMember("0.8.0"),
-			},
-			ver:      version.Must(version.NewVersion("0.8.0")),
-			expected: false,
-		},
-	}
-
-	for _, tc := range cases {
-		result := ServersMeetMinimumVersion(tc.members, tc.ver)
-		if result != tc.expected {
-			t.Fatalf("bad: %v, %v, %v", result, tc.ver.String(), tc)
+		if !fn(&srv) {
+			return
 		}
 	}
 }
 
 func TestServersInDCMeetMinimumVersion(t *testing.T) {
 	t.Parallel()
-	makeMember := func(version string, datacenter string) serf.Member {
-		return serf.Member{
-			Name: "foo",
-			Addr: net.IP([]byte{127, 0, 0, 1}),
-			Tags: map[string]string{
-				"role":          "consul",
-				"id":            "asdf",
-				"dc":            datacenter,
-				"port":          "10000",
-				"build":         version,
-				"wan_join_port": "1234",
-				"vsn":           "1",
-				"expect":        "3",
-				"raft_vsn":      "3",
-			},
-			Status: serf.StatusAlive,
+	makeServer := func(versionStr string, datacenter string) metadata.Server {
+		return metadata.Server{
+			Name:        "foo",
+			ID:          "asdf",
+			Port:        10000,
+			Expect:      3,
+			RaftVersion: 3,
+			Status:      serf.StatusAlive,
+			WanJoinPort: 1234,
+			Version:     1,
+			Build:       *version.Must(version.NewVersion(versionStr)),
+			Datacenter:  datacenter,
 		}
 	}
 
 	cases := []struct {
-		members       []serf.Member
+		servers       testServersProvider
 		ver           *version.Version
 		expected      bool
 		expectedFound bool
 	}{
 		// One server, meets reqs
 		{
-			members: []serf.Member{
-				makeMember("0.7.5", "primary"),
-				makeMember("0.7.3", "secondary"),
+			servers: testServersProvider{
+				makeServer("0.7.5", "primary"),
+				makeServer("0.7.3", "secondary"),
 			},
 			ver:           version.Must(version.NewVersion("0.7.5")),
 			expected:      true,
@@ -445,9 +390,9 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 		},
 		// One server, doesn't meet reqs
 		{
-			members: []serf.Member{
-				makeMember("0.7.5", "primary"),
-				makeMember("0.8.1", "secondary"),
+			servers: testServersProvider{
+				makeServer("0.7.5", "primary"),
+				makeServer("0.8.1", "secondary"),
 			},
 			ver:           version.Must(version.NewVersion("0.8.0")),
 			expected:      false,
@@ -455,10 +400,10 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 		},
 		// Multiple servers, meets req version
 		{
-			members: []serf.Member{
-				makeMember("0.7.5", "primary"),
-				makeMember("0.8.0", "primary"),
-				makeMember("0.7.0", "secondary"),
+			servers: testServersProvider{
+				makeServer("0.7.5", "primary"),
+				makeServer("0.8.0", "primary"),
+				makeServer("0.7.0", "secondary"),
 			},
 			ver:           version.Must(version.NewVersion("0.7.5")),
 			expected:      true,
@@ -466,20 +411,20 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 		},
 		// Multiple servers, doesn't meet req version
 		{
-			members: []serf.Member{
-				makeMember("0.7.5", "primary"),
-				makeMember("0.8.0", "primary"),
-				makeMember("0.9.1", "secondary"),
+			servers: testServersProvider{
+				makeServer("0.7.5", "primary"),
+				makeServer("0.8.0", "primary"),
+				makeServer("0.9.1", "secondary"),
 			},
 			ver:           version.Must(version.NewVersion("0.8.0")),
 			expected:      false,
 			expectedFound: true,
 		},
 		{
-			members: []serf.Member{
-				makeMember("0.7.5", "secondary"),
-				makeMember("0.8.0", "secondary"),
-				makeMember("0.9.1", "secondary"),
+			servers: testServersProvider{
+				makeServer("0.7.5", "secondary"),
+				makeServer("0.8.0", "secondary"),
+				makeServer("0.9.1", "secondary"),
 			},
 			ver:           version.Must(version.NewVersion("0.7.0")),
 			expected:      true,
@@ -488,7 +433,7 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		result, found := ServersInDCMeetMinimumVersion(tc.members, "primary", tc.ver)
+		result, found := ServersInDCMeetMinimumVersion(tc.servers, "primary", tc.ver)
 		require.Equal(t, tc.expected, result)
 		require.Equal(t, tc.expectedFound, found)
 	}
@@ -626,114 +571,110 @@ func TestInterpolateHIL(t *testing.T) {
 
 func TestServersGetACLMode(t *testing.T) {
 	t.Parallel()
-	makeMember := func(role string, datacenter string, acls structs.ACLMode, status serf.MemberStatus, addr net.IP) serf.Member {
-		return serf.Member{
-			Name: "foo",
-			Addr: addr,
-			Tags: map[string]string{
-				"role":          role,
-				"id":            "asdf",
-				"dc":            datacenter,
-				"port":          "10000",
-				"build":         "1.6.0",
-				"wan_join_port": "1234",
-				"vsn":           "1",
-				"expect":        "3",
-				"raft_vsn":      "3",
-				"acls":          string(acls),
-			},
-			Status: status,
+	makeServer := func(datacenter string, acls structs.ACLMode, status serf.MemberStatus, addr net.IP) metadata.Server {
+		return metadata.Server{
+			Name:        "foo",
+			ID:          "asdf",
+			Port:        10000,
+			Expect:      3,
+			RaftVersion: 3,
+			Status:      status,
+			WanJoinPort: 1234,
+			Version:     1,
+			Addr:        &net.TCPAddr{IP: addr, Port: 10000},
+			// shouldn't matter for these tests
+			Build:      *version.Must(version.NewVersion("1.7.0")),
+			Datacenter: datacenter,
+			ACLs:       acls,
 		}
 	}
 
 	type tcase struct {
-		members    []serf.Member
-		leaderAddr string
-		datacenter string
-		numServers int
-		minMode    structs.ACLMode
-		leaderMode structs.ACLMode
+		servers      testServersProvider
+		leaderAddr   string
+		datacenter   string
+		foundServers bool
+		minMode      structs.ACLMode
+		leaderMode   structs.ACLMode
 	}
 
 	cases := map[string]tcase{
 		"filter-members": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusFailed, net.IP([]byte{127, 0, 0, 2})),
-				// filter non-server
-				makeMember("client", "primary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 3})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusFailed, net.IP([]byte{127, 0, 0, 2})),
 				// filtered datacenter
-				makeMember("consul", "secondary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 4})),
+				makeServer("secondary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 4})),
 				// filtered status
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusLeaving, net.IP([]byte{127, 0, 0, 5})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusLeaving, net.IP([]byte{127, 0, 0, 5})),
 				// filtered status
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusLeft, net.IP([]byte{127, 0, 0, 6})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusLeft, net.IP([]byte{127, 0, 0, 6})),
 				// filtered status
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusNone, net.IP([]byte{127, 0, 0, 7})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusNone, net.IP([]byte{127, 0, 0, 7})),
 			},
-			numServers: 2,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "primary",
-			minMode:    structs.ACLModeLegacy,
-			leaderMode: structs.ACLModeLegacy,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeLegacy,
+			leaderMode:   structs.ACLModeLegacy,
 		},
 		"disabled": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
-				makeMember("consul", "primary", structs.ACLModeDisabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 3})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
+				makeServer("primary", structs.ACLModeDisabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 3})),
 			},
-			numServers: 3,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "",
-			minMode:    structs.ACLModeDisabled,
-			leaderMode: structs.ACLModeLegacy,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeDisabled,
+			leaderMode:   structs.ACLModeLegacy,
 		},
 		"unknown": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
 			},
-			numServers: 2,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "",
-			minMode:    structs.ACLModeUnknown,
-			leaderMode: structs.ACLModeLegacy,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeUnknown,
+			leaderMode:   structs.ACLModeLegacy,
 		},
 		"legacy": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
 			},
-			numServers: 2,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "",
-			minMode:    structs.ACLModeLegacy,
-			leaderMode: structs.ACLModeEnabled,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeLegacy,
+			leaderMode:   structs.ACLModeEnabled,
 		},
 		"enabled": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
-				makeMember("consul", "primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 3})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 2})),
+				makeServer("primary", structs.ACLModeEnabled, serf.StatusAlive, net.IP([]byte{127, 0, 0, 3})),
 			},
-			numServers: 3,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "",
-			minMode:    structs.ACLModeEnabled,
-			leaderMode: structs.ACLModeEnabled,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeEnabled,
+			leaderMode:   structs.ACLModeEnabled,
 		},
 		"failed-members": tcase{
-			members: []serf.Member{
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
-				makeMember("consul", "primary", structs.ACLModeUnknown, serf.StatusFailed, net.IP([]byte{127, 0, 0, 2})),
-				makeMember("consul", "primary", structs.ACLModeLegacy, serf.StatusFailed, net.IP([]byte{127, 0, 0, 3})),
+			servers: testServersProvider{
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusAlive, net.IP([]byte{127, 0, 0, 1})),
+				makeServer("primary", structs.ACLModeUnknown, serf.StatusFailed, net.IP([]byte{127, 0, 0, 2})),
+				makeServer("primary", structs.ACLModeLegacy, serf.StatusFailed, net.IP([]byte{127, 0, 0, 3})),
 			},
-			numServers: 3,
-			leaderAddr: "127.0.0.1:10000",
-			datacenter: "",
-			minMode:    structs.ACLModeUnknown,
-			leaderMode: structs.ACLModeLegacy,
+			foundServers: true,
+			leaderAddr:   "127.0.0.1:10000",
+			datacenter:   "primary",
+			minMode:      structs.ACLModeUnknown,
+			leaderMode:   structs.ACLModeLegacy,
 		},
 	}
 
@@ -741,11 +682,11 @@ func TestServersGetACLMode(t *testing.T) {
 		name := name
 		tc := tc
 		t.Run(name, func(t *testing.T) {
-			actualServers, actualMinMode, actualLeaderMode := ServersGetACLMode(tc.members, tc.leaderAddr, tc.datacenter)
+			actualServers, actualMinMode, actualLeaderMode := ServersGetACLMode(tc.servers, tc.leaderAddr, tc.datacenter)
 
-			require.Equal(t, tc.numServers, actualServers)
 			require.Equal(t, tc.minMode, actualMinMode)
 			require.Equal(t, tc.leaderMode, actualLeaderMode)
+			require.Equal(t, tc.foundServers, actualServers)
 		})
 	}
 }

--- a/agent/router/manager.go
+++ b/agent/router/manager.go
@@ -217,6 +217,23 @@ func (m *Manager) FindServer() *metadata.Server {
 	return l.servers[0]
 }
 
+// checkServers executes the given check against all managed servers
+// and returns whether that function decided to break the loop early
+func (m *Manager) checkServers(fn func(srv *metadata.Server) bool) bool {
+	for _, srv := range m.getServerList().servers {
+		if !fn(srv) {
+			return false
+		}
+	}
+	return true
+}
+
+// CheckServers executes the given check function on all the servers being
+// managed by this Manager
+func (m *Manager) CheckServers(fn func(srv *metadata.Server) bool) {
+	_ = m.checkServers(fn)
+}
+
 // getServerList is a convenience method which hides the locking semantics
 // of atomic.Value from the caller.
 func (m *Manager) getServerList() serverList {

--- a/agent/router/serf_adapter.go
+++ b/agent/router/serf_adapter.go
@@ -61,6 +61,7 @@ func HandleSerfEvents(logger *log.Logger, router *Router, areaID types.AreaID, s
 
 			// All of these event types are ignored.
 			case serf.EventMemberUpdate:
+				handleMemberEvent(logger, router.AddServer, areaID, e)
 			case serf.EventUser:
 			case serf.EventQuery:
 


### PR DESCRIPTION
Previously when checking for ACL modes or versions of servers we would give the various utility functions a list of Serf members to iterate through, pull out the servers and run the checks against. This worked okay when we only have to care about LAN and WAN serf instances but for enterprise we have other Serf instances.

The changes in this PR are just the OSS side of things but change things up to go through the router/server lookup infrastructure which tracks server metadata coming from multiple sources.

This also happens to fix a bug with ACL replication that would always start new ACL replication routines even when still in legacy ACL mode causing lots of errors in the logs.

These same changes already exist in master and the 1.7 release branch. This just backports those changes to the 1.6.x release branch.