### PR TITLE
ui: Fix token duplication bug

### DIFF
--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -29,8 +29,13 @@ export default Adapter.extend({
     let unserialized, serialized;
     const serializer = store.serializerFor(modelName);
     // workable way to decide whether this is a snapshot
+    // essentially 'is attributable'.
     // Snapshot is private so we can't do instanceof here
-    if (obj.constructor.name === 'Snapshot') {
+    // and using obj.constructor.name gets changed/minified
+    // during compilation so you can't rely on it
+    // checking for `attributes` being a function is more
+    // reliable as that is the thing we need to call
+    if (typeof obj.attributes === 'function') {
       unserialized = obj.attributes();
       serialized = serializer.serialize(obj, {});
     } else {


### PR DESCRIPTION
We need to detect whether an object is an ember-data snapshot or just a
plain object, and we where restricted from using `instanceof` due to
ember-data's `Snapshot` class being private.

[We'd chosen to go with `constructor.name`](https://github.com/hashicorp/consul/pull/6285) instead, which seemed to work,
but when the javascript gets minifed the name of the contructor is also
minified and therefore is not what you are expecting.

This commit reverts to our original idea of checking for the existence
and type of the `.attributes` function, which is the function we require
within the conditional, and therefore is more reliable (if the function
doesn't exist it will error out during development aswell as production)

cc @mkeeler 