### PR TITLE
More robust integration tests by forcing query on stats

### DIFF
--- a/agent/consul/federation_state_replication_test.go
+++ b/agent/consul/federation_state_replication_test.go
@@ -77,7 +77,7 @@ func TestReplication_FederationStates(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, local, len(remote))
-		for i, _ := range remote {
+		for i := range remote {
 			// zero out the raft data for future comparisons
 			remote[i].RaftIndex = structs.RaftIndex{}
 			local[i].RaftIndex = structs.RaftIndex{}
@@ -121,8 +121,12 @@ func TestReplication_FederationStates(t *testing.T) {
 		require.NoError(t, s1.RPC("FederationState.Apply", &arg, &out))
 	}
 
+	nTimesWithDelay := func() *retry.Counter {
+		return &retry.Counter{Count: 30, Wait: 750 * time.Millisecond}
+	}
+
 	// Wait for the replica to converge.
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(nTimesWithDelay(), t, func(r *retry.R) {
 		checkSame(r)
 	})
 

--- a/agent/consul/federation_state_replication_test.go
+++ b/agent/consul/federation_state_replication_test.go
@@ -142,7 +142,7 @@ func TestReplication_FederationStates(t *testing.T) {
 	}
 
 	// Wait for the replica to converge.
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(nTimesWithDelay(), t, func(r *retry.R) {
 		checkSame(r)
 	})
 }

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
@@ -35,7 +35,7 @@ load helpers
 
 # Note: when failover is configured the cluster is named for the original
 # service not any destination related to failover.
-@test "s1 upstream should have healthy endpoints for s2 in both primary and failover" {
+@test "s1 upstream should have 2 healthy endpoints for s2 for primary" {
   assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 2
 }
 
@@ -54,6 +54,10 @@ load helpers
   kill_envoy s2 primary
 }
 
+@test "s2 proxies should have 1 instance" {
+  assert_service_has_instances_once s2 1 primary
+}
+
 @test "s2 proxies should be unhealthy in primary" {
   assert_service_has_healthy_instances s2 0 primary
 }
@@ -65,6 +69,14 @@ load helpers
 
 @test "reset envoy statistics" {
   reset_envoy_metrics 127.0.0.1:19000
+}
+
+@test "s2 proxies should have 1 instance in secondary" {
+  assert_service_has_instances_once s2 1 secondary
+}
+
+@test "s2 proxies should have 1 healthy in secondary" {
+  assert_service_has_healthy_instances s2 1 secondary
 }
 
 @test "s1 upstream should be able to connect to s2 in secondary now" {

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/primary/verify.bats
@@ -39,6 +39,10 @@ load helpers
   assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 2
 }
 
+@test "wait for envoy metrics for cluster.s2.default.primary" {
+  wait_for_envoy_metric_to_exist 127.0.0.1:19000 "cluster.s2.default.primary.*cx_total"
+}
+
 @test "s1 upstream should be able to connect to s2 via upstream s2 to start" {
   assert_expected_fortio_name s2
 }

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
@@ -10,10 +10,6 @@ load helpers
   retry_default curl -f -s localhost:19002/stats | grep cx_total
 }
 
-@test "s2 proxy admin is up on :19002 and has metrics" {
-  wait_for_envoy_metric_to_exist 127.0.0.1:19002 "cluster.s2.default.secondary.*cx_total"
-}
-
 @test "gateway-secondary proxy admin is up on :19003" {
   retry_default curl -f -s localhost:19003/stats | grep cx_total
 }

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
@@ -14,8 +14,12 @@ load helpers
   retry_default curl -f -s localhost:19003/stats | grep cx_total
 }
 
+@test "s2 proxy should be healthy" {
+  assert_service_has_healthy_instances s2 1 secondary
+}
+
 @test "gateway-secondary stats should exist" {
-  assert_envoy_metric_exists 127.0.0.1:19003 "cluster.s2.default.secondary.*cx_total"
+  wait_for_envoy_metric_to_exist 127.0.0.1:19003 "cluster.s2.default.secondary.*cx_total"
 }
 
 @test "gateway-secondary stats should be 0 at startup" {
@@ -24,10 +28,6 @@ load helpers
 
 @test "s2 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s2 secondary
-}
-
-@test "s2 proxy should be healthy" {
-  assert_service_has_healthy_instances s2 1 secondary
 }
 
 @test "gateway-secondary is NOT used for the upstream connection" {

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
@@ -7,11 +7,19 @@ load helpers
 }
 
 @test "s2 proxy admin is up on :19002" {
-  retry_default curl -f -s localhost:19002/stats -o /dev/null
+  retry_default curl -f -s localhost:19002/stats | grep cx_total
 }
 
 @test "gateway-secondary proxy admin is up on :19003" {
-  retry_default curl -f -s localhost:19003/stats -o /dev/null
+  retry_default curl -f -s localhost:19003/stats | grep cx_total
+}
+
+@test "gateway-secondary stats should exist" {
+  assert_envoy_metric_exists 127.0.0.1:19003 "cluster.s2.default.secondary.*cx_total"
+}
+
+@test "gateway-secondary stats should be 0 at startup" {
+  assert_envoy_metric 127.0.0.1:19003 "cluster.s2.default.secondary.*cx_total" 0
 }
 
 @test "s2 proxy listener should be up and have right cert" {

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-none/secondary/verify.bats
@@ -10,6 +10,10 @@ load helpers
   retry_default curl -f -s localhost:19002/stats | grep cx_total
 }
 
+@test "s2 proxy admin is up on :19002 and has metrics" {
+  wait_for_envoy_metric_to_exist 127.0.0.1:19002 "cluster.s2.default.secondary.*cx_total"
+}
+
 @test "gateway-secondary proxy admin is up on :19003" {
   retry_default curl -f -s localhost:19003/stats | grep cx_total
 }

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-remote/primary/verify.bats
@@ -56,10 +56,6 @@ load helpers
   kill_envoy s2 primary
 }
 
-@test "s2 proxies should be unhealthy in primary" {
-  assert_service_has_healthy_instances s2 0 primary
-}
-
 @test "s1 upstream should have healthy endpoints for s2 secondary" {
   # in mesh gateway remote or local mode only the current leg of failover manifests in the load assignments
   assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1

--- a/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-cfg-resolver-dc-failover-gateways-remote/primary/verify.bats
@@ -56,6 +56,10 @@ load helpers
   kill_envoy s2 primary
 }
 
+@test "s2 proxies should be unhealthy in primary" {
+  assert_service_has_healthy_instances s2 0 primary
+}
+
 @test "s1 upstream should have healthy endpoints for s2 secondary" {
   # in mesh gateway remote or local mode only the current leg of failover manifests in the load assignments
   assert_upstream_has_endpoints_in_status 127.0.0.1:19000 s2.default.primary HEALTHY 1

--- a/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-local/primary/verify.bats
@@ -7,15 +7,19 @@ load helpers
 }
 
 @test "s1 proxy admin is up on :19000" {
-  retry_default curl -f -s localhost:19000/stats -o /dev/null
+  retry_default curl -f -s localhost:19000/stats | grep cx_total
 }
 
 @test "gateway-primary proxy admin is up on :19002" {
-  retry_default curl -f -s localhost:19002/stats -o /dev/null
+  retry_default curl -f -s localhost:19002/stats | grep cx_total
 }
 
 @test "s1 proxy listener should be up and have right cert" {
   assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxies should be healthy in secondary" {
+  assert_service_has_healthy_instances s2 1 secondary
 }
 
 @test "s1 upstream should have healthy endpoints for s2" {

--- a/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
+++ b/test/integration/connect/envoy/case-gateways-remote/primary/verify.bats
@@ -19,6 +19,10 @@ load helpers
   assert_upstream_has_endpoints_in_status 127.0.0.1:19000 dd412229~s2.default.secondary HEALTHY 1
 }
 
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats | grep cx_total
+}
+
 @test "s1 upstream should be able to connect to s2" {
   run retry_default curl -s -f -d hello localhost:5000
   [ "$status" -eq 0 ]

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -249,7 +249,8 @@ function wait_for_envoy_metric_to_exist {
   local HOSTPORT=$1
   local METRIC=$2
   local try=0
-  while [ $try -lt 10 ]
+  # Wait up to 1 minute
+  while [ $try -lt 60 ]
   do
     METRICS=$(get_envoy_metrics $HOSTPORT "$METRIC")
     if [ -z "${METRICS}" ]

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -248,15 +248,21 @@ function assert_envoy_metric_exists {
   set -eEuo pipefail
   local HOSTPORT=$1
   local METRIC=$2
-
-  METRICS=$(get_envoy_metrics $HOSTPORT "$METRIC")
-
-  if [ -z "${METRICS}" ]
-  then
-    echo "Metric not found" 1>&2
-    return 1
-  fi
-  return 0
+  local try=0
+  while [ try -lt 10 ]
+  do
+    METRICS=$(get_envoy_metrics $HOSTPORT "$METRIC")
+    if [ -z "${METRICS}" ]
+    then
+      echo "Metric not found" 1>&2
+      try=$((try + 1))
+      sleep 1
+    else
+      return 0
+    fi
+  done
+  echo "Metric not found after $try tries" 1>&2
+  return 1
 }
 
 function assert_envoy_metric {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -244,17 +244,17 @@ function assert_upstream_has_endpoints_in_status {
   [ "$status" -eq 0 ]
 }
 
-function assert_envoy_metric_exists {
-  set -eEuo pipefail
+function wait_for_envoy_metric_to_exist {
+  set -Euo pipefail
   local HOSTPORT=$1
   local METRIC=$2
   local try=0
-  while [ try -lt 10 ]
+  while [ $try -lt 10 ]
   do
     METRICS=$(get_envoy_metrics $HOSTPORT "$METRIC")
     if [ -z "${METRICS}" ]
     then
-      echo "Metric not found" 1>&2
+      echo "Metric $METRIC not found, retrying" 1>&2
       try=$((try + 1))
       sleep 1
     else

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -42,7 +42,7 @@ function retry {
 function retry_default {
   set +E
   ret=0
-  retry 5 1 "$@" || ret=1
+  retry 5 2 "$@" || ret=1
   set -E
   return $ret
 }

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -375,7 +375,7 @@ function get_healthy_service_count {
 
 function assert_alive_wan_member_count {
   local EXPECT_COUNT=$1
-  run retry_default assert_alive_wan_member_count_once $EXPECT_COUNT
+  run retry_long assert_alive_wan_member_count_once $EXPECT_COUNT
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
It seems envoy has a kind of lazy init for stats, this is causing some issues sometimes.

Added some intermediary tests to have better diagnostics

This seems to decrease quite a lot the failure rate