### PR TITLE
ci: small improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,12 @@ jobs:
     environment:
       <<: *ENVIRONMENT
       GOTAGS: "" # No tags for OSS but there are for enterprise
-      # GOMAXPROCS defaults to number of cores on underlying hardware, set explicitly to avoid OOM issues https://support.circleci.com/hc/en-us/articles/360034684273-common-GoLang-memory-issues
-      GOMAXPROCS: 2 # medium (default) boxes are 2 vCPUs, 4GB RAM https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+      # GOMAXPROCS defaults to number of cores on underlying hardware, set
+      # explicitly to avoid OOM issues https://support.circleci.com/hc/en-us/articles/360034684273-common-GoLang-memory-issues
+      GOMAXPROCS: 4
+      # The medium resource class (default) boxes are 2 vCPUs, 4GB RAM
+      # https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+      # but we can run a little over that limit.
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,14 +89,21 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: mkdir -p $TEST_RESULTS_DIR
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
-      - run: |
-          PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-          echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
-          echo $PACKAGE_NAMES
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags="$GOTAGS" -p 2 -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part $PACKAGE_NAMES
+      - run: go mod download
+      - run:
+          name: go test
+          command: |
+            mkdir -p $TEST_RESULTS_DIR
+            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
+            echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
+            echo $PACKAGE_NAMES
+            gotestsum --format=short-verbose \
+              --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
+              -tags="$GOTAGS" -p 2 \
+              -cover -coverprofile=cov_$CIRCLE_NODE_INDEX.part \
+              $PACKAGE_NAMES
 
       # save coverage report parts
       - persist_to_workspace:
@@ -120,12 +127,17 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: mkdir -p $TEST_RESULTS_DIR
+      - run: go mod download
       - run:
           working_directory: api
+          name: go test
           command: |
-            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags="$GOTAGS" -cover -coverprofile=cov_api.part $PACKAGE_NAMES
+            mkdir -p $TEST_RESULTS_DIR
+            gotestsum \
+              --format=short-verbose \
+              --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
+              -tags="$GOTAGS" -cover -coverprofile=cov_api.part \
+              ./...
 
       # save coverage report parts
       - persist_to_workspace:
@@ -149,12 +161,17 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: mkdir -p $TEST_RESULTS_DIR
+      - run: go mod download
       - run:
           working_directory: sdk
+          name: go test
           command: |
-            PACKAGE_NAMES=$(go list ./... | circleci tests split --split-by=timings --timings-type=classname)
-            gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- -tags=$GOTAGS -cover -coverprofile=cov_sdk.part $PACKAGE_NAMES
+            mkdir -p $TEST_RESULTS_DIR
+            gotestsum \
+              --format=short-verbose \
+              --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
+              -tags=$GOTAGS -cover -coverprofile=cov_sdk.part \
+              ./...
 
       # save coverage report parts
       - persist_to_workspace:
@@ -177,10 +194,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: mkdir -p $TEST_RESULTS_DIR
       - run:
           name: merge coverage reports
           command: |
+            mkdir -p $TEST_RESULTS_DIR
             echo "mode: set" > coverage.out
             grep -h -v "mode: set" cov_*.part >> coverage.out
             go tool cover -html=coverage.out -o $TEST_RESULTS_DIR/coverage.html
@@ -328,9 +345,6 @@ jobs:
       - attach_workspace:
           at: /go/bin
 
-      # make test result directory
-      - run: mkdir -p $TEST_RESULTS_DIR
-
       # make dev build of nomad
       - run:
           command: make pkg/linux_amd64/nomad
@@ -341,7 +355,13 @@ jobs:
 
       # run integration tests
       - run:
-          command: gotestsum --format=short-verbose --junitfile $TEST_RESULTS_DIR/results.xml -- ./command/agent/consul -run TestConsul
+          name: go test
+          command: |
+            mkdir -p $TEST_RESULTS_DIR
+            gotestsum \
+              --format=short-verbose \
+              --junitfile $TEST_RESULTS_DIR/results.xml -- \
+              ./command/agent/consul -run TestConsul
           working_directory: *NOMAD_WORKING_DIR
 
       # store test results for CircleCI
@@ -612,17 +632,19 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
-      # Install vault
-      - run: |
-          wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
-          sudo unzip -d /usr/local/bin /tmp/vault.zip
-          rm -rf /tmp/vault*
-      # Create directory to store test results
-      - run: mkdir -p $TEST_RESULTS_DIR
-      # Gather deps to run go tests
+      - run:
+          name: Install vault
+          command: |
+            wget -q -O /tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_BINARY_VERSION}/vault_${VAULT_BINARY_VERSION}_linux_amd64.zip
+            sudo unzip -d /usr/local/bin /tmp/vault.zip
+            rm -rf /tmp/vault*
       - checkout
-      # Run go tests
-      - run: make test-connect-ca-providers
+      - run: go mod download
+      - run:
+          name: go test
+          command: |
+            mkdir -p $TEST_RESULTS_DIR
+            make test-connect-ca-providers
       - store_test_results:
           path: *TEST_RESULTS_DIR
 
@@ -658,19 +680,17 @@ workflows:
                 - /^ui\/.*/
       - lint
       - dev-build
-      - go-test: &go-test
-          requires:
-            - dev-build
-            - lint
-            - check-vendor
-      - go-test-api: *go-test
-      - go-test-sdk: *go-test
+      - go-test:
+          requires: [dev-build]
+      - go-test-api:
+          requires: [dev-build]
+      - go-test-sdk
       - coverage-merge:
           requires:
             - go-test
             - go-test-api
             - go-test-sdk
-      - test-connect-ca-providers: *go-test
+      - test-connect-ca-providers
 
   build-distros:
     jobs:


### PR DESCRIPTION
Add some names to steps so that the long commands are not used as the name.

Run `go mod download` before the `go test` step so that dependencies are pulled in a separate step. This makes the test splitting and test output easier to scroll through.

Remove test splitting from the api/sdk test runs. These jobs do not use parallelism, so there is no test timing data injected into the job. They can't be split.

Also removed some dependencies from the `go-test` jobs. This may not speed up the workflow too much yet.