### PR TITLE
Update the Client code to use the common version checking infrastructure

### DIFF
--- a/agent/consul/acl_client.go
+++ b/agent/consul/acl_client.go
@@ -5,10 +5,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/serf/serf"
 )
 
 var clientACLCacheConfig *structs.ACLCachesConfig = &structs.ACLCachesConfig{
@@ -36,22 +34,11 @@ func (c *Client) UseLegacyACLs() bool {
 func (c *Client) monitorACLMode() {
 	waitTime := aclModeCheckMinInterval
 	for {
-		canUpgrade := false
-		for _, member := range c.LANMembers() {
-			if valid, parts := metadata.IsConsulServer(member); valid && parts.Status == serf.StatusAlive {
-				if parts.ACLs != structs.ACLModeEnabled {
-					canUpgrade = false
-					break
-				} else {
-					canUpgrade = true
-				}
-			}
-		}
-
-		if canUpgrade {
+		foundServers, mode, _ := ServersGetACLMode(c, "", c.config.Datacenter)
+		if foundServers && mode == structs.ACLModeEnabled {
 			c.logger.Debug("transitioned out of legacy ACL mode")
+			c.updateSerfTags("acls", string(structs.ACLModeEnabled))
 			atomic.StoreInt32(&c.useNewACLs, 1)
-			lib.UpdateSerfTag(c.serf, "acls", string(structs.ACLModeEnabled))
 			return
 		}
 
@@ -129,4 +116,9 @@ func (c *Client) ResolveTokenAndDefaultMeta(token string, entMeta *structs.Enter
 	entMeta.FillAuthzContext(authzContext)
 
 	return authz, err
+}
+
+func (c *Client) updateSerfTags(key, value string) {
+	// Update the LAN serf
+	lib.UpdateSerfTag(c.serf, key, value)
 }

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -111,7 +111,7 @@ func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
 	if !s.InACLDatacenter() {
 		foundServers, mode, _ := ServersGetACLMode(s, "", s.config.ACLDatacenter)
 		if mode != structs.ACLModeEnabled || !foundServers {
-			s.logger.Info("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "ACLDatacenter", s.config.ACLDatacenter, "mode", mode, "found", foundServers)
+			s.logger.Debug("Cannot upgrade to new ACLs, servers in acl datacenter are not yet upgraded", "ACLDatacenter", s.config.ACLDatacenter, "mode", mode, "found", foundServers)
 			return false
 		}
 	}
@@ -128,7 +128,7 @@ func (s *Server) canUpgradeToNewACLs(isLeader bool) bool {
 		}
 	}
 
-	s.logger.Info("Cannot upgrade to new ACLs", "leaderMode", leaderMode, "mode", mode, "found", foundServers, "leader", leaderAddr)
+	s.logger.Debug("Cannot upgrade to new ACLs", "leaderMode", leaderMode, "mode", mode, "found", foundServers, "leader", leaderAddr)
 	return false
 }
 

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -662,6 +662,9 @@ func (s *Server) initializeACLs(upgrade bool) error {
 			if s.IsACLReplicationEnabled() {
 				s.startLegacyACLReplication()
 			}
+			// return early as we don't want to start new ACL replication
+			// or ACL token reaping as these are new ACL features.
+			return nil
 		}
 
 		if upgrade {

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -363,6 +363,15 @@ func (s *Server) CheckServers(datacenter string, fn func(*metadata.Server) bool)
 	}
 }
 
+// CheckServers implements the checkServersProvider interface for the Client
+func (c *Client) CheckServers(datacenter string, fn func(*metadata.Server) bool) {
+	if datacenter != c.config.Datacenter {
+		return
+	}
+
+	c.routers.CheckServers(fn)
+}
+
 type serversACLMode struct {
 	// leader is the address of the leader
 	leader string


### PR DESCRIPTION
Also reduce the log level of some version checking messages on the server as they can be pretty noisy during upgrades and really are more for debugging purposes.

This also fixes a subtle bug where the leader would unconditionally start new ACL replication in addition to legacy ACL replication during upgrades of servers across the cluster. This was resulting in a bunch of useless errors in the logs which could also be misleading as to the current ACL mode.