### PR TITLE
sdk: Remove TestWriter

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/hashicorp/consul/agent/local"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
@@ -55,11 +55,11 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveFn func(strin
 	a := &TestACLAgent{Name: name, HCL: hcl, resolveTokenFn: resolveFn}
 	hclDataDir := `data_dir = "acl-agent"`
 
-	logOutput := testutil.TestWriter(t)
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   a.Name,
-		Level:  hclog.Debug,
-		Output: logOutput,
+		Name:       a.Name,
+		Level:      hclog.Debug,
+		Output:     os.Stdout,
+		TimeFormat: "04:05.000",
 	})
 
 	a.Config = TestConfig(logger,
@@ -73,7 +73,7 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveFn func(strin
 	}
 	a.Agent = agent
 
-	agent.LogOutput = logOutput
+	agent.LogOutput = os.Stdout
 	agent.logger = logger
 	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
 

--- a/agent/ae/ae_test.go
+++ b/agent/ae/ae_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/lib"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/assert"
 )
@@ -393,8 +392,7 @@ func (m *mock) SyncChanges() error {
 
 func testSyncer(t *testing.T) *StateSyncer {
 	logger := hclog.New(&hclog.LoggerOptions{
-		Level:  0,
-		Output: testutil.TestWriter(t),
+		Level: 0,
 	})
 
 	l := NewStateSyncer(nil, time.Second, nil, logger)

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -624,7 +624,7 @@ func newTestACLResolver(t *testing.T, delegate ACLResolverDelegate, cb func(*ACL
 	config.ACLDownPolicy = "extend-cache"
 	rconf := &ACLResolverConfig{
 		Config: config,
-		Logger: testutil.LoggerWithName(t, t.Name()),
+		Logger: testutil.LoggerWithName(t.Name()),
 		CacheConfig: &structs.ACLCachesConfig{
 			Identities:     4,
 			Policies:       4,

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
@@ -1195,7 +1194,7 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 	}()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.LogOutput = io.MultiWriter(pw, testutil.TestWriter(t))
+		c.LogOutput = io.MultiWriter(pw, os.Stdout)
 		c.Build = "1.6.0"
 		c.ConfigEntryBootstrap = []structs.ConfigEntry{
 			&structs.ServiceSplitterConfigEntry{

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -100,7 +100,6 @@ func testServerConfig(t *testing.T) (string, *Config) {
 	config.Bootstrap = true
 	config.Datacenter = "dc1"
 	config.DataDir = dir
-	config.LogOutput = testutil.TestWriter(t)
 
 	// bind the rpc server to a random port. config.RPCAdvertise will be
 	// set to the listen address unless it was set in the configuration.
@@ -261,9 +260,10 @@ func newServer(c *Config) (*Server, error) {
 		w = os.Stderr
 	}
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   c.NodeName,
-		Level:  hclog.Debug,
-		Output: w,
+		Name:       c.NodeName,
+		Level:      hclog.Debug,
+		Output:     w,
+		TimeFormat: "04:05.000",
 	})
 	tlsConf, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), logger)
 	if err != nil {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -235,11 +235,6 @@ func NewTestServerConfig(cb ServerConfigCallback) (*TestServer, error) {
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
 func NewTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, error) {
-	return newTestServerConfigT(t, cb)
-}
-
-// newTestServerConfigT is the internal helper for NewTestServerConfigT.
-func newTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, error) {
 	path, err := exec.LookPath("consul")
 	if err != nil || path == "" {
 		return nil, fmt.Errorf("consul not found on $PATH - download and install " +
@@ -257,10 +252,6 @@ func newTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, e
 	}
 
 	cfg := defaultServerConfig()
-	testWriter := TestWriter(t)
-	cfg.Stdout = testWriter
-	cfg.Stderr = testWriter
-
 	cfg.DataDir = filepath.Join(tmpdir, "data")
 	if cb != nil {
 		cb(cfg)
@@ -284,11 +275,11 @@ func newTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, e
 		return nil, errors.Wrap(err, "failed writing config content")
 	}
 
-	stdout := testWriter
+	var stdout io.Writer = os.Stdout
 	if cfg.Stdout != nil {
 		stdout = cfg.Stdout
 	}
-	stderr := testWriter
+	var stderr io.Writer = os.Stderr
 	if cfg.Stderr != nil {
 		stderr = cfg.Stderr
 	}

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -1,12 +1,9 @@
 package testutil
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -18,11 +15,6 @@ func init() {
 	sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
 }
 
-// Deprecated: use Logger(t)
-func TestLogger(t testing.TB) *log.Logger {
-	return log.New(&testWriter{t}, t.Name()+": ", log.LstdFlags)
-}
-
 func NewDiscardLogger() hclog.Logger {
 	return hclog.New(&hclog.LoggerOptions{
 		Level:  0,
@@ -31,59 +23,23 @@ func NewDiscardLogger() hclog.Logger {
 }
 
 func Logger(t testing.TB) hclog.InterceptLogger {
-	return LoggerWithOutput(t, &testWriter{t})
+	return LoggerWithOutput(t, os.Stdout)
 }
 
 func LoggerWithOutput(t testing.TB, output io.Writer) hclog.InterceptLogger {
 	return hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   t.Name(),
-		Level:  hclog.Trace,
-		Output: output,
+		Name:       t.Name(),
+		Level:      hclog.Trace,
+		Output:     output,
+		TimeFormat: "04:05.000",
 	})
 }
 
-// Deprecated: use LoggerWithName(t)
-func TestLoggerWithName(t testing.TB, name string) *log.Logger {
-	return log.New(&testWriter{t}, "test["+name+"]: ", log.LstdFlags)
-}
-
-func LoggerWithName(t testing.TB, name string) hclog.InterceptLogger {
+func LoggerWithName(name string) hclog.InterceptLogger {
 	return hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   "test[" + name + "]",
-		Level:  hclog.Debug,
-		Output: &testWriter{t},
+		Name:       "test[" + name + "]",
+		Level:      hclog.Debug,
+		Output:     os.Stdout,
+		TimeFormat: "04:05.000",
 	})
-}
-
-func TestWriter(t testing.TB) io.Writer {
-	return &testWriter{t}
-}
-
-type testWriter struct {
-	t testing.TB
-}
-
-func (tw *testWriter) Write(p []byte) (n int, err error) {
-	if tw.t != nil {
-		tw.t.Helper()
-	}
-	if sendTestLogsToStdout || tw.t == nil {
-		fmt.Fprint(os.Stdout, strings.TrimSpace(string(p))+"\n")
-	} else {
-		defer func() {
-			if r := recover(); r != nil {
-				if sr, ok := r.(string); ok {
-					if strings.HasPrefix(sr, "Log in goroutine after ") {
-						// These sorts of panics are undesirable, but requires
-						// total control over goroutine lifetimes to correct.
-						fmt.Fprint(os.Stdout, "SUPPRESSED PANIC: "+sr+"\n")
-						return
-					}
-				}
-				panic(r)
-			}
-		}()
-		tw.t.Log(strings.TrimSpace(string(p)))
-	}
-	return len(p), nil
 }


### PR DESCRIPTION
Follow up to #7546

I went back and looked at #5344 to better understand the problem that `TestWriter` was solving.

I believe `gotestsum`, which we use in CI, solves this same problem without having to wrap the logger in the test suite. The `short`, `short-verbose` and `short-with-failures` formats handle only printing logs for the tests that have failed. 

The `TestWriter` solution seems like it comes with a couple of disadvantages.

The first can be seen from the implementation. Loggers can outlive the lifetime of the testing.T instance, which causes panics.

The second is that it produces log messages which contain the test name twice. This results in log messages that are very long and hard to read. (#7546).

`sdk/README/md` suggests that we don't make any promises about backwards compatibility for the `sdk`, so I removed the unused functions.