### PR TITLE
testing: Remove old default value from NewTestAgent() calls

### DIFF
--- a/agent/acl_endpoint_legacy_test.go
+++ b/agent/acl_endpoint_legacy_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestACL_Legacy_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	tests := []func(resp http.ResponseWriter, req *http.Request) (interface{}, error){
@@ -71,7 +71,7 @@ func makeTestACL(t *testing.T, srv *HTTPServer) string {
 
 func TestACL_Legacy_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -101,7 +101,7 @@ func TestACL_Legacy_Update(t *testing.T) {
 
 func TestACL_Legacy_UpdateUpsert(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer(nil)
@@ -130,7 +130,7 @@ func TestACL_Legacy_UpdateUpsert(t *testing.T) {
 
 func TestACL_Legacy_Destroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -162,7 +162,7 @@ func TestACL_Legacy_Destroy(t *testing.T) {
 
 func TestACL_Legacy_Clone(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -207,7 +207,7 @@ func TestACL_Legacy_Clone(t *testing.T) {
 func TestACL_Legacy_Get(t *testing.T) {
 	t.Parallel()
 	t.Run("wrong id", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), TestACLConfig())
+		a := NewTestAgent(t, TestACLConfig())
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/acl/info/nope", nil)
@@ -227,7 +227,7 @@ func TestACL_Legacy_Get(t *testing.T) {
 	})
 
 	t.Run("right id", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), TestACLConfig())
+		a := NewTestAgent(t, TestACLConfig())
 		defer a.Shutdown()
 
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -251,7 +251,7 @@ func TestACL_Legacy_Get(t *testing.T) {
 
 func TestACL_Legacy_List(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -280,7 +280,7 @@ func TestACL_Legacy_List(t *testing.T) {
 
 func TestACLReplicationStatus(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/acl/replication", nil)

--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestACL_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	type testCase struct {
@@ -79,7 +79,7 @@ func jsonBody(v interface{}) io.Reader {
 
 func TestACL_Bootstrap(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, TestACLConfig()+`
       acl_master_token = ""
    `)
 	defer a.Shutdown()
@@ -127,7 +127,7 @@ func TestACL_Bootstrap(t *testing.T) {
 
 func TestACL_HTTP(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1092,7 +1092,7 @@ func TestACL_HTTP(t *testing.T) {
 func TestACL_LoginProcedure_HTTP(t *testing.T) {
 	// This tests AuthMethods, BindingRules, Login, and Logout.
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1592,7 +1592,7 @@ func TestACL_LoginProcedure_HTTP(t *testing.T) {
 
 func TestACL_Authorize(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), TestACLConfigWithParams(nil))
+	a1 := NewTestAgent(t, TestACLConfigWithParams(nil))
 	defer a1.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1", testrpc.WithToken(TestDefaultMasterToken))
@@ -1628,7 +1628,7 @@ func TestACL_Authorize(t *testing.T) {
 	secondaryParams.ReplicationToken = secondaryParams.MasterToken
 	secondaryParams.EnableTokenReplication = true
 
-	a2 := NewTestAgent(t, t.Name(), `datacenter = "dc2" `+TestACLConfigWithParams(secondaryParams))
+	a2 := NewTestAgent(t, `datacenter = "dc2" `+TestACLConfigWithParams(secondaryParams))
 	defer a2.Shutdown()
 
 	addr := fmt.Sprintf("127.0.0.1:%d", a1.Config.SerfPortWAN)

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1773,9 +1773,9 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 
 func TestAgent_ForceLeavePrune(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name()+"-a1", "")
+	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name()+"-a2", "")
+	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent2"})
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
 
@@ -5236,17 +5236,17 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	a1 := NewTestAgent(t, t.Name()+"-dc1", `
+	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "dc1", HCL: `
 		datacenter = "dc1"
 		primary_datacenter = "dc1"
-	`)
+	`})
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t, t.Name()+"-dc2", `
+	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "dc2", HCL: `
 		datacenter = "dc2"
 		primary_datacenter = "dc1"
-	`)
+	`})
 	defer a2.Shutdown()
 	testrpc.WaitForTestAgent(t, a2.RPC, "dc2")
 

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -55,7 +55,7 @@ func makeReadOnlyAgentACL(t *testing.T, srv *HTTPServer) string {
 
 func TestAgent_Services(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -83,7 +83,7 @@ func TestAgent_Services(t *testing.T) {
 
 func TestAgent_ServicesFiltered(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -129,7 +129,7 @@ func TestAgent_Services_ExternalConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -161,7 +161,7 @@ func TestAgent_Services_Sidecar(t *testing.T) {
 
 	require := require.New(t)
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -205,7 +205,7 @@ func TestAgent_Services_Sidecar(t *testing.T) {
 func TestAgent_Services_MeshGateway(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -237,7 +237,7 @@ func TestAgent_Services_MeshGateway(t *testing.T) {
 func TestAgent_Services_TerminatingGateway(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -267,7 +267,7 @@ func TestAgent_Services_TerminatingGateway(t *testing.T) {
 
 func TestAgent_Services_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -307,7 +307,7 @@ func TestAgent_Services_ACLFilter(t *testing.T) {
 func TestAgent_Service(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, TestACLConfig()+`
 	services {
 		name = "web"
 		port = 8181
@@ -618,7 +618,7 @@ func TestAgent_Service(t *testing.T) {
 
 func TestAgent_Checks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -646,7 +646,7 @@ func TestAgent_Checks(t *testing.T) {
 
 func TestAgent_ChecksWithFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -677,7 +677,7 @@ func TestAgent_ChecksWithFilter(t *testing.T) {
 
 func TestAgent_HealthServiceByID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -872,7 +872,7 @@ func TestAgent_HealthServiceByID(t *testing.T) {
 
 func TestAgent_HealthServiceByName(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	service := &structs.NodeService{
@@ -1115,7 +1115,7 @@ func TestAgent_HealthServiceByName(t *testing.T) {
 
 func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfigWithParams(nil))
+	a := NewTestAgent(t, TestACLConfigWithParams(nil))
 	defer a.Shutdown()
 
 	service := &structs.NodeService{
@@ -1168,7 +1168,7 @@ func TestAgent_HealthServicesACLEnforcement(t *testing.T) {
 
 func TestAgent_Checks_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1207,7 +1207,7 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 
 func TestAgent_Self(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_meta {
 			somekey = "somevalue"
 		}
@@ -1245,7 +1245,7 @@ func TestAgent_Self(t *testing.T) {
 
 func TestAgent_Self_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1274,7 +1274,7 @@ func TestAgent_Self_ACLDeny(t *testing.T) {
 
 func TestAgent_Metrics_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1304,7 +1304,7 @@ func TestAgent_Metrics_ACLDeny(t *testing.T) {
 func TestAgent_Reload(t *testing.T) {
 	t.Parallel()
 	dc1 := "dc1"
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		acl_enforce_version_8 = false
 		services = [
 			{
@@ -1376,7 +1376,7 @@ func TestAgent_Reload(t *testing.T) {
 
 func TestAgent_Reload_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1403,7 +1403,7 @@ func TestAgent_Reload_ACLDeny(t *testing.T) {
 
 func TestAgent_Members(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1424,7 +1424,7 @@ func TestAgent_Members(t *testing.T) {
 
 func TestAgent_Members_WAN(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1445,7 +1445,7 @@ func TestAgent_Members_WAN(t *testing.T) {
 
 func TestAgent_Members_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -1476,9 +1476,9 @@ func TestAgent_Members_ACLFilter(t *testing.T) {
 
 func TestAgent_Join(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "")
+	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "")
+	a2 := NewTestAgent(t, "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1506,9 +1506,9 @@ func TestAgent_Join(t *testing.T) {
 
 func TestAgent_Join_WAN(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "")
+	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "")
+	a2 := NewTestAgent(t, "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1536,9 +1536,9 @@ func TestAgent_Join_WAN(t *testing.T) {
 
 func TestAgent_Join_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), TestACLConfig())
+	a1 := NewTestAgent(t, TestACLConfig())
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "")
+	a2 := NewTestAgent(t, "")
 	defer a2.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
@@ -1578,11 +1578,11 @@ func (n *mockNotifier) Notify(state string) error {
 
 func TestAgent_JoinLANNotify(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "")
+	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		server = false
 		bootstrap = false
 	`)
@@ -1604,11 +1604,11 @@ func TestAgent_JoinLANNotify(t *testing.T) {
 
 func TestAgent_Leave(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "")
+	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
  		server = false
  		bootstrap = false
  	`)
@@ -1640,7 +1640,7 @@ func TestAgent_Leave(t *testing.T) {
 
 func TestAgent_Leave_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1671,9 +1671,9 @@ func TestAgent_Leave_ACLDeny(t *testing.T) {
 
 func TestAgent_ForceLeave(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "")
+	a1 := NewTestAgent(t, "")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "")
+	a2 := NewTestAgent(t, "")
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
 
@@ -1729,7 +1729,7 @@ func TestOpenMetricsMimeTypeHeaders(t *testing.T) {
 
 func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1821,7 +1821,7 @@ func TestAgent_ForceLeavePrune(t *testing.T) {
 
 func TestAgent_RegisterCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1864,7 +1864,7 @@ func TestAgent_RegisterCheck(t *testing.T) {
 // support as a result of https://github.com/hashicorp/consul/issues/3587.
 func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 `)
 	defer a.Shutdown()
@@ -1949,7 +1949,7 @@ func TestAgent_RegisterCheck_Scripts(t *testing.T) {
 
 func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1973,7 +1973,7 @@ func TestAgent_RegisterCheckScriptsExecDisable(t *testing.T) {
 
 func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_local_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1999,7 +1999,7 @@ func TestAgent_RegisterCheckScriptsExecRemoteDisable(t *testing.T) {
 
 func TestAgent_RegisterCheck_Passing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2035,7 +2035,7 @@ func TestAgent_RegisterCheck_Passing(t *testing.T) {
 
 func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2056,7 +2056,7 @@ func TestAgent_RegisterCheck_BadStatus(t *testing.T) {
 
 func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfigNew())
+	a := NewTestAgent(t, TestACLConfigNew())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2193,7 +2193,7 @@ func TestAgent_RegisterCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_DeregisterCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2217,7 +2217,7 @@ func TestAgent_DeregisterCheck(t *testing.T) {
 
 func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WithToken("root"))
 
@@ -2243,7 +2243,7 @@ func TestAgent_DeregisterCheckACLDeny(t *testing.T) {
 
 func TestAgent_PassCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2271,7 +2271,7 @@ func TestAgent_PassCheck(t *testing.T) {
 
 func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2298,7 +2298,7 @@ func TestAgent_PassCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_WarnCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2326,7 +2326,7 @@ func TestAgent_WarnCheck(t *testing.T) {
 
 func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2353,7 +2353,7 @@ func TestAgent_WarnCheck_ACLDeny(t *testing.T) {
 
 func TestAgent_FailCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2381,7 +2381,7 @@ func TestAgent_FailCheck(t *testing.T) {
 
 func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2409,7 +2409,7 @@ func TestAgent_FailCheck_ACLDeny(t *testing.T) {
 func TestAgent_UpdateCheck(t *testing.T) {
 	t.Parallel()
 	maxChecksSize := 256
-	a := NewTestAgent(t, t.Name(), fmt.Sprintf("check_output_max_size=%d", maxChecksSize))
+	a := NewTestAgent(t, fmt.Sprintf("check_output_max_size=%d", maxChecksSize))
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2493,7 +2493,7 @@ func TestAgent_UpdateCheck(t *testing.T) {
 
 func TestAgent_UpdateCheck_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2534,7 +2534,7 @@ func TestAgent_RegisterService(t *testing.T) {
 func testAgent_RegisterService(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2620,7 +2620,7 @@ func TestAgent_RegisterService_ReRegister(t *testing.T) {
 func testAgent_RegisterService_ReRegister(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2695,7 +2695,7 @@ func TestAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T) {
 
 func testAgent_RegisterService_ReRegister_ReplaceExistingChecks(t *testing.T, extraHCL string) {
 	t.Helper()
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -2780,7 +2780,7 @@ func testAgent_RegisterService_TranslateKeys(t *testing.T, extraHCL string) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.ip, func(t *testing.T) {
-			a := NewTestAgent(t, t.Name(), `
+			a := NewTestAgent(t, `
 	connect {}
 `+extraHCL)
 			defer a.Shutdown()
@@ -2987,7 +2987,7 @@ func TestAgent_RegisterService_ACLDeny(t *testing.T) {
 func testAgent_RegisterService_ACLDeny(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+" "+extraHCL)
+	a := NewTestAgent(t, TestACLConfig()+" "+extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3037,7 +3037,7 @@ func TestAgent_RegisterService_InvalidAddress(t *testing.T) {
 func testAgent_RegisterService_InvalidAddress(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3081,7 +3081,7 @@ func TestAgent_RegisterService_UnmanagedConnectProxy(t *testing.T) {
 func testAgent_RegisterService_UnmanagedConnectProxy(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3599,7 +3599,7 @@ func testAgent_RegisterServiceDeregisterService_Sidecar(t *testing.T, extraHCL s
 				hcl = hcl + TestACLConfig()
 			}
 
-			a := NewTestAgent(t, t.Name(), hcl+" "+extraHCL)
+			a := NewTestAgent(t, hcl+" "+extraHCL)
 			defer a.Shutdown()
 			testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3712,7 +3712,7 @@ func testAgent_RegisterService_UnmanagedConnectProxyInvalid(t *testing.T, extraH
 	t.Helper()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3755,7 +3755,7 @@ func testAgent_RegisterService_ConnectNative(t *testing.T, extraHCL string) {
 	t.Helper()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3799,7 +3799,7 @@ func TestAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T) {
 func testAgent_RegisterService_ScriptCheck_ExecDisable(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3845,7 +3845,7 @@ func TestAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T) {
 func testAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_local_script_checks = true
 	`+extraHCL)
 	defer a.Shutdown()
@@ -3881,7 +3881,7 @@ func testAgent_RegisterService_ScriptCheck_ExecRemoteDisable(t *testing.T, extra
 
 func TestAgent_DeregisterService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3909,7 +3909,7 @@ func TestAgent_DeregisterService(t *testing.T) {
 
 func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3938,7 +3938,7 @@ func TestAgent_DeregisterService_ACLDeny(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -3978,7 +3978,7 @@ func TestAgent_ServiceMaintenance_BadRequest(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4021,7 +4021,7 @@ func TestAgent_ServiceMaintenance_Enable(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4058,7 +4058,7 @@ func TestAgent_ServiceMaintenance_Disable(t *testing.T) {
 
 func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4088,7 +4088,7 @@ func TestAgent_ServiceMaintenance_ACLDeny(t *testing.T) {
 
 func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4105,7 +4105,7 @@ func TestAgent_NodeMaintenance_BadRequest(t *testing.T) {
 
 func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4138,7 +4138,7 @@ func TestAgent_NodeMaintenance_Enable(t *testing.T) {
 
 func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4163,7 +4163,7 @@ func TestAgent_NodeMaintenance_Disable(t *testing.T) {
 
 func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4184,7 +4184,7 @@ func TestAgent_NodeMaintenance_ACLDeny(t *testing.T) {
 
 func TestAgent_RegisterCheck_Service(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4235,7 +4235,7 @@ func TestAgent_RegisterCheck_Service(t *testing.T) {
 
 func TestAgent_Monitor(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4386,7 +4386,7 @@ func TestAgent_Monitor(t *testing.T) {
 
 func TestAgent_Monitor_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4476,7 +4476,7 @@ func TestAgent_TokenTriggersFullSync(t *testing.T) {
 		t.Run(tt.path, func(t *testing.T) {
 			url := fmt.Sprintf("/v1/agent/token/%s?token=root", tt.path)
 
-			a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+			a := NewTestAgent(t, TestACLConfig()+`
 				acl {
 					tokens {
 						default = ""
@@ -4515,7 +4515,7 @@ func TestAgent_Token(t *testing.T) {
 	// The behavior of this handler when ACLs are disabled is vetted over
 	// in TestACL_Disabled_Response since there's already good infra set
 	// up over there to test this, and it calls the common function.
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, TestACLConfig()+`
 		acl {
 			tokens {
 				default = ""
@@ -4771,7 +4771,7 @@ func TestAgentConnectCARoots_empty(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "connect { enabled = false }")
+	a := NewTestAgent(t, "connect { enabled = false }")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4787,7 +4787,7 @@ func TestAgentConnectCARoots_list(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -4864,7 +4864,7 @@ func TestAgentConnectCALeafCert_aclDefaultDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
@@ -4900,7 +4900,7 @@ func TestAgentConnectCALeafCert_aclServiceWrite(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
@@ -4957,7 +4957,7 @@ func TestAgentConnectCALeafCert_aclServiceReadDeny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
@@ -5012,7 +5012,7 @@ func TestAgentConnectCALeafCert_good(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
@@ -5115,7 +5115,7 @@ func TestAgentConnectCALeafCert_goodNotLocal(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	testrpc.WaitForActiveCARoot(t, a.RPC, "dc1", nil)
@@ -5453,7 +5453,7 @@ func TestAgentConnectAuthorize_badBody(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5473,7 +5473,7 @@ func TestAgentConnectAuthorize_noTarget(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5494,7 +5494,7 @@ func TestAgentConnectAuthorize_idInvalidFormat(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5518,7 +5518,7 @@ func TestAgentConnectAuthorize_idNotService(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5541,7 +5541,7 @@ func TestAgentConnectAuthorize_allow(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5638,7 +5638,7 @@ func TestAgentConnectAuthorize_deny(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5688,7 +5688,7 @@ func TestAgentConnectAuthorize_allowTrustDomain(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -5733,7 +5733,7 @@ func TestAgentConnectAuthorize_denyWildcard(t *testing.T) {
 
 	assert := assert.New(t)
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -5813,7 +5813,7 @@ func TestAgentConnectAuthorize_serviceWrite(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5851,7 +5851,7 @@ func TestAgentConnectAuthorize_defaultDeny(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5876,7 +5876,7 @@ func TestAgentConnectAuthorize_defaultAllow(t *testing.T) {
 
 	assert := assert.New(t)
 	dc1 := "dc1"
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		acl_datacenter = "`+dc1+`"
 		acl_default_policy = "allow"
 		acl_master_token = "root"
@@ -5908,7 +5908,7 @@ func TestAgent_Host(t *testing.T) {
 	assert := assert.New(t)
 
 	dc1 := "dc1"
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "allow"
 	acl_master_token = "master"
@@ -5936,7 +5936,7 @@ func TestAgent_HostBadACL(t *testing.T) {
 	assert := assert.New(t)
 
 	dc1 := "dc1"
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "deny"
 	acl_master_token = "root"
@@ -5959,7 +5959,7 @@ func TestAgent_HostBadACL(t *testing.T) {
 func TestAgent_Services_ExposeConfig(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -1773,9 +1773,9 @@ func TestAgent_ForceLeave_ACLDeny(t *testing.T) {
 
 func TestAgent_ForceLeavePrune(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent1"})
+	a1 := StartTestAgent(t, TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent2"})
+	a2 := StartTestAgent(t, TestAgent{Name: "Agent2"})
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 	testrpc.WaitForLeader(t, a2.RPC, "dc1")
 
@@ -5236,14 +5236,14 @@ func TestAgentConnectCALeafCert_secondaryDC_good(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "dc1", HCL: `
+	a1 := StartTestAgent(t, TestAgent{Name: "dc1", HCL: `
 		datacenter = "dc1"
 		primary_datacenter = "dc1"
 	`})
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "dc2", HCL: `
+	a2 := StartTestAgent(t, TestAgent{Name: "dc2", HCL: `
 		datacenter = "dc2"
 		primary_datacenter = "dc1"
 	`})

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1409,7 +1409,7 @@ func TestAgent_RestoreServiceWithAliasCheck(t *testing.T) {
 	    enable_central_service_config = false
 		data_dir = "` + dataDir + `"
 	`
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer os.RemoveAll(dataDir)
 	defer a.Shutdown()
 
@@ -1493,7 +1493,7 @@ node_name = "` + a.Config.NodeName + `"
 		t.Helper()
 
 		// Reload and retain former NodeID and data directory.
-		a2 := NewTestAgentWithFields(t, true, TestAgent{HCL: futureHCL, DataDir: dataDir})
+		a2 := StartTestAgent(t, TestAgent{HCL: futureHCL, DataDir: dataDir})
 		defer a2.Shutdown()
 		a = nil
 
@@ -1757,7 +1757,7 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 	t.Parallel()
 
 	run := func(t *testing.T, ca string) {
-		a := NewTestAgentWithFields(t, true, TestAgent{
+		a := StartTestAgent(t, TestAgent{
 			UseTLS: true,
 			HCL: `
 				enable_agent_tls_for_checks = true
@@ -1886,7 +1886,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 		bootstrap = false
 		data_dir = "` + dataDir + `"
 	` + extraHCL
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -1952,7 +1952,7 @@ func testAgent_PersistService(t *testing.T, extraHCL string) {
 	a.Shutdown()
 
 	// Should load it back during later start
-	a2 := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a2.Shutdown()
 
 	restored := a2.State.ServiceState(structs.NewServiceID(svc.ID, nil))
@@ -2098,7 +2098,7 @@ func testAgent_PurgeServiceOnDuplicate(t *testing.T, extraHCL string) {
 		server = false
 		bootstrap = false
 	` + extraHCL
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a.Shutdown()
 
 	svc1 := &structs.NodeService{
@@ -2114,7 +2114,7 @@ func testAgent_PurgeServiceOnDuplicate(t *testing.T, extraHCL string) {
 
 	// Try bringing the agent back up with the service already
 	// existing in the config
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent2", HCL: cfg + `
+	a2 := StartTestAgent(t, TestAgent{Name: "Agent2", HCL: cfg + `
 		service = {
 			id = "redis"
 			name = "redis"
@@ -2142,7 +2142,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 		bootstrap = false
 		enable_script_checks = true
 	`
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer os.RemoveAll(dataDir)
 	defer a.Shutdown()
 
@@ -2199,7 +2199,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 	a.Shutdown()
 
 	// Should load it back during later start
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent2", HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{Name: "Agent2", HCL: cfg, DataDir: dataDir})
 	defer a2.Shutdown()
 
 	result := requireCheckExists(t, a2, check.CheckID)
@@ -2251,7 +2251,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	t.Parallel()
 	nodeID := NodeID()
 	dataDir := testutil.TempDir(t, "agent")
-	a := NewTestAgentWithFields(t, true, TestAgent{
+	a := StartTestAgent(t, TestAgent{
 		DataDir: dataDir,
 		HCL: `
 	    node_id = "` + nodeID + `"
@@ -2279,7 +2279,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 	a.Shutdown()
 
 	// Start again with the check registered in config
-	a2 := NewTestAgentWithFields(t, true, TestAgent{
+	a2 := StartTestAgent(t, TestAgent{
 		Name:    "Agent2",
 		DataDir: dataDir,
 		HCL: `
@@ -4031,11 +4031,11 @@ func TestAgentCache_serviceInConfigFile_initialFetchErrors_Issue6521(t *testing.
 	// index for the next query from 0 to 1 for all queries, when it should
 	// have not done so for queries that errored.
 
-	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent1"})
+	a1 := StartTestAgent(t, TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()
 	testrpc.WaitForLeader(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "Agent2", HCL: `
+	a2 := StartTestAgent(t, TestAgent{Name: "Agent2", HCL: `
 		server = false
 		bootstrap = false
 services {
@@ -4127,7 +4127,7 @@ func TestAgent_JoinWAN_viaMeshGateway(t *testing.T) {
 	secondaryRPCPorts := freeport.MustTake(2)
 	defer freeport.Return(secondaryRPCPorts)
 
-	a1 := NewTestAgentWithFields(t, true, TestAgent{Name: "bob", HCL: `
+	a1 := StartTestAgent(t, TestAgent{Name: "bob", HCL: `
 		domain = "consul"
 		node_name = "bob"
 		datacenter = "dc1"
@@ -4212,7 +4212,7 @@ func TestAgent_JoinWAN_viaMeshGateway(t *testing.T) {
 		require.NotEmpty(r, a1.PickRandomMeshGatewaySuitableForDialing("dc1"))
 	})
 
-	a2 := NewTestAgentWithFields(t, true, TestAgent{Name: "betty", HCL: `
+	a2 := StartTestAgent(t, TestAgent{Name: "betty", HCL: `
 		domain = "consul"
 		node_name = "betty"
 		datacenter = "dc2"
@@ -4237,7 +4237,7 @@ func TestAgent_JoinWAN_viaMeshGateway(t *testing.T) {
 	defer a2.Shutdown()
 	testrpc.WaitForTestAgent(t, a2.RPC, "dc2")
 
-	a3 := NewTestAgentWithFields(t, true, TestAgent{Name: "bonnie", HCL: `
+	a3 := StartTestAgent(t, TestAgent{Name: "bonnie", HCL: `
 		domain = "consul"
 		node_name = "bonnie"
 		datacenter = "dc3"

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -99,7 +99,7 @@ func TestAgent_MultiStartStop(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			a := NewTestAgent(t, t.Name(), "")
+			a := NewTestAgent(t, "")
 			time.Sleep(250 * time.Millisecond)
 			a.Shutdown()
 		})
@@ -159,7 +159,7 @@ func TestAgent_ConnectClusterIDConfig(t *testing.T) {
 
 func TestAgent_StartStop(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	if err := a.Leave(); err != nil {
@@ -178,7 +178,7 @@ func TestAgent_StartStop(t *testing.T) {
 
 func TestAgent_RPCPing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -191,7 +191,7 @@ func TestAgent_RPCPing(t *testing.T) {
 func TestAgent_TokenStore(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		acl_token = "user"
 		acl_agent_token = "agent"
 		acl_agent_master_token = "master"`,
@@ -212,7 +212,7 @@ func TestAgent_TokenStore(t *testing.T) {
 func TestAgent_ReconnectConfigSettings(t *testing.T) {
 	t.Parallel()
 	func() {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		lan := a.consulConfig().SerfLANConfig.ReconnectTimeout
@@ -227,7 +227,7 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 	}()
 
 	func() {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 			reconnect_timeout = "24h"
 			reconnect_timeout_wan = "36h"
 		`)
@@ -248,7 +248,7 @@ func TestAgent_ReconnectConfigSettings(t *testing.T) {
 func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		ports { serf_wan = -1 }
 		reconnect_timeout_wan = "36h"
 	`)
@@ -260,7 +260,7 @@ func TestAgent_ReconnectConfigWanDisabled(t *testing.T) {
 
 func TestAgent_setupNodeID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_id = ""
 	`)
 	defer a.Shutdown()
@@ -328,7 +328,7 @@ func TestAgent_setupNodeID(t *testing.T) {
 
 func TestAgent_makeNodeID(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_id = ""
 	`)
 	defer a.Shutdown()
@@ -386,7 +386,7 @@ func TestAgent_AddService(t *testing.T) {
 func testAgent_AddService(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "node1"
 	`+extraHCL)
 	defer a.Shutdown()
@@ -582,7 +582,7 @@ func TestAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T) {
 func testAgent_AddServices_AliasUpdateCheckNotReverted(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "node1"
 	`+extraHCL)
 	defer a.Shutdown()
@@ -650,7 +650,7 @@ func TestAgent_AddServiceNoExec(t *testing.T) {
 func testAgent_AddServiceNoExec(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "node1"
 	`+extraHCL)
 	defer a.Shutdown()
@@ -692,7 +692,7 @@ func TestAgent_AddServiceNoRemoteExec(t *testing.T) {
 func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "node1"
 		enable_local_script_checks = true
 	`+extraHCL)
@@ -719,7 +719,7 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -748,7 +748,7 @@ func TestAddServiceIPv4TaggedDefault(t *testing.T) {
 func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -777,7 +777,7 @@ func TestAddServiceIPv6TaggedDefault(t *testing.T) {
 func TestAddServiceIPv4TaggedSet(t *testing.T) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -812,7 +812,7 @@ func TestAddServiceIPv4TaggedSet(t *testing.T) {
 func TestAddServiceIPv6TaggedSet(t *testing.T) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -858,7 +858,7 @@ func TestAgent_RemoveService(t *testing.T) {
 func testAgent_RemoveService(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 
 	// Remove a service that doesn't exist
@@ -969,7 +969,7 @@ func TestAgent_RemoveServiceRemovesAllChecks(t *testing.T) {
 func testAgent_RemoveServiceRemovesAllChecks(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "node1"
 	`+extraHCL)
 	defer a.Shutdown()
@@ -1043,7 +1043,7 @@ func TestAgent_IndexChurn(t *testing.T) {
 func verifyIndexChurn(t *testing.T, tags []string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	weights := &structs.Weights{
@@ -1135,7 +1135,7 @@ func verifyIndexChurn(t *testing.T, tags []string) {
 
 func TestAgent_AddCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1169,7 +1169,7 @@ func TestAgent_AddCheck(t *testing.T) {
 
 func TestAgent_AddCheck_StartPassing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1203,7 +1203,7 @@ func TestAgent_AddCheck_StartPassing(t *testing.T) {
 
 func TestAgent_AddCheck_MinInterval(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1236,7 +1236,7 @@ func TestAgent_AddCheck_MinInterval(t *testing.T) {
 
 func TestAgent_AddCheck_MissingService(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1259,7 +1259,7 @@ func TestAgent_AddCheck_MissingService(t *testing.T) {
 
 func TestAgent_AddCheck_RestoreState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create some state and persist it
@@ -1299,7 +1299,7 @@ func TestAgent_AddCheck_RestoreState(t *testing.T) {
 func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1332,7 +1332,7 @@ func TestAgent_AddCheck_ExecDisable(t *testing.T) {
 func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_local_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1359,7 +1359,7 @@ func TestAgent_AddCheck_ExecRemoteDisable(t *testing.T) {
 
 func TestAgent_AddCheck_GRPC(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1567,7 +1567,7 @@ func TestAgent_AddCheck_Alias(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1599,7 +1599,7 @@ func TestAgent_AddCheck_Alias_setToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1627,7 +1627,7 @@ func TestAgent_AddCheck_Alias_userToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 acl_token = "hello"
 	`)
 	defer a.Shutdown()
@@ -1657,7 +1657,7 @@ func TestAgent_AddCheck_Alias_userAndSetToken(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 acl_token = "hello"
 	`)
 	defer a.Shutdown()
@@ -1685,7 +1685,7 @@ acl_token = "hello"
 
 func TestAgent_RemoveCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		enable_script_checks = true
 	`)
 	defer a.Shutdown()
@@ -1736,7 +1736,7 @@ func TestAgent_HTTPCheck_TLSSkipVerify(t *testing.T) {
 	server := httptest.NewTLSServer(handler)
 	defer server.Close()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	health := &structs.HealthCheck{
@@ -1833,7 +1833,7 @@ func TestAgent_HTTPCheck_EnableAgentTLSForChecks(t *testing.T) {
 
 func TestAgent_updateTTLCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	checkBufSize := 100
 	health := &structs.HealthCheck{
@@ -1997,7 +1997,7 @@ func testAgent_persistedService_compat(t *testing.T, extraHCL string) {
 	t.Helper()
 
 	// Tests backwards compatibility of persisted services from pre-0.5.1
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2050,7 +2050,7 @@ func TestAgent_PurgeService(t *testing.T) {
 func testAgent_PurgeService(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2230,7 +2230,7 @@ func TestAgent_PersistCheck(t *testing.T) {
 
 func TestAgent_PurgeCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	check := &structs.HealthCheck{
@@ -2333,7 +2333,7 @@ func TestAgent_PurgeCheckOnDuplicate(t *testing.T) {
 
 func TestAgent_loadChecks_token(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		check = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2349,7 +2349,7 @@ func TestAgent_loadChecks_token(t *testing.T) {
 
 func TestAgent_unloadChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2401,7 +2401,7 @@ func TestAgent_loadServices_token(t *testing.T) {
 func testAgent_loadServices_token(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2431,7 +2431,7 @@ func TestAgent_loadServices_sidecar(t *testing.T) {
 func testAgent_loadServices_sidecar(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2472,7 +2472,7 @@ func TestAgent_loadServices_sidecarSeparateToken(t *testing.T) {
 func testAgent_loadServices_sidecarSeparateToken(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2511,7 +2511,7 @@ func TestAgent_loadServices_sidecarInheritMeta(t *testing.T) {
 func testAgent_loadServices_sidecarInheritMeta(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2555,7 +2555,7 @@ func TestAgent_loadServices_sidecarOverrideMeta(t *testing.T) {
 func testAgent_loadServices_sidecarOverrideMeta(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		service = {
 			id = "rabbitmq"
 			name = "rabbitmq"
@@ -2603,7 +2603,7 @@ func TestAgent_unloadServices(t *testing.T) {
 func testAgent_unloadServices(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2631,7 +2631,7 @@ func testAgent_unloadServices(t *testing.T, extraHCL string) {
 
 func TestAgent_Service_MaintenanceMode(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	svc := &structs.NodeService{
@@ -2697,7 +2697,7 @@ func TestAgent_Service_MaintenanceMode(t *testing.T) {
 
 func TestAgent_Service_Reap(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		check_reap_interval = "50ms"
 		check_deregister_interval_min = "0s"
 	`)
@@ -2752,7 +2752,7 @@ func TestAgent_Service_Reap(t *testing.T) {
 
 func TestAgent_Service_NoReap(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		check_reap_interval = "50ms"
 		check_deregister_interval_min = "0s"
 	`)
@@ -2805,7 +2805,7 @@ func TestAgent_AddService_restoresSnapshot(t *testing.T) {
 func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 	t.Helper()
 
-	a := NewTestAgent(t, t.Name(), extraHCL)
+	a := NewTestAgent(t, extraHCL)
 	defer a.Shutdown()
 
 	// First register a service
@@ -2837,7 +2837,7 @@ func testAgent_AddService_restoresSnapshot(t *testing.T, extraHCL string) {
 
 func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2877,7 +2877,7 @@ func TestAgent_AddCheck_restoresSnapshot(t *testing.T) {
 
 func TestAgent_NodeMaintenanceMode(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Enter maintenance mode for the node
@@ -2914,7 +2914,7 @@ func TestAgent_NodeMaintenanceMode(t *testing.T) {
 
 func TestAgent_checkStateSnapshot(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// First register a service
@@ -2965,7 +2965,7 @@ func TestAgent_checkStateSnapshot(t *testing.T) {
 
 func TestAgent_loadChecks_checkFails(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Persist a health check with an invalid service ID
@@ -3000,7 +3000,7 @@ func TestAgent_loadChecks_checkFails(t *testing.T) {
 
 func TestAgent_persistCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	cid := structs.NewCheckID("check1", nil)
@@ -3048,7 +3048,7 @@ func TestAgent_persistCheckState(t *testing.T) {
 
 func TestAgent_loadCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create a check whose state will expire immediately
@@ -3109,7 +3109,7 @@ func TestAgent_loadCheckState(t *testing.T) {
 
 func TestAgent_purgeCheckState(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	cid := structs.NewCheckID("check1", nil)
@@ -3143,7 +3143,7 @@ func TestAgent_purgeCheckState(t *testing.T) {
 func TestAgent_GetCoordinate(t *testing.T) {
 	t.Parallel()
 	check := func(server bool) {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 			server = true
 		`)
 		defer a.Shutdown()
@@ -3163,7 +3163,7 @@ func TestAgent_GetCoordinate(t *testing.T) {
 
 func TestAgent_reloadWatches(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Normal watch with http addr set, should succeed
@@ -3243,7 +3243,7 @@ func TestAgent_reloadWatchesHTTPS(t *testing.T) {
 
 func TestAgent_loadTokens(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		acl = {
 			enabled = true
 			tokens = {
@@ -3410,7 +3410,7 @@ func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 		key_file = "../test/key/ourdomain.key"
 		verify_server_hostname = false
 	`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	tlsConf := a.tlsConfigurator.OutgoingRPCConfig()
 	require.True(t, tlsConf.InsecureSkipVerify)
@@ -3443,7 +3443,7 @@ func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
 		  name="webserver1",
 		  check{id="check1", ttl="30s"}
 		}]`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 
 	require.NoError(t, a.updateTTLCheck(structs.NewCheckID("check1", nil), api.HealthPassing, "testing agent reload"))
@@ -3475,7 +3475,7 @@ func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 		key_file = "../test/key/ourdomain.key"
 		verify_server_hostname = false
 	`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	tlsConf := a.tlsConfigurator.IncomingRPCConfig()
 	require.NotNil(t, tlsConf.GetConfigForClient)
@@ -3515,7 +3515,7 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 		key_file = "../test/key/ourdomain.key"
 		verify_server_hostname = false
 	`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	tlsConf := a.tlsConfigurator.IncomingRPCConfig()
 
@@ -3544,7 +3544,7 @@ func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
 		key_file = "../test/key/ourdomain.key"
 		auto_encrypt { allow_tls = true }
 	`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	require.True(t, a.consulConfig().AutoEncryptAllowTLS)
 }
@@ -3554,7 +3554,7 @@ func TestAgent_consulConfig_RaftTrailingLogs(t *testing.T) {
 	hcl := `
 		raft_trailing_logs = 812345
 	`
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	require.Equal(t, uint64(812345), a.consulConfig().RaftConfig.TrailingLogs)
 }
@@ -3798,7 +3798,7 @@ func TestConfigSourceFromName(t *testing.T) {
 func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -3927,7 +3927,7 @@ func TestAgent_RerouteExistingHTTPChecks(t *testing.T) {
 func TestAgent_RerouteNewHTTPChecks(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	for _, addr := range []string{"0.0.0.0", "::", "[::]"} {
@@ -43,7 +43,7 @@ func TestCatalogRegister_Service_InvalidAddress(t *testing.T) {
 
 func TestCatalogDeregister(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Register node
@@ -62,7 +62,7 @@ func TestCatalogDeregister(t *testing.T) {
 
 func TestCatalogDatacenters(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	retry.Run(t, func(r *retry.R) {
@@ -81,7 +81,7 @@ func TestCatalogDatacenters(t *testing.T) {
 
 func TestCatalogNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -115,7 +115,7 @@ func TestCatalogNodes(t *testing.T) {
 
 func TestCatalogNodes_MetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -156,7 +156,7 @@ func TestCatalogNodes_MetaFilter(t *testing.T) {
 
 func TestCatalogNodes_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -192,7 +192,7 @@ func TestCatalogNodes_Filter(t *testing.T) {
 
 func TestCatalogNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -200,7 +200,7 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -290,7 +290,7 @@ func TestCatalogNodes_WanTranslation(t *testing.T) {
 
 func TestCatalogNodes_Blocking(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WaitForAntiEntropySync())
 
@@ -364,7 +364,7 @@ RUN_BLOCKING_QUERY:
 
 func TestCatalogNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -449,7 +449,7 @@ func TestCatalogNodes_DistanceSort(t *testing.T) {
 
 func TestCatalogServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -485,7 +485,7 @@ func TestCatalogServices(t *testing.T) {
 
 func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Register node
@@ -526,7 +526,7 @@ func TestCatalogServices_NodeMetaFilter(t *testing.T) {
 
 func TestCatalogRegister_checkRegistration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Register node with a service and check
@@ -579,7 +579,7 @@ func TestCatalogRegister_checkRegistration(t *testing.T) {
 
 func TestCatalogServiceNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	assert := assert.New(t)
@@ -692,7 +692,7 @@ func TestCatalogServiceNodes(t *testing.T) {
 
 func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is returned, not a nil
@@ -747,7 +747,7 @@ func TestCatalogServiceNodes_NodeMetaFilter(t *testing.T) {
 
 func TestCatalogServiceNodes_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	queryPath := "/v1/catalog/service/api?filter=" + url.QueryEscape("ServiceMeta.somekey == somevalue")
@@ -810,14 +810,14 @@ func TestCatalogServiceNodes_Filter(t *testing.T) {
 
 func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -892,7 +892,7 @@ func TestCatalogServiceNodes_WanTranslation(t *testing.T) {
 
 func TestCatalogServiceNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -985,7 +985,7 @@ func TestCatalogServiceNodes_ConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1013,7 +1013,7 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1040,7 +1040,7 @@ func TestCatalogConnectServiceNodes_good(t *testing.T) {
 func TestCatalogConnectServiceNodes_Filter(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1077,7 +1077,7 @@ func TestCatalogConnectServiceNodes_Filter(t *testing.T) {
 
 func TestCatalogNodeServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1120,7 +1120,7 @@ func TestCatalogNodeServices(t *testing.T) {
 
 func TestCatalogNodeServiceList(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1170,7 +1170,7 @@ func TestCatalogNodeServiceList(t *testing.T) {
 
 func TestCatalogNodeServices_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1211,7 +1211,7 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1235,7 +1235,7 @@ func TestCatalogNodeServices_ConnectProxy(t *testing.T) {
 
 func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -1243,7 +1243,7 @@ func TestCatalogNodeServices_WanTranslation(t *testing.T) {
 	defer a1.Shutdown()
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""

--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -16,7 +16,7 @@ import (
 func TestConfig_Get(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -97,7 +97,7 @@ func TestConfig_Delete(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -147,7 +147,7 @@ func TestConfig_Apply(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -185,7 +185,7 @@ func TestConfig_Apply(t *testing.T) {
 func TestConfig_Apply_ProxyDefaultsMeshGateway(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -224,7 +224,7 @@ func TestConfig_Apply_CAS(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -305,7 +305,7 @@ func TestConfig_Apply_CAS(t *testing.T) {
 func TestConfig_Apply_Decoding(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -377,7 +377,7 @@ func TestConfig_Apply_Decoding(t *testing.T) {
 func TestConfig_Apply_ProxyDefaultsExpose(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/connect_ca_endpoint_test.go
+++ b/agent/connect_ca_endpoint_test.go
@@ -19,7 +19,7 @@ func TestConnectCARoots_empty(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "connect { enabled = false }")
+	a := NewTestAgent(t, "connect { enabled = false }")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -34,7 +34,7 @@ func TestConnectCARoots_list(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -226,7 +226,7 @@ func TestConnectCAConfig(t *testing.T) {
 					}
 				}`
 			}
-			a := NewTestAgent(t, t.Name(), hcl)
+			a := NewTestAgent(t, hcl)
 			defer a.Shutdown()
 			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/coordinate_endpoint_test.go
+++ b/agent/coordinate_endpoint_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestCoordinate_Disabled_Response(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		disable_coordinates = true
 `)
 	defer a.Shutdown()
@@ -52,7 +52,7 @@ func TestCoordinate_Disabled_Response(t *testing.T) {
 
 func TestCoordinate_Datacenters(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -78,7 +78,7 @@ func TestCoordinate_Datacenters(t *testing.T) {
 
 func TestCoordinate_Nodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -229,7 +229,7 @@ func TestCoordinate_Nodes(t *testing.T) {
 
 func TestCoordinate_Node(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -342,7 +342,7 @@ func TestCoordinate_Node(t *testing.T) {
 
 func TestCoordinate_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -394,7 +394,7 @@ func TestCoordinate_Update(t *testing.T) {
 
 func TestCoordinate_Update_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/agent/discovery_chain_endpoint_test.go
+++ b/agent/discovery_chain_endpoint_test.go
@@ -18,7 +18,7 @@ import (
 func TestDiscoveryChainRead(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -157,7 +157,7 @@ func TestEncodeKVasRFC1464(t *testing.T) {
 
 func TestDNS_Over_TCP(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -190,7 +190,7 @@ func TestDNS_Over_TCP(t *testing.T) {
 
 func TestDNS_EmptyAltDomain(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -205,7 +205,7 @@ func TestDNS_EmptyAltDomain(t *testing.T) {
 
 func TestDNS_NodeLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -300,7 +300,7 @@ func TestDNS_NodeLookup(t *testing.T) {
 
 func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -332,7 +332,7 @@ func TestDNS_CaseInsensitiveNodeLookup(t *testing.T) {
 
 func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -372,7 +372,7 @@ func TestDNS_NodeLookup_PeriodName(t *testing.T) {
 
 func TestDNS_NodeLookup_AAAA(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -429,7 +429,7 @@ func TestDNSCycleRecursorCheck(t *testing.T) {
 	})
 	defer server2.Shutdown()
 	//Mock the agent startup with the necessary configs
-	agent := NewTestAgent(t, t.Name(),
+	agent := NewTestAgent(t,
 		`recursors = ["`+server1.Addr+`", "`+server2.Addr+`"]
 		`)
 	defer agent.Shutdown()
@@ -463,7 +463,7 @@ func TestDNSCycleRecursorCheckAllFail(t *testing.T) {
 	})
 	defer server3.Shutdown()
 	//Mock the agent startup with the necessary configs
-	agent := NewTestAgent(t, t.Name(),
+	agent := NewTestAgent(t,
 		`recursors = ["`+server1.Addr+`", "`+server2.Addr+`","`+server3.Addr+`"]
 		`)
 	defer agent.Shutdown()
@@ -487,7 +487,7 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -536,7 +536,7 @@ func TestDNS_NodeLookup_CNAME(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), ``)
+	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -582,7 +582,7 @@ func TestDNS_NodeLookup_TXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -628,7 +628,7 @@ func TestDNS_NodeLookup_TXT_DontSuppress(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), ``)
+	a := NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -669,7 +669,7 @@ func TestDNS_NodeLookup_ANY(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -710,7 +710,7 @@ func TestDNS_NodeLookup_ANY_DontSuppressTXT(t *testing.T) {
 }
 
 func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -747,7 +747,7 @@ func TestDNS_NodeLookup_A_SuppressTXT(t *testing.T) {
 
 func TestDNS_EDNS0(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -787,7 +787,7 @@ func TestDNS_EDNS0(t *testing.T) {
 
 func TestDNS_EDNS0_ECS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -879,7 +879,7 @@ func TestDNS_EDNS0_ECS(t *testing.T) {
 
 func TestDNS_ReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -919,7 +919,7 @@ func TestDNS_ReverseLookup(t *testing.T) {
 
 func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		domain = "custom"
 	`)
 	defer a.Shutdown()
@@ -961,7 +961,7 @@ func TestDNS_ReverseLookup_CustomDomain(t *testing.T) {
 
 func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1001,7 +1001,7 @@ func TestDNS_ReverseLookup_IPV6(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1049,7 +1049,7 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1097,7 +1097,7 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 
 func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		domain = "custom"
 	`)
 	defer a.Shutdown()
@@ -1148,7 +1148,7 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 func TestDNS_SOA_Settings(t *testing.T) {
 	t.Parallel()
 	testSoaWithConfig := func(config string, ttl, expire, refresh, retry uint) {
-		a := NewTestAgent(t, t.Name(), config)
+		a := NewTestAgent(t, config)
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1180,7 +1180,7 @@ func TestDNS_SOA_Settings(t *testing.T) {
 
 func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1228,7 +1228,7 @@ func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 
 func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1283,7 +1283,7 @@ func TestDNS_ServiceLookupNoMultiCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1341,7 +1341,7 @@ func TestDNS_ServiceLookupPreferNoCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1415,7 +1415,7 @@ func TestDNS_ServiceLookupMultiAddrNoCNAME(t *testing.T) {
 
 func TestDNS_ServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1536,7 +1536,7 @@ func TestDNS_ServiceLookup(t *testing.T) {
 
 func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "my.test-node"
 	`)
 	defer a.Shutdown()
@@ -1594,7 +1594,7 @@ func TestDNS_ServiceLookupWithInternalServiceAddress(t *testing.T) {
 func TestDNS_ConnectServiceLookup(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1638,7 +1638,7 @@ func TestDNS_ConnectServiceLookup(t *testing.T) {
 
 func TestDNS_ExternalServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1697,7 +1697,7 @@ func TestDNS_ExternalServiceLookup(t *testing.T) {
 func TestDNS_InifiniteRecursion(t *testing.T) {
 	// This test should not create an infinite recursion
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		domain = "CONSUL."
 		node_name = "test node"
 	`)
@@ -1751,7 +1751,7 @@ func TestDNS_InifiniteRecursion(t *testing.T) {
 
 func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		domain = "CONSUL."
 		node_name = "test node"
 	`)
@@ -1850,7 +1850,7 @@ func TestDNS_ExternalServiceToConsulCNAMELookup(t *testing.T) {
 
 func TestDNS_NSRecords(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		domain = "CONSUL."
 		node_name = "server1"
 	`)
@@ -1885,7 +1885,7 @@ func TestDNS_NSRecords(t *testing.T) {
 
 func TestDNS_NSRecords_IPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
  		domain = "CONSUL."
  		node_name = "server1"
  		advertise_addr = "::1"
@@ -1922,7 +1922,7 @@ func TestDNS_NSRecords_IPV6(t *testing.T) {
 
 func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "test-node"
 	`)
 	defer a.Shutdown()
@@ -2049,7 +2049,7 @@ func TestDNS_ExternalServiceToConsulCNAMENestedLookup(t *testing.T) {
 
 func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2150,7 +2150,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		               recursors = ["`+recursor.Addr+`"]
 		       `)
 	defer a.Shutdown()
@@ -2249,7 +2249,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 
 func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2342,14 +2342,14 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 
 func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -2550,7 +2550,7 @@ func TestDNS_ServiceLookup_WanTranslation(t *testing.T) {
 
 func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2740,7 +2740,7 @@ func TestDNS_Lookup_TaggedIPAddresses(t *testing.T) {
 
 func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2811,7 +2811,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 
 func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -2894,7 +2894,7 @@ func TestDNS_PreparedQueryNearIPEDNS(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3021,7 +3021,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 	}
 
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3126,7 +3126,7 @@ func TestDNS_PreparedQueryNearIP(t *testing.T) {
 
 func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3205,7 +3205,7 @@ func TestDNS_ServiceLookup_PreparedQueryNamePeriod(t *testing.T) {
 
 func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3308,7 +3308,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 
 func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3444,7 +3444,7 @@ func TestDNS_Recurse(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -3476,7 +3476,7 @@ func TestDNS_Recurse_Truncation(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -3517,7 +3517,7 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 	}
 	defer resolver.Close()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+resolver.LocalAddr().String()+`"] // host must cause a connection|read|write timeout
 		dns_config {
 			recursor_timeout = "`+serverClientTimeout.String()+`"
@@ -3556,7 +3556,7 @@ func TestDNS_RecursorTimeout(t *testing.T) {
 
 func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3712,7 +3712,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 
 func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -3825,7 +3825,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 
 func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			only_passing = true
 		}
@@ -3968,7 +3968,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 
 func TestDNS_ServiceLookup_Randomize(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -4099,7 +4099,7 @@ func TestBinarySearch(t *testing.T) {
 
 func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			enable_truncate = true
 		}
@@ -4204,7 +4204,7 @@ func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 
 func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			enable_truncate = true
 		}
@@ -4273,7 +4273,7 @@ func TestDNS_ServiceLookup_Truncate(t *testing.T) {
 
 func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			enable_truncate = true
 		}
@@ -4379,7 +4379,7 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 
 func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uint16,
 	expectedService, expectedQuery, expectedQueryID int) (bool, error) {
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "test-node"
 		dns_config {
 			udp_answer_limit = `+fmt.Sprintf("%d", answerLimit)+`
@@ -4468,7 +4468,7 @@ func testDNSServiceLookupResponseLimits(t *testing.T, answerLimit int, qType uin
 
 func checkDNSService(t *testing.T, generateNumNodes int, aRecordLimit int, qType uint16,
 	expectedResultsCount int, udpSize uint16, udpAnswerLimit int) error {
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "test-node"
 		dns_config {
 			a_record_limit = `+fmt.Sprintf("%d", aRecordLimit)+`
@@ -4701,7 +4701,7 @@ func TestDNS_ServiceLookup_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -4798,7 +4798,7 @@ func TestDNS_ServiceLookup_ServiceAddress_CNAME(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -4896,7 +4896,7 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 		dns_config {
 			node_ttl = "10s"
@@ -5014,7 +5014,7 @@ func TestDNS_NodeLookup_TTL(t *testing.T) {
 
 func TestDNS_ServiceLookup_TTL(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			service_ttl = {
 				"d*" = "42s"
@@ -5092,7 +5092,7 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 
 func TestDNS_PreparedQuery_TTL(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			service_ttl = {
 				"d*" = "42s"
@@ -5212,14 +5212,14 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 
 func TestDNS_PreparedQuery_Failover(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -5324,7 +5324,7 @@ func TestDNS_PreparedQuery_Failover(t *testing.T) {
 
 func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5399,7 +5399,7 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 
 func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5483,7 +5483,7 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("ACLToken == "+tt.token, func(t *testing.T) {
-			a := NewTestAgent(t, t.Name(), `
+			a := NewTestAgent(t, `
 				acl_token = "`+tt.token+`"
 				acl_master_token = "root"
 				acl_datacenter = "dc1"
@@ -5525,7 +5525,7 @@ func TestDNS_ServiceLookup_FilterACL(t *testing.T) {
 	}
 }
 func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = true }`)
+	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = true }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5571,7 +5571,7 @@ func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
 }
 
 func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `dns_config = { enable_additional_node_meta_txt = false }`)
+	a := NewTestAgent(t, `dns_config = { enable_additional_node_meta_txt = false }`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5615,7 +5615,7 @@ func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
 
 func TestDNS_AddressLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5652,7 +5652,7 @@ func TestDNS_AddressLookup(t *testing.T) {
 
 func TestDNS_AddressLookupIPV6(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5690,7 +5690,7 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 
 func TestDNS_NonExistingLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5719,7 +5719,7 @@ func TestDNS_NonExistingLookup(t *testing.T) {
 
 func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -5858,7 +5858,7 @@ func TestDNS_NonExistingLookupEmptyAorAAAA(t *testing.T) {
 
 func TestDNS_AltDomains_Service(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		alt_domain = "test-domain."
 	`)
 	defer a.Shutdown()
@@ -5930,7 +5930,7 @@ func TestDNS_AltDomains_Service(t *testing.T) {
 
 func TestDNS_AltDomains_SOA(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "test-node"
 		alt_domain = "test-domain."
 	`)
@@ -5975,7 +5975,7 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 	// than one potential match (i.e. ambiguous match)
 	// it should select the longer matching domain when dispatching
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		node_name = "test-node"
 		alt_domain = "test.consul."
 	`)
@@ -6016,7 +6016,7 @@ func TestDNS_AltDomains_Overlap(t *testing.T) {
 
 func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		dns_config {
 			allow_stale = true
 			max_stale = "1s"
@@ -6066,7 +6066,7 @@ func TestDNS_PreparedQuery_AllowStale(t *testing.T) {
 
 func TestDNS_InvalidQueries(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6108,7 +6108,7 @@ func TestDNS_InvalidQueries(t *testing.T) {
 
 func TestDNS_PreparedQuery_AgentSource(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6614,7 +6614,7 @@ func TestDNS_Compression_trimUDPResponse(t *testing.T) {
 
 func TestDNS_Compression_Query(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6701,7 +6701,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 
 func TestDNS_Compression_ReverseLookup(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -6758,7 +6758,7 @@ func TestDNS_Compression_Recurse(t *testing.T) {
 	})
 	defer recursor.Shutdown()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["`+recursor.Addr+`"]
 	`)
 	defer a.Shutdown()
@@ -6825,7 +6825,7 @@ func TestDNSInvalidRegex(t *testing.T) {
 func TestDNS_ConfigReload(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		recursors = ["8.8.8.8:53"]
 		dns_config = {
 			allow_stale = false
@@ -6926,7 +6926,7 @@ func TestDNS_ConfigReload(t *testing.T) {
 
 func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestEventFire(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -58,7 +58,7 @@ func TestEventFire(t *testing.T) {
 
 func TestEventFire_token(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, TestACLConfig()+`
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()
@@ -120,7 +120,7 @@ func TestEventFire_token(t *testing.T) {
 
 func TestEventList(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -153,7 +153,7 @@ func TestEventList(t *testing.T) {
 
 func TestEventList_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -191,7 +191,7 @@ func TestEventList_Filter(t *testing.T) {
 
 func TestEventList_ACLFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig())
+	a := NewTestAgent(t, TestACLConfig())
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -242,7 +242,7 @@ func TestEventList_ACLFilter(t *testing.T) {
 
 func TestEventList_Blocking(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -294,7 +294,7 @@ func TestEventList_Blocking(t *testing.T) {
 
 func TestEventList_EventBufOrder(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -22,7 +22,7 @@ import (
 func TestHealthChecksInState(t *testing.T) {
 	t.Parallel()
 	t.Run("warning", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/health/state/warning?dc=dc1", nil)
@@ -45,7 +45,7 @@ func TestHealthChecksInState(t *testing.T) {
 	})
 
 	t.Run("passing", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		req, _ := http.NewRequest("GET", "/v1/health/state/passing?dc=dc1", nil)
@@ -70,7 +70,7 @@ func TestHealthChecksInState(t *testing.T) {
 
 func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	args := &structs.RegisterRequest{
@@ -110,7 +110,7 @@ func TestHealthChecksInState_NodeMetaFilter(t *testing.T) {
 
 func TestHealthChecksInState_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	args := &structs.RegisterRequest{
@@ -156,7 +156,7 @@ func TestHealthChecksInState_Filter(t *testing.T) {
 
 func TestHealthChecksInState_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	args := &structs.RegisterRequest{
@@ -230,7 +230,7 @@ func TestHealthChecksInState_DistanceSort(t *testing.T) {
 
 func TestHealthNodeChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -265,7 +265,7 @@ func TestHealthNodeChecks(t *testing.T) {
 
 func TestHealthNodeChecks_Filtering(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -309,7 +309,7 @@ func TestHealthNodeChecks_Filtering(t *testing.T) {
 
 func TestHealthServiceChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -365,7 +365,7 @@ func TestHealthServiceChecks(t *testing.T) {
 
 func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -418,7 +418,7 @@ func TestHealthServiceChecks_NodeMetaFilter(t *testing.T) {
 
 func TestHealthServiceChecks_Filtering(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -479,7 +479,7 @@ func TestHealthServiceChecks_Filtering(t *testing.T) {
 
 func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -559,7 +559,7 @@ func TestHealthServiceChecks_DistanceSort(t *testing.T) {
 
 func TestHealthServiceNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -685,7 +685,7 @@ func TestHealthServiceNodes(t *testing.T) {
 
 func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -738,7 +738,7 @@ func TestHealthServiceNodes_NodeMetaFilter(t *testing.T) {
 
 func TestHealthServiceNodes_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -800,7 +800,7 @@ func TestHealthServiceNodes_Filter(t *testing.T) {
 
 func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	dc := "dc1"
 	// Create a service check
@@ -879,7 +879,7 @@ func TestHealthServiceNodes_DistanceSort(t *testing.T) {
 
 func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	dc := "dc1"
@@ -976,7 +976,7 @@ func TestHealthServiceNodes_PassingFilter(t *testing.T) {
 
 func TestHealthServiceNodes_CheckType(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -1029,14 +1029,14 @@ func TestHealthServiceNodes_CheckType(t *testing.T) {
 
 func TestHealthServiceNodes_WanTranslation(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), `
+	a1 := NewTestAgent(t, `
 		datacenter = "dc1"
 		translate_wan_addrs = true
 		acl_datacenter = ""
 	`)
 	defer a1.Shutdown()
 
-	a2 := NewTestAgent(t, t.Name(), `
+	a2 := NewTestAgent(t, `
 		datacenter = "dc2"
 		translate_wan_addrs = true
 		acl_datacenter = ""
@@ -1117,7 +1117,7 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Register
@@ -1142,7 +1142,7 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 func TestHealthConnectServiceNodes_Filter(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -1180,7 +1180,7 @@ func TestHealthConnectServiceNodes_Filter(t *testing.T) {
 func TestHealthConnectServiceNodes_PassingFilter(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Register

--- a/agent/http_oss_test.go
+++ b/agent/http_oss_test.go
@@ -62,7 +62,7 @@ func newHttpClient(timeout time.Duration) *http.Client {
 func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 	// To avoid actually triggering RPCs that are allowed, lock everything down
 	// with default-deny ACLs. This drops the test runtime from 11s to 0.6s.
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled        = true
@@ -124,7 +124,7 @@ func TestHTTPAPI_MethodNotAllowed_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `acl_datacenter = "dc1"`)
+	a := NewTestAgent(t, `acl_datacenter = "dc1"`)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -160,7 +160,7 @@ func TestHTTPAPI_OptionMethod_OSS(t *testing.T) {
 }
 
 func TestHTTPAPI_AllowedNets_OSS(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		acl_datacenter = "dc1"
 		http_config {
 			allow_write_http_from = ["127.0.0.1/8"]

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -42,7 +42,7 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 
 	// Only testing mode, since uid/gid might not be settable
 	// from test environment.
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		addresses {
 			http = "unix://`+socket+`"
 		}
@@ -111,7 +111,7 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 		t.Fatalf("not a regular file: %s", socket)
 	}
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		addresses {
 			http = "unix://`+socket+`"
 		}
@@ -287,7 +287,7 @@ func TestSetMeta(t *testing.T) {
 func TestHTTPAPI_BlockEndpoints(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		http_config {
 			block_endpoints = ["/v1/agent/self"]
 		}
@@ -320,7 +320,7 @@ func TestHTTPAPI_BlockEndpoints(t *testing.T) {
 }
 
 func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	req, err := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
@@ -339,7 +339,7 @@ func TestHTTPAPI_Ban_Nonprintable_Characters(t *testing.T) {
 }
 
 func TestHTTPAPI_Allow_Nonprintable_Characters_With_Flag(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), "disable_http_unprintable_char_filter = true")
+	a := NewTestAgent(t, "disable_http_unprintable_char_filter = true")
 	defer a.Shutdown()
 
 	req, err := http.NewRequest("GET", "/v1/kv/bad\x00ness", nil)
@@ -362,7 +362,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 	t.Parallel()
 	// Header should not be present if address translation is off.
 	{
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		resp := httptest.NewRecorder()
@@ -381,7 +381,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 
 	// Header should be set to true if it's turned on.
 	{
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 			translate_wan_addrs = true
 		`)
 		defer a.Shutdown()
@@ -403,7 +403,7 @@ func TestHTTPAPI_TranslateAddrHeader(t *testing.T) {
 
 func TestHTTPAPIResponseHeaders(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		http_config {
 			response_headers = {
 				"Access-Control-Allow-Origin" = "*"
@@ -433,7 +433,7 @@ func TestHTTPAPIResponseHeaders(t *testing.T) {
 }
 func TestUIResponseHeaders(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		http_config {
 			response_headers = {
 				"Access-Control-Allow-Origin" = "*"
@@ -464,7 +464,7 @@ func TestUIResponseHeaders(t *testing.T) {
 
 func TestContentTypeIsJSON(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -547,7 +547,7 @@ func TestPrettyPrintBare(t *testing.T) {
 }
 
 func testPrettyPrint(pretty string, t *testing.T) {
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	r := &structs.DirEntry{Key: "key"}
@@ -575,7 +575,7 @@ func testPrettyPrint(pretty string, t *testing.T) {
 
 func TestParseSource(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Default is agent's DC and no node (since the user didn't care, then
@@ -774,7 +774,7 @@ func TestParseWait(t *testing.T) {
 func TestPProfHandlers_EnableDebug(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "enable_debug = true")
+	a := NewTestAgent(t, "enable_debug = true")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -788,7 +788,7 @@ func TestPProfHandlers_EnableDebug(t *testing.T) {
 func TestPProfHandlers_DisableDebugNoACLs(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "enable_debug = false")
+	a := NewTestAgent(t, "enable_debug = false")
 	defer a.Shutdown()
 
 	resp := httptest.NewRecorder()
@@ -804,7 +804,7 @@ func TestPProfHandlers_ACLs(t *testing.T) {
 	assert := assert.New(t)
 	dc1 := "dc1"
 
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 	acl_datacenter = "`+dc1+`"
 	acl_default_policy = "deny"
 	acl_master_token = "master"
@@ -907,7 +907,7 @@ func TestParseConsistency(t *testing.T) {
 	var b structs.QueryOptions
 
 	req, _ := http.NewRequest("GET", "/v1/catalog/nodes?stale", nil)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	if d := a.srv.parseConsistency(resp, req, &b); d {
 		t.Fatalf("unexpected done")
@@ -959,7 +959,7 @@ func ensureConsistency(t *testing.T, a *TestAgent, path string, maxStale time.Du
 }
 
 func TestParseConsistencyAndMaxStale(t *testing.T) {
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Default => Consistent
@@ -995,7 +995,7 @@ func TestParseConsistency_Invalid(t *testing.T) {
 	var b structs.QueryOptions
 
 	req, _ := http.NewRequest("GET", "/v1/catalog/nodes?stale&consistent", nil)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	if d := a.srv.parseConsistency(resp, req, &b); !d {
 		t.Fatalf("expected done")
@@ -1056,7 +1056,7 @@ func TestACLResolution(t *testing.T) {
 	reqAuthBearerAndXToken.Header.Add("X-Consul-Token", "xtoken")
 	reqAuthBearerAndXToken.Header.Add("Authorization", "Bearer bearer-token")
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Check when no token is set
@@ -1146,7 +1146,7 @@ func TestACLResolution(t *testing.T) {
 
 func TestEnableWebUI(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		ui = true
 	`)
 	defer a.Shutdown()
@@ -1220,7 +1220,7 @@ func TestAllowedNets(t *testing.T) {
 			nets = append(nets, in)
 		}
 
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -132,7 +132,7 @@ func TestHTTPServer_H2(t *testing.T) {
 	t.Parallel()
 
 	// Fire up an agent with TLS enabled.
-	a := NewTestAgentWithFields(t, true, TestAgent{
+	a := StartTestAgent(t, TestAgent{
 		UseTLS: true,
 		HCL: `
 			key_file = "../test/client_certs/server.key"
@@ -486,7 +486,7 @@ func TestContentTypeIsJSON(t *testing.T) {
 func TestHTTP_wrap_obfuscateLog(t *testing.T) {
 	t.Parallel()
 	buf := new(bytes.Buffer)
-	a := NewTestAgentWithFields(t, true, TestAgent{LogOutput: buf})
+	a := StartTestAgent(t, TestAgent{LogOutput: buf})
 	defer a.Shutdown()
 
 	handler := func(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -1288,7 +1288,7 @@ func TestHTTPServer_HandshakeTimeout(t *testing.T) {
 	t.Parallel()
 
 	// Fire up an agent with TLS enabled.
-	a := NewTestAgentWithFields(t, true, TestAgent{
+	a := StartTestAgent(t, TestAgent{
 		UseTLS: true,
 		HCL: `
 			key_file = "../test/client_certs/server.key"
@@ -1354,7 +1354,7 @@ func TestRPC_HTTPSMaxConnsPerClient(t *testing.T) {
 			}
 
 			// Fire up an agent with TLS enabled.
-			a := NewTestAgentWithFields(t, true, TestAgent{
+			a := StartTestAgent(t, TestAgent{
 				UseTLS: tc.tlsEnabled,
 				HCL: hclPrefix + `
 					limits {

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -15,7 +15,7 @@ func TestIntentionsList_empty(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is non-nil.
@@ -33,7 +33,7 @@ func TestIntentionsList_values(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create some intentions, note we create the lowest precedence first to test
@@ -72,7 +72,7 @@ func TestIntentionsMatch_basic(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create some intentions
@@ -137,7 +137,7 @@ func TestIntentionsMatch_noBy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Request
@@ -154,7 +154,7 @@ func TestIntentionsMatch_byInvalid(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Request
@@ -171,7 +171,7 @@ func TestIntentionsMatch_noName(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Request
@@ -188,7 +188,7 @@ func TestIntentionsCheck_basic(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create some intentions
@@ -244,7 +244,7 @@ func TestIntentionsCheck_noSource(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Request
@@ -261,7 +261,7 @@ func TestIntentionsCheck_noDestination(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Request
@@ -278,7 +278,7 @@ func TestIntentionsCreate_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Make sure an empty list is non-nil.
@@ -309,7 +309,7 @@ func TestIntentionsCreate_good(t *testing.T) {
 func TestIntentionsCreate_noBody(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Create with no body
@@ -323,7 +323,7 @@ func TestIntentionsSpecificGet_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// The intention
@@ -359,7 +359,7 @@ func TestIntentionsSpecificGet_invalidId(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// Read intention with bad ID
@@ -376,7 +376,7 @@ func TestIntentionsSpecificUpdate_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// The intention
@@ -422,7 +422,7 @@ func TestIntentionsSpecificDelete_good(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	// The intention

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -54,7 +54,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Server should auto-load LAN and WAN keyring files
 	t.Run("server with keys", func(t *testing.T) {
-		a2 := NewTestAgentWithFields(t, true, TestAgent{Key: key})
+		a2 := StartTestAgent(t, TestAgent{Key: key})
 		defer a2.Shutdown()
 
 		c2 := a2.consulConfig()
@@ -80,7 +80,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Client should auto-load only the LAN keyring file
 	t.Run("client with keys", func(t *testing.T) {
-		a3 := NewTestAgentWithFields(t, true, TestAgent{HCL: `
+		a3 := StartTestAgent(t, TestAgent{HCL: `
 			server = false
 			bootstrap = false
 		`, Key: key})
@@ -272,7 +272,7 @@ func TestAgentKeyring_ACL(t *testing.T) {
 	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: TestACLConfig() + `
+	a := StartTestAgent(t, TestAgent{HCL: TestACLConfig() + `
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -34,7 +34,7 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Should be no configured keyring file by default
 	t.Run("no keys", func(t *testing.T) {
-		a1 := NewTestAgent(t, t.Name(), "")
+		a1 := NewTestAgent(t, "")
 		defer a1.Shutdown()
 
 		c1 := a1.consulConfig()
@@ -111,7 +111,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 
 	// Should be no configured keyring file by default
 	t.Run("no keys", func(t *testing.T) {
-		a1 := NewTestAgent(t, t.Name(), "")
+		a1 := NewTestAgent(t, "")
 		defer a1.Shutdown()
 
 		c1 := a1.consulConfig()
@@ -131,7 +131,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 
 	// Server should auto-load LAN and WAN keyring
 	t.Run("server with keys", func(t *testing.T) {
-		a2 := NewTestAgent(t, t.Name(), `
+		a2 := NewTestAgent(t, `
 			encrypt = "`+key+`"
 			disable_keyring_file = true
 		`)
@@ -160,7 +160,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 
 	// Client should auto-load only the LAN keyring
 	t.Run("client with keys", func(t *testing.T) {
-		a3 := NewTestAgent(t, t.Name(), `
+		a3 := NewTestAgent(t, `
 			encrypt = "`+key+`"
 			server = false
 			bootstrap = false
@@ -199,7 +199,7 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 			t.Fatalf("err: %v", err)
 		}
 
-		a4 := NewTestAgent(t, t.Name(), `
+		a4 := NewTestAgent(t, `
 			encrypt = "`+key+`"
 			disable_keyring_file = true
 			data_dir = "`+dir+`"

--- a/agent/kvs_endpoint_test.go
+++ b/agent/kvs_endpoint_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -74,7 +74,7 @@ func TestKVSEndpoint_PUT_GET_DELETE(t *testing.T) {
 
 func TestKVSEndpoint_Recurse(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -150,7 +150,7 @@ func TestKVSEndpoint_Recurse(t *testing.T) {
 
 func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	{
@@ -216,7 +216,7 @@ func TestKVSEndpoint_DELETE_CAS(t *testing.T) {
 
 func TestKVSEndpoint_CAS(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	{
@@ -292,7 +292,7 @@ func TestKVSEndpoint_CAS(t *testing.T) {
 
 func TestKVSEndpoint_ListKeys(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	keys := []string{
@@ -341,7 +341,7 @@ func TestKVSEndpoint_ListKeys(t *testing.T) {
 
 func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -400,7 +400,7 @@ func TestKVSEndpoint_AcquireRelease(t *testing.T) {
 
 func TestKVSEndpoint_GET_Raw(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte("test"))
@@ -430,7 +430,7 @@ func TestKVSEndpoint_GET_Raw(t *testing.T) {
 
 func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("PUT", "/v1/kv/test?cas=0&acquire=xxx", nil)
@@ -449,7 +449,7 @@ func TestKVSEndpoint_PUT_ConflictingFlags(t *testing.T) {
 
 func TestKVSEndpoint_DELETE_ConflictingFlags(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("DELETE", "/v1/kv/test?recurse&cas=0", nil)

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAgentAntiEntropy_Services(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -244,7 +244,7 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 	t.Parallel()
 
 	assert := assert.New(t)
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -406,7 +406,7 @@ func TestAgentAntiEntropy_Services_ConnectProxy(t *testing.T) {
 
 func TestAgent_ServiceWatchCh(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -490,7 +490,7 @@ func TestAgent_ServiceWatchCh(t *testing.T) {
 
 func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -621,7 +621,7 @@ func TestAgentAntiEntropy_EnableTagOverride(t *testing.T) {
 
 func TestAgentAntiEntropy_Services_WithChecks(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -751,7 +751,7 @@ var testRegisterRules = `
 
 func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
@@ -899,7 +899,7 @@ func TestAgentAntiEntropy_Services_ACLDeny(t *testing.T) {
 
 func TestAgentAntiEntropy_Checks(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1083,7 +1083,7 @@ func TestAgentAntiEntropy_Checks(t *testing.T) {
 
 func TestAgentAntiEntropy_RemovingServiceAndCheck(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -1378,7 +1378,7 @@ func TestAgentAntiEntropy_Checks_ACLDeny(t *testing.T) {
 
 func TestAgent_UpdateCheck_DiscardOutput(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		discard_check_output = true
 		check_update_interval = "0s" # set to "0s" since otherwise output checks are deferred
 	`)
@@ -1900,7 +1900,7 @@ func TestAgent_AliasCheck(t *testing.T) {
 
 func TestAgent_sendCoordinate(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		sync_coordinate_interval_min = "1ms"
 		sync_coordinate_rate_target = 10.0
 		consul = {
@@ -2032,7 +2032,7 @@ func TestState_Notify(t *testing.T) {
 func TestAliasNotifications_local(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/agent/operator_endpoint_test.go
+++ b/agent/operator_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestOperator_RaftConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer(nil)
@@ -46,7 +46,7 @@ func TestOperator_RaftConfiguration(t *testing.T) {
 func TestOperator_RaftPeer(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -62,7 +62,7 @@ func TestOperator_RaftPeer(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -82,7 +82,7 @@ func TestOperator_KeyringInstall(t *testing.T) {
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+oldKey+`"
 	`)
 	defer a.Shutdown()
@@ -117,7 +117,7 @@ func TestOperator_KeyringInstall(t *testing.T) {
 func TestOperator_KeyringList(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -166,7 +166,7 @@ func TestOperator_KeyringRemove(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
 	tempKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -224,7 +224,7 @@ func TestOperator_KeyringUse(t *testing.T) {
 	t.Parallel()
 	oldKey := "H3/9gBxcKKRf45CaI2DlRg=="
 	newKey := "z90lFx3sZZLtTOkutXcwYg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+oldKey+`"
 	`)
 	defer a.Shutdown()
@@ -267,7 +267,7 @@ func TestOperator_KeyringUse(t *testing.T) {
 func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -289,7 +289,7 @@ func TestOperator_Keyring_InvalidRelayFactor(t *testing.T) {
 func TestOperator_Keyring_LocalOnly(t *testing.T) {
 	t.Parallel()
 	key := "H3/9gBxcKKRf45CaI2DlRg=="
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		encrypt = "`+key+`"
 	`)
 	defer a.Shutdown()
@@ -323,7 +323,7 @@ func TestOperator_Keyring_LocalOnly(t *testing.T) {
 
 func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -348,7 +348,7 @@ func TestOperator_AutopilotGetConfiguration(t *testing.T) {
 
 func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	body := bytes.NewBuffer([]byte(`{"CleanupDeadServers": false}`))
@@ -376,7 +376,7 @@ func TestOperator_AutopilotSetConfiguration(t *testing.T) {
 
 func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -444,7 +444,7 @@ func TestOperator_AutopilotCASConfiguration(t *testing.T) {
 
 func TestOperator_ServerHealth(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		raft_protocol = 3
 	`)
 	defer a.Shutdown()
@@ -476,7 +476,7 @@ func TestOperator_ServerHealth(t *testing.T) {
 
 func TestOperator_ServerHealth_Unhealthy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		raft_protocol = 3
 		autopilot {
 			last_contact_threshold = "-1s"

--- a/agent/prepared_query_endpoint_test.go
+++ b/agent/prepared_query_endpoint_test.go
@@ -75,7 +75,7 @@ func (m *MockPreparedQuery) Explain(args *structs.PreparedQueryExecuteRequest,
 
 func TestPreparedQuery_Create(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -164,7 +164,7 @@ func TestPreparedQuery_Create(t *testing.T) {
 func TestPreparedQuery_List(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -197,7 +197,7 @@ func TestPreparedQuery_List(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -247,7 +247,7 @@ func TestPreparedQuery_List(t *testing.T) {
 func TestPreparedQuery_Execute(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -280,7 +280,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -335,7 +335,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -392,7 +392,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -468,7 +468,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure the proper params are set when no special args are passed
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -499,7 +499,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure WAN translation occurs for a response outside of the local DC.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 			datacenter = "dc1"
 			translate_wan_addrs = true
 		`)
@@ -553,7 +553,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 	// Ensure WAN translation doesn't occur for the local DC.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 			datacenter = "dc1"
 			translate_wan_addrs = true
 		`)
@@ -602,7 +602,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -620,7 +620,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 func TestPreparedQuery_ExecuteCached(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	failovers := int32(99)
@@ -677,7 +677,7 @@ func TestPreparedQuery_ExecuteCached(t *testing.T) {
 func TestPreparedQuery_Explain(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -732,7 +732,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -748,7 +748,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 
 	// Ensure that Connect is passed through
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		require := require.New(t)
 
@@ -772,7 +772,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 func TestPreparedQuery_Get(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		m := MockPreparedQuery{
@@ -820,7 +820,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		body := bytes.NewBuffer(nil)
@@ -837,7 +837,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 
 func TestPreparedQuery_Update(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -915,7 +915,7 @@ func TestPreparedQuery_Update(t *testing.T) {
 
 func TestPreparedQuery_Delete(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	m := MockPreparedQuery{
@@ -992,7 +992,7 @@ func TestPreparedQuery_parseLimit(t *testing.T) {
 // correctly when calling through to the real endpoints.
 func TestPreparedQuery_Integration(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/remote_exec_test.go
+++ b/agent/remote_exec_test.go
@@ -134,7 +134,7 @@ func TestRemoteExecGetSpec_ACLDeny(t *testing.T) {
 }
 
 func testRemoteExecGetSpec(t *testing.T, hcl string, token string, shouldSucceed bool, dc string) {
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	if dc != "" {
 		testrpc.WaitForLeader(t, a.RPC, dc)
@@ -208,7 +208,7 @@ func TestRemoteExecWrites_ACLDeny(t *testing.T) {
 }
 
 func testRemoteExecWrites(t *testing.T, hcl string, token string, shouldSucceed bool, dc string) {
-	a := NewTestAgent(t, t.Name(), hcl)
+	a := NewTestAgent(t, hcl)
 	defer a.Shutdown()
 	if dc != "" {
 		testrpc.WaitForLeader(t, a.RPC, dc)
@@ -270,7 +270,7 @@ func testRemoteExecWrites(t *testing.T, hcl string, token string, shouldSucceed 
 }
 
 func testHandleRemoteExec(t *testing.T, command string, expectedSubstring string, expectedReturnCode string) {
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	retry.Run(t, func(r *retry.R) {

--- a/agent/service_checks_test.go
+++ b/agent/service_checks_test.go
@@ -18,7 +18,7 @@ import (
 func TestAgent_ServiceHTTPChecksNotification(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -18,7 +18,7 @@ import (
 func TestServiceManager_RegisterService(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "enable_central_service_config = true")
+	a := NewTestAgent(t, "enable_central_service_config = true")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -65,7 +65,7 @@ func TestServiceManager_RegisterService(t *testing.T) {
 func TestServiceManager_RegisterSidecar(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "enable_central_service_config = true")
+	a := NewTestAgent(t, "enable_central_service_config = true")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -152,7 +152,7 @@ func TestServiceManager_RegisterSidecar(t *testing.T) {
 func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "enable_central_service_config = true")
+	a := NewTestAgent(t, "enable_central_service_config = true")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -208,7 +208,7 @@ func TestServiceManager_RegisterMeshGateway(t *testing.T) {
 func TestServiceManager_RegisterTerminatingGateway(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "enable_central_service_config = true")
+	a := NewTestAgent(t, "enable_central_service_config = true")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -269,7 +269,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	require := require.New(t)
 
 	// Launch a server to manage the config entries.
-	serverAgent := NewTestAgent(t, t.Name(), `enable_central_service_config = true`)
+	serverAgent := NewTestAgent(t, `enable_central_service_config = true`)
 	defer serverAgent.Shutdown()
 	testrpc.WaitForLeader(t, serverAgent.RPC, "dc1")
 
@@ -486,7 +486,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	t.Parallel()
 
 	// Launch a server to manage the config entries.
-	serverAgent := NewTestAgent(t, t.Name(), `enable_central_service_config = true`)
+	serverAgent := NewTestAgent(t, `enable_central_service_config = true`)
 	defer serverAgent.Shutdown()
 	testrpc.WaitForLeader(t, serverAgent.RPC, "dc1")
 
@@ -657,7 +657,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 func TestServiceManager_Disabled(t *testing.T) {
 	require := require.New(t)
 
-	a := NewTestAgent(t, t.Name(), "enable_central_service_config = false")
+	a := NewTestAgent(t, "enable_central_service_config = false")
 	defer a.Shutdown()
 
 	testrpc.WaitForLeader(t, a.RPC, "dc1")

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -302,7 +302,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 		bootstrap = false
 		data_dir = "` + dataDir + `"
 	`
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a.Shutdown()
 
 	// Join first
@@ -465,7 +465,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	serverAgent.Shutdown()
 
 	// Should load it back during later start.
-	a2 := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a2.Shutdown()
 
 	{
@@ -540,7 +540,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 		bootstrap = false
 	` + serviceSnippet
 
-	a := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a.Shutdown()
 
 	// Join first
@@ -639,7 +639,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	serverAgent.Shutdown()
 
 	// Should load it back during later start.
-	a2 := NewTestAgentWithFields(t, true, TestAgent{HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
 	defer a2.Shutdown()
 
 	{

--- a/agent/session_endpoint_test.go
+++ b/agent/session_endpoint_test.go
@@ -62,7 +62,7 @@ func verifySession(t *testing.T, r *retry.R, a *TestAgent, want structs.Session)
 
 func TestSessionCreate(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -120,7 +120,7 @@ func TestSessionCreate(t *testing.T) {
 
 func TestSessionCreate_NodeChecks(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -181,7 +181,7 @@ func TestSessionCreate_NodeChecks(t *testing.T) {
 
 func TestSessionCreate_Delete(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -239,7 +239,7 @@ func TestSessionCreate_Delete(t *testing.T) {
 
 func TestSessionCreate_DefaultCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -275,7 +275,7 @@ func TestSessionCreate_DefaultCheck(t *testing.T) {
 
 func TestSessionCreate_NoCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -431,7 +431,7 @@ func makeTestSessionTTL(t *testing.T, srv *HTTPServer, ttl string) string {
 
 func TestSessionDestroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -451,7 +451,7 @@ func TestSessionDestroy(t *testing.T) {
 func TestSessionCustomTTL(t *testing.T) {
 	t.Parallel()
 	ttl := 250 * time.Millisecond
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		session_ttl_min = "250ms"
 	`)
 	defer a.Shutdown()
@@ -495,7 +495,7 @@ func TestSessionCustomTTL(t *testing.T) {
 func TestSessionTTLRenew(t *testing.T) {
 	// t.Parallel() // timing test. no parallel
 	ttl := 250 * time.Millisecond
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		session_ttl_min = "250ms"
 	`)
 	defer a.Shutdown()
@@ -582,7 +582,7 @@ func TestSessionTTLRenew(t *testing.T) {
 func TestSessionGet(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -604,7 +604,7 @@ func TestSessionGet(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -628,7 +628,7 @@ func TestSessionGet(t *testing.T) {
 
 func TestSessionList(t *testing.T) {
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -648,7 +648,7 @@ func TestSessionList(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -676,7 +676,7 @@ func TestSessionList(t *testing.T) {
 func TestSessionsForNode(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -696,7 +696,7 @@ func TestSessionsForNode(t *testing.T) {
 	})
 
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -723,7 +723,7 @@ func TestSessionsForNode(t *testing.T) {
 
 func TestSessionDeleteDestroy(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -325,7 +325,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			require := require.New(t)
-			a := NewTestAgentWithFields(t, true, TestAgent{Name: "jones", HCL: hcl})
+			a := StartTestAgent(t, TestAgent{Name: "jones", HCL: hcl})
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -325,7 +325,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			require := require.New(t)
-			a := NewTestAgent(t, "jones", hcl)
+			a := NewTestAgentWithFields(t, "jones", hcl)
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {

--- a/agent/sidecar_service_test.go
+++ b/agent/sidecar_service_test.go
@@ -325,7 +325,7 @@ func TestAgent_sidecarServiceFromNodeService(t *testing.T) {
 			}
 
 			require := require.New(t)
-			a := NewTestAgentWithFields(t, "jones", hcl)
+			a := NewTestAgentWithFields(t, true, TestAgent{Name: "jones", HCL: hcl})
 			defer a.Shutdown()
 
 			if tt.preRegister != nil {

--- a/agent/snapshot_endpoint_test.go
+++ b/agent/snapshot_endpoint_test.go
@@ -16,7 +16,7 @@ func TestSnapshot(t *testing.T) {
 	t.Parallel()
 	var snap io.Reader
 	t.Run("create snapshot", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -43,7 +43,7 @@ func TestSnapshot(t *testing.T) {
 	})
 
 	t.Run("restore snapshot", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -59,7 +59,7 @@ func TestSnapshot_Options(t *testing.T) {
 	t.Parallel()
 	for _, method := range []string{"GET", "PUT"} {
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t, t.Name(), TestACLConfig())
+			a := NewTestAgent(t, TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
@@ -72,7 +72,7 @@ func TestSnapshot_Options(t *testing.T) {
 		})
 
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t, t.Name(), TestACLConfig())
+			a := NewTestAgent(t, TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)
@@ -85,7 +85,7 @@ func TestSnapshot_Options(t *testing.T) {
 		})
 
 		t.Run(method, func(t *testing.T) {
-			a := NewTestAgent(t, t.Name(), TestACLConfig())
+			a := NewTestAgent(t, TestACLConfig())
 			defer a.Shutdown()
 
 			body := bytes.NewBuffer(nil)

--- a/agent/status_endpoint_test.go
+++ b/agent/status_endpoint_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStatusLeader(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -29,9 +29,9 @@ func TestStatusLeader(t *testing.T) {
 
 func TestStatusLeaderSecondary(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "datacenter = \"primary\"")
+	a1 := NewTestAgent(t, "datacenter = \"primary\"")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "datacenter = \"secondary\"")
+	a2 := NewTestAgent(t, "datacenter = \"secondary\"")
 	defer a2.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a1.RPC, "primary")
@@ -68,7 +68,7 @@ func TestStatusLeaderSecondary(t *testing.T) {
 
 func TestStatusPeers(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	req, _ := http.NewRequest("GET", "/v1/status/peers", nil)
@@ -85,9 +85,9 @@ func TestStatusPeers(t *testing.T) {
 
 func TestStatusPeersSecondary(t *testing.T) {
 	t.Parallel()
-	a1 := NewTestAgent(t, t.Name(), "datacenter = \"primary\"")
+	a1 := NewTestAgent(t, "datacenter = \"primary\"")
 	defer a1.Shutdown()
-	a2 := NewTestAgent(t, t.Name(), "datacenter = \"secondary\"")
+	a2 := NewTestAgent(t, "datacenter = \"secondary\"")
 	defer a2.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a1.RPC, "primary")

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -91,20 +91,15 @@ type TestAgent struct {
 // The caller is responsible for calling Shutdown() to stop the agent and remove
 // temporary directories.
 func NewTestAgent(t *testing.T, hcl string) *TestAgent {
-	return NewTestAgentWithFields(t, true, TestAgent{HCL: hcl})
+	return StartTestAgent(t, TestAgent{HCL: hcl})
 }
 
-// NewTestAgentWithFields takes a TestAgent struct with any number of fields set,
-// and a boolean 'start', which indicates whether or not the TestAgent should
-// be started. If no LogOutput is set, it will automatically be set to
-// testutil.TestWriter(t). Name will default to t.Name() if not specified.
-func NewTestAgentWithFields(t *testing.T, start bool, ta TestAgent) *TestAgent {
-	// copy values
-	a := ta
-	if !start {
-		return &a
-	}
-
+// StartTestAgent and wait for it to become available. If the agent fails to
+// start the test will be marked failed and execution will stop.
+//
+// The caller is responsible for calling Shutdown() to stop the agent and remove
+// temporary directories.
+func StartTestAgent(t *testing.T, a TestAgent) *TestAgent {
 	retry.RunWith(retry.ThreeTimes(), t, func(r *retry.R) {
 		if err := a.Start(t); err != nil {
 			r.Fatal(err)

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -86,12 +86,12 @@ type TestAgent struct {
 	*Agent
 }
 
-// NewTestAgent returns a started agent with the given name and
-// configuration. It fails the test if the Agent could not be started. The
-// caller should call Shutdown() to stop the agent and remove temporary
-// directories.
-func NewTestAgent(t *testing.T, name string, hcl string) *TestAgent {
-	return NewTestAgentWithFields(t, true, TestAgent{Name: name, HCL: hcl})
+// NewTestAgent returns a started agent with the given configuration. It fails
+// the test if the Agent could not be started.
+// The caller is responsible for calling Shutdown() to stop the agent and remove
+// temporary directories.
+func NewTestAgent(t *testing.T, hcl string) *TestAgent {
+	return NewTestAgentWithFields(t, true, TestAgent{HCL: hcl})
 }
 
 // NewTestAgentWithFields takes a TestAgent struct with any number of fields set,

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -122,15 +122,7 @@ func (a *TestAgent) Start(t *testing.T) (err error) {
 	}
 
 	name := a.Name
-	// Many tests set Name to t.Name(), which takes up a lot of space at the
-	// start of the log messages. The only time we need to care about a name is
-	// when a test using multiple TestAgents.
-	// As a temporary workaround we ignore the default name and use a shorter
-	// default value. Tests which set a custom name for multiple agents will
-	// use the provided name.
-	// TODO: remove TestAgent.Name and accept a name arg on Start, to remove
-	// this workaround.
-	if name == "" || name == t.Name() {
+	if name == "" {
 		name = "TestAgent"
 	}
 

--- a/agent/txn_endpoint_test.go
+++ b/agent/txn_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestTxnEndpoint_Bad_JSON(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte("{"))
@@ -66,25 +66,25 @@ func TestTxnEndpoint_Bad_Size_Item(t *testing.T) {
 	}
 
 	t.Run("exceeds default limits", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
 
 	t.Run("exceeds configured max txn len", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 700000 }")
+		a := NewTestAgent(t, "limits = { txn_max_req_len = 700000 }")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
 
 	t.Run("exceeds default max kv value size", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 123456789 }")
+		a := NewTestAgent(t, "limits = { txn_max_req_len = 123456789 }")
 		testIt(t, a, false)
 		a.Shutdown()
 	})
 
 	t.Run("allowed", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 limits = {
 	txn_max_req_len = 123456789
 	kv_max_value_size = 123456789
@@ -139,25 +139,25 @@ func TestTxnEndpoint_Bad_Size_Net(t *testing.T) {
 	}
 
 	t.Run("exceeds default limits", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		testIt(a, false)
 		a.Shutdown()
 	})
 
 	t.Run("exceeds configured max txn len", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 700000 }")
+		a := NewTestAgent(t, "limits = { txn_max_req_len = 700000 }")
 		testIt(a, false)
 		a.Shutdown()
 	})
 
 	t.Run("exceeds default max kv value size", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { txn_max_req_len = 123456789 }")
+		a := NewTestAgent(t, "limits = { txn_max_req_len = 123456789 }")
 		testIt(a, false)
 		a.Shutdown()
 	})
 
 	t.Run("allowed", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), `
+		a := NewTestAgent(t, `
 limits = {
 	txn_max_req_len = 123456789
 	kv_max_value_size = 123456789
@@ -167,7 +167,7 @@ limits = {
 	})
 
 	t.Run("allowed kv max backward compatible", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "limits = { kv_max_value_size = 123456789 }")
+		a := NewTestAgent(t, "limits = { kv_max_value_size = 123456789 }")
 		testIt(a, true)
 		a.Shutdown()
 	})
@@ -175,7 +175,7 @@ limits = {
 
 func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	buf := bytes.NewBuffer([]byte(fmt.Sprintf(`
@@ -203,7 +203,7 @@ func TestTxnEndpoint_Bad_Size_Ops(t *testing.T) {
 func TestTxnEndpoint_KV_Actions(t *testing.T) {
 	t.Parallel()
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -446,7 +446,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 
 	// Verify an error inside a transaction.
 	t.Run("", func(t *testing.T) {
-		a := NewTestAgent(t, t.Name(), "")
+		a := NewTestAgent(t, "")
 		defer a.Shutdown()
 
 		buf := bytes.NewBuffer([]byte(`
@@ -483,7 +483,7 @@ func TestTxnEndpoint_KV_Actions(t *testing.T) {
 
 func TestTxnEndpoint_UpdateCheck(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -28,7 +28,7 @@ func TestUiIndex(t *testing.T) {
 	defer os.RemoveAll(uiDir)
 
 	// Make the server
-	a := NewTestAgent(t, t.Name(), `
+	a := NewTestAgent(t, `
 		ui_dir = "`+uiDir+`"
 	`)
 	defer a.Shutdown()
@@ -67,7 +67,7 @@ func TestUiIndex(t *testing.T) {
 
 func TestUiNodes(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -105,7 +105,7 @@ func TestUiNodes(t *testing.T) {
 
 func TestUiNodes_Filter(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -147,7 +147,7 @@ func TestUiNodes_Filter(t *testing.T) {
 
 func TestUiNodeInfo(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -197,7 +197,7 @@ func TestUiNodeInfo(t *testing.T) {
 
 func TestUiServices(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -48,7 +48,7 @@ func TestValidateUserEventParams(t *testing.T) {
 
 func TestShouldProcessUserEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	srv1 := &structs.NodeService{
@@ -117,7 +117,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 
 func TestIngestUserEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	for i := 0; i < 512; i++ {
@@ -148,7 +148,7 @@ func TestIngestUserEvent(t *testing.T) {
 
 func TestFireReceiveEvent(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	srv1 := &structs.NodeService{
@@ -184,7 +184,7 @@ func TestFireReceiveEvent(t *testing.T) {
 
 func TestUserEventToken(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), TestACLConfig()+`
+	a := NewTestAgent(t, TestACLConfig()+`
 		acl_default_policy = "deny"
 	`)
 	defer a.Shutdown()

--- a/command/acl/agenttokens/agent_tokens_test.go
+++ b/command/acl/agenttokens/agent_tokens_test.go
@@ -28,7 +28,7 @@ func TestAgentTokensCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -35,7 +35,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -115,7 +115,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -173,7 +173,7 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -32,7 +32,7 @@ func TestAuthMethodDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/authmethod/list/authmethod_list_test.go
+++ b/command/acl/authmethod/list/authmethod_list_test.go
@@ -33,7 +33,7 @@ func TestAuthMethodListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -113,7 +113,7 @@ func TestAuthMethodListCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/authmethod/read/authmethod_read_test.go
+++ b/command/acl/authmethod/read/authmethod_read_test.go
@@ -33,7 +33,7 @@ func TestAuthMethodReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -122,7 +122,7 @@ func TestAuthMethodReadCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -37,7 +37,7 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -132,7 +132,7 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -220,7 +220,7 @@ func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -318,7 +318,7 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -545,7 +545,7 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bindingrule/create/bindingrule_create_test.go
+++ b/command/acl/bindingrule/create/bindingrule_create_test.go
@@ -32,7 +32,7 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -182,7 +182,7 @@ func TestBindingRuleCreateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -31,7 +31,7 @@ func TestBindingRuleDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bindingrule/list/bindingrule_list_test.go
+++ b/command/acl/bindingrule/list/bindingrule_list_test.go
@@ -33,7 +33,7 @@ func TestBindingRuleListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bindingrule/read/bindingrule_read_test.go
+++ b/command/acl/bindingrule/read/bindingrule_read_test.go
@@ -32,7 +32,7 @@ func TestBindingRuleReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bindingrule/update/bindingrule_update_test.go
+++ b/command/acl/bindingrule/update/bindingrule_update_test.go
@@ -33,7 +33,7 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -473,7 +473,7 @@ func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/bootstrap/bootstrap_test.go
+++ b/command/acl/bootstrap/bootstrap_test.go
@@ -30,7 +30,7 @@ func TestBootstrapCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -61,7 +61,7 @@ func TestBootstrapCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -30,7 +30,7 @@ func TestPolicyCreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -68,7 +68,7 @@ func TestPolicyCreateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -29,7 +29,7 @@ func TestPolicyDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -30,7 +30,7 @@ func TestPolicyListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -84,7 +84,7 @@ func TestPolicyListCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -30,7 +30,7 @@ func TestPolicyReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -76,7 +76,7 @@ func TestPolicyReadCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -30,7 +30,7 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -78,7 +78,7 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -29,7 +29,7 @@ func TestRoleCreateCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -120,7 +120,7 @@ func TestRoleCreateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/role/delete/role_delete_test.go
+++ b/command/acl/role/delete/role_delete_test.go
@@ -28,7 +28,7 @@ func TestRoleDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/role/list/role_list_test.go
+++ b/command/acl/role/list/role_list_test.go
@@ -31,7 +31,7 @@ func TestRoleListCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -88,7 +88,7 @@ func TestRoleListCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/role/read/role_read_test.go
+++ b/command/acl/role/read/role_read_test.go
@@ -31,7 +31,7 @@ func TestRoleReadCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -198,7 +198,7 @@ func TestRoleReadCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/role/update/role_update_test.go
+++ b/command/acl/role/update/role_update_test.go
@@ -31,7 +31,7 @@ func TestRoleUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -200,7 +200,7 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -282,7 +282,7 @@ func TestRoleUpdateCommand_noMerge(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -28,7 +28,7 @@ func TestRulesTranslateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -66,7 +66,7 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
    primary_datacenter = "dc1"
    acl {
       enabled = true
@@ -173,7 +173,7 @@ func TestTokenCloneCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
    primary_datacenter = "dc1"
    acl {
       enabled = true

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -29,7 +29,7 @@ func TestTokenCreateCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -120,7 +120,7 @@ func TestTokenCreateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -29,7 +29,7 @@ func TestTokenDeleteCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -31,7 +31,7 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -85,7 +85,7 @@ func TestTokenListCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -31,7 +31,7 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -78,7 +78,7 @@ func TestTokenReadCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -34,7 +34,7 @@ func TestTokenUpdateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -197,7 +197,7 @@ func TestTokenUpdateCommand_JSON(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -81,10 +81,10 @@ func TestConfigFail(t *testing.T) {
 }
 
 func TestRetryJoin(t *testing.T) {
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
-	b := agent.NewTestAgent(t, t.Name(), `
+	b := agent.NewTestAgent(t, `
 		retry_join = ["`+a.Config.SerfBindAddrLAN.String()+`"]
 		retry_join_wan = ["`+a.Config.SerfBindAddrWAN.String()+`"]
 		retry_interval = "100ms"
@@ -207,7 +207,7 @@ func TestBadDataDirPermissions(t *testing.T) {
 }
 
 func TestReloadLoggerFail(t *testing.T) {
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -239,7 +239,7 @@ func TestReloadLoggerFail(t *testing.T) {
 }
 
 func TestReloadLoggerSuccess(t *testing.T) {
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/catalog/list/dc/catalog_list_datacenters_test.go
+++ b/command/catalog/list/dc/catalog_list_datacenters_test.go
@@ -53,7 +53,7 @@ func TestCatalogListDatacentersCommand_Validation(t *testing.T) {
 
 func TestCatalogListDatacentersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/catalog/list/nodes/catalog_list_nodes_test.go
+++ b/command/catalog/list/nodes/catalog_list_nodes_test.go
@@ -32,7 +32,7 @@ func TestCatalogListNodesCommand_Validation(t *testing.T) {
 
 func TestCatalogListNodesCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/catalog/list/nodes/catalog_list_nodes_test.go
+++ b/command/catalog/list/nodes/catalog_list_nodes_test.go
@@ -168,7 +168,7 @@ func TestCatalogListNodesCommand_verticalBar(t *testing.T) {
 	t.Parallel()
 
 	nodeName := "name|with|bars"
-	a := agent.NewTestAgent(t, "", `node_name = "`+nodeName+`"`)
+	a := agent.NewTestAgent(t, `node_name = "`+nodeName+`"`)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/catalog/list/services/catalog_list_services_test.go
+++ b/command/catalog/list/services/catalog_list_services_test.go
@@ -34,7 +34,7 @@ func TestCatalogListServicesCommand_Validation(t *testing.T) {
 
 func TestCatalogListServicesCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/config/delete/config_delete_test.go
+++ b/command/config/delete/config_delete_test.go
@@ -18,7 +18,7 @@ func TestConfigDelete_noTabs(t *testing.T) {
 func TestConfigDelete(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/config/list/config_list_test.go
+++ b/command/config/list/config_list_test.go
@@ -17,7 +17,7 @@ func TestConfigList_noTabs(t *testing.T) {
 }
 
 func TestConfigList(t *testing.T) {
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/config/read/config_read_test.go
+++ b/command/config/read/config_read_test.go
@@ -18,7 +18,7 @@ func TestConfigRead_noTabs(t *testing.T) {
 func TestConfigRead(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -23,7 +23,7 @@ func TestConfigWrite_noTabs(t *testing.T) {
 func TestConfigWrite(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/connect/ca/get/connect_ca_get_test.go
+++ b/command/connect/ca/get/connect_ca_get_test.go
@@ -19,7 +19,7 @@ func TestConnectCAGetConfigCommand_noTabs(t *testing.T) {
 
 func TestConnectCAGetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/connect/ca/set/connect_ca_set_test.go
+++ b/command/connect/ca/set/connect_ca_set_test.go
@@ -24,7 +24,7 @@ func TestConnectCASetConfigCommand_noTabs(t *testing.T) {
 func TestConnectCASetConfigCommand(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/connect/proxy/proxy_test.go
+++ b/command/connect/proxy/proxy_test.go
@@ -113,7 +113,7 @@ func TestCommandConfigWatcher(t *testing.T) {
 			require := require.New(t)
 
 			// Register a few services with 0, 1 and 2 sidecars
-			a := agent.NewTestAgent(t, t.Name(), `
+			a := agent.NewTestAgent(t, `
 			services {
 				name = "no-sidecar"
 				port = 1111

--- a/command/connect/proxy/register_test.go
+++ b/command/connect/proxy/register_test.go
@@ -16,7 +16,7 @@ func TestRegisterMonitor_good(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -39,7 +39,7 @@ func TestRegisterMonitor_good(t *testing.T) {
 func TestRegisterMonitor_heartbeat(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -30,7 +30,7 @@ func TestDebugCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	enable_debug = true
 	`)
 
@@ -67,7 +67,7 @@ func TestDebugCommand_Archive(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	enable_debug = true
 	`)
 	defer a.Shutdown()
@@ -152,7 +152,7 @@ func TestDebugCommand_OutputPathBad(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -184,7 +184,7 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -265,7 +265,7 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 		testDir := testutil.TempDir(t, "debug")
 		defer os.RemoveAll(testDir)
 
-		a := agent.NewTestAgent(t, t.Name(), `
+		a := agent.NewTestAgent(t, `
 		enable_debug = true
 		`)
 
@@ -331,7 +331,7 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	enable_debug = true
 	`)
 	defer a.Shutdown()
@@ -409,7 +409,7 @@ func TestDebugCommand_ValidateTiming(t *testing.T) {
 		testDir := testutil.TempDir(t, "debug")
 		defer os.RemoveAll(testDir)
 
-		a := agent.NewTestAgent(t, t.Name(), "")
+		a := agent.NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
 
@@ -441,7 +441,7 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	testDir := testutil.TempDir(t, "debug")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	enable_debug = false
 	`)
 	defer a.Shutdown()

--- a/command/event/event_test.go
+++ b/command/event/event_test.go
@@ -17,7 +17,7 @@ func TestEventCommand_noTabs(t *testing.T) {
 
 func TestEventCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/exec/exec_test.go
+++ b/command/exec/exec_test.go
@@ -22,7 +22,7 @@ func TestExecCommand_noTabs(t *testing.T) {
 
 func TestExecCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -45,7 +45,7 @@ func TestExecCommand(t *testing.T) {
 
 func TestExecCommand_NoShell(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -68,14 +68,14 @@ func TestExecCommand_NoShell(t *testing.T) {
 
 func TestExecCommand_CrossDC(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), `
+	a1 := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a1.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a1.RPC, "dc1")
 
-	a2 := agent.NewTestAgent(t, t.Name(), `
+	a2 := agent.NewTestAgent(t, `
 		datacenter = "dc2"
 		disable_remote_exec = false
 	`)
@@ -150,7 +150,7 @@ func TestExecCommand_Validate(t *testing.T) {
 
 func TestExecCommand_Sessions(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -190,7 +190,7 @@ func TestExecCommand_Sessions(t *testing.T) {
 
 func TestExecCommand_Sessions_Foreign(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -240,7 +240,7 @@ func TestExecCommand_Sessions_Foreign(t *testing.T) {
 
 func TestExecCommand_UploadDestroy(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()
@@ -297,7 +297,7 @@ func TestExecCommand_UploadDestroy(t *testing.T) {
 
 func TestExecCommand_StreamResults(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		disable_remote_exec = false
 	`)
 	defer a.Shutdown()

--- a/command/forceleave/forceleave_test.go
+++ b/command/forceleave/forceleave_test.go
@@ -19,8 +19,8 @@ func TestForceLeaveCommand_noTabs(t *testing.T) {
 
 func TestForceLeaveCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
-	a2 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
+	a2 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 
@@ -58,7 +58,7 @@ func TestForceLeaveCommand(t *testing.T) {
 
 func TestForceLeaveCommand_NoNodeWithName(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/forceleave/forceleave_test.go
+++ b/command/forceleave/forceleave_test.go
@@ -76,9 +76,9 @@ func TestForceLeaveCommand_NoNodeWithName(t *testing.T) {
 
 func TestForceLeaveCommand_prune(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name()+"-a1", ``)
+	a1 := agent.StartTestAgent(t, agent.TestAgent{Name: "Agent1"})
 	defer a1.Shutdown()
-	a2 := agent.NewTestAgent(t, t.Name()+"-a2", ``)
+	a2 := agent.StartTestAgent(t, agent.TestAgent{Name: "Agent2"})
 	defer a2.Shutdown()
 
 	_, err := a2.JoinLAN([]string{a1.Config.SerfBindAddrLAN.String()})

--- a/command/info/info_test.go
+++ b/command/info/info_test.go
@@ -17,7 +17,7 @@ func TestInfoCommand_noTabs(t *testing.T) {
 
 func TestInfoCommand(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/intention/check/check_test.go
+++ b/command/intention/check/check_test.go
@@ -68,7 +68,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/create/create_test.go
+++ b/command/intention/create/create_test.go
@@ -60,7 +60,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -85,7 +85,7 @@ func TestCommand_deny(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -111,7 +111,7 @@ func TestCommand_meta(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -137,7 +137,7 @@ func TestCommand_File(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -171,7 +171,7 @@ func TestCommand_FileNoExist(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -191,7 +191,7 @@ func TestCommand_replace(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/delete/delete_test.go
+++ b/command/intention/delete/delete_test.go
@@ -63,7 +63,7 @@ func TestCommand(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/finder/finder_test.go
+++ b/command/intention/finder/finder_test.go
@@ -12,7 +12,7 @@ func TestFinder(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/get/get_test.go
+++ b/command/intention/get/get_test.go
@@ -63,7 +63,7 @@ func TestCommand_id(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -95,7 +95,7 @@ func TestCommand_srcDst(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -127,7 +127,7 @@ func TestCommand_verticalBar(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/intention/match/match_test.go
+++ b/command/intention/match/match_test.go
@@ -68,7 +68,7 @@ func TestCommand_matchDst(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -111,7 +111,7 @@ func TestCommand_matchSource(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/join/join_test.go
+++ b/command/join/join_test.go
@@ -17,8 +17,8 @@ func TestJoinCommand_noTabs(t *testing.T) {
 
 func TestJoinCommandJoin_lan(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
-	a2 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
+	a2 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 
@@ -41,8 +41,8 @@ func TestJoinCommandJoin_lan(t *testing.T) {
 
 func TestJoinCommand_wan(t *testing.T) {
 	t.Parallel()
-	a1 := agent.NewTestAgent(t, t.Name(), ``)
-	a2 := agent.NewTestAgent(t, t.Name(), ``)
+	a1 := agent.NewTestAgent(t, ``)
+	a2 := agent.NewTestAgent(t, ``)
 	defer a1.Shutdown()
 	defer a2.Shutdown()
 

--- a/command/keyring/keyring_test.go
+++ b/command/keyring/keyring_test.go
@@ -21,7 +21,7 @@ func TestKeyringCommand(t *testing.T) {
 	key2 := "kZyFABeAmc64UMTrm9XuKA=="
 
 	// Begin with a single key
-	a1 := agent.NewTestAgent(t, t.Name(), `
+	a1 := agent.NewTestAgent(t, `
 		encrypt = "`+key1+`"
 	`)
 	defer a1.Shutdown()

--- a/command/kv/del/kv_delete_test.go
+++ b/command/kv/del/kv_delete_test.go
@@ -72,7 +72,7 @@ func TestKVDeleteCommand_Validation(t *testing.T) {
 
 func TestKVDeleteCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -109,7 +109,7 @@ func TestKVDeleteCommand(t *testing.T) {
 
 func TestKVDeleteCommand_Recurse(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -153,7 +153,7 @@ func TestKVDeleteCommand_Recurse(t *testing.T) {
 
 func TestKVDeleteCommand_CAS(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/exp/kv_export_test.go
+++ b/command/kv/exp/kv_export_test.go
@@ -21,7 +21,7 @@ func TestKVExportCommand_noTabs(t *testing.T) {
 
 func TestKVExportCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/get/kv_get_test.go
+++ b/command/kv/get/kv_get_test.go
@@ -59,7 +59,7 @@ func TestKVGetCommand_Validation(t *testing.T) {
 
 func TestKVGetCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -93,7 +93,7 @@ func TestKVGetCommand(t *testing.T) {
 
 func TestKVGetCommand_Base64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -128,7 +128,7 @@ func TestKVGetCommand_Base64(t *testing.T) {
 
 func TestKVGetCommand_Missing(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -147,7 +147,7 @@ func TestKVGetCommand_Missing(t *testing.T) {
 
 func TestKVGetCommand_Empty(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -176,7 +176,7 @@ func TestKVGetCommand_Empty(t *testing.T) {
 
 func TestKVGetCommand_Detailed(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -220,7 +220,7 @@ func TestKVGetCommand_Detailed(t *testing.T) {
 
 func TestKVGetCommand_Keys(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -255,7 +255,7 @@ func TestKVGetCommand_Keys(t *testing.T) {
 
 func TestKVGetCommand_Recurse(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -295,7 +295,7 @@ func TestKVGetCommand_Recurse(t *testing.T) {
 
 func TestKVGetCommand_RecurseBase64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -336,7 +336,7 @@ func TestKVGetCommand_RecurseBase64(t *testing.T) {
 
 func TestKVGetCommand_DetailedBase64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/imp/kv_import_test.go
+++ b/command/kv/imp/kv_import_test.go
@@ -17,7 +17,7 @@ func TestKVImportCommand_noTabs(t *testing.T) {
 
 func TestKVImportCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -77,7 +77,7 @@ func TestKVPutCommand_Validation(t *testing.T) {
 
 func TestKVPutCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -106,7 +106,7 @@ func TestKVPutCommand(t *testing.T) {
 
 func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -135,7 +135,7 @@ func TestKVPutCommand_EmptyDataQuoted(t *testing.T) {
 
 func TestKVPutCommand_Base64(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -172,7 +172,7 @@ func TestKVPutCommand_Base64(t *testing.T) {
 
 func TestKVPutCommand_File(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -227,7 +227,7 @@ func TestKVPutCommand_FileNoExist(t *testing.T) {
 
 func TestKVPutCommand_Stdin(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -264,7 +264,7 @@ func TestKVPutCommand_Stdin(t *testing.T) {
 
 func TestKVPutCommand_NegativeVal(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -293,7 +293,7 @@ func TestKVPutCommand_NegativeVal(t *testing.T) {
 
 func TestKVPutCommand_Flags(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -323,7 +323,7 @@ func TestKVPutCommand_Flags(t *testing.T) {
 
 func TestKVPutCommand_CAS(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/leave/leave_test.go
+++ b/command/leave/leave_test.go
@@ -17,7 +17,7 @@ func TestLeaveCommand_noTabs(t *testing.T) {
 
 func TestLeaveCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -36,7 +36,7 @@ func TestLeaveCommand(t *testing.T) {
 
 func TestLeaveCommand_FailOnNonFlagArgs(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/lock/lock_test.go
+++ b/command/lock/lock_test.go
@@ -42,7 +42,7 @@ func TestLockCommand_BadArgs(t *testing.T) {
 
 func TestLockCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -67,7 +67,7 @@ func TestLockCommand(t *testing.T) {
 
 func TestLockCommand_NoShell(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -92,7 +92,7 @@ func TestLockCommand_NoShell(t *testing.T) {
 
 func TestLockCommand_TryLock(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -126,7 +126,7 @@ func TestLockCommand_TryLock(t *testing.T) {
 
 func TestLockCommand_TrySemaphore(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -160,7 +160,7 @@ func TestLockCommand_TrySemaphore(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -195,7 +195,7 @@ func TestLockCommand_MonitorRetry_Lock_Default(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -230,7 +230,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Default(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -265,7 +265,7 @@ func TestLockCommand_MonitorRetry_Lock_Arg(t *testing.T) {
 
 func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
@@ -300,7 +300,7 @@ func TestLockCommand_MonitorRetry_Semaphore_Arg(t *testing.T) {
 
 func TestLockCommand_ChildExitCode(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -32,7 +32,7 @@ func TestLoginCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -226,7 +226,7 @@ func TestLoginCommand_k8s(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -31,7 +31,7 @@ func TestLogoutCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true
@@ -160,7 +160,7 @@ func TestLogoutCommand_k8s(t *testing.T) {
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
 
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
 		enabled = true

--- a/command/maint/maint_test.go
+++ b/command/maint/maint_test.go
@@ -41,7 +41,7 @@ func TestMaintCommand_ConflictingArgs(t *testing.T) {
 
 func TestMaintCommand_NoArgs(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	// Register the service and put it into maintenance mode
@@ -90,7 +90,7 @@ func TestMaintCommand_NoArgs(t *testing.T) {
 
 func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -114,7 +114,7 @@ func TestMaintCommand_EnableNodeMaintenance(t *testing.T) {
 
 func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -137,7 +137,7 @@ func TestMaintCommand_DisableNodeMaintenance(t *testing.T) {
 
 func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	// Register the service
@@ -171,7 +171,7 @@ func TestMaintCommand_EnableServiceMaintenance(t *testing.T) {
 
 func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	// Register the service
@@ -204,7 +204,7 @@ func TestMaintCommand_DisableServiceMaintenance(t *testing.T) {
 
 func TestMaintCommand_ServiceMaintenance_NoService(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/members/members_test.go
+++ b/command/members/members_test.go
@@ -125,7 +125,7 @@ func TestMembersCommand_verticalBar(t *testing.T) {
 	t.Parallel()
 
 	nodeName := "name|with|bars"
-	a := agent.NewTestAgent(t, "", `node_name = "`+nodeName+`"`)
+	a := agent.NewTestAgent(t, `node_name = "`+nodeName+`"`)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/members/members_test.go
+++ b/command/members/members_test.go
@@ -18,7 +18,7 @@ func TestMembersCommand_noTabs(t *testing.T) {
 
 func TestMembersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -50,7 +50,7 @@ func TestMembersCommand(t *testing.T) {
 
 func TestMembersCommand_WAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -71,7 +71,7 @@ func TestMembersCommand_WAN(t *testing.T) {
 
 func TestMembersCommand_statusFilter(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()
@@ -95,7 +95,7 @@ func TestMembersCommand_statusFilter(t *testing.T) {
 
 func TestMembersCommand_statusFilter_failed(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/monitor/monitor_test.go
+++ b/command/monitor/monitor_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestMonitorCommand_exitsOnSignalBeforeLinesArrive(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgentWithFields(t, true, agent.TestAgent{})
+	a := agent.StartTestAgent(t, agent.TestAgent{})
 	defer a.Shutdown()
 
 	shutdownCh := make(chan struct{})
@@ -64,7 +64,7 @@ func TestMonitorCommand_exitsOnSignalBeforeLinesArrive(t *testing.T) {
 
 func TestMonitorCommand_LogJSONValidFlag(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgentWithFields(t, true, agent.TestAgent{})
+	a := agent.StartTestAgent(t, agent.TestAgent{})
 	defer a.Shutdown()
 
 	shutdownCh := make(chan struct{})

--- a/command/operator/autopilot/get/operator_autopilot_get_test.go
+++ b/command/operator/autopilot/get/operator_autopilot_get_test.go
@@ -19,7 +19,7 @@ func TestOperatorAutopilotGetConfigCommand_noTabs(t *testing.T) {
 
 func TestOperatorAutopilotGetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/operator/autopilot/set/operator_autopilot_set_test.go
+++ b/command/operator/autopilot/set/operator_autopilot_set_test.go
@@ -22,7 +22,7 @@ func TestOperatorAutopilotSetConfigCommand_noTabs(t *testing.T) {
 
 func TestOperatorAutopilotSetConfigCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/command/operator/raft/listpeers/operator_raft_list_test.go
+++ b/command/operator/raft/listpeers/operator_raft_list_test.go
@@ -18,7 +18,7 @@ func TestOperatorRaftListPeersCommand_noTabs(t *testing.T) {
 
 func TestOperatorRaftListPeersCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	expected := fmt.Sprintf("%s  %s  127.0.0.1:%d  leader  true   3",

--- a/command/operator/raft/listpeers/operator_raft_list_test.go
+++ b/command/operator/raft/listpeers/operator_raft_list_test.go
@@ -43,7 +43,7 @@ func TestOperatorRaftListPeersCommand_verticalBar(t *testing.T) {
 	t.Parallel()
 
 	nodeName := "name|with|bars"
-	a := agent.NewTestAgent(t, "", `node_name = "`+nodeName+`"`)
+	a := agent.NewTestAgent(t, `node_name = "`+nodeName+`"`)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/command/operator/raft/removepeer/operator_raft_remove_test.go
+++ b/command/operator/raft/removepeer/operator_raft_remove_test.go
@@ -17,7 +17,7 @@ func TestOperatorRaftRemovePeerCommand_noTabs(t *testing.T) {
 
 func TestOperatorRaftRemovePeerCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	t.Run("Test the remove-peer subcommand directly", func(t *testing.T) {

--- a/command/reload/reload_test.go
+++ b/command/reload/reload_test.go
@@ -17,7 +17,7 @@ func TestReloadCommand_noTabs(t *testing.T) {
 
 func TestReloadCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	// Setup a dummy response to errCh to simulate a successful reload

--- a/command/rtt/rtt_test.go
+++ b/command/rtt/rtt_test.go
@@ -46,7 +46,7 @@ func TestRTTCommand_BadArgs(t *testing.T) {
 
 func TestRTTCommand_LAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), `
+	a := agent.NewTestAgent(t, `
 		consul = {
 			coordinate = {
 				update_period = "10ms"
@@ -155,7 +155,7 @@ func TestRTTCommand_LAN(t *testing.T) {
 
 func TestRTTCommand_WAN(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 

--- a/command/services/deregister/deregister_test.go
+++ b/command/services/deregister/deregister_test.go
@@ -64,7 +64,7 @@ func TestCommand_File_id(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -101,7 +101,7 @@ func TestCommand_File_nameOnly(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -138,7 +138,7 @@ func TestCommand_Flag(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -63,7 +63,7 @@ func TestCommand_File(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -96,7 +96,7 @@ func TestCommand_Flags(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -122,7 +122,7 @@ func TestCommand_Flags_TaggedAddresses(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 
@@ -157,7 +157,7 @@ func TestCommand_FileWithUnnamedCheck(t *testing.T) {
 	t.Parallel()
 
 	require := require.New(t)
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/inspect/snapshot_inspect_test.go
+++ b/command/snapshot/inspect/snapshot_inspect_test.go
@@ -61,7 +61,7 @@ func TestSnapshotInspectCommand_Validation(t *testing.T) {
 
 func TestSnapshotInspectCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/restore/snapshot_restore_test.go
+++ b/command/snapshot/restore/snapshot_restore_test.go
@@ -61,7 +61,7 @@ func TestSnapshotRestoreCommand_Validation(t *testing.T) {
 
 func TestSnapshotRestoreCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -60,7 +60,7 @@ func TestSnapshotSaveCommand_Validation(t *testing.T) {
 
 func TestSnapshotSaveCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	client := a.Client()
 

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -23,7 +23,7 @@ func TestWatchCommand_noTabs(t *testing.T) {
 
 func TestWatchCommand(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -42,7 +42,7 @@ func TestWatchCommand(t *testing.T) {
 }
 
 func TestWatchCommand_loadToken(t *testing.T) {
-	a := agent.NewTestAgent(t, t.Name(), ` `)
+	a := agent.NewTestAgent(t, ` `)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -137,7 +137,7 @@ func TestWatchCommand_loadToken(t *testing.T) {
 
 func TestWatchCommandNoConnect(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
@@ -158,7 +158,7 @@ func TestWatchCommandNoConnect(t *testing.T) {
 
 func TestWatchCommandNoAgentService(t *testing.T) {
 	t.Parallel()
-	a := agent.NewTestAgent(t, t.Name(), ``)
+	a := agent.NewTestAgent(t, ``)
 	defer a.Shutdown()
 
 	ui := cli.NewMockUi()

--- a/connect/proxy/config_test.go
+++ b/connect/proxy/config_test.go
@@ -81,7 +81,7 @@ func TestUpstreamResolverFuncFromClient(t *testing.T) {
 func TestAgentConfigWatcherSidecarProxy(t *testing.T) {
 	t.Parallel()
 
-	a := agent.NewTestAgent(t, "agent_smith", ``)
+	a := agent.StartTestAgent(t, agent.TestAgent{Name: "agent_smith"})
 	defer a.Shutdown()
 
 	client := a.Client()

--- a/connect/proxy/proxy_test.go
+++ b/connect/proxy/proxy_test.go
@@ -25,7 +25,7 @@ func TestProxy_public(t *testing.T) {
 	ports := freeport.MustTake(1)
 	defer freeport.Return(ports)
 
-	a := agent.NewTestAgent(t, t.Name(), "")
+	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -42,7 +42,7 @@ func TestStaticResolver_Resolve(t *testing.T) {
 
 func TestConsulResolver_Resolve(t *testing.T) {
 	// Setup a local test agent to query
-	agent := agent.NewTestAgent(t, "test-consul", "")
+	agent := agent.StartTestAgent(t, agent.TestAgent{Name: "test-consul"})
 	defer agent.Shutdown()
 
 	cfg := api.DefaultConfig()

--- a/connect/service_test.go
+++ b/connect/service_test.go
@@ -127,7 +127,7 @@ func TestService_Dial(t *testing.T) {
 func TestService_ServerTLSConfig(t *testing.T) {
 	require := require.New(t)
 
-	a := agent.NewTestAgent(t, "007", "")
+	a := agent.StartTestAgent(t, agent.TestAgent{Name: "007"})
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 	client := a.Client()

--- a/connect/tls_test.go
+++ b/connect/tls_test.go
@@ -152,7 +152,7 @@ func TestServerSideVerifier(t *testing.T) {
 	apiCA2 := testCertPEMBlock(t, apiCA2PEM)
 
 	// Setup a local test agent to query
-	agent := agent.NewTestAgent(t, "test-consul", "")
+	agent := agent.StartTestAgent(t, agent.TestAgent{Name: "test-consul"})
 	defer agent.Shutdown()
 	testrpc.WaitForTestAgent(t, agent.RPC, "dc1")
 


### PR DESCRIPTION
Follow up to #7546

`NewTestAgent` was being called with `t.Name()`, which was removed from name. This PR removes the name and uses the default value. 

I also noticed that `NewTestAgentWithFields` was only starting the agent, not creating a new one, so I renamed that to better reflect the behaviour.

Mostly an automated change with:
```
git grep -l 'NewTestAgent(t, t.Name(),' | xargs sed -i -e 's/NewTestAgent(t, t.Name(),/NewTestAgent(t,/g'
git grep -l 'StartTestAgent(t, true,' |  xargs sed -i -e 's/StartTestAgent(t, true,/StartTestAgent(t,/g'
```