### PR TITLE
[BUGFIX] Fix race condition in freeport

### DIFF
--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -185,7 +185,7 @@ func TestConfig_Apply(t *testing.T) {
 func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 

--- a/sdk/freeport/freeport.go
+++ b/sdk/freeport/freeport.go
@@ -129,8 +129,8 @@ func reset() {
 	}
 
 	if ticker != nil {
-		killTicker <- true
 		ticker.Stop()
+		killTicker <- true
 		ticker = nil
 	}
 

--- a/sdk/freeport/freeport.go
+++ b/sdk/freeport/freeport.go
@@ -126,9 +126,6 @@ func initialize() {
 
 // reset will reverse the setup from initialize() and then redo it (for tests)
 func reset() {
-	mu.Lock()
-	defer mu.Unlock()
-
 	logf("INFO", "resetting the freeport package state")
 	// Terminate background goroutine and wait for it to complete.
 	if stopCh != nil {
@@ -140,6 +137,8 @@ func reset() {
 		dur := time.Since(now)
 		logf("INFO", "took %s to wait for freeport goroutine to die", dur)
 	}
+	mu.Lock()
+	defer mu.Unlock()
 
 	effectiveMaxBlocks = 0
 	firstPort = 0


### PR DESCRIPTION
This removes a race condition in reset since pendingPorts can be set to nil in reset()

If ticker is hit at wrong time, it would crash the unit test.

We ensure in reset to avoid this race condition by cancelling the goroutine using
killTicker chan.

We also properly clean up eveything, so garbage collector can work as expected.

To reproduce existing bug:
`while go test -timeout 30s github.com/hashicorp/consul/sdk/freeport -run '^(Test.*)$'; do go clean -testcache; done`

Will crash after a few 10s runs on my machine.

Error could be seen in unit tests sometimes:

[INFO] freeport: resetting the freeport package state
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1125536]

goroutine 25 [running]:
container/list.(*List).Len(...)
	/usr/local/Cellar/go/1.14/libexec/src/container/list/list.go:66
github.com/hashicorp/consul/sdk/freeport.checkFreedPortsOnce()
	/Users/p.souchay/go/src/github.com/hashicorp/consul/sdk/freeport/freeport.go:157 +0x86
github.com/hashicorp/consul/sdk/freeport.checkFreedPorts()
	/Users/p.souchay/go/src/github.com/hashicorp/consul/sdk/freeport/freeport.go:147 +0x71
created by github.com/hashicorp/consul/sdk/freeport.initialize
	/Users/p.souchay/go/src/github.com/hashicorp/consul/sdk/freeport/freeport.go:113 +0x2cf
FAIL	github.com/hashicorp/consul/sdk/freeport	1.607s