### PR TITLE
[FIX BUILD] fix build due to merge of #7562

### DIFF
--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -185,7 +185,7 @@ func TestConfig_Apply(t *testing.T) {
 func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 	t.Parallel()
 
-	a := NewTestAgent(t, t.Name(), "")
+	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 


### PR DESCRIPTION
Due to merge #7562, upstream does not compile anymore.

Error is:

ERRO Running error: gofmt: analysis skipped: errors in package: [/Users/p.souchay/go/src/github.com/hashicorp/consul/agent/config_endpoint_test.go:188:33: too many arguments]

cc @dnephin 