### PR TITLE
ci: Fix working_directory for go mod download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: go mod download
+      - run:
+          working_directory: api
+          command: go mod download
       - run:
           working_directory: api
           name: go test
@@ -160,7 +162,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: go mod download
+      - run:
+          working_directory: sdk
+          command: go mod download
       - run:
           working_directory: sdk
           name: go test


### PR DESCRIPTION
I noticed that I had made a mistake in a previous PR. 

The previous PR which added these was accidentally performing the download
in the root directory. For the api, and sdk directories it should be in done
in the same directory that will be used to run tests. Otherwise the
wrong dependencies will be downloaded which may add unnecessary time to
the CI run.