### PR TITLE
ui: Change global/env url to start at / instead of /consul

### DIFF
--- a/ui-v2/app/components/hashicorp-consul/index.hbs
+++ b/ui-v2/app/components/hashicorp-consul/index.hbs
@@ -99,7 +99,7 @@
                             <a tabindex="-1" role="menuitem" href={{env 'CONSUL_DOCS_URL'}} rel="noopener noreferrer" target="_blank" onclick={{change}}>Documentation</a>
                           </li>
                           <li role="none" class="learn-link">
-                            <a tabindex="-1" role="menuitem" href={{env 'CONSUL_DOCS_LEARN_URL'}} rel="noopener noreferrer" target="_blank" onclick={{change}}>HashiCorp Learn</a>
+                            <a tabindex="-1" role="menuitem" href={{concat (env 'CONSUL_DOCS_LEARN_URL') '/consul'}} rel="noopener noreferrer" target="_blank" onclick={{change}}>HashiCorp Learn</a>
                           </li>
                           <li role="separator"></li>
                           <li role="none" class="feedback-link">

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -73,7 +73,7 @@ module.exports = function(environment, $ = process.env) {
     CONSUL_HOME_URL: 'https://www.consul.io',
     CONSUL_REPO_ISSUES_URL: 'https://github.com/hashicorp/consul/issues/new/choose',
     CONSUL_DOCS_URL: 'https://www.consul.io/docs',
-    CONSUL_DOCS_LEARN_URL: 'https://learn.hashicorp.com/consul',
+    CONSUL_DOCS_LEARN_URL: 'https://learn.hashicorp.com',
     CONSUL_DOCS_API_URL: 'https://www.consul.io/api',
     CONSUL_COPYRIGHT_URL: 'https://www.hashicorp.com',
   });


### PR DESCRIPTION
In case we ever need to link to anywhere on learn that isn't in the
`/consul` sub directory, this will let us do that whilst still using the
global env var.