### PR TITLE
More tolerance to latency for unstable test TestCacheNotifyPolling()

### DIFF
--- a/agent/cache/watch_test.go
+++ b/agent/cache/watch_test.go
@@ -249,7 +249,7 @@ func TestCacheNotifyPolling(t *testing.T) {
 	// wait for the next batch of responses
 	events := make([]UpdateEvent, 0)
 	// At least 110ms is needed to allow for the jitter
-	timeout := time.After(150 * time.Millisecond)
+	timeout := time.After(220 * time.Millisecond)
 
 	for i := 0; i < 2; i++ {
 		select {


### PR DESCRIPTION
Example of test where is fails: https://circleci.com/gh/hashicorp/consul/152390 (required around 50 runs to fail on my machine)