### PR TITLE
Ensure that token clone copies the roles

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -311,6 +311,7 @@ func (a *ACL) TokenClone(args *structs.ACLTokenSetRequest, reply *structs.ACLTok
 		Datacenter: args.Datacenter,
 		ACLToken: structs.ACLToken{
 			Policies:          token.Policies,
+			Roles:             token.Roles,
 			ServiceIdentities: token.ServiceIdentities,
 			Local:             token.Local,
 			Description:       token.Description,


### PR DESCRIPTION
Fixes #7576 

Also modified the test to ensure policies, roles and service identities are all set in the initial token and present in the cloned token.