### PR TITLE
Fix unstable test TestReplication_FederationStates()

### DIFF
--- a/agent/consul/federation_state_replication_test.go
+++ b/agent/consul/federation_state_replication_test.go
@@ -77,7 +77,7 @@ func TestReplication_FederationStates(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, local, len(remote))
-		for i, _ := range remote {
+		for i := range remote {
 			// zero out the raft data for future comparisons
 			remote[i].RaftIndex = structs.RaftIndex{}
 			local[i].RaftIndex = structs.RaftIndex{}
@@ -121,8 +121,12 @@ func TestReplication_FederationStates(t *testing.T) {
 		require.NoError(t, s1.RPC("FederationState.Apply", &arg, &out))
 	}
 
+	nTimesWithDelay := func() *retry.Counter {
+		return &retry.Counter{Count: 30, Wait: 750 * time.Millisecond}
+	}
+
 	// Wait for the replica to converge.
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(nTimesWithDelay(), t, func(r *retry.R) {
 		checkSame(r)
 	})
 
@@ -138,7 +142,7 @@ func TestReplication_FederationStates(t *testing.T) {
 	}
 
 	// Wait for the replica to converge.
-	retry.Run(t, func(r *retry.R) {
+	retry.RunWith(nTimesWithDelay(), t, func(r *retry.R) {
 		checkSame(r)
 	})
 }


### PR DESCRIPTION
This test fails quite often in CI, be less strict about convergence duration

Example of failure: https://circleci.com/gh/hashicorp/consul/153469#tests/containers/1