### PR TITLE
Fixed unstable test TestForwardSignals()

### DIFF
--- a/agent/util_test.go
+++ b/agent/util_test.go
@@ -202,7 +202,7 @@ func TestHelperProcess(t *testing.T) {
 		limitProcessLifetime(2 * time.Minute)
 
 		ch := make(chan os.Signal, 10)
-		signal.Notify(ch)
+		signal.Notify(ch, forwardSignals...)
 		defer signal.Stop(ch)
 
 		fmt.Fprintf(os.Stdout, "ready\n")


### PR DESCRIPTION
Sometimes, in the CI, it could receive a SIGURG, producing this line:

  FAIL: TestForwardSignals/signal-interrupt (0.06s)
        util_test.go:286: expected to read line "signal: interrupt" but got "signal: urgent I/O condition"

Only forward the signals we test to avoid this kind of false positive

Example of such unstable errors in CI:
https://circleci.com/gh/hashicorp/consul/153571