### PR TITLE
Enable filtering language support for the v1/connect/intentions listing API

### DIFF
--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -71,16 +71,16 @@ type Intention struct {
 
 	// CreatedAt and UpdatedAt keep track of when this record was created
 	// or modified.
-	CreatedAt, UpdatedAt time.Time `mapstructure:"-"`
+	CreatedAt, UpdatedAt time.Time `mapstructure:"-" bexpr:"-"`
 
 	// Hash of the contents of the intention
 	//
 	// This is needed mainly for replication purposes. When replicating from
 	// one DC to another keeping the content Hash will allow us to detect
 	// content changes more efficiently than checking every single field
-	Hash []byte
+	Hash []byte `bexpr:"-"`
 
-	RaftIndex
+	RaftIndex `bexpr:"-"`
 }
 
 func (t *Intention) UnmarshalJSON(data []byte) (err error) {

--- a/agent/structs/structs_filtering_test.go
+++ b/agent/structs/structs_filtering_test.go
@@ -525,6 +525,70 @@ var expectedFieldConfigNodeInfo bexpr.FieldConfigurations = bexpr.FieldConfigura
 	},
 }
 
+var expectedFieldConfigIntention bexpr.FieldConfigurations = bexpr.FieldConfigurations{
+	"ID": &bexpr.FieldConfiguration{
+		StructFieldName:     "ID",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"Description": &bexpr.FieldConfiguration{
+		StructFieldName:     "Description",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"SourceNS": &bexpr.FieldConfiguration{
+		StructFieldName:     "SourceNS",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"SourceName": &bexpr.FieldConfiguration{
+		StructFieldName:     "SourceName",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"DestinationNS": &bexpr.FieldConfiguration{
+		StructFieldName:     "DestinationNS",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"DestinationName": &bexpr.FieldConfiguration{
+		StructFieldName:     "DestinationName",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"SourceType": &bexpr.FieldConfiguration{
+		StructFieldName:     "SourceType",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"Action": &bexpr.FieldConfiguration{
+		StructFieldName:     "Action",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"DefaultAddr": &bexpr.FieldConfiguration{
+		StructFieldName:     "DefaultAddr",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
+	},
+	"DefaultPort": &bexpr.FieldConfiguration{
+		StructFieldName:     "DefaultPort",
+		CoerceFn:            bexpr.CoerceInt,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
+	},
+	"Precedence": &bexpr.FieldConfiguration{
+		StructFieldName:     "Precedence",
+		CoerceFn:            bexpr.CoerceInt,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
+	},
+	"Meta": &bexpr.FieldConfiguration{
+		StructFieldName:     "Meta",
+		CoerceFn:            bexpr.CoerceString,
+		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchIsEmpty, bexpr.MatchIsNotEmpty, bexpr.MatchIn, bexpr.MatchNotIn},
+		SubFields:           expectedFieldConfigMapStringValue,
+	},
+}
+
 // Only need to generate the field configurations for the top level filtered types
 // The internal types will be checked within these.
 var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
@@ -557,6 +621,10 @@ var fieldConfigTests map[string]fieldConfigTest = map[string]fieldConfigTest{
 		// this also happens to ensure that our API representation of a service that can be
 		// registered with an agent stays in sync with our internal NodeService structure
 		expected: expectedFieldConfigNodeService,
+	},
+	"Intention": fieldConfigTest{
+		dataType: (*Intention)(nil),
+		expected: expectedFieldConfigIntention,
 	},
 }
 

--- a/website/source/api/connect/intentions.html.md
+++ b/website/source/api/connect/intentions.html.md
@@ -165,11 +165,16 @@ The table below shows this endpoint's support for
 <sup>1</sup> Intention ACL rules are specified as part of a `service` rule.
 See [Intention Management Permissions](/docs/connect/intentions.html#intention-management-permissions) for more details.
 
+### Parameters
+
+- `filter` `(string: "")` - Specifies the expression used to filter the
+  queries results prior to returning the data.
+
 ### Sample Request
 
 ```text
 $ curl \
-    http://127.0.0.1:8500/v1/connect/intentions
+    'http://127.0.0.1:8500/v1/connect/intentions?SourceName==web'
 ```
 
 ### Sample Response
@@ -196,6 +201,27 @@ $ curl \
   }
 ]
 ```
+
+### Filtering
+
+The filter will be executed against each Intention in the result list with
+the following selectors and filter operations being supported:
+
+| Selector        | Supported Operations                               |
+| --------------- | -------------------------------------------------- |
+| Action          | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| DefaultAddr     | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| DefaultPort     | Equal, Not Equal                                   |
+| Description     | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| DestinationNS   | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| DestinationName | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| ID              | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| Meta            | Is Empty, Is Not Empty, In, Not In                 |
+| Meta.<any>      | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| Precedence      | Equal, Not Equal                                   |
+| SourceNS        | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| SourceName      | Equal, Not Equal, In, Not In, Matches, Not Matches |
+| SourceType      | Equal, Not Equal, In, Not In, Matches, Not Matches |
 
 ## Update Intention
 

--- a/website/source/api/connect/intentions.html.md
+++ b/website/source/api/connect/intentions.html.md
@@ -174,7 +174,7 @@ See [Intention Management Permissions](/docs/connect/intentions.html#intention-m
 
 ```text
 $ curl \
-    'http://127.0.0.1:8500/v1/connect/intentions?SourceName==web'
+    'http://127.0.0.1:8500/v1/connect/intentions?filter=SourceName==web'
 ```
 
 ### Sample Response


### PR DESCRIPTION
Fixes: #7478 

This allows using a filter expression on the Intention Listing endpoint.