### PR TITLE
`ConnectCALeafRequest` should factor in `DNSSAN` and `IPSAN` into its cache key

### DIFF
--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -660,6 +660,8 @@ func (r *ConnectCALeafRequest) Key() string {
 	v, err := hashstructure.Hash([]interface{}{
 		r.Service,
 		r.EnterpriseMeta,
+		r.DNSSAN,
+		r.IPSAN,
 	}, nil)
 	if err == nil {
 		return fmt.Sprintf("service:%d", v)

--- a/agent/cache-types/connect_ca_leaf_test.go
+++ b/agent/cache-types/connect_ca_leaf_test.go
@@ -2,6 +2,7 @@ package cachetype
 
 import (
 	"fmt"
+	"net"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -1022,12 +1023,26 @@ func TestConnectCALeaf_Key(t *testing.T) {
 	r1 := ConnectCALeafRequest{Service: "web"}
 	r2 := ConnectCALeafRequest{Service: "api"}
 
+	r3 := ConnectCALeafRequest{DNSSAN: []string{"a.com"}}
+	r4 := ConnectCALeafRequest{DNSSAN: []string{"b.com"}}
+
+	r5 := ConnectCALeafRequest{IPSAN: []net.IP{net.ParseIP("192.168.4.139")}}
+	r6 := ConnectCALeafRequest{IPSAN: []net.IP{net.ParseIP("192.168.4.140")}}
 	// hashstructure will hash the service name + ent meta to produce this key
 	r1Key := r1.Key()
 	r2Key := r2.Key()
+
+	r3Key := r3.Key()
+	r4Key := r4.Key()
+
+	r5Key := r5.Key()
+	r6Key := r6.Key()
+
 	require.True(t, strings.HasPrefix(r1Key, "service:"), "Key %s does not start with service:", r1Key)
 	require.True(t, strings.HasPrefix(r2Key, "service:"), "Key %s does not start with service:", r2Key)
 	require.NotEqual(t, r1Key, r2Key, "Cache keys for different services are not equal")
+	require.NotEqual(t, r3Key, r4Key, "Cache keys for different DNSSAN are not equal")
+	require.NotEqual(t, r5Key, r6Key, "Cache keys for different IPSAN are not equal")
 	r := ConnectCALeafRequest{Agent: "abc"}
 	require.Equal(t, "agent:abc", r.Key())
 }


### PR DESCRIPTION
This PR adding `DNSSAN` and `IPSAN` to `ConnectCALeafRequest` cache key
https://github.com/hashicorp/consul/issues/7514