### PR TITLE
Document consulPrefix properly

### DIFF
--- a/website/source/docs/platform/k8s/helm.html.md
+++ b/website/source/docs/platform/k8s/helm.html.md
@@ -388,6 +388,7 @@ to run the sync program.
   Namespace suffix is not added if `annotationServiceName` is provided.
 
   * <a name="v-synccatalog-consulPrefix" href="#v-synccatalog-consulPrefix">`consulPrefix`</a> (`string: ""`) - A prefix to prepend to all services registered in Consul from Kubernetes. This defaults to `""` where no prefix is prepended. Service names within Kubernetes remain unchanged. (Kubernetes -> Consul sync only)
+  The prefix is ignored if `annotationServiceName` is provided.
 
   * <a name="v-synccatalog-k8stag" href="#v-synccatalog-k8stag">`k8sTag`</a> (`string: null`) - An optional tag that is applied to all of the Kubernetes services that are synced into Consul. If nothing is set, this defaults to "k8s". (Kubernetes -> Consul sync only)
 


### PR DESCRIPTION
Updated the documentation as the [consul-helm repo states that](https://github.com/hashicorp/consul-helm/blob/master/values.yaml#L600):

>  consulPrefix is ignored when 'annotationServiceName' is provided.
