### PR TITLE
command/envoy: enable TLS when CONSUL_HTTP_ADDR=https://...

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -551,11 +551,11 @@ func NewClient(config *Config) (*Client, error) {
 	// bootstrap the config
 	defConfig := DefaultConfig()
 
-	if len(config.Address) == 0 {
+	if config.Address == "" {
 		config.Address = defConfig.Address
 	}
 
-	if len(config.Scheme) == 0 {
+	if config.Scheme == "" {
 		config.Scheme = defConfig.Scheme
 	}
 
@@ -599,7 +599,7 @@ func NewClient(config *Config) (*Client, error) {
 	if len(parts) == 2 {
 		switch parts[0] {
 		case "http":
-			config.Scheme = "http"
+			// Never revert to http if TLS was explicitly requested.
 		case "https":
 			config.Scheme = "https"
 		case "unix":

--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -3,6 +3,8 @@ package envoy
 // BootstrapTplArgs is the set of arguments that may be interpolated into the
 // Envoy bootstrap template.
 type BootstrapTplArgs struct {
+	GRPC
+
 	// ProxyCluster is the cluster name for the the Envoy `node` specification and
 	// is typically the same as the ProxyID.
 	ProxyCluster string
@@ -12,25 +14,9 @@ type BootstrapTplArgs struct {
 	// the agent to deliver the correct configuration.
 	ProxyID string
 
-	// AgentAddress is the IP address of the local agent where the proxy instance
-	// is registered.
-	AgentAddress string
-
-	// AgentPort is the gRPC port exposed on the local agent.
-	AgentPort string
-
-	// AgentTLS is true if the local agent gRPC service should be accessed over
-	// TLS.
-	AgentTLS bool
-
 	// AgentCAPEM is the CA to use to verify the local agent gRPC service if
 	// TLS is enabled.
 	AgentCAPEM string
-
-	// AgentSocket is the path to a Unix Socket for communicating with the
-	// local agent's gRPC endpoint. Disabled if the empty (the default),
-	// but overrides AgentAddress and AgentPort if set.
-	AgentSocket string
 
 	// AdminAccessLogPath The path to write the access log for the
 	// administration server. If no access log is desired specify
@@ -100,6 +86,25 @@ type BootstrapTplArgs struct {
 	// EnvoyVersion is the envoy version, which is necessary to generate the
 	// correct configuration.
 	EnvoyVersion string
+}
+
+// GRPC settings used in the bootstrap template.
+type GRPC struct {
+	// AgentAddress is the IP address of the local agent where the proxy instance
+	// is registered.
+	AgentAddress string
+
+	// AgentPort is the gRPC port exposed on the local agent.
+	AgentPort string
+
+	// AgentTLS is true if the local agent gRPC service should be accessed over
+	// TLS.
+	AgentTLS bool
+
+	// AgentSocket is the path to a Unix Socket for communicating with the
+	// local agent's gRPC endpoint. Disabled if the empty (the default),
+	// but overrides AgentAddress and AgentPort if set.
+	AgentSocket string
 }
 
 const bootstrapTemplate = `{

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -343,21 +343,6 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	// See if we need to lookup grpcAddr
-	if c.grpcAddr == "" {
-		port, err := c.lookupGRPCPort()
-		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
-		}
-		if port <= 0 {
-			// This is the dev mode default and recommended production setting if
-			// enabled.
-			port = 8502
-			c.UI.Info(fmt.Sprintf("Defaulting to grpc port = %d", port))
-		}
-		c.grpcAddr = fmt.Sprintf("localhost:%v", port)
-	}
-
 	// Generate config
 	bootstrapJson, err := c.generateConfig()
 	if err != nil {
@@ -409,6 +394,21 @@ func (c *cmd) templateArgs() (*BootstrapTplArgs, error) {
 	// Trigger the Client init to do any last-minute updates to the Config.
 	if _, err := api.NewClient(httpCfg); err != nil {
 		return nil, err
+	}
+
+	// See if we need to lookup grpcAddr
+	if c.grpcAddr == "" {
+		port, err := c.lookupGRPCPort()
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error connecting to Consul agent: %s", err))
+		}
+		if port <= 0 {
+			// This is the dev mode default and recommended production setting if
+			// enabled.
+			port = 8502
+			c.UI.Info(fmt.Sprintf("Defaulting to grpc port = %d", port))
+		}
+		c.grpcAddr = fmt.Sprintf("localhost:%v", port)
 	}
 
 	// Decide on TLS if the scheme is provided and indicates it, if the HTTP env

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -125,11 +125,13 @@ func TestGenerateConfig(t *testing.T) {
 			Name:  "defaults",
 			Flags: []string{"-proxy-id", "test-proxy"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502", // Note this is the gRPC port
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502", // Note this is the gRPC port
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -141,11 +143,13 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy",
 				"-token", "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502", // Note this is the gRPC port
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502", // Note this is the gRPC port
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -160,11 +164,13 @@ func TestGenerateConfig(t *testing.T) {
 				"CONSUL_HTTP_TOKEN=c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502", // Note this is the gRPC port
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502", // Note this is the gRPC port
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -181,11 +187,13 @@ func TestGenerateConfig(t *testing.T) {
 				"token.txt": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502", // Note this is the gRPC port
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502", // Note this is the gRPC port
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -203,11 +211,13 @@ func TestGenerateConfig(t *testing.T) {
 				"token.txt": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502", // Note this is the gRPC port
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502", // Note this is the gRPC port
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -226,8 +236,10 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "9999",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "9999",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -247,8 +259,10 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "9999",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "9999",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -260,10 +274,12 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy",
 				"-grpc-addr", "unix:///var/run/consul.sock"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentSocket:           "/var/run/consul.sock",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentSocket: "/var/run/consul.sock",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -281,8 +297,10 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "9999",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "9999",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -299,8 +317,10 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/some/path/access.log",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -317,8 +337,10 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress: "127.0.0.1",
-				AgentPort:    "8502",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 			},
 			WantErr: "Error loading CA File: open some/path: no such file or directory",
 		},
@@ -333,9 +355,11 @@ func TestGenerateConfig(t *testing.T) {
 				// Should resolve IP, note this might not resolve the same way
 				// everywhere which might make this test brittle but not sure what else
 				// to do.
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
-				AgentTLS:              true,
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+					AgentTLS:     true,
+				},
 				AgentCAPEM:            `-----BEGIN CERTIFICATE-----\nMIIEtzCCA5+gAwIBAgIJAIewRMI8OnvTMA0GCSqGSIb3DQEBBQUAMIGYMQswCQYD\nVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xHDAa\nBgNVBAoTE0hhc2hpQ29ycCBUZXN0IENlcnQxDDAKBgNVBAsTA0RldjEWMBQGA1UE\nAxMNdGVzdC5pbnRlcm5hbDEgMB4GCSqGSIb3DQEJARYRdGVzdEBpbnRlcm5hbC5j\nb20wHhcNMTQwNDA3MTkwMTA4WhcNMjQwNDA0MTkwMTA4WjCBmDELMAkGA1UEBhMC\nVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRwwGgYDVQQK\nExNIYXNoaUNvcnAgVGVzdCBDZXJ0MQwwCgYDVQQLEwNEZXYxFjAUBgNVBAMTDXRl\nc3QuaW50ZXJuYWwxIDAeBgkqhkiG9w0BCQEWEXRlc3RAaW50ZXJuYWwuY29tMIIB\nIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxrs6JK4NpiOItxrpNR/1ppUU\nmH7p2BgLCBZ6eHdclle9J56i68adt8J85zaqphCfz6VDP58DsFx+N50PZyjQaDsU\nd0HejRqfHRMtg2O+UQkv4Z66+Vo+gc6uGuANi2xMtSYDVTAqqzF48OOPQDgYkzcG\nxcFZzTRFFZt2vPnyHj8cHcaFo/NMNVh7C3yTXevRGNm9u2mrbxCEeiHzFC2WUnvg\nU2jQuC7Fhnl33Zd3B6d3mQH6O23ncmwxTcPUJe6xZaIRrDuzwUcyhLj5Z3faag/f\npFIIcHSiHRfoqHLGsGg+3swId/zVJSSDHr7pJUu7Cre+vZa63FqDaooqvnisrQID\nAQABo4IBADCB/TAdBgNVHQ4EFgQUo/nrOfqvbee2VklVKIFlyQEbuJUwgc0GA1Ud\nIwSBxTCBwoAUo/nrOfqvbee2VklVKIFlyQEbuJWhgZ6kgZswgZgxCzAJBgNVBAYT\nAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEcMBoGA1UE\nChMTSGFzaGlDb3JwIFRlc3QgQ2VydDEMMAoGA1UECxMDRGV2MRYwFAYDVQQDEw10\nZXN0LmludGVybmFsMSAwHgYJKoZIhvcNAQkBFhF0ZXN0QGludGVybmFsLmNvbYIJ\nAIewRMI8OnvTMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADa9fV9h\ngjapBlkNmu64WX0Ufub5dsJrdHS8672P30S7ILB7Mk0W8sL65IezRsZnG898yHf9\n2uzmz5OvNTM9K380g7xFlyobSVq+6yqmmSAlA/ptAcIIZT727P5jig/DB7fzJM3g\njctDlEGOmEe50GQXc25VKpcpjAsNQi5ER5gowQ0v3IXNZs+yU+LvxLHc0rUJ/XSp\nlFCAMOqd5uRoMOejnT51G6krvLNzPaQ3N9jQfNVY4Q0zfs0M+6dRWvqfqB9Vyq8/\nPOLMld+HyAZEBk9zK3ZVIXx6XS4dkDnSNR91njLq7eouf6M7+7s/oMQZZRtAfQ6r\nwlW975rYa1ZqEdA=\n-----END CERTIFICATE-----\n`,
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
@@ -369,11 +393,13 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -401,11 +427,13 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -438,11 +466,13 @@ func TestGenerateConfig(t *testing.T) {
 				} , { "name": "fake_sink_2" }`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -462,11 +492,13 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",
@@ -516,11 +548,13 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          defaultEnvoyVersion,
-				ProxyCluster:          "test-proxy",
-				ProxyID:               "test-proxy",
-				AgentAddress:          "127.0.0.1",
-				AgentPort:             "8502",
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+				},
 				AdminAccessLogPath:    "/dev/null",
 				AdminBindAddress:      "127.0.0.1",
 				AdminBindPort:         "19000",

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -561,6 +561,28 @@ func TestGenerateConfig(t *testing.T) {
 				LocalAgentClusterName: xds.LocalAgentClusterName,
 			},
 		},
+		{
+			Name:  "CONSUL_HTTP_ADDR-with-https-scheme-enables-tls",
+			Flags: []string{"-proxy-id", "test-proxy"},
+			Env:   []string{"CONSUL_HTTP_ADDR=https://127.0.0.1:8888"},
+			WantArgs: BootstrapTplArgs{
+				EnvoyVersion: defaultEnvoyVersion,
+				ProxyCluster: "test-proxy",
+				ProxyID:      "test-proxy",
+				// Should resolve IP, note this might not resolve the same way
+				// everywhere which might make this test brittle but not sure what else
+				// to do.
+				GRPC: GRPC{
+					AgentAddress: "127.0.0.1",
+					AgentPort:    "8502",
+					AgentTLS:     true,
+				},
+				AdminAccessLogPath:    "/dev/null",
+				AdminBindAddress:      "127.0.0.1",
+				AdminBindPort:         "19000",
+				LocalAgentClusterName: xds.LocalAgentClusterName,
+			},
+		},
 	}
 
 	copyAndReplaceAll := func(s []string, old, new string) []string {

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -1,0 +1,125 @@
+{
+  "admin": {
+    "access_log_path": "/dev/null",
+    "address": {
+      "socket_address": {
+        "address": "127.0.0.1",
+        "port_value": 19000
+      }
+    }
+  },
+  "node": {
+    "cluster": "test-proxy",
+    "id": "test-proxy",
+    "metadata": {
+      "namespace": "default",
+      "envoy_version": "1.13.1"
+    }
+  },
+  "static_resources": {
+    "clusters": [
+      {
+        "name": "local_agent",
+        "connect_timeout": "1s",
+        "type": "STATIC",
+        "tls_context": {
+          "common_tls_context": {
+            "validation_context": {
+              "trusted_ca": {
+                "inline_string": ""
+              }
+            }
+          }
+        },
+        "http2_protocol_options": {},
+        "hosts": [
+          {
+            "socket_address": {
+              "address": "127.0.0.1",
+              "port_value": 8502
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "stats_config": {
+    "stats_tags": [
+      {
+        "regex": "^cluster\\.((?:([^.]+)~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.custom_hash"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:([^.]+)\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.service_subset"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.service"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.namespace"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.datacenter"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.routing_type"
+      },
+      {
+        "regex": "^cluster\\.((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.([^.]+)\\.consul\\.)",
+        "tag_name": "consul.trust_domain"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+)\\.[^.]+\\.[^.]+\\.consul\\.)",
+        "tag_name": "consul.target"
+      },
+      {
+        "regex": "^cluster\\.(((?:[^.]+~)?(?:[^.]+\\.)?[^.]+\\.[^.]+\\.[^.]+\\.[^.]+\\.[^.]+)\\.consul\\.)",
+        "tag_name": "consul.full_target"
+      },
+      {
+        "tag_name": "local_cluster",
+        "fixed_value": "test-proxy"
+      }
+    ],
+    "use_all_default_tags": true
+  },
+  "dynamic_resources": {
+    "lds_config": {
+      "ads": {}
+    },
+    "cds_config": {
+      "ads": {}
+    },
+    "ads_config": {
+      "api_type": "GRPC",
+      "grpc_services": {
+        "initial_metadata": [
+          {
+            "key": "x-consul-token",
+            "value": ""
+          }
+        ],
+        "envoy_grpc": {
+          "cluster_name": "local_agent"
+        }
+      }
+    }
+  },
+  "layered_runtime": {
+    "layers": [
+      {
+        "name": "static_layer",
+        "static_layer": {
+          "envoy.deprecated_features:envoy.api.v2.Cluster.tls_context": true,
+          "envoy.deprecated_features:envoy.config.trace.v2.ZipkinConfig.HTTP_JSON_V1": true,
+          "envoy.deprecated_features:envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager.Tracing.operation_name": true
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes #7473

The documentation for [CONSUL_HTTP_ADDR](https://www.consul.io/docs/commands/index.html#consul_http_addr) and [CONSUL_GRPC_ADDR](https://www.consul.io/docs/commands/index.html#consul_grpc_addr) suggest that 

> If the https:// scheme is used, CONSUL_HTTP_SSL is implied to be true.

> As with CONSUL_HTTP_ADDR, if TLS is enabled either the https:// scheme should be used, or CONSUL_HTTP_SSL set.

It appears that the code was attempting to do this, however the call to `api.NewClient` was stripping the `https` scheme from `Config.Address`, which prevented it from working.

To test and fix this properly I had to make some substantial changes. I've split up the changes into a few commits to hopefully make it easier to review and show the process.

There are a few new TODOs to be resolved. I was thinking of leaving those for a follow up PR as this is already relatively large, but I could do them here if that is desirable. 