### PR TITLE
WIP: agent: use context for cancellation in agent.Start()

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -74,7 +74,7 @@ func (a *Agent) aclAccessorID(secretID string) string {
 	return ident.ID()
 }
 
-func (a *Agent) initializeACLs() error {
+func initializeACLs(nodeName string) (acl.Authorizer, error) {
 	// Build a policy for the agent master token.
 	// The builtin agent master policy allows reading any node information
 	// and allows writes to the agent with the node name of the running agent
@@ -83,25 +83,20 @@ func (a *Agent) initializeACLs() error {
 	policy := &acl.Policy{
 		PolicyRules: acl.PolicyRules{
 			Agents: []*acl.AgentRule{
-				&acl.AgentRule{
-					Node:   a.config.NodeName,
+				{
+					Node:   nodeName,
 					Policy: acl.PolicyWrite,
 				},
 			},
 			NodePrefixes: []*acl.NodeRule{
-				&acl.NodeRule{
+				{
 					Name:   "",
 					Policy: acl.PolicyRead,
 				},
 			},
 		},
 	}
-	master, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-	if err != nil {
-		return err
-	}
-	a.aclMasterAuthorizer = master
-	return nil
+	return acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
 }
 
 // vetServiceRegister makes sure the service registration action is allowed by

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -406,6 +406,7 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// load the tokens - this requires the logger to be setup
 	// which is why we can't do this in New
+	// TODO: logger is available from New() now, can this be moved to New() ?
 	a.loadTokens(a.config)
 	a.loadEnterpriseTokens(a.config)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -347,7 +347,9 @@ func New(c *config.RuntimeConfig, logger hclog.InterceptLogger) (*Agent, error) 
 	}
 	a.serviceManager = NewServiceManager(&a)
 
-	if err := a.initializeACLs(); err != nil {
+	var err error
+	a.aclMasterAuthorizer, err = initializeACLs(c.NodeName)
+	if err != nil {
 		return nil, err
 	}
 

--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -18,7 +19,7 @@ const (
 	retryJitterWindow = 30 * time.Second
 )
 
-func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token string, interruptCh chan struct{}) (*structs.SignedResponse, string, error) {
+func (c *Client) RequestAutoEncryptCerts(ctx context.Context, servers []string, port int, token string) (*structs.SignedResponse, string, error) {
 	errFn := func(err error) (*structs.SignedResponse, string, error) {
 		return nil, "", err
 	}
@@ -92,7 +93,7 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 	attempts := 0
 	for {
 		select {
-		case <-interruptCh:
+		case <-ctx.Done():
 			return errFn(fmt.Errorf("aborting AutoEncrypt because interrupted"))
 		default:
 		}
@@ -124,7 +125,7 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 		select {
 		case <-time.After(interval):
 			continue
-		case <-interruptCh:
+		case <-ctx.Done():
 			return errFn(fmt.Errorf("aborting AutoEncrypt because interrupted"))
 		case <-c.shutdownCh:
 			return errFn(fmt.Errorf("aborting AutoEncrypt because shutting down"))

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -208,7 +209,8 @@ func (a *TestAgent) Start(t *testing.T) (err error) {
 
 	id := string(a.Config.NodeID)
 
-	if err := agent.Start(); err != nil {
+	ctx := context.Background()
+	if err := agent.Start(ctx); err != nil {
 		cleanupTmpDir()
 		agent.ShutdownAgent()
 		agent.ShutdownEndpoints()

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -176,7 +175,7 @@ func (c *cmd) startupJoinWan(agent *agent.Agent, cfg *config.RuntimeConfig) erro
 func (c *cmd) run(args []string) int {
 	// Parse our configs
 	if err := c.flags.Parse(args); err != nil {
-		if !strings.Contains(err.Error(), "help requested") {
+		if err != flag.ErrHelp {
 			c.UI.Error(fmt.Sprintf("error parsing flags: %v", err))
 		}
 		return 1


### PR DESCRIPTION
I made these changes last week while digging into the agent command. They are not quite ready for review, but opening this PR in case anyone is interested.

Using `context` for cancellation has a number of advantages. Primarily:
* removes a field from the struct, a small step in shrinking `Agent`
* multiple go routines can call `<-Done` and get their own channel, all of which will be closed by a single `cancel`.