### PR TITLE
Add decode rules for Expose cfg in service-defaults

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -340,10 +340,15 @@ func ConfigEntryDecodeRulesForKind(kind string) (skipWhenPatching []string, tran
 				"config":          "",
 			}, nil
 	case ServiceDefaults:
-		return nil, map[string]string{
-			"mesh_gateway": "meshgateway",
-			"external_sni": "externalsni",
-		}, nil
+		return []string{
+				"expose.paths",
+				"Expose.Paths",
+			}, map[string]string{
+				"local_path_port": "localpathport",
+				"listener_port":   "listenerport",
+				"mesh_gateway":    "meshgateway",
+				"external_sni":    "externalsni",
+			}, nil
 	case ServiceRouter:
 		return []string{
 				"routes",

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -1170,6 +1170,12 @@ func TestParseConfigEntry(t *testing.T) {
 							listener_port = 21500
 							path = "/healthz"
 							protocol = "http2"
+						},
+						{
+							local_path_port = 8000
+							listener_port = 21501
+							path = "/metrics"
+							protocol = "http"
 						}
 					]
 				}`,
@@ -1184,6 +1190,12 @@ func TestParseConfigEntry(t *testing.T) {
 							ListenerPort = 21500
 							Path = "/healthz"
 							Protocol = "http2"
+						},
+						{
+							LocalPathPort = 8000
+							ListenerPort = 21501
+							Path = "/metrics"
+							Protocol = "http"
 						}
 					]
 				}`,
@@ -1199,6 +1211,12 @@ func TestParseConfigEntry(t *testing.T) {
 							"listener_port": 21500,
 							"path": "/healthz",
 							"protocol": "http2"
+						},
+						{
+							"local_path_port": 8000,
+							"listener_port": 21501,
+							"path": "/metrics",
+							"protocol": "http"
 						}
 					]
 				}
@@ -1216,6 +1234,12 @@ func TestParseConfigEntry(t *testing.T) {
 							"ListenerPort": 21500,
 							"Path": "/healthz",
 							"Protocol": "http2"
+						},
+						{
+							"LocalPathPort": 8000,
+							"ListenerPort": 21501,
+							"Path": "/metrics",
+							"Protocol": "http"
 						}
 					]
 				}
@@ -1232,6 +1256,122 @@ func TestParseConfigEntry(t *testing.T) {
 							Path:          "/healthz",
 							LocalPathPort: 8080,
 							Protocol:      "http2",
+						},
+						{
+							ListenerPort:  21501,
+							Path:          "/metrics",
+							LocalPathPort: 8000,
+							Protocol:      "http",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "expose paths: kitchen sink service defaults",
+			snake: `
+				kind = "service-defaults"
+				name = "web"
+				expose = {
+					checks = true
+					paths = [
+						{
+							local_path_port = 8080
+							listener_port = 21500
+							path = "/healthz"
+							protocol = "http2"
+						},
+						{
+							local_path_port = 8000
+							listener_port = 21501
+							path = "/metrics"
+							protocol = "http"
+						}
+					]
+				}`,
+			camel: `
+				Kind = "service-defaults"
+				Name = "web"
+				Expose = {
+					Checks = true
+					Paths = [
+						{
+							LocalPathPort = 8080
+							ListenerPort = 21500
+							Path = "/healthz"
+							Protocol = "http2"
+						},
+						{
+							LocalPathPort = 8000
+							ListenerPort = 21501
+							Path = "/metrics"
+							Protocol = "http"
+						}
+					]
+				}`,
+			snakeJSON: `
+			{
+				"kind": "service-defaults",
+				"name": "web",
+				"expose": {
+					"checks": true,
+					"paths": [
+						{
+							"local_path_port": 8080,
+							"listener_port": 21500,
+							"path": "/healthz",
+							"protocol": "http2"
+						},
+						{
+							"local_path_port": 8000,
+							"listener_port": 21501,
+							"path": "/metrics",
+							"protocol": "http"
+						}
+					]
+				}
+			}
+			`,
+			camelJSON: `
+			{
+				"Kind": "service-defaults",
+				"Name": "web",
+				"Expose": {
+					"Checks": true,
+					"Paths": [
+						{
+							"LocalPathPort": 8080,
+							"ListenerPort": 21500,
+							"Path": "/healthz",
+							"Protocol": "http2"
+						},
+						{
+							"LocalPathPort": 8000,
+							"ListenerPort": 21501,
+							"Path": "/metrics",
+							"Protocol": "http"
+						}
+					]
+				}
+			}
+			`,
+			expect: &api.ServiceConfigEntry{
+				Kind: "service-defaults",
+				Name: "web",
+				Expose: api.ExposeConfig{
+					Checks: true,
+					Paths: []api.ExposePath{
+						{
+							ListenerPort:  21500,
+							Path:          "/healthz",
+							LocalPathPort: 8080,
+							Protocol:      "http2",
+						},
+						{
+							ListenerPort:  21501,
+							Path:          "/metrics",
+							LocalPathPort: 8000,
+							Protocol:      "http",
 						},
 					},
 				},


### PR DESCRIPTION
Fixes: #7602

The `Expose` config did not have decode rules set for `service-defaults`. That leads to a panic when multiple paths are exposed.

This PR adds those rules as well as corresponding tests.