### PR TITLE
grpc: use default resolver scheme for grpc dialing

### DIFF
--- a/agent/checks/grpc.go
+++ b/agent/checks/grpc.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	hv1 "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/resolver"
 )
 
 var ErrGRPCUnhealthy = fmt.Errorf("gRPC application didn't report service healthy")
@@ -52,12 +53,12 @@ func NewGrpcHealthProbe(target string, timeout time.Duration, tlsConfig *tls.Con
 // If nil is returned, target is healthy, otherwise target is not healthy
 func (probe *GrpcHealthProbe) Check(target string) error {
 	serverAndService := strings.SplitN(target, "/", 2)
-	server := serverAndService[0]
+	serverWithScheme := fmt.Sprintf("%s:///%s", resolver.GetDefaultScheme(), serverAndService[0])
 
 	ctx, cancel := context.WithTimeout(context.Background(), probe.timeout)
 	defer cancel()
 
-	connection, err := grpc.DialContext(ctx, server, probe.dialOptions...)
+	connection, err := grpc.DialContext(ctx, serverWithScheme, probe.dialOptions...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently checks of type gRPC will emit log messages such as,

    2020/02/12 13:48:22 [INFO] parsed scheme: ""
    2020/02/12 13:48:22 [INFO] scheme "" not registered, fallback to default scheme

Without adding full support for using custom gRPC schemes (perhaps that's
right long-term option) we can just supply the default scheme as provided
by the grpc library.

Fixes https://github.com/hashicorp/consul/issues/7274
and transitively https://github.com/hashicorp/nomad/issues/7415

Did some manual testing.

## Without Proxy

##### Toy gRPC HC service
```bash
$ docker run --net=host --rm shoenig/grpc-healthcheck-example:v0.0.0
```

##### Consul config w/ check on service
```hcl
# consul.hcl

log_level = "INFO"
data_dir = "/tmp/consul"
server = true
bootstrap_expect = 1
bind_addr = "127.0.0.1"
addresses {
  http = "0.0.0.0"
}

services = {
  name = "grpc-healthcheck-example"
  port = 3333

  check = {
    "id"           = "example-check"
    "name"         = "gRPC Check Example"
    "grpc"         = "127.0.0.1:3333/example"
    "grpc_use_tls" = false
    "interval"     = "7s"
  }
}
```

##### Run Consul
```bash
$  consul agent -config-file=consul.hcl
```

##### Verify check passes

```bash
$ curl -s localhost:8500/v1/agent/checks | jq .
{
  "example-check": {
    "Node": "x1",
    "CheckID": "example-check",
    "Name": "gRPC Check Example",
    "Status": "passing",
    "Notes": "",
    "Output": "gRPC check 127.0.0.1:3333/example: success",
    "ServiceID": "grpc-healthcheck-example",
    "ServiceName": "grpc-healthcheck-example",
    "ServiceTags": [],
    "Type": "grpc",
    "Definition": {},
    "CreateIndex": 0,
    "ModifyIndex": 0
  }
}
```


## With Proxy (using Nomad)

##### Run Consul

```bash
$ consul agent -dev
```

##### Run Nomad

```bash
$ sudo nomad agent -dev-connect
```

##### Nomad job file w/ Connect enabled, exposed gRPC HC service

```hcl
# example.nomad

job "grpc-check-example" {
  datacenters = ["dc1"]

  group "group1" {
    network {
      mode = "bridge"

      port "healthcheck" {
	to = -1
      }
    }



    service {
      name = "grpc-healthcheck-example"
      port = "healthcheck"

      connect {
	sidecar_service {}
      }

      check {
	name = "example-check"
	type = "grpc"
	port = "healthcheck"
	interval = "5s"
	timeout = "3s"
	expose = true
      }
    }

    task "example" {
      driver = "docker"

      env {
	GRPCHC_PORT = "${NOMAD_PORT_healthcheck}"
      }

      config {
	image = "shoenig/grpc-healthcheck-example:v0.0.0"
      }
    }
  }
}
```


##### Wait for job to become healthy

```bash
$ nomad job status grpc-check-example
ID            = grpc-check-example
Name          = grpc-check-example
Submit Date   = 2020-04-08T13:46:44-06:00
Type          = service
Priority      = 50
Datacenters   = dc1
Namespace     = default
Status        = running
Periodic      = false
Parameterized = false

Summary
Task Group  Queued  Starting  Running  Failed  Complete  Lost
group1      0       0         1        0       0         0

Latest Deployment
ID          = cf59d40b
Status      = successful
Description = Deployment completed successfully

Deployed
Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
group1      1        1       1        0          2020-04-08T13:56:59-06:00

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
51972858  d3aa3a10  group1      0        run      running  31s ago  16s ago
```

##### Verify check is passing

```bash
$ curl -s localhost:8500/v1/agent/checks | jq '.[] | select(.Name=="example-check")'
{
  "Node": "x1",
  "CheckID": "_nomad-check-a20c0d5a5e2abd9d953c1731fbdcb5b185b7ef79",
  "Name": "example-check",
  "Status": "passing",
  "Notes": "",
  "Output": "gRPC check 192.168.1.252:30697/: success",
  "ServiceID": "_nomad-task-51972858-e1bd-0329-437a-81a942e34cd5-group-group1-grpc-healthcheck-example-healthcheck",
  "ServiceName": "grpc-healthcheck-example",
  "ServiceTags": [],
  "Type": "grpc",
  "Definition": {},
  "CreateIndex": 0,
  "ModifyIndex": 0
}
```

