### PR TITLE
Add support for RSA private key to TLS utils.

### DIFF
--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
@@ -130,6 +131,7 @@ func GenerateCert(signer crypto.Signer, ca string, sn *big.Int, name string, day
 func keyID(raw interface{}) ([]byte, error) {
 	switch raw.(type) {
 	case *ecdsa.PublicKey:
+	case *rsa.PublicKey:
 	default:
 		return nil, fmt.Errorf("invalid key type: %T", raw)
 	}

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -173,6 +173,10 @@ func ParseSigner(pemValue string) (crypto.Signer, error) {
 	switch block.Type {
 	case "EC PRIVATE KEY":
 		return x509.ParseECPrivateKey(block.Bytes)
+		
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+		
 	default:
 		return nil, fmt.Errorf("unknown PEM block type for signing key: %s", block.Type)
 	}

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -166,34 +166,7 @@ func parseCert(pemValue string) (*x509.Certificate, error) {
 // ParseSigner parses a crypto.Signer from a PEM-encoded key. The private key
 // is expected to be the first block in the PEM value.
 func ParseSigner(pemValue string) (crypto.Signer, error) {
-	// The _ result below is not an error but the remaining PEM bytes.
-	block, _ := pem.Decode([]byte(pemValue))
-	if block == nil {
-		return nil, fmt.Errorf("no PEM-encoded data found")
-	}
-
-	switch block.Type {
-	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
-
-	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(block.Bytes)
-
-	case "PRIVATE KEY":
-		signer, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return nil, err
-		}
-		pk, ok := signer.(crypto.Signer)
-		if !ok {
-			return nil, fmt.Errorf("private key is not a valid format")
-		}
-
-		return pk, nil
-
-	default:
-		return nil, fmt.Errorf("unknown PEM block type for signing key: %s", block.Type)
-	}
+	return connect.ParseSigner(pemValue)
 }
 
 func Verify(caString, certString, dns string) error {

--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -175,10 +175,22 @@ func ParseSigner(pemValue string) (crypto.Signer, error) {
 	switch block.Type {
 	case "EC PRIVATE KEY":
 		return x509.ParseECPrivateKey(block.Bytes)
-		
+
 	case "RSA PRIVATE KEY":
 		return x509.ParsePKCS1PrivateKey(block.Bytes)
-		
+
+	case "PRIVATE KEY":
+		signer, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		pk, ok := signer.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("private key is not a valid format")
+		}
+
+		return pk, nil
+
 	default:
 		return nil, fmt.Errorf("unknown PEM block type for signing key: %s", block.Type)
 	}

--- a/tlsutil/generate_test.go
+++ b/tlsutil/generate_test.go
@@ -95,6 +95,25 @@ func TestGenerateCA(t *testing.T) {
 	require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)
 
 	require.Equal(t, x509.KeyUsageCertSign|x509.KeyUsageCRLSign|x509.KeyUsageDigitalSignature, cert.KeyUsage)
+
+	// Test what happens with a correct RSA Key
+	s, err = rsa.GenerateKey(rand.Reader, 2048)
+	require.Nil(t, err)
+	ca, err = GenerateCA(s, sn, 365, nil)
+	require.Nil(t, err)
+	require.NotEmpty(t, ca)
+
+	cert, err = parseCert(ca)
+	require.Nil(t, err)
+	require.Equal(t, fmt.Sprintf("Consul Agent CA %d", sn), cert.Subject.CommonName)
+	require.Equal(t, true, cert.IsCA)
+	require.Equal(t, true, cert.BasicConstraintsValid)
+
+	require.WithinDuration(t, cert.NotBefore, time.Now(), time.Minute)
+	require.WithinDuration(t, cert.NotAfter, time.Now().AddDate(0, 0, 365), time.Minute)
+
+	require.Equal(t, x509.KeyUsageCertSign|x509.KeyUsageCRLSign|x509.KeyUsageDigitalSignature, cert.KeyUsage)
+
 }
 
 func TestGenerateCert(t *testing.T) {


### PR DESCRIPTION
Attempt to add RSA support in the TLS utils for parsing certs used in generating certs from your own CA/RSA private key.  Per https://github.com/hashicorp/consul/issues/7622

Not sure if this is all it would take. 