### PR TITLE
Adding links to new GS track in learn

### DIFF
--- a/website/source/docs/connect/connect-internals.html.md
+++ b/website/source/docs/connect/connect-internals.html.md
@@ -14,6 +14,10 @@ but will help you build a mental model of what's going on under the hood, which
 may help you reason about Connect's behavior in more complex deployment
 scenarios.
 
+To try Connect locally, complete the [Getting Started with Consul service 
+mesh](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) 
+guide.
+
 ## Mutual Transport Layer Security (mTLS)
 
 The core of Connect is based on [mutual TLS](https://en.wikipedia.org/wiki/Mutual_authentication).

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -47,14 +47,15 @@ applications can also send open tracing data through Envoy.
 
 There are several ways to try Connect in different environments.
 
- - The [getting started with Consul service mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+ - The [Getting Started with Consul Service Mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    walks you through installing Consul as service mesh for Kubernetes using the Helm
    chart, deploying services in the service mesh, and using intentions to secure service 
    communications.
    
- - The [secure service-to-service communication guide](https://learn.hashicorp.com/consul/developer-mesh/connect-services?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+ - The [Secure Service-to-Service Communication guide](https://learn.hashicorp.com/consul/developer-mesh/connect-services?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    is a simple walk through of connecting two services on your local machine
-   using Consul Connect's built-in proxy, and configuring your first intention.
+   using Consul Connect's built-in proxy and configuring your first intention. The guide also includes an introduction to 
+   using Envoy as the Connect sidecar proxy. 
 
  - The [Kubernetes guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    walks you through configuring Consul Connect in Kubernetes using the Helm

--- a/website/source/docs/connect/index.html.md
+++ b/website/source/docs/connect/index.html.md
@@ -47,20 +47,21 @@ applications can also send open tracing data through Envoy.
 
 There are several ways to try Connect in different environments.
 
- - The [Connect introduction guide](https://learn.hashicorp.com/consul/getting-started/connect)
+ - The [getting started with Consul service mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+   walks you through installing Consul as service mesh for Kubernetes using the Helm
+   chart, deploying services in the service mesh, and using intentions to secure service 
+   communications.
+   
+ - The [secure service-to-service communication guide](https://learn.hashicorp.com/consul/developer-mesh/connect-services?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    is a simple walk through of connecting two services on your local machine
-   using only Consul Connect, and configuring your first intention.
+   using Consul Connect's built-in proxy, and configuring your first intention.
 
- - The [Envoy guide](https://learn.hashicorp.com/consul/developer-segmentation/connect-envoy)
-   walks through using Envoy as a proxy. It uses Docker to run components
-   locally without installing anything else.
-
- - The [Kubernetes guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube)
+ - The [Kubernetes guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    walks you through configuring Consul Connect in Kubernetes using the Helm
    chart, and using intentions. You can run the guide on Minikube or an existing
    Kubernetes cluster.
 
- - The [observability guide](https://learn.hashicorp.com/consul/kubernetes/l7-observability-k8s)
+ - The [observability guide](https://learn.hashicorp.com/consul/kubernetes/l7-observability-k8s?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    shows how to deploy a basic metrics collection and visualization pipeline on
    a Minikube or Kubernetes cluster using the official Helm charts for Consul,
    Prometheus, and Grafana.

--- a/website/source/docs/connect/security.html.md
+++ b/website/source/docs/connect/security.html.md
@@ -13,7 +13,7 @@ description: |-
 Connect enables secure service-to-service communication over mutual TLS. This
 provides both in-transit data encryption as well as authorization. This page
 will document how to secure Connect. To try Connect locally, complete the
-[Getting Started guide](https://learn.hashicorp.com/consul/getting-started/connect?utm_source=consul.io&utm_medium=docs) or for a full security model reference,
+[Getting Started guide](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) or for a full security model reference,
 see the dedicated [Consul security model](/docs/internals/security.html) page.  When
 setting up Connect in production, review this [guide](https://learn.hashicorp.com/consul/developer-mesh/connect-production?utm_source=consul.io&utm_medium=docs).
 

--- a/website/source/docs/platform/k8s/index.html.md
+++ b/website/source/docs/platform/k8s/index.html.md
@@ -49,6 +49,11 @@ There are several ways to try Consul with Kubernetes in different environments.
 
 Guides
 
+ - The [getting started with Consul service mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+   walks you through installing Consul as service mesh for Kubernetes using the Helm
+   chart, deploying services in the service mesh, and using intentions to secure service 
+   communications.
+
  - The [Consul and minikube guide](https://learn.hashicorp.com/consul/
    getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs) is a quick walk through of how to deploy Consul with the official Helm chart on a local instance of Minikube. 
 

--- a/website/source/docs/platform/k8s/index.html.md
+++ b/website/source/docs/platform/k8s/index.html.md
@@ -49,7 +49,7 @@ There are several ways to try Consul with Kubernetes in different environments.
 
 Guides
 
- - The [getting started with Consul service mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+ - The [Getting Started with Consul Service Mesh track](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
    walks you through installing Consul as service mesh for Kubernetes using the Helm
    chart, deploying services in the service mesh, and using intentions to secure service 
    communications.

--- a/website/source/docs/platform/k8s/run.html.md
+++ b/website/source/docs/platform/k8s/run.html.md
@@ -16,9 +16,9 @@ a server running inside or outside of Kubernetes.
 This page starts with a large how-to section for various specific tasks.
 To learn more about the general architecture of Consul on Kubernetes, scroll
 down to the [architecture](/docs/platform/k8s/run.html#architecture) section.
-If you would like to get hands-on experience testing Consul on Kubernetes,
-try the step-by-step beginner tutorial with an accompanying video in the
-[Minikube with Consul guide](https://learn.hashicorp.com/consul/getting-started-k8s/minikube?utm_source=consul.io&utm_medium=docs)
+If you would like to get hands-on experience testing Consul as a service mesh 
+for Kubernetes, check the guides in the [Getting Started with Consul service 
+mesh](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) track.
 
 ## Helm Chart Installation
 


### PR DESCRIPTION
Adding links to the new Learn track to existing documentation pages.

* https://www.consul.io/docs/connect/connect-internals.html
* https://www.consul.io/docs/connect/security.html
* https://www.consul.io/docs/platform/k8s/run.html
* https://www.consul.io/docs/connect/index.html#getting-started-with-connect
* https://www.consul.io/docs/platform/k8s/index.html