### PR TITLE
ui: enable Babel source maps

### DIFF
--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -9,57 +9,51 @@ module.exports = function(defaults) {
   // const isProdLike = prodlike.indexOf(env) > -1;
   const sourcemaps = !isProd;
   let app = new EmberApp(
-    Object.assign(
-      {},
-      defaults,
-      {
-        productionEnvironments: prodlike
-      }
-    ), {
-    'ember-cli-babel': {
-      includePolyfill: true
-    },
-    'ember-cli-string-helpers': {
-      only: ['capitalize', 'lowercase', 'truncate', 'uppercase']
-    },
-    'ember-cli-math-helpers': {
-      only: ['div']
-    },
-    'babel': {
-      plugins: [
-        '@babel/plugin-proposal-object-rest-spread'
-      ]
-    },
-    'codemirror': {
-      keyMaps: ['sublime'],
-      addonFiles: [
-        'lint/lint.css',
-        'lint/lint.js',
-        'lint/json-lint.js',
-        'lint/yaml-lint.js',
-        'mode/loadmode.js'
-      ]
-    },
-    'ember-cli-uglify': {
-      uglify: {
-        compress: {
-          keep_fargs: false,
+    Object.assign({}, defaults, {
+      productionEnvironments: prodlike,
+    }),
+    {
+      'ember-cli-babel': {
+        includePolyfill: true,
+      },
+      'ember-cli-string-helpers': {
+        only: ['capitalize', 'lowercase', 'truncate', 'uppercase'],
+      },
+      'ember-cli-math-helpers': {
+        only: ['div'],
+      },
+      babel: {
+        plugins: ['@babel/plugin-proposal-object-rest-spread'],
+        sourceMaps: sourcemaps ? 'inline' : false,
+      },
+      codemirror: {
+        keyMaps: ['sublime'],
+        addonFiles: [
+          'lint/lint.css',
+          'lint/lint.js',
+          'lint/json-lint.js',
+          'lint/yaml-lint.js',
+          'mode/loadmode.js',
+        ],
+      },
+      'ember-cli-uglify': {
+        uglify: {
+          compress: {
+            keep_fargs: false,
+          },
         },
       },
-    },
-    'sassOptions': {
-      implementation: require('dart-sass'),
-      sourceMapEmbed: sourcemaps,
-    },
-    'autoprefixer': {
-      sourcemap: sourcemaps,
-      grid: true,
-      browsers: [
-        "defaults",
-        "ie 11"
-      ]
-    },
-  });
+      sassOptions: {
+        implementation: require('dart-sass'),
+        sourceMapEmbed: sourcemaps,
+      },
+      autoprefixer: {
+        sourcemap: sourcemaps,
+        grid: true,
+        browsers: ['defaults', 'ie 11'],
+      },
+    }
+  );
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //
@@ -74,21 +68,33 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
 
   // TextEncoder/Decoder polyfill. See assets/index.html
-  app.import('node_modules/text-encoding/lib/encoding-indexes.js', {outputFile: 'assets/encoding-indexes.js'});
+  app.import('node_modules/text-encoding/lib/encoding-indexes.js', {
+    outputFile: 'assets/encoding-indexes.js',
+  });
 
   // CSS.escape polyfill
-  app.import('node_modules/css.escape/css.escape.js', {outputFile: 'assets/css.escape.js'});
+  app.import('node_modules/css.escape/css.escape.js', { outputFile: 'assets/css.escape.js' });
 
   // JSON linting support. Possibly dynamically loaded via CodeMirror linting. See components/code-editor.js
-  app.import('node_modules/jsonlint/lib/jsonlint.js', {outputFile: 'assets/codemirror/mode/javascript/javascript.js'});
-  app.import('node_modules/codemirror/mode/javascript/javascript.js', {outputFile: 'assets/codemirror/mode/javascript/javascript.js'});
+  app.import('node_modules/jsonlint/lib/jsonlint.js', {
+    outputFile: 'assets/codemirror/mode/javascript/javascript.js',
+  });
+  app.import('node_modules/codemirror/mode/javascript/javascript.js', {
+    outputFile: 'assets/codemirror/mode/javascript/javascript.js',
+  });
 
   // HCL/Ruby linting support. Possibly dynamically loaded via CodeMirror linting. See components/code-editor.js
-  app.import('node_modules/codemirror/mode/ruby/ruby.js', {outputFile: 'assets/codemirror/mode/ruby/ruby.js'});
+  app.import('node_modules/codemirror/mode/ruby/ruby.js', {
+    outputFile: 'assets/codemirror/mode/ruby/ruby.js',
+  });
 
   // YAML linting support. Possibly dynamically loaded via CodeMirror linting. See components/code-editor.js
-  app.import('node_modules/js-yaml/dist/js-yaml.js', {outputFile: 'assets/codemirror/mode/yaml/yaml.js'});
-  app.import('node_modules/codemirror/mode/yaml/yaml.js', {outputFile: 'assets/codemirror/mode/yaml/yaml.js'});
+  app.import('node_modules/js-yaml/dist/js-yaml.js', {
+    outputFile: 'assets/codemirror/mode/yaml/yaml.js',
+  });
+  app.import('node_modules/codemirror/mode/yaml/yaml.js', {
+    outputFile: 'assets/codemirror/mode/yaml/yaml.js',
+  });
   let tree = app.toTree();
   return tree;
 };


### PR DESCRIPTION
To display pre-transpilation content matching the source files when viewing in a browser debugger, instead of the post-transpilation ES5 source.

The only actual change here is adding the line below to `babel` config block, the other changes are just reformatting from the Prettier hook.
```
sourceMaps: sourcemaps ? 'inline' : false,
```

As referenced in https://github.com/babel/ember-cli-babel#enabling-source-maps

Before:
<img width="652" alt="Screen Shot 2020-04-15 at 4 28 58 PM" src="https://user-images.githubusercontent.com/1149913/79385239-402eec80-7f36-11ea-9cfc-83cec31aedc3.png">

After:
<img width="652" alt="Screen Shot 2020-04-15 at 4 27 47 PM" src="https://user-images.githubusercontent.com/1149913/79385256-44f3a080-7f36-11ea-9e07-38a6d5c4534c.png">