### PR TITLE
Add unconvert linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   enable:
     - gofmt
     - govet
+    - unconvert
 
 issues:
   # Disable the default exclude list so that all excludes are explicitly

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -323,7 +323,7 @@ func TestAgent_makeNodeID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if _, err := uuid.ParseUUID(string(id)); err != nil {
+	if _, err := uuid.ParseUUID(id); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 

--- a/agent/config/limits.go
+++ b/agent/config/limits.go
@@ -9,5 +9,6 @@ import "golang.org/x/sys/unix"
 func getrlimit() (uint64, error) {
 	var limit unix.Rlimit
 	err := unix.Getrlimit(unix.RLIMIT_NOFILE, &limit)
+	// nolint:unconvert // Rlimit.Cur may not be uint64 on all platforms
 	return uint64(limit.Cur), err
 }

--- a/agent/consul/authmethod/kubeauth/k8s.go
+++ b/agent/consul/authmethod/kubeauth/k8s.go
@@ -162,7 +162,7 @@ func (v *Validator) ValidateLogin(ctx context.Context, loginToken string) (*auth
 	var (
 		saNamespace = parts[2]
 		saName      = parts[3]
-		saUID       = string(trResp.Status.User.UID)
+		saUID       = trResp.Status.User.UID
 	)
 
 	// Check to see  if there is an override name on the ServiceAccount object.

--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -43,7 +43,7 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 	id := &connect.SpiffeIDAgent{
 		Host:       dummyTrustDomain,
 		Datacenter: c.config.Datacenter,
-		Agent:      string(c.config.NodeName),
+		Agent:      c.config.NodeName,
 	}
 
 	conf, err := c.config.CAConfig.GetCommonConfig()
@@ -71,7 +71,7 @@ func (c *Client) RequestAutoEncryptCerts(servers []string, port int, token strin
 	//
 	// The Common Name includes the dummy trust domain for now but Server will
 	// override this when it is signed anyway so it's OK.
-	cn := connect.AgentCN(string(c.config.NodeName), dummyTrustDomain)
+	cn := connect.AgentCN(c.config.NodeName, dummyTrustDomain)
 	csr, err := connect.CreateCSR(id, cn, pk, dnsNames, ipAddresses)
 	if err != nil {
 		return errFn(err)

--- a/agent/consul/autopilot/autopilot.go
+++ b/agent/consul/autopilot/autopilot.go
@@ -3,15 +3,16 @@ package autopilot
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
-	"net"
-	"strconv"
-	"sync"
-	"time"
 )
 
 // Delegate is the interface for the Autopilot mechanism
@@ -175,7 +176,7 @@ func (a *Autopilot) RemoveDeadServers() {
 }
 
 func canRemoveServers(peers, minQuorum, deadServers int) (bool, string) {
-	if peers-deadServers < int(minQuorum) {
+	if peers-deadServers < minQuorum {
 		return false, fmt.Sprintf("denied, because removing %d/%d servers would leave less then minimal allowed quorum of %d servers", deadServers, peers, minQuorum)
 	}
 

--- a/agent/consul/server_serf.go
+++ b/agent/consul/server_serf.go
@@ -28,9 +28,6 @@ const (
 
 	// maxPeerRetries limits how many invalidate attempts are made
 	maxPeerRetries = 6
-
-	// peerRetryBase is a baseline retry time
-	peerRetryBase = 1 * time.Second
 )
 
 // setupSerf is used to setup and initialize a Serf
@@ -360,7 +357,7 @@ func (s *Server) maybeBootstrap() {
 		for attempt := uint(0); attempt < maxPeerRetries; attempt++ {
 			if err := s.connPool.RPC(s.config.Datacenter, server.ShortName, server.Addr, server.Version,
 				"Status.Peers", &structs.DCSpecificRequest{Datacenter: s.config.Datacenter}, &peers); err != nil {
-				nextRetry := time.Duration((1 << attempt) * peerRetryBase)
+				nextRetry := (1 << attempt) * time.Second
 				s.logger.Error("Failed to confirm peer status for server (will retry).",
 					"server", server.Name,
 					"retry_interval", nextRetry.String(),

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -392,7 +392,7 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 		Address: "1.2.3.4",
 	}
 	nodeID := string(req.ID)
-	nodeName := string(req.Node)
+	nodeName := req.Node
 	restore := s.Restore()
 	if err := restore.Registration(1, req); err != nil {
 		t.Fatalf("err: %s", err)
@@ -2106,7 +2106,7 @@ func TestStateStore_ConnectServiceNodes(t *testing.T) {
 	ws = memdb.NewWatchSet()
 	idx, nodes, err = s.ConnectServiceNodes(ws, "db", nil)
 	assert.Nil(err)
-	assert.Equal(idx, uint64(idx))
+	assert.Equal(idx, uint64(17))
 	assert.Len(nodes, 3)
 
 	for _, n := range nodes {
@@ -3562,7 +3562,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 	ws = memdb.NewWatchSet()
 	idx, nodes, err = s.CheckConnectServiceNodes(ws, "db", nil)
 	assert.Nil(err)
-	assert.Equal(idx, uint64(idx))
+	assert.Equal(idx, uint64(20))
 	assert.Len(nodes, 2)
 
 	for _, n := range nodes {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -4270,7 +4270,7 @@ func TestDNS_TCP_and_UDP_Truncate(t *testing.T) {
 								if protocol == "udp" {
 									maxSz = 8192
 								}
-								m.SetEdns0(uint16(maxSz), true)
+								m.SetEdns0(maxSz, true)
 								c := new(dns.Client)
 								c.Net = protocol
 								m.Compress = compress

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -972,7 +972,7 @@ func TestParseConsistencyAndMaxStale(t *testing.T) {
 	ensureConsistency(t, a, "/v1/catalog/nodes?stale&max_stale=3s", 3*time.Second, false)
 
 	// stale by defaul on discovery
-	a.config.DiscoveryMaxStale = time.Duration(7 * time.Second)
+	a.config.DiscoveryMaxStale = 7 * time.Second
 	ensureConsistency(t, a, "/v1/catalog/nodes", a.config.DiscoveryMaxStale, false)
 	// Not in KV
 	ensureConsistency(t, a, "/v1/kv/my/path", 0, false)

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -449,7 +449,7 @@ func (e *ServiceSplitterConfigEntry) Normalize() error {
 
 func NormalizeServiceSplitWeight(weight float32) float32 {
 	weightScaled := scaleWeight(weight)
-	return float32(float32(weightScaled) / 100.0)
+	return float32(weightScaled) / 100.0
 }
 
 func (e *ServiceSplitterConfigEntry) Validate() error {

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -529,7 +529,7 @@ func ParseDurationFunc() mapstructure.DecodeHookFunc {
 func Uint8ToString(bs []uint8) string {
 	b := make([]byte, len(bs))
 	for i, v := range bs {
-		b[i] = byte(v)
+		b[i] = v
 	}
 	return string(b)
 }

--- a/api/health.go
+++ b/api/health.go
@@ -170,7 +170,7 @@ type HealthChecks []*HealthCheck
 func (c HealthChecks) AggregatedStatus() string {
 	var passing, warning, critical, maintenance bool
 	for _, check := range c {
-		id := string(check.CheckID)
+		id := check.CheckID
 		if id == NodeMaint || strings.HasPrefix(id, ServiceMaintPrefix) {
 			maintenance = true
 			continue

--- a/api/operator_raft.go
+++ b/api/operator_raft.go
@@ -60,7 +60,7 @@ func (op *Operator) RaftRemovePeerByAddress(address string, q *WriteOptions) err
 	r := op.c.newRequest("DELETE", "/v1/operator/raft/peer")
 	r.setWriteOptions(q)
 
-	r.params.Set("address", string(address))
+	r.params.Set("address", address)
 
 	_, resp, err := requireOK(op.c.doRequest(r))
 	if err != nil {
@@ -77,7 +77,7 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 	r := op.c.newRequest("DELETE", "/v1/operator/raft/peer")
 	r.setWriteOptions(q)
 
-	r.params.Set("id", string(id))
+	r.params.Set("id", id)
 
 	_, resp, err := requireOK(op.c.doRequest(r))
 	if err != nil {

--- a/command/config/write/config_write.go
+++ b/command/config/write/config_write.go
@@ -65,7 +65,7 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 
-	entry, err := parseConfigEntry(string(data))
+	entry, err := parseConfigEntry(data)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Failed to decode config entry input: %v", err))
 		return 1

--- a/command/kv/get/kv_get.go
+++ b/command/kv/get/kv_get.go
@@ -109,7 +109,7 @@ func (c *cmd) Run(args []string) int {
 		}
 
 		for _, k := range keys {
-			c.UI.Info(string(k))
+			c.UI.Info(k)
 		}
 
 		return 0

--- a/command/maint/maint.go
+++ b/command/maint/maint.go
@@ -92,7 +92,7 @@ func (c *cmd) Run(args []string) int {
 				c.UI.Output("  Name:   " + nodeName)
 				c.UI.Output("  Reason: " + check.Notes)
 				c.UI.Output("")
-			} else if strings.HasPrefix(string(check.CheckID), "_service_maintenance:") {
+			} else if strings.HasPrefix(check.CheckID, "_service_maintenance:") {
 				c.UI.Output("Service:")
 				c.UI.Output("  ID:     " + check.ServiceID)
 				c.UI.Output("  Reason: " + check.Notes)

--- a/internal/go-sso/oidcauth/oidcjwt.go
+++ b/internal/go-sso/oidcauth/oidcjwt.go
@@ -213,7 +213,7 @@ func stringifyMetadataValue(rawValue interface{}) (string, bool) {
 	case int32:
 		return strconv.FormatInt(int64(v), 10), true
 	case int64:
-		return strconv.FormatInt(int64(v), 10), true
+		return strconv.FormatInt(v, 10), true
 	case int:
 		return strconv.FormatInt(int64(v), 10), true
 	case uint8:


### PR DESCRIPTION
Closes #7326 - I cherry-picked that commit into my branch to re-run CI on it

Adds the [unconvert](https://github.com/mdempsky/unconvert) linter to detect unnecessary type convertions.

The one issue I've had with this linter in the past is when a field on a struct in `x/sys/unix` has different types on different platforms. I've whitelisted the one case I found so we don't run into that problem.