### PR TITLE
agent: stub out auditing functionality in OSS

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/go-connlimit"
@@ -179,10 +178,6 @@ type Agent struct {
 	// In-memory sink used for collecting metrics
 	MemSink *metrics.InmemSink
 
-	// Eventer provides a backend for handling event logging. APIs are provided on the agent for interacting with
-	// this reloadable type
-	Eventer atomic.Value
-
 	// delegate is either a *consul.Server or *consul.Client
 	// depending on the configuration
 	delegate delegate
@@ -317,6 +312,9 @@ type Agent struct {
 	// httpConnLimiter is used to limit connections to the HTTP server by client
 	// IP.
 	httpConnLimiter connlimit.Limiter
+
+	// enterpriseAgent embeds fields that we only access in consul-enterprise builds
+	enterpriseAgent
 }
 
 // New verifies the configuration given has a Datacenter and DataDir

--- a/agent/agent_oss.go
+++ b/agent/agent_oss.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+// enterpriseAgent embeds fields that we only access in consul-enterprise builds
+type enterpriseAgent struct{}
+
 // fillAgentServiceEnterpriseMeta is a noop stub for the func defined agent_ent.go
 func fillAgentServiceEnterpriseMeta(_ *api.AgentService, _ *structs.EnterpriseMeta) {}
 

--- a/agent/agent_oss.go
+++ b/agent/agent_oss.go
@@ -9,14 +9,26 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-// fillAgentServiceEnterpriseMeta stub
+// fillAgentServiceEnterpriseMeta is a noop stub for the func defined agent_ent.go
 func fillAgentServiceEnterpriseMeta(_ *api.AgentService, _ *structs.EnterpriseMeta) {}
 
-// fillHealthCheckEnterpriseMeta stub
+// fillHealthCheckEnterpriseMeta is a noop stub for the func defined agent_ent.go
 func fillHealthCheckEnterpriseMeta(_ *api.HealthCheck, _ *structs.EnterpriseMeta) {}
 
-func (a *Agent) initEnterprise(consulCfg *consul.Config) {
+// initEnterprise is a noop stub for the func defined agent_ent.go
+func (a *Agent) initEnterprise(consulCfg *consul.Config) error {
+	return nil
 }
 
+// loadEnterpriseTokens is a noop stub for the func defined agent_ent.go
 func (a *Agent) loadEnterpriseTokens(conf *config.RuntimeConfig) {
+}
+
+// reloadEnterprise is a noop stub for the func defined agent_ent.go
+func (a *Agent) reloadEnterprise(conf *config.RuntimeConfig) error {
+	return nil
+}
+
+// WriteEvent is a noop stub for the func defined agent_ent.go
+func (a *Agent) WriteEvent(eventType string, payload interface{}) {
 }

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1004,7 +1004,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 	return rt, nil
 }
 
-// Validate performs semantical validation of the runtime configuration.
+// Validate performs semantic validation of the runtime configuration.
 func (b *Builder) Validate(rt RuntimeConfig) error {
 	// reDatacenter defines a regexp for a valid datacenter name
 	var reDatacenter = regexp.MustCompile("^[a-z0-9_-]+$")

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -188,6 +188,7 @@ type Config struct {
 	AdvertiseAddrWAN                 *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
 	AdvertiseAddrWANIPv4             *string                  `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
 	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
+	Audit                            Audit                    `json:"audit,omitempty"     hcl:"audit"     mapstructure:"audit"`
 	Autopilot                        Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                         *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
 	Bootstrap                        *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`
@@ -365,6 +366,24 @@ type AdvertiseAddrsConfig struct {
 	RPC     *string `json:"rpc,omitempty" hcl:"rpc" mapstructure:"rpc"`
 	SerfLAN *string `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
 	SerfWAN *string `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
+}
+
+// AuditSink can be provided multiple times to define pipelines for auditing
+type AuditSink struct {
+	Name              *string `json:"name,omitempty"               hcl:"name"               mapstructure:"name"`
+	Type              *string `json:"type,omitempty"               hcl:"type"               mapstructure:"type"`
+	Format            *string `json:"format,omitempty"             hcl:"format"             mapstructure:"format"`
+	Path              *string `json:"path,omitempty"               hcl:"path"               mapstructure:"path"`
+	DeliveryGuarantee *string `json:"delivery_guarantee,omitempty" hcl:"delivery_guarantee" mapstructure:"delivery_guarantee"`
+	RotateBytes       *int    `json:"rotate_bytes,omitempty"       hcl:"rotate_bytes"       mapstructure:"rotate_bytes"`
+	RotateDuration    *string `json:"rotate_duration,omitempty"    hcl:"rotate_duration"    mapstructure:"rotate_duration"`
+	RotateMaxFiles    *int    `json:"rotate_max_files,omitempty"   hcl:"rotate_max_files"   mapstructure:"rotate_max_files"`
+}
+
+// Audit allows us to enable and define destinations for auditing
+type Audit struct {
+	Enabled *bool                `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
+	Sinks   map[string]AuditSink `json:"sink,omitempty"    hcl:"sink"    mapstructure:"sink"`
 }
 
 type Autopilot struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -188,7 +188,6 @@ type Config struct {
 	AdvertiseAddrWAN                 *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
 	AdvertiseAddrWANIPv4             *string                  `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
 	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
-	Audit                            Audit                    `json:"audit,omitempty"     hcl:"audit"     mapstructure:"audit"`
 	Autopilot                        Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
 	BindAddr                         *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
 	Bootstrap                        *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`
@@ -317,6 +316,9 @@ type Config struct {
 	SyncCoordinateRateTarget   *float64 `json:"sync_coordinate_rate_target,omitempty" hcl:"sync_coordinate_rate_target" mapstructure:"sync_coordinate_rate_target"`
 	Version                    *string  `json:"version,omitempty" hcl:"version" mapstructure:"version"`
 	VersionPrerelease          *string  `json:"version_prerelease,omitempty" hcl:"version_prerelease" mapstructure:"version_prerelease"`
+
+	// enterpriseConfig embeds fields that we only access in consul-enterprise builds
+	EnterpriseConfig `hcl:",squash" mapstructure:",squash"`
 }
 
 type GossipLANConfig struct {
@@ -366,24 +368,6 @@ type AdvertiseAddrsConfig struct {
 	RPC     *string `json:"rpc,omitempty" hcl:"rpc" mapstructure:"rpc"`
 	SerfLAN *string `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
 	SerfWAN *string `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
-}
-
-// AuditSink can be provided multiple times to define pipelines for auditing
-type AuditSink struct {
-	Name              *string `json:"name,omitempty"               hcl:"name"               mapstructure:"name"`
-	Type              *string `json:"type,omitempty"               hcl:"type"               mapstructure:"type"`
-	Format            *string `json:"format,omitempty"             hcl:"format"             mapstructure:"format"`
-	Path              *string `json:"path,omitempty"               hcl:"path"               mapstructure:"path"`
-	DeliveryGuarantee *string `json:"delivery_guarantee,omitempty" hcl:"delivery_guarantee" mapstructure:"delivery_guarantee"`
-	RotateBytes       *int    `json:"rotate_bytes,omitempty"       hcl:"rotate_bytes"       mapstructure:"rotate_bytes"`
-	RotateDuration    *string `json:"rotate_duration,omitempty"    hcl:"rotate_duration"    mapstructure:"rotate_duration"`
-	RotateMaxFiles    *int    `json:"rotate_max_files,omitempty"   hcl:"rotate_max_files"   mapstructure:"rotate_max_files"`
-}
-
-// Audit allows us to enable and define destinations for auditing
-type Audit struct {
-	Enabled *bool                `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
-	Sinks   map[string]AuditSink `json:"sink,omitempty"    hcl:"sink"    mapstructure:"sink"`
 }
 
 type Autopilot struct {

--- a/agent/config/config_oss.go
+++ b/agent/config/config_oss.go
@@ -4,6 +4,9 @@ package config
 
 import "github.com/hashicorp/consul/agent/structs"
 
+// EnterpriseMeta provides a stub for the corresponding struct in config_ent.go
+type EnterpriseConfig struct{}
+
 // EnterpriseMeta stub
 type EnterpriseMeta struct{}
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3884,20 +3884,6 @@ func TestFullConfig(t *testing.T) {
 			},
 			"advertise_addr": "17.99.29.16",
 			"advertise_addr_wan": "78.63.37.19",
-			"audit": {
-				"enabled": true,
-				"sink": {
-					"test": {
-						"type": "file",
-						"format": "json",
-						"delivery_guarantee": "best-effort",
-						"path": "/test/path",
-						"rotate_bytes": 0,
-						"rotate_max_files": 0,
-						"rotate_duration": "0"
-					}
-				}
-			},
 			"autopilot": {
 				"cleanup_dead_servers": true,
 				"disable_upgrade_migration": true,
@@ -4529,18 +4515,6 @@ func TestFullConfig(t *testing.T) {
 			}
 			advertise_addr = "17.99.29.16"
 			advertise_addr_wan = "78.63.37.19"
-			audit {
-				enabled = true
-				sink "test" {
-					type = "file"
-					format = "json"
-					delivery_guarantee = "best-effort"
-					path = "/test/path"
-					rotate_bytes = 0
-					rotate_max_files = 0
-					rotate_duration = "0"
-				}
-			}
 			autopilot = {
 				cleanup_dead_servers = true
 				disable_upgrade_migration = true

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3884,6 +3884,20 @@ func TestFullConfig(t *testing.T) {
 			},
 			"advertise_addr": "17.99.29.16",
 			"advertise_addr_wan": "78.63.37.19",
+			"audit": {
+				"enabled": true,
+				"sink": {
+					"test": {
+						"type": "file",
+						"format": "json",
+						"delivery_guarantee": "best-effort",
+						"path": "/test/path",
+						"rotate_bytes": 0,
+						"rotate_max_files": 0,
+						"rotate_duration": "0"
+					}
+				}
+			},
 			"autopilot": {
 				"cleanup_dead_servers": true,
 				"disable_upgrade_migration": true,
@@ -4515,6 +4529,18 @@ func TestFullConfig(t *testing.T) {
 			}
 			advertise_addr = "17.99.29.16"
 			advertise_addr_wan = "78.63.37.19"
+			audit {
+				enabled = true
+				sink "test" {
+					type = "file"
+					format = "json"
+					delivery_guarantee = "best-effort"
+					path = "/test/path"
+					rotate_bytes = 0
+					rotate_max_files = 0
+					rotate_duration = "0"
+				}
+			}
 			autopilot = {
 				cleanup_dead_servers = true
 				disable_upgrade_migration = true
@@ -6158,6 +6184,9 @@ func TestSanitize(t *testing.T) {
 		"AEInterval": "0s",
 		"AdvertiseAddrLAN": "",
 		"AdvertiseAddrWAN": "",
+		"Audit": {
+			"enabled": false
+		},
 		"AutopilotCleanupDeadServers": false,
 		"AutopilotDisableUpgradeMigration": false,
 		"AutopilotLastContactThreshold": "0s",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -6184,9 +6184,6 @@ func TestSanitize(t *testing.T) {
 		"AEInterval": "0s",
 		"AdvertiseAddrLAN": "",
 		"AdvertiseAddrWAN": "",
-		"Audit": {
-			"enabled": false
-		},
 		"AutopilotCleanupDeadServers": false,
 		"AutopilotDisableUpgradeMigration": false,
 		"AutopilotLastContactThreshold": "0s",

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -523,7 +523,7 @@ func (c *Config) CheckACL() error {
 	return nil
 }
 
-// DefaultConfig returns a sane default configuration.
+// DefaultConfig returns a default configuration.
 func DefaultConfig() *Config {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -52,3 +52,14 @@ func parseACLAuthMethodEnterpriseMeta(req *http.Request, _ *structs.ACLAuthMetho
 
 	return nil
 }
+
+// auditReq is a noop stub for the corresponding func in http_ent.go
+func (s *HTTPServer) auditReq(req *http.Request) interface{} {
+	// note(kit): We return an nil here so we can pass it to auditResp. Auditing the response requires the
+	//  request object for context, so we have it pass it even when it's disabled
+	return nil
+}
+
+// auditResp is a noop stub for the corresponding func in http_ent.go
+func (s *HTTPServer) auditResp(reqPayload interface{}, httpCode int) {
+}


### PR DESCRIPTION
- Also included a little bit of cleanup that I found along the way.
- I decomposed `agent/http.parseTokenInternal()` into a few methods so I could use part of the parsing functionality in the auditing token resolver.