### PR TITLE
Expect default enterprise metadata in gateway tests

### DIFF
--- a/agent/config_endpoint_test.go
+++ b/agent/config_endpoint_test.go
@@ -227,13 +227,15 @@ func TestConfig_Apply_TerminatingGateway(t *testing.T) {
 		got := out.Entries[0].(*structs.TerminatingGatewayConfigEntry)
 		expect := []structs.LinkedService{
 			{
-				Name:     "web",
-				CAFile:   "/etc/web/ca.crt",
-				CertFile: "/etc/web/client.crt",
-				KeyFile:  "/etc/web/tls.key",
+				Name:           "web",
+				CAFile:         "/etc/web/ca.crt",
+				CertFile:       "/etc/web/client.crt",
+				KeyFile:        "/etc/web/tls.key",
+				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 			{
-				Name: "api",
+				Name:           "api",
+				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
 		}
 		require.Equal(t, expect, got.Services)
@@ -292,10 +294,14 @@ func TestConfig_Apply_IngressGateway(t *testing.T) {
 					Port:     8080,
 					Protocol: "tcp",
 					Services: []structs.IngressService{
-						{Name: "web"},
+						{
+							Name:           "web",
+							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+						},
 					},
 				},
 			},
+			EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 		}
 		require.Equal(t, expect, got)
 	}

--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -37,6 +37,7 @@ func TestIngressConfigEntry_Normalize(t *testing.T) {
 						Services: []IngressService{},
 					},
 				},
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 		},
 		{
@@ -72,6 +73,7 @@ func TestIngressConfigEntry_Normalize(t *testing.T) {
 						Services: []IngressService{},
 					},
 				},
+				EnterpriseMeta: *DefaultEnterpriseMeta(),
 			},
 		},
 	}

--- a/api/config_entry_gateways_test.go
+++ b/api/config_entry_gateways_test.go
@@ -105,12 +105,23 @@ func TestAPI_ConfigEntries_IngressGateway(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, ingress1.Kind, readIngress.Kind)
 			require.Equal(t, ingress1.Name, readIngress.Name)
+
+			require.Len(t, readIngress.Listeners, 1)
+			require.Len(t, readIngress.Listeners[0].Services, 1)
+			// Set namespace to blank so that OSS and ent can utilize the same tests
+			readIngress.Listeners[0].Services[0].Namespace = ""
+
 			require.Equal(t, ingress1.Listeners, readIngress.Listeners)
 		case "bar":
 			readIngress, ok = entry.(*IngressGatewayConfigEntry)
 			require.True(t, ok)
 			require.Equal(t, ingress2.Kind, readIngress.Kind)
 			require.Equal(t, ingress2.Name, readIngress.Name)
+			require.Len(t, readIngress.Listeners, 1)
+			require.Len(t, readIngress.Listeners[0].Services, 1)
+			// Set namespace to blank so that OSS and ent can utilize the same tests
+			readIngress.Listeners[0].Services[0].Namespace = ""
+
 			require.Equal(t, ingress2.Listeners, readIngress.Listeners)
 		}
 	}
@@ -224,12 +235,20 @@ func TestAPI_ConfigEntries_TerminatingGateway(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, terminating1.Kind, readTerminating.Kind)
 			require.Equal(t, terminating1.Name, readTerminating.Name)
+			require.Len(t, readTerminating.Services, 1)
+			// Set namespace to blank so that OSS and ent can utilize the same tests
+			readTerminating.Services[0].Namespace = ""
+
 			require.Equal(t, terminating1.Services, readTerminating.Services)
 		case "bar":
 			readTerminating, ok = entry.(*TerminatingGatewayConfigEntry)
 			require.True(t, ok)
 			require.Equal(t, terminating2.Kind, readTerminating.Kind)
 			require.Equal(t, terminating2.Name, readTerminating.Name)
+			require.Len(t, readTerminating.Services, 1)
+			// Set namespace to blank so that OSS and ent can utilize the same tests
+			readTerminating.Services[0].Namespace = ""
+
 			require.Equal(t, terminating2.Services, readTerminating.Services)
 		}
 	}


### PR DESCRIPTION
This makes it so that both OSS and enterprise tests pass correctly