### PR TITLE
ui: Improved main navigation

### DIFF
--- a/ui-v2/app/adapters/dc.js
+++ b/ui-v2/app/adapters/dc.js
@@ -1,11 +1,6 @@
 import Adapter from './application';
 
 export default Adapter.extend({
-  requestForFindAll: function(request) {
-    return request`
-      GET /v1/catalog/datacenters
-    `;
-  },
   requestForQuery: function(request) {
     return request`
       GET /v1/catalog/datacenters

--- a/ui-v2/app/adapters/dc.js
+++ b/ui-v2/app/adapters/dc.js
@@ -6,4 +6,9 @@ export default Adapter.extend({
       GET /v1/catalog/datacenters
     `;
   },
+  requestForQuery: function(request) {
+    return request`
+      GET /v1/catalog/datacenters
+    `;
+  },
 });

--- a/ui-v2/app/components/data-source/index.hbs
+++ b/ui-v2/app/components/data-source/index.hbs
@@ -1,4 +1,4 @@
 {{#if (eq loading "lazy")}}
 {{! in order to use intersection observer we need a DOM element on the page}}
-  <data aria-hidden="true" style="width: 0;height: 0;font-size: 0;padding: 0;margin: 0;" />
+  <data id={{guid}} aria-hidden="true" style="width: 0;height: 0;font-size: 0;padding: 0;margin: 0;" />
 {{/if}}

--- a/ui-v2/app/components/hashicorp-consul/index.hbs
+++ b/ui-v2/app/components/hashicorp-consul/index.hbs
@@ -1,3 +1,4 @@
+
     <header role="banner" data-test-navigation>
       <a data-test-main-nav-logo href={{href-to 'index'}}><svg width="28" height="27" xmlns="http://www.w3.org/2000/svg"><title>Consul</title><path d="M13.284 16.178a2.876 2.876 0 1 1-.008-5.751 2.876 2.876 0 0 1 .008 5.75zm5.596-1.547a1.333 1.333 0 1 1 0-2.667 1.333 1.333 0 0 1 0 2.667zm4.853 1.249a1.271 1.271 0 1 1 .027-.107c0 .031 0 .067-.027.107zm-.937-3.436a1.333 1.333 0 1 1 .986-1.595c.033.172.033.348 0 .52-.07.53-.465.96-.986 1.075zm4.72 3.29a1.333 1.333 0 1 1-1.076-1.538 1.333 1.333 0 0 1 1.116 1.417.342.342 0 0 0-.027.12h-.013zm-1.08-3.33a1.333 1.333 0 1 1 1.088-1.524c.014.114.014.229 0 .342a1.333 1.333 0 0 1-1.102 1.182h.014zm-.925 7.925a1.333 1.333 0 1 1 .165-.547c-.01.193-.067.38-.165.547zm-.48-12.191a1.333 1.333 0 1 1 .507-1.814c.14.237.198.514.164.787-.038.438-.289.828-.67 1.045v-.018zM13.333 26.667C5.97 26.667 0 20.697 0 13.333 0 5.97 5.97 0 13.333 0c2.929-.01 5.778.955 8.098 2.742L19.8 4.89a10.667 10.667 0 0 0-17.133 8.444 10.667 10.667 0 0 0 17.137 8.471l1.627 2.13a13.218 13.218 0 0 1-8.098 2.733z" fill="#FFF"/></svg></a>
         <input type="checkbox" name="menu" id="main-nav-toggle" onchange={{action 'change'}} />
@@ -30,6 +31,11 @@
                           <BlockSlot @name="menu">
                             <li role="separator">
                               Namespaces
+                              <DataSource
+                                @src={{concat '/*/*/namespaces'}}
+                                @onchange={{action (mut nspaces) value="data"}}
+                                @loading="lazy"
+                              />
                             </li>
                             {{#each (reject-by 'DeletedAt' nspaces) as |item|}}
                               <li role="none" class={{if (eq nspace.Name item.Name) 'is-active'}}>
@@ -58,6 +64,11 @@
                           <BlockSlot @name="menu">
                             <li role="separator">
                               Datacenters
+                              <DataSource
+                                @src={{concat '/*/*/datacenters'}}
+                                @onchange={{action (mut dcs) value="data"}}
+                                @loading="lazy"
+                              />
                             </li>
                             {{#each dcs as |item|}}
                               <li role="none" data-test-datacenter-picker class={{if (eq dc.Name item.Name) 'is-active'}}>

--- a/ui-v2/app/components/hashicorp-consul/index.js
+++ b/ui-v2/app/components/hashicorp-consul/index.js
@@ -38,11 +38,17 @@ export default Component.extend({
     } else {
       // TODO: Ideally we wouldn't need to use env() at a component level
       // transitionTo should probably remove it instead if NSPACES aren't enabled
-      if (this.env.var('CONSUL_NSPACES_ENABLED') && get(token, 'Namespace') !== this.nspace) {
+      if (this.env.var('CONSUL_NSPACES_ENABLED') && get(token, 'Namespace') !== this.nspace.Name) {
         if (!routeName.startsWith('nspace')) {
           routeName = `nspace.${routeName}`;
         }
-        return route.transitionTo(`${routeName}`, `~${get(token, 'Namespace')}`, this.dc.Name);
+        const nspace = get(token, 'Namespace');
+        // you potentially have a new namespace
+        if (typeof nspace !== 'undefined') {
+          return route.transitionTo(`${routeName}`, `~${nspace}`, this.dc.Name);
+        }
+        // you are logging out, just refresh
+        return route.refresh();
       } else {
         if (route.routeName === 'dc.acls.index') {
           return route.transitionTo('dc.acls.tokens.index');

--- a/ui-v2/app/controllers/application.js
+++ b/ui-v2/app/controllers/application.js
@@ -1,0 +1,3 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({});

--- a/ui-v2/app/helpers/href-mut.js
+++ b/ui-v2/app/helpers/href-mut.js
@@ -1,9 +1,10 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 import { hrefTo } from 'consul-ui/helpers/href-to';
+import { getOwner } from '@ember/application';
 
 const getRouteParams = function(route, params = {}) {
-  return route.paramNames.map(function(item) {
+  return (route.paramNames || []).map(function(item) {
     if (typeof params[item] !== 'undefined') {
       return params[item];
     }
@@ -13,16 +14,20 @@ const getRouteParams = function(route, params = {}) {
 export default Helper.extend({
   router: service('router'),
   compute([params], hash) {
-    let current = this.router.currentRoute;
+    let currentRoute = this.router.currentRoute;
+    if (currentRoute === null) {
+      currentRoute = getOwner(this).lookup('route:application');
+    }
     let parent;
-    let atts = getRouteParams(current, params);
+    let atts = getRouteParams(currentRoute, params);
     // walk up the entire route/s replacing any instances
     // of the specified params with the values specified
+    let current = currentRoute;
     while ((parent = current.parent)) {
       atts = atts.concat(getRouteParams(parent, params));
       current = parent;
     }
-    let route = this.router.currentRoute.name;
+    let route = currentRoute.name || 'application';
     // TODO: this is specific to consul/nspaces
     // 'ideally' we could try and do this elsewhere
     // not super important though.

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -10,16 +10,28 @@ const removeLoading = function($from) {
 };
 export default Route.extend(WithBlockingActions, {
   dom: service('dom'),
+  router: service('router'),
   nspacesRepo: service('repository/nspace/disabled'),
   repo: service('repository/dc'),
   settings: service('settings'),
+  model: function() {
+    return hash({
+      router: this.router,
+      dcs: this.repo.findAll(),
+      nspaces: this.nspacesRepo.findAll(),
+    });
+  },
+  setupController: function(controller, model) {
+    controller.setProperties(model);
+  },
   actions: {
     loading: function(transition, originRoute) {
       const $root = this.dom.root();
       let dc = null;
-      if (originRoute.routeName !== 'dc') {
-        const model = this.modelFor('dc') || { dcs: null, dc: { Name: null } };
-        dc = this.repo.getActive(model.dc.Name, model.dcs);
+      if (originRoute.routeName !== 'dc' && originRoute.routeName !== 'application') {
+        const app = this.modelFor('application');
+        const model = this.modelFor('dc') || { dc: { Name: null } };
+        dc = this.repo.getActive(model.dc.Name, app.dcs);
       }
       hash({
         loading: !$root.classList.contains('ember-loading'),
@@ -50,8 +62,6 @@ export default Route.extend(WithBlockingActions, {
         error = e.errors[0];
         error.message = error.title || error.detail || 'Error';
       }
-      // Try and get the currently attempted dc, whereever that may be
-      const model = this.modelFor('dc') || this.modelFor('nspace.dc');
       // TODO: Unfortunately ember will not maintain the correct URL
       // for you i.e. when this happens the URL in your browser location bar
       // will be the URL where you clicked on the link to come here
@@ -79,26 +89,46 @@ export default Route.extend(WithBlockingActions, {
       if (error.status === '') {
         error.message = 'Error';
       }
+      // Try and get the currently attempted dc, whereever that may be
+      let model = this.modelFor('dc') || this.modelFor('nspace.dc');
+      if (!model) {
+        const path = new URL(location.href).pathname
+          .substr(this.router.rootURL.length - 1)
+          .split('/')
+          .slice(1, 3);
+        model = {
+          nspace: { Name: 'default' },
+        };
+        if (path[0].startsWith('~')) {
+          model.nspace = {
+            Name: path.shift(),
+          };
+        }
+        model.dc = {
+          Name: path[0],
+        };
+      }
+      const app = this.modelFor('application') || {};
+      const dcs = app.dcs || [model.dc];
+      const nspaces = app.nspaces || [model.nspace];
       const $root = this.dom.root();
       hash({
-        error: error,
-        nspace: this.nspacesRepo.getActive(),
         dc:
           error.status.toString().indexOf('5') !== 0
-            ? this.repo.getActive()
-            : model && model.dc
-            ? model.dc
+            ? this.repo.getActive(model.dc.Name, dcs)
             : { Name: 'Error' },
-        dcs: model && model.dcs ? model.dcs : [],
+        dcs: dcs,
+        nspace: model.nspace,
+        nspaces: nspaces,
       })
         .then(model => Promise.all([model, this.repo.clearActive()]))
         .then(([model]) => {
           removeLoading($root);
-          model.nspaces = [model.nspace];
           // we can't use setupController as we received an error
           // so we do it manually instead
           next(() => {
-            this.controllerFor('error').setProperties(model);
+            this.controllerFor('application').setProperties(model);
+            this.controllerFor('error').setProperties({ error: error });
           });
         })
         .catch(e => {

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -19,6 +19,16 @@ export default Route.extend(WithBlockingActions, {
       router: this.router,
       dcs: this.repo.findAll(),
       nspaces: this.nspacesRepo.findAll(),
+
+      // these properties are added to the controller from route/dc
+      // as we don't have access to the dc and nspace params in the URL
+      // until we get to the route/dc route
+      // permissions also requires the dc param
+
+      // dc: null,
+      // nspace: null
+      // token: null
+      // permissions: null
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc.js
+++ b/ui-v2/app/routes/dc.js
@@ -65,7 +65,8 @@ export default Route.extend({
   setupController: function(controller, model) {
     // the model here is actually required for the entire application
     // but we need to wait until we are in this route so we know what the dc
-    // and or nspace is
+    // and or nspace is if the below changes please revists the comments
+    // in routes/application:model
     this.controllerFor('application').setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routes/nspace.js
+++ b/ui-v2/app/routes/nspace.js
@@ -4,24 +4,30 @@ import { hash } from 'rsvp';
 
 export default Route.extend({
   repo: service('repository/dc'),
-  router: service('router'),
   model: function(params) {
     return hash({
       item: this.repo.getActive(),
       nspace: params.nspace,
     });
   },
-  afterModel: function(params) {
-    // We need to redirect if someone doesn't specify
-    // the section they want, but not redirect if the 'section' is
-    // specified (i.e. /dc-1/ vs /dc-1/services)
-    // check how many parts are in the URL to figure this out
-    // if there is a better way to do this then would be good to change
-    if (this.router.currentURL.split('/').length < 4) {
-      if (!params.nspace.startsWith('~')) {
-        this.transitionTo('dc.services', params.nspace);
+
+  /**
+   * We need to redirect if someone doesn't specify the section they want,
+   * but not redirect if the 'section' is specified
+   * (i.e. /dc-1/ vs /dc-1/services).
+   *
+   * If the target route of the transition is `nspace.index`, it means that
+   * someone didn't specify a section and thus we forward them on to a
+   * default `.services` subroute.  The specific services route we target
+   * depends on whether or not a namespace was specified.
+   *
+   */
+  afterModel(model, transition) {
+    if (transition.to.name === 'nspace.index') {
+      if (model.nspace.startsWith('~')) {
+        this.transitionTo('nspace.dc.services', model.nspace, model.item.Name);
       } else {
-        this.transitionTo('nspace.dc.services', params.nspace, params.item.Name);
+        this.transitionTo('dc.services', model.nspace);
       }
     }
   },

--- a/ui-v2/app/routes/settings.js
+++ b/ui-v2/app/routes/settings.js
@@ -9,21 +9,16 @@ export default Route.extend({
   dcRepo: service('repository/dc'),
   nspacesRepo: service('repository/nspace/disabled'),
   model: function(params) {
+    const app = this.modelFor('application');
     return hash({
       item: this.repo.findAll(),
-      dcs: this.dcRepo.findAll(),
-      nspaces: this.nspacesRepo.findAll(),
+      dc: this.dcRepo.getActive(undefined, app.dcs),
       nspace: this.nspacesRepo.getActive(),
     }).then(model => {
       if (typeof get(model.item, 'client.blocking') === 'undefined') {
         set(model, 'item.client', { blocking: true });
       }
-      return hash({
-        ...model,
-        ...{
-          dc: this.dcRepo.getActive(null, model.dcs),
-        },
-      });
+      return model;
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/serializers/dc.js
+++ b/ui-v2/app/serializers/dc.js
@@ -10,7 +10,6 @@ export default Serializer.extend({
   normalizePayload: function(payload, id, requestType) {
     switch (requestType) {
       case 'query':
-      case 'findAll':
         return payload.map(item => {
           return {
             [this.primaryKey]: item,

--- a/ui-v2/app/serializers/dc.js
+++ b/ui-v2/app/serializers/dc.js
@@ -2,8 +2,14 @@ import Serializer from './application';
 
 export default Serializer.extend({
   primaryKey: 'Name',
+  respondForQuery: function(respond, query) {
+    return respond(function(headers, body) {
+      return body;
+    });
+  },
   normalizePayload: function(payload, id, requestType) {
     switch (requestType) {
+      case 'query':
       case 'findAll':
         return payload.map(item => {
           return {

--- a/ui-v2/app/services/data-source/protocols/http.js
+++ b/ui-v2/app/services/data-source/protocols/http.js
@@ -3,10 +3,11 @@ import { get } from '@ember/object';
 
 export default Service.extend({
   datacenters: service('repository/dc'),
+  namespaces: service('repository/nspace'),
   token: service('repository/token'),
   type: service('data-source/protocols/http/blocking'),
   source: function(src, configuration) {
-    const [, dc /*nspace*/, , model, ...rest] = src.split('/');
+    const [, , /*nspace*/ dc, model, ...rest] = src.split('/');
     let find;
     const repo = this[model];
     if (typeof repo.reconcile === 'function') {
@@ -23,6 +24,9 @@ export default Service.extend({
     }
     switch (model) {
       case 'datacenters':
+        find = configuration => repo.findAll(configuration);
+        break;
+      case 'namespaces':
         find = configuration => repo.findAll(configuration);
         break;
       case 'token':

--- a/ui-v2/app/services/data-source/service.js
+++ b/ui-v2/app/services/data-source/service.js
@@ -25,6 +25,12 @@ export default Service.extend({
   },
   willDestroy: function() {
     this._listeners.remove();
+    Object.entries(sources || {}).forEach(function([key, item]) {
+      item.close();
+    });
+    cache = null;
+    sources = null;
+    usage = null;
   },
 
   open: function(uri, ref) {
@@ -35,13 +41,10 @@ export default Service.extend({
       uri = `consul://${uri}`;
     }
     if (!sources.has(uri)) {
-      const url = new URL(uri);
-      let pathname = url.pathname;
+      let [providerName, pathname] = uri.split('://');
       if (pathname.startsWith('//')) {
         pathname = pathname.substr(2);
       }
-      const providerName = url.protocol.substr(0, url.protocol.length - 1);
-
       const provider = this[providerName];
 
       let configuration = {};

--- a/ui-v2/app/services/repository/dc.js
+++ b/ui-v2/app/services/repository/dc.js
@@ -10,7 +10,7 @@ export default RepositoryService.extend({
     return modelName;
   },
   findAll: function() {
-    return this.store.findAll(this.getModelName()).then(function(items) {
+    return this.store.query(this.getModelName(), {}).then(function(items) {
       // TODO: Move to view/template
       return items.sortBy('Name');
     });

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -103,6 +103,9 @@ export default LazyProxyService.extend({
     cache = createCache(cacheMap);
   },
   willDestroy: function() {
+    Object.entries(cacheMap || {}).forEach(function([key, item]) {
+      item.close();
+    });
     cacheMap = null;
     cache = null;
   },

--- a/ui-v2/app/templates/application.hbs
+++ b/ui-v2/app/templates/application.hbs
@@ -1,13 +1,15 @@
 <HeadLayout />
 {{title 'Consul' separator=' - '}}
+{{#if (not-eq router.currentRouteName 'application')}}
+  <HashicorpConsul @id="wrapper" @permissions={{permissions}} @dcs={{dcs}} @dc={{or dc dcs.firstObject}} @nspaces={{nspaces}} @nspace={{or nspace nspaces.firstObject}}>
 {{#if (not loading)}}
   {{outlet}}
 {{else}}
-  <HashicorpConsul @id="wrapper" @permissions={{permissions}} @dcs={{dcs}} @dc={{dc}} @nspaces={{nspaces}} @nspace={{nspace}}>
     <AppView @class="loading show">
       <BlockSlot @name="content">
         {{partial 'consul-loading'}}
       </BlockSlot>
     </AppView>
+{{/if}}
   </HashicorpConsul>
 {{/if}}

--- a/ui-v2/app/templates/dc.hbs
+++ b/ui-v2/app/templates/dc.hbs
@@ -1,3 +1,1 @@
-<HashicorpConsul @id="wrapper" @permissions={{permissions}} @dcs={{dcs}} @dc={{dc}} @nspaces={{nspaces}} @nspace={{nspace}}>
-  {{outlet}}
-</HashicorpConsul>
+{{outlet}}

--- a/ui-v2/app/templates/error.hbs
+++ b/ui-v2/app/templates/error.hbs
@@ -1,21 +1,19 @@
-<HashicorpConsul @id="wrapper" @permissions={{permissions}} @dcs={{dcs}} @dc={{dc}} @nspaces={{nspaces}} @nspace={{nspace}}>
-    <AppView @class="error show">
-        <BlockSlot @name="header">
-            <h1 data-test-error>
+<AppView @class="error show">
+    <BlockSlot @name="header">
+        <h1 data-test-error>
 {{#if error.status }}
-                {{error.status}} ({{error.message}})
+            {{error.status}} ({{error.message}})
 {{else}}
-                {{error.message}}
+            {{error.message}}
 {{/if}}
-            </h1>
-        </BlockSlot>
-        <BlockSlot @name="content">
-            <p>
-                Consul returned an error.
-                You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.<br />
-                Try looking in our <a href="{{env 'CONSUL_DOCS_URL'}}" target="_blank">documentation</a>
-            </p>
-            <a data-test-home rel="home" href={{href-to 'index'}}>Go back to root</a>
-        </BlockSlot>
-    </AppView>
-</HashicorpConsul>
+        </h1>
+    </BlockSlot>
+    <BlockSlot @name="content">
+        <p>
+            Consul returned an error.
+            You may have visited a URL that is loading an unknown resource, so you can try going back to the root or try re-submitting your ACL Token/SecretID by going back to ACLs.<br />
+            Try looking in our <a href="{{env 'CONSUL_DOCS_URL'}}" target="_blank">documentation</a>
+        </p>
+        <a data-test-home rel="home" href={{href-to 'index'}}>Go back to root</a>
+    </BlockSlot>
+</AppView>

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -1,43 +1,41 @@
 {{title "Settings"}}
-<HashicorpConsul @id="wrapper" @permissions={{permissions}} @dcs={{dcs}} @dc={{dc}} @nspaces={{nspaces}} @nspace={{nspace}}>
-  <AppView @class="settings show">
-    <BlockSlot @name="header">
-      <h1>
-        Settings
-      </h1>
-    </BlockSlot>
-    <BlockSlot @name="content">
-      <div class="notice info">
-        <h3>Local Storage</h3>
+<AppView @class="settings show">
+  <BlockSlot @name="header">
+    <h1>
+      Settings
+    </h1>
+  </BlockSlot>
+  <BlockSlot @name="content">
+    <div class="notice info">
+      <h3>Local Storage</h3>
+      <p>
+        These settings are immediately saved to local storage and persisted through browser usage.
+      </p>
+    </div>
+    <form>
+      <fieldset>
+        <h2>Dashboard Links</h2>
         <p>
-          These settings are immediately saved to local storage and persisted through browser usage.
+          Add a link to the service detail page in the UI to get quick access to a service-wide metrics dashboard. Enter the dashboard URL into the field below. You can use the placeholders <code>{{'{{Datacenter}}'}}</code> and <code>{{'{{Service.Name}}'}}</code> which will be replaced with the name of the datacenter/service currently being viewed.
         </p>
-      </div>
-      <form>
-        <fieldset>
-          <h2>Dashboard Links</h2>
-          <p>
-            Add a link to the service detail page in the UI to get quick access to a service-wide metrics dashboard. Enter the dashboard URL into the field below. You can use the placeholders <code>{{'{{Datacenter}}'}}</code> and <code>{{'{{Service.Name}}'}}</code> which will be replaced with the name of the datacenter/service currently being viewed.
-          </p>
-          <label class={{concat (if confirming 'confirming') ' type-text'}} id="urls_service">
-            <span>Link template for services</span>
-            <input type="text" name="urls[service]" value={{item.urls.service}} onchange={{action 'change'}} onkeypress={{action 'key'}} onkeydown={{action 'key'}} />
-            <em>e.g. https://grafana.example.com/d/1/consul-service-mesh&amp;orgid=1&amp;datacenter={{'{{Datacenter}}'}}&amp;service-name={{'{{Service.Name}}'}}</em>
+        <label class={{concat (if confirming 'confirming') ' type-text'}} id="urls_service">
+          <span>Link template for services</span>
+          <input type="text" name="urls[service]" value={{item.urls.service}} onchange={{action 'change'}} onkeypress={{action 'key'}} onkeydown={{action 'key'}} />
+          <em>e.g. https://grafana.example.com/d/1/consul-service-mesh&amp;orgid=1&amp;datacenter={{'{{Datacenter}}'}}&amp;service-name={{'{{Service.Name}}'}}</em>
+        </label>
+      </fieldset>
+    {{#if (not (env 'CONSUL_UI_DISABLE_REALTIME'))}}
+      <fieldset data-test-blocking-queries>
+        <h2>Blocking Queries</h2>
+        <p>Keep catalog info up-to-date without refreshing the page. Any changes made to services, nodes and intentions would be reflected in real time.</p>
+        <div class="type-toggle">
+          <label>
+            <input type="checkbox" name="client[blocking]" checked={{if item.client.blocking 'checked'}} onchange={{action 'change'}} />
+            <span>{{if item.client.blocking 'On' 'Off'}}</span>
           </label>
-        </fieldset>
-      {{#if (not (env 'CONSUL_UI_DISABLE_REALTIME'))}}
-        <fieldset data-test-blocking-queries>
-          <h2>Blocking Queries</h2>
-          <p>Keep catalog info up-to-date without refreshing the page. Any changes made to services, nodes and intentions would be reflected in real time.</p>
-          <div class="type-toggle">
-            <label>
-              <input type="checkbox" name="client[blocking]" checked={{if item.client.blocking 'checked'}} onchange={{action 'change'}} />
-              <span>{{if item.client.blocking 'On' 'Off'}}</span>
-            </label>
-          </div>
-        </fieldset>
-      {{/if}}
-      </form>
-    </BlockSlot>
-  </AppView>
-</HashicorpConsul>
+        </div>
+      </fieldset>
+    {{/if}}
+    </form>
+  </BlockSlot>
+</AppView>

--- a/ui-v2/tests/integration/adapters/dc-test.js
+++ b/ui-v2/tests/integration/adapters/dc-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 module('Integration | Adapter | dc', function(hooks) {
   setupTest(hooks);
-  test('requestForFindAll returns the correct url', function(assert) {
+  test('requestForQuery returns the correct url', function(assert) {
     const adapter = this.owner.lookup('adapter:dc');
     const client = this.owner.lookup('service:client/http');
     const expected = `GET /v1/catalog/datacenters`;
-    const actual = adapter.requestForFindAll(client.url);
+    const actual = adapter.requestForQuery(client.url);
     assert.equal(actual, expected);
   });
 });

--- a/ui-v2/tests/integration/serializers/dc-test.js
+++ b/ui-v2/tests/integration/serializers/dc-test.js
@@ -3,14 +3,14 @@ import { setupTest } from 'ember-qunit';
 import { get } from 'consul-ui/tests/helpers/api';
 module('Integration | Serializer | dc', function(hooks) {
   setupTest(hooks);
-  test('respondForFindAll returns the correct data for list endpoint', function(assert) {
+  test('respondForQuery returns the correct data for list endpoint', function(assert) {
     const serializer = this.owner.lookup('serializer:dc');
     const request = {
       url: `/v1/catalog/datacenters`,
     };
     return get(request.url).then(function(payload) {
       const expected = payload;
-      const actual = serializer.respondForFindAll(function(cb) {
+      const actual = serializer.respondForQuery(function(cb) {
         const headers = {};
         const body = payload;
         return cb(headers, body);

--- a/ui-v2/tests/unit/controllers/application-test.js
+++ b/ui-v2/tests/unit/controllers/application-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | application', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:application');
+    assert.ok(controller);
+  });
+});


### PR DESCRIPTION
This PR reduces the individual places where we use our 'app chrome' component (`<HashicorpConsul />`).

Previously it individually wrapped the loading state, the app itself, the app error state and then individually the settings page. This was all due to not knowing important data required for the main navigation such as the current DC and current namespace until the user had entered the DC route.

We now get around this restriction by passing data up from the child DC route to the parent application controller (thanks @meirish for the suggestion!)

As a consequence of this we have moved the loading of Datacenters and Namespace up to the application route, which is almost never reloaded/refreshed. We therefore use our new `<Datasource />` component to only reload datacenters and namespaces when the menus themselves are opened.

`<Datasource />`s work just like `<img />` tags, so you can set their `loading=""` to be `loading="eager"` or `loading="lazy"` for lazy loading, just like `<img />` tags.

We also move our Datacenter adapter to use `query` like the rest of the adapters in the UI instead of findAll.

There are a few other related changes here, such as trying to ensure that `href-mut` will always generated a URL even if the `router` service returns a `currentRoute === null`, and a more sane way of checking whether a user needs redirecting from a `nspace.index` route (big thanks to @randallmorey for the transition vs currentURL work here)

There's probably more work to come here in reducing the error and loading states in the application route to other individual components.

