### PR TITLE
netlify CLI outputs "Website Draft URL" now instead of "Live Draft URL"

### DIFF
--- a/website/scripts/link-check.sh
+++ b/website/scripts/link-check.sh
@@ -9,10 +9,10 @@ export PATH=$PATH:$(npm bin)
 
 # Deploy site to netlify
 # Assumes NETLIFY_SITE_ID and NETLIFY_AUTH_TOKEN env variables are set
-output=$(netlify deploy --dir=./website/build)
+output=$(netlify deploy --dir=./website/build --json)
 
 # Grab deploy URL
-url=$(echo "$output" | grep "Live Draft URL" | sed -E 's/.*(https:\/\/.*$)/\1/')
+url=$(echo "$output" | jq --raw-output '.deploy_url')
 
 # Checks broken links
 wget \


### PR DESCRIPTION
The script to do link checking looked for `Live Draft URL` previously but the Netlify CLI recently renamed this to `Website Draft URL`