### PR TITLE
Allow ingress gateways to route traffic based on Host header

### DIFF
--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -935,6 +935,7 @@ func TestInternal_GatewayServices_BothGateways(t *testing.T) {
 				Service:     structs.NewServiceID("db", nil),
 				Gateway:     structs.NewServiceID("ingress", nil),
 				GatewayKind: structs.ServiceKindIngressGateway,
+				Protocol:    "tcp",
 				Port:        8888,
 			},
 		}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2542,6 +2542,7 @@ func (s *Store) ingressConfigGatewayServices(tx *memdb.Txn, gateway structs.Serv
 				Gateway:     gateway,
 				Service:     service.ToServiceID(),
 				GatewayKind: structs.ServiceKindIngressGateway,
+				Hosts:       service.Hosts,
 				Port:        listener.Port,
 				Protocol:    listener.Protocol,
 			}

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2540,6 +2540,7 @@ func (s *Store) ingressConfigGatewayServices(tx *memdb.Txn, gateway structs.Serv
 				Service:     service.ToServiceID(),
 				GatewayKind: structs.ServiceKindIngressGateway,
 				Port:        listener.Port,
+				Protocol:    listener.Protocol,
 			}
 
 			gatewayServices = append(gatewayServices, mapping)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-uuid"
@@ -2006,9 +2007,7 @@ func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, 
 	// TODO(ingress) : Deal with incorporating index from mapping table
 	// Watch for index changes to the gateway nodes
 	idx, chans := s.maxIndexAndWatchChsForServiceNodes(tx, nodes, false, entMeta)
-	if idx > maxIdx {
-		maxIdx = idx
-	}
+	maxIdx = lib.MaxUint64(maxIdx, idx)
 	for _, ch := range chans {
 		ws.Add(ch)
 	}
@@ -2026,10 +2025,7 @@ func (s *Store) CheckIngressServiceNodes(ws memdb.WatchSet, serviceName string, 
 		if err != nil {
 			return 0, nil, err
 		}
-		if idx > maxIdx {
-			maxIdx = idx
-		}
-
+		maxIdx = lib.MaxUint64(maxIdx, idx)
 		results = append(results, n...)
 	}
 	return maxIdx, results, nil
@@ -2087,9 +2083,7 @@ func (s *Store) checkServiceNodesTxn(tx *memdb.Txn, ws memdb.WatchSet, serviceNa
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed gateway nodes lookup: %v", err)
 		}
-		if idx < gwIdx {
-			idx = gwIdx
-		}
+		idx = lib.MaxUint64(idx, gwIdx)
 		for i := 0; i < len(nodes); i++ {
 			results = append(results, nodes[i])
 			serviceNames[nodes[i].ServiceName] = struct{}{}
@@ -2117,9 +2111,7 @@ func (s *Store) checkServiceNodesTxn(tx *memdb.Txn, ws memdb.WatchSet, serviceNa
 			// below is always true.
 			svcIdx, svcCh := s.maxIndexAndWatchChForService(tx, svcName, true, true, entMeta)
 			// Take the max index represented
-			if idx < svcIdx {
-				idx = svcIdx
-			}
+			idx = lib.MaxUint64(idx, svcIdx)
 			if svcCh != nil {
 				// Watch the service-specific index for changes in liu of all iradix nodes
 				// for checks etc.
@@ -2139,9 +2131,7 @@ func (s *Store) checkServiceNodesTxn(tx *memdb.Txn, ws memdb.WatchSet, serviceNa
 		// be returned as we can't use the optimization in this case (and don't need
 		// to as there is only one chan to watch anyway).
 		svcIdx, _ := s.maxIndexAndWatchChForService(tx, serviceName, false, true, entMeta)
-		if idx < svcIdx {
-			idx = svcIdx
-		}
+		idx = lib.MaxUint64(idx, svcIdx)
 	}
 
 	// Create a nil watchset to pass below, we'll only pass the real one if we
@@ -2202,6 +2192,7 @@ func (s *Store) CheckServiceTagNodes(ws memdb.WatchSet, serviceName string, tags
 func (s *Store) GatewayServices(ws memdb.WatchSet, gateway string, entMeta *structs.EnterpriseMeta) (uint64, structs.GatewayServices, error) {
 	tx := s.db.Txn(false)
 	defer tx.Abort()
+	var maxIdx uint64
 
 	iter, err := s.gatewayServices(tx, gateway, entMeta)
 	if err != nil {
@@ -2214,12 +2205,19 @@ func (s *Store) GatewayServices(ws memdb.WatchSet, gateway string, entMeta *stru
 		svc := service.(*structs.GatewayService)
 
 		if svc.Service.ID != structs.WildcardSpecifier {
-			results = append(results, svc)
+			idx, matches, err := s.checkProtocolMatch(tx, ws, svc)
+			if err != nil {
+				return 0, nil, fmt.Errorf("failed checking protocol: %s", err)
+			}
+			maxIdx = lib.MaxUint64(maxIdx, idx)
+			if matches {
+				results = append(results, svc)
+			}
 		}
 	}
 
 	idx := maxIndexTxn(tx, gatewayServicesTableName)
-	return idx, results, nil
+	return lib.MaxUint64(maxIdx, idx), results, nil
 }
 
 // parseCheckServiceNodes is used to parse through a given set of services,
@@ -2727,10 +2725,7 @@ func (s *Store) serviceGatewayNodes(tx *memdb.Txn, ws memdb.WatchSet, service st
 		if mapping.GatewayKind != kind {
 			continue
 		}
-
-		if mapping.ModifyIndex > maxIdx {
-			maxIdx = mapping.ModifyIndex
-		}
+		maxIdx = lib.MaxUint64(maxIdx, mapping.ModifyIndex)
 
 		// Look up nodes for gateway
 		gwServices, err := s.catalogServiceNodeList(tx, mapping.Gateway.ID, "service", &mapping.Gateway.EnterpriseMeta)
@@ -2749,9 +2744,7 @@ func (s *Store) serviceGatewayNodes(tx *memdb.Txn, ws memdb.WatchSet, service st
 
 		// This prevents the index from sliding back in case all instances of the service are deregistered
 		svcIdx := s.maxIndexForService(tx, mapping.Gateway.ID, exists, false, &mapping.Service.EnterpriseMeta)
-		if maxIdx < svcIdx {
-			maxIdx = svcIdx
-		}
+		maxIdx = lib.MaxUint64(maxIdx, svcIdx)
 
 		// Ensure that blocking queries wake up if the gateway-service mapping exists, but the gateway does not exist yet
 		if !exists {
@@ -2759,4 +2752,23 @@ func (s *Store) serviceGatewayNodes(tx *memdb.Txn, ws memdb.WatchSet, service st
 		}
 	}
 	return maxIdx, ret, nil
+}
+
+// checkProtocolMatch filters out any GatewayService entries added from a wildcard with a protocol
+// that doesn't match the one configured in their discovery chain.
+func (s *Store) checkProtocolMatch(
+	tx *memdb.Txn,
+	ws memdb.WatchSet,
+	svc *structs.GatewayService,
+) (uint64, bool, error) {
+	if svc.GatewayKind != structs.ServiceKindIngressGateway || !svc.FromWildcard {
+		return 0, true, nil
+	}
+
+	idx, protocol, err := s.protocolForService(tx, ws, svc.Service)
+	if err != nil {
+		return 0, false, err
+	}
+
+	return idx, svc.Protocol == protocol, nil
 }

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -75,6 +75,9 @@ func gatewayServicesTableNameSchema() *memdb.TableSchema {
 						&ServiceIDIndex{
 							Field: "Service",
 						},
+						&memdb.IntFieldIndex{
+							Field: "Port",
+						},
 					},
 				},
 			},
@@ -2600,7 +2603,7 @@ func (s *Store) updateGatewayNamespace(tx *memdb.Txn, idx uint64, service *struc
 			continue
 		}
 
-		existing, err := tx.First(gatewayServicesTableName, "id", service.Gateway, sn.CompoundServiceName())
+		existing, err := tx.First(gatewayServicesTableName, "id", service.Gateway, sn.CompoundServiceName(), service.Port)
 		if err != nil {
 			return fmt.Errorf("gateway service lookup failed: %s", err)
 		}
@@ -2635,7 +2638,7 @@ func (s *Store) updateGatewayNamespace(tx *memdb.Txn, idx uint64, service *struc
 func (s *Store) updateGatewayService(tx *memdb.Txn, idx uint64, mapping *structs.GatewayService) error {
 	// Check if mapping already exists in table if it's already in the table
 	// Avoid insert if nothing changed
-	existing, err := tx.First(gatewayServicesTableName, "id", mapping.Gateway, mapping.Service)
+	existing, err := tx.First(gatewayServicesTableName, "id", mapping.Gateway, mapping.Service, mapping.Port)
 	if err != nil {
 		return fmt.Errorf("gateway service lookup failed: %s", err)
 	}

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -4997,6 +4997,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 		require.Len(results, 2)
 		require.Equal("ingress1", results[0].Gateway.ID)
 		require.Equal("service1", results[0].Service.ID)
+		require.Len(results[0].Hosts, 1)
 		require.Equal(1111, results[0].Port)
 		require.Equal("ingress1", results[1].Gateway.ID)
 		require.Equal("service2", results[1].Service.ID)
@@ -5217,7 +5218,8 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 				Protocol: "tcp",
 				Services: []structs.IngressService{
 					{
-						Name: "service1",
+						Name:  "service1",
+						Hosts: []string{"test.example.com"},
 					},
 				},
 			},

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -4920,7 +4920,7 @@ func TestStateStore_CheckIngressServiceNodes(t *testing.T) {
 	t.Run("check service1 ingress gateway", func(t *testing.T) {
 		idx, results, err := s.CheckIngressServiceNodes(ws, "service1", nil)
 		require.NoError(err)
-		require.Equal(uint64(13), idx)
+		require.Equal(uint64(14), idx)
 		// Multiple instances of the ingress2 service
 		require.Len(results, 4)
 
@@ -4939,7 +4939,7 @@ func TestStateStore_CheckIngressServiceNodes(t *testing.T) {
 	t.Run("check service2 ingress gateway", func(t *testing.T) {
 		idx, results, err := s.CheckIngressServiceNodes(ws, "service2", nil)
 		require.NoError(err)
-		require.Equal(uint64(12), idx)
+		require.Equal(uint64(14), idx)
 		require.Len(results, 2)
 
 		ids := make(map[string]struct{})
@@ -4957,7 +4957,7 @@ func TestStateStore_CheckIngressServiceNodes(t *testing.T) {
 		ws := memdb.NewWatchSet()
 		idx, results, err := s.CheckIngressServiceNodes(ws, "service3", nil)
 		require.NoError(err)
-		require.Equal(uint64(11), idx)
+		require.Equal(uint64(14), idx)
 		require.Len(results, 1)
 		require.Equal("wildcardIngress", results[0].Service.ID)
 	})
@@ -4968,17 +4968,17 @@ func TestStateStore_CheckIngressServiceNodes(t *testing.T) {
 
 		idx, results, err := s.CheckIngressServiceNodes(ws, "service1", nil)
 		require.NoError(err)
-		require.Equal(uint64(13), idx)
+		require.Equal(uint64(14), idx)
 		require.Len(results, 3)
 
 		idx, results, err = s.CheckIngressServiceNodes(ws, "service2", nil)
 		require.NoError(err)
-		require.Equal(uint64(12), idx)
+		require.Equal(uint64(14), idx)
 		require.Len(results, 1)
 
 		idx, results, err = s.CheckIngressServiceNodes(ws, "service3", nil)
 		require.NoError(err)
-		require.Equal(uint64(0), idx)
+		require.Equal(uint64(14), idx)
 		// TODO(ingress): index goes backward when deleting last config entry
 		// require.Equal(uint64(11), idx)
 		require.Len(results, 0)
@@ -4993,7 +4993,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 	t.Run("ingress1 gateway services", func(t *testing.T) {
 		idx, results, err := s.GatewayServices(ws, "ingress1", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 2)
 		require.Equal("ingress1", results[0].Gateway.ID)
 		require.Equal("service1", results[0].Service.ID)
@@ -5006,7 +5006,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 	t.Run("ingress2 gateway services", func(t *testing.T) {
 		idx, results, err := s.GatewayServices(ws, "ingress2", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 1)
 		require.Equal("ingress2", results[0].Gateway.ID)
 		require.Equal("service1", results[0].Service.ID)
@@ -5016,7 +5016,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 	t.Run("No gatway services associated", func(t *testing.T) {
 		idx, results, err := s.GatewayServices(ws, "nothingIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 0)
 	})
 
@@ -5024,7 +5024,7 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 		ws = memdb.NewWatchSet()
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 		require.Equal("wildcardIngress", results[0].Gateway.ID)
 		require.Equal("service1", results[0].Service.ID)
@@ -5035,6 +5035,29 @@ func TestStateStore_GatewayServices_Ingress(t *testing.T) {
 		require.Equal("wildcardIngress", results[2].Gateway.ID)
 		require.Equal("service3", results[2].Service.ID)
 		require.Equal(4444, results[2].Port)
+	})
+
+	t.Run("gateway with duplicate service", func(t *testing.T) {
+		idx, results, err := s.GatewayServices(ws, "ingress3", nil)
+		require.NoError(err)
+		require.Equal(uint64(15), idx)
+		require.Len(results, 4)
+		require.Equal("ingress3", results[0].Gateway.ID)
+		require.Equal("service1", results[0].Service.ID)
+		require.Equal(6666, results[0].Port)
+		require.Equal("tcp", results[0].Protocol)
+		require.Equal("ingress3", results[1].Gateway.ID)
+		require.Equal("service1", results[1].Service.ID)
+		require.Equal(5555, results[1].Port)
+		require.Equal("http", results[1].Protocol)
+		require.Equal("ingress3", results[2].Gateway.ID)
+		require.Equal("service2", results[2].Service.ID)
+		require.Equal(5555, results[2].Port)
+		require.Equal("http", results[2].Protocol)
+		require.Equal("ingress3", results[3].Gateway.ID)
+		require.Equal("service3", results[3].Service.ID)
+		require.Equal(5555, results[3].Port)
+		require.Equal("http", results[3].Protocol)
 	})
 
 	t.Run("deregistering a service", func(t *testing.T) {
@@ -5098,7 +5121,7 @@ func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
 	t.Run("base case for wildcard", func(t *testing.T) {
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 	})
 
@@ -5107,7 +5130,7 @@ func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
 		require.False(watchFired(ws))
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 	})
 
@@ -5120,7 +5143,7 @@ func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
 		require.False(watchFired(ws))
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 	})
 
@@ -5129,7 +5152,7 @@ func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
 		require.False(watchFired(ws))
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 	})
 
@@ -5140,7 +5163,7 @@ func TestStateStore_GatewayServices_WildcardAssociation(t *testing.T) {
 		require.False(watchFired(ws))
 		idx, results, err := s.GatewayServices(ws, "wildcardIngress", nil)
 		require.NoError(err)
-		require.Equal(uint64(14), idx)
+		require.Equal(uint64(15), idx)
 		require.Len(results, 3)
 	})
 }
@@ -5228,12 +5251,40 @@ func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {
 	}
 	assert.NoError(t, s.EnsureConfigEntry(13, ingress2, nil))
 
+	ingress3 := &structs.IngressGatewayConfigEntry{
+		Kind: "ingress-gateway",
+		Name: "ingress3",
+		Listeners: []structs.IngressListener{
+			{
+				Port:     5555,
+				Protocol: "http",
+				Services: []structs.IngressService{
+					{
+						Name: "*",
+					},
+				},
+			},
+			{
+				Port:     6666,
+				Protocol: "tcp",
+				Services: []structs.IngressService{
+					{
+						Name: "service1",
+					},
+				},
+			},
+		},
+	}
+	assert.NoError(t, s.EnsureConfigEntry(14, ingress3, nil))
+	assert.True(t, watchFired(ws))
+
 	nothingIngress := &structs.IngressGatewayConfigEntry{
 		Kind:      "ingress-gateway",
 		Name:      "nothingIngress",
 		Listeners: []structs.IngressListener{},
 	}
-	assert.NoError(t, s.EnsureConfigEntry(14, nothingIngress, nil))
+	assert.NoError(t, s.EnsureConfigEntry(15, nothingIngress, nil))
+	assert.True(t, watchFired(ws))
 
 	return ws
 }

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -847,7 +847,6 @@ func (s *Store) protocolForService(
 		return 0, "", err
 	}
 
-	// Check the wildcard entry's protocol against the discovery chain protocol for the service.
 	idx, serviceDefaults, err := s.configEntryTxn(tx, ws, structs.ServiceDefaults, svc.ID, &svc.EnterpriseMeta)
 	if err != nil {
 		return 0, "", err

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -842,7 +842,7 @@ func (s *Store) protocolForService(
 	svc structs.ServiceID,
 ) (uint64, string, error) {
 	// Get the global proxy defaults (for default protocol)
-	maxIdx, proxyConfig, err := s.configEntryTxn(tx, ws, structs.ProxyDefaults, structs.ProxyConfigGlobal, &svc.EnterpriseMeta)
+	maxIdx, proxyConfig, err := s.configEntryTxn(tx, ws, structs.ProxyDefaults, structs.ProxyConfigGlobal, structs.DefaultEnterpriseMeta())
 	if err != nil {
 		return 0, "", err
 	}

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/lib"
 	memdb "github.com/hashicorp/go-memdb"
 )
 
@@ -831,4 +832,47 @@ func (s *Store) configEntryWithOverridesTxn(
 	}
 
 	return s.configEntryTxn(tx, ws, kind, name, entMeta)
+}
+
+// protocolForService returns the service graph protocol associated to the
+// provided service, checking all relevant config entries.
+func (s *Store) protocolForService(
+	tx *memdb.Txn,
+	ws memdb.WatchSet,
+	svc structs.ServiceID,
+) (uint64, string, error) {
+	// Get the global proxy defaults (for default protocol)
+	maxIdx, proxyConfig, err := s.configEntryTxn(tx, ws, structs.ProxyDefaults, structs.ProxyConfigGlobal, &svc.EnterpriseMeta)
+	if err != nil {
+		return 0, "", err
+	}
+
+	// Check the wildcard entry's protocol against the discovery chain protocol for the service.
+	idx, serviceDefaults, err := s.configEntryTxn(tx, ws, structs.ServiceDefaults, svc.ID, &svc.EnterpriseMeta)
+	if err != nil {
+		return 0, "", err
+	}
+	maxIdx = lib.MaxUint64(maxIdx, idx)
+
+	entries := structs.NewDiscoveryChainConfigEntries()
+	if proxyConfig != nil {
+		entries.AddEntries(proxyConfig)
+	}
+	if serviceDefaults != nil {
+		entries.AddEntries(serviceDefaults)
+	}
+	req := discoverychain.CompileRequest{
+		ServiceName:          svc.ID,
+		EvaluateInNamespace:  svc.NamespaceOrDefault(),
+		EvaluateInDatacenter: "dc1",
+		// Use a dummy trust domain since that won't affect the protocol here.
+		EvaluateInTrustDomain: "b6fc9da3-03d4-4b5a-9134-c045e9b20152.consul",
+		UseInDatacenter:       "dc1",
+		Entries:               entries,
+	}
+	chain, err := discoverychain.Compile(req)
+	if err != nil {
+		return 0, "", err
+	}
+	return maxIdx, chain.Protocol, nil
 }

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -222,7 +222,7 @@ type IngressListenerKey struct {
 }
 
 func (k *IngressListenerKey) RouteName() string {
-	return fmt.Sprintf("%s_%d", k.Protocol, k.Port)
+	return fmt.Sprintf("%d", k.Port)
 }
 
 // ConfigSnapshot captures all the resulting config needed for a proxy instance.

--- a/agent/proxycfg/snapshot.go
+++ b/agent/proxycfg/snapshot.go
@@ -2,6 +2,8 @@ package proxycfg
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/mitchellh/copystructure"
 )
@@ -194,7 +196,7 @@ type configSnapshotIngressGateway struct {
 	// Upstreams is a list of upstreams this ingress gateway should serve traffic
 	// to. This is constructed from the ingress-gateway config entry, and uses
 	// the GatewayServices RPC to retrieve them.
-	Upstreams []structs.Upstream
+	Upstreams map[IngressListenerKey]structs.Upstreams
 
 	// WatchedDiscoveryChains is a map of upstream.Identifier() -> CancelFunc's
 	// in order to cancel any watches when the ingress gateway configuration is
@@ -212,6 +214,15 @@ func (c *configSnapshotIngressGateway) IsEmpty() bool {
 		len(c.WatchedDiscoveryChains) == 0 &&
 		len(c.WatchedUpstreams) == 0 &&
 		len(c.WatchedUpstreamEndpoints) == 0
+}
+
+type IngressListenerKey struct {
+	Protocol string
+	Port     int
+}
+
+func (k *IngressListenerKey) RouteName() string {
+	return fmt.Sprintf("%s_%d", k.Protocol, k.Port)
 }
 
 // ConfigSnapshot captures all the resulting config needed for a proxy instance.

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1355,6 +1355,11 @@ func makeUpstream(g *structs.GatewayService, bindAddr string) structs.Upstream {
 		DestinationName:      g.Service.ID,
 		DestinationNamespace: g.Service.NamespaceOrDefault(),
 		LocalBindPort:        g.Port,
+		// Pass the protocol that was configured on the ingress listener in order
+		// to force that protocol on the Envoy listener.
+		Config: map[string]interface{}{
+			"protocol": g.Protocol,
+		},
 	}
 	upstream.LocalBindAddress = bindAddr
 	if bindAddr == "" {
@@ -1376,7 +1381,6 @@ func (s *state) watchIngressDiscoveryChain(snap *ConfigSnapshot, u structs.Upstr
 		Name:                 u.DestinationName,
 		EvaluateInDatacenter: s.source.Datacenter,
 		EvaluateInNamespace:  u.DestinationNamespace,
-		// TODO(ingress): Deal with MeshGateway and Protocol overrides here
 	}, "discovery-chain:"+u.Identifier(), s.ch)
 	if err != nil {
 		cancel()

--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1355,6 +1355,7 @@ func makeUpstream(g *structs.GatewayService, bindAddr string) structs.Upstream {
 		DestinationName:      g.Service.ID,
 		DestinationNamespace: g.Service.NamespaceOrDefault(),
 		LocalBindPort:        g.Port,
+		IngressHosts:         g.Hosts,
 		// Pass the protocol that was configured on the ingress listener in order
 		// to force that protocol on the Envoy listener.
 		Config: map[string]interface{}{

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -725,9 +725,10 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 							Result: &structs.IndexedGatewayServices{
 								Services: structs.GatewayServices{
 									{
-										Gateway: structs.NewServiceID("ingress-gateway", nil),
-										Service: structs.NewServiceID("api", nil),
-										Port:    9999,
+										Gateway:  structs.NewServiceID("ingress-gateway", nil),
+										Service:  structs.NewServiceID("api", nil),
+										Port:     9999,
+										Protocol: "http",
 									},
 								},
 							},
@@ -736,6 +737,18 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 					},
 					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
 						require.Len(t, snap.IngressGateway.Upstreams, 1)
+						key := IngressListenerKey{Protocol: "http", Port: 9999}
+						require.Equal(t, snap.IngressGateway.Upstreams[key], structs.Upstreams{
+							{
+								DestinationNamespace: "default",
+								DestinationName:      "api",
+								LocalBindAddress:     "10.0.1.1",
+								LocalBindPort:        9999,
+								Config: map[string]interface{}{
+									"protocol": "http",
+								},
+							},
+						})
 						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 1)
 						require.Contains(t, snap.IngressGateway.WatchedDiscoveryChains, "api")
 					},

--- a/agent/proxycfg/state_test.go
+++ b/agent/proxycfg/state_test.go
@@ -810,6 +810,66 @@ func TestState_WatchesAndUpdates(t *testing.T) {
 				},
 			},
 		},
+		"ingress-gateway-update-upstreams": testCase{
+			ns: structs.NodeService{
+				Kind:    structs.ServiceKindIngressGateway,
+				ID:      "ingress-gateway",
+				Service: "ingress-gateway",
+				Address: "10.0.1.1",
+			},
+			sourceDC: "dc1",
+			stages: []verificationStage{
+				verificationStage{
+					requiredWatches: map[string]verifyWatchRequest{
+						rootsWatchID: genVerifyRootsWatch("dc1"),
+						leafWatchID:  genVerifyLeafWatch("ingress-gateway", "dc1"),
+					},
+					events: []cache.UpdateEvent{
+						rootWatchEvent(),
+						cache.UpdateEvent{
+							CorrelationID: leafWatchID,
+							Result:        issuedCert,
+							Err:           nil,
+						},
+						cache.UpdateEvent{
+							CorrelationID: gatewayServicesWatchID,
+							Result: &structs.IndexedGatewayServices{
+								Services: structs.GatewayServices{
+									{
+										Gateway: structs.NewServiceID("ingress-gateway", nil),
+										Service: structs.NewServiceID("api", nil),
+										Port:    9999,
+									},
+								},
+							},
+							Err: nil,
+						},
+					},
+					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
+						require.True(t, snap.Valid())
+						require.Len(t, snap.IngressGateway.Upstreams, 1)
+						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 1)
+						require.Contains(t, snap.IngressGateway.WatchedDiscoveryChains, "api")
+					},
+				},
+				verificationStage{
+					requiredWatches: map[string]verifyWatchRequest{},
+					events: []cache.UpdateEvent{
+						cache.UpdateEvent{
+							CorrelationID: gatewayServicesWatchID,
+							Result:        &structs.IndexedGatewayServices{},
+							Err:           nil,
+						},
+					},
+					verifySnapshot: func(t testing.TB, snap *ConfigSnapshot) {
+						require.True(t, snap.Valid())
+						require.Len(t, snap.IngressGateway.Upstreams, 0)
+						require.Len(t, snap.IngressGateway.WatchedDiscoveryChains, 0)
+						require.NotContains(t, snap.IngressGateway.WatchedDiscoveryChains, "api")
+					},
+				},
+			},
+		},
 		"terminating-gateway-initial": testCase{
 			ns: structs.NodeService{
 				Kind:    structs.ServiceKindTerminatingGateway,

--- a/agent/proxycfg/testing.go
+++ b/agent/proxycfg/testing.go
@@ -1143,6 +1143,7 @@ func setupTestVariationConfigEntriesAndSnapshot(
 				},
 			},
 		)
+	case "http-multiple-services":
 	default:
 		t.Fatalf("unexpected variation: %q", variation)
 		return ConfigSnapshotUpstreams{}
@@ -1233,6 +1234,13 @@ func setupTestVariationConfigEntriesAndSnapshot(
 	case "chain-and-splitter":
 	case "grpc-router":
 	case "chain-and-router":
+	case "http-multiple-services":
+		snap.WatchedUpstreamEndpoints["foo"] = map[string]structs.CheckServiceNodes{
+			"foo.default.dc1": TestUpstreamNodes(t),
+		}
+		snap.WatchedUpstreamEndpoints["bar"] = map[string]structs.CheckServiceNodes{
+			"bar.default.dc1": TestUpstreamNodesAlternate(t),
+		}
 	default:
 		t.Fatalf("unexpected variation: %q", variation)
 		return ConfigSnapshotUpstreams{}
@@ -1312,82 +1320,86 @@ func testConfigSnapshotMeshGateway(t testing.T, populateServices bool, useFedera
 }
 
 func TestConfigSnapshotIngress(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "simple")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "simple")
 }
 
 func TestConfigSnapshotIngressWithOverrides(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "simple-with-overrides")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "simple-with-overrides")
 }
 func TestConfigSnapshotIngress_SplitterWithResolverRedirectMultiDC(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "splitter-with-resolver-redirect-multidc")
+	return testConfigSnapshotIngressGateway(t, true, "http", "splitter-with-resolver-redirect-multidc")
+}
+
+func TestConfigSnapshotIngress_HTTPMultipleServices(t testing.T) *ConfigSnapshot {
+	return testConfigSnapshotIngressGateway(t, true, "http", "http-multiple-services")
 }
 
 func TestConfigSnapshotIngressExternalSNI(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "external-sni")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "external-sni")
 }
 
 func TestConfigSnapshotIngressWithFailover(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover")
 }
 
 func TestConfigSnapshotIngressWithFailoverThroughRemoteGateway(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-remote-gateway")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-remote-gateway")
 }
 
 func TestConfigSnapshotIngressWithFailoverThroughRemoteGatewayTriggered(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-remote-gateway-triggered")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-remote-gateway-triggered")
 }
 
 func TestConfigSnapshotIngressWithDoubleFailoverThroughRemoteGateway(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-double-remote-gateway")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-double-remote-gateway")
 }
 
 func TestConfigSnapshotIngressWithDoubleFailoverThroughRemoteGatewayTriggered(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-double-remote-gateway-triggered")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-double-remote-gateway-triggered")
 }
 
 func TestConfigSnapshotIngressWithFailoverThroughLocalGateway(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-local-gateway")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-local-gateway")
 }
 
 func TestConfigSnapshotIngressWithFailoverThroughLocalGatewayTriggered(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-local-gateway-triggered")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-local-gateway-triggered")
 }
 
 func TestConfigSnapshotIngressWithDoubleFailoverThroughLocalGateway(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-double-local-gateway")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-double-local-gateway")
 }
 
 func TestConfigSnapshotIngressWithDoubleFailoverThroughLocalGatewayTriggered(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "failover-through-double-local-gateway-triggered")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "failover-through-double-local-gateway-triggered")
 }
 
 func TestConfigSnapshotIngressWithSplitter(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "chain-and-splitter")
+	return testConfigSnapshotIngressGateway(t, true, "http", "chain-and-splitter")
 }
 
 func TestConfigSnapshotIngressWithGRPCRouter(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "grpc-router")
+	return testConfigSnapshotIngressGateway(t, true, "http", "grpc-router")
 }
 
 func TestConfigSnapshotIngressWithRouter(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "chain-and-router")
+	return testConfigSnapshotIngressGateway(t, true, "http", "chain-and-router")
 }
 
 func TestConfigSnapshotIngressGateway(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "default")
+	return testConfigSnapshotIngressGateway(t, true, "tcp", "default")
 }
 
 func TestConfigSnapshotIngressGatewayNoServices(t testing.T) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, false, "default")
+	return testConfigSnapshotIngressGateway(t, false, "tcp", "default")
 }
 
 func TestConfigSnapshotIngressDiscoveryChainWithEntries(t testing.T, additionalEntries ...structs.ConfigEntry) *ConfigSnapshot {
-	return testConfigSnapshotIngressGateway(t, true, "simple", additionalEntries...)
+	return testConfigSnapshotIngressGateway(t, true, "http", "simple", additionalEntries...)
 }
 
 func testConfigSnapshotIngressGateway(
-	t testing.T, populateServices bool, variation string,
+	t testing.T, populateServices bool, protocol, variation string,
 	additionalEntries ...structs.ConfigEntry,
 ) *ConfigSnapshot {
 	roots, leaf := TestCerts(t)
@@ -1404,12 +1416,14 @@ func testConfigSnapshotIngressGateway(
 			ConfigSnapshotUpstreams: setupTestVariationConfigEntriesAndSnapshot(
 				t, variation, leaf, additionalEntries...,
 			),
-			Upstreams: structs.Upstreams{
-				{
-					// We rely on this one having default type in a few tests...
-					DestinationName:  "db",
-					LocalBindPort:    9191,
-					LocalBindAddress: "2.3.4.5",
+			Upstreams: map[IngressListenerKey]structs.Upstreams{
+				IngressListenerKey{protocol, 9191}: structs.Upstreams{
+					{
+						// We rely on this one having default type in a few tests...
+						DestinationName:  "db",
+						LocalBindPort:    9191,
+						LocalBindAddress: "2.3.4.5",
+					},
 				},
 			},
 		}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -385,13 +385,11 @@ func ConfigEntryDecodeRulesForKind(kind string) (skipWhenPatching []string, tran
 		}, nil
 	case IngressGateway:
 		return []string{
-				"listeners",
-				"Listeners",
-				"listeners.services",
-				"Listeners.Services",
-			}, map[string]string{
-				"service_subset": "servicesubset",
-			}, nil
+			"listeners",
+			"Listeners",
+			"listeners.services",
+			"Listeners.Services",
+		}, nil, nil
 	case TerminatingGateway:
 		return []string{
 				"services",

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -51,11 +51,6 @@ type IngressService struct {
 	// protocol and means that the listener will forward traffic to all services.
 	Name string
 
-	// ServiceSubset declares the specific service subset to which traffic should
-	// be sent. This must match an existing service subset declared in a
-	// service-resolver config entry.
-	ServiceSubset string
-
 	EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 }
 

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -50,12 +50,19 @@ type IngressService struct {
 	// This can either be a specific service, or the wildcard specifier,
 	// "*". If the wildcard specifier is provided, the listener must be of "http"
 	// protocol and means that the listener will forward traffic to all services.
+	//
+	// A name can be specified on multiple listeners, and will be exposed on both
+	// of the listeners
 	Name string
 
 	// Hosts is a list of hostnames which should be associated to this service on
 	// the defined listener. Only allowed on layer 7 protocols, this will be used
 	// to route traffic to the service by matching the Host header of the HTTP
 	// request.
+	//
+	// If a host is provided for a service that also has a wildcard specifier
+	// defined, the host will override the wildcard-specifier-provided
+	// "<service-name>.*" domain for that listener.
 	//
 	// This cannot be specified when using the wildcard specifier, "*", or when
 	// using a "tcp" listener.

--- a/agent/structs/config_entry_gateways.go
+++ b/agent/structs/config_entry_gateways.go
@@ -300,6 +300,7 @@ type GatewayService struct {
 	Service      ServiceID
 	GatewayKind  ServiceKind
 	Port         int
+	Protocol     string
 	CAFile       string
 	CertFile     string
 	KeyFile      string
@@ -315,6 +316,7 @@ func (g *GatewayService) IsSame(o *GatewayService) bool {
 		g.Service.Matches(&o.Service) &&
 		g.GatewayKind == o.GatewayKind &&
 		g.Port == o.Port &&
+		g.Protocol == o.Protocol &&
 		g.CAFile == o.CAFile &&
 		g.CertFile == o.CertFile &&
 		g.KeyFile == o.KeyFile &&
@@ -328,6 +330,7 @@ func (g *GatewayService) Clone() *GatewayService {
 		Service:      g.Service,
 		GatewayKind:  g.GatewayKind,
 		Port:         g.Port,
+		Protocol:     g.Protocol,
 		CAFile:       g.CAFile,
 		CertFile:     g.CertFile,
 		KeyFile:      g.KeyFile,

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -566,7 +566,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 						services = [
 							{
 								name = "postgres"
-								service_subset = "v1"
 							}
 						]
 					}
@@ -603,7 +602,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 						Services = [
 							{
 								Name = "postgres"
-								ServiceSubset = "v1"
 							}
 						]
 					}
@@ -639,8 +637,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 						Protocol: "tcp",
 						Services: []IngressService{
 							IngressService{
-								Name:          "postgres",
-								ServiceSubset: "v1",
+								Name: "postgres",
 							},
 						},
 					},

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -545,6 +545,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 						services = [
 							{
 								name = "web"
+								hosts = ["test.example.com", "test2.example.com"]
 							},
 							{
 								name = "db"
@@ -581,6 +582,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 						Services = [
 							{
 								Name = "web"
+								Hosts = ["test.example.com", "test2.example.com"]
 							},
 							{
 								Name = "db"
@@ -616,7 +618,8 @@ func TestDecodeConfigEntry(t *testing.T) {
 						Protocol: "http",
 						Services: []IngressService{
 							IngressService{
-								Name: "web",
+								Name:  "web",
+								Hosts: []string{"test.example.com", "test2.example.com"},
 							},
 							IngressService{
 								Name: "db",

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -247,6 +247,10 @@ type Upstream struct {
 
 	// MeshGateway is the configuration for mesh gateway usage of this upstream
 	MeshGateway MeshGatewayConfig `json:",omitempty"`
+
+	// IngressHosts are a list of hosts that should route to this upstream from
+	// an ingress gateway
+	IngressHosts []string `json:"-" bexpr:"-"`
 }
 
 func (t *Upstream) UnmarshalJSON(data []byte) (err error) {

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -249,7 +249,8 @@ type Upstream struct {
 	MeshGateway MeshGatewayConfig `json:",omitempty"`
 
 	// IngressHosts are a list of hosts that should route to this upstream from
-	// an ingress gateway
+	// an ingress gateway. This cannot and should not be set by a user, it is
+	// used internally to store the association of hosts to an upstream service.
 	IngressHosts []string `json:"-" bexpr:"-"`
 }
 

--- a/agent/structs/connect_proxy_config_test.go
+++ b/agent/structs/connect_proxy_config_test.go
@@ -100,6 +100,8 @@ func TestUpstream_MarshalJSON(t *testing.T) {
 				DestinationName: "foo",
 				Datacenter:      "dc1",
 				LocalBindPort:   1234,
+				// Test IngressHosts does not marshal
+				IngressHosts: []string{"test.example.com"},
 			},
 			want: `{
 				"DestinationType": "service",
@@ -178,6 +180,22 @@ func TestUpstream_UnmarshalJSON(t *testing.T) {
 				Datacenter:      "dc1",
 			},
 			wantErr: false,
+		},
+		{
+			name: "ingress-hosts-do-not-unmarshal",
+			json: `{
+				"DestinationType": "service",
+				"DestinationName": "foo",
+				"Datacenter": "dc1",
+				"IngressHosts": ["asdf"]
+			}`,
+			want: Upstream{
+				DestinationType: UpstreamDestTypeService,
+				DestinationName: "foo",
+				Datacenter:      "dc1",
+				IngressHosts:    nil, // Make sure this doesn't get parsed
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -236,9 +236,17 @@ func (s *Server) makeGatewayServiceClusters(cfgSnap *proxycfg.ConfigSnapshot) ([
 
 func (s *Server) clustersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var clusters []proto.Message
+	createdClusters := make(map[string]bool)
 	for _, upstreams := range cfgSnap.IngressGateway.Upstreams {
 		for _, u := range upstreams {
 			id := u.Identifier()
+
+			// If we've already created a cluster for this upstream, skip it. Multiple listeners may
+			// reference the same upstream, so we don't need to create duplicate clusters in that case.
+			if createdClusters[id] {
+				continue
+			}
+
 			chain, ok := cfgSnap.IngressGateway.DiscoveryChain[id]
 			if !ok {
 				// this should not happen
@@ -259,6 +267,7 @@ func (s *Server) clustersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnap
 			for _, c := range upstreamClusters {
 				clusters = append(clusters, c)
 			}
+			createdClusters[id] = true
 		}
 	}
 	return clusters, nil

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -236,27 +236,29 @@ func (s *Server) makeGatewayServiceClusters(cfgSnap *proxycfg.ConfigSnapshot) ([
 
 func (s *Server) clustersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var clusters []proto.Message
-	for _, u := range cfgSnap.IngressGateway.Upstreams {
-		id := u.Identifier()
-		chain, ok := cfgSnap.IngressGateway.DiscoveryChain[id]
-		if !ok {
-			// this should not happen
-			return nil, fmt.Errorf("no discovery chain for upstream %q", id)
-		}
+	for _, upstreams := range cfgSnap.IngressGateway.Upstreams {
+		for _, u := range upstreams {
+			id := u.Identifier()
+			chain, ok := cfgSnap.IngressGateway.DiscoveryChain[id]
+			if !ok {
+				// this should not happen
+				return nil, fmt.Errorf("no discovery chain for upstream %q", id)
+			}
 
-		chainEndpoints, ok := cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id]
-		if !ok {
-			// this should not happen
-			return nil, fmt.Errorf("no endpoint map for upstream %q", id)
-		}
+			chainEndpoints, ok := cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id]
+			if !ok {
+				// this should not happen
+				return nil, fmt.Errorf("no endpoint map for upstream %q", id)
+			}
 
-		upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(u, chain, chainEndpoints, cfgSnap)
-		if err != nil {
-			return nil, err
-		}
+			upstreamClusters, err := s.makeUpstreamClustersForDiscoveryChain(u, chain, chainEndpoints, cfgSnap)
+			if err != nil {
+				return nil, err
+			}
 
-		for _, c := range upstreamClusters {
-			clusters = append(clusters, c)
+			for _, c := range upstreamClusters {
+				clusters = append(clusters, c)
+			}
 		}
 	}
 	return clusters, nil

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -485,6 +485,11 @@ func TestClustersFromSnapshot(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:   "ingress-multiple-listeners-duplicate-service",
+			create: proxycfg.TestConfigSnapshotIngress_MultipleListenersDuplicateService,
+			setup:  nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/agent/xds/endpoints.go
+++ b/agent/xds/endpoints.go
@@ -255,16 +255,18 @@ func (s *Server) endpointsFromServicesAndResolvers(
 
 func (s *Server) endpointsFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var resources []proto.Message
-	for _, u := range cfgSnap.IngressGateway.Upstreams {
-		id := u.Identifier()
+	for _, upstreams := range cfgSnap.IngressGateway.Upstreams {
+		for _, u := range upstreams {
+			id := u.Identifier()
 
-		es := s.endpointsFromDiscoveryChain(
-			cfgSnap.IngressGateway.DiscoveryChain[id],
-			cfgSnap.Datacenter,
-			cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id],
-			cfgSnap.IngressGateway.WatchedGatewayEndpoints[id],
-		)
-		resources = append(resources, es...)
+			es := s.endpointsFromDiscoveryChain(
+				cfgSnap.IngressGateway.DiscoveryChain[id],
+				cfgSnap.Datacenter,
+				cfgSnap.IngressGateway.WatchedUpstreamEndpoints[id],
+				cfgSnap.IngressGateway.WatchedGatewayEndpoints[id],
+			)
+			resources = append(resources, es...)
+		}
 	}
 	return resources, nil
 }

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -536,6 +536,11 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:   "ingress-multiple-listeners-duplicate-service",
+			create: proxycfg.TestConfigSnapshotIngress_MultipleListenersDuplicateService,
+			setup:  nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -270,25 +270,47 @@ func (s *Server) listenersFromSnapshotGateway(cfgSnap *proxycfg.ConfigSnapshot, 
 // See: https://www.consul.io/docs/connect/proxies/envoy.html#mesh-gateway-options
 func (s *Server) listenersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.Message, error) {
 	var resources []proto.Message
-	// TODO(ingress): We give each upstream a distinct listener at the moment,
-	// for http listeners we will need to multiplex upstreams on a single
-	// listener.
-	for _, u := range cfgSnap.IngressGateway.Upstreams {
-		id := u.Identifier()
+	for listenerKey, upstreams := range cfgSnap.IngressGateway.Upstreams {
+		if listenerKey.Protocol == "tcp" {
+			u := upstreams[0]
+			id := u.Identifier()
 
-		chain := cfgSnap.IngressGateway.DiscoveryChain[id]
+			chain := cfgSnap.IngressGateway.DiscoveryChain[id]
 
-		var upstreamListener proto.Message
-		var err error
-		if chain == nil || chain.IsDefault() {
-			upstreamListener, err = s.makeUpstreamListenerIgnoreDiscoveryChain(&u, chain, cfgSnap)
+			var upstreamListener proto.Message
+			var err error
+			if chain == nil || chain.IsDefault() {
+				upstreamListener, err = s.makeUpstreamListenerIgnoreDiscoveryChain(&u, chain, cfgSnap)
+			} else {
+				upstreamListener, err = s.makeUpstreamListenerForDiscoveryChain(&u, chain, cfgSnap)
+			}
+			if err != nil {
+				return nil, err
+			}
+			resources = append(resources, upstreamListener)
 		} else {
-			upstreamListener, err = s.makeUpstreamListenerForDiscoveryChain(&u, chain, cfgSnap)
+			// If multiple upstreams share this port, make a special listener for the protocol.
+			addr := cfgSnap.Address
+			if addr == "" {
+				addr = "0.0.0.0"
+			}
+
+			listener := makeListener(listenerKey.Protocol, addr, listenerKey.Port)
+			filter, err := makeListenerFilter(
+				true, listenerKey.Protocol, listenerKey.RouteName(), "", "ingress_upstream_", "", false)
+			if err != nil {
+				return nil, err
+			}
+
+			listener.FilterChains = []envoylistener.FilterChain{
+				{
+					Filters: []envoylistener.Filter{
+						filter,
+					},
+				},
+			}
+			resources = append(resources, listener)
 		}
-		if err != nil {
-			return nil, err
-		}
-		resources = append(resources, upstreamListener)
 	}
 
 	return resources, nil

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -272,6 +272,9 @@ func (s *Server) listenersFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSna
 	var resources []proto.Message
 	for listenerKey, upstreams := range cfgSnap.IngressGateway.Upstreams {
 		if listenerKey.Protocol == "tcp" {
+			// We rely on the invariant of upstreams slice always having at least 1
+			// member, because this key/value pair is created only when a
+			// GatewayService is returned in the RPC
 			u := upstreams[0]
 			id := u.Identifier()
 

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -364,6 +364,34 @@ func TestListenersFromSnapshot(t *testing.T) {
 			},
 		},
 		{
+			name:   "ingress-http-multiple-services",
+			create: proxycfg.TestConfigSnapshotIngress_HTTPMultipleServices,
+			setup: func(snap *proxycfg.ConfigSnapshot) {
+				snap.IngressGateway.Upstreams = map[proxycfg.IngressListenerKey]structs.Upstreams{
+					proxycfg.IngressListenerKey{Protocol: "http", Port: 8080}: structs.Upstreams{
+						{
+							DestinationName: "foo",
+							LocalBindPort:   8080,
+						},
+						{
+							DestinationName: "bar",
+							LocalBindPort:   8080,
+						},
+					},
+					proxycfg.IngressListenerKey{Protocol: "http", Port: 443}: structs.Upstreams{
+						{
+							DestinationName: "baz",
+							LocalBindPort:   443,
+						},
+						{
+							DestinationName: "qux",
+							LocalBindPort:   443,
+						},
+					},
+				}
+			},
+		},
+		{
 			name:   "terminating-gateway-no-api-cert",
 			create: proxycfg.TestConfigSnapshotTerminatingGateway,
 			setup: func(snap *proxycfg.ConfigSnapshot) {

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -98,6 +98,7 @@ func routesFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto
 				continue
 			}
 
+			namespace := u.GetEnterpriseMeta().NamespaceOrDefault()
 			var domains []string
 			switch {
 			case len(upstreams) == 1:
@@ -110,6 +111,8 @@ func routesFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto
 				// If a user has specified hosts, do not add the default
 				// "<service-name>.*" prefix
 				domains = u.IngressHosts
+			case namespace != structs.IntentionDefaultNamespace:
+				domains = []string{fmt.Sprintf("%s.ingress.%s.*", chain.ServiceName, namespace)}
 			default:
 				domains = []string{fmt.Sprintf("%s.*", chain.ServiceName)}
 			}

--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -55,8 +55,11 @@ func routesFromSnapshotConnectProxy(cfgSnap *proxycfg.ConfigSnapshot) ([]proto.M
 			}
 
 			route := &envoy.RouteConfiguration{
-				Name:             upstreamID,
-				VirtualHosts:     []envoyroute.VirtualHost{virtualHost},
+				Name:         upstreamID,
+				VirtualHosts: []envoyroute.VirtualHost{virtualHost},
+				// ValidateClusters defaults to true when defined statically and false
+				// when done via RDS. Re-set the sane value of true to prevent
+				// null-routing traffic.
 				ValidateClusters: makeBoolValue(true),
 			}
 			resources = append(resources, route)

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -117,6 +117,7 @@ func TestRoutesFromSnapshot(t *testing.T) {
 						{
 							DestinationName: "foo",
 							LocalBindPort:   8080,
+							IngressHosts:    []string{"test1.example.com", "test2.example.com"},
 						},
 						{
 							DestinationName: "bar",

--- a/agent/xds/testdata/clusters/ingress-multiple-listeners-duplicate-service.golden
+++ b/agent/xds/testdata/clusters/ingress-multiple-listeners-duplicate-service.golden
@@ -1,0 +1,103 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "outlierDetection": {
+
+      },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {
+
+        }
+      }
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Cluster",
+      "name": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "altStatName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "type": "EDS",
+      "edsClusterConfig": {
+        "edsConfig": {
+          "ads": {
+
+          }
+        }
+      },
+      "connectTimeout": "5s",
+      "circuitBreakers": {
+
+      },
+      "tlsContext": {
+        "commonTlsContext": {
+          "tlsParams": {
+
+          },
+          "tlsCertificates": [
+            {
+              "certificateChain": {
+                "inlineString": "-----BEGIN CERTIFICATE-----\nMIICjDCCAjKgAwIBAgIIC5llxGV1gB8wCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowDjEMMAoG\nA1UEAxMDd2ViMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADPv1RHVNRfa2VKR\nAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Favq5E0ivpNtv1QnFhxtPd7d5k4e+T7\nSkW1TaOCAXIwggFuMA4GA1UdDwEB/wQEAwIDuDAdBgNVHSUEFjAUBggrBgEFBQcD\nAgYIKwYBBQUHAwEwDAYDVR0TAQH/BAIwADBoBgNVHQ4EYQRfN2Q6MDc6ODc6M2E6\nNDA6MTk6NDc6YzM6NWE6YzA6YmE6NjI6ZGY6YWY6NGI6ZDQ6MDU6MjU6NzY6M2Q6\nNWE6OGQ6MTY6OGQ6Njc6NWU6MmU6YTA6MzQ6N2Q6ZGM6ZmYwagYDVR0jBGMwYYBf\nZDE6MTE6MTE6YWM6MmE6YmE6OTc6YjI6M2Y6YWM6N2I6YmQ6ZGE6YmU6YjE6OGE6\nZmM6OWE6YmE6YjU6YmM6ODM6ZTc6NWU6NDE6NmY6ZjI6NzM6OTU6NTg6MGM6ZGIw\nWQYDVR0RBFIwUIZOc3BpZmZlOi8vMTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1\nNTU1NTU1NTU1LmNvbnN1bC9ucy9kZWZhdWx0L2RjL2RjMS9zdmMvd2ViMAoGCCqG\nSM49BAMCA0gAMEUCIGC3TTvvjj76KMrguVyFf4tjOqaSCRie3nmHMRNNRav7AiEA\npY0heYeK9A6iOLrzqxSerkXXQyj5e9bE4VgUnxgPU6g=\n-----END CERTIFICATE-----\n"
+              },
+              "privateKey": {
+                "inlineString": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIMoTkpRggp3fqZzFKh82yS4LjtJI+XY+qX/7DefHFrtdoAoGCCqGSM49\nAwEHoUQDQgAEADPv1RHVNRfa2VKRAB16b6rZnEt7tuhaxCFpQXPj7M2omb0B9Fav\nq5E0ivpNtv1QnFhxtPd7d5k4e+T7SkW1TQ==\n-----END EC PRIVATE KEY-----\n"
+              }
+            }
+          ],
+          "validationContext": {
+            "trustedCa": {
+              "inlineString": "-----BEGIN CERTIFICATE-----\nMIICXDCCAgKgAwIBAgIICpZq70Z9LyUwCgYIKoZIzj0EAwIwFDESMBAGA1UEAxMJ\nVGVzdCBDQSAyMB4XDTE5MDMyMjEzNTgyNloXDTI5MDMyMjEzNTgyNlowFDESMBAG\nA1UEAxMJVGVzdCBDQSAyMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIhywH1gx\nAsMwuF3ukAI5YL2jFxH6Usnma1HFSfVyxbXX1/uoZEYrj8yCAtdU2yoHETyd+Zx2\nThhRLP79pYegCaOCATwwggE4MA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTAD\nAQH/MGgGA1UdDgRhBF9kMToxMToxMTphYzoyYTpiYTo5NzpiMjozZjphYzo3Yjpi\nZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1ZTo0MTo2ZjpmMjo3\nMzo5NTo1ODowYzpkYjBqBgNVHSMEYzBhgF9kMToxMToxMTphYzoyYTpiYTo5Nzpi\nMjozZjphYzo3YjpiZDpkYTpiZTpiMTo4YTpmYzo5YTpiYTpiNTpiYzo4MzplNzo1\nZTo0MTo2ZjpmMjo3Mzo5NTo1ODowYzpkYjA/BgNVHREEODA2hjRzcGlmZmU6Ly8x\nMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuY29uc3VsMAoGCCqG\nSM49BAMCA0gAMEUCICOY0i246rQHJt8o8Oya0D5PLL1FnmsQmQqIGCi31RwnAiEA\noR5f6Ku+cig2Il8T8LJujOp2/2A72QcHZA57B13y+8o=\n-----END CERTIFICATE-----\n"
+            }
+          }
+        },
+        "sni": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+      },
+      "outlierDetection": {
+
+      },
+      "commonLbConfig": {
+        "healthyPanicThreshold": {
+
+        }
+      }
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Cluster",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/endpoints/ingress-multiple-listeners-duplicate-service.golden
+++ b/agent/xds/testdata/endpoints/ingress-multiple-listeners-duplicate-service.golden
@@ -1,0 +1,75 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.20.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.20.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+      "clusterName": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.1",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            },
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "10.10.1.2",
+                    "portValue": 8080
+                  }
+                }
+              },
+              "healthStatus": "HEALTHY",
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
@@ -1,0 +1,85 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "http:1.2.3.4:443",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 443
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "rds": {
+                        "config_source": {
+                              "ads": {
+                                  }
+                            },
+                        "route_config_name": "http_443"
+                      },
+                  "stat_prefix": "ingress_upstream_http_443_http",
+                  "tracing": {
+                        "operation_name": "EGRESS",
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.Listener",
+      "name": "http:1.2.3.4:8080",
+      "address": {
+        "socketAddress": {
+          "address": "1.2.3.4",
+          "portValue": 8080
+        }
+      },
+      "filterChains": [
+        {
+          "filters": [
+            {
+              "name": "envoy.http_connection_manager",
+              "config": {
+                  "http_filters": [
+                        {
+                              "name": "envoy.router"
+                            }
+                      ],
+                  "rds": {
+                        "config_source": {
+                              "ads": {
+                                  }
+                            },
+                        "route_config_name": "http_8080"
+                      },
+                  "stat_prefix": "ingress_upstream_http_8080_http",
+                  "tracing": {
+                        "operation_name": "EGRESS",
+                        "random_sampling": {
+                            }
+                      }
+                }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.Listener",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
@@ -26,9 +26,9 @@
                               "ads": {
                                   }
                             },
-                        "route_config_name": "http_443"
+                        "route_config_name": "443"
                       },
-                  "stat_prefix": "ingress_upstream_http_443_http",
+                  "stat_prefix": "ingress_upstream_443_http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {
@@ -65,9 +65,9 @@
                               "ads": {
                                   }
                             },
-                        "route_config_name": "http_8080"
+                        "route_config_name": "8080"
                       },
-                  "stat_prefix": "ingress_upstream_http_8080_http",
+                  "stat_prefix": "ingress_upstream_8080_http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
@@ -3,10 +3,10 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.Listener",
-      "name": "db:2.3.4.5:9191",
+      "name": "http:1.2.3.4:9191",
       "address": {
         "socketAddress": {
-          "address": "2.3.4.5",
+          "address": "1.2.3.4",
           "portValue": 9191
         }
       },
@@ -26,9 +26,9 @@
                               "ads": {
                                   }
                             },
-                        "route_config_name": "db"
+                        "route_config_name": "http_9191"
                       },
-                  "stat_prefix": "upstream_db_http",
+                  "stat_prefix": "ingress_upstream_http_9191_http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
@@ -26,9 +26,9 @@
                               "ads": {
                                   }
                             },
-                        "route_config_name": "http_9191"
+                        "route_config_name": "9191"
                       },
-                  "stat_prefix": "ingress_upstream_http_9191_http",
+                  "stat_prefix": "ingress_upstream_9191_http",
                   "tracing": {
                         "operation_name": "EGRESS",
                         "random_sampling": {

--- a/agent/xds/testdata/routes/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/routes/ingress-http-multiple-services.golden
@@ -1,0 +1,85 @@
+{
+  "versionInfo": "00000001",
+  "resources": [
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+      "name": "http_443",
+      "virtualHosts": [
+        {
+          "name": "baz",
+          "domains": [
+            "baz.*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "baz.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        },
+        {
+          "name": "qux",
+          "domains": [
+            "qux.*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "qux.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    },
+    {
+      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+      "name": "http_8080",
+      "virtualHosts": [
+        {
+          "name": "foo",
+          "domains": [
+            "foo.*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "foo.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        },
+        {
+          "name": "bar",
+          "domains": [
+            "bar.*"
+          ],
+          "routes": [
+            {
+              "match": {
+                "prefix": "/"
+              },
+              "route": {
+                "cluster": "bar.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
+              }
+            }
+          ]
+        }
+      ],
+      "validateClusters": true
+    }
+  ],
+  "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+  "nonce": "00000001"
+}

--- a/agent/xds/testdata/routes/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/routes/ingress-http-multiple-services.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_443",
+      "name": "443",
       "virtualHosts": [
         {
           "name": "baz",
@@ -42,7 +42,7 @@
     },
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_8080",
+      "name": "8080",
       "virtualHosts": [
         {
           "name": "foo",

--- a/agent/xds/testdata/routes/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/routes/ingress-http-multiple-services.golden
@@ -47,7 +47,8 @@
         {
           "name": "foo",
           "domains": [
-            "foo.*"
+            "test1.example.com",
+            "test2.example.com"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_9191",
+      "name": "9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
+      "name": "http_9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-overrides.golden
@@ -1,29 +1,6 @@
 {
   "versionInfo": "00000001",
   "resources": [
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
-      "virtualHosts": [
-        {
-          "name": "db",
-          "domains": [
-            "*"
-          ],
-          "routes": [
-            {
-              "match": {
-                "prefix": "/"
-              },
-              "route": {
-                "cluster": "a236e964~db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
-              }
-            }
-          ]
-        }
-      ],
-      "validateClusters": true
-    }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
   "nonce": "00000001"

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_9191",
+      "name": "9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
+      "name": "http_9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_9191",
+      "name": "9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
+      "name": "http_9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-chain-external-sni.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-external-sni.golden
@@ -1,29 +1,6 @@
 {
   "versionInfo": "00000001",
   "resources": [
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
-      "virtualHosts": [
-        {
-          "name": "db",
-          "domains": [
-            "*"
-          ],
-          "routes": [
-            {
-              "match": {
-                "prefix": "/"
-              },
-              "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
-              }
-            }
-          ]
-        }
-      ],
-      "validateClusters": true
-    }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
   "nonce": "00000001"

--- a/agent/xds/testdata/routes/ingress-with-chain.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain.golden
@@ -1,29 +1,6 @@
 {
   "versionInfo": "00000001",
   "resources": [
-    {
-      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
-      "virtualHosts": [
-        {
-          "name": "db",
-          "domains": [
-            "*"
-          ],
-          "routes": [
-            {
-              "match": {
-                "prefix": "/"
-              },
-              "route": {
-                "cluster": "db.default.dc1.internal.11111111-2222-3333-4444-555555555555.consul"
-              }
-            }
-          ]
-        }
-      ],
-      "validateClusters": true
-    }
   ],
   "typeUrl": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
   "nonce": "00000001"

--- a/agent/xds/testdata/routes/ingress-with-grpc-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-grpc-router.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "http_9191",
+      "name": "9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/agent/xds/testdata/routes/ingress-with-grpc-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-grpc-router.golden
@@ -3,7 +3,7 @@
   "resources": [
     {
       "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-      "name": "db",
+      "name": "http_9191",
       "virtualHosts": [
         {
           "name": "db",

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -57,6 +57,15 @@ type IngressService struct {
 	// protocol and means that the listener will forward traffic to all services.
 	Name string
 
+	// Hosts is a list of hostnames which should be associated to this service on
+	// the defined listener. Only allowed on layer 7 protocols, this will be used
+	// to route traffic to the service by matching the Host header of the HTTP
+	// request.
+	//
+	// This cannot be specified when using the wildcard specifier, "*", or when
+	// using a "tcp" listener.
+	Hosts []string
+
 	// Namespace is the namespace where the service is located.
 	// Namespacing is a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -60,11 +60,6 @@ type IngressService struct {
 	// Namespace is the namespace where the service is located.
 	// Namespacing is a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`
-
-	// ServiceSubset declares the specific service subset to which traffic should
-	// be sent. This must match an existing service subset declared in a
-	// service-resolver config entry.
-	ServiceSubset string
 }
 
 func (i *IngressGatewayConfigEntry) GetKind() string {

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -52,15 +52,22 @@ type IngressListener struct {
 type IngressService struct {
 	// Name declares the service to which traffic should be forwarded.
 	//
-	// This can either be a specific service instance, or the wildcard specifier,
+	// This can either be a specific service, or the wildcard specifier,
 	// "*". If the wildcard specifier is provided, the listener must be of "http"
 	// protocol and means that the listener will forward traffic to all services.
+	//
+	// A name can be specified on multiple listeners, and will be exposed on both
+	// of the listeners
 	Name string
 
 	// Hosts is a list of hostnames which should be associated to this service on
 	// the defined listener. Only allowed on layer 7 protocols, this will be used
 	// to route traffic to the service by matching the Host header of the HTTP
 	// request.
+	//
+	// If a host is provided for a service that also has a wildcard specifier
+	// defined, the host will override the wildcard-specifier-provided
+	// "<service-name>.*" domain for that listener.
 	//
 	// This cannot be specified when using the wildcard specifier, "*", or when
 	// using a "tcp" listener.

--- a/api/config_entry_gateways_test.go
+++ b/api/config_entry_gateways_test.go
@@ -51,10 +51,11 @@ func TestAPI_ConfigEntries_IngressGateway(t *testing.T) {
 	ingress1.Listeners = []IngressListener{
 		{
 			Port:     2222,
-			Protocol: "tcp",
+			Protocol: "http",
 			Services: []IngressService{
 				{
-					Name: "asdf",
+					Name:  "asdf",
+					Hosts: []string{"test.example.com"},
 				},
 			},
 		},

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -1395,7 +1395,6 @@ func TestParseConfigEntry(t *testing.T) {
 						services = [
 							{
 								name = "web"
-								service_subset = "v1"
 							},
 							{
 								name = "db"
@@ -1415,7 +1414,6 @@ func TestParseConfigEntry(t *testing.T) {
 						Services = [
 							{
 								Name = "web"
-								ServiceSubset = "v1"
 							},
 							{
 								Name = "db"
@@ -1435,8 +1433,7 @@ func TestParseConfigEntry(t *testing.T) {
 						"protocol": "http",
 						"services": [
 							{
-								"name": "web",
-								"service_subset": "v1"
+								"name": "web"
 							},
 							{
 								"name": "db",
@@ -1457,8 +1454,7 @@ func TestParseConfigEntry(t *testing.T) {
 						"Protocol": "http",
 						"Services": [
 							{
-								"Name": "web",
-								"ServiceSubset": "v1"
+								"Name": "web"
 							},
 							{
 								"Name": "db",
@@ -1478,8 +1474,7 @@ func TestParseConfigEntry(t *testing.T) {
 						Protocol: "http",
 						Services: []api.IngressService{
 							{
-								Name:          "web",
-								ServiceSubset: "v1",
+								Name: "web",
 							},
 							{
 								Name:      "db",

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -1395,6 +1395,7 @@ func TestParseConfigEntry(t *testing.T) {
 						services = [
 							{
 								name = "web"
+								hosts = ["test.example.com"]
 							},
 							{
 								name = "db"
@@ -1414,6 +1415,7 @@ func TestParseConfigEntry(t *testing.T) {
 						Services = [
 							{
 								Name = "web"
+								Hosts = ["test.example.com"]
 							},
 							{
 								Name = "db"
@@ -1433,7 +1435,8 @@ func TestParseConfigEntry(t *testing.T) {
 						"protocol": "http",
 						"services": [
 							{
-								"name": "web"
+								"name": "web",
+								"hosts": ["test.example.com"]
 							},
 							{
 								"name": "db",
@@ -1454,7 +1457,8 @@ func TestParseConfigEntry(t *testing.T) {
 						"Protocol": "http",
 						"Services": [
 							{
-								"Name": "web"
+								"Name": "web",
+								"Hosts": ["test.example.com"]
 							},
 							{
 								"Name": "db",
@@ -1474,7 +1478,8 @@ func TestParseConfigEntry(t *testing.T) {
 						Protocol: "http",
 						Services: []api.IngressService{
 							{
-								Name: "web",
+								Name:  "web",
+								Hosts: []string{"test.example.com"},
 							},
 							{
 								Name:      "db",

--- a/lib/math.go
+++ b/lib/math.go
@@ -20,3 +20,10 @@ func MinInt(a, b int) int {
 	}
 	return a
 }
+
+func MaxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/lib/math_test.go
+++ b/lib/math_test.go
@@ -36,3 +36,14 @@ func TestMathMinInt(t *testing.T) {
 		}
 	}
 }
+
+func TestMathMaxUint64(t *testing.T) {
+	tests := [][3]uint64{{1, 2, 2}, {0, 1, 1}, {2, 0, 2}}
+	for _, test := range tests {
+		expected := test[2]
+		actual := lib.MaxUint64(test[0], test[1])
+		if expected != actual {
+			t.Fatalf("expected %d, got %d", expected, actual)
+		}
+	}
+}

--- a/test/integration/connect/envoy/case-ingress-gateway-http/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-http/verify.bats
@@ -31,28 +31,10 @@ load helpers
 }
 
 @test "ingress should be able to connect to s1 via configured path" {
-  run retry_default curl -s -f localhost:9999/s1/debug?env=dump
-  [ "$status" -eq 0 ]
-
-  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
-  EXPECT_NAME="s1"
-
-  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
-    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
-    return 1
-  fi
+  assert_expected_fortio_name s1 localhost 9999 /s1
 }
 
 @test "ingress should be able to connect to s2 via configured path" {
-  run retry_default curl -s -f localhost:9999/s2/debug?env=dump
-  [ "$status" -eq 0 ]
-
-  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
-  EXPECT_NAME="s2"
-
-  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
-    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
-    return 1
-  fi
+  assert_expected_fortio_name s2 localhost 9999 /s2
 }
 

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/capture.sh
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/capture.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+snapshot_envoy_admin localhost:20000 ingress-gateway primary || true

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
@@ -1,0 +1,29 @@
+enable_central_service_config = true
+
+config_entries {
+  bootstrap = [
+    {
+      kind = "ingress-gateway"
+      name = "ingress-gateway"
+
+      listeners = [
+        {
+          port = 9999
+          protocol = "http"
+          services = [
+            {
+              name = "*"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      kind = "proxy-defaults"
+      name = "global"
+      config {
+        protocol = "http"
+      }
+    }
+  ]
+}

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
@@ -15,6 +15,16 @@ config_entries {
               name = "*"
             }
           ]
+        },
+        {
+          port = 9998
+          protocol = "http"
+          services = [
+            {
+              name = "s1"
+              hosts = ["test.example.com"]
+            }
+          ]
         }
       ]
     },

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/gateway.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/gateway.hcl
@@ -1,0 +1,4 @@
+services {
+  name = "ingress-gateway"
+  kind = "ingress-gateway"
+}

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/setup.sh
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# wait for bootstrap to apply config entries
+wait_for_config_entry ingress-gateway ingress-gateway
+wait_for_config_entry proxy-defaults global
+
+gen_envoy_bootstrap ingress-gateway 20000 primary true
+gen_envoy_bootstrap s1 19000
+gen_envoy_bootstrap s2 19001

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/vars.sh
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+export REQUIRED_SERVICES="$DEFAULT_REQUIRED_SERVICES ingress-gateway-primary"

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "ingress proxy admin is up on :20000" {
+  retry_default curl -f -s localhost:20000/stats -o /dev/null
+}
+
+@test "s1 proxy admin is up on :19000" {
+  retry_default curl -f -s localhost:19000/stats -o /dev/null
+}
+
+@test "s2 proxy admin is up on :19001" {
+  retry_default curl -f -s localhost:19001/stats -o /dev/null
+}
+
+@test "s1 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21000 s1
+}
+
+@test "s2 proxy listener should be up and have right cert" {
+  assert_proxy_presents_cert_uri localhost:21001 s2
+}
+
+@test "ingress-gateway should have healthy endpoints for s1" {
+   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s1 HEALTHY 1
+}
+
+@test "ingress-gateway should have healthy endpoints for s2" {
+   assert_upstream_has_endpoints_in_status 127.0.0.1:20000 s2 HEALTHY 1
+}
+
+@test "ingress should be able to connect to s1 using Host header" {
+  run retry_default curl -H"Host: s1.example.consul" -s -f localhost:9999/debug?env=dump
+  [ "$status" -eq 0 ]
+
+  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
+  EXPECT_NAME="s1"
+
+  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
+    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
+    return 1
+  fi
+}
+
+@test "ingress should be able to connect to s2 using Host header" {
+  run retry_default curl -H"Host: s2.example.consul" -s -f localhost:9999/debug?env=dump
+  [ "$status" -eq 0 ]
+
+  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
+  EXPECT_NAME="s2"
+
+  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
+    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
+    return 1
+  fi
+}
+

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -31,28 +31,13 @@ load helpers
 }
 
 @test "ingress should be able to connect to s1 using Host header" {
-  run retry_default curl -H"Host: s1.example.consul" -s -f localhost:9999/debug?env=dump
-  [ "$status" -eq 0 ]
-
-  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
-  EXPECT_NAME="s1"
-
-  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
-    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
-    return 1
-  fi
+  assert_expected_fortio_name s1 s1.example.consul 9999
 }
 
 @test "ingress should be able to connect to s2 using Host header" {
-  run retry_default curl -H"Host: s2.example.consul" -s -f localhost:9999/debug?env=dump
-  [ "$status" -eq 0 ]
-
-  GOT=$(echo "$output" | grep -E "^FORTIO_NAME=")
-  EXPECT_NAME="s2"
-
-  if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
-    echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2
-    return 1
-  fi
+  assert_expected_fortio_name s2 s2.example.consul 9999
 }
 
+@test "ingress should be able to connect to s1 using a user-specified Host" {
+  assert_expected_fortio_name s1 test.example.com 9998
+}

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -646,15 +646,21 @@ function set_ttl_check_state {
 }
 
 function get_upstream_fortio_name {
-  run retry_default curl -v -s -f localhost:5000/debug?env=dump
+  local HOST=$1
+  local PORT=$2
+  local PREFIX=$3
+  run retry_default curl -v -s -f -H"Host: ${HOST}" "localhost:${PORT}${PREFIX}/debug?env=dump"
   [ "$status" == 0 ]
   echo "$output" | grep -E "^FORTIO_NAME="
 }
 
 function assert_expected_fortio_name {
   local EXPECT_NAME=$1
+  local HOST=${2:-"localhost"}
+  local PORT=${3:-5000}
+  local URL_PREFIX=${4:-""}
 
-  GOT=$(get_upstream_fortio_name)
+  GOT=$(get_upstream_fortio_name ${HOST} ${PORT} ${URL_PREFIX})
 
   if [ "$GOT" != "FORTIO_NAME=${EXPECT_NAME}" ]; then
     echo "expected name: $EXPECT_NAME, actual name: $GOT" 1>&2


### PR DESCRIPTION
Dependent on #7677 

This commit adds the necessary changes to allow an ingress gateway to
route traffic from a single defined port to multiple different upstream
services in the Consul mesh.

For reviewing, each commit should be an isolated piece of work and can be reviewed independently if desired.

To do this, we now require all HTTP requests coming into the ingress
gateway to specify a Host header that matches `<service-name>.*` in
order to correctly route traffic to the correct service.

- Adds a case in `xds` for allowing default discovery chains to create a
  route configuration when on an ingress gateway. This allows default
  services to easily use host header routing
- ingress-gateways have a single route config for each listener
  that utilizes domain matching to route to different services.

### Example Config Entry

```
kind = "ingress-gateway"
name = "ingress-gateway"

listeners = [
  {
    port = 8888
    protocol = "http"
    services = [
      {
        name = "*"
      }
    ]
  },
  {
    port = 9999
    protocol = "http"
    services = [
      {
        name = "api"
        hosts = ["site.company.domain"]
      }
    ]
  }
]
```

Given this config entry, an ingress-gateway will route traffic to all available services based on the provided HTTP `Host` header. For example, if a request is made to `web.ingress.consul` or `web.example.com`, then the ingress gateway will send that traffic to the `web` service.

For the `api` definition, the `hosts` fields defines the required host need to route to the `api` service, in this case `site.company.domain`. The `api` service would still be available over port `8888` via `api.ingress.consul` because of the wildcard definition.