### PR TITLE
Fix check deletion in anti-entropy sync

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1098,8 +1098,11 @@ func (l *State) deleteService(key structs.ServiceID) error {
 		delete(l.services, key)
 		// service deregister also deletes associated checks
 		for _, c := range l.checks {
-			if c.Deleted && c.Check != nil && c.Check.CompoundServiceID().Matches(&key) {
-				l.pruneCheck(c.Check.CompoundCheckID())
+			if c.Deleted && c.Check != nil {
+				sid := c.Check.CompoundServiceID()
+				if sid.Matches(&key) {
+					l.pruneCheck(c.Check.CompoundCheckID())
+				}
 			}
 		}
 		l.logger.Info("Deregistered service", "service", key.ID)

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -1098,7 +1098,7 @@ func (l *State) deleteService(key structs.ServiceID) error {
 		delete(l.services, key)
 		// service deregister also deletes associated checks
 		for _, c := range l.checks {
-			if c.Deleted && c.Check != nil && c.Check.ServiceID == key.ID {
+			if c.Deleted && c.Check != nil && c.Check.CompoundServiceID().Matches(&key) {
 				l.pruneCheck(c.Check.CompoundCheckID())
 			}
 		}


### PR DESCRIPTION
When the anti-entropy sync calls `deleteService` we also need to delete all associated checks.

Finding the checks to delete requires looping over the `map[structs.CheckID]*CheckState` which contains checks for all services registered with the agent. While looping we need to see if the service ID of the check matches the service ID that we are deleting.

Currently we are only matching on the service ID string, and not the `structs.ServiceID`, which incorporates `EnterpriseMeta`. 

That means that if we have service ID `web` registered in namespaces `prod` and `dev`, then a call to delete `dev/web` would delete checks for `web` across both namespaces.