### PR TITLE
A couple testing helper updates

### DIFF
--- a/agent/consul/cluster_test.go
+++ b/agent/consul/cluster_test.go
@@ -1,0 +1,100 @@
+package consul
+
+import (
+	"net/rpc"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+type testClusterConfig struct {
+	Datacenter string
+	Servers    int
+	Clients    int
+	ServerConf func(*Config)
+	ClientConf func(*Config)
+
+	ServerWait func(*testing.T, *Server)
+	ClientWait func(*testing.T, *Client)
+}
+
+type testCluster struct {
+	Servers      []*Server
+	ServerCodecs []rpc.ClientCodec
+	Clients      []*Client
+}
+
+func newTestCluster(t *testing.T, conf *testClusterConfig) *testCluster {
+	t.Helper()
+
+	require.NotNil(t, conf)
+	cluster := testCluster{}
+
+	// create the servers
+	for i := 0; i < conf.Servers; i++ {
+		dir, srv := testServerWithConfig(t, func(c *Config) {
+			if conf.Datacenter != "" {
+				c.Datacenter = conf.Datacenter
+			}
+			c.Bootstrap = false
+			c.BootstrapExpect = conf.Servers
+
+			if conf.ServerConf != nil {
+				conf.ServerConf(c)
+			}
+		})
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		t.Cleanup(func() { srv.Shutdown() })
+
+		cluster.Servers = append(cluster.Servers, srv)
+
+		codec := rpcClient(t, srv)
+
+		cluster.ServerCodecs = append(cluster.ServerCodecs, codec)
+		t.Cleanup(func() { codec.Close() })
+
+		if i > 0 {
+			joinLAN(t, srv, cluster.Servers[0])
+		}
+	}
+
+	waitForLeaderEstablishment(t, cluster.Servers...)
+	if conf.ServerWait != nil {
+		for _, srv := range cluster.Servers {
+			conf.ServerWait(t, srv)
+		}
+	}
+
+	// create the clients
+	for i := 0; i < conf.Clients; i++ {
+		dir, client := testClientWithConfig(t, func(c *Config) {
+			if conf.Datacenter != "" {
+				c.Datacenter = conf.Datacenter
+			}
+			if conf.ClientConf != nil {
+				conf.ClientConf(c)
+			}
+		})
+
+		t.Cleanup(func() { os.RemoveAll(dir) })
+		t.Cleanup(func() { client.Shutdown() })
+
+		if len(cluster.Servers) > 0 {
+			joinLAN(t, client, cluster.Servers[0])
+		}
+
+		cluster.Clients = append(cluster.Clients, client)
+	}
+
+	for _, client := range cluster.Clients {
+		if conf.ClientWait != nil {
+			conf.ClientWait(t, client)
+		} else {
+			testrpc.WaitForTestAgent(t, client.RPC, client.config.Datacenter)
+		}
+	}
+
+	return &cluster
+}

--- a/agent/consul/helper_test.go
+++ b/agent/consul/helper_test.go
@@ -115,6 +115,8 @@ type clientOrServer interface {
 //
 //   member.JoinLAN("127.0.0.1:"+leader.config.SerfLANConfig.MemberlistConfig.BindPort)
 func joinLAN(t *testing.T, member clientOrServer, leader *Server) {
+	t.Helper()
+
 	if member == nil || leader == nil {
 		panic("no server")
 	}
@@ -143,6 +145,8 @@ func joinLAN(t *testing.T, member clientOrServer, leader *Server) {
 //
 //   member.JoinWAN("127.0.0.1:"+leader.config.SerfWANConfig.MemberlistConfig.BindPort)
 func joinWAN(t *testing.T, member, leader *Server) {
+	t.Helper()
+
 	if member == nil || leader == nil {
 		panic("no server")
 	}


### PR DESCRIPTION
First I was getting tired of handrolling multi-node tests so I went ahead and created a helper to spin up a test cluster with some desired number of servers and clients. That is all what the new cluster_test.go file contains.

Second, I noticed that logs from my test clients were not being correlated with the test that were running those clients. Our servers setup the loggers to use a TestWriter log output and with a named hclog logger with the name being the node name. I made setting up test clients do the same as the test servers in that regard.

Lastly I added some t.Helper() calls in a couple member join functions to improve test output if they were to fail.

Note: none of this is currently used in OSS tests but we could certainly transition plenty of existing tests to use the `testCluster` and it will be useful when writing new tests.

Note: this utilizes the `Cleanup` method on the `testing.T` type from go 1.14 so running tests will now require that Go version. I could refactor things a bit to not require that but this ends up being much cleaner than requiring the caller who is creating the test cluster to defer a whole bunch of stuff.

Example usage of the new test cluster:

```
cluster := newTestCluster(t, &testClusterConfig{
		Datacenter: "primary",
		Servers:    3,
		Clients:    1,
		ServerConf: func(c *Config) {
			c.Build = "1.8.0"
		},
		ClientConf: func(c *Config) {
			c.Build = "1.8.0"
		},
	})
```

That will spin up 3 servers, join them all and wait for leadership establishment to complete, then spin up a single client, join it to the servers and wait for the client to be generally available (using the `testrpc.WaitForTestAgent` function by default). The test cluster struct itself will contain a slice of all the `Server` and `Client` structs that were created as well as a slice of the `rpc.ClientCodec` structs that can be used to make RPC calls to the servers.