### PR TITLE
ui: Use patch-package instead of make/sed for patching coverage addon

### DIFF
--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -65,18 +65,14 @@ test-oss-ci: deps test-node
 test-node:
 	yarn run test:node
 
-# This seems to be the only way to only include a subset of files for coverage
-# Right now we only want the /app/utils/ folder to be included for coverage
-specify-coverage:
-	sed -i "s/exclude, include/include: ['consul-ui\/utils\/**\/*','consul-ui\/search\/**\/*']/g" ./node_modules/ember-cli-code-coverage/index.js
 
-test-coverage: deps specify-coverage
+test-coverage: deps
 	yarn run test:coverage
 
-test-coverage-view: deps specify-coverage
+test-coverage-view: deps
 	yarn run test:coverage:view
 
-test-coverage-ci: deps specify-coverage
+test-coverage-ci: deps
 	yarn run test:coverage:ci
 
 test-parallel: deps

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -9,6 +9,7 @@
     "test": "tests"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "build": "ember build --environment=production",
     "build:staging": "ember build --environment staging",
     "build:ci": "ember build --environment test",
@@ -118,6 +119,7 @@
     "mnemonist": "^0.30.0",
     "ngraph.graph": "^18.0.3",
     "node-sass": "^4.9.3",
+    "patch-package": "^6.2.2",
     "pretender": "^3.2.0",
     "prettier": "^1.10.2",
     "qunit-dom": "^1.0.0",

--- a/ui-v2/patches/ember-cli-code-coverage+1.0.0-beta.8.patch
+++ b/ui-v2/patches/ember-cli-code-coverage+1.0.0-beta.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/ember-cli-code-coverage/index.js b/node_modules/ember-cli-code-coverage/index.js
+index 6d84d18..81ef6fd 100644
+--- a/node_modules/ember-cli-code-coverage/index.js
++++ b/node_modules/ember-cli-code-coverage/index.js
+@@ -65,7 +65,7 @@ module.exports = {
+         )
+           .filter(Boolean)
+           .map(getPlugins)
+-          .forEach((plugins) => plugins.push([IstanbulPlugin, { exclude, include }]));
++          .forEach((plugins) => plugins.push([IstanbulPlugin, { include: ['consul-ui/utils/**/*','consul-ui/search/**/*'] }]));
+ 
+       } else {
+         this.project.ui.writeWarnLine(

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1552,6 +1552,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 JSV@^4.0.x:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
@@ -8531,6 +8536,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 layout-bin-packer@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/layout-bin-packer/-/layout-bin-packer-1.5.0.tgz#2e950456083621fe01f82007d896294f5e31e89c"
@@ -10151,6 +10163,24 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.2.tgz#71d170d650c65c26556f0d0fbbb48d92b6cc5f39"
+  integrity sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+
 path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
@@ -11514,6 +11544,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/7027 we added code coverage reporting for the UI, but we specifically only wanted certain files included in code coverage for the moment.

> We also do a little hack to restrict the coverage report to only include what we want it to include as there doesn't seem to be a way to exclude files that have already been included by the addon.

This was achieved with `sed` and a makefile target.

This PR uses a more common solution. I would imagine we'll move this again to use `yarn patch` once we are eventually upgrade to Yarn 2, but that will probably not happen for quite a while.
