### PR TITLE
ui: ember cli code coverage config file

### DIFF
--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -65,18 +65,13 @@ test-oss-ci: deps test-node
 test-node:
 	yarn run test:node
 
-# This seems to be the only way to only include a subset of files for coverage
-# Right now we only want the /app/utils/ folder to be included for coverage
-specify-coverage:
-	sed -i "s/exclude, include/include: ['consul-ui\/utils\/**\/*','consul-ui\/search\/**\/*']/g" ./node_modules/ember-cli-code-coverage/index.js
-
-test-coverage: deps specify-coverage
+test-coverage: deps
 	yarn run test:coverage
 
-test-coverage-view: deps specify-coverage
+test-coverage-view: deps
 	yarn run test:coverage:view
 
-test-coverage-ci: deps specify-coverage
+test-coverage-ci: deps
 	yarn run test:coverage:ci
 
 test-parallel: deps

--- a/ui-v2/config/coverage.js
+++ b/ui-v2/config/coverage.js
@@ -1,0 +1,3 @@
+module.exports = {
+  include: ['consul-ui/utils/**/*', 'consul-ui/search/**/*'],
+};


### PR DESCRIPTION
Testing an alternative to #7695 for setting explicit `include` paths for UI code coverage measurement. I'm not entirely sure on expected current behavior, as the CodeCov web UI doesn't support flags (like we're using for `ui`) and the local CLI tooling (like viewing generated `consul/ui-v2/coverage/index.html`) appears to be showing broader coverage information than intended even prior to this change.

This approach is following the file-based config documented in https://github.com/kategengler/ember-cli-code-coverage#configuration as the diff from #7695 appears to show passing undocumented `exclude` and `include` config options into Istanbul. Using a [`.istanbul.yml`](https://github.com/gotwarlost/istanbul#configuring) could be an alternative if this doesn't work as expected.

It looks like the CodeCov GitHub status is not currently working because it's missing a base coverage from the `ui-staging` branch to diff from, so it seems like there's a bit more to sort out here...