### PR TITLE
Fixed comment on wrong line

### DIFF
--- a/agent/router/serf_adapter.go
+++ b/agent/router/serf_adapter.go
@@ -67,9 +67,10 @@ func HandleSerfEvents(logger hclog.Logger, router *Router, areaID types.AreaID, 
 			case serf.EventMemberFailed:
 				handleMemberEvent(logger, router.FailServer, areaID, e)
 
-			// All of these event types are ignored.
 			case serf.EventMemberUpdate:
 				handleMemberEvent(logger, router.AddServer, areaID, e)
+
+			// All of these event types are ignored.
 			case serf.EventUser:
 			case serf.EventQuery:
 


### PR DESCRIPTION
While investigating and fixing an issue on our 1.5.1 branch,
I saw you also/already fixed the bug I found (tags not updated
for existing servers), but comment is misplaced.