### PR TITLE
Configurable meta max size

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1201,7 +1201,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.SerfWANConfig.MemberlistConfig.ProbeTimeout = a.config.GossipWANProbeTimeout
 		base.SerfWANConfig.MemberlistConfig.SuspicionMult = a.config.GossipWANSuspicionMult
 		base.SerfWANConfig.MemberlistConfig.RetransmitMult = a.config.GossipWANRetransmitMult
-		base.SerfWANConfig.MemberlistConfig.MetaMaxSize = a.config.GossipWANMetaMaxSize
 		if a.config.ReconnectTimeoutWAN != 0 {
 			base.SerfWANConfig.ReconnectTimeout = a.config.ReconnectTimeoutWAN
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1183,6 +1183,7 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	base.SerfLANConfig.MemberlistConfig.ProbeTimeout = a.config.GossipLANProbeTimeout
 	base.SerfLANConfig.MemberlistConfig.SuspicionMult = a.config.GossipLANSuspicionMult
 	base.SerfLANConfig.MemberlistConfig.RetransmitMult = a.config.GossipLANRetransmitMult
+	base.SerfLANConfig.MemberlistConfig.MetaMaxSize = a.config.GossipLANMetaMaxSize
 	if a.config.ReconnectTimeoutLAN != 0 {
 		base.SerfLANConfig.ReconnectTimeout = a.config.ReconnectTimeoutLAN
 	}
@@ -1200,6 +1201,7 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		base.SerfWANConfig.MemberlistConfig.ProbeTimeout = a.config.GossipWANProbeTimeout
 		base.SerfWANConfig.MemberlistConfig.SuspicionMult = a.config.GossipWANSuspicionMult
 		base.SerfWANConfig.MemberlistConfig.RetransmitMult = a.config.GossipWANRetransmitMult
+		base.SerfWANConfig.MemberlistConfig.MetaMaxSize = a.config.GossipWANMetaMaxSize
 		if a.config.ReconnectTimeoutWAN != 0 {
 			base.SerfWANConfig.ReconnectTimeout = a.config.ReconnectTimeoutWAN
 		}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -768,12 +768,14 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		GossipLANProbeTimeout:   b.durationVal("gossip_lan..probe_timeout", c.GossipLAN.ProbeTimeout),
 		GossipLANSuspicionMult:  b.intVal(c.GossipLAN.SuspicionMult),
 		GossipLANRetransmitMult: b.intVal(c.GossipLAN.RetransmitMult),
+		GossipLANMetaMaxSize:    b.intVal(c.GossipLAN.MetaMaxSize),
 		GossipWANGossipInterval: b.durationVal("gossip_wan..gossip_interval", c.GossipWAN.GossipInterval),
 		GossipWANGossipNodes:    b.intVal(c.GossipWAN.GossipNodes),
 		GossipWANProbeInterval:  b.durationVal("gossip_wan..probe_interval", c.GossipWAN.ProbeInterval),
 		GossipWANProbeTimeout:   b.durationVal("gossip_wan..probe_timeout", c.GossipWAN.ProbeTimeout),
 		GossipWANSuspicionMult:  b.intVal(c.GossipWAN.SuspicionMult),
 		GossipWANRetransmitMult: b.intVal(c.GossipWAN.RetransmitMult),
+		GossipWANMetaMaxSize:    b.intVal(c.GossipWAN.MetaMaxSize),
 
 		// ACL
 		ACLEnforceVersion8:        b.boolValWithDefault(c.ACLEnforceVersion8, true),

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -775,7 +775,6 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		GossipWANProbeTimeout:   b.durationVal("gossip_wan..probe_timeout", c.GossipWAN.ProbeTimeout),
 		GossipWANSuspicionMult:  b.intVal(c.GossipWAN.SuspicionMult),
 		GossipWANRetransmitMult: b.intVal(c.GossipWAN.RetransmitMult),
-		GossipWANMetaMaxSize:    b.intVal(c.GossipWAN.MetaMaxSize),
 
 		// ACL
 		ACLEnforceVersion8:        b.boolValWithDefault(c.ACLEnforceVersion8, true),

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -338,7 +338,6 @@ type GossipWANConfig struct {
 	ProbeTimeout   *string `json:"probe_timeout,omitempty" hcl:"probe_timeout" mapstructure:"probe_timeout"`
 	SuspicionMult  *int    `json:"suspicion_mult,omitempty" hcl:"suspicion_mult" mapstructure:"suspicion_mult"`
 	RetransmitMult *int    `json:"retransmit_mult,omitempty" hcl:"retransmit_mult" mapstructure:"retransmit_mult"`
-	MetaMaxSize    *int    `json:"meta_max_size,omitempty" hcl:"meta_max_size" mapstructure:"meta_max_size"`
 }
 
 type Consul struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -328,6 +328,7 @@ type GossipLANConfig struct {
 	ProbeTimeout   *string `json:"probe_timeout,omitempty" hcl:"probe_timeout" mapstructure:"probe_timeout"`
 	SuspicionMult  *int    `json:"suspicion_mult,omitempty" hcl:"suspicion_mult" mapstructure:"suspicion_mult"`
 	RetransmitMult *int    `json:"retransmit_mult,omitempty" hcl:"retransmit_mult" mapstructure:"retransmit_mult"`
+	MetaMaxSize    *int    `json:"meta_max_size,omitempty" hcl:"meta_max_size" mapstructure:"meta_max_size"`
 }
 
 type GossipWANConfig struct {
@@ -337,6 +338,7 @@ type GossipWANConfig struct {
 	ProbeTimeout   *string `json:"probe_timeout,omitempty" hcl:"probe_timeout" mapstructure:"probe_timeout"`
 	SuspicionMult  *int    `json:"suspicion_mult,omitempty" hcl:"suspicion_mult" mapstructure:"suspicion_mult"`
 	RetransmitMult *int    `json:"retransmit_mult,omitempty" hcl:"retransmit_mult" mapstructure:"retransmit_mult"`
+	MetaMaxSize    *int    `json:"meta_max_size,omitempty" hcl:"meta_max_size" mapstructure:"meta_max_size"`
 }
 
 type Consul struct {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1260,6 +1260,9 @@ type RuntimeConfig struct {
 	// hcl: gossip_lan { retransmit_mult = int }
 	GossipLANRetransmitMult int
 
+	// TODO
+	GossipLANMetaMaxSize int
+
 	// GossipWANGossipInterval  is the interval between sending messages that need
 	// to be gossiped that haven't been able to piggyback on probing messages.
 	// If this is set to zero, non-piggyback gossip is disabled. By lowering
@@ -1336,6 +1339,9 @@ type RuntimeConfig struct {
 	//
 	// hcl: gossip_wan { retransmit_mult = int }
 	GossipWANRetransmitMult int
+
+	// TODO
+	GossipWANMetaMaxSize int
 
 	// ServerMode controls if this agent acts like a Consul server,
 	// or merely as a client. Servers have more state, take part

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1260,7 +1260,8 @@ type RuntimeConfig struct {
 	// hcl: gossip_lan { retransmit_mult = int }
 	GossipLANRetransmitMult int
 
-	// TODO
+	// GossipLANMetaMaxSize is the max size of node meta data. This
+	// configuration only applies to LAN gossip communications.
 	GossipLANMetaMaxSize int
 
 	// GossipWANGossipInterval  is the interval between sending messages that need
@@ -1340,7 +1341,8 @@ type RuntimeConfig struct {
 	// hcl: gossip_wan { retransmit_mult = int }
 	GossipWANRetransmitMult int
 
-	// TODO
+	// GossipWANMetaMaxSize is the max size of node meta data. This
+	// configuration only applies to WAN gossip communications.
 	GossipWANMetaMaxSize int
 
 	// ServerMode controls if this agent acts like a Consul server,

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1341,10 +1341,6 @@ type RuntimeConfig struct {
 	// hcl: gossip_wan { retransmit_mult = int }
 	GossipWANRetransmitMult int
 
-	// GossipWANMetaMaxSize is the max size of node meta data. This
-	// configuration only applies to WAN gossip communications.
-	GossipWANMetaMaxSize int
-
 	// ServerMode controls if this agent acts like a Consul server,
 	// or merely as a client. Servers have more state, take part
 	// in leader election, etc.

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4024,8 +4024,7 @@ func TestFullConfig(t *testing.T) {
 				"retransmit_mult" : 16384,
 				"suspicion_mult"  : 16385,
 				"probe_interval"  : "103ms",
-				"probe_timeout"   : "104ms",
-				"meta_max_size"   : 514
+				"probe_timeout"   : "104ms"
 			},
 			"data_dir": "` + dataDir + `",
 			"datacenter": "rzo029wg",
@@ -4659,7 +4658,6 @@ func TestFullConfig(t *testing.T) {
 				suspicion_mult  = 16385
 				probe_interval  = "103ms"
 				probe_timeout   = "104ms"
-				meta_max_size   = 514
 			}
 			data_dir = "` + dataDir + `"
 			datacenter = "rzo029wg"
@@ -5226,7 +5224,6 @@ func TestFullConfig(t *testing.T) {
 		GossipWANProbeTimeout:            104 * time.Millisecond,
 		GossipWANSuspicionMult:           16385,
 		GossipWANRetransmitMult:          16384,
-		GossipWANMetaMaxSize:             514,
 		ConsulServerHealthInterval:       17455 * time.Second,
 
 		// user configurable values
@@ -6244,7 +6241,6 @@ func TestSanitize(t *testing.T) {
 		"GossipWANProbeTimeout": "0s",
 		"GossipWANRetransmitMult": 0,
 		"GossipWANSuspicionMult": 0,
-		"GossipWANMetaMaxSize": 0,
 		"ConsulServerHealthInterval": "0s",
 		"DNSARecordLimit": 0,
 		"DNSAddrs": [

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4015,15 +4015,17 @@ func TestFullConfig(t *testing.T) {
 				"retransmit_mult" : 1234,
 				"suspicion_mult"  : 1235,
 				"probe_interval"  : "101ms",
-				"probe_timeout"   : "102ms"
+				"probe_timeout"   : "102ms",
+				"meta_max_size"   : 513
 			},
 			"gossip_wan" : {
 				"gossip_nodes" : 2,
 				"gossip_interval" : "6966s",
 				"retransmit_mult" : 16384,
 				"suspicion_mult"  : 16385,
-				"probe_interval" : "103ms",
-				"probe_timeout"  : "104ms"
+				"probe_interval"  : "103ms",
+				"probe_timeout"   : "104ms",
+				"meta_max_size"   : 514
 			},
 			"data_dir": "` + dataDir + `",
 			"datacenter": "rzo029wg",
@@ -4076,7 +4078,7 @@ func TestFullConfig(t *testing.T) {
 			"key_file": "IEkkwgIA",
 			"leave_on_terminate": true,
 			"limits": {
-				"http_max_conns_per_client": 250,
+				"http_max_conns_per_client": 100,
 				"https_handshake_timeout": "2391ms",
 				"rpc_handshake_timeout": "1932ms",
 				"rpc_rate": 12029.43,
@@ -4648,6 +4650,7 @@ func TestFullConfig(t *testing.T) {
 				suspicion_mult  = 1235
 				probe_interval  = "101ms"
 				probe_timeout   = "102ms"
+				meta_max_size   = 513
 			}
 			gossip_wan {
 				gossip_nodes    = 2
@@ -4656,6 +4659,7 @@ func TestFullConfig(t *testing.T) {
 				suspicion_mult  = 16385
 				probe_interval  = "103ms"
 				probe_timeout   = "104ms"
+				meta_max_size   = 514
 			}
 			data_dir = "` + dataDir + `"
 			datacenter = "rzo029wg"
@@ -4709,7 +4713,7 @@ func TestFullConfig(t *testing.T) {
 			key_file = "IEkkwgIA"
 			leave_on_terminate = true
 			limits {
-				http_max_conns_per_client = 250
+				http_max_conns_per_client = 100
 				https_handshake_timeout = "2391ms"
 				rpc_handshake_timeout = "1932ms"
 				rpc_rate = 12029.43
@@ -5215,12 +5219,14 @@ func TestFullConfig(t *testing.T) {
 		GossipLANProbeTimeout:            102 * time.Millisecond,
 		GossipLANSuspicionMult:           1235,
 		GossipLANRetransmitMult:          1234,
+		GossipLANMetaMaxSize:             513,
 		GossipWANGossipInterval:          6966 * time.Second,
 		GossipWANGossipNodes:             2,
 		GossipWANProbeInterval:           103 * time.Millisecond,
 		GossipWANProbeTimeout:            104 * time.Millisecond,
 		GossipWANSuspicionMult:           16385,
 		GossipWANRetransmitMult:          16384,
+		GossipWANMetaMaxSize:             514,
 		ConsulServerHealthInterval:       17455 * time.Second,
 
 		// user configurable values
@@ -5416,7 +5422,7 @@ func TestFullConfig(t *testing.T) {
 		HTTPPort:                               7999,
 		HTTPResponseHeaders:                    map[string]string{"M6TKa9NP": "xjuxjOzQ", "JRCrHZed": "rl0mTx81"},
 		HTTPSAddrs:                             []net.Addr{tcpAddr("95.17.17.19:15127")},
-		HTTPMaxConnsPerClient:                  250,
+		HTTPMaxConnsPerClient:                  100,
 		HTTPSHandshakeTimeout:                  2391 * time.Millisecond,
 		HTTPSPort:                              15127,
 		KeyFile:                                "IEkkwgIA",
@@ -6231,12 +6237,14 @@ func TestSanitize(t *testing.T) {
 		"GossipLANProbeTimeout": "0s",
 		"GossipLANRetransmitMult": 0,
 		"GossipLANSuspicionMult": 0,
+		"GossipLANMetaMaxSize": 0,
 		"GossipWANGossipInterval": "0s",
 		"GossipWANGossipNodes": 0,
 		"GossipWANProbeInterval": "0s",
 		"GossipWANProbeTimeout": "0s",
 		"GossipWANRetransmitMult": 0,
 		"GossipWANSuspicionMult": 0,
+		"GossipWANMetaMaxSize": 0,
 		"ConsulServerHealthInterval": "0s",
 		"DNSARecordLimit": 0,
 		"DNSAddrs": [

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -816,6 +816,8 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 * <a name="serf_lan"></a><a href="#serf_lan_bind">`serf_lan`</a> Equivalent to
   the [`-serf-lan-bind` command-line flag](#_serf_lan_bind).
 
+* <a name="serf_meta_max_size"></a><a href="#serf_meta_max_size">`serf_meta_max_size`</a> TODO
+
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).
 

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -816,8 +816,6 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 * <a name="serf_lan"></a><a href="#serf_lan_bind">`serf_lan`</a> Equivalent to
   the [`-serf-lan-bind` command-line flag](#_serf_lan_bind).
 
-* <a name="serf_meta_max_size"></a><a href="#serf_meta_max_size">`serf_meta_max_size`</a> TODO
-
 * <a name="advertise_addr_wan"></a><a href="#advertise_addr_wan">`advertise_addr_wan`</a> Equivalent to
   the [`-advertise-wan` command-line flag](#_advertise-wan).
 
@@ -1315,40 +1313,50 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     cluster before declaring it dead, giving that suspect node more time to refute if it is indeed still alive. The
     default is 4.
 
+  * <a name="meta_max_size"></a><a href="#meta_max_size">`meta_max_size`</a> - The max size of node meta data.
+    The default is 512. Consul Enterprise uses node meta data to store information about network segments. The default
+    limits the number of segments severely. Only the LAN version of this option has to be adjusted to allow for more
+    network segments.
+
 * <a name="gossip_wan"></a><a href="#gossip_wan">`gossip_wan`</a> - **(Advanced)** This object contains a number of sub-keys
   which can be set to tune the WAN gossip communications. These are only provided for users running especially large
   clusters that need fine tuning and are prepared to spend significant effort correctly tuning them for their
   environment and workload. **Tuning these improperly can cause Consul to fail in unexpected ways**.
   The default values are appropriate in almost all deployments.
 
-    * <a name="gossip_nodes"></a><a href="#gossip_nodes">`gossip_nodes`</a> - The number of random nodes to send
+    * <a name="gossip_nodes"></a><a href="#gossip_wan_gossip_nodes">`gossip_nodes`</a> - The number of random nodes to send
      gossip messages to per gossip_interval. Increasing this number causes the gossip messages to propagate
      across the cluster more quickly at the expense of increased bandwidth. The default is 3.
 
-  * <a name="gossip_interval"></a><a href="#gossip_interval">`gossip_interval`</a> - The interval between sending
+  * <a name="gossip_interval"></a><a href="#gossip_wan_gossip_interval">`gossip_interval`</a> - The interval between sending
     messages that need to be gossiped that haven't been able to piggyback on probing messages. If this is set to
     zero, non-piggyback gossip is disabled. By lowering this value (more frequent) gossip messages are propagated
     across the cluster more quickly at the expense of increased bandwidth. The default is 200ms.
 
-  * <a name="probe_interval"></a><a href="#probe_interval">`probe_interval`</a> - The interval between random node
+  * <a name="probe_interval"></a><a href="#gossip_wan_probe_interval">`probe_interval`</a> - The interval between random node
     probes. Setting this lower (more frequent) will cause the cluster to detect failed nodes more quickly
     at the expense of increased bandwidth usage. The default is 1s.
 
-  * <a name="probe_timeout"></a><a href="#probe_timeout">`probe_timeout`</a> - The timeout to wait for an ack from
+  * <a name="probe_timeout"></a><a href="#gossip_wan_probe_timeout">`probe_timeout`</a> - The timeout to wait for an ack from
     a probed node before assuming it is unhealthy. This should be at least the 99-percentile of RTT (round-trip time) on
     your network. The default is 500ms and is a conservative value suitable for almost all realistic deployments.
 
-  * <a name="retransmit_mult"></a><a href="#retransmit_mult">`retransmit_mult`</a> - The multiplier for the number
+  * <a name="retransmit_mult"></a><a href="#gossip_wan_retransmit_mult">`retransmit_mult`</a> - The multiplier for the number
     of retransmissions that are attempted for messages broadcasted over gossip. The number of retransmits is scaled
     using this multiplier and the cluster size. The higher the multiplier, the more likely a failed broadcast is to
     converge at the expense of increased bandwidth. The default is 4.
 
-  * <a name="suspicion_mult"></a><a href="#suspicion_mult">`suspicion_mult`</a> - The multiplier for determining the
+  * <a name="suspicion_mult"></a><a href="#gossip_wan_suspicion_mult">`suspicion_mult`</a> - The multiplier for determining the
     time an inaccessible node is considered suspect before declaring it dead. The timeout is scaled with the cluster
     size and the probe_interval. This allows the timeout to scale properly with expected propagation delay with a
     larger cluster size. The higher the multiplier, the longer an inaccessible node is considered part of the
     cluster before declaring it dead, giving that suspect node more time to refute if it is indeed still alive. The
     default is 4.
+
+  * <a name="meta_max_size"></a><a href="#gossip_wan_meta_max_size">`meta_max_size`</a> - The max size of node meta data.
+    The default is 512. Consul Enterprise uses node meta data to store information about network segments. The default
+    limits the number of segments severely. Only the LAN version of this option has to be adjusted to allow for more
+    network segments.
 
 * <a name="key_file"></a><a href="#key_file">`key_file`</a> This provides a the file path to a
   PEM-encoded private key. The key is used with the certificate to verify the agent's authenticity.

--- a/website/source/docs/agent/options.html.md
+++ b/website/source/docs/agent/options.html.md
@@ -1315,8 +1315,7 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
   * <a name="meta_max_size"></a><a href="#meta_max_size">`meta_max_size`</a> - The max size of node meta data.
     The default is 512. Consul Enterprise uses node meta data to store information about network segments. The default
-    limits the number of segments severely. Only the LAN version of this option has to be adjusted to allow for more
-    network segments.
+    limits the number of segments severely. 
 
 * <a name="gossip_wan"></a><a href="#gossip_wan">`gossip_wan`</a> - **(Advanced)** This object contains a number of sub-keys
   which can be set to tune the WAN gossip communications. These are only provided for users running especially large
@@ -1352,11 +1351,6 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     larger cluster size. The higher the multiplier, the longer an inaccessible node is considered part of the
     cluster before declaring it dead, giving that suspect node more time to refute if it is indeed still alive. The
     default is 4.
-
-  * <a name="meta_max_size"></a><a href="#gossip_wan_meta_max_size">`meta_max_size`</a> - The max size of node meta data.
-    The default is 512. Consul Enterprise uses node meta data to store information about network segments. The default
-    limits the number of segments severely. Only the LAN version of this option has to be adjusted to allow for more
-    network segments.
 
 * <a name="key_file"></a><a href="#key_file">`key_file`</a> This provides a the file path to a
   PEM-encoded private key. The key is used with the certificate to verify the agent's authenticity.


### PR DESCRIPTION
Requires https://github.com/hashicorp/serf/pull/600 and https://github.com/hashicorp/memberlist/pull/218.

> Consul Enterprise uses metadata for network segments. Limiting it to
512Bytes, impacts the number of segments that can be used severely. This
limit is very conservative and will remain the default. But it should be
safe to increase that most of the time and this PR is the foundation for
that.