### PR TITLE
ui: Fixup intention notifications and add SyncTime

### DIFF
--- a/ui-v2/app/models/intention.js
+++ b/ui-v2/app/models/intention.js
@@ -20,6 +20,7 @@ export default Model.extend({
   DefaultPort: attr('number'),
   //
   Meta: attr(),
+  SyncTime: attr('number'),
   Datacenter: attr('string'),
   CreatedAt: attr('date'),
   UpdatedAt: attr('date'),

--- a/ui-v2/app/templates/dc/intentions/-notifications.hbs
+++ b/ui-v2/app/templates/dc/intentions/-notifications.hbs
@@ -9,13 +9,13 @@
 {{else if (eq type 'update') }}
   {{#if (eq status 'success') }}
     Your intention has been saved.
-  {{else}}
+  {{else if (eq status 'error')}}
     There was an error saving your intention.
   {{/if}}
 {{ else if (eq type 'delete')}}
   {{#if (eq status 'success') }}
     Your intention was deleted.
-  {{else}}
+  {{else if (eq status 'error')}}
     There was an error deleting your intention.
   {{/if}}
 {{/if}}

--- a/ui-v2/tests/integration/services/repository/intention-test.js
+++ b/ui-v2/tests/integration/services/repository/intention-test.js
@@ -1,14 +1,19 @@
 import { moduleFor, test } from 'ember-qunit';
 import repo from 'consul-ui/tests/helpers/repo';
+import { get } from '@ember/object';
 const NAME = 'intention';
 moduleFor(`service:repository/${NAME}`, `Integration | Service | ${NAME}`, {
   integration: true,
 });
 
+const now = new Date().getTime();
 const dc = 'dc-1';
 const id = 'token-name';
 const nspace = 'default';
 test('findAllByDatacenter returns the correct data for list endpoint', function(assert) {
+  get(this.subject(), 'store').serializerFor(NAME).timestamp = function() {
+    return now;
+  };
   return repo(
     'Intention',
     'findAllByDatacenter',
@@ -29,6 +34,7 @@ test('findAllByDatacenter returns the correct data for list endpoint', function(
             Object.assign({}, item, {
               CreatedAt: new Date(item.CreatedAt),
               UpdatedAt: new Date(item.UpdatedAt),
+              SyncTime: now,
               Datacenter: dc,
               // TODO: nspace isn't required here, once we've
               // refactored out our Serializer this can go


### PR DESCRIPTION
This PR adds 2 things:

1. Specifically checks for error notifications rather than just not success (this prevents the intention notification text appearing when you get a warning following service deregistration)
2. Adds `SyncTime` to Intentions to enabled proper reconciliation of caches when Intentions are deleted.

As we begin to merge different data types into the same page, we'll get more of this similar problem, so I would imagine we will revisit our notifications soon to make sure we 'classify' them by data type as well as action and status.


