### PR TITLE
ui: Reuse repo.reconcile and restartWhenAvailable

### DIFF
--- a/ui-v2/app/services/data-source/protocols/http.js
+++ b/ui-v2/app/services/data-source/protocols/http.js
@@ -25,9 +25,7 @@ export default Service.extend({
           type: 'message',
           data: result,
         };
-        if (repo.reconcile === 'function') {
-          repo.reconcile(get(event, 'data.meta') || {});
-        }
+        repo.reconcile(get(event, 'data.meta'));
         return event;
       };
     }

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -1,41 +1,27 @@
 import { inject as service } from '@ember/service';
 import { get } from '@ember/object';
 
+import { restartWhenAvailable } from 'consul-ui/services/client/http';
 import LazyProxyService from 'consul-ui/services/lazy-proxy';
 
 import { cache as createCache, BlockingEventSource } from 'consul-ui/utils/dom/event-source';
 
 const createProxy = function(repo, find, settings, cache, serialize = JSON.stringify) {
   const client = this.client;
-  const store = this.store;
   // custom createEvent, here used to reconcile the ember-data store for each tick
-  const createEvent = function(result, configuration) {
-    const event = {
-      type: 'message',
-      data: result,
+  let createEvent;
+  if (typeof repo.reconcile === 'function') {
+    createEvent = function(result = {}, configuration) {
+      const event = {
+        type: 'message',
+        data: result,
+      };
+      if (repo.reconcile === 'function') {
+        repo.reconcile(get(event, 'data.meta'));
+      }
+      return event;
     };
-    const meta = get(event.data || {}, 'meta') || {};
-    if (typeof meta.date !== 'undefined') {
-      // unload anything older than our current sync date/time
-      const checkNspace = meta.nspace !== '';
-      store.peekAll(repo.getModelName()).forEach(function(item) {
-        const dc = get(item, 'Datacenter');
-        if (dc === meta.dc) {
-          if (checkNspace) {
-            const nspace = get(item, 'Namespace');
-            if (nspace !== meta.namespace) {
-              return;
-            }
-          }
-          const date = get(item, 'SyncTime');
-          if (typeof date !== 'undefined' && date != meta.date) {
-            store.unloadRecord(item);
-          }
-        }
-      });
-    }
-    return event;
-  };
+  }
   // proxied find*..(id, dc)
   return function() {
     const key = `${repo.getModelName()}.${find}.${serialize([...arguments])}`;
@@ -58,18 +44,7 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
             }
             return res;
           })
-          .catch(function(e) {
-            // setup the aborted connection restarting
-            // this should happen here to avoid cache deletion
-            const status = get(e, 'errors.firstObject.status');
-            if (status === '0') {
-              // Any '0' errors (abort) should possibly try again, depending upon the circumstances
-              // whenAvailable returns a Promise that resolves when the client is available
-              // again
-              return client.whenAvailable(e);
-            }
-            throw e;
-          });
+          .catch(restartWhenAvailable(client));
       },
       {
         key: key,
@@ -85,9 +60,7 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
 let cache = null;
 let cacheMap = null;
 export default LazyProxyService.extend({
-  store: service('store'),
   settings: service('settings'),
-  wait: service('timeout'),
   client: service('client/http'),
   init: function() {
     this._super(...arguments);


### PR DESCRIPTION
The original plan for `<DataSources />` (componentized `EventSources`) was to replace our `Proxy` based `EventSources`.

We decided not to do this in one go, and the more we think about it the more you might want to use both `Proxy` based `EventSources` (great for use in blocking `Routes`) and `Component` based `EventSources` (great for use in non-blocking `Controller`s/Templates/Composed or Higher Order `Components`) at the same time.

Eventually we'd like both to use all the same code and caching mechanisms, so this is a first step towards bringing that together.

We didn't want to get too deep in the weeds with this right now, so we only did some things that were a clear, straightforward change. But now these two approaches are in the same branch, it makes them easier to stare at to figure how we can bring the both approaches together in the future.

The change here additionally improves the previous reconciling approach for Proxy type EventSources by making it configurable per data model via each of their repositories instead of one single approach for all models just like the Component EventSources.
