### PR TITLE
ui: replace Makefile sed directive for coverage

### DIFF
--- a/ui-v2/.istanbul.yml
+++ b/ui-v2/.istanbul.yml
@@ -1,0 +1,4 @@
+instrumentation:
+  excludes: [
+    "!app/+(utils|search)/**/*"
+  ]

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -65,18 +65,13 @@ test-oss-ci: deps test-node
 test-node:
 	yarn run test:node
 
-# This seems to be the only way to only include a subset of files for coverage
-# Right now we only want the /app/utils/ folder to be included for coverage
-specify-coverage:
-	sed -i "s/exclude, include/include: ['consul-ui\/utils\/**\/*','consul-ui\/search\/**\/*']/g" ./node_modules/ember-cli-code-coverage/index.js
-
-test-coverage: deps specify-coverage
+test-coverage: deps
 	yarn run test:coverage
 
-test-coverage-view: deps specify-coverage
+test-coverage-view: deps
 	yarn run test:coverage:view
 
-test-coverage-ci: deps specify-coverage
+test-coverage-ci: deps
 	yarn run test:coverage:ci
 
 test-parallel: deps


### PR DESCRIPTION
Use [minimatch](https://www.npmjs.com/package/minimatch) negation and extglob syntax in `.istanbul.yml` config file instead. Closes #7695.

<img width="1440" alt="Screen Shot 2020-04-27 at 11 20 44 AM" src="https://user-images.githubusercontent.com/1149913/80390553-8d865480-887a-11ea-902a-ff5ba74c93d1.png">

Now to just figure out how to fix the missing base coverage from `ui-staging` branch to get the CodeCov GitHub status reporting...