### PR TITLE
website: add alert banner

### DIFF
--- a/website/source/assets/stylesheets/_alert-bar.scss
+++ b/website/source/assets/stylesheets/_alert-bar.scss
@@ -1,0 +1,29 @@
+.alert-bar {
+  color: white;
+  position: relative;
+  background: linear-gradient(90deg, #ca2171 1.56%, #8e134a 100%);
+  display: flex;
+  justify-content: center;
+
+  & a {
+    text-decoration: none;
+    display: inline-flex;
+    color: white;
+    padding: 14px 15px;
+
+    &:hover {
+      text-decoration: none;
+    }
+
+    & p {
+      padding: 0;
+      margin: 0;
+    }
+
+    & .link {
+      margin-left: 30px;
+      text-decoration: underline;
+      font-weight: 500;
+    }
+  }
+}

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@
 @import '_global';
 
 // Components
+@import '_alert-bar';
 @import '_header';
 @import '_footer';
 @import '_inner';

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -2,6 +2,7 @@
 description: |-
   Consul is a service networking solution to connect and secure services across
   any runtime platform and public or private cloud
+show_alert_bar: true
 ---
 
 <div class='consul-connect'>

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -2,7 +2,6 @@
 description: |-
   Consul is a service networking solution to connect and secure services across
   any runtime platform and public or private cloud
-show_alert_bar: true
 ---
 
 <div class='consul-connect'>

--- a/website/source/layouts/_alert-bar.erb
+++ b/website/source/layouts/_alert-bar.erb
@@ -1,6 +1,6 @@
 <div class="alert-bar g-type-body-small">
-  <a href="https://www.hashicorp.com/products/consul">
-    <p>HashiCorp Consul Announcement</p>
+  <a href="https://www.hashicorp.com/products/consul/service-on-azure">
+    <p>HashiCorp Consul Service on Azure Public Beta Available Now</p>
     <span class="link">Learn More</span>
   </a>
 </div>

--- a/website/source/layouts/_alert-bar.erb
+++ b/website/source/layouts/_alert-bar.erb
@@ -1,0 +1,6 @@
+<div class="alert-bar g-type-body-small">
+  <a href="https://www.hashicorp.com/products/consul">
+    <p>HashiCorp Consul Announcement</p>
+    <span class="link">Learn More</span>
+  </a>
+</div>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -47,9 +47,7 @@
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
 
-    <% if current_page.data.show_alert_bar == true %>
-      <%= partial("layouts/_alert-bar") %>
-    <% end %>
+    <%= partial("layouts/_alert-bar") %>
 
     <%= mega_nav :consul %>
 

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -47,6 +47,10 @@
 
   <body id="<%= body_id_for(current_page) %>" class="<%= body_classes_for(current_page) %>">
 
+    <% if current_page.data.show_alert_bar == true %>
+      <%= partial("layouts/_alert-bar") %>
+    <% end %>
+
     <%= mega_nav :consul %>
 
     <div id="header" class="navigation navbar-static-top hidden-print">


### PR DESCRIPTION
Adds Consul branded alert banner, toggled on a per page basis via `show_alert_bar` frontmatter.

<img width="1670" alt="Screenshot 2020-04-28 09 01 07" src="https://user-images.githubusercontent.com/845983/80490081-d4358680-892e-11ea-9a85-89014616123b.png">
