### PR TITLE
coverage: set CodeCov ui patch status to use ui flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,12 +119,12 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: &codecov_upload
+      - run:
           name: codecov upload
           when: always
           # The -C flag shouldn't be necessary, but it fails to find the commit
           # without it.
-          command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1"
+          command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1" -F backend
 
   # split off a job for the API package since it is separate
   go-test-api:
@@ -156,7 +156,12 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: *codecov_upload
+      - run:
+          name: codecov upload
+          when: always
+          # The -C flag shouldn't be necessary, but it fails to find the commit
+          # without it.
+          command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1" -F api
 
   # split off a job for the SDK package since it is separate
   go-test-sdk:
@@ -188,7 +193,12 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
-      - run: *codecov_upload
+      - run:
+          name: codecov upload
+          when: always
+          # The -C flag shouldn't be necessary, but it fails to find the commit
+          # without it.
+          command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1" -F sdk
 
   # build all distros
   build-distros: &build-distros

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,11 +510,11 @@ jobs:
           at: ui-v2
       - run:
           working_directory: ui-v2
-          command: make test-coverage-ci
+          command: yarn run test:coverage
       - run:
           name: codecov ui upload
           working_directory: ui-v2
-          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui
+          command: bash <(curl -s https://codecov.io/bash) -v -c -C $CIRCLE_SHA1 -F ui -f coverage/lcov.info
 
   envoy-integration-test-1.11.2:
     docker:

--- a/codecov.yml
+++ b/codecov.yml
@@ -61,5 +61,5 @@ ignore:
 
 # Fix relative coverage path processing by reducing CI-specific paths
 # https://docs.codecov.io/docs/fixing-paths
-# fixes:
-#    - "/home/circleci/project/::"
+fixes:
+   - "/home/circleci/project/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -42,3 +42,8 @@ ignore:
   - "agent/bindata_assetfs.go"
   - "vendor/**/*"
   - "**/*.pb.go"
+
+# Fix relative coverage path processing by reducing CI-specific paths
+# https://docs.codecov.io/docs/fixing-paths
+fixes:
+   - "/home/circleci/project/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -45,5 +45,5 @@ ignore:
 
 # Fix relative coverage path processing by reducing CI-specific paths
 # https://docs.codecov.io/docs/fixing-paths
-fixes:
-   - "/home/circleci/project/::"
+# fixes:
+#    - "/home/circleci/project/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,12 +4,20 @@ coverage:
     # only measure diff changes, not unexpected project changes from flakiness
     project: off
     patch:
-      default:
+      default: off
+      backend:
+        flags:
+          - backend
         # https://docs.codecov.io/docs/commit-status#section-informational
         informational: true
-        # https://docs.codecov.io/docs/commit-status#section-excluding-tests-example-
-        # TODO: should any paths be excluded from coverage metrics?
-        # paths:
+      api:
+        flags:
+          - api
+        informational: true
+      sdk:
+        flags:
+          - sdk
+        informational: true
       ui:
         flags:
           - ui
@@ -32,8 +40,16 @@ coverage:
 comment: false
 
 # https://docs.codecov.io/docs/flags
-# TODO: split out test coverage for API, SDK, UI, website?
 flags:
+  backend:
+    paths:
+      - !ui-v2/
+  api:
+    paths:
+      - api/
+  sdk:
+    paths:
+      - sdk/
   ui:
     paths:
       - ui-v2/

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,8 @@ coverage:
         # TODO: should any paths be excluded from coverage metrics?
         # paths:
       ui:
+        flags:
+          - ui
         informational: true
     # https://docs.codecov.io/docs/commit-status#section-changes-status
     # TODO: enable after eliminating current unexpected coverage changes?
@@ -33,7 +35,8 @@ comment: false
 # TODO: split out test coverage for API, SDK, UI, website?
 flags:
   ui:
-    paths: /ui-v2/
+    paths:
+      - ui-v2/
 
 ignore:
   - "agent/bindata_assetfs.go"

--- a/codecov.yml
+++ b/codecov.yml
@@ -62,8 +62,3 @@ ignore:
   - "agent/bindata_assetfs.go"
   - "vendor/**/*"
   - "**/*.pb.go"
-
-# Fix relative coverage path processing by reducing CI-specific paths
-# https://docs.codecov.io/docs/fixing-paths
-fixes:
-   - "/home/circleci/project/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,11 @@ coverage:
     project: off
     patch:
       default: off
-      backend:
-        flags:
-          - backend
-        # https://docs.codecov.io/docs/commit-status#section-informational
-        informational: true
+      # backend:
+      #   flags:
+      #     - backend
+      #   # https://docs.codecov.io/docs/commit-status#section-informational
+      #   informational: true
       api:
         flags:
           - api
@@ -44,15 +44,19 @@ flags:
   backend:
     paths:
       - !ui-v2/
+    carryforward: true
   api:
     paths:
       - api/
+    carryforward: true
   sdk:
     paths:
       - sdk/
+    carryforward: true
   ui:
     paths:
       - ui-v2/
+    carryforward: true
 
 ignore:
   - "agent/bindata_assetfs.go"

--- a/ui-v2/GNUmakefile
+++ b/ui-v2/GNUmakefile
@@ -71,9 +71,6 @@ test-coverage: deps
 test-coverage-view: deps
 	yarn run test:coverage:view
 
-test-coverage-ci: deps
-	yarn run test:coverage:ci
-
 test-parallel: deps
 	yarn run test:parallel
 

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -30,7 +30,6 @@
     "test:oss:view": "CONSUL_NSPACES_ENABLED=0 ember test --server --test-port=${EMBER_TEST_PORT:-7357}",
     "test:node": "tape ./node-tests/**/*.js",
     "test:coverage": "COVERAGE=true ember test --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
-    "test:coverage:ci": "COVERAGE=true ember test --environment test --filter=Unit --path dist --test-port=${EMBER_TEST_PORT:-7357}",
     "test:coverage:view": "COVERAGE=true ember test --server --environment test --filter=Unit --test-port=${EMBER_TEST_PORT:-7357}",
     "steps:list": "node ./lib/commands/bin/list.js"
   },


### PR DESCRIPTION
Trying to fix the GitHub status integration to show a UI-specific patch diff similar to the backend Go test coverage reporting like below.

<img width="671" alt="Screen Shot 2020-04-28 at 12 43 24 PM" src="https://user-images.githubusercontent.com/1149913/80514057-fd194400-894d-11ea-9c14-49b74a31d628.png">
