### PR TITLE
ui: Add background-color: currentColor to all our icon masks

### DIFF
--- a/ui-v2/app/styles/base/icons/base-placeholders.scss
+++ b/ui-v2/app/styles/base/icons/base-placeholders.scss
@@ -5,6 +5,7 @@
 %with-mask {
   mask-repeat: no-repeat;
   mask-position: center;
+  background-color: currentColor;
 }
 %as-pseudo {
   display: inline-block;


### PR DESCRIPTION
We currently define our 'decorational' iconography in our CSS via
background images and or psuedo content. For coloring these we use
`mask-image` and a background color.

This commit adds a `background-color: currentColor` to our `%with-mask`
placeholder that makes the color of these icons default to the `color`
of the current element, meaning the icons now inherit from things like
`:hover`.

This can easily be overwritten as before by just setting the
`background-color` on the icon manually as before.

This shouldn't effect any of the icons we currently use as they all have background-colors added manually (and if we spot any that don't we can update in a future PR). But we should be able to gradually remove these in future PRs and let them just inherit from the color of the text as we move forwards.

