### PR TITLE
ui: Refactors our AppView/%app-view component

### DIFF
--- a/ui-v2/app/components/app-view/index.hbs
+++ b/ui-v2/app/components/app-view/index.hbs
@@ -45,19 +45,25 @@
     </FlashMessage>
 {{/each}}
     <div>
-        <div class="actions">
-  {{#if authorized}}
-            <YieldSlot @name="actions">{{yield}}</YieldSlot>
-  {{/if}}
-        </div>
-
         <div>
   {{#if authorized}}
             <nav aria-label="Breadcrumb">
                 <YieldSlot @name="breadcrumbs">{{yield}}</YieldSlot>
             </nav>
   {{/if}}
-            <YieldSlot @name="header">{{yield}}</YieldSlot>
+            <div class="title">
+              <YieldSlot @name="header">
+                  {{yield}}
+              </YieldSlot>
+              <div class="actions">
+        {{#if authorized}}
+                  <YieldSlot @name="actions">{{yield}}</YieldSlot>
+        {{/if}}
+              </div>
+            </div>
+            <YieldSlot @name="nav">
+              {{yield}}
+            </YieldSlot>
         </div>
     </div>
   {{#if authorized}}

--- a/ui-v2/app/styles/base/components/tabs/skin.scss
+++ b/ui-v2/app/styles/base/components/tabs/skin.scss
@@ -4,9 +4,6 @@
   /* TODO: structure tabs don't actually have a top border */
   border-top: $decor-border-200;
 }
-%tab-nav .with-title-bar {
-  border-top: 0;
-}
 %tab-nav {
   /* %frame-gray-something */
   border-color: $gray-200;

--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -4,66 +4,19 @@
 
 @import '../base/components/popover-menu/index';
 
-%app-view-header .actions > [type='checkbox'] {
-  @extend %more-popover-menu;
-}
-%more-popover-menu-panel [type='checkbox']:checked ~ * {
-  /* this needs to autocalculate */
-  min-height: 143px;
-  max-height: 143px;
-}
-%more-popover-menu-panel [id$='logout']:checked ~ * {
-  /* this needs to autocalculate */
-  min-height: 163px;
-  max-height: 163px;
-}
-%more-popover-menu-panel [id$='delete']:checked ~ ul label[for$='delete'] + [role='menu'],
-%more-popover-menu-panel [id$='logout']:checked ~ ul label[for$='logout'] + [role='menu'],
-%more-popover-menu-panel [id$='use']:checked ~ ul label[for$='use'] + [role='menu'] {
-  display: block;
-}
-%app-view-header .actions label + div {
-  // We need this extra to allow tooltips to show
+%app-view-actions label + div {
+  /* We need this extra to allow tooltips to show */
   overflow: visible !important;
 }
 
 main {
   @extend %app-view;
 }
-%app-view > div > header {
-  @extend %app-view-header;
-}
-%app-view > div > div {
-  @extend %app-view-content;
-}
-%app-view header form {
+%app-view-header form {
   @extend %filter-bar;
 }
-@media #{$--lt-spacious-page-header} {
-  %app-view-header .actions {
-    margin-top: 9px;
-  }
-}
-// TODO: This should be its own component
-%app-view h1 {
-  padding-bottom: 0.2em;
-}
-%app-view h1 span[data-tooltip] {
-  @extend %with-external-source-icon;
-  margin-top: 13px;
-}
-%app-view h1 span.kind-proxy {
-  @extend %frame-gray-900;
-  @extend %pill;
-}
-%app-view h1 span.kind-proxy::before {
-  width: 0.3em !important;
-}
-%app-view h1 em {
-  color: $gray-600;
-}
-%app-view-header .actions a,
-%app-view-header .actions button {
+%app-view-actions a,
+%app-view-actions button {
   @extend %button-compact;
 }
 %app-view-content div > dl {
@@ -97,12 +50,14 @@ main {
     display: none;
   }
 }
+@media #{$--lt-spacious-page-header} {
+  %app-view-actions {
+    margin-top: 9px;
+  }
+}
 // reduced search magnifying icon layout
 @media #{$--lt-horizontal-selects} {
-  %app-view header h1 {
-    display: inline-block;
-  }
-  %app-view header h1 {
+  %app-view-header h1 {
     display: inline-block;
   }
   // on the instance detail page we don't have the magnifier

--- a/ui-v2/app/styles/components/app-view/index.scss
+++ b/ui-v2/app/styles/components/app-view/index.scss
@@ -1,2 +1,14 @@
 @import './skin';
 @import './layout';
+%app-view > div > header {
+  @extend %app-view-header;
+}
+%app-view-header .title {
+  @extend %app-view-title;
+}
+%app-view-header .actions {
+  @extend %app-view-actions;
+}
+%app-view > div > div {
+  @extend %app-view-content;
+}

--- a/ui-v2/app/styles/components/app-view/layout.scss
+++ b/ui-v2/app/styles/components/app-view/layout.scss
@@ -1,67 +1,61 @@
 /* layout */
-%app-view-header > div:last-of-type > div:first-child {
-  flex-grow: 1;
-}
 %app-view {
   position: relative;
 }
-%app-view-header .actions {
-  float: right;
-  display: flex;
-  align-items: flex-start;
-  margin-top: 9px;
-}
-%app-view-header dl {
-  float: left;
-  margin-top: 25px;
-  margin-right: 50px;
-  margin-bottom: 20px;
-}
-%app-view-header dt {
-  font-weight: bold;
-}
-%app-view-header dd > a {
-  color: $black;
-}
-%app-view-header .title-bar {
+%app-view-title {
   display: flex;
   align-items: center;
 }
-%app-view-header .title-bar > h1 {
-  border: 0;
+%app-view-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: flex-start;
 }
-%app-view-header .title-bar > span {
-  margin-left: 8px;
+%app-view-header dl {
+  float: left;
 }
 /* units */
 %app-view {
   margin-top: 50px;
 }
+/* give anything after the header a bit of room */
 %app-view-header + div > *:first-child {
   margin-top: 1.8em;
 }
-%app-view h2 {
+%app-view-title {
   padding-bottom: 0.2em;
-  margin-bottom: 0.5em;
 }
-%app-view-header .actions > *:not(:last-child) {
+%app-view-title > :not(:last-child) {
+  margin-right: 8px;
+}
+%app-view-actions {
+  margin-top: 9px;
+}
+%app-view-actions > *:not(:last-child) {
   margin-right: 12px;
 }
-
-// content
-%app-view-content div > dl > dt {
-  position: absolute;
+%app-view-header dl {
+  margin-top: 19px;
+  margin-bottom: 23px;
+  margin-right: 50px;
 }
-%app-view-content div > dl {
-  position: relative;
+
+/* content */
+%app-view-content h2 {
+  padding-bottom: 0.2em;
+  margin-bottom: 0.5em;
 }
 %app-view-content-empty {
   margin-top: 0;
   padding: 50px;
   text-align: center;
 }
-%app-view-content form:not(:last-child) {
-  margin-bottom: 2.2em;
+/* this should probably be its own component */
+%app-view-content div > dl {
+  position: relative;
+}
+%app-view-content div > dl > dt {
+  position: absolute;
 }
 %app-view-content div > dl > dt {
   width: 140px;
@@ -73,7 +67,8 @@
   min-height: 1em;
   margin-bottom: 0.4em;
 }
-// TODO: Think about an %app-form or similar
+/* */
+/* TODO: Think about an %app-form or similar */
 %app-view-content fieldset:not(.freetext-filter) {
   padding-bottom: 0.3em;
   margin-bottom: 2em;

--- a/ui-v2/app/styles/components/app-view/skin.scss
+++ b/ui-v2/app/styles/components/app-view/skin.scss
@@ -1,57 +1,33 @@
-/*TODO: Rename this to %app-view-brand-icon or similar */
-%with-external-source-icon {
-  background-repeat: no-repeat;
-  background-size: contain;
-  width: 18px;
-  height: 18px;
-
-  --kubernetes-icon: #{$kubernetes-logo-color-svg};
-  --terraform-icon: #{$terraform-logo-color-svg};
-  --nomad-icon: #{$nomad-logo-color-svg};
-  --consul-icon: #{$consul-logo-color-svg};
-  --aws-icon: #{$aws-logo-color-svg};
+%app-view-content-empty {
+  @extend %frame-gray-500;
 }
-%app-view h2,
-%app-view fieldset {
+%app-view-title {
   border-bottom: $decor-border-200;
 }
-%app-view fieldset h2 {
+%app-view-content h2,
+%app-view-content fieldset {
+  border-bottom: $decor-border-200;
+}
+%app-view-content fieldset h2 {
   border-bottom: none;
 }
-@media #{$--horizontal-selects} {
-  %app-view header h1,
-  %app-view-header .title-bar {
-    border-bottom: $decor-border-200;
-  }
+%app-view-header h1 > em {
+  color: $gray-600;
 }
-@media #{$--lt-horizontal-selects} {
-  %app-view header > div > div:last-child {
-    border-bottom: $decor-border-200;
-  }
-}
-%app-view header > div > div:last-child,
-%app-view header h1,
-%app-view-header .title-bar,
-%app-view h2,
-%app-view fieldset {
-  border-color: $gray-200;
-}
-%app-view-header .with-nav {
-  border: 0;
-}
-// We know that any sibling navs might have a top border
-// by default. As its squashed up to a h1, in this
-// case hide its border to avoid double border
-@media #{$--horizontal-selects} {
-  %app-view header h1 ~ nav {
-    border-top: 0 !important;
-  }
+%app-view-header dd > a {
+  color: $black;
 }
 %app-view-content div > dl > dd {
   color: $gray-400;
 }
-[role='tabpanel'] > p:only-child,
-.template-error > div,
-%app-view-content > p:only-child {
-  @extend %frame-gray-500;
+%app-view-title,
+%app-view-content h2,
+%app-view-content fieldset {
+  border-color: $gray-200;
+}
+// We know that any sibling navs might have a top border
+// by default. As its squashed up to a %app-view-title, in this
+// case hide its border to avoid double border
+%app-view-title ~ nav {
+  border-top: 0 !important;
 }

--- a/ui-v2/app/styles/components/filter-bar/layout.scss
+++ b/ui-v2/app/styles/components/filter-bar/layout.scss
@@ -1,8 +1,11 @@
 %filter-bar {
   padding: 4px;
   display: block;
+  margin-bottom: 8px;
   margin-top: 0 !important;
-  margin-bottom: 8px !important;
+}
+%filter-bar + :not(.notice) {
+  margin-top: 1.8em;
 }
 @media #{$--horizontal-filters} {
   %filter-bar {

--- a/ui-v2/app/styles/components/table.scss
+++ b/ui-v2/app/styles/components/table.scss
@@ -6,6 +6,21 @@
 %table-actions > [type='checkbox'] {
   @extend %more-popover-menu;
 }
+%more-popover-menu-panel [type='checkbox']:checked ~ * {
+  /* this needs to autocalculate */
+  min-height: 143px;
+  max-height: 143px;
+}
+%more-popover-menu-panel [id$='logout']:checked ~ * {
+  /* this needs to autocalculate */
+  min-height: 183px;
+  max-height: 183px;
+}
+%more-popover-menu-panel [id$='delete']:checked ~ ul label[for$='delete'] + [role='menu'],
+%more-popover-menu-panel [id$='logout']:checked ~ ul label[for$='logout'] + [role='menu'],
+%more-popover-menu-panel [id$='use']:checked ~ ul label[for$='use'] + [role='menu'] {
+  display: block;
+}
 %table-actions .confirmation-alert {
   @extend %confirmation-alert;
 }
@@ -15,18 +30,27 @@
   right: 15px;
 }
 
-html.template-service.template-list td:first-child a span,
-html.template-node.template-show #services td:first-child a span,
-html.template-service.template-show #instances td:first-child a span {
+/*TODO: Rename this to %app-view-brand-icon or similar */
+%with-external-source-icon {
+  background-repeat: no-repeat;
+  background-size: contain;
+  width: 18px;
+  height: 18px;
+
+  --kubernetes-icon: #{$kubernetes-logo-color-svg};
+  --terraform-icon: #{$terraform-logo-color-svg};
+  --nomad-icon: #{$nomad-logo-color-svg};
+  --consul-icon: #{$consul-logo-color-svg};
+  --aws-icon: #{$aws-logo-color-svg};
+}
+html.template-node.template-show #services td:first-child a span {
   @extend %with-external-source-icon;
   float: left;
   margin-right: 10px;
   margin-top: 2px;
 }
 /* This nudges the th in for the external source icons */
-html.template-node.template-show #services th:first-child,
-html.template-service.template-show #instances th:first-child,
-html.template-service.template-list main th:first-child {
+html.template-node.template-show #services th:first-child {
   text-indent: 28px;
 }
 
@@ -72,16 +96,10 @@ th span em {
   html.template-policy.template-list tr > :nth-child(2) {
     display: none;
   }
-  html.template-service.template-list tr > :nth-child(2) {
-    display: none;
-  }
 }
 @media #{$--lt-wide-table} {
   /* hide actions on narrow screens, you can always click in do everything from there */
   tr > .actions {
-    display: none;
-  }
-  html.template-service.template-list tr > :last-child {
     display: none;
   }
   html.template-node.template-show #services tr > :last-child {

--- a/ui-v2/app/styles/core/typography.scss
+++ b/ui-v2/app/styles/core/typography.scss
@@ -79,6 +79,7 @@ pre code,
 %button {
   font-weight: $typo-weight-semibold;
 }
+%app-view-header dt,
 %menu-panel dt,
 %route-card section dt,
 %route-card header:not(.short) dd,

--- a/ui-v2/app/templates/dc/acls/policies/index.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/index.hbs
@@ -16,9 +16,11 @@
     <h1>
       Access Controls
     </h1>
-    {{#if isAuthorized }}
-      {{partial 'dc/acls/nav'}}
-    {{/if}}
+  </BlockSlot>
+  <BlockSlot @name="nav">
+{{#if isAuthorized }}
+    {{partial 'dc/acls/nav'}}
+{{/if}}
   </BlockSlot>
   <BlockSlot @name="disabled">
     {{partial 'dc/acls/disabled'}}

--- a/ui-v2/app/templates/dc/acls/roles/index.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/index.hbs
@@ -16,9 +16,11 @@
     <h1>
       Access Controls
     </h1>
-    {{#if isAuthorized }}
-      {{partial 'dc/acls/nav'}}
-    {{/if}}
+  </BlockSlot>
+  <BlockSlot @name="nav">
+{{#if isAuthorized }}
+    {{partial 'dc/acls/nav'}}
+{{/if}}
   </BlockSlot>
   <BlockSlot @name="disabled">
     {{partial 'dc/acls/disabled'}}

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -16,6 +16,8 @@
     <h1>
       Access Controls
     </h1>
+  </BlockSlot>
+  <BlockSlot @name="nav">
 {{#if isAuthorized }}
     {{partial 'dc/acls/nav'}}
 {{/if}}

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -14,6 +14,8 @@
           {{ item.Node }}
         </h1>
         <label for="toolbar-toggle"></label>
+    </BlockSlot>
+    <BlockSlot @name="nav">
         <TabNav @items={{
           compact
               (array

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -10,12 +10,12 @@
         </ol>
     </BlockSlot>
     <BlockSlot @name="header">
-      <div class="title-bar">
-        <h1>
-          {{ item.ID }}
-        </h1>
-        <ConsulExternalSource @item={{item}} />
-      </div>
+      <h1>
+        {{ item.ID }}
+      </h1>
+      <ConsulExternalSource @item={{item}} />
+    </BlockSlot>
+    <BlockSlot @name="nav">
       <dl>
         <dt>Service Name</dt>
         <dd><a href="{{href-to 'dc.services.show' item.Service}}">{{item.Service}}</a></dd>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -10,12 +10,12 @@
     </ol>
   </BlockSlot>
   <BlockSlot @name="header">
-    <div class="title-bar with-nav">
-      <h1>
-        {{item.Service.Service}}
-      </h1>
-      <ConsulExternalSource @item={{item.Service}} />
-    </div>
+    <h1>
+      {{item.Service.Service}}
+    </h1>
+    <ConsulExternalSource @item={{item.Service}} />
+  </BlockSlot>
+  <BlockSlot @name="nav">
     <TabNav @items={{
       compact
           (array

--- a/ui-v2/tests/pages/dc/services/instance.js
+++ b/ui-v2/tests/pages/dc/services/instance.js
@@ -2,7 +2,7 @@ export default function(visitable, attribute, collection, text, tabs) {
   return {
     visit: visitable('/:dc/services/:service/instances/:node/:id'),
     externalSource: attribute('data-test-external-source', '[data-test-external-source]', {
-      scope: '.title-bar',
+      scope: '.title',
     }),
     tabs: tabs('tab', ['health-checks', 'proxy-info', 'addresses', 'tags', 'meta-data']),
     serviceChecks: collection('[data-test-service-checks] li'),

--- a/ui-v2/tests/pages/dc/services/show.js
+++ b/ui-v2/tests/pages/dc/services/show.js
@@ -2,7 +2,7 @@ export default function(visitable, attribute, collection, text, intentions, filt
   return {
     visit: visitable('/:dc/services/:service'),
     externalSource: attribute('data-test-external-source', '[data-test-external-source]', {
-      scope: '.title-bar',
+      scope: '.title',
     }),
     dashboardAnchor: {
       href: attribute('href', '[data-test-dashboard-anchor]'),


### PR DESCRIPTION
We noticed that it was about time we dug into the app-view component as
the skin of the UI has changed quite a bit since this component started out
and it has now become slightly more consistent. The `%app-view` CSS has
not changed much and things needed within it have gradually become
clearer.

Apart from some refactoring of CSS here, the biggest change is the
addition of a `nav` Slot, which gets placed immediately underneath the
title of the page. This contains any main navigation elements for the
page. The majority of the rest of the changes are mainly just moving bits
around.

I also moved the old `%with-external-source-icon` closer to the last place that we use it (that is soon to go) so it's clearer that it can be deleted once we remove the last place its used.