### PR TITLE
acl: refactor the authmethod.Validator interface

### DIFF
--- a/agent/consul/acl_authmethod_test.go
+++ b/agent/consul/acl_authmethod_test.go
@@ -3,11 +3,10 @@ package consul
 import (
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDoesBindingRuleMatch(t *testing.T) {
+func TestDoesSelectorMatch(t *testing.T) {
 	type matchable struct {
 		A string `bexpr:"a"`
 		C string `bexpr:"c"`
@@ -40,8 +39,7 @@ func TestDoesBindingRuleMatch(t *testing.T) {
 			"", &matchable{A: "b"}, true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			rule := structs.ACLBindingRule{Selector: test.selector}
-			ok := doesBindingRuleMatch(&rule, test.details)
+			ok := doesSelectorMatch(test.selector, test.details)
 			require.Equal(t, test.ok, ok)
 		})
 	}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -685,13 +686,13 @@ func validateBindingRuleBindName(bindType, bindName string, availableFields []st
 }
 
 // computeBindingRuleBindName processes the HIL for the provided bind type+name
-// using the verified fields.
+// using the projected variables.
 //
 // - If the HIL is invalid ("", false, AN_ERROR) is returned.
 // - If the computed name is not valid for the type ("INVALID_NAME", false, nil) is returned.
 // - If the computed name is valid for the type ("VALID_NAME", true, nil) is returned.
-func computeBindingRuleBindName(bindType, bindName string, verifiedFields map[string]string) (string, bool, error) {
-	bindName, err := InterpolateHIL(bindName, verifiedFields)
+func computeBindingRuleBindName(bindType, bindName string, projectedVars map[string]string) (string, bool, error) {
+	bindName, err := InterpolateHIL(bindName, projectedVars, true)
 	if err != nil {
 		return "", false, err
 	}
@@ -1870,9 +1871,11 @@ func (a *ACL) BindingRuleSet(args *structs.ACLBindingRuleSetRequest, reply *stru
 		return err
 	}
 
+	// Create a blank placeholder identity for use in validation below.
+	blankID := validator.NewIdentity()
+
 	if rule.Selector != "" {
-		selectableVars := validator.MakeFieldMapSelectable(map[string]string{})
-		_, err := bexpr.CreateEvaluatorForType(rule.Selector, nil, selectableVars)
+		_, err := bexpr.CreateEvaluatorForType(rule.Selector, nil, blankID.SelectableFields)
 		if err != nil {
 			return fmt.Errorf("invalid Binding Rule: Selector is invalid: %v", err)
 		}
@@ -1893,7 +1896,7 @@ func (a *ACL) BindingRuleSet(args *structs.ACLBindingRuleSetRequest, reply *stru
 		return fmt.Errorf("Invalid Binding Rule: unknown BindType %q", rule.BindType)
 	}
 
-	if valid, err := validateBindingRuleBindName(rule.BindType, rule.BindName, validator.AvailableFields()); err != nil {
+	if valid, err := validateBindingRuleBindName(rule.BindType, rule.BindName, blankID.ProjectedVarNames()); err != nil {
 		return fmt.Errorf("Invalid Binding Rule: invalid BindName: %v", err)
 	} else if !valid {
 		return fmt.Errorf("Invalid Binding Rule: invalid BindName")
@@ -1909,7 +1912,7 @@ func (a *ACL) BindingRuleSet(args *structs.ACLBindingRuleSetRequest, reply *stru
 	}
 
 	if respErr, ok := resp.(error); ok {
-		return respErr
+		return fmt.Errorf("Failed to apply binding rule upsert request: %v", respErr)
 	}
 
 	if _, rule, err := a.srv.fsm.State().ACLBindingRuleGetByID(nil, rule.ID, &rule.EnterpriseMeta); err == nil && rule != nil {
@@ -2283,16 +2286,16 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLToken) erro
 	}
 
 	// 2. Send args.Data.BearerToken to method validator and get back a fields map
-	verifiedFields, desiredMeta, err := validator.ValidateLogin(auth.BearerToken)
+	verifiedIdentity, err := validator.ValidateLogin(context.Background(), auth.BearerToken)
 	if err != nil {
 		return err
 	}
 
 	// This always will return a valid pointer
-	targetMeta := method.TargetEnterpriseMeta(desiredMeta)
+	targetMeta := method.TargetEnterpriseMeta(verifiedIdentity.EnterpriseMeta)
 
 	// 3. send map through role bindings
-	serviceIdentities, roleLinks, err := a.srv.evaluateRoleBindings(validator, verifiedFields, &auth.EnterpriseMeta, targetMeta)
+	serviceIdentities, roleLinks, err := a.srv.evaluateRoleBindings(validator, verifiedIdentity, &auth.EnterpriseMeta, targetMeta)
 	if err != nil {
 		return err
 	}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1875,8 +1875,7 @@ func (a *ACL) BindingRuleSet(args *structs.ACLBindingRuleSetRequest, reply *stru
 	blankID := validator.NewIdentity()
 
 	if rule.Selector != "" {
-		_, err := bexpr.CreateEvaluatorForType(rule.Selector, nil, blankID.SelectableFields)
-		if err != nil {
+		if _, err := bexpr.CreateEvaluatorForType(rule.Selector, nil, blankID.SelectableFields); err != nil {
 			return fmt.Errorf("invalid Binding Rule: Selector is invalid: %v", err)
 		}
 	}

--- a/agent/consul/authmethod/authmethods.go
+++ b/agent/consul/authmethod/authmethods.go
@@ -1,6 +1,7 @@
 package authmethod
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -31,6 +32,9 @@ type Validator interface {
 	// Name returns the name of the auth method backing this validator.
 	Name() string
 
+	// NewIdentity creates a blank identity populated with empty values.
+	NewIdentity() *Identity
+
 	// ValidateLogin takes raw user-provided auth method metadata and ensures
 	// it is sane, provably correct, and currently valid. Relevant identifying
 	// data is extracted and returned for immediate use by the role binding
@@ -42,16 +46,33 @@ type Validator interface {
 	// Returns auth method specific metadata suitable for the Role Binding
 	// process as well as the desired enterprise meta for the token to be
 	// created.
-	ValidateLogin(loginToken string) (map[string]string, *structs.EnterpriseMeta, error)
+	ValidateLogin(ctx context.Context, loginToken string) (*Identity, error)
 
-	// AvailableFields returns a slice of all fields that are returned as a
-	// result of ValidateLogin. These are valid fields for use in any
-	// BindingRule tied to this auth method.
-	AvailableFields() []string
+	// Stop should be called to cease any background activity and free up
+	// resources.
+	Stop()
+}
 
-	// MakeFieldMapSelectable converts a field map as returned by ValidateLogin
-	// into a structure suitable for selection with a binding rule.
-	MakeFieldMapSelectable(fieldMap map[string]string) interface{}
+type Identity struct {
+	// SelectableFields is the format of this Identity suitable for selection
+	// with a binding rule.
+	SelectableFields interface{}
+
+	// ProjectedVars is the format of this Identity suitable for interpolation
+	// in a bind name within a binding rule.
+	ProjectedVars map[string]string
+
+	*structs.EnterpriseMeta
+}
+
+// ProjectedVarNames returns just the keyspace of the ProjectedVars map.
+func (i *Identity) ProjectedVarNames() []string {
+	v := make([]string, 0, len(i.ProjectedVars))
+	for k, _ := range i.ProjectedVars {
+		v = append(v, k)
+	}
+	sort.Strings(v)
+	return v
 }
 
 var (
@@ -116,6 +137,7 @@ func (c *authMethodCache) PutValidatorIfNewer(method *structs.ACLAuthMethod, val
 		if prev.ModifyIndex >= idx {
 			return prev.Validator
 		}
+		prev.Validator.Stop()
 	}
 
 	c.entries[method.Name] = &authMethodValidatorEntry{
@@ -126,6 +148,9 @@ func (c *authMethodCache) PutValidatorIfNewer(method *structs.ACLAuthMethod, val
 }
 
 func (c *authMethodCache) Purge() {
+	for _, entry := range c.entries {
+		entry.Validator.Stop()
+	}
 	c.entries = make(map[string]*authMethodValidatorEntry)
 }
 

--- a/agent/consul/authmethod/authmethods.go
+++ b/agent/consul/authmethod/authmethods.go
@@ -71,7 +71,6 @@ func (i *Identity) ProjectedVarNames() []string {
 	for k, _ := range i.ProjectedVars {
 		v = append(v, k)
 	}
-	sort.Strings(v)
 	return v
 }
 

--- a/agent/consul/authmethod/authmethods_oss.go
+++ b/agent/consul/authmethod/authmethods_oss.go
@@ -33,6 +33,6 @@ func (c *syncCache) PutValidatorIfNewer(method *structs.ACLAuthMethod, validator
 
 func (c *syncCache) Purge() {
 	c.lock.Lock()
+	defer c.lock.Unlock()
 	c.cache.Purge()
-	c.lock.Unlock()
 }

--- a/agent/consul/authmethod/kubeauth/k8s_oss.go
+++ b/agent/consul/authmethod/kubeauth/k8s_oss.go
@@ -7,5 +7,5 @@ import "github.com/hashicorp/consul/agent/structs"
 type enterpriseConfig struct{}
 
 func (v *Validator) k8sEntMetaFromFields(fields map[string]string) *structs.EnterpriseMeta {
-	return structs.DefaultEnterpriseMeta()
+	return nil
 }

--- a/agent/consul/authmethod/testing.go
+++ b/agent/consul/authmethod/testing.go
@@ -1,0 +1,47 @@
+package authmethod
+
+import (
+	"sort"
+
+	"github.com/hashicorp/go-bexpr"
+	"github.com/mitchellh/go-testing-interface"
+	"github.com/stretchr/testify/require"
+)
+
+// RequireIdentityMatch tests to see if the given Identity matches the provided
+// projected vars and filters for testing purpose.
+func RequireIdentityMatch(t testing.T, id *Identity, projectedVars map[string]string, filters ...string) {
+	t.Helper()
+
+	require.Equal(t, projectedVars, id.ProjectedVars)
+
+	names := make([]string, 0, len(projectedVars))
+	for k, _ := range projectedVars {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	require.Equal(t, names, id.ProjectedVarNames())
+
+	require.Nil(t, id.EnterpriseMeta)
+	// defaultEntMeta := *structs.DefaultEnterpriseMeta()
+
+	// id.EnterpriseMeta.Normalize()
+	// require.Equal(t, defaultEntMeta, id.EnterpriseMeta,
+	// 	"this auth method doesn't modify ent meta")
+
+	for _, filter := range filters {
+		eval, err := bexpr.CreateEvaluatorForType(filter, nil, id.SelectableFields)
+		if err != nil {
+			t.Fatalf("filter %q got err: %v", filter, err)
+		}
+
+		result, err := eval.Evaluate(id.SelectableFields)
+		if err != nil {
+			t.Fatalf("filter %q got err: %v", filter, err)
+		}
+
+		if !result {
+			t.Fatalf("filter %q did not match", filter)
+		}
+	}
+}

--- a/agent/consul/authmethod/testing.go
+++ b/agent/consul/authmethod/testing.go
@@ -21,13 +21,7 @@ func RequireIdentityMatch(t testing.T, id *Identity, projectedVars map[string]st
 	}
 	sort.Strings(names)
 	require.Equal(t, names, id.ProjectedVarNames())
-
 	require.Nil(t, id.EnterpriseMeta)
-	// defaultEntMeta := *structs.DefaultEnterpriseMeta()
-
-	// id.EnterpriseMeta.Normalize()
-	// require.Equal(t, defaultEntMeta, id.EnterpriseMeta,
-	// 	"this auth method doesn't modify ent meta")
 
 	for _, filter := range filters {
 		eval, err := bexpr.CreateEvaluatorForType(filter, nil, id.SelectableFields)

--- a/agent/consul/authmethod/testing.go
+++ b/agent/consul/authmethod/testing.go
@@ -13,14 +13,18 @@ import (
 func RequireIdentityMatch(t testing.T, id *Identity, projectedVars map[string]string, filters ...string) {
 	t.Helper()
 
+	gotNames := id.ProjectedVarNames()
+
 	require.Equal(t, projectedVars, id.ProjectedVars)
 
-	names := make([]string, 0, len(projectedVars))
+	expectNames := make([]string, 0, len(projectedVars))
 	for k, _ := range projectedVars {
-		names = append(names, k)
+		expectNames = append(expectNames, k)
 	}
-	sort.Strings(names)
-	require.Equal(t, names, id.ProjectedVarNames())
+	sort.Strings(expectNames)
+	sort.Strings(gotNames)
+
+	require.Equal(t, expectNames, gotNames)
 	require.Nil(t, id.EnterpriseMeta)
 
 	for _, filter := range filters {

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -443,7 +443,7 @@ func ServersGetACLMode(provider checkServersProvider, leaderAddr string, datacen
 
 // InterpolateHIL processes the string as if it were HIL and interpolates only
 // the provided string->string map as possible variables.
-func InterpolateHIL(s string, vars map[string]string, forceValuesToLowercase bool) (string, error) {
+func InterpolateHIL(s string, vars map[string]string, lowercase bool) (string, error) {
 	if strings.Index(s, "${") == -1 {
 		// Skip going to the trouble of parsing something that has no HIL.
 		return s, nil
@@ -456,7 +456,7 @@ func InterpolateHIL(s string, vars map[string]string, forceValuesToLowercase boo
 
 	vm := make(map[string]ast.Variable)
 	for k, v := range vars {
-		if forceValuesToLowercase {
+		if lowercase {
 			v = strings.ToLower(v)
 		}
 		vm[k] = ast.Variable{

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -443,7 +443,7 @@ func ServersGetACLMode(provider checkServersProvider, leaderAddr string, datacen
 
 // InterpolateHIL processes the string as if it were HIL and interpolates only
 // the provided string->string map as possible variables.
-func InterpolateHIL(s string, vars map[string]string) (string, error) {
+func InterpolateHIL(s string, vars map[string]string, forceValuesToLowercase bool) (string, error) {
 	if strings.Index(s, "${") == -1 {
 		// Skip going to the trouble of parsing something that has no HIL.
 		return s, nil
@@ -456,6 +456,9 @@ func InterpolateHIL(s string, vars map[string]string) (string, error) {
 
 	vm := make(map[string]ast.Variable)
 	for k, v := range vars {
+		if forceValuesToLowercase {
+			v = strings.ToLower(v)
+		}
 		vm[k] = ast.Variable{
 			Type:  ast.TypeString,
 			Value: v,

--- a/agent/consul/util_test.go
+++ b/agent/consul/util_test.go
@@ -441,127 +441,152 @@ func TestServersInDCMeetMinimumVersion(t *testing.T) {
 }
 
 func TestInterpolateHIL(t *testing.T) {
-	for _, test := range []struct {
-		name string
-		in   string
-		vars map[string]string
-		exp  string
-		ok   bool
+	for name, test := range map[string]struct {
+		in       string
+		vars     map[string]string
+		exp      string // when lower=false
+		expLower string // when lower=true
+		ok       bool
 	}{
 		// valid HIL
-		{
-			"empty",
+		"empty": {
 			"",
 			map[string]string{},
 			"",
+			"",
 			true,
 		},
-		{
-			"no vars",
+		"no vars": {
 			"nothing",
 			map[string]string{},
 			"nothing",
+			"nothing",
 			true,
 		},
-		{
-			"just var",
+		"just lowercase var": {
 			"${item}",
 			map[string]string{"item": "value"},
 			"value",
+			"value",
 			true,
 		},
-		{
-			"var in middle",
+		"just uppercase var": {
+			"${item}",
+			map[string]string{"item": "VaLuE"},
+			"VaLuE",
+			"value",
+			true,
+		},
+		"lowercase var in middle": {
 			"before ${item}after",
 			map[string]string{"item": "value"},
 			"before valueafter",
+			"before valueafter",
 			true,
 		},
-		{
-			"two vars",
+		"uppercase var in middle": {
+			"before ${item}after",
+			map[string]string{"item": "VaLuE"},
+			"before VaLuEafter",
+			"before valueafter",
+			true,
+		},
+		"two vars": {
 			"before ${item}after ${more}",
 			map[string]string{"item": "value", "more": "xyz"},
 			"before valueafter xyz",
+			"before valueafter xyz",
 			true,
 		},
-		{
-			"missing map val",
+		"missing map val": {
 			"${item}",
 			map[string]string{"item": ""},
+			"",
 			"",
 			true,
 		},
 		// "weird" HIL, but not technically invalid
-		{
-			"just end",
+		"just end": {
 			"}",
 			map[string]string{},
 			"}",
+			"}",
 			true,
 		},
-		{
-			"var without start",
+		"var without start": {
 			" item }",
 			map[string]string{"item": "value"},
 			" item }",
+			" item }",
 			true,
 		},
-		{
-			"two vars missing second start",
+		"two vars missing second start": {
 			"before ${ item }after  more }",
 			map[string]string{"item": "value", "more": "xyz"},
+			"before valueafter  more }",
 			"before valueafter  more }",
 			true,
 		},
 		// invalid HIL
-		{
-			"just start",
+		"just start": {
 			"${",
 			map[string]string{},
 			"",
+			"",
 			false,
 		},
-		{
-			"backwards",
+		"backwards": {
 			"}${",
 			map[string]string{},
 			"",
+			"",
 			false,
 		},
-		{
-			"no varname",
+		"no varname": {
 			"${}",
 			map[string]string{},
 			"",
+			"",
 			false,
 		},
-		{
-			"missing map key",
+		"missing map key": {
 			"${item}",
 			map[string]string{},
 			"",
-			false,
-		},
-		{
-			"var without end",
-			"${ item ",
-			map[string]string{"item": "value"},
 			"",
 			false,
 		},
-		{
-			"two vars missing first end",
+		"var without end": {
+			"${ item ",
+			map[string]string{"item": "value"},
+			"",
+			"",
+			false,
+		},
+		"two vars missing first end": {
 			"before ${ item after ${ more }",
 			map[string]string{"item": "value", "more": "xyz"},
+			"",
 			"",
 			false,
 		},
 	} {
-		t.Run(test.name, func(t *testing.T) {
-			out, err := InterpolateHIL(test.in, test.vars)
+		test := test
+		t.Run(name+" lower=false", func(t *testing.T) {
+			out, err := InterpolateHIL(test.in, test.vars, false)
 			if test.ok {
 				require.NoError(t, err)
 				require.Equal(t, test.exp, out)
+			} else {
+				require.NotNil(t, err)
+				require.Equal(t, out, "")
+			}
+		})
+		t.Run(name+" lower=true", func(t *testing.T) {
+			out, err := InterpolateHIL(test.in, test.vars, true)
+			if test.ok {
+				require.NoError(t, err)
+				require.Equal(t, test.expLower, out)
 			} else {
 				require.NotNil(t, err)
 				require.Equal(t, out, "")


### PR DESCRIPTION
This is a collection of refactors that make upcoming PRs easier to digest.

The main change is the introduction of the authmethod.Identity struct.
In the one and only current auth method (type=kubernetes) all of the
trusted identity attributes are both selectable and projectable, so they
were just passed around as a map[string]string.

When namespaces were added, this was slightly changed so that the
enterprise metadata can also come back from the login operation, so
login now returned two fields.

Now with some upcoming auth methods it won't be true that all identity
attributes will be both selectable and projectable, so rather than
update the login function to return 3 pieces of data it seemed worth it
to wrap those fields up and give them a proper name.