### PR TITLE
cli: Fix issue when creating service healthchecks that use scripts

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -190,7 +190,7 @@ type AgentCheckRegistration struct {
 type AgentServiceCheck struct {
 	CheckID           string              `json:",omitempty"`
 	Name              string              `json:",omitempty"`
-	Args              []string            `json:"ScriptArgs,omitempty"`
+	ScriptArgs        []string            `json:",omitempty"`
 	DockerContainerID string              `json:",omitempty"`
 	Shell             string              `json:",omitempty"` // Only supported for Docker.
 	Interval          string              `json:",omitempty"`

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -905,8 +905,8 @@ func TestAPI_AgentScriptCheck(t *testing.T) {
 		reg := &AgentCheckRegistration{
 			Name: "foo",
 			AgentServiceCheck: AgentServiceCheck{
-				Interval: "10s",
-				Args:     []string{"sh", "-c", "false"},
+				Interval:   "10s",
+				ScriptArgs: []string{"sh", "-c", "false"},
 			},
 		}
 		if err := agent.CheckRegister(reg); err != nil {
@@ -928,8 +928,8 @@ func TestAPI_AgentScriptCheck(t *testing.T) {
 			Port: 1234,
 			Checks: AgentServiceChecks{
 				&AgentServiceCheck{
-					Interval: "10s",
-					Args:     []string{"sh", "-c", "false"},
+					Interval:   "10s",
+					ScriptArgs: []string{"sh", "-c", "false"},
 				},
 			},
 		}
@@ -1063,7 +1063,7 @@ func TestAPI_AgentChecks_Docker(t *testing.T) {
 		ServiceID: "redis",
 		AgentServiceCheck: AgentServiceCheck{
 			DockerContainerID: "f972c95ebf0e",
-			Args:              []string{"/bin/true"},
+			ScriptArgs:        []string{"/bin/true"},
 			Shell:             "/bin/bash",
 			Interval:          "10s",
 		},

--- a/command/services/config_test.go
+++ b/command/services/config_test.go
@@ -150,6 +150,27 @@ func TestStructsToAgentService(t *testing.T) {
 				},
 			},
 		},
+		{
+			"Service with scriptcheck",
+			&structs.ServiceDefinition{
+				Name: "web",
+				Checks: structs.CheckTypes{
+					&structs.CheckType{
+						Name:       "scriptcheck",
+						ScriptArgs: []string{"sh", "-c", "/bin/true"},
+					},
+				},
+			},
+			&api.AgentServiceRegistration{
+				Name: "web",
+				Checks: api.AgentServiceChecks{
+					&api.AgentServiceCheck{
+						Name:       "scriptcheck",
+						ScriptArgs: []string{"sh", "-c", "/bin/true"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
The CLI reads the service definitions from file and coerces them into
a `structs.ServiceDefinition`. This struct uses the key `ScriptArgs`
to refer to the healthcheck arguments. The business logic of the CLI
expects an `api.AgentServiceRegistration` struct, which uses the `Args`
key. Since the names do not match, and no further configuration is
given, the data is lost when the `ServiceDefiniton` is converted into
the `AgentServiceRegistration` using `mapstructure` in
`config.serviceToAgentService`.

Renaming `Args` to `ScriptArgs` fixes this issue.
As far as I can tell, this struct is not exposed in the public API.

An additional test has been added to prevent regressions.

Fixes #6923