### PR TITLE
docs: fix misleading example for HTTP healthcheck

### DIFF
--- a/website/pages/docs/agent/checks.mdx
+++ b/website/pages/docs/agent/checks.mdx
@@ -155,7 +155,7 @@ A HTTP check:
     "http": "https://localhost:5000/health",
     "tls_skip_verify": false,
     "method": "POST",
-    "header": {"Content-Type": "application/json"},
+    "header": {"Content-Type": ["application/json"]},
     "body": "{\"method\":\"health\"}",
     "interval": "10s",
     "timeout": "1s"


### PR DESCRIPTION
The documentation says the `header` field has type `map[string][]string`,
but the example has `map[string]string`.