### PR TITLE
Require individual services in ingress entry to match protocols

### DIFF
--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -1286,6 +1286,25 @@ func TestHealth_ServiceNodes_Ingress_ACL(t *testing.T) {
 	}
 	require.Nil(t, msgpackrpc.CallWithCodec(codec, "Catalog.Register", &arg, &out))
 
+	// Register proxy-defaults with 'http' protocol
+	{
+		req := structs.ConfigEntryRequest{
+			Op:         structs.ConfigEntryUpsert,
+			Datacenter: "dc1",
+			Entry: &structs.ProxyConfigEntry{
+				Kind: structs.ProxyDefaults,
+				Name: structs.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"protocol": "http",
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: "root"},
+		}
+		var out bool
+		require.Nil(t, msgpackrpc.CallWithCodec(codec, "ConfigEntry.Apply", &req, &out))
+		require.True(t, out)
+	}
+
 	// Register ingress-gateway config entry
 	{
 		args := &structs.IngressGatewayConfigEntry{

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -5433,46 +5433,6 @@ func TestStateStore_GatewayServices_IngressProtocolFiltering(t *testing.T) {
 		require.Equal(uint64(8), idx)
 		require.ElementsMatch(results, expected)
 	})
-
-	// Relies on service defaults for service1 being set to grpc above
-	t.Run("only filters on gateway services from wildcards", func(t *testing.T) {
-		require := require.New(t)
-		expected := structs.GatewayServices{
-			{
-				Gateway:     structs.NewServiceID("ingress1", nil),
-				Service:     structs.NewServiceID("service1", nil),
-				GatewayKind: structs.ServiceKindIngressGateway,
-				Port:        4444,
-				Protocol:    "http",
-				RaftIndex: structs.RaftIndex{
-					CreateIndex: 8,
-					ModifyIndex: 8,
-				},
-			},
-		}
-
-		ingress1 := &structs.IngressGatewayConfigEntry{
-			Kind: "ingress-gateway",
-			Name: "ingress1",
-			Listeners: []structs.IngressListener{
-				{
-					Port:     4444,
-					Protocol: "http",
-					Services: []structs.IngressService{
-						{
-							Name: "service1",
-						},
-					},
-				},
-			},
-		}
-		assert.NoError(t, s.EnsureConfigEntry(8, ingress1, nil))
-
-		idx, results, err := s.GatewayServices(nil, "ingress1", nil)
-		require.NoError(err)
-		require.Equal(uint64(8), idx)
-		require.ElementsMatch(results, expected)
-	})
 }
 
 func setupIngressState(t *testing.T, s *Store) memdb.WatchSet {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -1667,6 +1667,25 @@ func TestDNS_IngressServiceLookup(t *testing.T) {
 		require.Nil(t, a.RPC("Catalog.Register", args, &out))
 	}
 
+	// Register proxy-defaults with 'http' protocol
+	{
+		req := structs.ConfigEntryRequest{
+			Op:         structs.ConfigEntryUpsert,
+			Datacenter: "dc1",
+			Entry: &structs.ProxyConfigEntry{
+				Kind: structs.ProxyDefaults,
+				Name: structs.ProxyConfigGlobal,
+				Config: map[string]interface{}{
+					"protocol": "http",
+				},
+			},
+			WriteRequest: structs.WriteRequest{Token: "root"},
+		}
+		var out bool
+		require.Nil(t, a.RPC("ConfigEntry.Apply", req, &out))
+		require.True(t, out)
+	}
+
 	// Register ingress-gateway config entry
 	{
 		args := &structs.IngressGatewayConfigEntry{

--- a/api/config_entry_gateways_test.go
+++ b/api/config_entry_gateways_test.go
@@ -23,8 +23,21 @@ func TestAPI_ConfigEntries_IngressGateway(t *testing.T) {
 		Name: "bar",
 	}
 
+	global := &ProxyConfigEntry{
+		Kind: ProxyDefaults,
+		Name: ProxyConfigGlobal,
+		Config: map[string]interface{}{
+			"protocol": "http",
+		},
+	}
+	// set default protocol to http so that ingress gateways pass validation
+	_, wm, err := config_entries.Set(global, nil)
+	require.NoError(t, err)
+	require.NotNil(t, wm)
+	require.NotEqual(t, 0, wm.RequestTime)
+
 	// set it
-	_, wm, err := config_entries.Set(ingress1, nil)
+	_, wm, err = config_entries.Set(ingress1, nil)
 	require.NoError(t, err)
 	require.NotNil(t, wm)
 	require.NotEqual(t, 0, wm.RequestTime)

--- a/test/integration/connect/envoy/case-ingress-gateway-http/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-http/config_entries.hcl
@@ -3,6 +3,13 @@ enable_central_service_config = true
 config_entries {
   bootstrap = [
     {
+      kind = "proxy-defaults"
+      name = "global"
+      config {
+        protocol = "http"
+      }
+    },
+    {
       kind = "ingress-gateway"
       name = "ingress-gateway"
 
@@ -17,13 +24,6 @@ config_entries {
           ]
         }
       ]
-    },
-    {
-      kind = "proxy-defaults"
-      name = "global"
-      config {
-        protocol = "http"
-      }
     },
     {
       kind = "service-router"

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/config_entries.hcl
@@ -3,6 +3,13 @@ enable_central_service_config = true
 config_entries {
   bootstrap = [
     {
+      kind = "proxy-defaults"
+      name = "global"
+      config {
+        protocol = "http"
+      }
+    },
+    {
       kind = "ingress-gateway"
       name = "ingress-gateway"
 
@@ -27,13 +34,6 @@ config_entries {
           ]
         }
       ]
-    },
-    {
-      kind = "proxy-defaults"
-      name = "global"
-      config {
-        protocol = "http"
-      }
     }
   ]
 }


### PR DESCRIPTION
Depends on #7678 

We require any non-wildcard services to match the protocol defined in
the listener on write, so that we can maintain a consistent experience
through ingress gateways. This also helps guard against accidental
misconfiguration by a user.

- Update tests that require an updated protocol for ingress gateways

We only do this for individually defined services because a wildcard service, `*`, will only route traffic to services with the same protocol as the listener it was defined on.