### PR TITLE
Allow ingress gateways to send empty clusters, routes, and listeners

### DIFF
--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -219,19 +219,28 @@ func (s *Server) process(stream ADSStream, reqCh <-chan *envoy.DiscoveryRequest)
 			resources: s.clustersFromSnapshot,
 			stream:    stream,
 			allowEmptyFn: func(cfgSnap *proxycfg.ConfigSnapshot) bool {
-				// Mesh and Terminating gateways are allowed to inform CDS of no clusters.
-				return cfgSnap.Kind == structs.ServiceKindMeshGateway || cfgSnap.Kind == structs.ServiceKindTerminatingGateway
+				// Mesh, Ingress, and Terminating gateways are allowed to inform CDS of
+				// no clusters.
+				return cfgSnap.Kind == structs.ServiceKindMeshGateway ||
+					cfgSnap.Kind == structs.ServiceKindTerminatingGateway ||
+					cfgSnap.Kind == structs.ServiceKindIngressGateway
 			},
 		},
 		RouteType: {
 			typeURL:   RouteType,
 			resources: routesFromSnapshot,
 			stream:    stream,
+			allowEmptyFn: func(cfgSnap *proxycfg.ConfigSnapshot) bool {
+				return cfgSnap.Kind == structs.ServiceKindIngressGateway
+			},
 		},
 		ListenerType: {
 			typeURL:   ListenerType,
 			resources: s.listenersFromSnapshot,
 			stream:    stream,
+			allowEmptyFn: func(cfgSnap *proxycfg.ConfigSnapshot) bool {
+				return cfgSnap.Kind == structs.ServiceKindIngressGateway
+			},
 		},
 	}
 


### PR DESCRIPTION
The necessary parts of #7784 , while I consider the edge cases involved in that PR.

This is useful when updating an config entry with no services, and the
expected behavior is that envoy closes all listeners and clusters.

We also allow empty routes because ingress gateways name route
configurations based on the port of the listener, so it is important we
remove any stale routes. Then, if a new listener with an old port is
added, we will not have to deal with stale routes hanging around routing
to the wrong place.

Endpoints are associated with clusters, and thus by deleting the
clusters we don't have to care about sending empty endpoint responses.