### PR TITLE
Remove timeout and call to Fatal from goroutine

### DIFF
--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -485,13 +485,6 @@ func TestManager_deliverLatest(t *testing.T) {
 		Port:    2222,
 	}
 
-	// Put an overall time limit on this test case so we don't have to guard every
-	// call to ensure the whole test doesn't deadlock.
-	timer := time.AfterFunc(100*time.Millisecond, func() {
-		t.Fatal("test timed out")
-	})
-	defer timer.Stop()
-
 	// test 1 buffered chan
 	ch1 := make(chan *ConfigSnapshot, 1)
 

--- a/agent/proxycfg/manager_test.go
+++ b/agent/proxycfg/manager_test.go
@@ -487,9 +487,10 @@ func TestManager_deliverLatest(t *testing.T) {
 
 	// Put an overall time limit on this test case so we don't have to guard every
 	// call to ensure the whole test doesn't deadlock.
-	time.AfterFunc(100*time.Millisecond, func() {
+	timer := time.AfterFunc(100*time.Millisecond, func() {
 		t.Fatal("test timed out")
 	})
+	defer timer.Stop()
 
 	// test 1 buffered chan
 	ch1 := make(chan *ConfigSnapshot, 1)


### PR DESCRIPTION
Fixes: #7508

The timer from `TestManager_deliverLatest` is calling `t.Fatal` after the test was marked as done: 
https://go.googlesource.com/go/+/master/src/testing/testing.go#626

This PR explicitly stops the timer when the test finishes.