### PR TITLE
test: make auth method cli crud test helper ignore the default namespace

### DIFF
--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -516,6 +516,10 @@ func getTestMethod(t *testing.T, client *api.Client, methodName string) *api.ACL
 	method.CreateIndex = 0
 	method.ModifyIndex = 0
 
+	if method.Namespace == "default" {
+		method.Namespace = ""
+	}
+
 	return method
 }
 

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -890,6 +890,10 @@ func getTestMethod(t *testing.T, client *api.Client, methodName string) *api.ACL
 	method.CreateIndex = 0
 	method.ModifyIndex = 0
 
+	if method.Namespace == "default" {
+		method.Namespace = ""
+	}
+
 	return method
 }
 


### PR DESCRIPTION
This test helper is used in oss and ent, but in ent the default namespace is `default` not `<emptystring>` which makes all of the whole-struct tests fail.