### PR TITLE
cli: Output message on success writing config entry

### DIFF
--- a/command/config/delete/config_delete.go
+++ b/command/config/delete/config_delete.go
@@ -58,11 +58,11 @@ func (c *cmd) Run(args []string) int {
 
 	_, err = client.ConfigEntries().Delete(c.kind, c.name, nil)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error deleting config entry %q / %q: %v", c.kind, c.name, err))
+		c.UI.Error(fmt.Sprintf("Error deleting config entry %s/%s: %v", c.kind, c.name, err))
 		return 1
 	}
 
-	// TODO (mkeeler) should we output anything when successful
+	c.UI.Info(fmt.Sprintf("Config entry deleted: %s/%s", c.kind, c.name))
 	return 0
 }
 

--- a/command/config/delete/config_delete_test.go
+++ b/command/config/delete/config_delete_test.go
@@ -40,7 +40,8 @@ func TestConfigDelete(t *testing.T) {
 
 	code := c.Run(args)
 	require.Equal(t, 0, code)
-	require.Empty(t, ui.OutputWriter.String())
+	require.Contains(t, ui.OutputWriter.String(),
+		"Config entry deleted: service-defaults/web")
 	require.Empty(t, ui.ErrorWriter.String())
 
 	entry, _, err := client.ConfigEntries().Get(api.ServiceDefaults, "web", nil)

--- a/command/config/read/config_read.go
+++ b/command/config/read/config_read.go
@@ -61,7 +61,7 @@ func (c *cmd) Run(args []string) int {
 
 	entry, _, err := client.ConfigEntries().Get(c.kind, c.name, nil)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error reading config entry %q / %q: %v", c.kind, c.name, err))
+		c.UI.Error(fmt.Sprintf("Error reading config entry %s/%s: %v", c.kind, c.name, err))
 		return 1
 	}
 

--- a/command/config/write/config_write.go
+++ b/command/config/write/config_write.go
@@ -85,16 +85,16 @@ func (c *cmd) Run(args []string) int {
 		written, _, err = entries.Set(entry, nil)
 	}
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error writing config entry %q / %q: %v", entry.GetKind(), entry.GetName(), err))
+		c.UI.Error(fmt.Sprintf("Error writing config entry %s/%s: %v", entry.GetKind(), entry.GetName(), err))
 		return 1
 	}
 
 	if !written {
-		c.UI.Error(fmt.Sprintf("Config entry %q / %q not updated", entry.GetKind(), entry.GetName()))
+		c.UI.Error(fmt.Sprintf("Config entry not updated: %s/%s", entry.GetKind(), entry.GetName()))
 		return 1
 	}
 
-	// TODO (mkeeler) should we output anything when successful
+	c.UI.Info(fmt.Sprintf("Config entry written: %s/%s", entry.GetKind(), entry.GetName()))
 	return 0
 }
 

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -48,6 +48,8 @@ func TestConfigWrite(t *testing.T) {
 
 		code := c.Run(args)
 		require.Empty(t, ui.ErrorWriter.String())
+		require.Contains(t, ui.OutputWriter.String(),
+			`Config entry written: service-defaults/web`)
 		require.Equal(t, 0, code)
 
 		entry, _, err := client.ConfigEntries().Get("service-defaults", "web", nil)
@@ -85,6 +87,8 @@ func TestConfigWrite(t *testing.T) {
 
 		code := c.Run(args)
 		require.Empty(t, ui.ErrorWriter.String())
+		require.Contains(t, ui.OutputWriter.String(),
+			`Config entry written: proxy-defaults/global`)
 		require.Equal(t, 0, code)
 
 		entry, _, err := client.ConfigEntries().Get(api.ProxyDefaults, api.ProxyConfigGlobal, nil)


### PR DESCRIPTION
This helps users feel like an action occurred, rather than no output leading them to wonder if it worked or not.

This also converts the formatting output of config entries from `"proxy-defaults" / "global"` to `proxy-defaults/global` as a slightly more readable form.