### PR TITLE
website: add link to certification on /community

### DIFF
--- a/website/pages/community/index.jsx
+++ b/website/pages/community/index.jsx
@@ -35,6 +35,11 @@ export default function CommunityPage() {
             body:
               'Paid [HashiCorp training courses](https://www.hashicorp.com/training) are also available in a city near you. Private training courses are also available.',
           },
+          {
+            header: 'Certification',
+            body:
+              "Learn more about our [Cloud Engineer Certification program](https://www.hashicorp.com/certification/) and [HashiCorp's Networking Automation Certification ](https://www.hashicorp.com/certification/consul-associate/) exams.",
+          },
         ]}
       />
     </div>


### PR DESCRIPTION
🔗 Preview Link TK

Adds the following section...
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/49507/81320336-05186880-905f-11ea-96fb-4be2dcb24107.png">
