### PR TITLE
ui: Small CSS tweaks

### DIFF
--- a/ui-v2/app/styles/base/components/tabs/skin.scss
+++ b/ui-v2/app/styles/base/components/tabs/skin.scss
@@ -1,3 +1,7 @@
+%tab-nav {
+  border-top: $decor-border-200;
+  border-color: $gray-200;
+}
 %tab-nav ul {
   list-style-type: none;
 }

--- a/ui-v2/app/styles/components/dom-recycling-table/layout.scss
+++ b/ui-v2/app/styles/components/dom-recycling-table/layout.scss
@@ -6,6 +6,9 @@
 }
 %dom-recycling-table tr > * {
   flex: 1 0 auto;
+  /* this means no simple CSS drive tooltips in dom-recycling tables */
+  /* ideally the thing inside the td should be overflow hidden */
+  overflow: hidden;
 }
 %dom-recycling-table tbody {
   /* important required as ember-collection will inline an overflow: visible*/


### PR DESCRIPTION
1. Reinstate top border on in page tabs (removed in https://github.com/hashicorp/consul/pull/7772)
2. Keep `overflow:hidden` just for dom-recycling-tables

Previous Screengrabs:

![Screenshot 2020-05-07 at 17 17 33](https://user-images.githubusercontent.com/554604/81321240-3e1a0280-908a-11ea-84c3-09213dd75c05.png)

---

![Screenshot 2020-05-07 at 17 17 40](https://user-images.githubusercontent.com/554604/81321250-4114f300-908a-11ea-9725-e21e32358f5b.png)

After Screengrabs:

![Screenshot 2020-05-07 at 18 12 34](https://user-images.githubusercontent.com/554604/81324165-73c0ea80-908e-11ea-8a7b-cd7687c01783.png)

---

![Screenshot 2020-05-07 at 18 12 39](https://user-images.githubusercontent.com/554604/81324176-77547180-908e-11ea-9ec0-c32b4670dc0d.png)

