### PR TITLE
xds: Allow LB policy to be configured

### DIFF
--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -338,7 +338,10 @@ func (s *Server) makeAppCluster(cfgSnap *proxycfg.ConfigSnapshot, name, pathProt
 	return c, err
 }
 
-func (s *Server) makeUpstreamClusterForPreparedQuery(upstream structs.Upstream, cfgSnap *proxycfg.ConfigSnapshot) (*envoy.Cluster, error) {
+func (s *Server) makeUpstreamClusterForPreparedQuery(
+	upstream structs.Upstream,
+	cfgSnap *proxycfg.ConfigSnapshot,
+) (*envoy.Cluster, error) {
 	var c *envoy.Cluster
 	var err error
 
@@ -381,6 +384,9 @@ func (s *Server) makeUpstreamClusterForPreparedQuery(upstream structs.Upstream, 
 		}
 		if cfg.Protocol == "http2" || cfg.Protocol == "grpc" {
 			c.Http2ProtocolOptions = &envoycore.Http2ProtocolOptions{}
+		}
+		if err := cfg.LoadBalancer.ApplyToCluster(c); err != nil {
+			return nil, err
 		}
 	}
 
@@ -479,6 +485,9 @@ func (s *Server) makeUpstreamClustersForDiscoveryChain(
 				Thresholds: makeThresholdsIfNeeded(cfg.Limits),
 			},
 			OutlierDetection: cfg.PassiveHealthCheck.AsOutlierDetection(),
+		}
+		if err := cfg.LoadBalancer.ApplyToCluster(c); err != nil {
+			return nil, err
 		}
 
 		proto := cfg.Protocol

--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -1052,12 +1052,13 @@ func makeFilter(name string, cfg proto.Message) (*envoylistener.Filter, error) {
 }
 
 func makeCommonTLSContextFromLeaf(cfgSnap *proxycfg.ConfigSnapshot, leaf *structs.IssuedCert) *envoyauth.CommonTlsContext {
-	// Concatenate all the root PEMs into one.
-	// TODO(banks): verify this actually works with Envoy (docs are not clear).
-	rootPEMS := ""
 	if cfgSnap.Roots == nil {
 		return nil
 	}
+
+	rootPEMS := ""
+	// Concatenate all the root PEMs into one.
+	// TODO(banks): verify this actually works with Envoy (docs are not clear).
 	for _, root := range cfgSnap.Roots.Roots {
 		rootPEMS += root.RootCert
 	}

--- a/agent/xds/server.go
+++ b/agent/xds/server.go
@@ -170,7 +170,7 @@ func (s *Server) StreamAggregatedResources(stream ADSStream) error {
 
 	err := s.process(stream, reqCh)
 	if err != nil {
-		s.Logger.Debug("Error handling ADS stream", "error", err)
+		s.Logger.Error("Error handling ADS stream", "error", err)
 	}
 
 	// prevents writing to a closed channel if send failed on blocked recv

--- a/test/integration/connect/envoy/case-upstream-config/s1.hcl
+++ b/test/integration/connect/envoy/case-upstream-config/s1.hcl
@@ -18,6 +18,9 @@ services {
                 interval = "22s"
                 max_failures = 4
               }
+              load_balancer {
+                policy = "random"
+              }
             }
           }
         ]

--- a/test/integration/connect/envoy/case-upstream-config/verify.bats
+++ b/test/integration/connect/envoy/case-upstream-config/verify.bats
@@ -50,3 +50,10 @@ load helpers
   [ "$(echo $CLUSTER_CONFIG | jq --raw-output '.outlier_detection.consecutive_5xx')" = "4" ]
   [ "$(echo $CLUSTER_CONFIG | jq --raw-output '.outlier_detection.interval')" = "22s" ]
 }
+
+@test "s1 proxy should have been configured with load balancer ring_hash" {
+  CLUSTER_CONFIG=$(get_envoy_cluster_config localhost:19000 s2.default.primary)
+  echo $CLUSTER_CONFIG
+
+  [ "$(echo $CLUSTER_CONFIG | jq --raw-output '.lb_policy')" = "RANDOM" ]
+}

--- a/website/pages/docs/connect/proxies/envoy.mdx
+++ b/website/pages/docs/connect/proxies/envoy.mdx
@@ -287,6 +287,10 @@ definition](/docs/connect/registration/service-registration) or
   - `max_failures` - The number of consecutive failures which cause a host to be
     removed from the load balancer.
 
+- `load_balancer` - Load balancer settings determine which host in the upstream
+  cluster will receive a request.
+
+  - `policy` - one of `round_robin` (default), `random`, `least_request`
 
 ### Gateway Options
 


### PR DESCRIPTION
Closes #6525, replaces #7728

This PR removes the LB types that use a hash, removing the need for a hash policy. It allows configuring the LB policy to `random` or `least_request`.