### PR TITLE
ui: Moves/loads policy datacenters info into the policy detail panel

### DIFF
--- a/ui-v2/app/components/policy-selector/index.hbs
+++ b/ui-v2/app/components/policy-selector/index.hbs
@@ -57,14 +57,22 @@
         </td>
       </BlockSlot>
       <BlockSlot @name="details">
+          {{#if (eq item.template '')}}
+            <DataSource
+              @src={{concat '/' item.Namespace '/' item.Datacenter '/policy/' item.ID}}
+              @onchange={{action (mut loadedItem) value="data"}}
+              @loading="lazy"
+            />
+          {{/if}}
+          <dl>
+            <dt>Datacenters:</dt>
+            <dd>
+              {{join ', ' (policy/datacenters (or loadedItem item))}}
+            </dd>
+          </dl>
           <label class="type-text">
             <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
             {{#if (eq item.template '')}}
-              <DataSource
-                @src={{concat '/' item.Namespace '/' item.Datacenter '/policy/' item.ID}}
-                @onchange={{action (mut loadedItem) value="data"}}
-                @loading="lazy"
-              />
               <CodeEditor @syntax="hcl" @readonly={{true}} @value={{or loadedItem.Rules item.Rules}} />
             {{else}}
               <CodeEditor @syntax="hcl" @readonly={{true}}>


### PR DESCRIPTION
In #7681 we removed the datacenter column from the Role > Policies listing. This was due to the fact that at this point we only know the datacenters of a policy if it had just been saved.

https://github.com/hashicorp/consul/pull/7681/files#diff-d376c2264c9ef1bcb9a5eb4d130ce2f0L59-L61

This re-adds the Datacenter information into the details panel of each Policy instead of into the rows. The contents of this panel are loaded when the panel is opened, which means that when we list the datacenters here they are correct.

Fixes: https://github.com/hashicorp/consul/issues/7563


