### PR TITLE
ui: Improve language surrounding marking a token as local/global

### DIFF
--- a/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-fieldsets.hbs
@@ -1,12 +1,11 @@
 <fieldset>
 {{#if create }}
-  <div class="type-toggle type-negative">
-    <span>Restrict this token to a local datacenter?</span>
-    <em>Local tokens get set in the Raft store of the local DC and do not ever get transmitted to the primary DC or replicated to any other DC.</em>
+  <div class="type-toggle">
     <label>
-      <input type="checkbox" name="Local" checked={{if (not Local) 'checked' }} onchange={{action 'change'}} />
-      <span>No</span>
+      <input type="checkbox" name="Local" checked={{if Local 'checked' }} onchange={{action 'change'}} />
+      <span>Restrict this token to a local datacenter?</span>
     </label>
+    <em>Local tokens get set in the Raft store of the local DC and do not ever get transmitted to the primary DC or replicated to any other DC.</em>
   </div>
 {{/if}}
   <label class="type-text validate-optional">


### PR DESCRIPTION
This commit moved the checkbox used for marking a token as
local/global to use a more traditional UX, i.e.:

```
[ ] Question?
```
Clicking the radiobutton toggles true/false:

```
true/on = yes
false/off = no
```

![Screenshot 2020-05-11 at 11 39 04](https://user-images.githubusercontent.com/554604/81552814-0bb72080-937c-11ea-87f8-454a74860862.png)


instead of:

```
false/off = yes
true/on = no
```

<img src="https://user-images.githubusercontent.com/1034429/78093928-22835400-7388-11ea-8a1f-3adff15b63c7.png" />


Fixes: https://github.com/hashicorp/consul/issues/7564

@opihana @jnwright if you are ok with this new UX when you get chance we should update the designs to reflect this new UX.