### PR TITLE
ui: Restrict %secondary-button to only form buttons in the main content

### DIFF
--- a/ui-v2/app/styles/components/buttons.scss
+++ b/ui-v2/app/styles/components/buttons.scss
@@ -6,14 +6,14 @@ a.type-create {
 // TODO: Once we move action-groups to use aria menu we can get rid of
 // some of this and just use not(aria-haspopup)
 button[type='reset'],
-form button[type='button']:not([aria-haspopup='menu']),
+%app-view-content form button[type='button']:not([aria-haspopup='menu']),
 header .actions button[type='button']:not(.copy-btn),
 button.type-cancel,
 html.template-error div > a {
   @extend %secondary-button;
 }
 .with-confirmation .type-delete,
-form button[type='button'].type-delete {
+%app-view-content form button[type='button'].type-delete {
   @extend %dangerous-button;
 }
 button.copy-btn {


### PR DESCRIPTION
This means that the new sort dropdown internal buttons don't take on the styling of the `%secondary-buttons`.

