### PR TITLE
Fix TestInternal_GatewayServiceDump_Ingress

### DIFF
--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1624,6 +1624,7 @@ func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
 				Service:     structs.ServiceID{ID: "db"},
 				GatewayKind: "ingress-gateway",
 				Port:        8888,
+				Protocol:    "tcp",
 			},
 		},
 		{
@@ -1655,6 +1656,7 @@ func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
 				Service:     structs.ServiceID{ID: "db"},
 				GatewayKind: "ingress-gateway",
 				Port:        8888,
+				Protocol:    "tcp",
 			},
 		},
 		{
@@ -1664,6 +1666,7 @@ func TestInternal_GatewayServiceDump_Ingress(t *testing.T) {
 				Service:     structs.ServiceID{ID: "web"},
 				GatewayKind: "ingress-gateway",
 				Port:        8080,
+				Protocol:    "tcp",
 			},
 		},
 	}


### PR DESCRIPTION
Protocol was added as a field on GatewayServices after
GatewayServiceDump PR branch was created.