### PR TITLE
Make envoy integration tests a `go test` suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,13 +529,22 @@ jobs:
       - run: docker build -t consul-dev -f ./build-support/docker/Consul-Dev.dockerfile .
       - run:
           name: Envoy Integration Tests
-          command: make test-envoy-integ SKIP_DOCKER_BUILD=1
+          command: |
+            mkdir -p /tmp/test-results/
+            gotestsum -- -timeout=30m -tags integration ./test/integration/connect/envoy
           environment:
+            GOTESTSUM_JUNITFILE: /tmp/test-results/results.xml
+            GOTESTSUM_FORMAT: standard-verbose
+            COMPOSE_INTERACTIVE_NO_CLI: 1
             # tput complains if this isn't set to something.
             TERM: ansi
       - store_artifacts:
           path: ./test/integration/connect/envoy/workdir/logs
           destination: container-logs
+      - store_test_results:
+          path: *TEST_RESULTS_DIR
+      - store_artifacts:
+          path: *TEST_RESULTS_DIR
 
   envoy-integration-test-1.12.2:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
       # Circle images but pick Go since we have to pick one of them.
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSIONS: "1.11.2"
+      ENVOY_VERSION: "1.11.2"
     steps: &ENVOY_INTEGRATION_TEST_STEPS
       - checkout
       # Get go binary from workspace
@@ -541,21 +541,21 @@ jobs:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSIONS: "1.12.2"
+      ENVOY_VERSION: "1.12.2"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
   envoy-integration-test-1.13.1:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSIONS: "1.13.1"
+      ENVOY_VERSION: "1.13.1"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
   envoy-integration-test-1.14.1:
     docker:
       - image: *GOLANG_IMAGE
     environment:
-      ENVOY_VERSIONS: "1.14.1"
+      ENVOY_VERSION: "1.14.1"
     steps: *ENVOY_INTEGRATION_TEST_STEPS
 
   # run integration tests for the connect ca providers

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -354,7 +354,7 @@ ui-docker: ui-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui
 
 test-envoy-integ: $(ENVOY_INTEG_DEPS)
-	@$(SHELL) $(CURDIR)/test/integration/connect/envoy/run-tests.sh
+	@go test -v -timeout=30m ./test/integration/connect/envoy
 
 test-connect-ca-providers:
 ifeq ("$(CIRCLECI)","true")

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -354,7 +354,7 @@ ui-docker: ui-build-image
 	@$(SHELL) $(CURDIR)/build-support/scripts/build-docker.sh ui
 
 test-envoy-integ: $(ENVOY_INTEG_DEPS)
-	@go test -v -timeout=30m ./test/integration/connect/envoy
+	@go test -v -timeout=30m -tags integration ./test/integration/connect/envoy
 
 test-connect-ca-providers:
 ifeq ("$(CIRCLECI)","true")

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -431,7 +431,7 @@ function docker_wget {
 function docker_curl {
   local DC=$1
   shift 1
-  docker run -ti --rm --network container:envoy_consul-${DC}_1 --entrypoint curl consul-dev "$@"
+  docker run --rm --network container:envoy_consul-${DC}_1 --entrypoint curl consul-dev "$@"
 }
 
 function docker_exec {

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -1,0 +1,67 @@
+package envoy
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestEnvoy(t *testing.T) {
+	var testcases = []string{
+		"case-badauthz",
+		"case-basic",
+		"case-centralconf",
+		"case-cfg-resolver-dc-failover-gateways-none",
+		"case-cfg-resolver-dc-failover-gateways-remote",
+		"case-cfg-resolver-defaultsubset",
+		"case-cfg-resolver-subset-onlypassing",
+		"case-cfg-resolver-subset-redirect",
+		"case-cfg-resolver-svc-failover",
+		"case-cfg-resolver-svc-redirect-http",
+		"case-cfg-resolver-svc-redirect-tcp",
+		"case-consul-exec",
+		"case-dogstatsd-udp",
+		"case-gateways-local",
+		"case-gateways-remote",
+		"case-gateway-without-services",
+		"case-grpc",
+		"case-http",
+		"case-http2",
+		"case-http-badauthz",
+		"case-ingress-gateway-http",
+		"case-ingress-gateway-multiple-services",
+		"case-ingress-gateway-simple",
+		"case-ingress-mesh-gateways-resolver",
+		"case-multidc-rsa-ca",
+		"case-prometheus",
+		"case-statsd-udp",
+		"case-stats-proxy",
+		"case-terminating-gateway-simple",
+		"case-terminating-gateway-subsets",
+		"case-terminating-gateway-without-services",
+		"case-upstream-config",
+		"case-wanfed-gw",
+		"case-zipkin",
+	}
+
+	runCmd(t, "suite_setup")
+	defer runCmd(t, "suite_teardown")
+
+	for _, tc := range testcases {
+		t.Run(tc, func(t *testing.T) {
+			runCmd(t, "run_tests", "CASE_DIR="+tc)
+		})
+	}
+}
+
+func runCmd(t *testing.T, c string, env ...string) {
+	t.Helper()
+
+	cmd := exec.Command("./run-tests.sh", c)
+	cmd.Env = append(os.Environ(), env...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+}

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package envoy
 
 import (

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -16,8 +16,8 @@ FILTER_TESTS=${FILTER_TESTS:-}
 # only fail when run as part of a whole suite but work in isolation.
 STOP_ON_FAIL=${STOP_ON_FAIL:-}
 
-# ENVOY_VERSIONS is the list of envoy versions to run each test against
-ENVOY_VERSIONS=${ENVOY_VERSIONS:-"1.11.2 1.12.3 1.13.1 1.14.1"}
+# ENVOY_VERSION to run each test against
+ENVOY_VERSION=${ENVOY_VERSION:-"1.14.1"}
 
 if [ ! -z "$DEBUG" ] ; then
   set -x
@@ -26,9 +26,6 @@ fi
 DIR=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 cd $DIR
-
-LEAVE_CONSUL_UP=${LEAVE_CONSUL_UP:-}
-PROXY_LOGS_ON_FAIL=${PROXY_LOGS_ON_FAIL:-}
 
 source helpers.bash
 
@@ -319,12 +316,9 @@ function runTest {
 RESULT=0
 
 for c in ./case-*/ ; do
-  for ev in $ENVOY_VERSIONS ; do
     export CASE_DIR="${c}"
     export CASE_NAME=$( basename $c | cut -c6- )
-    export CASE_ENVOY_VERSION="envoy $ev"
-    export CASE_STR="$CASE_NAME, $CASE_ENVOY_VERSION"
-    export ENVOY_VERSION="${ev}"
+    export CASE_STR="$CASE_NAME, envoy $ENVOY_VERSION"
     export LOG_DIR="workdir/logs/${CASE_DIR}/${ENVOY_VERSION}"
     echo "================================================"
     echoblue "CASE $CASE_STR"
@@ -344,7 +338,6 @@ for c in ./case-*/ ; do
       echo "  => STOPPING because STOP_ON_FAIL set"
       break 2
     fi
-  done
 done
 
 cleanup


### PR DESCRIPTION
This is a small change to the envoy integration test suite. It wraps the existing test cases in golang so that we can easily create a junit xml test report. 

In the future we can port more of the setup logic to Go, and we can support new test cases that are written entirely in Go without having to rewrite every test case.