### PR TITLE
ui: Test Improvements

### DIFF
--- a/ui-v2/app/components/consul-service-list/index.hbs
+++ b/ui-v2/app/components/consul-service-list/index.hbs
@@ -21,7 +21,7 @@
     </li>
   {{/if}}
   {{#if (get proxies item.Name)}}
-    <li class="proxy">
+    <li data-test-proxy class="proxy">
       connected with proxy
     </li>
   {{/if}}

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -21,10 +21,10 @@
     <TabNav @items={{
       compact
           (array
-                (hash label="Instances" href=(href-to "dc.services.show.instances") selected=(is-href "dc.services.show.instances"))
-                (hash label="Intentions" href=(href-to "dc.services.show.intentions") selected=(is-href "dc.services.show.intentions"))
-  (if (not-eq chain)  (hash label="Routing" href=(href-to "dc.services.show.routing") selected=(is-href "dc.services.show.routing")) '')
-                (hash label="Tags" href=(href-to "dc.services.show.tags") selected=(is-href "dc.services.show.tags"))
+                        (hash label="Instances" href=(href-to "dc.services.show.instances") selected=(is-href "dc.services.show.instances"))
+                        (hash label="Intentions" href=(href-to "dc.services.show.intentions") selected=(is-href "dc.services.show.intentions"))
+(if (not-eq chain null) (hash label="Routing" href=(href-to "dc.services.show.routing") selected=(is-href "dc.services.show.routing")) '')
+                        (hash label="Tags" href=(href-to "dc.services.show.tags") selected=(is-href "dc.services.show.tags"))
           )
     }}/>
   {{/if}}

--- a/ui-v2/tests/acceptance/components/text-input.feature
+++ b/ui-v2/tests/acceptance/components/text-input.feature
@@ -2,7 +2,7 @@
 Feature: components / text-input: Text input
   Background:
     Given 1 datacenter model with the value "dc-1"
-  Scenario:
+  Scenario: KV page
     When I visit the kv page for yaml
     ---
       dc: dc-1
@@ -15,7 +15,7 @@ Feature: components / text-input: Text input
     {"additional": "hi", "value": "there"}
     ---
     Then I see submitIsEnabled
-  Scenario:
+  Scenario: ACL page
     When I visit the acl page for yaml
     ---
       dc: dc-1

--- a/ui-v2/tests/acceptance/dc/nodes/show.feature
+++ b/ui-v2/tests/acceptance/dc/nodes/show.feature
@@ -54,7 +54,7 @@ Feature: dc / nodes / show: Show node
     ---
     And I see healthChecks on the tabs
     And I see services on the tabs
-    And I see roundTripTime on the tabs
+    And I don't see roundTripTime on the tabs
     And I see lockSessions on the tabs
     And I see servicesIsSelected on the tabs
   Scenario: A node warns when deregistered whilst blocking

--- a/ui-v2/tests/acceptance/dc/services/index.feature
+++ b/ui-v2/tests/acceptance/dc/services/index.feature
@@ -75,6 +75,25 @@ Feature: dc / services / index: List Services
     - ingress-gateway
     - terminating-gateway
     ---
+  Scenario: View a Service with a proxy
+    Given 1 datacenter model with the value "dc-1"
+    And 3 service models from yaml
+    ---
+      - Name: Service-0
+        Kind: ~
+      - Name: Service-0-proxy
+        Kind: connect-proxy
+        ProxyFor: ['Service-0']
+      - Name: Service-1
+        Kind: ~
+    ---
 
-
-
+    When I visit the services page for yaml
+    ---
+      dc: dc-1
+    ---
+    Then the url should be /dc-1/services
+    And the title should be "Services - Consul"
+    Then I see 2 service models
+    And I see proxy on the services.0
+    And I don't see proxy on the services.1

--- a/ui-v2/tests/acceptance/dc/services/show-routing.feature
+++ b/ui-v2/tests/acceptance/dc/services/show-routing.feature
@@ -1,5 +1,5 @@
 @setupApplicationTest
-Feature: dc / services / Show Routing for Service
+Feature: dc / services / show-routing: Show Routing for Service
   Scenario: Given a service, the Routing tab should display
     Given 1 datacenter model with the value "dc1"
     And 1 node models

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -87,7 +87,7 @@ export default {
   index: create(index(visitable, collection)),
   dcs: create(dcs(visitable, clickable, attribute, collection)),
   services: create(
-    services(visitable, clickable, text, attribute, collection, popoverSort, radiogroup)
+    services(visitable, clickable, text, attribute, isPresent, collection, popoverSort, radiogroup)
   ),
   service: create(
     service(visitable, attribute, collection, text, consulIntentionList, catalogToolbar, tabgroup)

--- a/ui-v2/tests/pages/dc/services/index.js
+++ b/ui-v2/tests/pages/dc/services/index.js
@@ -1,9 +1,10 @@
-export default function(visitable, clickable, text, attribute, collection, popoverSort) {
+export default function(visitable, clickable, text, attribute, present, collection, popoverSort) {
   const service = {
     name: text('[data-test-service-name]'),
     service: clickable('a'),
     externalSource: attribute('data-test-external-source', '[data-test-external-source]'),
     kind: attribute('data-test-kind', '[data-test-kind]'),
+    proxy: present('[data-test-proxy]'),
   };
   return {
     visit: visitable('/:dc/services'),

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -114,7 +114,7 @@ export default function(assert, library) {
     }
     obj = parent[last];
     if (typeof obj === 'undefined') {
-      throw new Error(`The '${path}' object doesn't exist`);
+      throw new Error(`PageObject not found: The '${path}' object doesn't exist`);
     }
     if (typeof obj === 'function') {
       obj = obj.bind(parent);

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -105,35 +105,6 @@ export default function(scenario, assert, find, currentPage) {
         );
       });
     })
-    // .then(["I don't see $property"], function(property) {
-    //   const message = `Expected to not see ${property}`;
-    //   let prop;
-    //   try {
-    //     prop = currentPage()[property];
-    //   } catch (e) {
-    //     if (isExpectedError(e)) {
-    //       assert.ok(true, message);
-    //     } else {
-    //       throw e;
-    //     }
-    //   }
-    //   if (typeof prop === 'function') {
-    //     assert.throws(
-    //       function() {
-    //         prop();
-    //       },
-    //       function(e) {
-    //         return isExpectedError(e);
-    //       },
-    //       message
-    //     );
-    //   } else {
-    //     assert.notOk(prop);
-    //   }
-    // })
-    // .then(['I see $property'], function(property) {
-    //   assert.ok(currentPage()[property], `Expected to see ${property}`);
-    // })
     .then([`I${dont} see $property`, `I${dont} see $property on the $component`], function(
       negative,
       property,

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -1,9 +1,12 @@
 /* eslint no-console: "off" */
 import $ from '-jquery';
 
-const notFound = 'Element not found';
+const elementNotFound = 'Element not found';
+// this error comes from our pageObject `find `function
+const pageObjectNotFound = 'PageObject not found';
 const cannotDestructure = "Cannot destructure property 'context'";
 const cannotReadContext = "Cannot read property 'context' of undefined";
+
 // checking for existence of pageObjects is pretty difficult
 // errors are thrown but we should check to make sure its the error that we
 // want and not another real error
@@ -24,11 +27,20 @@ const cannotReadContext = "Cannot read property 'context' of undefined";
 // that real errors are picked up by the tests, so if this gets unmanageable at any point
 // look at checking for the instance of e being TypeError or similar
 const isExpectedError = function(e) {
-  return [notFound, cannotDestructure, cannotReadContext].some(item => e.message.startsWith(item));
+  return [pageObjectNotFound, elementNotFound, cannotDestructure, cannotReadContext].some(item =>
+    e.message.startsWith(item)
+  );
 };
-
+const dont = `( don't| shouldn't| can't)?`;
 export default function(scenario, assert, find, currentPage) {
   scenario
+    .then(['I see $num of the $component object'], function(num, component) {
+      assert.equal(
+        currentPage()[component].length,
+        num,
+        `Expected to see ${num} items in the ${component} object`
+      );
+    })
     .then('I see $property on the $component like yaml\n$yaml', function(
       property,
       component,
@@ -93,99 +105,86 @@ export default function(scenario, assert, find, currentPage) {
         );
       });
     })
-    .then(['I see $property on the $component'], function(property, component) {
-      // TODO: Time to work on repetition
-      // Collection
-      var obj;
-      if (typeof currentPage()[component].objectAt === 'function') {
-        obj = currentPage()[component].objectAt(0);
-      } else {
-        obj = currentPage()[component];
-      }
-      let _component;
-      if (typeof obj === 'function') {
-        const func = obj[property].bind(obj);
-        try {
-          _component = func();
-        } catch (e) {
+    // .then(["I don't see $property"], function(property) {
+    //   const message = `Expected to not see ${property}`;
+    //   let prop;
+    //   try {
+    //     prop = currentPage()[property];
+    //   } catch (e) {
+    //     if (isExpectedError(e)) {
+    //       assert.ok(true, message);
+    //     } else {
+    //       throw e;
+    //     }
+    //   }
+    //   if (typeof prop === 'function') {
+    //     assert.throws(
+    //       function() {
+    //         prop();
+    //       },
+    //       function(e) {
+    //         return isExpectedError(e);
+    //       },
+    //       message
+    //     );
+    //   } else {
+    //     assert.notOk(prop);
+    //   }
+    // })
+    // .then(['I see $property'], function(property) {
+    //   assert.ok(currentPage()[property], `Expected to see ${property}`);
+    // })
+    .then([`I${dont} see $property`, `I${dont} see $property on the $component`], function(
+      negative,
+      property,
+      component
+    ) {
+      const isNegative = typeof negative !== 'undefined';
+      let message = `Expected to${isNegative ? ' not' : ''} see ${property}`;
+      let target;
+      try {
+        if (typeof component === 'string') {
+          property = `${component}.${property}`;
+          message = `${message} on ${component}`;
+        }
+        target = find(property);
+      } catch (e) {
+        if (isNegative) {
+          if (isExpectedError(e)) {
+            assert.ok(true, message);
+            return Promise.resolve();
+          } else {
+            console.error(e);
+            throw e;
+          }
+        } else {
           console.error(e);
-          throw new Error(
-            `The '${property}' property on the '${component}' page object doesn't exist`
+          throw e;
+        }
+      }
+      if (typeof target === 'function') {
+        if (isNegative) {
+          assert.throws(
+            function() {
+              target();
+            },
+            function(e) {
+              return isExpectedError(e);
+            },
+            message
           );
-        }
-      } else {
-        _component = obj;
-      }
-      assert.ok(_component[property], `Expected to see ${property} on ${component}`);
-    })
-    .then(['I see $num of the $component object'], function(num, component) {
-      assert.equal(
-        currentPage()[component].length,
-        num,
-        `Expected to see ${num} items in the ${component} object`
-      );
-    })
-    .then(["I don't see $property on the $component"], function(property, component) {
-      const message = `Expected to not see ${property} on ${component}`;
-      // Cope with collections
-      let obj;
-      if (typeof currentPage()[component].objectAt === 'function') {
-        obj = currentPage()[component].objectAt(0);
-      } else {
-        obj = currentPage()[component];
-      }
-      let prop;
-      try {
-        prop = obj[property];
-      } catch (e) {
-        if (isExpectedError(e)) {
-          assert.ok(true, message);
+          return Promise.resolve();
         } else {
-          throw e;
+          try {
+            target = target();
+          } catch (e) {
+            console.error(e);
+            throw new Error(`The '${property}' page object doesn't exist`);
+          }
         }
       }
-      if (typeof prop === 'function') {
-        assert.throws(
-          function() {
-            prop();
-          },
-          function(e) {
-            return isExpectedError(e);
-          },
-          message
-        );
-      } else {
-        assert.notOk(prop);
-      }
-    })
-    .then(["I don't see $property"], function(property) {
-      const message = `Expected to not see ${property}`;
-      let prop;
-      try {
-        prop = currentPage()[property];
-      } catch (e) {
-        if (isExpectedError(e)) {
-          assert.ok(true, message);
-        } else {
-          throw e;
-        }
-      }
-      if (typeof prop === 'function') {
-        assert.throws(
-          function() {
-            prop();
-          },
-          function(e) {
-            return isExpectedError(e);
-          },
-          message
-        );
-      } else {
-        assert.notOk(prop);
-      }
-    })
-    .then(['I see $property'], function(property) {
-      assert.ok(currentPage()[property], `Expected to see ${property}`);
+      assert[isNegative ? 'notOk' : 'ok'](target, message);
+      return Promise.resolve();
     })
     .then(
       [


### PR DESCRIPTION
This PR does 4 things:

1. Combines all of our "I see/don't see" steps into 1 function instead of 4 that were implemented slightly differently.
2. As a consequence we found 2 assertions that weren't asserting what we expected, so we fix those up here also.
3. Add some more meta data/titles to a couple of scenarios
4. Add basic tests to the proxyFor/connected with proxy labels (the root of the reasoning for this PR)
