### PR TITLE
Connected with proxy

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -21,18 +21,18 @@ type GatewayConfig struct {
 
 // ServiceSummary is used to summarize a service
 type ServiceSummary struct {
-	Kind              structs.ServiceKind `json:",omitempty"`
-	Name              string
-	Tags              []string
-	Nodes             []string
-	Connected         bool
-	InstanceCount     int
-	ChecksPassing     int
-	ChecksWarning     int
-	ChecksCritical    int
-	ExternalSources   []string
-	externalSourceSet map[string]struct{} // internal to track uniqueness
-	GatewayConfig     GatewayConfig       `json:",omitempty"`
+	Kind               structs.ServiceKind `json:",omitempty"`
+	Name               string
+	Tags               []string
+	Nodes              []string
+	ConnectedWithProxy bool
+	InstanceCount      int
+	ChecksPassing      int
+	ChecksWarning      int
+	ChecksCritical     int
+	ExternalSources    []string
+	externalSourceSet  map[string]struct{} // internal to track uniqueness
+	GatewayConfig      GatewayConfig       `json:",omitempty"`
 
 	structs.EnterpriseMeta
 }
@@ -283,9 +283,13 @@ func summarizeServices(dump structs.ServiceDump) []*ServiceSummary {
 
 	// Loop over services one more time and populate whether they're connected with proxy using the info in the connected map
 	for _, csn := range dump {
+		// Will happen in cases where we only have the GatewayServices mapping in ServiceInfo
+		if csn.Service == nil {
+			continue
+		}
 		sid := structs.NewServiceID(csn.Service.Service, &csn.Service.EnterpriseMeta)
 		if sum, ok := summary[sid]; ok && connected[sid] {
-			sum.Connected = true
+			sum.ConnectedWithProxy = true
 		}
 	}
 

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -281,18 +281,6 @@ func summarizeServices(dump structs.ServiceDump) []*ServiceSummary {
 		}
 	}
 
-	// Loop over services one more time and populate whether they're connected with proxy using the info in the connected map
-	for _, csn := range dump {
-		// Will happen in cases where we only have the GatewayServices mapping in ServiceInfo
-		if csn.Service == nil {
-			continue
-		}
-		sid := structs.NewServiceID(csn.Service.Service, &csn.Service.EnterpriseMeta)
-		if sum, ok := summary[sid]; ok && connected[sid] {
-			sum.ConnectedWithProxy = true
-		}
-	}
-
 	// Return the services in sorted order
 	sort.Slice(services, func(i, j int) bool {
 		return services[i].LessThan(&services[j])
@@ -301,6 +289,9 @@ func summarizeServices(dump structs.ServiceDump) []*ServiceSummary {
 	for idx, service := range services {
 		// Sort the nodes and tags
 		sum := summary[service]
+		if connected[service] {
+			sum.ConnectedWithProxy = true
+		}
 		sort.Strings(sum.Nodes)
 		sort.Strings(sum.Tags)
 		output[idx] = sum

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -315,7 +315,6 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
-			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -324,6 +323,7 @@ func TestUiServices(t *testing.T) {
 				Name:           "api",
 				Tags:           []string{"tag1", "tag2"},
 				Nodes:          []string{"foo"},
+				Connected:      true,
 				InstanceCount:  1,
 				ChecksPassing:  2,
 				ChecksWarning:  1,
@@ -347,7 +347,6 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
-				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,
@@ -384,7 +383,6 @@ func TestUiServices(t *testing.T) {
 		// internal accounting that users don't see can be blown away
 		for _, sum := range summary {
 			sum.externalSourceSet = nil
-			sum.proxyForSet = nil
 		}
 
 		expected := []*ServiceSummary{
@@ -393,6 +391,7 @@ func TestUiServices(t *testing.T) {
 				Name:           "api",
 				Tags:           []string{"tag1", "tag2"},
 				Nodes:          []string{"foo"},
+				Connected:      true,
 				InstanceCount:  1,
 				ChecksPassing:  2,
 				ChecksWarning:  1,
@@ -405,7 +404,6 @@ func TestUiServices(t *testing.T) {
 				Tags:            nil,
 				Nodes:           []string{"bar", "foo"},
 				InstanceCount:   2,
-				ProxyFor:        []string{"api"},
 				ChecksPassing:   2,
 				ChecksWarning:   1,
 				ChecksCritical:  1,

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -319,16 +319,16 @@ func TestUiServices(t *testing.T) {
 
 		expected := []*ServiceSummary{
 			&ServiceSummary{
-				Kind:           structs.ServiceKindTypical,
-				Name:           "api",
-				Tags:           []string{"tag1", "tag2"},
-				Nodes:          []string{"foo"},
-				Connected:      true,
-				InstanceCount:  1,
-				ChecksPassing:  2,
-				ChecksWarning:  1,
-				ChecksCritical: 0,
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+				Kind:               structs.ServiceKindTypical,
+				Name:               "api",
+				Tags:               []string{"tag1", "tag2"},
+				Nodes:              []string{"foo"},
+				ConnectedWithProxy: true,
+				InstanceCount:      1,
+				ChecksPassing:      2,
+				ChecksWarning:      1,
+				ChecksCritical:     0,
+				EnterpriseMeta:     *structs.DefaultEnterpriseMeta(),
 			},
 			&ServiceSummary{
 				Kind:           structs.ServiceKindTypical,
@@ -387,16 +387,16 @@ func TestUiServices(t *testing.T) {
 
 		expected := []*ServiceSummary{
 			&ServiceSummary{
-				Kind:           structs.ServiceKindTypical,
-				Name:           "api",
-				Tags:           []string{"tag1", "tag2"},
-				Nodes:          []string{"foo"},
-				Connected:      true,
-				InstanceCount:  1,
-				ChecksPassing:  2,
-				ChecksWarning:  1,
-				ChecksCritical: 0,
-				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
+				Kind:               structs.ServiceKindTypical,
+				Name:               "api",
+				Tags:               []string{"tag1", "tag2"},
+				Nodes:              []string{"foo"},
+				ConnectedWithProxy: true,
+				InstanceCount:      1,
+				ChecksPassing:      2,
+				ChecksWarning:      1,
+				ChecksCritical:     0,
+				EnterpriseMeta:     *structs.DefaultEnterpriseMeta(),
 			},
 			&ServiceSummary{
 				Kind:            structs.ServiceKindConnectProxy,


### PR DESCRIPTION
For the UI to display if a service is `connected with proxy` they are currently checking whether that service's name is present in the `ProxyFor` array of a proxy. 

Terminating Gateways will need a similar flag since they act as a proxy for services. However, unlike sidecars, gateways can target services across namespaces to the ProxyFor string array is insufficient. 

With the `ConnectedWithX` flags we will track if a service in a namespace is a proxy's destination or is linked to a gateway.

We do not have the endpoint that provides the gateway association data yet, this PR just makes some changes to the summary function first.