### PR TITLE
ui: Add namespaces to gateway services

### DIFF
--- a/ui-v2/app/templates/dc/services/show/services.hbs
+++ b/ui-v2/app/templates/dc/services/show/services.hbs
@@ -7,11 +7,19 @@
         <a href="{{env 'CONSUL_DOCS_URL'}}/connect/terminating_gateway.html" target="_blank" rel="noopener noreferrer">step-by-step guide.</a>
         
       </p>
+    {{#let item.Service.Namespace as |nspace|}}
       <ListCollection @cellHeight={{73}} @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
         <a data-test-service-name href={{href-to 'dc.services.show' item.Name}} class={{service/health-checks item}}>
           {{item.Name}}
         </a>
         <ul>
+          {{#if (env 'CONSUL_NSPACES_ENABLED')}}
+            {{#if (not-eq item.Namespace nspace)}}
+              <li class="nspace">
+                {{item.Namespace}}
+              </li>
+            {{/if}}
+          {{/if}}
           {{#if (not-eq item.InstanceCount 0)}}
             <li>
               {{format-number item.InstanceCount}} {{pluralize item.InstanceCount 'Instance' without-count=true}}
@@ -24,6 +32,7 @@
           </TagList>
         </ul>
       </ListCollection>
+    {{/let}}
     </section>
   {{else}}
     <p>

--- a/ui-v2/app/templates/dc/services/show/upstreams.hbs
+++ b/ui-v2/app/templates/dc/services/show/upstreams.hbs
@@ -6,11 +6,19 @@
         Upstreams are services that may receive traffic from this gateway. Learn more about configuring gateways in our
         <a href="{{env 'CONSUL_DOCS_URL'}}/connect/ingress_gateway.html" target="_blank" rel="noopener noreferrer">documentation.</a>
       </p>
+    {{#let item.Service.Namespace as |nspace|}}
       <ListCollection @cellHeight={{73}} @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
         <a data-test-service-name href={{href-to 'dc.services.show' item.Name}}>
           {{item.Name}}
         </a>
         <ul>
+        {{#if (env 'CONSUL_NSPACES_ENABLED')}}
+          {{#if (not-eq item.Namespace nspace)}}
+            <li class="nspace">
+              {{item.Namespace}}
+            </li>
+          {{/if}}
+        {{/if}}
         {{#if (not-eq item.GatewayConfig.ListenerPort 0)}}
           <li class="port">
             <CopyButton
@@ -22,6 +30,7 @@
         {{/if}}
         </ul>
       </ListCollection>
+    {{/let}}
     </section>
   {{else}}
     <p>

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1211,9 +1211,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^2.6.2":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.15.0.tgz#033b3887449f92f26156b123f251f9e6e1b42e52"
-  integrity sha512-uPzwU/MPzPDhhsLjY3X1rKIjZDOSbqYHMGM0f6n15cDF2lEcbeBHwE0snuCvqTDn72qBVdYZvA13AQBm8XCy2A==
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.15.1.tgz#1b41c92ee7930e0bcead8283eea019b5f1238819"
+  integrity sha512-0q0h2krXFR5uj/A+x5WtsKVF1ltPPDrrxmX9g+SjUmeWHIcffH7qz/PCo4fdqWOPjcTXkPfBxSZwGd2uDishaQ==
 
 "@hashicorp/ember-cli-api-double@^3.0.2":
   version "3.0.2"


### PR DESCRIPTION
- Upgrade to Upgrade consul-api-double to version 2.15.1
- Future plans to add namespace tests to all lists with namespace info

Linked Services Tab for Terminating Gateways
<img width="234" alt="Screen Shot 2020-05-13 at 11 39 44 AM" src="https://user-images.githubusercontent.com/19161242/81835402-3639e280-9510-11ea-9a46-3e6b5d75365a.png">

Upstreams Tab for Ingress Gateways
<img width="211" alt="Screen Shot 2020-05-13 at 11 39 04 AM" src="https://user-images.githubusercontent.com/19161242/81835470-4c47a300-9510-11ea-8797-ed05624d47f9.png">



