### PR TITLE
Give ember-build a larger container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,9 +694,10 @@ workflows:
       - frontend-cache:
           filters:
             branches:
-              ignore:
-                - stable-website
-                - /^docs\/.*/
+              only:
+                - master
+                - ui-staging
+                - /^ui\/.*/
       - ember-build:
           requires:
             - frontend-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,6 +411,7 @@ jobs:
   ember-build:
     docker:
       - image: *EMBER_IMAGE
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:
@@ -427,6 +428,7 @@ jobs:
   ember-build-prod:
     docker:
       - image: *EMBER_IMAGE
+    resource_class: medium+
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
There have been errors in [`ember-build`](https://circleci.com/gh/hashicorp/consul/176430) and [`ember-build-prod`](https://app.circleci.com/pipelines/github/hashicorp/consul/9492/workflows/18dc3024-e402-402a-9b72-4977e3e59d26/jobs/177252/steps) recently due to ember OOMing. This bumps the workers to 3CPUx6GB RAM rather than 2x4. 

I have also modified the filter on the `frontend` workflow to only build `master`, `ui-staging` and `ui/*` branches so all the Go and docs changes don't trigger this anymore. 