### PR TITLE
docs: Add Dart client to list of Libraries and SDKs

### DIFF
--- a/website/pages/api-docs/libraries-and-sdks.mdx
+++ b/website/pages/api-docs/libraries-and-sdks.mdx
@@ -124,4 +124,8 @@ the community.
     <a href="https://github.com/rogerwelin/crystal-consul">crystal-consul</a> -
     Crystal client for the Consul HTTP API
   </li>
+  <li>
+    <a href="https://github.com/adaptant-labs/consul-dart">consul-dart</a> -
+    Dart client for the Consul HTTP API
+  </li>
 </ul>


### PR DESCRIPTION
In the development of Dart-based microservices, it became necessary to elaborate some of the Consul interfacing. Rather than copying the boilerplate stubs around, we decided to split this out into its own standalone library. At present not all APIs are support, but this will continue to be expanded over time.