### PR TITLE
ui: Styling fixes

### DIFF
--- a/ui-v2/app/components/consul-service-instance-list/index.hbs
+++ b/ui-v2/app/components/consul-service-instance-list/index.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#if (gt items.length 0)}}
-  <ListCollection @cellHeight={{73}} @items={{items}} class="consul-service-instance-list" as |item index|>
+  <ListCollection @items={{items}} class="consul-service-instance-list" as |item index|>
     <a href={{href-to routeName item.Service.Service item.Node.Node (or item.Service.ID item.Service.Service)}}>
       {{item.Service.ID}}
     </a>

--- a/ui-v2/app/components/consul-service-list/index.hbs
+++ b/ui-v2/app/components/consul-service-list/index.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#if (gt items.length 0)}}
-<ListCollection @cellHeight={{73}} @items={{items}} class="consul-service-list" as |item index|>
+<ListCollection @items={{items}} class="consul-service-list" as |item index|>
   <a data-test-service-name href={{href-to routeName item.Name}} class={{service/health-checks item}}>
     {{item.Name}}
   </a>

--- a/ui-v2/app/components/list-collection/index.js
+++ b/ui-v2/app/components/list-collection/index.js
@@ -10,6 +10,7 @@ export default Component.extend(WithResizing, {
   tagName: 'div',
   attributeBindings: ['style'],
   height: 500,
+  cellHeight: 73,
   style: style('getStyle'),
   classNames: ['list-collection'],
   init: function() {

--- a/ui-v2/app/styles/components/composite-row/skin.scss
+++ b/ui-v2/app/styles/components/composite-row/skin.scss
@@ -8,6 +8,7 @@
 %composite-row-intent {
   border-color: $gray-200;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  border-top-color: $transparent;
   cursor: pointer;
 }
 %composite-row-header {

--- a/ui-v2/app/styles/components/composite-row/skin.scss
+++ b/ui-v2/app/styles/components/composite-row/skin.scss
@@ -31,6 +31,10 @@
   @extend %with-cancel-square-fill-color-mask, %as-pseudo;
   background-color: $red-500;
 }
+%composite-row .empty::before {
+  @extend %with-minus-square-fill-color-mask, %as-pseudo;
+  background-color: $gray-500;
+}
 
 // Metadata
 %composite-row .node a {

--- a/ui-v2/app/templates/dc/services/show/services.hbs
+++ b/ui-v2/app/templates/dc/services/show/services.hbs
@@ -8,7 +8,7 @@
         
       </p>
     {{#let item.Service.Namespace as |nspace|}}
-      <ListCollection @cellHeight={{73}} @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
+      <ListCollection @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
         <a data-test-service-name href={{href-to 'dc.services.show' item.Name}} class={{service/health-checks item}}>
           {{item.Name}}
         </a>

--- a/ui-v2/app/templates/dc/services/show/upstreams.hbs
+++ b/ui-v2/app/templates/dc/services/show/upstreams.hbs
@@ -7,7 +7,7 @@
         <a href="{{env 'CONSUL_DOCS_URL'}}/connect/ingress_gateway.html" target="_blank" rel="noopener noreferrer">documentation.</a>
       </p>
     {{#let item.Service.Namespace as |nspace|}}
-      <ListCollection @cellHeight={{73}} @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
+      <ListCollection @items={{gateway.Services}} class="consul-gateway-services-list" as |item index|>
         <a data-test-service-name href={{href-to 'dc.services.show' item.Name}}>
           {{item.Name}}
         </a>


### PR DESCRIPTION
Small fixes here:
- Moving cellHeight over to js file to be set as a default height
- Fix a border-top color for the onHover state of composite-row
- Add empty health check icon to Composite Row

Before:
<img width="185" alt="Screen Shot 2020-05-14 at 9 51 52 AM" src="https://user-images.githubusercontent.com/19161242/81942763-8bd1c600-95c8-11ea-9055-4d57dadab860.png">

After: 
<img width="141" alt="Screen Shot 2020-05-14 at 9 52 31 AM" src="https://user-images.githubusercontent.com/19161242/81942861-aa37c180-95c8-11ea-9f70-d68df639607d.png">
