### PR TITLE
ui: Quote service names when filtering for intentions

### DIFF
--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -25,7 +25,11 @@ export default Route.extend({
         )
           ? model
           : hash({
-              intentions: this.intentionRepo.findByService(params.name, dc, nspace),
+              intentions: this.intentionRepo
+                .findByService(params.name, dc, nspace)
+                .catch(function() {
+                  return null;
+                }),
               chain: this.chainRepo.findBySlug(params.name, dc, nspace).catch(function(e) {
                 const code = get(e, 'errors.firstObject.status');
                 // Currently we are specifically catching a 500, but we return null

--- a/ui-v2/app/services/repository/intention.js
+++ b/ui-v2/app/services/repository/intention.js
@@ -12,7 +12,7 @@ export default RepositoryService.extend({
     const query = {
       dc: dc,
       nspace: nspace,
-      filter: `SourceName == ${slug} or DestinationName == ${slug}`,
+      filter: `SourceName == "${slug}" or DestinationName == "${slug}"`,
     };
     if (typeof configuration.cursor !== 'undefined') {
       query.index = configuration.cursor;

--- a/ui-v2/tests/acceptance/dc/services/show/intentions-error.feature
+++ b/ui-v2/tests/acceptance/dc/services/show/intentions-error.feature
@@ -1,0 +1,20 @@
+@setupApplicationTest
+Feature: dc / services / intentions-error: An error with intentions doesn't 500 the page
+  Scenario:
+    Given 1 datacenter model with the value "dc1"
+    And 1 node model
+    And 1 service model from yaml
+    ---
+    - Service:
+        Kind: ~
+        Name: service-0
+        ID: service-0-with-id
+    ---
+    And the url "/v1/connect/intentions" responds with a 500 status
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And the title should be "service-0 - Consul"
+    And I see 1 instance model

--- a/ui-v2/tests/acceptance/steps/dc/services/show/intentions-error-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/services/show/intentions-error-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}


### PR DESCRIPTION
This PR quotes service names when filtering for intentions. We also add a catch for any type of 500 error here to ensure that it doesn't 500 the entire page if that happens.

Moving forwards these requests will be moved down into the tabs themselves, meaning we can show more meaningful errors within the tabs themselves without affecting the entire page.
