### PR TITLE
Unindenting to remove shell pre-formatting

### DIFF
--- a/website/pages/docs/connect/ingress_gateway.mdx
+++ b/website/pages/docs/connect/ingress_gateway.mdx
@@ -51,10 +51,10 @@ You must complete the following steps to configure an ingress gateway to proxy t
 1. On a host with a Consul client agent, start an Envoy proxy using the [envoy
 subcommand](/docs/commands/connect/envoy), specifying the `ingress` gateway
 type:
-    ```shell
-    $ consul connect envoy -gateway=ingress -register -service ingress-service \
-      -address '{{ GetInterfaceIP "eth0" }}:8888'
-    ```
+  ```shell
+  $ consul connect envoy -gateway=ingress -register -service ingress-service \
+    -address '{{ GetInterfaceIP "eth0" }}:8888'
+  ```
 
 2. Create and apply an `ingress-gateway` [configuration entry](/docs/agent/config-entries/ingress-gateway) that defines
 a set of listeners that expose the desired backing services. The config entry can be applied via the

--- a/website/pages/docs/connect/terminating_gateway.mdx
+++ b/website/pages/docs/connect/terminating_gateway.mdx
@@ -75,10 +75,10 @@ You must complete the following steps to configure a terminating gateway to prox
 
 1. On a host with a Consul client agent, start an Envoy proxy using the [envoy subcommand](/docs/commands/connect/envoy#terminating-gateways) and
 specifying the `terminating` gateway type:
-    ```shell
-    $ consul connect envoy -gateway=terminating -register -service us-west-gateway \
-      -address '{{ GetInterfaceIP "eth0" }}:8443'
-    ```
+  ```shell
+  $ consul connect envoy -gateway=terminating -register -service us-west-gateway \
+    -address '{{ GetInterfaceIP "eth0" }}:8443'
+  ```
 
 2. Create and apply a `terminating-gateway` [configuration entry](/docs/agent/config-entries/terminating-gateway) that defines 
 a set of services that the gateway will proxy traffic to. The config entry can be applied via the 


### PR DESCRIPTION
Removing some indents to remove bash preformatting in public docs