### PR TITLE
Update ingress/terminating gateway ACL docs

### DIFF
--- a/website/pages/docs/connect/ingress_gateway.mdx
+++ b/website/pages/docs/connect/ingress_gateway.mdx
@@ -74,9 +74,9 @@ Connect proxy service, to define opaque configuration parameters useful for the 
 For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy#gateway-options) as well as
 [escape-hatch overrides](/docs/connect/proxies/envoy#escape-hatch-overrides).
 
--> **Note:** If ACLs are enabled, a token granting `service:write` for the gateway's service name
-and `service:read` for all services in the datacenter. These permissions authorize the token to route
-communications for other Connect services.
+-> **Note:** If ACLs are enabled, a token granting `service:write` for the ingress gateway's service name,
+`service:read` for all services in the ingress gateway's configuration entry, and `node:read` for all nodes of the services
+in the ingress gateway's configuration entry. These privileges authorize the token to route communications to other Connect services.
 
 ~> [Configuration entries](/docs/agent/config-entries) are global in scope. A configuration entry for a gateway name applies
    across all federated Consul datacenters. If ingress gateways in different Consul datacenters need to route to different

--- a/website/pages/docs/connect/ingress_gateway.mdx
+++ b/website/pages/docs/connect/ingress_gateway.mdx
@@ -74,7 +74,7 @@ Connect proxy service, to define opaque configuration parameters useful for the 
 For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy#gateway-options) as well as
 [escape-hatch overrides](/docs/connect/proxies/envoy#escape-hatch-overrides).
 
--> **Note:** If ACLs are enabled, a token granting `service:write` for the ingress gateway's service name,
+-> **Note:** If ACLs are enabled, ingress gateways must be registered with a token granting `service:write` for the ingress gateway's service name,
 `service:read` for all services in the ingress gateway's configuration entry, and `node:read` for all nodes of the services
 in the ingress gateway's configuration entry. These privileges authorize the token to route communications to other Connect services.
 

--- a/website/pages/docs/connect/ingress_gateway.mdx
+++ b/website/pages/docs/connect/ingress_gateway.mdx
@@ -77,6 +77,8 @@ For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy
 -> **Note:** If ACLs are enabled, ingress gateways must be registered with a token granting `service:write` for the ingress gateway's service name,
 `service:read` for all services in the ingress gateway's configuration entry, and `node:read` for all nodes of the services
 in the ingress gateway's configuration entry. These privileges authorize the token to route communications to other Connect services.
+If the Consul client agent on the gateway's node is not configured to use the default gRPC port, 8502, then the gateway's token
+must also provide `agent:read` for its node's name in order to discover the agent's gRPC port. gRPC is used to expose Envoy's xDS API to Envoy proxies.
 
 ~> [Configuration entries](/docs/agent/config-entries) are global in scope. A configuration entry for a gateway name applies
    across all federated Consul datacenters. If ingress gateways in different Consul datacenters need to route to different

--- a/website/pages/docs/connect/terminating_gateway.mdx
+++ b/website/pages/docs/connect/terminating_gateway.mdx
@@ -104,6 +104,8 @@ For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy
 of all services in its configuration entry. The token must also grant `service:write` for the terminating gateway's service name **and**
 the names of all services in the terminating gateway's configuration entry. These privileges will authorize the gateway
 to terminate mTLS connections on behalf of the linked services and then route the traffic to its final destination.
+If the Consul client agent on the gateway's node is not configured to use the default gRPC port, 8502, then the gateway's token
+must also provide `agent:read` for its node's name in order to discover the agent's gRPC port. gRPC is used to expose Envoy's xDS API to Envoy proxies.
 
 Linking services to a terminating gateway is done with a `terminating-gateway`
 [configuration entry](/docs/agent/config-entries/terminating-gateway). This config entry can be applied via the 

--- a/website/pages/docs/connect/terminating_gateway.mdx
+++ b/website/pages/docs/connect/terminating_gateway.mdx
@@ -100,9 +100,10 @@ Connect proxy service, to define opaque configuration parameters useful for the 
 For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy#gateway-options) as well as
 [escape-hatch overrides](/docs/connect/proxies/envoy#escape-hatch-overrides).
 
--> **Note:** If ACLs are enabled, the terminating gateways must be registered with a token granting `service:write`
-for the gateway's service name **and** all linked services. These privileges will authorize the gateway
-to terminate mTLS connections on behalf of the linked services.
+-> **Note:** If ACLs are enabled, the terminating gateways must be registered with a token granting `node:read` on the nodes
+of all services in its configuration entry. The token must also grant `service:write` for the terminating gateway's service name **and**
+the names of all services in the terminating gateway's configuration entry. These privileges will authorize the gateway
+to terminate mTLS connections on behalf of the linked services and then route the traffic to its final destination.
 
 Linking services to a terminating gateway is done with a `terminating-gateway`
 [configuration entry](/docs/agent/config-entries/terminating-gateway). This config entry can be applied via the 

--- a/website/pages/docs/connect/terminating_gateway.mdx
+++ b/website/pages/docs/connect/terminating_gateway.mdx
@@ -100,7 +100,7 @@ Connect proxy service, to define opaque configuration parameters useful for the 
 For Envoy there are some supported [gateway options](/docs/connect/proxies/envoy#gateway-options) as well as
 [escape-hatch overrides](/docs/connect/proxies/envoy#escape-hatch-overrides).
 
--> **Note:** If ACLs are enabled, the terminating gateways must be registered with a token granting `node:read` on the nodes
+-> **Note:** If ACLs are enabled, terminating gateways must be registered with a token granting `node:read` on the nodes
 of all services in its configuration entry. The token must also grant `service:write` for the terminating gateway's service name **and**
 the names of all services in the terminating gateway's configuration entry. These privileges will authorize the gateway
 to terminate mTLS connections on behalf of the linked services and then route the traffic to its final destination.


### PR DESCRIPTION
Adding `node:read` requirement for services associated with a gateway.

Without those privileges the gateway will not be able to discover the addresses of the services they are routing to.