### PR TITLE
ui: Misc discovery chain fixes

### DIFF
--- a/ui-v2/app/components/discovery-chain/index.hbs
+++ b/ui-v2/app/components/discovery-chain/index.hbs
@@ -95,7 +95,7 @@
       <path
         id={{concat 'splitter:' splitter.Name '>' item.NextNode}}
         class="split"
-        data-percentage={{item.Weight}}
+        data-percentage={{or item.Weight 0}}
         d={{
           svg-curve (hash
             x=dest.x

--- a/ui-v2/app/components/discovery-chain/utils.js
+++ b/ui-v2/app/components/discovery-chain/utils.js
@@ -138,7 +138,7 @@ export const getResolvers = function(dc, nspace = 'default', targets = {}, nodes
 export const createRoute = function(route, router, uid) {
   return {
     ...route,
-    Default: typeof route.Definition.Match === 'undefined',
+    Default: route.Default || typeof route.Definition.Match === 'undefined',
     ID: `route:${router}-${uid(route.Definition)}`,
   };
 };

--- a/ui-v2/tests/unit/components/discovery-chain/get-alternate-services-test.js
+++ b/ui-v2/tests/unit/components/discovery-chain/get-alternate-services-test.js
@@ -1,7 +1,7 @@
-import { getAlternateServices } from 'consul-ui/utils/components/discovery-chain/index';
+import { getAlternateServices } from 'consul-ui/components/discovery-chain/utils';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | components/discovery-chain/get-alternative-services', function() {
+module('Unit | Component | discovery-chain/get-alternative-services', function() {
   test('it guesses a different namespace', function(assert) {
     const expected = {
       Type: 'Namespace',

--- a/ui-v2/tests/unit/components/discovery-chain/get-resolvers-test.js
+++ b/ui-v2/tests/unit/components/discovery-chain/get-resolvers-test.js
@@ -1,4 +1,4 @@
-import { getResolvers } from 'consul-ui/utils/components/discovery-chain/index';
+import { getResolvers } from 'consul-ui/components/discovery-chain/utils';
 import { module, test } from 'qunit';
 import { get } from 'consul-ui/tests/helpers/api';
 
@@ -7,7 +7,7 @@ const nspace = 'default';
 const request = {
   url: `/v1/discovery-chain/service-name?dc=${dc}`,
 };
-module('Unit | Utility | components/discovery-chain/get-resolvers', function() {
+module('Unit | Component | discovery-chain/get-resolvers', function() {
   test('it assigns Subsets correctly', function(assert) {
     return get(request.url, {
       headers: {

--- a/ui-v2/tests/unit/components/discovery-chain/get-splitters-test.js
+++ b/ui-v2/tests/unit/components/discovery-chain/get-splitters-test.js
@@ -1,7 +1,7 @@
-import { getSplitters } from 'consul-ui/utils/components/discovery-chain/index';
+import { getSplitters } from 'consul-ui/components/discovery-chain/utils';
 import { module, test } from 'qunit';
 
-module('Unit | Utility | components/discovery-chain/get-splitters', function() {
+module('Unit | Component | discovery-chain/get-splitters', function() {
   test('it collects and correctly parses splitter Names', function(assert) {
     const actual = getSplitters({
       'splitter:splitter-name.default': {


### PR DESCRIPTION
1. Look for a default splitter before looking for a default resolver in
order to route to.
2. Delay adding svg listeners until afterRender (fixes split tooltip)
3. Make router id's consistent for highlighting default routers when
clicking the graph.

This PR also moves our utils specifically for the discovery-chain component into the same folder as the actual component now that we are using a colocated component folder structure.