### PR TITLE
ui: If an error occurs on the server, surface it in the notification

### DIFF
--- a/ui-v2/app/components/app-view/index.hbs
+++ b/ui-v2/app/components/app-view/index.hbs
@@ -6,11 +6,11 @@
         {{#let (lowercase component.flashType) (lowercase flash.action) as |status type|}}
           {{! flashes automatically ucfirst the type }}
 
-          <p data-notification class={{concat status ' notification-' type}}>
+          <p data-notification role="alert" class={{concat status ' notification-' type}}>
             <strong>
               {{capitalize status}}!
             </strong>
-            {{#yield-slot name="notification" params=(block-params status type flash.item)}}
+            {{#yield-slot name="notification" params=(block-params status type flash.item flash.error)}}
               {{yield}}
               {{#if (eq type 'logout')}}
                 {{#if (eq status 'success') }}

--- a/ui-v2/app/services/feedback.js
+++ b/ui-v2/app/services/feedback.js
@@ -55,6 +55,7 @@ export default Service.extend({
               ...notificationDefaults(),
               type: getStatus(TYPE_ERROR, e),
               action: getAction(),
+              error: e,
             });
           }
         })

--- a/ui-v2/app/templates/dc/acls/policies/-notifications.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/-notifications.hbs
@@ -17,4 +17,9 @@
     There was an error deleting your policy.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/acls/policies/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/edit.hbs
@@ -13,7 +13,7 @@
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >
-    <BlockSlot @name="notification" as |status type|>
+    <BlockSlot @name="notification" as |status type item error|>
       {{partial 'dc/acls/policies/notifications'}}
     </BlockSlot>
     <BlockSlot @name="disabled">

--- a/ui-v2/app/templates/dc/acls/roles/-notifications.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/-notifications.hbs
@@ -17,4 +17,9 @@
     There was an error deleting your role.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/acls/roles/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/edit.hbs
@@ -13,7 +13,7 @@
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >
-    <BlockSlot @name="notification" as |status type|>
+    <BlockSlot @name="notification" as |status type item error|>
       {{partial 'dc/acls/roles/notifications'}}
     </BlockSlot>
     <BlockSlot @name="disabled">

--- a/ui-v2/app/templates/dc/acls/tokens/-notifications.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/-notifications.hbs
@@ -29,4 +29,9 @@
     There was an error using that ACL token.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/edit.hbs
@@ -13,7 +13,7 @@
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >
-    <BlockSlot @name="notification" as |status type|>
+    <BlockSlot @name="notification" as |status type item error|>
       {{partial 'dc/acls/tokens/notifications'}}
     </BlockSlot>
     <BlockSlot @name="disabled">

--- a/ui-v2/app/templates/dc/intentions/-notifications.hbs
+++ b/ui-v2/app/templates/dc/intentions/-notifications.hbs
@@ -19,4 +19,9 @@
     There was an error deleting your intention.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/intentions/edit.hbs
+++ b/ui-v2/app/templates/dc/intentions/edit.hbs
@@ -5,7 +5,7 @@
 {{/if}}
 
 <AppView @class="intention edit" @loading={{isLoading}}>
-    <BlockSlot @name="notification" as |status type|>
+    <BlockSlot @name="notification" as |status type item error|>
       {{partial 'dc/intentions/notifications'}}
     </BlockSlot>
     <BlockSlot @name="breadcrumbs">

--- a/ui-v2/app/templates/dc/kv/-notifications.hbs
+++ b/ui-v2/app/templates/dc/kv/-notifications.hbs
@@ -2,13 +2,13 @@
   {{#if (eq status 'success') }}
     Your key has been added.
   {{else}}
-    There was an error adding your key.
+  There was an error adding your key.
   {{/if}}
 {{else if (eq type 'update') }}
   {{#if (eq status 'success') }}
     Your key has been saved.
   {{else}}
-    There was an error saving your key.
+  There was an error saving your key.
   {{/if}}
 {{ else if (eq type 'delete')}}
   {{#if (eq status 'success') }}
@@ -23,4 +23,9 @@
     There was an error invalidating your session.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -4,7 +4,7 @@
   {{title 'Edit Key/Value'}}
 {{/if}}
 <AppView @class="kv edit" @loading={{isLoading}}>
-  <BlockSlot @name="notification" as |status type|>
+  <BlockSlot @name="notification" as |status type item error|>
     {{partial 'dc/kv/notifications'}}
   </BlockSlot>
   <BlockSlot @name="breadcrumbs">

--- a/ui-v2/app/templates/dc/nspaces/-notifications.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-notifications.hbs
@@ -17,4 +17,9 @@
     There was an error deleting your namespace.
   {{/if}}
 {{/if}}
+{{#let error.errors.firstObject as |error|}}
+  {{#if error.detail }}
+    <br />{{concat '(' (if error.status (concat error.status ': ')) error.detail ')'}}
+  {{/if}}
+{{/let}}
 

--- a/ui-v2/app/templates/dc/nspaces/edit.hbs
+++ b/ui-v2/app/templates/dc/nspaces/edit.hbs
@@ -4,7 +4,7 @@
   {{title 'Edit Namespace'}}
 {{/if}}
 <AppView @class="nspace edit" @loading={{isLoading}}>
-  <BlockSlot @name="notification" as |status type|>
+  <BlockSlot @name="notification" as |status type item error|>
     {{partial 'dc/nspaces/notifications'}}
   </BlockSlot>
   <BlockSlot @name="breadcrumbs">


### PR DESCRIPTION
Previously, when an error was received from the server for an action such as deleting or edting, we would show a generic error message.

This keeps the generic message but also adds the error received from the server underneath so it is easier to see what the problem was.

![Screenshot 2020-05-18 at 13 37 13](https://user-images.githubusercontent.com/554604/82213859-c0b58400-990c-11ea-8d70-d93ad55357d0.png)

Fixes https://github.com/hashicorp/consul/issues/6020

@opihana @jnwright if you could take a look at this that'd be great. The idea is to present this information short term before we get a change to revisit the look and feel of the success/error notifications.