### PR TITLE
Remove error from GatewayServices RPC when a service is not a gateway

### DIFF
--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -414,8 +414,15 @@ func (m *Internal) GatewayServices(args *structs.ServiceSpecificRequest, reply *
 				}
 			}
 
+			// We log a warning here to indicate that there is a potential
+			// misconfiguration. We explicitly do NOT return an error because this
+			// can occur in the course of normal operation by deleting a
+			// configuration entry or starting the proxy before registering the
+			// config entry.
 			if !found {
-				return fmt.Errorf("service %q is not a configured terminating-gateway or ingress-gateway", args.ServiceName)
+				m.logger.Warn("no terminating-gateway or ingress-gateway associated with this gateway",
+					"gateway", args.ServiceName,
+				)
 			}
 
 			index, services, err = state.GatewayServices(ws, args.ServiceName, &args.EnterpriseMeta)

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -954,8 +954,11 @@ func TestInternal_GatewayServices_BothGateways(t *testing.T) {
 	}
 	var resp structs.IndexedGatewayServices
 	err := msgpackrpc.CallWithCodec(codec, "Internal.GatewayServices", &req, &resp)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), `service "api" is not a configured terminating-gateway or ingress-gateway`)
+	assert.NoError(t, err)
+	assert.Empty(t, resp.Services)
+	// Ensure that the index is not zero so that a blocking query still gets the
+	// latest GatewayServices index
+	assert.NotEqual(t, 0, resp.Index)
 }
 
 func TestInternal_GatewayServices_ACLFiltering(t *testing.T) {

--- a/agent/proxycfg/manager.go
+++ b/agent/proxycfg/manager.go
@@ -188,7 +188,7 @@ func (m *Manager) ensureProxyServiceLocked(ns *structs.NodeService, token string
 	}
 
 	// Set the necessary dependencies
-	state.logger = m.Logger
+	state.logger = m.Logger.With("service_id", sid.String())
 	state.cache = m.Cache
 	state.source = m.Source
 	state.dnsConfig = m.DNSConfig


### PR DESCRIPTION
This error caused the cache to not send an update to the proxycfg/xds packages in the following circumstances:

1. Setup ingress gateway proxy
2. Create ingress config entry
3. The ingress gateway should not be able to service traffic
4. Delete the ingress gateway config entry
5. **Bug** The config entry is deleted, causing blocking queries to fire. But an error is returned, causing the cache to return the last known good value. Thus, `proxycfg` never receives an update event.

I have not quite investigated all of the various possibilities of how this is routed through the `cache`, re: refreshing/valid entries/max age.

This PR fixes the bug by converting the error message to just a warning log line.

I considered writing an envoy integration test for this, but decided to hold off for now, would consider doing so if other people thought that was worthwhile!