### PR TITLE
acl: allow auth methods created in the primary datacenter to optionally create global tokens

### DIFF
--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -2125,14 +2125,14 @@ func (a *ACL) AuthMethodSet(args *structs.ACLAuthMethodSetRequest, reply *struct
 		}
 	}
 
-	switch method.TokenType {
+	switch method.TokenLocality {
 	case "local", "":
 	case "global":
 		if !a.srv.InACLDatacenter() {
-			return fmt.Errorf("Invalid Auth Method: TokenType 'global' can only be used in the primary datacenter")
+			return fmt.Errorf("Invalid Auth Method: TokenLocality 'global' can only be used in the primary datacenter")
 		}
 	default:
-		return fmt.Errorf("Invalid Auth Method: TokenType should be one of 'local' or 'global'")
+		return fmt.Errorf("Invalid Auth Method: TokenLocality should be one of 'local' or 'global'")
 	}
 
 	// Instantiate a validator but do not cache it yet. This will validate the
@@ -2393,7 +2393,7 @@ func (a *ACL) tokenSetFromAuthMethod(
 		EnterpriseMeta:    *targetMeta,
 	}
 
-	if method.TokenType == "global" {
+	if method.TokenLocality == "global" {
 		if !a.srv.InACLDatacenter() {
 			return errors.New("creating global tokens via auth methods is only permitted in the primary datacenter")
 		}

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -442,9 +442,6 @@ func (a *ACL) tokenSetInternal(args *structs.ACLTokenSetRequest, reply *structs.
 			if token.AuthMethod == "" {
 				return fmt.Errorf("AuthMethod field is required during Login")
 			}
-			if !token.Local {
-				return fmt.Errorf("Cannot create Global token via Login")
-			}
 		} else {
 			if token.AuthMethod != "" {
 				return fmt.Errorf("AuthMethod field is disallowed outside of Login")
@@ -2128,6 +2125,16 @@ func (a *ACL) AuthMethodSet(args *structs.ACLAuthMethodSetRequest, reply *struct
 		}
 	}
 
+	switch method.TokenType {
+	case "local", "":
+	case "global":
+		if !a.srv.InACLDatacenter() {
+			return fmt.Errorf("Invalid Auth Method: TokenType 'global' can only be used in the primary datacenter")
+		}
+	default:
+		return fmt.Errorf("Invalid Auth Method: TokenType should be one of 'local' or 'global'")
+	}
+
 	// Instantiate a validator but do not cache it yet. This will validate the
 	// configuration.
 	validator, err := authmethod.NewValidator(a.srv.logger, method)
@@ -2384,6 +2391,13 @@ func (a *ACL) tokenSetFromAuthMethod(
 		Roles:             roleLinks,
 		ExpirationTTL:     method.MaxTokenTTL,
 		EnterpriseMeta:    *targetMeta,
+	}
+
+	if method.TokenType == "global" {
+		if !a.srv.InACLDatacenter() {
+			return errors.New("creating global tokens via auth methods is only permitted in the primary datacenter")
+		}
+		createReq.ACLToken.Local = false
 	}
 
 	createReq.ACLToken.ACLAuthMethodEnterpriseMeta.FillWithEnterpriseMeta(entMeta)

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -5106,7 +5106,7 @@ func TestACLEndpoint_Login_with_MaxTokenTTL(t *testing.T) {
 	require.Equal(t, got, expect)
 }
 
-func TestACLEndpoint_Login_with_TokenType(t *testing.T) {
+func TestACLEndpoint_Login_with_TokenLocality(t *testing.T) {
 	t.Parallel()
 
 	dir1, s1 := testServerWithConfig(t, func(c *Config) {
@@ -5133,19 +5133,19 @@ func TestACLEndpoint_Login_with_TokenType(t *testing.T) {
 	)
 
 	cases := map[string]struct {
-		tokenType   string
-		expectLocal bool
+		tokenLocality string
+		expectLocal   bool
 	}{
-		"empty":  {tokenType: "", expectLocal: true},
-		"local":  {tokenType: "local", expectLocal: true},
-		"global": {tokenType: "global", expectLocal: false},
+		"empty":  {tokenLocality: "", expectLocal: true},
+		"local":  {tokenLocality: "local", expectLocal: true},
+		"global": {tokenLocality: "global", expectLocal: false},
 	}
 
 	for name, tc := range cases {
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			method, err := upsertTestCustomizedAuthMethod(codec, "root", "dc1", func(method *structs.ACLAuthMethod) {
-				method.TokenType = tc.tokenType
+				method.TokenLocality = tc.tokenLocality
 				method.Config = map[string]interface{}{
 					"SessionID": testSessionID,
 				}

--- a/agent/consul/acl_endpoint_test.go
+++ b/agent/consul/acl_endpoint_test.go
@@ -5106,6 +5106,108 @@ func TestACLEndpoint_Login_with_MaxTokenTTL(t *testing.T) {
 	require.Equal(t, got, expect)
 }
 
+func TestACLEndpoint_Login_with_TokenType(t *testing.T) {
+	t.Parallel()
+
+	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+		c.ACLDatacenter = "dc1"
+		c.ACLsEnabled = true
+		c.ACLMasterToken = "root"
+	})
+	defer os.RemoveAll(dir1)
+	defer s1.Shutdown()
+	codec := rpcClient(t, s1)
+	defer codec.Close()
+
+	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+
+	acl := ACL{srv: s1}
+
+	testSessionID := testauth.StartSession()
+	defer testauth.ResetSession(testSessionID)
+
+	testauth.InstallSessionToken(
+		testSessionID,
+		"fake-web", // no rules
+		"default", "web", "abc123",
+	)
+
+	cases := map[string]struct {
+		tokenType   string
+		expectLocal bool
+	}{
+		"empty":  {tokenType: "", expectLocal: true},
+		"local":  {tokenType: "local", expectLocal: true},
+		"global": {tokenType: "global", expectLocal: false},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			method, err := upsertTestCustomizedAuthMethod(codec, "root", "dc1", func(method *structs.ACLAuthMethod) {
+				method.TokenType = tc.tokenType
+				method.Config = map[string]interface{}{
+					"SessionID": testSessionID,
+				}
+			})
+			require.NoError(t, err)
+
+			_, err = upsertTestBindingRule(
+				codec, "root", "dc1", method.Name,
+				"",
+				structs.BindingRuleBindTypeService,
+				"web",
+			)
+			require.NoError(t, err)
+
+			// Create a token.
+			req := structs.ACLLoginRequest{
+				Auth: &structs.ACLLoginParams{
+					AuthMethod:  method.Name,
+					BearerToken: "fake-web",
+					Meta:        map[string]string{"pod": "pod1"},
+				},
+				Datacenter: "dc1",
+			}
+
+			resp := structs.ACLToken{}
+			require.NoError(t, acl.Login(&req, &resp))
+
+			secretID := resp.SecretID
+
+			got := &resp
+			got.CreateIndex = 0
+			got.ModifyIndex = 0
+			got.AccessorID = ""
+			got.SecretID = ""
+			got.Hash = nil
+
+			defaultEntMeta := structs.DefaultEnterpriseMeta()
+			expect := &structs.ACLToken{
+				AuthMethod:  method.Name,
+				Description: `token created via login: {"pod":"pod1"}`,
+				Local:       tc.expectLocal,
+				CreateTime:  got.CreateTime,
+				ServiceIdentities: []*structs.ACLServiceIdentity{
+					{ServiceName: "web"},
+				},
+				EnterpriseMeta: *defaultEntMeta,
+			}
+			expect.ACLAuthMethodEnterpriseMeta.FillWithEnterpriseMeta(defaultEntMeta)
+			require.Equal(t, got, expect)
+
+			// Now turn around and nuke it.
+			logoutReq := structs.ACLLogoutRequest{
+				Datacenter:   "dc1",
+				WriteRequest: structs.WriteRequest{Token: secretID},
+			}
+
+			var ignored bool
+			require.NoError(t, acl.Logout(&logoutReq, &ignored))
+		})
+	}
+}
+
 func TestACLEndpoint_Login_k8s(t *testing.T) {
 	t.Parallel()
 

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1052,9 +1052,9 @@ type ACLAuthMethod struct {
 	// MaxTokenTTL this is the maximum life of a token created by this method.
 	MaxTokenTTL time.Duration `json:",omitempty"`
 
-	// TokenType defines the kind of token that this auth method produces. This
-	// can be either 'local' or 'global'. If empty 'local' is assumed.
-	TokenType string `json:",omitempty"`
+	// TokenLocality defines the kind of token that this auth method produces.
+	// This can be either 'local' or 'global'. If empty 'local' is assumed.
+	TokenLocality string `json:",omitempty"`
 
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -1052,6 +1052,10 @@ type ACLAuthMethod struct {
 	// MaxTokenTTL this is the maximum life of a token created by this method.
 	MaxTokenTTL time.Duration `json:",omitempty"`
 
+	// TokenType defines the kind of token that this auth method produces. This
+	// can be either 'local' or 'global'. If empty 'local' is assumed.
+	TokenType string `json:",omitempty"`
+
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and
 	// maps).

--- a/api/acl.go
+++ b/api/acl.go
@@ -187,9 +187,9 @@ type ACLAuthMethod struct {
 	Description string        `json:",omitempty"`
 	MaxTokenTTL time.Duration `json:",omitempty"`
 
-	// TokenType defines the kind of token that this auth method produces. This
-	// can be either 'local' or 'global'. If empty 'local' is assumed.
-	TokenType string `json:",omitempty"`
+	// TokenLocality defines the kind of token that this auth method produces.
+	// This can be either 'local' or 'global'. If empty 'local' is assumed.
+	TokenLocality string `json:",omitempty"`
 
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and

--- a/api/acl.go
+++ b/api/acl.go
@@ -187,6 +187,10 @@ type ACLAuthMethod struct {
 	Description string        `json:",omitempty"`
 	MaxTokenTTL time.Duration `json:",omitempty"`
 
+	// TokenType defines the kind of token that this auth method produces. This
+	// can be either 'local' or 'global'. If empty 'local' is assumed.
+	TokenType string `json:",omitempty"`
+
 	// Configuration is arbitrary configuration for the auth method. This
 	// should only contain primitive values and containers (such as lists and
 	// maps).

--- a/command/acl/authmethod/create/authmethod_create.go
+++ b/command/acl/authmethod/create/authmethod_create.go
@@ -32,7 +32,7 @@ type cmd struct {
 	displayName    string
 	description    string
 	maxTokenTTL    time.Duration
-	tokenType      string
+	tokenLocality  string
 	config         string
 
 	k8sHost              string
@@ -89,8 +89,8 @@ func (c *cmd) init() {
 		"Duration of time all tokens created by this auth method should be valid for",
 	)
 	c.flags.StringVar(
-		&c.tokenType,
-		"token-type",
+		&c.tokenLocality,
+		"token-locality",
 		"",
 		"Defines the kind of token that this auth method should produce. "+
 			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
@@ -165,11 +165,11 @@ func (c *cmd) Run(args []string) int {
 	}
 
 	newAuthMethod := &api.ACLAuthMethod{
-		Type:        c.authMethodType,
-		Name:        c.name,
-		DisplayName: c.displayName,
-		Description: c.description,
-		TokenType:   c.tokenType,
+		Type:          c.authMethodType,
+		Name:          c.name,
+		DisplayName:   c.displayName,
+		Description:   c.description,
+		TokenLocality: c.tokenLocality,
 	}
 	if c.maxTokenTTL > 0 {
 		newAuthMethod.MaxTokenTTL = c.maxTokenTTL

--- a/command/acl/authmethod/create/authmethod_create.go
+++ b/command/acl/authmethod/create/authmethod_create.go
@@ -32,6 +32,7 @@ type cmd struct {
 	displayName    string
 	description    string
 	maxTokenTTL    time.Duration
+	tokenType      string
 	config         string
 
 	k8sHost              string
@@ -86,6 +87,13 @@ func (c *cmd) init() {
 		"max-token-ttl",
 		0,
 		"Duration of time all tokens created by this auth method should be valid for",
+	)
+	c.flags.StringVar(
+		&c.tokenType,
+		"token-type",
+		"",
+		"Defines the kind of token that this auth method should produce. "+
+			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
 	)
 
 	c.flags.StringVar(
@@ -161,6 +169,7 @@ func (c *cmd) Run(args []string) int {
 		Name:        c.name,
 		DisplayName: c.displayName,
 		Description: c.description,
+		TokenType:   c.tokenType,
 	}
 	if c.maxTokenTTL > 0 {
 		newAuthMethod.MaxTokenTTL = c.maxTokenTTL

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -163,7 +163,7 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 			"-name", name,
 			"-description=desc",
 			"-display-name=display",
-			"-token-type=global",
+			"-token-locality=global",
 		}
 
 		ui := cli.NewMockUi()
@@ -175,11 +175,11 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 
 		got := getTestMethod(t, client, name)
 		expect := &api.ACLAuthMethod{
-			Name:        name,
-			Type:        "testing",
-			DisplayName: "display",
-			Description: "desc",
-			TokenType:   "global",
+			Name:          name,
+			Type:          "testing",
+			DisplayName:   "display",
+			Description:   "desc",
+			TokenLocality: "global",
 		}
 		require.Equal(t, expect, got)
 	})
@@ -312,7 +312,7 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 			"-name", name,
 			"-description=desc",
 			"-display-name=display",
-			"-token-type=global",
+			"-token-locality=global",
 			"-format=json",
 		}
 
@@ -328,11 +328,11 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 
 		got := getTestMethod(t, client, name)
 		expect := &api.ACLAuthMethod{
-			Name:        name,
-			Type:        "testing",
-			DisplayName: "display",
-			Description: "desc",
-			TokenType:   "global",
+			Name:          name,
+			Type:          "testing",
+			DisplayName:   "display",
+			Description:   "desc",
+			TokenLocality: "global",
 		}
 		require.Equal(t, expect, got)
 
@@ -343,12 +343,12 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 		delete(raw, "Namespace")
 
 		require.Equal(t, map[string]interface{}{
-			"Name":        name,
-			"Type":        "testing",
-			"DisplayName": "display",
-			"Description": "desc",
-			"TokenType":   "global",
-			"Config":      nil,
+			"Name":          name,
+			"Type":          "testing",
+			"DisplayName":   "display",
+			"Description":   "desc",
+			"TokenLocality": "global",
+			"Config":        nil,
 		}, raw)
 	})
 }

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -153,6 +153,36 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 		}
 		require.Equal(t, expect, got)
 	})
+
+	t.Run("create testing with token type global", func(t *testing.T) {
+		name := getTestName(t)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-type=testing",
+			"-name", name,
+			"-description=desc",
+			"-display-name=display",
+			"-token-type=global",
+		}
+
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+
+		code := cmd.Run(args)
+		require.Equal(t, code, 0, "err: "+ui.ErrorWriter.String())
+		require.Empty(t, ui.ErrorWriter.String())
+
+		got := getTestMethod(t, client, name)
+		expect := &api.ACLAuthMethod{
+			Name:        name,
+			Type:        "testing",
+			DisplayName: "display",
+			Description: "desc",
+			TokenType:   "global",
+		}
+		require.Equal(t, expect, got)
+	})
 }
 
 func TestAuthMethodCreateCommand_JSON(t *testing.T) {
@@ -269,6 +299,55 @@ func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 			"DisplayName": "display",
 			"Description": "desc",
 			"MaxTokenTTL": "5m0s",
+			"Config":      nil,
+		}, raw)
+	})
+
+	t.Run("create testing with token type global", func(t *testing.T) {
+		name := getTestName(t)
+		args := []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-token=root",
+			"-type=testing",
+			"-name", name,
+			"-description=desc",
+			"-display-name=display",
+			"-token-type=global",
+			"-format=json",
+		}
+
+		ui := cli.NewMockUi()
+		cmd := New(ui)
+
+		code := cmd.Run(args)
+		out := ui.OutputWriter.String()
+
+		require.Equal(t, code, 0)
+		require.Empty(t, ui.ErrorWriter.String())
+		require.Contains(t, out, name)
+
+		got := getTestMethod(t, client, name)
+		expect := &api.ACLAuthMethod{
+			Name:        name,
+			Type:        "testing",
+			DisplayName: "display",
+			Description: "desc",
+			TokenType:   "global",
+		}
+		require.Equal(t, expect, got)
+
+		var raw map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(out), &raw))
+		delete(raw, "CreateIndex")
+		delete(raw, "ModifyIndex")
+		delete(raw, "Namespace")
+
+		require.Equal(t, map[string]interface{}{
+			"Name":        name,
+			"Type":        "testing",
+			"DisplayName": "display",
+			"Description": "desc",
+			"TokenType":   "global",
 			"Config":      nil,
 		}, raw)
 	})

--- a/command/acl/authmethod/formatter.go
+++ b/command/acl/authmethod/formatter.go
@@ -49,20 +49,20 @@ type prettyFormatter struct {
 func (f *prettyFormatter) FormatAuthMethod(method *api.ACLAuthMethod) (string, error) {
 	var buffer bytes.Buffer
 
-	buffer.WriteString(fmt.Sprintf("Name:         %s\n", method.Name))
-	buffer.WriteString(fmt.Sprintf("Type:         %s\n", method.Type))
+	buffer.WriteString(fmt.Sprintf("Name:          %s\n", method.Name))
+	buffer.WriteString(fmt.Sprintf("Type:          %s\n", method.Type))
 	if method.Namespace != "" {
-		buffer.WriteString(fmt.Sprintf("Namespace:    %s\n", method.Namespace))
+		buffer.WriteString(fmt.Sprintf("Namespace:     %s\n", method.Namespace))
 	}
 	if method.DisplayName != "" {
-		buffer.WriteString(fmt.Sprintf("DisplayName:  %s\n", method.DisplayName))
+		buffer.WriteString(fmt.Sprintf("DisplayName:   %s\n", method.DisplayName))
 	}
-	buffer.WriteString(fmt.Sprintf("Description:  %s\n", method.Description))
+	buffer.WriteString(fmt.Sprintf("Description:   %s\n", method.Description))
 	if method.MaxTokenTTL > 0 {
-		buffer.WriteString(fmt.Sprintf("MaxTokenTTL:  %s\n", method.MaxTokenTTL))
+		buffer.WriteString(fmt.Sprintf("MaxTokenTTL:   %s\n", method.MaxTokenTTL))
 	}
-	if method.TokenType != "" {
-		buffer.WriteString(fmt.Sprintf("TokenType:    %s\n", method.TokenType))
+	if method.TokenLocality != "" {
+		buffer.WriteString(fmt.Sprintf("TokenLocality: %s\n", method.TokenLocality))
 	}
 	if len(method.NamespaceRules) > 0 {
 		buffer.WriteString(fmt.Sprintln("NamespaceRules:"))
@@ -72,8 +72,8 @@ func (f *prettyFormatter) FormatAuthMethod(method *api.ACLAuthMethod) (string, e
 		}
 	}
 	if f.showMeta {
-		buffer.WriteString(fmt.Sprintf("Create Index: %d\n", method.CreateIndex))
-		buffer.WriteString(fmt.Sprintf("Modify Index: %d\n", method.ModifyIndex))
+		buffer.WriteString(fmt.Sprintf("Create Index:  %d\n", method.CreateIndex))
+		buffer.WriteString(fmt.Sprintf("Modify Index:  %d\n", method.ModifyIndex))
 	}
 	buffer.WriteString(fmt.Sprintln("Config:"))
 	output, err := json.MarshalIndent(method.Config, "", "  ")

--- a/command/acl/authmethod/formatter.go
+++ b/command/acl/authmethod/formatter.go
@@ -61,6 +61,9 @@ func (f *prettyFormatter) FormatAuthMethod(method *api.ACLAuthMethod) (string, e
 	if method.MaxTokenTTL > 0 {
 		buffer.WriteString(fmt.Sprintf("MaxTokenTTL:  %s\n", method.MaxTokenTTL))
 	}
+	if method.TokenType != "" {
+		buffer.WriteString(fmt.Sprintf("TokenType:    %s\n", method.TokenType))
+	}
 	if len(method.NamespaceRules) > 0 {
 		buffer.WriteString(fmt.Sprintln("NamespaceRules:"))
 		for _, rule := range method.NamespaceRules {

--- a/command/acl/authmethod/update/authmethod_update.go
+++ b/command/acl/authmethod/update/authmethod_update.go
@@ -29,11 +29,11 @@ type cmd struct {
 
 	name string
 
-	displayName string
-	description string
-	maxTokenTTL time.Duration
-	tokenType   string
-	config      string
+	displayName   string
+	description   string
+	maxTokenTTL   time.Duration
+	tokenLocality string
+	config        string
 
 	k8sHost              string
 	k8sCACert            string
@@ -87,8 +87,8 @@ func (c *cmd) init() {
 		"Duration of time all tokens created by this auth method should be valid for",
 	)
 	c.flags.StringVar(
-		&c.tokenType,
-		"token-type",
+		&c.tokenLocality,
+		"token-locality",
 		"",
 		"Defines the kind of token that this auth method should produce. "+
 			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
@@ -187,11 +187,11 @@ func (c *cmd) Run(args []string) int {
 	var method *api.ACLAuthMethod
 	if c.noMerge {
 		method = &api.ACLAuthMethod{
-			Name:        currentAuthMethod.Name,
-			Type:        currentAuthMethod.Type,
-			DisplayName: c.displayName,
-			Description: c.description,
-			TokenType:   c.tokenType,
+			Name:          currentAuthMethod.Name,
+			Type:          currentAuthMethod.Type,
+			DisplayName:   c.displayName,
+			Description:   c.description,
+			TokenLocality: c.tokenLocality,
 		}
 		if c.maxTokenTTL > 0 {
 			method.MaxTokenTTL = c.maxTokenTTL
@@ -248,8 +248,8 @@ func (c *cmd) Run(args []string) int {
 		if c.maxTokenTTL > 0 {
 			method.MaxTokenTTL = c.maxTokenTTL
 		}
-		if c.tokenType != "" {
-			method.TokenType = c.tokenType
+		if c.tokenLocality != "" {
+			method.TokenLocality = c.tokenLocality
 		}
 		if err := c.enterprisePopulateAuthMethod(method); err != nil {
 			c.UI.Error(err.Error())

--- a/command/acl/authmethod/update/authmethod_update.go
+++ b/command/acl/authmethod/update/authmethod_update.go
@@ -32,6 +32,7 @@ type cmd struct {
 	displayName string
 	description string
 	maxTokenTTL time.Duration
+	tokenType   string
 	config      string
 
 	k8sHost              string
@@ -84,6 +85,13 @@ func (c *cmd) init() {
 		"max-token-ttl",
 		0,
 		"Duration of time all tokens created by this auth method should be valid for",
+	)
+	c.flags.StringVar(
+		&c.tokenType,
+		"token-type",
+		"",
+		"Defines the kind of token that this auth method should produce. "+
+			"This can be either 'local' or 'global'. If empty the value of 'local' is assumed.",
 	)
 
 	c.flags.StringVar(
@@ -183,6 +191,7 @@ func (c *cmd) Run(args []string) int {
 			Type:        currentAuthMethod.Type,
 			DisplayName: c.displayName,
 			Description: c.description,
+			TokenType:   c.tokenType,
 		}
 		if c.maxTokenTTL > 0 {
 			method.MaxTokenTTL = c.maxTokenTTL
@@ -238,6 +247,9 @@ func (c *cmd) Run(args []string) int {
 		}
 		if c.maxTokenTTL > 0 {
 			method.MaxTokenTTL = c.maxTokenTTL
+		}
+		if c.tokenType != "" {
+			method.TokenType = c.tokenType
 		}
 		if err := c.enterprisePopulateAuthMethod(method); err != nil {
 			c.UI.Error(err.Error())

--- a/website/pages/api-docs/acl/auth-methods.mdx
+++ b/website/pages/api-docs/acl/auth-methods.mdx
@@ -61,7 +61,7 @@ The table below shows this endpoint's support for
 
   This must be set to a nonzero value for `type=oidc`.
 
-- `TokenType` `(string: "")` - Defines the kind of token that this auth method
+- `TokenLocality` `(string: "")` - Defines the kind of token that this auth method
   should produce. This can be either `"local"` or `"global"`. If empty the
   value of `"local"` is assumed. Added in Consul 1.8.0.
 
@@ -240,7 +240,7 @@ The table below shows this endpoint's support for
 
   This must be set to a nonzero value for `type=oidc`.
 
-- `TokenType` `(string: "")` - Defines the kind of token that this auth method
+- `TokenLocality` `(string: "")` - Defines the kind of token that this auth method
   should produce. This can be either `"local"` or `"global"`. If empty the
   value of `"local"` is assumed. Added in Consul 1.8.0.
 

--- a/website/pages/api-docs/acl/auth-methods.mdx
+++ b/website/pages/api-docs/acl/auth-methods.mdx
@@ -61,6 +61,10 @@ The table below shows this endpoint's support for
 
   This must be set to a nonzero value for `type=oidc`.
 
+- `TokenType` `(string: "")` - Defines the kind of token that this auth method
+  should produce. This can be either `"local"` or `"global"`. If empty the
+  value of `"local"` is assumed. Added in Consul 1.8.0.
+
 - `Config` `(map[string]string: <required>)` - The raw configuration to use for
   the chosen auth method. Contents will vary depending upon the type chosen.
   For more information on configuring specific auth method types, see the [auth
@@ -235,6 +239,10 @@ The table below shows this endpoint's support for
   smaller than 1 minute and no longer than 24 hours. Added in Consul 1.8.0.
 
   This must be set to a nonzero value for `type=oidc`.
+
+- `TokenType` `(string: "")` - Defines the kind of token that this auth method
+  should produce. This can be either `"local"` or `"global"`. If empty the
+  value of `"local"` is assumed. Added in Consul 1.8.0.
 
 - `Config` `(map[string]string: <required>)` - The raw configuration to use for
   the chosen auth method. Contents will vary depending upon the type chosen.

--- a/website/pages/docs/commands/acl/auth-method/create.mdx
+++ b/website/pages/docs/commands/acl/auth-method/create.mdx
@@ -37,7 +37,7 @@ Usage: `consul acl auth-method create [options] [args]`
 - `-max-token-ttl=<duration>` - Duration of time all tokens created by this
   auth method should be valid for. Added in Consul 1.8.0.
 
-- `-token-type=<string>` - Defines the kind of token that this auth method
+- `-token-locality=<string>` - Defines the kind of token that this auth method
   should produce. This can be either 'local' or 'global'. If empty the value of
   'local' is assumed. Added in Consul 1.8.0.
 

--- a/website/pages/docs/commands/acl/auth-method/create.mdx
+++ b/website/pages/docs/commands/acl/auth-method/create.mdx
@@ -37,6 +37,10 @@ Usage: `consul acl auth-method create [options] [args]`
 - `-max-token-ttl=<duration>` - Duration of time all tokens created by this
   auth method should be valid for. Added in Consul 1.8.0.
 
+- `-token-type=<string>` - Defines the kind of token that this auth method
+  should produce. This can be either 'local' or 'global'. If empty the value of
+  'local' is assumed. Added in Consul 1.8.0.
+
 - `-config=<string>` - The configuration for the auth method. Must be JSON. May
   be prefixed with '@' to indicate that the value is a file path to load the
   config from. '-' may also be given to indicate that the config is available on

--- a/website/pages/docs/commands/acl/auth-method/update.mdx
+++ b/website/pages/docs/commands/acl/auth-method/update.mdx
@@ -33,7 +33,7 @@ Usage: `consul acl auth-method update [options] [args]`
 - `-max-token-ttl=<duration>` - Duration of time all tokens created by this
   auth method should be valid for. Added in Consul 1.8.0.
 
-- `-token-type=<string>` - Defines the kind of token that this auth method
+- `-token-locality=<string>` - Defines the kind of token that this auth method
   should produce. This can be either 'local' or 'global'. If empty the value of
   'local' is assumed. Added in Consul 1.8.0.
 

--- a/website/pages/docs/commands/acl/auth-method/update.mdx
+++ b/website/pages/docs/commands/acl/auth-method/update.mdx
@@ -33,6 +33,10 @@ Usage: `consul acl auth-method update [options] [args]`
 - `-max-token-ttl=<duration>` - Duration of time all tokens created by this
   auth method should be valid for. Added in Consul 1.8.0.
 
+- `-token-type=<string>` - Defines the kind of token that this auth method
+  should produce. This can be either 'local' or 'global'. If empty the value of
+  'local' is assumed. Added in Consul 1.8.0.
+
 - `-config=<string>` - The configuration for the auth method. Must be JSON. May
   be prefixed with '@' to indicate that the value is a file path to load the
   config from. '-' may also be given to indicate that the config is available on


### PR DESCRIPTION
Currently auth methods (and binding rules) are dc-local items that are not replicated between datacenters. They are also restricted to only being able to create dc-local ACL tokens.

This restriction was initially set in place to avoid an availability issue in any application that headlessly would make use of an auth method to dynamically create a token _before application start_ (such as a kubernetes pod pre start hook). If these needed to make a synchronous RPC back to the primary datacenter (that may not even be up) then that would incur both an additional startup delay and the probability of bringing everything to a screeching halt in the event the primary datacenter is briefly disconnected.

While this argument still holds for any auth method used headlessly (`type=kubernetes` and `type=jwt`) it is harder to make the same justification for user-driven flows like `type=oidc`. 
In this PR I'm granting auth methods _defined in the primary datacenter_ the option of being configured to exclusively create global ACL tokens.

- Folks setting up OIDC in their primary datacenter would benefit from enabling this option to allow for the UI to forward requests to other datacenters without needing to SSO...multiple times.
- Anyone running headless workloads _in their primary datacenter_ could benefit from having this option available for `type=kubernetes` and `type=jwt` as well.
