### PR TITLE
intentions: fix a bug in Intention.SetHash

### DIFF
--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -86,7 +86,7 @@ func (s *Intention) prepareApplyCreate(ident structs.ACLIdentity, authz acl.Auth
 	}
 
 	// make sure we set the hash prior to raft application
-	args.Intention.SetHash(true)
+	args.Intention.SetHash()
 
 	return nil
 }
@@ -145,7 +145,7 @@ func (s *Intention) prepareApplyUpdate(ident structs.ACLIdentity, authz acl.Auth
 	}
 
 	// make sure we set the hash prior to raft application
-	args.Intention.SetHash(true)
+	args.Intention.SetHash()
 
 	return nil
 }

--- a/agent/http_decode_test.go
+++ b/agent/http_decode_test.go
@@ -1996,8 +1996,6 @@ func TestDecodeCatalogRegister(t *testing.T) {
 //     DestinationName	string
 //     SourceType	structs.IntentionSourceType
 //     Action	structs.IntentionAction
-//     DefaultAddr	string
-//     DefaultPort	int
 //     Meta	map[string]string
 //     Precedence	int
 //     CreatedAt	time.Time	mapstructure:'-'

--- a/agent/structs/intention_test.go
+++ b/agent/structs/intention_test.go
@@ -334,3 +334,28 @@ func TestIntentionPrecedenceSorter(t *testing.T) {
 		})
 	}
 }
+
+func TestIntention_SetHash(t *testing.T) {
+	i := Intention{
+		ID:              "the-id",
+		Description:     "the-description",
+		SourceNS:        "source-ns",
+		SourceName:      "source-name",
+		DestinationNS:   "dest-ns",
+		DestinationName: "dest-name",
+		SourceType:      "source-type",
+		Action:          "action",
+		Precedence:      123,
+		Meta: map[string]string{
+			"meta1": "one",
+			"meta2": "two",
+		},
+	}
+	i.SetHash()
+	expected := []byte{
+		0x20, 0x89, 0x55, 0xdb, 0x69, 0x34, 0xce, 0x89, 0xd8, 0xb9, 0x2e, 0x3a,
+		0x85, 0xb6, 0xea, 0x43, 0xb2, 0x23, 0x16, 0x93, 0x94, 0x13, 0x2a, 0xe4,
+		0x81, 0xfe, 0xe, 0x34, 0x91, 0x99, 0xe9, 0x8d,
+	}
+	require.Equal(t, expected, i.Hash)
+}

--- a/agent/structs/structs_filtering_test.go
+++ b/agent/structs/structs_filtering_test.go
@@ -566,16 +566,6 @@ var expectedFieldConfigIntention bexpr.FieldConfigurations = bexpr.FieldConfigur
 		CoerceFn:            bexpr.CoerceString,
 		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
 	},
-	"DefaultAddr": &bexpr.FieldConfiguration{
-		StructFieldName:     "DefaultAddr",
-		CoerceFn:            bexpr.CoerceString,
-		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual, bexpr.MatchIn, bexpr.MatchNotIn, bexpr.MatchMatches, bexpr.MatchNotMatches},
-	},
-	"DefaultPort": &bexpr.FieldConfiguration{
-		StructFieldName:     "DefaultPort",
-		CoerceFn:            bexpr.CoerceInt,
-		SupportedOperations: []bexpr.MatchOperator{bexpr.MatchEqual, bexpr.MatchNotEqual},
-	},
 	"Precedence": &bexpr.FieldConfiguration{
 		StructFieldName:     "Precedence",
 		CoerceFn:            bexpr.CoerceInt,

--- a/api/connect_intention.go
+++ b/api/connect_intention.go
@@ -36,10 +36,12 @@ type Intention struct {
 	// Action is whether this is an allowlist or denylist intention.
 	Action IntentionAction
 
-	// DefaultAddr, DefaultPort of the local listening proxy (if any) to
-	// make this connection.
-	DefaultAddr string
-	DefaultPort int
+	// DefaultAddr is not used.
+	// Deprecated: DefaultAddr is not used and may be removed in a future version.
+	DefaultAddr string `json:",omitempty"`
+	// DefaultPort is not used.
+	// Deprecated: DefaultPort is not used and may be removed in a future version.
+	DefaultPort int `json:",omitempty"`
 
 	// Meta is arbitrary metadata associated with the intention. This is
 	// opaque to Consul but is served in API responses.

--- a/ui-v2/app/models/intention.js
+++ b/ui-v2/app/models/intention.js
@@ -14,11 +14,6 @@ export default Model.extend({
   Precedence: attr('number'),
   SourceType: attr('string', { defaultValue: 'consul' }),
   Action: attr('string', { defaultValue: 'deny' }),
-  // These are in the API response but up until now
-  // aren't used for anything
-  DefaultAddr: attr('string'),
-  DefaultPort: attr('number'),
-  //
   Meta: attr(),
   SyncTime: attr('number'),
   Datacenter: attr('string'),

--- a/website/pages/api-docs/connect/intentions.mdx
+++ b/website/pages/api-docs/connect/intentions.mdx
@@ -145,8 +145,6 @@ $ curl \
   "DestinationName": "db",
   "SourceType": "consul",
   "Action": "allow",
-  "DefaultAddr": "",
-  "DefaultPort": 0,
   "Meta": {},
   "Precedence": 9,
   "CreatedAt": "2018-05-21T16:41:27.977155457Z",
@@ -208,8 +206,6 @@ $ curl \
     "DestinationName": "db",
     "SourceType": "consul",
     "Action": "allow",
-    "DefaultAddr": "",
-    "DefaultPort": 0,
     "Meta": {},
     "Precedence": 9,
     "CreatedAt": "2018-05-21T16:41:27.977155457Z",
@@ -228,8 +224,6 @@ the following selectors and filter operations being supported:
 | Selector          | Supported Operations                               |
 | ----------------- | -------------------------------------------------- |
 | `Action`          | Equal, Not Equal, In, Not In, Matches, Not Matches |
-| `DefaultAddr`     | Equal, Not Equal, In, Not In, Matches, Not Matches |
-| `DefaultPort`     | Equal, Not Equal                                   |
 | `Description`     | Equal, Not Equal, In, Not In, Matches, Not Matches |
 | `DestinationNS`   | Equal, Not Equal, In, Not In, Matches, Not Matches |
 | `DestinationName` | Equal, Not Equal, In, Not In, Matches, Not Matches |
@@ -450,8 +444,6 @@ $ curl \
       "DestinationName": "db",
       "SourceType": "consul",
       "Action": "deny",
-      "DefaultAddr": "",
-      "DefaultPort": 0,
       "Meta": {},
       "CreatedAt": "2018-05-21T16:41:33.296693825Z",
       "UpdatedAt": "2018-05-21T16:41:33.296694288Z",
@@ -467,8 +459,6 @@ $ curl \
       "DestinationName": "*",
       "SourceType": "consul",
       "Action": "allow",
-      "DefaultAddr": "",
-      "DefaultPort": 0,
       "Meta": {},
       "CreatedAt": "2018-05-21T16:41:27.977155457Z",
       "UpdatedAt": "2018-05-21T16:41:27.977157724Z",


### PR DESCRIPTION
Found using staticcheck.

`binary.Write` does not accept `int` types without a size. The error from `binary.Write` was ignored, so we never saw this error. Casting the data to uint64 produces a correct hash. 

Without this fix the new test would continue to pass if `DefaultPort` and `Precedence` changed value, because those two fields were never being added to the hash. After this change the test fails correctly if those values are changed.

I guess this would cause problems with replicating Intentions if only the port or precedence changed?