### PR TITLE
Documentation | Connect on Kubernetes | Change an "is" into "can be"

### DIFF
--- a/website/pages/docs/k8s/connect.mdx
+++ b/website/pages/docs/k8s/connect.mdx
@@ -27,7 +27,7 @@ automatically installed and configured using the
 
 When the
 [Connect injector is installed](/docs/k8s/connect#installation-and-configuration),
-the Connect sidecar is automatically added to all pods. This sidecar can both
+the Connect sidecar can be automatically added to all pods. This sidecar can both
 accept and establish connections using Connect, enabling the pod to communicate
 to clients and dependencies exclusively over authorized and encrypted
 connections.


### PR DESCRIPTION
The doc says: "When the Connect injector is installed, the Connect sidecar is automatically added to all pods." But, it depends on the configuration, so I think it's better to say: "When the Connect injector is installed, the Connect sidecar can automatically added to all pods."