### PR TITLE
Fix legacy management tokens in unupgraded secondary dcs

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -1154,16 +1154,17 @@ func (r *ACLResolver) ACLsEnabled() bool {
 	return true
 }
 
-func (r *ACLResolver) GetMergedPolicyForToken(token string) (*acl.Policy, error) {
-	policies, err := r.resolveTokenToPolicies(token)
+func (r *ACLResolver) GetMergedPolicyForToken(token string) (structs.ACLIdentity, *acl.Policy, error) {
+	ident, policies, err := r.resolveTokenToIdentityAndPolicies(token)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(policies) == 0 {
-		return nil, acl.ErrNotFound
+		return nil, nil, acl.ErrNotFound
 	}
 
-	return policies.Merge(r.cache, r.aclConf)
+	policy, err := policies.Merge(r.cache, r.aclConf)
+	return ident, policy, err
 }
 
 // aclFilter is used to filter results from our state store based on ACL rules

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1324,9 +1324,13 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicyResolveLegacyRequest, reply *stru
 	// Get the policy via the cache
 	parent := a.srv.config.ACLDefaultPolicy
 
-	policy, err := a.srv.acls.GetMergedPolicyForToken(args.ACL)
+	ident, policy, err := a.srv.acls.GetMergedPolicyForToken(args.ACL)
 	if err != nil {
 		return err
+	}
+
+	if token, ok := ident.(*structs.ACLToken); ok && token.Type == structs.ACLTokenTypeManagement {
+		parent = "manage"
 	}
 
 	// translates the structures internals to most closely match what could be expressed in the original rule language


### PR DESCRIPTION
The ACL.GetPolicy RPC endpoint was supposed to return the “parent” policy and not always the default policy. In the case of legacy management tokens the parent policy was supposed to be “manage”. The result of us not sending this properly was that operations that required specifically a management token such as saving a snapshot would not work in secondary DCs until they were upgraded.

We cannot do so in our unit tests but I also spun up a multi-dc cluster with the main DC on a dev build from this branch and the secondary DC on v1.2.4. The master token and legacy compatible management tokens in general are usable in the secondary dc.