### PR TITLE
ui: Ensure datacenter is sent to the API when loading in a policy panel

### DIFF
--- a/ui-v2/app/components/child-selector/index.js
+++ b/ui-v2/app/components/child-selector/index.js
@@ -76,9 +76,13 @@ export default Component.extend(SlotsMixin, WithListeners, {
             items,
             e.data,
           ]);
+          item.willDestroy();
           success();
         },
-        error: e => this.error(e),
+        error: e => {
+          item.willDestroy();
+          this.error(e);
+        },
       });
     },
     remove: function(item, items) {

--- a/ui-v2/app/components/policy-selector/index.hbs
+++ b/ui-v2/app/components/policy-selector/index.hbs
@@ -59,7 +59,7 @@
       <BlockSlot @name="details">
           {{#if (eq item.template '')}}
             <DataSource
-              @src={{concat '/' item.Namespace '/' item.Datacenter '/policy/' item.ID}}
+              @src={{concat '/' item.Namespace '/' dc '/policy/' item.ID}}
               @onchange={{action (mut loadedItem) value="data"}}
               @loading="lazy"
             />


### PR DESCRIPTION
This PR does two things:

1. Uses the datacenter in the URL to load in policies when a policy preview panel is opened.
2. Ensures the last of our Ember Proxy based event sources are cleaned up following our ember upgrade.