### PR TITLE
ui: Ensure value is always passed to CONSUL_SSO_ENABLED

### DIFF
--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -127,9 +127,11 @@ module.exports = function(environment, $ = process.env) {
       });
       break;
     case environment === 'production':
+      // Make sure all templated variables check for existence first
+      // before outputting them, this means they all should be conditionals
       ENV = Object.assign({}, ENV, {
-        CONSUL_ACLS_ENABLED: '{{.ACLsEnabled}}',
-        CONSUL_SSO_ENABLED: '{{.SSOEnabled}}',
+        CONSUL_ACLS_ENABLED: '{{ if .ACLsEnabled }}{{.ACLsEnabled}}{{ else }}false{{ end }}',
+        CONSUL_SSO_ENABLED: '{{ if .SSOEnabled }}{{.SSOEnabled}}{{ else }}false{{ end }}',
         CONSUL_NSPACES_ENABLED:
           '{{ if .NamespacesEnabled }}{{.NamespacesEnabled}}{{ else }}false{{ end }}',
       });

--- a/ui-v2/node-tests/config/environment.js
+++ b/ui-v2/node-tests/config/environment.js
@@ -9,8 +9,8 @@ test(
       {
         environment: 'production',
         CONSUL_BINARY_TYPE: 'oss',
-        CONSUL_ACLS_ENABLED: '{{.ACLsEnabled}}',
-        CONSUL_SSO_ENABLED: '{{.SSOEnabled}}',
+        CONSUL_ACLS_ENABLED: '{{ if .ACLsEnabled }}{{.ACLsEnabled}}{{ else }}false{{ end }}',
+        CONSUL_SSO_ENABLED: '{{ if .SSOEnabled }}{{.SSOEnabled}}{{ else }}false{{ end }}',
         CONSUL_NSPACES_ENABLED: '{{ if .NamespacesEnabled }}{{.NamespacesEnabled}}{{ else }}false{{ end }}',
       },
       {


### PR DESCRIPTION
`ACLsEnabled` is always set to either true or false. `.SSOEnabled` is only set if you are running enterprise (the same as `.NamespacesEnabled`). Therefore `.SSOEnabled` and `.NamespacesEnabled` require conditionals to check their existence.

In order to avoid future confusion we moved all go-template variables to use the conditional form, and added a comment to that effect.

Tests have been added to reflect this, but they only test that the template outputs what we expect, true e2e testing here would be advantageous.