### PR TITLE
ci: limit parallelism for Ember builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,8 @@ jobs:
   ember-build:
     docker:
       - image: *EMBER_IMAGE
-    resource_class: medium+
+    environment:
+      JOBS: 2 # limit parallelism for broccoli-babel-transpiler
     steps:
       - checkout
       - restore_cache:
@@ -428,7 +429,8 @@ jobs:
   ember-build-prod:
     docker:
       - image: *EMBER_IMAGE
-    resource_class: medium+
+    environment:
+      JOBS: 2 # limit parallelism for broccoli-babel-transpiler
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Refs https://github.com/emberjs/ember.js/issues/15641, https://github.com/hashicorp/vault/pull/8152

If not artificially limited by setting JOBS env var, broccoli-babel-transpiler will attempt to parallelize across the number of CPUs on the host VM rather than the Docker container, resulting in CI jobs being killed due to running out of memory.

Reverts the `resource_class` changes from https://github.com/hashicorp/consul/pull/7873 which should not be needed if parallelization is limited to the CPUs available in the Docker container.
