### PR TITLE
ui: Settings > Only save the specific setting that you've changed not the entire settings object

### DIFF
--- a/ui-v2/app/controllers/settings.js
+++ b/ui-v2/app/controllers/settings.js
@@ -35,14 +35,14 @@ export default Controller.extend({
       switch (target.name) {
         case 'client[blocking]':
           set(this, 'item.client.blocking', !blocking);
-          this.send('update', this.item);
+          this.send('update', 'client', this.item.client);
           break;
         case 'urls[service]':
           if (typeof get(this, 'item.urls') === 'undefined') {
             set(this, 'item.urls', {});
           }
           set(this, 'item.urls.service', target.value);
-          this.send('update', this.item);
+          this.send('update', 'urls', this.item.urls);
           break;
       }
     },

--- a/ui-v2/app/routes/settings.js
+++ b/ui-v2/app/routes/settings.js
@@ -25,11 +25,17 @@ export default Route.extend({
     controller.setProperties(model);
   },
   actions: {
-    update: function(item) {
-      if (!get(item, 'client.blocking')) {
-        this.client.abort();
+    update: function(slug, item) {
+      switch (slug) {
+        case 'client':
+          if (!get(item, 'client.blocking')) {
+            this.client.abort();
+          }
+          break;
       }
-      this.repo.persist(item);
+      this.repo.persist({
+        [slug]: item,
+      });
     },
   },
 });


### PR DESCRIPTION
Originally we assumed all settings would be editable in the settings
page, but over time we've added thigns to localStorage that aren't user
settable settings. This means we shouldn't save all you localStorage
settings everything time only a single setting has been saved.

This change only changes the setting you've changed via the settings
page, meaning it will never update non-user-settable settings.