### PR TITLE
Update NextJS Scripts and lint CSS

### DIFF
--- a/website/.stylelintrc.js
+++ b/website/.stylelintrc.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@hashicorp/nextjs-scripts/.stylelintrc.js'),
+  /* Specify overrides here */
+  ignoreFiles: ['public/**/*.css'],
   rules: {
     'selector-pseudo-class-no-unknown': [
       true,

--- a/website/components/learn-callout/style.css
+++ b/website/components/learn-callout/style.css
@@ -66,6 +66,8 @@
     }
 
     & > a {
+      display: flex;
+      cursor: pointer;
       margin: 0 16px;
       width: 33.333%;
       transition: box-shadow 0.25s, transform 0.25s, -webkit-transform 0.25s;

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "author": "HashiCorp",
   "dependencies": {
+    "@bugsnag/js": "^7.0.1",
+    "@bugsnag/plugin-react": "^7.0.1",
+    "@hashicorp/mktg-assets": "^1.0.0-alpha.7",
     "@hashicorp/nextjs-scripts": "^8.0.0",
     "@hashicorp/react-alert": "^2.0.0",
     "@hashicorp/react-alert-banner": "^3.1.0",


### PR DESCRIPTION
🎟️ [Asana](https://app.asana.com/0/1100423001970639/1176594948799179/f)

This updates the NextJS Scripts package to v8, which allows CSS files to be linted.

It automatically fixes several small issues, and even fixes an issue where the following CSS files were imported multiple times in the same file:

```
@import '~@hashicorp/react-consent-manager/dist/style.css';
@import '~@hashicorp/react-section-header/dist/style.css';
```

