### PR TITLE
ui: Blink/Webkit input[type=password] workaround

### DIFF
--- a/ui-v2/app/components/auth-form/index.hbs
+++ b/ui-v2/app/components/auth-form/index.hbs
@@ -43,7 +43,7 @@
           <input
             {{ref this 'input'}}
             disabled={{state-matches state "loading"}}
-            type="password"
+            type={{inputType}}
             name="auth[SecretID]"
             placeholder="SecretID"
             value={{secret}}

--- a/ui-v2/app/components/auth-form/index.js
+++ b/ui-v2/app/components/auth-form/index.js
@@ -1,4 +1,6 @@
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import Ember from 'ember';
 
 import chart from './chart.xstate';
 
@@ -6,6 +8,12 @@ export default Component.extend({
   tagName: '',
   onsubmit: function(e) {},
   onchange: function(e) {},
+  // Blink/Webkit based seem to leak password inputs
+  // this will only occur during acceptance testing so
+  // turn them into text inputs during acceptance testing
+  inputType: computed(function() {
+    return Ember.testing ? 'text' : 'password';
+  }),
   init: function() {
     this._super(...arguments);
     this.chart = chart;


### PR DESCRIPTION
It seems that blink/webkit browsers at least will leak memory when using
input[type=password] inputs. This only affects us during testing as we
'refresh' the ember app ~1000 times without actually refreshing
the browser (once per acceptance test). This means references to these
HTML input elements mount up now that every single page/test has an
input[password] in the DOM.

Following this change our memory usage during testing seems to have
reduced by as much as 75%.

During normal usage the single password element is only added to the
page once per login/logout.

Various related issues:

https://bugs.chromium.org/p/chromium/issues/detail?id=734427
https://bugs.chromium.org/p/chromium/issues/detail?id=967438

cc @mikemorris 


