### PR TITLE
agent: handle re-bootstrapping in a secondary datacenter when WAN federation via mesh gateways is configured

### DIFF
--- a/agent/consul/gateway_locator_test.go
+++ b/agent/consul/gateway_locator_test.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,11 +43,7 @@ func TestGatewayLocator(t *testing.T) {
 		UpdatedAt: time.Now().UTC(),
 	}
 
-	// Insert data for the dcs
-	require.NoError(t, state.FederationStateSet(1, dc1))
-	require.NoError(t, state.FederationStateSet(2, dc2))
-
-	t.Run("primary", func(t *testing.T) {
+	t.Run("primary - no data", func(t *testing.T) {
 		logger := testutil.Logger(t)
 		tsd := &testServerDelegate{State: state, isLeader: true}
 		g := NewGatewayLocator(
@@ -57,19 +55,14 @@ func TestGatewayLocator(t *testing.T) {
 
 		idx, err := g.runOnce(0)
 		require.NoError(t, err)
-		require.Equal(t, uint64(2), idx)
-		require.Len(t, tsd.Calls, 1)
-		require.Equal(t, []string{
-			"1.2.3.4:5555",
-			"4.3.2.1:9999",
-		}, g.listGateways(false))
-		require.Equal(t, []string{
-			"1.2.3.4:5555",
-			"4.3.2.1:9999",
-		}, g.listGateways(true))
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(1), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string(nil), g.listGateways(false))
+		assert.Equal(t, []string(nil), g.listGateways(true))
 	})
 
-	t.Run("secondary", func(t *testing.T) {
+	t.Run("secondary - no data", func(t *testing.T) {
 		logger := testutil.Logger(t)
 		tsd := &testServerDelegate{State: state, isLeader: true}
 		g := NewGatewayLocator(
@@ -81,15 +74,261 @@ func TestGatewayLocator(t *testing.T) {
 
 		idx, err := g.runOnce(0)
 		require.NoError(t, err)
-		require.Equal(t, uint64(2), idx)
-		require.Len(t, tsd.Calls, 1)
-		require.Equal(t, []string{
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(1), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string(nil), g.listGateways(false))
+		assert.Equal(t, []string(nil), g.listGateways(true))
+	})
+
+	t.Run("secondary - just fallback", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(1), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string(nil), g.listGateways(false))
+		assert.Equal(t, []string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		}, g.listGateways(true))
+	})
+
+	// Insert data for the dcs
+	require.NoError(t, state.FederationStateSet(1, dc1))
+	require.NoError(t, state.FederationStateSet(2, dc2))
+
+	t.Run("primary - with data", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc1",
+			"dc1",
+		)
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"1.2.3.4:5555",
+			"4.3.2.1:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"1.2.3.4:5555",
+			"4.3.2.1:9999",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
 			"5.6.7.8:5555",
 			"8.7.6.5:9999",
 		}, g.listGateways(false))
-		require.Equal(t, []string{
+		assert.Equal(t, []string{
 			"1.2.3.4:5555",
 			"4.3.2.1:9999",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data and fallback - no repl", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"1.2.3.4:5555",
+			"4.3.2.1:9999",
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data and fallback - repl ok", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		g.SetLastFederationStateReplicationError(nil)
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.True(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data and fallback - repl ok then failed 2 times", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		g.SetLastFederationStateReplicationError(nil)
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.True(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data and fallback - repl ok then failed 3 times", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		g.SetLastFederationStateReplicationError(nil)
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.False(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"1.2.3.4:5555",
+			"4.3.2.1:9999",
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		}, g.listGateways(true))
+	})
+
+	t.Run("secondary - with data and fallback - repl ok then failed 3 times then ok again", func(t *testing.T) {
+		logger := testutil.Logger(t)
+		tsd := &testServerDelegate{State: state, isLeader: true}
+		g := NewGatewayLocator(
+			logger,
+			tsd,
+			"dc2",
+			"dc1",
+		)
+
+		g.RefreshPrimaryGatewayFallbackAddresses([]string{
+			"7.7.7.7:7777",
+			"8.8.8.8:8888",
+		})
+
+		g.SetLastFederationStateReplicationError(nil)
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(errors.New("fake"))
+		g.SetLastFederationStateReplicationError(nil)
+
+		idx, err := g.runOnce(0)
+		require.NoError(t, err)
+		assert.True(t, g.DialPrimaryThroughLocalGateway())
+		assert.Equal(t, uint64(2), idx)
+		assert.Len(t, tsd.Calls, 1)
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
+		}, g.listGateways(false))
+		assert.Equal(t, []string{
+			"5.6.7.8:5555",
+			"8.7.6.5:9999",
 		}, g.listGateways(true))
 	})
 }
@@ -97,8 +336,7 @@ func TestGatewayLocator(t *testing.T) {
 type testServerDelegate struct {
 	State *state.Store
 
-	FallbackAddrs []string
-	Calls         []uint64
+	Calls []uint64
 
 	isLeader    bool
 	lastContact time.Time
@@ -126,10 +364,6 @@ func (d *testServerDelegate) blockingQuery(
 
 func newFakeStateStore() (*state.Store, error) {
 	return state.NewStateStore(nil)
-}
-
-func (d *testServerDelegate) PrimaryGatewayFallbackAddresses() []string {
-	return d.FallbackAddrs
 }
 
 func (d *testServerDelegate) IsLeader() bool {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -439,8 +439,11 @@ func NewServerLogger(config *Config, logger hclog.InterceptLogger, tokens *token
 	federationStateReplicatorConfig := ReplicatorConfig{
 		Name: logging.FederationState,
 		Delegate: &IndexReplicator{
-			Delegate: &FederationStateReplicator{srv: s},
-			Logger:   s.logger,
+			Delegate: &FederationStateReplicator{
+				srv:            s,
+				gatewayLocator: s.gatewayLocator,
+			},
+			Logger: s.logger,
 		},
 		Rate:   s.config.FederationStateReplicationRate,
 		Burst:  s.config.FederationStateReplicationBurst,

--- a/lib/slice.go
+++ b/lib/slice.go
@@ -15,3 +15,42 @@ func StringSliceEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// StringSliceMergeSorted takes two string slices that are assumed to be sorted
+// and does a zipper merge of the two sorted slices, removing any cross-slice
+// duplicates. If any individual slice contained duplicates those will be
+// retained.
+func StringSliceMergeSorted(a, b []string) []string {
+	if len(a) == 0 && len(b) == 0 {
+		return nil
+	} else if len(a) == 0 {
+		return b
+	} else if len(b) == 0 {
+		return a
+	}
+
+	out := make([]string, 0, len(a)+len(b))
+
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] < b[j]:
+			out = append(out, a[i])
+			i++
+		case a[i] > b[j]:
+			out = append(out, b[j])
+			j++
+		default:
+			out = append(out, a[i])
+			i++
+			j++
+		}
+	}
+	if i < len(a) {
+		out = append(out, a[i:]...)
+	}
+	if j < len(b) {
+		out = append(out, b[j:]...)
+	}
+	return out
+}

--- a/lib/slice_test.go
+++ b/lib/slice_test.go
@@ -28,3 +28,25 @@ func TestStringSliceEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSliceMergeSorted(t *testing.T) {
+	for name, tc := range map[string]struct {
+		a, b   []string
+		expect []string
+	}{
+		"nil":              {nil, nil, nil},
+		"empty":            {[]string{}, []string{}, nil},
+		"one and none":     {[]string{"foo"}, []string{}, []string{"foo"}},
+		"one and one dupe": {[]string{"foo"}, []string{"foo"}, []string{"foo"}},
+		"one and one":      {[]string{"foo"}, []string{"bar"}, []string{"bar", "foo"}},
+		"two and one":      {[]string{"baz", "foo"}, []string{"bar"}, []string{"bar", "baz", "foo"}},
+		"two and two":      {[]string{"baz", "foo"}, []string{"bar", "egg"}, []string{"bar", "baz", "egg", "foo"}},
+		"two and two dupe": {[]string{"bar", "foo"}, []string{"bar", "egg"}, []string{"bar", "egg", "foo"}},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tc.expect, StringSliceMergeSorted(tc.a, tc.b))
+			require.Equal(t, tc.expect, StringSliceMergeSorted(tc.b, tc.a))
+		})
+	}
+}


### PR DESCRIPTION
The main fix here is to always union the `primary-gateways` list with
the list of mesh gateways in the primary returned from the replicated
federation states list. This will allow any replicated (incorrect) state
to be supplemented with user-configured (correct) state in the config
file. Eventually the game of random selection whack-a-mole will pick a
winning entry and re-replicate the latest federation states from the
primary. If the user-configured state is actually the incorrect one,
then the same eventual correct selection process will work in that case,
too.

The secondary fix is actually to finish making wanfed-via-mgws actually
work as originally designed. Once a secondary datacenter has replicated
federation states for the primary AND managed to stand up its own local
mesh gateways then all of the RPCs from a secondary to the primary
SHOULD go through two sets of mesh gateways to arrive in the consul
servers in the primary (one hop for the secondary datacenter's mesh
gateway, and one hop through the primary datacenter's mesh gateway).
This was neglected in the initial implementation. While everything
works, ideally we should treat communications that go around the mesh
gateways as just provided for bootstrapping purposes.

Now we heuristically use the success/failure history of the federation
state replicator goroutine loop to determine if our current mesh gateway
route is working as intended. If it is, we try using the local gateways,
and if those don't work we fall back on trying the primary via the union
of the replicated state and the go-discover configuration flags.

This can be improved slightly in the future by possibly initializing the
gateway choice to local on startup if we already have replicated state.
This PR does not address that improvement.

Fixes #7339