### PR TITLE
state: fix unhandled error

### DIFF
--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -740,7 +740,7 @@ func (s *Store) EnsureService(idx uint64, node string, svc *structs.NodeService)
 var errCASCompareFailed = errors.New("compare-and-set: comparison failed")
 
 // ensureServiceCASTxn updates a service only if the existing index matches the given index.
-// Returns a bool indicating if a write happened and any error.
+// Returns an error if the write didn't happen and nil if write was successful.
 func (s *Store) ensureServiceCASTxn(tx *memdb.Txn, idx uint64, node string, svc *structs.NodeService) error {
 	// Retrieve the existing service.
 	_, existing, err := firstWatchCompoundWithTxn(tx, "services", "id", &svc.EnterpriseMeta, node, svc.ID)


### PR DESCRIPTION
Follow up to #7894, there was one more case where an error was being ignored, but the linter was not able to detect the problem because there was an `if err == nil` .

We can use the error value to identify the 'comparison failed' case which makes the function easier to use and should make it harder to mishandle the error case.