### PR TITLE
ui: Make only existing services in Upstreams linkabled with hover effect

### DIFF
--- a/ui-v2/app/components/list-collection/index.hbs
+++ b/ui-v2/app/components/list-collection/index.hbs
@@ -1,6 +1,15 @@
-<EmberNativeScrollable @tagName="ul" @content-size={{_contentSize}} @scroll-left={{_scrollLeft}} @scroll-top={{_scrollTop}} @scrollChange={{action "scrollChange"}} @clientSizeChange={{action "clientSizeChange"}}>
+<EmberNativeScrollable 
+  @tagName="ul" 
+  @content-size={{_contentSize}} 
+  @scroll-left={{_scrollLeft}} 
+  @scroll-top={{_scrollTop}} 
+  @scrollChange={{action "scrollChange"}} 
+  @clientSizeChange={{action "clientSizeChange"}}
+>
     <li></li>
     {{~#each _cells as |cell|~}}
-      <li onclick={{action 'click'}} style={{{cell.style}}}>{{yield cell.item cell.index }}</li>
+      <li onclick={{action 'click'}} style={{{cell.style}}} class={{if (service/exists cell.item) 'linkable' }}>
+        {{yield cell.item cell.index }}
+      </li>
     {{~/each~}}
 </EmberNativeScrollable>

--- a/ui-v2/app/helpers/service/exists.js
+++ b/ui-v2/app/helpers/service/exists.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+export function serviceExists([item], hash) {
+  if (typeof item.InstanceCount === 'undefined') {
+    return false;
+  }
+
+  return item.InstanceCount > 0;
+}
+
+export default helper(serviceExists);

--- a/ui-v2/app/styles/components/composite-row.scss
+++ b/ui-v2/app/styles/components/composite-row.scss
@@ -6,7 +6,7 @@
   @extend %composite-row;
 }
 /* hoverable rows */
-.consul-upstream-list > ul > li:not(:first-child),
+%composite-row.linkable,
 .consul-gateway-service-list > ul > li:not(:first-child),
 .consul-service-instance-list > ul > li:not(:first-child),
 .consul-service-list > ul > li:not(:first-child) {

--- a/ui-v2/app/templates/dc/services/show/upstreams.hbs
+++ b/ui-v2/app/templates/dc/services/show/upstreams.hbs
@@ -7,9 +7,15 @@
       </p>
     {{#let item.Service.Namespace as |nspace|}}
       <ListCollection @items={{gateway.Services}} class="consul-upstream-list" as |item index|>
+      {{#if (service/exists item)}}
         <a data-test-service-name href={{href-to 'dc.services.show' item.Name}}>
           {{item.Name}}
         </a>
+      {{else}}
+        <p data-test-service-name>
+          {{item.Name}}
+        </p>
+      {{/if}}
         <ul>
         {{#if (env 'CONSUL_NSPACES_ENABLED')}}
           {{#if (not-eq item.Namespace nspace)}}

--- a/ui-v2/tests/integration/helpers/service/exists-test.js
+++ b/ui-v2/tests/integration/helpers/service/exists-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | service/exists', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', { InstanceCount: 3 });
+
+    await render(hbs`{{service/exists inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'true');
+  });
+});


### PR DESCRIPTION
- Using InstanceCount we can tell if a service exists
- We've created a helper called service/exits that returns a boolean
- We then use the helper to add a class to each `<li>` and to return a `p` or an `a` tag
- If the `<li>` has a class of `"linkabled"` we style with the hover effect and cursor pointer 
![ingress-upstreams](https://user-images.githubusercontent.com/19161242/82573920-5f7ff180-9b54-11ea-9c28-10d42912cfef.gif)
