### PR TITLE
api/agent: enable setting check thresholds in agent API

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -188,26 +188,28 @@ type AgentCheckRegistration struct {
 
 // AgentServiceCheck is used to define a node or service level check
 type AgentServiceCheck struct {
-	CheckID           string              `json:",omitempty"`
-	Name              string              `json:",omitempty"`
-	Args              []string            `json:"ScriptArgs,omitempty"`
-	DockerContainerID string              `json:",omitempty"`
-	Shell             string              `json:",omitempty"` // Only supported for Docker.
-	Interval          string              `json:",omitempty"`
-	Timeout           string              `json:",omitempty"`
-	TTL               string              `json:",omitempty"`
-	HTTP              string              `json:",omitempty"`
-	Header            map[string][]string `json:",omitempty"`
-	Method            string              `json:",omitempty"`
-	Body              string              `json:",omitempty"`
-	TCP               string              `json:",omitempty"`
-	Status            string              `json:",omitempty"`
-	Notes             string              `json:",omitempty"`
-	TLSSkipVerify     bool                `json:",omitempty"`
-	GRPC              string              `json:",omitempty"`
-	GRPCUseTLS        bool                `json:",omitempty"`
-	AliasNode         string              `json:",omitempty"`
-	AliasService      string              `json:",omitempty"`
+	CheckID                string              `json:",omitempty"`
+	Name                   string              `json:",omitempty"`
+	Args                   []string            `json:"ScriptArgs,omitempty"`
+	DockerContainerID      string              `json:",omitempty"`
+	Shell                  string              `json:",omitempty"` // Only supported for Docker.
+	Interval               string              `json:",omitempty"`
+	Timeout                string              `json:",omitempty"`
+	TTL                    string              `json:",omitempty"`
+	HTTP                   string              `json:",omitempty"`
+	Header                 map[string][]string `json:",omitempty"`
+	Method                 string              `json:",omitempty"`
+	Body                   string              `json:",omitempty"`
+	TCP                    string              `json:",omitempty"`
+	Status                 string              `json:",omitempty"`
+	Notes                  string              `json:",omitempty"`
+	TLSSkipVerify          bool                `json:",omitempty"`
+	GRPC                   string              `json:",omitempty"`
+	GRPCUseTLS             bool                `json:",omitempty"`
+	AliasNode              string              `json:",omitempty"`
+	AliasService           string              `json:",omitempty"`
+	SuccessBeforePassing   int                 `json:",omitempty"`
+	FailuresBeforeCritical int                 `json:",omitempty"`
 
 	// In Consul 0.7 and later, checks that are associated with a service
 	// may also contain this optional DeregisterCriticalServiceAfter field,

--- a/website/pages/api-docs/agent/check.mdx
+++ b/website/pages/api-docs/agent/check.mdx
@@ -207,6 +207,14 @@ The table below shows this endpoint's support for
 
 - `Status` `(string: "")` - Specifies the initial status of the health check.
 
+- `SuccessBeforePassing` `(int: 0)` - Specifies the number of consecutive successful
+  results required before check status transitions to passing. Available for HTTP,
+  TCP, gRPC, Docker & Monitor checks.
+
+- `FailuresBeforeCritical` `(int: 0)` - Specifies the number of consecutive unsuccessful
+  results required before check status transitions to critical. Available for HTTP,
+  TCP, gRPC, Docker & Monitor checks.
+
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
api/agent: enable setting SuccessBeforePassing and FailuresBeforeCritical in API

Fixes #7764
Needed by https://github.com/hashicorp/nomad/issues/6913

Until now these two fields could only be set through on-disk agent configuration.
This change adds the fields to the agent API struct definition so that they can
be set using the agent HTTP API.