### PR TITLE
Replace whitelist/blacklist terminology with allowlist/denylist in api/connect_intention.go

### DIFF
--- a/api/connect_intention.go
+++ b/api/connect_intention.go
@@ -33,7 +33,7 @@ type Intention struct {
 	// SourceType is the type of the value for the source.
 	SourceType IntentionSourceType
 
-	// Action is whether this is a whitelist or blacklist intention.
+	// Action is whether this is an allowlist or denylist intention.
 	Action IntentionAction
 
 	// DefaultAddr, DefaultPort of the local listening proxy (if any) to
@@ -99,7 +99,7 @@ func (i *Intention) partString(ns, n string) string {
 const IntentionDefaultNamespace = "default"
 
 // IntentionAction is the action that the intention represents. This
-// can be "allow" or "deny" to whitelist or blacklist intentions.
+// can be "allow" or "deny" to allowlist or denylist intentions.
 type IntentionAction string
 
 const (


### PR DESCRIPTION
It looks like a broader effort to clean the consul codebase of these kinds of terms, but this PR addresses at least what appears in my `$DAY_JOB`'s vendored dependency of consul.