### PR TITLE
ACL Node Identities

### DIFF
--- a/agent/acl_endpoint_test.go
+++ b/agent/acl_endpoint_test.go
@@ -408,6 +408,12 @@ func TestACL_HTTP(t *testing.T) {
 						Name: policyMap[idMap["policy-read-all-nodes"]].Name,
 					},
 				},
+				NodeIdentities: []*structs.ACLNodeIdentity{
+					&structs.ACLNodeIdentity{
+						NodeName:   "web-node",
+						Datacenter: "foo",
+					},
+				},
 			}
 
 			req, _ := http.NewRequest("PUT", "/v1/acl/role?token=root", jsonBody(roleInput))
@@ -423,6 +429,7 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, roleInput.Name, role.Name)
 			require.Equal(t, roleInput.Description, role.Description)
 			require.Equal(t, roleInput.Policies, role.Policies)
+			require.Equal(t, roleInput.NodeIdentities, role.NodeIdentities)
 			require.True(t, role.CreateIndex > 0)
 			require.Equal(t, role.CreateIndex, role.ModifyIndex)
 			require.NotNil(t, role.Hash)
@@ -502,6 +509,12 @@ func TestACL_HTTP(t *testing.T) {
 						ServiceName: "web-indexer",
 					},
 				},
+				NodeIdentities: []*structs.ACLNodeIdentity{
+					&structs.ACLNodeIdentity{
+						NodeName:   "web-node",
+						Datacenter: "foo",
+					},
+				},
 			}
 
 			req, _ := http.NewRequest("PUT", "/v1/acl/role/"+idMap["role-test"]+"?token=root", jsonBody(roleInput))
@@ -518,6 +531,7 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, roleInput.Description, role.Description)
 			require.Equal(t, roleInput.Policies, role.Policies)
 			require.Equal(t, roleInput.ServiceIdentities, role.ServiceIdentities)
+			require.Equal(t, roleInput.NodeIdentities, role.NodeIdentities)
 			require.True(t, role.CreateIndex > 0)
 			require.True(t, role.CreateIndex < role.ModifyIndex)
 			require.NotNil(t, role.Hash)
@@ -623,6 +637,12 @@ func TestACL_HTTP(t *testing.T) {
 						Name: policyMap[idMap["policy-read-all-nodes"]].Name,
 					},
 				},
+				NodeIdentities: []*structs.ACLNodeIdentity{
+					&structs.ACLNodeIdentity{
+						NodeName:   "foo",
+						Datacenter: "bar",
+					},
+				},
 			}
 
 			req, _ := http.NewRequest("PUT", "/v1/acl/token?token=root", jsonBody(tokenInput))
@@ -638,6 +658,7 @@ func TestACL_HTTP(t *testing.T) {
 			require.Len(t, token.SecretID, 36)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
+			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
 			require.True(t, token.CreateIndex > 0)
 			require.Equal(t, token.CreateIndex, token.ModifyIndex)
 			require.NotNil(t, token.Hash)
@@ -741,6 +762,12 @@ func TestACL_HTTP(t *testing.T) {
 						Name: policyMap[idMap["policy-read-all-nodes"]].Name,
 					},
 				},
+				NodeIdentities: []*structs.ACLNodeIdentity{
+					&structs.ACLNodeIdentity{
+						NodeName:   "foo",
+						Datacenter: "bar",
+					},
+				},
 			}
 
 			req, _ := http.NewRequest("PUT", "/v1/acl/token/"+originalToken.AccessorID+"?token=root", jsonBody(tokenInput))
@@ -754,6 +781,7 @@ func TestACL_HTTP(t *testing.T) {
 			require.Equal(t, originalToken.SecretID, token.SecretID)
 			require.Equal(t, tokenInput.Description, token.Description)
 			require.Equal(t, tokenInput.Policies, token.Policies)
+			require.Equal(t, tokenInput.NodeIdentities, token.NodeIdentities)
 			require.True(t, token.CreateIndex > 0)
 			require.True(t, token.CreateIndex < token.ModifyIndex)
 			require.NotNil(t, token.Hash)

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -34,6 +34,8 @@ var (
 	validPolicyName              = regexp.MustCompile(`^[A-Za-z0-9\-_]{1,128}$`)
 	validServiceIdentityName     = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$`)
 	serviceIdentityNameMaxLength = 256
+	validNodeIdentityName        = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$`)
+	nodeIdentityNameMaxLength    = 256
 	validRoleName                = regexp.MustCompile(`^[A-Za-z0-9\-_]{1,256}$`)
 	validAuthMethod              = regexp.MustCompile(`^[A-Za-z0-9\-_]{1,128}$`)
 )
@@ -319,6 +321,7 @@ func (a *ACL) TokenClone(args *structs.ACLTokenSetRequest, reply *structs.ACLTok
 			Policies:          token.Policies,
 			Roles:             token.Roles,
 			ServiceIdentities: token.ServiceIdentities,
+			NodeIdentities:    token.NodeIdentities,
 			Local:             token.Local,
 			Description:       token.Description,
 			ExpirationTime:    token.ExpirationTime,
@@ -615,6 +618,19 @@ func (a *ACL) tokenSetInternal(args *structs.ACLTokenSetRequest, reply *structs.
 	}
 	token.ServiceIdentities = dedupeServiceIdentities(token.ServiceIdentities)
 
+	for _, nodeid := range token.NodeIdentities {
+		if nodeid.NodeName == "" {
+			return fmt.Errorf("Node identity is missing the node name field on this token")
+		}
+		if nodeid.Datacenter == "" {
+			return fmt.Errorf("Node identity is missing the datacenter field on this token")
+		}
+		if !isValidNodeIdentityName(nodeid.NodeName) {
+			return fmt.Errorf("Node identity has an invalid name. Only alphanumeric characters, '-' and '_' are allowed")
+		}
+	}
+	token.NodeIdentities = dedupeNodeIdentities(token.NodeIdentities)
+
 	if token.Rules != "" {
 		return fmt.Errorf("Rules cannot be specified for this token")
 	}
@@ -700,7 +716,8 @@ func computeBindingRuleBindName(bindType, bindName string, projectedVars map[str
 	switch bindType {
 	case structs.BindingRuleBindTypeService:
 		valid = isValidServiceIdentityName(bindName)
-
+	case structs.BindingRuleBindTypeNode:
+		valid = isValidNodeIdentityName(bindName)
 	case structs.BindingRuleBindTypeRole:
 		valid = validRoleName.MatchString(bindName)
 
@@ -720,6 +737,17 @@ func isValidServiceIdentityName(name string) bool {
 		return false
 	}
 	return validServiceIdentityName.MatchString(name)
+}
+
+// isValidNodeIdentityName returns true if the provided name can be used as
+// an ACLNodeIdentity NodeName. This is more restrictive than standard
+// catalog registration, which basically takes the view that "everything is
+// valid".
+func isValidNodeIdentityName(name string) bool {
+	if len(name) < 1 || len(name) > nodeIdentityNameMaxLength {
+		return false
+	}
+	return validNodeIdentityName.MatchString(name)
 }
 
 func (a *ACL) TokenDelete(args *structs.ACLTokenDeleteRequest, reply *string) error {
@@ -1572,6 +1600,19 @@ func (a *ACL) RoleSet(args *structs.ACLRoleSetRequest, reply *structs.ACLRole) e
 	}
 	role.ServiceIdentities = dedupeServiceIdentities(role.ServiceIdentities)
 
+	for _, nodeid := range role.NodeIdentities {
+		if nodeid.NodeName == "" {
+			return fmt.Errorf("Node identity is missing the node name field on this role")
+		}
+		if nodeid.Datacenter == "" {
+			return fmt.Errorf("Node identity is missing the datacenter field on this role")
+		}
+		if !isValidNodeIdentityName(nodeid.NodeName) {
+			return fmt.Errorf("Node identity has an invalid name. Only alphanumeric characters, '-' and '_' are allowed")
+		}
+	}
+	role.NodeIdentities = dedupeNodeIdentities(role.NodeIdentities)
+
 	// calculate the hash for this role
 	role.SetHash(true)
 
@@ -1892,6 +1933,7 @@ func (a *ACL) BindingRuleSet(args *structs.ACLBindingRuleSetRequest, reply *stru
 
 	switch rule.BindType {
 	case structs.BindingRuleBindTypeService:
+	case structs.BindingRuleBindTypeNode:
 	case structs.BindingRuleBindTypeRole:
 	default:
 		return fmt.Errorf("Invalid Binding Rule: unknown BindType %q", rule.BindType)
@@ -2365,14 +2407,14 @@ func (a *ACL) tokenSetFromAuthMethod(
 	}
 
 	// 3. send map through role bindings
-	serviceIdentities, roleLinks, err := a.srv.evaluateRoleBindings(validator, verifiedIdentity, entMeta, targetMeta)
+	bindings, err := a.srv.evaluateRoleBindings(validator, verifiedIdentity, entMeta, targetMeta)
 	if err != nil {
 		return err
 	}
 
 	// We try to prevent the creation of a useless token without taking a trip
 	// through the state store if we can.
-	if len(serviceIdentities) == 0 && len(roleLinks) == 0 {
+	if bindings == nil || (len(bindings.serviceIdentities) == 0 && len(bindings.nodeIdentities) == 0 && len(bindings.roles) == 0) {
 		return acl.ErrPermissionDenied
 	}
 
@@ -2392,8 +2434,9 @@ func (a *ACL) tokenSetFromAuthMethod(
 		Description:       description,
 		Local:             true,
 		AuthMethod:        method.Name,
-		ServiceIdentities: serviceIdentities,
-		Roles:             roleLinks,
+		ServiceIdentities: bindings.serviceIdentities,
+		NodeIdentities:    bindings.nodeIdentities,
+		Roles:             bindings.roles,
 		ExpirationTTL:     method.MaxTokenTTL,
 		EnterpriseMeta:    *targetMeta,
 	}

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -392,13 +392,8 @@ service "foo" {
 func TestIntention_WildcardACLEnforcement(t *testing.T) {
 	t.Parallel()
 
-	dir, srv := testACLServerWithConfig(t, nil, false)
-	defer os.RemoveAll(dir)
-	defer srv.Shutdown()
-	codec := rpcClient(t, srv)
-	defer codec.Close()
-
-	testrpc.WaitForLeader(t, srv.RPC, "dc1")
+	_, srv, codec := testACLServerWithConfig(t, nil, false)
+	waitForLeaderEstablishment(t, srv)
 
 	// create some test policies.
 
@@ -1222,13 +1217,8 @@ func TestIntentionMatch_good(t *testing.T) {
 func TestIntentionMatch_acl(t *testing.T) {
 	t.Parallel()
 
-	dir1, s1 := testACLServerWithConfig(t, nil, false)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
-
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	_, srv, codec := testACLServerWithConfig(t, nil, false)
+	waitForLeaderEstablishment(t, srv)
 
 	token, err := upsertTestTokenWithPolicyRules(codec, TestDefaultMasterToken, "dc1", `service "bar" { policy = "write" }`)
 	require.NoError(t, err)
@@ -1464,13 +1454,8 @@ service "bar" {
 func TestIntentionCheck_match(t *testing.T) {
 	t.Parallel()
 
-	dir1, s1 := testACLServerWithConfig(t, nil, false)
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
-	codec := rpcClient(t, s1)
-	defer codec.Close()
-
-	testrpc.WaitForLeader(t, s1.RPC, "dc1")
+	_, srv, codec := testACLServerWithConfig(t, nil, false)
+	waitForLeaderEstablishment(t, srv)
 
 	token, err := upsertTestTokenWithPolicyRules(codec, TestDefaultMasterToken, "dc1", `service "api" { policy = "read" }`)
 	require.NoError(t, err)

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -730,6 +730,7 @@ func (s *Server) legacyACLTokenUpgrade(ctx context.Context) error {
 			// Assign the global-management policy to legacy management tokens
 			if len(newToken.Policies) == 0 &&
 				len(newToken.ServiceIdentities) == 0 &&
+				len(newToken.NodeIdentities) == 0 &&
 				len(newToken.Roles) == 0 &&
 				newToken.Type == structs.ACLTokenTypeManagement {
 				newToken.Policies = append(newToken.Policies, structs.ACLTokenPolicyLink{ID: structs.ACLPolicyGlobalManagementID})

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1216,9 +1216,7 @@ func TestLeader_ACLLegacyReplication(t *testing.T) {
 		c.Datacenter = "dc2"
 		c.ACLTokenReplication = true
 	}
-	dir, srv := testACLServerWithConfig(t, cb, true)
-	defer os.RemoveAll(dir)
-	defer srv.Shutdown()
+	_, srv, _ := testACLServerWithConfig(t, cb, true)
 	waitForLeaderEstablishment(t, srv)
 
 	require.True(t, srv.leaderRoutineManager.IsRunning(legacyACLReplicationRoutineName))

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -742,8 +742,17 @@ func (s *Store) aclTokenSetTxn(tx *memdb.Txn, idx uint64, token *structs.ACLToke
 		}
 	}
 
+	for _, nodeid := range token.NodeIdentities {
+		if nodeid.NodeName == "" {
+			return fmt.Errorf("Encountered a Token with an empty node identity name in the state store")
+		}
+		if nodeid.Datacenter == "" {
+			return fmt.Errorf("Encountered a Token with an empty node identity datacenter in the state store")
+		}
+	}
+
 	if prohibitUnprivileged {
-		if numValidRoles == 0 && numValidPolicies == 0 && len(token.ServiceIdentities) == 0 {
+		if numValidRoles == 0 && numValidPolicies == 0 && len(token.ServiceIdentities) == 0 && len(token.NodeIdentities) == 0 {
 			return ErrTokenHasNoPrivileges
 		}
 	}
@@ -1366,6 +1375,15 @@ func (s *Store) aclRoleSetTxn(tx *memdb.Txn, idx uint64, role *structs.ACLRole, 
 	for _, svcid := range role.ServiceIdentities {
 		if svcid.ServiceName == "" {
 			return fmt.Errorf("Encountered a Role with an empty service identity name in the state store")
+		}
+	}
+
+	for _, nodeid := range role.NodeIdentities {
+		if nodeid.NodeName == "" {
+			return fmt.Errorf("Encountered a Role with an empty node identity name in the state store")
+		}
+		if nodeid.Datacenter == "" {
+			return fmt.Errorf("Encountered a Role with an empty node identity datacenter in the state store")
 		}
 	}
 

--- a/agent/structs/acl.go
+++ b/agent/structs/acl.go
@@ -119,6 +119,7 @@ type ACLIdentity interface {
 	RoleIDs() []string
 	EmbeddedPolicy() *ACLPolicy
 	ServiceIdentityList() []*ACLServiceIdentity
+	NodeIdentityList() []*ACLNodeIdentity
 	IsExpired(asOf time.Time) bool
 	IsLocal() bool
 	EnterpriseMetadata() *EnterpriseMeta
@@ -189,6 +190,50 @@ func (s *ACLServiceIdentity) SyntheticPolicy(entMeta *EnterpriseMeta) *ACLPolicy
 	return policy
 }
 
+// ACLNodeIdentity represents a high-level grant of all privileges
+// necessary to assume the identity of that node and manage it.
+type ACLNodeIdentity struct {
+	// NodeName identities the Node that this identity authorizes access to
+	NodeName string
+
+	// Datacenter is required and specifies the datacenter of the node.
+	Datacenter string
+}
+
+func (s *ACLNodeIdentity) Clone() *ACLNodeIdentity {
+	s2 := *s
+	return &s2
+}
+
+func (s *ACLNodeIdentity) AddToHash(h hash.Hash) {
+	h.Write([]byte(s.NodeName))
+	h.Write([]byte(s.Datacenter))
+}
+
+func (s *ACLNodeIdentity) EstimateSize() int {
+	return len(s.NodeName) + len(s.Datacenter)
+}
+
+func (s *ACLNodeIdentity) SyntheticPolicy() *ACLPolicy {
+	// Given that we validate this string name before persisting, we do not
+	// have to escape it before doing the following interpolation.
+	rules := fmt.Sprintf(aclPolicyTemplateNodeIdentity, s.NodeName)
+
+	hasher := fnv.New128a()
+	hashID := fmt.Sprintf("%x", hasher.Sum([]byte(rules)))
+
+	policy := &ACLPolicy{}
+	policy.ID = hashID
+	policy.Name = fmt.Sprintf("synthetic-policy-%s", hashID)
+	policy.Description = "synthetic policy"
+	policy.Rules = rules
+	policy.Syntax = acl.SyntaxCurrent
+	policy.Datacenters = []string{s.Datacenter}
+	policy.EnterpriseMeta = *DefaultEnterpriseMeta()
+	policy.SetHash(true)
+	return policy
+}
+
 type ACLToken struct {
 	// This is the UUID used for tracking and management purposes
 	AccessorID string
@@ -211,6 +256,9 @@ type ACLToken struct {
 
 	// List of services to generate synthetic policies for.
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+
+	// The node identities that this token should be allowed to manage.
+	NodeIdentities []*ACLNodeIdentity `json:",omitempty"`
 
 	// Type is the V1 Token Type
 	// DEPRECATED (ACL-Legacy-Compat) - remove once we no longer support v1 ACL compat
@@ -302,6 +350,7 @@ func (t *ACLToken) Clone() *ACLToken {
 	t2.Policies = nil
 	t2.Roles = nil
 	t2.ServiceIdentities = nil
+	t2.NodeIdentities = nil
 
 	if len(t.Policies) > 0 {
 		t2.Policies = make([]ACLTokenPolicyLink, len(t.Policies))
@@ -317,6 +366,13 @@ func (t *ACLToken) Clone() *ACLToken {
 			t2.ServiceIdentities[i] = s.Clone()
 		}
 	}
+	if len(t.NodeIdentities) > 0 {
+		t2.NodeIdentities = make([]*ACLNodeIdentity, len(t.NodeIdentities))
+		for i, n := range t.NodeIdentities {
+			t2.NodeIdentities[i] = n.Clone()
+		}
+	}
+
 	return &t2
 }
 
@@ -382,6 +438,7 @@ func (t *ACLToken) HasExpirationTime() bool {
 func (t *ACLToken) UsesNonLegacyFields() bool {
 	return len(t.Policies) > 0 ||
 		len(t.ServiceIdentities) > 0 ||
+		len(t.NodeIdentities) > 0 ||
 		len(t.Roles) > 0 ||
 		t.Type == "" ||
 		t.HasExpirationTime() ||
@@ -462,6 +519,10 @@ func (t *ACLToken) SetHash(force bool) []byte {
 			srvid.AddToHash(hash)
 		}
 
+		for _, nodeID := range t.NodeIdentities {
+			nodeID.AddToHash(hash)
+		}
+
 		t.EnterpriseMeta.addToHash(hash, false)
 
 		// Finalize the hash
@@ -485,6 +546,9 @@ func (t *ACLToken) EstimateSize() int {
 	for _, srvid := range t.ServiceIdentities {
 		size += srvid.EstimateSize()
 	}
+	for _, nodeID := range t.NodeIdentities {
+		size += nodeID.EstimateSize()
+	}
 	return size + t.EnterpriseMeta.estimateSize()
 }
 
@@ -497,6 +561,7 @@ type ACLTokenListStub struct {
 	Policies          []ACLTokenPolicyLink  `json:",omitempty"`
 	Roles             []ACLTokenRoleLink    `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	NodeIdentities    []*ACLNodeIdentity    `json:",omitempty"`
 	Local             bool
 	AuthMethod        string     `json:",omitempty"`
 	ExpirationTime    *time.Time `json:",omitempty"`
@@ -517,6 +582,7 @@ func (token *ACLToken) Stub() *ACLTokenListStub {
 		Policies:          token.Policies,
 		Roles:             token.Roles,
 		ServiceIdentities: token.ServiceIdentities,
+		NodeIdentities:    token.NodeIdentities,
 		Local:             token.Local,
 		AuthMethod:        token.AuthMethod,
 		ExpirationTime:    token.ExpirationTime,
@@ -811,6 +877,9 @@ type ACLRole struct {
 	// List of services to generate synthetic policies for.
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
 
+	// List of nodes to generate synthetic policies for.
+	NodeIdentities []*ACLNodeIdentity `json:",omitempty"`
+
 	// Hash of the contents of the role
 	// This does not take into account the ID (which is immutable)
 	// nor the raft metadata.
@@ -849,6 +918,7 @@ func (r *ACLRole) Clone() *ACLRole {
 	r2 := *r
 	r2.Policies = nil
 	r2.ServiceIdentities = nil
+	r2.NodeIdentities = nil
 
 	if len(r.Policies) > 0 {
 		r2.Policies = make([]ACLRolePolicyLink, len(r.Policies))
@@ -858,6 +928,12 @@ func (r *ACLRole) Clone() *ACLRole {
 		r2.ServiceIdentities = make([]*ACLServiceIdentity, len(r.ServiceIdentities))
 		for i, s := range r.ServiceIdentities {
 			r2.ServiceIdentities[i] = s.Clone()
+		}
+	}
+	if len(r.NodeIdentities) > 0 {
+		r2.NodeIdentities = make([]*ACLNodeIdentity, len(r.NodeIdentities))
+		for i, n := range r.NodeIdentities {
+			r2.NodeIdentities[i] = n.Clone()
 		}
 	}
 	return &r2
@@ -888,6 +964,9 @@ func (r *ACLRole) SetHash(force bool) []byte {
 		for _, srvid := range r.ServiceIdentities {
 			srvid.AddToHash(hash)
 		}
+		for _, nodeID := range r.NodeIdentities {
+			nodeID.AddToHash(hash)
+		}
 
 		r.EnterpriseMeta.addToHash(hash, false)
 
@@ -911,6 +990,9 @@ func (r *ACLRole) EstimateSize() int {
 	}
 	for _, srvid := range r.ServiceIdentities {
 		size += srvid.EstimateSize()
+	}
+	for _, nodeID := range r.NodeIdentities {
+		size += nodeID.EstimateSize()
 	}
 
 	return size + r.EnterpriseMeta.estimateSize()
@@ -945,6 +1027,21 @@ const (
 	//
 	// If it does not exist at login-time the rule is ignored.
 	BindingRuleBindTypeRole = "role"
+
+	// BindingRuleBindTypeNode is the binding rule bind type that assigns
+	// a Node Identity to the token that is created using the value of
+	// the computed BindName as the NodeName like:
+	//
+	// &ACLToken{
+	//   ...other fields...
+	//   NodeIdentities: []*ACLNodeIdentity{
+	//     &ACLNodeIdentity{
+	//       NodeName: "<computed BindName>",
+	//       Datacenter: "<local datacenter of the binding rule>"
+	//     }
+	//   }
+	// }
+	BindingRuleBindTypeNode = "node"
 )
 
 type ACLBindingRule struct {

--- a/agent/structs/acl_legacy.go
+++ b/agent/structs/acl_legacy.go
@@ -78,6 +78,7 @@ func (a *ACL) Convert() *ACLToken {
 		Description:       a.Name,
 		Policies:          nil,
 		ServiceIdentities: nil,
+		NodeIdentities:    nil,
 		Type:              a.Type,
 		Rules:             a.Rules,
 		Local:             false,

--- a/api/acl.go
+++ b/api/acl.go
@@ -37,6 +37,7 @@ type ACLToken struct {
 	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
 	Roles             []*ACLTokenRoleLink   `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	NodeIdentities    []*ACLNodeIdentity    `json:",omitempty"`
 	Local             bool
 	AuthMethod        string        `json:",omitempty"`
 	ExpirationTTL     time.Duration `json:",omitempty"`
@@ -61,6 +62,7 @@ type ACLTokenListEntry struct {
 	Policies          []*ACLTokenPolicyLink `json:",omitempty"`
 	Roles             []*ACLTokenRoleLink   `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	NodeIdentities    []*ACLNodeIdentity    `json:",omitempty"`
 	Local             bool
 	AuthMethod        string     `json:",omitempty"`
 	ExpirationTime    *time.Time `json:",omitempty"`
@@ -105,6 +107,13 @@ type ACLServiceIdentity struct {
 	Datacenters []string `json:",omitempty"`
 }
 
+// ACLNodeIdentity represents a high-level grant of all necessary privileges
+// to assume the identity of the named Node in the Catalog and within Connect.
+type ACLNodeIdentity struct {
+	NodeName   string
+	Datacenter string
+}
+
 // ACLPolicy represents an ACL Policy.
 type ACLPolicy struct {
 	ID          string
@@ -144,6 +153,7 @@ type ACLRole struct {
 	Description       string
 	Policies          []*ACLRolePolicyLink  `json:",omitempty"`
 	ServiceIdentities []*ACLServiceIdentity `json:",omitempty"`
+	NodeIdentities    []*ACLNodeIdentity    `json:",omitempty"`
 	Hash              []byte
 	CreateIndex       uint64
 	ModifyIndex       uint64

--- a/command/acl/acl_helpers.go
+++ b/command/acl/acl_helpers.go
@@ -217,6 +217,23 @@ func ExtractServiceIdentities(serviceIdents []string) ([]*api.ACLServiceIdentity
 	return out, nil
 }
 
+func ExtractNodeIdentities(nodeIdents []string) ([]*api.ACLNodeIdentity, error) {
+	var out []*api.ACLNodeIdentity
+	for _, nodeidRaw := range nodeIdents {
+		parts := strings.Split(nodeidRaw, ":")
+		switch len(parts) {
+		case 2:
+			out = append(out, &api.ACLNodeIdentity{
+				NodeName:   parts[0],
+				Datacenter: parts[1],
+			})
+		default:
+			return nil, fmt.Errorf("Malformed -node-identity argument: %q", nodeidRaw)
+		}
+	}
+	return out, nil
+}
+
 // TestKubernetesJWT_A is a valid service account jwt extracted from a minikube setup.
 //
 // {

--- a/command/acl/role/formatter.go
+++ b/command/acl/role/formatter.go
@@ -77,6 +77,12 @@ func (f *prettyFormatter) FormatRole(role *api.ACLRole) (string, error) {
 			}
 		}
 	}
+	if len(role.NodeIdentities) > 0 {
+		buffer.WriteString(fmt.Sprintln("Node Identities:"))
+		for _, nodeid := range role.NodeIdentities {
+			buffer.WriteString(fmt.Sprintf("   %s (Datacenter: %s)\n", nodeid.NodeName, nodeid.Datacenter))
+		}
+	}
 
 	return buffer.String(), nil
 }
@@ -119,6 +125,13 @@ func (f *prettyFormatter) formatRoleListEntry(role *api.ACLRole) string {
 			} else {
 				buffer.WriteString(fmt.Sprintf("      %s (Datacenters: all)\n", svcid.ServiceName))
 			}
+		}
+	}
+
+	if len(role.NodeIdentities) > 0 {
+		buffer.WriteString(fmt.Sprintln("   Node Identities:"))
+		for _, nodeid := range role.NodeIdentities {
+			buffer.WriteString(fmt.Sprintf("      %s (Datacenter: %s)\n", nodeid.NodeName, nodeid.Datacenter))
 		}
 	}
 

--- a/command/acl/role/formatter_test.go
+++ b/command/acl/role/formatter_test.go
@@ -1,0 +1,195 @@
+package role
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+// update allows golden files to be updated based on the current output.
+var update = flag.Bool("update", false, "update golden files")
+
+// golden reads and optionally writes the expected data to the golden file,
+// returning the contents as a string.
+func golden(t *testing.T, name, got string) string {
+	t.Helper()
+
+	golden := filepath.Join("testdata", name+".golden")
+	if *update && got != "" {
+		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		require.NoError(t, err)
+	}
+
+	expected, err := ioutil.ReadFile(golden)
+	require.NoError(t, err)
+
+	return string(expected)
+}
+
+func TestFormatRole(t *testing.T) {
+	type testCase struct {
+		role               api.ACLRole
+		overrideGoldenName string
+	}
+
+	cases := map[string]testCase{
+		"basic": {
+			role: api.ACLRole{
+				ID:          "bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852",
+				Name:        "basic",
+				Description: "test role",
+				Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+				CreateIndex: 42,
+				ModifyIndex: 100,
+			},
+		},
+		"complex": {
+			role: api.ACLRole{
+				ID:          "c29c4ee4-bca6-474e-be37-7d9606f9582a",
+				Name:        "complex",
+				Namespace:   "foo",
+				Description: "test role complex",
+				Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+				CreateIndex: 5,
+				ModifyIndex: 10,
+				Policies: []*api.ACLLink{
+					&api.ACLLink{
+						ID:   "beb04680-815b-4d7c-9e33-3d707c24672c",
+						Name: "hobbiton",
+					},
+					&api.ACLLink{
+						ID:   "18788457-584c-4812-80d3-23d403148a90",
+						Name: "bywater",
+					},
+				},
+				ServiceIdentities: []*api.ACLServiceIdentity{
+					&api.ACLServiceIdentity{
+						ServiceName: "gardener",
+						Datacenters: []string{"middleearth-northwest"},
+					},
+				},
+				NodeIdentities: []*api.ACLNodeIdentity{
+					&api.ACLNodeIdentity{
+						NodeName:   "bagend",
+						Datacenter: "middleearth-northwest",
+					},
+				},
+			},
+		},
+	}
+
+	formatters := map[string]Formatter{
+		"pretty":      newPrettyFormatter(false),
+		"pretty-meta": newPrettyFormatter(true),
+		// the JSON formatter ignores the showMeta
+		"json": newJSONFormatter(false),
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			for fmtName, formatter := range formatters {
+				t.Run(fmtName, func(t *testing.T) {
+					actual, err := formatter.FormatRole(&tcase.role)
+					require.NoError(t, err)
+
+					gName := fmt.Sprintf("%s.%s", name, fmtName)
+					if tcase.overrideGoldenName != "" {
+						gName = tcase.overrideGoldenName
+					}
+
+					expected := golden(t, path.Join("FormatRole", gName), actual)
+					require.Equal(t, expected, actual)
+				})
+			}
+		})
+	}
+}
+
+func TestFormatTokenList(t *testing.T) {
+	type testCase struct {
+		roles              []*api.ACLRole
+		overrideGoldenName string
+	}
+
+	cases := map[string]testCase{
+		"basic": {
+			roles: []*api.ACLRole{
+				&api.ACLRole{
+					ID:          "bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852",
+					Name:        "basic",
+					Description: "test role",
+					Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+					CreateIndex: 42,
+					ModifyIndex: 100,
+				},
+			},
+		},
+		"complex": {
+			roles: []*api.ACLRole{
+				&api.ACLRole{
+					ID:          "c29c4ee4-bca6-474e-be37-7d9606f9582a",
+					Name:        "complex",
+					Namespace:   "foo",
+					Description: "test role complex",
+					Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+					CreateIndex: 5,
+					ModifyIndex: 10,
+					Policies: []*api.ACLLink{
+						&api.ACLLink{
+							ID:   "beb04680-815b-4d7c-9e33-3d707c24672c",
+							Name: "hobbiton",
+						},
+						&api.ACLLink{
+							ID:   "18788457-584c-4812-80d3-23d403148a90",
+							Name: "bywater",
+						},
+					},
+					ServiceIdentities: []*api.ACLServiceIdentity{
+						&api.ACLServiceIdentity{
+							ServiceName: "gardener",
+							Datacenters: []string{"middleearth-northwest"},
+						},
+					},
+					NodeIdentities: []*api.ACLNodeIdentity{
+						&api.ACLNodeIdentity{
+							NodeName:   "bagend",
+							Datacenter: "middleearth-northwest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	formatters := map[string]Formatter{
+		"pretty":      newPrettyFormatter(false),
+		"pretty-meta": newPrettyFormatter(true),
+		// the JSON formatter ignores the showMeta
+		"json": newJSONFormatter(false),
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			for fmtName, formatter := range formatters {
+				t.Run(fmtName, func(t *testing.T) {
+					actual, err := formatter.FormatRoleList(tcase.roles)
+					require.NoError(t, err)
+
+					gName := fmt.Sprintf("%s.%s", name, fmtName)
+					if tcase.overrideGoldenName != "" {
+						gName = tcase.overrideGoldenName
+					}
+
+					expected := golden(t, path.Join("FormatRoleList", gName), actual)
+					require.Equal(t, expected, actual)
+				})
+			}
+		})
+	}
+}

--- a/command/acl/role/testdata/FormatRole/basic.json.golden
+++ b/command/acl/role/testdata/FormatRole/basic.json.golden
@@ -1,0 +1,8 @@
+{
+    "ID": "bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852",
+    "Name": "basic",
+    "Description": "test role",
+    "Hash": "YWJjZGVmZ2g=",
+    "CreateIndex": 42,
+    "ModifyIndex": 100
+}

--- a/command/acl/role/testdata/FormatRole/basic.pretty-meta.golden
+++ b/command/acl/role/testdata/FormatRole/basic.pretty-meta.golden
@@ -1,0 +1,6 @@
+ID:           bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852
+Name:         basic
+Description:  test role
+Hash:         6162636465666768
+Create Index: 42
+Modify Index: 100

--- a/command/acl/role/testdata/FormatRole/basic.pretty.golden
+++ b/command/acl/role/testdata/FormatRole/basic.pretty.golden
@@ -1,0 +1,3 @@
+ID:           bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852
+Name:         basic
+Description:  test role

--- a/command/acl/role/testdata/FormatRole/complex.json.golden
+++ b/command/acl/role/testdata/FormatRole/complex.json.golden
@@ -1,0 +1,33 @@
+{
+    "ID": "c29c4ee4-bca6-474e-be37-7d9606f9582a",
+    "Name": "complex",
+    "Description": "test role complex",
+    "Policies": [
+        {
+            "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+            "Name": "hobbiton"
+        },
+        {
+            "ID": "18788457-584c-4812-80d3-23d403148a90",
+            "Name": "bywater"
+        }
+    ],
+    "ServiceIdentities": [
+        {
+            "ServiceName": "gardener",
+            "Datacenters": [
+                "middleearth-northwest"
+            ]
+        }
+    ],
+    "NodeIdentities": [
+        {
+            "NodeName": "bagend",
+            "Datacenter": "middleearth-northwest"
+        }
+    ],
+    "Hash": "YWJjZGVmZ2g=",
+    "CreateIndex": 5,
+    "ModifyIndex": 10,
+    "Namespace": "foo"
+}

--- a/command/acl/role/testdata/FormatRole/complex.pretty-meta.golden
+++ b/command/acl/role/testdata/FormatRole/complex.pretty-meta.golden
@@ -1,0 +1,14 @@
+ID:           c29c4ee4-bca6-474e-be37-7d9606f9582a
+Name:         complex
+Namespace:    foo
+Description:  test role complex
+Hash:         6162636465666768
+Create Index: 5
+Modify Index: 10
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/command/acl/role/testdata/FormatRole/complex.pretty.golden
+++ b/command/acl/role/testdata/FormatRole/complex.pretty.golden
@@ -1,0 +1,11 @@
+ID:           c29c4ee4-bca6-474e-be37-7d9606f9582a
+Name:         complex
+Namespace:    foo
+Description:  test role complex
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/command/acl/role/testdata/FormatRoleList/basic.json.golden
+++ b/command/acl/role/testdata/FormatRoleList/basic.json.golden
@@ -1,0 +1,10 @@
+[
+    {
+        "ID": "bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852",
+        "Name": "basic",
+        "Description": "test role",
+        "Hash": "YWJjZGVmZ2g=",
+        "CreateIndex": 42,
+        "ModifyIndex": 100
+    }
+]

--- a/command/acl/role/testdata/FormatRoleList/basic.pretty-meta.golden
+++ b/command/acl/role/testdata/FormatRoleList/basic.pretty-meta.golden
@@ -1,0 +1,6 @@
+basic:
+   ID:           bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852
+   Description:  test role
+   Hash:         6162636465666768
+   Create Index: 42
+   Modify Index: 100

--- a/command/acl/role/testdata/FormatRoleList/basic.pretty.golden
+++ b/command/acl/role/testdata/FormatRoleList/basic.pretty.golden
@@ -1,0 +1,3 @@
+basic:
+   ID:           bd6c9fb0-2d1a-4b96-acaf-669f5d7e7852
+   Description:  test role

--- a/command/acl/role/testdata/FormatRoleList/complex.json.golden
+++ b/command/acl/role/testdata/FormatRoleList/complex.json.golden
@@ -1,0 +1,35 @@
+[
+    {
+        "ID": "c29c4ee4-bca6-474e-be37-7d9606f9582a",
+        "Name": "complex",
+        "Description": "test role complex",
+        "Policies": [
+            {
+                "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+                "Name": "hobbiton"
+            },
+            {
+                "ID": "18788457-584c-4812-80d3-23d403148a90",
+                "Name": "bywater"
+            }
+        ],
+        "ServiceIdentities": [
+            {
+                "ServiceName": "gardener",
+                "Datacenters": [
+                    "middleearth-northwest"
+                ]
+            }
+        ],
+        "NodeIdentities": [
+            {
+                "NodeName": "bagend",
+                "Datacenter": "middleearth-northwest"
+            }
+        ],
+        "Hash": "YWJjZGVmZ2g=",
+        "CreateIndex": 5,
+        "ModifyIndex": 10,
+        "Namespace": "foo"
+    }
+]

--- a/command/acl/role/testdata/FormatRoleList/complex.pretty-meta.golden
+++ b/command/acl/role/testdata/FormatRoleList/complex.pretty-meta.golden
@@ -1,0 +1,14 @@
+complex:
+   ID:           c29c4ee4-bca6-474e-be37-7d9606f9582a
+   Namespace:    foo
+   Description:  test role complex
+   Hash:         6162636465666768
+   Create Index: 5
+   Modify Index: 10
+   Policies:
+      beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+      18788457-584c-4812-80d3-23d403148a90 - bywater
+   Service Identities:
+      gardener (Datacenters: middleearth-northwest)
+   Node Identities:
+      bagend (Datacenter: middleearth-northwest)

--- a/command/acl/role/testdata/FormatRoleList/complex.pretty.golden
+++ b/command/acl/role/testdata/FormatRoleList/complex.pretty.golden
@@ -1,0 +1,11 @@
+complex:
+   ID:           c29c4ee4-bca6-474e-be37-7d9606f9582a
+   Namespace:    foo
+   Description:  test role complex
+   Policies:
+      beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+      18788457-584c-4812-80d3-23d403148a90 - bywater
+   Service Identities:
+      gardener (Datacenters: middleearth-northwest)
+   Node Identities:
+      bagend (Datacenter: middleearth-northwest)

--- a/command/acl/token/formatter.go
+++ b/command/acl/token/formatter.go
@@ -91,6 +91,12 @@ func (f *prettyFormatter) FormatToken(token *api.ACLToken) (string, error) {
 			}
 		}
 	}
+	if len(token.NodeIdentities) > 0 {
+		buffer.WriteString(fmt.Sprintln("Node Identities:"))
+		for _, nodeid := range token.NodeIdentities {
+			buffer.WriteString(fmt.Sprintf("   %s (Datacenter: %s)\n", nodeid.NodeName, nodeid.Datacenter))
+		}
+	}
 	if token.Rules != "" {
 		buffer.WriteString(fmt.Sprintln("Rules:"))
 		buffer.WriteString(fmt.Sprintln(token.Rules))
@@ -150,6 +156,16 @@ func (f *prettyFormatter) formatTokenListEntry(token *api.ACLTokenListEntry) str
 		}
 	}
 	if len(token.ServiceIdentities) > 0 {
+		buffer.WriteString(fmt.Sprintln("Service Identities:"))
+		for _, svcid := range token.ServiceIdentities {
+			if len(svcid.Datacenters) > 0 {
+				buffer.WriteString(fmt.Sprintf("   %s (Datacenters: %s)\n", svcid.ServiceName, strings.Join(svcid.Datacenters, ", ")))
+			} else {
+				buffer.WriteString(fmt.Sprintf("   %s (Datacenters: all)\n", svcid.ServiceName))
+			}
+		}
+	}
+	if len(token.NodeIdentities) > 0 {
 		buffer.WriteString(fmt.Sprintln("Service Identities:"))
 		for _, svcid := range token.ServiceIdentities {
 			if len(svcid.Datacenters) > 0 {

--- a/command/acl/token/formatter_test.go
+++ b/command/acl/token/formatter_test.go
@@ -1,0 +1,251 @@
+package token
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+)
+
+// update allows golden files to be updated based on the current output.
+var update = flag.Bool("update", false, "update golden files")
+
+// golden reads and optionally writes the expected data to the golden file,
+// returning the contents as a string.
+func golden(t *testing.T, name, got string) string {
+	t.Helper()
+
+	golden := filepath.Join("testdata", name+".golden")
+	if *update && got != "" {
+		err := ioutil.WriteFile(golden, []byte(got), 0644)
+		require.NoError(t, err)
+	}
+
+	expected, err := ioutil.ReadFile(golden)
+	require.NoError(t, err)
+
+	return string(expected)
+}
+
+func TestFormatToken(t *testing.T) {
+	type testCase struct {
+		token              api.ACLToken
+		overrideGoldenName string
+	}
+
+	timeRef := func(in time.Time) *time.Time {
+		return &in
+	}
+
+	cases := map[string]testCase{
+		"basic": {
+			token: api.ACLToken{
+				AccessorID:  "fbd2447f-7479-4329-ad13-b021d74f86ba",
+				SecretID:    "869c6e91-4de9-4dab-b56e-87548435f9c6",
+				Description: "test token",
+				Local:       false,
+				CreateTime:  time.Date(2020, 5, 22, 18, 52, 31, 0, time.UTC),
+				Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+				CreateIndex: 42,
+				ModifyIndex: 100,
+			},
+		},
+		"legacy": {
+			token: api.ACLToken{
+				AccessorID:  "8acc7486-ca54-4d3c-9aed-5cd85651b0ee",
+				SecretID:    "legacy-secret",
+				Description: "legacy",
+				Rules:       `operator = "read"`,
+			},
+		},
+		"complex": {
+			token: api.ACLToken{
+				AccessorID:     "fbd2447f-7479-4329-ad13-b021d74f86ba",
+				SecretID:       "869c6e91-4de9-4dab-b56e-87548435f9c6",
+				Namespace:      "foo",
+				Description:    "test token",
+				Local:          false,
+				AuthMethod:     "bar",
+				CreateTime:     time.Date(2020, 5, 22, 18, 52, 31, 0, time.UTC),
+				ExpirationTime: timeRef(time.Date(2020, 5, 22, 19, 52, 31, 0, time.UTC)),
+				Hash:           []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+				CreateIndex:    5,
+				ModifyIndex:    10,
+				Policies: []*api.ACLLink{
+					&api.ACLLink{
+						ID:   "beb04680-815b-4d7c-9e33-3d707c24672c",
+						Name: "hobbiton",
+					},
+					&api.ACLLink{
+						ID:   "18788457-584c-4812-80d3-23d403148a90",
+						Name: "bywater",
+					},
+				},
+				Roles: []*api.ACLLink{
+					&api.ACLLink{
+						ID:   "3b0a78fe-b9c3-40de-b8ea-7d4d6674b366",
+						Name: "shire",
+					},
+					&api.ACLLink{
+						ID:   "6c9d1e1d-34bc-4d55-80f3-add0890ad791",
+						Name: "west-farthing",
+					},
+				},
+				ServiceIdentities: []*api.ACLServiceIdentity{
+					&api.ACLServiceIdentity{
+						ServiceName: "gardener",
+						Datacenters: []string{"middleearth-northwest"},
+					},
+				},
+				NodeIdentities: []*api.ACLNodeIdentity{
+					&api.ACLNodeIdentity{
+						NodeName:   "bagend",
+						Datacenter: "middleearth-northwest",
+					},
+				},
+			},
+		},
+	}
+
+	formatters := map[string]Formatter{
+		"pretty":      newPrettyFormatter(false),
+		"pretty-meta": newPrettyFormatter(true),
+		// the JSON formatter ignores the showMeta
+		"json": newJSONFormatter(false),
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			for fmtName, formatter := range formatters {
+				t.Run(fmtName, func(t *testing.T) {
+					actual, err := formatter.FormatToken(&tcase.token)
+					require.NoError(t, err)
+
+					gName := fmt.Sprintf("%s.%s", name, fmtName)
+					if tcase.overrideGoldenName != "" {
+						gName = tcase.overrideGoldenName
+					}
+
+					expected := golden(t, path.Join("FormatToken", gName), actual)
+					require.Equal(t, expected, actual)
+				})
+			}
+		})
+	}
+}
+
+func TestFormatTokenList(t *testing.T) {
+	type testCase struct {
+		tokens             []*api.ACLTokenListEntry
+		overrideGoldenName string
+	}
+
+	timeRef := func(in time.Time) *time.Time {
+		return &in
+	}
+
+	cases := map[string]testCase{
+		"basic": {
+			tokens: []*api.ACLTokenListEntry{
+				&api.ACLTokenListEntry{
+					AccessorID:  "fbd2447f-7479-4329-ad13-b021d74f86ba",
+					Description: "test token",
+					Local:       false,
+					CreateTime:  time.Date(2020, 5, 22, 18, 52, 31, 0, time.UTC),
+					Hash:        []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+					CreateIndex: 42,
+					ModifyIndex: 100,
+				},
+			},
+		},
+		"legacy": {
+			tokens: []*api.ACLTokenListEntry{
+				&api.ACLTokenListEntry{
+					AccessorID:  "8acc7486-ca54-4d3c-9aed-5cd85651b0ee",
+					Description: "legacy",
+					Legacy:      true,
+				},
+			},
+		},
+		"complex": {
+			tokens: []*api.ACLTokenListEntry{
+				&api.ACLTokenListEntry{
+					AccessorID:     "fbd2447f-7479-4329-ad13-b021d74f86ba",
+					Namespace:      "foo",
+					Description:    "test token",
+					Local:          false,
+					AuthMethod:     "bar",
+					CreateTime:     time.Date(2020, 5, 22, 18, 52, 31, 0, time.UTC),
+					ExpirationTime: timeRef(time.Date(2020, 5, 22, 19, 52, 31, 0, time.UTC)),
+					Hash:           []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'},
+					CreateIndex:    5,
+					ModifyIndex:    10,
+					Policies: []*api.ACLLink{
+						&api.ACLLink{
+							ID:   "beb04680-815b-4d7c-9e33-3d707c24672c",
+							Name: "hobbiton",
+						},
+						&api.ACLLink{
+							ID:   "18788457-584c-4812-80d3-23d403148a90",
+							Name: "bywater",
+						},
+					},
+					Roles: []*api.ACLLink{
+						&api.ACLLink{
+							ID:   "3b0a78fe-b9c3-40de-b8ea-7d4d6674b366",
+							Name: "shire",
+						},
+						&api.ACLLink{
+							ID:   "6c9d1e1d-34bc-4d55-80f3-add0890ad791",
+							Name: "west-farthing",
+						},
+					},
+					ServiceIdentities: []*api.ACLServiceIdentity{
+						&api.ACLServiceIdentity{
+							ServiceName: "gardener",
+							Datacenters: []string{"middleearth-northwest"},
+						},
+					},
+					NodeIdentities: []*api.ACLNodeIdentity{
+						&api.ACLNodeIdentity{
+							NodeName:   "bagend",
+							Datacenter: "middleearth-northwest",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	formatters := map[string]Formatter{
+		"pretty":      newPrettyFormatter(false),
+		"pretty-meta": newPrettyFormatter(true),
+		// the JSON formatter ignores the showMeta
+		"json": newJSONFormatter(false),
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			for fmtName, formatter := range formatters {
+				t.Run(fmtName, func(t *testing.T) {
+					actual, err := formatter.FormatTokenList(tcase.tokens)
+					require.NoError(t, err)
+
+					gName := fmt.Sprintf("%s.%s", name, fmtName)
+					if tcase.overrideGoldenName != "" {
+						gName = tcase.overrideGoldenName
+					}
+
+					expected := golden(t, path.Join("FormatTokenList", gName), actual)
+					require.Equal(t, expected, actual)
+				})
+			}
+		})
+	}
+}

--- a/command/acl/token/testdata/FormatToken/basic.json.golden
+++ b/command/acl/token/testdata/FormatToken/basic.json.golden
@@ -1,0 +1,10 @@
+{
+    "CreateIndex": 42,
+    "ModifyIndex": 100,
+    "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
+    "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
+    "Description": "test token",
+    "Local": false,
+    "CreateTime": "2020-05-22T18:52:31Z",
+    "Hash": "YWJjZGVmZ2g="
+}

--- a/command/acl/token/testdata/FormatToken/basic.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatToken/basic.pretty-meta.golden
@@ -1,0 +1,8 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+SecretID:         869c6e91-4de9-4dab-b56e-87548435f9c6
+Description:      test token
+Local:            false
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Hash:             6162636465666768
+Create Index:     42
+Modify Index:     100

--- a/command/acl/token/testdata/FormatToken/basic.pretty.golden
+++ b/command/acl/token/testdata/FormatToken/basic.pretty.golden
@@ -1,0 +1,5 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+SecretID:         869c6e91-4de9-4dab-b56e-87548435f9c6
+Description:      test token
+Local:            false
+Create Time:      2020-05-22 18:52:31 +0000 UTC

--- a/command/acl/token/testdata/FormatToken/complex.json.golden
+++ b/command/acl/token/testdata/FormatToken/complex.json.golden
@@ -1,0 +1,47 @@
+{
+    "CreateIndex": 5,
+    "ModifyIndex": 10,
+    "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
+    "SecretID": "869c6e91-4de9-4dab-b56e-87548435f9c6",
+    "Description": "test token",
+    "Policies": [
+        {
+            "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+            "Name": "hobbiton"
+        },
+        {
+            "ID": "18788457-584c-4812-80d3-23d403148a90",
+            "Name": "bywater"
+        }
+    ],
+    "Roles": [
+        {
+            "ID": "3b0a78fe-b9c3-40de-b8ea-7d4d6674b366",
+            "Name": "shire"
+        },
+        {
+            "ID": "6c9d1e1d-34bc-4d55-80f3-add0890ad791",
+            "Name": "west-farthing"
+        }
+    ],
+    "ServiceIdentities": [
+        {
+            "ServiceName": "gardener",
+            "Datacenters": [
+                "middleearth-northwest"
+            ]
+        }
+    ],
+    "NodeIdentities": [
+        {
+            "NodeName": "bagend",
+            "Datacenter": "middleearth-northwest"
+        }
+    ],
+    "Local": false,
+    "AuthMethod": "bar",
+    "ExpirationTime": "2020-05-22T19:52:31Z",
+    "CreateTime": "2020-05-22T18:52:31Z",
+    "Hash": "YWJjZGVmZ2g=",
+    "Namespace": "foo"
+}

--- a/command/acl/token/testdata/FormatToken/complex.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatToken/complex.pretty-meta.golden
@@ -1,0 +1,21 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+SecretID:         869c6e91-4de9-4dab-b56e-87548435f9c6
+Namespace:        foo
+Description:      test token
+Local:            false
+Auth Method:      bar
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Expiration Time:  2020-05-22 19:52:31 +0000 UTC
+Hash:             6162636465666768
+Create Index:     5
+Modify Index:     10
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Roles:
+   3b0a78fe-b9c3-40de-b8ea-7d4d6674b366 - shire
+   6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/command/acl/token/testdata/FormatToken/complex.pretty.golden
+++ b/command/acl/token/testdata/FormatToken/complex.pretty.golden
@@ -1,0 +1,18 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+SecretID:         869c6e91-4de9-4dab-b56e-87548435f9c6
+Namespace:        foo
+Description:      test token
+Local:            false
+Auth Method:      bar
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Expiration Time:  2020-05-22 19:52:31 +0000 UTC
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Roles:
+   3b0a78fe-b9c3-40de-b8ea-7d4d6674b366 - shire
+   6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Node Identities:
+   bagend (Datacenter: middleearth-northwest)

--- a/command/acl/token/testdata/FormatToken/legacy.json.golden
+++ b/command/acl/token/testdata/FormatToken/legacy.json.golden
@@ -1,0 +1,10 @@
+{
+    "CreateIndex": 0,
+    "ModifyIndex": 0,
+    "AccessorID": "8acc7486-ca54-4d3c-9aed-5cd85651b0ee",
+    "SecretID": "legacy-secret",
+    "Description": "legacy",
+    "Local": false,
+    "CreateTime": "0001-01-01T00:00:00Z",
+    "Rules": "operator = \"read\""
+}

--- a/command/acl/token/testdata/FormatToken/legacy.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatToken/legacy.pretty-meta.golden
@@ -1,0 +1,10 @@
+AccessorID:       8acc7486-ca54-4d3c-9aed-5cd85651b0ee
+SecretID:         legacy-secret
+Description:      legacy
+Local:            false
+Create Time:      0001-01-01 00:00:00 +0000 UTC
+Hash:             
+Create Index:     0
+Modify Index:     0
+Rules:
+operator = "read"

--- a/command/acl/token/testdata/FormatToken/legacy.pretty.golden
+++ b/command/acl/token/testdata/FormatToken/legacy.pretty.golden
@@ -1,0 +1,7 @@
+AccessorID:       8acc7486-ca54-4d3c-9aed-5cd85651b0ee
+SecretID:         legacy-secret
+Description:      legacy
+Local:            false
+Create Time:      0001-01-01 00:00:00 +0000 UTC
+Rules:
+operator = "read"

--- a/command/acl/token/testdata/FormatTokenList/basic.json.golden
+++ b/command/acl/token/testdata/FormatTokenList/basic.json.golden
@@ -1,0 +1,12 @@
+[
+    {
+        "CreateIndex": 42,
+        "ModifyIndex": 100,
+        "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
+        "Description": "test token",
+        "Local": false,
+        "CreateTime": "2020-05-22T18:52:31Z",
+        "Hash": "YWJjZGVmZ2g=",
+        "Legacy": false
+    }
+]

--- a/command/acl/token/testdata/FormatTokenList/basic.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatTokenList/basic.pretty-meta.golden
@@ -1,0 +1,8 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+Description:      test token
+Local:            false
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Legacy:           false
+Hash:             6162636465666768
+Create Index:     42
+Modify Index:     100

--- a/command/acl/token/testdata/FormatTokenList/basic.pretty.golden
+++ b/command/acl/token/testdata/FormatTokenList/basic.pretty.golden
@@ -1,0 +1,5 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+Description:      test token
+Local:            false
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Legacy:           false

--- a/command/acl/token/testdata/FormatTokenList/complex.json.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.json.golden
@@ -1,0 +1,49 @@
+[
+    {
+        "CreateIndex": 5,
+        "ModifyIndex": 10,
+        "AccessorID": "fbd2447f-7479-4329-ad13-b021d74f86ba",
+        "Description": "test token",
+        "Policies": [
+            {
+                "ID": "beb04680-815b-4d7c-9e33-3d707c24672c",
+                "Name": "hobbiton"
+            },
+            {
+                "ID": "18788457-584c-4812-80d3-23d403148a90",
+                "Name": "bywater"
+            }
+        ],
+        "Roles": [
+            {
+                "ID": "3b0a78fe-b9c3-40de-b8ea-7d4d6674b366",
+                "Name": "shire"
+            },
+            {
+                "ID": "6c9d1e1d-34bc-4d55-80f3-add0890ad791",
+                "Name": "west-farthing"
+            }
+        ],
+        "ServiceIdentities": [
+            {
+                "ServiceName": "gardener",
+                "Datacenters": [
+                    "middleearth-northwest"
+                ]
+            }
+        ],
+        "NodeIdentities": [
+            {
+                "NodeName": "bagend",
+                "Datacenter": "middleearth-northwest"
+            }
+        ],
+        "Local": false,
+        "AuthMethod": "bar",
+        "ExpirationTime": "2020-05-22T19:52:31Z",
+        "CreateTime": "2020-05-22T18:52:31Z",
+        "Hash": "YWJjZGVmZ2g=",
+        "Legacy": false,
+        "Namespace": "foo"
+    }
+]

--- a/command/acl/token/testdata/FormatTokenList/complex.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.pretty-meta.golden
@@ -1,0 +1,21 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+Namespace:        foo
+Description:      test token
+Local:            false
+Auth Method:      bar
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Expiration Time:  2020-05-22 19:52:31 +0000 UTC
+Legacy:           false
+Hash:             6162636465666768
+Create Index:     5
+Modify Index:     10
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Roles:
+   3b0a78fe-b9c3-40de-b8ea-7d4d6674b366 - shire
+   6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)

--- a/command/acl/token/testdata/FormatTokenList/complex.pretty.golden
+++ b/command/acl/token/testdata/FormatTokenList/complex.pretty.golden
@@ -1,0 +1,18 @@
+AccessorID:       fbd2447f-7479-4329-ad13-b021d74f86ba
+Namespace:        foo
+Description:      test token
+Local:            false
+Auth Method:      bar
+Create Time:      2020-05-22 18:52:31 +0000 UTC
+Expiration Time:  2020-05-22 19:52:31 +0000 UTC
+Legacy:           false
+Policies:
+   beb04680-815b-4d7c-9e33-3d707c24672c - hobbiton
+   18788457-584c-4812-80d3-23d403148a90 - bywater
+Roles:
+   3b0a78fe-b9c3-40de-b8ea-7d4d6674b366 - shire
+   6c9d1e1d-34bc-4d55-80f3-add0890ad791 - west-farthing
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)
+Service Identities:
+   gardener (Datacenters: middleearth-northwest)

--- a/command/acl/token/testdata/FormatTokenList/legacy.json.golden
+++ b/command/acl/token/testdata/FormatTokenList/legacy.json.golden
@@ -1,0 +1,12 @@
+[
+    {
+        "CreateIndex": 0,
+        "ModifyIndex": 0,
+        "AccessorID": "8acc7486-ca54-4d3c-9aed-5cd85651b0ee",
+        "Description": "legacy",
+        "Local": false,
+        "CreateTime": "0001-01-01T00:00:00Z",
+        "Hash": null,
+        "Legacy": true
+    }
+]

--- a/command/acl/token/testdata/FormatTokenList/legacy.pretty-meta.golden
+++ b/command/acl/token/testdata/FormatTokenList/legacy.pretty-meta.golden
@@ -1,0 +1,8 @@
+AccessorID:       8acc7486-ca54-4d3c-9aed-5cd85651b0ee
+Description:      legacy
+Local:            false
+Create Time:      0001-01-01 00:00:00 +0000 UTC
+Legacy:           true
+Hash:             
+Create Index:     0
+Modify Index:     0

--- a/command/acl/token/testdata/FormatTokenList/legacy.pretty.golden
+++ b/command/acl/token/testdata/FormatTokenList/legacy.pretty.golden
@@ -1,0 +1,5 @@
+AccessorID:       8acc7486-ca54-4d3c-9aed-5cd85651b0ee
+Description:      legacy
+Local:            false
+Create Time:      0001-01-01 00:00:00 +0000 UTC
+Legacy:           true

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -15,6 +13,7 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTokenUpdateCommand_noTabs(t *testing.T) {
@@ -27,9 +26,6 @@ func TestTokenUpdateCommand_noTabs(t *testing.T) {
 
 func TestTokenUpdateCommand(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
-	// Alias because we need to access require package in Retry below
-	req := require.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
 	defer os.RemoveAll(testDir)
@@ -46,8 +42,6 @@ func TestTokenUpdateCommand(t *testing.T) {
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	ui := cli.NewMockUi()
-
 	// Create a policy
 	client := a.Client()
 
@@ -55,16 +49,17 @@ func TestTokenUpdateCommand(t *testing.T) {
 		&api.ACLPolicy{Name: "test-policy"},
 		&api.WriteOptions{Token: "root"},
 	)
-	req.NoError(err)
+	require.NoError(t, err)
 
 	// create a token
 	token, _, err := client.ACL().TokenCreate(
 		&api.ACLToken{Description: "test"},
 		&api.WriteOptions{Token: "root"},
 	)
-	req.NoError(err)
+	require.NoError(t, err)
 
-	// nolint: staticcheck // we want the deprecated legacy token
+	// create a legacy token
+	// nolint: staticcheck // we have to use the deprecated API to create a legacy token
 	legacyTokenSecretID, _, err := client.ACL().Create(&api.ACLEntry{
 		Name:  "Legacy token",
 		Type:  "client",
@@ -72,79 +67,100 @@ func TestTokenUpdateCommand(t *testing.T) {
 	},
 		&api.WriteOptions{Token: "root"},
 	)
-	req.NoError(err)
+	require.NoError(t, err)
 
 	// We fetch the legacy token later to give server time to async background
 	// upgrade it.
 
-	// update with policy by name
-	{
+	run := func(t *testing.T, args []string) *api.ACLToken {
+		ui := cli.NewMockUi()
 		cmd := New(ui)
-		args := []string{
+
+		code := cmd.Run(append(args, "-format=json"))
+		require.Equal(t, 0, code)
+		require.Empty(t, ui.ErrorWriter.String())
+
+		var token api.ACLToken
+		require.NoError(t, json.Unmarshal(ui.OutputWriter.Bytes(), &token))
+		return &token
+	}
+
+	// update with node identity
+	t.Run("node-identity", func(t *testing.T) {
+		token := run(t, []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-id=" + token.AccessorID,
+			"-token=root",
+			"-node-identity=foo:bar",
+			"-description=test token",
+		})
+
+		require.Len(t, token.NodeIdentities, 1)
+		require.Equal(t, "foo", token.NodeIdentities[0].NodeName)
+		require.Equal(t, "bar", token.NodeIdentities[0].Datacenter)
+	})
+
+	t.Run("node-identity-merge", func(t *testing.T) {
+		token := run(t, []string{
+			"-http-addr=" + a.HTTPAddr(),
+			"-id=" + token.AccessorID,
+			"-token=root",
+			"-node-identity=bar:baz",
+			"-description=test token",
+			"-merge-node-identities",
+		})
+
+		require.Len(t, token.NodeIdentities, 2)
+		expected := []*api.ACLNodeIdentity{
+			&api.ACLNodeIdentity{
+				NodeName:   "foo",
+				Datacenter: "bar",
+			},
+			&api.ACLNodeIdentity{
+				NodeName:   "bar",
+				Datacenter: "baz",
+			},
+		}
+		require.ElementsMatch(t, expected, token.NodeIdentities)
+	})
+
+	// update with policy by name
+	t.Run("policy-name", func(t *testing.T) {
+		token := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + token.AccessorID,
 			"-token=root",
 			"-policy-name=" + policy.Name,
 			"-description=test token",
-		}
+		})
 
-		code := cmd.Run(args)
-		assert.Equal(code, 0)
-		assert.Empty(ui.ErrorWriter.String())
-
-		token, _, err := client.ACL().TokenRead(
-			token.AccessorID,
-			&api.QueryOptions{Token: "root"},
-		)
-		assert.NoError(err)
-		assert.NotNil(token)
-	}
+		require.Len(t, token.Policies, 1)
+	})
 
 	// update with policy by id
-	{
-		cmd := New(ui)
-		args := []string{
+	t.Run("policy-id", func(t *testing.T) {
+		token := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + token.AccessorID,
 			"-token=root",
 			"-policy-id=" + policy.ID,
 			"-description=test token",
-		}
+		})
 
-		code := cmd.Run(args)
-		assert.Equal(code, 0)
-		assert.Empty(ui.ErrorWriter.String())
-
-		token, _, err := client.ACL().TokenRead(
-			token.AccessorID,
-			&api.QueryOptions{Token: "root"},
-		)
-		assert.NoError(err)
-		assert.NotNil(token)
-	}
+		require.Len(t, token.Policies, 1)
+	})
 
 	// update with no description shouldn't delete the current description
-	{
-		cmd := New(ui)
-		args := []string{
+	t.Run("merge-description", func(t *testing.T) {
+		token := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + token.AccessorID,
 			"-token=root",
 			"-policy-name=" + policy.Name,
-		}
+		})
 
-		code := cmd.Run(args)
-		assert.Equal(code, 0)
-		assert.Empty(ui.ErrorWriter.String())
-
-		token, _, err := client.ACL().TokenRead(
-			token.AccessorID,
-			&api.QueryOptions{Token: "root"},
-		)
-		assert.NoError(err)
-		assert.NotNil(token)
-		assert.Equal("test token", token.Description)
-	}
+		require.Equal(t, "test token", token.Description)
+	})
 
 	// Need legacy token now, hopefully server had time to generate an accessor ID
 	// in the background but wait for it if not.
@@ -153,39 +169,28 @@ func TestTokenUpdateCommand(t *testing.T) {
 		// Fetch the legacy token via new API so we can use it's accessor ID
 		legacyToken, _, err = client.ACL().TokenReadSelf(
 			&api.QueryOptions{Token: legacyTokenSecretID})
-		r.Check(err)
+		require.NoError(r, err)
 		require.NotEmpty(r, legacyToken.AccessorID)
 	})
 
 	// upgrade legacy token should replace rules and leave token in a "new" state!
-	{
-		cmd := New(ui)
-		args := []string{
+	t.Run("legacy-upgrade", func(t *testing.T) {
+		token := run(t, []string{
 			"-http-addr=" + a.HTTPAddr(),
 			"-id=" + legacyToken.AccessorID,
 			"-token=root",
 			"-policy-name=" + policy.Name,
 			"-upgrade-legacy",
-		}
+		})
 
-		code := cmd.Run(args)
-		assert.Equal(code, 0)
-		assert.Empty(ui.ErrorWriter.String())
-
-		gotToken, _, err := client.ACL().TokenRead(
-			legacyToken.AccessorID,
-			&api.QueryOptions{Token: "root"},
-		)
-		assert.NoError(err)
-		assert.NotNil(gotToken)
 		// Description shouldn't change
-		assert.Equal("Legacy token", gotToken.Description)
-		assert.Len(gotToken.Policies, 1)
+		require.Equal(t, "Legacy token", token.Description)
+		require.Len(t, token.Policies, 1)
 		// Rules should now be empty meaning this is no longer a legacy token
-		assert.Empty(gotToken.Rules)
+		require.Empty(t, token.Rules)
 		// Secret should not have changes
-		assert.Equal(legacyToken.SecretID, gotToken.SecretID)
-	}
+		require.Equal(t, legacyToken.SecretID, token.SecretID)
+	})
 }
 
 func TestTokenUpdateCommand_JSON(t *testing.T) {

--- a/website/pages/api-docs/acl/binding-rules.mdx
+++ b/website/pages/api-docs/acl/binding-rules.mdx
@@ -63,6 +63,17 @@ The table below shows this endpoint's support for
             ]
         }
         ```
+        
+  - `BindType=node` - The computed bind name value is used as an
+    `ACLNodeIdentity.NodeName` field in the token that is created.
+
+        ```json
+        { ...other fields...
+            "NodeIdentities": [
+                { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
+            ]
+        }
+        ```
 
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
@@ -232,7 +243,18 @@ The table below shows this endpoint's support for
             ]
         }
         ```
+        
+  - `BindType=node` - The computed bind name value is used as an
+    `ACLNodeIdentity.NodeName` field in the token that is created.
 
+        ```json
+        { ...other fields...
+            "NodeIdentities": [
+                { "NodeName": "<computed BindName>", "Datacenter": "<local datacenter>" }
+            ]
+        }
+        ```
+        
   - `BindType=role` - The computed bind name value is used as a `RoleLink.Name`
     field in the token that is created. This binding rule will only apply if a
     role with the given name exists at login-time. If it does not then this
@@ -394,6 +416,7 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/binding-rules
     "ID": "b4f0a0a3-69f2-7a4f-6bef-326034ace9fa",
     "Description": "example 2",
     "AuthMethod": "minikube-2",
+    "BindType": "service",
     "Selector": "serviceaccount.namespace==default",
     "BindName": "k8s-{{ serviceaccount.name }}",
     "CreateIndex": 18,

--- a/website/pages/api-docs/acl/roles.mdx
+++ b/website/pages/api-docs/acl/roles.mdx
@@ -62,6 +62,18 @@ The table below shows this endpoint's support for
     policy is valid in all datacenters including those which do not yet exist
     but may in the future.
 
+- `NodeIdentities` `(array<NodeIdentity>)` - The list of [node
+  identities](/docs/acl/acl-system#acl-node-identities) that should be
+  applied to the role. Added in Consul 1.8.1.
+
+  - `NodeName` `(string: <required>)` - The name of the node. The name
+    must be no longer than 256 characters, must start and end with a lowercase
+    alphanumeric character, and can only contain lowercase alphanumeric
+    characters as well as `-` and `_`.
+
+  - `Datacenter` `(string: <required>)` - Specifies the nodes datacenter. This
+    will result in effective policy only being valid in that datacenter.
+
 - `Namespace` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace to
   create the role. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used.
@@ -89,6 +101,12 @@ The table below shows this endpoint's support for
     {
       "ServiceName": "db",
       "Datacenters": ["dc1"]
+    }
+  ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
     }
   ]
 }
@@ -122,6 +140,12 @@ $ curl -X PUT \
     {
       "ServiceName": "db",
       "Datacenters": ["dc1"]
+    }
+  ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
     }
   ],
   "Hash": "mBWMIeX9zyUTdDMq8vWB0iYod+mKBArJoAhj6oPz3BI=",
@@ -188,6 +212,12 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/role/aa770e5b-8b0b-7fcf-e5a1-8535fcc3
       "Datacenters": ["dc1"]
     }
   ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
+    }
+  ],
   "Hash": "mBWMIeX9zyUTdDMq8vWB0iYod+mKBArJoAhj6oPz3BI=",
   "CreateIndex": 57,
   "ModifyIndex": 57
@@ -252,6 +282,12 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/role/name/example-role
       "Datacenters": ["dc1"]
     }
   ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
+    }
+  ],
   "Hash": "mBWMIeX9zyUTdDMq8vWB0iYod+mKBArJoAhj6oPz3BI=",
   "CreateIndex": 57,
   "ModifyIndex": 57
@@ -299,6 +335,10 @@ The table below shows this endpoint's support for
   identities](/docs/acl/acl-system#acl-service-identities) that should be
   applied to the role. Added in Consul 1.5.0.
 
+- `NodeIdentities` `(array<NodeIdentity>)` - The list of [node
+  identities](/docs/acl/acl-system#acl-node-identities) that should be
+  applied to the role. Added in Consul 1.8.1.
+  
 - `Namespace` `(string: "")` <EnterpriseAlert inline /> - Specifies the namespace of
   the role to update. If not provided in the JSON body, the value of
   the `ns` URL query parameter or in the `X-Consul-Namespace` header will be used.
@@ -319,6 +359,12 @@ The table below shows this endpoint's support for
   "ServiceIdentities": [
     {
       "ServiceName": "db"
+    }
+  ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
     }
   ]
 }
@@ -347,6 +393,12 @@ $ curl -X PUT \
   "ServiceIdentities": [
     {
       "ServiceName": "db"
+    }
+  ],
+  "NodeIdentities": [
+    {
+      "NodeName": "node-1",
+      "Datacenter": "dc2"
     }
   ],
   "Hash": "OtZUUKhInTLEqTPfNSSOYbRiSBKm3c4vI2p6MxZnGWc=",
@@ -473,6 +525,12 @@ $ curl -X GET http://127.0.0.1:8500/v1/acl/roles
       {
         "ServiceName": "db",
         "Datacenters": ["dc1"]
+      }
+    ],
+    "NodeIdentities": [
+      {
+        "NodeName": "node-1",
+        "Datacenter": "dc2"
       }
     ],
     "Hash": "mBWMIeX9zyUTdDMq8vWB0iYod+mKBArJoAhj6oPz3BI=",

--- a/website/pages/api-docs/acl/tokens.mdx
+++ b/website/pages/api-docs/acl/tokens.mdx
@@ -74,6 +74,18 @@ The table below shows this endpoint's support for
     policy is valid in all datacenters including those which do not yet exist
     but may in the future.
 
+- `NodeIdentities` `(array<NodeIdentity>)` - The list of [node
+  identities](/docs/acl/acl-system#acl-node-identities) that should be
+  applied to the token. Added in Consul 1.8.1.
+
+  - `NodeName` `(string: <required>)` - The name of the node. The name
+    must be no longer than 256 characters, must start and end with a lowercase
+    alphanumeric character, and can only contain lowercase alphanumeric
+    characters as well as `-` and `_`.
+
+  - `Datacenter` `(string: <required>)` - Specifies the nodes datacenter. This
+    will result in effective policy only being valid in that datacenter.
+
 - `Local` `(bool: false)` - If true, indicates that the token should not be
   replicated globally and instead be local to the current datacenter.
 
@@ -322,6 +334,18 @@ The table below shows this endpoint's support for
     policy is valid within. When no datacenters are provided the effective
     policy is valid in all datacenters including those which do not yet exist
     but may in the future.
+
+- `NodeIdentities` `(array<NodeIdentity>)` - The list of [node
+  identities](/docs/acl/acl-system#acl-node-identities) that should be
+  applied to the token. Added in Consul 1.8.1.
+
+  - `NodeName` `(string: <required>)` - The name of the node. The name
+    must be no longer than 256 characters, must start and end with a lowercase
+    alphanumeric character, and can only contain lowercase alphanumeric
+    characters as well as `-` and `_`.
+
+  - `Datacenter` `(string: <required>)` - Specifies the nodes datacenter. This
+    will result in effective policy only being valid in that datacenter.
 
 - `Local` `(bool: false)` - If true, indicates that this token should not be
   replicated globally and instead be local to the current datacenter. This

--- a/website/pages/docs/acl/acl-system.mdx
+++ b/website/pages/docs/acl/acl-system.mdx
@@ -45,6 +45,13 @@ may benefit from additional components in the ACL system:
   additional policy was attached, the contents of which are described further
   below. These are directly attached to tokens and roles and are not
   independently configured. (Added in Consul 1.5.0)
+  
+- **ACL Node Identities** - Node identities are a policy template for
+  expressing a link to a policy suitable for use as an [Consul `agent` token
+  ](/docs/agent/options#acl_tokens_agent). At authorization time this acts like an
+  additional policy was attached, the contents of which are described further
+  below. These are directly attached to tokens and roles and are not
+  independently configured. (Added in Consul 1.8.1)
 
 - **ACL Auth Methods and Binding Rules** - To learn more about these topics,
   see the [auth methods documentation page](/docs/acl/auth-methods).
@@ -122,6 +129,38 @@ examples of using a service identity.
 
 -> **Consul Enterprise Namespacing** - Service Identity rules will be scoped to the single namespace that
 the corresponding ACL Token or Role resides within.
+
+### ACL Node Identities
+
+-> Added in Consul 1.8.1
+
+An ACL node identity is an [ACL policy](/docs/acl/acl-system#acl-policies) template for expressing a link to a policy
+suitable for use as an [Consul `agent` token](/docs/agent/options#acl_tokens_agent). They are usable
+on both tokens and roles and are composed of the following elements:
+
+- **Node Name** - The name of the node to grant access to.
+- **Datacenter** - The datacenter that the node resides within.
+
+During the authorization process, the configured node identity is automatically
+applied as a policy with the following preconfigured [ACL
+rules](/docs/acl/acl-system#acl-rules-and-scope):
+
+```hcl
+# Allow the agent to register its own node in the Catalog and update its network coordinates
+node "<Node Name>" {
+  policy = "write"
+}
+
+# Allows the agent to detect and diff services registered to itself. This is used during
+# anti-entropy to reconcile difference between the agents knowledge of registered
+# services and checks in comparison with what is known in the Catalog.
+service_prefix "" {
+  policy = "read"
+}
+```
+
+-> **Consul Enterprise Namespacing** - Node Identities can only be applied to tokens and roles in the `default` namespace.
+The synthetic policy rules allow for `service:read` permissions on all services in all namespaces.
 
 ### ACL Roles
 


### PR DESCRIPTION
A Node Identity is very similar to a service identity. Its main targeted use is to allow creating tokens for use by Consul agents that will grant the necessary permissions for all the typical agent operations (node registration, coordinate updates, anti-entropy).

Half of the changes in this PR are for golden file based tests of the acl token and role cli output. Another big updates was to refactor many of the tests in agent/consul/acl_endpoint_test.go to use the same style of tests and the same helpers. Besides being less boiler plate in the tests it also uses a common way of starting a test server with ACLs that should operate without any warnings regarding deprecated non-uuid master tokens etc.

There is also a second commit in this PR to address some arm build issues where Gos builtin linker was having trouble linking Consul when CGO is enabled. We might be able to get rid of CGO now that a bug causing a crash on ARM was fixed in go 1.14. For the time being though, setting `-linkmode=external` will cause Go to use the systems linker which is more robust and can handle our binary perfectly well.
