### PR TITLE
Replace whitelist/blacklist terminology with allowlist/denylist

### DIFF
--- a/acl/static_authorizer.go
+++ b/acl/static_authorizer.go
@@ -24,7 +24,7 @@ var (
 
 // StaticAuthorizer is used to implement a base ACL policy. It either
 // allows or denies all requests. This can be used as a parent
-// ACL to act in a blacklist or whitelist mode.
+// ACL to act in a denylist or allowlist mode.
 type staticAuthorizer struct {
 	allowManage  bool
 	defaultAllow bool

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -905,7 +905,7 @@ func (a *Agent) listenHTTP() ([]*HTTPServer, error) {
 				},
 				ln:        l,
 				agent:     a,
-				blacklist: NewBlacklist(a.config.HTTPBlockEndpoints),
+				denylist:  NewDenylist(a.config.HTTPBlockEndpoints), 
 				proto:     proto,
 			}
 			srv.Server.Handler = srv.handler(a.config.EnableDebug)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -903,10 +903,10 @@ func (a *Agent) listenHTTP() ([]*HTTPServer, error) {
 					Addr:      l.Addr().String(),
 					TLSConfig: tlscfg,
 				},
-				ln:        l,
-				agent:     a,
-				denylist:  NewDenylist(a.config.HTTPBlockEndpoints), 
-				proto:     proto,
+				ln:       l,
+				agent:    a,
+				denylist: NewDenylist(a.config.HTTPBlockEndpoints),
+				proto:    proto,
 			}
 			srv.Server.Handler = srv.handler(a.config.EnableDebug)
 

--- a/agent/connect/uri_signing.go
+++ b/agent/connect/uri_signing.go
@@ -41,7 +41,7 @@ func (id *SpiffeIDSigning) Authorize(ixn *structs.Intention) (bool, bool) {
 // I choose to make this a fixed centralized method here for now rather than a
 // method on CertURI interface since we don't intend this to be extensible
 // outside and it's easier to reason about the security properties when they are
-// all in one place with "whitelist" semantics.
+// all in one place with "allowlist" semantics.
 func (id *SpiffeIDSigning) CanSign(cu CertURI) bool {
 	switch other := cu.(type) {
 	case *SpiffeIDSigning:

--- a/agent/consul/authmethod/kubeauth/testing.go
+++ b/agent/consul/authmethod/kubeauth/testing.go
@@ -66,7 +66,7 @@ func StartTestAPIServer(t testing.T) *TestAPIServer {
 	return s
 }
 
-// AuthorizeJWT whitelists the given JWT as able to use the API server.
+// AuthorizeJWT allowlists the given JWT as able to use the API server.
 func (s *TestAPIServer) AuthorizeJWT(jwt string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -398,7 +398,7 @@ func (s *ConnectCA) Roots(
 			}
 
 			// The API response must NEVER contain the secret information
-			// such as keys and so on. We use a whitelist below to copy the
+			// such as keys and so on. We use an allowlist below to copy the
 			// specific fields we want to expose.
 			for i, r := range reply.Roots {
 				// IMPORTANT: r must NEVER be modified, since it is a pointer

--- a/agent/consul/intention_endpoint_test.go
+++ b/agent/consul/intention_endpoint_test.go
@@ -1334,7 +1334,7 @@ func TestIntentionCheck_defaultNoACL(t *testing.T) {
 	require.True(resp.Allowed)
 }
 
-// Test the Check method defaults to deny with whitelist ACLs.
+// Test the Check method defaults to deny with allowlist ACLs.
 func TestIntentionCheck_defaultACLDeny(t *testing.T) {
 	t.Parallel()
 
@@ -1369,7 +1369,7 @@ func TestIntentionCheck_defaultACLDeny(t *testing.T) {
 	require.False(resp.Allowed)
 }
 
-// Test the Check method defaults to deny with blacklist ACLs.
+// Test the Check method defaults to deny with denylist ACLs.
 func TestIntentionCheck_defaultACLAllow(t *testing.T) {
 	t.Parallel()
 

--- a/agent/denylist.go
+++ b/agent/denylist.go
@@ -21,7 +21,7 @@ func NewDenylist(prefixes []string) *Denylist {
 
 // Block will return true if the given path is included among any of the
 // blocked prefixes.
-func (b *Denylist) Block(path string) bool {
-	_, _, blocked := b.tree.LongestPrefix(path)
+func (d *Denylist) Block(path string) bool {
+	_, _, blocked := d.tree.LongestPrefix(path)
 	return blocked
 }

--- a/agent/denylist.go
+++ b/agent/denylist.go
@@ -4,24 +4,24 @@ import (
 	"github.com/armon/go-radix"
 )
 
-// Blacklist implements an HTTP endpoint blacklist based on a list of endpoint
+// Denylist implements an HTTP endpoint denylist based on a list of endpoint
 // prefixes which should be blocked.
-type Blacklist struct {
+type Denylist struct {
 	tree *radix.Tree
 }
 
-// NewBlacklist returns a blacklist for the given list of prefixes.
-func NewBlacklist(prefixes []string) *Blacklist {
+// NewDenylist returns a denylist for the given list of prefixes.
+func NewDenylist(prefixes []string) *Denylist {
 	tree := radix.New()
 	for _, prefix := range prefixes {
 		tree.Insert(prefix, nil)
 	}
-	return &Blacklist{tree}
+	return &Denylist{tree}
 }
 
 // Block will return true if the given path is included among any of the
 // blocked prefixes.
-func (b *Blacklist) Block(path string) bool {
+func (b *Denylist) Block(path string) bool {
 	_, _, blocked := b.tree.LongestPrefix(path)
 	return blocked
 }

--- a/agent/denylist_test.go
+++ b/agent/denylist_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestBlacklist(t *testing.T) {
+func TestDenylist(t *testing.T) {
 	t.Parallel()
 
 	complex := []string{
@@ -30,8 +30,8 @@ func TestBlacklist(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			blacklist := NewBlacklist(tt.prefixes)
-			if got, want := blacklist.Block(tt.path), tt.block; got != want {
+			denylist := NewDenylist(tt.prefixes)
+			if got, want := denylist.Block(tt.path), tt.block; got != want {
 				t.Fatalf("got %v want %v", got, want)
 			}
 		})

--- a/agent/http.go
+++ b/agent/http.go
@@ -84,7 +84,7 @@ type HTTPServer struct {
 	*http.Server
 	ln        net.Listener
 	agent     *Agent
-	blacklist *Blacklist
+	denylist  *Denylist
 
 	// proto is filled by the agent to "http" or "https".
 	proto string
@@ -426,7 +426,7 @@ func (s *HTTPServer) wrap(handler endpoint, methods []string) http.HandlerFunc {
 		}
 		logURL = aclEndpointRE.ReplaceAllString(logURL, "$1<hidden>$4")
 
-		if s.blacklist.Block(req.URL.Path) {
+		if s.denylist.Block(req.URL.Path) {
 			errMsg := "Endpoint is blocked by agent configuration"
 			httpLogger.Error("Request error",
 				"method", req.Method,

--- a/agent/http.go
+++ b/agent/http.go
@@ -82,9 +82,9 @@ func (e ForbiddenError) Error() string {
 // HTTPServer provides an HTTP api for an agent.
 type HTTPServer struct {
 	*http.Server
-	ln        net.Listener
-	agent     *Agent
-	denylist  *Denylist
+	ln       net.Listener
+	agent    *Agent
+	denylist *Denylist
 
 	// proto is filled by the agent to "http" or "https".
 	proto string

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -52,7 +52,7 @@ type Intention struct {
 	// SourceType is the type of the value for the source.
 	SourceType IntentionSourceType
 
-	// Action is whether this is a whitelist or blacklist intention.
+	// Action is whether this is an allowlist or denylist intention.
 	Action IntentionAction
 
 	// DefaultAddr, DefaultPort of the local listening proxy (if any) to
@@ -349,7 +349,7 @@ func (x *Intention) EstimateSize() int {
 }
 
 // IntentionAction is the action that the intention represents. This
-// can be "allow" or "deny" to whitelist or blacklist intentions.
+// can be "allow" or "deny" to allowlist or denylist intentions.
 type IntentionAction string
 
 const (

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -349,7 +349,7 @@ func (x *Intention) EstimateSize() int {
 }
 
 // IntentionAction is the action that the intention represents. This
-// can be "allow" or "deny" to allowlist or denylist intentions.
+// can be "allow" or "deny".
 type IntentionAction string
 
 const (

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1328,7 +1328,7 @@ func TestStructs_ValidateServiceAndNodeMetadata(t *testing.T) {
 			"",
 			"",
 		},
-		"reserved key prefix allowed via whitelist just for gateway - " + MetaWANFederationKey: {
+		"reserved key prefix allowed via an allowlist just for gateway - " + MetaWANFederationKey: {
 			map[string]string{
 				MetaWANFederationKey: "value1",
 			},
@@ -1394,9 +1394,9 @@ func TestStructs_validateMetaPair(t *testing.T) {
 		{metaKeyReservedPrefix + "key", "value", "reserved for internal use", false, nil},
 		// reserved prefix, allowed
 		{metaKeyReservedPrefix + "key", "value", "", true, nil},
-		// reserved prefix, not allowed via whitelist
+		// reserved prefix, not allowed via an allowlist
 		{metaKeyReservedPrefix + "bad", "value", "reserved for internal use", false, map[string]struct{}{metaKeyReservedPrefix + "good": struct{}{}}},
-		// reserved prefix, allowed via whitelist
+		// reserved prefix, allowed via an allowlist
 		{metaKeyReservedPrefix + "good", "value", "", true, map[string]struct{}{metaKeyReservedPrefix + "good": struct{}{}}},
 		// value too long
 		{"key", longValue, "Value is too long", false, nil},

--- a/api/connect_intention.go
+++ b/api/connect_intention.go
@@ -33,7 +33,7 @@ type Intention struct {
 	// SourceType is the type of the value for the source.
 	SourceType IntentionSourceType
 
-	// Action is whether this is a whitelist or blacklist intention.
+	// Action is whether this is an allowlist or denylist intention.
 	Action IntentionAction
 
 	// DefaultAddr, DefaultPort of the local listening proxy (if any) to
@@ -99,7 +99,7 @@ func (i *Intention) partString(ns, n string) string {
 const IntentionDefaultNamespace = "default"
 
 // IntentionAction is the action that the intention represents. This
-// can be "allow" or "deny" to whitelist or blacklist intentions.
+// can be "allow" or "deny" to allowlist or denylist intentions.
 type IntentionAction string
 
 const (

--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -458,14 +458,14 @@ function find_git_remote {
    return ${ret}
 }
 
-function git_remote_not_blacklisted {
+function git_remote_not_denylisted {
    # Arguments:
    #   $1 - path to the repo
    #   $2 - the remote name
    #
    # Returns:
-   #   0 - not blacklisted
-   #   * - blacklisted
+   #   0 - not denylisted
+   #   * - denylisted
    return 0
 }
 

--- a/build-support/functions/40-publish.sh
+++ b/build-support/functions/40-publish.sh
@@ -399,9 +399,9 @@ function publish_release {
    status_stage "==> Confirming Git Changes"
    confirm_git_push_changes "$1" || return 1
    
-   status_stage "==> Checking for blacklisted Git Remote"
+   status_stage "==> Checking for denylisted Git Remote"
    local remote=$(find_git_remote "${sdir}") || return 1
-   git_remote_not_blacklisted "${sdir}" "${remote}" || return 1
+   git_remote_not_denylisted "${sdir}" "${remote}" || return 1
    
    status_stage "==> Confirming Git Remote"
    confirm_git_remote "${sdir}" "${remote}" || return 1

--- a/command/intention/create/create.go
+++ b/command/intention/create/create.go
@@ -249,7 +249,7 @@ Usage: consul intention create [options] -file FILE...
 
       $ echo "{ ... }" | consul intention create -file -
 
-  An "allow" intention is created by default (whitelist). To create a
+  An "allow" intention is created by default (allowlist). To create a
   "deny" intention, the "-deny" flag should be specified.
 
   If a conflicting intention is found, creation will fail. To replace any

--- a/website/pages/docs/acl/acl-legacy.mdx
+++ b/website/pages/docs/acl/acl-legacy.mdx
@@ -127,11 +127,11 @@ token are automatically applied. The anonymous token is managed using the
 #### ACL Rules and Scope
 
 Tokens are bound to a set of rules that control which Consul resources the token
-has access to. Policies can be defined in either a whitelist or blacklist mode
+has access to. Policies can be defined in either an allowlist or denylist mode
 depending on the configuration of
 [`acl_default_policy`](/docs/agent/options#acl_default_policy). If the default
-policy is to "deny" all actions, then token rules can be set to whitelist specific
-actions. In the inverse, the "allow" all default behavior is a blacklist where rules
+policy is to "deny" all actions, then token rules can be set to allowlist specific
+actions. In the inverse, the "allow" all default behavior is a denylist where rules
 are used to prohibit actions. By default, Consul will allow all actions.
 
 The following table summarizes the ACL policies that are available for constructing
@@ -199,7 +199,7 @@ as to whether they are set on servers, clients, or both.
 | Configuration Option                                                  | Servers    | Clients    | Purpose                                                                                   |
 | --------------------------------------------------------------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------- |
 | [`acl_datacenter`](/docs/agent/options#acl_datacenter)                | `REQUIRED` | `REQUIRED` | Master control that enables ACLs by defining the authoritative Consul datacenter for ACLs |
-| [`acl_default_policy`](/docs/agent/options#acl_default_policy_legacy) | `OPTIONAL` | `N/A`      | Determines whitelist or blacklist mode                                                    |
+| [`acl_default_policy`](/docs/agent/options#acl_default_policy_legacy) | `OPTIONAL` | `N/A`      | Determines allowlist or denylist mode                                                    |
 | [`acl_down_policy`](/docs/agent/options#acl_down_policy_legacy)       | `OPTIONAL` | `OPTIONAL` | Determines what to do when the ACL datacenter is offline                                  |
 | [`acl_ttl`](/docs/agent/options#acl_ttl_legacy)                       | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACLs                                                   |
 
@@ -275,9 +275,9 @@ datacenter. In this example, we are configuring the following:
 
 1. An ACL datacenter of "dc1", which is where these servers are
 2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl/acl#bootstrap-acls)
-3. A default policy of "deny" which means we are in whitelist mode
-4. A down policy of "extend-cache" which means that we will ignore token TTLs during an
-   outage
+3. A default policy of "deny" which means we are in allowlist mode
+4. A down policy of "extend-cache" which means that we will ignore token TTLs 
+during an outage
 
 Here's the corresponding JSON configuration file:
 

--- a/website/pages/docs/acl/acl-system.mdx
+++ b/website/pages/docs/acl/acl-system.mdx
@@ -189,10 +189,10 @@ token will be used.
 #### ACL Rules and Scope
 
 The rules from all policies, roles, and service identities linked with a token are combined to form that token's
-effective rule set. Policy rules can be defined in either a whitelist or blacklist
+effective rule set. Policy rules can be defined in either an allowlist or denylist
 mode depending on the configuration of [`acl_default_policy`](/docs/agent/options#acl_default_policy).
 If the default policy is to "deny" access to all resources, then policy rules can be set to
-whitelist access to specific resources. Conversely, if the default policy is “allow” then policy rules can
+allowlist access to specific resources. Conversely, if the default policy is “allow” then policy rules can
 be used to explicitly deny access to resources.
 
 The following table summarizes the ACL resources that are available for constructing
@@ -240,7 +240,7 @@ as to whether they are set on servers, clients, or both.
 | Configuration Option                                           | Servers    | Clients    | Purpose                                                                |
 | -------------------------------------------------------------- | ---------- | ---------- | ---------------------------------------------------------------------- |
 | [`acl.enabled`](/docs/agent/options#acl_enabled)               | `REQUIRED` | `REQUIRED` | Controls whether ACLs are enabled                                      |
-| [`acl.default_policy`](/docs/agent/options#acl_default_policy) | `OPTIONAL` | `N/A`      | Determines whitelist or blacklist mode                                 |
+| [`acl.default_policy`](/docs/agent/options#acl_default_policy) | `OPTIONAL` | `N/A`      | Determines allowlist or denylist mode                                 |
 | [`acl.down_policy`](/docs/agent/options#acl_down_policy)       | `OPTIONAL` | `OPTIONAL` | Determines what to do when the remote token or policy resolution fails |
 | [`acl.role_ttl`](/docs/agent/options#acl_role_ttl)             | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACL Roles                           |
 | [`acl.policy_ttl`](/docs/agent/options#acl_policy_ttl)         | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACL Policies                        |

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -622,9 +622,9 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
   - `default_policy` ((#acl_default_policy)) - Either "allow" or "deny";
     defaults to "allow" but this will be changed in a future major release. The default
     policy controls the behavior of a token when there is no matching rule. In "allow"
-    mode, ACLs are a blacklist: any operation not specifically prohibited is allowed.
-    In "deny" mode, ACLs are a whitelist: any operation not specifically allowed
-    is blocked. **Note**: this will not take effect until you've enabled ACLs.
+    mode, ACLs are a denylist: any operation not specifically prohibited is allowed.
+    In "deny" mode, ACLs are an allowlist: any operation not specifically
+    allowed is blocked. **Note**: this will not take effect until you'veenabled ACLs.
 
   - `enable_key_list_policy` ((#acl_enable_key_list_policy)) - Either "enabled"
     or "disabled", defaults to "disabled". When enabled, the `list` permission will
@@ -702,8 +702,8 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 - `acl_default_policy` ((#acl_default_policy_legacy)) - **Deprecated in Consul 1.4.0. See the [`acl.default_policy`](#acl_default_policy) field instead.**
   Either "allow" or "deny"; defaults to "allow". The default policy controls the
   behavior of a token when there is no matching rule. In "allow" mode, ACLs are a
-  blacklist: any operation not specifically prohibited is allowed. In "deny" mode,
-  ACLs are a whitelist: any operation not specifically allowed is blocked. **Note**:
+  denylist: any operation not specifically prohibited is allowed. In "deny" mode,
+  ACLs are an allowlist: any operation not specifically allowed is blocked. **Note**:
   this will not take effect until you've set `primary_datacenter` to enable ACL support.
 
 - `acl_down_policy` ((#acl_down_policy_legacy)) - **Deprecated in Consul

--- a/website/pages/docs/connect/security.mdx
+++ b/website/pages/docs/connect/security.mdx
@@ -34,7 +34,7 @@ of Consul.
 Consul must be configured to use ACLs with a default deny policy. This forces
 all requests to have explicit anonymous access or provide an ACL token. The
 configuration also forces all service-to-service communication to be explicitly
-whitelisted via an allow [intention](/docs/connect/intentions).
+allowed via an allow [intention](/docs/connect/intentions).
 
 To learn how to enable ACLs, please see the
 [guide on ACLs](https://learn.hashicorp.com/consul/security-networking/production-acls).

--- a/website/pages/docs/guides/acl-legacy.mdx
+++ b/website/pages/docs/guides/acl-legacy.mdx
@@ -115,11 +115,11 @@ token are automatically applied. The anonymous token is managed using the
 #### ACL Rules and Scope
 
 Tokens are bound to a set of rules that control which Consul resources the token
-has access to. Policies can be defined in either a whitelist or blacklist mode
+has access to. Policies can be defined in either an allowlist or denylist mode
 depending on the configuration of
 [`acl_default_policy`](/docs/agent/options#acl_default_policy). If the default
-policy is to "deny" all actions, then token rules can be set to whitelist specific
-actions. In the inverse, the "allow" all default behavior is a blacklist where rules
+policy is to "deny" all actions, then token rules can be set to allowlist specific
+actions. In the inverse, the "allow" all default behavior is a denylist where rules
 are used to prohibit actions. By default, Consul will allow all actions.
 
 The following table summarizes the ACL policies that are available for constructing
@@ -187,7 +187,7 @@ as to whether they are set on servers, clients, or both.
 | Configuration Option                                                  | Servers    | Clients    | Purpose                                                                                   |
 | --------------------------------------------------------------------- | ---------- | ---------- | ----------------------------------------------------------------------------------------- |
 | [`primary_datacenter`](/docs/agent/options#primary_datacenter)        | `REQUIRED` | `REQUIRED` | Master control that enables ACLs by defining the authoritative Consul datacenter for ACLs |
-| [`acl_default_policy`](/docs/agent/options#acl_default_policy_legacy) | `OPTIONAL` | `N/A`      | Determines whitelist or blacklist mode                                                    |
+| [`acl_default_policy`](/docs/agent/options#acl_default_policy_legacy) | `OPTIONAL` | `N/A`      | Determines allowlist or denylist mode                                                    |
 | [`acl_down_policy`](/docs/agent/options#acl_down_policy_legacy)       | `OPTIONAL` | `OPTIONAL` | Determines what to do when the ACL datacenter is offline                                  |
 | [`acl_ttl`](/docs/agent/options#acl_ttl_legacy)                       | `OPTIONAL` | `OPTIONAL` | Determines time-to-live for cached ACLs                                                   |
 
@@ -263,7 +263,7 @@ datacenter. In this example, we are configuring the following:
 
 1. An ACL datacenter of "dc1", which is where these servers are
 2. An ACL master token of "b1gs33cr3t"; see below for an alternative using the [/v1/acl/bootstrap API](/api/acl/acl#bootstrap-acls)
-3. A default policy of "deny" which means we are in whitelist mode
+3. A default policy of "deny" which means we are in allowlist mode
 4. A down policy of "extend-cache" which means that we will ignore token TTLs during an
    outage
 

--- a/website/pages/docs/guides/production-acls.mdx
+++ b/website/pages/docs/guides/production-acls.mdx
@@ -54,7 +54,7 @@ on them when you apply the token.
 of Consul, you cannot persist tokens when using the HTTP API.
 
 In this example, you configured the default policy of "deny", which means you
-are in whitelist mode. You also enabled token persistence when using the HTTP
+are in allowlist mode. You also enabled token persistence when using the HTTP
 API. With persistence enabled, tokens will be persisted to disk and
 reloaded when an agent restarts
 

--- a/website/pages/docs/internals/security.mdx
+++ b/website/pages/docs/internals/security.mdx
@@ -54,7 +54,7 @@ items outside of Consul's threat model as noted in sections below.
   - Secure against unprivileged users becoming root
 
 - **ACLs enabled with default deny.** Consul must be configured to use ACLs with
-  a whitelist (default deny) approach. This forces all requests to have explicit
+  an allowlist (default deny) approach. This forces all requests to have explicit
   anonymous access or provide an ACL token.
 
 - **Encryption enabled.** TCP and UDP encryption must be enabled and configured


### PR DESCRIPTION
Encompasses #7969, fixes #7901 .

Went through and updated the terms and functions outside of just the api to allowlist/denylist and correct "an" before it. One or two functions are directly impacted, so this is not a docs only change.

Thanks @cainejette for the original work and submitting the request! 