### PR TITLE
Implement cached results with empty body and HTTP 304 semantics

### DIFF
--- a/agent/agentpb/common.go
+++ b/agent/agentpb/common.go
@@ -77,6 +77,16 @@ func (q *QueryOptions) SetFilter(filter string) {
 	q.Filter = filter
 }
 
+// GetReturnEmptyResultOnUnmodified when true, means that returned data might be empty if cached data is not modified
+func (q *QueryOptions) GetReturnEmptyResultOnUnmodified() bool {
+	return q.EmptyCacheResult
+}
+
+// SetReturnEmptyResultOnUnmodified if true data might be ommited in response when cached data did not change
+func (q *QueryOptions) SetReturnEmptyResultOnUnmodified(v bool) {
+	q.EmptyCacheResult = v
+}
+
 // SetLastContact is needed to implement the structs.QueryMetaCompat interface
 func (q *QueryMeta) SetLastContact(lastContact time.Duration) {
 	q.LastContact = lastContact

--- a/agent/agentpb/common.pb.go
+++ b/agent/agentpb/common.pb.go
@@ -202,6 +202,8 @@ type QueryOptions struct {
 	// Filter specifies the go-bexpr filter expression to be used for
 	// filtering the data prior to returning a response
 	Filter string `protobuf:"bytes,11,opt,name=Filter,proto3" json:"Filter,omitempty"`
+	// EmptyCacheResult tells that result might be ommited in result if equal to previous cached value
+	EmptyCacheResult bool `protobuf:"varint,12,opt,name=EmptyCacheResult,proto3" json:"RequireConsistent,omitempty"`
 }
 
 func (m *QueryOptions) Reset()         { *m = QueryOptions{} }

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -354,6 +354,11 @@ func (c *Catalog) ServiceList(args *structs.DCSpecificRequest, reply *structs.In
 			}
 
 			reply.Index, reply.Services = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Services = nil
+				return nil
+			}
 			return c.srv.filterACLWithAuthorizer(authz, reply)
 		})
 }
@@ -434,6 +439,11 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			}
 
 			reply.Index, reply.ServiceNodes = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.ServiceNodes = nil
+				return nil
+			}
 			if len(args.NodeMetaFilters) > 0 {
 				var filtered structs.ServiceNodes
 				for _, service := range services {
@@ -532,6 +542,11 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 			}
 
 			reply.Index, reply.NodeServices = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.NodeServices = nil
+				return nil
+			}
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -587,6 +602,11 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 			}
 
 			reply.Index = index
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.NodeServices = structs.NodeServiceList{}
+				return nil
+			}
 			if services != nil {
 				reply.NodeServices = *services
 

--- a/agent/consul/health_endpoint.go
+++ b/agent/consul/health_endpoint.go
@@ -54,6 +54,11 @@ func (h *Health) ChecksInState(args *structs.ChecksInStateRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -98,6 +103,11 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -155,6 +165,11 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -227,6 +242,11 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 			}
 
 			reply.Index, reply.Nodes = index, nodes
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Nodes = nil
+				return nil
+			}
 			if len(args.NodeMetaFilters) > 0 {
 				reply.Nodes = nodeMetaFilter(args.NodeMetaFilters, reply.Nodes)
 			}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -751,6 +751,11 @@ func (s *Server) raftApplyWithEncoder(t structs.MessageType, msg interface{}, en
 // a snapshot.
 type queryFn func(memdb.WatchSet, *state.Store) error
 
+// CanSendEmptyResult will return true if we can return an empty result
+func CanSendEmptyResult(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat) bool {
+	return queryOpts.GetReturnEmptyResultOnUnmodified() && queryOpts.GetMinQueryIndex() == queryMeta.GetIndex()
+}
+
 // blockingQuery is used to process a potentially blocking query operation.
 func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat, fn queryFn) error {
 	var cancel func()

--- a/agent/http.go
+++ b/agent/http.go
@@ -32,6 +32,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// UnmodifiedCachedDataResponseHeader is a header of Consul to specify data does not need any refresh
+const UnmodifiedCachedDataResponseHeader = "X-Consul-Unmodified-Response"
+
 // MethodNotAllowedError should be returned by a handler when the HTTP method is not allowed.
 type MethodNotAllowedError struct {
 	Method string
@@ -570,7 +573,7 @@ func (s *HTTPServer) wrap(handler endpoint, methods []string) http.HandlerFunc {
 				return
 			}
 		}
-		if obj == nil {
+		if obj == nil || resp.Header().Get(UnmodifiedCachedDataResponseHeader) == "true" {
 			return
 		}
 		var buf []byte
@@ -756,6 +759,10 @@ func setMeta(resp http.ResponseWriter, m structs.QueryMetaCompat) {
 	setLastContact(resp, m.GetLastContact())
 	setKnownLeader(resp, m.GetKnownLeader())
 	setConsistency(resp, m.GetConsistencyLevel())
+	if m.GetEmptyCacheResult() {
+		resp.Header().Set(UnmodifiedCachedDataResponseHeader, "true")
+		resp.WriteHeader(304)
+	}
 }
 
 // setCacheMeta sets http response headers to indicate cache status.
@@ -876,6 +883,9 @@ func parseCacheControl(resp http.ResponseWriter, req *http.Request, b structs.Qu
 func (s *HTTPServer) parseConsistency(resp http.ResponseWriter, req *http.Request, b structs.QueryOptionsCompat) bool {
 	query := req.URL.Query()
 	defaults := true
+	if req.Header.Get("X-Consul-Unmodified-Empty") == "true" {
+		b.SetReturnEmptyResultOnUnmodified(true)
+	}
 	if _, ok := query["stale"]; ok {
 		b.SetAllowStale(true)
 		defaults = false

--- a/agent/structs/protobuf_compat.go
+++ b/agent/structs/protobuf_compat.go
@@ -30,6 +30,8 @@ type QueryOptionsCompat interface {
 	SetStaleIfError(time.Duration)
 	GetFilter() string
 	SetFilter(string)
+	GetReturnEmptyResultOnUnmodified() bool
+	SetReturnEmptyResultOnUnmodified(bool)
 }
 
 // QueryMetaCompat is the interface that both the structs.QueryMeta
@@ -44,6 +46,8 @@ type QueryMetaCompat interface {
 	SetIndex(uint64)
 	GetConsistencyLevel() string
 	SetConsistencyLevel(string)
+	GetEmptyCacheResult() bool
+	SetEmptyCacheResult(bool)
 }
 
 // GetToken helps implement the QueryOptionsCompat interface
@@ -211,6 +215,16 @@ func (q *QueryOptions) SetFilter(filter string) {
 	q.Filter = filter
 }
 
+// GetReturnEmptyResultOnUnmodified when true, means that returned data might be empty if cached data is not modified
+func (q *QueryOptions) GetReturnEmptyResultOnUnmodified() bool {
+	return q.ReturnEmptyResultOnUnmodified
+}
+
+// SetReturnEmptyResultOnUnmodified if true data might be ommited in response when cached data did not change
+func (q *QueryOptions) SetReturnEmptyResultOnUnmodified(v bool) {
+	q.ReturnEmptyResultOnUnmodified = v
+}
+
 //
 func (m *QueryMeta) GetIndex() uint64 {
 	if m != nil {
@@ -244,6 +258,16 @@ func (m *QueryMeta) GetConsistencyLevel() string {
 		return m.ConsistencyLevel
 	}
 	return ""
+}
+
+// GetEmptyCacheResult helps implement the QueryMetaCompat interface
+func (m *QueryMeta) GetEmptyCacheResult() bool {
+	return m != nil && m.EmptyCacheResult
+}
+
+// SetEmptyCacheResult is needed to implement the structs.QueryMetaCompat interface
+func (m *QueryMeta) SetEmptyCacheResult(emptyCacheResult bool) {
+	m.EmptyCacheResult = emptyCacheResult
 }
 
 // SetLastContact is needed to implement the structs.QueryMetaCompat interface


### PR DESCRIPTION
This PR implements using HTTP Cache semantics in Consul APIs by
returning HTTP 304 with no content when indexes do not change.

The patch is very small, smaller than what I expected.

This allows performing huge optimization since serialization is not performed between the server and the client.

This implements https://github.com/hashicorp/consul/issues/7968

### Example of usages with the agent running in dev-mode:

#### Without Header `X-Consul-Unmodified-Empty:true`

```
curl -si "localhost:8500/v1/health/service/consul?wait=1s&index=12" | head -n14
HTTP/1.1 200 OK
Content-Type: application/json
Vary: Accept-Encoding
X-Consul-Effective-Consistency: leader
X-Consul-Index: 12
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
Date: Fri, 29 May 2020 00:00:37 GMT
Content-Length: 1830

[
    {
        "Node": {
            "ID": "9fc3de8c-4436-6bb5-68ba-e36ed656dd34",
[...]
```

#### With Header `X-Consul-Unmodified-Empty:true`, but with older index (11 instead of 12)

```
curl -si -H X-Consul-Unmodified-Empty:true "localhost:8500/v1/health/service/consul?wait=1s&index=11"|head -n14
HTTP/1.1 200 OK
Content-Type: application/json
Vary: Accept-Encoding
X-Consul-Effective-Consistency: leader
X-Consul-Index: 12
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
Date: Fri, 29 May 2020 00:02:16 GMT
Content-Length: 1830

[
    {
        "Node": {
            "ID": "9fc3de8c-4436-6bb5-68ba-e36ed656dd34",
```

#### With Header `X-Consul-Unmodified-Empty:true`, and correct Index => no data
```
curl -si -H X-Consul-Unmodified-Empty:true "localhost:8500/v1/health/service/consul?wait=1s&index=12"
HTTP/1.1 304 Not Modified
Vary: Accept-Encoding
X-Consul-Effective-Consistency: leader
X-Consul-Index: 12
X-Consul-Knownleader: true
X-Consul-Lastcontact: 0
X-Consul-Unmodified-Response: true
Date: Thu, 28 May 2020 23:49:46 GMT
```

## Wins:
 * Most probably one of the biggest optimization possible without Streaming: huge RPC bandwidth reduction, huge CPU reduction due to very small serialization, probably x10+ performance on stable large clusters (because all queries running for 10min won't spend any kind of CPU)
 * Add 304 behavior for clients => huge optimization in SDKs are possible on large services

## Drawbacks of approach:
 * if the client changes its parameters (eg: filters), results might be outdated, the client must be careful
 * if ACLs do change in the meantime, results might be outdated for some endpoints (fixable)

## Possible improvement using instead ETag and If-None-Match

1. Compute an eTag, that could be of form

```
eTag: {lastSeen}-{hashOfParams}
lastSeen: Index or Hash (depending of the request)
hashOfParams: capture of all meaningful parameters (index, cached?, consistency, filters, Hash...)
```

Return this ETag in all HTTP Responses

2. When a request comes with `If-None-Match` and the value of eTag, compare the Hash to parameters, if all match => set flag corresponding to `X-Consul-Unmodified-Empty` in RPC request (aka `ReturnEmptyResultOnUnmodified`)

3. Use as previously

The big advantage would be:
* It would leverage cache for all clients (including browsers) => very useful for UIs for instance
* It would be standard
* it would fix the client is using `X-Consul-Unmodified-Empty:true` while changing input parameters and thus having bad data

## TODO:
* [x] Use it in cache
* [ ] Unit tests
* [ ] More endpoints (just made the biggest ones)
* [ ] Documentation