### PR TITLE
ui: Add an Address copy button to the service instance page

### DIFF
--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -27,7 +27,9 @@
       </dl>
     </BlockSlot>
     <BlockSlot @name="actions">
-      <CopyButton @value={{item.Address}} @name="Address">{{item.Address}}</CopyButton>
+      {{#let (or item.Address item.Node.Address) as |address|}}
+        <CopyButton @value={{address}} @name="Address">{{address}}</CopyButton>
+      {{/let}}
     </BlockSlot>
     <BlockSlot @name="content">
         <TabNav @items={{

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -26,6 +26,9 @@
         <dd><a href="{{href-to 'dc.nodes.show' item.Node.Node}}">{{item.Node.Node}}</a></dd>
       </dl>
     </BlockSlot>
+    <BlockSlot @name="actions">
+      <CopyButton @value={{item.Address}} @name="Address">{{item.Address}}</CopyButton>
+    </BlockSlot>
     <BlockSlot @name="content">
         <TabNav @items={{
           compact


### PR DESCRIPTION
This PR adds an Address copy button to the service instance detail page.

Partly addresses https://github.com/hashicorp/consul/issues/6529

<img width="1415" alt="Screenshot 2020-05-29 at 13 39 38" src="https://user-images.githubusercontent.com/554604/83260852-6214c380-a1b2-11ea-8fbe-07d8bcc43d98.png">

^ Note additional button to the top right.