### PR TITLE
ui: Exclude any component/pageobject.js files from being included

### DIFF
--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -1,28 +1,38 @@
 'use strict';
-
+const Funnel = require('broccoli-funnel');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   const env = EmberApp.env();
   const prodlike = ['production', 'staging'];
   const isProd = env === 'production';
-  // if we ever need a 'prodlike' staging environment with staging settings
-  // const isProdLike = prodlike.indexOf(env) > -1;
+  const isProdLike = prodlike.indexOf(env) > -1;
   const sourcemaps = !isProd;
+  let trees = {};
+  if(isProdLike) {
+    // exclude any component/pageobject.js files from production-like environments
+    trees.app = new Funnel(
+      'app',
+      {
+        exclude: ['components/**/pageobject.js']
+      }
+    );
+  }
   let app = new EmberApp(
     Object.assign({}, defaults, {
       productionEnvironments: prodlike,
     }),
     {
+      trees: trees,
       'ember-cli-babel': {
         includePolyfill: true,
       },
       'ember-cli-string-helpers': {
         only: [
-          'capitalize', 
-          'lowercase', 
-          'truncate', 
-          'uppercase', 
-          'humanize', 
+          'capitalize',
+          'lowercase',
+          'truncate',
+          'uppercase',
+          'humanize',
           'titleize'
         ],
       },

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -62,6 +62,7 @@
     "babel-eslint": "^10.0.3",
     "base64-js": "^1.3.0",
     "broccoli-asset-rev": "^3.0.0",
+    "broccoli-funnel": "^3.0.3",
     "chalk": "^2.4.2",
     "clipboard": "^2.0.4",
     "css.escape": "^1.5.1",

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -3179,6 +3179,22 @@ broccoli-funnel@^3.0.1:
     path-posix "^1.0.0"
     walk-sync "^2.0.2"
 
+broccoli-funnel@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz#26fd42632471f67a91f4770d1987118087219937"
+  integrity sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^4.0.1"
+    debug "^4.1.1"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^2.0.1"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    path-posix "^1.0.0"
+    walk-sync "^2.0.2"
+
 broccoli-kitchen-sink-helpers@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"


### PR DESCRIPTION
This excludes any `/components/**/pageobject.js` files from our production
builds which means we can co-locate all of our component page objects
(and selectors) along with the components themselves.

Currently we don't do any of this co-location, but moving forwards we plan on moving all of our component page objects into the same folders as the components themselves.

cc @meirish as you gave me a clue on how to do this and would be good if you cast your eye over this incase as I think you've done something similar elsewhere?