### PR TITLE
ui: Add ability to sort service based on health

### DIFF
--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -31,4 +31,38 @@ export default Controller.extend(WithEventSource, {
 
     return proxies;
   }),
+  actions: {
+    healthStatusComparator: function(key, serviceA, serviceB) {
+      const [, dir] = key.split(':');
+      let a, b;
+      if (dir === 'asc') {
+        b = serviceA;
+        a = serviceB;
+      } else {
+        a = serviceA;
+        b = serviceB;
+      }
+      switch (true) {
+        case a.ChecksCritical > b.ChecksCritical:
+          return 1;
+        case a.ChecksCritical < b.ChecksCritical:
+          return -1;
+        default:
+          switch (true) {
+            case a.ChecksWarning > b.ChecksWarning:
+              return 1;
+            case a.ChecksWarning < b.ChecksWarning:
+              return -1;
+            default:
+              switch (true) {
+                case a.ChecksPassing < b.ChecksPassing:
+                  return 1;
+                case a.ChecksPassing > b.ChecksPassing:
+                  return -1;
+              }
+          }
+          return 0;
+      }
+    },
+  },
 });

--- a/ui-v2/app/controllers/dc/services/index.js
+++ b/ui-v2/app/controllers/dc/services/index.js
@@ -31,38 +31,4 @@ export default Controller.extend(WithEventSource, {
 
     return proxies;
   }),
-  actions: {
-    healthStatusComparator: function(key, serviceA, serviceB) {
-      const [, dir] = key.split(':');
-      let a, b;
-      if (dir === 'asc') {
-        b = serviceA;
-        a = serviceB;
-      } else {
-        a = serviceA;
-        b = serviceB;
-      }
-      switch (true) {
-        case a.ChecksCritical > b.ChecksCritical:
-          return 1;
-        case a.ChecksCritical < b.ChecksCritical:
-          return -1;
-        default:
-          switch (true) {
-            case a.ChecksWarning > b.ChecksWarning:
-              return 1;
-            case a.ChecksWarning < b.ChecksWarning:
-              return -1;
-            default:
-              switch (true) {
-                case a.ChecksPassing < b.ChecksPassing:
-                  return 1;
-                case a.ChecksPassing > b.ChecksPassing:
-                  return -1;
-              }
-          }
-          return 0;
-      }
-    },
-  },
 });

--- a/ui-v2/app/helpers/comparator.js
+++ b/ui-v2/app/helpers/comparator.js
@@ -1,0 +1,9 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default Helper.extend({
+  sort: service('sort'),
+  compute([type, key], hash) {
+    return this.sort.comparator(type)(key);
+  },
+});

--- a/ui-v2/app/initializers/sort.js
+++ b/ui-v2/app/initializers/sort.js
@@ -1,0 +1,18 @@
+import service from 'consul-ui/sort/comparators/service';
+
+export function initialize(container) {
+  // Service-less injection using private properties at a per-project level
+  const Sort = container.resolveRegistration('service:sort');
+  const comparators = {
+    service: service(),
+  };
+  Sort.reopen({
+    comparator: function(type) {
+      return comparators[type];
+    },
+  });
+}
+
+export default {
+  initialize,
+};

--- a/ui-v2/app/services/sort.js
+++ b/ui-v2/app/services/sort.js
@@ -1,0 +1,4 @@
+import Service from '@ember/service';
+export default Service.extend({
+  comparator: function(type) {},
+});

--- a/ui-v2/app/sort/comparators/service.js
+++ b/ui-v2/app/sort/comparators/service.js
@@ -1,0 +1,37 @@
+export default () => key => {
+  if (key.startsWith('Status:')) {
+    return function(serviceA, serviceB) {
+      const [, dir] = key.split(':');
+      let a, b;
+      if (dir === 'asc') {
+        b = serviceA;
+        a = serviceB;
+      } else {
+        a = serviceA;
+        b = serviceB;
+      }
+      switch (true) {
+        case a.ChecksCritical > b.ChecksCritical:
+          return 1;
+        case a.ChecksCritical < b.ChecksCritical:
+          return -1;
+        default:
+          switch (true) {
+            case a.ChecksWarning > b.ChecksWarning:
+              return 1;
+            case a.ChecksWarning < b.ChecksWarning:
+              return -1;
+            default:
+              switch (true) {
+                case a.ChecksPassing < b.ChecksPassing:
+                  return 1;
+                case a.ChecksPassing > b.ChecksPassing:
+                  return -1;
+              }
+          }
+          return 0;
+      }
+    };
+  }
+  return key;
+};

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -2,6 +2,8 @@
 {{#let (selectable-key-values
     (array "Name:asc" "A to Z")
     (array "Name:desc" "Z to A")
+    (array "Status:asc" "Unhealthy to Healthy")
+    (array "Status:desc" "Healthy to Unhealthy")
       selected=sortBy
   )
   as |sort|
@@ -29,7 +31,12 @@
         {{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
-        <ChangeableSet @dispatcher={{searchable 'service' (sort-by sort.selected.key services)}} @terms={{search}}>
+{{#let (if (starts-with 'Name:' sort.selected.key)
+          (sort-by sort.selected.key services)
+          (sort-by (action "healthStatusComparator" sort.selected.key) services key=sort.selected.key)
+        )
+as |sorted|}}
+        <ChangeableSet @dispatcher={{searchable 'service' sorted}} @terms={{search}}>
           <BlockSlot @name="set" as |filtered|>
             <ConsulServiceList @routeName="dc.services.show" @items={{filtered}} @proxies={{proxies}}/>
           </BlockSlot>
@@ -64,6 +71,7 @@
             </EmptyState>
           </BlockSlot>
         </ChangeableSet>
+      {{/let}}
       </BlockSlot>
     </AppView>
 {{/let}}

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -31,11 +31,7 @@
         {{/if}}
       </BlockSlot>
       <BlockSlot @name="content">
-{{#let (if (starts-with 'Name:' sort.selected.key)
-          (sort-by sort.selected.key services)
-          (sort-by (action "healthStatusComparator" sort.selected.key) services key=sort.selected.key)
-        )
-as |sorted|}}
+{{#let (sort-by (comparator 'service' sort.selected.key) services) as |sorted|}}
         <ChangeableSet @dispatcher={{searchable 'service' sorted}} @terms={{search}}>
           <BlockSlot @name="set" as |filtered|>
             <ConsulServiceList @routeName="dc.services.show" @items={{filtered}} @proxies={{proxies}}/>

--- a/ui-v2/tests/acceptance/dc/services/sorting.feature
+++ b/ui-v2/tests/acceptance/dc/services/sorting.feature
@@ -6,16 +6,34 @@ Feature: dc / services / sorting
     ---
     - Name: Service-A
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 1
+      ChecksCritical: 3
     - Name: Service-B
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 1
+      ChecksCritical: 5
     - Name: Service-C
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 1
+      ChecksCritical: 4
     - Name: Service-D
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 5
+      ChecksCritical: 1
     - Name: Service-E
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 3
+      ChecksCritical: 1
     - Name: Service-F
       Kind: ~
+      ChecksPassing: 1
+      ChecksWarning: 4
+      ChecksCritical: 1
     ---
     When I visit the services page for yaml
     ---
@@ -42,4 +60,26 @@ Feature: dc / services / sorting
     - Service-D
     - Service-E
     - Service-F
+    ---
+    When I click selected on the sort
+    When I click options.2.button on the sort
+    Then I see name on the services vertically like yaml
+    ---
+    - Service-B
+    - Service-C
+    - Service-A
+    - Service-D
+    - Service-F
+    - Service-E
+    ---
+    When I click selected on the sort
+    When I click options.3.button on the sort
+    Then I see name on the services vertically like yaml
+    ---
+    - Service-E
+    - Service-F
+    - Service-D
+    - Service-A
+    - Service-C
+    - Service-B
     ---

--- a/ui-v2/tests/unit/services/sort-test.js
+++ b/ui-v2/tests/unit/services/sort-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | sort', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:sort');
+    assert.ok(service);
+  });
+});

--- a/ui-v2/tests/unit/sort/comparators/service-test.js
+++ b/ui-v2/tests/unit/sort/comparators/service-test.js
@@ -1,0 +1,56 @@
+import comparatorFactory from 'consul-ui/sort/comparators/service';
+import { module, test } from 'qunit';
+
+module('Unit | Sort | Comparator | service', function() {
+  const comparator = comparatorFactory();
+  test('Passing anything but Status: just returns what you gave it', function(assert) {
+    const expected = 'Name:asc';
+    const actual = comparator(expected);
+    assert.equal(actual, expected);
+  });
+  test('items are sorted by a fake Status which uses Checks{Passing,Warning,Critical}', function(assert) {
+    const items = [
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 1,
+      },
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 2,
+      },
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 3,
+      },
+    ];
+    const comp = comparator('Status:asc');
+    assert.equal(typeof comp, 'function');
+
+    const expected = [
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 3,
+      },
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 2,
+      },
+      {
+        ChecksPassing: 1,
+        ChecksWarning: 1,
+        ChecksCritical: 1,
+      },
+    ];
+    let actual = items.sort(comp);
+    assert.deepEqual(actual, expected);
+
+    expected.reverse();
+    actual = items.sort(comparator('Status:desc'));
+    assert.deepEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
This PR adds the ability to sort Services based on their health.

I would imagine that moving forwards we will potentially need several of these, so I followed the same pattern as our 'searchables' here, which allow us to use pure vanilla javascript to define searching functionality per model.

This gives us a set of 'comparators' (currently there only being one), that we can use in any template/component via the helper in a composable fashion, without the functionality being tied to any one Controller or Mixin.

'Comparators' can either return a simple string or a comparator function, both of which are accepted by the ember-composable-helpers `sort-by` helper.

Unit and simple acceptance tests are added here.
