### PR TITLE
Always require Host header values for http services

### DIFF
--- a/agent/xds/routes.go
+++ b/agent/xds/routes.go
@@ -101,20 +101,14 @@ func routesFromSnapshotIngressGateway(cfgSnap *proxycfg.ConfigSnapshot) ([]proto
 			namespace := u.GetEnterpriseMeta().NamespaceOrDefault()
 			var domains []string
 			switch {
-			case len(upstreams) == 1:
-				// Don't require a service prefix on the domain if there is only 1
-				// upstream. This makes it a smoother experience when only having a
-				// single service associated to a listener, which is probably a common
-				// case when demoing/testing
-				domains = []string{"*"}
 			case len(u.IngressHosts) > 0:
 				// If a user has specified hosts, do not add the default
-				// "<service-name>.*" prefix
+				// "<service-name>.ingress.*" prefixes
 				domains = u.IngressHosts
 			case namespace != structs.IntentionDefaultNamespace:
 				domains = []string{fmt.Sprintf("%s.ingress.%s.*", chain.ServiceName, namespace)}
 			default:
-				domains = []string{fmt.Sprintf("%s.*", chain.ServiceName)}
+				domains = []string{fmt.Sprintf("%s.ingress.*", chain.ServiceName)}
 			}
 
 			virtualHost, err := makeUpstreamRouteForDiscoveryChain(upstreamID, chain, domains)

--- a/agent/xds/testdata/routes/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/routes/ingress-http-multiple-services.golden
@@ -8,7 +8,7 @@
         {
           "name": "baz",
           "domains": [
-            "baz.*"
+            "baz.ingress.*"
           ],
           "routes": [
             {
@@ -24,7 +24,7 @@
         {
           "name": "qux",
           "domains": [
-            "qux.*"
+            "qux.ingress.*"
           ],
           "routes": [
             {
@@ -64,7 +64,7 @@
         {
           "name": "bar",
           "domains": [
-            "bar.*"
+            "bar.ingress.*"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
@@ -8,7 +8,7 @@
         {
           "name": "db",
           "domains": [
-            "*"
+            "db.ingress.*"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
@@ -8,7 +8,7 @@
         {
           "name": "db",
           "domains": [
-            "*"
+            "db.ingress.*"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
@@ -8,7 +8,7 @@
         {
           "name": "db",
           "domains": [
-            "*"
+            "db.ingress.*"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-grpc-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-grpc-router.golden
@@ -8,7 +8,7 @@
         {
           "name": "db",
           "domains": [
-            "*"
+            "db.ingress.*"
           ],
           "routes": [
             {

--- a/test/integration/connect/envoy/case-ingress-gateway-http/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-http/verify.bats
@@ -31,10 +31,10 @@ load helpers
 }
 
 @test "ingress should be able to connect to s1 via configured path" {
-  assert_expected_fortio_name s1 localhost 9999 /s1
+  assert_expected_fortio_name s1 router.ingress.consul 9999 /s1
 }
 
 @test "ingress should be able to connect to s2 via configured path" {
-  assert_expected_fortio_name s2 localhost 9999 /s2
+  assert_expected_fortio_name s2 router.ingress.consul 9999 /s2
 }
 

--- a/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-multiple-services/verify.bats
@@ -31,11 +31,11 @@ load helpers
 }
 
 @test "ingress should be able to connect to s1 using Host header" {
-  assert_expected_fortio_name s1 s1.example.consul 9999
+  assert_expected_fortio_name s1 s1.ingress.consul 9999
 }
 
 @test "ingress should be able to connect to s2 using Host header" {
-  assert_expected_fortio_name s2 s2.example.consul 9999
+  assert_expected_fortio_name s2 s2.ingress.consul 9999
 }
 
 @test "ingress should be able to connect to s1 using a user-specified Host" {


### PR DESCRIPTION
Previously, we did not require the 'service-name.*' host header value
when on a single http service was exposed. However, this allows a user
to get into a situation where, if they add another service to the
listener, suddenly the previous service's traffic might not be routed
correctly. Thus, we always require the Host header, even if there is
only 1 service.

In a similar vein, we keep the 'service-name.*' domain when there are
ingress hosts defined, in case a service still has traffic going over
that route.