### PR TITLE
Http 304 for unmodified results with etags

### DIFF
--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -155,7 +155,7 @@ func (s *HTTPServer) ACLRulesTranslateLegacyToken(resp http.ResponseWriter, req 
 	args.QueryOptions.MinQueryIndex = 0
 
 	var out structs.ACLTokenResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.TokenRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -195,7 +195,7 @@ func (s *HTTPServer) ACLPolicyList(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	var out structs.ACLPolicyListResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.PolicyList", &args, &out); err != nil {
 		return nil, err
 	}
@@ -256,7 +256,7 @@ func (s *HTTPServer) ACLPolicyRead(resp http.ResponseWriter, req *http.Request, 
 	}
 
 	var out structs.ACLPolicyResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.PolicyRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -380,7 +380,7 @@ func (s *HTTPServer) ACLTokenList(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	var out structs.ACLTokenListResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.TokenList", &args, &out); err != nil {
 		return nil, err
 	}
@@ -442,7 +442,7 @@ func (s *HTTPServer) ACLTokenSelf(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	var out structs.ACLTokenResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.TokenRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -482,7 +482,7 @@ func (s *HTTPServer) ACLTokenGet(resp http.ResponseWriter, req *http.Request, to
 	}
 
 	var out structs.ACLTokenResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.TokenRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -594,7 +594,7 @@ func (s *HTTPServer) ACLRoleList(resp http.ResponseWriter, req *http.Request) (i
 	args.Policy = req.URL.Query().Get("policy")
 
 	var out structs.ACLRoleListResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.RoleList", &args, &out); err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (s *HTTPServer) ACLRoleRead(resp http.ResponseWriter, req *http.Request, ro
 	}
 
 	var out structs.ACLRoleResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.RoleRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -758,7 +758,7 @@ func (s *HTTPServer) ACLBindingRuleList(resp http.ResponseWriter, req *http.Requ
 	args.AuthMethod = req.URL.Query().Get("authmethod")
 
 	var out structs.ACLBindingRuleListResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.BindingRuleList", &args, &out); err != nil {
 		return nil, err
 	}
@@ -818,7 +818,7 @@ func (s *HTTPServer) ACLBindingRuleRead(resp http.ResponseWriter, req *http.Requ
 	}
 
 	var out structs.ACLBindingRuleResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.BindingRuleRead", &args, &out); err != nil {
 		return nil, err
 	}
@@ -902,7 +902,7 @@ func (s *HTTPServer) ACLAuthMethodList(resp http.ResponseWriter, req *http.Reque
 	}
 
 	var out structs.ACLAuthMethodListResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.AuthMethodList", &args, &out); err != nil {
 		return nil, err
 	}
@@ -961,7 +961,7 @@ func (s *HTTPServer) ACLAuthMethodRead(resp http.ResponseWriter, req *http.Reque
 	}
 
 	var out structs.ACLAuthMethodResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.AuthMethodRead", &args, &out); err != nil {
 		return nil, err
 	}

--- a/agent/acl_endpoint_legacy.go
+++ b/agent/acl_endpoint_legacy.go
@@ -112,7 +112,7 @@ func (s *HTTPServer) ACLClone(resp http.ResponseWriter, req *http.Request) (inte
 	}
 
 	var out structs.IndexedACLs
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.Get", &args, &out); err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (s *HTTPServer) ACLGet(resp http.ResponseWriter, req *http.Request) (interf
 	}
 
 	var out structs.IndexedACLs
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.Get", &args, &out); err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func (s *HTTPServer) ACLList(resp http.ResponseWriter, req *http.Request) (inter
 	}
 
 	var out structs.IndexedACLs
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("ACL.List", &args, &out); err != nil {
 		return nil, err
 	}

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1330,7 +1330,7 @@ func (s *HTTPServer) AgentConnectCARoots(resp http.ResponseWriter, req *http.Req
 		// This should never happen, but we want to protect against panics
 		return nil, fmt.Errorf("internal error: response type not correct")
 	}
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 
 	return *reply, nil
 }

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -1321,7 +1321,7 @@ func (s *HTTPServer) AgentConnectCARoots(resp http.ResponseWriter, req *http.Req
 	if err != nil {
 		return nil, err
 	}
-	defer setCacheMeta(resp, &m)
+	defer setCacheMeta(resp, &m, nil)
 
 	// Add cache hit
 
@@ -1363,7 +1363,7 @@ func (s *HTTPServer) AgentConnectCALeafCert(resp http.ResponseWriter, req *http.
 	if err != nil {
 		return nil, err
 	}
-	defer setCacheMeta(resp, &m)
+	defer setCacheMeta(resp, &m, nil)
 
 	reply, ok := raw.(*structs.IssuedCert)
 	if !ok {
@@ -1400,7 +1400,7 @@ func (s *HTTPServer) AgentConnectAuthorize(resp http.ResponseWriter, req *http.R
 	if err != nil {
 		return nil, err
 	}
-	setCacheMeta(resp, cacheMeta)
+	setCacheMeta(resp, cacheMeta, nil)
 
 	return &connectAuthorizeResp{
 		Authorized: authz,

--- a/agent/agentpb/common.go
+++ b/agent/agentpb/common.go
@@ -77,6 +77,16 @@ func (q *QueryOptions) SetFilter(filter string) {
 	q.Filter = filter
 }
 
+// GetReturnEmptyResultOnUnmodified when true, means that returned data might be empty if cached data is not modified
+func (q *QueryOptions) GetReturnEmptyResultOnUnmodified() bool {
+	return q.EmptyCacheResult
+}
+
+// SetReturnEmptyResultOnUnmodified if true data might be ommited in response when cached data did not change
+func (q *QueryOptions) SetReturnEmptyResultOnUnmodified(v bool) {
+	q.EmptyCacheResult = v
+}
+
 // SetLastContact is needed to implement the structs.QueryMetaCompat interface
 func (q *QueryMeta) SetLastContact(lastContact time.Duration) {
 	q.LastContact = lastContact

--- a/agent/agentpb/common.pb.go
+++ b/agent/agentpb/common.pb.go
@@ -202,6 +202,8 @@ type QueryOptions struct {
 	// Filter specifies the go-bexpr filter expression to be used for
 	// filtering the data prior to returning a response
 	Filter string `protobuf:"bytes,11,opt,name=Filter,proto3" json:"Filter,omitempty"`
+	// EmptyCacheResult tells that result might be ommited in result if equal to previous cached value
+	EmptyCacheResult bool `protobuf:"varint,12,opt,name=EmptyCacheResult,proto3" json:"RequireConsistent,omitempty"`
 }
 
 func (m *QueryOptions) Reset()         { *m = QueryOptions{} }

--- a/agent/cache-types/catalog_list_services.go
+++ b/agent/cache-types/catalog_list_services.go
@@ -39,6 +39,7 @@ func (c *CatalogListServices) Fetch(opts cache.FetchOptions, req cache.Request) 
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedServices
@@ -48,5 +49,6 @@ func (c *CatalogListServices) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/catalog_service_list.go
+++ b/agent/cache-types/catalog_service_list.go
@@ -39,6 +39,7 @@ func (c *CatalogServiceList) Fetch(opts cache.FetchOptions, req cache.Request) (
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedServiceList
@@ -48,5 +49,6 @@ func (c *CatalogServiceList) Fetch(opts cache.FetchOptions, req cache.Request) (
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/catalog_services.go
+++ b/agent/cache-types/catalog_services.go
@@ -40,7 +40,7 @@ func (c *CatalogServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
-
+	reqReal.ReturnEmptyResultOnUnmodified = true
 	// Fetch
 	var reply structs.IndexedServiceNodes
 	if err := c.RPC.RPC("Catalog.ServiceNodes", reqReal, &reply); err != nil {
@@ -49,5 +49,6 @@ func (c *CatalogServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/config_entry.go
+++ b/agent/cache-types/config_entry.go
@@ -42,6 +42,7 @@ func (c *ConfigEntries) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedConfigEntries
@@ -51,6 +52,7 @@ func (c *ConfigEntries) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }
 
@@ -83,6 +85,7 @@ func (c *ConfigEntry) Fetch(opts cache.FetchOptions, req cache.Request) (cache.F
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.ConfigEntryResponse
@@ -92,5 +95,6 @@ func (c *ConfigEntry) Fetch(opts cache.FetchOptions, req cache.Request) (cache.F
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/discovery_chain.go
+++ b/agent/cache-types/discovery_chain.go
@@ -40,6 +40,7 @@ func (c *CompiledDiscoveryChain) Fetch(opts cache.FetchOptions, req cache.Reques
 	// allows cached compiled-discovery-chain to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.DiscoveryChainResponse
@@ -49,5 +50,6 @@ func (c *CompiledDiscoveryChain) Fetch(opts cache.FetchOptions, req cache.Reques
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/federation_state_list_gateways.go
+++ b/agent/cache-types/federation_state_list_gateways.go
@@ -39,6 +39,7 @@ func (c *FederationStateListMeshGateways) Fetch(opts cache.FetchOptions, req cac
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.DatacenterIndexedCheckServiceNodes
@@ -48,5 +49,6 @@ func (c *FederationStateListMeshGateways) Fetch(opts cache.FetchOptions, req cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/gateway_services.go
+++ b/agent/cache-types/gateway_services.go
@@ -39,6 +39,7 @@ func (g *GatewayServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedGatewayServices
@@ -48,5 +49,6 @@ func (g *GatewayServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/health_services.go
+++ b/agent/cache-types/health_services.go
@@ -40,6 +40,7 @@ func (c *HealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedCheckServiceNodes
@@ -49,5 +50,6 @@ func (c *HealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/node_services.go
+++ b/agent/cache-types/node_services.go
@@ -40,6 +40,7 @@ func (c *NodeServices) Fetch(opts cache.FetchOptions, req cache.Request) (cache.
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedNodeServices
@@ -49,5 +50,6 @@ func (c *NodeServices) Fetch(opts cache.FetchOptions, req cache.Request) (cache.
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/prepared_query.go
+++ b/agent/cache-types/prepared_query.go
@@ -36,6 +36,7 @@ func (c *PreparedQuery) Fetch(_ cache.FetchOptions, req cache.Request) (cache.Fe
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.PreparedQueryExecuteResponse
@@ -45,6 +46,7 @@ func (c *PreparedQuery) Fetch(_ cache.FetchOptions, req cache.Request) (cache.Fe
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 
 	return result, nil
 }

--- a/agent/cache-types/resolved_service_config.go
+++ b/agent/cache-types/resolved_service_config.go
@@ -40,6 +40,7 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 	// allows cached resolved-service-config to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.ServiceConfigResponse
@@ -49,5 +50,6 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache-types/service_dump.go
+++ b/agent/cache-types/service_dump.go
@@ -39,6 +39,7 @@ func (c *InternalServiceDump) Fetch(opts cache.FetchOptions, req cache.Request) 
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
+	reqReal.ReturnEmptyResultOnUnmodified = true
 
 	// Fetch
 	var reply structs.IndexedCheckServiceNodes
@@ -48,5 +49,6 @@ func (c *InternalServiceDump) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.EmptyCacheResult = reply.QueryMeta.EmptyCacheResult
 	return result, nil
 }

--- a/agent/cache/type.go
+++ b/agent/cache/type.go
@@ -78,4 +78,7 @@ type FetchResult struct {
 
 	// Index is the corresponding index value for this data.
 	Index uint64
+
+	// EmptyCacheResult Tell the result is empty because entry was not modified
+	EmptyCacheResult bool
 }

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -96,7 +96,7 @@ func (s *HTTPServer) CatalogDatacenters(resp http.ResponseWriter, req *http.Requ
 			// This should never happen, but we want to protect against panics
 			return nil, fmt.Errorf("internal error: response type not correct")
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 		out = *reply
 	} else {
 		if err := s.agent.RPC("Catalog.ListDatacenters", &args, &out); err != nil {
@@ -178,7 +178,7 @@ func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request
 			// This should never happen, but we want to protect against panics
 			return nil, fmt.Errorf("internal error: response type not correct")
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 		out = *reply
 	} else {
 	RETRY_ONCE:
@@ -262,7 +262,7 @@ func (s *HTTPServer) catalogServiceNodes(resp http.ResponseWriter, req *http.Req
 				[]metrics.Label{{Name: "node", Value: s.nodeName()}})
 			return nil, err
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 		reply, ok := raw.(*structs.IndexedServiceNodes)
 		if !ok {
 			// This should never happen, but we want to protect against panics

--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -126,7 +126,7 @@ func (s *HTTPServer) CatalogNodes(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	var out structs.IndexedNodes
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Catalog.ListNodes", &args, &out); err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (s *HTTPServer) CatalogServices(resp http.ResponseWriter, req *http.Request
 		return nil, nil
 	}
 	var out structs.IndexedServices
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 
 	if args.QueryOptions.UseCache {
 		raw, m, err := s.agent.cache.Get(cachetype.CatalogListServicesName, &args)
@@ -253,7 +253,7 @@ func (s *HTTPServer) catalogServiceNodes(resp http.ResponseWriter, req *http.Req
 
 	// Make the RPC request
 	var out structs.IndexedServiceNodes
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 
 	if args.QueryOptions.UseCache {
 		raw, m, err := s.agent.cache.Get(cachetype.CatalogServicesName, &args)
@@ -326,7 +326,7 @@ func (s *HTTPServer) CatalogNodeServices(resp http.ResponseWriter, req *http.Req
 
 	// Make the RPC request
 	var out structs.IndexedNodeServices
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Catalog.NodeServices", &args, &out); err != nil {
 		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_node_services"}, 1,
@@ -389,7 +389,7 @@ func (s *HTTPServer) CatalogNodeServiceList(resp http.ResponseWriter, req *http.
 
 	// Make the RPC request
 	var out structs.IndexedNodeServiceList
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Catalog.NodeServiceList", &args, &out); err != nil {
 		metrics.IncrCounterWithLabels([]string{"client", "rpc", "error", "catalog_node_service_list"}, 1,

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -677,7 +677,7 @@ func TestCatalogServiceNodes(t *testing.T) {
 
 			nodes := obj.(structs.ServiceNodes)
 			if len(nodes) != 2 {
-				r.Fatalf("Want 2 nodes")
+				r.Fatalf("Want 2 nodes, has %v", len(nodes))
 			}
 
 			// Should be a cache hit! The data should've updated in the cache

--- a/agent/config_endpoint.go
+++ b/agent/config_endpoint.go
@@ -45,7 +45,7 @@ func (s *HTTPServer) configGet(resp http.ResponseWriter, req *http.Request) (int
 		if err := s.agent.RPC("ConfigEntry.Get", &args, &reply); err != nil {
 			return nil, err
 		}
-		setMeta(resp, &reply.QueryMeta)
+		s.setMeta(resp, &reply.QueryMeta, req)
 
 		if reply.Entry == nil {
 			return nil, NotFoundError{Reason: fmt.Sprintf("Config entry not found for %q / %q", pathArgs[0], pathArgs[1])}
@@ -63,7 +63,7 @@ func (s *HTTPServer) configGet(resp http.ResponseWriter, req *http.Request) (int
 		if err := s.agent.RPC("ConfigEntry.List", &args, &reply); err != nil {
 			return nil, err
 		}
-		setMeta(resp, &reply.QueryMeta)
+		s.setMeta(resp, &reply.QueryMeta, req)
 
 		return reply.Entries, nil
 	default:

--- a/agent/connect_ca_endpoint.go
+++ b/agent/connect_ca_endpoint.go
@@ -16,7 +16,7 @@ func (s *HTTPServer) ConnectCARoots(resp http.ResponseWriter, req *http.Request)
 	}
 
 	var reply structs.IndexedCARoots
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 	if err := s.agent.RPC("ConnectCA.Roots", &args, &reply); err != nil {
 		return nil, err
 	}

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -273,6 +273,7 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 				reply.Nodes = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			reply.Nodes = nodes
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
@@ -327,6 +328,7 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 				reply.Services = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			return c.srv.filterACLWithAuthorizer(authz, reply)
 		})
 }
@@ -360,6 +362,7 @@ func (c *Catalog) ServiceList(args *structs.DCSpecificRequest, reply *structs.In
 				reply.Services = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			return c.srv.filterACLWithAuthorizer(authz, reply)
 		})
 }
@@ -445,6 +448,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 				reply.ServiceNodes = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if len(args.NodeMetaFilters) > 0 {
 				var filtered structs.ServiceNodes
 				for _, service := range services {
@@ -464,9 +468,7 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			if err != nil {
 				return err
 			}
-
 			reply.ServiceNodes = raw.(structs.ServiceNodes)
-
 			return c.srv.sortNodesByDistanceFrom(args.Source, reply.ServiceNodes)
 		})
 
@@ -548,6 +550,7 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 				reply.NodeServices = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -608,6 +611,7 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 				reply.NodeServices = structs.NodeServiceList{}
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if services != nil {
 				reply.NodeServices = *services
 

--- a/agent/consul/catalog_endpoint.go
+++ b/agent/consul/catalog_endpoint.go
@@ -267,7 +267,13 @@ func (c *Catalog) ListNodes(args *structs.DCSpecificRequest, reply *structs.Inde
 				return err
 			}
 
-			reply.Index, reply.Nodes = index, nodes
+			reply.Index = index
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Nodes = nil
+				return nil
+			}
+			reply.Nodes = nodes
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -316,6 +322,11 @@ func (c *Catalog) ListServices(args *structs.DCSpecificRequest, reply *structs.I
 			}
 
 			reply.Index, reply.Services, reply.EnterpriseMeta = index, services, args.EnterpriseMeta
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Services = nil
+				return nil
+			}
 			return c.srv.filterACLWithAuthorizer(authz, reply)
 		})
 }
@@ -344,6 +355,11 @@ func (c *Catalog) ServiceList(args *structs.DCSpecificRequest, reply *structs.In
 			}
 
 			reply.Index, reply.Services = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Services = nil
+				return nil
+			}
 			return c.srv.filterACLWithAuthorizer(authz, reply)
 		})
 }
@@ -424,6 +440,11 @@ func (c *Catalog) ServiceNodes(args *structs.ServiceSpecificRequest, reply *stru
 			}
 
 			reply.Index, reply.ServiceNodes = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.ServiceNodes = nil
+				return nil
+			}
 			if len(args.NodeMetaFilters) > 0 {
 				var filtered structs.ServiceNodes
 				for _, service := range services {
@@ -522,6 +543,11 @@ func (c *Catalog) NodeServices(args *structs.NodeSpecificRequest, reply *structs
 			}
 
 			reply.Index, reply.NodeServices = index, services
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.NodeServices = nil
+				return nil
+			}
 			if err := c.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -577,6 +603,11 @@ func (c *Catalog) NodeServiceList(args *structs.NodeSpecificRequest, reply *stru
 			}
 
 			reply.Index = index
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.NodeServices = structs.NodeServiceList{}
+				return nil
+			}
 			if services != nil {
 				reply.NodeServices = *services
 

--- a/agent/consul/health_endpoint.go
+++ b/agent/consul/health_endpoint.go
@@ -59,6 +59,7 @@ func (h *Health) ChecksInState(args *structs.ChecksInStateRequest,
 				reply.HealthChecks = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -108,6 +109,7 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 				reply.HealthChecks = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -170,6 +172,7 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 				reply.HealthChecks = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -247,6 +250,7 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 				reply.Nodes = nil
 				return nil
 			}
+			reply.SetEmptyCacheResult(false)
 			if len(args.NodeMetaFilters) > 0 {
 				reply.Nodes = nodeMetaFilter(args.NodeMetaFilters, reply.Nodes)
 			}

--- a/agent/consul/health_endpoint.go
+++ b/agent/consul/health_endpoint.go
@@ -54,6 +54,11 @@ func (h *Health) ChecksInState(args *structs.ChecksInStateRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -98,6 +103,11 @@ func (h *Health) NodeChecks(args *structs.NodeSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -155,6 +165,11 @@ func (h *Health) ServiceChecks(args *structs.ServiceSpecificRequest,
 				return err
 			}
 			reply.Index, reply.HealthChecks = index, checks
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.HealthChecks = nil
+				return nil
+			}
 			if err := h.srv.filterACL(args.Token, reply); err != nil {
 				return err
 			}
@@ -227,6 +242,11 @@ func (h *Health) ServiceNodes(args *structs.ServiceSpecificRequest, reply *struc
 			}
 
 			reply.Index, reply.Nodes = index, nodes
+			if CanSendEmptyResult(&args.QueryOptions, &reply.QueryMeta) {
+				reply.SetEmptyCacheResult(true)
+				reply.Nodes = nil
+				return nil
+			}
 			if len(args.NodeMetaFilters) > 0 {
 				reply.Nodes = nodeMetaFilter(args.NodeMetaFilters, reply.Nodes)
 			}

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -752,7 +752,7 @@ type queryFn func(memdb.WatchSet, *state.Store) error
 
 // CanSendEmptyResult will return true if we can return an empty result
 func CanSendEmptyResult(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat) bool {
-	return queryOpts.GetReturnEmptyResultOnUnmodified() && queryOpts.GetMinQueryIndex() == queryMeta.GetIndex()
+	return queryOpts.GetReturnEmptyResultOnUnmodified() && queryOpts.GetMinQueryIndex() > 1 && queryOpts.GetMinQueryIndex() == queryMeta.GetIndex()
 }
 
 // blockingQuery is used to process a potentially blocking query operation.

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -750,6 +750,11 @@ func (s *Server) raftApplyWithEncoder(t structs.MessageType, msg interface{}, en
 // a snapshot.
 type queryFn func(memdb.WatchSet, *state.Store) error
 
+// CanSendEmptyResult will return true if we can return an empty result
+func CanSendEmptyResult(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat) bool {
+	return queryOpts.GetReturnEmptyResultOnUnmodified() && queryOpts.GetMinQueryIndex() == queryMeta.GetIndex()
+}
+
 // blockingQuery is used to process a potentially blocking query operation.
 func (s *Server) blockingQuery(queryOpts structs.QueryOptionsCompat, queryMeta structs.QueryMetaCompat, fn queryFn) error {
 	var timeout *time.Timer

--- a/agent/coordinate_endpoint.go
+++ b/agent/coordinate_endpoint.go
@@ -84,7 +84,7 @@ func (s *HTTPServer) CoordinateNodes(resp http.ResponseWriter, req *http.Request
 	}
 
 	var out structs.IndexedCoordinates
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("Coordinate.ListNodes", &args, &out); err != nil {
 		sort.Sort(&sorter{out.Coordinates})
 		return nil, err
@@ -107,7 +107,7 @@ func (s *HTTPServer) CoordinateNode(resp http.ResponseWriter, req *http.Request)
 	}
 
 	var out structs.IndexedCoordinates
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("Coordinate.Node", &args, &out); err != nil {
 		return nil, err
 	}

--- a/agent/discovery_chain_endpoint.go
+++ b/agent/discovery_chain_endpoint.go
@@ -65,7 +65,7 @@ func (s *HTTPServer) DiscoveryChainRead(resp http.ResponseWriter, req *http.Requ
 		if err != nil {
 			return nil, err
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 
 		reply, ok := raw.(*structs.DiscoveryChainResponse)
 		if !ok {

--- a/agent/discovery_chain_endpoint.go
+++ b/agent/discovery_chain_endpoint.go
@@ -58,7 +58,7 @@ func (s *HTTPServer) DiscoveryChainRead(resp http.ResponseWriter, req *http.Requ
 
 	// Make the RPC request
 	var out structs.DiscoveryChainResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 
 	if args.QueryOptions.UseCache {
 		raw, m, err := s.agent.cache.Get(cachetype.CompiledDiscoveryChainName, &args)

--- a/agent/federation_state_endpoint.go
+++ b/agent/federation_state_endpoint.go
@@ -22,7 +22,7 @@ func (s *HTTPServer) FederationStateGet(resp http.ResponseWriter, req *http.Requ
 	}
 
 	var out structs.FederationStateResponse
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("FederationState.Get", &args, &out); err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (s *HTTPServer) FederationStateList(resp http.ResponseWriter, req *http.Req
 	}
 
 	var out structs.IndexedFederationStates
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("FederationState.List", &args, &out); err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (s *HTTPServer) FederationStateListMeshGateways(resp http.ResponseWriter, r
 	}
 
 	var out structs.DatacenterIndexedCheckServiceNodes
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("FederationState.ListMeshGateways", &args, &out); err != nil {
 		return nil, err
 	}

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -203,7 +203,7 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 		if err != nil {
 			return nil, err
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 		reply, ok := raw.(*structs.IndexedCheckServiceNodes)
 		if !ok {
 			// This should never happen, but we want to protect against panics

--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -33,7 +33,7 @@ func (s *HTTPServer) HealthChecksInState(resp http.ResponseWriter, req *http.Req
 
 	// Make the RPC request
 	var out structs.IndexedHealthChecks
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Health.ChecksInState", &args, &out); err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (s *HTTPServer) HealthNodeChecks(resp http.ResponseWriter, req *http.Reques
 
 	// Make the RPC request
 	var out structs.IndexedHealthChecks
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Health.NodeChecks", &args, &out); err != nil {
 		return nil, err
@@ -127,7 +127,7 @@ func (s *HTTPServer) HealthServiceChecks(resp http.ResponseWriter, req *http.Req
 
 	// Make the RPC request
 	var out structs.IndexedHealthChecks
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("Health.ServiceChecks", &args, &out); err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 
 	// Make the RPC request
 	var out structs.IndexedCheckServiceNodes
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 
 	if args.QueryOptions.UseCache {
 		raw, m, err := s.agent.cache.Get(cachetype.HealthServicesName, &args)

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -269,7 +269,7 @@ func TestSetMeta(t *testing.T) {
 		LastContact: 123456 * time.Microsecond,
 	}
 	resp := httptest.NewRecorder()
-	setMeta(resp, &meta)
+	setMetaWithoutETag(resp, &meta)
 	header := resp.Header().Get("X-Consul-Index")
 	if header != "1000" {
 		t.Fatalf("Bad: %v", header)

--- a/agent/intentions_endpoint.go
+++ b/agent/intentions_endpoint.go
@@ -33,7 +33,7 @@ func (s *HTTPServer) IntentionList(resp http.ResponseWriter, req *http.Request) 
 	}
 
 	var reply structs.IndexedIntentions
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 	if err := s.agent.RPC("Intention.List", &args, &reply); err != nil {
 		return nil, err
 	}

--- a/agent/kvs_endpoint.go
+++ b/agent/kvs_endpoint.go
@@ -72,7 +72,7 @@ func (s *HTTPServer) KVSGet(resp http.ResponseWriter, req *http.Request, args *s
 	if err := s.agent.RPC(method, &args, &out); err != nil {
 		return nil, err
 	}
-	setMeta(resp, &out.QueryMeta)
+	s.setMeta(resp, &out.QueryMeta, req)
 
 	// Check if we get a not found
 	if len(out.Entries) == 0 {
@@ -123,7 +123,7 @@ func (s *HTTPServer) KVSGetKeys(resp http.ResponseWriter, req *http.Request, arg
 	if err := s.agent.RPC("KVS.ListKeys", &listArgs, &out); err != nil {
 		return nil, err
 	}
-	setMeta(resp, &out.QueryMeta)
+	s.setMeta(resp, &out.QueryMeta, req)
 
 	// Check if we get a not found. We do not generate
 	// not found for the root, but just provide the empty list

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -132,7 +132,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 				return nil, err
 			}
 		}
-		defer setCacheMeta(resp, &m)
+		defer setCacheMeta(resp, &m, &args.QueryOptions)
 		r, ok := raw.(*structs.PreparedQueryExecuteResponse)
 		if !ok {
 			// This should never happen, but we want to protect against panics

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -44,7 +44,7 @@ func (s *HTTPServer) preparedQueryList(resp http.ResponseWriter, req *http.Reque
 	}
 
 	var reply structs.IndexedPreparedQueries
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("PreparedQuery.List", &args, &reply); err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 	}
 
 	var reply structs.PreparedQueryExecuteResponse
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 
 	if args.QueryOptions.UseCache {
 		raw, m, err := s.agent.cache.Get(cachetype.PreparedQueryName, &args)
@@ -193,7 +193,7 @@ func (s *HTTPServer) preparedQueryExplain(id string, resp http.ResponseWriter, r
 	}
 
 	var reply structs.PreparedQueryExplainResponse
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("PreparedQuery.Explain", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
@@ -224,7 +224,7 @@ func (s *HTTPServer) preparedQueryGet(id string, resp http.ResponseWriter, req *
 	}
 
 	var reply structs.IndexedPreparedQueries
-	defer setMeta(resp, &reply.QueryMeta)
+	defer s.setMeta(resp, &reply.QueryMeta, req)
 RETRY_ONCE:
 	if err := s.agent.RPC("PreparedQuery.Get", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds

--- a/agent/session_endpoint.go
+++ b/agent/session_endpoint.go
@@ -137,7 +137,7 @@ func (s *HTTPServer) SessionGet(resp http.ResponseWriter, req *http.Request) (in
 	}
 
 	var out structs.IndexedSessions
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("Session.Get", &args, &out); err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (s *HTTPServer) SessionList(resp http.ResponseWriter, req *http.Request) (i
 	}
 
 	var out structs.IndexedSessions
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("Session.List", &args, &out); err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (s *HTTPServer) SessionsForNode(resp http.ResponseWriter, req *http.Request
 	}
 
 	var out structs.IndexedSessions
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 	if err := s.agent.RPC("Session.NodeSessions", &args, &out); err != nil {
 		return nil, err
 	}

--- a/agent/snapshot_endpoint.go
+++ b/agent/snapshot_endpoint.go
@@ -24,7 +24,7 @@ func (s *HTTPServer) Snapshot(resp http.ResponseWriter, req *http.Request) (inte
 
 		// Headers need to go out before we stream the body.
 		replyFn := func(reply *structs.SnapshotResponse) error {
-			setMeta(resp, &reply.QueryMeta)
+			s.setMeta(resp, &reply.QueryMeta, req)
 			return nil
 		}
 

--- a/agent/structs/protobuf_compat.go
+++ b/agent/structs/protobuf_compat.go
@@ -30,6 +30,8 @@ type QueryOptionsCompat interface {
 	SetStaleIfError(time.Duration)
 	GetFilter() string
 	SetFilter(string)
+	GetReturnEmptyResultOnUnmodified() bool
+	SetReturnEmptyResultOnUnmodified(bool)
 }
 
 // QueryMetaCompat is the interface that both the structs.QueryMeta
@@ -44,6 +46,8 @@ type QueryMetaCompat interface {
 	SetIndex(uint64)
 	GetConsistencyLevel() string
 	SetConsistencyLevel(string)
+	GetEmptyCacheResult() bool
+	SetEmptyCacheResult(bool)
 }
 
 // GetToken helps implement the QueryOptionsCompat interface
@@ -211,6 +215,16 @@ func (q *QueryOptions) SetFilter(filter string) {
 	q.Filter = filter
 }
 
+// GetReturnEmptyResultOnUnmodified when true, means that returned data might be empty if cached data is not modified
+func (q *QueryOptions) GetReturnEmptyResultOnUnmodified() bool {
+	return q.ReturnEmptyResultOnUnmodified
+}
+
+// SetReturnEmptyResultOnUnmodified if true data might be ommited in response when cached data did not change
+func (q *QueryOptions) SetReturnEmptyResultOnUnmodified(v bool) {
+	q.ReturnEmptyResultOnUnmodified = v
+}
+
 //
 func (m *QueryMeta) GetIndex() uint64 {
 	if m != nil {
@@ -244,6 +258,16 @@ func (m *QueryMeta) GetConsistencyLevel() string {
 		return m.ConsistencyLevel
 	}
 	return ""
+}
+
+// GetEmptyCacheResult helps implement the QueryMetaCompat interface
+func (m *QueryMeta) GetEmptyCacheResult() bool {
+	return m != nil && m.EmptyCacheResult
+}
+
+// SetEmptyCacheResult is needed to implement the structs.QueryMetaCompat interface
+func (m *QueryMeta) SetEmptyCacheResult(emptyCacheResult bool) {
+	m.EmptyCacheResult = emptyCacheResult
 }
 
 // SetLastContact is needed to implement the structs.QueryMetaCompat interface

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -212,6 +212,10 @@ type QueryOptions struct {
 	// Filter specifies the go-bexpr filter expression to be used for
 	// filtering the data prior to returning a response
 	Filter string
+
+	// ReturnEmptyResultOnUnmodified will return an empty result if data
+	// is unchanged since last call.
+	ReturnEmptyResultOnUnmodified bool
 }
 
 // IsRead is always true for QueryOption.
@@ -283,6 +287,10 @@ type QueryMeta struct {
 	// Having `discovery_max_stale` on the agent can affect whether
 	// the request was served by a leader.
 	ConsistencyLevel string
+
+	// EmptyCacheResult tells the result is empty because query was containing
+	// ReturnEmptyResultOnUnmodified, so result is unchanged and not present
+	EmptyCacheResult bool
 }
 
 // RegisterRequest is used for the Catalog.Register endpoint

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -55,7 +55,7 @@ func (s *HTTPServer) UINodes(resp http.ResponseWriter, req *http.Request) (inter
 
 	// Make the RPC request
 	var out structs.IndexedNodeDump
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RPC:
 	if err := s.agent.RPC("Internal.NodeDump", &args, &out); err != nil {
 		// Retry the request allowing stale data if no leader
@@ -104,7 +104,7 @@ func (s *HTTPServer) UINodeInfo(resp http.ResponseWriter, req *http.Request) (in
 
 	// Make the RPC request
 	var out structs.IndexedNodeDump
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RPC:
 	if err := s.agent.RPC("Internal.NodeInfo", &args, &out); err != nil {
 		// Retry the request allowing stale data if no leader
@@ -148,7 +148,7 @@ func (s *HTTPServer) UIServices(resp http.ResponseWriter, req *http.Request) (in
 
 	// Make the RPC request
 	var out structs.IndexedCheckServiceNodes
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RPC:
 	if err := s.agent.RPC("Internal.ServiceDump", &args, &out); err != nil {
 		// Retry the request allowing stale data if no leader
@@ -185,7 +185,7 @@ func (s *HTTPServer) UIGatewayServicesNodes(resp http.ResponseWriter, req *http.
 
 	// Make the RPC request
 	var out structs.IndexedServiceDump
-	defer setMeta(resp, &out.QueryMeta)
+	defer s.setMeta(resp, &out.QueryMeta, req)
 RPC:
 	if err := s.agent.RPC("Internal.GatewayServiceDump", &args, &out); err != nil {
 		// Retry the request allowing stale data if no leader


### PR DESCRIPTION
This PR goes beyond https://github.com/hashicorp/consul/pull/7974 and adds support for transparent caching on APIs by implementing ETags semantics combined with `If-None-Match`.

Features:

 * Allow any web browser to use Consul APIs with very high performance:l when you request an read-API, content is downloaded only when needed, otherwise, HTTP 304 is returned. Creating Hi-Performance UIs might be far easier. Since the index (might be possible to use Hash as well) is part of ETag, all information is available directly
 * works with `?cache` as well as with `?stale` or any consistency. With `?cache`, no data will be exchanged with servers over RPC, without, an RPC request will be issued, but the server will send the data only when content has changed, thus not consuming CPU time for serialization or network bandwidth.
 * It also allows you to implement hi-performance polling: if you choose to download content every n minutes, you store the ETag, you re-issue the same request and will have an empty response with 304 HTTP Code if the content did not change.
 * Other good things: we don't need to implement full caching for all endpoints, support might be added progressively, it could also support Hash-based signatures instead of index-based signatures
 * On the future, it might improve quite a lot the API as clients have to embed less Consul specific optimizations and simply use web-standards
 
It thus implements fully #3871 and #7968.

Screenshot of chrome web inspector while refreshing several times the `/v1/health/service/consul` endpoint using F5 key:

<img width="784" alt="Chrome Web-Inspector" src="https://user-images.githubusercontent.com/8089033/83332109-8bf4e580-a299-11ea-8c28-51fb9acdc557.png">

Note: works with Firefox, Chrome, Edge but not with Safari (because it requires additional headers by default to trigger caching on the main document - but easily fixable)

