### PR TITLE
streaming: track changes to state

### DIFF
--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -35,7 +35,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) (interface
 
 		return true, nil
 	case structs.CAOpDeleteProviderState:
-		if err := c.state.CADeleteProviderState(req.ProviderState.ID); err != nil {
+		if err := c.state.CADeleteProviderState(idx+1, req.ProviderState.ID); err != nil {
 			return nil, err
 		}
 

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -205,7 +205,7 @@ func (c *FSM) applyTombstoneOperation(buf []byte, index uint64) interface{} {
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.TombstoneReap:
-		return c.state.ReapTombstones(req.ReapIndex)
+		return c.state.ReapTombstones(index, req.ReapIndex)
 	default:
 		c.logger.Warn("Invalid Tombstone operation", "operation", req.Op)
 		return fmt.Errorf("Invalid Tombstone operation '%s'", req.Op)
@@ -339,7 +339,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 
 		return act
 	case structs.CAOpDeleteProviderState:
-		if err := c.state.CADeleteProviderState(req.ProviderState.ID); err != nil {
+		if err := c.state.CADeleteProviderState(index, req.ProviderState.ID); err != nil {
 			return err
 		}
 
@@ -359,7 +359,7 @@ func (c *FSM) applyConnectCAOperation(buf []byte, index uint64) interface{} {
 		}
 		return act
 	case structs.CAOpIncrementProviderSerialNumber:
-		sn, err := c.state.CAIncrementProviderSerialNumber()
+		sn, err := c.state.CAIncrementProviderSerialNumber(index)
 		if err != nil {
 			return err
 		}
@@ -381,7 +381,9 @@ func (c *FSM) applyConnectCALeafOperation(buf []byte, index uint64) interface{} 
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.CALeafOpIncrementIndex:
-		if err := c.state.CALeafSetIndex(index); err != nil {
+		// Use current index as the new value as well as the value to write at.
+		// TODO(banks) do we even use this op any more?
+		if err := c.state.CALeafSetIndex(index, index); err != nil {
 			return err
 		}
 		return index

--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -202,7 +202,9 @@ func (c *FSM) Restore(old io.ReadCloser) error {
 			return fmt.Errorf("Unrecognized msg type %d", msg)
 		}
 	}
-	restore.Commit()
+	if err := restore.Commit(); err != nil {
+		return err
+	}
 
 	// External code might be calling State(), so we need to synchronize
 	// here to make sure we swap in the new state store atomically.

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -310,8 +310,7 @@ func (s *Store) ACLBootstrap(idx, resetIndex uint64, token *structs.ACLToken, le
 	if err := tx.Insert("index", &IndexEntry{"acl-token-bootstrap", idx}); err != nil {
 		return fmt.Errorf("failed to mark ACL bootstrapping as complete: %v", err)
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // CanBootstrapACLToken checks if bootstrapping is possible and returns the reset index
@@ -636,8 +635,7 @@ func (s *Store) ACLTokenSet(idx uint64, token *structs.ACLToken, legacy bool) er
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ACLTokenBatchSet(idx uint64, tokens structs.ACLTokens, cas, allowMissingPolicyAndRoleIDs, prohibitUnprivileged bool) error {
@@ -650,8 +648,7 @@ func (s *Store) ACLTokenBatchSet(idx uint64, tokens structs.ACLTokens, cas, allo
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // aclTokenSetTxn is the inner method used to insert an ACL token with the
@@ -1030,8 +1027,7 @@ func (s *Store) ACLTokenBatchDelete(idx uint64, tokenIDs []string) error {
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclTokenDelete(idx uint64, value, index string, entMeta *structs.EnterpriseMeta) error {
@@ -1042,8 +1038,7 @@ func (s *Store) aclTokenDelete(idx uint64, value, index string, entMeta *structs
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclTokenDeleteTxn(tx *txnWrapper, idx uint64, value, index string, entMeta *structs.EnterpriseMeta) error {
@@ -1099,8 +1094,7 @@ func (s *Store) ACLPolicyBatchSet(idx uint64, policies structs.ACLPolicies) erro
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ACLPolicySet(idx uint64, policy *structs.ACLPolicy) error {
@@ -1111,8 +1105,7 @@ func (s *Store) ACLPolicySet(idx uint64, policy *structs.ACLPolicy) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclPolicySetTxn(tx *txnWrapper, idx uint64, policy *structs.ACLPolicy) error {
@@ -1277,8 +1270,7 @@ func (s *Store) ACLPolicyBatchDelete(idx uint64, policyIDs []string) error {
 			return err
 		}
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclPolicyDelete(idx uint64, value string, fn aclPolicyGetFn, entMeta *structs.EnterpriseMeta) error {
@@ -1289,8 +1281,7 @@ func (s *Store) aclPolicyDelete(idx uint64, value string, fn aclPolicyGetFn, ent
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclPolicyDeleteTxn(tx *txnWrapper, idx uint64, value string, fn aclPolicyGetFn, entMeta *structs.EnterpriseMeta) error {
@@ -1323,8 +1314,7 @@ func (s *Store) ACLRoleBatchSet(idx uint64, roles structs.ACLRoles, allowMissing
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ACLRoleSet(idx uint64, role *structs.ACLRole) error {
@@ -1335,8 +1325,7 @@ func (s *Store) ACLRoleSet(idx uint64, role *structs.ACLRole) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclRoleSetTxn(tx *txnWrapper, idx uint64, role *structs.ACLRole, allowMissing bool) error {
@@ -1518,8 +1507,7 @@ func (s *Store) ACLRoleBatchDelete(idx uint64, roleIDs []string) error {
 			return err
 		}
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclRoleDelete(idx uint64, value string, fn aclRoleGetFn, entMeta *structs.EnterpriseMeta) error {
@@ -1530,8 +1518,7 @@ func (s *Store) aclRoleDelete(idx uint64, value string, fn aclRoleGetFn, entMeta
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclRoleDeleteTxn(tx *txnWrapper, idx uint64, value string, fn aclRoleGetFn, entMeta *structs.EnterpriseMeta) error {
@@ -1560,8 +1547,7 @@ func (s *Store) ACLBindingRuleBatchSet(idx uint64, rules structs.ACLBindingRules
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ACLBindingRuleSet(idx uint64, rule *structs.ACLBindingRule) error {
@@ -1571,8 +1557,7 @@ func (s *Store) ACLBindingRuleSet(idx uint64, rule *structs.ACLBindingRule) erro
 	if err := s.aclBindingRuleSetTxn(tx, idx, rule); err != nil {
 		return err
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclBindingRuleSetTxn(tx *txnWrapper, idx uint64, rule *structs.ACLBindingRule) error {
@@ -1677,8 +1662,7 @@ func (s *Store) ACLBindingRuleBatchDelete(idx uint64, bindingRuleIDs []string) e
 	for _, bindingRuleID := range bindingRuleIDs {
 		s.aclBindingRuleDeleteTxn(tx, idx, bindingRuleID, nil)
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclBindingRuleDelete(idx uint64, id string, entMeta *structs.EnterpriseMeta) error {
@@ -1689,8 +1673,7 @@ func (s *Store) aclBindingRuleDelete(idx uint64, id string, entMeta *structs.Ent
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclBindingRuleDeleteTxn(tx *txnWrapper, idx uint64, id string, entMeta *structs.EnterpriseMeta) error {
@@ -1748,8 +1731,7 @@ func (s *Store) ACLAuthMethodBatchSet(idx uint64, methods structs.ACLAuthMethods
 			return err
 		}
 	}
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ACLAuthMethodSet(idx uint64, method *structs.ACLAuthMethod) error {
@@ -1760,8 +1742,7 @@ func (s *Store) ACLAuthMethodSet(idx uint64, method *structs.ACLAuthMethod) erro
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclAuthMethodSetTxn(tx *txnWrapper, idx uint64, method *structs.ACLAuthMethod) error {
@@ -1865,8 +1846,7 @@ func (s *Store) ACLAuthMethodBatchDelete(idx uint64, names []string, entMeta *st
 		s.aclAuthMethodDeleteTxn(tx, idx, name, entMeta)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclAuthMethodDelete(idx uint64, name string, entMeta *structs.EnterpriseMeta) error {
@@ -1877,8 +1857,7 @@ func (s *Store) aclAuthMethodDelete(idx uint64, name string, entMeta *structs.En
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) aclAuthMethodDeleteTxn(tx *txnWrapper, idx uint64, name string, entMeta *structs.EnterpriseMeta) error {

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -206,7 +206,7 @@ func authMethodsTableSchema() *memdb.TableSchema {
 /////                        ACL Policy Functions                         /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclPolicyInsert(tx *memdb.Txn, policy *structs.ACLPolicy) error {
+func (s *Store) aclPolicyInsert(tx *txnWrapper, policy *structs.ACLPolicy) error {
 	if err := tx.Insert("acl-policies", policy); err != nil {
 		return fmt.Errorf("failed inserting acl policy: %v", err)
 	}
@@ -218,19 +218,19 @@ func (s *Store) aclPolicyInsert(tx *memdb.Txn, policy *structs.ACLPolicy) error 
 	return nil
 }
 
-func (s *Store) aclPolicyGetByID(tx *memdb.Txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclPolicyGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "id", id)
 }
 
-func (s *Store) aclPolicyGetByName(tx *memdb.Txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclPolicyGetByName(tx *txnWrapper, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "name", name)
 }
 
-func (s *Store) aclPolicyList(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclPolicyList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-policies", "id")
 }
 
-func (s *Store) aclPolicyDeleteWithPolicy(tx *memdb.Txn, policy *structs.ACLPolicy, idx uint64) error {
+func (s *Store) aclPolicyDeleteWithPolicy(tx *txnWrapper, policy *structs.ACLPolicy, idx uint64) error {
 	// remove the policy
 	if err := tx.Delete("acl-policies", policy); err != nil {
 		return fmt.Errorf("failed deleting acl policy: %v", err)
@@ -243,11 +243,11 @@ func (s *Store) aclPolicyDeleteWithPolicy(tx *memdb.Txn, policy *structs.ACLPoli
 	return nil
 }
 
-func (s *Store) aclPolicyMaxIndex(tx *memdb.Txn, _ *structs.ACLPolicy, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclPolicyMaxIndex(tx *txnWrapper, _ *structs.ACLPolicy, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-policies")
 }
 
-func (s *Store) aclPolicyUpsertValidateEnterprise(*memdb.Txn, *structs.ACLPolicy, *structs.ACLPolicy) error {
+func (s *Store) aclPolicyUpsertValidateEnterprise(*txnWrapper, *structs.ACLPolicy, *structs.ACLPolicy) error {
 	return nil
 }
 
@@ -259,7 +259,7 @@ func (s *Store) ACLPolicyUpsertValidateEnterprise(*structs.ACLPolicy, *structs.A
 /////                        ACL Token Functions                          /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclTokenInsert(tx *memdb.Txn, token *structs.ACLToken) error {
+func (s *Store) aclTokenInsert(tx *txnWrapper, token *structs.ACLToken) error {
 	// insert the token into memdb
 	if err := tx.Insert("acl-tokens", token); err != nil {
 		return fmt.Errorf("failed inserting acl token: %v", err)
@@ -273,35 +273,35 @@ func (s *Store) aclTokenInsert(tx *memdb.Txn, token *structs.ACLToken) error {
 	return nil
 }
 
-func (s *Store) aclTokenGetFromIndex(tx *memdb.Txn, id string, index string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclTokenGetFromIndex(tx *txnWrapper, id string, index string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-tokens", index, id)
 }
 
-func (s *Store) aclTokenListAll(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListAll(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "id")
 }
 
-func (s *Store) aclTokenListLocal(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListLocal(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "local", true)
 }
 
-func (s *Store) aclTokenListGlobal(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListGlobal(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "local", false)
 }
 
-func (s *Store) aclTokenListByPolicy(tx *memdb.Txn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByPolicy(tx *txnWrapper, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "policies", policy)
 }
 
-func (s *Store) aclTokenListByRole(tx *memdb.Txn, role string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByRole(tx *txnWrapper, role string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "roles", role)
 }
 
-func (s *Store) aclTokenListByAuthMethod(tx *memdb.Txn, authMethod string, _, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByAuthMethod(tx *txnWrapper, authMethod string, _, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "authmethod", authMethod)
 }
 
-func (s *Store) aclTokenDeleteWithToken(tx *memdb.Txn, token *structs.ACLToken, idx uint64) error {
+func (s *Store) aclTokenDeleteWithToken(tx *txnWrapper, token *structs.ACLToken, idx uint64) error {
 	// remove the token
 	if err := tx.Delete("acl-tokens", token); err != nil {
 		return fmt.Errorf("failed deleting acl token: %v", err)
@@ -314,11 +314,11 @@ func (s *Store) aclTokenDeleteWithToken(tx *memdb.Txn, token *structs.ACLToken, 
 	return nil
 }
 
-func (s *Store) aclTokenMaxIndex(tx *memdb.Txn, _ *structs.ACLToken, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclTokenMaxIndex(tx *txnWrapper, _ *structs.ACLToken, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-tokens")
 }
 
-func (s *Store) aclTokenUpsertValidateEnterprise(tx *memdb.Txn, token *structs.ACLToken, existing *structs.ACLToken) error {
+func (s *Store) aclTokenUpsertValidateEnterprise(tx *txnWrapper, token *structs.ACLToken, existing *structs.ACLToken) error {
 	return nil
 }
 
@@ -330,7 +330,7 @@ func (s *Store) ACLTokenUpsertValidateEnterprise(token *structs.ACLToken, existi
 /////                         ACL Role Functions                          /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclRoleInsert(tx *memdb.Txn, role *structs.ACLRole) error {
+func (s *Store) aclRoleInsert(tx *txnWrapper, role *structs.ACLRole) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-roles", role); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -343,23 +343,23 @@ func (s *Store) aclRoleInsert(tx *memdb.Txn, role *structs.ACLRole) error {
 	return nil
 }
 
-func (s *Store) aclRoleGetByID(tx *memdb.Txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclRoleGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "id", id)
 }
 
-func (s *Store) aclRoleGetByName(tx *memdb.Txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclRoleGetByName(tx *txnWrapper, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "name", name)
 }
 
-func (s *Store) aclRoleList(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclRoleList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-roles", "id")
 }
 
-func (s *Store) aclRoleListByPolicy(tx *memdb.Txn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclRoleListByPolicy(tx *txnWrapper, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-roles", "policies", policy)
 }
 
-func (s *Store) aclRoleDeleteWithRole(tx *memdb.Txn, role *structs.ACLRole, idx uint64) error {
+func (s *Store) aclRoleDeleteWithRole(tx *txnWrapper, role *structs.ACLRole, idx uint64) error {
 	// remove the role
 	if err := tx.Delete("acl-roles", role); err != nil {
 		return fmt.Errorf("failed deleting acl role: %v", err)
@@ -372,11 +372,11 @@ func (s *Store) aclRoleDeleteWithRole(tx *memdb.Txn, role *structs.ACLRole, idx 
 	return nil
 }
 
-func (s *Store) aclRoleMaxIndex(tx *memdb.Txn, _ *structs.ACLRole, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclRoleMaxIndex(tx *txnWrapper, _ *structs.ACLRole, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-roles")
 }
 
-func (s *Store) aclRoleUpsertValidateEnterprise(tx *memdb.Txn, role *structs.ACLRole, existing *structs.ACLRole) error {
+func (s *Store) aclRoleUpsertValidateEnterprise(tx *txnWrapper, role *structs.ACLRole, existing *structs.ACLRole) error {
 	return nil
 }
 
@@ -388,7 +388,7 @@ func (s *Store) ACLRoleUpsertValidateEnterprise(role *structs.ACLRole, existing 
 /////                     ACL Binding Rule Functions                      /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclBindingRuleInsert(tx *memdb.Txn, rule *structs.ACLBindingRule) error {
+func (s *Store) aclBindingRuleInsert(tx *txnWrapper, rule *structs.ACLBindingRule) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-binding-rules", rule); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -402,19 +402,19 @@ func (s *Store) aclBindingRuleInsert(tx *memdb.Txn, rule *structs.ACLBindingRule
 	return nil
 }
 
-func (s *Store) aclBindingRuleGetByID(tx *memdb.Txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclBindingRuleGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-binding-rules", "id", id)
 }
 
-func (s *Store) aclBindingRuleList(tx *memdb.Txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclBindingRuleList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-binding-rules", "id")
 }
 
-func (s *Store) aclBindingRuleListByAuthMethod(tx *memdb.Txn, method string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclBindingRuleListByAuthMethod(tx *txnWrapper, method string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-binding-rules", "authmethod", method)
 }
 
-func (s *Store) aclBindingRuleDeleteWithRule(tx *memdb.Txn, rule *structs.ACLBindingRule, idx uint64) error {
+func (s *Store) aclBindingRuleDeleteWithRule(tx *txnWrapper, rule *structs.ACLBindingRule, idx uint64) error {
 	// remove the rule
 	if err := tx.Delete("acl-binding-rules", rule); err != nil {
 		return fmt.Errorf("failed deleting acl binding rule: %v", err)
@@ -427,11 +427,11 @@ func (s *Store) aclBindingRuleDeleteWithRule(tx *memdb.Txn, rule *structs.ACLBin
 	return nil
 }
 
-func (s *Store) aclBindingRuleMaxIndex(tx *memdb.Txn, _ *structs.ACLBindingRule, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclBindingRuleMaxIndex(tx *txnWrapper, _ *structs.ACLBindingRule, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-binding-rules")
 }
 
-func (s *Store) aclBindingRuleUpsertValidateEnterprise(tx *memdb.Txn, rule *structs.ACLBindingRule, existing *structs.ACLBindingRule) error {
+func (s *Store) aclBindingRuleUpsertValidateEnterprise(tx *txnWrapper, rule *structs.ACLBindingRule, existing *structs.ACLBindingRule) error {
 	return nil
 }
 
@@ -443,7 +443,7 @@ func (s *Store) ACLBindingRuleUpsertValidateEnterprise(rule *structs.ACLBindingR
 /////                     ACL Auth Method Functions                       /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclAuthMethodInsert(tx *memdb.Txn, method *structs.ACLAuthMethod) error {
+func (s *Store) aclAuthMethodInsert(tx *txnWrapper, method *structs.ACLAuthMethod) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-auth-methods", method); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -457,15 +457,15 @@ func (s *Store) aclAuthMethodInsert(tx *memdb.Txn, method *structs.ACLAuthMethod
 	return nil
 }
 
-func (s *Store) aclAuthMethodGetByName(tx *memdb.Txn, method string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclAuthMethodGetByName(tx *txnWrapper, method string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-auth-methods", "id", method)
 }
 
-func (s *Store) aclAuthMethodList(tx *memdb.Txn, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclAuthMethodList(tx *txnWrapper, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-auth-methods", "id")
 }
 
-func (s *Store) aclAuthMethodDeleteWithMethod(tx *memdb.Txn, method *structs.ACLAuthMethod, idx uint64) error {
+func (s *Store) aclAuthMethodDeleteWithMethod(tx *txnWrapper, method *structs.ACLAuthMethod, idx uint64) error {
 	// remove the method
 	if err := tx.Delete("acl-auth-methods", method); err != nil {
 		return fmt.Errorf("failed deleting acl auth method: %v", err)
@@ -478,11 +478,11 @@ func (s *Store) aclAuthMethodDeleteWithMethod(tx *memdb.Txn, method *structs.ACL
 	return nil
 }
 
-func (s *Store) aclAuthMethodMaxIndex(tx *memdb.Txn, _ *structs.ACLAuthMethod, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclAuthMethodMaxIndex(tx *txnWrapper, _ *structs.ACLAuthMethod, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-auth-methods")
 }
 
-func (s *Store) aclAuthMethodUpsertValidateEnterprise(tx *memdb.Txn, method *structs.ACLAuthMethod, existing *structs.ACLAuthMethod) error {
+func (s *Store) aclAuthMethodUpsertValidateEnterprise(tx *txnWrapper, method *structs.ACLAuthMethod, existing *structs.ACLAuthMethod) error {
 	return nil
 }
 

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -206,7 +206,7 @@ func authMethodsTableSchema() *memdb.TableSchema {
 /////                        ACL Policy Functions                         /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclPolicyInsert(tx *txnWrapper, policy *structs.ACLPolicy) error {
+func (s *Store) aclPolicyInsert(tx *txn, policy *structs.ACLPolicy) error {
 	if err := tx.Insert("acl-policies", policy); err != nil {
 		return fmt.Errorf("failed inserting acl policy: %v", err)
 	}
@@ -218,19 +218,19 @@ func (s *Store) aclPolicyInsert(tx *txnWrapper, policy *structs.ACLPolicy) error
 	return nil
 }
 
-func (s *Store) aclPolicyGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclPolicyGetByID(tx *txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "id", id)
 }
 
-func (s *Store) aclPolicyGetByName(tx *txnWrapper, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclPolicyGetByName(tx *txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "name", name)
 }
 
-func (s *Store) aclPolicyList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclPolicyList(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-policies", "id")
 }
 
-func (s *Store) aclPolicyDeleteWithPolicy(tx *txnWrapper, policy *structs.ACLPolicy, idx uint64) error {
+func (s *Store) aclPolicyDeleteWithPolicy(tx *txn, policy *structs.ACLPolicy, idx uint64) error {
 	// remove the policy
 	if err := tx.Delete("acl-policies", policy); err != nil {
 		return fmt.Errorf("failed deleting acl policy: %v", err)
@@ -243,11 +243,11 @@ func (s *Store) aclPolicyDeleteWithPolicy(tx *txnWrapper, policy *structs.ACLPol
 	return nil
 }
 
-func (s *Store) aclPolicyMaxIndex(tx *txnWrapper, _ *structs.ACLPolicy, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclPolicyMaxIndex(tx *txn, _ *structs.ACLPolicy, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-policies")
 }
 
-func (s *Store) aclPolicyUpsertValidateEnterprise(*txnWrapper, *structs.ACLPolicy, *structs.ACLPolicy) error {
+func (s *Store) aclPolicyUpsertValidateEnterprise(*txn, *structs.ACLPolicy, *structs.ACLPolicy) error {
 	return nil
 }
 
@@ -259,7 +259,7 @@ func (s *Store) ACLPolicyUpsertValidateEnterprise(*structs.ACLPolicy, *structs.A
 /////                        ACL Token Functions                          /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclTokenInsert(tx *txnWrapper, token *structs.ACLToken) error {
+func (s *Store) aclTokenInsert(tx *txn, token *structs.ACLToken) error {
 	// insert the token into memdb
 	if err := tx.Insert("acl-tokens", token); err != nil {
 		return fmt.Errorf("failed inserting acl token: %v", err)
@@ -273,35 +273,35 @@ func (s *Store) aclTokenInsert(tx *txnWrapper, token *structs.ACLToken) error {
 	return nil
 }
 
-func (s *Store) aclTokenGetFromIndex(tx *txnWrapper, id string, index string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclTokenGetFromIndex(tx *txn, id string, index string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-tokens", index, id)
 }
 
-func (s *Store) aclTokenListAll(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListAll(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "id")
 }
 
-func (s *Store) aclTokenListLocal(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListLocal(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "local", true)
 }
 
-func (s *Store) aclTokenListGlobal(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListGlobal(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "local", false)
 }
 
-func (s *Store) aclTokenListByPolicy(tx *txnWrapper, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByPolicy(tx *txn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "policies", policy)
 }
 
-func (s *Store) aclTokenListByRole(tx *txnWrapper, role string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByRole(tx *txn, role string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "roles", role)
 }
 
-func (s *Store) aclTokenListByAuthMethod(tx *txnWrapper, authMethod string, _, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclTokenListByAuthMethod(tx *txn, authMethod string, _, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-tokens", "authmethod", authMethod)
 }
 
-func (s *Store) aclTokenDeleteWithToken(tx *txnWrapper, token *structs.ACLToken, idx uint64) error {
+func (s *Store) aclTokenDeleteWithToken(tx *txn, token *structs.ACLToken, idx uint64) error {
 	// remove the token
 	if err := tx.Delete("acl-tokens", token); err != nil {
 		return fmt.Errorf("failed deleting acl token: %v", err)
@@ -314,11 +314,11 @@ func (s *Store) aclTokenDeleteWithToken(tx *txnWrapper, token *structs.ACLToken,
 	return nil
 }
 
-func (s *Store) aclTokenMaxIndex(tx *txnWrapper, _ *structs.ACLToken, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclTokenMaxIndex(tx *txn, _ *structs.ACLToken, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-tokens")
 }
 
-func (s *Store) aclTokenUpsertValidateEnterprise(tx *txnWrapper, token *structs.ACLToken, existing *structs.ACLToken) error {
+func (s *Store) aclTokenUpsertValidateEnterprise(tx *txn, token *structs.ACLToken, existing *structs.ACLToken) error {
 	return nil
 }
 
@@ -330,7 +330,7 @@ func (s *Store) ACLTokenUpsertValidateEnterprise(token *structs.ACLToken, existi
 /////                         ACL Role Functions                          /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclRoleInsert(tx *txnWrapper, role *structs.ACLRole) error {
+func (s *Store) aclRoleInsert(tx *txn, role *structs.ACLRole) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-roles", role); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -343,23 +343,23 @@ func (s *Store) aclRoleInsert(tx *txnWrapper, role *structs.ACLRole) error {
 	return nil
 }
 
-func (s *Store) aclRoleGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclRoleGetByID(tx *txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "id", id)
 }
 
-func (s *Store) aclRoleGetByName(tx *txnWrapper, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclRoleGetByName(tx *txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "name", name)
 }
 
-func (s *Store) aclRoleList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclRoleList(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-roles", "id")
 }
 
-func (s *Store) aclRoleListByPolicy(tx *txnWrapper, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclRoleListByPolicy(tx *txn, policy string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-roles", "policies", policy)
 }
 
-func (s *Store) aclRoleDeleteWithRole(tx *txnWrapper, role *structs.ACLRole, idx uint64) error {
+func (s *Store) aclRoleDeleteWithRole(tx *txn, role *structs.ACLRole, idx uint64) error {
 	// remove the role
 	if err := tx.Delete("acl-roles", role); err != nil {
 		return fmt.Errorf("failed deleting acl role: %v", err)
@@ -372,11 +372,11 @@ func (s *Store) aclRoleDeleteWithRole(tx *txnWrapper, role *structs.ACLRole, idx
 	return nil
 }
 
-func (s *Store) aclRoleMaxIndex(tx *txnWrapper, _ *structs.ACLRole, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclRoleMaxIndex(tx *txn, _ *structs.ACLRole, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-roles")
 }
 
-func (s *Store) aclRoleUpsertValidateEnterprise(tx *txnWrapper, role *structs.ACLRole, existing *structs.ACLRole) error {
+func (s *Store) aclRoleUpsertValidateEnterprise(tx *txn, role *structs.ACLRole, existing *structs.ACLRole) error {
 	return nil
 }
 
@@ -388,7 +388,7 @@ func (s *Store) ACLRoleUpsertValidateEnterprise(role *structs.ACLRole, existing 
 /////                     ACL Binding Rule Functions                      /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclBindingRuleInsert(tx *txnWrapper, rule *structs.ACLBindingRule) error {
+func (s *Store) aclBindingRuleInsert(tx *txn, rule *structs.ACLBindingRule) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-binding-rules", rule); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -402,19 +402,19 @@ func (s *Store) aclBindingRuleInsert(tx *txnWrapper, rule *structs.ACLBindingRul
 	return nil
 }
 
-func (s *Store) aclBindingRuleGetByID(tx *txnWrapper, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclBindingRuleGetByID(tx *txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-binding-rules", "id", id)
 }
 
-func (s *Store) aclBindingRuleList(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclBindingRuleList(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-binding-rules", "id")
 }
 
-func (s *Store) aclBindingRuleListByAuthMethod(tx *txnWrapper, method string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclBindingRuleListByAuthMethod(tx *txn, method string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-binding-rules", "authmethod", method)
 }
 
-func (s *Store) aclBindingRuleDeleteWithRule(tx *txnWrapper, rule *structs.ACLBindingRule, idx uint64) error {
+func (s *Store) aclBindingRuleDeleteWithRule(tx *txn, rule *structs.ACLBindingRule, idx uint64) error {
 	// remove the rule
 	if err := tx.Delete("acl-binding-rules", rule); err != nil {
 		return fmt.Errorf("failed deleting acl binding rule: %v", err)
@@ -427,11 +427,11 @@ func (s *Store) aclBindingRuleDeleteWithRule(tx *txnWrapper, rule *structs.ACLBi
 	return nil
 }
 
-func (s *Store) aclBindingRuleMaxIndex(tx *txnWrapper, _ *structs.ACLBindingRule, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclBindingRuleMaxIndex(tx *txn, _ *structs.ACLBindingRule, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-binding-rules")
 }
 
-func (s *Store) aclBindingRuleUpsertValidateEnterprise(tx *txnWrapper, rule *structs.ACLBindingRule, existing *structs.ACLBindingRule) error {
+func (s *Store) aclBindingRuleUpsertValidateEnterprise(tx *txn, rule *structs.ACLBindingRule, existing *structs.ACLBindingRule) error {
 	return nil
 }
 
@@ -443,7 +443,7 @@ func (s *Store) ACLBindingRuleUpsertValidateEnterprise(rule *structs.ACLBindingR
 /////                     ACL Auth Method Functions                       /////
 ///////////////////////////////////////////////////////////////////////////////
 
-func (s *Store) aclAuthMethodInsert(tx *txnWrapper, method *structs.ACLAuthMethod) error {
+func (s *Store) aclAuthMethodInsert(tx *txn, method *structs.ACLAuthMethod) error {
 	// insert the role into memdb
 	if err := tx.Insert("acl-auth-methods", method); err != nil {
 		return fmt.Errorf("failed inserting acl role: %v", err)
@@ -457,15 +457,15 @@ func (s *Store) aclAuthMethodInsert(tx *txnWrapper, method *structs.ACLAuthMetho
 	return nil
 }
 
-func (s *Store) aclAuthMethodGetByName(tx *txnWrapper, method string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) aclAuthMethodGetByName(tx *txn, method string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-auth-methods", "id", method)
 }
 
-func (s *Store) aclAuthMethodList(tx *txnWrapper, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) aclAuthMethodList(tx *txn, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-auth-methods", "id")
 }
 
-func (s *Store) aclAuthMethodDeleteWithMethod(tx *txnWrapper, method *structs.ACLAuthMethod, idx uint64) error {
+func (s *Store) aclAuthMethodDeleteWithMethod(tx *txn, method *structs.ACLAuthMethod, idx uint64) error {
 	// remove the method
 	if err := tx.Delete("acl-auth-methods", method); err != nil {
 		return fmt.Errorf("failed deleting acl auth method: %v", err)
@@ -478,11 +478,11 @@ func (s *Store) aclAuthMethodDeleteWithMethod(tx *txnWrapper, method *structs.AC
 	return nil
 }
 
-func (s *Store) aclAuthMethodMaxIndex(tx *txnWrapper, _ *structs.ACLAuthMethod, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) aclAuthMethodMaxIndex(tx *txn, _ *structs.ACLAuthMethod, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "acl-auth-methods")
 }
 
-func (s *Store) aclAuthMethodUpsertValidateEnterprise(tx *txnWrapper, method *structs.ACLAuthMethod, existing *structs.ACLAuthMethod) error {
+func (s *Store) aclAuthMethodUpsertValidateEnterprise(tx *txn, method *structs.ACLAuthMethod, existing *structs.ACLAuthMethod) error {
 	return nil
 }
 

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -4105,7 +4105,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		_, err := s.resolveACLLinks(tx, links, func(*memdb.Txn, string) (string, error) {
+		_, err := s.resolveACLLinks(tx, links, func(*txnWrapper, string) (string, error) {
 			err := fmt.Errorf("Should not be attempting to resolve an empty id")
 			require.Fail(t, err.Error())
 			return "", err
@@ -4131,7 +4131,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := s.resolveACLLinks(tx, links, func(_ *memdb.Txn, linkID string) (string, error) {
+		numValid, err := s.resolveACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
 			switch linkID {
 			case "e81887b4-836b-4053-a1fa-7e8305902be9":
 				return "foo", nil
@@ -4161,7 +4161,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := s.resolveACLLinks(tx, links, func(_ *memdb.Txn, linkID string) (string, error) {
+		numValid, err := s.resolveACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
 			require.Equal(t, "b985e082-25d3-45a9-9dd8-fd1a41b83b0d", linkID)
 			return "", nil
 		})
@@ -4201,7 +4201,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *memdb.Txn, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4228,7 +4228,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *memdb.Txn, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4260,7 +4260,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *memdb.Txn, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4287,7 +4287,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		_, _, err := s.fixupACLLinks(tx, links, func(*memdb.Txn, string) (string, error) {
+		_, _, err := s.fixupACLLinks(tx, links, func(*txnWrapper, string) (string, error) {
 			return "", fmt.Errorf("Resolver Error")
 		})
 

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -4105,7 +4105,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		_, err := s.resolveACLLinks(tx, links, func(*txnWrapper, string) (string, error) {
+		_, err := s.resolveACLLinks(tx, links, func(*txn, string) (string, error) {
 			err := fmt.Errorf("Should not be attempting to resolve an empty id")
 			require.Fail(t, err.Error())
 			return "", err
@@ -4131,7 +4131,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := s.resolveACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
+		numValid, err := s.resolveACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
 			switch linkID {
 			case "e81887b4-836b-4053-a1fa-7e8305902be9":
 				return "foo", nil
@@ -4161,7 +4161,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := s.resolveACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
+		numValid, err := s.resolveACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
 			require.Equal(t, "b985e082-25d3-45a9-9dd8-fd1a41b83b0d", linkID)
 			return "", nil
 		})
@@ -4201,7 +4201,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4228,7 +4228,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4260,7 +4260,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txnWrapper, linkID string) (string, error) {
+		newLinks, cloned, err := s.fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4287,7 +4287,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		_, _, err := s.fixupACLLinks(tx, links, func(*txnWrapper, string) (string, error) {
+		_, _, err := s.fixupACLLinks(tx, links, func(*txn, string) (string, error) {
 			return "", fmt.Errorf("Resolver Error")
 		})
 

--- a/agent/consul/state/autopilot.go
+++ b/agent/consul/state/autopilot.go
@@ -81,8 +81,7 @@ func (s *Store) AutopilotSetConfig(idx uint64, config *autopilot.Config) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // AutopilotCASConfig is used to try updating the Autopilot configuration with a
@@ -110,8 +109,8 @@ func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 func (s *Store) autopilotSetConfigTxn(idx uint64, tx *txnWrapper, config *autopilot.Config) error {

--- a/agent/consul/state/autopilot.go
+++ b/agent/consul/state/autopilot.go
@@ -113,7 +113,7 @@ func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (
 	return err == nil, err
 }
 
-func (s *Store) autopilotSetConfigTxn(idx uint64, tx *txnWrapper, config *autopilot.Config) error {
+func (s *Store) autopilotSetConfigTxn(idx uint64, tx *txn, config *autopilot.Config) error {
 	// Check for an existing config
 	existing, err := tx.First("autopilot-config", "id")
 	if err != nil {

--- a/agent/consul/state/autopilot.go
+++ b/agent/consul/state/autopilot.go
@@ -74,7 +74,7 @@ func (s *Store) AutopilotConfig() (uint64, *autopilot.Config, error) {
 
 // AutopilotSetConfig is used to set the current Autopilot configuration.
 func (s *Store) AutopilotSetConfig(idx uint64, config *autopilot.Config) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	if err := s.autopilotSetConfigTxn(idx, tx, config); err != nil {
@@ -89,7 +89,7 @@ func (s *Store) AutopilotSetConfig(idx uint64, config *autopilot.Config) error {
 // given Raft index. If the CAS index specified is not equal to the last observed index
 // for the config, then the call is a noop,
 func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (bool, error) {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// Check for an existing config
@@ -114,7 +114,7 @@ func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (
 	return true, nil
 }
 
-func (s *Store) autopilotSetConfigTxn(idx uint64, tx *memdb.Txn, config *autopilot.Config) error {
+func (s *Store) autopilotSetConfigTxn(idx uint64, tx *txnWrapper, config *autopilot.Config) error {
 	// Check for an existing config
 	existing, err := tx.First("autopilot-config", "id")
 	if err != nil {

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -233,8 +233,7 @@ func (s *Store) EnsureRegistration(idx uint64, req *structs.RegisterRequest) err
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) ensureCheckIfNodeMatches(tx *txnWrapper, idx uint64, node string, check *structs.HealthCheck) error {
@@ -324,8 +323,7 @@ func (s *Store) EnsureNode(idx uint64, node *structs.Node) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // ensureNoNodeWithSimilarNameTxn checks that no other node has conflict in its name
@@ -599,8 +597,7 @@ func (s *Store) DeleteNode(idx uint64, nodeName string) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // deleteNodeCASTxn is used to try doing a node delete operation with a given
@@ -733,8 +730,7 @@ func (s *Store) EnsureService(idx uint64, node string, svc *structs.NodeService)
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 var errCASCompareFailed = errors.New("compare-and-set: comparison failed")
@@ -1403,8 +1399,7 @@ func (s *Store) DeleteService(idx uint64, nodeName, serviceID string, entMeta *s
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // deleteServiceCASTxn is used to try doing a service delete operation with a given
@@ -1541,8 +1536,7 @@ func (s *Store) EnsureCheck(idx uint64, hc *structs.HealthCheck) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // updateAllServiceIndexesOfNode updates the Raft index of all the services associated with this node
@@ -1879,8 +1873,7 @@ func (s *Store) DeleteCheck(idx uint64, node string, checkID types.CheckID, entM
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // deleteCheckCASTxn is used to try doing a check delete operation with a given

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -236,7 +236,7 @@ func (s *Store) EnsureRegistration(idx uint64, req *structs.RegisterRequest) err
 	return tx.Commit()
 }
 
-func (s *Store) ensureCheckIfNodeMatches(tx *txnWrapper, idx uint64, node string, check *structs.HealthCheck) error {
+func (s *Store) ensureCheckIfNodeMatches(tx *txn, idx uint64, node string, check *structs.HealthCheck) error {
 	if check.Node != node {
 		return fmt.Errorf("check node %q does not match node %q",
 			check.Node, node)
@@ -250,7 +250,7 @@ func (s *Store) ensureCheckIfNodeMatches(tx *txnWrapper, idx uint64, node string
 // ensureRegistrationTxn is used to make sure a node, service, and check
 // registration is performed within a single transaction to avoid race
 // conditions on state updates.
-func (s *Store) ensureRegistrationTxn(tx *txnWrapper, idx uint64, req *structs.RegisterRequest) error {
+func (s *Store) ensureRegistrationTxn(tx *txn, idx uint64, req *structs.RegisterRequest) error {
 	if _, err := s.validateRegisterRequestTxn(tx, req); err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func (s *Store) EnsureNode(idx uint64, node *structs.Node) error {
 
 // ensureNoNodeWithSimilarNameTxn checks that no other node has conflict in its name
 // If allowClashWithoutID then, getting a conflict on another node without ID will be allowed
-func (s *Store) ensureNoNodeWithSimilarNameTxn(tx *txnWrapper, node *structs.Node, allowClashWithoutID bool) error {
+func (s *Store) ensureNoNodeWithSimilarNameTxn(tx *txn, node *structs.Node, allowClashWithoutID bool) error {
 	// Retrieve all of the nodes
 	enodes, err := tx.Get("nodes", "id")
 	if err != nil {
@@ -364,7 +364,7 @@ func (s *Store) ensureNoNodeWithSimilarNameTxn(tx *txnWrapper, node *structs.Nod
 
 // ensureNodeCASTxn updates a node only if the existing index matches the given index.
 // Returns a bool indicating if a write happened and any error.
-func (s *Store) ensureNodeCASTxn(tx *txnWrapper, idx uint64, node *structs.Node) (bool, error) {
+func (s *Store) ensureNodeCASTxn(tx *txn, idx uint64, node *structs.Node) (bool, error) {
 	// Retrieve the existing entry.
 	existing, err := getNodeTxn(tx, node.Node)
 	if err != nil {
@@ -394,7 +394,7 @@ func (s *Store) ensureNodeCASTxn(tx *txnWrapper, idx uint64, node *structs.Node)
 // ensureNodeTxn is the inner function called to actually create a node
 // registration or modify an existing one in the state store. It allows
 // passing in a memdb transaction so it may be part of a larger txn.
-func (s *Store) ensureNodeTxn(tx *txnWrapper, idx uint64, node *structs.Node) error {
+func (s *Store) ensureNodeTxn(tx *txn, idx uint64, node *structs.Node) error {
 	// See if there's an existing node with this UUID, and make sure the
 	// name is the same.
 	var n *structs.Node
@@ -492,7 +492,7 @@ func (s *Store) GetNode(id string) (uint64, *structs.Node, error) {
 	return idx, node, nil
 }
 
-func getNodeTxn(tx *txnWrapper, nodeName string) (*structs.Node, error) {
+func getNodeTxn(tx *txn, nodeName string) (*structs.Node, error) {
 	node, err := tx.First("nodes", "id", nodeName)
 	if err != nil {
 		return nil, fmt.Errorf("node lookup failed: %s", err)
@@ -503,7 +503,7 @@ func getNodeTxn(tx *txnWrapper, nodeName string) (*structs.Node, error) {
 	return nil, nil
 }
 
-func getNodeIDTxn(tx *txnWrapper, id types.NodeID) (*structs.Node, error) {
+func getNodeIDTxn(tx *txn, id types.NodeID) (*structs.Node, error) {
 	strnode := string(id)
 	uuidValue, err := uuid.ParseUUID(strnode)
 	if err != nil {
@@ -603,7 +603,7 @@ func (s *Store) DeleteNode(idx uint64, nodeName string) error {
 // deleteNodeCASTxn is used to try doing a node delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given check, then the call is a noop, otherwise a normal check delete is invoked.
-func (s *Store) deleteNodeCASTxn(tx *txnWrapper, idx, cidx uint64, nodeName string) (bool, error) {
+func (s *Store) deleteNodeCASTxn(tx *txn, idx, cidx uint64, nodeName string) (bool, error) {
 	// Look up the node.
 	node, err := getNodeTxn(tx, nodeName)
 	if err != nil {
@@ -630,7 +630,7 @@ func (s *Store) deleteNodeCASTxn(tx *txnWrapper, idx, cidx uint64, nodeName stri
 
 // deleteNodeTxn is the inner method used for removing a node from
 // the store within a given transaction.
-func (s *Store) deleteNodeTxn(tx *txnWrapper, idx uint64, nodeName string) error {
+func (s *Store) deleteNodeTxn(tx *txn, idx uint64, nodeName string) error {
 	// Look up the node.
 	node, err := tx.First("nodes", "id", nodeName)
 	if err != nil {
@@ -737,7 +737,7 @@ var errCASCompareFailed = errors.New("compare-and-set: comparison failed")
 
 // ensureServiceCASTxn updates a service only if the existing index matches the given index.
 // Returns an error if the write didn't happen and nil if write was successful.
-func (s *Store) ensureServiceCASTxn(tx *txnWrapper, idx uint64, node string, svc *structs.NodeService) error {
+func (s *Store) ensureServiceCASTxn(tx *txn, idx uint64, node string, svc *structs.NodeService) error {
 	// Retrieve the existing service.
 	_, existing, err := firstWatchCompoundWithTxn(tx, "services", "id", &svc.EnterpriseMeta, node, svc.ID)
 	if err != nil {
@@ -762,7 +762,7 @@ func (s *Store) ensureServiceCASTxn(tx *txnWrapper, idx uint64, node string, svc
 
 // ensureServiceTxn is used to upsert a service registration within an
 // existing memdb transaction.
-func (s *Store) ensureServiceTxn(tx *txnWrapper, idx uint64, node string, svc *structs.NodeService) error {
+func (s *Store) ensureServiceTxn(tx *txn, idx uint64, node string, svc *structs.NodeService) error {
 	// Check for existing service
 	_, existing, err := firstWatchCompoundWithTxn(tx, "services", "id", &svc.EnterpriseMeta, node, svc.ID)
 	if err != nil {
@@ -859,7 +859,7 @@ func (s *Store) ServiceList(ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) 
 	return s.serviceListTxn(tx, ws, entMeta)
 }
 
-func (s *Store) serviceListTxn(tx *txnWrapper, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceList, error) {
+func (s *Store) serviceListTxn(tx *txn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceList, error) {
 	idx := s.catalogServicesMaxIndex(tx, entMeta)
 
 	services, err := s.catalogServiceList(tx, entMeta, true)
@@ -963,7 +963,7 @@ func (s *Store) ServicesByNodeMeta(ws memdb.WatchSet, filters map[string]string,
 //   * return when the last instance of a service is removed
 //   * block until an instance for this service is available, or another
 //     service is unregistered.
-func (s *Store) maxIndexForService(tx *txnWrapper, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) maxIndexForService(tx *txn, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) uint64 {
 	idx, _ := s.maxIndexAndWatchChForService(tx, serviceName, serviceExists, checks, entMeta)
 	return idx
 }
@@ -982,7 +982,7 @@ func (s *Store) maxIndexForService(tx *txnWrapper, serviceName string, serviceEx
 // returned for the chan. This allows for blocking watchers to _only_ watch this
 // one chan in the common case, falling back to watching all touched MemDB
 // indexes in more complicated cases.
-func (s *Store) maxIndexAndWatchChForService(tx *txnWrapper, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) (uint64, <-chan struct{}) {
+func (s *Store) maxIndexAndWatchChForService(tx *txn, serviceName string, serviceExists, checks bool, entMeta *structs.EnterpriseMeta) (uint64, <-chan struct{}) {
 	if !serviceExists {
 		res, err := s.catalogServiceLastExtinctionIndex(tx, entMeta)
 		if missingIdx, ok := res.(*IndexEntry); ok && err == nil {
@@ -999,7 +999,7 @@ func (s *Store) maxIndexAndWatchChForService(tx *txnWrapper, serviceName string,
 }
 
 // Wrapper for maxIndexAndWatchChForService that operates on a list of ServiceNodes
-func (s *Store) maxIndexAndWatchChsForServiceNodes(tx *txnWrapper,
+func (s *Store) maxIndexAndWatchChsForServiceNodes(tx *txn,
 	nodes structs.ServiceNodes, watchChecks bool) (uint64, []<-chan struct{}) {
 
 	var watchChans []<-chan struct{}
@@ -1206,7 +1206,7 @@ func (s *Store) ServiceAddressNodes(ws memdb.WatchSet, address string, entMeta *
 
 // parseServiceNodes iterates over a services query and fills in the node details,
 // returning a ServiceNodes slice.
-func (s *Store) parseServiceNodes(tx *txnWrapper, ws memdb.WatchSet, services structs.ServiceNodes) (structs.ServiceNodes, error) {
+func (s *Store) parseServiceNodes(tx *txn, ws memdb.WatchSet, services structs.ServiceNodes) (structs.ServiceNodes, error) {
 	// We don't want to track an unlimited number of nodes, so we pull a
 	// top-level watch to use as a fallback.
 	allNodes, err := tx.Get("nodes", "id")
@@ -1263,7 +1263,7 @@ func (s *Store) NodeService(nodeName string, serviceID string, entMeta *structs.
 	return idx, service, nil
 }
 
-func (s *Store) getNodeServiceTxn(tx *txnWrapper, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (*structs.NodeService, error) {
+func (s *Store) getNodeServiceTxn(tx *txn, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (*structs.NodeService, error) {
 	// Query the service
 	_, service, err := firstWatchCompoundWithTxn(tx, "services", "id", entMeta, nodeName, serviceID)
 	if err != nil {
@@ -1405,7 +1405,7 @@ func (s *Store) DeleteService(idx uint64, nodeName, serviceID string, entMeta *s
 // deleteServiceCASTxn is used to try doing a service delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given service, then the call is a noop, otherwise a normal delete is invoked.
-func (s *Store) deleteServiceCASTxn(tx *txnWrapper, idx, cidx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) deleteServiceCASTxn(tx *txn, idx, cidx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) (bool, error) {
 	// Look up the service.
 	service, err := s.getNodeServiceTxn(tx, nodeName, serviceID, entMeta)
 	if err != nil {
@@ -1432,7 +1432,7 @@ func (s *Store) deleteServiceCASTxn(tx *txnWrapper, idx, cidx uint64, nodeName, 
 
 // deleteServiceTxn is the inner method called to remove a service
 // registration within an existing transaction.
-func (s *Store) deleteServiceTxn(tx *txnWrapper, idx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteServiceTxn(tx *txn, idx uint64, nodeName, serviceID string, entMeta *structs.EnterpriseMeta) error {
 	// Look up the service.
 	_, service, err := firstWatchCompoundWithTxn(tx, "services", "id", entMeta, nodeName, serviceID)
 	if err != nil {
@@ -1540,7 +1540,7 @@ func (s *Store) EnsureCheck(idx uint64, hc *structs.HealthCheck) error {
 }
 
 // updateAllServiceIndexesOfNode updates the Raft index of all the services associated with this node
-func (s *Store) updateAllServiceIndexesOfNode(tx *txnWrapper, idx uint64, nodeID string) error {
+func (s *Store) updateAllServiceIndexesOfNode(tx *txn, idx uint64, nodeID string) error {
 	services, err := tx.Get("services", "node", nodeID)
 	if err != nil {
 		return fmt.Errorf("failed updating services for node %s: %s", nodeID, err)
@@ -1559,7 +1559,7 @@ func (s *Store) updateAllServiceIndexesOfNode(tx *txnWrapper, idx uint64, nodeID
 
 // ensureCheckCASTxn updates a check only if the existing index matches the given index.
 // Returns a bool indicating if a write happened and any error.
-func (s *Store) ensureCheckCASTxn(tx *txnWrapper, idx uint64, hc *structs.HealthCheck) (bool, error) {
+func (s *Store) ensureCheckCASTxn(tx *txn, idx uint64, hc *structs.HealthCheck) (bool, error) {
 	// Retrieve the existing entry.
 	_, existing, err := s.getNodeCheckTxn(tx, hc.Node, hc.CheckID, &hc.EnterpriseMeta)
 	if err != nil {
@@ -1589,7 +1589,7 @@ func (s *Store) ensureCheckCASTxn(tx *txnWrapper, idx uint64, hc *structs.Health
 // ensureCheckTxn is used as the inner method to handle inserting
 // a health check into the state store. It ensures safety against inserting
 // checks with no matching node or service.
-func (s *Store) ensureCheckTxn(tx *txnWrapper, idx uint64, hc *structs.HealthCheck) error {
+func (s *Store) ensureCheckTxn(tx *txn, idx uint64, hc *structs.HealthCheck) error {
 	// Check if we have an existing health check
 	_, existing, err := firstWatchCompoundWithTxn(tx, "checks", "id", &hc.EnterpriseMeta, hc.Node, string(hc.CheckID))
 	if err != nil {
@@ -1692,7 +1692,7 @@ func (s *Store) NodeCheck(nodeName string, checkID types.CheckID, entMeta *struc
 
 // nodeCheckTxn is used as the inner method to handle reading a health check
 // from the state store.
-func (s *Store) getNodeCheckTxn(tx *txnWrapper, nodeName string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (uint64, *structs.HealthCheck, error) {
+func (s *Store) getNodeCheckTxn(tx *txn, nodeName string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (uint64, *structs.HealthCheck, error) {
 	// Get the table index.
 	idx := s.catalogChecksMaxIndex(tx, entMeta)
 
@@ -1808,7 +1808,7 @@ func (s *Store) ChecksInStateByNodeMeta(ws memdb.WatchSet, state string, filters
 	return s.parseChecksByNodeMeta(tx, ws, idx, iter, filters)
 }
 
-func (s *Store) checksInStateTxn(tx *txnWrapper, ws memdb.WatchSet, state string, entMeta *structs.EnterpriseMeta) (uint64, memdb.ResultIterator, error) {
+func (s *Store) checksInStateTxn(tx *txn, ws memdb.WatchSet, state string, entMeta *structs.EnterpriseMeta) (uint64, memdb.ResultIterator, error) {
 	// Get the table index.
 	idx := s.catalogChecksMaxIndex(tx, entMeta)
 
@@ -1830,7 +1830,7 @@ func (s *Store) checksInStateTxn(tx *txnWrapper, ws memdb.WatchSet, state string
 
 // parseChecksByNodeMeta is a helper function used to deduplicate some
 // repetitive code for returning health checks filtered by node metadata fields.
-func (s *Store) parseChecksByNodeMeta(tx *txnWrapper, ws memdb.WatchSet,
+func (s *Store) parseChecksByNodeMeta(tx *txn, ws memdb.WatchSet,
 	idx uint64, iter memdb.ResultIterator, filters map[string]string) (uint64, structs.HealthChecks, error) {
 
 	// We don't want to track an unlimited number of nodes, so we pull a
@@ -1879,7 +1879,7 @@ func (s *Store) DeleteCheck(idx uint64, node string, checkID types.CheckID, entM
 // deleteCheckCASTxn is used to try doing a check delete operation with a given
 // raft index. If the CAS index specified is not equal to the last observed index for
 // the given check, then the call is a noop, otherwise a normal check delete is invoked.
-func (s *Store) deleteCheckCASTxn(tx *txnWrapper, idx, cidx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) deleteCheckCASTxn(tx *txn, idx, cidx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) (bool, error) {
 	// Try to retrieve the existing health check.
 	_, hc, err := s.getNodeCheckTxn(tx, node, checkID, entMeta)
 	if err != nil {
@@ -1906,7 +1906,7 @@ func (s *Store) deleteCheckCASTxn(tx *txnWrapper, idx, cidx uint64, node string,
 
 // deleteCheckTxn is the inner method used to call a health
 // check deletion within an existing transaction.
-func (s *Store) deleteCheckTxn(tx *txnWrapper, idx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteCheckTxn(tx *txn, idx uint64, node string, checkID types.CheckID, entMeta *structs.EnterpriseMeta) error {
 	// Try to retrieve the existing health check.
 	_, hc, err := firstWatchCompoundWithTxn(tx, "checks", "id", entMeta, node, string(checkID))
 	if err != nil {
@@ -2023,7 +2023,7 @@ func (s *Store) checkServiceNodes(ws memdb.WatchSet, serviceName string, connect
 	return s.checkServiceNodesTxn(tx, ws, serviceName, connect, entMeta)
 }
 
-func (s *Store) checkServiceNodesTxn(tx *txnWrapper, ws memdb.WatchSet, serviceName string, connect bool, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) checkServiceNodesTxn(tx *txn, ws memdb.WatchSet, serviceName string, connect bool, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
 	// Function for lookup
 	index := "service"
 	if connect {
@@ -2213,7 +2213,7 @@ func (s *Store) GatewayServices(ws memdb.WatchSet, gateway string, entMeta *stru
 // and query for an associated node and a set of checks. This is the inner
 // method used to return a rich set of results from a more simple query.
 func (s *Store) parseCheckServiceNodes(
-	tx *txnWrapper, ws memdb.WatchSet, idx uint64,
+	tx *txn, ws memdb.WatchSet, idx uint64,
 	serviceName string, services structs.ServiceNodes,
 	err error) (uint64, structs.CheckServiceNodes, error) {
 	if err != nil {
@@ -2338,7 +2338,7 @@ func (s *Store) ServiceDump(ws memdb.WatchSet, kind structs.ServiceKind, useKind
 	}
 }
 
-func (s *Store) serviceDumpAllTxn(tx *txnWrapper, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) serviceDumpAllTxn(tx *txn, ws memdb.WatchSet, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
 	// Get the table index
 	idx := s.catalogMaxIndexWatch(tx, ws, entMeta, true)
 
@@ -2356,7 +2356,7 @@ func (s *Store) serviceDumpAllTxn(tx *txnWrapper, ws memdb.WatchSet, entMeta *st
 	return s.parseCheckServiceNodes(tx, nil, idx, "", results, err)
 }
 
-func (s *Store) serviceDumpKindTxn(tx *txnWrapper, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
+func (s *Store) serviceDumpKindTxn(tx *txn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.CheckServiceNodes, error) {
 	// unlike when we are dumping all services here we only need to watch the kind specific index entry for changing (or nodes, checks)
 	// updating any services, nodes or checks will bump the appropriate service kind index so there is no need to watch any of the individual
 	// entries
@@ -2380,7 +2380,7 @@ func (s *Store) serviceDumpKindTxn(tx *txnWrapper, ws memdb.WatchSet, kind struc
 // parseNodes takes an iterator over a set of nodes and returns a struct
 // containing the nodes along with all of their associated services
 // and/or health checks.
-func (s *Store) parseNodes(tx *txnWrapper, ws memdb.WatchSet, idx uint64,
+func (s *Store) parseNodes(tx *txn, ws memdb.WatchSet, idx uint64,
 	iter memdb.ResultIterator, entMeta *structs.EnterpriseMeta) (uint64, structs.NodeDump, error) {
 
 	// We don't want to track an unlimited number of services, so we pull a
@@ -2440,7 +2440,7 @@ func (s *Store) parseNodes(tx *txnWrapper, ws memdb.WatchSet, idx uint64,
 }
 
 // checkSessionsTxn returns the IDs of all sessions associated with a health check
-func checkSessionsTxn(tx *txnWrapper, hc *structs.HealthCheck) ([]*sessionCheck, error) {
+func checkSessionsTxn(tx *txn, hc *structs.HealthCheck) ([]*sessionCheck, error) {
 	mappings, err := getCompoundWithTxn(tx, "session_checks", "node_check", &hc.EnterpriseMeta, hc.Node, string(hc.CheckID))
 	if err != nil {
 		return nil, fmt.Errorf("failed session checks lookup: %s", err)
@@ -2454,7 +2454,7 @@ func checkSessionsTxn(tx *txnWrapper, hc *structs.HealthCheck) ([]*sessionCheck,
 }
 
 // updateGatewayServices associates services with gateways as specified in a gateway config entry
-func (s *Store) updateGatewayServices(tx *txnWrapper, idx uint64, conf structs.ConfigEntry, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) updateGatewayServices(tx *txn, idx uint64, conf structs.ConfigEntry, entMeta *structs.EnterpriseMeta) error {
 	var (
 		noChange        bool
 		gatewayServices structs.GatewayServices
@@ -2511,7 +2511,7 @@ func (s *Store) updateGatewayServices(tx *txnWrapper, idx uint64, conf structs.C
 // insertion into the memdb table, specific to ingress gateways. The boolean
 // returned indicates that there are no changes necessary to the memdb table.
 func (s *Store) ingressConfigGatewayServices(
-	tx *txnWrapper,
+	tx *txn,
 	gateway structs.ServiceName,
 	conf structs.ConfigEntry,
 	entMeta *structs.EnterpriseMeta,
@@ -2556,7 +2556,7 @@ func (s *Store) ingressConfigGatewayServices(
 // boolean returned indicates that there are no changes necessary to the memdb
 // table.
 func (s *Store) terminatingConfigGatewayServices(
-	tx *txnWrapper,
+	tx *txn,
 	gateway structs.ServiceName,
 	conf structs.ConfigEntry,
 	entMeta *structs.EnterpriseMeta,
@@ -2596,7 +2596,7 @@ func (s *Store) terminatingConfigGatewayServices(
 }
 
 // updateGatewayNamespace is used to target all services within a namespace
-func (s *Store) updateGatewayNamespace(tx *txnWrapper, idx uint64, service *structs.GatewayService, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) updateGatewayNamespace(tx *txn, idx uint64, service *structs.GatewayService, entMeta *structs.EnterpriseMeta) error {
 	services, err := s.catalogServiceListByKind(tx, structs.ServiceKindTypical, entMeta)
 	if err != nil {
 		return fmt.Errorf("failed querying services: %s", err)
@@ -2643,7 +2643,7 @@ func (s *Store) updateGatewayNamespace(tx *txnWrapper, idx uint64, service *stru
 
 // updateGatewayService associates services with gateways after an eligible event
 // ie. Registering a service in a namespace targeted by a gateway
-func (s *Store) updateGatewayService(tx *txnWrapper, idx uint64, mapping *structs.GatewayService) error {
+func (s *Store) updateGatewayService(tx *txn, idx uint64, mapping *structs.GatewayService) error {
 	// Check if mapping already exists in table if it's already in the table
 	// Avoid insert if nothing changed
 	existing, err := tx.First(gatewayServicesTableName, "id", mapping.Gateway, mapping.Service, mapping.Port)
@@ -2674,7 +2674,7 @@ func (s *Store) updateGatewayService(tx *txnWrapper, idx uint64, mapping *struct
 // checkWildcardForGatewaysAndUpdate checks whether a service matches a
 // wildcard definition in gateway config entries and if so adds it the the
 // gateway-services table.
-func (s *Store) checkGatewayWildcardsAndUpdate(tx *txnWrapper, idx uint64, svc *structs.NodeService) error {
+func (s *Store) checkGatewayWildcardsAndUpdate(tx *txn, idx uint64, svc *structs.NodeService) error {
 	// Do not associate non-typical services with gateways or consul services
 	if svc.Kind != structs.ServiceKindTypical || svc.Service == "consul" {
 		return nil
@@ -2703,18 +2703,18 @@ func (s *Store) checkGatewayWildcardsAndUpdate(tx *txnWrapper, idx uint64, svc *
 
 // serviceGateways returns all GatewayService entries with the given service name. This effectively looks up
 // all the gateways mapped to this service.
-func (s *Store) serviceGateways(tx *txnWrapper, name string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) serviceGateways(tx *txn, name string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(gatewayServicesTableName, "service", structs.NewServiceName(name, entMeta))
 }
 
-func (s *Store) gatewayServices(tx *txnWrapper, name string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) gatewayServices(tx *txn, name string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(gatewayServicesTableName, "gateway", structs.NewServiceName(name, entMeta))
 }
 
 // TODO(ingress): How to handle index rolling back when a config entry is
 // deleted that references a service?
 // We might need something like the service_last_extinction index?
-func (s *Store) serviceGatewayNodes(tx *txnWrapper, ws memdb.WatchSet, service string, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
+func (s *Store) serviceGatewayNodes(tx *txn, ws memdb.WatchSet, service string, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) (uint64, structs.ServiceNodes, error) {
 	// Look up gateway name associated with the service
 	gws, err := s.serviceGateways(tx, service, entMeta)
 	if err != nil {
@@ -2766,7 +2766,7 @@ func (s *Store) serviceGatewayNodes(tx *txnWrapper, ws memdb.WatchSet, service s
 // checkProtocolMatch filters out any GatewayService entries added from a wildcard with a protocol
 // that doesn't match the one configured in their discovery chain.
 func (s *Store) checkProtocolMatch(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	svc *structs.GatewayService,
 ) (uint64, bool, error) {

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -4,6 +4,7 @@ package state
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/consul/agent/structs"
 	memdb "github.com/hashicorp/go-memdb"
 )
@@ -167,7 +168,7 @@ func serviceKindIndexName(kind structs.ServiceKind, _ *structs.EnterpriseMeta) s
 	}
 }
 
-func (s *Store) catalogUpdateServicesIndexes(tx *txnWrapper, idx uint64, _ *structs.EnterpriseMeta) error {
+func (s *Store) catalogUpdateServicesIndexes(tx *txn, idx uint64, _ *structs.EnterpriseMeta) error {
 	// overall services index
 	if err := indexUpdateMaxTxn(tx, idx, "services"); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -176,7 +177,7 @@ func (s *Store) catalogUpdateServicesIndexes(tx *txnWrapper, idx uint64, _ *stru
 	return nil
 }
 
-func (s *Store) catalogUpdateServiceKindIndexes(tx *txnWrapper, kind structs.ServiceKind, idx uint64, _ *structs.EnterpriseMeta) error {
+func (s *Store) catalogUpdateServiceKindIndexes(tx *txn, kind structs.ServiceKind, idx uint64, _ *structs.EnterpriseMeta) error {
 	// service-kind index
 	if err := indexUpdateMaxTxn(tx, idx, serviceKindIndexName(kind, nil)); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -185,7 +186,7 @@ func (s *Store) catalogUpdateServiceKindIndexes(tx *txnWrapper, kind structs.Ser
 	return nil
 }
 
-func (s *Store) catalogUpdateServiceIndexes(tx *txnWrapper, serviceName string, idx uint64, _ *structs.EnterpriseMeta) error {
+func (s *Store) catalogUpdateServiceIndexes(tx *txn, serviceName string, idx uint64, _ *structs.EnterpriseMeta) error {
 	// per-service index
 	if err := indexUpdateMaxTxn(tx, idx, serviceIndexName(serviceName, nil)); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -194,14 +195,14 @@ func (s *Store) catalogUpdateServiceIndexes(tx *txnWrapper, serviceName string, 
 	return nil
 }
 
-func (s *Store) catalogUpdateServiceExtinctionIndex(tx *txnWrapper, idx uint64, _ *structs.EnterpriseMeta) error {
+func (s *Store) catalogUpdateServiceExtinctionIndex(tx *txn, idx uint64, _ *structs.EnterpriseMeta) error {
 	if err := tx.Insert("index", &IndexEntry{serviceLastExtinctionIndexName, idx}); err != nil {
 		return fmt.Errorf("failed updating missing service extinction index: %s", err)
 	}
 	return nil
 }
 
-func (s *Store) catalogInsertService(tx *txnWrapper, svc *structs.ServiceNode) error {
+func (s *Store) catalogInsertService(tx *txn, svc *structs.ServiceNode) error {
 	// Insert the service and update the index
 	if err := tx.Insert("services", svc); err != nil {
 		return fmt.Errorf("failed inserting service: %s", err)
@@ -222,53 +223,53 @@ func (s *Store) catalogInsertService(tx *txnWrapper, svc *structs.ServiceNode) e
 	return nil
 }
 
-func (s *Store) catalogServicesMaxIndex(tx *txnWrapper, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) catalogServicesMaxIndex(tx *txn, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "services")
 }
 
-func (s *Store) catalogServiceMaxIndex(tx *txnWrapper, serviceName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func (s *Store) catalogServiceMaxIndex(tx *txn, serviceName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("index", "id", serviceIndexName(serviceName, nil))
 }
 
-func (s *Store) catalogServiceKindMaxIndex(tx *txnWrapper, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) catalogServiceKindMaxIndex(tx *txn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexWatchTxn(tx, ws, serviceKindIndexName(kind, nil))
 }
 
-func (s *Store) catalogServiceList(tx *txnWrapper, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
+func (s *Store) catalogServiceList(tx *txn, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
 	return tx.Get("services", "id")
 }
 
-func (s *Store) catalogServiceListByKind(tx *txnWrapper, kind structs.ServiceKind, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogServiceListByKind(tx *txn, kind structs.ServiceKind, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("services", "kind", string(kind))
 }
 
-func (s *Store) catalogServiceListByNode(tx *txnWrapper, node string, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
+func (s *Store) catalogServiceListByNode(tx *txn, node string, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
 	return tx.Get("services", "node", node)
 }
 
-func (s *Store) catalogServiceNodeList(tx *txnWrapper, name string, index string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogServiceNodeList(tx *txn, name string, index string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("services", index, name)
 }
 
-func (s *Store) catalogServiceLastExtinctionIndex(tx *txnWrapper, _ *structs.EnterpriseMeta) (interface{}, error) {
+func (s *Store) catalogServiceLastExtinctionIndex(tx *txn, _ *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First("index", "id", serviceLastExtinctionIndexName)
 }
 
-func (s *Store) catalogMaxIndex(tx *txnWrapper, _ *structs.EnterpriseMeta, checks bool) uint64 {
+func (s *Store) catalogMaxIndex(tx *txn, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
 		return maxIndexTxn(tx, "nodes", "services", "checks")
 	}
 	return maxIndexTxn(tx, "nodes", "services")
 }
 
-func (s *Store) catalogMaxIndexWatch(tx *txnWrapper, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
+func (s *Store) catalogMaxIndexWatch(tx *txn, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
 		return maxIndexWatchTxn(tx, ws, "nodes", "services", "checks")
 	}
 	return maxIndexWatchTxn(tx, ws, "nodes", "services")
 }
 
-func (s *Store) catalogUpdateCheckIndexes(tx *txnWrapper, idx uint64, _ *structs.EnterpriseMeta) error {
+func (s *Store) catalogUpdateCheckIndexes(tx *txn, idx uint64, _ *structs.EnterpriseMeta) error {
 	// update the universal index entry
 	if err := tx.Insert("index", &IndexEntry{"checks", idx}); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
@@ -276,36 +277,36 @@ func (s *Store) catalogUpdateCheckIndexes(tx *txnWrapper, idx uint64, _ *structs
 	return nil
 }
 
-func (s *Store) catalogChecksMaxIndex(tx *txnWrapper, _ *structs.EnterpriseMeta) uint64 {
+func (s *Store) catalogChecksMaxIndex(tx *txn, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "checks")
 }
 
-func (s *Store) catalogListChecksByNode(tx *txnWrapper, node string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogListChecksByNode(tx *txn, node string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node", node)
 }
 
-func (s *Store) catalogListChecksByService(tx *txnWrapper, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogListChecksByService(tx *txn, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "service", service)
 }
 
-func (s *Store) catalogListChecksInState(tx *txnWrapper, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogListChecksInState(tx *txn, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	// simpler than normal due to the use of the CompoundMultiIndex
 	return tx.Get("checks", "status", state)
 }
 
-func (s *Store) catalogListChecks(tx *txnWrapper, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogListChecks(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "id")
 }
 
-func (s *Store) catalogListNodeChecks(tx *txnWrapper, node string) (memdb.ResultIterator, error) {
+func (s *Store) catalogListNodeChecks(tx *txn, node string) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service_check", node, false)
 }
 
-func (s *Store) catalogListServiceChecks(tx *txnWrapper, node string, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogListServiceChecks(tx *txn, node string, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service", node, service)
 }
 
-func (s *Store) catalogInsertCheck(tx *txnWrapper, chk *structs.HealthCheck, idx uint64) error {
+func (s *Store) catalogInsertCheck(tx *txn, chk *structs.HealthCheck, idx uint64) error {
 	// Insert the check
 	if err := tx.Insert("checks", chk); err != nil {
 		return fmt.Errorf("failed inserting check: %s", err)
@@ -318,11 +319,11 @@ func (s *Store) catalogInsertCheck(tx *txnWrapper, chk *structs.HealthCheck, idx
 	return nil
 }
 
-func (s *Store) catalogChecksForNodeService(tx *txnWrapper, node string, service string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func (s *Store) catalogChecksForNodeService(tx *txn, node string, service string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service", node, service)
 }
 
-func (s *Store) validateRegisterRequestTxn(tx *txnWrapper, args *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
+func (s *Store) validateRegisterRequestTxn(tx *txn, args *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
 	return nil, nil
 }
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -4385,7 +4385,7 @@ func TestStateStore_ensureServiceCASTxn(t *testing.T) {
 	tx := s.db.WriteTxnRestore()
 	err := s.ensureServiceCASTxn(tx, 3, "node1", &ns)
 	require.Equal(t, err, errCASCompareFailed)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	// ensure no update happened
 	tx = s.db.Txn(false)
@@ -4393,14 +4393,14 @@ func TestStateStore_ensureServiceCASTxn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nsRead)
 	require.Equal(t, uint64(2), nsRead.ModifyIndex)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	ns.ModifyIndex = 99
 	// attempt to update with a non-matching index
 	tx = s.db.WriteTxnRestore()
 	err = s.ensureServiceCASTxn(tx, 4, "node1", &ns)
 	require.Equal(t, err, errCASCompareFailed)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	// ensure no update happened
 	tx = s.db.Txn(false)
@@ -4408,14 +4408,14 @@ func TestStateStore_ensureServiceCASTxn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nsRead)
 	require.Equal(t, uint64(2), nsRead.ModifyIndex)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	ns.ModifyIndex = 2
 	// update with the matching modify index
 	tx = s.db.WriteTxnRestore()
 	err = s.ensureServiceCASTxn(tx, 7, "node1", &ns)
 	require.NoError(t, err)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	// ensure the update happened
 	tx = s.db.Txn(false)
@@ -4423,7 +4423,7 @@ func TestStateStore_ensureServiceCASTxn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, nsRead)
 	require.Equal(t, uint64(7), nsRead.ModifyIndex)
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 }
 
 func TestStateStore_GatewayServices_Terminating(t *testing.T) {

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -174,8 +174,7 @@ func (s *Store) EnsureConfigEntry(idx uint64, conf structs.ConfigEntry, entMeta 
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // ensureConfigEntryTxn upserts a config entry inside of a transaction.
@@ -246,8 +245,8 @@ func (s *Store) EnsureConfigEntryCAS(idx, cidx uint64, conf structs.ConfigEntry,
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 func (s *Store) DeleteConfigEntry(idx uint64, kind, name string, entMeta *structs.EnterpriseMeta) error {
@@ -294,8 +293,7 @@ func (s *Store) DeleteConfigEntry(idx uint64, kind, name string, entMeta *struct
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) insertConfigEntryWithTxn(tx *txnWrapper, idx uint64, conf structs.ConfigEntry) error {

--- a/agent/consul/state/config_entry.go
+++ b/agent/consul/state/config_entry.go
@@ -106,7 +106,7 @@ func (s *Store) ConfigEntry(ws memdb.WatchSet, kind, name string, entMeta *struc
 	return s.configEntryTxn(tx, ws, kind, name, entMeta)
 }
 
-func (s *Store) configEntryTxn(tx *txnWrapper, ws memdb.WatchSet, kind, name string, entMeta *structs.EnterpriseMeta) (uint64, structs.ConfigEntry, error) {
+func (s *Store) configEntryTxn(tx *txn, ws memdb.WatchSet, kind, name string, entMeta *structs.EnterpriseMeta) (uint64, structs.ConfigEntry, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, configTableName)
 
@@ -141,7 +141,7 @@ func (s *Store) ConfigEntriesByKind(ws memdb.WatchSet, kind string, entMeta *str
 	return s.configEntriesByKindTxn(tx, ws, kind, entMeta)
 }
 
-func (s *Store) configEntriesByKindTxn(tx *txnWrapper, ws memdb.WatchSet, kind string, entMeta *structs.EnterpriseMeta) (uint64, []structs.ConfigEntry, error) {
+func (s *Store) configEntriesByKindTxn(tx *txn, ws memdb.WatchSet, kind string, entMeta *structs.EnterpriseMeta) (uint64, []structs.ConfigEntry, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, configTableName)
 
@@ -178,7 +178,7 @@ func (s *Store) EnsureConfigEntry(idx uint64, conf structs.ConfigEntry, entMeta 
 }
 
 // ensureConfigEntryTxn upserts a config entry inside of a transaction.
-func (s *Store) ensureConfigEntryTxn(tx *txnWrapper, idx uint64, conf structs.ConfigEntry, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) ensureConfigEntryTxn(tx *txn, idx uint64, conf structs.ConfigEntry, entMeta *structs.EnterpriseMeta) error {
 	// Check for existing configuration.
 	existing, err := s.firstConfigEntryWithTxn(tx, conf.GetKind(), conf.GetName(), entMeta)
 	if err != nil {
@@ -296,7 +296,7 @@ func (s *Store) DeleteConfigEntry(idx uint64, kind, name string, entMeta *struct
 	return tx.Commit()
 }
 
-func (s *Store) insertConfigEntryWithTxn(tx *txnWrapper, idx uint64, conf structs.ConfigEntry) error {
+func (s *Store) insertConfigEntryWithTxn(tx *txn, idx uint64, conf structs.ConfigEntry) error {
 	if conf == nil {
 		return fmt.Errorf("cannot insert nil config entry")
 	}
@@ -328,7 +328,7 @@ func (s *Store) insertConfigEntryWithTxn(tx *txnWrapper, idx uint64, conf struct
 // May return *ConfigEntryGraphValidationError if there is a concern to surface
 // to the caller that they can correct.
 func (s *Store) validateProposedConfigEntryInGraph(
-	tx *txnWrapper,
+	tx *txn,
 	idx uint64,
 	kind, name string,
 	next structs.ConfigEntry,
@@ -369,7 +369,7 @@ func (s *Store) validateProposedConfigEntryInGraph(
 }
 
 func (s *Store) checkGatewayClash(
-	tx *txnWrapper,
+	tx *txn,
 	name, selfKind, otherKind string,
 	entMeta *structs.EnterpriseMeta,
 ) error {
@@ -391,7 +391,7 @@ var serviceGraphKinds = []string{
 }
 
 func (s *Store) validateProposedConfigEntryInServiceGraph(
-	tx *txnWrapper,
+	tx *txn,
 	idx uint64,
 	kind, name string,
 	next structs.ConfigEntry,
@@ -447,7 +447,7 @@ func (s *Store) validateProposedConfigEntryInServiceGraph(
 }
 
 func (s *Store) testCompileDiscoveryChain(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	chainName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -510,7 +510,7 @@ func (s *Store) readDiscoveryChainConfigEntries(
 }
 
 func (s *Store) readDiscoveryChainConfigEntriesTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	serviceName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -699,7 +699,7 @@ func anyKey(m map[structs.ServiceID]struct{}) (structs.ServiceID, bool) {
 //
 // If an override is returned the index returned will be 0.
 func (s *Store) getProxyConfigEntryTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	name string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -724,7 +724,7 @@ func (s *Store) getProxyConfigEntryTxn(
 //
 // If an override is returned the index returned will be 0.
 func (s *Store) getServiceConfigEntryTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	serviceName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -749,7 +749,7 @@ func (s *Store) getServiceConfigEntryTxn(
 //
 // If an override is returned the index returned will be 0.
 func (s *Store) getRouterConfigEntryTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	serviceName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -774,7 +774,7 @@ func (s *Store) getRouterConfigEntryTxn(
 //
 // If an override is returned the index returned will be 0.
 func (s *Store) getSplitterConfigEntryTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	serviceName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -799,7 +799,7 @@ func (s *Store) getSplitterConfigEntryTxn(
 //
 // If an override is returned the index returned will be 0.
 func (s *Store) getResolverConfigEntryTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	serviceName string,
 	overrides map[structs.ConfigEntryKindName]structs.ConfigEntry,
@@ -820,7 +820,7 @@ func (s *Store) getResolverConfigEntryTxn(
 }
 
 func (s *Store) configEntryWithOverridesTxn(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	kind string,
 	name string,
@@ -840,7 +840,7 @@ func (s *Store) configEntryWithOverridesTxn(
 }
 
 func (s *Store) validateProposedIngressProtocolsInServiceGraph(
-	tx *txnWrapper,
+	tx *txn,
 	next structs.ConfigEntry,
 	entMeta *structs.EnterpriseMeta,
 ) error {
@@ -884,7 +884,7 @@ func (s *Store) validateProposedIngressProtocolsInServiceGraph(
 // protocolForService returns the service graph protocol associated to the
 // provided service, checking all relevant config entries.
 func (s *Store) protocolForService(
-	tx *txnWrapper,
+	tx *txn,
 	ws memdb.WatchSet,
 	svc structs.ServiceName,
 ) (uint64, string, error) {

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -49,25 +49,25 @@ func configTableSchema() *memdb.TableSchema {
 	}
 }
 
-func (s *Store) firstConfigEntryWithTxn(tx *memdb.Txn,
+func (s *Store) firstConfigEntryWithTxn(tx *txnWrapper,
 	kind, name string, entMeta *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First(configTableName, "id", kind, name)
 }
 
-func (s *Store) firstWatchConfigEntryWithTxn(tx *memdb.Txn,
+func (s *Store) firstWatchConfigEntryWithTxn(tx *txnWrapper,
 	kind, name string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(configTableName, "id", kind, name)
 }
 
-func (s *Store) validateConfigEntryEnterprise(tx *memdb.Txn, conf structs.ConfigEntry) error {
+func (s *Store) validateConfigEntryEnterprise(tx *txnWrapper, conf structs.ConfigEntry) error {
 	return nil
 }
 
-func getAllConfigEntriesWithTxn(tx *memdb.Txn, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func getAllConfigEntriesWithTxn(tx *txnWrapper, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "id")
 }
 
-func getConfigEntryKindsWithTxn(tx *memdb.Txn,
+func getConfigEntryKindsWithTxn(tx *txnWrapper,
 	kind string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "kind", kind)
 }

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -49,25 +49,25 @@ func configTableSchema() *memdb.TableSchema {
 	}
 }
 
-func (s *Store) firstConfigEntryWithTxn(tx *txnWrapper,
+func (s *Store) firstConfigEntryWithTxn(tx *txn,
 	kind, name string, entMeta *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First(configTableName, "id", kind, name)
 }
 
-func (s *Store) firstWatchConfigEntryWithTxn(tx *txnWrapper,
+func (s *Store) firstWatchConfigEntryWithTxn(tx *txn,
 	kind, name string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(configTableName, "id", kind, name)
 }
 
-func (s *Store) validateConfigEntryEnterprise(tx *txnWrapper, conf structs.ConfigEntry) error {
+func (s *Store) validateConfigEntryEnterprise(tx *txn, conf structs.ConfigEntry) error {
 	return nil
 }
 
-func getAllConfigEntriesWithTxn(tx *txnWrapper, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func getAllConfigEntriesWithTxn(tx *txn, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "id")
 }
 
-func getConfigEntryKindsWithTxn(tx *txnWrapper,
+func getConfigEntryKindsWithTxn(tx *txn,
 	kind string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "kind", kind)
 }

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -116,7 +116,7 @@ func (s *Store) CAConfig(ws memdb.WatchSet) (uint64, *structs.CAConfiguration, e
 	return s.caConfigTxn(tx, ws)
 }
 
-func (s *Store) caConfigTxn(tx *txnWrapper, ws memdb.WatchSet) (uint64, *structs.CAConfiguration, error) {
+func (s *Store) caConfigTxn(tx *txn, ws memdb.WatchSet) (uint64, *structs.CAConfiguration, error) {
 	// Get the CA config
 	ch, c, err := tx.FirstWatch(caConfigTableName, "id")
 	if err != nil {
@@ -174,7 +174,7 @@ func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfigur
 	return err == nil, err
 }
 
-func (s *Store) caSetConfigTxn(idx uint64, tx *txnWrapper, config *structs.CAConfiguration) error {
+func (s *Store) caSetConfigTxn(idx uint64, tx *txn, config *structs.CAConfiguration) error {
 	// Check for an existing config
 	prev, err := tx.First(caConfigTableName, "id")
 	if err != nil {
@@ -236,7 +236,7 @@ func (s *Store) CARoots(ws memdb.WatchSet) (uint64, structs.CARoots, error) {
 	return s.caRootsTxn(tx, ws)
 }
 
-func (s *Store) caRootsTxn(tx *txnWrapper, ws memdb.WatchSet) (uint64, structs.CARoots, error) {
+func (s *Store) caRootsTxn(tx *txn, ws memdb.WatchSet) (uint64, structs.CARoots, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, caRootTableName)
 

--- a/agent/consul/state/connect_ca.go
+++ b/agent/consul/state/connect_ca.go
@@ -142,8 +142,7 @@ func (s *Store) CASetConfig(idx uint64, config *structs.CAConfiguration) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // CACheckAndSetConfig is used to try updating the CA configuration with a
@@ -171,8 +170,8 @@ func (s *Store) CACheckAndSetConfig(idx, cidx uint64, config *structs.CAConfigur
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 func (s *Store) caSetConfigTxn(idx uint64, tx *txnWrapper, config *structs.CAConfiguration) error {
@@ -336,8 +335,8 @@ func (s *Store) CARootSetCAS(idx, cidx uint64, rs []*structs.CARoot) (bool, erro
 		return false, fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // CAProviderState is used to pull the built-in provider states from the snapshot.
@@ -417,9 +416,8 @@ func (s *Store) CASetProviderState(idx uint64, state *structs.CAConsulProviderSt
 		return false, fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // CADeleteProviderState is used to remove the built-in Consul CA provider
@@ -447,9 +445,7 @@ func (s *Store) CADeleteProviderState(idx uint64, id string) error {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) CALeafSetIndex(idx uint64, index uint64) error {
@@ -504,7 +500,6 @@ func (s *Store) CAIncrementProviderSerialNumber(idx uint64) (uint64, error) {
 		return 0, fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-
-	return next, nil
+	err = tx.Commit()
+	return next, err
 }

--- a/agent/consul/state/connect_ca_test.go
+++ b/agent/consul/state/connect_ca_test.go
@@ -429,15 +429,15 @@ func TestStore_CABuiltinProvider(t *testing.T) {
 		// Since we've already written to the builtin provider table the serial
 		// numbers will initialize from the max index of the provider table.
 		// That's why this first serial is 2 and not 1.
-		sn, err := s.CAIncrementProviderSerialNumber()
+		sn, err := s.CAIncrementProviderSerialNumber(10)
 		assert.NoError(err)
 		assert.Equal(uint64(2), sn)
 
-		sn, err = s.CAIncrementProviderSerialNumber()
+		sn, err = s.CAIncrementProviderSerialNumber(10)
 		assert.NoError(err)
 		assert.Equal(uint64(3), sn)
 
-		sn, err = s.CAIncrementProviderSerialNumber()
+		sn, err = s.CAIncrementProviderSerialNumber(10)
 		assert.NoError(err)
 		assert.Equal(uint64(4), sn)
 	}

--- a/agent/consul/state/coordinate.go
+++ b/agent/consul/state/coordinate.go
@@ -167,6 +167,5 @@ func (s *Store) CoordinateBatchUpdate(idx uint64, updates structs.Coordinates) e
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }

--- a/agent/consul/state/coordinate.go
+++ b/agent/consul/state/coordinate.go
@@ -130,7 +130,7 @@ func (s *Store) Coordinates(ws memdb.WatchSet) (uint64, structs.Coordinates, err
 // CoordinateBatchUpdate processes a batch of coordinate updates and applies
 // them in a single transaction.
 func (s *Store) CoordinateBatchUpdate(idx uint64, updates structs.Coordinates) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// Upsert the coordinates.

--- a/agent/consul/state/coordinate_test.go
+++ b/agent/consul/state/coordinate_test.go
@@ -270,7 +270,7 @@ func TestStateStore_Coordinate_Snapshot_Restore(t *testing.T) {
 		Node:  "node3",
 		Coord: &coordinate.Coordinate{Height: math.NaN()},
 	}
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(5)
 	if err := tx.Insert("coordinates", badUpdate); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/state/coordinate_test.go
+++ b/agent/consul/state/coordinate_test.go
@@ -274,7 +274,7 @@ func TestStateStore_Coordinate_Snapshot_Restore(t *testing.T) {
 	if err := tx.Insert("coordinates", badUpdate); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	// Snapshot the coordinates.
 	snap := s.Snapshot()

--- a/agent/consul/state/federation_state.go
+++ b/agent/consul/state/federation_state.go
@@ -84,7 +84,7 @@ func (s *Store) FederationStateSet(idx uint64, config *structs.FederationState) 
 }
 
 // federationStateSetTxn upserts a federation state inside of a transaction.
-func (s *Store) federationStateSetTxn(tx *txnWrapper, idx uint64, config *structs.FederationState) error {
+func (s *Store) federationStateSetTxn(tx *txn, idx uint64, config *structs.FederationState) error {
 	if config.Datacenter == "" {
 		return fmt.Errorf("missing datacenter on federation state")
 	}
@@ -134,7 +134,7 @@ func (s *Store) FederationStateGet(ws memdb.WatchSet, datacenter string) (uint64
 	return s.federationStateGetTxn(tx, ws, datacenter)
 }
 
-func (s *Store) federationStateGetTxn(tx *txnWrapper, ws memdb.WatchSet, datacenter string) (uint64, *structs.FederationState, error) {
+func (s *Store) federationStateGetTxn(tx *txn, ws memdb.WatchSet, datacenter string) (uint64, *structs.FederationState, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, federationStateTableName)
 
@@ -164,7 +164,7 @@ func (s *Store) FederationStateList(ws memdb.WatchSet) (uint64, []*structs.Feder
 	return s.federationStateListTxn(tx, ws)
 }
 
-func (s *Store) federationStateListTxn(tx *txnWrapper, ws memdb.WatchSet) (uint64, []*structs.FederationState, error) {
+func (s *Store) federationStateListTxn(tx *txn, ws memdb.WatchSet) (uint64, []*structs.FederationState, error) {
 	// Get the index
 	idx := maxIndexTxn(tx, federationStateTableName)
 
@@ -205,7 +205,7 @@ func (s *Store) FederationStateBatchDelete(idx uint64, datacenters []string) err
 	return tx.Commit()
 }
 
-func (s *Store) federationStateDeleteTxn(tx *txnWrapper, idx uint64, datacenter string) error {
+func (s *Store) federationStateDeleteTxn(tx *txn, idx uint64, datacenter string) error {
 	// Try to retrieve the existing federation state.
 	existing, err := tx.First(federationStateTableName, "id", datacenter)
 	if err != nil {

--- a/agent/consul/state/federation_state.go
+++ b/agent/consul/state/federation_state.go
@@ -68,8 +68,7 @@ func (s *Store) FederationStateBatchSet(idx uint64, configs structs.FederationSt
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // FederationStateSet is called to do an upsert of a given federation state.
@@ -81,8 +80,7 @@ func (s *Store) FederationStateSet(idx uint64, config *structs.FederationState) 
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // federationStateSetTxn upserts a federation state inside of a transaction.
@@ -191,8 +189,7 @@ func (s *Store) FederationStateDelete(idx uint64, datacenter string) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) FederationStateBatchDelete(idx uint64, datacenters []string) error {
@@ -205,8 +202,7 @@ func (s *Store) FederationStateBatchDelete(idx uint64, datacenters []string) err
 		}
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 func (s *Store) federationStateDeleteTxn(tx *txnWrapper, idx uint64, datacenter string) error {

--- a/agent/consul/state/graveyard.go
+++ b/agent/consul/state/graveyard.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
 )
@@ -27,7 +28,7 @@ func NewGraveyard(gc *TombstoneGC) *Graveyard {
 }
 
 // InsertTxn adds a new tombstone.
-func (g *Graveyard) InsertTxn(tx *memdb.Txn, key string, idx uint64, entMeta *structs.EnterpriseMeta) error {
+func (g *Graveyard) InsertTxn(tx *txnWrapper, key string, idx uint64, entMeta *structs.EnterpriseMeta) error {
 	stone := &Tombstone{
 		Key:   key,
 		Index: idx,
@@ -50,7 +51,7 @@ func (g *Graveyard) InsertTxn(tx *memdb.Txn, key string, idx uint64, entMeta *st
 
 // GetMaxIndexTxn returns the highest index tombstone whose key matches the
 // given context, using a prefix match.
-func (g *Graveyard) GetMaxIndexTxn(tx *memdb.Txn, prefix string, entMeta *structs.EnterpriseMeta) (uint64, error) {
+func (g *Graveyard) GetMaxIndexTxn(tx *txnWrapper, prefix string, entMeta *structs.EnterpriseMeta) (uint64, error) {
 	stones, err := getWithTxn(tx, "tombstones", "id_prefix", prefix, entMeta)
 	if err != nil {
 		return 0, fmt.Errorf("failed querying tombstones: %s", err)
@@ -67,7 +68,7 @@ func (g *Graveyard) GetMaxIndexTxn(tx *memdb.Txn, prefix string, entMeta *struct
 }
 
 // DumpTxn returns all the tombstones.
-func (g *Graveyard) DumpTxn(tx *memdb.Txn) (memdb.ResultIterator, error) {
+func (g *Graveyard) DumpTxn(tx *txnWrapper) (memdb.ResultIterator, error) {
 	iter, err := tx.Get("tombstones", "id")
 	if err != nil {
 		return nil, err
@@ -78,7 +79,7 @@ func (g *Graveyard) DumpTxn(tx *memdb.Txn) (memdb.ResultIterator, error) {
 
 // RestoreTxn is used when restoring from a snapshot. For general inserts, use
 // InsertTxn.
-func (g *Graveyard) RestoreTxn(tx *memdb.Txn, stone *Tombstone) error {
+func (g *Graveyard) RestoreTxn(tx *txnWrapper, stone *Tombstone) error {
 	if err := g.insertTombstoneWithTxn(tx, "tombstones", stone, true); err != nil {
 		return fmt.Errorf("failed inserting tombstone: %s", err)
 	}
@@ -88,7 +89,7 @@ func (g *Graveyard) RestoreTxn(tx *memdb.Txn, stone *Tombstone) error {
 
 // ReapTxn cleans out all tombstones whose index values are less than or equal
 // to the given idx. This prevents unbounded storage growth of the tombstones.
-func (g *Graveyard) ReapTxn(tx *memdb.Txn, idx uint64) error {
+func (g *Graveyard) ReapTxn(tx *txnWrapper, idx uint64) error {
 	// This does a full table scan since we currently can't index on a
 	// numeric value. Since this is all in-memory and done infrequently
 	// this pretty reasonable.

--- a/agent/consul/state/graveyard_oss.go
+++ b/agent/consul/state/graveyard_oss.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-func (g *Graveyard) insertTombstoneWithTxn(tx *txnWrapper,
+func (g *Graveyard) insertTombstoneWithTxn(tx *txn,
 	table string, stone *Tombstone, updateMax bool) error {
 
 	if err := tx.Insert("tombstones", stone); err != nil {

--- a/agent/consul/state/graveyard_oss.go
+++ b/agent/consul/state/graveyard_oss.go
@@ -4,11 +4,9 @@ package state
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/go-memdb"
 )
 
-func (g *Graveyard) insertTombstoneWithTxn(tx *memdb.Txn,
+func (g *Graveyard) insertTombstoneWithTxn(tx *txnWrapper,
 	table string, stone *Tombstone, updateMax bool) error {
 
 	if err := tx.Insert("tombstones", stone); err != nil {

--- a/agent/consul/state/graveyard_test.go
+++ b/agent/consul/state/graveyard_test.go
@@ -14,7 +14,7 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 
 	// Create some tombstones.
 	func() {
-		tx := s.db.Txn(true)
+		tx := s.db.WriteTxnRestore()
 		defer tx.Abort()
 
 		if err := g.InsertTxn(tx, "foo/in/the/house", 2, nil); err != nil {
@@ -62,7 +62,7 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 
 	// Reap some tombstones.
 	func() {
-		tx := s.db.Txn(true)
+		tx := s.db.WriteTxnRestore()
 		defer tx.Abort()
 
 		if err := g.ReapTxn(tx, 6); err != nil {
@@ -121,7 +121,7 @@ func TestGraveyard_GC_Trigger(t *testing.T) {
 	// GC.
 	s := testStateStore(t)
 	func() {
-		tx := s.db.Txn(true)
+		tx := s.db.WriteTxnRestore()
 		defer tx.Abort()
 
 		if err := g.InsertTxn(tx, "foo/in/the/house", 2, nil); err != nil {
@@ -136,7 +136,7 @@ func TestGraveyard_GC_Trigger(t *testing.T) {
 
 	// Now commit.
 	func() {
-		tx := s.db.Txn(true)
+		tx := s.db.WriteTxnRestore()
 		defer tx.Abort()
 
 		if err := g.InsertTxn(tx, "foo/in/the/house", 2, nil); err != nil {
@@ -170,7 +170,7 @@ func TestGraveyard_Snapshot_Restore(t *testing.T) {
 
 	// Create some tombstones.
 	func() {
-		tx := s.db.Txn(true)
+		tx := s.db.WriteTxnRestore()
 		defer tx.Abort()
 
 		if err := g.InsertTxn(tx, "foo/in/the/house", 2, nil); err != nil {
@@ -232,7 +232,7 @@ func TestGraveyard_Snapshot_Restore(t *testing.T) {
 	func() {
 		s := testStateStore(t)
 		func() {
-			tx := s.db.Txn(true)
+			tx := s.db.WriteTxnRestore()
 			defer tx.Abort()
 
 			for _, stone := range dump {

--- a/agent/consul/state/graveyard_test.go
+++ b/agent/consul/state/graveyard_test.go
@@ -3,6 +3,8 @@ package state
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGraveyard_Lifecycle(t *testing.T) {
@@ -29,7 +31,7 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 		if err := g.InsertTxn(tx, "some/other/path", 9, nil); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		tx.Commit()
+		require.NoError(t, tx.Commit())
 	}()
 
 	// Check some prefixes.
@@ -68,7 +70,7 @@ func TestGraveyard_Lifecycle(t *testing.T) {
 		if err := g.ReapTxn(tx, 6); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		tx.Commit()
+		require.NoError(t, tx.Commit())
 	}()
 
 	// Check prefixes to see that the reap took effect at the right index.
@@ -142,7 +144,7 @@ func TestGraveyard_GC_Trigger(t *testing.T) {
 		if err := g.InsertTxn(tx, "foo/in/the/house", 2, nil); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		tx.Commit()
+		require.NoError(t, tx.Commit())
 	}()
 
 	// Make sure the GC got hinted.
@@ -185,7 +187,7 @@ func TestGraveyard_Snapshot_Restore(t *testing.T) {
 		if err := g.InsertTxn(tx, "some/other/path", 9, nil); err != nil {
 			t.Fatalf("err: %s", err)
 		}
-		tx.Commit()
+		require.NoError(t, tx.Commit())
 	}()
 
 	// Verify the index was set correctly.
@@ -240,7 +242,7 @@ func TestGraveyard_Snapshot_Restore(t *testing.T) {
 					t.Fatalf("err: %s", err)
 				}
 			}
-			tx.Commit()
+			require.NoError(t, tx.Commit())
 		}()
 
 		// Verify that the restore works.

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -164,8 +164,7 @@ func (s *Store) IntentionSet(idx uint64, ixn *structs.Intention) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // intentionSetTxn is the inner method used to insert an intention with
@@ -260,8 +259,7 @@ func (s *Store) IntentionDelete(idx uint64, id string) error {
 		return fmt.Errorf("failed intention delete: %s", err)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // intentionDeleteTxn is the inner method used to delete a intention

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -169,7 +169,7 @@ func (s *Store) IntentionSet(idx uint64, ixn *structs.Intention) error {
 
 // intentionSetTxn is the inner method used to insert an intention with
 // the proper indexes into the state store.
-func (s *Store) intentionSetTxn(tx *txnWrapper, idx uint64, ixn *structs.Intention) error {
+func (s *Store) intentionSetTxn(tx *txn, idx uint64, ixn *structs.Intention) error {
 	// ID is required
 	if ixn.ID == "" {
 		return ErrMissingIntentionID
@@ -264,7 +264,7 @@ func (s *Store) IntentionDelete(idx uint64, id string) error {
 
 // intentionDeleteTxn is the inner method used to delete a intention
 // with the proper indexes into the state store.
-func (s *Store) intentionDeleteTxn(tx *txnWrapper, idx uint64, queryID string) error {
+func (s *Store) intentionDeleteTxn(tx *txn, idx uint64, queryID string) error {
 	// Pull the query.
 	wrapped, err := tx.First(intentionsTableName, "id", queryID)
 	if err != nil {

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -157,7 +157,7 @@ func (s *Store) Intentions(ws memdb.WatchSet) (uint64, structs.Intentions, error
 
 // IntentionSet creates or updates an intention.
 func (s *Store) IntentionSet(idx uint64, ixn *structs.Intention) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	if err := s.intentionSetTxn(tx, idx, ixn); err != nil {
@@ -170,7 +170,7 @@ func (s *Store) IntentionSet(idx uint64, ixn *structs.Intention) error {
 
 // intentionSetTxn is the inner method used to insert an intention with
 // the proper indexes into the state store.
-func (s *Store) intentionSetTxn(tx *memdb.Txn, idx uint64, ixn *structs.Intention) error {
+func (s *Store) intentionSetTxn(tx *txnWrapper, idx uint64, ixn *structs.Intention) error {
 	// ID is required
 	if ixn.ID == "" {
 		return ErrMissingIntentionID
@@ -253,7 +253,7 @@ func (s *Store) IntentionGet(ws memdb.WatchSet, id string) (uint64, *structs.Int
 
 // IntentionDelete deletes the given intention by ID.
 func (s *Store) IntentionDelete(idx uint64, id string) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	if err := s.intentionDeleteTxn(tx, idx, id); err != nil {
@@ -266,7 +266,7 @@ func (s *Store) IntentionDelete(idx uint64, id string) error {
 
 // intentionDeleteTxn is the inner method used to delete a intention
 // with the proper indexes into the state store.
-func (s *Store) intentionDeleteTxn(tx *memdb.Txn, idx uint64, queryID string) error {
+func (s *Store) intentionDeleteTxn(tx *txnWrapper, idx uint64, queryID string) error {
 	// Pull the query.
 	wrapped, err := tx.First(intentionsTableName, "id", queryID)
 	if err != nil {

--- a/agent/consul/state/kvs.go
+++ b/agent/consul/state/kvs.go
@@ -117,7 +117,7 @@ func (s *Store) KVSSet(idx uint64, entry *structs.DirEntry) error {
 // If updateSession is true, then the incoming entry will set the new
 // session (should be validated before calling this). Otherwise, we will keep
 // whatever the existing session is.
-func (s *Store) kvsSetTxn(tx *txnWrapper, idx uint64, entry *structs.DirEntry, updateSession bool) error {
+func (s *Store) kvsSetTxn(tx *txn, idx uint64, entry *structs.DirEntry, updateSession bool) error {
 	// Retrieve an existing KV pair
 	existingNode, err := firstWithTxn(tx, "kvs", "id", entry.Key, &entry.EnterpriseMeta)
 	if err != nil {
@@ -170,7 +170,7 @@ func (s *Store) KVSGet(ws memdb.WatchSet, key string, entMeta *structs.Enterpris
 
 // kvsGetTxn is the inner method that gets a KVS entry inside an existing
 // transaction.
-func (s *Store) kvsGetTxn(tx *txnWrapper,
+func (s *Store) kvsGetTxn(tx *txn,
 	ws memdb.WatchSet, key string, entMeta *structs.EnterpriseMeta) (uint64, *structs.DirEntry, error) {
 
 	// Get the table index.
@@ -203,7 +203,7 @@ func (s *Store) KVSList(ws memdb.WatchSet,
 
 // kvsListTxn is the inner method that gets a list of KVS entries matching a
 // prefix.
-func (s *Store) kvsListTxn(tx *txnWrapper,
+func (s *Store) kvsListTxn(tx *txn,
 	ws memdb.WatchSet, prefix string, entMeta *structs.EnterpriseMeta) (uint64, structs.DirEntries, error) {
 
 	// Get the table indexes.
@@ -252,7 +252,7 @@ func (s *Store) KVSDelete(idx uint64, key string, entMeta *structs.EnterpriseMet
 
 // kvsDeleteTxn is the inner method used to perform the actual deletion
 // of a key/value pair within an existing transaction.
-func (s *Store) kvsDeleteTxn(tx *txnWrapper, idx uint64, key string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) kvsDeleteTxn(tx *txn, idx uint64, key string, entMeta *structs.EnterpriseMeta) error {
 	// Look up the entry in the state store.
 	entry, err := firstWithTxn(tx, "kvs", "id", key, entMeta)
 	if err != nil {
@@ -289,7 +289,7 @@ func (s *Store) KVSDeleteCAS(idx, cidx uint64, key string, entMeta *structs.Ente
 
 // kvsDeleteCASTxn is the inner method that does a CAS delete within an existing
 // transaction.
-func (s *Store) kvsDeleteCASTxn(tx *txnWrapper, idx, cidx uint64, key string, entMeta *structs.EnterpriseMeta) (bool, error) {
+func (s *Store) kvsDeleteCASTxn(tx *txn, idx, cidx uint64, key string, entMeta *structs.EnterpriseMeta) (bool, error) {
 	// Retrieve the existing kvs entry, if any exists.
 	entry, err := firstWithTxn(tx, "kvs", "id", key, entMeta)
 	if err != nil {
@@ -330,7 +330,7 @@ func (s *Store) KVSSetCAS(idx uint64, entry *structs.DirEntry) (bool, error) {
 
 // kvsSetCASTxn is the inner method used to do a CAS inside an existing
 // transaction.
-func (s *Store) kvsSetCASTxn(tx *txnWrapper, idx uint64, entry *structs.DirEntry) (bool, error) {
+func (s *Store) kvsSetCASTxn(tx *txn, idx uint64, entry *structs.DirEntry) (bool, error) {
 	// Retrieve the existing entry.
 	existing, err := firstWithTxn(tx, "kvs", "id", entry.Key, &entry.EnterpriseMeta)
 	if err != nil {
@@ -394,7 +394,7 @@ func (s *Store) KVSLock(idx uint64, entry *structs.DirEntry) (bool, error) {
 
 // kvsLockTxn is the inner method that does a lock inside an existing
 // transaction.
-func (s *Store) kvsLockTxn(tx *txnWrapper, idx uint64, entry *structs.DirEntry) (bool, error) {
+func (s *Store) kvsLockTxn(tx *txn, idx uint64, entry *structs.DirEntry) (bool, error) {
 	// Verify that a session is present.
 	if entry.Session == "" {
 		return false, fmt.Errorf("missing session")
@@ -460,7 +460,7 @@ func (s *Store) KVSUnlock(idx uint64, entry *structs.DirEntry) (bool, error) {
 
 // kvsUnlockTxn is the inner method that does an unlock inside an existing
 // transaction.
-func (s *Store) kvsUnlockTxn(tx *txnWrapper, idx uint64, entry *structs.DirEntry) (bool, error) {
+func (s *Store) kvsUnlockTxn(tx *txn, idx uint64, entry *structs.DirEntry) (bool, error) {
 	// Verify that a session is present.
 	if entry.Session == "" {
 		return false, fmt.Errorf("missing session")
@@ -498,7 +498,7 @@ func (s *Store) kvsUnlockTxn(tx *txnWrapper, idx uint64, entry *structs.DirEntry
 
 // kvsCheckSessionTxn checks to see if the given session matches the current
 // entry for a key.
-func (s *Store) kvsCheckSessionTxn(tx *txnWrapper,
+func (s *Store) kvsCheckSessionTxn(tx *txn,
 	key string, session string, entMeta *structs.EnterpriseMeta) (*structs.DirEntry, error) {
 
 	entry, err := firstWithTxn(tx, "kvs", "id", key, entMeta)
@@ -519,7 +519,7 @@ func (s *Store) kvsCheckSessionTxn(tx *txnWrapper,
 
 // kvsCheckIndexTxn checks to see if the given modify index matches the current
 // entry for a key.
-func (s *Store) kvsCheckIndexTxn(tx *txnWrapper,
+func (s *Store) kvsCheckIndexTxn(tx *txn,
 	key string, cidx uint64, entMeta *structs.EnterpriseMeta) (*structs.DirEntry, error) {
 
 	entry, err := firstWithTxn(tx, "kvs", "id", key, entMeta)

--- a/agent/consul/state/kvs.go
+++ b/agent/consul/state/kvs.go
@@ -96,8 +96,7 @@ func (s *Store) ReapTombstones(idx uint64, index uint64) error {
 		return fmt.Errorf("failed to reap kvs tombstones: %s", err)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // KVSSet is used to store a key/value pair.
@@ -110,8 +109,7 @@ func (s *Store) KVSSet(idx uint64, entry *structs.DirEntry) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // kvsSetTxn is used to insert or update a key/value pair in the state
@@ -249,8 +247,7 @@ func (s *Store) KVSDelete(idx uint64, key string, entMeta *structs.EnterpriseMet
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // kvsDeleteTxn is the inner method used to perform the actual deletion
@@ -286,8 +283,8 @@ func (s *Store) KVSDeleteCAS(idx, cidx uint64, key string, entMeta *structs.Ente
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // kvsDeleteCASTxn is the inner method that does a CAS delete within an existing
@@ -327,8 +324,8 @@ func (s *Store) KVSSetCAS(idx uint64, entry *structs.DirEntry) (bool, error) {
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // kvsSetCASTxn is the inner method used to do a CAS inside an existing
@@ -371,8 +368,7 @@ func (s *Store) KVSDeleteTree(idx uint64, prefix string, entMeta *structs.Enterp
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // KVSLockDelay returns the expiration time for any lock delay associated with
@@ -392,8 +388,8 @@ func (s *Store) KVSLock(idx uint64, entry *structs.DirEntry) (bool, error) {
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // kvsLockTxn is the inner method that does a lock inside an existing
@@ -458,8 +454,8 @@ func (s *Store) KVSUnlock(idx uint64, entry *structs.DirEntry) (bool, error) {
 		return false, err
 	}
 
-	tx.Commit()
-	return true, nil
+	err = tx.Commit()
+	return err == nil, err
 }
 
 // kvsUnlockTxn is the inner method that does an unlock inside an existing

--- a/agent/consul/state/kvs_oss.go
+++ b/agent/consul/state/kvs_oss.go
@@ -16,7 +16,7 @@ func kvsIndexer() *memdb.StringFieldIndex {
 	}
 }
 
-func (s *Store) insertKVTxn(tx *memdb.Txn, entry *structs.DirEntry, updateMax bool) error {
+func (s *Store) insertKVTxn(tx *txnWrapper, entry *structs.DirEntry, updateMax bool) error {
 	if err := tx.Insert("kvs", entry); err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (s *Store) insertKVTxn(tx *memdb.Txn, entry *structs.DirEntry, updateMax bo
 	return nil
 }
 
-func (s *Store) kvsListEntriesTxn(tx *memdb.Txn, ws memdb.WatchSet, prefix string, entMeta *structs.EnterpriseMeta) (uint64, structs.DirEntries, error) {
+func (s *Store) kvsListEntriesTxn(tx *txnWrapper, ws memdb.WatchSet, prefix string, entMeta *structs.EnterpriseMeta) (uint64, structs.DirEntries, error) {
 	var ents structs.DirEntries
 	var lindex uint64
 
@@ -56,7 +56,7 @@ func (s *Store) kvsListEntriesTxn(tx *memdb.Txn, ws memdb.WatchSet, prefix strin
 
 // kvsDeleteTreeTxn is the inner method that does a recursive delete inside an
 // existing transaction.
-func (s *Store) kvsDeleteTreeTxn(tx *memdb.Txn, idx uint64, prefix string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) kvsDeleteTreeTxn(tx *txnWrapper, idx uint64, prefix string, entMeta *structs.EnterpriseMeta) error {
 	// For prefix deletes, only insert one tombstone and delete the entire subtree
 	deleted, err := tx.DeletePrefix("kvs", "id_prefix", prefix)
 	if err != nil {
@@ -77,11 +77,11 @@ func (s *Store) kvsDeleteTreeTxn(tx *memdb.Txn, idx uint64, prefix string, entMe
 	return nil
 }
 
-func kvsMaxIndex(tx *memdb.Txn, entMeta *structs.EnterpriseMeta) uint64 {
+func kvsMaxIndex(tx *txnWrapper, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "kvs", "tombstones")
 }
 
-func (s *Store) kvsDeleteWithEntry(tx *memdb.Txn, entry *structs.DirEntry, idx uint64) error {
+func (s *Store) kvsDeleteWithEntry(tx *txnWrapper, entry *structs.DirEntry, idx uint64) error {
 	// Delete the entry and update the index.
 	if err := tx.Delete("kvs", entry); err != nil {
 		return fmt.Errorf("failed deleting kvs entry: %s", err)

--- a/agent/consul/state/kvs_oss.go
+++ b/agent/consul/state/kvs_oss.go
@@ -16,7 +16,7 @@ func kvsIndexer() *memdb.StringFieldIndex {
 	}
 }
 
-func (s *Store) insertKVTxn(tx *txnWrapper, entry *structs.DirEntry, updateMax bool) error {
+func (s *Store) insertKVTxn(tx *txn, entry *structs.DirEntry, updateMax bool) error {
 	if err := tx.Insert("kvs", entry); err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (s *Store) insertKVTxn(tx *txnWrapper, entry *structs.DirEntry, updateMax b
 	return nil
 }
 
-func (s *Store) kvsListEntriesTxn(tx *txnWrapper, ws memdb.WatchSet, prefix string, entMeta *structs.EnterpriseMeta) (uint64, structs.DirEntries, error) {
+func (s *Store) kvsListEntriesTxn(tx *txn, ws memdb.WatchSet, prefix string, entMeta *structs.EnterpriseMeta) (uint64, structs.DirEntries, error) {
 	var ents structs.DirEntries
 	var lindex uint64
 
@@ -56,7 +56,7 @@ func (s *Store) kvsListEntriesTxn(tx *txnWrapper, ws memdb.WatchSet, prefix stri
 
 // kvsDeleteTreeTxn is the inner method that does a recursive delete inside an
 // existing transaction.
-func (s *Store) kvsDeleteTreeTxn(tx *txnWrapper, idx uint64, prefix string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) kvsDeleteTreeTxn(tx *txn, idx uint64, prefix string, entMeta *structs.EnterpriseMeta) error {
 	// For prefix deletes, only insert one tombstone and delete the entire subtree
 	deleted, err := tx.DeletePrefix("kvs", "id_prefix", prefix)
 	if err != nil {
@@ -77,11 +77,11 @@ func (s *Store) kvsDeleteTreeTxn(tx *txnWrapper, idx uint64, prefix string, entM
 	return nil
 }
 
-func kvsMaxIndex(tx *txnWrapper, entMeta *structs.EnterpriseMeta) uint64 {
+func kvsMaxIndex(tx *txn, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "kvs", "tombstones")
 }
 
-func (s *Store) kvsDeleteWithEntry(tx *txnWrapper, entry *structs.DirEntry, idx uint64) error {
+func (s *Store) kvsDeleteWithEntry(tx *txn, entry *structs.DirEntry, idx uint64) error {
 	// Delete the entry and update the index.
 	if err := tx.Delete("kvs", entry); err != nil {
 		return fmt.Errorf("failed deleting kvs entry: %s", err)

--- a/agent/consul/state/memdb_wrapper.go
+++ b/agent/consul/state/memdb_wrapper.go
@@ -1,0 +1,89 @@
+package state
+
+import (
+	"github.com/hashicorp/go-memdb"
+)
+
+// memDBWrapper is a thin shim over memdb.DB which forces all new tranactions to
+// report changes and for those changes to automatically deliver the changed
+// objects to our central event handler in case new streaming events need to be
+// omitted.
+type memDBWrapper struct {
+	*memdb.MemDB
+	// TODO: add publisher
+}
+
+// Txn intercepts MemDB.Txn(). It allows read-only transactions to pass through
+// but fails write transactions as we now need to force callers to use a
+// slightly different API so that change capture can happen automatically. The
+// returned Txn object is wrapped with a no-op wrapper that just keeps all
+// transactions in our state store the same type. The wrapper only has
+// non-passthrough behavior for write transactions though.
+func (db *memDBWrapper) Txn(write bool) *txnWrapper {
+	if write {
+		panic("don't use db.Txn(true), use db.WriteTxn(idx uin64)")
+	}
+	return &txnWrapper{
+		Txn: db.MemDB.Txn(false),
+	}
+}
+
+// WriteTxn returns a wrapped memdb.Txn suitable for writes to the state store.
+// It will track changes and publish events for them automatically when Commit
+// is called. The idx argument should be the index of the currently operating
+// Raft operation. Almost all mutations to state should happen as part of a raft
+// apply so the index of that log being applied should be plumbed through to
+// here. A few exceptional cases are transactions that are only executed on a
+// fresh memdb store during a Restore and a few places in tests where we insert
+// data directly into the DB. These cases may use WriteTxnRestore.
+func (db *memDBWrapper) WriteTxn(idx uint64) *txnWrapper {
+	t := &txnWrapper{
+		Txn:   db.MemDB.Txn(true),
+		Index: idx,
+	}
+	t.Txn.TrackChanges()
+	return t
+}
+
+// WriteTxnRestore returns a wrapped RW transaction that does NOT have change
+// tracking enabled. This should only be used in Restore where we need to
+// replace the entire contents of the Store without a need to track the changes
+// made and emit events. Subscribers will all reset on a restore and start
+// again. It also uses a zero index since the whole restore doesn't really occur
+// at one index - the effect is to write many values that were previously
+// written across many indexes.
+func (db *memDBWrapper) WriteTxnRestore() *txnWrapper {
+	t := &txnWrapper{
+		Txn:   db.MemDB.Txn(true),
+		Index: 0,
+	}
+	return t
+}
+
+// txnWrapper wraps a memdb.Txn to automatically capture changes and process
+// events for the write as it commits. This can't be done just with txn.Defer
+// because errors the callback is invoked after commit completes so errors
+// during event publishing would cause silent dropped events while the state
+// store still changed and the write looked successful from the outside.
+type txnWrapper struct {
+	// Index stores the index the write is occuring at in raft if this is a write
+	// transaction. If it's zero it means this is a read transaction.
+	Index uint64
+	*memdb.Txn
+
+	store *Store
+}
+
+// Commit overrides Commit on the underlying memdb.Txn and causes events to be
+// published for any changes. Note that it has a different signature to
+// memdb.Txn - returning an error that should be checked since an error implies
+// that something prevented the commit from completing.
+//
+// TODO: currently none of the callers check error, should they all be changed?
+func (tx *txnWrapper) Commit() error {
+	//changes := tx.Txn.Changes()
+	// TODO: publish changes
+
+	tx.Txn.Commit()
+	return nil
+}

--- a/agent/consul/state/memdb_wrapper.go
+++ b/agent/consul/state/memdb_wrapper.go
@@ -85,11 +85,9 @@ type txnWrapper struct {
 // Note that this function, unlike memdb.Txn, returns an error which must be checked
 // by the caller. A non-nil error indicates that a commit failed and was not
 // applied.
-// TODO: currently none of the callers check error, should they all be changed?
 func (tx *txnWrapper) Commit() error {
 	// changes may be empty if this is a read-only or WriteTxnRestore transaction.
-	//changes := tx.Txn.Changes()
-	// TODO: publish changes
+	// TODO: publish changes: changes := tx.Txn.Changes()
 
 	tx.Txn.Commit()
 	return nil

--- a/agent/consul/state/memdb_wrapper.go
+++ b/agent/consul/state/memdb_wrapper.go
@@ -17,7 +17,7 @@ type changeTrackerDB struct {
 // with write=true.
 //
 // Deprecated: use either ReadTxn, or WriteTxn.
-func (db *changeTrackerDB) Txn(write bool) *txnWrapper {
+func (db *changeTrackerDB) Txn(write bool) *txn {
 	if write {
 		panic("don't use db.Txn(true), use db.WriteTxn(idx uin64)")
 	}
@@ -26,8 +26,8 @@ func (db *changeTrackerDB) Txn(write bool) *txnWrapper {
 
 // ReadTxn returns a read-only transaction which behaves exactly the same as
 // memdb.Txn
-func (db *changeTrackerDB) ReadTxn() *txnWrapper {
-	return &txnWrapper{Txn: db.db.Txn(false)}
+func (db *changeTrackerDB) ReadTxn() *txn {
+	return &txn{Txn: db.db.Txn(false)}
 }
 
 // WriteTxn returns a wrapped memdb.Txn suitable for writes to the state store.
@@ -40,8 +40,8 @@ func (db *changeTrackerDB) ReadTxn() *txnWrapper {
 // The exceptional cases are transactions that are executed on an empty
 // memdb.DB as part of Restore, and those executed by tests where we insert
 // data directly into the DB. These cases may use WriteTxnRestore.
-func (db *changeTrackerDB) WriteTxn(idx uint64) *txnWrapper {
-	t := &txnWrapper{
+func (db *changeTrackerDB) WriteTxn(idx uint64) *txn {
+	t := &txn{
 		Txn:   db.db.Txn(true),
 		Index: idx,
 	}
@@ -55,22 +55,21 @@ func (db *changeTrackerDB) WriteTxn(idx uint64) *txnWrapper {
 // WriteTxnRestore uses a zero index since the whole restore doesn't really occur
 // at one index - the effect is to write many values that were previously
 // written across many indexes.
-func (db *changeTrackerDB) WriteTxnRestore() *txnWrapper {
-	t := &txnWrapper{
+func (db *changeTrackerDB) WriteTxnRestore() *txn {
+	t := &txn{
 		Txn:   db.db.Txn(true),
 		Index: 0,
 	}
 	return t
 }
 
-// txnWrapper wraps a memdb.Txn to capture changes and send them to the
-// EventPublisher.
+// txn wraps a memdb.Txn to capture changes and send them to the EventPublisher.
 //
 // This can not be done with txn.Defer because the callback passed to Defer is
 // invoked after commit completes, and because the callback can not return an
 // error. Any errors from the callback would be lost,  which would result in a
 // missing change event, even though the state store had changed.
-type txnWrapper struct {
+type txn struct {
 	// Index in raft where the write is occurring. The value is zero for a
 	// read-only transaction, and for a WriteTxnRestore transaction.
 	// Index is stored so that it may be passed along to any subscribers as part
@@ -85,9 +84,9 @@ type txnWrapper struct {
 // Note that this function, unlike memdb.Txn, returns an error which must be checked
 // by the caller. A non-nil error indicates that a commit failed and was not
 // applied.
-func (tx *txnWrapper) Commit() error {
+func (tx *txn) Commit() error {
 	// changes may be empty if this is a read-only or WriteTxnRestore transaction.
-	// TODO: publish changes: changes := tx.Txn.Changes()
+	// TODO(streaming): publish changes: changes := tx.Txn.Changes()
 
 	tx.Txn.Commit()
 	return nil

--- a/agent/consul/state/operations_oss.go
+++ b/agent/consul/state/operations_oss.go
@@ -7,30 +7,30 @@ import (
 	"github.com/hashicorp/go-memdb"
 )
 
-func firstWithTxn(tx *memdb.Txn,
+func firstWithTxn(tx *txnWrapper,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (interface{}, error) {
 
 	return tx.First(table, index, idxVal)
 }
 
-func firstWatchWithTxn(tx *memdb.Txn,
+func firstWatchWithTxn(tx *txnWrapper,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 
 	return tx.FirstWatch(table, index, idxVal)
 }
 
-func firstWatchCompoundWithTxn(tx *memdb.Txn,
+func firstWatchCompoundWithTxn(tx *txnWrapper,
 	table, index string, _ *structs.EnterpriseMeta, idxVals ...interface{}) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(table, index, idxVals...)
 }
 
-func getWithTxn(tx *memdb.Txn,
+func getWithTxn(tx *txnWrapper,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 
 	return tx.Get(table, index, idxVal)
 }
 
-func getCompoundWithTxn(tx *memdb.Txn, table, index string,
+func getCompoundWithTxn(tx *txnWrapper, table, index string,
 	_ *structs.EnterpriseMeta, idxVals ...interface{}) (memdb.ResultIterator, error) {
 
 	return tx.Get(table, index, idxVals...)

--- a/agent/consul/state/operations_oss.go
+++ b/agent/consul/state/operations_oss.go
@@ -7,30 +7,30 @@ import (
 	"github.com/hashicorp/go-memdb"
 )
 
-func firstWithTxn(tx *txnWrapper,
+func firstWithTxn(tx *txn,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (interface{}, error) {
 
 	return tx.First(table, index, idxVal)
 }
 
-func firstWatchWithTxn(tx *txnWrapper,
+func firstWatchWithTxn(tx *txn,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 
 	return tx.FirstWatch(table, index, idxVal)
 }
 
-func firstWatchCompoundWithTxn(tx *txnWrapper,
+func firstWatchCompoundWithTxn(tx *txn,
 	table, index string, _ *structs.EnterpriseMeta, idxVals ...interface{}) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(table, index, idxVals...)
 }
 
-func getWithTxn(tx *txnWrapper,
+func getWithTxn(tx *txn,
 	table, index, idxVal string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 
 	return tx.Get(table, index, idxVal)
 }
 
-func getCompoundWithTxn(tx *txnWrapper, table, index string,
+func getCompoundWithTxn(tx *txn, table, index string,
 	_ *structs.EnterpriseMeta, idxVals ...interface{}) (memdb.ResultIterator, error) {
 
 	return tx.Get(table, index, idxVals...)

--- a/agent/consul/state/prepared_query.go
+++ b/agent/consul/state/prepared_query.go
@@ -137,8 +137,7 @@ func (s *Store) PreparedQuerySet(idx uint64, query *structs.PreparedQuery) error
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // preparedQuerySetTxn is the inner method used to insert a prepared query with
@@ -254,8 +253,7 @@ func (s *Store) PreparedQueryDelete(idx uint64, queryID string) error {
 		return fmt.Errorf("failed prepared query delete: %s", err)
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // preparedQueryDeleteTxn is the inner method used to delete a prepared query

--- a/agent/consul/state/prepared_query.go
+++ b/agent/consul/state/prepared_query.go
@@ -130,7 +130,7 @@ func (s *Restore) PreparedQuery(query *structs.PreparedQuery) error {
 
 // PreparedQuerySet is used to create or update a prepared query.
 func (s *Store) PreparedQuerySet(idx uint64, query *structs.PreparedQuery) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	if err := s.preparedQuerySetTxn(tx, idx, query); err != nil {
@@ -143,7 +143,7 @@ func (s *Store) PreparedQuerySet(idx uint64, query *structs.PreparedQuery) error
 
 // preparedQuerySetTxn is the inner method used to insert a prepared query with
 // the proper indexes into the state store.
-func (s *Store) preparedQuerySetTxn(tx *memdb.Txn, idx uint64, query *structs.PreparedQuery) error {
+func (s *Store) preparedQuerySetTxn(tx *txnWrapper, idx uint64, query *structs.PreparedQuery) error {
 	// Check that the ID is set.
 	if query.ID == "" {
 		return ErrMissingQueryID
@@ -247,7 +247,7 @@ func (s *Store) preparedQuerySetTxn(tx *memdb.Txn, idx uint64, query *structs.Pr
 
 // PreparedQueryDelete deletes the given query by ID.
 func (s *Store) PreparedQueryDelete(idx uint64, queryID string) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	if err := s.preparedQueryDeleteTxn(tx, idx, queryID); err != nil {
@@ -260,7 +260,7 @@ func (s *Store) PreparedQueryDelete(idx uint64, queryID string) error {
 
 // preparedQueryDeleteTxn is the inner method used to delete a prepared query
 // with the proper indexes into the state store.
-func (s *Store) preparedQueryDeleteTxn(tx *memdb.Txn, idx uint64, queryID string) error {
+func (s *Store) preparedQueryDeleteTxn(tx *txnWrapper, idx uint64, queryID string) error {
 	// Pull the query.
 	wrapped, err := tx.First("prepared-queries", "id", queryID)
 	if err != nil {

--- a/agent/consul/state/prepared_query.go
+++ b/agent/consul/state/prepared_query.go
@@ -142,7 +142,7 @@ func (s *Store) PreparedQuerySet(idx uint64, query *structs.PreparedQuery) error
 
 // preparedQuerySetTxn is the inner method used to insert a prepared query with
 // the proper indexes into the state store.
-func (s *Store) preparedQuerySetTxn(tx *txnWrapper, idx uint64, query *structs.PreparedQuery) error {
+func (s *Store) preparedQuerySetTxn(tx *txn, idx uint64, query *structs.PreparedQuery) error {
 	// Check that the ID is set.
 	if query.ID == "" {
 		return ErrMissingQueryID
@@ -258,7 +258,7 @@ func (s *Store) PreparedQueryDelete(idx uint64, queryID string) error {
 
 // preparedQueryDeleteTxn is the inner method used to delete a prepared query
 // with the proper indexes into the state store.
-func (s *Store) preparedQueryDeleteTxn(tx *txnWrapper, idx uint64, queryID string) error {
+func (s *Store) preparedQueryDeleteTxn(tx *txn, idx uint64, queryID string) error {
 	// Pull the query.
 	wrapped, err := tx.First("prepared-queries", "id", queryID)
 	if err != nil {

--- a/agent/consul/state/session.go
+++ b/agent/consul/state/session.go
@@ -170,8 +170,7 @@ func (s *Store) SessionCreate(idx uint64, sess *structs.Session) error {
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // sessionCreateTxn is the inner method used for creating session entries in
@@ -297,8 +296,7 @@ func (s *Store) SessionDestroy(idx uint64, sessionID string, entMeta *structs.En
 		return err
 	}
 
-	tx.Commit()
-	return nil
+	return tx.Commit()
 }
 
 // deleteSessionTxn is the inner method, which is used to do the actual

--- a/agent/consul/state/session.go
+++ b/agent/consul/state/session.go
@@ -155,7 +155,7 @@ func (s *Restore) Session(sess *structs.Session) error {
 
 // SessionCreate is used to register a new session in the state store.
 func (s *Store) SessionCreate(idx uint64, sess *structs.Session) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// This code is technically able to (incorrectly) update an existing
@@ -177,7 +177,7 @@ func (s *Store) SessionCreate(idx uint64, sess *structs.Session) error {
 // sessionCreateTxn is the inner method used for creating session entries in
 // an open transaction. Any health checks registered with the session will be
 // checked for failing status. Returns any error encountered.
-func (s *Store) sessionCreateTxn(tx *memdb.Txn, idx uint64, sess *structs.Session) error {
+func (s *Store) sessionCreateTxn(tx *txnWrapper, idx uint64, sess *structs.Session) error {
 	// Check that we have a session ID
 	if sess.ID == "" {
 		return ErrMissingSessionID
@@ -289,7 +289,7 @@ func (s *Store) NodeSessions(ws memdb.WatchSet, nodeID string, entMeta *structs.
 // implicitly invalidate the session and invoke the specified
 // session destroy behavior.
 func (s *Store) SessionDestroy(idx uint64, sessionID string, entMeta *structs.EnterpriseMeta) error {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	// Call the session deletion.
@@ -303,7 +303,7 @@ func (s *Store) SessionDestroy(idx uint64, sessionID string, entMeta *structs.En
 
 // deleteSessionTxn is the inner method, which is used to do the actual
 // session deletion and handle session invalidation, etc.
-func (s *Store) deleteSessionTxn(tx *memdb.Txn, idx uint64, sessionID string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteSessionTxn(tx *txnWrapper, idx uint64, sessionID string, entMeta *structs.EnterpriseMeta) error {
 	// Look up the session.
 	sess, err := firstWithTxn(tx, "sessions", "id", sessionID, entMeta)
 	if err != nil {

--- a/agent/consul/state/session.go
+++ b/agent/consul/state/session.go
@@ -176,7 +176,7 @@ func (s *Store) SessionCreate(idx uint64, sess *structs.Session) error {
 // sessionCreateTxn is the inner method used for creating session entries in
 // an open transaction. Any health checks registered with the session will be
 // checked for failing status. Returns any error encountered.
-func (s *Store) sessionCreateTxn(tx *txnWrapper, idx uint64, sess *structs.Session) error {
+func (s *Store) sessionCreateTxn(tx *txn, idx uint64, sess *structs.Session) error {
 	// Check that we have a session ID
 	if sess.ID == "" {
 		return ErrMissingSessionID
@@ -301,7 +301,7 @@ func (s *Store) SessionDestroy(idx uint64, sessionID string, entMeta *structs.En
 
 // deleteSessionTxn is the inner method, which is used to do the actual
 // session deletion and handle session invalidation, etc.
-func (s *Store) deleteSessionTxn(tx *txnWrapper, idx uint64, sessionID string, entMeta *structs.EnterpriseMeta) error {
+func (s *Store) deleteSessionTxn(tx *txn, idx uint64, sessionID string, entMeta *structs.EnterpriseMeta) error {
 	// Look up the session.
 	sess, err := firstWithTxn(tx, "sessions", "id", sessionID, entMeta)
 	if err != nil {

--- a/agent/consul/state/session_oss.go
+++ b/agent/consul/state/session_oss.go
@@ -35,7 +35,7 @@ func nodeChecksIndexer() *memdb.CompoundIndex {
 	}
 }
 
-func (s *Store) sessionDeleteWithSession(tx *memdb.Txn, session *structs.Session, idx uint64) error {
+func (s *Store) sessionDeleteWithSession(tx *txnWrapper, session *structs.Session, idx uint64) error {
 	if err := tx.Delete("sessions", session); err != nil {
 		return fmt.Errorf("failed deleting session: %s", err)
 	}
@@ -48,7 +48,7 @@ func (s *Store) sessionDeleteWithSession(tx *memdb.Txn, session *structs.Session
 	return nil
 }
 
-func (s *Store) insertSessionTxn(tx *memdb.Txn, session *structs.Session, idx uint64, updateMax bool) error {
+func (s *Store) insertSessionTxn(tx *txnWrapper, session *structs.Session, idx uint64, updateMax bool) error {
 	if err := tx.Insert("sessions", session); err != nil {
 		return err
 	}
@@ -80,11 +80,11 @@ func (s *Store) insertSessionTxn(tx *memdb.Txn, session *structs.Session, idx ui
 	return nil
 }
 
-func (s *Store) allNodeSessionsTxn(tx *memdb.Txn, node string) (structs.Sessions, error) {
+func (s *Store) allNodeSessionsTxn(tx *txnWrapper, node string) (structs.Sessions, error) {
 	return s.nodeSessionsTxn(tx, nil, node, nil)
 }
 
-func (s *Store) nodeSessionsTxn(tx *memdb.Txn,
+func (s *Store) nodeSessionsTxn(tx *txnWrapper,
 	ws memdb.WatchSet, node string, entMeta *structs.EnterpriseMeta) (structs.Sessions, error) {
 
 	sessions, err := tx.Get("sessions", "node", node)
@@ -100,11 +100,11 @@ func (s *Store) nodeSessionsTxn(tx *memdb.Txn,
 	return result, nil
 }
 
-func (s *Store) sessionMaxIndex(tx *memdb.Txn, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) sessionMaxIndex(tx *txnWrapper, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "sessions")
 }
 
-func (s *Store) validateSessionChecksTxn(tx *memdb.Txn, session *structs.Session) error {
+func (s *Store) validateSessionChecksTxn(tx *txnWrapper, session *structs.Session) error {
 	// Go over the session checks and ensure they exist.
 	for _, checkID := range session.CheckIDs() {
 		check, err := tx.First("checks", "id", session.Node, string(checkID))

--- a/agent/consul/state/session_oss.go
+++ b/agent/consul/state/session_oss.go
@@ -35,7 +35,7 @@ func nodeChecksIndexer() *memdb.CompoundIndex {
 	}
 }
 
-func (s *Store) sessionDeleteWithSession(tx *txnWrapper, session *structs.Session, idx uint64) error {
+func (s *Store) sessionDeleteWithSession(tx *txn, session *structs.Session, idx uint64) error {
 	if err := tx.Delete("sessions", session); err != nil {
 		return fmt.Errorf("failed deleting session: %s", err)
 	}
@@ -48,7 +48,7 @@ func (s *Store) sessionDeleteWithSession(tx *txnWrapper, session *structs.Sessio
 	return nil
 }
 
-func (s *Store) insertSessionTxn(tx *txnWrapper, session *structs.Session, idx uint64, updateMax bool) error {
+func (s *Store) insertSessionTxn(tx *txn, session *structs.Session, idx uint64, updateMax bool) error {
 	if err := tx.Insert("sessions", session); err != nil {
 		return err
 	}
@@ -80,11 +80,11 @@ func (s *Store) insertSessionTxn(tx *txnWrapper, session *structs.Session, idx u
 	return nil
 }
 
-func (s *Store) allNodeSessionsTxn(tx *txnWrapper, node string) (structs.Sessions, error) {
+func (s *Store) allNodeSessionsTxn(tx *txn, node string) (structs.Sessions, error) {
 	return s.nodeSessionsTxn(tx, nil, node, nil)
 }
 
-func (s *Store) nodeSessionsTxn(tx *txnWrapper,
+func (s *Store) nodeSessionsTxn(tx *txn,
 	ws memdb.WatchSet, node string, entMeta *structs.EnterpriseMeta) (structs.Sessions, error) {
 
 	sessions, err := tx.Get("sessions", "node", node)
@@ -100,11 +100,11 @@ func (s *Store) nodeSessionsTxn(tx *txnWrapper,
 	return result, nil
 }
 
-func (s *Store) sessionMaxIndex(tx *txnWrapper, entMeta *structs.EnterpriseMeta) uint64 {
+func (s *Store) sessionMaxIndex(tx *txn, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "sessions")
 }
 
-func (s *Store) validateSessionChecksTxn(tx *txnWrapper, session *structs.Session) error {
+func (s *Store) validateSessionChecksTxn(tx *txn, session *structs.Session) error {
 	// Go over the session checks and ensure they exist.
 	for _, checkID := range session.CheckIDs() {
 		check, err := tx.First("checks", "id", session.Node, string(checkID))

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -161,7 +161,7 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 		lockDelay:    NewDelay(),
 	}
 	s.db = &memDBWrapper{
-		MemDB: db,
+		db: db,
 	}
 	return s, nil
 }

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -3,8 +3,9 @@ package state
 import (
 	"errors"
 	"fmt"
+
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/go-memdb"
+	memdb "github.com/hashicorp/go-memdb"
 )
 
 var (
@@ -97,7 +98,7 @@ const (
 // from the Raft log through the FSM.
 type Store struct {
 	schema *memdb.DBSchema
-	db     *memdb.MemDB
+	db     *memDBWrapper
 
 	// abandonCh is used to signal watchers that this state store has been
 	// abandoned (usually during a restore). This is only ever closed.
@@ -114,7 +115,7 @@ type Store struct {
 // works by starting a read transaction against the whole state store.
 type Snapshot struct {
 	store     *Store
-	tx        *memdb.Txn
+	tx        *txnWrapper
 	lastIndex uint64
 }
 
@@ -122,7 +123,7 @@ type Snapshot struct {
 // data to a state store.
 type Restore struct {
 	store *Store
-	tx    *memdb.Txn
+	tx    *txnWrapper
 }
 
 // IndexEntry keeps a record of the last index per-table.
@@ -155,10 +156,12 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 	// Create and return the state store.
 	s := &Store{
 		schema:       schema,
-		db:           db,
 		abandonCh:    make(chan struct{}),
 		kvsGraveyard: NewGraveyard(gc),
 		lockDelay:    NewDelay(),
+	}
+	s.db = &memDBWrapper{
+		MemDB: db,
 	}
 	return s, nil
 }
@@ -206,7 +209,7 @@ func (s *Snapshot) Close() {
 // the state store. It works by doing all the restores inside of a single
 // transaction.
 func (s *Store) Restore() *Restore {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxnRestore()
 	return &Restore{s, tx}
 }
 
@@ -244,11 +247,11 @@ func (s *Store) maxIndex(tables ...string) uint64 {
 
 // maxIndexTxn is a helper used to retrieve the highest known index
 // amongst a set of tables in the db.
-func maxIndexTxn(tx *memdb.Txn, tables ...string) uint64 {
+func maxIndexTxn(tx *txnWrapper, tables ...string) uint64 {
 	return maxIndexWatchTxn(tx, nil, tables...)
 }
 
-func maxIndexWatchTxn(tx *memdb.Txn, ws memdb.WatchSet, tables ...string) uint64 {
+func maxIndexWatchTxn(tx *txnWrapper, ws memdb.WatchSet, tables ...string) uint64 {
 	var lindex uint64
 	for _, table := range tables {
 		ch, ti, err := tx.FirstWatch("index", "id", table)
@@ -265,7 +268,7 @@ func maxIndexWatchTxn(tx *memdb.Txn, ws memdb.WatchSet, tables ...string) uint64
 
 // indexUpdateMaxTxn is used when restoring entries and sets the table's index to
 // the given idx only if it's greater than the current index.
-func indexUpdateMaxTxn(tx *memdb.Txn, idx uint64, table string) error {
+func indexUpdateMaxTxn(tx *txnWrapper, idx uint64, table string) error {
 	ti, err := tx.First("index", "id", table)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve existing index: %s", err)

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -221,8 +221,8 @@ func (s *Restore) Abort() {
 
 // Commit commits the changes made by a restore. This or Abort should always be
 // called.
-func (s *Restore) Commit() {
-	s.tx.Commit()
+func (s *Restore) Commit() error {
+	return s.tx.Commit()
 }
 
 // AbandonCh returns a channel you can wait on to know if the state store was

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -115,7 +115,7 @@ type Store struct {
 // works by starting a read transaction against the whole state store.
 type Snapshot struct {
 	store     *Store
-	tx        *txnWrapper
+	tx        *txn
 	lastIndex uint64
 }
 
@@ -123,7 +123,7 @@ type Snapshot struct {
 // data to a state store.
 type Restore struct {
 	store *Store
-	tx    *txnWrapper
+	tx    *txn
 }
 
 // IndexEntry keeps a record of the last index per-table.
@@ -247,11 +247,11 @@ func (s *Store) maxIndex(tables ...string) uint64 {
 
 // maxIndexTxn is a helper used to retrieve the highest known index
 // amongst a set of tables in the db.
-func maxIndexTxn(tx *txnWrapper, tables ...string) uint64 {
+func maxIndexTxn(tx *txn, tables ...string) uint64 {
 	return maxIndexWatchTxn(tx, nil, tables...)
 }
 
-func maxIndexWatchTxn(tx *txnWrapper, ws memdb.WatchSet, tables ...string) uint64 {
+func maxIndexWatchTxn(tx *txn, ws memdb.WatchSet, tables ...string) uint64 {
 	var lindex uint64
 	for _, table := range tables {
 		ch, ti, err := tx.FirstWatch("index", "id", table)
@@ -268,7 +268,7 @@ func maxIndexWatchTxn(tx *txnWrapper, ws memdb.WatchSet, tables ...string) uint6
 
 // indexUpdateMaxTxn is used when restoring entries and sets the table's index to
 // the given idx only if it's greater than the current index.
-func indexUpdateMaxTxn(tx *txnWrapper, idx uint64, table string) error {
+func indexUpdateMaxTxn(tx *txn, idx uint64, table string) error {
 	ti, err := tx.First("index", "id", table)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve existing index: %s", err)

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -98,7 +98,7 @@ const (
 // from the Raft log through the FSM.
 type Store struct {
 	schema *memdb.DBSchema
-	db     *memDBWrapper
+	db     *changeTrackerDB
 
 	// abandonCh is used to signal watchers that this state store has been
 	// abandoned (usually during a restore). This is only ever closed.
@@ -160,7 +160,7 @@ func NewStateStore(gc *TombstoneGC) (*Store, error) {
 		kvsGraveyard: NewGraveyard(gc),
 		lockDelay:    NewDelay(),
 	}
-	s.db = &memDBWrapper{
+	s.db = &changeTrackerDB{
 		db: db,
 	}
 	return s, nil

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -296,7 +296,7 @@ func TestStateStore_indexUpdateMaxTxn(t *testing.T) {
 	testRegisterNode(t, s, 0, "foo")
 	testRegisterNode(t, s, 1, "bar")
 
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxnRestore()
 	if err := indexUpdateMaxTxn(tx, 3, "nodes"); err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -300,7 +300,7 @@ func TestStateStore_indexUpdateMaxTxn(t *testing.T) {
 	if err := indexUpdateMaxTxn(tx, 3, "nodes"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	tx.Commit()
+	require.NoError(t, tx.Commit())
 
 	if max := s.maxIndex("nodes"); max != 3 {
 		t.Fatalf("bad max: %d", max)

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -390,7 +390,12 @@ func (s *Store) TxnRW(idx uint64, ops structs.TxnOps) (structs.TxnResults, struc
 		return nil, errors
 	}
 
-	tx.Commit()
+	err := tx.Commit()
+	if err != nil {
+		return nil, structs.TxnErrors{
+			{What: err.Error(), OpIndex: 0},
+		}
+	}
 	return results, nil
 }
 

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -5,11 +5,10 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-memdb"
 )
 
 // txnKVS handles all KV-related operations.
-func (s *Store) txnKVS(tx *memdb.Txn, idx uint64, op *structs.TxnKVOp) (structs.TxnResults, error) {
+func (s *Store) txnKVS(tx *txnWrapper, idx uint64, op *structs.TxnKVOp) (structs.TxnResults, error) {
 	var entry *structs.DirEntry
 	var err error
 
@@ -111,7 +110,7 @@ func (s *Store) txnKVS(tx *memdb.Txn, idx uint64, op *structs.TxnKVOp) (structs.
 }
 
 // txnSession handles all Session-related operations.
-func (s *Store) txnSession(tx *memdb.Txn, idx uint64, op *structs.TxnSessionOp) error {
+func (s *Store) txnSession(tx *txnWrapper, idx uint64, op *structs.TxnSessionOp) error {
 	var err error
 
 	switch op.Verb {
@@ -128,7 +127,7 @@ func (s *Store) txnSession(tx *memdb.Txn, idx uint64, op *structs.TxnSessionOp) 
 }
 
 // txnIntention handles all Intention-related operations.
-func (s *Store) txnIntention(tx *memdb.Txn, idx uint64, op *structs.TxnIntentionOp) error {
+func (s *Store) txnIntention(tx *txnWrapper, idx uint64, op *structs.TxnIntentionOp) error {
 	switch op.Op {
 	case structs.IntentionOpCreate, structs.IntentionOpUpdate:
 		return s.intentionSetTxn(tx, idx, op.Intention)
@@ -140,7 +139,7 @@ func (s *Store) txnIntention(tx *memdb.Txn, idx uint64, op *structs.TxnIntention
 }
 
 // txnNode handles all Node-related operations.
-func (s *Store) txnNode(tx *memdb.Txn, idx uint64, op *structs.TxnNodeOp) (structs.TxnResults, error) {
+func (s *Store) txnNode(tx *txnWrapper, idx uint64, op *structs.TxnNodeOp) (structs.TxnResults, error) {
 	var entry *structs.Node
 	var err error
 
@@ -209,7 +208,7 @@ func (s *Store) txnNode(tx *memdb.Txn, idx uint64, op *structs.TxnNodeOp) (struc
 }
 
 // txnService handles all Service-related operations.
-func (s *Store) txnService(tx *memdb.Txn, idx uint64, op *structs.TxnServiceOp) (structs.TxnResults, error) {
+func (s *Store) txnService(tx *txnWrapper, idx uint64, op *structs.TxnServiceOp) (structs.TxnResults, error) {
 	switch op.Verb {
 	case api.ServiceGet:
 		entry, err := s.getNodeServiceTxn(tx, op.Node, op.Service.ID, &op.Service.EnterpriseMeta)
@@ -271,7 +270,7 @@ func newTxnResultFromNodeServiceEntry(entry *structs.NodeService) structs.TxnRes
 }
 
 // txnCheck handles all Check-related operations.
-func (s *Store) txnCheck(tx *memdb.Txn, idx uint64, op *structs.TxnCheckOp) (structs.TxnResults, error) {
+func (s *Store) txnCheck(tx *txnWrapper, idx uint64, op *structs.TxnCheckOp) (structs.TxnResults, error) {
 	var entry *structs.HealthCheck
 	var err error
 
@@ -333,7 +332,7 @@ func (s *Store) txnCheck(tx *memdb.Txn, idx uint64, op *structs.TxnCheckOp) (str
 }
 
 // txnDispatch runs the given operations inside the state store transaction.
-func (s *Store) txnDispatch(tx *memdb.Txn, idx uint64, ops structs.TxnOps) (structs.TxnResults, structs.TxnErrors) {
+func (s *Store) txnDispatch(tx *txnWrapper, idx uint64, ops structs.TxnOps) (structs.TxnResults, structs.TxnErrors) {
 	results := make(structs.TxnResults, 0, len(ops))
 	errors := make(structs.TxnErrors, 0, len(ops))
 	for i, op := range ops {
@@ -383,7 +382,7 @@ func (s *Store) txnDispatch(tx *memdb.Txn, idx uint64, ops structs.TxnOps) (stru
 // is done in a full write transaction on the state store, so reads and writes
 // are possible
 func (s *Store) TxnRW(idx uint64, ops structs.TxnOps) (structs.TxnResults, structs.TxnErrors) {
-	tx := s.db.Txn(true)
+	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
 	results, errors := s.txnDispatch(tx, idx, ops)

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -8,7 +8,7 @@ import (
 )
 
 // txnKVS handles all KV-related operations.
-func (s *Store) txnKVS(tx *txnWrapper, idx uint64, op *structs.TxnKVOp) (structs.TxnResults, error) {
+func (s *Store) txnKVS(tx *txn, idx uint64, op *structs.TxnKVOp) (structs.TxnResults, error) {
 	var entry *structs.DirEntry
 	var err error
 
@@ -110,7 +110,7 @@ func (s *Store) txnKVS(tx *txnWrapper, idx uint64, op *structs.TxnKVOp) (structs
 }
 
 // txnSession handles all Session-related operations.
-func (s *Store) txnSession(tx *txnWrapper, idx uint64, op *structs.TxnSessionOp) error {
+func (s *Store) txnSession(tx *txn, idx uint64, op *structs.TxnSessionOp) error {
 	var err error
 
 	switch op.Verb {
@@ -127,7 +127,7 @@ func (s *Store) txnSession(tx *txnWrapper, idx uint64, op *structs.TxnSessionOp)
 }
 
 // txnIntention handles all Intention-related operations.
-func (s *Store) txnIntention(tx *txnWrapper, idx uint64, op *structs.TxnIntentionOp) error {
+func (s *Store) txnIntention(tx *txn, idx uint64, op *structs.TxnIntentionOp) error {
 	switch op.Op {
 	case structs.IntentionOpCreate, structs.IntentionOpUpdate:
 		return s.intentionSetTxn(tx, idx, op.Intention)
@@ -139,7 +139,7 @@ func (s *Store) txnIntention(tx *txnWrapper, idx uint64, op *structs.TxnIntentio
 }
 
 // txnNode handles all Node-related operations.
-func (s *Store) txnNode(tx *txnWrapper, idx uint64, op *structs.TxnNodeOp) (structs.TxnResults, error) {
+func (s *Store) txnNode(tx *txn, idx uint64, op *structs.TxnNodeOp) (structs.TxnResults, error) {
 	var entry *structs.Node
 	var err error
 
@@ -208,7 +208,7 @@ func (s *Store) txnNode(tx *txnWrapper, idx uint64, op *structs.TxnNodeOp) (stru
 }
 
 // txnService handles all Service-related operations.
-func (s *Store) txnService(tx *txnWrapper, idx uint64, op *structs.TxnServiceOp) (structs.TxnResults, error) {
+func (s *Store) txnService(tx *txn, idx uint64, op *structs.TxnServiceOp) (structs.TxnResults, error) {
 	switch op.Verb {
 	case api.ServiceGet:
 		entry, err := s.getNodeServiceTxn(tx, op.Node, op.Service.ID, &op.Service.EnterpriseMeta)
@@ -270,7 +270,7 @@ func newTxnResultFromNodeServiceEntry(entry *structs.NodeService) structs.TxnRes
 }
 
 // txnCheck handles all Check-related operations.
-func (s *Store) txnCheck(tx *txnWrapper, idx uint64, op *structs.TxnCheckOp) (structs.TxnResults, error) {
+func (s *Store) txnCheck(tx *txn, idx uint64, op *structs.TxnCheckOp) (structs.TxnResults, error) {
 	var entry *structs.HealthCheck
 	var err error
 
@@ -332,7 +332,7 @@ func (s *Store) txnCheck(tx *txnWrapper, idx uint64, op *structs.TxnCheckOp) (st
 }
 
 // txnDispatch runs the given operations inside the state store transaction.
-func (s *Store) txnDispatch(tx *txnWrapper, idx uint64, ops structs.TxnOps) (structs.TxnResults, structs.TxnErrors) {
+func (s *Store) txnDispatch(tx *txn, idx uint64, ops structs.TxnOps) (structs.TxnResults, structs.TxnErrors) {
 	results := make(structs.TxnResults, 0, len(ops))
 	errors := make(structs.TxnErrors, 0, len(ops))
 	for i, op := range ops {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/hashicorp/go-connlimit v0.2.0
 	github.com/hashicorp/go-discover v0.0.0-20200501174627-ad1e96bde088
 	github.com/hashicorp/go-hclog v0.12.0
-	github.com/hashicorp/go-memdb v1.0.3
+	github.com/hashicorp/go-memdb v1.1.0
 	github.com/hashicorp/go-msgpack v0.5.5
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-raftchunking v0.6.1
@@ -46,7 +46,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.0
-	github.com/hashicorp/golang-lru v0.5.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hil v0.0.0-20160711231837-1e86c6b523c5
 	github.com/hashicorp/memberlist v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0 h1:vN9wG1D6KG6YHRTWr8512cxGOVgTMEfgEdSj/hr8MPc=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-memdb v1.0.3 h1:iiqzNk8jKB6/sLRj623Ui/Vi1zf21LOUpgzGjTge6a8=
-github.com/hashicorp/go-memdb v1.0.3/go.mod h1:LWQ8R70vPrS4OEY9k28D2z8/Zzyu34NVzeRibGAzHO0=
+github.com/hashicorp/go-memdb v1.1.0 h1:ClvpUXpBA6UDs5+vc1h3wqe4UJU+rwum7CU219SeCbk=
+github.com/hashicorp/go-memdb v1.1.0/go.mod h1:LWQ8R70vPrS4OEY9k28D2z8/Zzyu34NVzeRibGAzHO0=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -246,6 +246,8 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hil v0.0.0-20160711231837-1e86c6b523c5 h1:uk280DXEbQiCOZgCOI3elFSeNxf8YIZiNsbr2pQLYD0=

--- a/vendor/github.com/hashicorp/go-memdb/changes.go
+++ b/vendor/github.com/hashicorp/go-memdb/changes.go
@@ -1,0 +1,34 @@
+package memdb
+
+// Changes describes a set of mutations to memDB tables performed during a
+// transaction.
+type Changes []Change
+
+// Change describes a mutation to an object in a table.
+type Change struct {
+	Table  string
+	Before interface{}
+	After  interface{}
+
+	// primaryKey stores the raw key value from the primary index so that we can
+	// de-duplicate multiple updates of the same object in the same transaction
+	// but we don't expose this implementation detail to the consumer.
+	primaryKey []byte
+}
+
+// Created returns true if the mutation describes a new object being inserted.
+func (m *Change) Created() bool {
+	return m.Before == nil && m.After != nil
+}
+
+// Updated returns true if the mutation describes an existing object being
+// updated.
+func (m *Change) Updated() bool {
+	return m.Before != nil && m.After != nil
+}
+
+// Deleted returns true if the mutation describes an existing object being
+// deleted.
+func (m *Change) Deleted() bool {
+	return m.Before != nil && m.After == nil
+}

--- a/vendor/github.com/hashicorp/go-memdb/index.go
+++ b/vendor/github.com/hashicorp/go-memdb/index.go
@@ -73,7 +73,7 @@ func (s *StringFieldIndex) FromObject(obj interface{}) (bool, []byte, error) {
 
 	if isPtr && !fv.IsValid() {
 		val := ""
-		return true, []byte(val), nil
+		return false, []byte(val), nil
 	}
 
 	val := fv.String()

--- a/vendor/github.com/hashicorp/go-memdb/txn.go
+++ b/vendor/github.com/hashicorp/go-memdb/txn.go
@@ -33,7 +33,23 @@ type Txn struct {
 	rootTxn *iradix.Txn
 	after   []func()
 
+	// changes is used to track the changes performed during the transaction. If
+	// it is nil at transaction start then changes are not tracked.
+	changes Changes
+
 	modified map[tableIndex]*iradix.Txn
+}
+
+// TrackChanges enables change tracking for the transaction. If called at any
+// point before commit, subsequent mutations will be recorded and can be
+// retrieved using ChangeSet. Once this has been called on a transaction it
+// can't be unset. As with other Txn methods it's not safe to call this from a
+// different goroutine than the one making mutations or committing the
+// transaction.
+func (txn *Txn) TrackChanges() {
+	if txn.changes == nil {
+		txn.changes = make(Changes, 0, 1)
+	}
 }
 
 // readableIndex returns a transaction usable for reading the given
@@ -101,6 +117,7 @@ func (txn *Txn) Abort() {
 	// Clear the txn
 	txn.rootTxn = nil
 	txn.modified = nil
+	txn.changes = nil
 
 	// Release the writer lock since this is invalid
 	txn.db.writer.Unlock()
@@ -265,6 +282,14 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 			indexTxn.Insert(val, obj)
 		}
 	}
+	if txn.changes != nil {
+		txn.changes = append(txn.changes, Change{
+			Table:      table,
+			Before:     existing, // might be nil on a create
+			After:      obj,
+			primaryKey: idVal,
+		})
+	}
 	return nil
 }
 
@@ -332,6 +357,14 @@ func (txn *Txn) Delete(table string, obj interface{}) error {
 			}
 		}
 	}
+	if txn.changes != nil {
+		txn.changes = append(txn.changes, Change{
+			Table:      table,
+			Before:     existing,
+			After:      nil, // Now nil indicates deletion
+			primaryKey: idVal,
+		})
+	}
 	return nil
 }
 
@@ -376,6 +409,19 @@ func (txn *Txn) DeletePrefix(table string, prefix_index string, prefix string) (
 		if !ok {
 			return false, fmt.Errorf("object missing primary index")
 		}
+		if txn.changes != nil {
+			// Record the deletion
+			idTxn := txn.writableIndex(table, id)
+			existing, ok := idTxn.Get(idVal)
+			if ok {
+				txn.changes = append(txn.changes, Change{
+					Table:      table,
+					Before:     existing,
+					After:      nil, // Now nil indicates deletion
+					primaryKey: idVal,
+				})
+			}
+		}
 		// Remove the object from all the indexes except the given prefix index
 		for name, indexSchema := range tableSchema.Indexes {
 			if name == deletePrefixIndex {
@@ -413,6 +459,7 @@ func (txn *Txn) DeletePrefix(table string, prefix_index string, prefix string) (
 				}
 			}
 		}
+
 	}
 	if foundAny {
 		indexTxn := txn.writableIndex(table, deletePrefixIndex)
@@ -627,6 +674,82 @@ func (txn *Txn) LowerBound(table, index string, args ...interface{}) (ResultIter
 		iter: indexIter,
 	}
 	return iter, nil
+}
+
+// objectID is a tuple of table name and the raw internal id byte slice
+// converted to a string. It's only converted to a string to make it comparable
+// so this struct can be used as a map index.
+type objectID struct {
+	Table    string
+	IndexVal string
+}
+
+// mutInfo stores metadata about mutations to allow collapsing multiple
+// mutations to the same object into one.
+type mutInfo struct {
+	firstBefore interface{}
+	lastIdx     int
+}
+
+// Changes returns the set of object changes that have been made in the
+// transaction so far. If change tracking is not enabled it wil always return
+// nil. It can be called before or after Commit. If it is before Commit it will
+// return all changes made so far which may not be the same as the final
+// Changes. After abort it will always return nil. As with other Txn methods
+// it's not safe to call this from a different goroutine than the one making
+// mutations or committing the transaction. Mutations will appear in the order
+// they were performed in the transaction but multiple operations to the same
+// object will be collapsed so only the effective overall change to that object
+// is present. If transaction operations are dependent (e.g. copy object X to Y
+// then delete X) this might mean the set of mutations is incomplete to verify
+// history, but it is complete in that the net effect is preserved (Y got a new
+// value, X got removed).
+func (txn *Txn) Changes() Changes {
+	if txn.changes == nil {
+		return nil
+	}
+
+	// De-duplicate mutations by key so all take effect at the point of the last
+	// write but we keep the mutations in order.
+	dups := make(map[objectID]mutInfo)
+	for i, m := range txn.changes {
+		oid := objectID{
+			Table:    m.Table,
+			IndexVal: string(m.primaryKey),
+		}
+		// Store the latest mutation index for each key value
+		mi, ok := dups[oid]
+		if !ok {
+			// First entry for key, store the before value
+			mi.firstBefore = m.Before
+		}
+		mi.lastIdx = i
+		dups[oid] = mi
+	}
+	if len(dups) == len(txn.changes) {
+		// No duplicates found, fast path return it as is
+		return txn.changes
+	}
+
+	// Need to remove the duplicates
+	cs := make(Changes, 0, len(dups))
+	for i, m := range txn.changes {
+		oid := objectID{
+			Table:    m.Table,
+			IndexVal: string(m.primaryKey),
+		}
+		mi := dups[oid]
+		if mi.lastIdx == i {
+			// This was the latest value for this key copy it with the before value in
+			// case it's different. Note that m is not a pointer so we are not
+			// modifying the txn.changeSet here - it's already a copy.
+			m.Before = mi.firstBefore
+			cs = append(cs, m)
+		}
+	}
+	// Store the de-duped version in case this is called again
+	txn.changes = cs
+	return cs
 }
 
 func (txn *Txn) getIndexIterator(table, index string, args ...interface{}) (*iradix.Iterator, []byte, error) {

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/golang-lru
+
+go 1.12

--- a/vendor/github.com/hashicorp/golang-lru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/lru.go
@@ -37,7 +37,7 @@ func (c *Cache) Purge() {
 	c.lock.Unlock()
 }
 
-// Add adds a value to the cache.  Returns true if an eviction occurred.
+// Add adds a value to the cache. Returns true if an eviction occurred.
 func (c *Cache) Add(key, value interface{}) (evicted bool) {
 	c.lock.Lock()
 	evicted = c.lru.Add(key, value)
@@ -71,8 +71,8 @@ func (c *Cache) Peek(key interface{}) (value interface{}, ok bool) {
 	return value, ok
 }
 
-// ContainsOrAdd checks if a key is in the cache  without updating the
-// recent-ness or deleting it for being stale,  and if not, adds the value.
+// ContainsOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
 // Returns whether found and whether an eviction occurred.
 func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
 	c.lock.Lock()
@@ -85,18 +85,52 @@ func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evicted bool) {
 	return false, evicted
 }
 
-// Remove removes the provided key from the cache.
-func (c *Cache) Remove(key interface{}) {
+// PeekOrAdd checks if a key is in the cache without updating the
+// recent-ness or deleting it for being stale, and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) PeekOrAdd(key, value interface{}) (previous interface{}, ok, evicted bool) {
 	c.lock.Lock()
-	c.lru.Remove(key)
+	defer c.lock.Unlock()
+
+	previous, ok = c.lru.Peek(key)
+	if ok {
+		return previous, true, false
+	}
+
+	evicted = c.lru.Add(key, value)
+	return nil, false, evicted
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) (present bool) {
+	c.lock.Lock()
+	present = c.lru.Remove(key)
 	c.lock.Unlock()
+	return
+}
+
+// Resize changes the cache size.
+func (c *Cache) Resize(size int) (evicted int) {
+	c.lock.Lock()
+	evicted = c.lru.Resize(size)
+	c.lock.Unlock()
+	return evicted
 }
 
 // RemoveOldest removes the oldest item from the cache.
-func (c *Cache) RemoveOldest() {
+func (c *Cache) RemoveOldest() (key interface{}, value interface{}, ok bool) {
 	c.lock.Lock()
-	c.lru.RemoveOldest()
+	key, value, ok = c.lru.RemoveOldest()
 	c.lock.Unlock()
+	return
+}
+
+// GetOldest returns the oldest entry
+func (c *Cache) GetOldest() (key interface{}, value interface{}, ok bool) {
+	c.lock.Lock()
+	key, value, ok = c.lru.GetOldest()
+	c.lock.Unlock()
+	return
 }
 
 // Keys returns a slice of the keys in the cache, from oldest to newest.

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -73,6 +73,9 @@ func (c *LRU) Add(key, value interface{}) (evicted bool) {
 func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
+		if ent.Value.(*entry) == nil {
+			return nil, false
+		}
 		return ent.Value.(*entry).value, true
 	}
 	return
@@ -140,6 +143,19 @@ func (c *LRU) Keys() []interface{} {
 // Len returns the number of items in the cache.
 func (c *LRU) Len() int {
 	return c.evictList.Len()
+}
+
+// Resize changes the cache size.
+func (c *LRU) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
 }
 
 // removeOldest removes the oldest item from the cache.

--- a/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/simplelru/lru_interface.go
@@ -10,7 +10,7 @@ type LRUCache interface {
 	// updates the "recently used"-ness of the key. #value, isFound
 	Get(key interface{}) (value interface{}, ok bool)
 
-	// Check if a key exsists in cache without updating the recent-ness.
+	// Checks if a key exists in cache without updating the recent-ness.
 	Contains(key interface{}) (ok bool)
 
 	// Returns key's value without updating the "recently used"-ness of the key.
@@ -31,6 +31,9 @@ type LRUCache interface {
 	// Returns the number of items in the cache.
 	Len() int
 
-	// Clear all cache entries
+	// Clears all cache entries.
 	Purge()
+
+  // Resizes cache, returning number evicted
+  Resize(int) int
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,7 +208,7 @@ github.com/hashicorp/go-discover/provider/vsphere
 github.com/hashicorp/go-hclog
 # github.com/hashicorp/go-immutable-radix v1.1.0
 github.com/hashicorp/go-immutable-radix
-# github.com/hashicorp/go-memdb v1.0.3
+# github.com/hashicorp/go-memdb v1.1.0
 github.com/hashicorp/go-memdb
 # github.com/hashicorp/go-msgpack v0.5.5
 github.com/hashicorp/go-msgpack/codec
@@ -230,7 +230,7 @@ github.com/hashicorp/go-syslog
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/go-version v1.2.0
 github.com/hashicorp/go-version
-# github.com/hashicorp/golang-lru v0.5.1
+# github.com/hashicorp/golang-lru v0.5.4
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/hashicorp/hcl v1.0.0


### PR DESCRIPTION
Extracted from 7965767de0bd62ab07669b85d6879bd5f815d157 (#7547).

This PR adds `agent/consul/state/memdb_wrapper.go` which is used in all state functions to enable `TrackChanges`, and provide a hook to send them to an EventPublisher when `Commit` is called. This is the core mechanism that will allow streaming of change events.

Many of the changes from 7965767de0bd62ab07669b85d6879bd5f815d157 were not included, and will be added in the next PR.

In addition to the changes from 7965767de0bd62ab07669b85d6879bd5f815d157, this PR also makes a few other changes (in separate commits):
* updates vendor to pickup the new memdb methods
* handles the new return error from `Commit`
* updates the godoc strings from the wrappers
* adds a `ReadTxn` method to replace `Txn(false)`
* un-embeds `memdb.DB` so that callers can not accidentally get access to methods that were not wrapped