### PR TITLE
ci: fix log capture for envoy integration tests

### DIFF
--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -51,7 +51,17 @@ func TestEnvoy(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc, func(t *testing.T) {
-			runCmd(t, "run_tests", "CASE_DIR="+tc)
+			caseDir := "CASE_DIR=" + tc
+
+			t.Cleanup(func() {
+				if t.Failed() {
+					runCmd(t, "capture_logs", caseDir)
+				}
+
+				runCmd(t, "test_teardown", caseDir)
+			})
+
+			runCmd(t, "run_tests", caseDir)
 		})
 	}
 }


### PR DESCRIPTION
The previous change, which moved test running to Go, appears to have broken log capturing. I am not entirely sure why, but the `run_tests` function seems to exit on the first error. I guess it's possible that previously it was only the exit trap that was capturing logs, and these calls to `capture_logs` were not doing anything.

This change moves test teardown and log capturing out of run_test, and has the go test runner call them when necessary.