### PR TITLE
docs: fix a link in docs/agent/options

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -194,7 +194,7 @@ The options below are all specified on the command-line.
   the data directory. This is useful when running multiple Consul agents on the same
   host for testing. This defaults to false in Consul prior to version 0.8.5 and in
   0.8.5 and later defaults to true, so you must opt-in for host-based IDs. Host-based
-  IDs are generated using https://github.com/shirou/gopsutil/tree/master/host, which
+  IDs are generated using [gopsutil](https://github.com/shirou/gopsutil/tree/master/host), which
   is shared with HashiCorp's [Nomad](https://www.nomadproject.io/), so if you opt-in
   to host-based IDs then Consul and Nomad will use information on the host to automatically
   assign the same ID in both systems.


### PR DESCRIPTION
The description for the `-disable-host-node-id` parameter has a misformatted link that does not appear after markdown rendering.

<img width="928" alt="Screenshot 2020-06-03 at 10 15 03" src="https://user-images.githubusercontent.com/1161924/83617018-cb1c8280-a588-11ea-9b32-ace39da0a059.png">
