### PR TITLE
ci: Increase lint timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,4 +30,4 @@ linters-settings:
     simplify: false
 
 run:
-  timeout: 5m
+  timeout: 10m


### PR DESCRIPTION
We occasionally see the lint job fail due to this timeout. Likely when the node running lint is under heavy load, because normally it runs much faster (2 minutes).

This commit increases the timeout substantially to work around that problem.