### PR TITLE
[docs/contributing] Fixed github labels

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,8 +18,8 @@ work on an issue, comment on it first and tell us the approach you want to take.
 * Report potential bugs.
 * Suggest product enhancements.
 * Increase our test coverage.
-* Fix a [bug](https://github.com/hashicorp/consul/labels/bug).
-* Implement a requested [enhancement](https://github.com/hashicorp/consul/labels/enhancement).
+* Fix a [bug](https://github.com/hashicorp/consul/labels/type/bug).
+* Implement a requested [enhancement](https://github.com/hashicorp/consul/labels/type/enhancement).
 * Improve our guides and documentation. Consul's [Guides](https://www.consul.io/docs/guides/index.html), [Docs](https://www.consul.io/docs/index.html), and [api godoc](https://godoc.org/github.com/hashicorp/consul/api)
 are deployed from this repo.
 * Respond to questions about usage on the issue tracker or the Consul section of the [HashiCorp forum]: (https://discuss.hashicorp.com/c/consul)


### PR DESCRIPTION
The github labels were changed.

`label:bug` -> ` label:type/bug`
`label:enhancement` -> `label:type/enhancement`

Fixes #8019

