### PR TITLE
Ensure that the ServiceExists helper function normalizes entmeta

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -487,6 +487,8 @@ func (l *State) AddAliasCheck(checkID structs.CheckID, srcServiceID structs.Serv
 
 // ServiceExists return true if the given service does exists
 func (l *State) ServiceExists(serviceID structs.ServiceID) bool {
+	serviceID.EnterpriseMeta.Normalize()
+
 	l.Lock()
 	defer l.Unlock()
 	return l.services[serviceID] != nil


### PR DESCRIPTION
This fixes a unit test failure over in enterprise due to https://github.com/hashicorp/consul/pull/7384