### PR TITLE
Use linkmode=external for the arm builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,18 +236,18 @@ jobs:
             GOARM: 5
             CC: arm-linux-gnueabi-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/linux_armel/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armel/consul  -ldflags="-linkmode=external ${GOLDFLAGS}"
       - run:
           environment:
             GOARM: 6
             CC: arm-linux-gnueabihf-gcc
             GOARCH: arm
-          command: go build -o ./pkg/bin/linux_armhf/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_armhf/consul  -ldflags="-linkmode=external ${GOLDFLAGS}"
       - run:
           environment:
             CC: aarch64-linux-gnu-gcc
             GOARCH: arm64
-          command: go build -o ./pkg/bin/linux_aarch64/consul  -ldflags="${GOLDFLAGS}"
+          command: go build -o ./pkg/bin/linux_aarch64/consul  -ldflags="-linkmode=external ${GOLDFLAGS}"
       - store_artifacts:
           path: ./pkg/bin
 


### PR DESCRIPTION
This gets around some issues regarding too large plt offsets when compiling with CGO