### PR TITLE
ci: Enabled SA2002 staticcheck check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,10 +21,6 @@ issues:
     - linters: [staticcheck]
       text: "SA4006:"
 
-    # Temp ignore SA2002: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test
-    - linters: [staticcheck]
-      text: "SA2002:"
-
 linters-settings:
   gofmt:
     simplify: false

--- a/agent/catalog_endpoint_test.go
+++ b/agent/catalog_endpoint_test.go
@@ -315,7 +315,7 @@ func TestCatalogNodes_Blocking(t *testing.T) {
 		}
 		var out struct{}
 		if err := a.RPC("Catalog.Register", args, &out); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 

--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -1418,10 +1418,11 @@ func TestCatalog_ListServices_Blocking(t *testing.T) {
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		if err := s1.fsm.State().EnsureNode(idx+1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
+			return
 		}
 		if err := s1.fsm.State().EnsureService(idx+2, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "127.0.0.1", Port: 5000}); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 

--- a/agent/consul/kvs_endpoint_test.go
+++ b/agent/consul/kvs_endpoint_test.go
@@ -354,7 +354,7 @@ func TestKVSEndpoint_List_Blocking(t *testing.T) {
 		}
 		var out bool
 		if err := msgpackrpc.CallWithCodec(codec, "KVS.Apply", &arg, &out); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("RPC call failed: %v", err)
 		}
 	}()
 
@@ -891,7 +891,8 @@ func TestKVS_Issue_1626(t *testing.T) {
 		}
 		var dirent structs.IndexedDirEntries
 		if err := msgpackrpc.CallWithCodec(codec, "KVS.Get", &getR, &dirent); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("RPC call failed: %v", err)
+			return
 		}
 		doneCh <- &dirent
 	}()

--- a/agent/event_endpoint_test.go
+++ b/agent/event_endpoint_test.go
@@ -269,7 +269,7 @@ func TestEventList_Blocking(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		p := &UserEvent{Name: "second"}
 		if err := a.UserEvent("dc1", "root", p); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 

--- a/api/kv_test.go
+++ b/api/kv_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPI_ClientPutGetDelete(t *testing.T) {
@@ -246,16 +248,14 @@ func TestAPI_ClientWatchGet(t *testing.T) {
 
 	// Put the key
 	value := []byte("test")
-	doneCh := make(chan struct{})
+	doneCh := make(chan error)
 	go func() {
 		kv := c.KV()
 
 		time.Sleep(100 * time.Millisecond)
 		p := &KVPair{Key: key, Flags: 42, Value: value}
-		if _, err := kv.Put(p, nil); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		doneCh <- struct{}{}
+		_, err := kv.Put(p, nil)
+		doneCh <- err
 	}()
 
 	// Get should work
@@ -278,7 +278,8 @@ func TestAPI_ClientWatchGet(t *testing.T) {
 	}
 
 	// Block until put finishes to avoid a race between it and deferred s.Stop()
-	<-doneCh
+	err = <-doneCh
+	require.NoError(t, err)
 }
 
 func TestAPI_ClientWatchList(t *testing.T) {
@@ -304,16 +305,14 @@ func TestAPI_ClientWatchList(t *testing.T) {
 
 	// Put the key
 	value := []byte("test")
-	doneCh := make(chan struct{})
+	doneCh := make(chan error)
 	go func() {
 		kv := c.KV()
 
 		time.Sleep(100 * time.Millisecond)
 		p := &KVPair{Key: key, Flags: 42, Value: value}
-		if _, err := kv.Put(p, nil); err != nil {
-			t.Fatalf("err: %v", err)
-		}
-		doneCh <- struct{}{}
+		_, err := kv.Put(p, nil)
+		doneCh <- err
 	}()
 
 	// Get should work
@@ -336,7 +335,8 @@ func TestAPI_ClientWatchList(t *testing.T) {
 	}
 
 	// Block until put finishes to avoid a race between it and deferred s.Stop()
-	<-doneCh
+	err = <-doneCh
+	require.NoError(t, err)
 }
 
 func TestAPI_ClientKeys_DeleteRecurse(t *testing.T) {

--- a/api/lock_test.go
+++ b/api/lock_test.go
@@ -189,10 +189,12 @@ func TestAPI_LockContend(t *testing.T) {
 			// Should work eventually, will contend
 			leaderCh, err := lock.Lock(nil)
 			if err != nil {
-				t.Fatalf("err: %v", err)
+				t.Errorf("err: %v", err)
+				return
 			}
 			if leaderCh == nil {
-				t.Fatalf("not leader")
+				t.Errorf("not leader")
+				return
 			}
 			defer lock.Unlock()
 			log.Printf("Contender %d acquired", idx)
@@ -358,7 +360,7 @@ func TestAPI_LockReclaimLock(t *testing.T) {
 	go func() {
 		l2Ch, err := l2.Lock(nil)
 		if err != nil {
-			t.Fatalf("not locked: %v", err)
+			t.Errorf("not locked: %v", err)
 		}
 		reclaimed <- l2Ch
 	}()

--- a/api/semaphore_test.go
+++ b/api/semaphore_test.go
@@ -184,10 +184,12 @@ func TestAPI_SemaphoreContend(t *testing.T) {
 			// Should work eventually, will contend
 			lockCh, err := sema.Acquire(nil)
 			if err != nil {
-				t.Fatalf("err: %v", err)
+				t.Errorf("err: %v", err)
+				return
 			}
 			if lockCh == nil {
-				t.Fatalf("not locked")
+				t.Errorf("not locked")
+				return
 			}
 			defer sema.Release()
 			log.Printf("Contender %d acquired", idx)

--- a/api/watch/funcs_test.go
+++ b/api/watch/funcs_test.go
@@ -127,7 +127,7 @@ func TestKeyWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -194,7 +194,7 @@ func TestKeyWatch_With_PrefixDelete(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -259,7 +259,7 @@ func TestKeyPrefixWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -325,7 +325,7 @@ func TestServicesWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -399,7 +399,7 @@ func TestNodesWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -475,7 +475,7 @@ func TestServiceWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -545,7 +545,7 @@ func TestServiceMultipleTagsWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -637,7 +637,7 @@ func TestChecksWatch_State(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -713,7 +713,7 @@ func TestChecksWatch_Service(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -791,7 +791,7 @@ func TestEventWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -855,7 +855,7 @@ func TestConnectRootsWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -931,7 +931,7 @@ func TestConnectLeafWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()
@@ -1013,7 +1013,7 @@ func TestAgentServiceWatch(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		if err := plan.Run(s.HTTPAddr); err != nil {
-			t.Fatalf("err: %v", err)
+			t.Errorf("err: %v", err)
 		}
 	}()
 	defer plan.Stop()


### PR DESCRIPTION
And handle errors in the main test goroutine.

Calling `Errorf` from a different goroutine is fine because it won't try to exit the goroutine and cause a panic. The test may continue to run for a bit, but will still result in a failure.

In one case changed the channels to pass errors, so the main goroutine can `Fatalf`. The line numbers wont be that useful, but each error should be unique.