### PR TITLE
agent-http: cleanup: return nil instead of err

### DIFF
--- a/agent/http.go
+++ b/agent/http.go
@@ -599,7 +599,7 @@ func (s *HTTPServer) marshalJSON(req *http.Request, obj interface{}) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	return buf, err
+	return buf, nil
 }
 
 // Returns true if the UI is enabled.


### PR DESCRIPTION
Since err is already checked, it should return `nil`.