### PR TITLE
docs: Fix rendering of markdown on performance page

### DIFF
--- a/website/pages/docs/install/performance.mdx
+++ b/website/pages/docs/install/performance.mdx
@@ -104,7 +104,7 @@ Here are some general recommendations:
 
 - Consul will make use of multiple cores, and at least 2 cores are recommended.
 
-- <a name="last-contact"></a>Spurious leader elections can be caused by networking
+- Spurious leader elections can be caused by networking
   issues between the servers or insufficient CPU resources. Users in cloud environments
   often bump their servers up to the next instance class with improved networking
   and CPU until leader elections stabilize, and in Consul 0.7 or later the [performance


### PR DESCRIPTION
Fixes #8049 issue with markdown not being rendered on /docs/install/performance.mdx.