### PR TITLE
Tokens converted from legacy ACLs get their Hash computed (#8047)

### DIFF
--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -630,6 +630,9 @@ func restoreToken(header *snapshotHeader, restore *state.Restore, decoder *codec
 		structs.SanitizeLegacyACLToken(&req)
 	}
 
+	// only set if unset - mitigates a bug where converted legacy tokens could end up without a hash
+	req.SetHash(false)
+
 	return restore.ACLToken(&req)
 }
 

--- a/agent/consul/state/acl.go
+++ b/agent/consul/state/acl.go
@@ -765,6 +765,9 @@ func (s *Store) aclTokenSetTxn(tx *memdb.Txn, idx uint64, token *structs.ACLToke
 		token.ModifyIndex = idx
 	}
 
+	// ensure that a hash is set
+	token.SetHash(false)
+
 	return s.aclTokenInsert(tx, token)
 }
 

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -501,6 +501,7 @@ func TestStateStore_ACLToken_SetGet(t *testing.T) {
 		idx, rtoken, err := s.ACLTokenGetByAccessor(nil, "daf37c07-d04d-4fd5-9678-a8206a57d61a", nil)
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), idx)
+		require.NotEmpty(t, rtoken.Hash)
 		compareTokens(t, token, rtoken)
 		require.Equal(t, uint64(2), rtoken.CreateIndex)
 		require.Equal(t, uint64(2), rtoken.ModifyIndex)
@@ -3843,6 +3844,10 @@ func stripIrrelevantTokenFields(token *structs.ACLToken) *structs.ACLToken {
 	// The raft indexes won't match either because the requester will not
 	// have access to that.
 	tokenCopy.RaftIndex = structs.RaftIndex{}
+
+	// nil out the hash - this is a computed field and we should assert
+	// elsewhere that its not empty when expected
+	tokenCopy.Hash = nil
 	return tokenCopy
 }
 

--- a/agent/structs/acl_legacy.go
+++ b/agent/structs/acl_legacy.go
@@ -72,7 +72,7 @@ func (a *ACL) Convert() *ACLToken {
 		a.Rules = correctedRules
 	}
 
-	return &ACLToken{
+	token := &ACLToken{
 		AccessorID:        "",
 		SecretID:          a.ID,
 		Description:       a.Name,
@@ -83,6 +83,9 @@ func (a *ACL) Convert() *ACLToken {
 		Local:             false,
 		RaftIndex:         a.RaftIndex,
 	}
+
+	token.SetHash(true)
+	return token
 }
 
 // Convert attempts to convert an ACLToken into an ACLCompat.

--- a/agent/structs/acl_legacy_test.go
+++ b/agent/structs/acl_legacy_test.go
@@ -73,6 +73,7 @@ func TestStructs_ACL_Convert(t *testing.T) {
 	require.Equal(t, acl.Rules, token.Rules)
 	require.Equal(t, acl.CreateIndex, token.CreateIndex)
 	require.Equal(t, acl.ModifyIndex, token.ModifyIndex)
+	require.NotEmpty(t, token.Hash)
 }
 
 func TestStructs_ACLToken_Convert(t *testing.T) {


### PR DESCRIPTION
This allows new style token replication to work for legacy tokens as well when they change.

Fixes #5606