### PR TITLE
Add API query parameter ?ingress to allow users to find ingress gateways associated to a service

### DIFF
--- a/agent/health_endpoint.go
+++ b/agent/health_endpoint.go
@@ -164,7 +164,7 @@ func (s *HTTPServer) HealthServiceNodes(resp http.ResponseWriter, req *http.Requ
 
 func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Request, connect bool) (interface{}, error) {
 	// Set default DC
-	args := structs.ServiceSpecificRequest{Connect: connect}
+	args := structs.ServiceSpecificRequest{}
 	if err := s.parseEntMetaNoWildcard(req, &args.EnterpriseMeta); err != nil {
 		return nil, err
 	}
@@ -185,19 +185,19 @@ func (s *HTTPServer) healthServiceNodes(resp http.ResponseWriter, req *http.Requ
 	prefix := "/v1/health/service/"
 	if connect {
 		prefix = "/v1/health/connect/"
-	}
 
-	// Check for ingress request only when requesting connect services
-	if connect {
+		// Check for ingress request only when requesting connect services
 		ingress, err := getBoolQueryParam(params, "ingress")
 		if err != nil {
 			resp.WriteHeader(http.StatusBadRequest)
 			fmt.Fprint(resp, "Invalid value for ?ingress")
 			return nil, nil
 		}
+
 		if ingress {
-			args.Connect = false
 			args.Ingress = true
+		} else {
+			args.Connect = true
 		}
 	}
 

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -513,9 +513,6 @@ type ServiceSpecificRequest struct {
 	// Connect if true will only search for Connect-compatible services.
 	Connect bool
 
-	// TODO(ingress): Add corresponding API changes after figuring out what the
-	// HTTP endpoint looks like
-
 	// Ingress if true will only search for Ingress gateways for the given service.
 	Ingress bool
 

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -211,7 +211,6 @@ func TestAPI_HealthChecks(t *testing.T) {
 	if err := agent.ServiceRegister(reg); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer agent.ServiceDeregister("foo")
 
 	retry.Run(t, func(r *retry.R) {
 		checks := HealthChecks{
@@ -264,7 +263,6 @@ func TestAPI_HealthChecks_NodeMetaFilter(t *testing.T) {
 	if err := agent.ServiceRegister(reg); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer agent.ServiceDeregister("foo")
 
 	retry.Run(t, func(r *retry.R) {
 		checks, meta, err := health.Checks("foo", &QueryOptions{NodeMeta: meta})
@@ -354,7 +352,6 @@ func TestAPI_HealthService_SingleTag(t *testing.T) {
 		},
 	}
 	require.NoError(t, agent.ServiceRegister(reg))
-	defer agent.ServiceDeregister("foo1")
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := health.Service("foo", "bar", true, nil)
 		require.NoError(r, err)
@@ -390,7 +387,6 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 		},
 	}
 	require.NoError(t, agent.ServiceRegister(reg))
-	defer agent.ServiceDeregister("foo1")
 
 	reg2 := &AgentServiceRegistration{
 		Name: "foo",
@@ -402,7 +398,6 @@ func TestAPI_HealthService_MultipleTags(t *testing.T) {
 		},
 	}
 	require.NoError(t, agent.ServiceRegister(reg2))
-	defer agent.ServiceDeregister("foo2")
 
 	// Test searching with one tag (two results)
 	retry.Run(t, func(r *retry.R) {
@@ -488,7 +483,6 @@ func TestAPI_HealthConnect(t *testing.T) {
 	}
 	err := agent.ServiceRegister(reg)
 	require.NoError(t, err)
-	defer agent.ServiceDeregister("foo")
 
 	// Register the proxy
 	proxyReg := &AgentServiceRegistration{
@@ -501,7 +495,6 @@ func TestAPI_HealthConnect(t *testing.T) {
 	}
 	err = agent.ServiceRegister(proxyReg)
 	require.NoError(t, err)
-	defer agent.ServiceDeregister("foo-proxy")
 
 	retry.Run(t, func(r *retry.R) {
 		services, meta, err := health.Connect("foo", "", true, nil)
@@ -563,7 +556,6 @@ func TestAPI_HealthConnect_Ingress(t *testing.T) {
 	}
 	err := agent.ServiceRegister(reg)
 	require.NoError(t, err)
-	defer agent.ServiceDeregister("foo")
 
 	// Register the gateway
 	gatewayReg := &AgentServiceRegistration{
@@ -573,7 +565,6 @@ func TestAPI_HealthConnect_Ingress(t *testing.T) {
 	}
 	err = agent.ServiceRegister(gatewayReg)
 	require.NoError(t, err)
-	defer agent.ServiceDeregister("foo-gateway")
 
 	// Associate service and gateway
 	gatewayConfig := &IngressGatewayConfigEntry{


### PR DESCRIPTION
This PR adds the query parameter `?ingress` to the `/v1/health/connect/:service` endpoint. It also adds to the `api` module a new method `health.Ingress()`.

We only allow the option on the connect-enabled health endpoint, not the regular `/v1/health/service/:service` endpoint.