### PR TITLE
ui: Reduce discovery-chain log spam

### DIFF
--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -30,23 +30,7 @@ export default Route.extend({
                 .catch(function() {
                   return null;
                 }),
-              chain: this.chainRepo.findBySlug(params.name, dc, nspace).catch(function(e) {
-                const code = get(e, 'errors.firstObject.status');
-                // Currently we are specifically catching a 500, but we return null
-                // by default, so null for all errors.
-                // The extra code here is mainly for documentation purposes
-                // and for if we need to perform different actions based on the error code
-                // in the future
-                switch (code) {
-                  case '500':
-                    // connect is likely to be disabled
-                    // we just return a null to hide the tab
-                    // `Connect must be enabled in order to use this endpoint`
-                    return null;
-                  default:
-                    return null;
-                }
-              }),
+              chain: this.chainRepo.findBySlug(params.name, dc, nspace),
               proxies: this.proxyRepo.findAllBySlug(params.name, dc, nspace),
               ...model,
             });

--- a/ui-v2/app/services/repository/discovery-chain.js
+++ b/ui-v2/app/services/repository/discovery-chain.js
@@ -1,8 +1,29 @@
 import RepositoryService from 'consul-ui/services/repository';
+import { get, set } from '@ember/object';
 
 const modelName = 'discovery-chain';
+const ERROR_MESH_DISABLED = 'Connect must be enabled in order to use this endpoint';
 export default RepositoryService.extend({
+  meshEnabled: true,
   getModelName: function() {
     return modelName;
+  },
+  findBySlug: function() {
+    if (!this.meshEnabled) {
+      return Promise.resolve();
+    }
+    return this._super(...arguments).catch(e => {
+      const code = get(e, 'errors.firstObject.status');
+      const body = get(e, 'errors.firstObject.detail').trim();
+      switch (code) {
+        case '500':
+          if (body === ERROR_MESH_DISABLED) {
+            set(this, 'meshEnabled', false);
+          }
+          return;
+        default:
+          return;
+      }
+    });
   },
 });

--- a/ui-v2/app/services/repository/type/event-source.js
+++ b/ui-v2/app/services/repository/type/event-source.js
@@ -36,8 +36,8 @@ const createProxy = function(repo, find, settings, cache, serialize = JSON.strin
         // original find... with configuration now added
         return repo[find](...args)
           .then(res => {
-            if (!configuration.settings.enabled) {
-              // blocking isn't enabled, immediately close
+            if (!configuration.settings.enabled || typeof res === 'undefined') {
+              // blocking isn't enabled, or we got no data, immediately close
               this.close();
             }
             return res;

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -31,7 +31,7 @@
 (if (not item.Service.Kind)
                 (hash label="Intentions" href=(href-to "dc.services.show.intentions") selected=(is-href "dc.services.show.intentions"))
 '')
-(if chain
+(if chain.Chain
                 (hash label="Routing" href=(href-to "dc.services.show.routing") selected=(is-href "dc.services.show.routing"))
 '')
 (if (not item.Service.Kind)


### PR DESCRIPTION
Currently the only way that the UI can know whether connect is enabled
or not is whether we get 500 errors from certain endpoints.

One of these endpoints we already use, so aswell as recovering from a
500 error, we also remember that connect is disabled for the rest of the
page 'session' (so until the page is refreshed), and make no further
http requests to the endpoint.

This means that log spam is reduced to only 1 log per page refresh
instead of 1 log per service navigation.

Longer term we'll need some way to dynamically discover whether connect
is enabled per datacenter without relying on something that will add
error logs to consul.

Partly addresses https://github.com/hashicorp/consul/issues/8033