### PR TITLE
Fix ingress dns entry

### DIFF
--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -35,7 +35,7 @@ description: >-
     [protocol](/docs/agent/config-entries/ingress-gateway#protocol) as the
     listener will be routable.
   - The ingress gateway will route traffic based on the host/authority header,
-    expecting a value matching `<service-name>.*`, or if using namespaces,
+    expecting a value matching `<service-name>.ingress.*`, or if using namespaces,
     `<service-name>.ingress.<namespace>.*`.
 
   A wildcard specifier cannot be set on a listener of protocol `tcp`.


### PR DESCRIPTION
In the consul documentation it says that services at ingress gateways are available at one of two locations

```
<service-name>.*
```

or

```
<service-name>.ingress.<namespace>.*
```


This doesn't seem to match wha the ingress gateway documentation says

>To enable easier service discovery, a new Consul DNS subdomain is provided, on \<service>.ingress.\<domain>.

```
<service-name>.ingress.<domain>
```

https://www.consul.io/docs/connect/ingress_gateway

![Screenshot 2020-06-09 14 08 40](https://user-images.githubusercontent.com/242382/84194746-ba717e00-aa5a-11ea-9758-d65e8b8c695a.png)


Its very possible I'm misunderstanding something because I have yet to get ingress-gateways working. I am taking a guess that the documentation is wrong on the ingress-gateway.mdx page and the correct domain should be

```
<service-name>.ingress.*
```

