### PR TITLE
Move ingress param to a new endpoint

### DIFF
--- a/agent/health_endpoint_test.go
+++ b/agent/health_endpoint_test.go
@@ -1139,7 +1139,7 @@ func TestHealthConnectServiceNodes(t *testing.T) {
 	assert.Len(nodes[0].Checks, 0)
 }
 
-func TestHealthConnectServiceNodes_Ingress(t *testing.T) {
+func TestHealthIngressServiceNodes(t *testing.T) {
 	t.Parallel()
 
 	a := NewTestAgent(t, "")
@@ -1179,12 +1179,12 @@ func TestHealthConnectServiceNodes_Ingress(t *testing.T) {
 	require.Nil(t, a.RPC("ConfigEntry.Apply", req, &outB))
 	require.True(t, outB)
 
-	t.Run("no_query_value", func(t *testing.T) {
+	t.Run("associated service", func(t *testing.T) {
 		assert := assert.New(t)
 		req, _ := http.NewRequest("GET", fmt.Sprintf(
-			"/v1/health/connect/%s?ingress", args.Service.Service), nil)
+			"/v1/health/ingress/%s", args.Service.Service), nil)
 		resp := httptest.NewRecorder()
-		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
+		obj, err := a.srv.HealthIngressServiceNodes(resp, req)
 		assert.Nil(err)
 		assertIndex(t, resp)
 
@@ -1195,46 +1195,17 @@ func TestHealthConnectServiceNodes_Ingress(t *testing.T) {
 		require.Equal(t, gatewayArgs.Service.Proxy, nodes[0].Service.Proxy)
 	})
 
-	t.Run("true_value", func(t *testing.T) {
+	t.Run("non-associated service", func(t *testing.T) {
 		assert := assert.New(t)
-		req, _ := http.NewRequest("GET", fmt.Sprintf(
-			"/v1/health/connect/%s?ingress=true", args.Service.Service), nil)
+		req, _ := http.NewRequest("GET",
+			"/v1/health/connect/notexist", nil)
 		resp := httptest.NewRecorder()
-		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.Nil(err)
-		assertIndex(t, resp)
-
-		nodes := obj.(structs.CheckServiceNodes)
-		require.Len(t, nodes, 1)
-		require.Equal(t, structs.ServiceKindIngressGateway, nodes[0].Service.Kind)
-		require.Equal(t, gatewayArgs.Service.Address, nodes[0].Service.Address)
-		require.Equal(t, gatewayArgs.Service.Proxy, nodes[0].Service.Proxy)
-	})
-
-	t.Run("false_value", func(t *testing.T) {
-		assert := assert.New(t)
-		req, _ := http.NewRequest("GET", fmt.Sprintf(
-			"/v1/health/connect/%s?ingress=false", args.Service.Service), nil)
-		resp := httptest.NewRecorder()
-		obj, err := a.srv.HealthConnectServiceNodes(resp, req)
+		obj, err := a.srv.HealthIngressServiceNodes(resp, req)
 		assert.Nil(err)
 		assertIndex(t, resp)
 
 		nodes := obj.(structs.CheckServiceNodes)
 		require.Len(t, nodes, 0)
-	})
-
-	t.Run("invalid_value", func(t *testing.T) {
-		assert := assert.New(t)
-		req, _ := http.NewRequest("GET", fmt.Sprintf(
-			"/v1/health/connect/%s?ingress=notabool", args.Service.Service), nil)
-		resp := httptest.NewRecorder()
-		_, err := a.srv.HealthConnectServiceNodes(resp, req)
-		assert.Equal(400, resp.Code)
-
-		body, err := ioutil.ReadAll(resp.Body)
-		assert.Nil(err)
-		assert.True(bytes.Contains(body, []byte("Invalid value for ?ingress")))
 	})
 }
 

--- a/agent/http_register.go
+++ b/agent/http_register.go
@@ -91,6 +91,7 @@ func init() {
 	registerEndpoint("/v1/health/state/", []string{"GET"}, (*HTTPServer).HealthChecksInState)
 	registerEndpoint("/v1/health/service/", []string{"GET"}, (*HTTPServer).HealthServiceNodes)
 	registerEndpoint("/v1/health/connect/", []string{"GET"}, (*HTTPServer).HealthConnectServiceNodes)
+	registerEndpoint("/v1/health/ingress/", []string{"GET"}, (*HTTPServer).HealthIngressServiceNodes)
 	registerEndpoint("/v1/internal/ui/nodes", []string{"GET"}, (*HTTPServer).UINodes)
 	registerEndpoint("/v1/internal/ui/node/", []string{"GET"}, (*HTTPServer).UINodeInfo)
 	registerEndpoint("/v1/internal/ui/services", []string{"GET"}, (*HTTPServer).UIServices)

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -539,7 +539,7 @@ func TestAPI_HealthConnect_Filter(t *testing.T) {
 	require.Len(t, services, 1)
 }
 
-func TestAPI_HealthConnect_Ingress(t *testing.T) {
+func TestAPI_HealthIngress(t *testing.T) {
 	t.Parallel()
 	c, s := makeClient(t)
 	defer s.Stop()


### PR DESCRIPTION
In discussion with team, it was pointed out that query parameters tend
to be filter mechanism, and that semantically the "/v1/health/connect"
endpoint should return "all healthy connect-enabled endpoints (e.g.
could be side car proxies or native instances) for this service so I can
connect with mTLS".

That does not fit an ingress gateway, so we remove the query parameter
and add a new endpoint "/v1/health/ingress" that semantically means
"all the healthy ingress gateway instances that I can connect to
to access this connect-enabled service without mTLS"