### PR TITLE
Allow users to set hosts to the wildcard specifier when TLS is disabled

### DIFF
--- a/agent/structs/config_entry_gateways_test.go
+++ b/agent/structs/config_entry_gateways_test.go
@@ -392,6 +392,48 @@ func TestIngressConfigEntry_Validate(t *testing.T) {
 			},
 			expectErr: `Host "*-test.example.com" is not valid, a wildcard specifier is only allowed as the leftmost label`,
 		},
+		{
+			name: "wildcard specifier is allowed for hosts when TLS is disabled",
+			entry: IngressGatewayConfigEntry{
+				Kind: "ingress-gateway",
+				Name: "ingress-web",
+				Listeners: []IngressListener{
+					{
+						Port:     1111,
+						Protocol: "http",
+						Services: []IngressService{
+							{
+								Name:  "db",
+								Hosts: []string{"*"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "wildcard specifier is not allowed for hosts when TLS is enabled",
+			entry: IngressGatewayConfigEntry{
+				Kind: "ingress-gateway",
+				Name: "ingress-web",
+				TLS: GatewayTLSConfig{
+					Enabled: true,
+				},
+				Listeners: []IngressListener{
+					{
+						Port:     1111,
+						Protocol: "http",
+						Services: []IngressService{
+							{
+								Name:  "db",
+								Hosts: []string{"*"},
+							},
+						},
+					},
+				},
+			},
+			expectErr: `Host '*' is not allowed when TLS is enabled, all hosts must be valid DNS records to add as a DNSSAN`,
+		},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
This allows easier demoing/testing of ingress gateways, while still
preserving the validation we have for DNSSANs

In https://github.com/hashicorp/consul/pull/7990, we defaulted to always requiring a host header, even if only 1 service is exposed, so that adding another service to the configuration would not accidentally break traffic flows. However, that then made it hard to test ingress gateways using a single service by requiring the correct `Host` header always.

With this PR, a config like so is valid:
```
Kind = "ingress-gateway"
Name = "ingress-gateway"
Listeners = [
  {
    Port = 80
    Protocol = "http"
    Services = [
      {
        Name = "web"
        Hosts = ["*"]
      }
    ]
  }
]
```
and this allows a user to send traffic to the ingress gateway and see it reach the `web` service without having to specify a specific host.

We disallow `*` host when TLS is enabled, because we want all hosts to be valid DNSSAN records.