### PR TITLE
Only pass one hostname via EDS and prefer healthy ones

### DIFF
--- a/agent/proxycfg/state.go
+++ b/agent/proxycfg/state.go
@@ -1568,7 +1568,7 @@ func (s *state) hostnameEndpoints(loggerName string, localDC string, nodes struc
 		sid := nodes[0].Service.CompoundServiceName()
 
 		s.logger.Named(loggerName).
-			Warn("service contains instances with mix of hostnames and IP addresses; only hostnames will be passed to Envoy.",
+			Warn("service contains instances with mix of hostnames and IP addresses; only hostnames will be passed to Envoy",
 				"dc", dc, "service", sid.String())
 	}
 	return resp

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -654,6 +654,7 @@ func (s *Server) makeGatewayCluster(snap *proxycfg.ConfigSnapshot, opts gatewayC
 
 			hostname = addr
 			idx = i
+			break
 		}
 	}
 
@@ -674,7 +675,7 @@ func (s *Server) makeGatewayCluster(snap *proxycfg.ConfigSnapshot, opts gatewayC
 	}
 	if len(uniqueHostnames) > 1 {
 		s.Logger.Named(loggerName).
-			Warn(fmt.Sprintf("service contains instances with more than one unique hostname; only %q be resolved by Envoy.", hostname),
+			Warn(fmt.Sprintf("service contains instances with more than one unique hostname; only %q be resolved by Envoy", hostname),
 				"dc", dc, "service", service.String())
 	}
 

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -672,7 +672,7 @@ func (s *Server) makeGatewayCluster(snap *proxycfg.ConfigSnapshot, opts gatewayC
 
 		return nil
 	}
-	if len(uniqueHostnames) > 0 {
+	if len(uniqueHostnames) > 1 {
 		s.Logger.Named(loggerName).
 			Warn(fmt.Sprintf("service contains instances with more than one unique hostname; only %q be resolved by Envoy.", hostname),
 				"dc", dc, "service", service.String())

--- a/agent/xds/clusters.go
+++ b/agent/xds/clusters.go
@@ -642,9 +642,7 @@ func (s *Server) makeGatewayCluster(snap *proxycfg.ConfigSnapshot, opts gatewayC
 	)
 	for i, e := range opts.hostnameEndpoints {
 		addr, port := e.BestAddress(opts.isRemote)
-		if !uniqueHostnames[addr] {
-			uniqueHostnames[addr] = true
-		}
+		uniqueHostnames[addr] = true
 
 		health, weight := calculateEndpointHealthAndWeight(e, opts.onlyPassing)
 		if health == envoycore.HealthStatus_UNHEALTHY {

--- a/agent/xds/testdata/clusters/mesh-gateway-ignore-extra-resolvers.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-ignore-extra-resolvers.golden
@@ -54,18 +54,6 @@
                 },
                 "healthStatus": "HEALTHY",
                 "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "456.us-west-2.elb.notaws.com",
-                      "portValue": 443
-                    }
-                  }
-                },
-                "healthStatus": "HEALTHY",
-                "loadBalancingWeight": 1
               }
             ]
           }

--- a/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-service-subsets.golden
@@ -54,18 +54,6 @@
                 },
                 "healthStatus": "HEALTHY",
                 "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "456.us-west-2.elb.notaws.com",
-                      "portValue": 443
-                    }
-                  }
-                },
-                "healthStatus": "HEALTHY",
-                "loadBalancingWeight": 1
               }
             ]
           }

--- a/agent/xds/testdata/clusters/mesh-gateway-service-timeouts.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-service-timeouts.golden
@@ -54,18 +54,6 @@
                 },
                 "healthStatus": "HEALTHY",
                 "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "456.us-west-2.elb.notaws.com",
-                      "portValue": 443
-                    }
-                  }
-                },
-                "healthStatus": "HEALTHY",
-                "loadBalancingWeight": 1
               }
             ]
           }

--- a/agent/xds/testdata/clusters/mesh-gateway-using-federation-states.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway-using-federation-states.golden
@@ -54,18 +54,6 @@
                 },
                 "healthStatus": "HEALTHY",
                 "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "456.us-west-2.elb.notaws.com",
-                      "portValue": 443
-                    }
-                  }
-                },
-                "healthStatus": "HEALTHY",
-                "loadBalancingWeight": 1
               }
             ]
           }

--- a/agent/xds/testdata/clusters/mesh-gateway.golden
+++ b/agent/xds/testdata/clusters/mesh-gateway.golden
@@ -54,18 +54,6 @@
                 },
                 "healthStatus": "HEALTHY",
                 "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
-                      "address": "456.us-west-2.elb.notaws.com",
-                      "portValue": 443
-                    }
-                  }
-                },
-                "healthStatus": "HEALTHY",
-                "loadBalancingWeight": 1
               }
             ]
           }

--- a/agent/xds/testdata/clusters/terminating-gateway-hostname-service-subsets.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-hostname-service-subsets.golden
@@ -69,18 +69,6 @@
                 "endpoint": {
                   "address": {
                     "socketAddress": {
-                      "address": "api.mydomain",
-                      "portValue": 8081
-                    }
-                  }
-                },
-                "healthStatus": "UNHEALTHY",
-                "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
                       "address": "api.altdomain",
                       "portValue": 8081
                     }

--- a/agent/xds/testdata/clusters/terminating-gateway-ignore-extra-resolvers.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-ignore-extra-resolvers.golden
@@ -15,18 +15,6 @@
                 "endpoint": {
                   "address": {
                     "socketAddress": {
-                      "address": "api.mydomain",
-                      "portValue": 8081
-                    }
-                  }
-                },
-                "healthStatus": "UNHEALTHY",
-                "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
                       "address": "api.altdomain",
                       "portValue": 8081
                     }

--- a/agent/xds/testdata/clusters/terminating-gateway-service-subsets.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway-service-subsets.golden
@@ -15,18 +15,6 @@
                 "endpoint": {
                   "address": {
                     "socketAddress": {
-                      "address": "api.mydomain",
-                      "portValue": 8081
-                    }
-                  }
-                },
-                "healthStatus": "UNHEALTHY",
-                "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
                       "address": "api.altdomain",
                       "portValue": 8081
                     }

--- a/agent/xds/testdata/clusters/terminating-gateway.golden
+++ b/agent/xds/testdata/clusters/terminating-gateway.golden
@@ -15,18 +15,6 @@
                 "endpoint": {
                   "address": {
                     "socketAddress": {
-                      "address": "api.mydomain",
-                      "portValue": 8081
-                    }
-                  }
-                },
-                "healthStatus": "UNHEALTHY",
-                "loadBalancingWeight": 1
-              },
-              {
-                "endpoint": {
-                  "address": {
-                    "socketAddress": {
                       "address": "api.altdomain",
                       "portValue": 8081
                     }


### PR DESCRIPTION
Currently when passing hostname clusters to Envoy, we set each service instance registered with Consul as an LbEndpoint for the cluster.

However, Envoy can only handle one per cluster:
`[2020-06-04 18:32:34.094][1][warning][config] [source/common/config/grpc_subscription_impl.cc:87] gRPC config for type.googleapis.com/envoy.api.v2.Cluster rejected: Error adding/updating cluster(s) dc2.internal.ddd90499-9b47-91c5-4616-c0cbf0fc358a.consul: LOGICAL_DNS clusters must have a single locality_lb_endpoint and a single lb_endpoint, server.dc2.consul: LOGICAL_DNS clusters must have a single locality_lb_endpoint and a single lb_endpoint`

Envoy is currently handling this gracefully by only picking one of the endpoints. However, we should avoid passing multiple to avoid these warning logs.

This PR:
- Ensures we only pass one endpoint, which is tied to one service instance.
- We prefer sending an endpoint which is marked as Healthy by Consul.
- If no endpoints are healthy we emit a warning and skip the cluster.
- If multiple unique hostnames are spread across service instances we emit a warning and let the user know which will be resolved.