### PR TITLE
ui: Upgrade consul-api-double to use intention response w/o old fields

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -56,7 +56,7 @@
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^2.6.2",
+    "@hashicorp/consul-api-double": "^3.0.0",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1210,10 +1210,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^2.6.2":
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.15.2.tgz#e2c34a348b9959fcc95ffad797c1fed9644a41bd"
-  integrity sha512-VNdwsL3ut4SubCtwWfqX4prD9R/RczKtWUID6s6K9h1TCdzTgpZQhbb+gdzaYGqzCE3Mrw416JzclxVTIFIUFw==
+"@hashicorp/consul-api-double@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-3.0.0.tgz#a1ad94f33e006d01cebf2b22d1f87efef1756ece"
+  integrity sha512-wB1YgDBN3eOvNWRzSOc2k0eVE7C8YHFC5rJEdNWWTzjOokj6zDr40g2yLiaDMXl21XQs5LE8kNstEe8pf2+JUQ==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
`DefaultAddr` and `DefaultPort` where removed from the intentions API both in the backend and frontend in https://github.com/hashicorp/consul/pull/7900.

This updates our API doubles to reflect this removal.

