### PR TITLE
ui: Ensure encoder.js polyfill is available

### DIFF
--- a/ui-v2/ember-cli-build.js
+++ b/ui-v2/ember-cli-build.js
@@ -18,11 +18,11 @@ module.exports = function(defaults) {
       },
       'ember-cli-string-helpers': {
         only: [
-          'capitalize', 
-          'lowercase', 
-          'truncate', 
-          'uppercase', 
-          'humanize', 
+          'capitalize',
+          'lowercase',
+          'truncate',
+          'uppercase',
+          'humanize',
           'titleize'
         ],
       },
@@ -75,6 +75,9 @@ module.exports = function(defaults) {
   // along with the exports of each module as its value.
 
   // TextEncoder/Decoder polyfill. See assets/index.html
+  app.import('node_modules/text-encoding/lib/encoding.js', {
+    outputFile: 'assets/encoding.js',
+  });
   app.import('node_modules/text-encoding/lib/encoding-indexes.js', {
     outputFile: 'assets/encoding-indexes.js',
   });


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/6746 the `encoder.js` polyfill was removed. Meaning our code-editor ceased to work in browsers without TextDecoder support (old Edge versions).

This PR adds this polyfill back in again.