### PR TITLE
Switching service-route, service-resolver, service-splitter examples to CamelCase

### DIFF
--- a/website/pages/docs/agent/config-entries/service-resolver.mdx
+++ b/website/pages/docs/agent/config-entries/service-resolver.mdx
@@ -28,15 +28,15 @@ and discovery terminates.
 Create service subsets based on a version metadata and override the defaults:
 
 ```hcl
-kind           = "service-resolver"
-name           = "web"
-default_subset = "v1"
-subsets = {
+Kind           = "service-resolver"
+Name           = "web"
+DefaultSubset = "v1"
+Subsets = {
   "v1" = {
-    filter = "Service.Meta.version == v1"
+    Filter = "Service.Meta.version == v1"
   }
   "v2" = {
-    filter = "Service.Meta.version == v2"
+    Filter = "Service.Meta.version == v2"
   }
 }
 ```
@@ -44,23 +44,23 @@ subsets = {
 Expose a set of services in another datacenter as a virtual service:
 
 ```hcl
-kind = "service-resolver"
-name = "web-dc2"
-redirect {
-  service    = "web"
-  datacenter = "dc2"
+Kind = "service-resolver"
+Name = "web-dc2"
+Redirect {
+  Service    = "web"
+  Datacenter = "dc2"
 }
 ```
 
 Enable failover for all subsets:
 
 ```hcl
-kind            = "service-resolver"
-name            = "web"
-connect_timeout = "15s"
-failover = {
+Kind            = "service-resolver"
+Name            = "web"
+ConnectTimeout = "15s"
+Failover = {
   "*" = {
-    datacenters = ["dc3", "dc4"]
+    Datacenters = ["dc3", "dc4"]
   }
 }
 ```
@@ -68,8 +68,8 @@ failover = {
 Representation of the defaults when a resolver is not configured:
 
 ```hcl
-kind = "service-resolver"
-name = "web"
+Kind = "service-resolver"
+Name = "web"
 ```
 
 ## Available Fields

--- a/website/pages/docs/agent/config-entries/service-router.mdx
+++ b/website/pages/docs/agent/config-entries/service-router.mdx
@@ -41,18 +41,18 @@ service of the same name.
 Route HTTP requests with a path starting with `/admin` to a different service:
 
 ```hcl
-kind = "service-router"
-name = "web"
-routes = [
+Kind = "service-router"
+Name = "web"
+Routes = [
   {
-    match {
-      http {
-        path_prefix = "/admin"
+    Match {
+      HTTP {
+        PathPrefix = "/admin"
       }
     }
 
-    destination {
-      service = "admin"
+    Destination {
+      Service = "admin"
     }
   },
   # NOTE: a default catch-all will send unmatched traffic to "web"
@@ -62,39 +62,39 @@ routes = [
 Route HTTP requests with a special url parameter or header to a canary subset:
 
 ```hcl
-kind = "service-router"
-name = "web"
-routes = [
+Kind = "service-router"
+Name = "web"
+Routes = [
   {
-    match {
-      http {
-        header = [
+    Match {
+      HTTP {
+        Header = [
           {
-            name  = "x-debug"
-            exact = "1"
+            Name  = "x-debug"
+            Exact = "1"
           },
         ]
       }
     }
-    destination {
-      service        = "web"
-      service_subset = "canary"
+    Destination {
+      Service        = "web"
+      ServiceSubset = "canary"
     }
   },
   {
-    match {
-      http {
-        query_param = [
+    Match {
+      HTTP {
+        QueryParam = [
           {
-            name  = "x-debug"
-            exact = "1"
+            Name  = "x-debug"
+            Exact = "1"
           },
         ]
       }
     }
-    destination {
-      service        = "web"
-      service_subset = "canary"
+    Destination {
+      Service        = "web"
+      ServiceSubset = "canary"
     }
   },
   # NOTE: a default catch-all will send unmatched traffic to "web"
@@ -105,18 +105,18 @@ Re-route a gRPC method to another service. Since gRPC method calls [are
 HTTP2](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), we can use an HTTP path match rule to re-route traffic:
 
 ```hcl
-kind = "service-router"
-name = "billing"
-routes = [
+Kind = "service-router"
+Name = "billing"
+Routes = [
   {
-    match {
-      http {
-        path_exact = "/mycompany.BillingService/GenerateInvoice"
+    Match {
+      HTTP {
+        PathExact = "/mycompany.BillingService/GenerateInvoice"
       }
     }
 
-    destination {
-      service = "invoice-generator"
+    Destination {
+      Service = "invoice-generator"
     }
   },
   # NOTE: a default catch-all will send unmatched traffic to "billing"

--- a/website/pages/docs/agent/config-entries/service-splitter.mdx
+++ b/website/pages/docs/agent/config-entries/service-splitter.mdx
@@ -44,16 +44,16 @@ resolution stage.
 Split traffic between two subsets of the same service:
 
 ```hcl
-kind = "service-splitter"
-name = "web"
-splits = [
+Kind = "service-splitter"
+Name = "web"
+Splits = [
   {
-    weight         = 90
-    service_subset = "v1"
+    Weight         = 90
+    ServiceSubset = "v1"
   },
   {
-    weight         = 10
-    service_subset = "v2"
+    Weight         = 10
+    ServiceSubset = "v2"
   },
 ]
 ```
@@ -61,16 +61,16 @@ splits = [
 Split traffic between two services:
 
 ```hcl
-kind = "service-splitter"
-name = "web"
-splits = [
+Kind = "service-splitter"
+Name = "web"
+Splits = [
   {
-    weight = 50
+    Weight = 50
     # will default to service with same name as config entry ("web")
   },
   {
-    weight  = 10
-    service = "web-rewrite"
+    Weight  = 10
+    Service = "web-rewrite"
   },
 ]
 ```


### PR DESCRIPTION
Switch examples from lower to CamelCase for consistency across all configuration entries. Config entries also are case insensitive, but we prefer to use camelcase for consistency. 