### PR TITLE
docs: add section for /health/ingress/:service API

### DIFF
--- a/website/pages/api-docs/catalog.mdx
+++ b/website/pages/api-docs/catalog.mdx
@@ -904,6 +904,8 @@ top level object. The following selectors and filter operations are supported:
 
 ## List Services for Gateway
 
+-> **1.8.0+:** This API is available in Consul versions 1.8.0 and later.
+
 This endpoint returns the services associated with an ingress gateway or terminating gateway.
 
 | Method | Path                           | Produces           |

--- a/website/pages/api-docs/health.mdx
+++ b/website/pages/api-docs/health.mdx
@@ -405,6 +405,8 @@ Parameters and response format are the same as
 
 ## List Nodes for Ingress Gateways Associated to a Service
 
+-> **1.8.0+:** This API is available in Consul versions 1.8.0 and later.
+
 This endpoint returns the nodes providing a [ingress
 gateway](/docs/connect/ingress-gateway) for a service in a given datacenter.
 

--- a/website/pages/api-docs/health.mdx
+++ b/website/pages/api-docs/health.mdx
@@ -403,6 +403,18 @@ so this endpoint may be used to filter only the Connect-capable endpoints.
 Parameters and response format are the same as
 [`/health/service/:service`](/api/health#list-nodes-for-service).
 
+## List Nodes for Ingress Gateways Associated to a Service
+
+This endpoint returns the nodes providing a [ingress
+gateway](/docs/connect/ingress-gateway) for a service in a given datacenter.
+
+| Method | Path                       | Produces           |
+| ------ | -------------------------- | ------------------ |
+| `GET`  | `/health/ingress/:service` | `application/json` |
+
+Parameters and response format are the same as
+[`/health/service/:service`](/api/health#list-nodes-for-service).
+
 ## List Checks in State
 
 This endpoint returns the checks in the state provided on the path.


### PR DESCRIPTION
Adds API documentation for `/health/ingress/:service`.