### PR TITLE
Add AgentMemberStatus const

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -128,7 +128,7 @@ type AgentMember struct {
 	Addr        string
 	Port        uint16
 	Tags        map[string]string
-	Status      int
+	Status      AgentMemberStatus
 	ProtocolMin uint8
 	ProtocolMax uint8
 	ProtocolCur uint8
@@ -137,7 +137,8 @@ type AgentMember struct {
 	DelegateCur uint8
 }
 
-// AgentMemberStatus corresponds the member status integers to the string status
+// AgentMemberStatus corresponds the member status integers to the string status.
+// The values correspond to those of github.com/hashicorp/serf/serf.MemberStatus.
 type AgentMemberStatus int
 
 const (

--- a/api/agent.go
+++ b/api/agent.go
@@ -122,6 +122,7 @@ type AgentServiceConnectProxyConfig struct {
 }
 
 // AgentMember represents a cluster member known to the agent
+// AgentMemberStatus corresponds the Status integer to a string
 type AgentMember struct {
 	Name        string
 	Addr        string
@@ -135,6 +136,17 @@ type AgentMember struct {
 	DelegateMax uint8
 	DelegateCur uint8
 }
+
+// AgentMemberStatus corresponds the member status integers to the string status
+type AgentMemberStatus int
+
+const (
+	AgentMemberNone    = 0
+	AgentMemberAlive   = 1
+	AgentMemberLeaving = 2
+	AgentMemberLeft    = 3
+	AgentMemberFailed  = 4
+)
 
 // AllSegments is used to select for all segments in MembersOpts.
 const AllSegments = "_all"

--- a/api/agent.go
+++ b/api/agent.go
@@ -128,7 +128,7 @@ type AgentMember struct {
 	Addr        string
 	Port        uint16
 	Tags        map[string]string
-	Status      AgentMemberStatus
+	Status      int
 	ProtocolMin uint8
 	ProtocolMax uint8
 	ProtocolCur uint8

--- a/api/agent.go
+++ b/api/agent.go
@@ -122,12 +122,19 @@ type AgentServiceConnectProxyConfig struct {
 }
 
 // AgentMember represents a cluster member known to the agent
-// AgentMemberStatus corresponds the Status integer to a string
 type AgentMember struct {
-	Name        string
-	Addr        string
-	Port        uint16
-	Tags        map[string]string
+	Name string
+	Addr string
+	Port uint16
+	Tags map[string]string
+	// Status of the Member which corresponds to  github.com/hashicorp/serf/serf.MemberStatus
+	// Value is one of:
+	//
+	// 	  AgentMemberNone    = 0
+	//	  AgentMemberAlive   = 1
+	//	  AgentMemberLeaving = 2
+	//	  AgentMemberLeft    = 3
+	//	  AgentMemberFailed  = 4
 	Status      int
 	ProtocolMin uint8
 	ProtocolMax uint8
@@ -136,18 +143,6 @@ type AgentMember struct {
 	DelegateMax uint8
 	DelegateCur uint8
 }
-
-// AgentMemberStatus corresponds the member status integers to the string status.
-// The values correspond to those of github.com/hashicorp/serf/serf.MemberStatus.
-type AgentMemberStatus int
-
-const (
-	AgentMemberNone    = 0
-	AgentMemberAlive   = 1
-	AgentMemberLeaving = 2
-	AgentMemberLeft    = 3
-	AgentMemberFailed  = 4
-)
 
 // AllSegments is used to select for all segments in MembersOpts.
 const AllSegments = "_all"


### PR DESCRIPTION
Fixing issue brought up in [this Google Groups](https://groups.google.com/g/consul-tool/c/5brpAoNHuAI/m/AJ117ferBAAJ) forum - making it more clear to understand the Status integer in the AgentMember struct. 