### PR TITLE
ui: Change code-editor tested to use querySelectorAll (#8087)

### DIFF
--- a/ui-v2/tests/integration/components/code-editor-test.js
+++ b/ui-v2/tests/integration/components/code-editor-test.js
@@ -15,12 +15,12 @@ module('Integration | Component | code editor', function(hooks) {
     // this test is just to prove it renders something without producing
     // an error. It renders the number 1, but seems to also render some sort of trailing space
     // so just check for presence of CodeMirror
-    assert.equal(this.$().find('.CodeMirror').length, 1);
+    assert.equal(this.element.querySelectorAll('.CodeMirror').length, 1);
 
     // Template block usage:
     await render(hbs`
       {{#code-editor}}{{/code-editor}}
     `);
-    assert.equal(this.$().find('.CodeMirror').length, 1);
+    assert.equal(this.element.querySelectorAll('.CodeMirror').length, 1);
   });
 });


### PR DESCRIPTION
This is a duplicate PR of #8087 to bring it down from ui-staging to master, before removing the ui-staging branch.