### PR TITLE
ui: Don't show duplicate services in the intentions form dropdown

### DIFF
--- a/ui-v2/app/helpers/uniq-by.js
+++ b/ui-v2/app/helpers/uniq-by.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { isEmpty } from '@ember/utils';
+import { A as emberArray } from '@ember/array';
+
+export function uniqBy([byPath, array]) {
+  if (isEmpty(byPath)) {
+    return [];
+  }
+
+  return emberArray(array).uniqBy(byPath);
+}
+
+export default helper(uniqBy);

--- a/ui-v2/app/templates/dc/intentions/edit.hbs
+++ b/ui-v2/app/templates/dc/intentions/edit.hbs
@@ -39,7 +39,7 @@
     <BlockSlot @name="content">
       <ConsulIntentionForm
         @item={{item}}
-        @services={{services}}
+        @services={{uniq-by 'Name' services}}
         @nspaces={{nspaces}}
         @ondelete={{action "route" "delete"}}
         @onsubmit={{action "route" (if item.isNew "create" "update")}}

--- a/ui-v2/tests/acceptance/dc/intentions/filtered-select.feature
+++ b/ui-v2/tests/acceptance/dc/intentions/filtered-select.feature
@@ -8,9 +8,9 @@ Feature: dc / intentions / filtered-select: Intention Service Select Dropdowns
     And 4 service models from yaml
     ---
     - Name: service-0
-      Kind: consul
+      Kind: ~
     - Name: service-1
-      Kind: consul
+      Kind: ~
     - Name: service-2
       Kind: connect-proxy
     - Name: service-3
@@ -26,6 +26,31 @@ Feature: dc / intentions / filtered-select: Intention Service Select Dropdowns
     Then I see the text "* (All Services)" in ".ember-power-select-option:nth-last-child(3)"
     Then I see the text "service-0" in ".ember-power-select-option:nth-last-child(2)"
     Then I see the text "service-1" in ".ember-power-select-option:last-child"
+    Where:
+      ---------------
+      | Name        |
+      | source      |
+      | destination |
+      ---------------
+  Scenario: Opening the [Name] dropdown with 2 services with the same name from different nspaces
+    Given 1 datacenter model with the value "datacenter"
+    And 2 service models from yaml
+    ---
+    - Name: service-0
+      Kind: ~
+    - Name: service-0
+      Namespace: nspace
+      Kind: ~
+    ---
+    When I visit the intention page for yaml
+    ---
+      dc: datacenter
+      intention: intention
+    ---
+    Then the url should be /datacenter/intentions/intention
+    And I click "[data-test-[Name]-element] .ember-power-select-trigger"
+    Then I see the text "* (All Services)" in ".ember-power-select-option:nth-last-child(2)"
+    Then I see the text "service-0" in ".ember-power-select-option:last-child"
     Where:
       ---------------
       | Name        |


### PR DESCRIPTION
This PR adds a uniq-by helper (following `ember-composable-helpers`) and uses it to pass a unique list of services through to the intentions form to be used in the dropdowns for selecting a service.

Fixes https://github.com/hashicorp/consul/issues/8124