### PR TITLE
ui: Remove now unused intention fields DefaultAddr and DefaultPort

### DIFF
--- a/ui-v2/app/models/intention.js
+++ b/ui-v2/app/models/intention.js
@@ -14,11 +14,6 @@ export default Model.extend({
   Precedence: attr('number'),
   SourceType: attr('string', { defaultValue: 'consul' }),
   Action: attr('string', { defaultValue: 'deny' }),
-  // These are in the API response but up until now
-  // aren't used for anything
-  DefaultAddr: attr('string'),
-  DefaultPort: attr('number'),
-  //
   Meta: attr(),
   SyncTime: attr('number'),
   Datacenter: attr('string'),

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -56,7 +56,7 @@
     "@ember/optional-features": "^1.3.0",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^2.6.2",
+    "@hashicorp/consul-api-double": "^3.0.0",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1210,10 +1210,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^2.6.2":
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-2.15.2.tgz#e2c34a348b9959fcc95ffad797c1fed9644a41bd"
-  integrity sha512-VNdwsL3ut4SubCtwWfqX4prD9R/RczKtWUID6s6K9h1TCdzTgpZQhbb+gdzaYGqzCE3Mrw416JzclxVTIFIUFw==
+"@hashicorp/consul-api-double@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-3.0.0.tgz#a1ad94f33e006d01cebf2b22d1f87efef1756ece"
+  integrity sha512-wB1YgDBN3eOvNWRzSOc2k0eVE7C8YHFC5rJEdNWWTzjOokj6zDr40g2yLiaDMXl21XQs5LE8kNstEe8pf2+JUQ==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/7900 these fields where removed, yet the our mocks where not removed to reflect this change, therefore we also PRed https://github.com/hashicorp/consul/pull/8089 to remove these fields from our mocks.

The above changes are earmarked for a 1.9 release, although this complicates matters from a frontend perspective. Therefore we've decided to apply this change to our 1.8.x branch at which point the test will fail until we cherry-pick https://github.com/hashicorp/consul/pull/8089 onto this PR.

None of this has any effect on the app, and just makes things easier moving forwards.