### PR TITLE
Fixing multiple document updates

### DIFF
--- a/website/pages/api-docs/config.mdx
+++ b/website/pages/api-docs/config.mdx
@@ -38,10 +38,15 @@ The table below shows this endpoint's support for
   <sup>1</sup> The ACL required depends on the config entry kind being updated:
 </p>
 
-| Config Entry Kind | Required ACL     |
-| ----------------- | ---------------- |
-| service-defaults  | `service:write`  |
-| proxy-defaults    | `operator:write` |
+| Config Entry Kind   | Required ACL     |
+| -----------------   | ---------------- |
+| ingress-gateway     |
+| proxy-defaults      | `operator:write` |
+| service-defaults    | `service:write`  |
+| service-resolver    |  |
+| service-router      |  |
+| service-splitter    |  |
+| terminating-gateway |  |
 
 ### Parameters
 
@@ -99,10 +104,15 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> The ACL required depends on the config entry kind being read:
 
-| Config Entry Kind | Required ACL   |
-| ----------------- | -------------- |
-| service-defaults  | `service:read` |
-| proxy-defaults    | `<none>`       |
+| Config Entry Kind   | Required ACL     |
+| -----------------   | ---------------- |
+| ingress-gateway     |
+| proxy-defaults      | `<none>` |
+| service-defaults    | `service:read`  |
+| service-resolver    |  |
+| service-router      |  |
+| service-splitter    |  |
+| terminating-gateway |  |
 
 ### Parameters
 
@@ -161,10 +171,15 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> The ACL required depends on the config entry kind being read:
 
-| Config Entry Kind | Required ACL   |
-| ----------------- | -------------- |
-| service-defaults  | `service:read` |
-| proxy-defaults    | `<none>`       |
+| Config Entry Kind   | Required ACL     |
+| -----------------   | ---------------- |
+| ingress-gateway     |
+| proxy-defaults      | `<none>` |
+| service-defaults    | `service:read`  |
+| service-resolver    |  |
+| service-router      |  |
+| service-splitter    |  |
+| terminating-gateway |  |
 
 ### Parameters
 
@@ -229,10 +244,15 @@ The table below shows this endpoint's support for
 
 <sup>1</sup> The ACL required depends on the config entry kind being deleted:
 
-| Config Entry Kind | Required ACL     |
-| ----------------- | ---------------- |
-| service-defaults  | `service:write`  |
-| proxy-defaults    | `operator:write` |
+| Config Entry Kind   | Required ACL     |
+| -----------------   | ---------------- |
+| ingress-gateway     |
+| proxy-defaults      | `operator:write` |
+| service-defaults    | `service:write`  |
+| service-resolver    |  |
+| service-router      |  |
+| service-splitter    |  |
+| terminating-gateway |  |
 
 ### Parameters
 

--- a/website/pages/api-docs/config.mdx
+++ b/website/pages/api-docs/config.mdx
@@ -40,13 +40,13 @@ The table below shows this endpoint's support for
 
 | Config Entry Kind   | Required ACL     |
 | -----------------   | ---------------- |
-| ingress-gateway     |
+| ingress-gateway     | `operator:write` |
 | proxy-defaults      | `operator:write` |
 | service-defaults    | `service:write`  |
-| service-resolver    |  |
-| service-router      |  |
-| service-splitter    |  |
-| terminating-gateway |  |
+| service-resolver    | `service:write`  |
+| service-router      | `service:write`  |
+| service-splitter    | `service:write`  |
+| terminating-gateway | `operator:write` |
 
 ### Parameters
 
@@ -106,13 +106,13 @@ The table below shows this endpoint's support for
 
 | Config Entry Kind   | Required ACL     |
 | -----------------   | ---------------- |
-| ingress-gateway     |
-| proxy-defaults      | `<none>` |
-| service-defaults    | `service:read`  |
-| service-resolver    |  |
-| service-router      |  |
-| service-splitter    |  |
-| terminating-gateway |  |
+| ingress-gateway     | `service:read`   |
+| proxy-defaults      | `<none>`         |
+| service-defaults    | `service:read`   |
+| service-resolver    | `service:read`   |
+| service-router      | `service:read`   |
+| service-splitter    | `service:read`   |
+| terminating-gateway | `service:read`   |
 
 ### Parameters
 
@@ -173,13 +173,13 @@ The table below shows this endpoint's support for
 
 | Config Entry Kind   | Required ACL     |
 | -----------------   | ---------------- |
-| ingress-gateway     |
-| proxy-defaults      | `<none>` |
-| service-defaults    | `service:read`  |
-| service-resolver    |  |
-| service-router      |  |
-| service-splitter    |  |
-| terminating-gateway |  |
+| ingress-gateway     | `service:read`   | 
+| proxy-defaults      | `<none>`         |
+| service-defaults    | `service:read`   |
+| service-resolver    | `service:read`   |
+| service-router      | `service:read`   |
+| service-splitter    | `service:read`   |
+| terminating-gateway | `service:read`   |
 
 ### Parameters
 
@@ -246,13 +246,13 @@ The table below shows this endpoint's support for
 
 | Config Entry Kind   | Required ACL     |
 | -----------------   | ---------------- |
-| ingress-gateway     |
+| ingress-gateway     | `operator:write` |
 | proxy-defaults      | `operator:write` |
 | service-defaults    | `service:write`  |
-| service-resolver    |  |
-| service-router      |  |
-| service-splitter    |  |
-| terminating-gateway |  |
+| service-resolver    | `service:write`  |
+| service-router      | `service:write`  |
+| service-splitter    | `service:write`  |
+| terminating-gateway | `operator:write` |
 
 ### Parameters
 

--- a/website/pages/api-docs/kv.mdx
+++ b/website/pages/api-docs/kv.mdx
@@ -255,6 +255,11 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
+- `dc` `(string: "")` - Specifies the datacenter to query. This will default to
+  the datacenter of the agent being queried. This is specified as part of the
+  URL as a query parameter, and gives "No path to datacenter" error when dc is
+  invalid.
+
 - `recurse` `(bool: false)` - Specifies to delete all keys which have the
   specified prefix. Without this, only a key with an exact match will be
   deleted.

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -40,7 +40,9 @@ documented below in the
 [reload command](/docs/commands/reload) can also be used to trigger a
 configuration reload.
 
-You can test the following configuration options by following the [Getting Started](https://learn.hashicorp.com/consul/getting-started/install?utm_source=consul.io&utm_medium=docs) guides to install a local agent.
+You can test the following configuration options by following the
+[Getting Started](https://learn.hashicorp.com/consul/getting-started/install?utm_source=consul.io&utm_medium=docs)
+guides to install a local agent.
 
 ## Environment Variables
 
@@ -1802,11 +1804,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
   or "tls13". This defaults to "tls12". WARNING: TLS 1.1 and lower are generally
   considered less secure; avoid using these if possible.
 
-- `tls_cipher_suites` Added in Consul 0.8.2, this
-  specifies the list of supported ciphersuites as a comma-separated-list. The list
-  of all supported ciphersuites is available in the source code
-  [here](https://github.com/hashicorp/consul/blob/master/tlsutil/config.go#L939)
-  or through [this search](https://github.com/hashicorp/consul/search?q=cipherMap+%3A%3D+map&unscoped_q=cipherMap+%3A%3D+map).
+- `tls_cipher_suites` Added in Consul 0.8.2, this specifies the list of
+  supported ciphersuites as a comma-separated-list. The list of all supported
+  ciphersuites is available through 
+  [this search](https://github.com/hashicorp/consul/search?q=cipherMap+%3A%3D+map&unscoped_q=cipherMap+%3A%3D+map).
 
 - `tls_prefer_server_cipher_suites` Added in Consul 0.8.2, this
   will cause Consul to prefer the server's ciphersuite over the client ciphersuites.
@@ -1930,6 +1931,7 @@ Reloading configuration does not reload all configuration items. The
 items which are reloaded include:
 
 - ACL Tokens
+- [Bootstrap](#config_entries_bootstrap)
 - Checks
 - [Discard Check Output](#discard_check_output)
 - HTTP Client Address
@@ -1937,6 +1939,7 @@ items which are reloaded include:
 - [Metric Prefix Filter](#telemetry-prefix_filter)
 - [Node Metadata](#node_meta)
 - [RPC rate limiting](#limits)
+- [HTTP Maximum Connections per Client](#http_max_conns_per_client)
 - Services
 - TLS Configuration
   - Please be aware that this is currently limited to reload a configuration that is already TLS enabled. You cannot enable or disable TLS only with reloading.

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1927,14 +1927,15 @@ required ports and their default settings.
 Reloading configuration does not reload all configuration items. The
 items which are reloaded include:
 
-- Log level
+- ACL Tokens
 - Checks
-- Services
-- Watches
+- [Discard Check Output](#discard_check_output)
 - HTTP Client Address
+- Log level
+- [Metric Prefix Filter](#telemetry-prefix_filter)
+- [Node Metadata](#node_meta)
+- [RPC rate limiting](#limits)
+- Services
 - TLS Configuration
   - Please be aware that this is currently limited to reload a configuration that is already TLS enabled. You cannot enable or disable TLS only with reloading.
-- [Node Metadata](#node_meta)
-- [Metric Prefix Filter](#telemetry-prefix_filter)
-- [Discard Check Output](#discard_check_output)
-- [RPC rate limiting](#limits)
+- Watches

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1751,9 +1751,9 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     statsite.
 
   - `prefix_filter` ((#telemetry-prefix_filter))
-    This is a list of filter rules to apply for allowing/blocking metrics by prefix
-    in the following format:
-
+    This is a list of filter rules to apply for allowing/blocking metrics by
+    prefix in the following format:
+    
     ```json
     ["+consul.raft.apply", "-consul.http", "+consul.http.GET"]
     ```
@@ -1804,7 +1804,9 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
 - `tls_cipher_suites` Added in Consul 0.8.2, this
   specifies the list of supported ciphersuites as a comma-separated-list. The list
-  of all supported ciphersuites is available in the [source code](https://github.com/hashicorp/consul/blob/master/tlsutil/config.go#L363).
+  of all supported ciphersuites is available in the source code
+  [here](https://github.com/hashicorp/consul/blob/master/tlsutil/config.go#L939)
+  or through [this search](https://github.com/hashicorp/consul/search?q=cipherMap+%3A%3D+map&unscoped_q=cipherMap+%3A%3D+map).
 
 - `tls_prefer_server_cipher_suites` Added in Consul 0.8.2, this
   will cause Consul to prefer the server's ciphersuite over the client ciphersuites.

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1931,7 +1931,7 @@ Reloading configuration does not reload all configuration items. The
 items which are reloaded include:
 
 - ACL Tokens
-- [Bootstrap](#config_entries_bootstrap)
+- [Configuration Entry Bootstrap](#config_entries_bootstrap)
 - Checks
 - [Discard Check Output](#discard_check_output)
 - HTTP Client Address

--- a/website/pages/docs/commands/operator/raft.mdx
+++ b/website/pages/docs/commands/operator/raft.mdx
@@ -59,7 +59,7 @@ but may be upgraded to a GUID in a future version of Consul.
 Raft configuration.
 
 `Voter` is "true" or "false", indicating if the server has a vote in the Raft
-configuration. Future versions of Consul may add support for non-voting servers.
+configuration. 
 
 ## remove-peer
 


### PR DESCRIPTION
Fixes #7385 - Document KV Delete DC
Fixes #7432 - Updates Cipher Suites
Fixes #7646 - Config Entry types
Fixes #7663 - ACL Token Reloadable Docs
Updated Reft peers documentation to remove note about future information.