### PR TITLE
ui: Support for Node Identities

### DIFF
--- a/ui-v2/app/adapters/role.js
+++ b/ui-v2/app/adapters/role.js
@@ -50,6 +50,7 @@ export default Adapter.extend({
         Description: serialized.Description,
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
+        NodeIdentities: serialized.NodeIdentities,
         ...Namespace(serialized.Namespace),
       }}
     `;
@@ -66,6 +67,7 @@ export default Adapter.extend({
         Description: serialized.Description,
         Policies: serialized.Policies,
         ServiceIdentities: serialized.ServiceIdentities,
+        NodeIdentities: serialized.NodeIdentities,
         ...Namespace(serialized.Namespace),
       }}
     `;

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -53,6 +53,7 @@ export default Adapter.extend({
         Policies: serialized.Policies,
         Roles: serialized.Roles,
         ServiceIdentities: serialized.ServiceIdentities,
+        NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,
         ...Namespace(serialized.Namespace),
       }}
@@ -84,6 +85,7 @@ export default Adapter.extend({
         Policies: serialized.Policies,
         Roles: serialized.Roles,
         ServiceIdentities: serialized.ServiceIdentities,
+        NodeIdentities: serialized.NodeIdentities,
         Local: serialized.Local,
         ...Namespace(serialized.Namespace),
       }}

--- a/ui-v2/app/components/consul-intention-form/index.hbs
+++ b/ui-v2/app/components/consul-intention-form/index.hbs
@@ -3,7 +3,7 @@
     <div role="group">
       <fieldset>
         <h2>Source</h2>
-        <label data-test-source-element class="type-text{{if _item.error.SourceName ' has-error'}}">
+        <label data-test-source-element class="type-select{{if _item.error.SourceName ' has-error'}}">
           <span>Source Service</span>
           <PowerSelectWithCreate
               @options={{_services}}
@@ -23,7 +23,7 @@
           <em>Search for an existing service, or enter any Service name.</em>
         </label>
   {{#if (env 'CONSUL_NSPACES_ENABLED')}}
-        <label data-test-source-nspace class="type-text{{if _item.error.SourceNS ' has-error'}}">
+        <label data-test-source-nspace class="type-select{{if _item.error.SourceNS ' has-error'}}">
           <span>Source Namespace</span>
           <PowerSelectWithCreate
               @options={{_nspaces}}
@@ -46,7 +46,7 @@
       </fieldset>
       <fieldset>
         <h2>Destination</h2>
-        <label data-test-destination-element class="type-text{{if _item.error.DestinationName ' has-error'}}">
+        <label data-test-destination-element class="type-select{{if _item.error.DestinationName ' has-error'}}">
           <span>Destination Service</span>
           <PowerSelectWithCreate
               @options={{_services}}
@@ -66,7 +66,7 @@
           <em>Search for an existing service, or enter any Service name.</em>
         </label>
   {{#if (env 'CONSUL_NSPACES_ENABLED')}}
-        <label data-test-destination-nspace class="type-text{{if _item.error.DestinationNS ' has-error'}}">
+        <label data-test-destination-nspace class="type-select{{if _item.error.DestinationNS ' has-error'}}">
           <span>Destination Namespace</span>
           <PowerSelectWithCreate
               @options={{_nspaces}}

--- a/ui-v2/app/components/consul-token-list/index.hbs
+++ b/ui-v2/app/components/consul-token-list/index.hbs
@@ -36,7 +36,7 @@
           <dt>Identities</dt>
           <dd>
               {{#each (append (get policies 'identities')) as |item|}}
-                <span data-test-policy class={{policy/typeof item}}>Service Identity: {{item.Name}}</span>
+                <span data-test-policy class={{policy/typeof item}}>{{if (eq item.template 'service-identity') 'Service' 'Node'}} Identity: {{item.Name}}</span>
               {{/each}}
           </dd>
         </dl>

--- a/ui-v2/app/components/consul-token-list/index.hbs
+++ b/ui-v2/app/components/consul-token-list/index.hbs
@@ -10,7 +10,7 @@
           </dd>
         </dl>
 {{/if}}
-<a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>{{substr item.AccessorID -8}}</a>
+        <a href={{href-to 'dc.acls.tokens.edit' item.AccessorID}}>{{substr item.AccessorID -8}}</a>
     </BlockSlot>
     <BlockSlot @name="details">
         <dl>
@@ -23,7 +23,9 @@
   {{#let (get policies 'management') as |management|}}
     {{#if (gt management.length 0)}}
         <dl>
-          <dt>Management</dt>
+          <dt>
+            Management
+          </dt>
           <dd>
               {{#each (get policies 'management') as |item|}}
                 <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
@@ -32,26 +34,34 @@
         </dl>
     {{/if}}
   {{/let}}
+  {{#let (get policies 'identities') as |identities|}}
+    {{#if (gt identities.length 0)}}
         <dl>
           <dt>Identities</dt>
           <dd>
-              {{#each (append (get policies 'identities')) as |item|}}
+              {{#each identities as |item|}}
                 <span data-test-policy class={{policy/typeof item}}>{{if (eq item.template 'service-identity') 'Service' 'Node'}} Identity: {{item.Name}}</span>
               {{/each}}
           </dd>
         </dl>
+    {{/if}}
+  {{/let}}
+  {{#let (append (get policies 'policies') item.Roles) as |policies|}}
+    {{#if (gt policies.length 0)}}
         <dl>
           <dt>Rules</dt>
           <dd>
             {{#if (token/is-legacy item) }}
               Legacy tokens have embedded rules.
             {{ else }}
-              {{#each (append (get policies 'policies') item.Roles) as |item|}}
+              {{#each policies as |item|}}
                 <span data-test-policy class={{policy/typeof item}}>{{item.Name}}</span>
               {{/each}}
             {{/if}}
           </dd>
         </dl>
+    {{/if}}
+  {{/let}}
 {{/let}}
         <dl>
           <dt>Description</dt>

--- a/ui-v2/app/components/node-identity/index.hbs
+++ b/ui-v2/app/components/node-identity/index.hbs
@@ -1,0 +1,6 @@
+node "{{name}}" {
+	policy = "write"
+}
+service_prefix "" {
+	policy = "read"
+}

--- a/ui-v2/app/components/node-identity/index.js
+++ b/ui-v2/app/components/node-identity/index.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: '',
+});

--- a/ui-v2/app/components/policy-form/index.hbs
+++ b/ui-v2/app/components/policy-form/index.hbs
@@ -3,11 +3,11 @@
   {{#yield-slot name='template'}}
   {{else}}
     <header>
-      Policy{{if allowServiceIdentity ' or service identity?' ''}}
+      Policy{{if allowIdentity ' or identity?' ''}}
     </header>
-  {{#if allowServiceIdentity}}
+  {{#if allowIdentity}}
     <p>
-      A Service Identity is default policy with a configurable service name. This saves you some time and effort you're using Consul for Connect features.
+      Identities are default policies with configurable names. They save you some time and effort you're using Consul for Connect features.
     </p>
     {{! this should use radio-group }}
     <div role="radiogroup" class={{if item.error.Type ' has-error'}}>
@@ -34,17 +34,38 @@
     </label>
     <label class="type-text" data-test-rules>
         <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-{{#if (eq item.template '') }}
+{{#if (eq item.template 'service-identity')}}
+        <CodeEditor @readonly={{true}} @name={{concat name "[Rules]"}} @syntax="hcl" @oninput={{action "change" (concat name "[Rules]")}}>
+          {{~component 'service-identity' name=item.Name~}}
+        </CodeEditor>
+{{else if (eq item.template 'node-identity')}}
+        <CodeEditor @readonly={{true}} @name={{concat name "[Rules]"}} @syntax="hcl" @oninput={{action "change" (concat name "[Rules]")}}>
+          {{~component 'node-identity' name=item.Name~}}
+        </CodeEditor>
+{{else}}
         <CodeEditor @syntax="hcl" @class={{if item.error.Rules "error"}} @name={{concat name "[Rules]"}} @value={{item.Rules}} @onkeyup={{action "change" (concat name "[Rules]")}} />
         {{#if item.error.Rules}}
           <strong>{{item.error.Rules.validation}}</strong>
         {{/if}}
-{{else}}
-        <CodeEditor @readonly={{true}} @name={{concat name "[Rules]"}} @syntax="hcl" @oninput={{action "change" (concat name "[Rules]")}}>
-          {{~component 'service-identity' name=item.Name~}}
-        </CodeEditor>
 {{/if}}
     </label>
+{{#if (eq item.template 'node-identity')}}
+
+    <DataSource @src="/*/*/datacenters"
+      @onchange={{action (mut datacenters) value="data"}}
+    />
+    <label class="type-select" data-test-datacenter>
+      <span>Datacenter</span>
+      <PowerSelect
+          @options={{map-by 'Name' datacenters}}
+          @searchField="Name"
+          @selected={{or item.Datacenter dc}}
+          @searchPlaceholder="Type a datacenter name"
+          @onChange={{action "change" "Datacenter"}} as |Name|>
+            {{Name}}
+      </PowerSelect>
+    </label>
+{{else}}
     <div class="type-toggle">
       <span>Valid datacenters</span>
       <label>
@@ -52,10 +73,11 @@
         <span>All</span>
       </label>
     </div>
-{{#if isScoped }}
+  {{#if isScoped }}
     <DataSource @src="/*/*/datacenters"
       @onchange={{action (mut datacenters) value="data"}}
     />
+
     <div class="checkbox-group" role="group">
       {{#each datacenters as |dc| }}
         <label class="type-checkbox">
@@ -72,6 +94,9 @@
 {{/if}}
       {{/each}}
     </div>
+
+
+  {{/if}}
 {{/if}}
 {{#if (eq item.template '') }}
   <label class="type-text">

--- a/ui-v2/app/components/policy-form/index.js
+++ b/ui-v2/app/components/policy-form/index.js
@@ -4,7 +4,7 @@ import { get, set } from '@ember/object';
 export default FormComponent.extend({
   type: 'policy',
   name: 'policy',
-  allowServiceIdentity: true,
+  allowIdentity: true,
   classNames: ['policy-form'],
 
   isScoped: false,
@@ -19,6 +19,10 @@ export default FormComponent.extend({
       {
         name: 'Service Identity',
         template: 'service-identity',
+      },
+      {
+        name: 'Node Identity',
+        template: 'node-identity',
       },
     ];
   },

--- a/ui-v2/app/components/policy-form/pageobject.js
+++ b/ui-v2/app/components/policy-form/pageobject.js
@@ -8,7 +8,7 @@ export default (submitable, cancelable, radiogroup, text) => (
     prefix: 'policy',
     ...submitable(),
     ...cancelable(),
-    ...radiogroup('template', ['', 'service-identity'], 'policy'),
+    ...radiogroup('template', ['', 'service-identity', 'node-identity'], 'policy'),
     rules: {
       error: text('[data-test-rules] strong'),
     },

--- a/ui-v2/app/components/policy-selector/index.hbs
+++ b/ui-v2/app/components/policy-selector/index.hbs
@@ -50,35 +50,48 @@
       <BlockSlot @name="row">
         <td class={{policy/typeof item}}>
 {{#if item.ID }}
-<a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
+          <a href={{href-to 'dc.acls.policies.edit' item.ID}}>{{item.Name}}</a>
 {{else}}
           <a name={{item.Name}}>{{item.Name}}</a>
 {{/if}}
         </td>
       </BlockSlot>
       <BlockSlot @name="details">
-          {{#if (eq item.template '')}}
-            <DataSource
-              @src={{concat '/' item.Namespace '/' dc '/policy/' item.ID}}
-              @onchange={{action (mut loadedItem) value="data"}}
-              @loading="lazy"
-            />
-          {{/if}}
+{{#if (eq item.template '')}}
+        <DataSource
+          @src={{concat '/' item.Namespace '/' dc '/policy/' item.ID}}
+          @onchange={{action (mut loadedItem) value="data"}}
+          @loading="lazy"
+        />
+{{/if}}
+{{#if (eq item.template 'node-identity')}}
+          <dl>
+            <dt>Datacenter:</dt>
+            <dd>
+              {{item.Datacenter}}
+            </dd>
+          </dl>
+{{else}}
           <dl>
             <dt>Datacenters:</dt>
             <dd>
               {{join ', ' (policy/datacenters (or loadedItem item))}}
             </dd>
           </dl>
+{{/if}}
           <label class="type-text">
             <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
-            {{#if (eq item.template '')}}
-              <CodeEditor @syntax="hcl" @readonly={{true}} @value={{or loadedItem.Rules item.Rules}} />
-            {{else}}
-              <CodeEditor @syntax="hcl" @readonly={{true}}>
-                {{~component 'service-identity' name=item.Name~}}
-              </CodeEditor>
-            {{/if}}
+{{#if (eq item.template 'service-identity')}}
+            <CodeEditor @syntax="hcl" @readonly={{true}}>
+              {{~component 'service-identity' name=item.Name~}}
+            </CodeEditor>
+{{else if (eq item.template 'node-identity')}}
+            <CodeEditor @syntax="hcl" @readonly={{true}}>
+              {{~component 'node-identity' name=item.Name~}}
+            </CodeEditor>
+{{else}}
+            <CodeEditor @syntax="hcl" @readonly={{true}} @value={{or loadedItem.Rules item.Rules}} />
+{{/if}}
           </label>
           <div>
             <ConfirmationDialog @message="Are you sure you want to remove this policy from this token?">

--- a/ui-v2/app/components/policy-selector/index.js
+++ b/ui-v2/app/components/policy-selector/index.js
@@ -10,7 +10,7 @@ export default ChildSelectorComponent.extend({
   repo: service('repository/policy/component'),
   name: 'policy',
   type: 'policy',
-  allowServiceIdentity: true,
+  allowIdentity: true,
   classNames: ['policy-selector'],
   init: function() {
     this._super(...arguments);

--- a/ui-v2/app/models/role.js
+++ b/ui-v2/app/models/role.js
@@ -22,6 +22,11 @@ export default Model.extend({
       return [];
     },
   }),
+  NodeIdentities: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
   // frontend only for ordering where CreateIndex can't be used
   CreateTime: attr('date'),
   //

--- a/ui-v2/app/models/token.js
+++ b/ui-v2/app/models/token.js
@@ -39,6 +39,11 @@ export default Model.extend({
       return [];
     },
   }),
+  NodeIdentities: attr({
+    defaultValue: function() {
+      return [];
+    },
+  }),
   CreateTime: attr('date'),
   Hash: attr('string'),
   CreateIndex: attr('number'),

--- a/ui-v2/app/styles/base/components/radio-group/layout.scss
+++ b/ui-v2/app/styles/base/components/radio-group/layout.scss
@@ -15,7 +15,6 @@
 }
 %radio-group label > span {
   margin-left: 1em;
-  margin-top: 0.2em;
 }
 %radio-group label,
 %radio-group label > span {

--- a/ui-v2/app/styles/components/composite-row.scss
+++ b/ui-v2/app/styles/components/composite-row.scss
@@ -13,6 +13,11 @@
 .consul-token-list > ul > li:not(:first-child) {
   @extend %with-composite-row-intent;
 }
+/*TODO: This hides the icons-less dt's in the below lists as */
+/* they don't have tooltips */
+.consul-token-list > ul > li:not(:first-child) dt {
+  display: none;
+}
 /* TODO: the service list has a 1px offset */
 .consul-service-list li > div:first-child > dl:first-child dd {
   margin-top: 1px;

--- a/ui-v2/app/styles/components/form-elements.scss
+++ b/ui-v2/app/styles/components/form-elements.scss
@@ -20,6 +20,7 @@ label span {
   @extend %form-row;
 }
 %radio-group label,
+%main-content .type-select,
 %main-content .type-password,
 %main-content .type-text {
   @extend %form-element;

--- a/ui-v2/app/templates/dc/nspaces/-form.hbs
+++ b/ui-v2/app/templates/dc/nspaces/-form.hbs
@@ -30,7 +30,7 @@
     <p>
       By adding policies to this namespaces, you will apply them to all tokens created within this namespace.
     </p>
-    <PolicySelector @dc={{dc}} @nspace="default" @allowServiceIdentity={{false}} @items={{item.ACLs.PolicyDefaults}} />
+    <PolicySelector @dc={{dc}} @nspace="default" @allowIdentity={{false}} @items={{item.ACLs.PolicyDefaults}} />
   </fieldset>
 {{/if}}
   <div>

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-existing.feature
@@ -6,6 +6,7 @@ Feature: dc / acls / policies / as many / add existing: Add existing policy
     ---
       Policies: ~
       ServiceIdentities: ~
+      NodeIdentities: ~
     ---
     And 2 policy models from yaml
     ---

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/add-new.feature
@@ -6,6 +6,7 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     ---
       Policies: ~
       ServiceIdentities: ~
+      NodeIdentities: ~
     ---
     When I visit the [Model] page for yaml
     ---
@@ -52,7 +53,6 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     Then I fill in the policies.form with yaml
     ---
       Name: New-Service-Identity
-      Description: New Service Identity Description
     ---
     And I click serviceIdentity on the policies.form
     And I click submit on the policies.form
@@ -63,6 +63,31 @@ Feature: dc / acls / policies / as many / add new: Add new policy
         Namespace: @namespace
         ServiceIdentities:
           - ServiceName: New-Service-Identity
+    ---
+    Then the url should be /datacenter/acls/[Model]s
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class
+  Where:
+    -------------
+    | Model     |
+    | token     |
+    | role      |
+    -------------
+  Scenario: Adding a new node identity as a child of [Model]
+    Then I fill in the policies.form with yaml
+    ---
+      Name: New-Node-Identity
+    ---
+    And I click nodeIdentity on the policies.form
+    And I click submit on the policies.form
+    And I submit
+    Then a PUT request was made to "/v1/acl/[Model]/key?dc=datacenter" from yaml
+    ---
+      body:
+        Namespace: @namespace
+        NodeIdentities:
+          - NodeName: New-Node-Identity
+            Datacenter: datacenter
     ---
     Then the url should be /datacenter/acls/[Model]s
     And "[data-notification]" has the "notification-update" class
@@ -103,6 +128,18 @@ Feature: dc / acls / policies / as many / add new: Add new policy
     -------------
   Scenario: Try to edit the Service Identity using the code editor
     And I click serviceIdentity on the policies.form
+    Then I can't fill in the policies.form with yaml
+    ---
+      Rules: key {}
+    ---
+  Where:
+    -------------
+    | Model     |
+    | token     |
+    | role      |
+    -------------
+  Scenario: Try to edit the Node Identity using the code editor
+    And I click nodeIdentity on the policies.form
     Then I can't fill in the policies.form with yaml
     ---
       Rules: key {}

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/list.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/list.feature
@@ -6,8 +6,8 @@ Feature: dc / acls / policies / as many / list: List
     ---
       ServiceIdentities:
         - ServiceName: Service-Identity
-        - ServiceName: Service-Identity 2
-        - ServiceName: Service-Identity 3
+      NodeIdentities:
+        - NodeName: Node-Identity
       Policies:
         - Name: Policy
           ID: 0000
@@ -22,8 +22,8 @@ Feature: dc / acls / policies / as many / list: List
       [Model]: key
     ---
     Then the url should be /datacenter/acls/[Model]s/key
-    # ServiceIdentities turn into policies
-    Then I see 6 policy models on the policies component
+    # Identities turn into policies
+    Then I see 5 policy models on the policies component
   Where:
     -------------
     | Model     |

--- a/ui-v2/tests/acceptance/dc/acls/policies/as-many/remove.feature
+++ b/ui-v2/tests/acceptance/dc/acls/policies/as-many/remove.feature
@@ -5,6 +5,7 @@ Feature: dc / acls / policies / as many / remove: Remove
     And 1 [Model] model from yaml
     ---
       ServiceIdentities: ~
+      NodeIdentities: ~
       Policies:
         - Name: Policy
           ID: 00000000-0000-0000-0000-000000000001

--- a/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
+++ b/ui-v2/tests/acceptance/dc/acls/tokens/clone.feature
@@ -6,6 +6,7 @@ Feature: dc / acls / tokens / clone: Cloning an ACL token
     ---
       AccessorID: token
       SecretID: ee52203d-989f-4f7a-ab5a-2bef004164ca
+      Legacy: ~
     ---
   Scenario: Cloning an ACL token from the listing page
     When I visit the tokens page for yaml

--- a/ui-v2/tests/helpers/normalizers.js
+++ b/ui-v2/tests/helpers/normalizers.js
@@ -4,16 +4,27 @@ export const createPolicies = function(item) {
       template: '',
       ...item,
     };
-  }).concat(
-    item.ServiceIdentities.map(function(item) {
-      const policy = {
-        template: 'service-identity',
-        Name: item.ServiceName,
-      };
-      if (typeof item.Datacenters !== 'undefined') {
-        policy.Datacenters = item.Datacenters;
-      }
-      return policy;
-    })
-  );
+  })
+    .concat(
+      item.ServiceIdentities.map(function(item) {
+        const policy = {
+          template: 'service-identity',
+          Name: item.ServiceName,
+        };
+        if (typeof item.Datacenters !== 'undefined') {
+          policy.Datacenters = item.Datacenters;
+        }
+        return policy;
+      })
+    )
+    .concat(
+      item.NodeIdentities.map(function(item) {
+        const policy = {
+          template: 'node-identity',
+          Name: item.NodeName,
+          Datacenter: item.Datacenter,
+        };
+        return policy;
+      })
+    );
 };

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1211,9 +1211,9 @@
     js-yaml "^3.13.1"
 
 "@hashicorp/consul-api-double@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-3.0.0.tgz#a1ad94f33e006d01cebf2b22d1f87efef1756ece"
-  integrity sha512-wB1YgDBN3eOvNWRzSOc2k0eVE7C8YHFC5rJEdNWWTzjOokj6zDr40g2yLiaDMXl21XQs5LE8kNstEe8pf2+JUQ==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-3.1.0.tgz#6f0cfc32d99b6f0c876d473ff8fdc489b7403904"
+  integrity sha512-TsRvkBJTzMaXlSyaFT4HU+Phhk+7K2kWPmnuM41cqkHsCLfoTllQ37avQyLYGM/57yfd0ajbI4M6IKoYJnQUWg==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
https://github.com/hashicorp/consul/pull/7970 adds backend support for Node Identities, which are a templated policy similar to Service Identities.

This PR adds Phase 1 frontend UI support for Node Identities:

1. Amend ember-data layer for policies to deal with NodeIdentities. This uses the same approach as with ServiceIdentities i.e. we merge and unmerge all identities with policies. All of these policies are actually 'Templated Policies', normal policies having an empty template, in other words the rules for the normal policy are 100% user defined, all other policies use a template.

2. Specifically highlight Node Identities and Service Identities in the ConsulTokenList component. 

![Screenshot 2020-06-18 at 13 02 41](https://user-images.githubusercontent.com/554604/85017814-065fa980-b164-11ea-9e86-1882bd3d76fd.png)

This will be replicated in the role listing via a new ConsulRoleList component in a later PR ontop of this branch.

3. Add an option to select the Node Identity 'template' to use for Policy creation in the PolicyForm.

![Screenshot 2020-06-18 at 13 03 24](https://user-images.githubusercontent.com/554604/85017869-1d9e9700-b164-11ea-9db7-3ca1518981e2.png)

4. Ensure that during listing of Policies in the Policy preview listings, that NodeIdentities can also be previewed.

![Screenshot 2020-06-18 at 13 04 01](https://user-images.githubusercontent.com/554604/85017930-3313c100-b164-11ea-8e54-00f5c2913481.png)



