### PR TITLE
Bump golang to 1.14.4 to avoid known runtime issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.14.1
+    go: &GOLANG_IMAGE circleci/golang:1.14.4
     middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.40
     ember: &EMBER_IMAGE circleci/node:12-browsers
 


### PR DESCRIPTION
An issue where the golang runtime would hang and loop forever