### PR TITLE
Agent Auto Configuration: Change auto config authorizer to allow for future extension

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4594,19 +4594,21 @@ func TestAutoConfig_Integration(t *testing.T) {
 		connect { enabled = true }
 		auto_encrypt { allow_tls = true }
 		auto_config {
-			authorizer {
+			authorization {
 				enabled = true
-				claim_mappings = {
-					consul_node_name = "node"
+				static {
+					claim_mappings = {
+						consul_node_name = "node"
+					}
+					claim_assertions = [
+						"value.node == \"${node}\""
+					]
+					bound_issuer = "consul"
+					bound_audiences = [
+						"consul"
+					]
+					jwt_validation_pub_keys = ["` + strings.ReplaceAll(pub, "\n", "\\n") + `"]
 				}
-				claim_assertions = [
-					"value.node == \"${node}\""
-				]
-				bound_issuer = "consul"
-				bound_audiences = [
-					"consul"
-				]
-				jwt_validation_pub_keys = ["` + strings.ReplaceAll(pub, "\n", "\\n") + `"]
 			}
 		}
 	`

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -689,17 +689,21 @@ type AuditSink struct {
 }
 
 type AutoConfigRaw struct {
-	Enabled         *bool                   `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
-	IntroToken      *string                 `json:"intro_token,omitempty" hcl:"intro_token" mapstructure:"intro_token"`
-	IntroTokenFile  *string                 `json:"intro_token_file,omitempty" hcl:"intro_token_file" mapstructure:"intro_token_file"`
-	ServerAddresses []string                `json:"server_addresses,omitempty" hcl:"server_addresses" mapstructure:"server_addresses"`
-	DNSSANs         []string                `json:"dns_sans,omitempty" hcl:"dns_sans" mapstructure:"dns_sans"`
-	IPSANs          []string                `json:"ip_sans,omitempty" hcl:"ip_sans" mapstructure:"ip_sans"`
-	Authorizer      AutoConfigAuthorizerRaw `json:"authorizer,omitempty" hcl:"authorizer" mapstructure:"authorizer"`
+	Enabled         *bool                      `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
+	IntroToken      *string                    `json:"intro_token,omitempty" hcl:"intro_token" mapstructure:"intro_token"`
+	IntroTokenFile  *string                    `json:"intro_token_file,omitempty" hcl:"intro_token_file" mapstructure:"intro_token_file"`
+	ServerAddresses []string                   `json:"server_addresses,omitempty" hcl:"server_addresses" mapstructure:"server_addresses"`
+	DNSSANs         []string                   `json:"dns_sans,omitempty" hcl:"dns_sans" mapstructure:"dns_sans"`
+	IPSANs          []string                   `json:"ip_sans,omitempty" hcl:"ip_sans" mapstructure:"ip_sans"`
+	Authorization   AutoConfigAuthorizationRaw `json:"authorization,omitempty" hcl:"authorization" mapstructure:"authorization"`
+}
+
+type AutoConfigAuthorizationRaw struct {
+	Enabled *bool                   `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
+	Static  AutoConfigAuthorizerRaw `json:"static,omitempty" hcl:"static" mapstructure:"static"`
 }
 
 type AutoConfigAuthorizerRaw struct {
-	Enabled         *bool    `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
 	ClaimAssertions []string `json:"claim_assertions,omitempty" hcl:"claim_assertions" mapstructure:"claim_assertions"`
 	AllowReuse      *bool    `json:"allow_reuse,omitempty" hcl:"allow_reuse" mapstructure:"allow_reuse"`
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -3918,7 +3918,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			hcl: []string{`
 				auto_config {
-					authorizer {
+					authorization {
 						enabled = true
 					}
 				}
@@ -3926,12 +3926,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			json: []string{`
 			{
 				"auto_config": {
-					"authorizer": {
+					"authorization": {
 						"enabled": true
 					}
 				}
 			}`},
-			err: "auto_config.authorizer.enabled cannot be set to true for client agents",
+			err: "auto_config.authorization.enabled cannot be set to true for client agents",
 		},
 
 		{
@@ -3942,7 +3942,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			hcl: []string{`
 				auto_config {
-					authorizer {
+					authorization {
 						enabled = true
 					}
 				}
@@ -3950,12 +3950,12 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			json: []string{`
 			{
 				"auto_config": {
-					"authorizer": {
+					"authorization": {
 						"enabled": true
 					}
 				}
 			}`},
-			err: `auto_config.authorizer has invalid configuration: exactly one of 'JWTValidationPubKeys', 'JWKSURL', or 'OIDCDiscoveryURL' must be set for type "jwt"`,
+			err: `auto_config.authorization.static has invalid configuration: exactly one of 'JWTValidationPubKeys', 'JWKSURL', or 'OIDCDiscoveryURL' must be set for type "jwt"`,
 		},
 
 		{
@@ -3966,24 +3966,28 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			hcl: []string{`
 				auto_config {
-					authorizer {
+					authorization {
 						enabled = true
-						jwks_url = "https://fake.uri.local"
-						oidc_discovery_url = "https://fake.uri.local"
+						static {
+							jwks_url = "https://fake.uri.local"
+							oidc_discovery_url = "https://fake.uri.local"
+						}
 					}
 				}
 			`},
 			json: []string{`
 			{
 				"auto_config": {
-					"authorizer": {
+					"authorization": {
 						"enabled": true,
-						"jwks_url": "https://fake.uri.local",
-						"oidc_discovery_url": "https://fake.uri.local"
+						"static": {
+							"jwks_url": "https://fake.uri.local",
+							"oidc_discovery_url": "https://fake.uri.local"
+						}
 					}
 				}
 			}`},
-			err: `auto_config.authorizer has invalid configuration: exactly one of 'JWTValidationPubKeys', 'JWKSURL', or 'OIDCDiscoveryURL' must be set for type "jwt"`,
+			err: `auto_config.authorization.static has invalid configuration: exactly one of 'JWTValidationPubKeys', 'JWKSURL', or 'OIDCDiscoveryURL' must be set for type "jwt"`,
 		},
 
 		{
@@ -3994,28 +3998,32 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			hcl: []string{`
 				auto_config {
-					authorizer {
+					authorization {
 						enabled = true
-						jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
-						claim_assertions = [
-							"values.node == ${node}"
-						]
+						static {
+							jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
+							claim_assertions = [
+								"values.node == ${node}"
+							]
+						}
 					}
 				}
 			`},
 			json: []string{`
 			{
 				"auto_config": {
-					"authorizer": {
+					"authorization": {
 						"enabled": true,
-						"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"],
-						"claim_assertions": [
-							"values.node == ${node}"
-						]
+						"static": {
+							"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"],
+							"claim_assertions": [
+								"values.node == ${node}"
+							]
+						}
 					}
 				}
 			}`},
-			err: `auto_config.claim_assertion "values.node == ${node}" is invalid: Selector "values" is not valid`,
+			err: `auto_config.authorization.static.claim_assertion "values.node == ${node}" is invalid: Selector "values" is not valid`,
 		},
 		{
 			desc: "auto config authorizer ok",
@@ -4025,14 +4033,16 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			hcl: []string{`
 				auto_config {
-					authorizer {
+					authorization {
 						enabled = true
-						jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
-						claim_assertions = [
-							"value.node == ${node}"
-						]
-						claim_mappings = {
-							node = "node"
+						static {
+							jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
+							claim_assertions = [
+								"value.node == ${node}"
+							]
+							claim_mappings = {
+								node = "node"
+							}
 						}
 					}
 				}
@@ -4040,14 +4050,16 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 			json: []string{`
 			{
 				"auto_config": {
-					"authorizer": {
+					"authorization": {
 						"enabled": true,
-						"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"],
-						"claim_assertions": [
-							"value.node == ${node}"
-						],
-						"claim_mappings": {
-							"node": "node"
+						"static": {
+							"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"],
+							"claim_assertions": [
+								"value.node == ${node}"
+							],
+							"claim_mappings": {
+								"node": "node"
+							}
 						}
 					}
 				}
@@ -4304,19 +4316,21 @@ func TestFullConfig(t *testing.T) {
 				"dns_sans": ["6zdaWg9J"],
 				"ip_sans": ["198.18.99.99"],
 				"server_addresses": ["198.18.100.1"],
-				"authorizer": {
+				"authorization": {
 					"enabled": true,
-					"allow_reuse": true,
-					"claim_mappings": {
-						"node": "node"
-					},
-					"list_claim_mappings": {
-						"foo": "bar"
-					},
-					"bound_issuer": "consul",
-					"bound_audiences": ["consul-cluster-1"],
-					"claim_assertions": ["value.node == \"${node}\""],
-					"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
+					"static": {
+						"allow_reuse": true,
+						"claim_mappings": {
+							"node": "node"
+						},
+						"list_claim_mappings": {
+							"foo": "bar"
+						},
+						"bound_issuer": "consul",
+						"bound_audiences": ["consul-cluster-1"],
+						"claim_assertions": ["value.node == \"${node}\""],
+						"jwt_validation_pub_keys": ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
+					}
 				}
 			},
 			"autopilot": {
@@ -4962,19 +4976,21 @@ func TestFullConfig(t *testing.T) {
 				dns_sans = ["6zdaWg9J"]
 				ip_sans = ["198.18.99.99"]
 				server_addresses = ["198.18.100.1"]
-				authorizer = {
+				authorization = {
 					enabled = true
-					allow_reuse = true
-					claim_mappings = {
-						node = "node"
+					static {
+						allow_reuse = true
+						claim_mappings = {
+							node = "node"
+						}
+						list_claim_mappings = {
+							foo = "bar"
+						}
+						bound_issuer = "consul"
+						bound_audiences = ["consul-cluster-1"]
+						claim_assertions = ["value.node == \"${node}\""]
+						jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
 					}
-					list_claim_mappings = {
-						foo = "bar"
-					}
-					bound_issuer = "consul"
-					bound_audiences = ["consul-cluster-1"]
-					claim_assertions = ["value.node == \"${node}\""]
-					jwt_validation_pub_keys = ["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"]
 				}
 			}
 			autopilot = {
@@ -5828,7 +5844,6 @@ func TestFullConfig(t *testing.T) {
 				AuthMethod: structs.ACLAuthMethod{
 					Name:           "Auto Config Authorizer",
 					Type:           "jwt",
-					MaxTokenTTL:    72 * time.Hour,
 					EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 					Config: map[string]interface{}{
 						"JWTValidationPubKeys": []string{"-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERVchfCZng4mmdvQz1+sJHRN40snC\nYt8NjYOnbnScEXMkyoUmASr88gb7jaVAVt3RYASAbgBjB2Z+EUizWkx5Tg==\n-----END PUBLIC KEY-----"},
@@ -5849,7 +5864,6 @@ func TestFullConfig(t *testing.T) {
 						"ClockSkewLeeway":     0 * time.Second,
 						"JWTSupportedAlgs":    []string(nil),
 					},
-					TokenLocality: "local",
 				},
 			},
 		},


### PR DESCRIPTION
The configuration now looks like:

```hcl
auto_config {
   authorization {
      enabled = true
      static {
        // static authorizer settings
      }
   }
}
```

Where before it looked like:

```hcl
auto_config {
   authorizer {
      enabled = true
      // static authorizer settings
   }
}
```

In the future we could add extra settings to enable dynamically defined auth methods to be used instead of or in addition to the statically defined one in the configuration. For now this is just the necessary configuration changes to not box our selves into
