### PR TITLE
Require enabling TLS to enable Auto Config

### DIFF
--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -193,7 +193,8 @@ func TestInitialConfiguration_cancelled(t *testing.T) {
 	cfgFile := filepath.Join(configDir, "test.json")
 	require.NoError(t, ioutil.WriteFile(cfgFile, []byte(`{
 		"primary_datacenter": "primary", 
-		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]}
+		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]},
+		"verify_outgoing": true
 	}`), 0600))
 
 	builderOpts.ConfigFiles = append(builderOpts.ConfigFiles, cfgFile)
@@ -227,7 +228,7 @@ func TestInitialConfiguration_restored(t *testing.T) {
 
 	cfgFile := filepath.Join(configDir, "test.json")
 	require.NoError(t, ioutil.WriteFile(cfgFile, []byte(`{
-		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]}
+		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]}, "verify_outgoing": true
 	}`), 0600))
 
 	builderOpts.ConfigFiles = append(builderOpts.ConfigFiles, cfgFile)
@@ -261,7 +262,7 @@ func TestInitialConfiguration_success(t *testing.T) {
 
 	cfgFile := filepath.Join(configDir, "test.json")
 	require.NoError(t, ioutil.WriteFile(cfgFile, []byte(`{
-		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]}
+		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["127.0.0.1:8300"]}, "verify_outgoing": true
 	}`), 0600))
 
 	builderOpts.ConfigFiles = append(builderOpts.ConfigFiles, cfgFile)
@@ -313,7 +314,7 @@ func TestInitialConfiguration_retries(t *testing.T) {
 
 	cfgFile := filepath.Join(configDir, "test.json")
 	require.NoError(t, ioutil.WriteFile(cfgFile, []byte(`{
-		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["198.18.0.1", "198.18.0.2:8398", "198.18.0.3:8399", "127.0.0.1:1234"]}
+		"auto_config": {"enabled": true, "intro_token": "blarg", "server_addresses": ["198.18.0.1", "198.18.0.2:8398", "198.18.0.3:8399", "127.0.0.1:1234"]}, "verify_outgoing": true
 	}`), 0600))
 
 	builderOpts.ConfigFiles = append(builderOpts.ConfigFiles, cfgFile)

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1997,6 +1997,12 @@ func (b *Builder) validateAutoConfig(rt RuntimeConfig) error {
 		return nil
 	}
 
+	// Right now we require TLS as everything we are going to transmit via auto-config is sensitive. Signed Certificates, Tokens
+	// and other encryption keys. This must be transmitted over a secure connection so we don't allow doing otherwise.
+	if !rt.VerifyOutgoing {
+		return fmt.Errorf("auto_config.enabled cannot be set without configuring TLS for server communications")
+	}
+
 	// Auto Config doesn't currently support configuring servers
 	if rt.ServerMode {
 		return fmt.Errorf("auto_config.enabled cannot be set to true for server agents.")
@@ -2028,6 +2034,12 @@ func (b *Builder) validateAutoConfigAuthorizer(rt RuntimeConfig) error {
 	// Auto Config Authorization is only supported on servers
 	if !rt.ServerMode {
 		return fmt.Errorf("auto_config.authorization.enabled cannot be set to true for client agents")
+	}
+
+	// Right now we require TLS as everything we are going to transmit via auto-config is sensitive. Signed Certificates, Tokens
+	// and other encryption keys. This must be transmitted over a secure connection so we don't allow doing otherwise.
+	if rt.CertFile == "" {
+		return fmt.Errorf("auto_config.authorization.enabled cannot be set without providing a TLS certificate for the server")
 	}
 
 	// build out the validator to ensure that the given configuration was valid


### PR DESCRIPTION
On the servers they must have a certificate.

On the clients they just have to set verify_outgoing to true to attempt TLS connections for RPCs.

Eventually we may relax these restrictions but right now all of the settings we push down (acl tokens, acl related settings, certificates, gossip key) are sensitive and shouldn’t be transmitted over an unencrypted connection. Our guides and docs should recoommend verify_server_hostname on the clients as well although it is not strictly necessary.

Another reason to do this is weird things happen when making an insecure RPC when TLS is not enabled. Basically it tries TLS anyways. We should probably fix that to make it clearer what is going on although for the time being and specifically for auto config we can just prevent enabling the feature.