### PR TITLE
Fix quorum formula in consensus.mdx

### DIFF
--- a/website/pages/docs/internals/consensus.mdx
+++ b/website/pages/docs/internals/consensus.mdx
@@ -38,8 +38,8 @@ There are a few key terms to know when discussing Raft:
 - Peer set - The peer set is the set of all members participating in log replication.
   For Consul's purposes, all server nodes are in the peer set of the local datacenter.
 
-- Quorum - A quorum is a majority of members from a peer set: for a set of size `n`,
-  quorum requires at least `(n+1)/2` members.
+- Quorum - A quorum is a majority of members from a peer set: for a set of size `N`,
+  quorum requires at least `(N/2)+1` members.
   For example, if there are 5 members in the peer set, we would need 3 nodes
   to form a quorum. If a quorum of nodes is unavailable for any reason, the
   cluster becomes _unavailable_ and no new logs can be committed.


### PR DESCRIPTION
[Add & Remove Servers](https://learn.hashicorp.com/consul/day-2-operations/servers) guide uses `(N/2)+1` quorum formula.  So does the [Raft implementation](https://github.com/hashicorp/raft/blob/5927dcda05104774d2e6bbcda1d0a93c34384f9a/raft.go#L909).

Consensus Protocol document uses `(n+1)/2` formula.  This formula is not only different, it also conflicts with the [Deployment Table](https://www.consul.io/docs/internals/consensus.html#deployment_table) presented in the same document; e.g., (6+1)/2 = 3, not 4.

Replace `(n+1)/2` with `(N/2)+1` in Consensus Protocol document.