### PR TITLE
docs: Specify port in host for ingress example

### DIFF
--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -90,11 +90,11 @@ Listeners = [
     Services = [
       {
         Name  = "api"
-        Hosts = ["foo.example.com"]
+        Hosts = ["foo.example.com", "foo.example.com:4567"]
       },
       {
         Name  = "web"
-        Hosts = ["website.example.com"]
+        Hosts = ["website.example.com", "website.example.com:4567"]
       }
     ]
   }


### PR DESCRIPTION
This example shows a TLS enabled ingress config on a non-https port.
Currently, that means we require the port to be specified in one of the
host entries to route traffic.

Pulled from https://github.com/hashicorp/consul/pull/8062#issuecomment-647120323.