### PR TITLE
Let users know namespaces are ent only in config entry decode

### DIFF
--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -12,10 +12,10 @@ import (
 
 func (s *HTTPServer) parseEntMeta(req *http.Request, entMeta *structs.EnterpriseMeta) error {
 	if headerNS := req.Header.Get("X-Consul-Namespace"); headerNS != "" {
-		return BadRequestError{Reason: "Invalid header: \"X-Consul-Namespace\" - Namespaces is a Consul Enterprise feature"}
+		return BadRequestError{Reason: "Invalid header: \"X-Consul-Namespace\" - Namespaces are a Consul Enterprise feature"}
 	}
 	if queryNS := req.URL.Query().Get("ns"); queryNS != "" {
-		return BadRequestError{Reason: "Invalid query parameter: \"ns\" - Namespaces is a Consul Enterprise feature"}
+		return BadRequestError{Reason: "Invalid query parameter: \"ns\" - Namespaces are a Consul Enterprise feature"}
 	}
 	return nil
 }
@@ -36,7 +36,7 @@ func (s *HTTPServer) rewordUnknownEnterpriseFieldError(err error) error {
 
 		switch quotedField {
 		case `"Namespace"`:
-			return fmt.Errorf("%v - Namespaces is a Consul Enterprise feature", err)
+			return fmt.Errorf("%v - Namespaces are a Consul Enterprise feature", err)
 		}
 	}
 
@@ -47,7 +47,7 @@ func (s *HTTPServer) addEnterpriseHTMLTemplateVars(vars map[string]interface{}) 
 
 func parseACLAuthMethodEnterpriseMeta(req *http.Request, _ *structs.ACLAuthMethodEnterpriseMeta) error {
 	if methodNS := req.URL.Query().Get("authmethod-ns"); methodNS != "" {
-		return BadRequestError{Reason: "Invalid query parameter: \"authmethod-ns\" - Namespaces is a Consul Enterprise feature"}
+		return BadRequestError{Reason: "Invalid query parameter: \"authmethod-ns\" - Namespaces are a Consul Enterprise feature"}
 	}
 
 	return nil

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -309,7 +309,7 @@ func DecodeConfigEntry(raw map[string]interface{}) (ConfigEntry, error) {
 		switch {
 		case k == "CreateIndex" || k == "ModifyIndex":
 		case strings.HasSuffix(strings.ToLower(k), "namespace"):
-			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces is a consul enterprise feature", k))
+			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces are a consul enterprise feature", k))
 		default:
 			err = multierror.Append(err, fmt.Errorf("invalid config key %q", k))
 		}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -306,8 +306,11 @@ func DecodeConfigEntry(raw map[string]interface{}) (ConfigEntry, error) {
 	}
 
 	for _, k := range md.Unused {
-		switch k {
-		case "CreateIndex", "ModifyIndex":
+		switch {
+		case k == "CreateIndex" || k == "ModifyIndex":
+			break
+		case strings.HasSuffix(strings.ToLower(k), "namespace"):
+			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces is a consul enterprise feature", k))
 		default:
 			err = multierror.Append(err, fmt.Errorf("invalid config key %q", k))
 		}

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -308,7 +308,6 @@ func DecodeConfigEntry(raw map[string]interface{}) (ConfigEntry, error) {
 	for _, k := range md.Unused {
 		switch {
 		case k == "CreateIndex" || k == "ModifyIndex":
-			break
 		case strings.HasSuffix(strings.ToLower(k), "namespace"):
 			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces is a consul enterprise feature", k))
 		default:

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -98,7 +98,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 				Name = "terminating-gateway"
 				Namespace = "foo"
 			`,
-			expectErr: `invalid config key "namespace", namespaces is a consul enterprise feature`,
+			expectErr: `invalid config key "namespace", namespaces are a consul enterprise feature`,
 		},
 		{
 			name: "namespaces invalid deep",
@@ -137,7 +137,7 @@ func TestDecodeConfigEntry(t *testing.T) {
 					},
 				]
 			`,
-			expectErr: `invalid config key "listeners[0].services[0].namespace", namespaces is a consul enterprise feature`,
+			expectErr: `invalid config key "listeners[0].services[0].namespace", namespaces are a consul enterprise feature`,
 		},
 		{
 			name: "service-defaults",

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -87,6 +87,59 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
+			name: "namespaces invalid top level",
+			snake: `
+				kind = "terminating-gateway"
+				name = "terminating-gateway"
+				namespace = "foo"
+			`,
+			camel: `
+				Kind = "terminating-gateway"
+				Name = "terminating-gateway"
+				Namespace = "foo"
+			`,
+			expectErr: `invalid config key "namespace", namespaces is a consul enterprise feature`,
+		},
+		{
+			name: "namespaces invalid deep",
+			snake: `
+				kind = "ingress-gateway"
+				name = "ingress-web"
+				listeners = [
+					{
+						port = 8080
+						protocol = "http"
+						services = [
+							{
+								name = "web"
+								hosts = ["test.example.com", "test2.example.com"]
+								namespace = "frontend"
+							},
+						]
+					}
+				]
+			`,
+			camel: `
+				Kind = "ingress-gateway"
+				Name = "ingress-web"
+				Namespace = "blah"
+				Listeners = [
+					{
+						Port = 8080
+						Protocol = "http"
+						Services = [
+							{
+								Name = "web"
+								Hosts = ["test.example.com", "test2.example.com"]
+								Namespace = "frontend"
+							},
+						]
+					},
+				]
+			`,
+			expectErr: `invalid config key "listeners[0].services[0].namespace", namespaces is a consul enterprise feature`,
+		},
+		{
 			name: "service-defaults",
 			snake: `
 				kind = "service-defaults"

--- a/api/acl.go
+++ b/api/acl.go
@@ -50,7 +50,7 @@ type ACLToken struct {
 	Rules string `json:",omitempty"`
 
 	// Namespace is the namespace the ACLToken is associated with.
-	// Namespaces is a Consul Enterprise feature.
+	// Namespaces are a Consul Enterprise feature.
 	Namespace string `json:",omitempty"`
 }
 

--- a/command/flags/http.go
+++ b/command/flags/http.go
@@ -79,7 +79,7 @@ func (f *HTTPFlags) NamespaceFlags() *flag.FlagSet {
 	fs.Var(&f.namespace, "namespace",
 		"Specifies the namespace to query. If not provided, the namespace will be inferred "+
 			"from the request's ACL token, or will default to the `default` namespace. "+
-			"Namespaces is a Consul Enterprise feature.")
+			"Namespaces are a Consul Enterprise feature.")
 	return fs
 }
 

--- a/website/pages/partials/http_api_namespace_options.mdx
+++ b/website/pages/partials/http_api_namespace_options.mdx
@@ -1,1 +1,1 @@
-- `-namespace=<string>` - Specifies the namespace to query. If not provided, the namespace will be inferred from the request's ACL token, or will default to the `default` namespace. Namespaces is a Consul Enterprise feature added in v1.7.0.
+- `-namespace=<string>` - Specifies the namespace to query. If not provided, the namespace will be inferred from the request's ACL token, or will default to the `default` namespace. Namespaces are a Consul Enterprise feature added in v1.7.0.


### PR DESCRIPTION
Fixes: #8069

Previously, when users would load config entries via [agent config](https://www.consul.io/docs/agent/options.html#config_entries_bootstrap) we wouldn't accept a namespace if specified, but also would not provide an informative error.

This PR checks for namespaces in the config decode. Note that this doesn't have to be done in `TestParseConfigEntry` because enterprise users need to be able to specify a namespace when using the CLI.