### PR TITLE
ui: Add namespaced versions of templated policies

### DIFF
--- a/ui-v2/app/components/node-identity/index.hbs
+++ b/ui-v2/app/components/node-identity/index.hbs
@@ -1,6 +1,19 @@
+{{#if (env "CONSUL_NSPACES_ENABLED")}}
+namespace "default" {
+  node "{{name}}" {
+	  policy = "write"
+  }
+}
+namespace_prefix "" {
+  service_prefix "" {
+	  policy = "read"
+  }
+}
+{{else}}
 node "{{name}}" {
 	policy = "write"
 }
 service_prefix "" {
 	policy = "read"
 }
+{{/if}}

--- a/ui-v2/app/components/policy-form/index.hbs
+++ b/ui-v2/app/components/policy-form/index.hbs
@@ -36,7 +36,7 @@
         <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
 {{#if (eq item.template 'service-identity')}}
         <CodeEditor @readonly={{true}} @name={{concat name "[Rules]"}} @syntax="hcl" @oninput={{action "change" (concat name "[Rules]")}}>
-          {{~component 'service-identity' name=item.Name~}}
+          {{~component 'service-identity' nspace=nspace name=item.Name~}}
         </CodeEditor>
 {{else if (eq item.template 'node-identity')}}
         <CodeEditor @readonly={{true}} @name={{concat name "[Rules]"}} @syntax="hcl" @oninput={{action "change" (concat name "[Rules]")}}>

--- a/ui-v2/app/components/policy-selector/index.hbs
+++ b/ui-v2/app/components/policy-selector/index.hbs
@@ -21,7 +21,7 @@
           <h2>New Policy</h2>
         </BlockSlot>
         <BlockSlot @name="body">
-          <PolicyForm @form={{form}} @dc={{dc}} @allowServiceIdentity={{allowServiceIdentity}} />
+          <PolicyForm @form={{form}} @nspace={{nspace}} @dc={{dc}} @allowServiceIdentity={{allowServiceIdentity}} />
         </BlockSlot>
         <BlockSlot @name="actions" as |close|>
           <button type="submit" {{action 'save' item items (queue (action close) (action 'reset'))}} disabled={{if (or item.isSaving item.isPristine item.isInvalid) 'disabled'}}>
@@ -83,7 +83,7 @@
             <span>Rules <a href="{{env 'CONSUL_DOCS_URL'}}/guides/acl.html#rule-specification" rel="help noopener noreferrer" target="_blank">(HCL Format)</a></span>
 {{#if (eq item.template 'service-identity')}}
             <CodeEditor @syntax="hcl" @readonly={{true}}>
-              {{~component 'service-identity' name=item.Name~}}
+              {{~component 'service-identity' nspace=nspace name=item.Name~}}
             </CodeEditor>
 {{else if (eq item.template 'node-identity')}}
             <CodeEditor @syntax="hcl" @readonly={{true}}>

--- a/ui-v2/app/components/service-identity/index.hbs
+++ b/ui-v2/app/components/service-identity/index.hbs
@@ -1,3 +1,19 @@
+{{#if (env "CONSUL_NSPACES_ENABLED")}}
+namespace "{{nspace}}" {
+  service "{{name}}" {
+	  policy = "write"
+  }
+  service "{{name}}-sidecar-proxy" {
+	  policy = "write"
+  }
+  service_prefix "" {
+	  policy = "read"
+  }
+  node_prefix "" {
+	  policy = "read"
+  }
+}
+{{else}}
 service "{{name}}" {
 	policy = "write"
 }
@@ -10,3 +26,4 @@ service_prefix "" {
 node_prefix "" {
 	policy = "read"
 }
+{{/if}}

--- a/ui-v2/app/templates/dc/acls/policies/-form.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/-form.hbs
@@ -1,5 +1,5 @@
 <form>
-  <PolicyForm @form={{form}} @item={{item}}>
+  <PolicyForm @form={{form}} @nspace={{nspace}} @item={{item}}>
     {{!don't show template selection here, i.e. Service Identity}}
     <BlockSlot @name="template" />
   </PolicyForm>


### PR DESCRIPTION
Policy templates for ServiceIdentities and NodeIdentities are slightly different for a namespace enabled Consul. Whilst our templates aren't actually used to save the identities (they are just for user visibility in the UI), we make sure we show the namespaced version here if you are using a namespace enabled Consul.