### PR TITLE
Don’t leak metrics go routines in tests

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -171,6 +171,7 @@ func (c *cmd) run(args []string) int {
 		agent.WithBuilderOpts(c.flagArgs),
 		agent.WithCLI(c.UI),
 		agent.WithLogWriter(&logGate),
+		agent.WithTelemetry(true),
 	}
 
 	agent, err := agent.New(agentOptions...)


### PR DESCRIPTION
We were unconditionally configuring the metrics sinks before, even for tests. Now this requires that an option be set for the system to be initialized (which starts some go routines)
