### PR TITLE
ui: Ensure the tooltip panel chevron isn't hidden by overflow

### DIFF
--- a/ui-v2/app/styles/components/tooltip-panel/layout.scss
+++ b/ui-v2/app/styles/components/tooltip-panel/layout.scss
@@ -3,6 +3,7 @@
 }
 %tooltip-panel dd > div {
   top: auto !important;
+  overflow: visible;
 }
 %tooltip-panel dt {
   cursor: pointer;


### PR DESCRIPTION
Before:

![Screenshot 2020-06-24 at 17 05 08](https://user-images.githubusercontent.com/554604/85591080-e4bb6200-b63c-11ea-9a19-b56966b53815.png)

After:

![Screenshot 2020-06-24 at 17 04 54](https://user-images.githubusercontent.com/554604/85591106-e9801600-b63c-11ea-8dd4-d45b774ccd7d.png)
