### PR TITLE
ui: Don't hide TTL check output

### DIFF
--- a/ui-v2/app/components/healthcheck-list/index.hbs
+++ b/ui-v2/app/components/healthcheck-list/index.hbs
@@ -33,13 +33,11 @@
           <dd>{{or item.Notes '-'}}</dd>
         </dl>
         <dl>
-  {{#if (not-eq item.Type 'ttl')}}
           <dt>Output</dt>
           <dd>
               <pre><code>{{item.Output}}</code></pre>
               <CopyButton @value={{item.Output}} @name="output" />
           </dd>
-  {{/if}}
         </dl>
       </div>
     </li>


### PR DESCRIPTION
We'd assumed that TTL check outputs shouldn't be shown as it seemed like
they never had outputs, but they can be submitted with notes, which are
then converted into the output.

This unhides the output for TTLs and treats them exactly the same as
other healthchecks.

This reverts a change originally made in #6575

Fixes https://github.com/hashicorp/consul/issues/8161

