### PR TITLE
Split up unused key validation for oss/ent

### DIFF
--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/lib/decode"
 	"github.com/hashicorp/go-msgpack/codec"
-	"github.com/hashicorp/go-multierror"
 	"github.com/mitchellh/hashstructure"
 	"github.com/mitchellh/mapstructure"
 )
@@ -305,12 +304,7 @@ func DecodeConfigEntry(raw map[string]interface{}) (ConfigEntry, error) {
 		return nil, err
 	}
 
-	multiErr := validateUnusedKeys(md.Unused)
-	if multiErr != nil {
-		err = multierror.Append(err, multiErr)
-	}
-
-	if err != nil {
+	if err := validateUnusedKeys(md.Unused); err != nil {
 		return nil, err
 	}
 	return entry, nil

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -305,15 +305,11 @@ func DecodeConfigEntry(raw map[string]interface{}) (ConfigEntry, error) {
 		return nil, err
 	}
 
-	for _, k := range md.Unused {
-		switch {
-		case k == "CreateIndex" || k == "ModifyIndex":
-		case strings.HasSuffix(strings.ToLower(k), "namespace"):
-			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces are a consul enterprise feature", k))
-		default:
-			err = multierror.Append(err, fmt.Errorf("invalid config key %q", k))
-		}
+	multiErr := validateUnusedKeys(md.Unused)
+	if multiErr != nil {
+		err = multierror.Append(err, multiErr)
 	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/agent/structs/config_entry_oss.go
+++ b/agent/structs/config_entry_oss.go
@@ -2,6 +2,28 @@
 
 package structs
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+)
+
 func (e *ProxyConfigEntry) validateEnterpriseMeta() error {
 	return nil
+}
+
+func validateUnusedKeys(unused []string) error {
+	var err error
+
+	for _, k := range unused {
+		switch {
+		case k == "CreateIndex" || k == "ModifyIndex":
+		case strings.HasSuffix(strings.ToLower(k), "namespace"):
+			err = multierror.Append(err, fmt.Errorf("invalid config key %q, namespaces are a consul enterprise feature", k))
+		default:
+			err = multierror.Append(err, fmt.Errorf("invalid config key %q", k))
+		}
+	}
+	return err
 }

--- a/agent/structs/config_entry_oss_test.go
+++ b/agent/structs/config_entry_oss_test.go
@@ -1,0 +1,101 @@
+// +build !consulent
+
+package structs
+
+import (
+	"github.com/hashicorp/hcl"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDecodeConfigEntry_OSS(t *testing.T) {
+
+	for _, tc := range []struct {
+		name      string
+		camel     string
+		snake     string
+		expect    ConfigEntry
+		expectErr string
+	}{
+		{
+			name: "namespaces invalid top level",
+			snake: `
+				kind = "terminating-gateway"
+				name = "terminating-gateway"
+				namespace = "foo"
+			`,
+			camel: `
+				Kind = "terminating-gateway"
+				Name = "terminating-gateway"
+				Namespace = "foo"
+			`,
+			expectErr: `invalid config key "namespace", namespaces are a consul enterprise feature`,
+		},
+		{
+			name: "namespaces invalid deep",
+			snake: `
+				kind = "ingress-gateway"
+				name = "ingress-web"
+				listeners = [
+					{
+						port = 8080
+						protocol = "http"
+						services = [
+							{
+								name = "web"
+								hosts = ["test.example.com", "test2.example.com"]
+								namespace = "frontend"
+							},
+						]
+					}
+				]
+			`,
+			camel: `
+				Kind = "ingress-gateway"
+				Name = "ingress-web"
+				Namespace = "blah"
+				Listeners = [
+					{
+						Port = 8080
+						Protocol = "http"
+						Services = [
+							{
+								Name = "web"
+								Hosts = ["test.example.com", "test2.example.com"]
+								Namespace = "frontend"
+							},
+						]
+					},
+				]
+			`,
+			expectErr: `* invalid config key "listeners[0].services[0].namespace", namespaces are a consul enterprise feature`,
+		},
+	} {
+		tc := tc
+
+		testbody := func(t *testing.T, body string) {
+			t.Helper()
+
+			var raw map[string]interface{}
+			err := hcl.Decode(&raw, body)
+			require.NoError(t, err)
+
+			got, err := DecodeConfigEntry(raw)
+			if tc.expectErr != "" {
+				require.Nil(t, got)
+				require.Error(t, err)
+				requireContainsLower(t, err.Error(), tc.expectErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expect, got)
+			}
+		}
+
+		t.Run(tc.name+" (snake case)", func(t *testing.T) {
+			testbody(t, tc.snake)
+		})
+		t.Run(tc.name+" (camel case)", func(t *testing.T) {
+			testbody(t, tc.camel)
+		})
+	}
+}

--- a/agent/structs/config_entry_oss_test.go
+++ b/agent/structs/config_entry_oss_test.go
@@ -74,8 +74,6 @@ func TestDecodeConfigEntry_OSS(t *testing.T) {
 		tc := tc
 
 		testbody := func(t *testing.T, body string) {
-			t.Helper()
-
 			var raw map[string]interface{}
 			err := hcl.Decode(&raw, body)
 			require.NoError(t, err)

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -723,8 +723,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 		tc := tc
 
 		testbody := func(t *testing.T, body string) {
-			t.Helper()
-
 			var raw map[string]interface{}
 			err := hcl.Decode(&raw, body)
 			require.NoError(t, err)

--- a/agent/structs/config_entry_test.go
+++ b/agent/structs/config_entry_test.go
@@ -87,59 +87,6 @@ func TestDecodeConfigEntry(t *testing.T) {
 			},
 		},
 		{
-			name: "namespaces invalid top level",
-			snake: `
-				kind = "terminating-gateway"
-				name = "terminating-gateway"
-				namespace = "foo"
-			`,
-			camel: `
-				Kind = "terminating-gateway"
-				Name = "terminating-gateway"
-				Namespace = "foo"
-			`,
-			expectErr: `invalid config key "namespace", namespaces are a consul enterprise feature`,
-		},
-		{
-			name: "namespaces invalid deep",
-			snake: `
-				kind = "ingress-gateway"
-				name = "ingress-web"
-				listeners = [
-					{
-						port = 8080
-						protocol = "http"
-						services = [
-							{
-								name = "web"
-								hosts = ["test.example.com", "test2.example.com"]
-								namespace = "frontend"
-							},
-						]
-					}
-				]
-			`,
-			camel: `
-				Kind = "ingress-gateway"
-				Name = "ingress-web"
-				Namespace = "blah"
-				Listeners = [
-					{
-						Port = 8080
-						Protocol = "http"
-						Services = [
-							{
-								Name = "web"
-								Hosts = ["test.example.com", "test2.example.com"]
-								Namespace = "frontend"
-							},
-						]
-					},
-				]
-			`,
-			expectErr: `invalid config key "listeners[0].services[0].namespace", namespaces are a consul enterprise feature`,
-		},
-		{
 			name: "service-defaults",
 			snake: `
 				kind = "service-defaults"


### PR DESCRIPTION
The previous PR to validate unused keys in agent config entry bootstrapping did not have split OSS/ENT implementations.

This is needed because we don't want to return an error if namespaces are provided in enterprise.

This PR pulls that validation into files guarded by build tags.