### PR TITLE
Append port number to ingress host domain

### DIFF
--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -117,7 +117,11 @@ func TestRoutesFromSnapshot(t *testing.T) {
 						{
 							DestinationName: "foo",
 							LocalBindPort:   8080,
-							IngressHosts:    []string{"test1.example.com", "test2.example.com"},
+							IngressHosts: []string{
+								"test1.example.com",
+								"test2.example.com",
+								"test2.example.com:8080",
+							},
 						},
 						{
 							DestinationName: "bar",

--- a/agent/xds/testdata/routes/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/routes/ingress-http-multiple-services.golden
@@ -8,7 +8,8 @@
         {
           "name": "baz",
           "domains": [
-            "baz.ingress.*"
+            "baz.ingress.*",
+            "baz.ingress.*:443"
           ],
           "routes": [
             {
@@ -24,7 +25,8 @@
         {
           "name": "qux",
           "domains": [
-            "qux.ingress.*"
+            "qux.ingress.*",
+            "qux.ingress.*:443"
           ],
           "routes": [
             {
@@ -48,7 +50,9 @@
           "name": "foo",
           "domains": [
             "test1.example.com",
-            "test2.example.com"
+            "test2.example.com",
+            "test2.example.com:8080",
+            "test1.example.com:8080"
           ],
           "routes": [
             {
@@ -64,7 +68,8 @@
         {
           "name": "bar",
           "domains": [
-            "bar.ingress.*"
+            "bar.ingress.*",
+            "bar.ingress.*:8080"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/routes/ingress-splitter-with-resolver-redirect.golden
@@ -8,7 +8,8 @@
         {
           "name": "db",
           "domains": [
-            "db.ingress.*"
+            "db.ingress.*",
+            "db.ingress.*:9191"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-router.golden
@@ -8,7 +8,8 @@
         {
           "name": "db",
           "domains": [
-            "db.ingress.*"
+            "db.ingress.*",
+            "db.ingress.*:9191"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
+++ b/agent/xds/testdata/routes/ingress-with-chain-and-splitter.golden
@@ -8,7 +8,8 @@
         {
           "name": "db",
           "domains": [
-            "db.ingress.*"
+            "db.ingress.*",
+            "db.ingress.*:9191"
           ],
           "routes": [
             {

--- a/agent/xds/testdata/routes/ingress-with-grpc-router.golden
+++ b/agent/xds/testdata/routes/ingress-with-grpc-router.golden
@@ -8,7 +8,8 @@
         {
           "name": "db",
           "domains": [
-            "db.ingress.*"
+            "db.ingress.*",
+            "db.ingress.*:9191"
           ],
           "routes": [
             {

--- a/test/integration/connect/envoy/case-ingress-gateway-tls/config_entries.hcl
+++ b/test/integration/connect/envoy/case-ingress-gateway-tls/config_entries.hcl
@@ -19,6 +19,15 @@ config_entries {
 
       listeners = [
         {
+          port = 9998
+          protocol = "http"
+          services = [
+            {
+              name = "s1"
+            }
+          ]
+        },
+        {
           port = 9999
           protocol = "http"
           services = [

--- a/test/integration/connect/envoy/case-ingress-gateway-tls/verify.bats
+++ b/test/integration/connect/envoy/case-ingress-gateway-tls/verify.bats
@@ -23,12 +23,12 @@ load helpers
 }
 
 @test "should be able to connect to s1 through the TLS-enabled ingress port" {
-  assert_dnssan_in_cert localhost:9999 '\*.ingress.consul'
+  assert_dnssan_in_cert localhost:9998 '\*.ingress.consul'
   # Use the --resolve argument to fake dns resolution for now so we can use the
   # s1.ingress.consul domain to validate the cert
   run retry_default curl --cacert <(get_ca_root) -s -f -d hello \
-    --resolve s1.ingress.consul:9999:127.0.0.1 \
-    https://s1.ingress.consul:9999
+    --resolve s1.ingress.consul:9998:127.0.0.1 \
+    https://s1.ingress.consul:9998
   [ "$status" -eq 0 ]
   [ "$output" = "hello" ]
 }

--- a/test/integration/connect/envoy/main_test.go
+++ b/test/integration/connect/envoy/main_test.go
@@ -32,6 +32,7 @@ func TestEnvoy(t *testing.T) {
 		"case-ingress-gateway-http",
 		"case-ingress-gateway-multiple-services",
 		"case-ingress-gateway-simple",
+		"case-ingress-gateway-tls",
 		"case-ingress-mesh-gateways-resolver",
 		"case-multidc-rsa-ca",
 		"case-prometheus",


### PR DESCRIPTION
A port can be sent in the Host header as defined in the HTTP RFC, so we
take any hosts that we want to match traffic to and also add another
host with the listener port added.

Also fix an issue with envoy integration tests not running the
case-ingress-gateway-tls test.

This fixes issues seen in https://github.com/hashicorp/consul/issues/8045. Also, see envoy issue https://github.com/envoyproxy/envoy/issues/886 for more context.

This seems like a good improvement/fix to backport to `1.8.1` as well, any other thoughts on that welcome.