### PR TITLE
sdk: Use /v1/status/leader endpoint when starting a test server

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -381,17 +381,12 @@ func (s *TestServer) waitForAPI() error {
 		time.Sleep(timer.Wait)
 
 		url := s.url("/v1/status/leader")
-		resp, err := s.masterGet(url)
+		_, err := s.masterGet(url)
 		if err != nil {
 			failed = true
 			continue
 		}
-		resp.Body.Close()
 
-		if err = s.requireOK(resp); err != nil {
-			failed = true
-			continue
-		}
 		failed = false
 	}
 	if failed {

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -366,9 +366,12 @@ func (s *TestServer) Stop() error {
 	return s.cmd.Wait()
 }
 
-// waitForAPI waits for only the agent HTTP endpoint to start
+// waitForAPI waits for the /status/leader HTTP endpoint to start
 // responding. This is an indication that the agent has started,
 // but will likely return before a leader is elected.
+// Note: We do not check for a successful response status because
+// we want this function to return without error even when
+// there's no leader elected.
 func (s *TestServer) waitForAPI() error {
 	var failed bool
 

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -380,7 +380,7 @@ func (s *TestServer) waitForAPI() error {
 	for !time.Now().After(deadline) {
 		time.Sleep(timer.Wait)
 
-		url := s.url("/v1/agent/self")
+		url := s.url("/v1/status/leader")
 		resp, err := s.masterGet(url)
 		if err != nil {
 			failed = true


### PR DESCRIPTION
This PR proposes to switch from `/v1/agent/self` to `/v1/status/leader` when checking if the test server has come up successfully in the `waitForAPI` function:

https://github.com/hashicorp/consul/blob/833211c14cfecd64e36ab238ca943ceb97acee37/sdk/testutil/server.go#L372-L401

### Background
Previously, the test server was relying (probably not intentionally) on the default value of the `acl_enforce_version_8` in the TestConfig, which was `false`. So if you create a test server and enabled ACLs, they would not be enforced and the server would be able to come up pretty quickly because `/v1/agent/self` would return a `200` status pretty much as soon as the agent is running and most likely before leader election is finished.

Now that we have removed `acl_enforce_version_8` property (equivalent to being true by default) if you've created a test server with ACLs enabled, it will need to wait for leader election and for ACLs to be initialized before it'll get a successful response from the `/v1/agent/self`.

### Notes

There might be a better API endpoint to call, but I thought that `/v1/status/leader` is the closest option to what was originally intended by this method and to how we're currently using in the hashicorp/consul-k8s repo. 

With this change, waitForAPI function no longer requires a 200 response status from the `v1/status/leader` endpoint. This is because in some tests, namely `TestAPI_AgentLeave` we are only running clients, and this endpoint returns a `500` status.

