### PR TITLE
Default AddUserAgent envoy headers to true

### DIFF
--- a/agent/xds/listeners.go
+++ b/agent/xds/listeners.go
@@ -914,8 +914,9 @@ func makeHTTPFilter(
 	}
 
 	cfg := &envoyhttp.HttpConnectionManager{
-		StatPrefix: makeStatPrefix(proto, statPrefix, filterName),
-		CodecType:  envoyhttp.HttpConnectionManager_AUTO,
+		StatPrefix:   makeStatPrefix(proto, statPrefix, filterName),
+		CodecType:    envoyhttp.HttpConnectionManager_AUTO,
+		AddUserAgent: &wrappers.BoolValue{Value: true},
 		HttpFilters: []*envoyhttp.HttpFilter{
 			{
 				Name: "envoy.router",

--- a/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-chain-and-overrides.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http2_protocol_options": {
                       },
                   "http_filters": [

--- a/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-grpc-chain.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http2_protocol_options": {
                       },
                   "http_filters": [

--- a/agent/xds/testdata/listeners/connect-proxy-with-http-chain.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http-chain.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.golden
+++ b/agent/xds/testdata/listeners/connect-proxy-with-http2-chain.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http2_protocol_options": {
                       },
                   "http_filters": [

--- a/agent/xds/testdata/listeners/expose-paths-local-app-paths.golden
+++ b/agent/xds/testdata/listeners/expose-paths-local-app-paths.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"
@@ -68,6 +69,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.golden
+++ b/agent/xds/testdata/listeners/expose-paths-new-cluster-http2.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http2_protocol_options": {
                       },
                   "http_filters": [
@@ -70,6 +71,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/http-public-listener.golden
+++ b/agent/xds/testdata/listeners/http-public-listener.golden
@@ -102,6 +102,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/http-upstream.golden
+++ b/agent/xds/testdata/listeners/http-upstream.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
+++ b/agent/xds/testdata/listeners/ingress-http-multiple-services.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"
@@ -55,6 +56,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/listeners/ingress-splitter-with-resolver-redirect.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"

--- a/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.golden
+++ b/agent/xds/testdata/listeners/ingress-with-chain-and-overrides.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http2_protocol_options": {
                       },
                   "http_filters": [

--- a/agent/xds/testdata/listeners/splitter-with-resolver-redirect.golden
+++ b/agent/xds/testdata/listeners/splitter-with-resolver-redirect.golden
@@ -16,6 +16,7 @@
             {
               "name": "envoy.http_connection_manager",
               "config": {
+                  "add_user_agent": true,
                   "http_filters": [
                         {
                               "name": "envoy.router"


### PR DESCRIPTION
To allow internal services to distinguish which service is calling them Envoy allows for adding additional headers (e.g. [x-envoy-downstream-service-cluster](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=add_user_agent#x-envoy-downstream-service-cluster)) to HTTP requests via HTTP Connection Manager configuration [add_user_agent](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-add-user-agent).

This change proposes to default these additional headers to true via add_user_agent configuration in the default HTTPFilters built by Consul.

This would be useful for example by application that is serving as an upstream for multiple mesh services which can use the downstream name to give context to its own metrics and logs.

