### PR TITLE
ui: Ensure routing tab is always shown when connect enabled

### DIFF
--- a/ui-v2/app/services/repository/discovery-chain.js
+++ b/ui-v2/app/services/repository/discovery-chain.js
@@ -24,7 +24,7 @@ export default RepositoryService.extend({
           }
           return;
         default:
-          return;
+          throw e;
       }
     });
   },


### PR DESCRIPTION
Currently we can only tell if connect is disabled on a datacenter by detecting a 500 error from a connect related endpoint.

In https://github.com/hashicorp/consul/pull/8065 we attempted to reduce the amount of times that the UI requests the discovery chain endpoint when connect is disabled on a datacenter.

In the above PR (present in Consul 1.8.0) we mistakenly `return`ed from a catch instead of rethrowing the error, which meant that when a `500` error was caught, the discovery chain data would be removed. Whilst at first glance this doesn't seem like a big problem due to the endpoint erroring, but we also receive a `0` status errors when we abort endpoints during blocking queries. This means that in certain cases we can replace cached data for the discovery chain with `undefined` which will not get replaced until the blocking query responds again. From a user perspective, this can result in the Routing tab being hidden in certain situations.

This PR replaces the `return` with a `throw`, which means that other errors are dealt with correctly via the blocking query error detection/logic.

In the meantime, a page refresh will bring back the routing tab and visualisation when it has been removed.