### PR TITLE
Fix a handful of auto encrypt issues

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -840,7 +840,7 @@ func (a *Agent) setupClientAutoEncrypt(ctx context.Context) (*structs.SignedResp
 	}
 	addrs = append(addrs, retryJoinAddrs(disco, retryJoinSerfVariant, "LAN", a.config.RetryJoinLAN, a.logger)...)
 
-	reply, priv, err := client.RequestAutoEncryptCerts(ctx, addrs, a.config.ServerPort, a.tokens.AgentToken())
+	reply, priv, err := client.RequestAutoEncryptCerts(ctx, addrs, a.config.ServerPort, a.tokens.AgentToken(), a.config.AutoEncryptDNSSAN, a.config.AutoEncryptIPSAN)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -532,7 +532,7 @@ func (c *ConnectCALeaf) generateNewLeaf(req *ConnectCALeafRequest,
 		}
 		commonName = connect.AgentCN(req.Agent, roots.TrustDomain)
 		dnsNames = append([]string{"localhost"}, req.DNSSAN...)
-		ipAddresses = append([]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::")}, req.IPSAN...)
+		ipAddresses = append([]net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}, req.IPSAN...)
 	} else {
 		return result, errors.New("URI must be either service or agent")
 	}

--- a/agent/cache-types/connect_ca_leaf.go
+++ b/agent/cache-types/connect_ca_leaf.go
@@ -121,6 +121,15 @@ type fetchState struct {
 	consecutiveRateLimitErrs int
 }
 
+func ConnectCALeafSuccess(authorityKeyID string) interface{} {
+	return fetchState{
+		authorityKeyID:           authorityKeyID,
+		forceExpireAfter:         time.Time{},
+		consecutiveRateLimitErrs: 0,
+		activeRootRotationStart:  time.Time{},
+	}
+}
+
 // fetchStart is called on each fetch that is about to block and wait for
 // changes to the leaf. It subscribes a chan to receive updates from the shared
 // root watcher and triggers root watcher if it's not already running.

--- a/agent/consul/auto_encrypt_test.go
+++ b/agent/consul/auto_encrypt_test.go
@@ -2,11 +2,17 @@ package consul
 
 import (
 	"context"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"net"
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/connect"
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
@@ -98,7 +104,7 @@ func TestAutoEncrypt_RequestAutoEncryptCerts(t *testing.T) {
 	doneCh := make(chan struct{})
 	var err error
 	go func() {
-		_, _, err = c1.RequestAutoEncryptCerts(ctx, servers, port, token)
+		_, _, err = c1.RequestAutoEncryptCerts(ctx, servers, port, token, nil, nil)
 		close(doneCh)
 	}()
 	select {
@@ -111,5 +117,89 @@ func TestAutoEncrypt_RequestAutoEncryptCerts(t *testing.T) {
 	case <-ctx.Done():
 		// this is the happy case since auto encrypt is in its loop to
 		// try to request certs.
+	}
+}
+
+func TestAutoEncrypt_autoEncryptCSR(t *testing.T) {
+	type testCase struct {
+		conf         *Config
+		extraDNSSANs []string
+		extraIPSANs  []net.IP
+		err          string
+
+		// to validate the csr
+		expectedSubject  pkix.Name
+		expectedSigAlg   x509.SignatureAlgorithm
+		expectedPubAlg   x509.PublicKeyAlgorithm
+		expectedDNSNames []string
+		expectedIPs      []net.IP
+		expectedURIs     []*url.URL
+	}
+
+	cases := map[string]testCase{
+		"sans": {
+			conf: &Config{
+				Datacenter: "dc1",
+				NodeName:   "test-node",
+				CAConfig:   &structs.CAConfiguration{},
+			},
+			extraDNSSANs: []string{"foo.local", "bar.local"},
+			extraIPSANs:  []net.IP{net.IPv4(198, 18, 0, 1), net.IPv4(198, 18, 0, 2)},
+			expectedSubject: pkix.Name{
+				CommonName: connect.AgentCN("test-node", dummyTrustDomain),
+				Names: []pkix.AttributeTypeAndValue{
+					{
+						// 2,5,4,3 is the CommonName type ASN1 identifier
+						Type:  asn1.ObjectIdentifier{2, 5, 4, 3},
+						Value: "testnode.agnt.dummy.tr.consul",
+					},
+				},
+			},
+			expectedSigAlg: x509.ECDSAWithSHA256,
+			expectedPubAlg: x509.ECDSA,
+			expectedDNSNames: []string{
+				"localhost",
+				"foo.local",
+				"bar.local",
+			},
+			expectedIPs: []net.IP{
+				{127, 0, 0, 1},
+				net.ParseIP("::1"),
+				{198, 18, 0, 1},
+				{198, 18, 0, 2},
+			},
+			expectedURIs: []*url.URL{
+				{
+					Scheme: "spiffe",
+					Host:   dummyTrustDomain,
+					Path:   "/agent/client/dc/dc1/id/test-node",
+				},
+			},
+		},
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(t *testing.T) {
+			client := Client{config: tcase.conf}
+
+			_, csr, err := client.autoEncryptCSR(tcase.extraDNSSANs, tcase.extraIPSANs)
+			if tcase.err == "" {
+				require.NoError(t, err)
+
+				request, err := connect.ParseCSR(csr)
+				require.NoError(t, err)
+				require.NotNil(t, request)
+
+				require.Equal(t, tcase.expectedSubject, request.Subject)
+				require.Equal(t, tcase.expectedSigAlg, request.SignatureAlgorithm)
+				require.Equal(t, tcase.expectedPubAlg, request.PublicKeyAlgorithm)
+				require.Equal(t, tcase.expectedDNSNames, request.DNSNames)
+				require.Equal(t, tcase.expectedIPs, request.IPAddresses)
+				require.Equal(t, tcase.expectedURIs, request.URIs)
+			} else {
+				require.Error(t, err)
+				require.Empty(t, csr)
+			}
+		})
 	}
 }

--- a/agent/consul/connect_ca_endpoint.go
+++ b/agent/consul/connect_ca_endpoint.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/hashicorp/consul/lib/semaphore"
 	"github.com/hashicorp/go-hclog"
 
 	"golang.org/x/time/rate"
@@ -53,57 +51,6 @@ type ConnectCA struct {
 	srv *Server
 
 	logger hclog.Logger
-
-	// csrRateLimiter limits the rate of signing new certs if configured. Lazily
-	// initialized from current config to support dynamic changes.
-	// csrRateLimiterMu must be held while dereferencing the pointer or storing a
-	// new one, but methods can be called on the limiter object outside of the
-	// locked section. This is done only in the getCSRRateLimiterWithLimit method.
-	csrRateLimiter   *rate.Limiter
-	csrRateLimiterMu sync.RWMutex
-
-	// csrConcurrencyLimiter is a dynamically resizable semaphore used to limit
-	// Sign RPC concurrency if configured. The zero value is usable as soon as
-	// SetSize is called which we do dynamically in the RPC handler to avoid
-	// having to hook elaborate synchronization mechanisms through the CA config
-	// endpoint and config reload etc.
-	csrConcurrencyLimiter semaphore.Dynamic
-}
-
-// getCSRRateLimiterWithLimit returns a rate.Limiter with the desired limit set.
-// It uses the shared server-wide limiter unless the limit has been changed in
-// config or the limiter has not been setup yet in which case it just-in-time
-// configures the new limiter. We assume that limit changes are relatively rare
-// and that all callers (there is currently only one) use the same config value
-// as the limit. There might be some flapping if there are multiple concurrent
-// requests in flight at the time the config changes where A sees the new value
-// and updates, B sees the old but then gets this lock second and changes back.
-// Eventually though and very soon (once all current RPCs are complete) we are
-// guaranteed to have the correct limit set by the next RPC that comes in so I
-// assume this is fine. If we observe strange behavior because of it, we could
-// add hysteresis that prevents changes too soon after a previous change but
-// that seems unnecessary for now.
-func (s *ConnectCA) getCSRRateLimiterWithLimit(limit rate.Limit) *rate.Limiter {
-	s.csrRateLimiterMu.RLock()
-	lim := s.csrRateLimiter
-	s.csrRateLimiterMu.RUnlock()
-
-	// If there is a current limiter with the same limit, return it. This should
-	// be the common case.
-	if lim != nil && lim.Limit() == limit {
-		return lim
-	}
-
-	// Need to change limiter, get write lock
-	s.csrRateLimiterMu.Lock()
-	defer s.csrRateLimiterMu.Unlock()
-	// No limiter yet, or limit changed in CA config, reconfigure a new limiter.
-	// We use burst of 1 for a hard limit. Note that either bursting or waiting is
-	// necessary to get expected behavior in fact of random arrival times, but we
-	// don't need both and we use Wait with a small delay to smooth noise. See
-	// https://github.com/banks/sim-rate-limit-backoff/blob/master/README.md.
-	s.csrRateLimiter = rate.NewLimiter(limit, 1)
-	return s.csrRateLimiter
 }
 
 // ConfigurationGet returns the configuration for the CA.
@@ -514,7 +461,7 @@ func (s *ConnectCA) Sign(
 		return err
 	}
 	if commonCfg.CSRMaxPerSecond > 0 {
-		lim := s.getCSRRateLimiterWithLimit(rate.Limit(commonCfg.CSRMaxPerSecond))
+		lim := s.srv.caLeafLimiter.getCSRRateLimiterWithLimit(rate.Limit(commonCfg.CSRMaxPerSecond))
 		// Wait up to the small threshold we allow for a token.
 		ctx, cancel := context.WithTimeout(context.Background(), csrLimitWait)
 		defer cancel()
@@ -522,13 +469,13 @@ func (s *ConnectCA) Sign(
 			return ErrRateLimited
 		}
 	} else if commonCfg.CSRMaxConcurrent > 0 {
-		s.csrConcurrencyLimiter.SetSize(int64(commonCfg.CSRMaxConcurrent))
+		s.srv.caLeafLimiter.csrConcurrencyLimiter.SetSize(int64(commonCfg.CSRMaxConcurrent))
 		ctx, cancel := context.WithTimeout(context.Background(), csrLimitWait)
 		defer cancel()
-		if err := s.csrConcurrencyLimiter.Acquire(ctx); err != nil {
+		if err := s.srv.caLeafLimiter.csrConcurrencyLimiter.Acquire(ctx); err != nil {
 			return ErrRateLimited
 		}
-		defer s.csrConcurrencyLimiter.Release()
+		defer s.srv.caLeafLimiter.csrConcurrencyLimiter.Release()
 	}
 
 	// All seems to be in order, actually sign it.

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -153,6 +153,9 @@ type Server struct {
 	caProviderRoot *structs.CARoot
 	caProviderLock sync.RWMutex
 
+	// rate limiter to use when signing leaf certificates
+	caLeafLimiter connectSignRateLimiter
+
 	// Consul configuration
 	config *Config
 

--- a/agent/consul/server_connect.go
+++ b/agent/consul/server_connect.go
@@ -1,0 +1,61 @@
+package consul
+
+import (
+	"sync"
+
+	"github.com/hashicorp/consul/lib/semaphore"
+	"golang.org/x/time/rate"
+)
+
+type connectSignRateLimiter struct {
+	// csrRateLimiter limits the rate of signing new certs if configured. Lazily
+	// initialized from current config to support dynamic changes.
+	// csrRateLimiterMu must be held while dereferencing the pointer or storing a
+	// new one, but methods can be called on the limiter object outside of the
+	// locked section. This is done only in the getCSRRateLimiterWithLimit method.
+	csrRateLimiter   *rate.Limiter
+	csrRateLimiterMu sync.RWMutex
+
+	// csrConcurrencyLimiter is a dynamically resizable semaphore used to limit
+	// Sign RPC concurrency if configured. The zero value is usable as soon as
+	// SetSize is called which we do dynamically in the RPC handler to avoid
+	// having to hook elaborate synchronization mechanisms through the CA config
+	// endpoint and config reload etc.
+	csrConcurrencyLimiter semaphore.Dynamic
+}
+
+// getCSRRateLimiterWithLimit returns a rate.Limiter with the desired limit set.
+// It uses the shared server-wide limiter unless the limit has been changed in
+// config or the limiter has not been setup yet in which case it just-in-time
+// configures the new limiter. We assume that limit changes are relatively rare
+// and that all callers (there is currently only one) use the same config value
+// as the limit. There might be some flapping if there are multiple concurrent
+// requests in flight at the time the config changes where A sees the new value
+// and updates, B sees the old but then gets this lock second and changes back.
+// Eventually though and very soon (once all current RPCs are complete) we are
+// guaranteed to have the correct limit set by the next RPC that comes in so I
+// assume this is fine. If we observe strange behavior because of it, we could
+// add hysteresis that prevents changes too soon after a previous change but
+// that seems unnecessary for now.
+func (l *connectSignRateLimiter) getCSRRateLimiterWithLimit(limit rate.Limit) *rate.Limiter {
+	l.csrRateLimiterMu.RLock()
+	lim := l.csrRateLimiter
+	l.csrRateLimiterMu.RUnlock()
+
+	// If there is a current limiter with the same limit, return it. This should
+	// be the common case.
+	if lim != nil && lim.Limit() == limit {
+		return lim
+	}
+
+	// Need to change limiter, get write lock
+	l.csrRateLimiterMu.Lock()
+	defer l.csrRateLimiterMu.Unlock()
+	// No limiter yet, or limit changed in CA config, reconfigure a new limiter.
+	// We use burst of 1 for a hard limit. Note that either bursting or waiting is
+	// necessary to get expected behavior in fact of random arrival times, but we
+	// don't need both and we use Wait with a small delay to smooth noise. See
+	// https://github.com/banks/sim-rate-limit-backoff/blob/master/README.md.
+	l.csrRateLimiter = rate.NewLimiter(limit, 1)
+	return l.csrRateLimiter
+}

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -505,6 +505,12 @@ func (c *Configurator) commonTLSConfig(verifyIncoming bool) *tls.Config {
 			cert = c.manual.cert
 		}
 
+		if cert == nil {
+			// the return value MUST not be nil but an empty certificate will be
+			// treated the same as having no client certificate
+			cert = &tls.Certificate{}
+		}
+
 		return cert, nil
 	}
 

--- a/tlsutil/config_test.go
+++ b/tlsutil/config_test.go
@@ -649,7 +649,8 @@ func TestConfigurator_CommonTLSConfigGetClientCertificate(t *testing.T) {
 
 	cert, err := c.commonTLSConfig(false).GetClientCertificate(nil)
 	require.NoError(t, err)
-	require.Nil(t, cert)
+	require.NotNil(t, cert)
+	require.Empty(t, cert.Certificate)
 
 	c1, err := loadKeyPair("../test/key/something_expired.cer", "../test/key/something_expired.key")
 	require.NoError(t, err)


### PR DESCRIPTION
* Ensure that the original auto encrypt CSR contains the DNS and IP SANs from the configuration
* Initialize State of the agent leaf cert cache fetch result to prevent always issuing a second certificate signing RPC to the servers
* Move the connect CA signing rate limiter to the Server so that it can be shared with auto-encrypt and the main certificate signing RPC endpoints.
* Overwrite the agent leaf certificate trust domain on the servers. This ensures that the first certificate sent back is "correct" and has the correct trust domain instead of the dummy one.
* Fixed a bug where Consul would segfault if no client TLS certificate was available when initiating a connection.