### PR TITLE
agent/consul: Add support for NotModified to two endpoints

### DIFF
--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -783,6 +783,21 @@ func TestCatalog_ListNodes(t *testing.T) {
 	if out.Nodes[0].Address != "127.0.0.1" {
 		t.Fatalf("bad: %v", out)
 	}
+	require.False(t, out.QueryMeta.NotModified)
+
+	t.Run("with option AllowNotModifiedResponse", func(t *testing.T) {
+		args.QueryOptions = structs.QueryOptions{
+			MinQueryIndex:            out.QueryMeta.Index,
+			MaxQueryTime:             20 * time.Millisecond,
+			AllowNotModifiedResponse: true,
+		}
+		err := msgpackrpc.CallWithCodec(codec, "Catalog.ListNodes", &args, &out)
+		require.NoError(t, err)
+
+		require.Equal(t, out.Index, out.QueryMeta.Index)
+		require.Len(t, out.Nodes, 0)
+		require.True(t, out.QueryMeta.NotModified, "NotModified should be true")
+	})
 }
 
 func TestCatalog_ListNodes_NodeMetaFilter(t *testing.T) {
@@ -1322,6 +1337,21 @@ func TestCatalog_ListServices(t *testing.T) {
 	if out.Services["db"][0] != "primary" {
 		t.Fatalf("bad: %v", out)
 	}
+	require.False(t, out.QueryMeta.NotModified)
+
+	t.Run("with option AllowNotModifiedResponse", func(t *testing.T) {
+		args.QueryOptions = structs.QueryOptions{
+			MinQueryIndex:            out.QueryMeta.Index,
+			MaxQueryTime:             20 * time.Millisecond,
+			AllowNotModifiedResponse: true,
+		}
+		err := msgpackrpc.CallWithCodec(codec, "Catalog.ListServices", &args, &out)
+		require.NoError(t, err)
+
+		require.Equal(t, out.Index, out.QueryMeta.Index)
+		require.Len(t, out.Services, 0)
+		require.True(t, out.QueryMeta.NotModified, "NotModified should be true")
+	})
 }
 
 func TestCatalog_ListServices_NodeMetaFilter(t *testing.T) {

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -212,6 +212,11 @@ type QueryOptions struct {
 	// Filter specifies the go-bexpr filter expression to be used for
 	// filtering the data prior to returning a response
 	Filter string
+
+	// AllowNotModifiedResponse indicates that if the MinIndex matches the
+	// QueryMeta.Index, the response can be left empty and QueryMeta.NotModified
+	// will be set to true to indicate the result of the query has not changed.
+	AllowNotModifiedResponse bool
 }
 
 // IsRead is always true for QueryOption.
@@ -268,7 +273,7 @@ func (w *WriteRequest) SetTokenSecret(s string) {
 // QueryMeta allows a query response to include potentially
 // useful metadata about a query
 type QueryMeta struct {
-	// This is the index associated with the read
+	// Index in the raft log of the latest item returned by the query.
 	Index uint64
 
 	// If AllowStale is used, this is time elapsed since
@@ -283,6 +288,12 @@ type QueryMeta struct {
 	// Having `discovery_max_stale` on the agent can affect whether
 	// the request was served by a leader.
 	ConsistencyLevel string
+
+	// NotModified is true when the Index of the query is the same value as the
+	// requested MinIndex. It indicates that the entity has not been modified.
+	// When NotModified is true, the response will not contain the result of
+	// the query.
+	NotModified bool
 }
 
 // RegisterRequest is used for the Catalog.Register endpoint


### PR DESCRIPTION
Related to #7968 (#7974, #7995).

A query made with `AllowNotModifiedResponse` and a `MinIndex`, where the result has the same `Index` as `MinIndex`, will return an empty response with `QueryMeta.NotModified` set to true.

This PR adds support to only 2 RPC endpoints to focus the review and discussion on the naming and server side implementation. If this looks good next steps (in follow up PRs) would be: add the same support to other endpoints, set `AllowNotModifiedResponse` when RPC calls are made from the client cache, and finally figure out how to expose this parameter from the HTTP API.