### PR TITLE
Update lock.mdx

### DIFF
--- a/website/pages/docs/commands/lock.mdx
+++ b/website/pages/docs/commands/lock.mdx
@@ -77,12 +77,9 @@ Windows has no POSIX compatible notion for `SIGTERM`.
 
 - `-pass-stdin` - Pass stdin to child process.
 
-- `-timeout` - Maximum amount of time to wait to acquire the lock, specified
-  as a duration like `1s` or `3h`. The default value is 0.
-
 - `-timeout` - Attempt to acquire the lock up to the given timeout. The timeout is a
   positive decimal number, with unit suffix, such as "500ms". Valid time units
-  are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  are "ns", "us" (or "µs"), "ms", "s", "m", "h". The default value is 0.
 
 - `-verbose` - Enables verbose output.
 


### PR DESCRIPTION
There is a duplicated line in the `-timeout`  option for `consul lock` causing a bit of confusion, I have removed the duplicated `-timeout` value.