### PR TITLE
Consul not returning NXDOMAIN for DNS queries to a non-existent datacenter

### DIFF
--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -14,11 +13,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-uuid"
-)
-
-var (
-	// ErrQueryNotFound is returned if the query lookup failed.
-	ErrQueryNotFound = errors.New("Query not found")
 )
 
 // PreparedQuery manages the prepared query endpoint.
@@ -228,7 +222,7 @@ func (p *PreparedQuery) Get(args *structs.PreparedQuerySpecificRequest,
 				return err
 			}
 			if query == nil {
-				return ErrQueryNotFound
+				return structs.ErrQueryNotFound
 			}
 
 			// If no prefix ACL applies to this query, then they are
@@ -303,7 +297,7 @@ func (p *PreparedQuery) Explain(args *structs.PreparedQueryExecuteRequest,
 		return err
 	}
 	if query == nil {
-		return ErrQueryNotFound
+		return structs.ErrQueryNotFound
 	}
 
 	// Place the query into a list so we can run the standard ACL filter on
@@ -350,7 +344,7 @@ func (p *PreparedQuery) Execute(args *structs.PreparedQueryExecuteRequest,
 		return err
 	}
 	if query == nil {
-		return ErrQueryNotFound
+		return structs.ErrQueryNotFound
 	}
 
 	// Execute the query for the local DC.

--- a/agent/consul/prepared_query_endpoint_test.go
+++ b/agent/consul/prepared_query_endpoint_test.go
@@ -175,7 +175,7 @@ func TestPreparedQuery_Apply(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		if err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp); err != nil {
-			if err.Error() != ErrQueryNotFound.Error() {
+			if !structs.IsErrQueryNotFound(err) {
 				t.Fatalf("err: %v", err)
 			}
 		}
@@ -317,7 +317,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		if err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp); err != nil {
-			if err.Error() != ErrQueryNotFound.Error() {
+			if !structs.IsErrQueryNotFound(err) {
 				t.Fatalf("err: %v", err)
 			}
 		}
@@ -412,7 +412,7 @@ func TestPreparedQuery_Apply_ACLDeny(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		if err = msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp); err != nil {
-			if err.Error() != ErrQueryNotFound.Error() {
+			if !structs.IsErrQueryNotFound(err) {
 				t.Fatalf("err: %v", err)
 			}
 		}
@@ -1082,7 +1082,7 @@ func TestPreparedQuery_Get(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		if err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Get", req, &resp); err != nil {
-			if err.Error() != ErrQueryNotFound.Error() {
+			if !structs.IsErrQueryNotFound(err) {
 				t.Fatalf("err: %v", err)
 			}
 		}
@@ -1429,7 +1429,7 @@ func TestPreparedQuery_Explain(t *testing.T) {
 		}
 		var resp structs.IndexedPreparedQueries
 		if err := msgpackrpc.CallWithCodec(codec, "PreparedQuery.Explain", req, &resp); err != nil {
-			if err.Error() != ErrQueryNotFound.Error() {
+			if !structs.IsErrQueryNotFound(err) {
 				t.Fatalf("err: %v", err)
 			}
 		}
@@ -1617,7 +1617,7 @@ func TestPreparedQuery_Execute(t *testing.T) {
 
 		var reply structs.PreparedQueryExecuteResponse
 		err := msgpackrpc.CallWithCodec(codec1, "PreparedQuery.Execute", &req, &reply)
-		assert.EqualError(t, err, ErrQueryNotFound.Error())
+		assert.EqualError(t, err, structs.ErrQueryNotFound.Error())
 		assert.Len(t, reply.Nodes, 0)
 	})
 

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -829,7 +829,7 @@ func (d *DNSServer) computeRCode(err error) int {
 		return dns.RcodeSuccess
 	}
 	dErr := err.Error()
-	if dErr == structs.ErrNoDCPath.Error() || dErr == consul.ErrQueryNotFound.Error() {
+	if structs.IsErrNoDCPath(err) || dErr == consul.ErrQueryNotFound.Error() {
 		return dns.RcodeNameError
 	}
 	return dns.RcodeServerFailure

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -16,7 +16,6 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
 	"github.com/hashicorp/consul/agent/config"
-	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/ipaddr"
@@ -828,8 +827,7 @@ func (d *DNSServer) computeRCode(err error) int {
 	if err == nil {
 		return dns.RcodeSuccess
 	}
-	dErr := err.Error()
-	if structs.IsErrNoDCPath(err) || dErr == consul.ErrQueryNotFound.Error() {
+	if structs.IsErrNoDCPath(err) || structs.IsErrQueryNotFound(err) {
 		return dns.RcodeNameError
 	}
 	return dns.RcodeServerFailure

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -5790,18 +5790,61 @@ func TestDNS_AddressLookupIPV6(t *testing.T) {
 	}
 }
 
-func TestDNS_NonExistingDC(t *testing.T) {
+// TestDNS_NonExistentDC_Server verifies NXDOMAIN is returned when
+// Consul server agent is queried for a service in a non-existent
+// domain.
+func TestDNS_NonExistentDC_Server(t *testing.T) {
 	t.Parallel()
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
-	// lookup a non-existing node, we should receive a SOA
 	m := new(dns.Msg)
-	m.SetQuestion("consul.dc2.consul.", dns.TypeANY)
+	m.SetQuestion("consul.service.dc2.consul.", dns.TypeANY)
 
 	c := new(dns.Client)
 	in, _, err := c.Exchange(m, a.DNSAddr())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if in.Rcode != dns.RcodeNameError {
+		t.Fatalf("Expected RCode: %#v, had: %#v", dns.RcodeNameError, in.Rcode)
+	}
+}
+
+// TestDNS_NonExistentDC_RPC verifies NXDOMAIN is returned when
+// Consul server agent is queried over RPC by a non-server agent
+// for a service in a non-existent domain
+func TestDNS_NonExistentDC_RPC(t *testing.T) {
+	t.Parallel()
+	s := NewTestAgent(t, `
+		node_name = "test-server"
+	`)
+
+	defer s.Shutdown()
+	c := NewTestAgent(t, `
+		node_name = "test-client"
+		bootstrap = false
+		server = false
+	`)
+	defer c.Shutdown()
+	testrpc.WaitForLeader(t, s.RPC, "dc1")
+
+	// Join LAN cluster
+	addr := fmt.Sprintf("127.0.0.1:%d", s.Config.SerfPortLAN)
+	_, err := c.JoinLAN([]string{addr})
+	require.NoError(t, err)
+	retry.Run(t, func(r *retry.R) {
+		require.Len(r, s.LANMembers(), 2)
+		require.Len(r, c.LANMembers(), 2)
+	})
+
+	m := new(dns.Msg)
+	m.SetQuestion("consul.service.dc2.consul.", dns.TypeANY)
+
+	d := new(dns.Client)
+	in, _, err := d.Exchange(m, c.DNSAddr())
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/prepared_query_endpoint.go
+++ b/agent/prepared_query_endpoint.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	cachetype "github.com/hashicorp/consul/agent/cache-types"
-	"github.com/hashicorp/consul/agent/consul"
 	"github.com/hashicorp/consul/agent/structs"
 )
 
@@ -144,7 +143,7 @@ func (s *HTTPServer) preparedQueryExecute(id string, resp http.ResponseWriter, r
 		if err := s.agent.RPC("PreparedQuery.Execute", &args, &reply); err != nil {
 			// We have to check the string since the RPC sheds
 			// the specific error type.
-			if err.Error() == consul.ErrQueryNotFound.Error() {
+			if structs.IsErrQueryNotFound(err) {
 				resp.WriteHeader(http.StatusNotFound)
 				fmt.Fprint(resp, err.Error())
 				return nil, nil
@@ -198,7 +197,7 @@ RETRY_ONCE:
 	if err := s.agent.RPC("PreparedQuery.Explain", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
 		// the specific error type.
-		if err.Error() == consul.ErrQueryNotFound.Error() {
+		if structs.IsErrQueryNotFound(err) {
 			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil
@@ -229,7 +228,7 @@ RETRY_ONCE:
 	if err := s.agent.RPC("PreparedQuery.Get", &args, &reply); err != nil {
 		// We have to check the string since the RPC sheds
 		// the specific error type.
-		if err.Error() == consul.ErrQueryNotFound.Error() {
+		if structs.IsErrQueryNotFound(err) {
 			resp.WriteHeader(http.StatusNotFound)
 			fmt.Fprint(resp, err.Error())
 			return nil, nil

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -14,6 +14,7 @@ const (
 	errSegmentsNotSupported       = "Network segments are not supported in this version of Consul"
 	errRPCRateExceeded            = "RPC rate limit exceeded"
 	errServiceNotFound            = "Service not found: "
+	errQueryNotFound              = "Query not found"
 )
 
 var (
@@ -24,10 +25,15 @@ var (
 	ErrSegmentsNotSupported       = errors.New(errSegmentsNotSupported)
 	ErrRPCRateExceeded            = errors.New(errRPCRateExceeded)
 	ErrDCNotAvailable             = errors.New(errDCNotAvailable)
+	ErrQueryNotFound              = errors.New(errQueryNotFound)
 )
 
 func IsErrNoDCPath(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errNoDCPath)
+}
+
+func IsErrQueryNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errQueryNotFound)
 }
 
 func IsErrNoLeader(err error) bool {

--- a/agent/structs/errors.go
+++ b/agent/structs/errors.go
@@ -26,6 +26,10 @@ var (
 	ErrDCNotAvailable             = errors.New(errDCNotAvailable)
 )
 
+func IsErrNoDCPath(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errNoDCPath)
+}
+
 func IsErrNoLeader(err error) bool {
 	return err != nil && strings.Contains(err.Error(), errNoLeader)
 }


### PR DESCRIPTION
### Overview
Recently we found an issue when a DNS query sent to Consul for a non-existent domain makes client agent to keep querying servers indefinitely for that domain, when DNS cache is enabled, i.e. `dns_config.use_cache` is set to `true`. We were able to reproduce the issue locally with the most recent versions (1.7.4, 1.8.0):
```
2020-07-01T02:00:49.159+0100 [WARN]  agent.server.rpc: RPC request for DC is currently failing as no path was found: datacenter=locxx method=Health.ServiceNodes
2020-07-01T02:00:49.159+0100 [ERROR] agent.client: RPC failed to server: method=Health.ServiceNodes server=127.0.0.103:8310 error="rpc error making call: No path to datacenter"
...
```
In addition to be an annoying bug, this is also a DDoS vector allowing to quickly exhaust memory on all Consul servers in the cluster by flooding a single Consul agent with random queries in non-existent domains. Once DNS cache is disabled, the agent sends only a single query to the servers available.
All of this is happening due to the bug where `SERVFAIL` is returned when `NXDOMAIN` should be. The bug was supposed to be fixed in #8103, but unfortunately it's not for the case where a DNS query goes through a non-server agent first:
```bash
$ consul version
Consul 1.8.0-dev
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
$ dig -p 8600  +noall +answer +comment srv consul.service.locXX.consul-testing @127.0.0.201
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 34400
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
```
Configuration used to reproduce the issue: https://gist.github.com/yurkeen/7bc4bc12c7551b8c979cbf01a3cb5bea

### Reasons
There are two consequent reasons why this issue is happening: 
I. The test provided in #8103, `TestDNS_NonExistingDC` checks the DNS response received from the agent, when the agent is a Consul server itself. However, this test does not cover the case when DNS resolution happens over RPC through client agent reaching a server agent.
II. The error being provided for the `computeRCode()` method in [dns.go](https://github.com/hashicorp/consul/blob/a891ee84282d89ae392e7457469ffd2b98e92947/agent/dns.go#L832) is compared to the `"No path to datacenter"` string. In case when resolution happens through a Consul agent, the error looks slightly different: `"rpc error making call: No path to datacenter"`, i.e. RPC layer adds more context to this error causing the condition to fail and slip through to [returning the default](https://github.com/hashicorp/consul/blob/a891ee84282d89ae392e7457469ffd2b98e92947/agent/dns.go#L835) `dns.RcodeServerFailure`.

### Solution
This PR is split into three commits:
- `3b4ddaa` adds a test to make sure NXDOMAIN is returned when Consul server agent is queried over RPC by a non-server agent. If ran without applying the next commit `8d18422`, the test will fail.
- `8d18422` adds a fix to compare errors properly, so NXDOMAIN is returned for both cases — direct on the server agent and over RPC;
- `10361dd` is a bonus track adding small refactoring of the `ErrQueryNotFound` error and adding the `IsErrQueryNotFound(err)` helper for it to align it with the rest of the errors.