### PR TITLE
agent/consul: Set defaults when applying ConsulOptions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -680,7 +680,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start Consul enterprise component: %v", err)
 	}
 
-	options := []consul.ConsulOption{
+	options := []consul.Op{
 		consul.WithLogger(a.logger),
 		consul.WithTokenStore(a.tokens),
 		consul.WithTLSConfigurator(a.tlsConfigurator),

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
-	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
 	"golang.org/x/time/rate"
@@ -85,8 +84,6 @@ type Client struct {
 
 	// embedded struct to hold all the enterprise specific data
 	EnterpriseClient
-
-	tlsConfigurator *tlsutil.Configurator
 }
 
 // NewClientWithOptions creates a new Client from the list of options.
@@ -127,12 +124,11 @@ func NewClientWithOptions(config *Config, options ...Op) (*Client, error) {
 
 	// Create client
 	c := &Client{
-		config:          config,
-		connPool:        connPool,
-		eventCh:         make(chan serf.Event, serfEventBacklog),
-		logger:          flat.logger.NamedIntercept(logging.ConsulClient),
-		shutdownCh:      make(chan struct{}),
-		tlsConfigurator: flat.tlsConfigurator,
+		config:     config,
+		connPool:   connPool,
+		eventCh:    make(chan serf.Event, serfEventBacklog),
+		logger:     flat.logger.NamedIntercept(logging.ConsulClient),
+		shutdownCh: make(chan struct{}),
 	}
 
 	c.rpcLimiter.Store(rate.NewLimiter(config.RPCRate, config.RPCMaxBurst))

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -292,11 +292,6 @@ func (c *Client) RemoveFailedNode(node string, prune bool) error {
 	return c.serf.RemoveFailedNode(node)
 }
 
-// KeyManagerLAN returns the LAN Serf keyring manager
-func (c *Client) KeyManagerLAN() *serf.KeyManager {
-	return c.serf.KeyManager()
-}
-
 // RPC is used to forward an RPC call to a consul server, or fail if no servers
 func (c *Client) RPC(method string, args interface{}, reply interface{}) error {
 	// This is subtle but we start measuring the time on the client side

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -89,18 +89,7 @@ type Client struct {
 	tlsConfigurator *tlsutil.Configurator
 }
 
-// NewClient is used to construct a new Consul client from the configuration,
-// potentially returning an error.
-// NewClient only used to help setting up a client for testing. Normal code
-// exercises NewClientLogger.
-func NewClient(config *Config) (*Client, error) {
-	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
-	if err != nil {
-		return nil, err
-	}
-	return NewClientLogger(config, nil, c)
-}
-
+// NewClientWithOptions creates a new Client from the list of options.
 func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, error) {
 	flat := flattenConsulOptions(options)
 
@@ -208,10 +197,6 @@ func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, err
 	}
 
 	return c, nil
-}
-
-func NewClientLogger(config *Config, logger hclog.InterceptLogger, tlsConfigurator *tlsutil.Configurator) (*Client, error) {
-	return NewClientWithOptions(config, WithLogger(logger), WithTLSConfigurator(tlsConfigurator))
 }
 
 // Shutdown is used to shutdown the client

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -445,7 +445,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -498,7 +498,7 @@ func newClient(config *Config) (*Client, error) {
 func TestClient_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -610,7 +610,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -88,7 +88,7 @@ func testClientWithConfigWithErr(t *testing.T, cb func(c *Config)) (string, *Cli
 		t.Fatalf("err: %v", err)
 	}
 
-	client, err := NewClientLogger(config, logger, tlsConf)
+	client, err := NewClientWithOptions(config, WithLogger(logger), WithTLSConfigurator(tlsConf))
 	if err != nil {
 		config.NotifyShutdown()
 	}
@@ -456,7 +456,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 	defer conf2.NotifyShutdown()
 	conf2.VerifyOutgoing = true
 	configureTLS(conf2)
-	c1, err := NewClient(conf2)
+	c1, err := newClient(conf2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -486,6 +486,15 @@ func TestClient_RPC_TLS(t *testing.T) {
 	})
 }
 
+// Deprecated: use NewClientWithOptions
+func newClient(config *Config) (*Client, error) {
+	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return NewClientWithOptions(config, WithTLSConfigurator(c))
+}
+
 func TestClient_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
@@ -501,7 +510,7 @@ func TestClient_RPC_RateLimit(t *testing.T) {
 	defer conf2.NotifyShutdown()
 	conf2.RPCRate = 2
 	conf2.RPCMaxBurst = 2
-	c1, err := NewClient(conf2)
+	c1, err := newClient(conf2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -569,7 +578,7 @@ func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
 	defer conf1.NotifyShutdown()
 	conf1.RPCRate = 2
 	conf1.RPCMaxBurst = 2
-	c1, err := NewClient(conf1)
+	c1, err := newClient(conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -612,7 +621,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	defer conf2.NotifyShutdown()
 	conf2.VerifyOutgoing = true
 	configureTLS(conf2)
-	c1, err := NewClient(conf2)
+	c1, err := newClient(conf2)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -1,49 +1,75 @@
 package consul
 
 import (
+	"io"
+	"os"
+
 	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/go-hclog"
 )
 
+// consulOptions are dependencies provided to a Client or Server constructor.
+// A consulOptions struct is populated by Ops, and read by the constructor.
 type consulOptions struct {
+	logOutput       io.Writer
 	logger          hclog.InterceptLogger
 	tlsConfigurator *tlsutil.Configurator
 	connPool        *pool.ConnPool
 	tokens          *token.Store
 }
 
-type ConsulOption func(*consulOptions)
+// Op is a function (an operation) which updates a consulOptions. Ops are
+// applied using applyOps.
+type Op func(*consulOptions)
 
-func WithLogger(logger hclog.InterceptLogger) ConsulOption {
+func WithLogger(logger hclog.InterceptLogger) Op {
 	return func(opt *consulOptions) {
 		opt.logger = logger
 	}
 }
 
-func WithTLSConfigurator(tlsConfigurator *tlsutil.Configurator) ConsulOption {
+func WithTLSConfigurator(tlsConfigurator *tlsutil.Configurator) Op {
 	return func(opt *consulOptions) {
 		opt.tlsConfigurator = tlsConfigurator
 	}
 }
 
-func WithConnectionPool(connPool *pool.ConnPool) ConsulOption {
+func WithConnectionPool(connPool *pool.ConnPool) Op {
 	return func(opt *consulOptions) {
 		opt.connPool = connPool
 	}
 }
 
-func WithTokenStore(tokens *token.Store) ConsulOption {
+func WithTokenStore(tokens *token.Store) Op {
 	return func(opt *consulOptions) {
 		opt.tokens = tokens
 	}
 }
 
-func flattenConsulOptions(options []ConsulOption) consulOptions {
+// applyOps to construct a consulOptions, then apply default values, and return
+// the consulOptions.
+func applyOps(options []Op) consulOptions {
 	var flat consulOptions
 	for _, opt := range options {
 		opt(&flat)
 	}
+
+	if flat.logOutput == nil {
+		flat.logOutput = os.Stderr
+	}
+
+	if flat.logger == nil {
+		flat.logger = hclog.NewInterceptLogger(&hclog.LoggerOptions{
+			Level:  hclog.Debug,
+			Output: flat.logOutput,
+		})
+	}
+
+	if flat.tokens == nil {
+		flat.tokens = new(token.Store)
+	}
+
 	return flat
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -312,25 +312,6 @@ type Server struct {
 	EnterpriseServer
 }
 
-// NewServer is only used to help setting up a server for testing. Normal code
-// exercises NewServerLogger.
-func NewServer(config *Config) (*Server, error) {
-	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
-	if err != nil {
-		return nil, err
-	}
-	return NewServerLogger(config, nil, new(token.Store), c)
-}
-
-// NewServerLogger is used to construct a new Consul server from the
-// configuration, potentially returning an error
-func NewServerLogger(config *Config, logger hclog.InterceptLogger, tokens *token.Store, tlsConfigurator *tlsutil.Configurator) (*Server, error) {
-	return NewServerWithOptions(config,
-		WithLogger(logger),
-		WithTokenStore(tokens),
-		WithTLSConfigurator(tlsConfigurator))
-}
-
 // NewServerWithOptions is used to construct a new Consul server from the configuration
 // and extra options, potentially returning an error
 func NewServerWithOptions(config *Config, options ...ConsulOption) (*Server, error) {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1201,11 +1201,6 @@ func (s *Server) LeaderLastContact() time.Time {
 	return s.raft.LastContact()
 }
 
-// KeyManagerLAN returns the LAN Serf keyring manager
-func (s *Server) KeyManagerLAN() *serf.KeyManager {
-	return s.serfLAN.KeyManager()
-}
-
 // KeyManagerWAN returns the WAN Serf keyring manager
 func (s *Server) KeyManagerWAN() *serf.KeyManager {
 	return s.serfWAN.KeyManager()

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -321,10 +321,7 @@ func newServer(c *Config) (*Server, error) {
 		return nil, err
 	}
 
-	srv, err := NewServerWithOptions(c,
-		WithLogger(logger),
-		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(tlsConf))
+	srv, err := NewServerWithOptions(c, WithLogger(logger), WithTLSConfigurator(tlsConf))
 	if err != nil {
 		return nil, err
 	}
@@ -1517,10 +1514,7 @@ func TestServer_CALogging(t *testing.T) {
 	c, err := tlsutil.NewConfigurator(conf1.ToTLSUtilConfig(), logger)
 	require.NoError(t, err)
 
-	s1, err := NewServerWithOptions(conf1,
-		WithLogger(logger),
-		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(c))
+	s1, err := NewServerWithOptions(conf1, WithLogger(logger), WithTLSConfigurator(c))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -320,7 +320,11 @@ func newServer(c *Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	srv, err := NewServerLogger(c, logger, new(token.Store), tlsConf)
+
+	srv, err := NewServerWithOptions(c,
+		WithLogger(logger),
+		WithTokenStore(new(token.Store)),
+		WithTLSConfigurator(tlsConf))
 	if err != nil {
 		return nil, err
 	}
@@ -1486,7 +1490,7 @@ func TestServer_RPC_RateLimit(t *testing.T) {
 	dir1, conf1 := testServerConfig(t)
 	conf1.RPCRate = 2
 	conf1.RPCMaxBurst = 2
-	s1, err := NewServer(conf1)
+	s1, err := newServer(conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -1512,7 +1516,11 @@ func TestServer_CALogging(t *testing.T) {
 
 	c, err := tlsutil.NewConfigurator(conf1.ToTLSUtilConfig(), logger)
 	require.NoError(t, err)
-	s1, err := NewServerLogger(conf1, logger, new(token.Store), c)
+
+	s1, err := NewServerWithOptions(conf1,
+		WithLogger(logger),
+		WithTokenStore(new(token.Store)),
+		WithTLSConfigurator(c))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}


### PR DESCRIPTION
Removes a few unused methods, and old constructors.

Also makes some small naming changes to `ConsulOptions`, and sets defaults in the apply function.

Probably best viewed by individual comit.