### PR TITLE
Remove ACLsEnabled from delegate interface

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -21,7 +21,7 @@ func (a *Agent) resolveToken(id string) (acl.Authorizer, error) {
 // The defaulted metadata is then used to fill in an acl.AuthorizationContext.
 func (a *Agent) resolveTokenAndDefaultMeta(id string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error) {
 	// ACLs are disabled
-	if !a.delegate.ACLsEnabled() {
+	if !a.config.ACLsEnabled {
 		return nil, nil
 	}
 

--- a/agent/acl_endpoint.go
+++ b/agent/acl_endpoint.go
@@ -21,7 +21,7 @@ type aclBootstrapResponse struct {
 // checkACLDisabled will return a standard response if ACLs are disabled. This
 // returns true if they are disabled and we should not continue.
 func (s *HTTPServer) checkACLDisabled(resp http.ResponseWriter, _req *http.Request) bool {
-	if s.agent.delegate.ACLsEnabled() {
+	if s.agent.config.ACLsEnabled {
 		return false
 	}
 

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -92,11 +92,6 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	return a
 }
 
-func (a *TestACLAgent) ACLsEnabled() bool {
-	// the TestACLAgent always has ACLs enabled
-	return true
-}
-
 func (a *TestACLAgent) UseLegacyACLs() bool {
 	return false
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -143,7 +143,6 @@ type delegate interface {
 	ResolveTokenToIdentity(secretID string) (structs.ACLIdentity, error)
 	ResolveTokenAndDefaultMeta(secretID string, entMeta *structs.EnterpriseMeta, authzContext *acl.AuthorizerContext) (acl.Authorizer, error)
 	RPC(method string, args interface{}, reply interface{}) error
-	ACLsEnabled() bool
 	UseLegacyACLs() bool
 	SnapshotRPC(args *structs.SnapshotRequest, in io.Reader, out io.Writer, replyFn structs.SnapshotReplyFn) error
 	Shutdown() error

--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -140,7 +140,6 @@ func tokenSecretCacheID(token string) string {
 }
 
 type ACLResolverDelegate interface {
-	ACLsEnabled() bool
 	ACLDatacenter(legacy bool) string
 	UseLegacyACLs() bool
 	ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error)
@@ -1196,7 +1195,7 @@ func (r *ACLResolver) ResolveTokenToIdentity(token string) (structs.ACLIdentity,
 
 func (r *ACLResolver) ACLsEnabled() bool {
 	// Whether we desire ACLs to be enabled according to configuration
-	if !r.delegate.ACLsEnabled() {
+	if !r.config.ACLsEnabled {
 		return false
 	}
 

--- a/agent/consul/acl_client.go
+++ b/agent/consul/acl_client.go
@@ -71,10 +71,6 @@ func (c *Client) ACLDatacenter(legacy bool) string {
 	return c.config.Datacenter
 }
 
-func (c *Client) ACLsEnabled() bool {
-	return c.config.ACLsEnabled
-}
-
 func (c *Client) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// clients do no local identity resolution at the moment
 	return false, nil, nil

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -98,7 +98,7 @@ func (a *ACL) removeBootstrapResetFile() {
 }
 
 func (a *ACL) aclPreCheck() error {
-	if !a.srv.ACLsEnabled() {
+	if !a.srv.config.ACLsEnabled {
 		return acl.ErrDisabled
 	}
 

--- a/agent/consul/acl_endpoint_legacy.go
+++ b/agent/consul/acl_endpoint_legacy.go
@@ -159,7 +159,7 @@ func (a *ACL) Apply(args *structs.ACLRequest, reply *string) error {
 	defer metrics.MeasureSince([]string{"acl", "apply"}, time.Now())
 
 	// Verify we are allowed to serve this request
-	if !a.srv.ACLsEnabled() {
+	if !a.srv.config.ACLsEnabled {
 		return acl.ErrDisabled
 	}
 
@@ -208,7 +208,7 @@ func (a *ACL) Get(args *structs.ACLSpecificRequest,
 	// authorization in and of itself.
 
 	// Verify we are allowed to serve this request
-	if !a.srv.ACLsEnabled() {
+	if !a.srv.config.ACLsEnabled {
 		return acl.ErrDisabled
 	}
 
@@ -250,7 +250,7 @@ func (a *ACL) List(args *structs.DCSpecificRequest,
 	}
 
 	// Verify we are allowed to serve this request
-	if !a.srv.ACLsEnabled() {
+	if !a.srv.config.ACLsEnabled {
 		return acl.ErrDisabled
 	}
 

--- a/agent/consul/acl_server.go
+++ b/agent/consul/acl_server.go
@@ -167,10 +167,6 @@ func (s *Server) ACLDatacenter(legacy bool) string {
 	return s.config.Datacenter
 }
 
-func (s *Server) ACLsEnabled() bool {
-	return s.config.ACLsEnabled
-}
-
 // ResolveIdentityFromToken retrieves a token's full identity given its secretID.
 func (s *Server) ResolveIdentityFromToken(token string) (bool, structs.ACLIdentity, error) {
 	// only allow remote RPC resolution when token replication is off and

--- a/agent/consul/acl_test.go
+++ b/agent/consul/acl_test.go
@@ -509,6 +509,9 @@ func testRoleForID(roleID string) (bool, *structs.ACLRole, error) {
 // ACLResolverTestDelegate is used to test
 // the ACLResolver without running Agents
 type ACLResolverTestDelegate struct {
+	// enabled is no longer part of the delegate. It is still here as a field on
+	// the fake delegate because many tests use this field to enable ACLs. This field
+	// is now used to set ACLResolverConfig.Config.ACLsEnabled.
 	enabled         bool
 	datacenter      string
 	legacy          bool
@@ -619,10 +622,6 @@ func (d *ACLResolverTestDelegate) plainRoleResolveFn(args *structs.ACLRoleBatchG
 	return nil
 }
 
-func (d *ACLResolverTestDelegate) ACLsEnabled() bool {
-	return d.enabled
-}
-
 func (d *ACLResolverTestDelegate) ACLDatacenter(legacy bool) string {
 	return d.datacenter
 }
@@ -691,10 +690,11 @@ func (d *ACLResolverTestDelegate) RPC(method string, args interface{}, reply int
 	panic("Bad Test Implementation: Was the ACLResolver updated to use new RPC methods")
 }
 
-func newTestACLResolver(t *testing.T, delegate ACLResolverDelegate, cb func(*ACLResolverConfig)) *ACLResolver {
+func newTestACLResolver(t *testing.T, delegate *ACLResolverTestDelegate, cb func(*ACLResolverConfig)) *ACLResolver {
 	config := DefaultConfig()
 	config.ACLDefaultPolicy = "deny"
 	config.ACLDownPolicy = "extend-cache"
+	config.ACLsEnabled = delegate.enabled
 	rconf := &ACLResolverConfig{
 		Config: config,
 		Logger: testutil.LoggerWithName(t, t.Name()),

--- a/agent/consul/acl_token_exp.go
+++ b/agent/consul/acl_token_exp.go
@@ -54,7 +54,7 @@ func (s *Server) reapExpiredLocalACLTokens() (int, error) {
 	return s.reapExpiredACLTokens(true, false)
 }
 func (s *Server) reapExpiredACLTokens(local, global bool) (int, error) {
-	if !s.ACLsEnabled() {
+	if !s.config.ACLsEnabled {
 		return 0, nil
 	}
 	if s.UseLegacyACLs() {

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -413,7 +413,7 @@ func (c *Client) Stats() map[string]map[string]string {
 		"runtime":  runtimeStats(),
 	}
 
-	if c.ACLsEnabled() {
+	if c.config.ACLsEnabled {
 		if c.UseLegacyACLs() {
 			stats["consul"]["acl"] = "legacy"
 		} else {

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -58,7 +58,7 @@ func (s *Server) monitorLeadership() {
 
 	aclModeCheckWait := aclModeCheckMinInterval
 	var aclUpgradeCh <-chan time.Time
-	if s.ACLsEnabled() {
+	if s.config.ACLsEnabled {
 		aclUpgradeCh = time.After(aclModeCheckWait)
 	}
 	var weAreLeaderCh chan struct{}
@@ -384,7 +384,7 @@ func (s *Server) revokeLeadership() {
 
 // DEPRECATED (ACL-Legacy-Compat) - Remove once old ACL compatibility is removed
 func (s *Server) initializeLegacyACL() error {
-	if !s.ACLsEnabled() {
+	if !s.config.ACLsEnabled {
 		return nil
 	}
 
@@ -484,7 +484,7 @@ func (s *Server) initializeLegacyACL() error {
 // initializeACLs is used to setup the ACLs if we are the leader
 // and need to do this.
 func (s *Server) initializeACLs(upgrade bool) error {
-	if !s.ACLsEnabled() {
+	if !s.config.ACLsEnabled {
 		return nil
 	}
 

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -1355,7 +1355,7 @@ func (s *Server) Stats() map[string]map[string]string {
 		"runtime":  runtimeStats(),
 	}
 
-	if s.ACLsEnabled() {
+	if s.config.ACLsEnabled {
 		if s.UseLegacyACLs() {
 			stats["consul"]["acl"] = "legacy"
 		} else {

--- a/agent/http.go
+++ b/agent/http.go
@@ -370,7 +370,7 @@ func (s *HTTPServer) handler(enableDebug bool) http.Handler {
 func (s *HTTPServer) GenerateHTMLTemplateVars() map[string]interface{} {
 	vars := map[string]interface{}{
 		"ContentPath": s.agent.config.UIContentPath,
-		"ACLsEnabled": s.agent.delegate.ACLsEnabled(),
+		"ACLsEnabled": s.agent.config.ACLsEnabled,
 	}
 
 	s.addEnterpriseHTMLTemplateVars(vars)


### PR DESCRIPTION
In all cases (oss/ent, client/server) this method was returning a value from config. Since the value is consistent, it doesn't need to be part of the delegate interface.