### PR TITLE
Append redirects

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -33,6 +33,9 @@
 /docs/connect/mesh_gateway                           /docs/connect/mesh-gateway                        301!
 /docs/connect/ingress_gateway                        /docs/connect/ingress-gateway                     301!
 /docs/connect/terminating_gateway                    /docs/connect/terminating-gateway                 301!
+/docs/connect/mesh_gateway.html                      /docs/connect/mesh-gateway                        301!
+/docs/connect/ingress_gateway.html                   /docs/connect/ingress-gateway                     301!
+/docs/connect/terminating_gateway.html               /docs/connect/terminating-gateway                 301!
 
 # CLI renames
 


### PR DESCRIPTION
Consul 1.8.0 includes a few gateway URLs that need to be handled via redirects. This PR appends 3 new routes.

----

@jescalan do you something like:

```
/*.html       /:splat     301!
```

is a more appropriate catch-all redirect as it doesn't look like we support the `.html` extension anymore? 