### PR TITLE
Update URLs for gateway docs

### DIFF
--- a/ui-v2/app/components/consul-kind/index.hbs
+++ b/ui-v2/app/components/consul-kind/index.hbs
@@ -45,9 +45,9 @@
                 </li>
           {{/let}}
           {{#let (from-entries
-            (array 'ingress-gateway' '/connect/ingress_gateway.html')
-            (array 'terminating-gateway' '/connect/terminating_gateway.html')
-            (array 'mesh-gateway' '/connect/mesh_gateway.html')
+            (array 'ingress-gateway' '/connect/ingress-gateway')
+            (array 'terminating-gateway' '/connect/terminating-gateway')
+            (array 'mesh-gateway' '/connect/mesh-gateway')
           ) as |link|}}
                 <li role="none" class="docs-link">
                   <a tabindex="-1" role="menuitem" href={{concat (env 'CONSUL_DOCS_URL') (get link item.Kind)}} rel="noopener noreferrer" target="_blank">

--- a/ui-v2/app/templates/dc/services/show/services.hbs
+++ b/ui-v2/app/templates/dc/services/show/services.hbs
@@ -4,7 +4,7 @@
     <section>
       <p>
         The following services may receive traffic from external services through this gateway. Learn more about configuring gateways in our
-        <a href="{{env 'CONSUL_DOCS_URL'}}/connect/terminating_gateway.html" target="_blank" rel="noopener noreferrer">step-by-step guide</a>.
+        <a href="{{env 'CONSUL_DOCS_URL'}}/connect/terminating-gateway" target="_blank" rel="noopener noreferrer">step-by-step guide</a>.
       </p>
       <ConsulServiceList @items={{gatewayServices}} @nspace={{nspace}} />
     </section>

--- a/ui-v2/app/templates/dc/services/show/upstreams.hbs
+++ b/ui-v2/app/templates/dc/services/show/upstreams.hbs
@@ -3,7 +3,7 @@
   {{#if (gt gatewayServices.length 0)}}
     <section>
       <p>
-        Upstreams are services that may receive traffic from this gateway. Learn more about configuring gateways in our <a href="{{env 'CONSUL_DOCS_URL'}}/connect/ingress_gateway.html" target="_blank" rel="noopener noreferrer">documentation</a>.
+        Upstreams are services that may receive traffic from this gateway. Learn more about configuring gateways in our <a href="{{env 'CONSUL_DOCS_URL'}}/connect/ingress-gateway" target="_blank" rel="noopener noreferrer">documentation</a>.
       </p>
       <ConsulUpstreamList @items={{gatewayServices}} @dc={{dc}} @nspace={{nspace}} />
     </section>


### PR DESCRIPTION
PRs #7610 and #7962 changed the locations/URLs for the gateway docs which results in a HTTP 404 Not Found being returned when accessing the previous URLs.

Update URLs for gateway docs to point to new URLs.

PR #8243 adds corresponding redirects on consul.io.