### PR TITLE
agent/cache: Use AllowNotModified in CatalogListServices

### DIFF
--- a/agent/cache-types/catalog_list_services.go
+++ b/agent/cache-types/catalog_list_services.go
@@ -38,9 +38,12 @@ func (c *CatalogListServices) Fetch(opts cache.FetchOptions, req cache.Request) 
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedServices
 	if err := c.RPC.RPC("Catalog.ListServices", reqReal, &reply); err != nil {
 		return result, err
@@ -48,5 +51,6 @@ func (c *CatalogListServices) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/catalog_list_services_test.go
+++ b/agent/cache-types/catalog_list_services_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -58,5 +59,60 @@ func TestCatalogListServices_badReqType(t *testing.T) {
 		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wrong type")
+	rpc.AssertExpectations(t)
+}
+
+func TestCatalogListServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &CatalogListServices{RPC: rpc}
+
+	services := map[string][]string{
+		"foo": {"prod", "linux"},
+		"bar": {"qa", "windows"},
+	}
+	rpc.On("RPC", "Catalog.ListServices", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.DCSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedServices)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(nil)
+	c.RegisterType(CatalogListServicesName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedServices{
+			Services:  services,
+			QueryMeta: structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.DCSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(CatalogListServicesName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, CatalogListServicesName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedServices{
+		Services:  services,
+		QueryMeta: structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
 	rpc.AssertExpectations(t)
 }

--- a/agent/cache/type.go
+++ b/agent/cache/type.go
@@ -78,4 +78,8 @@ type FetchResult struct {
 
 	// Index is the corresponding index value for this data.
 	Index uint64
+
+	// NotModified indicates that the Value has not changed since LastResult, and
+	// the LastResult value should be used instead of Value.
+	NotModified bool
 }


### PR DESCRIPTION
Related to #7968, follow up to #8215

If there is a previous result then we enable `AllowNotModifiedResponse` to avoid re-serializing the result if it has not changed. The blocking query will not response if there is no change, unless the `RefreshTimeout` is hit, so this will only skip serializing a `NotModified` result once every 10 minutes. This is probably only an improvement on very large clusters.