### PR TITLE
docs: fix link to connect authorize endpoint

### DIFF
--- a/website/pages/docs/connect/intentions.mdx
+++ b/website/pages/docs/connect/intentions.mdx
@@ -17,7 +17,7 @@ managed via the API, CLI, or UI.
 Intentions are enforced by the [proxy](/docs/connect/proxies)
 or [natively integrated application](/docs/connect/native) on
 inbound connections. After verifying the TLS client certificate, the
-[authorize API endpoint](#) is called which verifies the connection
+[authorize API endpoint](/api-docs/agent/connect#authorize) is called which verifies the connection
 is allowed by testing the intentions. If authorize returns false the
 connection must be terminated.
 


### PR DESCRIPTION
/docs/connect/intentions has a broken link presumably meant
to go to /api-docs/agent/connect#authorize

This PR fixes the link.