### PR TITLE
docs: Document that dns_config.cache_max_age=0 means "no max age"

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1249,6 +1249,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     is enabled, the agent will attempt to re-fetch the result from the servers if
     the cached value is older than this duration. See: [agent caching](/api/features/caching).
 
+    **Note** that unlike the `max-age` HTTP header, a value of 0 for this field is
+    equivalent to "no max age". To get a fresh value from the cache use a very small value
+    of `1ns` instead of 0.
+
   - `prefer_namespace` ((#dns_prefer_namespace)) <EnterpriseAlert inline /> -
     When set to true, in a DNS query for a service, the label between the domain
     and the `service` label will be treated as a namespace name instead of a datacenter.


### PR DESCRIPTION
Closes #7073

This was confusing because we linked to the API docs for caching, where the HTTP header behaves differently.

The zero value meaning "no max age" seems correct. I suspect the only reason we handled this differently in the HTTP header was to comply with the spec for those headers.