### PR TITLE
ui: Fix up styling for the Tags tab

### DIFF
--- a/ui-v2/app/styles/components/tag-list/layout.scss
+++ b/ui-v2/app/styles/components/tag-list/layout.scss
@@ -1,5 +1,6 @@
 %tag-list {
   white-space: nowrap;
+  display: inline-flex;
 }
 // TODO: Currently this is here to overwrite
 // the default definition list layout used in edit pages
@@ -8,6 +9,8 @@
 %tag-list dt::before {
   @extend %with-tag-mask, %as-pseudo;
   margin-right: 4px;
+  margin-top: 3px;
+  background-color: $gray-500;
 }
 %tag-list dd {
   display: inline-flex;


### PR DESCRIPTION
<img width="550" alt="Screen Shot 2020-07-08 at 9 16 42 AM" src="https://user-images.githubusercontent.com/19161242/86923215-bf7a2980-c0fb-11ea-9c5e-413bc4c800f9.png">
