### PR TITLE
ui: Enable keyboard access for the sorting dropdown menus

### DIFF
--- a/ui-v2/app/components/aria-menu/index.js
+++ b/ui-v2/app/components/aria-menu/index.js
@@ -82,9 +82,10 @@ export default Component.extend({
       // TODO: We need to use > somehow here so we don't select submenus
       const $items = [...this.dom.elements(MENU_ITEMS, this.$menu)];
       if (!this.expanded) {
-        this.$trigger.dispatchEvent(new MouseEvent('click'));
         if (e.keyCode === ENTER || e.keyCode === SPACE) {
-          $items[0].focus();
+          next(() => {
+            $items[0].focus();
+          });
           return;
         }
       }

--- a/ui-v2/app/components/popover-select/index.hbs
+++ b/ui-v2/app/components/popover-select/index.hbs
@@ -1,5 +1,5 @@
 <div class="popover-select" ...attributes>
-  <PopoverMenu @keyboardAccess={{false}}>
+  <PopoverMenu>
     <BlockSlot @name="trigger">
       <span>
         {{selected.value}}


### PR DESCRIPTION
We temporarily disabled keyboard access for the sort dropdown menus in order to move forwards with a feature, but never came back to investigate the problem and re-enable.

This re-enables keyboard access for the sorting menus.
