### PR TITLE
ci: add 'go test -race'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,8 @@ jobs:
             PACKAGE_NAMES=$(go list -tags "$GOTAGS" ./... | circleci tests split --split-by=timings --timings-type=classname)
             echo "Running $(echo $PACKAGE_NAMES | wc -w) packages"
             echo $PACKAGE_NAMES
-            gotestsum --format=short-verbose \
+            gotestsum \
+              --format=short-verbose \
               --jsonfile /tmp/jsonfile/go-test-${CIRCLE_NODE_INDEX}.log \
               --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
               -tags="$GOTAGS" -p 2 \
@@ -133,6 +134,40 @@ jobs:
           # The -C flag shouldn't be necessary, but it fails to find the commit
           # without it.
           command: bash <(curl -s https://codecov.io/bash) -C "$CIRCLE_SHA1"
+
+  go-test-race:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      <<: *ENVIRONMENT
+      GOTAGS: "" # No tags for OSS but there are for enterprise
+      # GOMAXPROCS defaults to number of cores on underlying hardware, set
+      # explicitly to avoid OOM issues https://support.circleci.com/hc/en-us/articles/360034684273-common-GoLang-memory-issues
+      GOMAXPROCS: 4
+      # The medium resource class (default) boxes are 2 vCPUs, 4GB RAM
+      # https://circleci.com/docs/2.0/configuration-reference/#docker-executor
+      # but we can run a little over that limit.
+    steps:
+      - checkout
+      - run: *install-gotestsum
+      - run: go mod download
+      - run:
+          name: go test -race
+          command: |
+            mkdir -p $TEST_RESULTS_DIR
+            gotestsum \
+              --format=short-verbose \
+              --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
+              -tags="$GOTAGS" -p 2 \
+              -race -gcflags=all=-d=checkptr=0 \
+              ./agent/{ae,cache,checks,config,pool,proxycfg,router} \
+              ./agent/consul/{authmethod/...,autopilot,fsm,state,stream} \
+              ./snapshot
+
+      - store_test_results:
+          path: *TEST_RESULTS_DIR
+      - store_artifacts:
+          path: *TEST_RESULTS_DIR
 
   # split off a job for the API package since it is separate
   go-test-api:
@@ -660,6 +695,7 @@ workflows:
           requires: [dev-build]
       - go-test-api:
           requires: [dev-build]
+      - go-test-race: *filter-ignore-non-go-branches
       - go-test-sdk: *filter-ignore-non-go-branches
 
   build-distros:


### PR DESCRIPTION
I tried `-race` on all the packages ([example](https://circleci.com/gh/hashicorp/consul/204265)) but there were many failures. I expect it to add a lot of time to CI, but it actually ran in pretty reasonable time.

Since there were over 100 failures, I'm hoping we can get this enabled on a smaller number of packages with a few fixes and opt more in over time.

`-race` also enables `-d=checkptr` ([ref](https://golang.org/doc/go1.14#compiler)), which fails in the boltdb package. It looks like this was still an issue with bbolt until very recently (https://github.com/etcd-io/bbolt/issues/187, https://github.com/etcd-io/bbolt/pull/201). So for now that check is disabled.

There are still a bunch of failures in the smaller list of packages. I need to look over those failures to see if we should drop some of the packages from the list. Making this a draft PR until CI is green.