### PR TITLE
Add api mod support for /catalog/gateway-services

### DIFF
--- a/api/catalog.go
+++ b/api/catalog.go
@@ -81,6 +81,27 @@ type CatalogDeregistration struct {
 	Namespace  string `json:",omitempty"`
 }
 
+type CompoundServiceName struct {
+	Name string
+	Namespace string
+}
+
+// GatewayService associates a gateway with a linked service.
+// It also contains service-specific gateway configuration like ingress listener port and protocol.
+type CatalogGatewayService struct {
+	Gateway      CompoundServiceName
+	Service      CompoundServiceName
+	GatewayKind  ServiceKind
+	Port         int      `json:",omitempty"`
+	Protocol     string   `json:",omitempty"`
+	Hosts        []string `json:",omitempty"`
+	CAFile       string   `json:",omitempty"`
+	CertFile     string   `json:",omitempty"`
+	KeyFile      string   `json:",omitempty"`
+	SNI          string   `json:",omitempty"`
+	FromWildcard bool     `json:",omitempty"`
+}
+
 // Catalog can be used to query the Catalog endpoints
 type Catalog struct {
 	c *Client
@@ -277,6 +298,27 @@ func (c *Catalog) NodeServiceList(node string, q *QueryOptions) (*CatalogNodeSer
 	qm.RequestTime = rtt
 
 	var out *CatalogNodeServiceList
+	if err := decodeBody(resp, &out); err != nil {
+		return nil, nil, err
+	}
+	return out, qm, nil
+}
+
+// GatewayServices is used to query the services associated with an ingress gateway or terminating gateway.
+func (c *Catalog) GatewayServices(gateway string, q *QueryOptions) ([]*CatalogGatewayService, *QueryMeta, error) {
+	r := c.c.newRequest("GET", "/v1/catalog/gateway-services/"+gateway)
+	r.setQueryOptions(q)
+	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	qm := &QueryMeta{}
+	parseQueryMeta(resp, qm)
+	qm.RequestTime = rtt
+
+	var out []*CatalogGatewayService
 	if err := decodeBody(resp, &out); err != nil {
 		return nil, nil, err
 	}

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -82,13 +82,13 @@ type CatalogDeregistration struct {
 }
 
 type CompoundServiceName struct {
-	Name string
+	Name      string
 	Namespace string
 }
 
 // GatewayService associates a gateway with a linked service.
 // It also contains service-specific gateway configuration like ingress listener port and protocol.
-type CatalogGatewayService struct {
+type GatewayService struct {
 	Gateway      CompoundServiceName
 	Service      CompoundServiceName
 	GatewayKind  ServiceKind
@@ -305,7 +305,7 @@ func (c *Catalog) NodeServiceList(node string, q *QueryOptions) (*CatalogNodeSer
 }
 
 // GatewayServices is used to query the services associated with an ingress gateway or terminating gateway.
-func (c *Catalog) GatewayServices(gateway string, q *QueryOptions) ([]*CatalogGatewayService, *QueryMeta, error) {
+func (c *Catalog) GatewayServices(gateway string, q *QueryOptions) ([]*GatewayService, *QueryMeta, error) {
 	r := c.c.newRequest("GET", "/v1/catalog/gateway-services/"+gateway)
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(c.c.doRequest(r))
@@ -318,7 +318,7 @@ func (c *Catalog) GatewayServices(gateway string, q *QueryOptions) ([]*CatalogGa
 	parseQueryMeta(resp, qm)
 	qm.RequestTime = rtt
 
-	var out []*CatalogGatewayService
+	var out []*GatewayService
 	if err := decodeBody(resp, &out); err != nil {
 		return nil, nil, err
 	}

--- a/api/catalog.go
+++ b/api/catalog.go
@@ -82,8 +82,10 @@ type CatalogDeregistration struct {
 }
 
 type CompoundServiceName struct {
-	Name      string
-	Namespace string
+	Name string
+
+	// Namespacing is a Consul Enterprise feature.
+	Namespace string `json:",omitempty"`
 }
 
 // GatewayService associates a gateway with a linked service.

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1086,5 +1087,241 @@ func TestAPI_CatalogEnableTagOverride(t *testing.T) {
 		if services[0].ServiceEnableTagOverride != true {
 			r.Fatal("tag override not set")
 		}
+	})
+}
+
+func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+	s.WaitForSerfCheck(t)
+
+	catalog := c.Catalog()
+
+	// Register the gateway
+	svc := &AgentService{
+		Kind: ServiceKindTerminatingGateway,
+		ID:      "terminating",
+		Service: "terminating",
+		Port:    443,
+	}
+	reg := &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "foo",
+		Address:    "192.168.10.10",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	// Register services the gateway will route to
+	svc = &AgentService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    6379,
+	}
+	reg = &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "bar",
+		Address:    "192.168.10.11",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	svc = &AgentService{
+		ID:      "api",
+		Service: "api",
+		Port:    8080,
+	}
+	reg = &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "baz",
+		Address:    "192.168.10.12",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	entries := c.ConfigEntries()
+
+	// Associate the gateway and api/redis services
+	gwEntry := TerminatingGatewayConfigEntry{
+		Kind:        TerminatingGateway,
+		Name:        "terminating",
+		Services:    []LinkedService{
+			{
+				Name:     "api",
+				CAFile:   "api/ca.crt",
+				CertFile: "api/client.crt",
+				KeyFile:  "api/client.key",
+				SNI:      "my-domain",
+			},
+			{
+				Name:     "*",
+				CAFile:   "ca.crt",
+				CertFile: "client.crt",
+				KeyFile:  "client.key",
+				SNI:      "my-alt-domain",
+			},
+		},
+	}
+	retry.Run(t, func(r *retry.R) {
+		if success, _, err := entries.Set(&gwEntry, nil); err != nil || !success {
+			r.Fatal(err)
+		}
+	})
+
+	expect := []*CatalogGatewayService{
+		{
+			Service:     CompoundServiceName{"api", defaultNamespace},
+			Gateway:     CompoundServiceName{"terminating", defaultNamespace},
+			GatewayKind: ServiceKindTerminatingGateway,
+			CAFile:      "api/ca.crt",
+			CertFile:    "api/client.crt",
+			KeyFile:     "api/client.key",
+			SNI:         "my-domain",
+		},
+		{
+			Service:     CompoundServiceName{"redis", defaultNamespace},
+			Gateway:     CompoundServiceName{"terminating", defaultNamespace},
+			GatewayKind:  ServiceKindTerminatingGateway,
+			CAFile:       "ca.crt",
+			CertFile:     "client.crt",
+			KeyFile:      "client.key",
+			SNI:          "my-alt-domain",
+			FromWildcard: true,
+		},
+	}
+	retry.Run(t, func(r *retry.R) {
+		resp, _, err := catalog.GatewayServices("terminating", nil)
+		assert.NoError(t, err)
+		assert.Equal(r, expect, resp)
+	})
+}
+
+func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+
+	s.WaitForSerfCheck(t)
+
+	catalog := c.Catalog()
+
+	// Register the gateway
+	svc := &AgentService{
+		Kind: ServiceKindTerminatingGateway,
+		ID:      "ingress",
+		Service: "ingress",
+		Port:    443,
+	}
+	reg := &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "foo",
+		Address:    "192.168.10.10",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	// Register services the gateway will route to
+	svc = &AgentService{
+		ID:      "redis",
+		Service: "redis",
+		Port:    6379,
+	}
+	reg = &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "bar",
+		Address:    "192.168.10.11",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	svc = &AgentService{
+		ID:      "api",
+		Service: "api",
+		Port:    8080,
+	}
+	reg = &CatalogRegistration{
+		Datacenter: "dc1",
+		Node:       "baz",
+		Address:    "192.168.10.12",
+		Service:    svc,
+	}
+	retry.Run(t, func(r *retry.R) {
+		if _, err := catalog.Register(reg, nil); err != nil {
+			r.Fatal(err)
+		}
+	})
+
+	entries := c.ConfigEntries()
+
+	// Associate the gateway and api/redis services
+	gwEntry := IngressGatewayConfigEntry{
+		Kind: "ingress-gateway",
+		Name: "ingress",
+		Listeners: []IngressListener{
+			{
+				Port: 8888,
+				Services: []IngressService{
+					{
+						Name: "api",
+					},
+				},
+			},
+			{
+				Port: 9999,
+				Services: []IngressService{
+					{
+						Name: "redis",
+					},
+				},
+			},
+		},
+	}
+	retry.Run(t, func(r *retry.R) {
+		if success, _, err := entries.Set(&gwEntry, nil); err != nil || !success {
+			r.Fatal(err)
+		}
+	})
+
+	expect := []*CatalogGatewayService{
+		{
+			Service:     CompoundServiceName{"api", defaultNamespace},
+			Gateway:     CompoundServiceName{"ingress", defaultNamespace},
+			GatewayKind: ServiceKindIngressGateway,
+			Protocol:    "tcp",
+			Port:        8888,
+		},
+		{
+			Service:     CompoundServiceName{"redis", defaultNamespace},
+			Gateway:     CompoundServiceName{"ingress", defaultNamespace},
+			GatewayKind: ServiceKindIngressGateway,
+			Protocol:    "tcp",
+			Port:        9999,
+		},
+	}
+	retry.Run(t, func(r *retry.R) {
+		resp, _, err := catalog.GatewayServices("ingress", nil)
+		assert.NoError(t, err)
+		assert.Equal(r, expect, resp)
 	})
 }

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -1100,7 +1100,7 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 
 	// Register the gateway
 	svc := &AgentService{
-		Kind: ServiceKindTerminatingGateway,
+		Kind:    ServiceKindTerminatingGateway,
 		ID:      "terminating",
 		Service: "terminating",
 		Port:    443,
@@ -1156,9 +1156,9 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 
 	// Associate the gateway and api/redis services
 	gwEntry := TerminatingGatewayConfigEntry{
-		Kind:        TerminatingGateway,
-		Name:        "terminating",
-		Services:    []LinkedService{
+		Kind: TerminatingGateway,
+		Name: "terminating",
+		Services: []LinkedService{
 			{
 				Name:     "api",
 				CAFile:   "api/ca.crt",
@@ -1181,7 +1181,7 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 		}
 	})
 
-	expect := []*CatalogGatewayService{
+	expect := []*GatewayService{
 		{
 			Service:     CompoundServiceName{"api", defaultNamespace},
 			Gateway:     CompoundServiceName{"terminating", defaultNamespace},
@@ -1192,8 +1192,8 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 			SNI:         "my-domain",
 		},
 		{
-			Service:     CompoundServiceName{"redis", defaultNamespace},
-			Gateway:     CompoundServiceName{"terminating", defaultNamespace},
+			Service:      CompoundServiceName{"redis", defaultNamespace},
+			Gateway:      CompoundServiceName{"terminating", defaultNamespace},
 			GatewayKind:  ServiceKindTerminatingGateway,
 			CAFile:       "ca.crt",
 			CertFile:     "client.crt",
@@ -1220,7 +1220,7 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 
 	// Register the gateway
 	svc := &AgentService{
-		Kind: ServiceKindTerminatingGateway,
+		Kind:    ServiceKindTerminatingGateway,
 		ID:      "ingress",
 		Service: "ingress",
 		Port:    443,
@@ -1303,7 +1303,7 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 		}
 	})
 
-	expect := []*CatalogGatewayService{
+	expect := []*GatewayService{
 		{
 			Service:     CompoundServiceName{"api", defaultNamespace},
 			Gateway:     CompoundServiceName{"ingress", defaultNamespace},

--- a/api/catalog_test.go
+++ b/api/catalog_test.go
@@ -1098,52 +1098,16 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 
 	catalog := c.Catalog()
 
-	// Register the gateway
+	// Register a service to be covered by a wildcard in the config entry
 	svc := &AgentService{
-		Kind:    ServiceKindTerminatingGateway,
-		ID:      "terminating",
-		Service: "terminating",
-		Port:    443,
-	}
-	reg := &CatalogRegistration{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "192.168.10.10",
-		Service:    svc,
-	}
-	retry.Run(t, func(r *retry.R) {
-		if _, err := catalog.Register(reg, nil); err != nil {
-			r.Fatal(err)
-		}
-	})
-
-	// Register services the gateway will route to
-	svc = &AgentService{
 		ID:      "redis",
 		Service: "redis",
 		Port:    6379,
 	}
-	reg = &CatalogRegistration{
+	reg := &CatalogRegistration{
 		Datacenter: "dc1",
 		Node:       "bar",
 		Address:    "192.168.10.11",
-		Service:    svc,
-	}
-	retry.Run(t, func(r *retry.R) {
-		if _, err := catalog.Register(reg, nil); err != nil {
-			r.Fatal(err)
-		}
-	})
-
-	svc = &AgentService{
-		ID:      "api",
-		Service: "api",
-		Port:    8080,
-	}
-	reg = &CatalogRegistration{
-		Datacenter: "dc1",
-		Node:       "baz",
-		Address:    "192.168.10.12",
 		Service:    svc,
 	}
 	retry.Run(t, func(r *retry.R) {
@@ -1204,7 +1168,7 @@ func TestAPI_CatalogGatewayServices_Terminating(t *testing.T) {
 	}
 	retry.Run(t, func(r *retry.R) {
 		resp, _, err := catalog.GatewayServices("terminating", nil)
-		assert.NoError(t, err)
+		assert.NoError(r, err)
 		assert.Equal(r, expect, resp)
 	})
 }
@@ -1215,62 +1179,6 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 	defer s.Stop()
 
 	s.WaitForSerfCheck(t)
-
-	catalog := c.Catalog()
-
-	// Register the gateway
-	svc := &AgentService{
-		Kind:    ServiceKindTerminatingGateway,
-		ID:      "ingress",
-		Service: "ingress",
-		Port:    443,
-	}
-	reg := &CatalogRegistration{
-		Datacenter: "dc1",
-		Node:       "foo",
-		Address:    "192.168.10.10",
-		Service:    svc,
-	}
-	retry.Run(t, func(r *retry.R) {
-		if _, err := catalog.Register(reg, nil); err != nil {
-			r.Fatal(err)
-		}
-	})
-
-	// Register services the gateway will route to
-	svc = &AgentService{
-		ID:      "redis",
-		Service: "redis",
-		Port:    6379,
-	}
-	reg = &CatalogRegistration{
-		Datacenter: "dc1",
-		Node:       "bar",
-		Address:    "192.168.10.11",
-		Service:    svc,
-	}
-	retry.Run(t, func(r *retry.R) {
-		if _, err := catalog.Register(reg, nil); err != nil {
-			r.Fatal(err)
-		}
-	})
-
-	svc = &AgentService{
-		ID:      "api",
-		Service: "api",
-		Port:    8080,
-	}
-	reg = &CatalogRegistration{
-		Datacenter: "dc1",
-		Node:       "baz",
-		Address:    "192.168.10.12",
-		Service:    svc,
-	}
-	retry.Run(t, func(r *retry.R) {
-		if _, err := catalog.Register(reg, nil); err != nil {
-			r.Fatal(err)
-		}
-	})
 
 	entries := c.ConfigEntries()
 
@@ -1303,6 +1211,8 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 		}
 	})
 
+	catalog := c.Catalog()
+
 	expect := []*GatewayService{
 		{
 			Service:     CompoundServiceName{"api", defaultNamespace},
@@ -1321,7 +1231,7 @@ func TestAPI_CatalogGatewayServices_Ingress(t *testing.T) {
 	}
 	retry.Run(t, func(r *retry.R) {
 		resp, _, err := catalog.GatewayServices("ingress", nil)
-		assert.NoError(t, err)
+		assert.NoError(r, err)
 		assert.Equal(r, expect, resp)
 	})
 }


### PR DESCRIPTION
Follow-up of: #8099

This endpoint was primarily exposed for 3rd party integrations, so it should be accessible via the API module.