### PR TITLE
Small typo in docstring

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -4,7 +4,7 @@ const (
 	WildcardName = "*"
 )
 
-// Config encapsualtes all of the generic configuration parameters used for
+// Config encapsulates all of the generic configuration parameters used for
 // policy parsing and enforcement
 type Config struct {
 	// WildcardName is the string that represents a request to authorize a wildcard permission


### PR DESCRIPTION
Just a small typo in acl package docstring :)