### PR TITLE
ui: Lint staged no longer requires git add to be specified

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -41,12 +41,10 @@
   },
   "lint-staged": {
     "{app,config,lib,server,tests}/**/*.js": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "app/styles/**/*.*": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Following on from https://github.com/hashicorp/consul/pull/8276