### PR TITLE
ui: Adds definition-table class to RTT values table

### DIFF
--- a/ui-v2/app/templates/dc/nodes/show/rtt.hbs
+++ b/ui-v2/app/templates/dc/nodes/show/rtt.hbs
@@ -1,26 +1,28 @@
 <div id="round-trip-time" class="tab-section">
   <div role="tabpanel">
-    <dl>
-        <dt>
-            Minimum
-        </dt>
-        <dd>
-            {{format-number tomography.min maximumFractionDigits=2}}ms
-        </dd>
-        <dt>
-            Median
-        </dt>
-        <dd>
-            {{format-number tomography.median maximumFractionDigits=2}}ms
-        </dd>
-        <dt>
-            Maximum
-        </dt>
-        <dd>
-            {{format-number tomography.max maximumFractionDigits=2}}ms
-        </dd>
-    </dl>
-<TomographyGraph @tomography={{tomography}} />
+    <div class="definition-table">
+      <dl>
+          <dt>
+              Minimum
+          </dt>
+          <dd>
+              {{format-number tomography.min maximumFractionDigits=2}}ms
+          </dd>
+          <dt>
+              Median
+          </dt>
+          <dd>
+              {{format-number tomography.median maximumFractionDigits=2}}ms
+          </dd>
+          <dt>
+              Maximum
+          </dt>
+          <dd>
+              {{format-number tomography.max maximumFractionDigits=2}}ms
+          </dd>
+      </dl>
+    </div>
+    <TomographyGraph @tomography={{tomography}} />
   </div>
 </div>
 


### PR DESCRIPTION
We changed our default definition list layout in https://github.com/hashicorp/consul/pull/8117.

We replaced the default with a definition-table class but missed one place where the old default was previously used.

This adds the definition-table class in RTT where it used to use the default.

Before:

<img width="461" alt="Screenshot 2020-07-10 at 12 47 43" src="https://user-images.githubusercontent.com/554604/87151337-939da600-c2ab-11ea-8686-a6014c1ea52b.png">

After:

<img width="473" alt="Screenshot 2020-07-10 at 12 47 18" src="https://user-images.githubusercontent.com/554604/87151352-97c9c380-c2ab-11ea-9d82-af436e67d4ae.png">
