### PR TITLE
ui: Revert ember-composable-helpers to ~4.0.0 due to faster sort-by

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -88,7 +88,7 @@
     "ember-cli-uglify": "^3.0.0",
     "ember-cli-yadda": "^0.5.0",
     "ember-collection": "^1.0.0-alpha.9",
-    "ember-composable-helpers": "^4.2.2",
+    "ember-composable-helpers": "~4.0.0",
     "ember-computed-style": "^0.3.0",
     "ember-data": "~3.16.0",
     "ember-exam": "^4.0.0",

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -5558,10 +5558,10 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-co
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-composable-helpers@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.2.2.tgz#6e1d8cd0372a0b904d89f2391453598f10ba71f0"
-  integrity sha512-gupkBd9nRRUaRuDXqnHj0BozILKpE18TKizDJPU075JL6YD22gP0JtlhtRFYszlljUHfbHMG6r2Ns38md3kyxA==
+ember-composable-helpers@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.0.0.tgz#856cf4d86f2245feeb69ae1684e5a58ec742fcca"
+  integrity sha512-SF/mrLEoB0W7Mf+G2ye13K1I9IgkUaeFaWDVDTRzSAX7xmjBiPepLsqZvNJ1WcXimFTodGffku4AbQ2D0t+/2Q==
   dependencies:
     "@babel/core" "^7.0.0"
     broccoli-funnel "2.0.1"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8276 we upgraded `ember-composable-helpers` partly for routine upgrade/maintenance and party to make use of its `from-entries` helper instead of using our own.

We've since noticed that `sort-by` now seems to be a lot slower, and this seems to be due to a switch to a custom BubbleSort implementation from version 4.0.0 to version 4.1.0.

For the moment we are reverting our dependency to 4.0.0 which seems to function at the same speed as before whilst we look into this further incase its due to something in our codebase that we've not noticed/considered.