### PR TITLE
Issue #8294 - Table element's have vertical scrollbars

### DIFF
--- a/ui-v2/app/styles/base/components/table/layout.scss
+++ b/ui-v2/app/styles/base/components/table/layout.scss
@@ -30,7 +30,7 @@
   display: none;
 }
 %table td:not(.actions) > *:only-child {
-  overflow-x: hidden;
+  overflow: hidden;
 }
 %table td:not(.actions) > * {
   white-space: nowrap;


### PR DESCRIPTION
Set overflow to hidden for both x and y axis. This prevents the overflow-y defaulting to auto, and creating scrollbars. Given the text overflow is set to ellipsis, this doesn't change the UI functionality.