### PR TITLE
ui: Move dc sorting to the view/template

### DIFF
--- a/ui-v2/app/components/hashicorp-consul/index.hbs
+++ b/ui-v2/app/components/hashicorp-consul/index.hbs
@@ -70,7 +70,7 @@
                                 @loading="lazy"
                               />
                             </li>
-                            {{#each dcs as |item|}}
+                            {{#each (sort-by 'Name' dcs) as |item|}}
                               <li role="none" data-test-datacenter-picker class={{if (eq dc.Name item.Name) 'is-active'}}>
                                 <a tabindex="-1" role="menuitem" href={{href-mut (hash dc=item.Name)}}>{{item.Name}}</a>
                               </li>

--- a/ui-v2/app/services/repository/dc.js
+++ b/ui-v2/app/services/repository/dc.js
@@ -10,10 +10,7 @@ export default RepositoryService.extend({
     return modelName;
   },
   findAll: function() {
-    return this.store.query(this.getModelName(), {}).then(function(items) {
-      // TODO: Move to view/template
-      return items.sortBy('Name');
-    });
+    return this.store.query(this.getModelName(), {});
   },
   findBySlug: function(name, items) {
     if (name != null) {

--- a/ui-v2/app/services/repository/node.js
+++ b/ui-v2/app/services/repository/node.js
@@ -1,9 +1,7 @@
 import RepositoryService from 'consul-ui/services/repository';
-import { inject as service } from '@ember/service';
 
 const modelName = 'node';
 export default RepositoryService.extend({
-  coordinates: service('repository/coordinate'),
   getModelName: function() {
     return modelName;
   },

--- a/ui-v2/tests/integration/services/repository/dc-test.js
+++ b/ui-v2/tests/integration/services/repository/dc-test.js
@@ -24,11 +24,7 @@ test('findAll returns the correct data for list endpoint', function(assert) {
       assert.deepEqual(
         actual,
         expected(function(payload) {
-          return payload.map(item => ({ Name: item })).sort(function(a, b) {
-            if (a.Name < b.Name) return -1;
-            if (a.Name > b.Name) return 1;
-            return 0;
-          });
+          return payload.map(item => ({ Name: item }));
         })
       );
     }


### PR DESCRIPTION
Whenever we request a list of datacenters we sort them in the model layer, whereas the reason for sorting them is a design/visual thing. Therefore this moves the sorting to the view/template.

We also spotted some dead code in the node repository, so we removed that whilst we were here.