### PR TITLE
ui: Replaces old request method with rpc.

### DIFF
--- a/ui-v2/app/adapters/acl.js
+++ b/ui-v2/app/adapters/acl.js
@@ -54,7 +54,7 @@ export default Adapter.extend({
     `;
   },
   clone: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForCloneRecord(request, serialized, unserialized);
       },

--- a/ui-v2/app/adapters/application.js
+++ b/ui-v2/app/adapters/application.js
@@ -16,9 +16,4 @@ export default Adapter.extend({
       [DATACENTER_QUERY_PARAM]: dc,
     };
   },
-  // TODO: Deprecated, remove `request` usage from everywhere and replace with
-  // `HTTPAdapter.rpc`
-  request: function(req, resp, obj, modelName) {
-    return this.rpc(...arguments);
-  },
 });

--- a/ui-v2/app/adapters/node.js
+++ b/ui-v2/app/adapters/node.js
@@ -24,7 +24,7 @@ export default Adapter.extend({
     `;
   },
   queryLeader: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForQueryLeader(request, serialized, unserialized);
       },

--- a/ui-v2/app/adapters/nspace.js
+++ b/ui-v2/app/adapters/nspace.js
@@ -65,7 +65,7 @@ export default Adapter.extend({
     `;
   },
   authorize: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForAuthorize(request, serialized, unserialized);
       },

--- a/ui-v2/app/adapters/oidc-provider.js
+++ b/ui-v2/app/adapters/oidc-provider.js
@@ -70,7 +70,7 @@ export default Adapter.extend({
     `;
   },
   authorize: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForAuthorize(request, serialized, unserialized);
       },
@@ -82,7 +82,7 @@ export default Adapter.extend({
     );
   },
   logout: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, unserialized) {
         return adapter.requestForLogout(request, serialized, unserialized);
       },

--- a/ui-v2/app/adapters/token.js
+++ b/ui-v2/app/adapters/token.js
@@ -130,7 +130,7 @@ export default Adapter.extend({
   // thing is its probably not the same shape as a 'Token',
   // plus we can't create Snapshots as they are private, see services/store.js
   self: function(store, type, id, unserialized) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, data) {
         return adapter.requestForSelf(request, serialized, data);
       },
@@ -142,7 +142,7 @@ export default Adapter.extend({
     );
   },
   clone: function(store, type, id, snapshot) {
-    return this.request(
+    return this.rpc(
       function(adapter, request, serialized, data) {
         return adapter.requestForCloneRecord(request, serialized, data);
       },


### PR DESCRIPTION
`rpc` is used to define how to make a HTTP request/response messages.
This used to be called 'request' but the term is overused  and sounded
like only one 'leg' of the HTTP message, so the naming was moved to `rpc` a
while ago, this cleans up the places where we still used the old term.