### PR TITLE
ui: Only try and load sessions and coordinates if the node exists

### DIFF
--- a/ui-v2/app/routes/dc/nodes/show.js
+++ b/ui-v2/app/routes/dc/nodes/show.js
@@ -12,8 +12,12 @@ export default Route.extend({
     const name = params.name;
     return hash({
       item: this.repo.findBySlug(name, dc, nspace),
-      sessions: this.sessionRepo.findByNode(name, dc, nspace),
-      tomography: this.coordinateRepo.findAllByNode(name, dc),
+    }).then(model => {
+      return hash({
+        ...model,
+        sessions: this.sessionRepo.findByNode(name, dc, nspace),
+        tomography: this.coordinateRepo.findAllByNode(name, dc),
+      });
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -1,5 +1,7 @@
 {{title item.Node}}
 <EventSource @src={{item}} @onerror={{action "error"}} />
+<EventSource @src={{sessions}} />
+<EventSource @src={{tomography}} />
 <AppView @class="node show">
     <BlockSlot @name="notification" as |status type|>
       {{!TODO: Move sessions to its own folder within nodes }}


### PR DESCRIPTION
There's no point trying to load the sessions and coordinate data for a node if it doesn't exist.

https://github.com/hashicorp/consul/pull/7953

> The only downside here is that you must remember to add an EventSource component in order to clean up properly (previously the mixin would automatically detect whether a property was an EventSource that needed cleaning up. Longer term everything should really have some sort of error catching anyway, plus the benefit of being able to remove the mixin and all of the other custom code here is worth the small inconvenience.

This PR also ensures that sessions and coordinate blocking queries are closed when we leave the page 😿 