### PR TITLE
remove GIT_DESCRIBE variable since we have a revision line

### DIFF
--- a/.circleci/bash_env.sh
+++ b/.circleci/bash_env.sh
@@ -3,6 +3,5 @@
 export GIT_COMMIT=$(git rev-parse --short HEAD)
 export GIT_COMMIT_YEAR=$(git show -s --format=%cd --date=format:%Y HEAD)
 export GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
-export GIT_DESCRIBE=$(git describe --tags --always --match "v*")
 export GIT_IMPORT=github.com/hashicorp/consul/version
-export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"
+export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,9 +21,8 @@ ASSETFS_PATH?=agent/bindata_assetfs.go
 GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_COMMIT_YEAR?=$(shell git show -s --format=%cd --date=format:%Y HEAD)
 GIT_DIRTY?=$(shell test -n "`git status --porcelain`" && echo "+CHANGES" || true)
-GIT_DESCRIBE?=$(shell git describe --tags --always --match "v*")
 GIT_IMPORT=github.com/hashicorp/consul/version
-GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY) -X $(GIT_IMPORT).GitDescribe=$(GIT_DESCRIBE)
+GOLDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)
 
 PROTOFILES?=$(shell find . -name '*.proto' | grep -v 'vendor/')
 PROTOGOFILES=$(PROTOFILES:.proto=.pb.go)
@@ -124,7 +123,6 @@ export BUILD_CONTAINER_NAME
 export GIT_COMMIT
 export GIT_COMMIT_YEAR
 export GIT_DIRTY
-export GIT_DESCRIBE
 export GOTAGS
 export GOLDFLAGS
 
@@ -282,7 +280,6 @@ test-docker: linux go-build-image
 		-e 'GIT_COMMIT=$(GIT_COMMIT)' \
 		-e 'GIT_COMMIT_YEAR=$(GIT_COMMIT_YEAR)' \
 		-e 'GIT_DIRTY=$(GIT_DIRTY)' \
-		-e 'GIT_DESCRIBE=$(GIT_DESCRIBE)' \
 		$(TEST_PARALLELIZATION) \
 		$(TEST_DOCKER_RESOURCE_CONSTRAINTS) \
 		$(TEST_MODCACHE_VOL) \

--- a/build-support/functions/10-util.sh
+++ b/build-support/functions/10-util.sh
@@ -110,7 +110,7 @@ function parse_version {
    # Arguments:
    #   $1 - Path to the top level Consul source
    #   $2 - boolean value for whether the release version should be parsed from the source
-   #   $3 - boolean whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
+   #   $3 - boolean whether to use GIT_COMMIT environment variable
    #   $4 - boolean whether to omit the version part of the version string. (optional)
    #
    # Return:
@@ -134,7 +134,6 @@ function parse_version {
    local use_git_env="$3"
    local omit_version="$4"
 
-   local git_version=""
    local git_commit=""
 
    if test -z "${include_release}"
@@ -149,7 +148,6 @@ function parse_version {
 
    if is_set "${use_git_env}"
    then
-      git_version="${GIT_DESCRIBE}"
       git_commit="${GIT_COMMIT}"
    fi
 
@@ -172,11 +170,6 @@ function parse_version {
    done
 
    local version="${version_main}"
-   # override the version from source with the value of the GIT_DESCRIBE env var if present
-   if test -n "${git_version}"
-   then
-      version="${git_version}"
-   fi
 
    local rel_ver=""
    if is_set "${include_release}"
@@ -184,9 +177,8 @@ function parse_version {
       # Default to pre-release from the source
       rel_ver="${release_main}"
 
-      # When no GIT_DESCRIBE env var is present and no release is in the source then we
-      # are definitely in dev mode
-      if test -z "${git_version}" -a -z "${rel_ver}" && is_set "${use_git_env}"
+      # When no release is in the source then we are definitely in dev mode
+      if test -z "${rel_ver}" && is_set "${use_git_env}"
       then
          rel_ver="dev"
       fi
@@ -220,7 +212,7 @@ function get_version {
    # Arguments:
    #   $1 - Path to the top level Consul source
    #   $2 - Whether the release version should be parsed from source (optional)
-   #   $3 - Whether to use GIT_DESCRIBE and GIT_COMMIT environment variables
+   #   $3 - Whether to use GIT_COMMIT environment variable
    #
    # Returns:
    #   0 - success (the version is also echoed to stdout)
@@ -519,9 +511,8 @@ function update_git_env {
 
    export GIT_COMMIT=$(git rev-parse --short HEAD)
    export GIT_DIRTY=$(test -n "$(git status --porcelain)" && echo "+CHANGES")
-   export GIT_DESCRIBE=$(git describe --tags --always --match "v*")
    export GIT_IMPORT=github.com/hashicorp/consul/version
-   export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X ${GIT_IMPORT}.GitDescribe=${GIT_DESCRIBE}"
+   export GOLDFLAGS="-X ${GIT_IMPORT}.GitCommit=${GIT_COMMIT}${GIT_DIRTY}"
    return 0
 }
 

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -64,13 +64,13 @@ function build_ui {
    then
       commit_hash=$(git rev-parse --short HEAD)
    fi
-   
+
    local commit_year="${GIT_COMMIT_YEAR}"
    if test -z "${commit_year}"
    then
       commit_year=$(git show -s --format=%cd --date=format:%Y HEAD)
    fi
-   
+
    local logo_type="${CONSUL_BINARY_TYPE}"
    if test "$logo_type" != "oss"
    then
@@ -140,7 +140,7 @@ function build_assetfs {
    #   * - error
    #
    # Note:
-   #   The GIT_COMMIT, GIT_DIRTY and GIT_DESCRIBE environment variables will be used if present
+   #   The GIT_COMMIT and GIT_DIRTY environment variables will be used if present
 
    if ! test -d "$1"
    then
@@ -157,7 +157,7 @@ function build_assetfs {
 
    pushd ${sdir} > /dev/null
    status "Creating the Go Build Container with image: ${image_name}"
-   local container_id=$(docker create -it -e GIT_COMMIT=${GIT_COMMIT} -e GIT_DIRTY=${GIT_DIRTY} -e GIT_DESCRIBE=${GIT_DESCRIBE} ${image_name} make static-assets ASSETFS_PATH=bindata_assetfs.go)
+   local container_id=$(docker create -it -e GIT_COMMIT=${GIT_COMMIT} -e GIT_DIRTY=${GIT_DIRTY} ${image_name} make static-assets ASSETFS_PATH=bindata_assetfs.go)
    local ret=$?
    if test $ret -eq 0
    then
@@ -436,7 +436,7 @@ function build_consul_local {
                if test "${arch}" != "amd64"
                then
                   continue
-               fi            
+               fi
                ;;
             "linux" )
                # build all the binaries for Linux
@@ -444,7 +444,7 @@ function build_consul_local {
             *)
                continue
             ;;
-         esac         
+         esac
 
          echo "--->   ${osarch}"
 

--- a/version/version.go
+++ b/version/version.go
@@ -8,8 +8,7 @@ import (
 var (
 	// The git commit that was compiled. These will be filled in by the
 	// compiler.
-	GitCommit   string
-	GitDescribe string
+	GitCommit string
 
 	// The main version number that is being run at the moment.
 	//
@@ -27,22 +26,12 @@ var (
 // for displaying to humans.
 func GetHumanVersion() string {
 	version := Version
-	if GitDescribe != "" {
-		version = GitDescribe
-	}
-
 	release := VersionPrerelease
-	if GitDescribe == "" && release == "" {
-		release = "dev"
-	}
 
 	if release != "" {
 		if !strings.HasSuffix(version, "-"+release) {
 			// if we tagged a prerelease version then the release is in the version already
 			version += fmt.Sprintf("-%s", release)
-		}
-		if GitCommit != "" {
-			version += fmt.Sprintf(" (%s)", GitCommit)
 		}
 	}
 


### PR DESCRIPTION
#8268 introduced a `Revision` line in `consul version` that outputs the ref that is currently built. For production builds, this didn't have a huge impact besides adding the extra line. However, for dev builds, we previous had:

```
$ make dev 
$ ./pkg/bin/darwin_amd64/consul version
Consul v1.7.0-124-g5f9029c65-dev (5f9029c65+CHANGES)
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
```

This PR changes this to:
```
$ make dev
$./pkg/bin/darwin_amd64/consul version
Consul 1.8.0-dev
Revision 41dab50e8+CHANGES
Protocol 2 spoken by default, understands 2 to 3 (agent will automatically use protocol >2 when speaking to compatible agents)
```

Most notably, the revision is no longer in parentheses in the version line and instead, the revision line contains the SHA and `+CHANGES` if the git repo is dirty (has uncommitted changes).