### PR TITLE
[skip ci] bump master to 1.9.0 to track next release version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.8.0"
+	Version = "1.9.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Bumping the version in the `master` branch to 1.9.0 to track the next release version. This is important for Cloud nightly integration environments. 

I am skipping CI on this commit because I think it is trivial enough to not spend any cycles running tests. 