### PR TITLE
minor: fix docstring of DNSOnlyPassing

### DIFF
--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -293,7 +293,7 @@ type RuntimeConfig struct {
 	// whose health checks are in any non-passing state. By
 	// default, only nodes in a critical state are excluded.
 	//
-	// hcl: dns_config { only_passing = "duration" }
+	// hcl: dns_config { only_passing = (true|false) }
 	DNSOnlyPassing bool
 
 	// DNSRecursorTimeout specifies the timeout in seconds


### PR DESCRIPTION
In runtime.go it had "duration" but it is actually a boolean.