### PR TITLE
feature: add NeverExclude feature to consul DNS

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -834,6 +834,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		DNSMaxStale:           b.durationVal("dns_config.max_stale", c.DNS.MaxStale),
 		DNSNodeTTL:            b.durationVal("dns_config.node_ttl", c.DNS.NodeTTL),
 		DNSOnlyPassing:        b.boolVal(c.DNS.OnlyPassing),
+		DNSNeverExclude:       b.boolVal(c.DNS.NeverExclude),
 		DNSPort:               dnsPort,
 		DNSRecursorTimeout:    b.durationVal("recursor_timeout", c.DNS.RecursorTimeout),
 		DNSRecursors:          dnsRecursors,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -536,6 +536,7 @@ type DNS struct {
 	MaxStale           *string           `json:"max_stale,omitempty" hcl:"max_stale" mapstructure:"max_stale"`
 	NodeTTL            *string           `json:"node_ttl,omitempty" hcl:"node_ttl" mapstructure:"node_ttl"`
 	OnlyPassing        *bool             `json:"only_passing,omitempty" hcl:"only_passing" mapstructure:"only_passing"`
+	NeverExclude       *bool             `json:"never_exclude,omitempty" hcl:"never_exclude" mapstructure:"never_exclude"`
 	RecursorTimeout    *string           `json:"recursor_timeout,omitempty" hcl:"recursor_timeout" mapstructure:"recursor_timeout"`
 	ServiceTTL         map[string]string `json:"service_ttl,omitempty" hcl:"service_ttl" mapstructure:"service_ttl"`
 	UDPAnswerLimit     *int              `json:"udp_answer_limit,omitempty" hcl:"udp_answer_limit" mapstructure:"udp_answer_limit"`

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -296,6 +296,13 @@ type RuntimeConfig struct {
 	// hcl: dns_config { only_passing = "duration" }
 	DNSOnlyPassing bool
 
+	// DNSNeverExclude is used to determine whether to never exclude nodes
+	// whose health checks are failing. By
+	// default, the behavior of DNSOnlyPassing is used.
+	//
+	// hcl: dns_config { never_exclude = (true|false) }
+	DNSNeverExclude bool
+
 	// DNSRecursorTimeout specifies the timeout in seconds
 	// for Consul's internal dns client used for recursion.
 	// This value is used for the connection, read and write timeout.

--- a/agent/consul/prepared_query_endpoint.go
+++ b/agent/consul/prepared_query_endpoint.go
@@ -520,8 +520,10 @@ func (p *PreparedQuery) execute(query *structs.PreparedQuery,
 	}
 
 	// Filter out any unhealthy nodes.
-	nodes = nodes.FilterIgnore(query.Service.OnlyPassing,
-		query.Service.IgnoreCheckIDs)
+	if !query.Service.NeverExclude {
+		nodes = nodes.FilterIgnore(query.Service.OnlyPassing,
+			query.Service.IgnoreCheckIDs)
+	}
 
 	// Apply the node metadata filters, if any.
 	if len(query.Service.NodeMeta) > 0 {

--- a/agent/structs/config_entry_discoverychain.go
+++ b/agent/structs/config_entry_discoverychain.go
@@ -885,6 +885,11 @@ type ServiceResolverSubset struct {
 	// returned. (behaves identically to the similarly named field on prepared
 	// queries).
 	OnlyPassing bool `json:",omitempty" alias:"only_passing"`
+
+	// NeverExclude - Specifies the behavior of the resolver's health check
+	// filtering. If this is set to false, the behavior of `OnlyPassing` is used
+	// otherwise we return even failing hosts.
+	NeverExclude bool `json:",omitempty" alias:"never_exclude"`
 }
 
 type ServiceResolverRedirect struct {

--- a/agent/structs/prepared_query.go
+++ b/agent/structs/prepared_query.go
@@ -42,6 +42,10 @@ type ServiceQuery struct {
 	// discarded)
 	OnlyPassing bool
 
+	// If NeverExclude is true then we will only all nodes, even with failing
+	// health checks. Otherwise we use OnlyPassing behavior.
+	NeverExclude bool
+
 	// IgnoreCheckIDs is an optional list of health check IDs to ignore when
 	// considering which nodes are healthy. It is useful as an emergency measure
 	// to temporarily override some health check that is producing false negatives

--- a/api/config_entry_discoverychain.go
+++ b/api/config_entry_discoverychain.go
@@ -184,8 +184,9 @@ func (e *ServiceResolverConfigEntry) GetCreateIndex() uint64 { return e.CreateIn
 func (e *ServiceResolverConfigEntry) GetModifyIndex() uint64 { return e.ModifyIndex }
 
 type ServiceResolverSubset struct {
-	Filter      string `json:",omitempty"`
-	OnlyPassing bool   `json:",omitempty" alias:"only_passing"`
+	Filter       string `json:",omitempty"`
+	OnlyPassing  bool   `json:",omitempty" alias:"only_passing"`
+	NeverExclude bool   `json:",omitempty" alias:"never_exclude"`
 }
 
 type ServiceResolverRedirect struct {

--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1191,6 +1191,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     then all services on that node will be excluded because they are also considered
     critical.
 
+  - `never_exclude` - If set to true, any nodes whose
+    health checks are failing aren't excluded from DNS results. If false,
+    the default, the behavior of `only_passing` is used.
+
   - `recursor_timeout` - Timeout used by Consul when
     recursively querying an upstream DNS server. See [`recursors`](#recursors) for more details. Default is 2s. This is available in Consul 0.7 and later.
 


### PR DESCRIPTION
NeverExclude adds a new behavior to consul DNS where we simply return what is in the catalog for the service without any exclusion due to health checks failing.

I feel this is important for companies that are still in the transition to be cloud native. Consul already plays a key role as a service registry and k/v store at some of these companies but due to the recent adoption of cloud native technologies the developer teams might be more used to think of DNS as something static. Not something that automatically remove records due to failures.

Introducing this change would allow the consul registry to also play a key role at these companies as a more traditional DNS server. The intent of this PR is:

1. To not break existing functionality or cause backwards incompatibility;
2. To be opt-in;
3. To allow Consul DNS to be configured in such way that it doesn't care about service health checks or node health checks failing. It is more of a registry instead of a dynamic load balancer.

It is my first time making code changes to the consul code base, please let me know if the approach is valid and if I touched the right files :) 

I have added a test to verify that the new feature doesn't break existing behavior as well as work as intended. I should probably add a couple more tests, would appreciate any advice that would help to achieve the goals in this merge request even if these changes might end up not being wanted!

Thank you

