### PR TITLE
ui: Better error message checking for cross dc connect check

### DIFF
--- a/ui-v2/app/services/repository/discovery-chain.js
+++ b/ui-v2/app/services/repository/discovery-chain.js
@@ -19,7 +19,7 @@ export default RepositoryService.extend({
       const body = get(e, 'errors.firstObject.detail').trim();
       switch (code) {
         case '500':
-          if (datacenter !== null && body === ERROR_MESH_DISABLED) {
+          if (datacenter !== null && body.endsWith(ERROR_MESH_DISABLED)) {
             set(datacenter, 'MeshEnabled', false);
           }
           return;


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8065 we added a feature to disable further attempts to use API endpoints that are only enabled when connect is enabled in order to reduce HTTP log spam from the UI.

This PR improves this by making sure this error string checking works cross datacenter:

Error messages:

Same datacenter: `Connect must be enabled in order to use this endpoint`
Cross datacenter: `rpc error making call: Connect must be enabled in order to use this endpoint`