### PR TITLE
ui: Fix sticky action popover menus

### DIFF
--- a/ui-v2/app/components/more-popover-menu/action/index.hbs
+++ b/ui-v2/app/components/more-popover-menu/action/index.hbs
@@ -7,7 +7,7 @@
   <div role="menu">
     <YieldSlot @name="confirmation" @params={{
       block-params (component 'confirmation-alert'
-        onclick=(action onclick)
+        onclick=(queue (action onclick) (action menu.clickTrigger))
         name=(concat menu.confirm guid)
       )
     }}>{{yield}}</YieldSlot>

--- a/ui-v2/app/components/more-popover-menu/index.hbs
+++ b/ui-v2/app/components/more-popover-menu/index.hbs
@@ -3,12 +3,13 @@
     <BlockSlot @name="trigger">
       More
     </BlockSlot>
-    <BlockSlot @name="menu" as |confirm send keypressClick|>
+    <BlockSlot @name="menu" as |confirm send keypressClick clickTrigger|>
       {{yield (component 'more-popover-menu/action' menu=(hash
         addSubmenu=api.addSubmenu
         removeSubmenu=api.removeSubmenu
         confirm=confirm
         keypressClick=keypressClick
+        clickTrigger=clickTrigger
       ))}}
     </BlockSlot>
   </PopoverMenu>

--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -56,7 +56,7 @@
               <BlockSlot @name="trigger">
                 More
               </BlockSlot>
-              <BlockSlot @name="menu" as |confirm send keypressClick|>
+              <BlockSlot @name="menu" as |confirm send keypressClick clickTrigger|>
                   <li role="none">
                     <a data-test-edit role="menuitem" tabindex="-1" href={{href-to (if item.isFolder 'dc.kv.folder' 'dc.kv.edit') item.Key}}>{{if item.isFolder 'View' 'Edit'}}</a>
                   </li>
@@ -74,7 +74,7 @@
                         </div>
                         <ul>
                           <li class="dangerous">
-                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{queue (action send 'delete' item) (action clickTrigger)}}>Delete</button>
                           </li>
                           <li>
                             <label for={{confirm}}>Cancel</label>

--- a/ui-v2/app/templates/dc/nspaces/index.hbs
+++ b/ui-v2/app/templates/dc/nspaces/index.hbs
@@ -58,7 +58,7 @@
               <BlockSlot @name="trigger">
                 More
               </BlockSlot>
-              <BlockSlot @name="menu" as |confirm send keypressClick|>
+              <BlockSlot @name="menu" as |confirm send keypressClick clickTrigger|>
                   <li role="none">
                     <a data-test-edit role="menuitem" tabindex="-1" href={{href-to 'dc.nspaces.edit' item.Name}}>Edit</a>
                   </li>
@@ -77,7 +77,7 @@
                         </div>
                         <ul>
                           <li class="dangerous">
-                            <button tabindex="-1" type="button" class="type-delete" onclick={{action send 'delete' item}}>Delete</button>
+                            <button tabindex="-1" type="button" class="type-delete" onclick={{queue (action send 'delete' item) (queue clickTrigger)}}>Delete</button>
                           </li>
                           <li>
                             <label for={{confirm}}>Cancel</label>


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/8219 we noticed we were completely destroying and re-inserting our top-level `AppView` component / `outlet` everytime the app went through its loading state. We switched this out for a CSS based hide/show approach. 

This means that ember can reuse more DOM nodes, but as a consequence we noticed the menus within our dom recycling scrollpane would 'hang around' as they are now being reused.

This PR specifically closes these menus when the 'action' is clicked, which also closes the menu back to its initial state ready for reuse.

We noticed that this problem doesn't occur in Intentions which use our new Intention components.

Before:

![menu-before](https://user-images.githubusercontent.com/554604/87783092-ae33ca00-c82b-11ea-80ab-d63225315c3f.gif)

After:

![menu-after](https://user-images.githubusercontent.com/554604/87783102-b429ab00-c82b-11ea-9ea2-5a6dc458af2d.gif)


