### PR TITLE
ci: separate install-gotestsum step into its own config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,22 @@ references:
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: *TEST_RESULTS_DIR
-    GOTESTSUM_RELEASE: 0.4.2
     EMAIL: noreply@hashicorp.com
     GIT_AUTHOR_NAME: circleci-consul
     GIT_COMMITTER_NAME: circleci-consul
     S3_ARTIFACT_BUCKET: consul-dev-artifacts
     BASH_ENV: .circleci/bash_env.sh
     VAULT_BINARY_VERSION: 1.2.2
+
+steps:
+  install-gotestsum: &install-gotestsum
+    name: install gotestsum
+    environment:
+      GOTESTSUM_RELEASE: 0.5.1
+    command: |
+      url=https://github.com/gotestyourself/gotestsum/releases/download
+      curl -sSL "${url}/v${GOTESTSUM_RELEASE}/gotestsum_${GOTESTSUM_RELEASE}_linux_amd64.tar.gz" | \
+      sudo tar -xz --overwrite -C /usr/local/bin gotestsum
 
 jobs:
   # lint consul tests
@@ -95,12 +104,7 @@ jobs:
           at: /go/bin
       - run: sudo apt-get update && sudo apt-get install -y rsyslog
       - run: sudo service rsyslog start
-      - run: &install_gotestsum
-          name: Install gotestsum
-          command: |
-            url=https://github.com/gotestyourself/gotestsum/releases/download
-            curl -sSL "${url}/v${GOTESTSUM_RELEASE}/gotestsum_${GOTESTSUM_RELEASE}_linux_amd64.tar.gz" | \
-              sudo tar -xz --overwrite -C /usr/local/bin gotestsum
+      - run: *install-gotestsum
       - run: go mod download
       - run:
           name: go test
@@ -141,7 +145,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: *install_gotestsum
+      - run: *install-gotestsum
       - run:
           working_directory: api
           command: go mod download
@@ -176,7 +180,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: /go/bin
-      - run: *install_gotestsum
+      - run: *install-gotestsum
       - run:
           working_directory: sdk
           command: go mod download
@@ -340,7 +344,7 @@ jobs:
           command: make pkg/linux_amd64/nomad
           working_directory: *NOMAD_WORKING_DIR
 
-      - run: *install_gotestsum
+      - run: *install-gotestsum
 
       # run integration tests
       - run:


### PR DESCRIPTION
This separates out the gotestsum installation step into its own reusable configuration and also pulls down the `GOTESTSUM_RELEASE` variable outside of the environment variables block to be closer to where it is actually being used.

This is helpful while setting up the vault integration test job since it needs gotestsum but does not need all the various Consul CI enviornment variables that is in the whole `ENVIRONMENT` dictionary. 