### PR TITLE
ci: Use go1.14.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.14.4
+    go: &GOLANG_IMAGE circleci/golang:1.14.6
     middleman: &MIDDLEMAN_IMAGE hashicorp/middleman-hashicorp:0.3.40
     ember: &EMBER_IMAGE circleci/node:12-browsers
 


### PR DESCRIPTION
Includes the security patches from go14.5 and https://github.com/golang/go/issues/39308 to fix our test logs.