### PR TITLE
ui: Mark gateway retrieval as not reconcilable

### DIFF
--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -6,9 +6,8 @@ export default RepositoryService.extend({
     return modelName;
   },
   shouldReconcile: function(method) {
-    switch (true) {
-      case method === 'findGatewayBySlug' || method.indexOf('for-service') !== -1:
-        return false;
+    if (method === 'findGatewayBySlug' || method.indexOf('for-service') !== -1) {
+      return false;
     }
     return this._super(...arguments);
   },

--- a/ui-v2/app/services/repository/service.js
+++ b/ui-v2/app/services/repository/service.js
@@ -6,8 +6,8 @@ export default RepositoryService.extend({
     return modelName;
   },
   shouldReconcile: function(method) {
-    switch (method) {
-      case 'findGatewayBySlug':
+    switch (true) {
+      case method === 'findGatewayBySlug' || method.indexOf('for-service') !== -1:
         return false;
     }
     return this._super(...arguments);


### PR DESCRIPTION
This PR excludes any request that responds with a partial set of results from reconciliation (if the response set is a partial response it shouldn't clean up any records that aren't in the response)

The current way of marking these types of responses are soon to be moved to the adapters so this kind of configuration is kept all together with the rest of the request configuration.