### PR TITLE
docs: Add raft_multiplier default clarification

### DIFF
--- a/website/pages/docs/install/performance.mdx
+++ b/website/pages/docs/install/performance.mdx
@@ -73,7 +73,7 @@ The value of `raft_multiplier` is a scaling factor and directly affects the foll
 | ElectionTimeout    | 1000ms | default |
 | LeaderLeaseTimeout |  500ms | default |
 
-By default, Consul uses `raft_multiplier: 5`, which results in the following values:
+By default, Consul uses a scaling factor of `5` (i.e. `raft_multiplier: 5`), which results in the following values:
 
 | Param              |  Value | Calculation |
 | ------------------ | -----: | ----------: |

--- a/website/pages/docs/install/performance.mdx
+++ b/website/pages/docs/install/performance.mdx
@@ -73,7 +73,7 @@ The value of `raft_multiplier` is a scaling factor and directly affects the foll
 | ElectionTimeout    | 1000ms | default |
 | LeaderLeaseTimeout |  500ms | default |
 
-So a scaling factor of `5` (i.e. `raft_multiplier: 5`) updates the following values:
+By default, Consul uses `raft_multiplier: 5`, which results in the following values:
 
 | Param              |  Value | Calculation |
 | ------------------ | -----: | ----------: |


### PR DESCRIPTION
`raft_multiplier` defaults to `5`, but when I was reading through the [Server Performance docs](https://www.consul.io/docs/install/performance.html) for the first time it seemed like the default setting for `raft_multiplier` was actually what would be `1` due to this bit:

![image](https://user-images.githubusercontent.com/244/87954044-71591480-ca71-11ea-903b-73fcdf1ca8a3.png)

After reading the [`raft_multiplier` docs](https://www.consul.io/docs/agent/options#raft_multiplier), it was clear that this was not the case and the chart was referring to the default values for those settings individually and not `raft_multiplier`. This PR updates some of the verbiage to clarify this a bit further.