### PR TITLE
stream: handle empty event in TestEventSnapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,9 +154,10 @@ jobs:
       - run:
           name: go test -race
           command: |
-            mkdir -p $TEST_RESULTS_DIR
+            mkdir -p $TEST_RESULTS_DIR /tmp/jsonfile
             gotestsum \
               --format=short-verbose \
+              --jsonfile /tmp/jsonfile/go-test-race.log \
               --junitfile $TEST_RESULTS_DIR/gotestsum-report.xml -- \
               -tags="$GOTAGS" -p 2 \
               -race -gcflags=all=-d=checkptr=0 \
@@ -168,6 +169,8 @@ jobs:
           path: *TEST_RESULTS_DIR
       - store_artifacts:
           path: *TEST_RESULTS_DIR
+      - store_artifacts:
+          path: /tmp/jsonfile
 
   # split off a job for the API package since it is separate
   go-test-api:

--- a/agent/consul/stream/event_snapshot_test.go
+++ b/agent/consul/stream/event_snapshot_test.go
@@ -121,6 +121,12 @@ func TestEventSnapshot(t *testing.T) {
 				require.NoError(t, err,
 					"current state: snapDone=%v snapIDs=%s updateIDs=%s", snapDone,
 					snapIDs, updateIDs)
+				if len(curItem.Events) == 0 {
+					// An item without an error or events is a bufferItem.NextLink event.
+					// A subscription handles this by proceeding to the next item,
+					// so we do the same here.
+					continue
+				}
 				e := curItem.Events[0]
 				switch {
 				case snapDone:


### PR DESCRIPTION
When the race detector is enabled we see this test fail occasionally. The reordering of execution seems to make it possible for the snapshot splice to happen before any events are published to the topicBuffers.

We can handle this case in the test the same way it is handled by a subscription, by proceeding to the next event.

Example failure:
```
Failed
=== RUN   TestEventSnapshot/empty_snapshot_with_concurrent_mutations
    --- FAIL: TestEventSnapshot/empty_snapshot_with_concurrent_mutations (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 1043 [running]:
testing.tRunner.func1.1(0x8aaea0, 0xc0000d64a0)
	/usr/local/go/src/testing/testing.go:940 +0x421
testing.tRunner.func1(0xc0000d8a20)
	/usr/local/go/src/testing/testing.go:943 +0x600
panic(0x8aaea0, 0xc0000d64a0)
	/usr/local/go/src/runtime/panic.go:975 +0x3e3
github.com/hashicorp/consul/agent/consul/stream.TestEventSnapshot.func1(0xc0000d8a20)
	/home/circleci/project/agent/consul/stream/event_snapshot_test.go:124 +0x171b
testing.tRunner(0xc0000d8a20, 0xc0006832c0)
	/usr/local/go/src/testing/testing.go:991 +0x1ec
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1042 +0x661
```