### PR TITLE
checks: wait for goroutine to complete (fix go-test-race failures)

### DIFF
--- a/agent/checks/alias.go
+++ b/agent/checks/alias.go
@@ -32,8 +32,7 @@ type CheckAlias struct {
 	stop     bool
 	stopCh   chan struct{}
 	stopLock sync.Mutex
-
-	stopWg sync.WaitGroup
+	stopWg   sync.WaitGroup
 
 	structs.EnterpriseMeta
 }
@@ -55,6 +54,7 @@ func (c *CheckAlias) Start() {
 	defer c.stopLock.Unlock()
 	c.stop = false
 	c.stopCh = make(chan struct{})
+	c.stopWg.Add(1)
 	go c.run(c.stopCh)
 }
 
@@ -76,7 +76,6 @@ func (c *CheckAlias) Stop() {
 
 // run is invoked in a goroutine until Stop() is called.
 func (c *CheckAlias) run(stopCh chan struct{}) {
-	c.stopWg.Add(1)
 	defer c.stopWg.Done()
 
 	// If we have a specific node set, then use a blocking query


### PR DESCRIPTION
Fixes https://github.com/hashicorp/consul/issues/8329#issuecomment-661245463

CheckAlias already had a WaitGroup, but the Add() call was happening too late, which was causing a race in tests. The add must happen before the goroutine is started.

CheckHTTP did not have a WaitGroup, so I added it to match CheckAlias.

It looks like `CheckTCP`, `CheckMonitor`, `CheckDocker`, `CheckGRPC`, and `CheckTTL` all may have the same problem. I'm not sure why it seems that only alias and http are failing. I saw one failure for GRPC, so maybe alias and http happen to have more tests written for them?

If this fix looks good, I will look at refactoring so that all of these can share the "run" mechanism and remove the need to copy the fix 7 times.