### PR TITLE
api: Add X-Allow-NotModified header to support 304 Not Modified responses

### DIFF
--- a/agent/catalog_endpoint.go
+++ b/agent/catalog_endpoint.go
@@ -258,6 +258,11 @@ RETRY_ONCE:
 	}
 	out.ConsistencyLevel = args.QueryOptions.ConsistencyLevel()
 
+	if allowsNotModifiedResponse(req) && args.QueryOptions.MinQueryIndex == out.Index {
+		resp.WriteHeader(http.StatusNotModified)
+		return nil, nil
+	}
+
 	s.agent.TranslateAddresses(args.Datacenter, out.Nodes, TranslateAddressAcceptAny)
 
 	// Use empty list instead of nil

--- a/agent/http.go
+++ b/agent/http.go
@@ -756,6 +756,14 @@ func setCacheMeta(resp http.ResponseWriter, m *cache.ResultMeta) {
 	}
 }
 
+const httpHeaderAllowNotModified = "X-Allow-NotModified"
+
+// allowsNotModifiedResponse returns true if the request has the X-Allow-NotModified
+// header set to "true".
+func allowsNotModifiedResponse(req *http.Request) bool {
+	return req.Header.Get(httpHeaderAllowNotModified) == "true"
+}
+
 // setHeaders is used to set canonical response header fields
 func setHeaders(resp http.ResponseWriter, headers map[string]string) {
 	for field, value := range headers {


### PR DESCRIPTION
Implements part of #10170

This PR adds  a new query parameter for enabling the functionality. When enabled, if a blocking query times out without any new data, a 304 response will be returned (with an empty response body) instead of 200 with all the data in the response body.

TODO:
* [ ] this PR only adds support for one endpoint. Either add more or create an issue to track adding them.
* [ ] docs updates
* [ ] changelog entry