### PR TITLE
Restore link to /intro docs in main menu

### DIFF
--- a/website/data/subnav.js
+++ b/website/data/subnav.js
@@ -1,5 +1,5 @@
 export default [
-  { text: 'Overview', url: '/', type: 'inbound' },
+  { text: 'Overview', url: '/intro' },
   {
     text: 'Use Cases',
     submenu: [


### PR DESCRIPTION
🌏 [Consul.io Staging Preview](https://deploy-preview-8356--consul-docs-preview.netlify.app/)

The "Overview" link previously went to a summary of Consul features and a
comparison to other products. This commit restores that destination at the
request of Consul PMs.

This commit previously removed the link (it went to `/` instead of `/intro`).

https://github.com/hashicorp/consul/commit/ac612a9cdcf81c713b4a2fadb3201980197a26ca#diff-f98b55875118725d1373dd2da36d9ee5