### PR TITLE
Move generation of CA Configuration into a method on the `RuntimeConfig`

### DIFF
--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -594,9 +594,9 @@ func DefaultConfig() *Config {
 		CAConfig: &structs.CAConfiguration{
 			Provider: "consul",
 			Config: map[string]interface{}{
-				"RotationPeriod":      "2160h",
-				"LeafCertTTL":         "72h",
-				"IntermediateCertTTL": "8760h", // 365 * 24h
+				"RotationPeriod":      structs.DefaultCARotationPeriod,
+				"LeafCertTTL":         structs.DefaultLeafCertTTL,
+				"IntermediateCertTTL": structs.DefaultIntermediateCertTTL,
 			},
 		},
 

--- a/agent/structs/connect_ca.go
+++ b/agent/structs/connect_ca.go
@@ -9,6 +9,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const (
+	DefaultCARotationPeriod    = "2160h"
+	DefaultLeafCertTTL         = "72h"
+	DefaultIntermediateCertTTL = "8760h" // 365 * 24h
+)
+
 // IndexedCARoots is the list of currently trusted CA Roots.
 type IndexedCARoots struct {
 	// ActiveRootID is the ID of a root in Roots that is the active CA root.


### PR DESCRIPTION
Previously this was done in the `Agent.consulConfig` function but we will need this in other places for Agent Auto Configuration so this functionality is being moved to a method on the `RuntimeConfig`