### PR TITLE
state: speed up tests that use watchLimit

### DIFF
--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -1611,12 +1611,14 @@ func TestStateStore_Services(t *testing.T) {
 func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	s := testStateStore(t)
 
-	// Listing with no results returns nil.
 	ws := memdb.NewWatchSet()
-	idx, res, err := s.ServicesByNodeMeta(ws, map[string]string{"somekey": "somevalue"}, nil)
-	if idx != 0 || len(res) != 0 || err != nil {
-		t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, res, err)
-	}
+
+	t.Run("Listing with no results returns nil", func(t *testing.T) {
+		idx, res, err := s.ServicesByNodeMeta(ws, map[string]string{"somekey": "somevalue"}, nil)
+		if idx != 0 || len(res) != 0 || err != nil {
+			t.Fatalf("expected (0, nil, nil), got: (%d, %#v, %#v)", idx, res, err)
+		}
+	})
 
 	// Create some nodes and services in the state store.
 	node0 := &structs.Node{Node: "node0", Address: "127.0.0.1", Meta: map[string]string{"role": "client", "common": "1"}}
@@ -1648,94 +1650,85 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 	if !watchFired(ws) {
-		t.Fatalf("bad")
+		t.Fatalf("expected the watch to be triggered by the queries")
 	}
 
-	// Filter the services by the first node's meta value.
 	ws = memdb.NewWatchSet()
-	_, res, err = s.ServicesByNodeMeta(ws, map[string]string{"role": "client"}, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	expected := structs.Services{
-		"redis": []string{"master", "prod"},
-	}
-	sort.Strings(res["redis"])
-	if !reflect.DeepEqual(res, expected) {
-		t.Fatalf("bad: %v %v", res, expected)
-	}
 
-	// Get all services using the common meta value
-	_, res, err = s.ServicesByNodeMeta(ws, map[string]string{"common": "1"}, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	expected = structs.Services{
-		"redis": []string{"master", "prod", "slave"},
-	}
-	sort.Strings(res["redis"])
-	if !reflect.DeepEqual(res, expected) {
-		t.Fatalf("bad: %v %v", res, expected)
-	}
+	t.Run("Filter the services by the first node's meta value", func(t *testing.T) {
+		_, res, err := s.ServicesByNodeMeta(ws, map[string]string{"role": "client"}, nil)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		expected := structs.Services{
+			"redis": []string{"master", "prod"},
+		}
+		sort.Strings(res["redis"])
+		require.Equal(t, expected, res)
+	})
 
-	// Get an empty list for an invalid meta value
-	_, res, err = s.ServicesByNodeMeta(ws, map[string]string{"invalid": "nope"}, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	expected = structs.Services{}
-	if !reflect.DeepEqual(res, expected) {
-		t.Fatalf("bad: %v %v", res, expected)
-	}
+	t.Run("Get all services using the common meta value", func(t *testing.T) {
+		_, res, err := s.ServicesByNodeMeta(ws, map[string]string{"common": "1"}, nil)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		expected := structs.Services{
+			"redis": []string{"master", "prod", "slave"},
+		}
+		sort.Strings(res["redis"])
+		require.Equal(t, expected, res)
+	})
 
-	// Get the first node's service instance using multiple meta filters
-	_, res, err = s.ServicesByNodeMeta(ws, map[string]string{"role": "client", "common": "1"}, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	expected = structs.Services{
-		"redis": []string{"master", "prod"},
-	}
-	sort.Strings(res["redis"])
-	if !reflect.DeepEqual(res, expected) {
-		t.Fatalf("bad: %v %v", res, expected)
-	}
+	t.Run("Get an empty list for an invalid meta value", func(t *testing.T) {
+		_, res, err := s.ServicesByNodeMeta(ws, map[string]string{"invalid": "nope"}, nil)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		expected := structs.Services{}
+		require.Equal(t, expected, res)
+	})
 
-	// Sanity check the watch before we proceed.
-	if watchFired(ws) {
-		t.Fatalf("bad")
-	}
+	t.Run("Get the first node's service instance using multiple meta filters", func(t *testing.T) {
+		_, res, err := s.ServicesByNodeMeta(ws, map[string]string{"role": "client", "common": "1"}, nil)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		expected := structs.Services{
+			"redis": []string{"master", "prod"},
+		}
+		sort.Strings(res["redis"])
+		require.Equal(t, expected, res)
+	})
 
-	// Registering some unrelated node + service should not fire the watch.
-	testRegisterNode(t, s, 4, "nope")
-	testRegisterService(t, s, 5, "nope", "nope")
-	if watchFired(ws) {
-		t.Fatalf("bad")
-	}
+	t.Run("Registering some unrelated node + service should not fire the watch.", func(t *testing.T) {
+		testRegisterNode(t, s, 4, "nope")
+		testRegisterService(t, s, 5, "nope", "nope")
+		if watchFired(ws) {
+			t.Fatalf("expected the watch to timeout and not be triggered")
+		}
+	})
 
-	// Overwhelm the service tracking.
-	idx = 6
-	for i := 0; i < 2*watchLimit; i++ {
-		node := fmt.Sprintf("many%d", i)
-		testRegisterNodeWithMeta(t, s, idx, node, map[string]string{"common": "1"})
-		idx++
-		testRegisterService(t, s, idx, node, "nope")
-		idx++
-	}
+	t.Run("Uses watchLimit to limit the number of watches", func(t *testing.T) {
+		var idx uint64 = 6
+		for i := 0; i < 2*watchLimit; i++ {
+			node := fmt.Sprintf("many%d", i)
+			testRegisterNodeWithMeta(t, s, idx, node, map[string]string{"common": "1"})
+			idx++
+			testRegisterService(t, s, idx, node, "nope")
+			idx++
+		}
 
-	// Now get a fresh watch, which will be forced to watch the whole
-	// service table.
-	ws = memdb.NewWatchSet()
-	_, _, err = s.ServicesByNodeMeta(ws, map[string]string{"common": "1"}, nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+		// Now get a fresh watch, which will be forced to watch the whole
+		// service table.
+		ws := memdb.NewWatchSet()
+		_, _, err := s.ServicesByNodeMeta(ws, map[string]string{"common": "1"}, nil)
+		require.NoError(t, err)
 
-	// Registering some unrelated node + service should not fire the watch.
-	testRegisterService(t, s, idx, "nope", "more-nope")
-	if !watchFired(ws) {
-		t.Fatalf("bad")
-	}
+		testRegisterService(t, s, idx, "nope", "more-nope")
+		if !watchFired(ws) {
+			t.Fatalf("expected the watch to timeout and not be triggered")
+		}
+	})
 }
 
 func TestStateStore_ServiceNodes(t *testing.T) {

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -82,7 +82,7 @@ var (
 	ErrMissingIntentionID = errors.New("Missing Intention ID")
 )
 
-const (
+var (
 	// watchLimit is used as a soft limit to cap how many watches we allow
 	// for a given blocking query. If this is exceeded, then we will use a
 	// higher-level watch that's less fine-grained.  Choosing the perfect


### PR DESCRIPTION
I saw `TestStateStore_ServicesByNodeMeta` flake a few times in the `go-test-race` job. When I went to try and reproduce the flake I noticed the test was taking 6s to run (even longer in CI)! Attempting to reproduce the flake was not working well because it individual test run was so long.

To find the slowdown I started by splitting the test into sub-tests. The sub-tests help identify all the independent cases.

I was able to speed up the test significantly by making `watchLimit` a `var` and patching it to a much lower value. This test was previously creating 16000+ nodes and services, which is where all the time was spent. After this change it only creates 12 of each. We could create fewer, but the test runs in 0.01s now, so that is probably fast enough.

Unfortunately I was not able to reproduce the flake. Maybe these changes fixed it, or will at least reduce the likelihood of it occurring.

I applied the same patching to the other tests which were also creating 16000+ state objects. Now all the test in the package run in under 5s!
