### PR TITLE
Add script to print available module updates

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -378,6 +378,12 @@ proto: $(PROTOGOFILES) $(PROTOGOBINFILES)
 %.pb.go %.pb.binary.go: %.proto
 	@$(SHELL) $(CURDIR)/build-support/scripts/proto-gen.sh --grpc --import-replace "$<"
 
+.PHONY: module-versions
+# Print a list of modules which can be updated.
+# Columns are: module current_version date_of_current_version latest_version
+module-versions:
+	@go list -m -u -f '{{if .Update}} {{printf "%-50v %-40s" .Path .Version}} {{with .Time}} {{ .Format "2006-01-02" -}} {{else}} {{printf "%9s" ""}} {{end}}   {{ .Update.Version}} {{end}}' all
+
 
 .PHONY: all ci bin dev dist cov test test-flake test-internal cover lint ui static-assets tools
 .PHONY: docker-images go-build-image ui-build-image static-assets-docker consul-docker ui-docker


### PR DESCRIPTION
This should make it easy for us to find modules that are very out of date, or which have newer versions available.



<details><summary>Example output:</summary>

```
 cloud.google.com/go                                v0.38.0                                   2019-05-01   v0.61.0
 github.com/Azure/azure-sdk-for-go                  v40.3.0+incompatible                      2020-03-10   v44.2.0+incompatible
 github.com/Azure/go-autorest/autorest              v0.10.0                                   2020-02-24   v0.11.2
 github.com/Azure/go-autorest/autorest/adal         v0.8.2                                    2020-02-07   v0.9.0
 github.com/Azure/go-autorest/autorest/azure/auth   v0.4.2                                    2019-12-13   v0.5.0
 github.com/Azure/go-autorest/autorest/azure/cli    v0.3.1                                    2019-12-06   v0.4.0
 github.com/Azure/go-autorest/autorest/date         v0.2.0                                    2019-08-16   v0.3.0
 github.com/Azure/go-autorest/autorest/mocks        v0.3.0                                    2019-08-16   v0.4.0
 github.com/Azure/go-autorest/autorest/to           v0.3.0                                    2019-08-16   v0.4.0
 github.com/Azure/go-autorest/autorest/validation   v0.2.0                                    2019-08-16   v0.3.0
 github.com/Azure/go-autorest/logger                v0.1.0                                    2019-04-19   v0.2.0
 github.com/Azure/go-autorest/tracing               v0.5.0                                    2019-08-15   v0.6.0
 github.com/DataDog/datadog-go                      v3.2.0+incompatible                       2019-10-28   v3.7.2+incompatible
 github.com/Microsoft/go-winio                      v0.4.3                                    2017-07-12   v0.4.14
 github.com/NYTimes/gziphandler                     v1.0.1                                    2018-02-21   v1.1.1
 github.com/OneOfOne/xxhash                         v1.2.2                                    2018-05-30   v1.2.8
 github.com/PuerkitoBio/purell                      v1.0.0                                    2016-07-28   v1.1.1
 github.com/PuerkitoBio/urlesc                      v0.0.0-20160726150825-5bd2802263f2        2016-07-26   v0.0.0-20170810143723-de5bf2ad4578
 github.com/StackExchange/wmi                       v0.0.0-20180116203802-5d049714c4a6        2018-01-16   v0.0.0-20190523213315-cbe66965904d
 github.com/alecthomas/units                        v0.0.0-20190717042225-c3de453c63f4        2019-07-17   v0.0.0-20190924025748-f65c72e2690d
 github.com/armon/circbuf                           v0.0.0-20150827004946-bbbad097214e        2015-08-27   v0.0.0-20190214190532-5111143e8da2
 github.com/aws/aws-sdk-go                          v1.25.41                                  2019-11-22   v1.33.11
 github.com/census-instrumentation/opencensus-proto v0.2.1                                    2019-07-18   v0.3.0
 github.com/circonus-labs/circonusllhist            v0.1.3                                    2018-11-28   v0.1.4
 github.com/cncf/udpa/go                            v0.0.0-20200313221541-5f7e5dd04533        2020-03-13   v0.0.0-20200629203442-efcf912fb354
 github.com/coredns/coredns                         v1.1.2                                    2018-04-23   v1.7.0
 github.com/coreos/bbolt                            v1.3.2                                    2019-01-28   v1.3.5
 github.com/coreos/etcd                             v3.3.10+incompatible                      2018-10-10   v3.3.22+incompatible
 github.com/coreos/go-oidc                          v2.1.0+incompatible                       2019-08-15   v2.2.1+incompatible
 github.com/coreos/go-semver                        v0.2.0                                    2016-07-13   v0.3.0
 github.com/coreos/go-systemd                       v0.0.0-20190321100706-95778dfbb74e        2019-03-21   v0.0.0-20191104093116-d3cd4ed1dbcf
 github.com/denverdino/aliyungo                     v0.0.0-20170926055100-d3308649c661        2017-09-26   v0.0.0-20200720072455-26fa39a46424
 github.com/dgryski/go-sip13                        v0.0.0-20181026042036-e10d5fee7954        2018-10-26   v0.0.0-20190329191031-25c5027a8c7b
 github.com/digitalocean/godo                       v1.10.0                                   2019-03-20   v1.42.0
 github.com/docker/go-connections                   v0.3.0                                    2017-06-23   v0.4.0
 github.com/docker/spdystream                       v0.0.0-20160310174837-449fdfce4d96        2016-03-10   v0.0.0-20181023171402-6480d4af844c
 github.com/elazarl/go-bindata-assetfs              v0.0.0-20160803192304-e1a2a7ec64b0        2016-08-03   v1.0.1
 github.com/elazarl/goproxy                         v0.0.0-20170405201442-c4fc26588b6e        2017-04-05   v0.0.0-20200710112657-153946a5f232
 github.com/emicklei/go-restful                     v0.0.0-20170410110728-ff4f55a20633        2017-04-10   v2.13.0+incompatible
 github.com/envoyproxy/go-control-plane             v0.9.5                                    2020-04-01   v0.9.6
 github.com/envoyproxy/protoc-gen-validate          v0.1.0                                    2019-06-13   v0.4.0
 github.com/evanphx/json-patch                      v4.2.0+incompatible                       2019-02-03   v4.5.0+incompatible
 github.com/fsnotify/fsnotify                       v1.4.7                                    2018-01-10   v1.4.9
 github.com/go-kit/kit                              v0.9.0                                    2019-06-24   v0.10.0
 github.com/go-ldap/ldap                            v3.0.2+incompatible                       2019-03-04   v3.0.3+incompatible
 github.com/go-logfmt/logfmt                        v0.4.0                                    2018-11-22   v0.5.0
 github.com/go-logr/logr                            v0.1.0                                    2018-06-29   v0.2.0
 github.com/go-ole/go-ole                           v1.2.1                                    2017-11-10   v1.2.4
 github.com/go-openapi/jsonpointer                  v0.0.0-20160704185906-46af16f9f7b1        2016-07-04   v0.19.3
 github.com/go-openapi/jsonreference                v0.0.0-20160704190145-13c6e3589ad9        2016-07-04   v0.19.4
 github.com/go-openapi/spec                         v0.0.0-20160808142527-6aced65f8501        2016-08-08   v0.19.9
 github.com/go-openapi/swag                         v0.0.0-20160704191624-1d0bd113de87        2016-07-04   v0.19.9
 github.com/go-test/deep                            v1.0.2                                    2019-07-14   v1.0.7
 github.com/gogo/protobuf                           v1.2.2-0.20190723190241-65acae22fc9d      2019-07-23   v1.3.1
 github.com/golang/groupcache                       v0.0.0-20190129154638-5b532d6fd5ef        2019-01-29   v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/mock                             v1.2.0                                    2018-12-08   v1.4.3
 github.com/golang/protobuf                         v1.3.5                                    2020-03-12   v1.4.2
 github.com/google/go-cmp                           v0.4.0                                    2019-12-16   v0.5.1
 github.com/google/pprof                            v0.0.0-20181206194817-3ea8567a2e57        2018-12-06   v0.0.0-20200708004538-1a94d8640e99
 github.com/google/tcpproxy                         v0.0.0-20180808230851-dfa16c61dad2        2018-08-08   v0.0.0-20200125044825-b6bb9b5b8252
 github.com/googleapis/gnostic                      v0.2.0                                    2018-05-19   v0.5.1
 github.com/gophercloud/gophercloud                 v0.1.0                                    2019-05-25   v0.12.0
 github.com/gorilla/websocket                       v1.4.0                                    2018-08-25   v1.4.2
 github.com/gregjones/httpcache                     v0.0.0-20180305231024-9cad4c3443a7        2018-03-05   v0.0.0-20190611155906-901d90724c79
 github.com/grpc-ecosystem/go-grpc-middleware       v1.0.0                                    2018-05-02   v1.2.0
 github.com/grpc-ecosystem/grpc-gateway             v1.9.0                                    2019-05-14   v1.14.6
 github.com/hashicorp/consul/api                    v1.4.0                                                 v1.5.0
 github.com/hashicorp/consul/sdk                    v0.4.0                                                 v0.5.0
 github.com/hashicorp/go-checkpoint                 v0.0.0-20171009173528-1545e56e46de        2017-10-09   v0.5.0
 github.com/hashicorp/go-discover                   v0.0.0-20200501174627-ad1e96bde088        2020-05-01   v0.0.0-20200713171816-3392d2f47463
 github.com/hashicorp/go-hclog                      v0.12.0                                   2020-01-23   v0.14.1
 github.com/hashicorp/go-memdb                      v1.1.0                                    2020-02-19   v1.2.1
 github.com/hashicorp/go-msgpack                    v0.5.5                                    2019-05-02   v1.1.5
 github.com/hashicorp/go-plugin                     v1.0.1                                    2019-06-18   v1.3.0
 github.com/hashicorp/go-raftchunking               v0.6.1                                    2019-07-24   v0.6.2
 github.com/hashicorp/go-retryablehttp              v0.5.4                                    2019-06-08   v0.6.6
 github.com/hashicorp/go-version                    v1.2.0                                    2019-04-22   v1.2.1
 github.com/hashicorp/hil                           v0.0.0-20160711231837-1e86c6b523c5        2016-07-11   v0.0.0-20200423225030-a18a1cd20038
 github.com/hashicorp/mdns                          v1.0.1                                    2019-03-27   v1.0.3
 github.com/hashicorp/raft-boltdb                   v0.0.0-20171010151810-6e5ba93211ea        2017-10-10   v0.0.0-20191021154308-4207f1bf0617
 github.com/hashicorp/yamux                         v0.0.0-20181012175058-2f1d1f20f75d        2018-10-12   v0.0.0-20200609203250-aecfd211c9ce
 github.com/imdario/mergo                           v0.3.6                                    2018-07-30   v0.3.10
 github.com/jackc/pgx                               v3.3.0+incompatible                       2018-12-01   v3.6.2+incompatible
 github.com/jarcoal/httpmock                        v0.0.0-20180424175123-9c70cfe4a1da        2018-04-24   v1.0.5
 github.com/jmespath/go-jmespath                    v0.0.0-20180206201540-c2b33e8439af        2018-02-06   v0.3.0
 github.com/jonboulle/clockwork                     v0.1.0                                    2016-06-15   v0.2.0
 github.com/joyent/triton-go                        v1.7.1-0.20200416154420-6801d15b779f      2020-04-16   v1.8.4
 github.com/json-iterator/go                        v1.1.9                                    2019-12-21   v1.1.10
 github.com/jstemmer/go-junit-report                v0.0.0-20190106144839-af01ea7f8024        2019-01-06   v0.9.1
 github.com/julienschmidt/httprouter                v1.2.0                                    2018-07-15   v1.3.0
 github.com/kisielk/errcheck                        v1.2.0                                    2019-01-03   v1.4.0
 github.com/konsorten/go-windows-terminal-sequences v1.0.2                                    2019-02-26   v1.0.3
 github.com/kr/pty                                  v1.1.1                                    2018-01-13   v1.1.8
 github.com/kr/text                                 v0.1.0                                    2018-05-06   v0.2.0
 github.com/lib/pq                                  v1.1.1                                    2019-05-03   v1.7.1
 github.com/linode/linodego                         v0.7.1                                    2019-02-05   v0.19.0
 github.com/magiconair/properties                   v1.8.0                                    2018-05-15   v1.8.1
 github.com/mailru/easyjson                         v0.0.0-20160728113105-d5b7844b561a        2016-07-28   v0.7.1
 github.com/mattn/go-colorable                      v0.1.6                                    2020-02-28   v0.1.7
 github.com/mattn/go-runewidth                      v0.0.3                                    2018-04-08   v0.0.9
 github.com/miekg/dns                               v1.1.26                                   2019-12-20   v1.1.30
 github.com/mitchellh/cli                           v1.1.0                                    2020-03-26   v1.1.1
 github.com/mitchellh/go-testing-interface          v1.14.0                                   2020-03-24   v1.14.1
 github.com/mitchellh/hashstructure                 v0.0.0-20170609045927-2bca23e0e452        2017-06-09   v1.0.0
 github.com/munnerz/goautoneg                       v0.0.0-20120707110453-a547fc61f48d        2012-07-07   v0.0.0-20191010083416-a7dc8b61c822
 github.com/mwitkow/go-conntrack                    v0.0.0-20161129095857-cc309e4a2223        2016-11-29   v0.0.0-20190716064945-2f068394615f
 github.com/oklog/run                               v1.0.0                                    2017-11-14   v1.1.0
 github.com/olekukonko/tablewriter                  v0.0.0-20180130162743-b8a9be070da4        2018-01-30   v0.0.4
 github.com/onsi/ginkgo                             v1.8.0                                    2019-03-08   v1.14.0
 github.com/onsi/gomega                             v1.5.0                                    2019-03-12   v1.10.1
 github.com/packethost/packngo                      v0.1.1-0.20180711074735-b9cb5096f54c      2018-07-11   v0.2.0
 github.com/pelletier/go-toml                       v1.2.0                                    2018-06-05   v1.8.0
 github.com/pierrec/lz4                             v2.0.5+incompatible                       2018-08-30   v2.5.2+incompatible
 github.com/pkg/errors                              v0.8.1                                    2019-01-03   v0.9.1
 github.com/prometheus/client_golang                v1.4.0                                    2020-01-27   v1.7.1
 github.com/prometheus/common                       v0.9.1                                    2020-01-20   v0.10.0
 github.com/prometheus/procfs                       v0.0.8                                    2019-11-25   v0.1.3
 github.com/prometheus/tsdb                         v0.7.1                                    2019-04-24   v0.10.0
 github.com/renier/xmlrpc                           v0.0.0-20170708154548-ce4a1a486c03        2017-07-08   v0.0.0-20191022213033-ce560eccbd00
 github.com/rogpeppe/fastuuid                       v0.0.0-20150106093220-6724a57986af        2015-01-06   v1.2.0
 github.com/rs/zerolog                              v1.4.0                                    2018-01-04   v1.19.0
 github.com/shirou/gopsutil                         v2.20.6-0.20200630091542-01afd763e6c0+incompatible  2020-06-30   v2.20.6+incompatible
 github.com/shopspring/decimal                      v0.0.0-20180709203117-cd690d0c9e24        2018-07-09   v1.2.0
 github.com/sirupsen/logrus                         v1.4.2                                    2019-05-18   v1.6.0
 github.com/softlayer/softlayer-go                  v0.0.0-20180806151055-260589d94c7d        2018-08-06   v1.0.1
 github.com/spaolacci/murmur3                       v0.0.0-20180118202830-f09979ecbc72        2018-01-18   v1.1.0
 github.com/spf13/afero                             v1.2.2                                    2019-03-26   v1.3.2
 github.com/spf13/cast                              v1.3.0                                    2018-10-24   v1.3.1
 github.com/spf13/cobra                             v0.0.5                                    2019-06-07   v1.0.0
 github.com/spf13/jwalterweatherman                 v1.0.0                                    2018-09-07   v1.1.0
 github.com/spf13/viper                             v1.4.0                                    2019-05-24   v1.7.0
 github.com/stretchr/objx                           v0.1.1                                    2018-01-25   v0.3.0
 github.com/stretchr/testify                        v1.5.1                                    2020-02-19   v1.6.1
 github.com/tencentcloud/tencentcloud-sdk-go        v3.0.83+incompatible                      2019-08-28   v3.0.218+incompatible
 github.com/tmc/grpc-websocket-proxy                v0.0.0-20190109142713-0ad062ec5ee5        2019-01-09   v0.0.0-20200427203606-3cfed13b9966
 github.com/tv42/httpunix                           v0.0.0-20150427012821-b75d8614f926        2015-04-27   v0.0.0-20191220191345-2ba4b9c3382c
 github.com/ugorji/go                               v1.1.4                                    2019-04-08   v1.1.7
 github.com/ugorji/go/codec                         v0.0.0-20181204163529-d75b2dcb6bc8        2018-12-04   v1.1.7
 github.com/vmware/govmomi                          v0.18.0                                   2018-05-24   v0.23.1
 github.com/yuin/goldmark                           v1.1.27                                   2020-03-31   v1.2.0
 go.etcd.io/bbolt                                   v1.3.2                                    2019-01-28   v1.3.5
 go.opencensus.io                                   v0.22.0                                   2019-05-29   v0.22.4
 go.uber.org/atomic                                 v1.4.0                                    2019-05-01   v1.6.0
 go.uber.org/goleak                                 v1.0.0                                    2020-01-07   v1.1.10
 go.uber.org/multierr                               v1.1.0                                    2017-06-30   v1.5.0
 go.uber.org/zap                                    v1.10.0                                   2019-04-30   v1.15.0
 golang.org/x/crypto                                v0.0.0-20200604202706-70a84ac30bf9        2020-06-04   v0.0.0-20200709230013-948cd5f35899
 golang.org/x/exp                                   v0.0.0-20190121172915-509febef88a4        2019-01-21   v0.0.0-20200513190911-00229845015e
 golang.org/x/lint                                  v0.0.0-20190930215403-16217165b5de        2019-09-30   v0.0.0-20200302205851-738671d3881b
 golang.org/x/mod                                   v0.2.0                                    2020-01-02   v0.3.0
 golang.org/x/net                                   v0.0.0-20200226121028-0de0cce0169b        2020-02-26   v0.0.0-20200707034311-ab3426394381
 golang.org/x/oauth2                                v0.0.0-20190604053449-0f29369cfe45        2019-06-04   v0.0.0-20200107190931-bf48bf16ab8d
 golang.org/x/sync                                  v0.0.0-20200317015054-43a5402ce75a        2020-03-17   v0.0.0-20200625203802-6e8e738ad208
 golang.org/x/sys                                   v0.0.0-20200625212154-ddb9806d33ae        2020-06-25   v0.0.0-20200722175500-76b94024e4b6
 golang.org/x/text                                  v0.3.2                                    2019-04-25   v0.3.3
 golang.org/x/time                                  v0.0.0-20200416051211-89c76fbcd5d1        2020-04-16   v0.0.0-20200630173020-3af7569d3a1e
 golang.org/x/tools                                 v0.0.0-20200513154647-78b527d18275        2020-05-13   v0.0.0-20200723195734-b3d141ddef4a
 google.golang.org/api                              v0.9.0                                    2019-08-20   v0.29.0
 google.golang.org/appengine                        v1.6.0                                    2019-05-14   v1.6.6
 google.golang.org/genproto                         v0.0.0-20190819201941-24fa4b261c55        2019-08-19   v0.0.0-20200722002428-88e341933a54
 google.golang.org/grpc                             v1.25.1                                   2019-11-08   v1.30.0
 gopkg.in/check.v1                                  v1.0.0-20190902080502-41f04d3bba15        2019-09-02   v1.0.0-20200227125254-8fa46927fb4f
 gopkg.in/square/go-jose.v2                         v2.4.1                                    2019-12-16   v2.5.1
 gopkg.in/yaml.v2                                   v2.2.8                                    2020-01-21   v2.3.0
 honnef.co/go/tools                                 v0.0.0-20190523083050-ea95bdfd59fc        2019-05-23   v0.0.1-2020.1.4
 k8s.io/api                                         v0.16.9                                   2020-04-17   v0.18.6
 k8s.io/apimachinery                                v0.16.9                                   2020-04-10   v0.18.6
 k8s.io/client-go                                   v0.16.9                                   2020-04-17   v11.0.0+incompatible
 k8s.io/gengo                                       v0.0.0-20190128074634-0689ccc1d7d6        2019-01-28   v0.0.0-20200710205751-c0d492a0f3ca
 k8s.io/kube-openapi                                v0.0.0-20190816220812-743ec37842bf        2019-08-16   v0.0.0-20200615155156-dffdd1682719
 k8s.io/utils                                       v0.0.0-20190801114015-581e00157fb1        2019-08-01   v0.0.0-20200720150651-0bdb4ca86cbc
 sigs.k8s.io/structured-merge-diff                  v0.0.0-20190525122527-15d366b2352e        2019-05-25   v1.0.2
 sigs.k8s.io/yaml                                   v1.1.0                                    2018-11-02   v1.2.0
```
</details>