### PR TITLE
docs: Add redirect for /docs/k8s/connect.html

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -37,6 +37,7 @@
 /docs/connect/ingress_gateway.html                   /docs/connect/ingress-gateway                     301!
 /docs/connect/terminating_gateway.html               /docs/connect/terminating-gateway                 301!
 /docs/k8s/connect                                    /docs/k8s/connect/overview                        301!
+/docs/k8s/connect.html                               /docs/k8s/connect/overview                        301!
 
 # CLI renames
 


### PR DESCRIPTION
A few online search engines (DuckDuckGo, Google, Yahoo, etc) currently return a link to https://www.consul.io/docs/k8s/connect.html as the first result when searching for "consul connect kubernetes". This page was moved in PR #8140 to https://www.consul.io/docs/k8s/connect/overview. The previous URL no longer exists and results in a HTTP 404 being returned when accessed.

This change resolves the 404 error by redirecting /docs/k8s/connect.html to /docs/k8s/connect/overview.