### PR TITLE
docs: Modify network segments limitation callout

### DIFF
--- a/website/pages/docs/enterprise/network-segments.mdx
+++ b/website/pages/docs/enterprise/network-segments.mdx
@@ -24,7 +24,7 @@ with each other.
 To get started with network segments you can review the guide on HashiCorp Learn for
 [Network Segments](https://learn.hashicorp.com/consul/day-2-operations/network-segments).
 
-~> **Note:** Due to limitations in [Serf](/docs/internals/gossip), a Consul agent configured with too many network segments may not be able to start
+~> **Note:** Prior to Consul 1.7.3, a Consul agent configured with too many network segments may not be able to start due to [limitations](https://learn.hashicorp.com/consul/day-2-operations/network-segments#network-segments-limitations) in Serf.
 
 # Consul Networking Models
 


### PR DESCRIPTION
Change the callout on the Network Segments page to specify the limitation applies to versions of Consul prior to version 1.7.3.