### PR TITLE
docs: Modify website redirects for gateways

### DIFF
--- a/website/_redirects
+++ b/website/_redirects
@@ -30,12 +30,15 @@
 /segmentation                                        /mesh                                             301!
 /configuration.html                                  /                                                 301!
 /configuration                                       /                                                 301!
-/docs/connect/mesh_gateway                           /docs/connect/mesh-gateway                        301!
-/docs/connect/ingress_gateway                        /docs/connect/ingress-gateway                     301!
-/docs/connect/terminating_gateway                    /docs/connect/terminating-gateway                 301!
-/docs/connect/mesh_gateway.html                      /docs/connect/mesh-gateway                        301!
-/docs/connect/ingress_gateway.html                   /docs/connect/ingress-gateway                     301!
-/docs/connect/terminating_gateway.html               /docs/connect/terminating-gateway                 301!
+/docs/connect/mesh_gateway                           /docs/connect/gateways/mesh-gateway               301!
+/docs/connect/mesh_gateway.html                      /docs/connect/gateways/mesh-gateway               301!
+/docs/connect/mesh-gateway                           /docs/connect/gateways/mesh-gateway               301!
+/docs/connect/ingress_gateway                        /docs/connect/gateways/ingress-gateway            301!
+/docs/connect/ingress_gateway.html                   /docs/connect/gateways/ingress-gateway            301!
+/docs/connect/ingress-gateway                        /docs/connect/gateways/ingress-gateway            301!
+/docs/connect/terminating_gateway                    /docs/connect/gateways/terminating-gateway        301!
+/docs/connect/terminating_gateway.html               /docs/connect/gateways/terminating-gateway        301!
+/docs/connect/terminating-gateway                    /docs/connect/gateways/terminating-gateway        301!
 /docs/k8s/connect                                    /docs/k8s/connect/overview                        301!
 /docs/k8s/connect.html                               /docs/k8s/connect/overview                        301!
 


### PR DESCRIPTION
Modify the HTTP redirects for the gateway documentation to point to the updated URL locations. Missed in PR #8195.