### PR TITLE
ci: Add check-generated-protobuf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,36 @@ jobs:
           fi
       - run: *notify-slack-failure
 
+  check-generated-protobuf:
+    docker:
+      - image: *GOLANG_IMAGE
+    environment:
+      <<: *ENVIRONMENT
+    steps:
+      - checkout
+      - run:
+          name: Install protobuf
+          command: |
+            wget https://github.com/protocolbuffers/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip
+            sudo unzip -d /usr/local protoc-*.zip
+            sudo chmod +x /usr/local/bin/protoc
+            rm protoc-*.zip
+      - run:
+          name: Install gogo/protobuf
+          command: |
+            gogo_version=$(go list -m github.com/gogo/protobuf | awk '{print $2}')
+            mkdir -p .gotools; cd .gotools; go mod init consul-tools
+            go get -v github.com/hashicorp/protoc-gen-go-binary
+            go get -v github.com/gogo/protobuf/protoc-gen-gofast@${gogo_version}
+
+      - run:
+          command: make --always-make proto
+      - run: |
+          if ! git diff --exit-code; then
+            echo "Generated code was not updated correctly"
+            exit 1
+          fi
+
   go-test:
     docker:
       - image: *GOLANG_IMAGE
@@ -744,6 +774,7 @@ workflows:
                 - stable-website
                 - /^docs\/.*/
                 - /^ui\/.*/
+      - check-generated-protobuf: *filter-ignore-non-go-branches
       - lint-consul-retry: *filter-ignore-non-go-branches
       - lint: *filter-ignore-non-go-branches
       - test-connect-ca-providers: *filter-ignore-non-go-branches

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -363,14 +363,6 @@ else
 	@go test -v ./agent/connect/ca
 endif
 
-proto-delete:
-	@echo "Removing $(PROTOGOFILES)"
-	-@rm $(PROTOGOFILES)
-	@echo "Removing $(PROTOGOBINFILES)"
-	-@rm $(PROTOGOBINFILES)
-
-proto-rebuild: proto-delete proto
-
 proto: $(PROTOGOFILES) $(PROTOGOBINFILES)
 	@echo "Generated all protobuf Go files"
 
@@ -387,4 +379,4 @@ module-versions:
 
 .PHONY: all ci bin dev dist cov test test-flake test-internal cover lint ui static-assets tools
 .PHONY: docker-images go-build-image ui-build-image static-assets-docker consul-docker ui-docker
-.PHONY: version proto proto-rebuild proto-delete test-envoy-integ
+.PHONY: version proto test-envoy-integ

--- a/build-support/scripts/proto-gen.sh
+++ b/build-support/scripts/proto-gen.sh
@@ -116,7 +116,7 @@ function main {
       return 1
    fi
 
-   BUILD_TAGS=$(sed -e '/^[:space:]*$/,$d' < "${proto_path}" | grep '// +build')
+   BUILD_TAGS=$(sed -e '/^[[:space:]]*$/,$d' < "${proto_path}" | grep '// +build')
    if test -n "${BUILD_TAGS}"
    then
       echo -e "${BUILD_TAGS}\n" >> "${proto_go_path}.new"

--- a/proto/pbacl/acl.pb.go
+++ b/proto/pbacl/acl.pb.go
@@ -9,6 +9,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -41,7 +42,7 @@ func (m *ACLLink) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_ACLLink.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +87,7 @@ var fileDescriptor_ad2d2c73a6a0d8b5 = []byte{
 func (m *ACLLink) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -94,33 +95,42 @@ func (m *ACLLink) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ACLLink) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ACLLink) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.ID) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAcl(dAtA, i, uint64(len(m.ID)))
-		i += copy(dAtA[i:], m.ID)
-	}
 	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
 		i = encodeVarintAcl(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintAcl(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAcl(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAcl(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *ACLLink) Size() (n int) {
 	if m == nil {
@@ -140,14 +150,7 @@ func (m *ACLLink) Size() (n int) {
 }
 
 func sovAcl(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAcl(x uint64) (n int) {
 	return sovAcl(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/proto/pbautoconf/auto_config.pb.go
+++ b/proto/pbautoconf/auto_config.pb.go
@@ -10,6 +10,7 @@ import (
 	pbconnect "github.com/hashicorp/consul/proto/pbconnect"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -63,7 +64,7 @@ func (m *AutoConfigRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return xxx_messageInfo_AutoConfigRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +155,7 @@ func (m *AutoConfigResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, 
 		return xxx_messageInfo_AutoConfigResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -239,7 +240,7 @@ var fileDescriptor_ccc5af992e5daf69 = []byte{
 func (m *AutoConfigRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -247,56 +248,68 @@ func (m *AutoConfigRequest) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AutoConfigRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AutoConfigRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Datacenter) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Datacenter)))
-		i += copy(dAtA[i:], m.Datacenter)
-	}
-	if len(m.Node) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Node)))
-		i += copy(dAtA[i:], m.Node)
-	}
-	if len(m.Segment) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Segment)))
-		i += copy(dAtA[i:], m.Segment)
-	}
-	if len(m.JWT) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.JWT)))
-		i += copy(dAtA[i:], m.JWT)
-	}
-	if len(m.ConsulToken) > 0 {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.ConsulToken)))
-		i += copy(dAtA[i:], m.ConsulToken)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.CSR) > 0 {
-		dAtA[i] = 0x3a
-		i++
+		i -= len(m.CSR)
+		copy(dAtA[i:], m.CSR)
 		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.CSR)))
-		i += copy(dAtA[i:], m.CSR)
+		i--
+		dAtA[i] = 0x3a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.ConsulToken) > 0 {
+		i -= len(m.ConsulToken)
+		copy(dAtA[i:], m.ConsulToken)
+		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.ConsulToken)))
+		i--
+		dAtA[i] = 0x32
 	}
-	return i, nil
+	if len(m.JWT) > 0 {
+		i -= len(m.JWT)
+		copy(dAtA[i:], m.JWT)
+		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.JWT)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Segment) > 0 {
+		i -= len(m.Segment)
+		copy(dAtA[i:], m.Segment)
+		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Segment)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Node) > 0 {
+		i -= len(m.Node)
+		copy(dAtA[i:], m.Node)
+		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Node)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Datacenter) > 0 {
+		i -= len(m.Datacenter)
+		copy(dAtA[i:], m.Datacenter)
+		i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.Datacenter)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *AutoConfigResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -304,69 +317,77 @@ func (m *AutoConfigResponse) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AutoConfigResponse) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AutoConfigResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Config != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(m.Config.Size()))
-		n1, err := m.Config.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	if m.CARoots != nil {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(m.CARoots.Size()))
-		n2, err := m.CARoots.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n2
-	}
-	if m.Certificate != nil {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintAutoConfig(dAtA, i, uint64(m.Certificate.Size()))
-		n3, err := m.Certificate.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.ExtraCACertificates) > 0 {
-		for _, s := range m.ExtraCACertificates {
+		for iNdEx := len(m.ExtraCACertificates) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ExtraCACertificates[iNdEx])
+			copy(dAtA[i:], m.ExtraCACertificates[iNdEx])
+			i = encodeVarintAutoConfig(dAtA, i, uint64(len(m.ExtraCACertificates[iNdEx])))
+			i--
 			dAtA[i] = 0x22
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Certificate != nil {
+		{
+			size, err := m.Certificate.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAutoConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x1a
 	}
-	return i, nil
+	if m.CARoots != nil {
+		{
+			size, err := m.CARoots.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAutoConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Config != nil {
+		{
+			size, err := m.Config.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintAutoConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintAutoConfig(dAtA []byte, offset int, v uint64) int {
+	offset -= sovAutoConfig(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *AutoConfigRequest) Size() (n int) {
 	if m == nil {
@@ -435,14 +456,7 @@ func (m *AutoConfigResponse) Size() (n int) {
 }
 
 func sovAutoConfig(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozAutoConfig(x uint64) (n int) {
 	return sovAutoConfig(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/proto/pbcommon/common.pb.go
+++ b/proto/pbcommon/common.pb.go
@@ -11,6 +11,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 	time "time"
 )
 
@@ -47,7 +48,7 @@ func (m *RaftIndex) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_RaftIndex.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +87,7 @@ func (m *TargetDatacenter) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return xxx_messageInfo_TargetDatacenter.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +126,7 @@ func (m *WriteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_WriteRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -218,7 +219,7 @@ func (m *QueryOptions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error)
 		return xxx_messageInfo_QueryOptions.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -345,7 +346,7 @@ func (m *QueryMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_QueryMeta.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -445,7 +446,7 @@ var fileDescriptor_a6f5ac44994d718c = []byte{
 func (m *RaftIndex) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -453,27 +454,32 @@ func (m *RaftIndex) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *RaftIndex) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RaftIndex) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.CreateIndex != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(m.CreateIndex))
-	}
 	if m.ModifyIndex != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintCommon(dAtA, i, uint64(m.ModifyIndex))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.CreateIndex != 0 {
+		i = encodeVarintCommon(dAtA, i, uint64(m.CreateIndex))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *TargetDatacenter) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -481,23 +487,29 @@ func (m *TargetDatacenter) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TargetDatacenter) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TargetDatacenter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Datacenter) > 0 {
-		dAtA[i] = 0xa
-		i++
+		i -= len(m.Datacenter)
+		copy(dAtA[i:], m.Datacenter)
 		i = encodeVarintCommon(dAtA, i, uint64(len(m.Datacenter)))
-		i += copy(dAtA[i:], m.Datacenter)
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *WriteRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -505,23 +517,29 @@ func (m *WriteRequest) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *WriteRequest) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *WriteRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Token) > 0 {
-		dAtA[i] = 0xa
-		i++
+		i -= len(m.Token)
+		copy(dAtA[i:], m.Token)
 		i = encodeVarintCommon(dAtA, i, uint64(len(m.Token)))
-		i += copy(dAtA[i:], m.Token)
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *QueryOptions) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -529,106 +547,113 @@ func (m *QueryOptions) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *QueryOptions) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryOptions) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Token) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(len(m.Token)))
-		i += copy(dAtA[i:], m.Token)
+	if len(m.Filter) > 0 {
+		i -= len(m.Filter)
+		copy(dAtA[i:], m.Filter)
+		i = encodeVarintCommon(dAtA, i, uint64(len(m.Filter)))
+		i--
+		dAtA[i] = 0x5a
 	}
-	if m.MinQueryIndex != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(m.MinQueryIndex))
+	n1, err1 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.StaleIfError, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.StaleIfError):])
+	if err1 != nil {
+		return 0, err1
 	}
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintCommon(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxQueryTime)))
-	n1, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxQueryTime, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if m.AllowStale {
-		dAtA[i] = 0x20
-		i++
-		if m.AllowStale {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.RequireConsistent {
-		dAtA[i] = 0x28
-		i++
-		if m.RequireConsistent {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.UseCache {
-		dAtA[i] = 0x30
-		i++
-		if m.UseCache {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	dAtA[i] = 0x3a
-	i++
-	i = encodeVarintCommon(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxStaleDuration)))
-	n2, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxStaleDuration, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	dAtA[i] = 0x42
-	i++
-	i = encodeVarintCommon(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxAge)))
-	n3, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxAge, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n3
+	i -= n1
+	i = encodeVarintCommon(dAtA, i, uint64(n1))
+	i--
+	dAtA[i] = 0x52
 	if m.MustRevalidate {
-		dAtA[i] = 0x48
-		i++
+		i--
 		if m.MustRevalidate {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x48
 	}
-	dAtA[i] = 0x52
-	i++
-	i = encodeVarintCommon(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.StaleIfError)))
-	n4, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.StaleIfError, dAtA[i:])
-	if err != nil {
-		return 0, err
+	n2, err2 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxAge, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxAge):])
+	if err2 != nil {
+		return 0, err2
 	}
-	i += n4
-	if len(m.Filter) > 0 {
-		dAtA[i] = 0x5a
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(len(m.Filter)))
-		i += copy(dAtA[i:], m.Filter)
+	i -= n2
+	i = encodeVarintCommon(dAtA, i, uint64(n2))
+	i--
+	dAtA[i] = 0x42
+	n3, err3 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxStaleDuration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxStaleDuration):])
+	if err3 != nil {
+		return 0, err3
 	}
-	return i, nil
+	i -= n3
+	i = encodeVarintCommon(dAtA, i, uint64(n3))
+	i--
+	dAtA[i] = 0x3a
+	if m.UseCache {
+		i--
+		if m.UseCache {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.RequireConsistent {
+		i--
+		if m.RequireConsistent {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.AllowStale {
+		i--
+		if m.AllowStale {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	n4, err4 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.MaxQueryTime, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.MaxQueryTime):])
+	if err4 != nil {
+		return 0, err4
+	}
+	i -= n4
+	i = encodeVarintCommon(dAtA, i, uint64(n4))
+	i--
+	dAtA[i] = 0x1a
+	if m.MinQueryIndex != 0 {
+		i = encodeVarintCommon(dAtA, i, uint64(m.MinQueryIndex))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Token) > 0 {
+		i -= len(m.Token)
+		copy(dAtA[i:], m.Token)
+		i = encodeVarintCommon(dAtA, i, uint64(len(m.Token)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *QueryMeta) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -636,50 +661,58 @@ func (m *QueryMeta) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *QueryMeta) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Index != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(m.Index))
+	if len(m.ConsistencyLevel) > 0 {
+		i -= len(m.ConsistencyLevel)
+		copy(dAtA[i:], m.ConsistencyLevel)
+		i = encodeVarintCommon(dAtA, i, uint64(len(m.ConsistencyLevel)))
+		i--
+		dAtA[i] = 0x22
 	}
-	dAtA[i] = 0x12
-	i++
-	i = encodeVarintCommon(dAtA, i, uint64(github_com_gogo_protobuf_types.SizeOfStdDuration(m.LastContact)))
-	n5, err := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.LastContact, dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n5
 	if m.KnownLeader {
-		dAtA[i] = 0x18
-		i++
+		i--
 		if m.KnownLeader {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x18
 	}
-	if len(m.ConsistencyLevel) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintCommon(dAtA, i, uint64(len(m.ConsistencyLevel)))
-		i += copy(dAtA[i:], m.ConsistencyLevel)
+	n5, err5 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.LastContact, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.LastContact):])
+	if err5 != nil {
+		return 0, err5
 	}
-	return i, nil
+	i -= n5
+	i = encodeVarintCommon(dAtA, i, uint64(n5))
+	i--
+	dAtA[i] = 0x12
+	if m.Index != 0 {
+		i = encodeVarintCommon(dAtA, i, uint64(m.Index))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintCommon(dAtA []byte, offset int, v uint64) int {
+	offset -= sovCommon(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *RaftIndex) Size() (n int) {
 	if m == nil {
@@ -784,14 +817,7 @@ func (m *QueryMeta) Size() (n int) {
 }
 
 func sovCommon(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCommon(x uint64) (n int) {
 	return sovCommon(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/proto/pbcommon/common_oss.pb.go
+++ b/proto/pbcommon/common_oss.pb.go
@@ -10,6 +10,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -43,7 +44,7 @@ func (m *EnterpriseMeta) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_EnterpriseMeta.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -83,7 +84,7 @@ var fileDescriptor_8f9d7cd54dd4e173 = []byte{
 func (m *EnterpriseMeta) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -91,24 +92,32 @@ func (m *EnterpriseMeta) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *EnterpriseMeta) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *EnterpriseMeta) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintCommonOss(dAtA []byte, offset int, v uint64) int {
+	offset -= sovCommonOss(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *EnterpriseMeta) Size() (n int) {
 	if m == nil {
@@ -123,14 +132,7 @@ func (m *EnterpriseMeta) Size() (n int) {
 }
 
 func sovCommonOss(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozCommonOss(x uint64) (n int) {
 	return sovCommonOss(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/proto/pbconfig/config.pb.go
+++ b/proto/pbconfig/config.pb.go
@@ -8,6 +8,7 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -49,7 +50,7 @@ func (m *Config) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Config.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -146,7 +147,7 @@ func (m *Gossip) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Gossip.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +203,7 @@ func (m *GossipEncryption) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return xxx_messageInfo_GossipEncryption.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -267,7 +268,7 @@ func (m *TLS) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_TLS.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -352,7 +353,7 @@ func (m *ACL) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_ACL.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -474,7 +475,7 @@ func (m *ACLTokens) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_ACLTokens.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -557,7 +558,7 @@ func (m *ACLServiceProviderToken) XXX_Marshal(b []byte, deterministic bool) ([]b
 		return xxx_messageInfo_ACLServiceProviderToken.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -614,7 +615,7 @@ func (m *AutoEncrypt) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_AutoEncrypt.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -731,7 +732,7 @@ var fileDescriptor_aefa824db7b74d77 = []byte{
 func (m *Config) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -739,84 +740,102 @@ func (m *Config) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Config) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Config) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Datacenter) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Datacenter)))
-		i += copy(dAtA[i:], m.Datacenter)
-	}
-	if len(m.PrimaryDatacenter) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.PrimaryDatacenter)))
-		i += copy(dAtA[i:], m.PrimaryDatacenter)
-	}
-	if len(m.NodeName) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.NodeName)))
-		i += copy(dAtA[i:], m.NodeName)
-	}
-	if len(m.SegmentName) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.SegmentName)))
-		i += copy(dAtA[i:], m.SegmentName)
-	}
-	if m.ACL != nil {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.ACL.Size()))
-		n1, err := m.ACL.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n1
-	}
-	if m.AutoEncrypt != nil {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.AutoEncrypt.Size()))
-		n2, err := m.AutoEncrypt.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n2
-	}
-	if m.Gossip != nil {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.Gossip.Size()))
-		n3, err := m.Gossip.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.TLS != nil {
-		dAtA[i] = 0x42
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.TLS.Size()))
-		n4, err := m.TLS.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.TLS.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
 		}
-		i += n4
+		i--
+		dAtA[i] = 0x42
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Gossip != nil {
+		{
+			size, err := m.Gossip.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x3a
 	}
-	return i, nil
+	if m.AutoEncrypt != nil {
+		{
+			size, err := m.AutoEncrypt.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
+	}
+	if m.ACL != nil {
+		{
+			size, err := m.ACL.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.SegmentName) > 0 {
+		i -= len(m.SegmentName)
+		copy(dAtA[i:], m.SegmentName)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.SegmentName)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.NodeName) > 0 {
+		i -= len(m.NodeName)
+		copy(dAtA[i:], m.NodeName)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.NodeName)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.PrimaryDatacenter) > 0 {
+		i -= len(m.PrimaryDatacenter)
+		copy(dAtA[i:], m.PrimaryDatacenter)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.PrimaryDatacenter)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Datacenter) > 0 {
+		i -= len(m.Datacenter)
+		copy(dAtA[i:], m.Datacenter)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Datacenter)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Gossip) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -824,45 +843,47 @@ func (m *Gossip) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Gossip) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Gossip) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Encryption != nil {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.Encryption.Size()))
-		n5, err := m.Encryption.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n5
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.RetryJoinLAN) > 0 {
-		for _, s := range m.RetryJoinLAN {
+		for iNdEx := len(m.RetryJoinLAN) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.RetryJoinLAN[iNdEx])
+			copy(dAtA[i:], m.RetryJoinLAN[iNdEx])
+			i = encodeVarintConfig(dAtA, i, uint64(len(m.RetryJoinLAN[iNdEx])))
+			i--
 			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.Encryption != nil {
+		{
+			size, err := m.Encryption.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *GossipEncryption) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -870,46 +891,53 @@ func (m *GossipEncryption) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *GossipEncryption) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *GossipEncryption) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Key) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Key)))
-		i += copy(dAtA[i:], m.Key)
-	}
-	if m.VerifyIncoming {
-		dAtA[i] = 0x10
-		i++
-		if m.VerifyIncoming {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.VerifyOutgoing {
-		dAtA[i] = 0x18
-		i++
+		i--
 		if m.VerifyOutgoing {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x18
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.VerifyIncoming {
+		i--
+		if m.VerifyIncoming {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *TLS) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -917,62 +945,70 @@ func (m *TLS) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TLS) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TLS) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.VerifyOutgoing {
-		dAtA[i] = 0x8
-		i++
-		if m.VerifyOutgoing {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.VerifyServerHostname {
-		dAtA[i] = 0x10
-		i++
-		if m.VerifyServerHostname {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.CipherSuites) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.CipherSuites)))
-		i += copy(dAtA[i:], m.CipherSuites)
-	}
-	if len(m.MinVersion) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.MinVersion)))
-		i += copy(dAtA[i:], m.MinVersion)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.PreferServerCipherSuites {
-		dAtA[i] = 0x28
-		i++
+		i--
 		if m.PreferServerCipherSuites {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x28
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.MinVersion) > 0 {
+		i -= len(m.MinVersion)
+		copy(dAtA[i:], m.MinVersion)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.MinVersion)))
+		i--
+		dAtA[i] = 0x22
 	}
-	return i, nil
+	if len(m.CipherSuites) > 0 {
+		i -= len(m.CipherSuites)
+		copy(dAtA[i:], m.CipherSuites)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.CipherSuites)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.VerifyServerHostname {
+		i--
+		if m.VerifyServerHostname {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.VerifyOutgoing {
+		i--
+		if m.VerifyOutgoing {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ACL) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -980,106 +1016,120 @@ func (m *ACL) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ACL) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ACL) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Enabled {
-		dAtA[i] = 0x8
-		i++
-		if m.Enabled {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.PolicyTTL) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.PolicyTTL)))
-		i += copy(dAtA[i:], m.PolicyTTL)
-	}
-	if len(m.RoleTTL) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.RoleTTL)))
-		i += copy(dAtA[i:], m.RoleTTL)
-	}
-	if len(m.TokenTTL) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.TokenTTL)))
-		i += copy(dAtA[i:], m.TokenTTL)
-	}
-	if len(m.DownPolicy) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.DownPolicy)))
-		i += copy(dAtA[i:], m.DownPolicy)
-	}
-	if len(m.DefaultPolicy) > 0 {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.DefaultPolicy)))
-		i += copy(dAtA[i:], m.DefaultPolicy)
-	}
-	if m.EnableKeyListPolicy {
-		dAtA[i] = 0x38
-		i++
-		if m.EnableKeyListPolicy {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.Tokens != nil {
-		dAtA[i] = 0x42
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(m.Tokens.Size()))
-		n6, err := m.Tokens.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n6
-	}
-	if len(m.DisabledTTL) > 0 {
-		dAtA[i] = 0x4a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.DisabledTTL)))
-		i += copy(dAtA[i:], m.DisabledTTL)
-	}
-	if m.EnableTokenPersistence {
-		dAtA[i] = 0x50
-		i++
-		if m.EnableTokenPersistence {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.MSPDisableBootstrap {
-		dAtA[i] = 0x58
-		i++
+		i--
 		if m.MSPDisableBootstrap {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x58
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.EnableTokenPersistence {
+		i--
+		if m.EnableTokenPersistence {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x50
 	}
-	return i, nil
+	if len(m.DisabledTTL) > 0 {
+		i -= len(m.DisabledTTL)
+		copy(dAtA[i:], m.DisabledTTL)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.DisabledTTL)))
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.Tokens != nil {
+		{
+			size, err := m.Tokens.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConfig(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x42
+	}
+	if m.EnableKeyListPolicy {
+		i--
+		if m.EnableKeyListPolicy {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
+	if len(m.DefaultPolicy) > 0 {
+		i -= len(m.DefaultPolicy)
+		copy(dAtA[i:], m.DefaultPolicy)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.DefaultPolicy)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.DownPolicy) > 0 {
+		i -= len(m.DownPolicy)
+		copy(dAtA[i:], m.DownPolicy)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.DownPolicy)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.TokenTTL) > 0 {
+		i -= len(m.TokenTTL)
+		copy(dAtA[i:], m.TokenTTL)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.TokenTTL)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.RoleTTL) > 0 {
+		i -= len(m.RoleTTL)
+		copy(dAtA[i:], m.RoleTTL)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.RoleTTL)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.PolicyTTL) > 0 {
+		i -= len(m.PolicyTTL)
+		copy(dAtA[i:], m.PolicyTTL)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.PolicyTTL)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Enabled {
+		i--
+		if m.Enabled {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ACLTokens) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1087,62 +1137,75 @@ func (m *ACLTokens) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ACLTokens) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ACLTokens) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Master) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Master)))
-		i += copy(dAtA[i:], m.Master)
-	}
-	if len(m.Replication) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Replication)))
-		i += copy(dAtA[i:], m.Replication)
-	}
-	if len(m.AgentMaster) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.AgentMaster)))
-		i += copy(dAtA[i:], m.AgentMaster)
-	}
-	if len(m.Default) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Default)))
-		i += copy(dAtA[i:], m.Default)
-	}
-	if len(m.Agent) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.Agent)))
-		i += copy(dAtA[i:], m.Agent)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.ManagedServiceProvider) > 0 {
-		for _, msg := range m.ManagedServiceProvider {
-			dAtA[i] = 0x32
-			i++
-			i = encodeVarintConfig(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.ManagedServiceProvider) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.ManagedServiceProvider[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintConfig(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x32
 		}
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.Agent) > 0 {
+		i -= len(m.Agent)
+		copy(dAtA[i:], m.Agent)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Agent)))
+		i--
+		dAtA[i] = 0x2a
 	}
-	return i, nil
+	if len(m.Default) > 0 {
+		i -= len(m.Default)
+		copy(dAtA[i:], m.Default)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Default)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.AgentMaster) > 0 {
+		i -= len(m.AgentMaster)
+		copy(dAtA[i:], m.AgentMaster)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.AgentMaster)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Replication) > 0 {
+		i -= len(m.Replication)
+		copy(dAtA[i:], m.Replication)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Replication)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Master) > 0 {
+		i -= len(m.Master)
+		copy(dAtA[i:], m.Master)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.Master)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ACLServiceProviderToken) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1150,32 +1213,40 @@ func (m *ACLServiceProviderToken) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ACLServiceProviderToken) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ACLServiceProviderToken) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.AccessorID) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConfig(dAtA, i, uint64(len(m.AccessorID)))
-		i += copy(dAtA[i:], m.AccessorID)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if len(m.SecretID) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.SecretID)
+		copy(dAtA[i:], m.SecretID)
 		i = encodeVarintConfig(dAtA, i, uint64(len(m.SecretID)))
-		i += copy(dAtA[i:], m.SecretID)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.AccessorID) > 0 {
+		i -= len(m.AccessorID)
+		copy(dAtA[i:], m.AccessorID)
+		i = encodeVarintConfig(dAtA, i, uint64(len(m.AccessorID)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *AutoEncrypt) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1183,74 +1254,70 @@ func (m *AutoEncrypt) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *AutoEncrypt) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *AutoEncrypt) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.TLS {
-		dAtA[i] = 0x8
-		i++
-		if m.TLS {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if len(m.DNSSAN) > 0 {
-		for _, s := range m.DNSSAN {
-			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if len(m.IPSAN) > 0 {
-		for _, s := range m.IPSAN {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.AllowTLS {
-		dAtA[i] = 0x20
-		i++
+		i--
 		if m.AllowTLS {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x20
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.IPSAN) > 0 {
+		for iNdEx := len(m.IPSAN) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.IPSAN[iNdEx])
+			copy(dAtA[i:], m.IPSAN[iNdEx])
+			i = encodeVarintConfig(dAtA, i, uint64(len(m.IPSAN[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
-	return i, nil
+	if len(m.DNSSAN) > 0 {
+		for iNdEx := len(m.DNSSAN) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.DNSSAN[iNdEx])
+			copy(dAtA[i:], m.DNSSAN[iNdEx])
+			i = encodeVarintConfig(dAtA, i, uint64(len(m.DNSSAN[iNdEx])))
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if m.TLS {
+		i--
+		if m.TLS {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintConfig(dAtA []byte, offset int, v uint64) int {
+	offset -= sovConfig(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Config) Size() (n int) {
 	if m == nil {
@@ -1510,14 +1577,7 @@ func (m *AutoEncrypt) Size() (n int) {
 }
 
 func sovConfig(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozConfig(x uint64) (n int) {
 	return sovConfig(uint64((x << 1) ^ uint64((int64(x) >> 63))))

--- a/proto/pbconnect/connect.pb.go
+++ b/proto/pbconnect/connect.pb.go
@@ -10,6 +10,7 @@ import (
 	pbcommon "github.com/hashicorp/consul/proto/pbcommon"
 	io "io"
 	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -76,7 +77,7 @@ func (m *CARoots) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_CARoots.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -194,7 +195,7 @@ func (m *CARoot) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_CARoot.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -368,7 +369,7 @@ func (m *IssuedCert) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_IssuedCert.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
@@ -521,7 +522,7 @@ var fileDescriptor_80627e709958eb04 = []byte{
 func (m *CARoots) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -529,54 +530,66 @@ func (m *CARoots) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CARoots) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CARoots) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.ActiveRootID) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.ActiveRootID)))
-		i += copy(dAtA[i:], m.ActiveRootID)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.TrustDomain) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.TrustDomain)))
-		i += copy(dAtA[i:], m.TrustDomain)
-	}
-	if len(m.Roots) > 0 {
-		for _, msg := range m.Roots {
-			dAtA[i] = 0x1a
-			i++
-			i = encodeVarintConnect(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
+	if m.QueryMeta != nil {
+		{
+			size, err := m.QueryMeta.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
-			i += n
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
 		}
-	}
-	if m.QueryMeta != nil {
+		i--
 		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.QueryMeta.Size()))
-		n1, err := m.QueryMeta.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	}
+	if len(m.Roots) > 0 {
+		for iNdEx := len(m.Roots) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Roots[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintConnect(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
 		}
-		i += n1
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if len(m.TrustDomain) > 0 {
+		i -= len(m.TrustDomain)
+		copy(dAtA[i:], m.TrustDomain)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.TrustDomain)))
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	if len(m.ActiveRootID) > 0 {
+		i -= len(m.ActiveRootID)
+		copy(dAtA[i:], m.ActiveRootID)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.ActiveRootID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *CARoot) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -584,145 +597,161 @@ func (m *CARoot) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CARoot) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CARoot) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.ID) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.ID)))
-		i += copy(dAtA[i:], m.ID)
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
-	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if m.SerialNumber != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.SerialNumber))
-	}
-	if len(m.SigningKeyID) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningKeyID)))
-		i += copy(dAtA[i:], m.SigningKeyID)
-	}
-	if len(m.ExternalTrustDomain) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.ExternalTrustDomain)))
-		i += copy(dAtA[i:], m.ExternalTrustDomain)
-	}
-	if m.NotBefore != nil {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.NotBefore.Size()))
-		n2, err := m.NotBefore.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n2
-	}
-	if m.NotAfter != nil {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.NotAfter.Size()))
-		n3, err := m.NotAfter.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n3
-	}
-	if len(m.RootCert) > 0 {
-		dAtA[i] = 0x42
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.RootCert)))
-		i += copy(dAtA[i:], m.RootCert)
-	}
-	if len(m.IntermediateCerts) > 0 {
-		for _, s := range m.IntermediateCerts {
-			dAtA[i] = 0x4a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
+	if m.RaftIndex != nil {
+		{
+			size, err := m.RaftIndex.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
 			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
 		}
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x82
 	}
-	if len(m.SigningCert) > 0 {
-		dAtA[i] = 0x52
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningCert)))
-		i += copy(dAtA[i:], m.SigningCert)
+	if m.PrivateKeyBits != 0 {
+		i = encodeVarintConnect(dAtA, i, uint64(m.PrivateKeyBits))
+		i--
+		dAtA[i] = 0x78
 	}
-	if len(m.SigningKey) > 0 {
-		dAtA[i] = 0x5a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningKey)))
-		i += copy(dAtA[i:], m.SigningKey)
+	if len(m.PrivateKeyType) > 0 {
+		i -= len(m.PrivateKeyType)
+		copy(dAtA[i:], m.PrivateKeyType)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.PrivateKeyType)))
+		i--
+		dAtA[i] = 0x72
+	}
+	if m.RotatedOutAt != nil {
+		{
+			size, err := m.RotatedOutAt.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x6a
 	}
 	if m.Active {
-		dAtA[i] = 0x60
-		i++
+		i--
 		if m.Active {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x60
 	}
-	if m.RotatedOutAt != nil {
-		dAtA[i] = 0x6a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.RotatedOutAt.Size()))
-		n4, err := m.RotatedOutAt.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	if len(m.SigningKey) > 0 {
+		i -= len(m.SigningKey)
+		copy(dAtA[i:], m.SigningKey)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningKey)))
+		i--
+		dAtA[i] = 0x5a
+	}
+	if len(m.SigningCert) > 0 {
+		i -= len(m.SigningCert)
+		copy(dAtA[i:], m.SigningCert)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningCert)))
+		i--
+		dAtA[i] = 0x52
+	}
+	if len(m.IntermediateCerts) > 0 {
+		for iNdEx := len(m.IntermediateCerts) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.IntermediateCerts[iNdEx])
+			copy(dAtA[i:], m.IntermediateCerts[iNdEx])
+			i = encodeVarintConnect(dAtA, i, uint64(len(m.IntermediateCerts[iNdEx])))
+			i--
+			dAtA[i] = 0x4a
 		}
-		i += n4
 	}
-	if len(m.PrivateKeyType) > 0 {
-		dAtA[i] = 0x72
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.PrivateKeyType)))
-		i += copy(dAtA[i:], m.PrivateKeyType)
+	if len(m.RootCert) > 0 {
+		i -= len(m.RootCert)
+		copy(dAtA[i:], m.RootCert)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.RootCert)))
+		i--
+		dAtA[i] = 0x42
 	}
-	if m.PrivateKeyBits != 0 {
-		dAtA[i] = 0x78
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.PrivateKeyBits))
-	}
-	if m.RaftIndex != nil {
-		dAtA[i] = 0x82
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.RaftIndex.Size()))
-		n5, err := m.RaftIndex.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+	if m.NotAfter != nil {
+		{
+			size, err := m.NotAfter.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
 		}
-		i += n5
+		i--
+		dAtA[i] = 0x3a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.NotBefore != nil {
+		{
+			size, err := m.NotBefore.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x32
 	}
-	return i, nil
+	if len(m.ExternalTrustDomain) > 0 {
+		i -= len(m.ExternalTrustDomain)
+		copy(dAtA[i:], m.ExternalTrustDomain)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.ExternalTrustDomain)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.SigningKeyID) > 0 {
+		i -= len(m.SigningKeyID)
+		copy(dAtA[i:], m.SigningKeyID)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.SigningKeyID)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.SerialNumber != 0 {
+		i = encodeVarintConnect(dAtA, i, uint64(m.SerialNumber))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *IssuedCert) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -730,106 +759,129 @@ func (m *IssuedCert) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *IssuedCert) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *IssuedCert) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.SerialNumber) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.SerialNumber)))
-		i += copy(dAtA[i:], m.SerialNumber)
-	}
-	if len(m.CertPEM) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.CertPEM)))
-		i += copy(dAtA[i:], m.CertPEM)
-	}
-	if len(m.PrivateKeyPEM) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.PrivateKeyPEM)))
-		i += copy(dAtA[i:], m.PrivateKeyPEM)
-	}
-	if len(m.Service) > 0 {
-		dAtA[i] = 0x22
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.Service)))
-		i += copy(dAtA[i:], m.Service)
-	}
-	if len(m.ServiceURI) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.ServiceURI)))
-		i += copy(dAtA[i:], m.ServiceURI)
-	}
-	if len(m.Agent) > 0 {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.Agent)))
-		i += copy(dAtA[i:], m.Agent)
-	}
-	if len(m.AgentURI) > 0 {
-		dAtA[i] = 0x3a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(len(m.AgentURI)))
-		i += copy(dAtA[i:], m.AgentURI)
-	}
-	if m.ValidAfter != nil {
-		dAtA[i] = 0x42
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.ValidAfter.Size()))
-		n6, err := m.ValidAfter.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n6
-	}
-	if m.ValidBefore != nil {
-		dAtA[i] = 0x4a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.ValidBefore.Size()))
-		n7, err := m.ValidBefore.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n7
-	}
-	if m.EnterpriseMeta != nil {
-		dAtA[i] = 0x52
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.EnterpriseMeta.Size()))
-		n8, err := m.EnterpriseMeta.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
-		}
-		i += n8
+	if m.XXX_unrecognized != nil {
+		i -= len(m.XXX_unrecognized)
+		copy(dAtA[i:], m.XXX_unrecognized)
 	}
 	if m.RaftIndex != nil {
-		dAtA[i] = 0x5a
-		i++
-		i = encodeVarintConnect(dAtA, i, uint64(m.RaftIndex.Size()))
-		n9, err := m.RaftIndex.MarshalTo(dAtA[i:])
-		if err != nil {
-			return 0, err
+		{
+			size, err := m.RaftIndex.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
 		}
-		i += n9
+		i--
+		dAtA[i] = 0x5a
 	}
-	if m.XXX_unrecognized != nil {
-		i += copy(dAtA[i:], m.XXX_unrecognized)
+	if m.EnterpriseMeta != nil {
+		{
+			size, err := m.EnterpriseMeta.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x52
 	}
-	return i, nil
+	if m.ValidBefore != nil {
+		{
+			size, err := m.ValidBefore.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x4a
+	}
+	if m.ValidAfter != nil {
+		{
+			size, err := m.ValidAfter.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintConnect(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x42
+	}
+	if len(m.AgentURI) > 0 {
+		i -= len(m.AgentURI)
+		copy(dAtA[i:], m.AgentURI)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.AgentURI)))
+		i--
+		dAtA[i] = 0x3a
+	}
+	if len(m.Agent) > 0 {
+		i -= len(m.Agent)
+		copy(dAtA[i:], m.Agent)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.Agent)))
+		i--
+		dAtA[i] = 0x32
+	}
+	if len(m.ServiceURI) > 0 {
+		i -= len(m.ServiceURI)
+		copy(dAtA[i:], m.ServiceURI)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.ServiceURI)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Service) > 0 {
+		i -= len(m.Service)
+		copy(dAtA[i:], m.Service)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.Service)))
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.PrivateKeyPEM) > 0 {
+		i -= len(m.PrivateKeyPEM)
+		copy(dAtA[i:], m.PrivateKeyPEM)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.PrivateKeyPEM)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.CertPEM) > 0 {
+		i -= len(m.CertPEM)
+		copy(dAtA[i:], m.CertPEM)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.CertPEM)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.SerialNumber) > 0 {
+		i -= len(m.SerialNumber)
+		copy(dAtA[i:], m.SerialNumber)
+		i = encodeVarintConnect(dAtA, i, uint64(len(m.SerialNumber)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintConnect(dAtA []byte, offset int, v uint64) int {
+	offset -= sovConnect(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *CARoots) Size() (n int) {
 	if m == nil {
@@ -993,14 +1045,7 @@ func (m *IssuedCert) Size() (n int) {
 }
 
 func sovConnect(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozConnect(x uint64) (n int) {
 	return sovConnect(uint64((x << 1) ^ uint64((int64(x) >> 63))))


### PR DESCRIPTION
This PR adds a CI job which checks that the generated Go files match the `.proto` files. 

With this change we ensure that:

1. all code is generated with the same version of protobuf.
2. contributors can discover which version to use by looking at the CI config.
3. if the proto files were ever changed without generating the code, we would catch the mistake immediately in the PR which made the change.
4. nothing unintentional was hidden in the generated code files (because generated code is rarely reviewed in-depth).

The CI check is currently failing. I guess because `protobuf` `v3.12.3` is not the version that was used to generate these files? Do we have a specific version to use, or should I update these files using `v3.12.3`.