### PR TITLE
docs: Fix typo in -pid file description

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -415,7 +415,7 @@ The options below are all specified on the command-line.
 
 - `-pid-file` ((#\_pid_file)) - This flag provides the file path for the
   agent to store its PID. This is useful for sending signals (for example, `SIGINT`
-  to close the agent or `SIGHUP` to update check definite
+  to close the agent or `SIGHUP` to update check definitions) to the agent.
 
 - `-protocol` ((#\_protocol)) - The Consul protocol version to use. Consul
   agents speak protocol 2 by default, however agents will automatically use protocol > 2 when speaking to compatible agents. This should be set only when [upgrading](/docs/upgrading). You can view the protocol versions supported by Consul by running `consul -v`.


### PR DESCRIPTION
Fix typo in `-pid` file option description. This change restores text which was erroneously deleted in PR #736 with commit f41dce9.

Fixes #8388