### PR TITLE
Allow setting verify_incoming* when using auto_encrypt or auto_config

### DIFF
--- a/agent/cert-monitor/cert_monitor.go
+++ b/agent/cert-monitor/cert_monitor.go
@@ -149,7 +149,7 @@ func (m *CertMonitor) Update(certs *structs.SignedResponse) error {
 	// that the recipient of the response who also has access to the private key will
 	// have filled it in. The Cache definitely does this but auto-encrypt/auto-config
 	// will need to ensure the original response is setup this way too.
-	err := m.tlsConfigurator.UpdateAutoEncrypt(
+	err := m.tlsConfigurator.UpdateAutoTLS(
 		certs.ManualCARoots,
 		connectCAPems,
 		certs.IssuedCert.CertPEM,
@@ -311,7 +311,7 @@ func (m *CertMonitor) handleCacheEvent(u cache.UpdateEvent) error {
 			pems = append(pems, root.RootCert)
 		}
 
-		if err := m.tlsConfigurator.UpdateAutoEncryptCA(pems); err != nil {
+		if err := m.tlsConfigurator.UpdateAutoTLSCA(pems); err != nil {
 			return fmt.Errorf("failed to update Connect CA certificates: %w", err)
 		}
 	case leafWatchID:
@@ -324,7 +324,7 @@ func (m *CertMonitor) handleCacheEvent(u cache.UpdateEvent) error {
 		if !ok {
 			return fmt.Errorf("invalid type for agent leaf cert watch response: %T", u.Result)
 		}
-		if err := m.tlsConfigurator.UpdateAutoEncryptCert(leaf.CertPEM, leaf.PrivateKeyPEM); err != nil {
+		if err := m.tlsConfigurator.UpdateAutoTLSCert(leaf.CertPEM, leaf.PrivateKeyPEM); err != nil {
 			return fmt.Errorf("failed to update the agent leaf cert: %w", err)
 		}
 	}

--- a/agent/cert-monitor/cert_monitor_test.go
+++ b/agent/cert-monitor/cert_monitor_test.go
@@ -118,7 +118,7 @@ func waitForChans(timeout time.Duration, chans ...<-chan struct{}) bool {
 func testTLSConfigurator(t *testing.T) *tlsutil.Configurator {
 	t.Helper()
 	logger := testutil.Logger(t)
-	cfg, err := tlsutil.NewConfigurator(tlsutil.Config{AutoEncryptTLS: true}, logger)
+	cfg, err := tlsutil.NewConfigurator(tlsutil.Config{AutoTLS: true}, logger)
 	require.NoError(t, err)
 	return cfg
 }

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1799,7 +1799,7 @@ func (c *RuntimeConfig) ToTLSUtilConfig() tlsutil.Config {
 		CipherSuites:             c.TLSCipherSuites,
 		PreferServerCipherSuites: c.TLSPreferServerCipherSuites,
 		EnableAgentTLSForChecks:  c.EnableAgentTLSForChecks,
-		AutoEncryptTLS:           c.AutoEncryptTLS,
+		AutoTLS:                  c.AutoEncryptTLS || c.AutoConfig.Enabled,
 	}
 }
 

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -7357,7 +7357,47 @@ func TestRuntime_ToTLSUtilConfig(t *testing.T) {
 	require.True(t, r.VerifyIncomingHTTPS)
 	require.True(t, r.VerifyOutgoing)
 	require.True(t, r.EnableAgentTLSForChecks)
-	require.True(t, r.AutoEncryptTLS)
+	require.True(t, r.AutoTLS)
+	require.True(t, r.VerifyServerHostname)
+	require.True(t, r.PreferServerCipherSuites)
+	require.Equal(t, "a", r.CAFile)
+	require.Equal(t, "b", r.CAPath)
+	require.Equal(t, "c", r.CertFile)
+	require.Equal(t, "d", r.KeyFile)
+	require.Equal(t, "e", r.NodeName)
+	require.Equal(t, "f", r.ServerName)
+	require.Equal(t, "g", r.Domain)
+	require.Equal(t, "tls12", r.TLSMinVersion)
+	require.Equal(t, []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA}, r.CipherSuites)
+}
+
+func TestRuntime_ToTLSUtilConfig_AutoConfig(t *testing.T) {
+	c := &RuntimeConfig{
+		VerifyIncoming:              true,
+		VerifyIncomingRPC:           true,
+		VerifyIncomingHTTPS:         true,
+		VerifyOutgoing:              true,
+		VerifyServerHostname:        true,
+		CAFile:                      "a",
+		CAPath:                      "b",
+		CertFile:                    "c",
+		KeyFile:                     "d",
+		NodeName:                    "e",
+		ServerName:                  "f",
+		DNSDomain:                   "g",
+		TLSMinVersion:               "tls12",
+		TLSCipherSuites:             []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
+		TLSPreferServerCipherSuites: true,
+		EnableAgentTLSForChecks:     true,
+		AutoConfig:                  AutoConfig{Enabled: true},
+	}
+	r := c.ToTLSUtilConfig()
+	require.True(t, r.VerifyIncoming)
+	require.True(t, r.VerifyIncomingRPC)
+	require.True(t, r.VerifyIncomingHTTPS)
+	require.True(t, r.VerifyOutgoing)
+	require.True(t, r.EnableAgentTLSForChecks)
+	require.True(t, r.AutoTLS)
 	require.True(t, r.VerifyServerHostname)
 	require.True(t, r.PreferServerCipherSuites)
 	require.Equal(t, "a", r.CAFile)

--- a/agent/consul/auto_encrypt_endpoint_test.go
+++ b/agent/consul/auto_encrypt_endpoint_test.go
@@ -89,7 +89,7 @@ func TestAutoEncryptSign(t *testing.T) {
 			}
 
 			cfg := test.Config
-			cfg.AutoEncryptTLS = true
+			cfg.AutoTLS = true
 			cfg.Domain = "consul"
 			codec, err := insecureRPCClient(s, cfg)
 			if test.ConnError {

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -647,7 +647,7 @@ func (s *Server) connectCARootsMonitor(ctx context.Context) {
 		for _, ca := range cas {
 			caPems = append(caPems, ca.RootCert)
 		}
-		if err := s.tlsConfigurator.UpdateAutoEncryptCA(caPems); err != nil {
+		if err := s.tlsConfigurator.UpdateAutoTLSCA(caPems); err != nil {
 			s.logger.Error("Failed to update AutoEncrypt CAPems", "error", err)
 		}
 


### PR DESCRIPTION
Previously we disallowed that configuration with a note saying that auto encrypt didn't affect incoming connections. However the other code in the TLS configurator would use the auto_encrypt or auto_config generated TLS certificate for the public HTTPs API if no other certificate was provided manually. Therefore the restriction on the configuration has been relaxed to allow setting the configuration if either a certificate was manually provided or one of the auto tls features is enabled.