### PR TITLE
api: restore Leader() and Peers() to avoid breaking function signatures

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -11,9 +11,13 @@ func (c *Client) Status() *Status {
 }
 
 // Leader is used to query for a known leader
-func (s *Status) Leader(q *QueryOptions) (string, error) {
+func (s *Status) LeaderWithQueryOptions(q *QueryOptions) (string, error) {
 	r := s.c.newRequest("GET", "/v1/status/leader")
-	r.setQueryOptions(q)
+
+	if q != nil {
+		r.setQueryOptions(q)
+	}
+
 	_, resp, err := requireOK(s.c.doRequest(r))
 	if err != nil {
 		return "", err
@@ -27,10 +31,18 @@ func (s *Status) Leader(q *QueryOptions) (string, error) {
 	return leader, nil
 }
 
+func (s *Status) Leader() (string, error) {
+	return s.LeaderWithQueryOptions(nil)
+}
+
 // Peers is used to query for a known raft peers
-func (s *Status) Peers(q *QueryOptions) ([]string, error) {
+func (s *Status) PeersWithQueryOptions(q *QueryOptions) ([]string, error) {
 	r := s.c.newRequest("GET", "/v1/status/peers")
-	r.setQueryOptions(q)
+
+	if q != nil {
+		r.setQueryOptions(q)
+	}
+
 	_, resp, err := requireOK(s.c.doRequest(r))
 	if err != nil {
 		return nil, err
@@ -42,4 +54,8 @@ func (s *Status) Peers(q *QueryOptions) ([]string, error) {
 		return nil, err
 	}
 	return peers, nil
+}
+
+func (s *Status) Peers() ([]string, error) {
+	return s.PeersWithQueryOptions(nil)
 }

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -18,7 +18,7 @@ func TestAPI_StatusLeader(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if leader == "" {
-		t.Fatalf("Expected leader")
+		t.Fatalf("Expected leader, found empty string")
 	}
 }
 
@@ -39,7 +39,7 @@ func TestAPI_StatusLeaderWithQueryOptions(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if leader == "" {
-		t.Fatalf("Expected leader")
+		t.Fatalf("Expected leader, found empty string")
 	}
 }
 
@@ -56,7 +56,28 @@ func TestAPI_StatusPeers(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 	if len(peers) == 0 {
-		t.Fatalf("Expected peers ")
+		t.Fatalf("Expected peers, found %d", len(peers))
+	}
+}
+
+func TestAPI_StatusPeersWithQueryOptions(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+	s.WaitForSerfCheck(t)
+
+	status := c.Status()
+
+	opts := QueryOptions{
+		Datacenter: "dc1",
+	}
+
+	peers, err := status.PeersWithQueryOptions(&opts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(peers) == 0 {
+		t.Fatalf("Expected peers, found %d", len(peers))
 	}
 }
 

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -13,11 +13,28 @@ func TestAPI_StatusLeader(t *testing.T) {
 
 	status := c.Status()
 
+	leader, err := status.Leader()
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if leader == "" {
+		t.Fatalf("Expected leader")
+	}
+}
+
+func TestAPI_StatusLeaderWithQueryOptions(t *testing.T) {
+	t.Parallel()
+	c, s := makeClient(t)
+	defer s.Stop()
+	s.WaitForSerfCheck(t)
+
+	status := c.Status()
+
 	opts := QueryOptions{
 		Datacenter: "dc1",
 	}
 
-	leader, err := status.Leader(&opts)
+	leader, err := status.LeaderWithQueryOptions(&opts)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -34,10 +51,7 @@ func TestAPI_StatusPeers(t *testing.T) {
 
 	status := c.Status()
 
-	opts := QueryOptions{
-		Datacenter: "dc1",
-	}
-	peers, err := status.Peers(&opts)
+	peers, err := status.Peers()
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -59,7 +73,8 @@ func TestAPI_StatusLeader_WrongDC(t *testing.T) {
 	opts := QueryOptions{
 		Datacenter: "wrong_dc1",
 	}
-	_, err := status.Leader(&opts)
+
+	_, err := status.LeaderWithQueryOptions(&opts)
 	require.Error(err)
 	require.Contains(err.Error(), "No path to datacenter")
 }
@@ -77,7 +92,7 @@ func TestAPI_StatusPeers_WrongDC(t *testing.T) {
 	opts := QueryOptions{
 		Datacenter: "wrong_dc1",
 	}
-	_, err := status.Peers(&opts)
+	_, err := status.PeersWithQueryOptions(&opts)
 	require.Error(err)
 	require.Contains(err.Error(), "No path to datacenter")
 }


### PR DESCRIPTION
Refs https://github.com/hashicorp/consul/pull/7818

Restores `Leader()` and `Peers()` function signatures as wrappers to avoid a breaking change, moves new implementations with `QueryOptions` support to `LeaderWithQueryOptions(q *QueryOptions)` and `PeersWithQueryOptions(q *QueryOptions)`