### PR TITLE
ui: Ensure URLs for tabs change when selecting a different DC

### DIFF
--- a/ui-v2/app/components/tab-nav/pageobject.js
+++ b/ui-v2/app/components/tab-nav/pageobject.js
@@ -1,4 +1,4 @@
-import { is, clickable } from 'ember-cli-page-object';
+import { is, clickable, attribute } from 'ember-cli-page-object';
 import ucfirst from 'consul-ui/utils/ucfirst';
 export default function(name, items, blankKey = 'all') {
   return items.reduce(function(prev, item, i, arr) {
@@ -17,6 +17,7 @@ export default function(name, items, blankKey = 'all') {
       ...prev,
       ...{
         [`${key}IsSelected`]: is('.selected', `[data-test-tab="${name}_${item}"]`),
+        [`${key}Url`]: attribute('href', `[data-test-tab="${name}_${item}"] a`),
         [key]: clickable(`[data-test-tab="${name}_${item}"] a`),
       },
     };

--- a/ui-v2/app/helpers/href-to.js
+++ b/ui-v2/app/helpers/href-to.js
@@ -1,8 +1,11 @@
+/*eslint ember/no-observers: "warn"*/
+// TODO: Remove ^
 // This helper requires `ember-href-to` for the moment at least
 // It's similar code but allows us to check on the type of route
 // (dynamic or wildcard) and encode or not depending on the type
 import { inject as service } from '@ember/service';
 import Helper from '@ember/component/helper';
+import { observer } from '@ember/object';
 import { hrefTo as _hrefTo } from 'ember-href-to/helpers/href-to';
 
 import wildcard from 'consul-ui/utils/routing/wildcard';
@@ -39,4 +42,7 @@ export default Helper.extend({
   compute(params, hash) {
     return hrefTo(this, this.router, params, hash);
   },
+  onURLChange: observer('router.currentURL', function() {
+    this.recompute();
+  }),
 });

--- a/ui-v2/tests/acceptance/dc/services/show/dc-switch.feature
+++ b/ui-v2/tests/acceptance/dc/services/show/dc-switch.feature
@@ -1,0 +1,27 @@
+@setupApplicationTest
+Feature: dc / services / show / dc-switch : Switching Datacenters
+  Scenario: Seeing all services when switching datacenters
+    Given 2 datacenter models from yaml
+    ---
+      - dc-1
+      - dc-2
+    ---
+    And 1 node model
+    And 1 service model from yaml
+    ---
+    - Service:
+        Service: consul
+        Kind: ~
+    ---
+
+    When I visit the service page for yaml
+    ---
+      dc: dc-1
+      service: consul
+    ---
+    Then the url should be /dc-1/services/consul/instances
+    And I see instancesUrl on the tabs contains "/dc-1/services/consul/instances"
+    When I click dc on the navigation
+    And I click dcs.1.name
+    Then the url should be /dc-2/services/consul/instances
+    And I see instancesUrl on the tabs contains "/dc-2/services/consul/instances"

--- a/ui-v2/tests/acceptance/steps/dc/services/show/dc-switch-steps.js
+++ b/ui-v2/tests/acceptance/steps/dc/services/show/dc-switch-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -150,7 +150,16 @@ export default {
     )
   ),
   service: create(
-    service(visitable, attribute, collection, text, consulIntentionList, catalogToolbar, tabgroup)
+    service(
+      visitable,
+      clickable,
+      attribute,
+      collection,
+      text,
+      consulIntentionList,
+      catalogToolbar,
+      tabgroup
+    )
   ),
   instance: create(instance(visitable, attribute, collection, text, tabgroup)),
   nodes: create(nodes(visitable, clickable, attribute, collection, catalogFilter)),

--- a/ui-v2/tests/pages/dc/services/show.js
+++ b/ui-v2/tests/pages/dc/services/show.js
@@ -1,4 +1,13 @@
-export default function(visitable, attribute, collection, text, intentions, filter, tabs) {
+export default function(
+  visitable,
+  clickable,
+  attribute,
+  collection,
+  text,
+  intentions,
+  filter,
+  tabs
+) {
   const page = {
     visit: visitable('/:dc/services/:service'),
     externalSource: attribute('data-test-external-source', '[data-test-external-source]', {
@@ -16,6 +25,10 @@ export default function(visitable, attribute, collection, text, intentions, filt
       'tags',
     ]),
     filter: filter(),
+
+    dcs: collection('[data-test-datacenter-picker]', {
+      name: clickable('a'),
+    }),
 
     // TODO: These need to somehow move to subpages
     instances: collection('.consul-service-instance-list > ul > li:not(:first-child)', {

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -159,10 +159,10 @@ export default function(scenario, assert, find, currentPage) {
     })
     .then(
       [
-        'I see $property on the $component like "$value"',
-        "I see $property on the $component like '$value'",
+        `I see $property on the $component (contains|like) "$value"`,
+        `I see $property on the $component (contains|like) '$value'`,
       ],
-      function(property, component, value) {
+      function(property, component, containsLike, value) {
         let target;
         try {
           if (typeof component === 'string') {
@@ -172,11 +172,18 @@ export default function(scenario, assert, find, currentPage) {
         } catch (e) {
           throw e;
         }
-        assert.equal(
-          target,
-          value,
-          `Expected to see ${property} on ${component} as ${value}, was ${target}`
-        );
+        if (containsLike === 'like') {
+          assert.equal(
+            target,
+            value,
+            `Expected to see ${property} on ${component} as ${value}, was ${target}`
+          );
+        } else {
+          assert.ok(
+            target.indexOf(value) !== -1,
+            `Expected to see ${property} on ${component} within ${value}, was ${target}`
+          );
+        }
       }
     )
     .then(['I see $property like "$value"'], function(property, value) {


### PR DESCRIPTION
DC switching whilst you are on 'item' view page will either:

1. Show you an error page if the same 'item' _doesn't_ exist in the other DC
2. Show you the equivalent item in the other DC if it _does_ exist in the other DC (which can generally be the case for cross DC services)

If point 2 occurs, then the URLs of the tabs in the sub navigation can potentially maintain the links to the previous DC due to the fact that we aren't passing the DC into the `href-to` helper as a dependency property in the call to the helper.

The straightforward fix here is to update any `href-to` hrefs on url change (which is the exact same functionality as `is-href`). This is in someway a shortcut, ideally all `href-to`/`is-href` calls would include all their dependants, but unfortunately this isn't the case in various parts of the UI (a hangover from the beginning of the UI build).

This solution here uses observers and uses the same approach as `is-href`.  I'm half happy with this as we already use this approach elsewhere - but only half happy as observers are now a deprecated feature of ember, so ideally we'd avoid using them.

Longer term we will need to alter both `href-to` and `is-href` across the entire app to ensure that every call to the helper contains the dependants they need - something that may well be more complicated than it sounds as we often have conditional dependants for generating URLs.


