### PR TITLE
Use Logger consistently, instead of LogOutput

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -37,10 +37,6 @@ type TestACLAgent struct {
 	// when Shutdown() is called.
 	Config *config.RuntimeConfig
 
-	// LogOutput is the sink for the logs. If nil, logs are written
-	// to os.Stderr.
-	LogOutput io.Writer
-
 	// DataDir is the data directory which is used when Config.DataDir
 	// is not set. It is created automatically and removed when
 	// Shutdown() is called.
@@ -59,11 +55,10 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	a := &TestACLAgent{Name: name, HCL: hcl, resolveAuthzFn: resolveAuthz, resolveIdentFn: resolveIdent}
 	dataDir := `data_dir = "acl-agent"`
 
-	logOutput := testutil.NewLogBuffer(t)
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Name:   a.Name,
 		Level:  hclog.Debug,
-		Output: logOutput,
+		Output: testutil.NewLogBuffer(t),
 	})
 
 	opts := []AgentOption{
@@ -82,7 +77,6 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	a.Config = agent.GetConfig()
 	a.Agent = agent
 
-	agent.LogOutput = logOutput
 	agent.logger = logger
 	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -591,16 +591,10 @@ func (a *Agent) initializeConnectionPool() error {
 		rpcSrcAddr = &net.TCPAddr{IP: a.config.RPCBindAddr.IP}
 	}
 
-	// Ensure we have a log output for the connection pool.
-	logOutput := a.LogOutput
-	if logOutput == nil {
-		logOutput = os.Stderr
-	}
-
 	pool := &pool.ConnPool{
 		Server:          a.config.ServerMode,
 		SrcAddr:         rpcSrcAddr,
-		LogOutput:       logOutput,
+		Logger:          a.logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
 		TLSConfigurator: a.tlsConfigurator,
 		Datacenter:      a.config.Datacenter,
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1263,7 +1263,7 @@ func (a *Agent) reloadWatches(cfg *config.RuntimeConfig) error {
 				httpConfig := wp.Exempt["http_handler_config"].(*watch.HttpHandlerConfig)
 				wp.Handler = makeHTTPWatchHandler(a.logger, httpConfig)
 			}
-			wp.LogOutput = a.LogOutput
+			wp.Logger = a.logger.Named("watch")
 
 			addr := config.Address
 			if config.Scheme == "https" {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -695,13 +695,13 @@ func (a *Agent) Start(ctx context.Context) error {
 
 	// Setup either the client or the server.
 	if c.ServerMode {
-		server, err := consul.NewServerWithOptions(consulCfg, options...)
+		server, err := consul.NewServer(consulCfg, options...)
 		if err != nil {
 			return fmt.Errorf("Failed to start Consul server: %v", err)
 		}
 		a.delegate = server
 	} else {
-		client, err := consul.NewClientWithOptions(consulCfg, options...)
+		client, err := consul.NewClient(consulCfg, options...)
 		if err != nil {
 			return fmt.Errorf("Failed to start Consul client: %v", err)
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1517,9 +1517,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 		}
 	}
 
-	// Setup the loggers
-	base.LogOutput = a.LogOutput
-
 	// This will set up the LAN keyring, as well as the WAN and any segments
 	// for servers.
 	if err := a.setupKeyrings(base); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -174,15 +174,6 @@ type Agent struct {
 	// Used for writing our logs
 	logger hclog.InterceptLogger
 
-	// LogOutput is a Writer which is used when creating dependencies that
-	// require logging. Note that this LogOutput is not used by the agent logger,
-	// so setting this field does not result in the agent logs being written to
-	// LogOutput.
-	// FIXME: refactor so that: dependencies accept an hclog.Logger,
-	// or LogOutput is part of RuntimeConfig, or change Agent.logger to be
-	// a new type with an Out() io.Writer method which returns this value.
-	LogOutput io.Writer
-
 	// In-memory sink used for collecting metrics
 	MemSink *metrics.InmemSink
 
@@ -477,13 +468,10 @@ func New(options ...AgentOption) (*Agent, error) {
 			LogRotateMaxFiles: config.LogRotateMaxFiles,
 		}
 
-		logger, logOutput, err := logging.Setup(logConf, flat.writers)
+		a.logger, err = logging.Setup(logConf, flat.writers)
 		if err != nil {
 			return nil, err
 		}
-
-		a.logger = logger
-		a.LogOutput = logOutput
 
 		grpclog.SetLoggerV2(logging.NewGRPCLogger(logConf, a.logger))
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1524,7 +1524,6 @@ func (a *Agent) consulConfig() (*consul.Config, error) {
 	}
 
 	// Setup the loggers
-	base.LogLevel = a.config.LogLevel
 	base.LogOutput = a.LogOutput
 
 	// This will set up the LAN keyring, as well as the WAN and any segments

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -140,7 +140,7 @@ func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, err
 		connPool = &pool.ConnPool{
 			Server:          false,
 			SrcAddr:         config.RPCSrcAddr,
-			LogOutput:       config.LogOutput,
+			Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
 			MaxTime:         clientRPCConnMaxIdle,
 			MaxStreams:      clientMaxStreams,
 			TLSConfigurator: tlsConfigurator,

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -88,7 +88,8 @@ type Client struct {
 	tlsConfigurator *tlsutil.Configurator
 }
 
-func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, error) {
+// NewClient creates and returns a Client
+func NewClient(config *Config, options ...ConsulOption) (*Client, error) {
 	flat := flattenConsulOptions(options)
 
 	tlsConfigurator := flat.tlsConfigurator

--- a/agent/consul/client.go
+++ b/agent/consul/client.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"fmt"
 	"io"
-	"os"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -89,58 +88,30 @@ type Client struct {
 	tlsConfigurator *tlsutil.Configurator
 }
 
-// NewClient is used to construct a new Consul client from the configuration,
-// potentially returning an error.
-// NewClient only used to help setting up a client for testing. Normal code
-// exercises NewClientLogger.
-func NewClient(config *Config) (*Client, error) {
-	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
-	if err != nil {
-		return nil, err
-	}
-	return NewClientLogger(config, nil, c)
-}
-
 func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, error) {
 	flat := flattenConsulOptions(options)
 
-	logger := flat.logger
 	tlsConfigurator := flat.tlsConfigurator
 	connPool := flat.connPool
 
-	// Check the protocol version
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
 	}
-
-	// Check for a data directory!
 	if config.DataDir == "" {
 		return nil, fmt.Errorf("Config must provide a DataDir")
 	}
-
-	// Sanity check the ACLs
 	if err := config.CheckACL(); err != nil {
 		return nil, err
 	}
-
-	// Ensure we have a log output
-	if config.LogOutput == nil {
-		config.LogOutput = os.Stderr
-	}
-
-	// Create a logger
-	if logger == nil {
-		logger = hclog.NewInterceptLogger(&hclog.LoggerOptions{
-			Level:  hclog.Debug,
-			Output: config.LogOutput,
-		})
+	if flat.logger == nil {
+		return nil, fmt.Errorf("logger is required")
 	}
 
 	if connPool == nil {
 		connPool = &pool.ConnPool{
 			Server:          false,
 			SrcAddr:         config.RPCSrcAddr,
-			Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
+			Logger:          flat.logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
 			MaxTime:         clientRPCConnMaxIdle,
 			MaxStreams:      clientMaxStreams,
 			TLSConfigurator: tlsConfigurator,
@@ -153,7 +124,7 @@ func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, err
 		config:          config,
 		connPool:        connPool,
 		eventCh:         make(chan serf.Event, serfEventBacklog),
-		logger:          logger.NamedIntercept(logging.ConsulClient),
+		logger:          flat.logger.NamedIntercept(logging.ConsulClient),
 		shutdownCh:      make(chan struct{}),
 		tlsConfigurator: tlsConfigurator,
 	}
@@ -208,10 +179,6 @@ func NewClientWithOptions(config *Config, options ...ConsulOption) (*Client, err
 	}
 
 	return c, nil
-}
-
-func NewClientLogger(config *Config, logger hclog.InterceptLogger, tlsConfigurator *tlsutil.Configurator) (*Client, error) {
-	return NewClientWithOptions(config, WithLogger(logger), WithTLSConfigurator(tlsConfigurator))
 }
 
 // Shutdown is used to shutdown the client

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -438,7 +438,7 @@ func TestClient_RPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(t, conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -494,7 +494,7 @@ func newClient(t *testing.T, config *Config) (*Client, error) {
 func TestClient_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
 	dir1, conf1 := testServerConfig(t)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(t, conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -606,7 +606,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
-	s1, err := NewServer(conf1)
+	s1, err := newServer(t, conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -2,7 +2,6 @@ package consul
 
 import (
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"time"
@@ -160,10 +159,6 @@ type Config struct {
 	// that are force removed, as well as intermittent unavailability during
 	// leader election.
 	ReconcileInterval time.Duration
-
-	// LogOutput is the location to write logs to. If this is not set,
-	// logs will go to stderr.
-	LogOutput io.Writer
 
 	// ProtocolVersion is the protocol version to speak. This must be between
 	// ProtocolVersionMin and ProtocolVersionMax.

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -161,9 +161,6 @@ type Config struct {
 	// leader election.
 	ReconcileInterval time.Duration
 
-	// LogLevel is the level of the logs to write. Defaults to "INFO".
-	LogLevel string
-
 	// LogOutput is the location to write logs to. If this is not set,
 	// logs will go to stderr.
 	LogOutput io.Writer

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -10,10 +10,13 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/go-hclog"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/serf"
 	"github.com/stretchr/testify/require"
@@ -1283,24 +1286,39 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 		}
 	}()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
-		c.LogOutput = io.MultiWriter(pw, testutil.NewLogBuffer(t))
-		c.Build = "1.6.0"
-		c.ConfigEntryBootstrap = []structs.ConfigEntry{
-			&structs.ServiceSplitterConfigEntry{
-				Kind: structs.ServiceSplitter,
-				Name: "web",
-				Splits: []structs.ServiceSplit{
-					{Weight: 100, Service: "web"},
-				},
+	dir, config := testServerConfig(t)
+	defer os.RemoveAll(dir)
+	config.Build = "1.6.0"
+	config.ConfigEntryBootstrap = []structs.ConfigEntry{
+		&structs.ServiceSplitterConfigEntry{
+			Kind: structs.ServiceSplitter,
+			Name: "web",
+			Splits: []structs.ServiceSplit{
+				{Weight: 100, Service: "web"},
 			},
-		}
-	})
-	defer os.RemoveAll(dir1)
-	defer s1.Shutdown()
+		},
+	}
 
-	result := <-ch
-	require.Empty(t, result)
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:   config.NodeName,
+		Level:  hclog.Debug,
+		Output: io.MultiWriter(pw, testutil.NewLogBuffer(t)),
+	})
+	tlsConf, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), logger)
+	require.NoError(t, err)
+	srv, err := NewServerWithOptions(config,
+		WithLogger(logger),
+		WithTokenStore(new(token.Store)),
+		WithTLSConfigurator(tlsConf))
+	require.NoError(t, err)
+	defer srv.Shutdown()
+
+	select {
+	case result := <-ch:
+		require.Empty(t, result)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for a result from tailing logs")
+	}
 }
 
 func TestLeader_ACLLegacyReplication(t *testing.T) {

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1306,7 +1306,7 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 	})
 	tlsConf, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), logger)
 	require.NoError(t, err)
-	srv, err := NewServerWithOptions(config,
+	srv, err := NewServer(config,
 		WithLogger(logger),
 		WithTokenStore(new(token.Store)),
 		WithTLSConfigurator(tlsConf))

--- a/agent/consul/rpc.go
+++ b/agent/consul/rpc.go
@@ -295,7 +295,10 @@ func (s *Server) handleNativeTLS(conn net.Conn) {
 func (s *Server) handleMultiplexV2(conn net.Conn) {
 	defer conn.Close()
 	conf := yamux.DefaultConfig()
-	conf.LogOutput = s.config.LogOutput
+	// override the default because LogOutput conflicts with Logger
+	conf.LogOutput = nil
+	// TODO: should this be created once and cached?
+	conf.Logger = s.logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true})
 	server, _ := yamux.Server(conn, conf)
 	for {
 		sub, err := server.Accept()

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -313,9 +313,9 @@ type Server struct {
 	EnterpriseServer
 }
 
-// NewServerWithOptions is used to construct a new Consul server from the configuration
-// and extra options, potentially returning an error
-func NewServerWithOptions(config *Config, options ...ConsulOption) (*Server, error) {
+// NewServer is used to construct a new Consul server from the configuration
+// and extra options, potentially returning an error.
+func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	flat := flattenConsulOptions(options)
 
 	logger := flat.logger

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -400,7 +400,7 @@ func NewServerWithOptions(config *Config, options ...ConsulOption) (*Server, err
 		connPool = &pool.ConnPool{
 			Server:          true,
 			SrcAddr:         config.RPCSrcAddr,
-			LogOutput:       config.LogOutput,
+			Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
 			MaxTime:         serverRPCCache,
 			MaxStreams:      serverMaxStreams,
 			TLSConfigurator: tlsConfigurator,

--- a/api/watch/plan.go
+++ b/api/watch/plan.go
@@ -31,8 +31,10 @@ func (p *Plan) Run(address string) error {
 
 // Run is used to run a watch plan
 func (p *Plan) RunWithConfig(address string, conf *consulapi.Config) error {
-	// Create the logger
-	logger := newWatchLogger(p.LogOutput)
+	logger := p.Logger
+	if logger == nil {
+		logger = newWatchLogger(p.LogOutput)
+	}
 
 	// Setup the client
 	p.address = address

--- a/api/watch/watch.go
+++ b/api/watch/watch.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/go-hclog"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -29,7 +30,10 @@ type Plan struct {
 	// on index param. To support hash based watches, set HybridHandler instead.
 	Handler       HandlerFunc
 	HybridHandler HybridHandlerFunc
-	LogOutput     io.Writer
+
+	Logger hclog.Logger
+	// Deprecated: use Logger
+	LogOutput io.Writer
 
 	address      string
 	client       *consulapi.Client

--- a/command/connect/proxy/proxy.go
+++ b/command/connect/proxy/proxy.go
@@ -140,7 +140,7 @@ func (c *cmd) Run(args []string) int {
 
 	logGate := logging.GatedWriter{Writer: &cli.UiWriter{Ui: c.UI}}
 
-	logger, _, err := logging.Setup(logConfig, []io.Writer{&logGate})
+	logger, err := logging.Setup(logConfig, []io.Writer{&logGate})
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -19,9 +19,8 @@ func TestLogger_SetupBasic(t *testing.T) {
 		LogLevel: "INFO",
 	}
 
-	logger, writer, err := Setup(cfg, nil)
+	logger, err := Setup(cfg, nil)
 	require.NoError(err)
-	require.NotNil(writer)
 	require.NotNil(logger)
 }
 
@@ -29,7 +28,7 @@ func TestLogger_SetupInvalidLogLevel(t *testing.T) {
 	t.Parallel()
 	cfg := &Config{}
 
-	_, _, err := Setup(cfg, nil)
+	_, err := Setup(cfg, nil)
 	testutil.RequireErrorContains(t, err, "Invalid log level")
 }
 
@@ -62,7 +61,7 @@ func TestLogger_SetupLoggerErrorLevel(t *testing.T) {
 			require := require.New(t)
 			var buf bytes.Buffer
 
-			logger, _, err := Setup(&cfg, []io.Writer{&buf})
+			logger, err := Setup(&cfg, []io.Writer{&buf})
 			require.NoError(err)
 			require.NotNil(logger)
 
@@ -85,7 +84,7 @@ func TestLogger_SetupLoggerDebugLevel(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.NoError(err)
 	require.NotNil(logger)
 
@@ -107,7 +106,7 @@ func TestLogger_SetupLoggerWithName(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.NoError(err)
 	require.NotNil(logger)
 
@@ -126,7 +125,7 @@ func TestLogger_SetupLoggerWithJSON(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.NoError(err)
 	require.NotNil(logger)
 
@@ -154,7 +153,7 @@ func TestLogger_SetupLoggerWithValidLogPath(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.NoError(err)
 	require.NotNil(logger)
 }
@@ -169,7 +168,7 @@ func TestLogger_SetupLoggerWithInValidLogPath(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.Error(err)
 	require.True(errors.Is(err, os.ErrNotExist))
 	require.Nil(logger)
@@ -190,7 +189,7 @@ func TestLogger_SetupLoggerWithInValidLogPathPermission(t *testing.T) {
 	}
 	var buf bytes.Buffer
 
-	logger, _, err := Setup(cfg, []io.Writer{&buf})
+	logger, err := Setup(cfg, []io.Writer{&buf})
 	require.Error(err)
 	require.True(errors.Is(err, os.ErrPermission))
 	require.Nil(logger)


### PR DESCRIPTION
This PR resolves a FIXME about the duplicate `LogOutput` field. Through large parts of the code (agent, client, server, watches, rpc) we pass around both a `Logger` and a `LogOutput io.Writer`. The Writer was passed to dependencies that I guess previously did not accept a Logger in some form. It seems that now all of those dependencies accept a `Logger`, so we can remove `LogOutput` which cleans up a few things.

Instead of a `Writer` a `Logger` is passed to dependencies that require one. This change allows us to delete a few `LogOutput` fields. It also removes, or moves duplicate Client and Server constructors into the test packages where they are used.

This change is being made to facilitate adding a `grpcHandler` to the RPC Server for streaming. It is the first of a few PRs that will refactor the way a `Server` is created to make it possible to add new components without further growing the already massive `Agent` and `Server` structs.

@mkeeler CC'ing you on this because I think you have done some work near to this recently for auto-config