### PR TITLE
Modify Status Leader API to return Status 500 when there is no leader

### DIFF
--- a/.changelog/8408.txt
+++ b/.changelog/8408.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+api: when the cluster has no leader return an error from `/v1/status/leader` to be consistent with all other endpoints.
+```
+

--- a/agent/status_endpoint.go
+++ b/agent/status_endpoint.go
@@ -16,6 +16,12 @@ func (s *HTTPHandlers) StatusLeader(resp http.ResponseWriter, req *http.Request)
 	if err := s.agent.RPC("Status.Leader", &args, &out); err != nil {
 		return nil, err
 	}
+
+	// check there is a leader, if not return a status no content
+	if out == "" {
+		return nil, structs.ErrNoLeader
+	}
+
 	return out, nil
 }
 

--- a/agent/status_endpoint_test.go
+++ b/agent/status_endpoint_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,18 @@ func TestStatusLeader(t *testing.T) {
 	if val == "" {
 		t.Fatalf("bad addr: %v", obj)
 	}
+}
+
+func TestStatusLeaderNoLeaderReturnsStatus500(t *testing.T) {
+	t.Parallel()
+	a := NewTestAgent(t, "bootstrap_expect=2 bootstrap=false")
+	defer a.Shutdown()
+
+	req, _ := http.NewRequest("GET", "/v1/status/leader", nil)
+	_, err := a.srv.StatusLeader(nil, req)
+
+	require.Error(t, err)
+	require.Equal(t, structs.ErrNoLeader, err)
 }
 
 func TestStatusLeaderSecondary(t *testing.T) {


### PR DESCRIPTION
The API endpoint /v1/status/leader can return a HTTP status 200 and no leader in the response in certain instances. This mainly occurs in a race condition when you need to check if an agent has successfully joined a cluster before making a request to register a service or submit L7 config.

This PR implements a better RESTFull behaviour in the instance that the API is called and no leader is available. When there is no leader the API will return a HTTP status InternalServerError. I am not 100% convinced this is the correct status code as in fact the API is not returning an error but this mimics other No Leader error messages which can be returned from this API.
