### PR TITLE
Ensure certificates retrieved through the cache get persisted with auto-config

### DIFF
--- a/agent/auto-config/config_translate.go
+++ b/agent/auto-config/config_translate.go
@@ -226,3 +226,34 @@ func mapstructureTranslateToStructs(in interface{}, out interface{}) error {
 
 	return decoder.Decode(in)
 }
+
+func translateCARootsToProtobuf(in *structs.IndexedCARoots) (*pbconnect.CARoots, error) {
+	var out pbconnect.CARoots
+	if err := mapstructureTranslateToProtobuf(in, &out); err != nil {
+		return nil, fmt.Errorf("Failed to re-encode CA Roots: %w", err)
+	}
+
+	return &out, nil
+}
+
+func translateIssuedCertToProtobuf(in *structs.IssuedCert) (*pbconnect.IssuedCert, error) {
+	var out pbconnect.IssuedCert
+	if err := mapstructureTranslateToProtobuf(in, &out); err != nil {
+		return nil, fmt.Errorf("Failed to re-encode CA Roots: %w", err)
+	}
+
+	return &out, nil
+}
+
+func mapstructureTranslateToProtobuf(in interface{}, out interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: proto.HookTimeToPBTimestamp,
+		Result:     out,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(in)
+}

--- a/agent/cert-monitor/config.go
+++ b/agent/cert-monitor/config.go
@@ -16,6 +16,9 @@ import (
 // method of updating the certificate is required.
 type FallbackFunc func(context.Context) (*structs.SignedResponse, error)
 
+// PersistFunc is used to persist the data from a signed response
+type PersistFunc func(*structs.SignedResponse) error
+
 type Config struct {
 	// Logger is the logger to be used while running. If not set
 	// then no logging will be performed.
@@ -33,6 +36,9 @@ type Config struct {
 	// agent token as well as getting notifications when that token is updated.
 	// This field is required.
 	Tokens *token.Store
+
+	// Persist is a function to run when there are new certs or keys
+	Persist PersistFunc
 
 	// Fallback is a function to run when the normal cache updating of the
 	// agent's certificates has failed to work for one reason or another.
@@ -133,5 +139,12 @@ func (cfg *Config) WithFallbackLeeway(leeway time.Duration) *Config {
 // the fallback func in the case of it erroring out.
 func (cfg *Config) WithFallbackRetry(after time.Duration) *Config {
 	cfg.FallbackRetry = after
+	return cfg
+}
+
+// WithPersistence will configure the CertMonitor to use this callback for persisting
+// a new TLS configuration.
+func (cfg *Config) WithPersistence(persist PersistFunc) *Config {
+	cfg.Persist = persist
 	return cfg
 }


### PR DESCRIPTION
When implementing auto-config certificate generation without auto-encrypt I missed a crucial feature which is that certificates for auto-config must be persisted to allow for restarts to function properly after the agent has existed for 3 days. The initial certificates get persisted but I wasn't updating the persisted configuration once new certificates were retrieved.

This PR implements that persistence.

In the near future I am going to be doing more refactoring and merging. The auto-encrypt code will be consumed by the auto-config packages as well as the cert-monitor package. Basically, with this PR I don't love how the persistence has to happen through a series of callbacks. I think with that the conclusion I have come to is that the code in the cert-monitor package really needs to be a part of the auto-config package and subsequently so should the auto-encrypt code currently living on the Client struct. That is a much larger change and more work than would be able to be accomplished before the 1.8.1 release. Outward behavior that a user can observe is correct and will not change even with needing to refactor this to not be quite so bad next week.