### PR TITLE
Avoid panics during shutdown routine

### DIFF
--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -958,15 +958,21 @@ func (s *Server) Shutdown() error {
 	}
 
 	// Close the connection pool
-	s.connPool.Shutdown()
+	if s.connPool != nil {
+		s.connPool.Shutdown()
+	}
 
-	s.acls.Close()
+	if s.acls != nil {
+		s.acls.Close()
+	}
 
 	if s.config.NotifyShutdown != nil {
 		s.config.NotifyShutdown()
 	}
 
-	s.fsm.State().Abandon()
+	if s.fsm != nil {
+		s.fsm.State().Abandon()
+	}
 
 	return nil
 }


### PR DESCRIPTION
Currently Consul can panic when starting up if one of the setup functions in `NewServerWithOptions()` fails. 

This is because:

- There are multiple calls to `s.Shutdown()` in `NewServerWithOptions()`
- `s.Shutdown()` calls to pointers like `s.fsm.State().Abandon()`, which will panic if the error and call to Shutdown came before they were setup.

This PR adds more nil checks to `s.Shutdown()` so that the shutdown can finish and the error from the setup function that failed is surfaced.