### PR TITLE
xds: revert setting set_node_on_first_message_only to true when generating envoy bootstrap config

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -188,7 +188,6 @@ const bootstrapTemplate = `{
     "cds_config": { "ads": {} },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
+++ b/command/connect/envoy/testdata/CONSUL_HTTP_ADDR-with-https-scheme-enables-tls.golden
@@ -97,7 +97,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -97,7 +97,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -110,7 +110,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -101,7 +101,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -87,7 +87,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-address-specified.golden
@@ -161,7 +161,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-no-auto-register.golden
@@ -161,7 +161,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-and-proxy-id.golden
@@ -161,7 +161,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
+++ b/command/connect/envoy/testdata/ingress-gateway-register-with-service-without-proxy-id.golden
@@ -161,7 +161,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -161,7 +161,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -46,7 +46,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -121,7 +121,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {


### PR DESCRIPTION
When consul is restarted and an envoy that had already sent DiscoveryRequests to the previous consul process sends a request to the new process it doesn't respect the `set_node_on_first_message_only` setting and never populates DiscoveryRequest.Node for the life of the new consul process due to this bug: https://github.com/envoyproxy/envoy/issues/9682

Fixes #8430