### PR TITLE
[backport/1.7.x] xds: revert setting set_node_on_first_message_only to true when generating envoy bootstrap config

### DIFF
--- a/command/connect/envoy/bootstrap_tpl.go
+++ b/command/connect/envoy/bootstrap_tpl.go
@@ -183,9 +183,6 @@ const bootstrapTemplate = `{
     "cds_config": { "ads": {} },
     "ads_config": {
       "api_type": "GRPC",
-      {{- if ne .EnvoyVersion "1.10.0"}}
-      "set_node_on_first_message_only": true,
-      {{- end }}
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -97,7 +97,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -110,7 +110,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -101,7 +101,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -87,7 +87,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -46,7 +46,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -88,7 +88,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -121,7 +121,6 @@
     },
     "ads_config": {
       "api_type": "GRPC",
-      "set_node_on_first_message_only": true,
       "grpc_services": {
         "initial_metadata": [
           {


### PR DESCRIPTION
This is a backport of https://github.com/hashicorp/consul/pull/8440 to 1.7.x