### PR TITLE
Merge 1.8.1 updates back into release branch

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	//
 	// Version must conform to the format expected by github.com/hashicorp/go-version
 	// for tests to work.
-	Version = "1.8.0"
+	Version = "1.8.1"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release

--- a/website/data/version.js
+++ b/website/data/version.js
@@ -1,1 +1,1 @@
-export default '1.7.2'
+export default '1.8.1'


### PR DESCRIPTION
Fixes #8445 

Did a manual `git merge release/1.8.1` branch from CLI to resolve a minor changelog conflict, is this going to cause weirdness with a double merge commit or anything?

Should this instead be merged to `master` and backported to 1.8.x?