### PR TITLE
Require token replication to be enabled in secondary dcs when ACLs are enabled with AutoConfig

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2060,7 +2060,7 @@ func (b *Builder) validateAutoConfigAuthorizer(rt RuntimeConfig) error {
 	// we would have to have a token with the ability to create ACL tokens in the primary and make
 	// RPCs in response to auto config requests.
 	if rt.ACLsEnabled && rt.PrimaryDatacenter != rt.Datacenter && !rt.ACLTokenReplication {
-		return fmt.Errorf("Enabling auto-onfig authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)")
+		return fmt.Errorf("Enabling auto-config authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)")
 	}
 
 	// Auto Config Authorization is only supported on servers

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -2045,7 +2045,6 @@ func (b *Builder) validateAutoConfig(rt RuntimeConfig) error {
 		return fmt.Errorf("auto_config.enabled is set without providing a list of addresses")
 	}
 
-	// TODO (autoconf) should we validate the DNS and IP SANs? The IP SANs have already been parsed into IPs
 	return nil
 }
 
@@ -2055,6 +2054,15 @@ func (b *Builder) validateAutoConfigAuthorizer(rt RuntimeConfig) error {
 	if !authz.Enabled {
 		return nil
 	}
+
+	// When in a secondary datacenter with ACLs enabled, we require token replication to be enabled
+	// as that is what allows us to create the local tokens to distribute to the clients. Otherwise
+	// we would have to have a token with the ability to create ACL tokens in the primary and make
+	// RPCs in response to auto config requests.
+	if rt.ACLsEnabled && rt.PrimaryDatacenter != rt.Datacenter && !rt.ACLTokenReplication {
+		return fmt.Errorf("Enabling auto-onfig authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)")
+	}
+
 	// Auto Config Authorization is only supported on servers
 	if !rt.ServerMode {
 		return fmt.Errorf("auto_config.authorization.enabled cannot be set to true for client agents")

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4119,7 +4119,7 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 				},
 				"cert_file": "foo"
 			}`},
-			err: `Enabling auto-onfig authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)`,
+			err: `Enabling auto-config authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)`,
 		},
 
 		{

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4081,6 +4081,48 @@ func TestConfigFlagsAndEdgecases(t *testing.T) {
 		},
 
 		{
+			desc: "auto config authorizer require token replication in secondary",
+			args: []string{
+				`-data-dir=` + dataDir,
+				`-server`,
+			},
+			hcl: []string{`
+				primary_datacenter = "otherdc"
+				acl {
+					enabled = true
+				}
+				auto_config {
+					authorization {
+						enabled = true
+						static {
+							jwks_url = "https://fake.uri.local"
+							oidc_discovery_url = "https://fake.uri.local"
+						}
+					}
+				}
+				cert_file = "foo"
+			`},
+			json: []string{`
+			{
+				"primary_datacenter": "otherdc",
+				"acl": {
+					"enabled": true
+				},
+				"auto_config": {
+					"authorization": {
+						"enabled": true,
+						"static": {
+							"jwks_url": "https://fake.uri.local",
+							"oidc_discovery_url": "https://fake.uri.local"
+						}
+					}
+				},
+				"cert_file": "foo"
+			}`},
+			err: `Enabling auto-onfig authorization (auto_config.authorization.enabled) in non primary datacenters with ACLs enabled (acl.enabled) requires also enabling ACL token replication (acl.enable_token_replication)`,
+		},
+
+		{
 			desc: "auto config authorizer invalid claim assertion",
 			args: []string{
 				`-data-dir=` + dataDir,


### PR DESCRIPTION
AutoConfig will generate local tokens for clients and the ability to use local tokens is gated off of token replication being enabled and being configured with a replication token. Therefore we already have a hard requirement on having token replication enabled, this commit just makes sure to surface that to the operator instead of having to discern what the issue is from RPC errors.