### PR TITLE
Specify allowed ingress gateway protocols in docs

### DIFF
--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -343,8 +343,7 @@ Also make two services in the frontend namespace available over a custom port wi
   - `Port` `(int: 0)` - The port that the listener should receive traffic on.
 
   - `Protocol` `(string: "tcp")` - The protocol associated with the listener.
-    This can be any protocol supported by
-    [service-defaults](/docs/agent/config-entries/service-defaults#protocol).
+    Either `tls` or `http`.
 
   - `Services` `(array<IngressService>: <optional>)` - A list of services to be
     exposed via this listener. For "tcp" listeners, only a single service is

--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -343,7 +343,7 @@ Also make two services in the frontend namespace available over a custom port wi
   - `Port` `(int: 0)` - The port that the listener should receive traffic on.
 
   - `Protocol` `(string: "tcp")` - The protocol associated with the listener.
-    Either `tls` or `http`.
+    Either `tcp` or `http`.
 
   - `Services` `(array<IngressService>: <optional>)` - A list of services to be
     exposed via this listener. For "tcp" listeners, only a single service is


### PR DESCRIPTION
It seems like only `tls` and `http` are supported right now.
https://github.com/hashicorp/consul/blob/586ee2566f1b75e675adc66a68639ecf22c69ab3/agent/structs/config_entry_gateways.go#L37-L40
https://github.com/hashicorp/consul/blob/586ee2566f1b75e675adc66a68639ecf22c69ab3/agent/structs/config_entry_gateways.go#L123-L126

I found this confusing when I was going through it. I'm hoping this will make someone else's life easier.