### PR TITLE
Notify alias checks when aliased service is [de]registered

### DIFF
--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -305,6 +305,8 @@ func (l *State) removeServiceLocked(id structs.ServiceID) error {
 		close(s.WatchCh)
 		s.WatchCh = nil
 	}
+
+	l.notifyIfAliased(id)
 	l.TriggerSyncChanges()
 	l.broadcastUpdateLocked()
 
@@ -378,6 +380,10 @@ func (l *State) setServiceStateLocked(s *ServiceState) {
 
 	if hasOld && old.WatchCh != nil {
 		close(old.WatchCh)
+	} else {
+		// The status of an alias check is updated if the alias service is added/removed
+		// Only try notify alias checks if service didn't already exist (!hasOld)
+		l.notifyIfAliased(key)
 	}
 
 	l.TriggerSyncChanges()
@@ -1353,7 +1359,7 @@ func (l *State) syncNodeInfo() error {
 	}
 }
 
-// notifyIfAliased will notify waiters if this is a check for an aliased service
+// notifyIfAliased will notify waiters of changes to an aliased service
 func (l *State) notifyIfAliased(serviceID structs.ServiceID) {
 	if aliases, ok := l.checkAliases[serviceID]; ok && len(aliases) > 0 {
 		for _, notifyCh := range aliases {

--- a/agent/local/state.go
+++ b/agent/local/state.go
@@ -380,7 +380,8 @@ func (l *State) setServiceStateLocked(s *ServiceState) {
 
 	if hasOld && old.WatchCh != nil {
 		close(old.WatchCh)
-	} else {
+	}
+	if !hasOld {
 		// The status of an alias check is updated if the alias service is added/removed
 		// Only try notify alias checks if service didn't already exist (!hasOld)
 		l.notifyIfAliased(key)

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1912,6 +1912,51 @@ func TestAgent_AliasCheck(t *testing.T) {
 	}
 }
 
+func TestAgent_AliasCheck_ServiceNotification(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+	cfg := config.DefaultRuntimeConfig(`bind_addr = "127.0.0.1" data_dir = "dummy"`)
+	l := local.NewState(agent.LocalConfig(cfg), nil, new(token.Store))
+	l.TriggerSyncChanges = func() {}
+
+	// Add an alias check for service s1
+	notifyCh := make(chan struct{}, 1)
+	require.NoError(l.AddAliasCheck(structs.NewCheckID(types.CheckID("a1"), nil), structs.NewServiceID("s1", nil), notifyCh))
+
+	// Add aliased service, s1, and verify we get notified
+	require.NoError(l.AddService(&structs.NodeService{Service: "s1"}, ""))
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("notify not received")
+	}
+
+	// Re-adding same service should not lead to a notification
+	require.NoError(l.AddService(&structs.NodeService{Service: "s1"}, ""))
+	select {
+	case <-notifyCh:
+		t.Fatal("notify received")
+	default:
+	}
+
+	// Add different service and verify we do not get notified
+	require.NoError(l.AddService(&structs.NodeService{Service: "s2"}, ""))
+	select {
+	case <-notifyCh:
+		t.Fatal("notify received")
+	default:
+	}
+
+	// Delete service and verify we get notified
+	require.NoError(l.RemoveService(structs.NewServiceID("s1", nil)))
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("notify not received")
+	}
+}
+
 func TestAgent_sendCoordinate(t *testing.T) {
 	t.Parallel()
 	a := agent.StartTestAgent(t, agent.TestAgent{Overrides: `

--- a/agent/local/state_test.go
+++ b/agent/local/state_test.go
@@ -1955,6 +1955,14 @@ func TestAgent_AliasCheck_ServiceNotification(t *testing.T) {
 	default:
 		t.Fatal("notify not received")
 	}
+
+	// Delete different service and verify we do not get notified
+	require.NoError(l.RemoveService(structs.NewServiceID("s2", nil)))
+	select {
+	case <-notifyCh:
+		t.Fatal("notify received")
+	default:
+	}
 }
 
 func TestAgent_sendCoordinate(t *testing.T) {


### PR DESCRIPTION
Currently when monitoring alias checks locally we have two mechanisms for updating the status of the alias check:

1. [Get a notification](https://github.com/hashicorp/consul/blob/586ee2566f1b75e675adc66a68639ecf22c69ab3/agent/checks/alias.go#L129) when a check for the service we are aliasing is updated
2. Catch updates that didn't trigger a notification by [checking every minute](https://github.com/hashicorp/consul/blob/586ee2566f1b75e675adc66a68639ecf22c69ab3/agent/checks/alias.go#L105-L108)

PR #7384 added a check so that alias health checks do not pass if the underlying service doesn't exist. However, we did not notify existing alias checks when services were added/removed. This means we could wait up to a minute to update the check status in these cases (per item 2 above).

This PR triggers an alias check notification when services are added or removed from local state.