### PR TITLE
agent/consul: Remove NotifyShutdown

### DIFF
--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -428,7 +428,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 
 func TestClient_RPC_TLS(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
@@ -436,18 +436,12 @@ func TestClient_RPC_TLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
-	dir2, conf2 := testClientConfig(t)
+	_, conf2 := testClientConfig(t)
 	conf2.VerifyOutgoing = true
 	configureTLS(conf2)
-	c1, err := newClient(t, conf2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir2)
-	defer c1.Shutdown()
+	c1 := newClient(t, conf2)
 
 	// Try an RPC
 	var out struct{}
@@ -472,38 +466,38 @@ func TestClient_RPC_TLS(t *testing.T) {
 	})
 }
 
-func newClient(t *testing.T, config *Config) (*Client, error) {
+func newClient(t *testing.T, config *Config) *Client {
+	t.Helper()
+
 	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err, "failed to create tls configuration")
+
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Level:  hclog.Debug,
 		Output: testutil.NewLogBuffer(t),
 	})
-	return NewClient(config, WithLogger(logger), WithTLSConfigurator(c))
+	client, err := NewClient(config, WithLogger(logger), WithTLSConfigurator(c))
+	require.NoError(t, err, "failed to create client")
+	t.Cleanup(func() {
+		client.Shutdown()
+	})
+	return client
 }
 
 func TestClient_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 	s1, err := newServer(t, conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
-	dir2, conf2 := testClientConfig(t)
+	_, conf2 := testClientConfig(t)
 	conf2.RPCRate = 2
 	conf2.RPCMaxBurst = 2
-	c1, err := newClient(t, conf2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir2)
-	defer c1.Shutdown()
+	c1 := newClient(t, conf2)
 
 	joinLAN(t, c1, s1)
 	retry.Run(t, func(r *retry.R) {
@@ -557,20 +551,14 @@ func TestClient_SnapshotRPC(t *testing.T) {
 
 func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
 	t.Parallel()
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
+	_, s1 := testServer(t)
 	defer s1.Shutdown()
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
-	dir2, conf1 := testClientConfig(t)
+	_, conf1 := testClientConfig(t)
 	conf1.RPCRate = 2
 	conf1.RPCMaxBurst = 2
-	c1, err := newClient(t, conf1)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir2)
-	defer c1.Shutdown()
+	c1 := newClient(t, conf1)
 
 	joinLAN(t, c1, s1)
 	retry.Run(t, func(r *retry.R) {
@@ -593,7 +581,7 @@ func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
 
 func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
@@ -601,18 +589,12 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
-	dir2, conf2 := testClientConfig(t)
+	_, conf2 := testClientConfig(t)
 	conf2.VerifyOutgoing = true
 	configureTLS(conf2)
-	c1, err := newClient(t, conf2)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	defer os.RemoveAll(dir2)
-	defer c1.Shutdown()
+	c1 := newClient(t, conf2)
 
 	// Wait for the leader
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")

--- a/agent/consul/config.go
+++ b/agent/consul/config.go
@@ -119,9 +119,6 @@ type Config struct {
 	// configured at this point.
 	NotifyListen func()
 
-	// NotifyShutdown is called after Server is completely Shutdown.
-	NotifyShutdown func()
-
 	// RPCAddr is the RPC address used by Consul. This should be reachable
 	// by the WAN and LAN
 	RPCAddr *net.TCPAddr

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -1286,8 +1286,7 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 		}
 	}()
 
-	dir, config := testServerConfig(t)
-	defer os.RemoveAll(dir)
+	_, config := testServerConfig(t)
 	config.Build = "1.6.0"
 	config.ConfigEntryBootstrap = []structs.ConfigEntry{
 		&structs.ServiceSplitterConfigEntry{

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -933,10 +933,6 @@ func (s *Server) Shutdown() error {
 		s.acls.Close()
 	}
 
-	if s.config.NotifyShutdown != nil {
-		s.config.NotifyShutdown()
-	}
-
 	if s.fsm != nil {
 		s.fsm.State().Abandon()
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -272,7 +272,6 @@ func testServerWithConfig(t *testing.T, cb func(*Config)) (string, *Server) {
 // cb is a function that can alter the test servers configuration prior to the server starting.
 func testACLServerWithConfig(t *testing.T, cb func(*Config), initReplicationToken bool) (string, *Server, rpc.ClientCodec) {
 	dir, srv := testServerWithConfig(t, testServerACLConfig(cb))
-	t.Cleanup(func() { os.RemoveAll(dir) })
 	t.Cleanup(func() { srv.Shutdown() })
 
 	if initReplicationToken {
@@ -333,8 +332,7 @@ func newServer(t *testing.T, c *Config) (*Server, error) {
 func TestServer_StartStop(t *testing.T) {
 	t.Parallel()
 	// Start up a server and then stop it.
-	dir1, s1 := testServer(t)
-	defer os.RemoveAll(dir1)
+	_, s1 := testServer(t)
 	if err := s1.Shutdown(); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -348,20 +346,18 @@ func TestServer_StartStop(t *testing.T) {
 func TestServer_fixupACLDatacenter(t *testing.T) {
 	t.Parallel()
 
-	dir1, s1 := testServerWithConfig(t, func(c *Config) {
+	_, s1 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "aye"
 		c.PrimaryDatacenter = "aye"
 		c.ACLsEnabled = true
 	})
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 
-	dir2, s2 := testServerWithConfig(t, func(c *Config) {
+	_, s2 := testServerWithConfig(t, func(c *Config) {
 		c.Datacenter = "bee"
 		c.PrimaryDatacenter = "aye"
 		c.ACLsEnabled = true
 	})
-	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()
 
 	// Try to join
@@ -1072,7 +1068,7 @@ func TestServer_RPC(t *testing.T) {
 
 func TestServer_JoinLAN_TLS(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 	conf1.VerifyIncoming = true
 	conf1.VerifyOutgoing = true
 	configureTLS(conf1)
@@ -1080,11 +1076,10 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	testrpc.WaitForTestAgent(t, s1.RPC, "dc1")
 
-	dir2, conf2 := testServerConfig(t)
+	_, conf2 := testServerConfig(t)
 	conf2.Bootstrap = false
 	conf2.VerifyIncoming = true
 	conf2.VerifyOutgoing = true
@@ -1093,7 +1088,6 @@ func TestServer_JoinLAN_TLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir2)
 	defer s2.Shutdown()
 
 	// Try to join
@@ -1471,14 +1465,13 @@ func TestServer_Reload(t *testing.T) {
 
 func TestServer_RPC_RateLimit(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 	conf1.RPCRate = 2
 	conf1.RPCMaxBurst = 2
 	s1, err := newServer(t, conf1)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 
@@ -1492,7 +1485,7 @@ func TestServer_RPC_RateLimit(t *testing.T) {
 
 func TestServer_CALogging(t *testing.T) {
 	t.Parallel()
-	dir1, conf1 := testServerConfig(t)
+	_, conf1 := testServerConfig(t)
 
 	// Setup dummy logger to catch output
 	var buf bytes.Buffer
@@ -1508,7 +1501,6 @@ func TestServer_CALogging(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dir1)
 	defer s1.Shutdown()
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 


### PR DESCRIPTION
NotifyShutdown was only used for testing. Now that `t.Cleanup` exists, we can use that instead of attaching cleanup to the Server shutdown. This is one small step in reducing or removing the `agent/consul.Config` struct.

The Autopilot test which used NotifyShutdown doesn't need this notification because Shutdown is synchronous. Waiting for the function to return is equivalent.

Also removes a bunch of `defer os.RemoveAll()`, the directory can be removed by the test helper that creates it.

