### PR TITLE
ui: Fix up default namespace no delete test

### DIFF
--- a/ui-v2/tests/acceptance/dc/nspaces/index.feature
+++ b/ui-v2/tests/acceptance/dc/nspaces/index.feature
@@ -10,7 +10,15 @@ Feature: dc / nspaces / index: Nspaces List
       Namespace: default
     ---
     And 1 datacenter model with the value "dc-1"
-    And 3 nspace models
+    And 3 nspace models from yaml
+    ---
+    - Name:  a-namespace
+      Description: a namespace
+    - Name:  default
+      Description: The default namespace
+    - Name:  z-namespace
+      Description: z namespace
+    ---
     When I visit the nspaces page for yaml
     ---
       dc: dc-1
@@ -29,9 +37,5 @@ Feature: dc / nspaces / index: Nspaces List
     And I see 1 nspace model with the description "The default namespace"
   Scenario: The default namespace can't be deleted
     Then I see 3 nspace models
-    Then I fill in with yaml
-    ---
-    s: default
-    ---
-    And I click actions on the nspaces
-    Then I don't see delete on the nspaces
+    And I click nspaces.1.actions
+    Then I don't see nspaces.1.delete


### PR DESCRIPTION
Mock out namespaces to test to prevent things changing at all in future, but make sure the default namespace is second in order, then assert on the second row (the default namespace) in the listing.