### PR TITLE
ui: Add unique slug key id to proxy

### DIFF
--- a/ui-v2/app/models/proxy.js
+++ b/ui-v2/app/models/proxy.js
@@ -2,10 +2,10 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 
 export const PRIMARY_KEY = 'uid';
-export const SLUG_KEY = 'ID';
+export const SLUG_KEY = 'Node,ServiceID';
 export default Model.extend({
   [PRIMARY_KEY]: attr('string'),
-  [SLUG_KEY]: attr('string'),
+  ID: attr('string'),
   ServiceName: attr('string'),
   ServiceID: attr('string'),
   Node: attr('string'),

--- a/ui-v2/app/utils/create-fingerprinter.js
+++ b/ui-v2/app/utils/create-fingerprinter.js
@@ -4,16 +4,20 @@ export default function(foreignKey, nspaceKey, hash = JSON.stringify) {
       throw new Error('Unable to create fingerprint, missing foreignKey value');
     }
     return function(item) {
-      if (item[slugKey] == null || item[slugKey].length < 1) {
-        throw new Error('Unable to create fingerprint, missing slug');
-      }
+      const slugKeys = slugKey.split(',');
+      const slugValues = slugKeys.map(function(slugKey) {
+        if (item[slugKey] == null || item[slugKey].length < 1) {
+          throw new Error('Unable to create fingerprint, missing slug');
+        }
+        return item[slugKey];
+      });
       const nspaceValue = item[nspaceKey] || 'default';
       return {
         ...item,
         ...{
           [nspaceKey]: nspaceValue,
           [foreignKey]: foreignKeyValue,
-          [primaryKey]: hash([nspaceValue, foreignKeyValue, item[slugKey]]),
+          [primaryKey]: hash([nspaceValue, foreignKeyValue].concat(slugValues)),
         },
       };
     };


### PR DESCRIPTION
Recently, we noticed not all instances had the label connected with proxy even when they did have a proxy. Looking into the issue we realized Ember Data was not able to differentiate between the instances because they don't have a unique ID. The solution to this was to create a unique slug key. We did this by concatenating Node, and Service ID (dc and nspace is already concatenated to generate a unique id). This is a temporary solution. Long term, we plan on implementing a better solution in the serializer. 