### PR TITLE
state: remove unused Store method receiver

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -510,7 +510,7 @@ func New(options ...AgentOption) (*Agent, error) {
 
 	// Retrieve or generate the node ID before setting up the rest of the
 	// agent, which depends on it.
-	config.NodeID, err = newNodeIDFromConfig(a.config, a.logger)
+	cfg.NodeID, err = newNodeIDFromConfig(a.config, a.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup node ID: %w", err)
 	}

--- a/agent/consul/state/acl_oss.go
+++ b/agent/consul/state/acl_oss.go
@@ -218,15 +218,15 @@ func aclPolicyInsert(tx *txn, policy *structs.ACLPolicy) error {
 	return nil
 }
 
-func aclPolicyGetByID(tx *txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func aclPolicyGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "id", id)
 }
 
-func aclPolicyGetByName(tx *txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func aclPolicyGetByName(tx ReadTxn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-policies", "name", name)
 }
 
-func aclPolicyList(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func aclPolicyList(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-policies", "id")
 }
 
@@ -343,15 +343,15 @@ func aclRoleInsert(tx *txn, role *structs.ACLRole) error {
 	return nil
 }
 
-func aclRoleGetByID(tx *txn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func aclRoleGetByID(tx ReadTxn, id string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "id", id)
 }
 
-func aclRoleGetByName(tx *txn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func aclRoleGetByName(tx ReadTxn, name string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("acl-roles", "name", name)
 }
 
-func aclRoleList(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func aclRoleList(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("acl-roles", "id")
 }
 

--- a/agent/consul/state/acl_test.go
+++ b/agent/consul/state/acl_test.go
@@ -4105,7 +4105,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		_, err := resolveACLLinks(tx, links, func(*txn, string) (string, error) {
+		_, err := resolveACLLinks(tx, links, func(ReadTxn, string) (string, error) {
 			err := fmt.Errorf("Should not be attempting to resolve an empty id")
 			require.Fail(t, err.Error())
 			return "", err
@@ -4131,7 +4131,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := resolveACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
+		numValid, err := resolveACLLinks(tx, links, func(_ ReadTxn, linkID string) (string, error) {
 			switch linkID {
 			case "e81887b4-836b-4053-a1fa-7e8305902be9":
 				return "foo", nil
@@ -4161,7 +4161,7 @@ func TestStateStore_resolveACLLinks(t *testing.T) {
 			},
 		}
 
-		numValid, err := resolveACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
+		numValid, err := resolveACLLinks(tx, links, func(_ ReadTxn, linkID string) (string, error) {
 			require.Equal(t, "b985e082-25d3-45a9-9dd8-fd1a41b83b0d", linkID)
 			return "", nil
 		})
@@ -4201,7 +4201,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
+		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ ReadTxn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4228,7 +4228,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
+		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ ReadTxn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4260,7 +4260,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ *txn, linkID string) (string, error) {
+		newLinks, cloned, err := fixupACLLinks(tx, links, func(_ ReadTxn, linkID string) (string, error) {
 			switch linkID {
 			case "40b57f86-97ea-40e4-a99a-c399cc81f4dd":
 				return "foo", nil
@@ -4287,7 +4287,7 @@ func TestStateStore_fixupACLLinks(t *testing.T) {
 		tx := s.db.Txn(false)
 		defer tx.Abort()
 
-		_, _, err := fixupACLLinks(tx, links, func(*txn, string) (string, error) {
+		_, _, err := fixupACLLinks(tx, links, func(ReadTxn, string) (string, error) {
 			return "", fmt.Errorf("Resolver Error")
 		})
 

--- a/agent/consul/state/autopilot.go
+++ b/agent/consul/state/autopilot.go
@@ -77,7 +77,7 @@ func (s *Store) AutopilotSetConfig(idx uint64, config *autopilot.Config) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
-	if err := s.autopilotSetConfigTxn(idx, tx, config); err != nil {
+	if err := autopilotSetConfigTxn(tx, idx, config); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (
 		return false, nil
 	}
 
-	if err := s.autopilotSetConfigTxn(idx, tx, config); err != nil {
+	if err := autopilotSetConfigTxn(tx, idx, config); err != nil {
 		return false, err
 	}
 
@@ -113,7 +113,7 @@ func (s *Store) AutopilotCASConfig(idx, cidx uint64, config *autopilot.Config) (
 	return err == nil, err
 }
 
-func (s *Store) autopilotSetConfigTxn(idx uint64, tx *txn, config *autopilot.Config) error {
+func autopilotSetConfigTxn(tx *txn, idx uint64, config *autopilot.Config) error {
 	// Check for an existing config
 	existing, err := tx.First("autopilot-config", "id")
 	if err != nil {

--- a/agent/consul/state/catalog_oss.go
+++ b/agent/consul/state/catalog_oss.go
@@ -223,46 +223,46 @@ func catalogInsertService(tx *txn, svc *structs.ServiceNode) error {
 	return nil
 }
 
-func catalogServicesMaxIndex(tx *txn, _ *structs.EnterpriseMeta) uint64 {
+func catalogServicesMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "services")
 }
 
-func catalogServiceMaxIndex(tx *txn, serviceName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func catalogServiceMaxIndex(tx ReadTxn, serviceName string, _ *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch("index", "id", serviceIndexName(serviceName, nil))
 }
 
-func catalogServiceKindMaxIndex(tx *txn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) uint64 {
+func catalogServiceKindMaxIndex(tx ReadTxn, ws memdb.WatchSet, kind structs.ServiceKind, entMeta *structs.EnterpriseMeta) uint64 {
 	return maxIndexWatchTxn(tx, ws, serviceKindIndexName(kind, nil))
 }
 
-func catalogServiceList(tx *txn, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
+func catalogServiceList(tx ReadTxn, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
 	return tx.Get("services", "id")
 }
 
-func catalogServiceListByKind(tx *txn, kind structs.ServiceKind, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogServiceListByKind(tx ReadTxn, kind structs.ServiceKind, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("services", "kind", string(kind))
 }
 
-func catalogServiceListByNode(tx *txn, node string, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
+func catalogServiceListByNode(tx ReadTxn, node string, _ *structs.EnterpriseMeta, _ bool) (memdb.ResultIterator, error) {
 	return tx.Get("services", "node", node)
 }
 
-func catalogServiceNodeList(tx *txn, name string, index string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogServiceNodeList(tx ReadTxn, name string, index string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("services", index, name)
 }
 
-func catalogServiceLastExtinctionIndex(tx *txn, _ *structs.EnterpriseMeta) (interface{}, error) {
+func catalogServiceLastExtinctionIndex(tx ReadTxn, _ *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First("index", "id", serviceLastExtinctionIndexName)
 }
 
-func catalogMaxIndex(tx *txn, _ *structs.EnterpriseMeta, checks bool) uint64 {
+func catalogMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
 		return maxIndexTxn(tx, "nodes", "services", "checks")
 	}
 	return maxIndexTxn(tx, "nodes", "services")
 }
 
-func catalogMaxIndexWatch(tx *txn, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
+func catalogMaxIndexWatch(tx ReadTxn, ws memdb.WatchSet, _ *structs.EnterpriseMeta, checks bool) uint64 {
 	if checks {
 		return maxIndexWatchTxn(tx, ws, "nodes", "services", "checks")
 	}
@@ -277,32 +277,32 @@ func catalogUpdateCheckIndexes(tx *txn, idx uint64, _ *structs.EnterpriseMeta) e
 	return nil
 }
 
-func catalogChecksMaxIndex(tx *txn, _ *structs.EnterpriseMeta) uint64 {
+func catalogChecksMaxIndex(tx ReadTxn, _ *structs.EnterpriseMeta) uint64 {
 	return maxIndexTxn(tx, "checks")
 }
 
-func catalogListChecksByNode(tx *txn, node string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogListChecksByNode(tx ReadTxn, node string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node", node)
 }
 
-func catalogListChecksByService(tx *txn, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogListChecksByService(tx ReadTxn, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "service", service)
 }
 
-func catalogListChecksInState(tx *txn, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogListChecksInState(tx ReadTxn, state string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	// simpler than normal due to the use of the CompoundMultiIndex
 	return tx.Get("checks", "status", state)
 }
 
-func catalogListChecks(tx *txn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogListChecks(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "id")
 }
 
-func catalogListNodeChecks(tx *txn, node string) (memdb.ResultIterator, error) {
+func catalogListNodeChecks(tx ReadTxn, node string) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service_check", node, false)
 }
 
-func catalogListServiceChecks(tx *txn, node string, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogListServiceChecks(tx ReadTxn, node string, service string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service", node, service)
 }
 
@@ -319,14 +319,14 @@ func catalogInsertCheck(tx *txn, chk *structs.HealthCheck, idx uint64) error {
 	return nil
 }
 
-func catalogChecksForNodeService(tx *txn, node string, service string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func catalogChecksForNodeService(tx ReadTxn, node string, service string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get("checks", "node_service", node, service)
 }
 
-func validateRegisterRequestTxn(tx *txn, args *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
+func validateRegisterRequestTxn(_ *txn, _ *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
 	return nil, nil
 }
 
-func (s *Store) ValidateRegisterRequest(args *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
+func (s *Store) ValidateRegisterRequest(_ *structs.RegisterRequest) (*structs.EnterpriseMeta, error) {
 	return nil, nil
 }

--- a/agent/consul/state/config_entry_oss.go
+++ b/agent/consul/state/config_entry_oss.go
@@ -49,25 +49,27 @@ func configTableSchema() *memdb.TableSchema {
 	}
 }
 
-func firstConfigEntryWithTxn(tx *txn,
-	kind, name string, entMeta *structs.EnterpriseMeta) (interface{}, error) {
+func firstConfigEntryWithTxn(tx ReadTxn, kind, name string, _ *structs.EnterpriseMeta) (interface{}, error) {
 	return tx.First(configTableName, "id", kind, name)
 }
 
-func firstWatchConfigEntryWithTxn(tx *txn,
-	kind, name string, entMeta *structs.EnterpriseMeta) (<-chan struct{}, interface{}, error) {
+func firstWatchConfigEntryWithTxn(
+	tx ReadTxn,
+	kind string,
+	name string,
+	_ *structs.EnterpriseMeta,
+) (<-chan struct{}, interface{}, error) {
 	return tx.FirstWatch(configTableName, "id", kind, name)
 }
 
-func validateConfigEntryEnterprise(tx *txn, conf structs.ConfigEntry) error {
+func validateConfigEntryEnterprise(_ ReadTxn, _ structs.ConfigEntry) error {
 	return nil
 }
 
-func getAllConfigEntriesWithTxn(tx *txn, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func getAllConfigEntriesWithTxn(tx ReadTxn, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "id")
 }
 
-func getConfigEntryKindsWithTxn(tx *txn,
-	kind string, entMeta *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
+func getConfigEntryKindsWithTxn(tx ReadTxn, kind string, _ *structs.EnterpriseMeta) (memdb.ResultIterator, error) {
 	return tx.Get(configTableName, "kind", kind)
 }

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -10,6 +10,8 @@ import (
 // ReadTxn is implemented by memdb.Txn to perform read operations.
 type ReadTxn interface {
 	Get(table, index string, args ...interface{}) (memdb.ResultIterator, error)
+	First(table, index string, args ...interface{}) (interface{}, error)
+	FirstWatch(table, index string, args ...interface{}) (<-chan struct{}, interface{}, error)
 	Abort()
 }
 

--- a/agent/consul/state/state_store.go
+++ b/agent/consul/state/state_store.go
@@ -258,11 +258,11 @@ func (s *Store) maxIndex(tables ...string) uint64 {
 
 // maxIndexTxn is a helper used to retrieve the highest known index
 // amongst a set of tables in the db.
-func maxIndexTxn(tx *txn, tables ...string) uint64 {
+func maxIndexTxn(tx ReadTxn, tables ...string) uint64 {
 	return maxIndexWatchTxn(tx, nil, tables...)
 }
 
-func maxIndexWatchTxn(tx *txn, ws memdb.WatchSet, tables ...string) uint64 {
+func maxIndexWatchTxn(tx ReadTxn, ws memdb.WatchSet, tables ...string) uint64 {
 	var lindex uint64
 	for _, table := range tables {
 		ch, ti, err := tx.FirstWatch("index", "id", table)

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -110,7 +110,7 @@ func (s *Store) txnKVS(tx *txn, idx uint64, op *structs.TxnKVOp) (structs.TxnRes
 }
 
 // txnSession handles all Session-related operations.
-func (s *Store) txnSession(tx *txn, idx uint64, op *structs.TxnSessionOp) error {
+func txnSession(tx *txn, idx uint64, op *structs.TxnSessionOp) error {
 	var err error
 
 	switch op.Verb {
@@ -127,7 +127,7 @@ func (s *Store) txnSession(tx *txn, idx uint64, op *structs.TxnSessionOp) error 
 }
 
 // txnIntention handles all Intention-related operations.
-func (s *Store) txnIntention(tx *txn, idx uint64, op *structs.TxnIntentionOp) error {
+func txnIntention(tx *txn, idx uint64, op *structs.TxnIntentionOp) error {
 	switch op.Op {
 	case structs.IntentionOpCreate, structs.IntentionOpUpdate:
 		return intentionSetTxn(tx, idx, op.Intention)
@@ -344,7 +344,7 @@ func (s *Store) txnDispatch(tx *txn, idx uint64, ops structs.TxnOps) (structs.Tx
 		case op.KV != nil:
 			ret, err = s.txnKVS(tx, idx, op.KV)
 		case op.Intention != nil:
-			err = s.txnIntention(tx, idx, op.Intention)
+			err = txnIntention(tx, idx, op.Intention)
 		case op.Node != nil:
 			ret, err = s.txnNode(tx, idx, op.Node)
 		case op.Service != nil:
@@ -352,7 +352,7 @@ func (s *Store) txnDispatch(tx *txn, idx uint64, ops structs.TxnOps) (structs.Tx
 		case op.Check != nil:
 			ret, err = s.txnCheck(tx, idx, op.Check)
 		case op.Session != nil:
-			err = s.txnSession(tx, idx, op.Session)
+			err = txnSession(tx, idx, op.Session)
 		default:
 			err = fmt.Errorf("no operation specified")
 		}


### PR DESCRIPTION
This is a follow up to #8282. I'll need this for adding Terminating Gateways to streaming as a follow up to #8357. 

This was the last of the methods that I could find that do not use their receiver.

Also changed some functions to use the `ReadTxn` interface where appropriate.

