### PR TITLE
Backport catalog snapshot index fix to 1.7.x

### DIFF
--- a/agent/consul/fsm/snapshot_oss.go
+++ b/agent/consul/fsm/snapshot_oss.go
@@ -95,6 +95,7 @@ func (s *snapshot) persistNodes(sink raft.SnapshotSink,
 			Address:         n.Address,
 			TaggedAddresses: n.TaggedAddresses,
 			NodeMeta:        n.Meta,
+			RaftIndex:       n.RaftIndex,
 		}
 
 		// Register the node itself

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -357,7 +357,7 @@ func (s *Store) ensureNodeTxn(tx *memdb.Txn, idx uint64, preserveIndexes bool, n
 		node.ModifyIndex = idx
 	} else if !preserveIndexes || node.CreateIndex == 0 {
 		// If this isn't a snapshot or there were no saved indexes, set CreateIndex
-		// and ModifyIndex from the given index. Prior to 1.9.0/1.8.3/1.7.7/1.6.8 nodes
+		// and ModifyIndex from the given index. Prior to 1.9.0/1.8.3/1.7.7, nodes
 		// were not saved with an index, so this is to avoid ending up with a 0 index
 		// when loading a snapshot from an older version.
 		node.CreateIndex = idx

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -138,7 +138,7 @@ func TestStateStore_ensureNoNodeWithSimilarNameTxn(t *testing.T) {
 	if err := s.ensureNoNodeWithSimilarNameTxn(tx, newNode, false); err == nil {
 		t.Fatalf("Should return an error since the previous node is still healthy")
 	}
-	s.ensureCheckTxn(tx, 5, &structs.HealthCheck{
+	s.ensureCheckTxn(tx, 5, false, &structs.HealthCheck{
 		Node:    "node1",
 		CheckID: structs.SerfCheckID,
 		Status:  api.HealthCritical,
@@ -391,6 +391,10 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 		ID:      makeRandomNodeID(t),
 		Node:    "node1",
 		Address: "1.2.3.4",
+		RaftIndex: structs.RaftIndex{
+			CreateIndex: 1,
+			ModifyIndex: 1,
+		},
 	}
 	nodeID := string(req.ID)
 	nodeName := string(req.Node)
@@ -429,6 +433,10 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 		Address: "1.1.1.1",
 		Port:    8080,
 		Weights: &structs.Weights{Passing: 1, Warning: 1},
+		RaftIndex: structs.RaftIndex{
+			CreateIndex: 2,
+			ModifyIndex: 2,
+		},
 	}
 	restore = s.Restore()
 	if err := restore.Registration(2, req); err != nil {
@@ -461,6 +469,10 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 		Node:    nodeName,
 		CheckID: "check1",
 		Name:    "check",
+		RaftIndex: structs.RaftIndex{
+			CreateIndex: 3,
+			ModifyIndex: 3,
+		},
 	}
 	restore = s.Restore()
 	if err := restore.Registration(3, req); err != nil {
@@ -498,6 +510,10 @@ func TestStateStore_EnsureRegistration_Restore(t *testing.T) {
 			Node:    nodeName,
 			CheckID: "check2",
 			Name:    "check",
+			RaftIndex: structs.RaftIndex{
+				CreateIndex: 4,
+				ModifyIndex: 4,
+			},
 		},
 	}
 	restore = s.Restore()

--- a/agent/consul/state/txn.go
+++ b/agent/consul/state/txn.go
@@ -160,7 +160,7 @@ func (s *Store) txnNode(tx *memdb.Txn, idx uint64, op *structs.TxnNodeOp) (struc
 		}
 
 	case api.NodeSet:
-		err = s.ensureNodeTxn(tx, idx, &op.Node)
+		err = s.ensureNodeTxn(tx, idx, false, &op.Node)
 		if err == nil {
 			entry, err = getNode()
 		}
@@ -221,7 +221,7 @@ func (s *Store) txnService(tx *memdb.Txn, idx uint64, op *structs.TxnServiceOp) 
 		}
 
 	case api.ServiceSet:
-		err = s.ensureServiceTxn(tx, idx, op.Node, &op.Service)
+		err = s.ensureServiceTxn(tx, idx, op.Node, false, &op.Service)
 		entry, err = s.getNodeServiceTxn(tx, op.Node, op.Service.ID, &op.Service.EnterpriseMeta)
 
 	case api.ServiceCAS:
@@ -280,7 +280,7 @@ func (s *Store) txnCheck(tx *memdb.Txn, idx uint64, op *structs.TxnCheckOp) (str
 		}
 
 	case api.CheckSet:
-		err = s.ensureCheckTxn(tx, idx, &op.Check)
+		err = s.ensureCheckTxn(tx, idx, false, &op.Check)
 		if err == nil {
 			_, entry, err = s.getNodeCheckTxn(tx, op.Check.Node, op.Check.CheckID, &op.Check.EnterpriseMeta)
 		}

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -294,6 +294,7 @@ type RegisterRequest struct {
 	EnterpriseMeta `hcl:",squash" mapstructure:",squash"`
 
 	WriteRequest
+	RaftIndex `bexpr:"-"`
 }
 
 func (r *RegisterRequest) RequestDatacenter() string {


### PR DESCRIPTION
This pulls the changes from #8474 into the `release/1.7.x` branch.