### PR TITLE
Refactor api-docs links to learn

### DIFF
--- a/website/pages/api-docs/acl-legacy.mdx
+++ b/website/pages/api-docs/acl-legacy.mdx
@@ -12,8 +12,8 @@ the new ACL [Token](/docs/api/acl-token) and [Policy](/docs/api/acl-policy) APIs
 
 # ACL HTTP API
 
-These `/acl` endpoints create, update, destroy, and query ACL tokens in Consul. For more information about ACLs, please see the
-[ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls).
+These `/acl` endpoints create, update, destroy, and query ACL tokens in Consul. For more information about ACLs, please check the
+[ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Bootstrap ACLs
 
@@ -62,8 +62,8 @@ a 403 means that the cluster has already been bootstrapped, at which point you s
 consider the cluster in a potentially compromised state.
 
 The returned token will be a management token which can be used to further configure the
-ACL system. Please see the
-[ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls) for more details.
+ACL system. Please check the
+[ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production) for more details.
 
 ## Create ACL Token
 
@@ -94,7 +94,7 @@ The table below shows this endpoint's support for
   are: `client` and `management`.
 
 - `Rules` `(string: "")` - Specifies rules for this ACL token. The format of the
-  `Rules` property is documented in the [ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls).
+  `Rules` property is documented in the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ### Sample Payload
 
@@ -348,7 +348,7 @@ This endpoint returns the status of the ACL replication process in the
 datacenter. This is intended to be used by operators, or by automation checking
 the health of ACL replication.
 
-Please see the [ACL Replication Guide](https://learn.hashicorp.com/consul/day-2-operations/acl-replication) for more details.
+Please check the [ACL Replication tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-replication-multiple-datacenters)
 for more details.
 
 | Method | Path               | Produces           |

--- a/website/pages/api-docs/acl/auth-methods.mdx
+++ b/website/pages/api-docs/acl/auth-methods.mdx
@@ -14,8 +14,8 @@ The `/acl/auth-method` endpoints [create](#create-an-auth-method),
 [list](#list-auth-methods) and [delete](#delete-an-auth-method)
 ACL auth methods in Consul.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create an Auth Method
 

--- a/website/pages/api-docs/acl/binding-rules.mdx
+++ b/website/pages/api-docs/acl/binding-rules.mdx
@@ -14,8 +14,8 @@ The `/acl/binding-rule` endpoints [create](#create-a-binding-rule),
 [list](#list-binding-rules) and [delete](#delete-a-binding-rule) ACL binding
 rules in Consul.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create a Binding Rule
 

--- a/website/pages/api-docs/acl/index.mdx
+++ b/website/pages/api-docs/acl/index.mdx
@@ -11,8 +11,8 @@ description: The /acl endpoints manage the Consul's ACL system.
 
 The `/acl` endpoints are used to manage ACL tokens and policies in Consul, [bootstrap the ACL system](#bootstrap-acls), [check ACL replication status](#check-acl-replication), and [translate rules](#translate-rules). There are additional pages for managing [tokens](/api/acl/tokens) and [policies](/api/acl/policies) with the `/acl` endpoints.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Bootstrap ACLs
 
@@ -78,8 +78,8 @@ a 403 means that the cluster has already been bootstrapped, at which point you s
 consider the cluster in a potentially compromised state.
 
 The returned token will have unrestricted privileges to manage all details of the system.
-It can then be used to further configure the ACL system. Please see the
-[ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls) for more details.
+It can then be used to further configure the ACL system. Please check the
+[ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production) for more details.
 
 ## Check ACL Replication
 
@@ -87,7 +87,7 @@ This endpoint returns the status of the ACL replication processes in the
 datacenter. This is intended to be used by operators or by automation checking
 to discover the health of ACL replication.
 
-Please see the [ACL Replication Guide](https://learn.hashicorp.com/consul/day-2-operations/acl-replication)
+Please check the [ACL Replication tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-replication-multiple-datacenters)
 for more details.
 
 | Method | Path               | Produces           |

--- a/website/pages/api-docs/acl/legacy.mdx
+++ b/website/pages/api-docs/acl/legacy.mdx
@@ -15,7 +15,7 @@ the new ACL [Token](/api/acl/tokens) and [Policy](/api/acl/policies) APIs instea
 
 The `/acl` endpoints create, update, destroy, and query ACL tokens in Consul.
 
-For more information about ACLs, please see the [ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls).
+For more information about ACLs, please check the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create ACL Token
 

--- a/website/pages/api-docs/acl/policies.mdx
+++ b/website/pages/api-docs/acl/policies.mdx
@@ -13,8 +13,8 @@ The `/acl/policy` endpoints [create](#create-a-policy), [read](#read-a-policy),
 [update](#update-a-policy), [list](#list-policies) and
 [delete](#delete-a-policy) ACL policies in Consul.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create a Policy
 

--- a/website/pages/api-docs/acl/roles.mdx
+++ b/website/pages/api-docs/acl/roles.mdx
@@ -12,8 +12,8 @@ description: The /acl/role endpoints manage Consul's ACL Roles.
 The `/acl/role` endpoints [create](#create-a-role), [read](#read-a-role),
 [update](#update-a-role), [list](#list-roles) and [delete](#delete-a-role) ACL roles in Consul.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create a Role
 

--- a/website/pages/api-docs/acl/tokens.mdx
+++ b/website/pages/api-docs/acl/tokens.mdx
@@ -12,8 +12,8 @@ description: The /acl/token endpoints manage Consul's ACL Tokens.
 The `/acl/token` endpoints [create](#create-a-token), [read](#read-a-token),
 [update](#update-a-token), [list](#list-tokens), [clone](#clone-a-token) and [delete](#delete-a-token) ACL tokens in Consul.
 
-For more information on how to setup ACLs, please see
-the [ACL Guide](https://learn.hashicorp.com/consul/advanced/day-1-operations/production-acls).
+For more information on how to setup ACLs, please check
+the [ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production).
 
 ## Create a Token
 

--- a/website/pages/api-docs/kv.mdx
+++ b/website/pages/api-docs/kv.mdx
@@ -197,7 +197,8 @@ The table below shows this endpoint's support for
   that does not include the acquire parameter will proceed normally even if another
   session has locked the key.**
 
-  For an example of how to use the lock feature, see the [Leader Election Guide](https://learn.hashicorp.com/consul/developer-configuration/elections).
+  For an example of how to use the lock feature, check the 
+  [Leader Election tutorial](https://learn.hashicorp.com/tutorials/consul/application-leader-elections).
 
 - `release` `(string: "")` - Supply a session ID to use in a release operation. This is
   useful when paired with `?acquire=` as it allows clients to yield a lock. This

--- a/website/pages/api-docs/operator/area.mdx
+++ b/website/pages/api-docs/operator/area.mdx
@@ -25,7 +25,7 @@ datacenters, so not all servers need to be fully connected. This allows for
 complex topologies among Consul datacenters like hub/spoke and more general
 trees.
 
-Please see the [Network Areas Guide](https://learn.hashicorp.com/consul/day-2-operations/advanced-federation) for more details.
+Please check the [Network Areas tutorial](https://learn.hashicorp.com/tutorials/consul/federation-network-areas) for more details.
 
 ## Create Network Area
 

--- a/website/pages/api-docs/operator/autopilot.mdx
+++ b/website/pages/api-docs/operator/autopilot.mdx
@@ -14,7 +14,7 @@ The `/operator/autopilot` endpoints allow for automatic operator-friendly
 management of Consul servers including cleanup of dead servers, monitoring
 the state of the Raft cluster, and stable server introduction.
 
-Please see the [Autopilot Guide](https://learn.hashicorp.com/consul/day-2-operations/autopilot) for more details.
+Please check the [Autopilot tutorial](https://learn.hashicorp.com/tutorials/consul/autopilot-datacenter-operations) for more details.
 
 ## Read Configuration
 

--- a/website/pages/api-docs/operator/index.mdx
+++ b/website/pages/api-docs/operator/index.mdx
@@ -11,14 +11,14 @@ description: |-
 
 The `/operator` endpoints provide cluster-level tools for Consul operators,
 such as interacting with the Raft subsystem. For a CLI to perform these
-operations manually, please see the documentation for the
+operations manually, please check the documentation for the
 [`consul operator`](/docs/commands/operator) command.
 
 If ACLs are enabled then a token with operator privileges may be required in
-order to use this interface. See the [ACL Rules documentation](/docs/acl/acl-rules#operator-rules)
+order to use this interface. Check the [ACL Rules documentation](/docs/acl/acl-rules#operator-rules)
 for more information.
 
-See the [Outage Recovery](https://learn.hashicorp.com/consul/day-2-operations/outage) guide for some examples of
+Check the [Outage Recovery](https://learn.hashicorp.com/tutorials/consul/recovery-outage) tutorial for some examples of
 how these capabilities are used.
 
 Please choose a sub-section in the navigation for more information.

--- a/website/pages/api-docs/operator/segment.mdx
+++ b/website/pages/api-docs/operator/segment.mdx
@@ -19,7 +19,7 @@ The network area functionality described here is available only in
 later. Network segments are operator-defined sections of agents on the LAN, typically
 isolated from other segments by network configuration.
 
-Please see the [Network Segments Guide](https://learn.hashicorp.com/consul/day-2-operations/network-segments) for more details.
+Please check the [Network Segments tutorial](https://learn.hashicorp.com/tutorials/consul/network-partition-datacenters) for more details.
 
 ## List Network Segments
 

--- a/website/pages/api-docs/query.mdx
+++ b/website/pages/api-docs/query.mdx
@@ -15,10 +15,10 @@ service. This is particularly useful in combination with Consul's
 [DNS Interface](/docs/agent/dns) as it allows for much richer queries than
 would be possible given the limited entry points exposed by DNS.
 
-See the [Geo Failover Guide](https://learn.hashicorp.com/consul/developer-discovery/geo-failover) for details and
+Check the [Geo Failover tutorial](https://learn.hashicorp.com/tutorials/consul/automate-geo-failover) for details and
 examples for using prepared queries to implement geo failover for services.
 
-See the [prepared query rules](/docs/agent/acl-rules#prepared-query-rules)
+Check the [prepared query rules](/docs/agent/acl-rules#prepared-query-rules)
 section of the agent ACL documentation for more details about how prepared
 queries work with Consul's ACL system.
 

--- a/website/pages/api-docs/session.mdx
+++ b/website/pages/api-docs/session.mdx
@@ -61,7 +61,7 @@ The table below shows this endpoint's support for
   86400s). If provided, the session is invalidated if it is not renewed before
   the TTL expires. The lowest practical TTL should be used to keep the number of
   managed sessions low. When locks are forcibly expired, such as when following
-  the [leader election pattern](https://learn.hashicorp.com/consul/developer-configuration/elections) in an application,
+  the [leader election pattern](https://learn.hashicorp.com/tutorials/consul/application-leader-elections) in an application,
   sessions may not be reaped for up to double this TTL, so long TTL
   values (> 1 hour) should be avoided. Valid time units include "s", "m" and "h".
 


### PR DESCRIPTION
First batch of changes for the link refactor that is following the switch to Collections in learn.hashicorp.com.

This PR contains all the changes for pages under `website/pages/api-docs`.

First PR: https://github.com/hashicorp/consul/pull/8488
Second PR: https://github.com/hashicorp/consul/pull/8490
Third: PR: https://github.com/hashicorp/consul/pull/8491

Related PR: https://github.com/hashicorp/consul/pull/8487

