### PR TITLE
Refactor docs links to learn 2

### DIFF
--- a/website/pages/docs/commands/acl/bootstrap.mdx
+++ b/website/pages/docs/commands/acl/bootstrap.mdx
@@ -11,7 +11,7 @@ Command: `consul acl bootstrap`
 The `acl bootstrap` command will request Consul to generate a new token with unlimited privileges to use
 for management purposes and output its details. This can only be done once and afterwards bootstrapping
 will be disabled. If all tokens are lost and you need to bootstrap again you can follow the bootstrap
-[reset procedure](https://learn.hashicorp.com/consul/security-networking/acl-troubleshooting?utm_source=consul.io&utm_medium=docs#reset-the-acl-system).
+[reset procedure](https://learn.hashicorp.com/tutorials/consul/access-control-troubleshoot?utm_source=consul.io&utm_medium=docs#reset-the-acl-system).
 
 The ACL system can also be bootstrapped via the [HTTP API](/api/acl/acl#bootstrap-acls).
 

--- a/website/pages/docs/commands/acl/token/update.mdx
+++ b/website/pages/docs/commands/acl/token/update.mdx
@@ -56,8 +56,8 @@ Usage: `consul acl token update [options]`
 specified grant equivalent or appropriate access for the existing clients using
 this token. You can find examples on how to use the parameter in the [legacy
 token
-migration](https://learn.hashicorp.com/consul/day-2-agent-authentication/migrate-acl-tokens)
-guide.
+migration](https://learn.hashicorp.com/tutorials/consul/access-control-token-migration)
+tutorial.
 
 - `-format={pretty|json}` - Command output format. The default value is `pretty`.
 

--- a/website/pages/docs/commands/force-leave.mdx
+++ b/website/pages/docs/commands/force-leave.mdx
@@ -48,7 +48,7 @@ consul force-leave ec2-001-staging
 ```
 
 When run on a server that is part of a
-[WAN gossip pool](https://learn.hashicorp.com/consul/security-networking/datacenters),
+[WAN gossip pool](https://learn.hashicorp.com/tutorials/consul/federarion-gossip-wan),
 `force-leave` can remove failed servers in other datacenters from the WAN pool.
 
 The identifying node-name in a WAN pool is `[node-name].[datacenter]`.

--- a/website/pages/docs/commands/license.mdx
+++ b/website/pages/docs/commands/license.mdx
@@ -17,8 +17,8 @@ The `license` command provides datacenter-level management of the Consul Enterpr
 
 If ACLs are enabled then a token with operator privileges may be required in
 order to use this command. Requests are forwarded internally to the leader
-if required, so this can be run from any Consul node in a cluster. See the
-[ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls) for more information.
+if required, so this can be run from any Consul node in a cluster. Review the
+[ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production) for more information.
 
 ```text
 Usage: consul license <subcommand> [options] [args]

--- a/website/pages/docs/commands/lock.mdx
+++ b/website/pages/docs/commands/lock.mdx
@@ -19,11 +19,11 @@ communication is disrupted, the child process is terminated.
 
 The number of lock holders is configurable with the `-n` flag. By default,
 a single holder is allowed, and a lock is used for mutual exclusion. This
-uses the [leader election algorithm](https://learn.hashicorp.com/consul/developer-configuration/elections).
+uses the [leader election algorithm](https://learn.hashicorp.com/tutorials/consul/application-leader-elections).
 
 If the lock holder count is more than one, then a semaphore is used instead.
 A semaphore allows more than a single holder, but this is less efficient than
-a simple lock. This follows the [semaphore algorithm](https://learn.hashicorp.com/consul/developer-configuration/semaphore).
+a simple lock. This follows the [semaphore algorithm](https://learn.hashicorp.com/tutorials/consul/distributed-semaphore).
 
 All locks using the same prefix must agree on the value of `-n`. If conflicting
 values of `-n` are provided, an error will be returned.

--- a/website/pages/docs/commands/operator/area.mdx
+++ b/website/pages/docs/commands/operator/area.mdx
@@ -22,7 +22,7 @@ and relationships can be made between independent pairs of datacenters, so not a
 need to be fully connected. This allows for complex topologies among Consul datacenters like
 hub/spoke and more general trees.
 
-See the [Network Areas Guide](https://learn.hashicorp.com/consul/day-2-operations/advanced-federation) for more details.
+Review the [Network Areas tutorial](https://learn.hashicorp.com/tutorials/consul/federation-network-areas) for more details.
 
 ```text
 Usage: consul operator area <subcommand> [options]

--- a/website/pages/docs/commands/operator/autopilot.mdx
+++ b/website/pages/docs/commands/operator/autopilot.mdx
@@ -12,8 +12,8 @@ description: >
 Command: `consul operator autopilot`
 
 The Autopilot operator command is used to interact with Consul's Autopilot subsystem. The
-command can be used to view or modify the current Autopilot configuration. See the
-[Autopilot Guide](https://learn.hashicorp.com/consul/day-2-operations/autopilot) for more information about Autopilot.
+command can be used to view or modify the current Autopilot configuration. Review the
+[Autopilot tutorial](https://learn.hashicorp.com/tutorials/consul/autopilot-datacenter-operations) for more information about Autopilot.
 
 ```text
 Usage: consul operator autopilot <subcommand> [options]

--- a/website/pages/docs/commands/operator/index.mdx
+++ b/website/pages/docs/commands/operator/index.mdx
@@ -18,12 +18,12 @@ outage and even loss of data.
 
 If ACLs are enabled then a token with operator privileges may be required in
 order to use this command. Requests are forwarded internally to the leader
-if required, so this can be run from any Consul node in a cluster. See the
-[ACL Guide](https://learn.hashicorp.com/consul/security-networking/production-acls) for more information.
+if required, so this can be run from any Consul node in a cluster. Review the
+[ACL tutorial](https://learn.hashicorp.com/tutorials/consul/access-control-setup-production) for more information.
 
-See the [Outage Recovery](https://learn.hashicorp.com/consul/day-2-operations/outage) guide for some examples of how
+Review the [Outage Recovery](https://learn.hashicorp.com/tutorials/consul/recovery-outage) tutorial for some examples of how
 this command is used. For an API to perform these operations programmatically,
-please see the documentation for the [Operator](/api/operator)
+please check the documentation for the [Operator](/api/operator)
 endpoint.
 
 ## Usage

--- a/website/pages/docs/connect/configuration.mdx
+++ b/website/pages/docs/connect/configuration.mdx
@@ -63,7 +63,7 @@ via API.
 
 !> **Security note:** Enabling Connect is enough to try the feature but doesn't
 automatically ensure complete security. Please read the [Connect production
-guide](https://learn.hashicorp.com/consul/developer-segmentation/connect-production) to understand the additional steps
+tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-production-checklist) to understand the additional steps
 needed for a secure deployment.
 
 ## Centralized Proxy and Service Configuration

--- a/website/pages/docs/connect/connect-internals.mdx
+++ b/website/pages/docs/connect/connect-internals.mdx
@@ -16,8 +16,8 @@ may help you reason about Connect's behavior in more complex deployment
 scenarios.
 
 To try Connect locally, complete the [Getting Started with Consul service
-mesh](https://learn.hashicorp.com/consul/gs-consul-service-mesh/understand-consul-service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
-guide.
+mesh](https://learn.hashicorp.com/tutorials/consul/service-mesh?utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS)
+tutorial.
 
 ## Mutual Transport Layer Security (mTLS)
 
@@ -96,7 +96,7 @@ a long period of inactivity (3 days by default), the cache will empty itself.
 
 Sidecar proxy's [upstream configuration](/docs/connect/registration/service-registration#upstream-configuration-reference)
 may specify an alternative datacenter or a prepared query that can address services
-in multiple datacenters (such as the [geo failover](https://learn.hashicorp.com/consul/developer-discovery/geo-failover) pattern).
+in multiple datacenters (such as the [geo failover](https://learn.hashicorp.com/tutorials/consul/automate-geo-failover) pattern).
 
 [Intentions](/docs/connect/intentions) verify connections between services by
 source and destination name seamlessly across datacenters.

--- a/website/pages/docs/connect/connectivity-tasks.mdx
+++ b/website/pages/docs/connect/connectivity-tasks.mdx
@@ -25,7 +25,7 @@ the Gateway.
 As of Consul 1.8.0, mesh gateways can also forward gossip and RPC traffic between Consul servers. 
 This is enabled by [WAN federation via mesh gateways](/docs/connect/gateways/wan-federation-via-mesh-gateways).
 
-For more information about mesh gateways review the [complete documentation](/docs/connect/gateways/mesh-gateway)
+For more information about mesh gateways, review the [complete documentation](/docs/connect/gateways/mesh-gateway)
 and the [mesh gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Mesh Gateway Architecture](/img/mesh-gateways.png)
@@ -42,7 +42,7 @@ an ingress gateway by defining a set of listeners that can map to different sets
 Ingress gateways are tightly integrated with Consul’s L7 configuration and enable dynamic routing of HTTP requests by
 attributes like the request path.
 
-For more information about ingress gateways review the [complete documentation](/docs/connect/gateways/ingress-gateway)
+For more information about ingress gateways, review the [complete documentation](/docs/connect/gateways/ingress-gateway)
 and the [ingress gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
@@ -62,7 +62,7 @@ These gateways also simplify authorization from dynamic service addresses. Consu
 connections through the gateway are authorized. Then traditional tools like firewalls or IAM roles can authorize the
 connections from the known gateway nodes to the destination services.
 
-For more information about terminating gateways review the [complete documentation](/docs/connect/gateways/terminating-gateway)
+For more information about terminating gateways, review the [complete documentation](/docs/connect/gateways/terminating-gateway)
 and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/pages/docs/connect/connectivity-tasks.mdx
+++ b/website/pages/docs/connect/connectivity-tasks.mdx
@@ -25,8 +25,8 @@ the Gateway.
 As of Consul 1.8.0, mesh gateways can also forward gossip and RPC traffic between Consul servers. 
 This is enabled by [WAN federation via mesh gateways](/docs/connect/gateways/wan-federation-via-mesh-gateways).
 
-For more information about mesh gateways see the [complete documentation](/docs/connect/gateways/mesh-gateway)
-and the [mesh gateway guide](https://learn.hashicorp.com/consul/developer-mesh/connect-gateways).
+For more information about mesh gateways review the [complete documentation](/docs/connect/gateways/mesh-gateway)
+and the [mesh gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Mesh Gateway Architecture](/img/mesh-gateways.png)
 
@@ -42,8 +42,8 @@ an ingress gateway by defining a set of listeners that can map to different sets
 Ingress gateways are tightly integrated with Consul’s L7 configuration and enable dynamic routing of HTTP requests by
 attributes like the request path.
 
-For more information about ingress gateways see the [complete documentation](/docs/connect/gateways/ingress-gateway)
-and the [ingress gateway guide](https://learn.hashicorp.com/consul/developer-mesh/ingress-gateways).
+For more information about ingress gateways review the [complete documentation](/docs/connect/gateways/ingress-gateway)
+and the [ingress gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
 
@@ -62,7 +62,7 @@ These gateways also simplify authorization from dynamic service addresses. Consu
 connections through the gateway are authorized. Then traditional tools like firewalls or IAM roles can authorize the
 connections from the known gateway nodes to the destination services.
 
-For more information about terminating gateways see the [complete documentation](/docs/connect/gateways/terminating-gateway)
-and the [terminating gateway guide](https://learn.hashicorp.com/consul/developer-mesh/terminating-gateways).
+For more information about terminating gateways review the [complete documentation](/docs/connect/gateways/terminating-gateway)
+and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/pages/docs/connect/gateways/index.mdx
+++ b/website/pages/docs/connect/gateways/index.mdx
@@ -28,7 +28,7 @@ the Gateway.
 As of Consul 1.8.0, mesh gateways can also forward gossip and RPC traffic between Consul servers. 
 This is enabled by [WAN federation via mesh gateways](/docs/connect/gateways/wan-federation-via-mesh-gateways).
 
-For more information about mesh gateways review the [complete documentation](/docs/connect/gateways/mesh-gateway)
+For more information about mesh gateways, review the [complete documentation](/docs/connect/gateways/mesh-gateway)
 and the [mesh gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Mesh Gateway Architecture](/img/mesh-gateways.png)
@@ -45,7 +45,7 @@ an ingress gateway by defining a set of listeners that can map to different sets
 Ingress gateways are tightly integrated with Consul’s L7 configuration and enable dynamic routing of HTTP requests by
 attributes like the request path.
 
-For more information about ingress gateways review the [complete documentation](/docs/connect/gateways/ingress-gateway)
+For more information about ingress gateways, review the [complete documentation](/docs/connect/gateways/ingress-gateway)
 and the [ingress gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-ingress-gateways).
 
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
@@ -65,7 +65,7 @@ These gateways also simplify authorization from dynamic service addresses. Consu
 connections through the gateway are authorized. Then traditional tools like firewalls or IAM roles can authorize the
 connections from the known gateway nodes to the destination services.
 
-For more information about terminating gateways review the [complete documentation](/docs/connect/gateways/terminating-gateway)
+For more information about terminating gateways, review the [complete documentation](/docs/connect/gateways/terminating-gateway)
 and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/pages/docs/connect/gateways/index.mdx
+++ b/website/pages/docs/connect/gateways/index.mdx
@@ -28,8 +28,8 @@ the Gateway.
 As of Consul 1.8.0, mesh gateways can also forward gossip and RPC traffic between Consul servers. 
 This is enabled by [WAN federation via mesh gateways](/docs/connect/gateways/wan-federation-via-mesh-gateways).
 
-For more information about mesh gateways see the [complete documentation](/docs/connect/gateways/mesh-gateway)
-and the [mesh gateway guide](https://learn.hashicorp.com/consul/developer-mesh/connect-gateways).
+For more information about mesh gateways review the [complete documentation](/docs/connect/gateways/mesh-gateway)
+and the [mesh gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-gateways).
 
 ![Mesh Gateway Architecture](/img/mesh-gateways.png)
 
@@ -45,8 +45,8 @@ an ingress gateway by defining a set of listeners that can map to different sets
 Ingress gateways are tightly integrated with Consul’s L7 configuration and enable dynamic routing of HTTP requests by
 attributes like the request path.
 
-For more information about ingress gateways see the [complete documentation](/docs/connect/gateways/ingress-gateway)
-and the [ingress gateway guide](https://learn.hashicorp.com/consul/developer-mesh/ingress-gateways).
+For more information about ingress gateways review the [complete documentation](/docs/connect/gateways/ingress-gateway)
+and the [ingress gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-ingress-gateways).
 
 ![Ingress Gateway Architecture](/img/ingress-gateways.png)
 
@@ -65,7 +65,7 @@ These gateways also simplify authorization from dynamic service addresses. Consu
 connections through the gateway are authorized. Then traditional tools like firewalls or IAM roles can authorize the
 connections from the known gateway nodes to the destination services.
 
-For more information about terminating gateways see the [complete documentation](/docs/connect/gateways/terminating-gateway)
-and the [terminating gateway guide](https://learn.hashicorp.com/consul/developer-mesh/terminating-gateways).
+For more information about terminating gateways review the [complete documentation](/docs/connect/gateways/terminating-gateway)
+and the [terminating gateway tutorial](https://learn.hashicorp.com/tutorials/consul/teminating-gateways-connect-external-services).
 
 ![Terminating Gateway Architecture](/img/terminating-gateways.png)

--- a/website/pages/docs/connect/gateways/ingress-gateway.mdx
+++ b/website/pages/docs/connect/gateways/ingress-gateway.mdx
@@ -50,7 +50,7 @@ Currently, [Envoy](https://www.envoyproxy.io/) is the only proxy with ingress ga
 ## Running and Using an Ingress Gateway
 
 For a complete example of how to allow external traffic inside your Consul service mesh,
-review the [ingress gateway guide](https://learn.hashicorp.com/consul/developer-mesh/ingress-gateways).
+review the [ingress gateway tutorial](https://learn.hashicorp.com/tutorials/consul/service-mesh-ingress-gateways).
 
 ## Ingress Gateway Configuration
 


### PR DESCRIPTION
Third batch of changes for the link refactor that is following the switch to Collections in learn.hashicorp.com.

This PR contains all the changes for pages under `website/pages/docs/commands` and some of the `website/pages/docs/connect`.

First PR: https://github.com/hashicorp/consul/pull/8488
Second PR: https://github.com/hashicorp/consul/pull/8490
Third: PR: https://github.com/hashicorp/consul/pull/8491

Related PR: https://github.com/hashicorp/consul/pull/8487