### PR TITLE
Link issue in note template

### DIFF
--- a/.changelog/note.tmpl
+++ b/.changelog/note.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{.Body}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/pull/{{- .Issue -}})]
+{{.Body}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/issues/{{- .Issue -}})]
 {{- end -}}


### PR DESCRIPTION
Issue and PR numbers do not overlap, they are based of the same counter.
A PR can be also linked to via issues, if it is a PR, Github will
redirect to it.
This change has the benefit that one can link to both - issues and PRs.