### PR TITLE
testing: Use t.cleanup in TestAgent , and fix two flaky tests

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -5829,16 +5829,12 @@ func TestDNS_NonExistentDC_RPC(t *testing.T) {
 		server = false
 	`)
 	defer c.Shutdown()
-	testrpc.WaitForLeader(t, s.RPC, "dc1")
 
 	// Join LAN cluster
 	addr := fmt.Sprintf("127.0.0.1:%d", s.Config.SerfPortLAN)
 	_, err := c.JoinLAN([]string{addr})
 	require.NoError(t, err)
-	retry.Run(t, func(r *retry.R) {
-		require.Len(r, s.LANMembers(), 2)
-		require.Len(r, c.LANMembers(), 2)
-	})
+	testrpc.WaitForTestAgent(t, c.RPC, "dc1")
 
 	m := new(dns.Msg)
 	m.SetQuestion("consul.service.dc2.consul.", dns.TypeANY)

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -54,7 +54,10 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Server should auto-load LAN and WAN keyring files
 	t.Run("server with keys", func(t *testing.T) {
-		a2 := StartTestAgent(t, TestAgent{Key: key})
+		dataDir := testutil.TempDir(t, "keyfile")
+		writeKeyRings(t, key, dataDir)
+
+		a2 := StartTestAgent(t, TestAgent{DataDir: dataDir})
 		defer a2.Shutdown()
 
 		c2 := a2.consulConfig()
@@ -80,10 +83,16 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 
 	// Client should auto-load only the LAN keyring file
 	t.Run("client with keys", func(t *testing.T) {
-		a3 := StartTestAgent(t, TestAgent{HCL: `
+		dataDir := testutil.TempDir(t, "keyfile")
+		writeKeyRings(t, key, dataDir)
+
+		a3 := StartTestAgent(t, TestAgent{
+			HCL: `
 			server = false
 			bootstrap = false
-		`, Key: key})
+			`,
+			DataDir: dataDir,
+		})
 		defer a3.Shutdown()
 
 		c3 := a3.consulConfig()
@@ -103,6 +112,16 @@ func TestAgent_LoadKeyrings(t *testing.T) {
 			t.Fatalf("keyring should not be loaded")
 		}
 	})
+}
+
+func writeKeyRings(t *testing.T, key string, dataDir string) {
+	t.Helper()
+	writeKey := func(key, filename string) {
+		path := filepath.Join(dataDir, filename)
+		require.NoError(t, initKeyring(path, key), "Error creating keyring %s", path)
+	}
+	writeKey(key, SerfLANKeyring)
+	writeKey(key, SerfWANKeyring)
 }
 
 func TestAgent_InmemKeyrings(t *testing.T) {
@@ -272,11 +291,14 @@ func TestAgentKeyring_ACL(t *testing.T) {
 	key1 := "tbLJg26ZJyJ9pK3qhc9jig=="
 	key2 := "4leC33rgtXKIVUr9Nr0snQ=="
 
+	dataDir := testutil.TempDir(t, "keyfile")
+	writeKeyRings(t, key1, dataDir)
+
 	a := StartTestAgent(t, TestAgent{HCL: TestACLConfig() + `
 		acl_datacenter = "dc1"
 		acl_master_token = "root"
 		acl_default_policy = "deny"
-	`, Key: key1})
+	`, DataDir: dataDir})
 	defer a.Shutdown()
 
 	// List keys without access fails

--- a/agent/service_manager_test.go
+++ b/agent/service_manager_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/stretchr/testify/require"
@@ -293,16 +292,12 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	)
 
 	// Now launch a single client agent
-	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
-
 	cfg := `
 	    enable_central_service_config = true
 		server = false
 		bootstrap = false
-		data_dir = "` + dataDir + `"
 	`
-	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg})
 	defer a.Shutdown()
 
 	// Join first
@@ -465,7 +460,7 @@ func TestServiceManager_PersistService_API(t *testing.T) {
 	serverAgent.Shutdown()
 
 	// Should load it back during later start.
-	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: a.DataDir})
 	defer a2.Shutdown()
 
 	{
@@ -510,9 +505,6 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	)
 
 	// Now launch a single client agent
-	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
-
 	serviceSnippet := `
 		service = {
 		  kind  = "connect-proxy"
@@ -535,12 +527,11 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 
 	cfg := `
 	    enable_central_service_config = true
-		data_dir = "` + dataDir + `"
 		server = false
 		bootstrap = false
 	` + serviceSnippet
 
-	a := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
+	a := StartTestAgent(t, TestAgent{HCL: cfg})
 	defer a.Shutdown()
 
 	// Join first
@@ -639,7 +630,7 @@ func TestServiceManager_PersistService_ConfigFiles(t *testing.T) {
 	serverAgent.Shutdown()
 
 	// Should load it back during later start.
-	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: dataDir})
+	a2 := StartTestAgent(t, TestAgent{HCL: cfg, DataDir: a.DataDir})
 	defer a2.Shutdown()
 
 	{

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -37,9 +36,6 @@ import (
 func init() {
 	rand.Seed(time.Now().UnixNano()) // seed random number generator
 }
-
-// TempDir defines the base dir for temporary directories.
-var TempDir = os.TempDir()
 
 // TestAgent encapsulates an Agent with a default configuration and
 // startup procedure suitable for testing. It panics if there are errors


### PR DESCRIPTION
While working on another change I had to make some changes to TestAgent, so I am splitting out some of these changes ahead of the other PR.

While testing these changes I hit a few flaky tests, so this PR includes fixes for them, in separate commits. Details of each change in the commit messages.