### PR TITLE
agent: extract dependency creation from New

### DIFF
--- a/agent/acl.go
+++ b/agent/acl.go
@@ -59,7 +59,7 @@ func (a *Agent) aclAccessorID(secretID string) string {
 	return ident.ID()
 }
 
-func (a *Agent) initializeACLs() error {
+func initializeACLs(nodeName string) (acl.Authorizer, error) {
 	// Build a policy for the agent master token.
 	// The builtin agent master policy allows reading any node information
 	// and allows writes to the agent with the node name of the running agent
@@ -69,7 +69,7 @@ func (a *Agent) initializeACLs() error {
 		PolicyRules: acl.PolicyRules{
 			Agents: []*acl.AgentRule{
 				{
-					Node:   a.config.NodeName,
+					Node:   nodeName,
 					Policy: acl.PolicyWrite,
 				},
 			},
@@ -81,12 +81,7 @@ func (a *Agent) initializeACLs() error {
 			},
 		},
 	}
-	master, err := acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
-	if err != nil {
-		return err
-	}
-	a.aclMasterAuthorizer = master
-	return nil
+	return acl.NewPolicyAuthorizerWithDefaults(acl.DenyAll(), []*acl.Policy{policy}, nil)
 }
 
 // vetServiceRegister makes sure the service registration action is allowed by

--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -35,37 +35,38 @@ type TestACLAgent struct {
 // Basically it needs a local state for some of the vet* functions, a logger and a delegate.
 // The key is that we are the delegate so we can control the ResolveToken responses
 func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzResolver, resolveIdent identResolver) *TestACLAgent {
+	t.Helper()
+
 	a := &TestACLAgent{resolveAuthzFn: resolveAuthz, resolveIdentFn: resolveIdent}
 
 	dataDir := testutil.TempDir(t, "acl-agent")
-	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   name,
-		Level:  hclog.Debug,
-		Output: testutil.NewLogBuffer(t),
-	})
 
-	opts := []AgentOption{
-		WithLogger(logger),
-		WithBuilderOpts(config.BuilderOpts{
-			HCL: []string{
-				TestConfigHCL(NodeID()),
-				hcl,
-				fmt.Sprintf(`data_dir = "%s"`, dataDir),
-			},
-		}),
+	logBuffer := testutil.NewLogBuffer(t)
+	loader := func(source config.Source) (cfg *config.RuntimeConfig, warnings []string, err error) {
+		dataDir := fmt.Sprintf(`data_dir = "%s"`, dataDir)
+		opts := config.BuilderOpts{
+			HCL: []string{TestConfigHCL(NodeID()), hcl, dataDir},
+		}
+		return config.Load(opts, source)
 	}
-
-	agent, err := New(opts...)
+	bd, err := NewBaseDeps(loader, logBuffer)
 	require.NoError(t, err)
-	cfg := agent.GetConfig()
+
+	bd.Logger = hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:       name,
+		Level:      hclog.Debug,
+		Output:     logBuffer,
+		TimeFormat: "04:05.000",
+	})
+	bd.TelemetrySink = metrics.NewInmemSink(1*time.Second, time.Minute)
+
+	agent, err := New(bd)
+	require.NoError(t, err)
+
+	agent.delegate = a
+	agent.State = local.NewState(LocalConfig(bd.RuntimeConfig), bd.Logger, bd.Tokens)
+	agent.State.TriggerSyncChanges = func() {}
 	a.Agent = agent
-
-	agent.logger = logger
-	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
-
-	a.Agent.delegate = a
-	a.Agent.State = local.NewState(LocalConfig(cfg), logger, a.Agent.tokens)
-	a.Agent.State.TriggerSyncChanges = func() {}
 	return a
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -171,7 +171,7 @@ type Agent struct {
 	logger hclog.InterceptLogger
 
 	// In-memory sink used for collecting metrics
-	MemSink *metrics.InmemSink
+	MemSink MetricsHandler
 
 	// delegate is either a *consul.Server or *consul.Client
 	// depending on the configuration
@@ -349,7 +349,7 @@ func New(bd BaseDeps) (*Agent, error) {
 		tlsConfigurator: bd.TLSConfigurator,
 		config:          bd.RuntimeConfig,
 		cache:           bd.Cache,
-		MemSink:         bd.TelemetrySink,
+		MemSink:         bd.MetricsHandler,
 		connPool:        bd.ConnPool,
 		autoConf:        bd.AutoConfig,
 	}

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -35,11 +35,11 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// LoadConfig will build the configuration including the extraHead source injected
+// Load will build the configuration including the extraHead source injected
 // after all other defaults but before any user supplied configuration and the overrides
 // source injected as the final source in the configuration parsing chain.
-func Load(builderOpts BuilderOpts, extraHead Source, overrides ...Source) (*RuntimeConfig, []string, error) {
-	b, err := NewBuilder(builderOpts)
+func Load(opts BuilderOpts, extraHead Source, overrides ...Source) (*RuntimeConfig, []string, error) {
+	b, err := NewBuilder(opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -7100,6 +7100,7 @@ func TestSanitize(t *testing.T) {
 			"CirconusCheckTags": "",
 			"CirconusSubmissionInterval": "",
 			"CirconusSubmissionURL": "",
+			"Disable": false,
 			"DisableHostname": false,
 			"DogstatsdAddr": "",
 			"DogstatsdTags": [],

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/armon/go-metrics"
+	autoconf "github.com/hashicorp/consul/agent/auto-config"
+	"github.com/hashicorp/consul/agent/cache"
+	certmon "github.com/hashicorp/consul/agent/cert-monitor"
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/consul/ipaddr"
+	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/consul/tlsutil"
+	"github.com/hashicorp/go-hclog"
+)
+
+// TODO: BaseDeps should be renamed in the future once more of Agent.Start
+// has been moved out in front of Agent.New, and we can better see the setup
+// dependencies.
+type BaseDeps struct {
+	Logger          hclog.InterceptLogger
+	TLSConfigurator *tlsutil.Configurator // TODO: use an interface
+	TelemetrySink   *metrics.InmemSink    // TODO: use an interface
+	RuntimeConfig   *config.RuntimeConfig
+	Tokens          *token.Store
+	Cache           *cache.Cache
+	AutoConfig      *autoconf.AutoConfig // TODO: use an interface
+	ConnPool        *pool.ConnPool       // TODO: use an interface
+}
+
+type ConfigLoader func(source config.Source) (cfg *config.RuntimeConfig, warnings []string, err error)
+
+func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer) (BaseDeps, error) {
+	d := BaseDeps{}
+	cfg, warnings, err := configLoader(nil)
+	if err != nil {
+		return d, err
+	}
+
+	// TODO: use logging.Config in RuntimeConfig instead of separate fields
+	logConf := &logging.Config{
+		LogLevel:          cfg.LogLevel,
+		LogJSON:           cfg.LogJSON,
+		Name:              logging.Agent,
+		EnableSyslog:      cfg.EnableSyslog,
+		SyslogFacility:    cfg.SyslogFacility,
+		LogFilePath:       cfg.LogFile,
+		LogRotateDuration: cfg.LogRotateDuration,
+		LogRotateBytes:    cfg.LogRotateBytes,
+		LogRotateMaxFiles: cfg.LogRotateMaxFiles,
+	}
+	d.Logger, err = logging.Setup(logConf, []io.Writer{logOut})
+	if err != nil {
+		return d, err
+	}
+
+	for _, w := range warnings {
+		d.Logger.Warn(w)
+	}
+
+	cfg.NodeID, err = newNodeIDFromConfig(cfg, d.Logger)
+	if err != nil {
+		return d, fmt.Errorf("failed to setup node ID: %w", err)
+	}
+
+	d.TelemetrySink, err = lib.InitTelemetry(cfg.Telemetry)
+	if err != nil {
+		return d, fmt.Errorf("failed to initialize telemetry: %w", err)
+	}
+
+	d.TLSConfigurator, err = tlsutil.NewConfigurator(cfg.ToTLSUtilConfig(), d.Logger)
+	if err != nil {
+		return d, err
+	}
+
+	d.RuntimeConfig = cfg
+	d.Tokens = new(token.Store)
+	// cache-types are not registered yet, but they won't be used until the components are started.
+	d.Cache = cache.New(cfg.Cache)
+	d.ConnPool = newConnPool(cfg, d.Logger, d.TLSConfigurator)
+
+	deferredAC := &deferredAutoConfig{}
+
+	cmConf := new(certmon.Config).
+		WithCache(d.Cache).
+		WithTLSConfigurator(d.TLSConfigurator).
+		WithDNSSANs(cfg.AutoConfig.DNSSANs).
+		WithIPSANs(cfg.AutoConfig.IPSANs).
+		WithDatacenter(cfg.Datacenter).
+		WithNodeName(cfg.NodeName).
+		WithFallback(deferredAC.autoConfigFallbackTLS).
+		WithLogger(d.Logger.Named(logging.AutoConfig)).
+		WithTokens(d.Tokens).
+		WithPersistence(deferredAC.autoConfigPersist)
+	acCertMon, err := certmon.New(cmConf)
+	if err != nil {
+		return d, err
+	}
+
+	acConf := autoconf.Config{
+		DirectRPC:   d.ConnPool,
+		Logger:      d.Logger,
+		CertMonitor: acCertMon,
+		Loader:      configLoader,
+	}
+	d.AutoConfig, err = autoconf.New(acConf)
+	if err != nil {
+		return d, err
+	}
+	// TODO: can this cyclic dependency be un-cycled?
+	deferredAC.autoConf = d.AutoConfig
+
+	return d, nil
+}
+
+func newConnPool(config *config.RuntimeConfig, logger hclog.Logger, tls *tlsutil.Configurator) *pool.ConnPool {
+	var rpcSrcAddr *net.TCPAddr
+	if !ipaddr.IsAny(config.RPCBindAddr) {
+		rpcSrcAddr = &net.TCPAddr{IP: config.RPCBindAddr.IP}
+	}
+
+	pool := &pool.ConnPool{
+		Server:          config.ServerMode,
+		SrcAddr:         rpcSrcAddr,
+		Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
+		TLSConfigurator: tls,
+		Datacenter:      config.Datacenter,
+	}
+	if config.ServerMode {
+		pool.MaxTime = 2 * time.Minute
+		pool.MaxStreams = 64
+	} else {
+		pool.MaxTime = 127 * time.Second
+		pool.MaxStreams = 32
+	}
+	return pool
+}
+
+type deferredAutoConfig struct {
+	autoConf *autoconf.AutoConfig // TODO: use an interface
+}
+
+func (a *deferredAutoConfig) autoConfigFallbackTLS(ctx context.Context) (*structs.SignedResponse, error) {
+	if a.autoConf == nil {
+		return nil, fmt.Errorf("AutoConfig manager has not been created yet")
+	}
+	return a.autoConf.FallbackTLS(ctx)
+}
+
+func (a *deferredAutoConfig) autoConfigPersist(resp *structs.SignedResponse) error {
+	if a.autoConf == nil {
+		return fmt.Errorf("AutoConfig manager has not been created yet")
+	}
+	return a.autoConf.RecordUpdatedCerts(resp)
+}

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-hclog"
 	uuid "github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/config"
@@ -167,38 +168,35 @@ func (a *TestAgent) Start(t *testing.T) (err error) {
 	portsConfig, returnPortsFn := randomPortsSource(a.UseTLS)
 	t.Cleanup(returnPortsFn)
 
-	nodeID := NodeID()
-
-	opts := []AgentOption{
-		WithLogger(logger),
-		WithBuilderOpts(config.BuilderOpts{
-			HCL: []string{
-				TestConfigHCL(nodeID),
-				portsConfig,
-				a.HCL,
-				hclDataDir,
-			},
-		}),
-		WithOverrides(config.FileSource{
-			Name:   "test-overrides",
-			Format: "hcl",
-			Data:   a.Overrides},
+	// Create NodeID outside the closure, so that it does not change
+	testHCLConfig := TestConfigHCL(NodeID())
+	loader := func(source config.Source) (cfg *config.RuntimeConfig, warnings []string, err error) {
+		opts := config.BuilderOpts{
+			HCL: []string{testHCLConfig, portsConfig, a.HCL, hclDataDir},
+		}
+		overrides := []config.Source{
+			config.FileSource{
+				Name:   "test-overrides",
+				Format: "hcl",
+				Data:   a.Overrides},
 			config.DefaultConsulSource(),
 			config.DevConsulSource(),
-		),
+		}
+		return config.Load(opts, source, overrides...)
 	}
+	bd, err := NewBaseDeps(loader, logOutput)
+	require.NoError(t, err)
 
-	agent, err := New(opts...)
+	bd.Logger = logger
+	bd.TelemetrySink = metrics.NewInmemSink(1*time.Second, time.Minute)
+	a.Config = bd.RuntimeConfig
+
+	agent, err := New(bd)
 	if err != nil {
 		return fmt.Errorf("Error creating agent: %s", err)
 	}
 
-	a.Config = agent.GetConfig()
-
-	agent.MemSink = metrics.NewInmemSink(1*time.Second, time.Minute)
-
 	id := string(a.Config.NodeID)
-
 	if err := agent.Start(context.Background()); err != nil {
 		agent.ShutdownAgent()
 		agent.ShutdownEndpoints()

--- a/lib/telemetry.go
+++ b/lib/telemetry.go
@@ -19,6 +19,10 @@ import (
 // the shared InitTelemetry functions below, but we can't import agent/config
 // due to a dependency cycle.
 type TelemetryConfig struct {
+	// Disable may be set to true to have InitTelemetry to skip initialization
+	// and return a nil MetricsSink.
+	Disable bool
+
 	// Circonus*: see https://github.com/circonus-labs/circonus-gometrics
 	// for more details on the various configuration options.
 	// Valid configuration combinations:
@@ -326,6 +330,9 @@ func circonusSink(cfg TelemetryConfig, hostname string) (metrics.MetricSink, err
 // InitTelemetry configures go-metrics based on map of telemetry config
 // values as returned by Runtimecfg.Config().
 func InitTelemetry(cfg TelemetryConfig) (*metrics.InmemSink, error) {
+	if cfg.Disable {
+		return nil, nil
+	}
 	// Setup telemetry
 	// Aggregate on 10 second intervals for 1 minute. Expose the
 	// metrics over stderr when there is a SIGUSR1 received.

--- a/logging/grpc.go
+++ b/logging/grpc.go
@@ -19,9 +19,9 @@ type GRPCLogger struct {
 // Note that grpclog has Info, Warning, Error, Fatal severity levels AND integer
 // verbosity levels for additional info. Verbose logs in glog are always INFO
 // severity so we map Info,V0 to INFO, Info,V1 to DEBUG, and Info,V>1 to TRACE.
-func NewGRPCLogger(config *Config, logger hclog.Logger) *GRPCLogger {
+func NewGRPCLogger(logLevel string, logger hclog.Logger) *GRPCLogger {
 	return &GRPCLogger{
-		level:  config.LogLevel,
+		level:  logLevel,
 		logger: logger,
 	}
 }

--- a/logging/grpc_test.go
+++ b/logging/grpc_test.go
@@ -20,7 +20,7 @@ func TestGRPCLogger(t *testing.T) {
 		Output:     &out,
 		TimeFormat: "timeformat",
 	})
-	grpclog.SetLoggerV2(NewGRPCLogger(&Config{LogLevel: "TRACE"}, logger))
+	grpclog.SetLoggerV2(NewGRPCLogger("TRACE", logger))
 
 	// All of these should output something
 	grpclog.Info("Info,")
@@ -92,7 +92,7 @@ func TestGRPCLogger_V(t *testing.T) {
 				Level:  hclog.Trace,
 				Output: &out,
 			})
-			grpclog.SetLoggerV2(NewGRPCLogger(&Config{LogLevel: tt.level}, logger))
+			grpclog.SetLoggerV2(NewGRPCLogger(tt.level, logger))
 
 			assert.Equal(t, tt.want, grpclog.V(tt.v))
 		})

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -63,6 +63,7 @@ type LogSetupErrorFn func(string)
 // The provided ui object will get any log messages related to setting up
 // logging itself, and will also be hooked up to the gated logger. The final bool
 // parameter indicates if logging was set up successfully.
+// TODO: accept a single io.Writer
 func Setup(config *Config, writers []io.Writer) (hclog.InterceptLogger, error) {
 	if !ValidateLogLevel(config.LogLevel) {
 		return nil, fmt.Errorf("Invalid log level: %s. Valid log levels are: %v",


### PR DESCRIPTION
With this change, `Agent.New()` accepts many of the dependencies instead of creating them in `New`. Accepting fully constructed dependencies from a constructor has many advantages:

* the type is easier to test, because fakes can be passed to the constructor.
* the type is easier to reason about, because its state is more static. This can be seen in methods like `Shutdown` which have to check if a bunch of dependencies are `nil`. If all the dependencies are passed in and not-nil, we no longer have to worry about that class of bugs.
* the type can shrink significantly. For example in this PR `initializeConnectionPool` and `initializeACL` are no longer methods on `Agent`, and really do not need to know anything about `Agent`. They can be constructed ahead of time. Anything that is being passed to `Agent` exclusively to construct a dependency can now be handled ahead of time, and the scope of `Agent` is reduced.
* the lifecycle of Agent becomes easier to manage. As dependencies move out of `Start` we will no longer need to `Agent.Shutdown` on failures, because nothing will have been started, so there is nothing to shutdown.

There are still a number of dependencies created in Start() which can be addressed in a follow up.