### PR TITLE
Add NotModifiedSupport for all blocking query cache-types

### DIFF
--- a/.changelog/8513.txt
+++ b/.changelog/8513.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent caching: add support for NotModified to internal agent caching requests for every endpoint that supports blocking requests.
+```

--- a/agent/cache-types/catalog_datacenters.go
+++ b/agent/cache-types/catalog_datacenters.go
@@ -32,7 +32,7 @@ func (c *CatalogDatacenters) Fetch(opts cache.FetchOptions, req cache.Request) (
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
 

--- a/agent/cache-types/catalog_list_services.go
+++ b/agent/cache-types/catalog_list_services.go
@@ -36,7 +36,7 @@ func (c *CatalogListServices) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/catalog_service_list.go
+++ b/agent/cache-types/catalog_service_list.go
@@ -36,7 +36,7 @@ func (c *CatalogServiceList) Fetch(opts cache.FetchOptions, req cache.Request) (
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/catalog_service_list.go
+++ b/agent/cache-types/catalog_service_list.go
@@ -38,9 +38,12 @@ func (c *CatalogServiceList) Fetch(opts cache.FetchOptions, req cache.Request) (
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedServiceList
 	if err := c.RPC.RPC("Catalog.ServiceList", reqReal, &reply); err != nil {
 		return result, err
@@ -48,5 +51,6 @@ func (c *CatalogServiceList) Fetch(opts cache.FetchOptions, req cache.Request) (
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/catalog_services.go
+++ b/agent/cache-types/catalog_services.go
@@ -37,7 +37,7 @@ func (c *CatalogServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/catalog_services.go
+++ b/agent/cache-types/catalog_services.go
@@ -39,9 +39,12 @@ func (c *CatalogServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedServiceNodes
 	if err := c.RPC.RPC("Catalog.ServiceNodes", reqReal, &reply); err != nil {
 		return result, err
@@ -49,5 +52,6 @@ func (c *CatalogServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/catalog_services_test.go
+++ b/agent/cache-types/catalog_services_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -63,4 +64,58 @@ func TestCatalogServices_badReqType(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "wrong type")
 
+}
+
+func TestCatalogServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &CatalogServices{RPC: rpc}
+
+	nodes := structs.ServiceNodes{
+		&structs.ServiceNode{ID: "id"},
+	}
+	rpc.On("RPC", "Catalog.ServiceNodes", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.ServiceSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedServiceNodes)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(CatalogServicesName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedServiceNodes{
+			ServiceNodes: nodes,
+			QueryMeta:    structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(CatalogServicesName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, CatalogServicesName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedServiceNodes{
+		ServiceNodes: nodes,
+		QueryMeta:    structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
+	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/config_entry.go
+++ b/agent/cache-types/config_entry.go
@@ -39,7 +39,7 @@ func (c *ConfigEntries) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
 
@@ -80,7 +80,7 @@ func (c *ConfigEntry) Fetch(opts cache.FetchOptions, req cache.Request) (cache.F
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/connect_ca_root.go
+++ b/agent/cache-types/connect_ca_root.go
@@ -38,7 +38,7 @@ func (c *ConnectCARoot) Fetch(opts cache.FetchOptions, req cache.Request) (cache
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/connect_ca_root_test.go
+++ b/agent/cache-types/connect_ca_root_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -54,4 +55,56 @@ func TestConnectCARoot_badReqType(t *testing.T) {
 	require.NotNil(err)
 	require.Contains(err.Error(), "wrong type")
 
+}
+
+func TestConnectCARoot_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &ConnectCARoot{RPC: rpc}
+
+	id := "active-root-id"
+	rpc.On("RPC", "ConnectCA.Roots", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.DCSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedCARoots)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(ConnectCARootName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedCARoots{
+			ActiveRootID: id,
+			QueryMeta:    structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.DCSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(ConnectCARootName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, ConnectCARootName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedCARoots{
+		ActiveRootID: id,
+		QueryMeta:    structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
+	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/discovery_chain.go
+++ b/agent/cache-types/discovery_chain.go
@@ -37,7 +37,7 @@ func (c *CompiledDiscoveryChain) Fetch(opts cache.FetchOptions, req cache.Reques
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/discovery_chain.go
+++ b/agent/cache-types/discovery_chain.go
@@ -36,12 +36,15 @@ func (c *CompiledDiscoveryChain) Fetch(opts cache.FetchOptions, req cache.Reques
 	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
 
 	// Always allow stale - there's no point in hitting leader if the request is
-	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached compiled-discovery-chain to automatically read scale across all
+	// going to be served from cache and end up arbitrarily stale anyway. This
+	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.DiscoveryChainResponse
 	if err := c.RPC.RPC("DiscoveryChain.Get", reqReal, &reply); err != nil {
 		return result, err
@@ -49,5 +52,6 @@ func (c *CompiledDiscoveryChain) Fetch(opts cache.FetchOptions, req cache.Reques
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/federation_state_list_gateways.go
+++ b/agent/cache-types/federation_state_list_gateways.go
@@ -36,7 +36,7 @@ func (c *FederationStateListMeshGateways) Fetch(opts cache.FetchOptions, req cac
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/federation_state_list_gateways.go
+++ b/agent/cache-types/federation_state_list_gateways.go
@@ -38,9 +38,12 @@ func (c *FederationStateListMeshGateways) Fetch(opts cache.FetchOptions, req cac
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.DatacenterIndexedCheckServiceNodes
 	if err := c.RPC.RPC("FederationState.ListMeshGateways", reqReal, &reply); err != nil {
 		return result, err
@@ -48,5 +51,6 @@ func (c *FederationStateListMeshGateways) Fetch(opts cache.FetchOptions, req cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/federation_state_list_gateways_test.go
+++ b/agent/cache-types/federation_state_list_gateways_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -103,5 +104,68 @@ func TestFederationStateListMeshGateways_badReqType(t *testing.T) {
 		t, cache.RequestInfo{Key: "foo", MinIndex: 64}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wrong type")
+	rpc.AssertExpectations(t)
+}
+
+func TestFederationStateListMeshGateways_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &FederationStateListMeshGateways{RPC: rpc}
+
+	nodes := map[string]structs.CheckServiceNodes{
+		"dc1": []structs.CheckServiceNode{
+			{
+				Node: &structs.Node{
+					ID:         "664bac9f-4de7-4f1b-ad35-0e5365e8f329",
+					Node:       "gateway1",
+					Datacenter: "dc1",
+					Address:    "1.2.3.4",
+				},
+			},
+		},
+	}
+	rpc.On("RPC", "FederationState.ListMeshGateways", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.DCSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.DatacenterIndexedCheckServiceNodes)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(FederationStateListMeshGatewaysName, typ)
+	last := cache.FetchResult{
+		Value: &structs.DatacenterIndexedCheckServiceNodes{
+			DatacenterNodes: nodes,
+			QueryMeta:       structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.DCSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(FederationStateListMeshGatewaysName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, FederationStateListMeshGatewaysName, req)
+	require.NoError(t, err)
+
+	expected := &structs.DatacenterIndexedCheckServiceNodes{
+		DatacenterNodes: nodes,
+		QueryMeta:       structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
 	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/gateway_services.go
+++ b/agent/cache-types/gateway_services.go
@@ -38,9 +38,12 @@ func (g *GatewayServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedGatewayServices
 	if err := g.RPC.RPC("Catalog.GatewayServices", reqReal, &reply); err != nil {
 		return result, err
@@ -48,5 +51,6 @@ func (g *GatewayServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/gateway_services.go
+++ b/agent/cache-types/gateway_services.go
@@ -36,7 +36,7 @@ func (g *GatewayServices) Fetch(opts cache.FetchOptions, req cache.Request) (cac
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/gateway_services_test.go
+++ b/agent/cache-types/gateway_services_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -56,6 +57,60 @@ func TestGatewayServices(t *testing.T) {
 		Value: resp,
 		Index: 48,
 	}, resultA)
+
+	rpc.AssertExpectations(t)
+}
+
+func TestGatewayServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &GatewayServices{RPC: rpc}
+
+	services := structs.GatewayServices{
+		&structs.GatewayService{Gateway: structs.NewServiceName("gateway", nil)},
+	}
+	rpc.On("RPC", "Catalog.GatewayServices", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.ServiceSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedGatewayServices)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(GatewayServicesName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedGatewayServices{
+			Services:  services,
+			QueryMeta: structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(GatewayServicesName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, GatewayServicesName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedGatewayServices{
+		Services:  services,
+		QueryMeta: structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
 
 	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/health_services.go
+++ b/agent/cache-types/health_services.go
@@ -36,12 +36,15 @@ func (c *HealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
 
 	// Always allow stale - there's no point in hitting leader if the request is
-	// going to be served from cache and endup arbitrarily stale anyway. This
+	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedCheckServiceNodes
 	if err := c.RPC.RPC("Health.ServiceNodes", reqReal, &reply); err != nil {
 		return result, err
@@ -49,5 +52,6 @@ func (c *HealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/health_services.go
+++ b/agent/cache-types/health_services.go
@@ -37,7 +37,7 @@ func (c *HealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/health_services_test.go
+++ b/agent/cache-types/health_services_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -63,4 +64,58 @@ func TestHealthServices_badReqType(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "wrong type")
 
+}
+
+func TestHealthServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &HealthServices{RPC: rpc}
+
+	nodes := []structs.CheckServiceNode{
+		{Service: &structs.NodeService{Service: "foo"}},
+	}
+	rpc.On("RPC", "Health.ServiceNodes", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.ServiceSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedCheckServiceNodes)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(HealthServicesName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedCheckServiceNodes{
+			Nodes:     nodes,
+			QueryMeta: structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(HealthServicesName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, HealthServicesName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedCheckServiceNodes{
+		Nodes:     nodes,
+		QueryMeta: structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
+	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/intention_match.go
+++ b/agent/cache-types/intention_match.go
@@ -36,7 +36,7 @@ func (c *IntentionMatch) Fetch(opts cache.FetchOptions, req cache.Request) (cach
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/intention_match_test.go
+++ b/agent/cache-types/intention_match_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -54,4 +55,59 @@ func TestIntentionMatch_badReqType(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "wrong type")
 
+}
+
+func TestIntentionMatch_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &IntentionMatch{RPC: rpc}
+
+	intentions := []structs.Intentions{
+		{&structs.Intention{ID: "id"}},
+	}
+	rpc.On("RPC", "Intention.Match", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.IntentionQueryRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedIntentionMatches)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(IntentionMatchName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedIntentionMatches{
+			Matches:   intentions,
+			QueryMeta: structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.IntentionQueryRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+		Match: &structs.IntentionQueryMatch{},
+	}
+
+	err := c.Prepopulate(IntentionMatchName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, IntentionMatchName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedIntentionMatches{
+		Matches:   intentions,
+		QueryMeta: structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
+	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/node_services.go
+++ b/agent/cache-types/node_services.go
@@ -37,7 +37,7 @@ func (c *NodeServices) Fetch(opts cache.FetchOptions, req cache.Request) (cache.
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/node_services_test.go
+++ b/agent/cache-types/node_services_test.go
@@ -1,6 +1,7 @@
 package cachetype
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -68,4 +69,63 @@ func TestNodeServices_badReqType(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "wrong type")
 
+}
+
+func TestNodeServices_IntegrationWithCache_NotModifiedResponse(t *testing.T) {
+	rpc := &MockRPC{}
+	typ := &NodeServices{RPC: rpc}
+
+	services := &structs.NodeServices{
+		Node: &structs.Node{
+			ID:         "abcdef",
+			Node:       "node-01",
+			Address:    "127.0.0.5",
+			Datacenter: "dc1",
+		},
+	}
+	rpc.On("RPC", "Catalog.NodeServices", mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			req := args.Get(1).(*structs.NodeSpecificRequest)
+			require.True(t, req.AllowStale)
+			require.True(t, req.AllowNotModifiedResponse)
+
+			reply := args.Get(2).(*structs.IndexedNodeServices)
+			reply.QueryMeta.Index = 44
+			reply.NotModified = true
+		})
+
+	c := cache.New(cache.Options{})
+	c.RegisterType(NodeServicesName, typ)
+	last := cache.FetchResult{
+		Value: &structs.IndexedNodeServices{
+			NodeServices: services,
+			QueryMeta:    structs.QueryMeta{Index: 42},
+		},
+		Index: 42,
+	}
+	req := &structs.NodeSpecificRequest{
+		Datacenter: "dc1",
+		QueryOptions: structs.QueryOptions{
+			Token:         "token",
+			MinQueryIndex: 44,
+			MaxQueryTime:  time.Second,
+		},
+	}
+
+	err := c.Prepopulate(NodeServicesName, last, "dc1", "token", req.CacheInfo().Key)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	actual, _, err := c.Get(ctx, NodeServicesName, req)
+	require.NoError(t, err)
+
+	expected := &structs.IndexedNodeServices{
+		NodeServices: services,
+		QueryMeta:    structs.QueryMeta{Index: 42},
+	}
+	require.Equal(t, expected, actual)
+
+	rpc.AssertExpectations(t)
 }

--- a/agent/cache-types/prepared_query.go
+++ b/agent/cache-types/prepared_query.go
@@ -33,7 +33,7 @@ func (c *PreparedQuery) Fetch(_ cache.FetchOptions, req cache.Request) (cache.Fe
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.AllowStale = true
 

--- a/agent/cache-types/resolved_service_config.go
+++ b/agent/cache-types/resolved_service_config.go
@@ -37,7 +37,7 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/resolved_service_config.go
+++ b/agent/cache-types/resolved_service_config.go
@@ -36,12 +36,15 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 	reqReal.QueryOptions.MaxQueryTime = opts.Timeout
 
 	// Always allow stale - there's no point in hitting leader if the request is
-	// going to be served from cache and endup arbitrarily stale anyway. This
-	// allows cached resolved-service-config to automatically read scale across all
+	// going to be served from cache and end up arbitrarily stale anyway. This
+	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.ServiceConfigResponse
 	if err := c.RPC.RPC("ConfigEntry.ResolveServiceConfig", reqReal, &reply); err != nil {
 		return result, err
@@ -49,5 +52,6 @@ func (c *ResolvedServiceConfig) Fetch(opts cache.FetchOptions, req cache.Request
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }

--- a/agent/cache-types/service_dump.go
+++ b/agent/cache-types/service_dump.go
@@ -36,7 +36,7 @@ func (c *InternalServiceDump) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	// Always allow stale - there's no point in hitting leader if the request is
 	// going to be served from cache and end up arbitrarily stale anyway. This
-	// allows cached service-discover to automatically read scale across all
+	// allows cached entries to automatically read scale across all
 	// servers too.
 	reqReal.QueryOptions.AllowStale = true
 

--- a/agent/cache-types/service_dump.go
+++ b/agent/cache-types/service_dump.go
@@ -38,9 +38,12 @@ func (c *InternalServiceDump) Fetch(opts cache.FetchOptions, req cache.Request) 
 	// going to be served from cache and end up arbitrarily stale anyway. This
 	// allows cached service-discover to automatically read scale across all
 	// servers too.
-	reqReal.AllowStale = true
+	reqReal.QueryOptions.AllowStale = true
 
-	// Fetch
+	if opts.LastResult != nil {
+		reqReal.QueryOptions.AllowNotModifiedResponse = true
+	}
+
 	var reply structs.IndexedCheckServiceNodes
 	if err := c.RPC.RPC("Internal.ServiceDump", reqReal, &reply); err != nil {
 		return result, err
@@ -48,5 +51,6 @@ func (c *InternalServiceDump) Fetch(opts cache.FetchOptions, req cache.Request) 
 
 	result.Value = &reply
 	result.Index = reply.QueryMeta.Index
+	result.NotModified = reply.QueryMeta.NotModified
 	return result, nil
 }


### PR DESCRIPTION
  Following https://github.com/hashicorp/consul/pull/8245.

  * [ ] ~~catalog_datacenters~~ (no blocking support)
  * [x] catalog_list_services
  * [x] catalog_service_list
  * [x] catalog_services
  * [x] config_entry
  * [ ] ~~connect_ca_leaf~~ (not sure if possible to apply)
  * [x] connect_ca_root
  * [x] discovery_chain
  * [x] federation_state_list_gateways
  * [x] gateway_services
  * [x] health_services
  * [x] intention_match
  * [x] node_services
  * [ ] ~~prepared_query~~
  * [x] resolved_service_config
  * [ ] ~~service_checks~~ (hash based)
  * [x] service_dump