### PR TITLE
testing: small improvements to TestSessionCreate and testutil.retry

### DIFF
--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -1298,10 +1298,8 @@ func TestAllowedNets(t *testing.T) {
 
 // assertIndex tests that X-Consul-Index is set and non-zero
 func assertIndex(t *testing.T, resp *httptest.ResponseRecorder) {
-	header := resp.Header().Get("X-Consul-Index")
-	if header == "" || header == "0" {
-		t.Fatalf("Bad: %v", header)
-	}
+	t.Helper()
+	require.NoError(t, checkIndex(resp))
 }
 
 // checkIndex is like assertIndex but returns an error

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -155,10 +155,8 @@ func TestUiNodeInfo(t *testing.T) {
 	req, _ := http.NewRequest("GET", fmt.Sprintf("/v1/internal/ui/node/%s", a.Config.NodeName), nil)
 	resp := httptest.NewRecorder()
 	obj, err := a.srv.UINodeInfo(resp, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
+	require.NoError(t, err)
+	require.Equal(t, resp.Code, http.StatusOK)
 	assertIndex(t, resp)
 
 	// Should be 1 node for the server

--- a/sdk/testutil/retry/retry.go
+++ b/sdk/testutil/retry/retry.go
@@ -23,6 +23,8 @@ import (
 
 // Failer is an interface compatible with testing.T.
 type Failer interface {
+	Helper()
+
 	// Log is called for the final test output
 	Log(args ...interface{})
 
@@ -116,6 +118,7 @@ func dedup(a []string) string {
 func run(r Retryer, t Failer, f func(r *R)) {
 	rr := &R{}
 	fail := func() {
+		t.Helper()
 		out := dedup(rr.output)
 		if out != "" {
 			t.Log(out)


### PR DESCRIPTION
While working on another change I caused a bunch of these tests to fail.
Unfortunately the failure messages were not super helpful at first.

One problem was that the request and response were created outside of
the retry. This meant that when the second attempt happened, the request
body was empty (because the buffer had been consumed), and so the
request was not actually being retried. This was fixed by moving more of
the request creation into the retry block.

Another problem was that these functions can return errors in two ways, and
are not consistent about which way they use. Some errors are returned to
the response writer, but the tests were not checking those errors, which
was causing a panic later on. This was fixed by adding a check for the
response code.

Also adds some missing t.Helper(), and has `assertIndex` use `checkIndex` so
that it is clear these are the same implementation.