### PR TITLE
testing: remove all the 'defer os.RemoveAll'

### DIFF
--- a/agent/acl_test.go
+++ b/agent/acl_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"io"
-	"os"
 	"testing"
 	"time"
 
@@ -39,10 +38,6 @@ func NewTestACLAgent(t *testing.T, name string, hcl string, resolveAuthz authzRe
 	a := &TestACLAgent{resolveAuthzFn: resolveAuthz, resolveIdentFn: resolveIdent}
 
 	dataDir := testutil.TempDir(t, "acl-agent")
-	t.Cleanup(func() {
-		os.RemoveAll(dataDir)
-	})
-
 	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Name:   name,
 		Level:  hclog.Debug,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3511,7 +3511,6 @@ func TestAgent_SecurityChecks(t *testing.T) {
 func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
 	hcl := `
 		data_dir = "` + dataDir + `"
 		verify_outgoing = true
@@ -3546,7 +3545,6 @@ func TestAgent_ReloadConfigOutgoingRPCConfig(t *testing.T) {
 func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
 	hcl := `data_dir = "` + dataDir + `"
 		enable_local_script_checks=true
 		services=[{
@@ -3576,7 +3574,6 @@ func TestAgent_ReloadConfigAndKeepChecksStatus(t *testing.T) {
 func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
 	hcl := `
 		data_dir = "` + dataDir + `"
 		verify_outgoing = true
@@ -3616,7 +3613,6 @@ func TestAgent_ReloadConfigIncomingRPCConfig(t *testing.T) {
 func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
 	hcl := `
 		data_dir = "` + dataDir + `"
 		verify_outgoing = true
@@ -3645,7 +3641,6 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	defer os.RemoveAll(dataDir)
 	hcl := `
 		data_dir = "` + dataDir + `"
 		verify_incoming = true

--- a/agent/auto-config/auto_config_test.go
+++ b/agent/auto-config/auto_config_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -162,8 +161,6 @@ func setupRuntimeConfig(t *testing.T) *config.RuntimeConfig {
 	t.Helper()
 
 	dataDir := testutil.TempDir(t, "auto-config")
-	t.Cleanup(func() { os.RemoveAll(dataDir) })
-
 	rtConfig := &config.RuntimeConfig{
 		DataDir:    dataDir,
 		Datacenter: "dc1",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -50,7 +50,6 @@ type configTest struct {
 
 func TestConfigFlagsAndEdgecases(t *testing.T) {
 	dataDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dataDir)
 
 	tests := []configTest{
 		// ------------------------------------------------------------
@@ -4387,7 +4386,6 @@ func testConfig(t *testing.T, tests []configTest, dataDir string) {
 //
 func TestFullConfig(t *testing.T) {
 	dataDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dataDir)
 
 	cidr := func(s string) *net.IPNet {
 		_, n, _ := net.ParseCIDR(s)

--- a/agent/config/segment_oss_test.go
+++ b/agent/config/segment_oss_test.go
@@ -3,7 +3,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -11,7 +10,6 @@ import (
 
 func TestSegments(t *testing.T) {
 	dataDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dataDir)
 
 	tests := []configTest{
 		{

--- a/agent/consul/auto_config_endpoint_test.go
+++ b/agent/consul/auto_config_endpoint_test.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -394,8 +393,6 @@ func TestAutoConfig_updateTLSSettingsInConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	dir := testutil.TempDir(t, "auto-config-tls-settings")
-	t.Cleanup(func() { os.RemoveAll(dir) })
-
 	cafile := path.Join(dir, "cacert.pem")
 	err = ioutil.WriteFile(cafile, []byte(cacert), 0600)
 	require.NoError(t, err)
@@ -602,8 +599,6 @@ func TestAutoConfig_updateTLSCertificatesInConfig(t *testing.T) {
 	// this is necessary but creation of the tlsutil.Configurator
 	// will error if it cannot load the CA certificate from disk
 	dir := testutil.TempDir(t, "auto-config-tls-certificate")
-	t.Cleanup(func() { os.RemoveAll(dir) })
-
 	cafile := path.Join(dir, "cacert.pem")
 	err = ioutil.WriteFile(cafile, []byte(cacert), 0600)
 	require.NoError(t, err)

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -23,9 +23,6 @@ import (
 
 func testClientConfig(t *testing.T) (string, *Config) {
 	dir := testutil.TempDir(t, "consul")
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
 	config := DefaultConfig()
 
 	ports := freeport.MustTake(2)

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -129,9 +129,6 @@ func waitForLeaderEstablishment(t *testing.T, servers ...*Server) {
 
 func testServerConfig(t *testing.T) (string, *Config) {
 	dir := testutil.TempDir(t, "consul")
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
 	config := DefaultConfig()
 
 	ports := freeport.MustTake(3)

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -39,7 +39,6 @@ func TestHTTPServer_UnixSocket(t *testing.T) {
 	}
 
 	tempDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(tempDir)
 	socket := filepath.Join(tempDir, "test.sock")
 
 	// Only testing mode, since uid/gid might not be settable
@@ -98,7 +97,6 @@ func TestHTTPServer_UnixSocket_FileExists(t *testing.T) {
 	}
 
 	tempDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(tempDir)
 	socket := filepath.Join(tempDir, "test.sock")
 
 	// Create a regular file at the socket path

--- a/agent/keyring_test.go
+++ b/agent/keyring_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -208,7 +207,6 @@ func TestAgent_InmemKeyrings(t *testing.T) {
 	// Any keyring files should be ignored
 	t.Run("ignore files", func(t *testing.T) {
 		dir := testutil.TempDir(t, "consul")
-		defer os.RemoveAll(dir)
 
 		badKey := "unUzC2X3JgMKVJlZna5KVg=="
 		if err := initKeyring(filepath.Join(dir, SerfLANKeyring), badKey); err != nil {
@@ -254,8 +252,6 @@ func TestAgent_InitKeyring(t *testing.T) {
 	expected := fmt.Sprintf(`["%s"]`, key1)
 
 	dir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dir)
-
 	file := filepath.Join(dir, "keyring")
 
 	// First initialize the keyring

--- a/agent/nodeid_test.go
+++ b/agent/nodeid_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,9 +18,6 @@ import (
 func TestNewNodeIDFromConfig(t *testing.T) {
 	logger := hclog.New(nil)
 	tmpDir := testutil.TempDir(t, "")
-	t.Cleanup(func() {
-		os.RemoveAll(tmpDir)
-	})
 	cfg := &config.RuntimeConfig{
 		DataDir: tmpDir,
 	}

--- a/agent/routine-leak-checker/leak_test.go
+++ b/agent/routine-leak-checker/leak_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -58,7 +57,6 @@ func testTLSCertificates(serverName string) (cert string, key string, cacert str
 
 func setupPrimaryServer(t *testing.T) *agent.TestAgent {
 	d := testutil.TempDir(t, "leaks-primary-server")
-	t.Cleanup(func() { os.RemoveAll(d) })
 
 	certPEM, keyPEM, caPEM, err := testTLSCertificates("server.primary.consul")
 	require.NoError(t, err)

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,7 +24,6 @@ func TestUiIndex(t *testing.T) {
 	t.Parallel()
 	// Make a test dir to serve UI files
 	uiDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(uiDir)
 
 	// Make the server
 	a := NewTestAgent(t, `

--- a/agent/util_test.go
+++ b/agent/util_test.go
@@ -31,7 +31,6 @@ func TestSetFilePermissions(t *testing.T) {
 	}
 	tempFile := testutil.TempFile(t, "consul")
 	path := tempFile.Name()
-	defer os.Remove(path)
 
 	// Bad UID fails
 	if err := setFilePermissions(path, "%", "", ""); err == nil {

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -85,7 +85,6 @@ func TestAPI_AgentReload(t *testing.T) {
 
 	// Create our initial empty config file, to be overwritten later
 	cfgDir := testutil.TempDir(t, "consul-config")
-	defer os.RemoveAll(cfgDir)
 
 	cfgFilePath := filepath.Join(cfgDir, "reload.json")
 	configFile, err := os.Create(cfgFilePath)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -867,7 +867,6 @@ func TestAPI_UnixSocket(t *testing.T) {
 	}
 
 	tempDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(tempDir)
 	socket := filepath.Join(tempDir, "test.sock")
 
 	c, s := makeClientWithConfig(t, func(c *Config) {

--- a/command/acl/agenttokens/agent_tokens_test.go
+++ b/command/acl/agenttokens/agent_tokens_test.go
@@ -1,13 +1,11 @@
 package agenttokens
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -24,9 +22,6 @@ func TestAgentTokensCommand_noTabs(t *testing.T) {
 func TestAgentTokensCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/authmethod/create/authmethod_create_test.go
+++ b/command/acl/authmethod/create/authmethod_create_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -34,9 +33,6 @@ func TestAuthMethodCreateCommand_noTabs(t *testing.T) {
 
 func TestAuthMethodCreateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -187,9 +183,6 @@ func TestAuthMethodCreateCommand(t *testing.T) {
 
 func TestAuthMethodCreateCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -357,7 +350,6 @@ func TestAuthMethodCreateCommand_k8s(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -500,7 +492,6 @@ func TestAuthMethodCreateCommand_config(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "auth-method")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/authmethod/delete/authmethod_delete_test.go
+++ b/command/acl/authmethod/delete/authmethod_delete_test.go
@@ -2,13 +2,11 @@ package authmethoddelete
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -28,9 +26,6 @@ func TestAuthMethodDeleteCommand_noTabs(t *testing.T) {
 
 func TestAuthMethodDeleteCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/authmethod/list/authmethod_list_test.go
+++ b/command/acl/authmethod/list/authmethod_list_test.go
@@ -2,13 +2,11 @@ package authmethodlist
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -29,9 +27,6 @@ func TestAuthMethodListCommand_noTabs(t *testing.T) {
 
 func TestAuthMethodListCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -109,9 +104,6 @@ func TestAuthMethodListCommand(t *testing.T) {
 
 func TestAuthMethodListCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/authmethod/read/authmethod_read_test.go
+++ b/command/acl/authmethod/read/authmethod_read_test.go
@@ -2,13 +2,11 @@ package authmethodread
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -29,9 +27,6 @@ func TestAuthMethodReadCommand_noTabs(t *testing.T) {
 
 func TestAuthMethodReadCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -118,9 +113,6 @@ func TestAuthMethodReadCommand(t *testing.T) {
 
 func TestAuthMethodReadCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/authmethod/update/authmethod_update_test.go
+++ b/command/acl/authmethod/update/authmethod_update_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -33,9 +32,6 @@ func TestAuthMethodUpdateCommand_noTabs(t *testing.T) {
 
 func TestAuthMethodUpdateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -170,9 +166,6 @@ func TestAuthMethodUpdateCommand(t *testing.T) {
 func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 	t.Parallel()
 
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
-
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
@@ -259,9 +252,6 @@ func TestAuthMethodUpdateCommand_JSON(t *testing.T) {
 
 func TestAuthMethodUpdateCommand_noMerge(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -362,7 +352,6 @@ func TestAuthMethodUpdateCommand_k8s(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -597,7 +586,6 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -784,7 +772,6 @@ func TestAuthMethodUpdateCommand_k8s_noMerge(t *testing.T) {
 func TestAuthMethodUpdateCommand_config(t *testing.T) {
 	t.Parallel()
 	testDir := testutil.TempDir(t, "auth-method")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bindingrule/create/bindingrule_create_test.go
+++ b/command/acl/bindingrule/create/bindingrule_create_test.go
@@ -2,13 +2,11 @@ package bindingrulecreate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -28,9 +26,6 @@ func TestBindingRuleCreateCommand_noTabs(t *testing.T) {
 
 func TestBindingRuleCreateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -178,9 +173,6 @@ func TestBindingRuleCreateCommand(t *testing.T) {
 
 func TestBindingRuleCreateCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bindingrule/delete/bindingrule_delete_test.go
+++ b/command/acl/bindingrule/delete/bindingrule_delete_test.go
@@ -2,13 +2,11 @@ package bindingruledelete
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -27,9 +25,6 @@ func TestBindingRuleDeleteCommand_noTabs(t *testing.T) {
 
 func TestBindingRuleDeleteCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bindingrule/list/bindingrule_list_test.go
+++ b/command/acl/bindingrule/list/bindingrule_list_test.go
@@ -3,13 +3,11 @@ package bindingrulelist
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -29,9 +27,6 @@ func TestBindingRuleListCommand_noTabs(t *testing.T) {
 
 func TestBindingRuleListCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bindingrule/read/bindingrule_read_test.go
+++ b/command/acl/bindingrule/read/bindingrule_read_test.go
@@ -2,13 +2,11 @@ package bindingruleread
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -28,9 +26,6 @@ func TestBindingRuleReadCommand_noTabs(t *testing.T) {
 
 func TestBindingRuleReadCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bindingrule/update/bindingrule_update_test.go
+++ b/command/acl/bindingrule/update/bindingrule_update_test.go
@@ -2,13 +2,11 @@ package bindingruleupdate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -29,9 +27,6 @@ func TestBindingRuleUpdateCommand_noTabs(t *testing.T) {
 
 func TestBindingRuleUpdateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -469,9 +464,6 @@ func TestBindingRuleUpdateCommand(t *testing.T) {
 
 func TestBindingRuleUpdateCommand_noMerge(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/bootstrap/bootstrap_test.go
+++ b/command/acl/bootstrap/bootstrap_test.go
@@ -2,13 +2,11 @@ package bootstrap
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -26,9 +24,6 @@ func TestBootstrapCommand_noTabs(t *testing.T) {
 func TestBootstrapCommand_Pretty(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -57,9 +52,6 @@ func TestBootstrapCommand_Pretty(t *testing.T) {
 func TestBootstrapCommand_JSON(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/policy/create/policy_create_test.go
+++ b/command/acl/policy/create/policy_create_test.go
@@ -3,7 +3,6 @@ package policycreate
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +27,6 @@ func TestPolicyCreateCommand(t *testing.T) {
 	require := require.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -66,7 +64,6 @@ func TestPolicyCreateCommand_JSON(t *testing.T) {
 	require := require.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/policy/delete/policy_delete_test.go
+++ b/command/acl/policy/delete/policy_delete_test.go
@@ -2,13 +2,11 @@ package policydelete
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -25,9 +23,6 @@ func TestPolicyDeleteCommand_noTabs(t *testing.T) {
 func TestPolicyDeleteCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/policy/list/policy_list_test.go
+++ b/command/acl/policy/list/policy_list_test.go
@@ -3,13 +3,11 @@ package policylist
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -26,9 +24,6 @@ func TestPolicyListCommand_noTabs(t *testing.T) {
 func TestPolicyListCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -80,9 +75,6 @@ func TestPolicyListCommand(t *testing.T) {
 func TestPolicyListCommand_JSON(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/policy/read/policy_read_test.go
+++ b/command/acl/policy/read/policy_read_test.go
@@ -3,13 +3,11 @@ package policyread
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -26,9 +24,6 @@ func TestPolicyReadCommand_noTabs(t *testing.T) {
 func TestPolicyReadCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -72,9 +67,6 @@ func TestPolicyReadCommand(t *testing.T) {
 func TestPolicyReadCommand_JSON(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/policy/update/policy_update_test.go
+++ b/command/acl/policy/update/policy_update_test.go
@@ -3,7 +3,6 @@ package policyupdate
 import (
 	"encoding/json"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +27,6 @@ func TestPolicyUpdateCommand(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -76,7 +74,6 @@ func TestPolicyUpdateCommand_JSON(t *testing.T) {
 	assert := assert.New(t)
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/role/create/role_create_test.go
+++ b/command/acl/role/create/role_create_test.go
@@ -2,13 +2,11 @@ package rolecreate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -25,9 +23,6 @@ func TestRoleCreateCommand_noTabs(t *testing.T) {
 
 func TestRoleCreateCommand_Pretty(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -117,9 +112,6 @@ func TestRoleCreateCommand_Pretty(t *testing.T) {
 
 func TestRoleCreateCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/role/delete/role_delete_test.go
+++ b/command/acl/role/delete/role_delete_test.go
@@ -2,13 +2,11 @@ package roledelete
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -24,9 +22,6 @@ func TestRoleDeleteCommand_noTabs(t *testing.T) {
 
 func TestRoleDeleteCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/role/list/role_list_test.go
+++ b/command/acl/role/list/role_list_test.go
@@ -3,13 +3,11 @@ package rolelist
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -27,9 +25,6 @@ func TestRoleListCommand_noTabs(t *testing.T) {
 func TestRoleListCommand(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -84,9 +79,6 @@ func TestRoleListCommand(t *testing.T) {
 func TestRoleListCommand_JSON(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/role/read/role_read_test.go
+++ b/command/acl/role/read/role_read_test.go
@@ -3,13 +3,11 @@ package roleread
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -27,9 +25,6 @@ func TestRoleReadCommand_noTabs(t *testing.T) {
 
 func TestRoleReadCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -194,9 +189,6 @@ func TestRoleReadCommand(t *testing.T) {
 
 func TestRoleReadCommand_JSON(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/role/update/role_update_test.go
+++ b/command/acl/role/update/role_update_test.go
@@ -2,13 +2,11 @@ package roleupdate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -27,9 +25,6 @@ func TestRoleUpdateCommand_noTabs(t *testing.T) {
 
 func TestRoleUpdateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -201,9 +196,6 @@ func TestRoleUpdateCommand(t *testing.T) {
 func TestRoleUpdateCommand_JSON(t *testing.T) {
 	t.Parallel()
 
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
-
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
 	acl {
@@ -282,9 +274,6 @@ func TestRoleUpdateCommand_JSON(t *testing.T) {
 
 func TestRoleUpdateCommand_noMerge(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/rules/translate_test.go
+++ b/command/acl/rules/translate_test.go
@@ -3,7 +3,6 @@ package rules
 import (
 	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -26,7 +25,6 @@ func TestRulesTranslateCommand(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/token/clone/token_clone_test.go
+++ b/command/acl/token/clone/token_clone_test.go
@@ -2,7 +2,6 @@ package tokenclone
 
 import (
 	"encoding/json"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -62,9 +60,6 @@ func TestTokenCloneCommand_noTabs(t *testing.T) {
 func TestTokenCloneCommand_Pretty(t *testing.T) {
 	t.Parallel()
 	req := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
    primary_datacenter = "dc1"
@@ -169,9 +164,6 @@ func TestTokenCloneCommand_Pretty(t *testing.T) {
 func TestTokenCloneCommand_JSON(t *testing.T) {
 	t.Parallel()
 	req := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
    primary_datacenter = "dc1"

--- a/command/acl/token/create/token_create_test.go
+++ b/command/acl/token/create/token_create_test.go
@@ -2,13 +2,11 @@ package tokencreate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/require"
@@ -24,9 +22,6 @@ func TestTokenCreateCommand_noTabs(t *testing.T) {
 
 func TestTokenCreateCommand_Pretty(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -122,9 +117,6 @@ func TestTokenCreateCommand_Pretty(t *testing.T) {
 func TestTokenCreateCommand_JSON(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/token/delete/token_delete_test.go
+++ b/command/acl/token/delete/token_delete_test.go
@@ -2,13 +2,11 @@ package tokendelete
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -25,9 +23,6 @@ func TestTokenDeleteCommand_noTabs(t *testing.T) {
 func TestTokenDeleteCommand(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/token/list/token_list_test.go
+++ b/command/acl/token/list/token_list_test.go
@@ -3,13 +3,11 @@ package tokenlist
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -27,9 +25,6 @@ func TestTokenListCommand_noTabs(t *testing.T) {
 func TestTokenListCommand_Pretty(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -81,9 +76,6 @@ func TestTokenListCommand_Pretty(t *testing.T) {
 func TestTokenListCommand_JSON(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/token/read/token_read_test.go
+++ b/command/acl/token/read/token_read_test.go
@@ -3,13 +3,11 @@ package tokenread
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
 	"github.com/stretchr/testify/assert"
@@ -27,9 +25,6 @@ func TestTokenReadCommand_noTabs(t *testing.T) {
 func TestTokenReadCommand_Pretty(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -74,9 +69,6 @@ func TestTokenReadCommand_Pretty(t *testing.T) {
 func TestTokenReadCommand_JSON(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/acl/token/update/token_update_test.go
+++ b/command/acl/token/update/token_update_test.go
@@ -2,13 +2,11 @@ package tokenupdate
 
 import (
 	"encoding/json"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/mitchellh/cli"
@@ -26,9 +24,6 @@ func TestTokenUpdateCommand_noTabs(t *testing.T) {
 
 func TestTokenUpdateCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -198,9 +193,6 @@ func TestTokenUpdateCommand_JSON(t *testing.T) {
 	assert := assert.New(t)
 	// Alias because we need to access require package in Retry below
 	req := require.New(t)
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -21,7 +21,6 @@ func TestConfigFail(t *testing.T) {
 	t.Parallel()
 
 	dataDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dataDir)
 
 	tests := []struct {
 		args []string
@@ -108,7 +107,6 @@ func TestRetryJoin(t *testing.T) {
 func TestRetryJoinFail(t *testing.T) {
 	t.Parallel()
 	tmpDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(tmpDir)
 
 	ui := cli.NewMockUi()
 	cmd := New(ui, "", "", "", "", nil)
@@ -129,7 +127,6 @@ func TestRetryJoinFail(t *testing.T) {
 func TestRetryJoinWanFail(t *testing.T) {
 	t.Parallel()
 	tmpDir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(tmpDir)
 
 	ui := cli.NewMockUi()
 	cmd := New(ui, "", "", "", "", nil)
@@ -151,14 +148,12 @@ func TestRetryJoinWanFail(t *testing.T) {
 func TestProtectDataDir(t *testing.T) {
 	t.Parallel()
 	dir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dir)
 
 	if err := os.MkdirAll(filepath.Join(dir, "mdb"), 0700); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	cfgDir := testutil.TempDir(t, "consul-config")
-	defer os.RemoveAll(cfgDir)
 
 	cfgFilePath := filepath.Join(cfgDir, "consul.json")
 	cfgFile, err := os.Create(cfgFilePath)
@@ -186,13 +181,10 @@ func TestProtectDataDir(t *testing.T) {
 func TestBadDataDirPermissions(t *testing.T) {
 	t.Parallel()
 	dir := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(dir)
-
 	dataDir := filepath.Join(dir, "mdb")
 	if err := os.MkdirAll(dataDir, 0400); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	defer os.RemoveAll(dataDir)
 
 	ui := cli.NewMockUi()
 	cmd := New(ui, "", "", "", "", nil)

--- a/command/config/write/config_write_test.go
+++ b/command/config/write/config_write_test.go
@@ -2,7 +2,6 @@ package write
 
 import (
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +31,6 @@ func TestConfigWrite(t *testing.T) {
 		c := New(ui)
 
 		f := testutil.TempFile(t, "config-write-svc-web.hcl")
-		defer os.Remove(f.Name())
 		_, err := f.WriteString(`
       Kind = "service-defaults"
       Name = "web"

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -3,7 +3,6 @@ package envoy
 import (
 	"encoding/json"
 	"flag"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/xds"
@@ -685,7 +686,6 @@ func TestGenerateConfig(t *testing.T) {
 			require := require.New(t)
 
 			testDir := testutil.TempDir(t, "envoytest")
-			defer os.RemoveAll(testDir)
 
 			if len(tc.Files) > 0 {
 				for fn, fv := range tc.Files {

--- a/command/debug/debug_test.go
+++ b/command/debug/debug_test.go
@@ -28,7 +28,6 @@ func TestDebugCommand(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	enable_debug = true
@@ -65,7 +64,6 @@ func TestDebugCommand_Archive(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	enable_debug = true
@@ -125,9 +123,6 @@ func TestDebugCommand_Archive(t *testing.T) {
 func TestDebugCommand_ArgsBad(t *testing.T) {
 	t.Parallel()
 
-	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
-
 	ui := cli.NewMockUi()
 	cmd := New(ui, nil)
 
@@ -148,9 +143,6 @@ func TestDebugCommand_ArgsBad(t *testing.T) {
 
 func TestDebugCommand_OutputPathBad(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -182,7 +174,6 @@ func TestDebugCommand_OutputPathExists(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, "")
 	defer a.Shutdown()
@@ -263,7 +254,6 @@ func TestDebugCommand_CaptureTargets(t *testing.T) {
 
 	for name, tc := range cases {
 		testDir := testutil.TempDir(t, "debug")
-		defer os.RemoveAll(testDir)
 
 		a := agent.NewTestAgent(t, `
 		enable_debug = true
@@ -329,7 +319,6 @@ func TestDebugCommand_ProfilesExist(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	enable_debug = true
@@ -406,9 +395,6 @@ func TestDebugCommand_ValidateTiming(t *testing.T) {
 		// the valid duration test to avoid hanging
 		shutdownCh := make(chan struct{})
 
-		testDir := testutil.TempDir(t, "debug")
-		defer os.RemoveAll(testDir)
-
 		a := agent.NewTestAgent(t, "")
 		defer a.Shutdown()
 		testrpc.WaitForLeader(t, a.RPC, "dc1")
@@ -439,7 +425,6 @@ func TestDebugCommand_DebugDisabled(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "debug")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	enable_debug = false

--- a/command/intention/create/create_test.go
+++ b/command/intention/create/create_test.go
@@ -1,7 +1,6 @@
 package create
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -146,7 +145,6 @@ func TestCommand_File(t *testing.T) {
 
 	contents := `{ "SourceName": "foo", "DestinationName": "bar", "Action": "allow" }`
 	f := testutil.TempFile(t, "intention-create-command-file")
-	defer os.Remove(f.Name())
 	if _, err := f.WriteString(contents); err != nil {
 		t.Fatalf("err: %#v", err)
 	}

--- a/command/kv/put/kv_put_test.go
+++ b/command/kv/put/kv_put_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -176,7 +175,6 @@ func TestKVPutCommand_File(t *testing.T) {
 	c := New(ui)
 
 	f := testutil.TempFile(t, "kv-put-command-file")
-	defer os.Remove(f.Name())
 	if _, err := f.WriteString("bar"); err != nil {
 		t.Fatalf("err: %#v", err)
 	}

--- a/command/login/login_test.go
+++ b/command/login/login_test.go
@@ -34,7 +34,6 @@ func TestLoginCommand(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -228,7 +227,6 @@ func TestLoginCommand_k8s(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -323,7 +321,6 @@ func TestLoginCommand_jwt(t *testing.T) {
 	t.Parallel()
 
 	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/logout/logout_test.go
+++ b/command/logout/logout_test.go
@@ -1,7 +1,6 @@
 package logout
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/hashicorp/consul/agent/consul/authmethod/testauth"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/command/acl"
-	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/go-uuid"
 	"github.com/mitchellh/cli"
@@ -27,9 +25,6 @@ func TestLogout_noTabs(t *testing.T) {
 
 func TestLogoutCommand(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"
@@ -156,9 +151,6 @@ func TestLogoutCommand(t *testing.T) {
 
 func TestLogoutCommand_k8s(t *testing.T) {
 	t.Parallel()
-
-	testDir := testutil.TempDir(t, "acl")
-	defer os.RemoveAll(testDir)
 
 	a := agent.NewTestAgent(t, `
 	primary_datacenter = "dc1"

--- a/command/services/deregister/deregister_test.go
+++ b/command/services/deregister/deregister_test.go
@@ -172,13 +172,11 @@ func testFile(t *testing.T, suffix string) *os.File {
 
 	newName := f.Name() + "." + suffix
 	if err := os.Rename(f.Name(), newName); err != nil {
-		os.Remove(f.Name())
 		t.Fatalf("err: %s", err)
 	}
 
 	f, err := os.Create(newName)
 	if err != nil {
-		os.Remove(newName)
 		t.Fatalf("err: %s", err)
 	}
 

--- a/command/snapshot/inspect/snapshot_inspect_test.go
+++ b/command/snapshot/inspect/snapshot_inspect_test.go
@@ -66,8 +66,6 @@ func TestSnapshotInspectCommand(t *testing.T) {
 	client := a.Client()
 
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
-
 	file := filepath.Join(dir, "backup.tgz")
 
 	// Save a snapshot of the current Consul state

--- a/command/snapshot/restore/snapshot_restore_test.go
+++ b/command/snapshot/restore/snapshot_restore_test.go
@@ -74,8 +74,6 @@ func TestSnapshotRestoreCommand(t *testing.T) {
 	c := New(ui)
 
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
-
 	file := filepath.Join(dir, "backup.tgz")
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -134,7 +132,6 @@ func TestSnapshotRestoreCommand_TruncatedSnapshot(t *testing.T) {
 	}
 
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
 
 	for _, removeBytes := range []int{200, 16, 8, 4, 2, 1} {
 		t.Run(fmt.Sprintf("truncate %d bytes from end", removeBytes), func(t *testing.T) {

--- a/command/snapshot/save/snapshot_save_test.go
+++ b/command/snapshot/save/snapshot_save_test.go
@@ -78,8 +78,6 @@ func TestSnapshotSaveCommand(t *testing.T) {
 	c := New(ui)
 
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
-
 	file := filepath.Join(dir, "backup.tgz")
 	args := []string{
 		"-http-addr=" + a.HTTPAddr(),
@@ -160,7 +158,6 @@ func TestSnapshotSaveCommand_TruncatedStream(t *testing.T) {
 	})
 
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
 
 	for _, removeBytes := range []int{200, 16, 8, 4, 2, 1} {
 		t.Run(fmt.Sprintf("truncate %d bytes from end", removeBytes), func(t *testing.T) {

--- a/command/tls/ca/create/tls_ca_create_test.go
+++ b/command/tls/ca/create/tls_ca_create_test.go
@@ -24,7 +24,6 @@ func TestValidateCommand_noTabs(t *testing.T) {
 
 func TestCACreateCommand(t *testing.T) {
 	testDir := testutil.TempDir(t, "ca-create")
-	defer os.RemoveAll(testDir)
 
 	defer switchToTempDir(t, testDir)()
 

--- a/command/tls/cert/create/tls_cert_create_test.go
+++ b/command/tls/cert/create/tls_cert_create_test.go
@@ -74,7 +74,6 @@ func TestTlsCertCreateCommand_InvalidArgs(t *testing.T) {
 
 func TestTlsCertCreateCommand_fileCreate(t *testing.T) {
 	testDir := testutil.TempDir(t, "tls")
-	defer os.RemoveAll(testDir)
 
 	defer switchToTempDir(t, testDir)()
 

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -34,7 +34,6 @@ func TestValidateCommand_FailOnEmptyFile(t *testing.T) {
 func TestValidateCommand_SucceedOnMinimalConfigFile(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "config.json")
 	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
@@ -50,7 +49,6 @@ func TestValidateCommand_SucceedOnMinimalConfigFile(t *testing.T) {
 func TestValidateCommand_SucceedWithMinimalJSONConfigFormat(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "json.conf")
 	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
@@ -66,7 +64,6 @@ func TestValidateCommand_SucceedWithMinimalJSONConfigFormat(t *testing.T) {
 func TestValidateCommand_SucceedWithMinimalHCLConfigFormat(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "hcl.conf")
 	err := ioutil.WriteFile(fp, []byte("bind_addr = \"10.0.0.1\"\ndata_dir = \""+td+"\""), 0644)
@@ -82,7 +79,6 @@ func TestValidateCommand_SucceedWithMinimalHCLConfigFormat(t *testing.T) {
 func TestValidateCommand_SucceedWithJSONAsHCL(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "json.conf")
 	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
@@ -98,7 +94,6 @@ func TestValidateCommand_SucceedWithJSONAsHCL(t *testing.T) {
 func TestValidateCommand_SucceedOnMinimalConfigDir(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	err := ioutil.WriteFile(filepath.Join(td, "config.json"), []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)
 	require.Nilf(t, err, "err: %s", err)
@@ -113,7 +108,6 @@ func TestValidateCommand_SucceedOnMinimalConfigDir(t *testing.T) {
 func TestValidateCommand_FailForInvalidJSONConfigFormat(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "hcl.conf")
 	err := ioutil.WriteFile(fp, []byte(`bind_addr = "10.0.0.1"\ndata_dir = "`+td+`"`), 0644)
@@ -129,7 +123,6 @@ func TestValidateCommand_FailForInvalidJSONConfigFormat(t *testing.T) {
 func TestValidateCommand_Quiet(t *testing.T) {
 	t.Parallel()
 	td := testutil.TempDir(t, "consul")
-	defer os.RemoveAll(td)
 
 	fp := filepath.Join(td, "config.json")
 	err := ioutil.WriteFile(fp, []byte(`{"bind_addr":"10.0.0.1", "data_dir":"`+td+`"}`), 0644)

--- a/command/validate/validate_test.go
+++ b/command/validate/validate_test.go
@@ -2,7 +2,6 @@ package validate
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,7 +21,6 @@ func TestValidateCommand_noTabs(t *testing.T) {
 func TestValidateCommand_FailOnEmptyFile(t *testing.T) {
 	t.Parallel()
 	tmpFile := testutil.TempFile(t, "consul")
-	defer os.RemoveAll(tmpFile.Name())
 
 	cmd := New(cli.NewMockUi())
 	args := []string{tmpFile.Name()}

--- a/command/watch/watch_test.go
+++ b/command/watch/watch_test.go
@@ -48,7 +48,6 @@ func TestWatchCommand_loadToken(t *testing.T) {
 
 	const testToken = "4a0db5a1-869f-4602-ae8a-b0306a82f1ef"
 	testDir := testutil.TempDir(t, "watchtest")
-	defer os.RemoveAll(testDir)
 
 	fullname := filepath.Join(testDir, "token.txt")
 	require.NoError(t, ioutil.WriteFile(fullname, []byte(testToken), 0600))

--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,7 +18,6 @@ const (
 func TestLogFile_timeRotation(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterTime")
-	defer os.Remove(tempDir)
 	logFile := LogFile{
 		fileName: testFileName,
 		logPath:  tempDir,
@@ -37,7 +35,6 @@ func TestLogFile_timeRotation(t *testing.T) {
 func TestLogFile_openNew(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterOpen")
-	defer os.Remove(tempDir)
 	logFile := LogFile{fileName: testFileName, logPath: tempDir, duration: testDuration}
 	if err := logFile.openNew(); err != nil {
 		t.Errorf("Expected open file %s, got an error (%s)", testFileName, err)
@@ -51,7 +48,6 @@ func TestLogFile_openNew(t *testing.T) {
 func TestLogFile_byteRotation(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterBytes")
-	defer os.Remove(tempDir)
 	logFile := LogFile{
 		fileName: testFileName,
 		logPath:  tempDir,
@@ -70,7 +66,6 @@ func TestLogFile_byteRotation(t *testing.T) {
 func TestLogFile_deleteArchives(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriteDeleteArchives")
-	defer os.Remove(tempDir)
 	logFile := LogFile{
 		fileName: testFileName,
 		logPath:  tempDir,
@@ -107,7 +102,6 @@ func TestLogFile_deleteArchives(t *testing.T) {
 func TestLogFile_deleteArchivesDisabled(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, t.Name())
-	defer os.Remove(tempDir)
 	logFile := LogFile{
 		fileName: testFileName,
 		logPath:  tempDir,
@@ -129,7 +123,6 @@ func TestLogFile_deleteArchivesDisabled(t *testing.T) {
 func TestLogFile_rotationDisabled(t *testing.T) {
 	t.Parallel()
 	tempDir := testutil.TempDir(t, t.Name())
-	defer os.Remove(tempDir)
 	logFile := LogFile{
 		fileName: testFileName,
 		logPath:  tempDir,

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -145,7 +145,6 @@ func TestLogger_SetupLoggerWithValidLogPath(t *testing.T) {
 	require := require.New(t)
 
 	tmpDir := testutil.TempDir(t, t.Name())
-	defer os.RemoveAll(tmpDir)
 
 	cfg := &Config{
 		LogLevel:    "INFO",

--- a/sdk/testutil/io.go
+++ b/sdk/testutil/io.go
@@ -31,9 +31,10 @@ func init() {
 
 var noCleanup = strings.ToLower(os.Getenv("TEST_NOCLEANUP")) == "true"
 
-// TempDir creates a temporary directory within tmpdir
-// with the name 'testname-name'. If the directory cannot
-// be created t.Fatal is called.
+// TempDir creates a temporary directory within tmpdir with the name 'testname-name'.
+// If the directory cannot be created t.Fatal is called.
+// The directory will be removed when the test ends. Set TEST_NOCLEANUP env var
+// to prevent the directory from being removed.
 func TempDir(t *testing.T, name string) string {
 	if t == nil {
 		panic("argument t must be non-nil")
@@ -54,22 +55,28 @@ func TempDir(t *testing.T, name string) string {
 	return d
 }
 
-// TempFile creates a temporary file within tmpdir
-// with the name 'testname-name'. If the file cannot
-// be created t.Fatal is called. If a temporary directory
-// has been created before consider storing the file
-// inside this directory to avoid double cleanup.
+// TempFile creates a temporary file within tmpdir with the name 'testname-name'.
+// If the file cannot be created t.Fatal is called. If a temporary directory
+// has been created before consider storing the file inside this directory to
+// avoid double cleanup.
+// The file will be removed when the test ends.  Set TEST_NOCLEANUP env var
+// to prevent the file from being removed.
 func TempFile(t *testing.T, name string) *os.File {
-	if t != nil && t.Name() != "" {
-		name = t.Name() + "-" + name
+	if t == nil {
+		panic("argument t must be non-nil")
 	}
+	name = t.Name() + "-" + name
 	name = strings.Replace(name, "/", "_", -1)
 	f, err := ioutil.TempFile(tmpdir, name)
 	if err != nil {
-		if t == nil {
-			panic(err)
-		}
 		t.Fatalf("err: %s", err)
 	}
+	t.Cleanup(func() {
+		if noCleanup {
+			t.Logf("skipping cleanup because TEST_NOCLEANUP was enabled")
+			return
+		}
+		os.Remove(f.Name())
+	})
 	return f
 }

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -126,7 +125,6 @@ func makeRaft(t *testing.T, dir string) (*raft.Raft, *MockFSM) {
 
 func TestSnapshot(t *testing.T) {
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
 
 	// Make a Raft and populate it with some data. We tee everything we
 	// apply off to a buffer for checking post-snapshot.
@@ -235,7 +233,6 @@ func TestSnapshot_BadVerify(t *testing.T) {
 
 func TestSnapshot_TruncatedVerify(t *testing.T) {
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
 
 	// Make a Raft and populate it with some data. We tee everything we
 	// apply off to a buffer for checking post-snapshot.
@@ -281,7 +278,6 @@ func TestSnapshot_TruncatedVerify(t *testing.T) {
 
 func TestSnapshot_BadRestore(t *testing.T) {
 	dir := testutil.TempDir(t, "snapshot")
-	defer os.RemoveAll(dir)
 
 	// Make a Raft and populate it with some data.
 	before, _ := makeRaft(t, filepath.Join(dir, "before"))


### PR DESCRIPTION
Also add `t.Cleanup` to `testutil.TempFile` so that it behaves the same way as `testutil.TempDir`.

`t.Cleanup` was added to `testutil.TempDir` in a previous commit, to call `os.RemovAll` when the test ends. We no longer need to call `os.Removall` every place that it is used.