### PR TITLE
Add RSA PRIVATE KEY to the list of supported certificate authority types for the generation of TLS certificates.

### DIFF
--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -173,6 +173,10 @@ func ParseSigner(pemValue string) (crypto.Signer, error) {
 	switch block.Type {
 	case "EC PRIVATE KEY":
 		return x509.ParseECPrivateKey(block.Bytes)
+
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+
 	default:
 		return nil, fmt.Errorf("unknown PEM block type for signing key: %s", block.Type)
 	}


### PR DESCRIPTION
We are deploying consul using bosh, with a ca certificate generated by credhub.
Unfortunately, the tls generator does not support the RSA private key type that credhub generate.

This PR's only goal is to enable RSA private key in the tsl generate subcommand.