### PR TITLE
Fix panic when decoding 'Connect: null'

### DIFF
--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1056,10 +1056,12 @@ func (t *ServiceConnect) UnmarshalJSON(data []byte) (err error) {
 	}{
 		Alias: (*Alias)(t),
 	}
+
 	if err = json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	if t.SidecarService == nil {
+
+	if t.SidecarService == nil && aux != nil {
 		t.SidecarService = aux.SidecarServiceSnake
 	}
 	return nil

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/types"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +172,46 @@ func testServiceNode(t *testing.T) *ServiceNode {
 			Native: true,
 		},
 	}
+}
+
+func TestRegisterRequest_UnmarshalJSON_WithConnectNilDoesNotPanic(t *testing.T) {
+	in := `
+{
+    "ID": "",
+    "Node": "k8s-sync",
+    "Address": "127.0.0.1",
+    "TaggedAddresses": null,
+    "NodeMeta": {
+        "external-source": "kubernetes"
+    },
+    "Datacenter": "",
+    "Service": {
+        "Kind": "",
+        "ID": "test-service-f8fd5f0f4e6c",
+        "Service": "test-service",
+        "Tags": [
+            "k8s"
+        ],
+        "Meta": {
+            "external-k8s-ns": "",
+            "external-source": "kubernetes",
+            "port-stats": "18080"
+        },
+        "Port": 8080,
+        "Address": "192.0.2.10",
+        "EnableTagOverride": false,
+        "CreateIndex": 0,
+        "ModifyIndex": 0,
+        "Connect": null
+    },
+    "Check": null,
+    "SkipNodeUpdate": true
+}
+`
+
+	var req RegisterRequest
+	err := lib.DecodeJSON(strings.NewReader(in), &req)
+	require.NoError(t, err)
 }
 
 func TestNode_IsSame(t *testing.T) {


### PR DESCRIPTION
Fixes #8529

Surprisingly the `json.Unmarshal` updates the `aux` pointer to a nil, even though it was passed in non-nil. 

Note that while this fixes the panic, that request would still fail with a `400` because `ProxyDestination` was removed in 65be58703cfb4a19d8fb7fc81228dabc8bd407de and a704ebe6392a645f64ce56e87aec30bf1ac3df29 made unknown fields fail validation.

If we backport this fix to 1.6.x, that request should work.