### PR TITLE
Fix usage typo for `consul acl translate-rules`

### DIFF
--- a/website/pages/commands/acl/translate-rules.mdx
+++ b/website/pages/commands/acl/translate-rules.mdx
@@ -15,7 +15,7 @@ This command translates the legacy ACL rule syntax into the new syntax.
 
 ### Usage
 
-Usage: `consul acl translate rules [options] TRANSLATE`
+Usage: `consul acl translate-rules [options] TRANSLATE`
 
 #### API Options
 


### PR DESCRIPTION
Just fixes a typo in the command's usage info.