### PR TITLE
agent: expose the list of supported envoy versions on /v1/agent/self

### DIFF
--- a/.changelog/8545.txt
+++ b/.changelog/8545.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+agent: expose the list of supported envoy versions on /v1/agent/self
+```

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -2,6 +2,9 @@ package proxysupport
 
 // EnvoyVersions lists the latest officially supported versions of envoy.
 //
+// This list must be sorted by semver descending. Only one point release for
+// each major release should be present.
+//
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
 	"1.15.0",


### PR DESCRIPTION
The xDS api exposed on a Consul agent's gRPC port can only successfully emit xDS configuration for a supported range of envoy versions documented here: https://www.consul.io/docs/connect/proxies/envoy#supported-versions

For systems that may wish to automatically launch the latest supported envoy version (like Nomad) this support matrix currently has to be copied from markdown into code in that system.

This PR exposes consul's own internal knowledge of the last 4 supported envoy versions on the `/v1/agent/self` endpoint like this:

```
$ curl -sL 'localhost:8500/v1/agent/self' | jq .xDS
{
  "SupportedProxies": {
    "envoy": [
      "1.15.0",
      "1.14.4",
      "1.13.4",
      "1.12.6"
    ]
  }
}
```
