### PR TITLE
testing: Fix govet errors

### DIFF
--- a/agent/consul/acl.go
+++ b/agent/consul/acl.go
@@ -2143,7 +2143,7 @@ func vetNodeTxnOp(op *structs.TxnNodeOp, rule acl.Authorizer) error {
 	var authzContext acl.AuthorizerContext
 	op.FillAuthzContext(&authzContext)
 
-	if rule != nil && rule.NodeWrite(op.Node.Node, &authzContext) != acl.Allow {
+	if rule.NodeWrite(op.Node.Node, &authzContext) != acl.Allow {
 		return acl.ErrPermissionDenied
 	}
 

--- a/agent/consul/acl_endpoint.go
+++ b/agent/consul/acl_endpoint.go
@@ -1225,9 +1225,7 @@ func (a *ACL) PolicyDelete(args *structs.ACLPolicyDeleteRequest, reply *string) 
 		return respErr
 	}
 
-	if policy != nil {
-		*reply = policy.Name
-	}
+	*reply = policy.Name
 
 	return nil
 }
@@ -1692,9 +1690,7 @@ func (a *ACL) RoleDelete(args *structs.ACLRoleDeleteRequest, reply *string) erro
 		return respErr
 	}
 
-	if role != nil {
-		*reply = role.Name
-	}
+	*reply = role.Name
 
 	return nil
 }
@@ -2525,9 +2521,7 @@ func (a *ACL) Logout(args *structs.ACLLogoutRequest, reply *bool) error {
 	}
 
 	// Purge the identity from the cache to prevent using the previous definition of the identity
-	if token != nil {
-		a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(token.SecretID))
-	}
+	a.srv.acls.cache.RemoveIdentity(tokenSecretCacheID(token.SecretID))
 
 	if respErr, ok := resp.(error); ok {
 		return respErr

--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -229,7 +229,8 @@ func (r *aclPolicyReplicator) UpdateLocalBatch(ctx context.Context, srv *Server,
 	if err != nil {
 		return err
 	}
-	if respErr, ok := resp.(error); ok && err != nil {
+
+	if respErr, ok := resp.(error); ok {
 		return respErr
 	}
 
@@ -336,9 +337,11 @@ func (r *aclRoleReplicator) DeleteLocalBatch(srv *Server, batch []string) error 
 	if err != nil {
 		return err
 	}
-	if respErr, ok := resp.(error); ok && err != nil {
+
+	if respErr, ok := resp.(error); ok {
 		return respErr
 	}
+
 	return nil
 }
 
@@ -364,7 +367,8 @@ func (r *aclRoleReplicator) UpdateLocalBatch(ctx context.Context, srv *Server, s
 	if err != nil {
 		return err
 	}
-	if respErr, ok := resp.(error); ok && err != nil {
+
+	if respErr, ok := resp.(error); ok {
 		return respErr
 	}
 

--- a/agent/consul/config_replication.go
+++ b/agent/consul/config_replication.go
@@ -79,7 +79,8 @@ func (s *Server) reconcileLocalConfig(ctx context.Context, configs []structs.Con
 		if err != nil {
 			return false, fmt.Errorf("Failed to apply config %s: %v", op, err)
 		}
-		if respErr, ok := resp.(error); ok && err != nil {
+
+		if respErr, ok := resp.(error); ok {
 			return false, fmt.Errorf("Failed to apply config %s: %v", op, respErr)
 		}
 

--- a/agent/consul/federation_state_replication.go
+++ b/agent/consul/federation_state_replication.go
@@ -158,7 +158,8 @@ func (r *FederationStateReplicator) PerformDeletions(ctx context.Context, deleti
 		if err != nil {
 			return false, err
 		}
-		if respErr, ok := resp.(error); ok && err != nil {
+
+		if respErr, ok := resp.(error); ok {
 			return false, respErr
 		}
 
@@ -202,7 +203,8 @@ func (r *FederationStateReplicator) PerformUpdates(ctx context.Context, updatesR
 		if err != nil {
 			return false, err
 		}
-		if respErr, ok := resp.(error); ok && err != nil {
+
+		if respErr, ok := resp.(error); ok {
 			return false, respErr
 		}
 

--- a/agent/consul/leader_federation_state_ae.go
+++ b/agent/consul/leader_federation_state_ae.go
@@ -219,7 +219,7 @@ func (s *Server) pruneStaleFederationStates() error {
 		if err != nil {
 			return fmt.Errorf("Failed to delete federation state %s: %v", dc, err)
 		}
-		if respErr, ok := resp.(error); ok && err != nil {
+		if respErr, ok := resp.(error); ok {
 			return fmt.Errorf("Failed to delete federation state %s: %v", dc, respErr)
 		}
 	}


### PR DESCRIPTION
I tried to run the tests but `govet`failed immediately:
```
➜  consul git:(master) make test
--> Checking for other consul instances
==> Building Consul - OSes: darwin, Architectures: amd64
Building sequentially with go install
--->   darwin/amd64
--> Running go golangci-lint
agent/consul/acl.go:2146:10: nilness: tautological condition: non-nil != nil (govet)
	if rule != nil && rule.NodeWrite(op.Node.Node, &authzContext) != acl.Allow {
	        ^
agent/consul/acl_endpoint.go:1228:12: nilness: tautological condition: non-nil != nil (govet)
	if policy != nil {
	          ^
agent/consul/acl_endpoint.go:1695:10: nilness: tautological condition: non-nil != nil (govet)
	if role != nil {
	        ^
agent/consul/acl_replication_types.go:232:44: nilness: impossible condition: nil != nil (govet)
	if respErr, ok := resp.(error); ok && err != nil {
	                                          ^
agent/consul/acl_replication_types.go:339:44: nilness: impossible condition: nil != nil (govet)
	if respErr, ok := resp.(error); ok && err != nil {
	                                          ^
agent/consul/acl_replication_types.go:367:44: nilness: impossible condition: nil != nil (govet)
	if respErr, ok := resp.(error); ok && err != nil {
	                                          ^
agent/consul/acl_endpoint.go:2524:11: nilness: tautological condition: non-nil != nil (govet)
	if token != nil {
	         ^
agent/consul/config_replication.go:82:45: nilness: impossible condition: nil != nil (govet)
		if respErr, ok := resp.(error); ok && err != nil {
		                                          ^
agent/consul/federation_state_replication.go:161:45: nilness: impossible condition: nil != nil (govet)
		if respErr, ok := resp.(error); ok && err != nil {
		                                          ^
agent/consul/federation_state_replication.go:205:45: nilness: impossible condition: nil != nil (govet)
		if respErr, ok := resp.(error); ok && err != nil {

agent/consul/leader_federation_state_ae.go:222:45: nilness: impossible condition: nil != nil (govet)
		if respErr, ok := resp.(error); ok && err != nil {            

make: *** [lint] Error 1
```

This PR fixes these errors.