### PR TITLE
agent: ensure that we normalize bootstrapped config entries

### DIFF
--- a/.changelog/8547.txt
+++ b/.changelog/8547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: ensure that we normalize bootstrapped config entries
+```

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -777,6 +777,9 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 			if err != nil {
 				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %s", i, err)
 			}
+			if err := entry.Normalize(); err != nil {
+				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %s", i, err)
+			}
 			if err := entry.Validate(); err != nil {
 				return RuntimeConfig{}, fmt.Errorf("config_entries.bootstrap[%d]: %s", i, err)
 			}


### PR DESCRIPTION
In all other ways to commit config entries to the state store we `Normalize()` before invoking `Validate()` save for the bootstrap angle which this PR corrects.