### PR TITLE
Fix TestStore_RegularTokens

### DIFF
--- a/agent/token/store_test.go
+++ b/agent/token/store_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestStore_RegularTokens(t *testing.T) {
-	t.Parallel()
-
 	type tokens struct {
 		userSource   TokenSource
 		user         string
@@ -89,13 +87,22 @@ func TestStore_RegularTokens(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			s := new(Store)
-			require.True(t, s.UpdateUserToken(tt.set.user, tt.set.userSource))
-			require.True(t, s.UpdateAgentToken(tt.set.agent, tt.set.agentSource))
-			require.True(t, s.UpdateReplicationToken(tt.set.repl, tt.set.replSource))
-			require.True(t, s.UpdateAgentMasterToken(tt.set.master, tt.set.masterSource))
+			if tt.set.user != "" {
+				require.True(t, s.UpdateUserToken(tt.set.user, tt.set.userSource))
+			}
+
+			if tt.set.agent != "" {
+				require.True(t, s.UpdateAgentToken(tt.set.agent, tt.set.agentSource))
+			}
+
+			if tt.set.repl != "" {
+				require.True(t, s.UpdateReplicationToken(tt.set.repl, tt.set.replSource))
+			}
+
+			if tt.set.master != "" {
+				require.True(t, s.UpdateAgentMasterToken(tt.set.master, tt.set.masterSource))
+			}
 
 			// If they don't change then they return false.
 			require.False(t, s.UpdateUserToken(tt.set.user, tt.set.userSource))
@@ -128,7 +135,6 @@ func TestStore_RegularTokens(t *testing.T) {
 }
 
 func TestStore_AgentMasterToken(t *testing.T) {
-	t.Parallel()
 	s := new(Store)
 
 	verify := func(want bool, toks ...string) {
@@ -152,7 +158,6 @@ func TestStore_AgentMasterToken(t *testing.T) {
 }
 
 func TestStore_Notify(t *testing.T) {
-	t.Parallel()
 	s := new(Store)
 
 	newNotification := func(t *testing.T, s *Store, kind TokenKind) Notifier {


### PR DESCRIPTION
While working on a change to the `agent/token` package I noticed these tests fail.

This test was only passing because `t.Parallel` was causing every subtest to run with the last value in the iteration, which sets a value for all tokens. The test started to fail once t.Parallel was removed, but the same failure could have been produced by adding `tt := tt` to the t.Run() func. Capturing the loop variable in the scope of the loop ensures that each iteration runs with the expected value.

These tests run in under 10ms, so there is no reason to use t.Parallel. In general I think we should avoid using `t.Parallel` as much as possible. It's somewhat necessary in the `agent` and `agent/consul` packages, but everywhere  else we can skip slower tests by adding `if testing.Short { t.Skip(...) }` instead of trying to run them in parallel.

