### PR TITLE
Move RPC router from Client/Server and into BaseDeps

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul/agent/dns"
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/go-connlimit"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
@@ -306,6 +307,9 @@ type Agent struct {
 	// Connection Pool
 	connPool *pool.ConnPool
 
+	// Shared RPC Router
+	router *router.Router
+
 	// enterpriseAgent embeds fields that we only access in consul-enterprise builds
 	enterpriseAgent
 }
@@ -351,6 +355,7 @@ func New(bd BaseDeps) (*Agent, error) {
 		MemSink:         bd.MetricsHandler,
 		connPool:        bd.ConnPool,
 		autoConf:        bd.AutoConfig,
+		router:          bd.Router,
 	}
 
 	a.serviceManager = NewServiceManager(&a)
@@ -462,6 +467,7 @@ func (a *Agent) Start(ctx context.Context) error {
 		consul.WithTokenStore(a.tokens),
 		consul.WithTLSConfigurator(a.tlsConfigurator),
 		consul.WithConnectionPool(a.connPool),
+		consul.WithRouter(a.router),
 	}
 
 	// Setup either the client or the server.

--- a/agent/consul/auto_encrypt.go
+++ b/agent/consul/auto_encrypt.go
@@ -73,7 +73,7 @@ func (c *Client) RequestAutoEncryptCerts(ctx context.Context, servers []string, 
 	// Check if we know about a server already through gossip. Depending on
 	// how the agent joined, there might already be one. Also in case this
 	// gets called because the cert expired.
-	server := c.routers.FindServer()
+	server := c.router.FindLANServer()
 	if server != nil {
 		servers = []string{server.Addr.String()}
 	}

--- a/agent/consul/client_serf.go
+++ b/agent/consul/client_serf.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/serf"
 )
@@ -115,7 +116,7 @@ func (c *Client) nodeJoin(me serf.MemberEvent) {
 			continue
 		}
 		c.logger.Info("adding server", "server", parts)
-		c.routers.AddServer(parts)
+		c.router.AddServer(types.AreaLAN, parts)
 
 		// Trigger the callback
 		if c.config.ServerUp != nil {
@@ -139,7 +140,7 @@ func (c *Client) nodeUpdate(me serf.MemberEvent) {
 			continue
 		}
 		c.logger.Info("updating server", "server", parts.String())
-		c.routers.AddServer(parts)
+		c.router.AddServer(types.AreaLAN, parts)
 	}
 }
 
@@ -151,7 +152,7 @@ func (c *Client) nodeFail(me serf.MemberEvent) {
 			continue
 		}
 		c.logger.Info("removing server", "server", parts.String())
-		c.routers.RemoveServer(parts)
+		c.router.RemoveServer(types.AreaLAN, parts)
 	}
 }
 

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -112,7 +112,7 @@ func TestClient_JoinLAN(t *testing.T) {
 	joinLAN(t, c1, s1)
 	testrpc.WaitForTestAgent(t, c1.RPC, "dc1")
 	retry.Run(t, func(r *retry.R) {
-		if got, want := c1.routers.NumServers(), 1; got != want {
+		if got, want := c1.router.GetLANManager().NumServers(), 1; got != want {
 			r.Fatalf("got %d servers want %d", got, want)
 		}
 		if got, want := len(s1.LANMembers()), 2; got != want {
@@ -150,7 +150,7 @@ func TestClient_LANReap(t *testing.T) {
 
 	// Check the router has both
 	retry.Run(t, func(r *retry.R) {
-		server := c1.routers.FindServer()
+		server := c1.router.FindLANServer()
 		require.NotNil(t, server)
 		require.Equal(t, s1.config.NodeName, server.Name)
 	})
@@ -160,7 +160,7 @@ func TestClient_LANReap(t *testing.T) {
 
 	retry.Run(t, func(r *retry.R) {
 		require.Len(r, c1.LANMembers(), 1)
-		server := c1.routers.FindServer()
+		server := c1.router.FindLANServer()
 		require.Nil(t, server)
 	})
 }
@@ -390,7 +390,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 	}
 
 	// Sleep to allow Serf to sync, shuffle, and let the shuffle complete
-	c.routers.ResetRebalanceTimer()
+	c.router.GetLANManager().ResetRebalanceTimer()
 	time.Sleep(time.Second)
 
 	if len(c.LANMembers()) != numServers+numClients {
@@ -406,7 +406,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 	var pingCount int
 	for range servers {
 		time.Sleep(200 * time.Millisecond)
-		s := c.routers.FindServer()
+		m, s := c.router.FindLANRoute()
 		ok, err := c.connPool.Ping(s.Datacenter, s.ShortName, s.Addr)
 		if !ok {
 			t.Errorf("Unable to ping server %v: %s", s.String(), err)
@@ -415,7 +415,7 @@ func TestClient_RPC_ConsulServerPing(t *testing.T) {
 
 		// Artificially fail the server in order to rotate the server
 		// list
-		c.routers.NotifyFailedServer(s)
+		m.NotifyFailedServer(s)
 	}
 
 	if pingCount != numServers {
@@ -524,7 +524,7 @@ func TestClient_SnapshotRPC(t *testing.T) {
 
 	// Wait until we've got a healthy server.
 	retry.Run(t, func(r *retry.R) {
-		if got, want := c1.routers.NumServers(), 1; got != want {
+		if got, want := c1.router.GetLANManager().NumServers(), 1; got != want {
 			r.Fatalf("got %d servers want %d", got, want)
 		}
 	})
@@ -559,7 +559,7 @@ func TestClient_SnapshotRPC_RateLimit(t *testing.T) {
 
 	joinLAN(t, c1, s1)
 	retry.Run(t, func(r *retry.R) {
-		if got, want := c1.routers.NumServers(), 1; got != want {
+		if got, want := c1.router.GetLANManager().NumServers(), 1; got != want {
 			r.Fatalf("got %d servers want %d", got, want)
 		}
 	})
@@ -607,7 +607,7 @@ func TestClient_SnapshotRPC_TLS(t *testing.T) {
 		}
 
 		// Wait until we've got a healthy server.
-		if got, want := c1.routers.NumServers(), 1; got != want {
+		if got, want := c1.router.GetLANManager().NumServers(), 1; got != want {
 			r.Fatalf("got %d servers want %d", got, want)
 		}
 	})

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -2,6 +2,7 @@ package consul
 
 import (
 	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/go-hclog"
@@ -12,6 +13,7 @@ type consulOptions struct {
 	tlsConfigurator *tlsutil.Configurator
 	connPool        *pool.ConnPool
 	tokens          *token.Store
+	router          *router.Router
 }
 
 type ConsulOption func(*consulOptions)
@@ -37,6 +39,12 @@ func WithConnectionPool(connPool *pool.ConnPool) ConsulOption {
 func WithTokenStore(tokens *token.Store) ConsulOption {
 	return func(opt *consulOptions) {
 		opt.tokens = tokens
+	}
+}
+
+func WithRouter(router *router.Router) ConsulOption {
+	return func(opt *consulOptions) {
+		opt.router = router
 	}
 }
 

--- a/agent/consul/util.go
+++ b/agent/consul/util.go
@@ -156,7 +156,7 @@ func (c *Client) CheckServers(datacenter string, fn func(*metadata.Server) bool)
 		return
 	}
 
-	c.routers.CheckServers(fn)
+	c.router.CheckServers(datacenter, fn)
 }
 
 type serversACLMode struct {

--- a/agent/router/manager.go
+++ b/agent/router/manager.go
@@ -254,6 +254,9 @@ func (m *Manager) CheckServers(fn func(srv *metadata.Server) bool) {
 // getServerList is a convenience method which hides the locking semantics
 // of atomic.Value from the caller.
 func (m *Manager) getServerList() serverList {
+	if m == nil {
+		return serverList{}
+	}
 	return m.listValue.Load().(serverList)
 }
 

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -144,6 +144,12 @@ func (r *Router) AddArea(areaID types.AreaID, cluster RouterSerfCluster, pinger 
 	}
 	r.areas[areaID] = area
 
+	// always ensure we have a started manager for the LAN area
+	if areaID == types.AreaLAN {
+		r.logger.Info("Initializing LAN area manager")
+		r.maybeInitializeManager(area, r.localDatacenter)
+	}
+
 	// Do an initial populate of the manager so that we don't have to wait
 	// for events to fire. This lets us attempt to use all the known servers
 	// initially, and then will quickly detect that they are failed if we
@@ -151,10 +157,12 @@ func (r *Router) AddArea(areaID types.AreaID, cluster RouterSerfCluster, pinger 
 	for _, m := range cluster.Members() {
 		ok, parts := metadata.IsConsulServer(m)
 		if !ok {
-			r.logger.Warn("Non-server in server-only area",
-				"non_server", m.Name,
-				"area", areaID,
-			)
+			if areaID != types.AreaLAN {
+				r.logger.Warn("Non-server in server-only area",
+					"non_server", m.Name,
+					"area", areaID,
+				)
+			}
 			continue
 		}
 
@@ -233,24 +241,35 @@ func (r *Router) RemoveArea(areaID types.AreaID) error {
 	return nil
 }
 
+// maybeInitializeManager will initialize a new manager for the given area/dc
+// if its not already created. Calling this function should only be done if
+// holding a write lock on the Router.
+func (r *Router) maybeInitializeManager(area *areaInfo, dc string) *Manager {
+	info, ok := area.managers[dc]
+	if ok {
+		return info.manager
+	}
+
+	shutdownCh := make(chan struct{})
+	manager := New(r.logger, shutdownCh, area.cluster, area.pinger, r.serverName)
+	info = &managerInfo{
+		manager:    manager,
+		shutdownCh: shutdownCh,
+	}
+	area.managers[dc] = info
+
+	managers := r.managers[dc]
+	r.managers[dc] = append(managers, manager)
+	go manager.Start()
+
+	return manager
+}
+
 // addServer does the work of AddServer once the write lock is held.
 func (r *Router) addServer(area *areaInfo, s *metadata.Server) error {
 	// Make the manager on the fly if this is the first we've seen of it,
 	// and add it to the index.
-	info, ok := area.managers[s.Datacenter]
-	if !ok {
-		shutdownCh := make(chan struct{})
-		manager := New(r.logger, shutdownCh, area.cluster, area.pinger, r.serverName)
-		info = &managerInfo{
-			manager:    manager,
-			shutdownCh: shutdownCh,
-		}
-		area.managers[s.Datacenter] = info
-
-		managers := r.managers[s.Datacenter]
-		r.managers[s.Datacenter] = append(managers, manager)
-		go manager.Start()
-	}
+	manager := r.maybeInitializeManager(area, s.Datacenter)
 
 	// If TLS is enabled for the area, set it on the server so the manager
 	// knows to use TLS when pinging it.
@@ -258,7 +277,7 @@ func (r *Router) addServer(area *areaInfo, s *metadata.Server) error {
 		s.UseTLS = true
 	}
 
-	info.manager.AddServer(s)
+	manager.AddServer(s)
 	return nil
 }
 
@@ -339,6 +358,28 @@ func (r *Router) FailServer(areaID types.AreaID, s *metadata.Server) error {
 // also returned, by calling NotifyFailedServer().
 func (r *Router) FindRoute(datacenter string) (*Manager, *metadata.Server, bool) {
 	return r.routeFn(datacenter)
+}
+
+// FindLANRoute returns a healthy server within the local datacenter. In some
+// cases this may return a best-effort unhealthy server that can be used for a
+// connection attempt. If any problem occurs with the given server, the caller
+// should feed that back to the manager associated with the server, which is
+// also returned, by calling NotifyFailedServer().
+func (r *Router) FindLANRoute() (*Manager, *metadata.Server) {
+	mgr := r.GetLANManager()
+
+	if mgr == nil {
+		return nil, nil
+	}
+
+	return mgr, mgr.FindServer()
+}
+
+// FindLANServer will look for a server in the local datacenter.
+// This function may return a nil value if no server is available.
+func (r *Router) FindLANServer() *metadata.Server {
+	_, srv := r.FindLANRoute()
+	return srv
 }
 
 // findDirectRoute looks for a route to the given datacenter if it's directly
@@ -430,6 +471,24 @@ func (r *Router) HasDatacenter(dc string) bool {
 	defer r.RUnlock()
 	_, ok := r.managers[dc]
 	return ok
+}
+
+// GetLANManager returns the Manager for the LAN area and the local datacenter
+func (r *Router) GetLANManager() *Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	area, ok := r.areas[types.AreaLAN]
+	if !ok {
+		return nil
+	}
+
+	managerInfo, ok := area.managers[r.localDatacenter]
+	if !ok {
+		return nil
+	}
+
+	return managerInfo.manager
 }
 
 // datacenterSorter takes a list of DC names and a parallel vector of distances

--- a/agent/setup.go
+++ b/agent/setup.go
@@ -13,6 +13,7 @@ import (
 	certmon "github.com/hashicorp/consul/agent/cert-monitor"
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/pool"
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/ipaddr"
@@ -35,6 +36,7 @@ type BaseDeps struct {
 	Cache           *cache.Cache
 	AutoConfig      *autoconf.AutoConfig // TODO: use an interface
 	ConnPool        *pool.ConnPool       // TODO: use an interface
+	Router          *router.Router
 }
 
 // MetricsHandler provides an http.Handler for displaying metrics.
@@ -85,6 +87,8 @@ func NewBaseDeps(configLoader ConfigLoader, logOut io.Writer) (BaseDeps, error) 
 	d.ConnPool = newConnPool(cfg, d.Logger, d.TLSConfigurator)
 
 	deferredAC := &deferredAutoConfig{}
+
+	d.Router = router.NewRouter(d.Logger, cfg.Datacenter, fmt.Sprintf("%s.%s", cfg.NodeName, cfg.Datacenter))
 
 	cmConf := new(certmon.Config).
 		WithCache(d.Cache).

--- a/types/area.go
+++ b/types/area.go
@@ -7,3 +7,7 @@ type AreaID string
 // This represents the existing WAN area that's built in to Consul. Consul
 // Enterprise generalizes areas, which are represented with UUIDs.
 const AreaWAN AreaID = "wan"
+
+// This represents the existing LAN area that's built in to Consul. Consul
+// Enterprise generalizes areas, which are represented with UUIDs.
+const AreaLAN AreaID = "lan"


### PR DESCRIPTION
This will allow it to be a shared component which is needed for AutoConfig