### PR TITLE
ui: Tooltip Bugs

### DIFF
--- a/ui-v2/app/components/discovery-chain/index.hbs
+++ b/ui-v2/app/components/discovery-chain/index.hbs
@@ -135,7 +135,7 @@
       {{/if}}
     {{/each}}
   </svg>
-  <div class={{concat 'tooltip' (if activeTooltip ' active' '')}} style={{{ concat 'position: absolute;top:' y 'px;left:' x 'px;'}}}>
+  <div class={{concat 'tooltip' (if activeTooltip ' active' '')}} style={{{ concat 'top:' y 'px;left:' x 'px;'}}}>
     <span role="tooltip">{{round tooltip decimals=2}}%</span>
   </div>
 {{/if}}

--- a/ui-v2/app/components/discovery-chain/index.js
+++ b/ui-v2/app/components/discovery-chain/index.js
@@ -177,8 +177,8 @@ export default Component.extend({
   actions: {
     showSplit: function(e) {
       this.setProperties({
-        x: e.offsetX,
-        y: e.offsetY - 5,
+        x: e.clientX,
+        y: e.clientY - 3,
         tooltip: e.target.dataset.percentage,
         activeTooltip: true,
       });

--- a/ui-v2/app/styles/base/components/tooltip/layout.scss
+++ b/ui-v2/app/styles/base/components/tooltip/layout.scss
@@ -55,4 +55,5 @@
 .ember-tooltip {
   padding: 12px;
   max-width: 192px;
+  z-index: 4;
 }

--- a/ui-v2/app/styles/components/discovery-chain/layout.scss
+++ b/ui-v2/app/styles/components/discovery-chain/layout.scss
@@ -25,6 +25,10 @@
 %discovery-chain [id*=':']:not(path):hover {
   @extend %chain-node-active;
 }
+%discovery-chain .tooltip {
+  position: fixed;
+  z-index: 5;
+}
 %discovery-chain .tooltip.active > [role='tooltip'],
 %discovery-chain .tooltip.active > [role='tooltip']::after {
   @extend %blink-in-fade-out-active;


### PR DESCRIPTION
- Fix for the tooltip bug in Discovery Chain while using Firefox Browser
![firefox_tooltip](https://user-images.githubusercontent.com/19161242/91220673-7fdac180-e6ea-11ea-91f3-97bf6193a8c7.gif)

- Fix stack order of the ember-tooltip to be above the search/sort
<img width="257" alt="Screen Shot 2020-08-25 at 1 35 14 PM" src="https://user-images.githubusercontent.com/19161242/91220734-96811880-e6ea-11ea-8af3-a4da6d9ad4a4.png">
