### PR TITLE
agent: expose the list of supported envoy versions on /v1/agent/self

### DIFF
--- a/.changelog/8545.txt
+++ b/.changelog/8545.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+agent: expose the list of supported envoy versions on /v1/agent/self
+```

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -11,6 +11,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -527,7 +528,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {
@@ -737,14 +738,4 @@ func setupTLSRootsAndLeaf(t *testing.T, snap *proxycfg.ConfigSnapshot) {
 	if snap.Roots != nil {
 		snap.Roots.Roots[0].RootCert = golden(t, "test-root-cert", "", "")
 	}
-}
-
-// supportedEnvoyVersions lists the versions that we generated golden tests for
-//
-// see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
-var supportedEnvoyVersions = []string{
-	"1.14.2",
-	"1.13.2",
-	"1.12.4",
-	"1.11.2",
 }

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -14,6 +14,7 @@ import (
 	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 )
@@ -554,7 +555,7 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -11,6 +11,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -433,7 +434,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -1,0 +1,11 @@
+package proxysupport
+
+// EnvoyVersions lists the latest officially supported versions of envoy.
+//
+// see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
+var EnvoyVersions = []string{
+	"1.14.2",
+	"1.13.2",
+	"1.12.4",
+	"1.11.2",
+}

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -2,6 +2,9 @@ package proxysupport
 
 // EnvoyVersions lists the latest officially supported versions of envoy.
 //
+// This list must be sorted by semver descending. Only one point release for
+// each major release should be present.
+//
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
 	"1.14.2",

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/discoverychain"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -175,7 +176,7 @@ func TestRoutesFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/xds"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/api"
 	proxyCmd "github.com/hashicorp/consul/command/connect/proxy"
 	"github.com/hashicorp/consul/command/flags"
@@ -68,10 +69,9 @@ type cmd struct {
 	gatewayKind    api.ServiceKind
 }
 
-const (
-	defaultEnvoyVersion = "1.14.2"
-	meshGatewayVal      = "mesh"
-)
+const meshGatewayVal = "mesh"
+
+var defaultEnvoyVersion = proxysupport.EnvoyVersions[0]
 
 var supportedGateways = map[string]api.ServiceKind{
 	"mesh":        api.ServiceKindMeshGateway,


### PR DESCRIPTION
Backport of #8545 and a portion of `c599a2f` from #8424 into `release/1.8.x`.