### PR TITLE
agent: expose the list of supported envoy versions on /v1/agent/self

### DIFF
--- a/.changelog/8545.txt
+++ b/.changelog/8545.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+agent: expose the list of supported envoy versions on /v1/agent/self
+```

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -25,6 +24,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	tokenStore "github.com/hashicorp/consul/agent/token"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -1175,39 +1175,65 @@ func TestAgent_Checks_ACLFilter(t *testing.T) {
 
 func TestAgent_Self(t *testing.T) {
 	t.Parallel()
-	a := NewTestAgent(t, t.Name(), `
-		node_meta {
-			somekey = "somevalue"
-		}
-	`)
-	defer a.Shutdown()
 
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-	req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
-	obj, err := a.srv.AgentSelf(nil, req)
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	cases := map[string]struct {
+		hcl       string
+		expectXDS bool
+	}{
+		"normal": {
+			hcl: `
+			node_meta {
+				somekey = "somevalue"
+			}
+			`,
+			expectXDS: true,
+		},
+		"no grpc": {
+			hcl: `
+			node_meta {
+				somekey = "somevalue"
+			}
+			ports = {
+				grpc = -1
+			}
+			`,
+			expectXDS: false,
+		},
 	}
 
-	val := obj.(Self)
-	if int(val.Member.Port) != a.Config.SerfPortLAN {
-		t.Fatalf("incorrect port: %v", obj)
-	}
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			a := NewTestAgent(t, t.Name(), tc.hcl)
+			defer a.Shutdown()
 
-	if val.DebugConfig["SerfPortLAN"].(int) != a.Config.SerfPortLAN {
-		t.Fatalf("incorrect port: %v", obj)
-	}
+			testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+			req, _ := http.NewRequest("GET", "/v1/agent/self", nil)
+			obj, err := a.srv.AgentSelf(nil, req)
+			require.NoError(t, err)
 
-	cs, err := a.GetLANCoordinate()
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	if c := cs[a.config.SegmentName]; !reflect.DeepEqual(c, val.Coord) {
-		t.Fatalf("coordinates are not equal: %v != %v", c, val.Coord)
-	}
-	delete(val.Meta, structs.MetaSegmentKey) // Added later, not in config.
-	if !reflect.DeepEqual(a.config.NodeMeta, val.Meta) {
-		t.Fatalf("meta fields are not equal: %v != %v", a.config.NodeMeta, val.Meta)
+			val := obj.(Self)
+			require.Equal(t, a.Config.SerfPortLAN, int(val.Member.Port))
+			require.Equal(t, a.Config.SerfPortLAN, val.DebugConfig["SerfPortLAN"].(int))
+
+			cs, err := a.GetLANCoordinate()
+			require.NoError(t, err)
+			require.Equal(t, cs[a.config.SegmentName], val.Coord)
+
+			delete(val.Meta, structs.MetaSegmentKey) // Added later, not in config.
+			require.Equal(t, a.config.NodeMeta, val.Meta)
+
+			if tc.expectXDS {
+				require.NotNil(t, val.XDS, "xds component missing when gRPC is enabled")
+				require.Equal(t,
+					map[string][]string{"envoy": proxysupport.EnvoyVersions},
+					val.XDS.SupportedProxies,
+				)
+
+			} else {
+				require.Nil(t, val.XDS, "xds component should be missing when gRPC is disabled")
+			}
+		})
 	}
 }
 

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -378,7 +378,7 @@ func (a *TestAgent) consulConfig() *consul.Config {
 // Instead of relying on one set of ports to be sufficient we retry
 // starting the agent with different ports on port conflict.
 func randomPortsSource(tls bool) (src config.Source, returnPortsFn func()) {
-	ports := freeport.MustTake(6)
+	ports := freeport.MustTake(7)
 
 	var http, https int
 	if tls {
@@ -400,6 +400,7 @@ func randomPortsSource(tls bool) (src config.Source, returnPortsFn func()) {
 				serf_lan = ` + strconv.Itoa(ports[3]) + `
 				serf_wan = ` + strconv.Itoa(ports[4]) + `
 				server = ` + strconv.Itoa(ports[5]) + `
+				grpc = ` + strconv.Itoa(ports[6]) + `
 			}
 		`,
 	}, func() { freeport.Return(ports) }

--- a/agent/xds/clusters_test.go
+++ b/agent/xds/clusters_test.go
@@ -11,6 +11,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -336,7 +337,7 @@ func TestClustersFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {
@@ -565,14 +566,4 @@ func customAppClusterJSON(t *testing.T, opts customClusterJSONOptions) string {
 	err := customAppClusterJSONTemplate.Execute(&buf, opts)
 	require.NoError(t, err)
 	return buf.String()
-}
-
-// supportedEnvoyVersions lists the versions that we generated golden tests for
-//
-// see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
-var supportedEnvoyVersions = []string{
-	"1.13.1",
-	"1.12.3",
-	"1.11.2",
-	"1.10.0",
 }

--- a/agent/xds/endpoints_test.go
+++ b/agent/xds/endpoints_test.go
@@ -14,6 +14,7 @@ import (
 	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 )
@@ -378,7 +379,7 @@ func Test_endpointsFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/agent/xds/listeners_test.go
+++ b/agent/xds/listeners_test.go
@@ -11,6 +11,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
@@ -261,7 +262,7 @@ func TestListenersFromSnapshot(t *testing.T) {
 		},
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -2,6 +2,9 @@ package proxysupport
 
 // EnvoyVersions lists the latest officially supported versions of envoy.
 //
+// This list must be sorted by semver descending. Only one point release for
+// each major release should be present.
+//
 // see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
 var EnvoyVersions = []string{
 	"1.13.1",

--- a/agent/xds/proxysupport/proxysupport.go
+++ b/agent/xds/proxysupport/proxysupport.go
@@ -1,0 +1,11 @@
+package proxysupport
+
+// EnvoyVersions lists the latest officially supported versions of envoy.
+//
+// see: https://www.consul.io/docs/connect/proxies/envoy#supported-versions
+var EnvoyVersions = []string{
+	"1.13.1",
+	"1.12.3",
+	"1.11.2",
+	"1.10.0",
+}

--- a/agent/xds/routes_test.go
+++ b/agent/xds/routes_test.go
@@ -9,6 +9,7 @@ import (
 	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/hashicorp/consul/agent/proxycfg"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	testinf "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/require"
 )
@@ -325,7 +326,7 @@ func TestRoutesFromSnapshot(t *testing.T) {
 		// TODO(rb): test match stanza skipped for grpc
 	}
 
-	for _, envoyVersion := range supportedEnvoyVersions {
+	for _, envoyVersion := range proxysupport.EnvoyVersions {
 		sf := determineSupportedProxyFeaturesFromString(envoyVersion)
 		t.Run("envoy-"+envoyVersion, func(t *testing.T) {
 			for _, tt := range tests {

--- a/command/connect/envoy/envoy.go
+++ b/command/connect/envoy/envoy.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/xds"
+	"github.com/hashicorp/consul/agent/xds/proxysupport"
 	"github.com/hashicorp/consul/api"
 	proxyCmd "github.com/hashicorp/consul/command/connect/proxy"
 	"github.com/hashicorp/consul/command/flags"
@@ -68,6 +69,8 @@ type cmd struct {
 	meshGatewaySvcName string
 }
 
+var defaultEnvoyVersion = proxysupport.EnvoyVersions[0]
+
 func (c *cmd) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 
@@ -111,7 +114,7 @@ func (c *cmd) init() {
 		"Set the agent's gRPC address and port (in http(s)://host:port format). "+
 			"Alternatively, you can specify CONSUL_GRPC_ADDR in ENV.")
 
-	c.flags.StringVar(&c.envoyVersion, "envoy-version", "1.13.0",
+	c.flags.StringVar(&c.envoyVersion, "envoy-version", defaultEnvoyVersion,
 		"Sets the envoy-version that the envoy binary has.")
 
 	c.flags.BoolVar(&c.register, "register", false,

--- a/command/connect/envoy/envoy_test.go
+++ b/command/connect/envoy/envoy_test.go
@@ -83,7 +83,7 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy"},
 			Env:   []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -100,7 +100,7 @@ func TestGenerateConfig(t *testing.T) {
 				"-token", "c9a52720-bf6c-4aa6-b8bc-66881a5ade95"},
 			Env: []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -119,7 +119,7 @@ func TestGenerateConfig(t *testing.T) {
 				"CONSUL_HTTP_TOKEN=c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -141,7 +141,7 @@ func TestGenerateConfig(t *testing.T) {
 				"token.txt": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -163,7 +163,7 @@ func TestGenerateConfig(t *testing.T) {
 				"token.txt": "c9a52720-bf6c-4aa6-b8bc-66881a5ade95",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -181,7 +181,7 @@ func TestGenerateConfig(t *testing.T) {
 				"-grpc-addr", "localhost:9999"},
 			Env: []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -202,7 +202,7 @@ func TestGenerateConfig(t *testing.T) {
 				"CONSUL_GRPC_ADDR=localhost:9999",
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -222,7 +222,7 @@ func TestGenerateConfig(t *testing.T) {
 				"-grpc-addr", "unix:///var/run/consul.sock"},
 			Env: []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentSocket:           "/var/run/consul.sock",
@@ -237,7 +237,7 @@ func TestGenerateConfig(t *testing.T) {
 			Flags:    []string{"-proxy-id", "test-proxy"},
 			GRPCPort: 9999,
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -256,7 +256,7 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy", "-admin-access-log-path", "/some/path/access.log"},
 			Env:   []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -275,7 +275,7 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy", "-ca-file", "some/path"},
 			Env:   []string{},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -291,7 +291,7 @@ func TestGenerateConfig(t *testing.T) {
 			Flags: []string{"-proxy-id", "test-proxy", "-ca-file", "../../../test/ca/root.cer"},
 			Env:   []string{"CONSUL_HTTP_SSL=1"},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion: "1.13.0",
+				EnvoyVersion: "1.13.1",
 				ProxyCluster: "test-proxy",
 				ProxyID:      "test-proxy",
 				// Should resolve IP, note this might not resolve the same way
@@ -334,7 +334,7 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -367,7 +367,7 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -405,7 +405,7 @@ func TestGenerateConfig(t *testing.T) {
 				} , { "name": "fake_sink_2" }`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -430,7 +430,7 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",
@@ -485,7 +485,7 @@ func TestGenerateConfig(t *testing.T) {
 				}`,
 			},
 			WantArgs: BootstrapTplArgs{
-				EnvoyVersion:          "1.13.0",
+				EnvoyVersion:          "1.13.1",
 				ProxyCluster:          "test-proxy",
 				ProxyID:               "test-proxy",
 				AgentAddress:          "127.0.0.1",

--- a/command/connect/envoy/testdata/access-log-path.golden
+++ b/command/connect/envoy/testdata/access-log-path.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/defaults.golden
+++ b/command/connect/envoy/testdata/defaults.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/existing-ca-file.golden
+++ b/command/connect/envoy/testdata/existing-ca-file.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-multiple.golden
+++ b/command/connect/envoy/testdata/extra_-multiple.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/extra_-single.golden
+++ b/command/connect/envoy/testdata/extra_-single.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-config.golden
+++ b/command/connect/envoy/testdata/grpc-addr-config.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-env.golden
+++ b/command/connect/envoy/testdata/grpc-addr-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-flag.golden
+++ b/command/connect/envoy/testdata/grpc-addr-flag.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/grpc-addr-unix.golden
+++ b/command/connect/envoy/testdata/grpc-addr-unix.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/stats-config-override.golden
+++ b/command/connect/envoy/testdata/stats-config-override.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-arg.golden
+++ b/command/connect/envoy/testdata/token-arg.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-env.golden
+++ b/command/connect/envoy/testdata/token-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-arg.golden
+++ b/command/connect/envoy/testdata/token-file-arg.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/token-file-env.golden
+++ b/command/connect/envoy/testdata/token-file-env.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {

--- a/command/connect/envoy/testdata/zipkin-tracing-config.golden
+++ b/command/connect/envoy/testdata/zipkin-tracing-config.golden
@@ -13,7 +13,7 @@
     "id": "test-proxy",
     "metadata": {
       "namespace": "default",
-      "envoy_version": "1.13.0"
+      "envoy_version": "1.13.1"
     }
   },
   "static_resources": {


### PR DESCRIPTION
Backport of #8545 and a portion of c599a2f from #8424 into release/1.7.x.

Also one small `testagent.go` backport that was added with auto-config to allocate a `grpc` port during tests by default.