### PR TITLE
agent: extract userEventHandler and remoteExecHandler

### DIFF
--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -118,9 +118,10 @@ func (s *HTTPHandlers) EventList(resp http.ResponseWriter, req *http.Request) (i
 	// Setup a notification channel for changes
 SETUP_NOTIFY:
 	if b.MinQueryIndex > 0 {
+		notifier := s.agent.userEventHandler.NotifyGroup()
 		notifyCh = make(chan struct{}, 1)
-		s.agent.eventNotify.Wait(notifyCh)
-		defer s.agent.eventNotify.Clear(notifyCh)
+		notifier.Wait(notifyCh)
+		defer notifier.Clear(notifyCh)
 	}
 
 RUN_QUERY:

--- a/agent/event_endpoint.go
+++ b/agent/event_endpoint.go
@@ -125,7 +125,7 @@ SETUP_NOTIFY:
 
 RUN_QUERY:
 	// Get the recent events
-	events := s.agent.UserEvents()
+	events := s.agent.userEventHandler.UserEvents()
 
 	// Filter the events using the ACL, if present
 	if authz != nil {

--- a/agent/intentions_endpoint_test.go
+++ b/agent/intentions_endpoint_test.go
@@ -6,11 +6,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIntentionList(t *testing.T) {
@@ -696,6 +698,14 @@ func TestIntentionSpecificDelete(t *testing.T) {
 		err := a.RPC("Intention.Get", req, &resp)
 		testutil.RequireErrorContains(t, err, "not found")
 	}
+}
+
+func generateUUID() (ret string) {
+	var err error
+	if ret, err = uuid.GenerateUUID(); err != nil {
+		panic(fmt.Sprintf("Unable to generate a UUID, %v", err))
+	}
+	return ret
 }
 
 func TestParseIntentionStringComponent(t *testing.T) {

--- a/agent/rpcclient/kv/kv.go
+++ b/agent/rpcclient/kv/kv.go
@@ -1,0 +1,27 @@
+package kv
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/agent/structs"
+)
+
+type Client struct {
+	NetRPC NetRPC
+}
+
+type NetRPC interface {
+	RPC(method string, args interface{}, reply interface{}) error
+}
+
+func (c *Client) Get(_ context.Context, req structs.KeyRequest) (structs.IndexedDirEntries, error) {
+	var out structs.IndexedDirEntries
+	err := c.NetRPC.RPC("KVS.Get", &req, &out)
+	return out, err
+}
+
+func (c *Client) Apply(_ context.Context, req structs.KVSRequest) (bool, error) {
+	var out bool
+	err := c.NetRPC.RPC("KVS.Apply", &req, &out)
+	return out, err
+}

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -57,7 +57,7 @@ func TestUserEventHandler_ShouldProcessUserEvent(t *testing.T) {
 
 	cfg := UserEventHandlerConfig{
 		NodeName: "the-node",
-		State: &fakeServiceLister{
+		Services: &fakeServiceLister{
 			serviceID:   "the-service-id",
 			serviceTags: []string{"tag1", "tag2"},
 		},
@@ -131,9 +131,7 @@ func (f *fakeServiceLister) Services(_ *structs.EnterpriseMeta) map[structs.Serv
 }
 
 func TestUserEventHandler_IngestUserEvent(t *testing.T) {
-	cfg := UserEventHandlerConfig{
-		Notifier: new(NotifyGroup),
-	}
+	cfg := UserEventHandlerConfig{}
 	u := newUserEventHandler(cfg, hclog.New(nil))
 
 	for i := 0; i < 512; i++ {

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -55,14 +55,17 @@ func TestUserEventHandler_ShouldProcessUserEvent(t *testing.T) {
 		expected bool
 	}
 
-	cfg := UserEventHandlerConfig{
-		NodeName: "the-node",
+	deps := UserEventHandlerDeps{
 		Services: &fakeServiceLister{
 			serviceID:   "the-service-id",
 			serviceTags: []string{"tag1", "tag2"},
 		},
+		Logger: hclog.New(nil),
 	}
-	u := newUserEventHandler(cfg, hclog.New(nil))
+	cfg := UserEventHandlerConfig{
+		NodeName: "the-node",
+	}
+	u := newUserEventHandler(deps, cfg)
 
 	fn := func(t *testing.T, tc testCase) {
 		require.Equal(t, tc.expected, u.shouldProcessUserEvent(tc.event))
@@ -131,8 +134,8 @@ func (f *fakeServiceLister) Services(_ *structs.EnterpriseMeta) map[structs.Serv
 }
 
 func TestUserEventHandler_IngestUserEvent(t *testing.T) {
-	cfg := UserEventHandlerConfig{}
-	u := newUserEventHandler(cfg, hclog.New(nil))
+	deps := UserEventHandlerDeps{Logger: hclog.New(nil)}
+	u := newUserEventHandler(deps, UserEventHandlerConfig{})
 
 	for i := 0; i < 512; i++ {
 		msg := &UserEvent{LTime: uint64(i), Name: "test"}


### PR DESCRIPTION
The UserEventHandler needs to be passed to the delegate, so in order to support passing in a delegate to `Agent` all its dependencies must be able to exist before an `Agent`.

`UserEventHandler` was one of these dependencies. Previously it was part of the `Agent` struct. This PR extracts it, along with `remoteExecHandler` which is another of its dependencies. This PR is just the first step. Now that these are separate structs it should be possible to move them to a different package. I have not done that yet to keep the size of the diff small and easier to review.

This PR is a small step in a number of efforts:
* reduce the scope of the `Agent` struct, and `agent` package
* support accepting dependencies to constructors
* allow RPC calls to be cancellable  using a context, which will likely require something other than net/rpc, like gRPC
* use `context.Context` for managing the lifetime of goroutines
* speed up tests by not requiring a full agent for every test

TODO:
* [x] finish porting the tests for remote_exec
* [x] restore support for reloading the config used by these new structs