### PR TITLE
logging: Remove t.Parallel from tests

### DIFF
--- a/logging/logfile_test.go
+++ b/logging/logfile_test.go
@@ -11,12 +11,11 @@ import (
 
 const (
 	testFileName = "Consul.log"
-	testDuration = 2 * time.Second
+	testDuration = 50 * time.Millisecond
 	testBytes    = 10
 )
 
 func TestLogFile_timeRotation(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterTime")
 	logFile := LogFile{
 		fileName: testFileName,
@@ -24,7 +23,7 @@ func TestLogFile_timeRotation(t *testing.T) {
 		duration: testDuration,
 	}
 	logFile.Write([]byte("Hello World"))
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * testDuration)
 	logFile.Write([]byte("Second File"))
 	want := 2
 	if got, _ := ioutil.ReadDir(tempDir); len(got) != want {
@@ -33,7 +32,6 @@ func TestLogFile_timeRotation(t *testing.T) {
 }
 
 func TestLogFile_openNew(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterOpen")
 	logFile := LogFile{fileName: testFileName, logPath: tempDir, duration: testDuration}
 	if err := logFile.openNew(); err != nil {
@@ -46,7 +44,6 @@ func TestLogFile_openNew(t *testing.T) {
 }
 
 func TestLogFile_byteRotation(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriterBytes")
 	logFile := LogFile{
 		fileName: testFileName,
@@ -64,7 +61,6 @@ func TestLogFile_byteRotation(t *testing.T) {
 }
 
 func TestLogFile_deleteArchives(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, "LogWriteDeleteArchives")
 	logFile := LogFile{
 		fileName: testFileName,
@@ -100,7 +96,6 @@ func TestLogFile_deleteArchives(t *testing.T) {
 }
 
 func TestLogFile_deleteArchivesDisabled(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, t.Name())
 	logFile := LogFile{
 		fileName: testFileName,
@@ -121,7 +116,6 @@ func TestLogFile_deleteArchivesDisabled(t *testing.T) {
 }
 
 func TestLogFile_rotationDisabled(t *testing.T) {
-	t.Parallel()
 	tempDir := testutil.TempDir(t, t.Name())
 	logFile := LogFile{
 		fileName: testFileName,

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestLogger_SetupBasic(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	cfg := Config{LogLevel: "INFO"}
 
@@ -22,7 +21,6 @@ func TestLogger_SetupBasic(t *testing.T) {
 }
 
 func TestLogger_SetupInvalidLogLevel(t *testing.T) {
-	t.Parallel()
 	cfg := Config{}
 
 	_, err := Setup(cfg, nil)
@@ -30,7 +28,6 @@ func TestLogger_SetupInvalidLogLevel(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerErrorLevel(t *testing.T) {
-	t.Parallel()
 
 	cases := []struct {
 		desc   string
@@ -74,7 +71,6 @@ func TestLogger_SetupLoggerErrorLevel(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerDebugLevel(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	cfg := Config{LogLevel: "DEBUG"}
 	var buf bytes.Buffer
@@ -93,7 +89,6 @@ func TestLogger_SetupLoggerDebugLevel(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerWithName(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	cfg := Config{
 		LogLevel: "DEBUG",
@@ -111,7 +106,6 @@ func TestLogger_SetupLoggerWithName(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerWithJSON(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 	cfg := Config{
 		LogLevel: "DEBUG",
@@ -136,7 +130,6 @@ func TestLogger_SetupLoggerWithJSON(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerWithValidLogPath(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	tmpDir := testutil.TempDir(t, t.Name())
@@ -153,7 +146,6 @@ func TestLogger_SetupLoggerWithValidLogPath(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerWithInValidLogPath(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	cfg := Config{
@@ -169,7 +161,6 @@ func TestLogger_SetupLoggerWithInValidLogPath(t *testing.T) {
 }
 
 func TestLogger_SetupLoggerWithInValidLogPathPermission(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	tmpDir := "/tmp/" + t.Name()

--- a/logging/monitor/monitor_test.go
+++ b/logging/monitor/monitor_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestMonitor_Start(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -41,7 +40,6 @@ func TestMonitor_Start(t *testing.T) {
 }
 
 func TestMonitor_Stop(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -82,7 +80,6 @@ func TestMonitor_Stop(t *testing.T) {
 }
 
 func TestMonitor_DroppedMessages(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -125,7 +122,6 @@ func TestMonitor_DroppedMessages(t *testing.T) {
 }
 
 func TestMonitor_ZeroBufSizeDefault(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{
@@ -162,7 +158,6 @@ func TestMonitor_ZeroBufSizeDefault(t *testing.T) {
 }
 
 func TestMonitor_WriteStopped(t *testing.T) {
-	t.Parallel()
 	require := require.New(t)
 
 	logger := log.NewInterceptLogger(&log.LoggerOptions{


### PR DESCRIPTION
I was going through my local branches to remove some merged ones and I found this one sitting around from a while ago.

The tests in this package all run fast enough (including compile time, under 600ms) that there is no advantage to using Parallel.

The one test that was slow used a long sleep. Changing the sleep to a few milliseconds speeds up the test considerably.