### PR TITLE
ui: Reinstate tooltip for exposed paths pill

### DIFF
--- a/ui-v2/app/styles/components/healthcheck-output.scss
+++ b/ui-v2/app/styles/components/healthcheck-output.scss
@@ -2,7 +2,10 @@
 .healthcheck-output {
   @extend %healthcheck-output;
 }
-%healthcheck-output em::before {
+%healthcheck-output dd em[data-tooltip] {
+  @extend %with-pseudo-tooltip;
+}
+%healthcheck-output dd em::before {
   width: 250px;
   /* TODO: All tooltips previously used */
   /* nowrap, they shouldn't */

--- a/ui-v2/app/styles/components/healthcheck-output/skin.scss
+++ b/ui-v2/app/styles/components/healthcheck-output/skin.scss
@@ -16,6 +16,7 @@
 }
 %healthcheck-output dd em {
   @extend %pill;
+  background-color: $gray-100;
   /*TODO: Should this be merged into %pill? */
   cursor: default;
   font-style: normal;


### PR DESCRIPTION
Reinstates tooltip on the exposed path pill within healthchecks

<img width="674" alt="Screenshot 2020-09-02 at 11 23 02" src="https://user-images.githubusercontent.com/554604/91970091-10c72380-ed0f-11ea-8d51-3d56332899d8.png">
