### PR TITLE
api: create fresh http client for unix sockets

### DIFF
--- a/.changelog/8602.txt
+++ b/.changelog/8602.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Allow for the client to use TLS over a Unix domain socket.
+```

--- a/api/api.go
+++ b/api/api.go
@@ -607,9 +607,11 @@ func NewClient(config *Config) (*Client, error) {
 			trans.DialContext = func(_ context.Context, _, _ string) (net.Conn, error) {
 				return net.Dial("unix", parts[1])
 			}
-			config.HttpClient = &http.Client{
-				Transport: trans,
+			httpClient, err := NewHttpClient(trans, config.TLSConfig)
+			if err != nil {
+				return nil, err
 			}
+			config.HttpClient = httpClient
 		default:
 			return nil, fmt.Errorf("Unknown protocol scheme: %s", parts[0])
 		}


### PR DESCRIPTION
The HTTP client over unix socket needs a special transport object,
and in doing so we need to create a fresh HTTP client so that we
pickup the environment variable based configuration options.