### PR TITLE
ui: [Bugfix] KV creation from within a 'folder'

### DIFF
--- a/ui-v2/app/components/consul-kv-form/index.hbs
+++ b/ui-v2/app/components/consul-kv-form/index.hbs
@@ -31,7 +31,7 @@
             <label for="" class="type-text{{if api.data.error.Value ' has-error'}}">
                 <span>Value</span>
 {{#if json}}
-                <CodeEditor @value={{atob api.data.Value}} @onkeyup={{action api.change "value"}} />
+                <CodeEditor @name="value" @value={{atob api.data.Value}} @onkeyup={{action api.change "value"}} />
 {{else}}
                 <textarea autofocus={{not api.isCreate}} name="value" oninput={{action api.change}}>{{atob api.data.Value}}</textarea>
 {{/if}}

--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -9,6 +9,11 @@ export default Route.extend({
   repo: service('repository/kv'),
   sessionRepo: service('repository/session'),
   model: function(params) {
+    const create =
+      this.routeName
+        .split('.')
+        .pop()
+        .indexOf('create') !== -1;
     const key = params.key;
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
@@ -19,7 +24,12 @@ export default Route.extend({
         typeof key !== 'undefined'
           ? this.repo.findBySlug(ascend(key, 1) || '/', dc, nspace)
           : this.repo.findBySlug('/', dc, nspace),
-      item: typeof key !== 'undefined' ? this.repo.findBySlug(key, dc, nspace) : undefined,
+      item: create
+        ? this.repo.create({
+            Datacenter: dc,
+            Namespace: nspace,
+          })
+        : this.repo.findBySlug(key, dc, nspace),
       session: null,
     }).then(model => {
       // TODO: Consider loading this after initial page load

--- a/ui-v2/tests/acceptance/dc/kvs/create.feature
+++ b/ui-v2/tests/acceptance/dc/kvs/create.feature
@@ -1,6 +1,6 @@
 @setupApplicationTest
 Feature: dc / kvs / create
-  Scenario: 
+  Scenario: Creating a root KV
     Given 1 datacenter model with the value "datacenter"
     When I visit the kv page for yaml
     ---
@@ -8,7 +8,43 @@ Feature: dc / kvs / create
     ---
     Then the url should be /datacenter/kv/create
     And the title should be "New Key/Value - Consul"
-
-@ignore
-  Scenario: Test we can create a KV
-  Then ok
+    Then I fill in with yaml
+    ---
+      additional: key-value
+      value: value
+    ---
+    And I submit
+    Then the url should be /datacenter/kv
+    Then a PUT request was made to "/v1/kv/key-value?dc=datacenter&ns=@namespace"
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class
+  Scenario: Creating a folder
+    Given 1 datacenter model with the value "datacenter"
+    When I visit the kv page for yaml
+    ---
+      dc: datacenter
+    ---
+    Then the url should be /datacenter/kv/create
+    And the title should be "New Key/Value - Consul"
+    Then I fill in with yaml
+    ---
+      additional: key-value/
+    ---
+    And I submit
+    Then the url should be /datacenter/kv
+    Then a PUT request was made to "/v1/kv/key-value/?dc=datacenter&ns=@namespace"
+    And "[data-notification]" has the "notification-update" class
+    And "[data-notification]" has the "success" class
+  Scenario: Clicking create from within a folder
+    Given 1 datacenter model with the value "datacenter"
+    And 1 kv model from yaml
+    ---
+    - key-value/
+    ---
+    When I visit the kvs page for yaml
+    ---
+      dc: datacenter
+    ---
+    And I click kv on the kvs
+    And I click create
+    And I see the text "New Key / Value" in "h1"


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8307 moved the KV area to use KVForm and KVListing components.

This unfortunately broke the creation of KVs when within a folder.

This fixes the bug by prefilling an empty KV for the form if we are on a create page.

We also added some more acceptance tests here.