### PR TITLE
ui: Reinstate listing of available test steps via CLI

### DIFF
--- a/ui-v2/.gitignore
+++ b/ui-v2/.gitignore
@@ -1,3 +1,4 @@
+!bin
 /public/consul-api-double
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 

--- a/ui-v2/lib/commands/bin/list.js
+++ b/ui-v2/lib/commands/bin/list.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/list.js')(`${process.cwd()}/tests/steps.js`);

--- a/ui-v2/lib/commands/lib/list.js
+++ b/ui-v2/lib/commands/lib/list.js
@@ -40,11 +40,12 @@ const library = {
     return this;
   },
 };
+const root = process.cwd();
 const exec = function(filename) {
   const js = read(filename);
   const code = babel.transform(js.toString(), {
     filename: filename,
-    presets: [require('babel-preset-env')],
+    presets: ['@babel/preset-env'],
   }).code;
   const exports = {};
   vm.runInNewContext(
@@ -52,7 +53,7 @@ const exec = function(filename) {
     {
       exports: exports,
       require: function(str) {
-        return exec(path.resolve(`${process.cwd()}/tests`, `${str}.js`)).default;
+        return exec(path.resolve(`${root}/tests`, `${str}.js`)).default;
       },
     },
     {
@@ -63,5 +64,6 @@ const exec = function(filename) {
 };
 
 module.exports = function(filename) {
-  exec(filename).default(function() {}, library, {}, {}, {}, function() {});
+  const assert = () => {};
+  exec(filename).default({ assert, library });
 };

--- a/ui-v2/tests/acceptance/steps/steps.js
+++ b/ui-v2/tests/acceptance/steps/steps.js
@@ -1,5 +1,19 @@
 import steps from 'consul-ui/tests/steps';
+import pages from 'consul-ui/tests/pages';
+import Inflector from 'ember-inflector';
+import utils from '@ember/test-helpers';
+import $ from '-jquery';
+
+import api from 'consul-ui/tests/helpers/api';
 
 export default function({ assert, library }) {
-  return steps(assert, library);
+  return steps({
+    assert,
+    library,
+    pages,
+    utils,
+    api,
+    Inflector,
+    $,
+  });
 }

--- a/ui-v2/tests/steps.js
+++ b/ui-v2/tests/steps.js
@@ -1,8 +1,6 @@
-import pages from 'consul-ui/tests/pages';
-import Inflector from 'ember-inflector';
-import utils from '@ember/test-helpers';
-
-import api from 'consul-ui/tests/helpers/api';
+// This files export is executed from 2 places:
+// 1. consul-ui/tests/acceptance/steps/steps.js - run during testing
+// 2. consul-ui/lib/commands/lib/list.js - run when listing steps via the CLI
 
 import models from './steps/doubles/model';
 import http from './steps/doubles/http';
@@ -18,40 +16,48 @@ import assertForm from './steps/assertions/form';
 
 // const dont = `( don't| shouldn't| can't)?`;
 
-const pluralize = function(str) {
-  return Inflector.inflector.pluralize(str);
-};
-const getLastNthRequest = function(getRequests) {
-  return function(n, method) {
-    let requests = getRequests()
-      .slice(0)
-      .reverse();
-    if (method) {
-      requests = requests.filter(function(item) {
-        return item.method === method;
-      });
-    }
-    if (n == null) {
-      return requests;
-    }
-    return requests[n];
+export default function({
+  assert,
+  library,
+  pages = {},
+  utils = {},
+  api = {},
+  Inflector = {},
+  $ = {},
+}) {
+  const pluralize = function(str) {
+    return Inflector.inflector.pluralize(str);
   };
-};
-const mb = function(path) {
-  return function(obj) {
-    return (
-      path.map(function(prop) {
-        obj = obj || {};
-        if (isNaN(parseInt(prop))) {
-          return (obj = obj[prop]);
-        } else {
-          return (obj = obj.objectAt(parseInt(prop)));
-        }
-      }) && obj
-    );
+  const getLastNthRequest = function(getRequests) {
+    return function(n, method) {
+      let requests = getRequests()
+        .slice(0)
+        .reverse();
+      if (method) {
+        requests = requests.filter(function(item) {
+          return item.method === method;
+        });
+      }
+      if (n == null) {
+        return requests;
+      }
+      return requests[n];
+    };
   };
-};
-export default function(assert, library) {
+  const mb = function(path) {
+    return function(obj) {
+      return (
+        path.map(function(prop) {
+          obj = obj || {};
+          if (isNaN(parseInt(prop))) {
+            return (obj = obj[prop]);
+          } else {
+            return (obj = obj.objectAt(parseInt(prop)));
+          }
+        }) && obj
+      );
+    };
+  };
   const pauseUntil = function(run, message = 'assertion timed out') {
     return new Promise(function(r) {
       let count = 0;
@@ -135,7 +141,7 @@ export default function(assert, library) {
   debug(library, assert, utils.currentURL);
   assertHttp(library, assert, lastNthRequest);
   assertModel(library, assert, find, getCurrentPage, pauseUntil, pluralize);
-  assertPage(library, assert, find, getCurrentPage);
+  assertPage(library, assert, find, getCurrentPage, $);
   assertDom(library, assert, pauseUntil, utils.find, utils.currentURL, clipboard);
   assertForm(library, assert, find, getCurrentPage);
 

--- a/ui-v2/tests/steps/assertions/page.js
+++ b/ui-v2/tests/steps/assertions/page.js
@@ -1,5 +1,4 @@
 /* eslint no-console: "off" */
-import $ from '-jquery';
 
 const elementNotFound = 'Element not found';
 // this error comes from our pageObject `find `function
@@ -32,7 +31,7 @@ const isExpectedError = function(e) {
   );
 };
 const dont = `( don't| shouldn't| can't)?`;
-export default function(scenario, assert, find, currentPage) {
+export default function(scenario, assert, find, currentPage, $) {
   scenario
     .then(['I see $num of the $component object'], function(num, component) {
       assert.equal(


### PR DESCRIPTION
We use a set of BDD testing steps for our acceptance testing and its often useful to know what steps are available whilst writing steps.

We did have an `ember steps:list` command to do list these steps, but at some point during development this has ceased to work.

This PR reinstates this:

![Screenshot 2020-09-04 at 14 21 39](https://user-images.githubusercontent.com/554604/92243909-1ad95580-eeba-11ea-9cd1-55f0a2b32951.png)

The list is visible by running either of the following commands:

```
yarn run steps:list
make steps
ember steps:list
```