### PR TITLE
[docs] Clarify consul maint enable/disable scope

### DIFF
--- a/website/pages/commands/maint.mdx
+++ b/website/pages/commands/maint.mdx
@@ -30,11 +30,13 @@ Usage: `consul maint [options]`
 
 #### Command Options
 
-- `-enable` - Enable maintenance mode on all services on a node. If
-  combined with the `-service` flag, we operate on a specific service ID.
+- `-enable` - Enable node-wide maintenance mode flag. If combined with the
+  `-service` flag, we operate on a specific service ID instead. Node and
+  service maintenance flags are independent.
 
-- `-disable` - Disable maintenance mode on all services on a node. If
-  combined with the `-service` flag, we operate on a specific service ID.
+- `-disable` - Disable the node-wide maintenance flag. If combined with the
+  `-service` flag, we operate on a specific service ID instead. Node and
+   service maintenance flags are independent.
 
 - `-reason` - An optional reason for placing the service into
   maintenance mode. If provided, this reason will be visible in the newly-


### PR DESCRIPTION
Try to make it more clear to an operator that toggling off a node-level
maintenance is independent of toggling service level maintenance.

Recently, we had an outage and there was some confusion by the subtle distinction between node and service level maintenance. In particular, that invoking `consul maint -disable` _does not_ clear all current maintenance checks on the node and instead only affects the node-level check. This PR aims to make that more clear to our sleep deprived future selves.

Future idea, perhaps there is some argument to be had for having an `-all-services` flag.