### PR TITLE
add checkout to dev-upload-s3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,6 +414,7 @@ jobs:
     environment:
       <<: *ENVIRONMENT
     steps:
+      - checkout
       - *get-aws-cli
       - *aws-assume-role
       # get consul binary


### PR DESCRIPTION
Since the new `aws-assume-role` step writes creds to the BASH_ENV I forgot we needed to `checkout` the code in the `dev-upload-s3` job now to get the `.circleci/bash_env.sh` file, otherwise the job fails looking for it to write to.   