### PR TITLE
agent: move DNSServer to apiServers

### DIFF
--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -7205,7 +7205,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Do a manual exchange with compression on (the default).
-		a.DNSDisableCompression(false)
+		a.DNSDisableCompression(t, false)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -7216,7 +7216,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Disable compression and try again.
-		a.DNSDisableCompression(true)
+		a.DNSDisableCompression(t, true)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -7274,7 +7274,7 @@ func TestDNS_Compression_ReverseLookup(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.DNSDisableCompression(true)
+	a.DNSDisableCompression(t, true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -7326,7 +7326,7 @@ func TestDNS_Compression_Recurse(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.DNSDisableCompression(true)
+	a.DNSDisableCompression(t, true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/reload.go
+++ b/agent/reload.go
@@ -5,3 +5,20 @@ import "github.com/hashicorp/consul/agent/config"
 // ConfigReloader is a function type which may be implemented to support reloading
 // of configuration.
 type ConfigReloader func(rtConfig *config.RuntimeConfig) error
+
+// reloadConfigDNSServer returns a closure that translates RuntimeConfig into
+// dnsConfig and then calls DNSServer.ReloadConfig.
+// This function exists so that all references to RuntimeConfig stay in the
+// agent package. In the future the DNSServer would be moved out into a separate
+// package which should not reference RuntimeConfig. This is done in advance as
+// a demonstration of this pattern, and so that config reload looks consistent
+// across all components.
+func reloadConfigDNSServer(s *DNSServer) func(runtimeConfig *config.RuntimeConfig) error {
+	return func(rtConfig *config.RuntimeConfig) error {
+		cfg, err := newDNSConfig(rtConfig)
+		if err != nil {
+			return err
+		}
+		return s.ReloadConfig(cfg)
+	}
+}

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -339,10 +339,12 @@ func (a *TestAgent) Client() *api.Client {
 }
 
 // DNSDisableCompression disables compression for all started DNS servers.
-func (a *TestAgent) DNSDisableCompression(b bool) {
+func (a *TestAgent) DNSDisableCompression(t *testing.T, b bool) {
+	t.Helper()
+
+	a.config.DNSDisableCompression = b
 	for _, srv := range a.dnsServers {
-		cfg := srv.config.Load().(*dnsConfig)
-		cfg.DisableCompression = b
+		require.NoError(t, srv.ReloadConfig(a.config))
 	}
 }
 


### PR DESCRIPTION
This PR continues the work done in #8234 to ensure that the agent shuts down if one of the long running servers fails, instead of continuing in a degraded state. This is very likely even more important for the DNS server because if a process manager is checking the health of the Consul Agent, it may be doing so with the HTTP API, and wouldn't necessarily noticed if the DNS server had failed.