### PR TITLE
dns: decouple Agent from DNSServer

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -49,7 +49,6 @@ import (
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 	"golang.org/x/net/http2"
@@ -253,16 +252,11 @@ type Agent struct {
 	endpoints     map[string]string
 	endpointsLock sync.RWMutex
 
-	// dnsServer provides the DNS API
-	dnsServers []*DNSServer
-
 	// apiServers listening for connections. If any of these server goroutines
 	// fail, the agent will be shutdown.
 	apiServers *apiServers
 
-	// wgServers is the wait group for all HTTP and DNS servers
-	// TODO: remove once dnsServers are handled by apiServers
-	wgServers sync.WaitGroup
+	configReloaders []ConfigReloader
 
 	// watchPlans tracks all the currently-running watch plans for the
 	// agent.
@@ -650,46 +644,39 @@ func (a *Agent) listenAndServeGRPC() error {
 }
 
 func (a *Agent) listenAndServeDNS() error {
-	notif := make(chan net.Addr, len(a.config.DNSAddrs))
-	errCh := make(chan error, len(a.config.DNSAddrs))
+	chNotify := make(chan struct{}, len(a.config.DNSAddrs))
+
 	for _, addr := range a.config.DNSAddrs {
-		// create server
 		s, err := NewDNSServer(a)
 		if err != nil {
 			return err
 		}
-		a.dnsServers = append(a.dnsServers, s)
 
-		// start server
-		a.wgServers.Add(1)
-		go func(addr net.Addr) {
-			defer a.wgServers.Done()
-			err := s.ListenAndServe(addr.Network(), addr.String(), func() { notif <- addr })
-			if err != nil && !strings.Contains(err.Error(), "accept") {
-				errCh <- err
-			}
-		}(addr)
+		done := func() {
+			chNotify <- struct{}{}
+		}
+		a.apiServers.Start(newAPIServerDNS(s, addr, done))
+		a.configReloaders = append(a.configReloaders, reloadConfigDNSServer(s))
 	}
 
-	// wait for servers to be up
+	// Unlike the HTTP server, the dns.Server listens and serves in the same call.
+	// We could fix this by calling ActivateAndServe instead of ListenAndServe,
+	// however that would require duplicating the network switch/case in
+	// ListenAndServe. Do we actually support more than one network type?
+	// For now we are handling this difference by waiting up to a second for
+	// the listener to listen.
+	// TODO: fix this by using dns.Server.ActivateAndServe
 	timeout := time.After(time.Second)
-	var merr *multierror.Error
 	for range a.config.DNSAddrs {
 		select {
-		case addr := <-notif:
-			a.logger.Info("Started DNS server",
-				"address", addr.String(),
-				"network", addr.Network(),
-			)
-
-		case err := <-errCh:
-			merr = multierror.Append(merr, err)
+		case <-chNotify:
 		case <-timeout:
-			merr = multierror.Append(merr, fmt.Errorf("agent: timeout starting DNS servers"))
-			return merr.ErrorOrNil()
+			return fmt.Errorf("agent: timeout starting DNS servers")
+		case <-a.apiServers.failed:
+			return fmt.Errorf("DNS servers failed to listen or serve")
 		}
 	}
-	return merr.ErrorOrNil()
+	return nil
 }
 
 func (a *Agent) startListeners(addrs []net.Addr) ([]net.Listener, error) {
@@ -1362,19 +1349,6 @@ func (a *Agent) ShutdownEndpoints() {
 	defer a.shutdownLock.Unlock()
 
 	ctx := context.TODO()
-
-	for _, srv := range a.dnsServers {
-		if srv.Server != nil {
-			a.logger.Info("Stopping server",
-				"protocol", "DNS",
-				"address", srv.Server.Addr,
-				"network", srv.Server.Net,
-			)
-			srv.Shutdown()
-		}
-	}
-	a.dnsServers = nil
-
 	a.apiServers.Shutdown(ctx)
 	a.logger.Info("Waiting for endpoints to shut down")
 	if err := a.apiServers.WaitForShutdown(); err != nil {
@@ -3460,6 +3434,7 @@ func (a *Agent) loadLimits(conf *config.RuntimeConfig) {
 // ReloadConfig will atomically reload all configuration, including
 // all services, checks, tokens, metadata, dnsServer configs, etc.
 // It will also reload all ongoing watches.
+// TODO: move to reload.go
 func (a *Agent) ReloadConfig() error {
 	newCfg, err := a.autoConf.ReadConfig()
 	if err != nil {
@@ -3477,6 +3452,7 @@ func (a *Agent) ReloadConfig() error {
 // reloadConfigInternal is mainly needed for some unit tests. Instead of parsing
 // the configuration using CLI flags and on disk config, this just takes a
 // runtime configuration and applies it.
+// TODO: move to reload.go
 func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 	// Change the log level and update it
 	if logging.ValidateLogLevel(newCfg.Logging.LogLevel) {
@@ -3537,9 +3513,9 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		MaxConnsPerClientIP: newCfg.HTTPMaxConnsPerClient,
 	})
 
-	for _, s := range a.dnsServers {
-		if err := s.ReloadConfig(newCfg); err != nil {
-			return fmt.Errorf("Failed reloading dns config : %v", err)
+	for _, r := range a.configReloaders {
+		if err := r(newCfg); err != nil {
+			return err
 		}
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -647,7 +647,7 @@ func (a *Agent) listenAndServeDNS() error {
 	chNotify := make(chan struct{}, len(a.config.DNSAddrs))
 
 	for _, addr := range a.config.DNSAddrs {
-		s, err := NewDNSServer(a)
+		s, err := NewDNSServer(a, a.tokens, a.cache)
 		if err != nil {
 			return err
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -775,18 +775,7 @@ func (a *Agent) listenHTTP() ([]apiServer, error) {
 				httpServer.ConnState = connLimitFn
 			}
 
-			servers = append(servers, apiServer{
-				Protocol: proto,
-				Addr:     l.Addr(),
-				Shutdown: httpServer.Shutdown,
-				Run: func() error {
-					err := httpServer.Serve(l)
-					if err == nil || err == http.ErrServerClosed {
-						return nil
-					}
-					return fmt.Errorf("%s server %s failed: %w", proto, l.Addr(), err)
-				},
-			})
+			servers = append(servers, newAPIServerHTTP(proto, l, httpServer))
 		}
 		return nil
 	}

--- a/agent/apiserver.go
+++ b/agent/apiserver.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 
@@ -91,4 +93,19 @@ func (s *apiServers) Shutdown(ctx context.Context) {
 // must be called before WaitForShutdown, otherwise it will block forever.
 func (s *apiServers) WaitForShutdown() error {
 	return s.group.Wait()
+}
+
+func newAPIServerHTTP(proto string, l net.Listener, httpServer *http.Server) apiServer {
+	return apiServer{
+		Protocol: proto,
+		Addr:     l.Addr(),
+		Shutdown: httpServer.Shutdown,
+		Run: func() error {
+			err := httpServer.Serve(l)
+			if err == nil || err == http.ErrServerClosed {
+				return nil
+			}
+			return fmt.Errorf("%s server %s failed: %w", proto, l.Addr(), err)
+		},
+	}
 }

--- a/agent/dns.go
+++ b/agent/dns.go
@@ -84,10 +84,11 @@ type serviceLookup struct {
 	structs.EnterpriseMeta
 }
 
-// DNSServer is used to wrap an Agent and expose various
-// service discovery endpoints using a DNS interface.
+// DNSServer is used to wrap an Agent and expose various service discovery
+// endpoints using a DNS interface.
+//
+// TODO: rename to DNSHandler, it is not a server.
 type DNSServer struct {
-	*dns.Server
 	agent     *Agent
 	mux       *dns.ServeMux
 	domain    string
@@ -113,7 +114,7 @@ func NewDNSServer(a *Agent) (*DNSServer, error) {
 		altDomain: altDomain,
 		logger:    a.logger.Named(logging.DNS),
 	}
-	cfg, err := GetDNSConfig(a.config)
+	cfg, err := newDNSConfig(a.config)
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +123,8 @@ func NewDNSServer(a *Agent) (*DNSServer, error) {
 	return srv, nil
 }
 
-// GetDNSConfig takes global config and creates the config used by DNS server
-func GetDNSConfig(conf *config.RuntimeConfig) (*dnsConfig, error) {
+// newDNSConfig creates a newConfig from a RuntimeConfig.
+func newDNSConfig(conf *config.RuntimeConfig) (*dnsConfig, error) {
 	cfg := &dnsConfig{
 		AllowStale:         conf.DNSAllowStale,
 		ARecordLimit:       conf.DNSARecordLimit,
@@ -191,7 +192,29 @@ func (cfg *dnsConfig) GetTTLForService(service string) (time.Duration, bool) {
 	return 0, false
 }
 
-func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
+// TODO: rename to newDNSServer once DNSServer has been renamed to DNSHandler
+func newAPIServerDNS(handler *DNSServer, addr net.Addr, notify func()) apiServer {
+	handler.setupMux()
+
+	srv := &dns.Server{
+		Addr:              addr.String(),
+		Net:               addr.Network(),
+		Handler:           handler.mux,
+		NotifyStartedFunc: notify,
+	}
+	if addr.Network() == "udp" {
+		srv.UDPSize = 65535
+	}
+
+	return apiServer{
+		Protocol: "dns",
+		Addr:     addr,
+		Run:      srv.ListenAndServe,
+		Shutdown: srv.ShutdownContext,
+	}
+}
+
+func (d *DNSServer) setupMux() {
 	cfg := d.config.Load().(*dnsConfig)
 
 	d.mux = dns.NewServeMux()
@@ -207,17 +230,6 @@ func (d *DNSServer) ListenAndServe(network, addr string, notif func()) error {
 		d.mux.HandleFunc(d.altDomain, d.handleQuery)
 	}
 	d.toggleRecursorHandlerFromConfig(cfg)
-
-	d.Server = &dns.Server{
-		Addr:              addr,
-		Net:               network,
-		Handler:           d.mux,
-		NotifyStartedFunc: notif,
-	}
-	if network == "udp" {
-		d.UDPSize = 65535
-	}
-	return d.Server.ListenAndServe()
 }
 
 // toggleRecursorHandlerFromConfig enables or disables the recursor handler based on config idempotently
@@ -238,11 +250,7 @@ func (d *DNSServer) toggleRecursorHandlerFromConfig(cfg *dnsConfig) {
 }
 
 // ReloadConfig hot-reloads the server config with new parameters under config.RuntimeConfig.DNS*
-func (d *DNSServer) ReloadConfig(newCfg *config.RuntimeConfig) error {
-	cfg, err := GetDNSConfig(newCfg)
-	if err != nil {
-		return err
-	}
+func (d *DNSServer) ReloadConfig(cfg *dnsConfig) error {
 	d.config.Store(cfg)
 	d.toggleRecursorHandlerFromConfig(cfg)
 	return nil

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/serf/coordinate"
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/require"
@@ -6986,58 +6988,53 @@ func TestDNSInvalidRegex(t *testing.T) {
 }
 
 func TestDNS_ConfigReload(t *testing.T) {
-	t.Parallel()
-
-	a := NewTestAgent(t, `
-		recursors = ["8.8.8.8:53"]
-		dns_config = {
-			allow_stale = false
-			max_stale = "20s"
-			node_ttl = "10s"
-			service_ttl = {
-				"my_services*" = "5s"
-				"my_specific_service" = "30s"
-			}
-			enable_truncate = false
-			only_passing = false
-			recursor_timeout = "15s"
-			disable_compression = false
-			a_record_limit = 1
-			enable_additional_node_meta_txt = false
-			soa = {
-				refresh = 1
-				retry = 2
-				expire = 3
-				min_ttl = 4
-			}
-		}
-	`)
-	defer a.Shutdown()
-	testrpc.WaitForLeader(t, a.RPC, "dc1")
-
-	for _, s := range a.dnsServers {
-		cfg := s.config.Load().(*dnsConfig)
-		require.Equal(t, []string{"8.8.8.8:53"}, cfg.Recursors)
-		require.False(t, cfg.AllowStale)
-		require.Equal(t, 20*time.Second, cfg.MaxStale)
-		require.Equal(t, 10*time.Second, cfg.NodeTTL)
-		ttl, _ := cfg.GetTTLForService("my_services_1")
-		require.Equal(t, 5*time.Second, ttl)
-		ttl, _ = cfg.GetTTLForService("my_specific_service")
-		require.Equal(t, 30*time.Second, ttl)
-		require.False(t, cfg.EnableTruncate)
-		require.False(t, cfg.OnlyPassing)
-		require.Equal(t, 15*time.Second, cfg.RecursorTimeout)
-		require.False(t, cfg.DisableCompression)
-		require.Equal(t, 1, cfg.ARecordLimit)
-		require.False(t, cfg.NodeMetaTXT)
-		require.Equal(t, uint32(1), cfg.SOAConfig.Refresh)
-		require.Equal(t, uint32(2), cfg.SOAConfig.Retry)
-		require.Equal(t, uint32(3), cfg.SOAConfig.Expire)
-		require.Equal(t, uint32(4), cfg.SOAConfig.Minttl)
+	rtConfig := &config.RuntimeConfig{
+		Logging: logging.Config{
+			LogLevel: "INFO",
+		},
+		DNSRecursors: []string{"8.8.8.8:53"},
+		DNSMaxStale:  20 * time.Second,
+		DNSNodeTTL:   10 * time.Second,
+		DNSServiceTTL: map[string]time.Duration{
+			"my_services*":        5 * time.Second,
+			"my_specific_service": 30 * time.Second,
+		},
+		DNSRecursorTimeout: 15 * time.Second,
+		DNSARecordLimit:    1,
+		DNSSOA: config.RuntimeSOAConfig{
+			Refresh: 1,
+			Retry:   2,
+			Expire:  3,
+			Minttl:  4,
+		},
 	}
 
-	newCfg := *a.Config
+	agent := &Agent{config: rtConfig, logger: hclog.NewInterceptLogger(nil)}
+	s, err := NewDNSServer(agent)
+	require.NoError(t, err)
+	s.setupMux()
+
+	cfg := s.config.Load().(*dnsConfig)
+	require.Equal(t, []string{"8.8.8.8:53"}, cfg.Recursors)
+	require.False(t, cfg.AllowStale)
+	require.Equal(t, 20*time.Second, cfg.MaxStale)
+	require.Equal(t, 10*time.Second, cfg.NodeTTL)
+	ttl, _ := cfg.GetTTLForService("my_services_1")
+	require.Equal(t, 5*time.Second, ttl)
+	ttl, _ = cfg.GetTTLForService("my_specific_service")
+	require.Equal(t, 30*time.Second, ttl)
+	require.False(t, cfg.EnableTruncate)
+	require.False(t, cfg.OnlyPassing)
+	require.Equal(t, 15*time.Second, cfg.RecursorTimeout)
+	require.False(t, cfg.DisableCompression)
+	require.Equal(t, 1, cfg.ARecordLimit)
+	require.False(t, cfg.NodeMetaTXT)
+	require.Equal(t, uint32(1), cfg.SOAConfig.Refresh)
+	require.Equal(t, uint32(2), cfg.SOAConfig.Retry)
+	require.Equal(t, uint32(3), cfg.SOAConfig.Expire)
+	require.Equal(t, uint32(4), cfg.SOAConfig.Minttl)
+
+	newCfg := *agent.config
 	newCfg.DNSRecursors = []string{"1.1.1.1:53"}
 	newCfg.DNSAllowStale = true
 	newCfg.DNSMaxStale = 21 * time.Second
@@ -7057,34 +7054,32 @@ func TestDNS_ConfigReload(t *testing.T) {
 	newCfg.DNSSOA.Expire = 30
 	newCfg.DNSSOA.Minttl = 40
 
-	err := a.reloadConfigInternal(&newCfg)
+	err = reloadConfigDNSServer(s)(&newCfg)
 	require.NoError(t, err)
 
-	for _, s := range a.dnsServers {
-		cfg := s.config.Load().(*dnsConfig)
-		require.Equal(t, []string{"1.1.1.1:53"}, cfg.Recursors)
-		require.True(t, cfg.AllowStale)
-		require.Equal(t, 21*time.Second, cfg.MaxStale)
-		require.Equal(t, 11*time.Second, cfg.NodeTTL)
-		ttl, _ := cfg.GetTTLForService("my_services_1")
-		require.Equal(t, time.Duration(0), ttl)
-		ttl, _ = cfg.GetTTLForService("2_my_services_1")
-		require.Equal(t, 6*time.Second, ttl)
-		ttl, _ = cfg.GetTTLForService("my_specific_service")
-		require.Equal(t, time.Duration(0), ttl)
-		ttl, _ = cfg.GetTTLForService("2_my_specific_service")
-		require.Equal(t, 31*time.Second, ttl)
-		require.True(t, cfg.EnableTruncate)
-		require.True(t, cfg.OnlyPassing)
-		require.Equal(t, 16*time.Second, cfg.RecursorTimeout)
-		require.True(t, cfg.DisableCompression)
-		require.Equal(t, 2, cfg.ARecordLimit)
-		require.True(t, cfg.NodeMetaTXT)
-		require.Equal(t, uint32(10), cfg.SOAConfig.Refresh)
-		require.Equal(t, uint32(20), cfg.SOAConfig.Retry)
-		require.Equal(t, uint32(30), cfg.SOAConfig.Expire)
-		require.Equal(t, uint32(40), cfg.SOAConfig.Minttl)
-	}
+	cfg = s.config.Load().(*dnsConfig)
+	require.Equal(t, []string{"1.1.1.1:53"}, cfg.Recursors)
+	require.True(t, cfg.AllowStale)
+	require.Equal(t, 21*time.Second, cfg.MaxStale)
+	require.Equal(t, 11*time.Second, cfg.NodeTTL)
+	ttl, _ = cfg.GetTTLForService("my_services_1")
+	require.Equal(t, time.Duration(0), ttl)
+	ttl, _ = cfg.GetTTLForService("2_my_services_1")
+	require.Equal(t, 6*time.Second, ttl)
+	ttl, _ = cfg.GetTTLForService("my_specific_service")
+	require.Equal(t, time.Duration(0), ttl)
+	ttl, _ = cfg.GetTTLForService("2_my_specific_service")
+	require.Equal(t, 31*time.Second, ttl)
+	require.True(t, cfg.EnableTruncate)
+	require.True(t, cfg.OnlyPassing)
+	require.Equal(t, 16*time.Second, cfg.RecursorTimeout)
+	require.True(t, cfg.DisableCompression)
+	require.Equal(t, 2, cfg.ARecordLimit)
+	require.True(t, cfg.NodeMetaTXT)
+	require.Equal(t, uint32(10), cfg.SOAConfig.Refresh)
+	require.Equal(t, uint32(20), cfg.SOAConfig.Retry)
+	require.Equal(t, uint32(30), cfg.SOAConfig.Expire)
+	require.Equal(t, uint32(40), cfg.SOAConfig.Minttl)
 }
 
 func TestDNS_ReloadConfig_DuringQuery(t *testing.T) {

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -6833,7 +6833,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Do a manual exchange with compression on (the default).
-		a.DNSDisableCompression(false)
+		a.DNSDisableCompression(t, false)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -6844,7 +6844,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 		}
 
 		// Disable compression and try again.
-		a.DNSDisableCompression(true)
+		a.DNSDisableCompression(t, true)
 		if err := conn.WriteMsg(m); err != nil {
 			t.Fatalf("err: %v", err)
 		}
@@ -6898,7 +6898,7 @@ func TestDNS_Compression_ReverseLookup(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.DNSDisableCompression(true)
+	a.DNSDisableCompression(t, true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -6946,7 +6946,7 @@ func TestDNS_Compression_Recurse(t *testing.T) {
 	}
 
 	// Disable compression and try again.
-	a.DNSDisableCompression(true)
+	a.DNSDisableCompression(t, true)
 	if err := conn.WriteMsg(m); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/consul/agent/config"
 	agentdns "github.com/hashicorp/consul/agent/dns"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
@@ -7010,7 +7011,7 @@ func TestDNS_ConfigReload(t *testing.T) {
 	}
 
 	agent := &Agent{config: rtConfig, logger: hclog.NewInterceptLogger(nil)}
-	s, err := NewDNSServer(agent)
+	s, err := NewDNSServer(agent, new(token.Store), nil)
 	require.NoError(t, err)
 	s.setupMux()
 

--- a/agent/reload.go
+++ b/agent/reload.go
@@ -1,0 +1,24 @@
+package agent
+
+import "github.com/hashicorp/consul/agent/config"
+
+// ConfigReloader is a function type which may be implemented to support reloading
+// of configuration.
+type ConfigReloader func(rtConfig *config.RuntimeConfig) error
+
+// reloadConfigDNSServer returns a closure that translates RuntimeConfig into
+// dnsConfig and then calls DNSServer.ReloadConfig.
+// This function exists so that all references to RuntimeConfig stay in the
+// agent package. In the future the DNSServer would be moved out into a separate
+// package which should not reference RuntimeConfig. This is done in advance as
+// a demonstration of this pattern, and so that config reload looks consistent
+// across all components.
+func reloadConfigDNSServer(s *DNSServer) func(runtimeConfig *config.RuntimeConfig) error {
+	return func(rtConfig *config.RuntimeConfig) error {
+		cfg, err := newDNSConfig(rtConfig)
+		if err != nil {
+			return err
+		}
+		return s.ReloadConfig(cfg)
+	}
+}

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -351,10 +351,12 @@ func (a *TestAgent) Client() *api.Client {
 }
 
 // DNSDisableCompression disables compression for all started DNS servers.
-func (a *TestAgent) DNSDisableCompression(b bool) {
+func (a *TestAgent) DNSDisableCompression(t *testing.T, b bool) {
+	t.Helper()
+
+	a.config.DNSDisableCompression = b
 	for _, srv := range a.dnsServers {
-		cfg := srv.config.Load().(*dnsConfig)
-		cfg.DisableCompression = b
+		require.NoError(t, srv.ReloadConfig(a.config))
 	}
 }
 


### PR DESCRIPTION
Branched from #8623

This change removes any references to `Agent` from the `DNSServer`. The config references are moved to the `dnsConfig`, `token.Store` and `cache.Cache` are split out into their own since they are available from `BaseDeps`. The rest of `Agent` is replaced with an interface which contains the 4 methods used by `DNSServer`. This interface is a bit weird right now, but this is just a small step. In the future the `RPC` method can be replaced by [something like this rpcclient](https://github.com/hashicorp/consul/pull/8580/files#diff-b3dc76d7d79b0775081ffcc9c503dec9). I'm not sure what to make of the Translate methods just yet.