### PR TITLE
docs: Fix rendering of link under service config endpoint

### DIFF
--- a/website/pages/api-docs/agent/service.mdx
+++ b/website/pages/api-docs/agent/service.mdx
@@ -145,8 +145,7 @@ The table below shows this endpoint's support for
 | ----------------- | ----------------- | ------------- | -------------- |
 | `YES`<sup>1</sup> | `none`            | `none`        | `service:read` |
 
-<sup>1</sup> Supports [hash-based blocking](/api/features/blocking#hash-based-blocking-queries)
-only.
+<sup>1</sup> Supports <a href="/api/features/blocking#hash-based-blocking-queries">hash-based blocking</a> only.
 
 ### Parameters
 


### PR DESCRIPTION
HTML and markdown cannot be present in the same line. Change markdown link to HTML anchor element.