### PR TITLE
ui: Default test latency to 0

### DIFF
--- a/ui-v2/tests/helpers/yadda-annotations.js
+++ b/ui-v2/tests/helpers/yadda-annotations.js
@@ -18,6 +18,9 @@ const reset = function() {
     list.add(item);
   });
 };
+const startup = function() {
+  api.server.setCookie('CONSUL_LATENCY', 0);
+};
 
 const runTest = function(context, libraries, steps, scenarioContext) {
   return new Promise((resolve, reject) => {
@@ -89,6 +92,9 @@ export const setupFeature = function(featureAnnotations) {
 };
 export const setupScenario = function(featureAnnotations, scenarioAnnotations) {
   return function(model) {
+    model.beforeEach(function() {
+      startup();
+    });
     model.afterEach(function() {
       reset();
     });


### PR DESCRIPTION
During development a HTTP request will pause for 1 minute ONLY when an
`?index` is set. This gives a realistic emulation of blocking queries.

During testing we can change this latency when we are testing blocking
queries, which we do in numerous places.

A problem can arise during testing on a very slow machine.

If you are not testing blocking queries and therefore you haven't set a latency
to test with, if the machine you are testing on is slow enough, a normal
test case can assert, yet not tear down before a further
blocking query request is made. This blocking query then uses the default
latency which causes the page to hang for 1 minute, which in turn causes
the test to timeout.

This only seems to happen on a very slow system, but it does potentially
explain why we occasionally see the odd flakey test popping up.

The fix here just sets the default latency to zero at test case startup.
If a test is testing blocking queries this is then overridden during the test.