### PR TITLE
Move IntermediateCertTTL to common CA config

### DIFF
--- a/.changelog/8646.txt
+++ b/.changelog/8646.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: fix Vault provider not respecting IntermediateCertTTL
+```

--- a/agent/connect/ca/provider_consul_config.go
+++ b/agent/connect/ca/provider_consul_config.go
@@ -44,13 +44,13 @@ func ParseConsulCAConfig(raw map[string]interface{}) (*structs.ConsulCAProviderC
 func defaultConsulCAProviderConfig() structs.ConsulCAProviderConfig {
 	return structs.ConsulCAProviderConfig{
 		CommonCAProviderConfig: defaultCommonConfig(),
-		IntermediateCertTTL:    24 * 365 * time.Hour,
 	}
 }
 func defaultCommonConfig() structs.CommonCAProviderConfig {
 	return structs.CommonCAProviderConfig{
-		LeafCertTTL:    3 * 24 * time.Hour,
-		PrivateKeyType: connect.DefaultPrivateKeyType,
-		PrivateKeyBits: connect.DefaultPrivateKeyBits,
+		LeafCertTTL:         3 * 24 * time.Hour,
+		IntermediateCertTTL: 24 * 365 * time.Hour,
+		PrivateKeyType:      connect.DefaultPrivateKeyType,
+		PrivateKeyBits:      connect.DefaultPrivateKeyBits,
 	}
 }

--- a/agent/connect/ca/provider_test.go
+++ b/agent/connect/ca/provider_test.go
@@ -26,12 +26,13 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 		"PrivateKeyBits":   int64(4096),
 	}
 	expectCommonBase := &structs.CommonCAProviderConfig{
-		LeafCertTTL:      30 * time.Hour,
-		SkipValidate:     true,
-		CSRMaxPerSecond:  5.25,
-		CSRMaxConcurrent: 55,
-		PrivateKeyType:   "rsa",
-		PrivateKeyBits:   4096,
+		LeafCertTTL:         30 * time.Hour,
+		IntermediateCertTTL: 90 * time.Hour,
+		SkipValidate:        true,
+		CSRMaxPerSecond:     5.25,
+		CSRMaxConcurrent:    55,
+		PrivateKeyType:      "rsa",
+		PrivateKeyBits:      4096,
 	}
 
 	cases := map[string]testcase{
@@ -60,7 +61,6 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 				PrivateKey:             "key",
 				RootCert:               "cert",
 				RotationPeriod:         5 * time.Minute,
-				IntermediateCertTTL:    90 * time.Hour,
 				DisableCrossSigning:    true,
 			},
 			parseFunc: func(t *testing.T, raw map[string]interface{}) interface{} {
@@ -86,6 +86,7 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 					"Token":               "token",
 					"RootPKIPath":         "root-pki/",
 					"IntermediatePKIPath": "im-pki/",
+					"IntermediateCertTTL": "90h",
 					"CAFile":              "ca-file",
 					"CAPath":              "ca-path",
 					"CertFile":            "cert-file",
@@ -126,8 +127,9 @@ func TestStructs_CAConfiguration_MsgpackEncodeDecode(t *testing.T) {
 					ModifyIndex: 99,
 				},
 				Config: map[string]interface{}{
-					"ExistingARN":  "arn://foo",
-					"DeleteOnExit": true,
+					"ExistingARN":         "arn://foo",
+					"DeleteOnExit":        true,
+					"IntermediateCertTTL": "90h",
 				},
 			},
 			expectConfig: &structs.AWSCAProviderConfig{

--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -153,7 +153,7 @@ func (v *VaultProvider) setupIntermediatePKIPath() error {
 			Type:        "pki",
 			Description: "intermediate CA backend for Consul Connect",
 			Config: vaultapi.MountConfigInput{
-				MaxLeaseTTL: "2160h",
+				MaxLeaseTTL: v.config.IntermediateCertTTL.String(),
 			},
 		})
 

--- a/agent/connect/generate_test.go
+++ b/agent/connect/generate_test.go
@@ -38,9 +38,10 @@ var badParams = []KeyConfig{
 
 func makeConfig(kc KeyConfig) structs.CommonCAProviderConfig {
 	return structs.CommonCAProviderConfig{
-		LeafCertTTL:    3 * 24 * time.Hour,
-		PrivateKeyType: kc.keyType,
-		PrivateKeyBits: kc.keyBits,
+		LeafCertTTL:         3 * 24 * time.Hour,
+		IntermediateCertTTL: 365 * 24 * time.Hour,
+		PrivateKeyType:      kc.keyType,
+		PrivateKeyBits:      kc.keyBits,
 	}
 }
 


### PR DESCRIPTION
This PR moves the IntermediateCertTTL field into the common CA config so that it can be used in the Vault provider. The documentation sort of implied this was already the case, but it was actually a field specific to the Consul CA.