### PR TITLE
testutil: use TestingTB instead of testing.TB

### DIFF
--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -134,7 +134,7 @@ type ServerConfigCallback func(c *TestServerConfig)
 
 // defaultServerConfig returns a new TestServerConfig struct
 // with all of the listen ports incremented by one.
-func defaultServerConfig(t CleanupT) *TestServerConfig {
+func defaultServerConfig(t TestingTB) *TestServerConfig {
 	nodeID, err := uuid.GenerateUUID()
 	if err != nil {
 		panic(err)
@@ -216,11 +216,11 @@ type TestServer struct {
 	tmpdir string
 }
 
-// NewTestServerConfig creates a new TestServer, and makes a call to an optional
+// NewTestServerConfigT creates a new TestServer, and makes a call to an optional
 // callback function to modify the configuration. If there is an error
 // configuring or starting the server, the server will NOT be running when the
 // function returns (thus you do not need to stop it).
-func NewTestServerConfigT(t testing.TB, cb ServerConfigCallback) (*TestServer, error) {
+func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, error) {
 	path, err := exec.LookPath("consul")
 	if err != nil || path == "" {
 		return nil, fmt.Errorf("consul not found on $PATH - download and install " +

--- a/sdk/testutil/testlog.go
+++ b/sdk/testutil/testlog.go
@@ -10,11 +10,11 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-func Logger(t testing.TB) hclog.InterceptLogger {
+func Logger(t TestingTB) hclog.InterceptLogger {
 	return LoggerWithOutput(t, NewLogBuffer(t))
 }
 
-func LoggerWithOutput(t testing.TB, output io.Writer) hclog.InterceptLogger {
+func LoggerWithOutput(t TestingTB, output io.Writer) hclog.InterceptLogger {
 	return hclog.NewInterceptLogger(&hclog.LoggerOptions{
 		Name:   t.Name(),
 		Level:  hclog.Trace,
@@ -30,7 +30,7 @@ var sendTestLogsToStdout = os.Getenv("NOLOGBUFFER") == "1"
 //
 // Set the env var NOLOGBUFFER=1 to disable buffering, resulting in all log
 // output being written immediately to stdout.
-func NewLogBuffer(t CleanupT) io.Writer {
+func NewLogBuffer(t TestingTB) io.Writer {
 	if sendTestLogsToStdout {
 		return os.Stdout
 	}
@@ -43,11 +43,6 @@ func NewLogBuffer(t CleanupT) io.Writer {
 		}
 	})
 	return buf
-}
-
-type CleanupT interface {
-	Cleanup(f func())
-	Failed() bool
 }
 
 type logBuffer struct {

--- a/sdk/testutil/types.go
+++ b/sdk/testutil/types.go
@@ -1,0 +1,11 @@
+package testutil
+
+// TestingTB is an interface that describes the implementation of the testing object.
+// Using an interface that describes testing.TB instead of the actual implementation
+// makes testutil usable in a wider variety of contexts (e.g. use with ginkgo : https://godoc.org/github.com/onsi/ginkgo#GinkgoT)
+type TestingTB interface {
+	Cleanup(func())
+	Failed() bool
+	Logf(format string, args ...interface{})
+	Name() string
+}


### PR DESCRIPTION
These changes were made as a result of a suggestion by @dnephin in https://github.com/hashicorp/consul/pull/7559.
This PR enables using a `testing.TB` like interface (e.g. [GinkgoT](https://godoc.org/github.com/onsi/ginkgo#GinkgoT)) in addition to the 'real' [`testing.TB`](https://golang.org/pkg/testing/#TB) interface.
See https://github.com/onsi/ginkgo/issues/582 for further details.

cc @dnephin