### PR TITLE
Go changelog updates from go-changelog

### DIFF
--- a/.changelog/8588.txt
+++ b/.changelog/8588.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: fix renewing secondary intermediate certificates
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUGFIXES:
 * api: Fixed a panic caused by an api request with Connect=null [[GH-8537](https://github.com/hashicorp/consul/issues/8537)]
 * connect: `connect envoy` command now respects the `-ca-path` flag [[GH-8606](https://github.com/hashicorp/consul/issues/8606)]
 * connect: fix bug in preventing some namespaced config entry modifications [[GH-8601](https://github.com/hashicorp/consul/issues/8601)]
+* connect: fix renewing secondary intermediate certificates [[GH-8588](https://github.com/hashicorp/consul/issues/8588)]
 * ui: fixed a bug related to in-folder KV creation [GH-8613](https://github.com/hashicorp/consul/pull/8613)
 
 ## 1.8.3 (August 12, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,28 @@
 ## UNRELEASED
 
+FEATURES:
+
+* agent: expose the list of supported envoy versions on /v1/agent/self [[GH-8545](https://github.com/hashicorp/consul/issues/8545)]
+* cache: Config parameters for cache throttling are now reloaded automatically on agent reload. Restarting the agent is not needed anymore. [[GH-8552](https://github.com/hashicorp/consul/issues/8552)]
+* connect: all config entries pick up a meta field [[GH-8596](https://github.com/hashicorp/consul/issues/8596)]
+
+IMPROVEMENTS:
+
+* api: Added `ACLMode` method to the `AgentMember` type to determine what ACL mode the agent is operating in. [[GH-8575](https://github.com/hashicorp/consul/issues/8575)]
+* api: Added `IsConsulServer` method to the `AgentMember` type to easily determine whether the agent is a server. [[GH-8575](https://github.com/hashicorp/consul/issues/8575)]
+* api: Added constants for common tag keys and values in the `Tags` field of the `AgentMember` struct. [[GH-8575](https://github.com/hashicorp/consul/issues/8575)]
+* api: Allow for the client to use TLS over a Unix domain socket. [[GH-8602](https://github.com/hashicorp/consul/issues/8602)]
+* api: `GET v1/operator/keyring` also lists primary keys. [[GH-8522](https://github.com/hashicorp/consul/issues/8522)]
+* connect: Add support for http2 and grpc to ingress gateways [[GH-8458](https://github.com/hashicorp/consul/issues/8458)]
+* serf: update to `v0.9.4` which supports primary keys in the ListKeys operation. [[GH-8522](https://github.com/hashicorp/consul/issues/8522)]
+
 BUGFIXES:
 
+* [backport/1.8.x] connect: use stronger validation that ingress gateways have compatible protocols defined for their upstreams [[GH-8494](https://github.com/hashicorp/consul/issues/8494)]
+* agent: ensure that we normalize bootstrapped config entries [[GH-8547](https://github.com/hashicorp/consul/issues/8547)]
+* api: Fixed a panic caused by an api request with Connect=null [[GH-8537](https://github.com/hashicorp/consul/issues/8537)]
+* connect: `connect envoy` command now respects the `-ca-path` flag [[GH-8606](https://github.com/hashicorp/consul/issues/8606)]
+* connect: fix bug in preventing some namespaced config entry modifications [[GH-8601](https://github.com/hashicorp/consul/issues/8601)]
 * ui: fixed a bug related to in-folder KV creation [GH-8613](https://github.com/hashicorp/consul/pull/8613)
 
 ## 1.8.3 (August 12, 2020)


### PR DESCRIPTION
Changelog entries produced by:

```
$ go install github.com/hashicorp/go-changelog
$ changelog-build -last-release v1.8.3 -entries-dir .changelog/ -changelog-template .changelog/changelog.tmpl -note-template .changelog/note.tmpl -this-release 2e59d304b0307743931a195047710cee5826a048
```

Other potential missing entries:

* [x] `(Alvin Huang) * switch to new aws account s3 bucket for dev artifacts [[GH-8612](https://github.com/hashicorp/consul/pull/8612)]`
* [x] `(Daniel Nephin) * Merge pull request #8461 from hashicorp/dnephin/remove-notify-shutdown [[GH-8461](https://github.com/hashicorp/consul/pull/8461)]`
* [x] `(Daniel Nephin) * Merge pull request #8463 from hashicorp/dnephin/unmethod-make-node-id [[GH-8463](https://github.com/hashicorp/consul/pull/8463)]`
* [x] `(Daniel Nephin) * Merge pull request #8469 from hashicorp/dnephin/config-source [[GH-8469](https://github.com/hashicorp/consul/pull/8469)]`
* [x] `(Daniel Nephin) * Merge pull request #8473 from hashicorp/dnephin/unmethod-consul-config [[GH-8473](https://github.com/hashicorp/consul/pull/8473)]`
* [x] `(Daniel Nephin) * Merge pull request #8511 from hashicorp/dnephin/agent-setup [[GH-8511](https://github.com/hashicorp/consul/pull/8511)]`
* [x] `(Daniel Nephin) * Merge pull request #8514 from hashicorp/dnephin/testing-improvements-1 [[GH-8514](https://github.com/hashicorp/consul/pull/8514)]`
* [x] `(Daniel Nephin) * Merge pull request #8515 from hashicorp/dnephin/unexport-testing-shims [[GH-8515](https://github.com/hashicorp/consul/pull/8515)]`
* [x] `(Daniel Nephin) * Merge pull request #8528 from hashicorp/dnephin/move-node-name-validation [[GH-8528](https://github.com/hashicorp/consul/pull/8528)]`
* [x] `(Daniel Nephin) * Merge pull request #8540 from hashicorp/dnephin/logging-setup-cleanup [[GH-8540](https://github.com/hashicorp/consul/pull/8540)]`
* [x] `(Daniel Nephin) * Merge pull request #8573 from hashicorp/backport-agent-setup [[GH-8573](https://github.com/hashicorp/consul/pull/8573)]`
* [x] `(Daniel Nephin) * Merge pull request #8584 from hashicorp/1.8.x-fix-the-build [[GH-8584](https://github.com/hashicorp/consul/pull/8584)]`
* [x] `(Freddy) * Add docs for using namespaces with intentions [[GH-8594](https://github.com/hashicorp/consul/pull/8594)]`
* [x] `(Matt Keeler) * backport: #8523 [[GH-8523](https://github.com/hashicorp/consul/pull/8523)]`
* [x] `(R.B. Boyer) * agent: expose the list of supported envoy versions on /v1/agent/self [[GH-8566](https://github.com/hashicorp/consul/pull/8566)]`
* [x] `(hashicorp-ci) * Clarifying service definition requirements for registering a service … [[GH-8608](https://github.com/hashicorp/consul/pull/8608)]`
* [x] `(hashicorp-ci) * Link issue in note template [[GH-8502](https://github.com/hashicorp/consul/pull/8502)]`
* [x] `(hashicorp-ci) * Merge pull request #8365 from hashicorp/dnephin/fix-service-by-node-meta-flake [[GH-8365](https://github.com/hashicorp/consul/pull/8365)]`
* [x] `(hashicorp-ci) * Merge pull request #8509 from hashicorp/dnephin/use-t.cleanup-in-testagent [[GH-8509](https://github.com/hashicorp/consul/pull/8509)]`
* [x] `(hashicorp-ci) * Merge pull request #8546 from edevil/fix_vet [[GH-8546](https://github.com/hashicorp/consul/pull/8546)]`
* [x] `(hashicorp-ci) * Merge pull request #8548 from edevil/fix_flake [[GH-8548](https://github.com/hashicorp/consul/pull/8548)]`
* [x] `(hashicorp-ci) * Merge pull request #8577 from hashicorp/dnephin/changelog-for-8537 [[GH-8577](https://github.com/hashicorp/consul/pull/8577)]`
* [x] `(hashicorp-ci) * Merge pull request #8586 from pierresouchay/changelog_for_8552 [[GH-8586](https://github.com/hashicorp/consul/pull/8586)]`
* [x] `(hashicorp-ci) * Move RPC router from Client/Server and into BaseDeps [[GH-8559](https://github.com/hashicorp/consul/pull/8559)]`
* [x] `(hashicorp-ci) * add checkout to dev-upload-s3 [[GH-8617](https://github.com/hashicorp/consul/pull/8617)]`
* [x] `(hashicorp-ci) * sdk: also print test agent logs in verbose mode [[GH-8616](https://github.com/hashicorp/consul/pull/8616)]`
* [x] `(hashicorp-ci) * secondaryIntermediateCertRenewalWatch abort on success [[GH-8588](https://github.com/hashicorp/consul/pull/8588)]`
* [x] `(hashicorp-ci) * ui: Add new Service.Mesh* properties for improved sorting [[GH-8542](https://github.com/hashicorp/consul/pull/8542)]`
