### PR TITLE
ci: pin Nomad integration test to Go 1.14 for Consul 1.6.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
   # run integration tests on nomad/master
   nomad-integration-master:
     docker:
-      - image: circleci/golang:1.13 # nomad uses -trimpath which was introduced in Go 1.13
+      - image: circleci/golang:1.14
     environment:
       <<: *ENVIRONMENT
       NOMAD_WORKING_DIR: /go/src/github.com/hashicorp/nomad


### PR DESCRIPTION
Required by usage of `t.Cleanup` introduced by newer `consul/sdk` version in https://github.com/hashicorp/nomad/pull/8709