### PR TITLE
ui: Use runInDebug to add error logging to logger service

### DIFF
--- a/ui-v2/app/services/logger.js
+++ b/ui-v2/app/services/logger.js
@@ -1,5 +1,15 @@
 import Service from '@ember/service';
+import { runInDebug } from '@ember/debug';
 
 export default Service.extend({
-  execute: function(obj) {},
+  execute: function(obj) {
+    runInDebug(() => {
+      obj = typeof obj.error !== 'undefined' ? obj.error : obj;
+      if (obj instanceof Error) {
+        console.error(obj); // eslint-disable-line no-console
+      } else {
+        console.log(obj); // eslint-disable-line no-console
+      }
+    });
+  },
 });

--- a/ui-v2/app/services/state.js
+++ b/ui-v2/app/services/state.js
@@ -7,7 +7,7 @@ export default Service.extend({
   logger: service('logger'),
   // @xstate/fsm
   log: function(chart, state) {
-    this.logger.execute(`${chart.id} > ${state.value}`);
+    // this.logger.execute(`${chart.id} > ${state.value}`);
   },
   addGuards: function(chart, options) {
     this.guards(chart).forEach(function([path, name]) {


### PR DESCRIPTION
We've had a logger service that we've used for debug logging for a while, but we've never found a nice way to commit actual error logging into the production source, so we've edited in debug logging here when we've needed it.

Any calls to `runInDebug` are compiled out of production sourcecode, which make this ideal for what we need here.

Additionally we've commented out state transition logging for the moment for a less noisy console, ideally we'd be able to turn this on and off during development via cookies or similar, but this is best left for a future task/PR.