### PR TITLE
docs: Add -node-identity option to token and role command

### DIFF
--- a/website/pages/commands/acl/role/create.mdx
+++ b/website/pages/commands/acl/role/create.mdx
@@ -29,6 +29,10 @@ Usage: `consul acl role create [options] [args]`
 
 - `-name=<string>` - The new role's name. This flag is required.
 
+- `-node-identity=<value>` - Name of a node identity to use for this role. May
+  be specified multiple times. Format is `NODENAME:DATACENTER`. Added in Consul
+  1.8.1.
+
 - `-policy-id=<value>` - ID of a policy to use for this role. May be specified
   multiple times
 

--- a/website/pages/commands/acl/role/update.mdx
+++ b/website/pages/commands/acl/role/update.mdx
@@ -36,6 +36,10 @@ Usage: `consul acl role update [options] [args]`
 
 - `-name=<string>` - The role name.
 
+- `-node-identity=<value>` - Name of a node identity to use for this role. May
+  be specified multiple times. Format is `NODENAME:DATACENTER`. Added in Consul
+  1.8.1.
+
 - `-no-merge` - Do not merge the current role information with what is provided
   to the command. Instead overwrite all fields with the exception of the role
   ID which is immutable.

--- a/website/pages/commands/acl/token/create.mdx
+++ b/website/pages/commands/acl/token/create.mdx
@@ -36,6 +36,10 @@ Usage: `consul acl token create [options] [args]`
 - `-meta` - Indicates that token metadata such as the content hash and raft indices should be shown
   for each entry.
 
+- `-node-identity=<value>` - Name of a node identity to use for this role. May
+  be specified multiple times. Format is `NODENAME:DATACENTER`. Added in Consul
+  1.8.1.
+
 - `-policy-id=<value>` - ID of a policy to use for this token. May be specified multiple times.
 
 - `-policy-name=<value>` - Name of a policy to use for this token. May be specified multiple times.

--- a/website/pages/commands/acl/token/update.mdx
+++ b/website/pages/commands/acl/token/update.mdx
@@ -37,6 +37,10 @@ Usage: `consul acl token update [options]`
 - `-meta` - Indicates that token metadata such as the content hash and Raft indices should be
   shown for each entry.
 
+- `-node-identity=<value>` - Name of a node identity to use for this role. May
+  be specified multiple times. Format is `NODENAME:DATACENTER`. Added in Consul
+  1.8.1.
+
 - `-policy-id=<value>` - ID of a policy to use for this token. May be specified multiple times.
 
 - `-policy-name=<value>` - Name of a policy to use for this token. May be specified multiple times.

--- a/website/pages/commands/acl/token/update.mdx
+++ b/website/pages/commands/acl/token/update.mdx
@@ -28,6 +28,9 @@ Usage: `consul acl token update [options]`
 - `-id=<string>` - The Accessor ID of the token to read. It may be specified as a
   unique ID prefix but will error if the prefix matches multiple token Accessor IDs
 
+- `merge-node-identities` - Merge the new node identities with the existing node
+  identities.
+
 - `-merge-policies` - Merge the new policies with the existing policies.
 
 - `-merge-roles` - Merge the new roles with the existing roles.


### PR DESCRIPTION
Document `-node-identity` option which was added in #7970 for `acl token <create|update>` and `acl role <create|update>` commands.