### PR TITLE
Add path-based routing example to Ingress docs

### DIFF
--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -445,23 +445,23 @@ Routes = [
   {
     Match {
       HTTP {
-        PathPrefix = "/api_service1"
+        PathPrefix = "/billing"
       }
     }
 
     Destination {
-      Service = "api_service1"
+      Service = "billing-api"
     }
   },
   {
     Match {
       HTTP {
-        PathPrefix = "/api_service2"
+        PathPrefix = "/payments"
       }
     }
 
     Destination {
-      Service = "api_service2"
+      Service = "payments-api"
     }
   }
 ]
@@ -478,24 +478,24 @@ Routes = [
   {
     Match {
       HTTP {
-        PathPrefix = "/api_service1"
+        PathPrefix = "/billing"
       }
     }
 
     Destination {
-      Service = "api_service1"
+      Service = "billing-api"
       Namespace = "frontend"
     }
   },
   {
     Match {
       HTTP {
-        PathPrefix = "/api_service2"
+        PathPrefix = "/payments"
       }
     }
 
     Destination {
-      Service = "api_service2"
+      Service = "payments-api"
       Namespace = "frontend"
     }
   }
@@ -513,21 +513,21 @@ Routes = [
     {
       "Match": {
         "HTTP": {
-          "PathPrefix": "/api_service1"
+          "PathPrefix": "/billing"
         }
       },
       "Destination": {
-        "Service": "api_service1"
+        "Service": "billing-api"
       }
     },
     {
       "Match": {
         "HTTP": {
-          "PathPrefix": "/api_service2"
+          "PathPrefix": "/payments"
         }
       },
       "Destination": {
-        "Service": "api_service2"
+        "Service": "payments-api"
       }
     }
   ]
@@ -546,22 +546,22 @@ Routes = [
     {
       "Match": {
         "HTTP": {
-          "PathPrefix": "/api_service1"
+          "PathPrefix": "/billing"
         }
       },
       "Destination": {
-        "Service": "api_service1",
+        "Service": "billing-api",
         "Namespace": "frontend"
       }
     },
     {
       "Match": {
         "HTTP": {
-          "PathPrefix": "/api_service2"
+          "PathPrefix": "/payments"
         }
       },
       "Destination": {
-        "Service": "api_service2",
+        "Service": "payments-api",
         "Namespace": "frontend"
       }
     }

--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -382,7 +382,6 @@ traffic to a virtual service named "api".
 {
   "Kind": "ingress-gateway",
   "Name": "us-east-ingress",
-  "Namespace": "default",
   "Listeners": [
     {
       "Port": 80,
@@ -390,7 +389,6 @@ traffic to a virtual service named "api".
       "Services": [
         {
           "Name": "api",
-          "Namespace": "frontend"
         }
       ]
     }

--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -44,6 +44,8 @@ A wildcard specifier cannot be set on a listener of protocol `tcp`.
 
 ## Sample Config Entries
 
+### TCP listener
+
 <Tabs>
 <Tab heading="HCL">
 
@@ -143,6 +145,8 @@ to proxy traffic to the "db" service in the ops namespace:
 </Tab>
 </Tabs>
 
+### Wildcard HTTP listener
+
 <Tabs>
 <Tab heading="HCL">
 
@@ -315,6 +319,255 @@ Also make two services in the frontend namespace available over a custom port wi
 }
 ```
 
+</Tab>
+</Tabs>
+
+### HTTP listener with path-based routing
+
+<Tabs>
+<Tab heading="HCL">
+
+Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
+traffic to a virtual service named "api".
+
+```hcl
+Kind = "ingress-gateway"
+Name = "us-east-ingress"
+
+Listeners = [
+  {
+    Port     = 80
+    Protocol = "http"
+    Services = [
+      {
+        Name = "api"
+      }
+    ]
+  }
+]
+```
+
+</Tab>
+<Tab heading="HCL (Consul Enterprise)">
+
+Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
+default namespace to proxy traffic to a virtual service named "api". The virtual
+service uses path-based routing to route requests to different backend services.
+
+```hcl
+Kind = "ingress-gateway"
+Name = "us-east-ingress"
+Namespace = "default"
+
+Listeners = [
+  {
+    Port     = 80
+    Protocol = "http"
+    Services = [
+      {
+        Name = "api"
+        Namespace = "frontend"
+      }
+    ]
+  }
+]
+```
+
+</Tab>
+<Tab heading="JSON">
+
+Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
+traffic to a virtual service named "api". The virtual service uses path-based
+routing to route requests to different backend services.
+
+```json
+{
+  "Kind": "ingress-gateway",
+  "Name": "us-east-ingress",
+  "Namespace": "default",
+  "Listeners": [
+    {
+      "Port": 80,
+      "Protocol": "http",
+      "Services": [
+        {
+          "Name": "api",
+          "Namespace": "frontend"
+        }
+      ]
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab heading="JSON (Consul Enterprise)">
+
+Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
+default namespace to proxy traffic to a virtual service named "api". The virtual
+service uses path-based routing to route requests to different backend services.
+
+```json
+{
+  "Kind": "ingress-gateway",
+  "Name": "us-east-ingress",
+  "Namespace": "default",
+  "Listeners": [
+    {
+      "Port": 80,
+      "Protocol": "http",
+      "Services": [
+        {
+          "Name": "api",
+          "Namespace": "frontend"
+        }
+      ]
+    }
+  ]
+}
+```
+
+</Tab>
+</Tabs>
+
+The `api` service is not an actual registered service. It exist as a "virtual"
+service for L7 configuration only. A `service-router` is defined for this
+virtual service which uses path-based routing to route requests to different
+backend services.
+
+<Tabs>
+<Tab heading="HCL">
+
+```hcl
+Kind = "service-router"
+Name = "api"
+Routes = [
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/api_service1"
+      }
+    }
+
+    Destination {
+      Service = "api_service1"
+    }
+  },
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/api_service2"
+      }
+    }
+
+    Destination {
+      Service = "api_service2"
+    }
+  }
+]
+```
+
+</Tab>
+<Tab heading="HCL (Consul Enterprise)">
+
+```hcl
+Kind = "service-router"
+Name = "api"
+Namespace = "default"
+Routes = [
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/api_service1"
+      }
+    }
+
+    Destination {
+      Service = "api_service1"
+      Namespace = "frontend"
+    }
+  },
+  {
+    Match {
+      HTTP {
+        PathPrefix = "/api_service2"
+      }
+    }
+
+    Destination {
+      Service = "api_service2"
+      Namespace = "frontend"
+    }
+  }
+]
+```
+
+</Tab>
+<Tab heading="JSON">
+
+```json
+{
+  "Kind": "service-router",
+  "Name": "api",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/api_service1"
+        }
+      },
+      "Destination": {
+        "Service": "api_service1"
+      }
+    },
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/api_service2"
+        }
+      },
+      "Destination": {
+        "Service": "api_service2"
+      }
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab heading="JSON (Consul Enterprise)">
+
+```json
+{
+  "Kind": "service-router",
+  "Name": "api",
+  "Namespace": "default",
+  "Routes": [
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/api_service1"
+        }
+      },
+      "Destination": {
+        "Service": "api_service1",
+        "Namespace": "frontend"
+      }
+    },
+    {
+      "Match": {
+        "HTTP": {
+          "PathPrefix": "/api_service2"
+        }
+      },
+      "Destination": {
+        "Service": "api_service2",
+        "Namespace": "frontend"
+      }
+    }
+  ]
+}
+```
 </Tab>
 </Tabs>
 

--- a/website/pages/docs/agent/config-entries/ingress-gateway.mdx
+++ b/website/pages/docs/agent/config-entries/ingress-gateway.mdx
@@ -351,8 +351,7 @@ Listeners = [
 <Tab heading="HCL (Consul Enterprise)">
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
-default namespace to proxy traffic to a virtual service named "api". The virtual
-service uses path-based routing to route requests to different backend services.
+default namespace to proxy traffic to a virtual service named "api".
 
 ```hcl
 Kind = "ingress-gateway"
@@ -377,8 +376,7 @@ Listeners = [
 <Tab heading="JSON">
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" to proxy
-traffic to a virtual service named "api". The virtual service uses path-based
-routing to route requests to different backend services.
+traffic to a virtual service named "api".
 
 ```json
 {
@@ -404,8 +402,7 @@ routing to route requests to different backend services.
 <Tab heading="JSON (Consul Enterprise)">
 
 Set up a HTTP listener on an ingress gateway named "us-east-ingress" in the
-default namespace to proxy traffic to a virtual service named "api". The virtual
-service uses path-based routing to route requests to different backend services.
+default namespace to proxy traffic to a virtual service named "api".
 
 ```json
 {


### PR DESCRIPTION
Add configuration example for path-based HTTP routing with virtual services to Ingress gateway configuration entry documentation.

Resolves #8018