### PR TITLE
docs: Add go-sockaddr examples for bind_addr

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1106,6 +1106,28 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
 
 - `bind_addr` Equivalent to the [`-bind` command-line flag](#_bind).
 
+  This parameter can be set to a go-sockaddr template that resolves to a single
+  address. Special characters such as blackslashes `\` or double quotes `"`
+  within a double quoted string value must be escaped with a backslash `\`.
+  Some example templates:
+
+  <Tabs>
+  <Tab heading="HCL">
+
+  ```hcl
+  bind_addr = "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr \"address\" }}"
+  ```
+  </Tab>
+  <Tab heading="JSON">
+
+  ```json
+  {
+    "bind_addr": "{{ GetPrivateInterfaces | include \"network\" \"10.0.0.0/8\" | attr \"address\" }}"
+  }
+  ```
+  </Tab>
+  </Tabs>
+
 - `cache` Cache configuration of agent. The configurable values are the following:
 
   - `entry_fetch_max_burst`: The size of the token bucket used to recharge the rate-limit per


### PR DESCRIPTION
Add examples of using a go-sockaddr template with `bind_addr` within HCL or JSON configuration.

Resolves #8633