### PR TITLE
agent: Repalce ConsulOptions with a new struct from agent.BaseDeps

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -152,7 +152,7 @@ func (s *HTTPServer) AgentMetrics(resp http.ResponseWriter, req *http.Request) (
 		handler.ServeHTTP(resp, req)
 		return nil, nil
 	}
-	return s.agent.MemSink.DisplayMetrics(resp, req)
+	return s.agent.baseDeps.MetricsHandler.DisplayMetrics(resp, req)
 }
 
 func (s *HTTPServer) AgentReload(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -4607,7 +4607,7 @@ func TestSharedRPCRouter(t *testing.T) {
 
 	testrpc.WaitForTestAgent(t, srv.RPC, "dc1")
 
-	mgr, server := srv.Agent.router.FindLANRoute()
+	mgr, server := srv.Agent.baseDeps.Router.FindLANRoute()
 	require.NotNil(t, mgr)
 	require.NotNil(t, server)
 
@@ -4619,7 +4619,7 @@ func TestSharedRPCRouter(t *testing.T) {
 
 	testrpc.WaitForTestAgent(t, client.RPC, "dc1")
 
-	mgr, server = client.Agent.router.FindLANRoute()
+	mgr, server = client.Agent.baseDeps.Router.FindLANRoute()
 	require.NotNil(t, mgr)
 	require.NotNil(t, server)
 }

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -2,12 +2,14 @@ package consul
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -75,7 +77,11 @@ func testClientWithConfigWithErr(t *testing.T, cb func(c *Config)) (string, *Cli
 		t.Fatalf("err: %v", err)
 	}
 
-	client, err := NewClient(config, WithLogger(logger), WithTLSConfigurator(tlsConf))
+	r := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
+	client, err := NewClient(config,
+		WithLogger(logger),
+		WithTLSConfigurator(tlsConf),
+		WithRouter(r))
 	return dir, client, err
 }
 
@@ -473,7 +479,11 @@ func newClient(t *testing.T, config *Config) *Client {
 		Level:  hclog.Debug,
 		Output: testutil.NewLogBuffer(t),
 	})
-	client, err := NewClient(config, WithLogger(logger), WithTLSConfigurator(c))
+	r := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
+	client, err := NewClient(config,
+		WithLogger(logger),
+		WithTLSConfigurator(c),
+		WithRouter(r))
 	require.NoError(t, err, "failed to create client")
 	t.Cleanup(func() {
 		client.Shutdown()

--- a/agent/consul/client_test.go
+++ b/agent/consul/client_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/pool"
 	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
@@ -66,22 +68,8 @@ func testClientWithConfigWithErr(t *testing.T, cb func(c *Config)) (string, *Cli
 	if cb != nil {
 		cb(config)
 	}
-	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   config.NodeName,
-		Level:  hclog.Debug,
-		Output: testutil.NewLogBuffer(t),
-	})
 
-	tlsConf, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), logger)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	r := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
-	client, err := NewClient(config,
-		WithLogger(logger),
-		WithTLSConfigurator(tlsConf),
-		WithRouter(r))
+	client, err := NewClient(config, newDefaultDeps(t, config))
 	return dir, client, err
 }
 
@@ -472,23 +460,45 @@ func TestClient_RPC_TLS(t *testing.T) {
 func newClient(t *testing.T, config *Config) *Client {
 	t.Helper()
 
-	c, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), nil)
-	require.NoError(t, err, "failed to create tls configuration")
-
-	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Level:  hclog.Debug,
-		Output: testutil.NewLogBuffer(t),
-	})
-	r := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
-	client, err := NewClient(config,
-		WithLogger(logger),
-		WithTLSConfigurator(c),
-		WithRouter(r))
+	client, err := NewClient(config, newDefaultDeps(t, config))
 	require.NoError(t, err, "failed to create client")
 	t.Cleanup(func() {
 		client.Shutdown()
 	})
 	return client
+}
+
+func newDefaultDeps(t *testing.T, c *Config) Deps {
+	t.Helper()
+
+	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
+		Name:   c.NodeName,
+		Level:  hclog.Debug,
+		Output: testutil.NewLogBuffer(t),
+	})
+
+	tls, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), logger)
+	require.NoError(t, err, "failed to create tls configuration")
+
+	r := router.NewRouter(logger, c.Datacenter, fmt.Sprintf("%s.%s", c.NodeName, c.Datacenter))
+
+	connPool := &pool.ConnPool{
+		Server:          false,
+		SrcAddr:         c.RPCSrcAddr,
+		Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
+		MaxTime:         2 * time.Minute,
+		MaxStreams:      4,
+		TLSConfigurator: tls,
+		Datacenter:      c.Datacenter,
+	}
+
+	return Deps{
+		Logger:          logger,
+		TLSConfigurator: tls,
+		Tokens:          new(token.Store),
+		Router:          r,
+		ConnPool:        connPool,
+	}
 }
 
 func TestClient_RPC_RateLimit(t *testing.T) {

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
@@ -1305,10 +1306,13 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 	})
 	tlsConf, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), logger)
 	require.NoError(t, err)
+
+	rpcRouter := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
 	srv, err := NewServer(config,
 		WithLogger(logger),
 		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(tlsConf))
+		WithTLSConfigurator(tlsConf),
+		WithRouter(rpcRouter))
 	require.NoError(t, err)
 	defer srv.Shutdown()
 

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -9,14 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/agent/token"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
-	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/go-hclog"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/serf/serf"
@@ -1304,15 +1301,11 @@ func TestLeader_ConfigEntryBootstrap_Fail(t *testing.T) {
 		Level:  hclog.Debug,
 		Output: io.MultiWriter(pw, testutil.NewLogBuffer(t)),
 	})
-	tlsConf, err := tlsutil.NewConfigurator(config.ToTLSUtilConfig(), logger)
-	require.NoError(t, err)
 
-	rpcRouter := router.NewRouter(logger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
-	srv, err := NewServer(config,
-		WithLogger(logger),
-		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(tlsConf),
-		WithRouter(rpcRouter))
+	deps := newDefaultDeps(t, config)
+	deps.Logger = logger
+
+	srv, err := NewServer(config, deps)
 	require.NoError(t, err)
 	defer srv.Shutdown()
 

--- a/agent/consul/options.go
+++ b/agent/consul/options.go
@@ -8,50 +8,10 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
-type consulOptions struct {
-	logger          hclog.InterceptLogger
-	tlsConfigurator *tlsutil.Configurator
-	connPool        *pool.ConnPool
-	tokens          *token.Store
-	router          *router.Router
-}
-
-type ConsulOption func(*consulOptions)
-
-func WithLogger(logger hclog.InterceptLogger) ConsulOption {
-	return func(opt *consulOptions) {
-		opt.logger = logger
-	}
-}
-
-func WithTLSConfigurator(tlsConfigurator *tlsutil.Configurator) ConsulOption {
-	return func(opt *consulOptions) {
-		opt.tlsConfigurator = tlsConfigurator
-	}
-}
-
-func WithConnectionPool(connPool *pool.ConnPool) ConsulOption {
-	return func(opt *consulOptions) {
-		opt.connPool = connPool
-	}
-}
-
-func WithTokenStore(tokens *token.Store) ConsulOption {
-	return func(opt *consulOptions) {
-		opt.tokens = tokens
-	}
-}
-
-func WithRouter(router *router.Router) ConsulOption {
-	return func(opt *consulOptions) {
-		opt.router = router
-	}
-}
-
-func flattenConsulOptions(options []ConsulOption) consulOptions {
-	var flat consulOptions
-	for _, opt := range options {
-		opt(&flat)
-	}
-	return flat
+type Deps struct {
+	Logger          hclog.InterceptLogger
+	TLSConfigurator *tlsutil.Configurator
+	Tokens          *token.Store
+	Router          *router.Router
+	ConnPool        *pool.ConnPool
 }

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -70,14 +70,6 @@ const (
 	raftState         = "raft/"
 	snapshotsRetained = 2
 
-	// serverRPCCache controls how long we keep an idle connection
-	// open to a server
-	serverRPCCache = 2 * time.Minute
-
-	// serverMaxStreams controls how many idle streams we keep
-	// open to a server
-	serverMaxStreams = 64
-
 	// raftLogCacheSize is the maximum number of logs to cache in-memory.
 	// This is used to reduce disk I/O for the recently committed entries.
 	raftLogCacheSize = 512
@@ -324,14 +316,8 @@ type connHandler interface {
 
 // NewServer is used to construct a new Consul server from the configuration
 // and extra options, potentially returning an error.
-func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
-	flat := flattenConsulOptions(options)
-
-	logger := flat.logger
-	tokens := flat.tokens
-	tlsConfigurator := flat.tlsConfigurator
-	connPool := flat.connPool
-
+func NewServer(config *Config, flat Deps) (*Server, error) {
+	logger := flat.Logger
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
 	}
@@ -340,12 +326,6 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	}
 	if err := config.CheckACL(); err != nil {
 		return nil, err
-	}
-	if logger == nil {
-		return nil, fmt.Errorf("logger is required")
-	}
-	if flat.router == nil {
-		return nil, fmt.Errorf("router is required")
 	}
 
 	// Check if TLS is enabled
@@ -375,36 +355,24 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	// Create the shutdown channel - this is closed but never written to.
 	shutdownCh := make(chan struct{})
 
-	if connPool == nil {
-		connPool = &pool.ConnPool{
-			Server:          true,
-			SrcAddr:         config.RPCSrcAddr,
-			Logger:          logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
-			MaxTime:         serverRPCCache,
-			MaxStreams:      serverMaxStreams,
-			TLSConfigurator: tlsConfigurator,
-			Datacenter:      config.Datacenter,
-		}
-	}
-
-	serverLogger := logger.NamedIntercept(logging.ConsulServer)
+	serverLogger := flat.Logger.NamedIntercept(logging.ConsulServer)
 	loggers := newLoggerStore(serverLogger)
 
 	// Create server.
 	s := &Server{
 		config:                  config,
-		tokens:                  tokens,
-		connPool:                connPool,
+		tokens:                  flat.Tokens,
+		connPool:                flat.ConnPool,
 		eventChLAN:              make(chan serf.Event, serfEventChSize),
 		eventChWAN:              make(chan serf.Event, serfEventChSize),
 		logger:                  serverLogger,
 		loggers:                 loggers,
 		leaveCh:                 make(chan struct{}),
 		reconcileCh:             make(chan serf.Member, reconcileChSize),
-		router:                  flat.router,
+		router:                  flat.Router,
 		rpcServer:               rpc.NewServer(),
 		insecureRPCServer:       rpc.NewServer(),
-		tlsConfigurator:         tlsConfigurator,
+		tlsConfigurator:         flat.TLSConfigurator,
 		reassertLeaderCh:        make(chan chan error),
 		segmentLAN:              make(map[string]*serf.Serf, len(config.Segments)),
 		sessionTimers:           NewSessionTimers(),

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -331,7 +331,6 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	tokens := flat.tokens
 	tlsConfigurator := flat.tlsConfigurator
 	connPool := flat.connPool
-	rpcRouter := flat.router
 
 	if err := config.CheckProtocolVersion(); err != nil {
 		return nil, err
@@ -344,6 +343,9 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	}
 	if logger == nil {
 		return nil, fmt.Errorf("logger is required")
+	}
+	if flat.router == nil {
+		return nil, fmt.Errorf("router is required")
 	}
 
 	// Check if TLS is enabled
@@ -388,10 +390,6 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 	serverLogger := logger.NamedIntercept(logging.ConsulServer)
 	loggers := newLoggerStore(serverLogger)
 
-	if rpcRouter == nil {
-		rpcRouter = router.NewRouter(serverLogger, config.Datacenter, fmt.Sprintf("%s.%s", config.NodeName, config.Datacenter))
-	}
-
 	// Create server.
 	s := &Server{
 		config:                  config,
@@ -403,7 +401,7 @@ func NewServer(config *Config, options ...ConsulOption) (*Server, error) {
 		loggers:                 loggers,
 		leaveCh:                 make(chan struct{}),
 		reconcileCh:             make(chan serf.Member, reconcileChSize),
-		router:                  rpcRouter,
+		router:                  flat.router,
 		rpcServer:               rpc.NewServer(),
 		insecureRPCServer:       rpc.NewServer(),
 		tlsConfigurator:         tlsConfigurator,

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/tcpproxy"
 	"github.com/hashicorp/consul/agent/connect/ca"
+	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/memberlist"
 
@@ -301,10 +302,13 @@ func newServer(t *testing.T, c *Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	rpcRouter := router.NewRouter(logger, c.Datacenter, fmt.Sprintf("%s.%s", c.NodeName, c.Datacenter))
 	srv, err := NewServer(c,
 		WithLogger(logger),
 		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(tlsConf))
+		WithTLSConfigurator(tlsConf),
+		WithRouter(rpcRouter))
 	if err != nil {
 		return nil, err
 	}
@@ -1491,10 +1495,13 @@ func TestServer_CALogging(t *testing.T) {
 	c, err := tlsutil.NewConfigurator(conf1.ToTLSUtilConfig(), logger)
 	require.NoError(t, err)
 
+	rpcRouter := router.NewRouter(logger, "dc1", fmt.Sprintf("%s.%s", "nodename", "dc1"))
+
 	s1, err := NewServer(conf1,
 		WithLogger(logger),
 		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(c))
+		WithTLSConfigurator(c),
+		WithRouter(rpcRouter))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/google/tcpproxy"
 	"github.com/hashicorp/consul/agent/connect/ca"
-	"github.com/hashicorp/consul/agent/router"
 	"github.com/hashicorp/consul/ipaddr"
 	"github.com/hashicorp/memberlist"
 
@@ -31,7 +30,6 @@ import (
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/hashicorp/consul/tlsutil"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-uuid"
 	"golang.org/x/time/rate"
 
@@ -293,22 +291,7 @@ func newServer(t *testing.T, c *Config) (*Server, error) {
 		}
 	}
 
-	logger := hclog.NewInterceptLogger(&hclog.LoggerOptions{
-		Name:   c.NodeName,
-		Level:  hclog.Debug,
-		Output: testutil.NewLogBuffer(t),
-	})
-	tlsConf, err := tlsutil.NewConfigurator(c.ToTLSUtilConfig(), logger)
-	if err != nil {
-		return nil, err
-	}
-
-	rpcRouter := router.NewRouter(logger, c.Datacenter, fmt.Sprintf("%s.%s", c.NodeName, c.Datacenter))
-	srv, err := NewServer(c,
-		WithLogger(logger),
-		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(tlsConf),
-		WithRouter(rpcRouter))
+	srv, err := NewServer(c, newDefaultDeps(t, c))
 	if err != nil {
 		return nil, err
 	}
@@ -1492,19 +1475,11 @@ func TestServer_CALogging(t *testing.T) {
 	var buf bytes.Buffer
 	logger := testutil.LoggerWithOutput(t, &buf)
 
-	c, err := tlsutil.NewConfigurator(conf1.ToTLSUtilConfig(), logger)
+	deps := newDefaultDeps(t, conf1)
+	deps.Logger = logger
+
+	s1, err := NewServer(conf1, deps)
 	require.NoError(t, err)
-
-	rpcRouter := router.NewRouter(logger, "dc1", fmt.Sprintf("%s.%s", "nodename", "dc1"))
-
-	s1, err := NewServer(conf1,
-		WithLogger(logger),
-		WithTokenStore(new(token.Store)),
-		WithTLSConfigurator(c),
-		WithRouter(rpcRouter))
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
 	defer s1.Shutdown()
 	testrpc.WaitForLeader(t, s1.RPC, "dc1")
 


### PR DESCRIPTION
The first commit is extracted from #8667. This change will be necessary once #8667 is merged and we start using the `ClientConnPool`.

In an upcoming change we will need to pass a grpc.ClientConnPool from
BaseDeps into Server. While looking at that change I noticed all of the
existing consulOption fields are already on BaseDeps.

Instead of duplicating the fields, we can create a struct used by
agent/consul, and use that struct in BaseDeps. This allows us to pass
along dependencies without translating them into different
representations.

I also looked at moving all of BaseDeps in agent/consul, however that
created a circular import. Resolving the cycles wouldn't be too
bad (it was only an error in agent/consul being imported from
cache-types), however this change seems a little better by starting to
introduce some structure to BaseDeps.

This change is also a small step in reducing the scope of Agent.
                                                                                                                                                                                                                                               
Also remove some constants that were only used by tests, and move the
relevant comment to where the live configuration is set.
                                                                                                                                                                                                                                               
Removed some validation from NewServer and NewClient, as these are not
really runtime errors. They would be code errors, which will cause a
panic anyway, so no reason to handle them specially here.
