### PR TITLE
[BUGFIX] Avoid GetDatacenter* methods to flood Consul servers logs

### DIFF
--- a/.changelog/8685.txt
+++ b/.changelog/8685.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Avoid logs to be flooded with `[WARN] agent.router: Non-server in server-only area: non_server=myClientNode area=lan` [GH-8663](https://github.com/hashicorp/consul/issues/8663)
+```

--- a/.changelog/8685.txt
+++ b/.changelog/8685.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-Avoid logs to be flooded with `[WARN] agent.router: Non-server in server-only area: non_server=myClientNode area=lan` [GH-8663](https://github.com/hashicorp/consul/issues/8663)
+fixed a bug that caused logs to be flooded with `[WARN] agent.router: Non-server in server-only area`
 ```

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -536,10 +536,13 @@ func (r *Router) GetDatacentersByDistance() ([]string, error) {
 		for _, m := range info.cluster.Members() {
 			ok, parts := metadata.IsConsulServer(m)
 			if !ok {
-				r.logger.Warn("Non-server in server-only area",
-					"non_server", m.Name,
-					"area", areaID,
-				)
+				if areaID != types.AreaLAN {
+					r.logger.Warn("Non-server in server-only area",
+						"non_server", m.Name,
+						"area", areaID,
+						"func", "GetDatacentersByDistance",
+					)
+				}
 				continue
 			}
 
@@ -547,6 +550,7 @@ func (r *Router) GetDatacentersByDistance() ([]string, error) {
 				r.logger.Debug("server in area left, skipping",
 					"server", m.Name,
 					"area", areaID,
+					"func", "GetDatacentersByDistance",
 				)
 				continue
 			}
@@ -607,10 +611,13 @@ func (r *Router) GetDatacenterMaps() ([]structs.DatacenterMap, error) {
 		for _, m := range info.cluster.Members() {
 			ok, parts := metadata.IsConsulServer(m)
 			if !ok {
-				r.logger.Warn("Non-server in server-only area",
-					"non_server", m.Name,
-					"area", areaID,
-				)
+				if areaID != types.AreaLAN {
+					r.logger.Warn("Non-server in server-only area",
+						"non_server", m.Name,
+						"area", areaID,
+						"func", "GetDatacenterMaps",
+					)
+				}
 				continue
 			}
 
@@ -618,6 +625,7 @@ func (r *Router) GetDatacenterMaps() ([]structs.DatacenterMap, error) {
 				r.logger.Debug("server in area left, skipping",
 					"server", m.Name,
 					"area", areaID,
+					"func", "GetDatacenterMaps",
 				)
 				continue
 			}


### PR DESCRIPTION
When calling `GetDatacentersByDistance()` or `GetDatacentersMap()`, an
incorrect condition was used to diplay log message, thus flooding
Consul's logs.

Example of message:

```
  [WARN] agent.router: Non-server in server-only area: non_server=myClientNode area=lan
```

This message is only valid for WAN areas, filter to avoid creating
hundreds of logs/s on our custers, each time someone is calling this
method.

Our logs were flooded by such messages when migrating our Consul servers
from 1.7.7 to 1.8.4.

This will issue fix #8663