### PR TITLE
test: update tag names for database services

### DIFF
--- a/agent/consul/catalog_endpoint_test.go
+++ b/agent/consul/catalog_endpoint_test.go
@@ -35,7 +35,7 @@ func TestCatalog_Register(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    8000,
 		},
 		Check: &structs.HealthCheck{
@@ -135,7 +135,7 @@ func TestCatalog_Register_NodeID(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    8000,
 		},
 		Check: &structs.HealthCheck{
@@ -199,7 +199,7 @@ node "foo" {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    8000,
 		},
 		WriteRequest: structs.WriteRequest{Token: id},
@@ -285,7 +285,7 @@ func TestCatalog_Register_ForwardLeader(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    8000,
 		},
 	}
@@ -318,7 +318,7 @@ func TestCatalog_Register_ForwardDC(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    8000,
 		},
 	}
@@ -1615,7 +1615,7 @@ func TestCatalog_ListServiceNodes(t *testing.T) {
 	args := structs.ServiceSpecificRequest{
 		Datacenter:  "dc1",
 		ServiceName: "db",
-		ServiceTags: []string{"slave"},
+		ServiceTags: []string{"replica"},
 		TagFilter:   false,
 	}
 	var out structs.IndexedServiceNodes

--- a/agent/consul/health_endpoint_test.go
+++ b/agent/consul/health_endpoint_test.go
@@ -539,7 +539,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -559,7 +559,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"slave"},
+			Tags:    []string{"replica"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -575,7 +575,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 	req := structs.ServiceSpecificRequest{
 		Datacenter:  "dc1",
 		ServiceName: "db",
-		ServiceTags: []string{"master"},
+		ServiceTags: []string{"primary"},
 		TagFilter:   false,
 	}
 	if err := msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2); err != nil {
@@ -592,10 +592,10 @@ func TestHealth_ServiceNodes(t *testing.T) {
 	if nodes[1].Node.Node != "foo" {
 		t.Fatalf("Bad: %v", nodes[1])
 	}
-	if !stringslice.Contains(nodes[0].Service.Tags, "slave") {
+	if !stringslice.Contains(nodes[0].Service.Tags, "replica") {
 		t.Fatalf("Bad: %v", nodes[0])
 	}
-	if !stringslice.Contains(nodes[1].Service.Tags, "master") {
+	if !stringslice.Contains(nodes[1].Service.Tags, "primary") {
 		t.Fatalf("Bad: %v", nodes[1])
 	}
 	if nodes[0].Checks[0].Status != api.HealthWarning {
@@ -613,7 +613,7 @@ func TestHealth_ServiceNodes(t *testing.T) {
 		req := structs.ServiceSpecificRequest{
 			Datacenter:  "dc1",
 			ServiceName: "db",
-			ServiceTag:  "master",
+			ServiceTag:  "primary",
 			TagFilter:   false,
 		}
 		if err := msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2); err != nil {
@@ -630,10 +630,10 @@ func TestHealth_ServiceNodes(t *testing.T) {
 		if nodes[1].Node.Node != "foo" {
 			t.Fatalf("Bad: %v", nodes[1])
 		}
-		if !stringslice.Contains(nodes[0].Service.Tags, "slave") {
+		if !stringslice.Contains(nodes[0].Service.Tags, "replica") {
 			t.Fatalf("Bad: %v", nodes[0])
 		}
-		if !stringslice.Contains(nodes[1].Service.Tags, "master") {
+		if !stringslice.Contains(nodes[1].Service.Tags, "primary") {
 			t.Fatalf("Bad: %v", nodes[1])
 		}
 		if nodes[0].Checks[0].Status != api.HealthWarning {
@@ -662,7 +662,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"master", "v2"},
+			Tags:    []string{"primary", "v2"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -680,7 +680,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"slave", "v2"},
+			Tags:    []string{"replica", "v2"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -694,7 +694,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 	req := structs.ServiceSpecificRequest{
 		Datacenter:  "dc1",
 		ServiceName: "db",
-		ServiceTags: []string{"master", "v2"},
+		ServiceTags: []string{"primary", "v2"},
 		TagFilter:   true,
 	}
 	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Health.ServiceNodes", &req, &out2))
@@ -703,7 +703,7 @@ func TestHealth_ServiceNodes_MultipleServiceTags(t *testing.T) {
 	require.Len(t, nodes, 1)
 	require.Equal(t, nodes[0].Node.Node, "foo")
 	require.Contains(t, nodes[0].Service.Tags, "v2")
-	require.Contains(t, nodes[0].Service.Tags, "master")
+	require.Contains(t, nodes[0].Service.Tags, "primary")
 	require.Equal(t, nodes[0].Checks[0].Status, api.HealthPassing)
 }
 

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -34,7 +34,7 @@ func TestInternal_NodeInfo(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -63,7 +63,7 @@ func TestInternal_NodeInfo(t *testing.T) {
 	if nodes[0].Node != "foo" {
 		t.Fatalf("Bad: %v", nodes[0])
 	}
-	if !stringslice.Contains(nodes[0].Services[0].Tags, "master") {
+	if !stringslice.Contains(nodes[0].Services[0].Tags, "primary") {
 		t.Fatalf("Bad: %v", nodes[0])
 	}
 	if nodes[0].Checks[0].Status != api.HealthPassing {
@@ -88,7 +88,7 @@ func TestInternal_NodeDump(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -108,7 +108,7 @@ func TestInternal_NodeDump(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"slave"},
+			Tags:    []string{"replica"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -138,7 +138,7 @@ func TestInternal_NodeDump(t *testing.T) {
 		switch node.Node {
 		case "foo":
 			foundFoo = true
-			if !stringslice.Contains(node.Services[0].Tags, "master") {
+			if !stringslice.Contains(node.Services[0].Tags, "primary") {
 				t.Fatalf("Bad: %v", nodes[0])
 			}
 			if node.Checks[0].Status != api.HealthPassing {
@@ -147,7 +147,7 @@ func TestInternal_NodeDump(t *testing.T) {
 
 		case "bar":
 			foundBar = true
-			if !stringslice.Contains(node.Services[0].Tags, "slave") {
+			if !stringslice.Contains(node.Services[0].Tags, "replica") {
 				t.Fatalf("Bad: %v", nodes[1])
 			}
 			if node.Checks[0].Status != api.HealthWarning {
@@ -180,7 +180,7 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -198,7 +198,7 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 		Service: &structs.NodeService{
 			ID:      "db",
 			Service: "db",
-			Tags:    []string{"slave"},
+			Tags:    []string{"replica"},
 		},
 		Check: &structs.HealthCheck{
 			Name:      "db connect",
@@ -212,7 +212,7 @@ func TestInternal_NodeDump_Filter(t *testing.T) {
 	var out2 structs.IndexedNodeDump
 	req := structs.DCSpecificRequest{
 		Datacenter:   "dc1",
-		QueryOptions: structs.QueryOptions{Filter: "master in Services.Tags"},
+		QueryOptions: structs.QueryOptions{Filter: "primary in Services.Tags"},
 	}
 	require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.NodeDump", &req, &out2))
 

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -199,7 +199,7 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 		Address: "1.1.1.1",
 		Port:    8080,
 		Meta:    map[string]string{strings.Repeat("a", 129): "somevalue"},
-		Tags:    []string{"master"},
+		Tags:    []string{"primary"},
 	}
 	if err := s.EnsureRegistration(9, req); err == nil {
 		t.Fatalf("Service should not have been registered since Meta is invalid")
@@ -211,7 +211,7 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 		Service: "redis",
 		Address: "1.1.1.1",
 		Port:    8080,
-		Tags:    []string{"master"},
+		Tags:    []string{"primary"},
 		Weights: &structs.Weights{Passing: 1, Warning: 1},
 	}
 	if err := s.EnsureRegistration(2, req); err != nil {
@@ -226,7 +226,7 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 				Service:        "redis",
 				Address:        "1.1.1.1",
 				Port:           8080,
-				Tags:           []string{"master"},
+				Tags:           []string{"primary"},
 				Weights:        &structs.Weights{Passing: 1, Warning: 1},
 				RaftIndex:      structs.RaftIndex{CreateIndex: 2, ModifyIndex: 2},
 				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
@@ -321,7 +321,7 @@ func TestStateStore_EnsureRegistration(t *testing.T) {
 				Status:         "critical",
 				ServiceID:      "redis1",
 				ServiceName:    "redis",
-				ServiceTags:    []string{"master"},
+				ServiceTags:    []string{"primary"},
 				RaftIndex:      structs.RaftIndex{CreateIndex: 4, ModifyIndex: 4},
 				EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 			},
@@ -1568,7 +1568,7 @@ func TestStateStore_Services(t *testing.T) {
 	ns1 := &structs.NodeService{
 		ID:      "service1",
 		Service: "redis",
-		Tags:    []string{"prod", "master"},
+		Tags:    []string{"prod", "primary"},
 		Address: "1.1.1.1",
 		Port:    1111,
 	}
@@ -1580,7 +1580,7 @@ func TestStateStore_Services(t *testing.T) {
 	ns2 := &structs.NodeService{
 		ID:      "service3",
 		Service: "redis",
-		Tags:    []string{"prod", "slave"},
+		Tags:    []string{"prod", "replica"},
 		Address: "1.1.1.1",
 		Port:    1111,
 	}
@@ -1604,7 +1604,7 @@ func TestStateStore_Services(t *testing.T) {
 	// Verify the result. We sort the lists since the order is
 	// non-deterministic (it's built using a map internally).
 	expected := structs.Services{
-		"redis": []string{"prod", "master", "slave"},
+		"redis": []string{"prod", "primary", "replica"},
 		"dogs":  []string{},
 	}
 	sort.Strings(expected["redis"])
@@ -1648,7 +1648,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	ns1 := &structs.NodeService{
 		ID:      "service1",
 		Service: "redis",
-		Tags:    []string{"prod", "master"},
+		Tags:    []string{"prod", "primary"},
 		Address: "1.1.1.1",
 		Port:    1111,
 	}
@@ -1658,7 +1658,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 	ns2 := &structs.NodeService{
 		ID:      "service1",
 		Service: "redis",
-		Tags:    []string{"prod", "slave"},
+		Tags:    []string{"prod", "replica"},
 		Address: "1.1.1.1",
 		Port:    1111,
 	}
@@ -1677,7 +1677,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 		expected := structs.Services{
-			"redis": []string{"master", "prod"},
+			"redis": []string{"primary", "prod"},
 		}
 		sort.Strings(res["redis"])
 		require.Equal(t, expected, res)
@@ -1689,7 +1689,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 		expected := structs.Services{
-			"redis": []string{"master", "prod", "slave"},
+			"redis": []string{"primary", "prod", "replica"},
 		}
 		sort.Strings(res["redis"])
 		require.Equal(t, expected, res)
@@ -1710,7 +1710,7 @@ func TestStateStore_ServicesByNodeMeta(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 		expected := structs.Services{
-			"redis": []string{"master", "prod"},
+			"redis": []string{"primary", "prod"},
 		}
 		sort.Strings(res["redis"])
 		require.Equal(t, expected, res)
@@ -1788,13 +1788,13 @@ func TestStateStore_ServiceNodes(t *testing.T) {
 	if err := s.EnsureService(13, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(14, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(14, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(15, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(15, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(16, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}); err != nil {
+	if err := s.EnsureService(16, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if !watchFired(ws) {
@@ -1822,7 +1822,7 @@ func TestStateStore_ServiceNodes(t *testing.T) {
 	if nodes[0].ServiceID != "db" {
 		t.Fatalf("bad: %v", nodes)
 	}
-	if !stringslice.Contains(nodes[0].ServiceTags, "slave") {
+	if !stringslice.Contains(nodes[0].ServiceTags, "replica") {
 		t.Fatalf("bad: %v", nodes)
 	}
 	if nodes[0].ServicePort != 8000 {
@@ -1837,7 +1837,7 @@ func TestStateStore_ServiceNodes(t *testing.T) {
 	if nodes[1].ServiceID != "db2" {
 		t.Fatalf("bad: %v", nodes)
 	}
-	if !stringslice.Contains(nodes[1].ServiceTags, "slave") {
+	if !stringslice.Contains(nodes[1].ServiceTags, "replica") {
 		t.Fatalf("bad: %v", nodes)
 	}
 	if nodes[1].ServicePort != 8001 {
@@ -1852,7 +1852,7 @@ func TestStateStore_ServiceNodes(t *testing.T) {
 	if nodes[2].ServiceID != "db" {
 		t.Fatalf("bad: %v", nodes)
 	}
-	if !stringslice.Contains(nodes[2].ServiceTags, "master") {
+	if !stringslice.Contains(nodes[2].ServiceTags, "primary") {
 		t.Fatalf("bad: %v", nodes)
 	}
 	if nodes[2].ServicePort != 8000 {
@@ -1907,7 +1907,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 
 	// Listing with no results returns an empty list.
 	ws := memdb.NewWatchSet()
-	idx, nodes, err := s.ServiceTagNodes(ws, "db", []string{"master"}, nil)
+	idx, nodes, err := s.ServiceTagNodes(ws, "db", []string{"primary"}, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1925,13 +1925,13 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 	if err := s.EnsureNode(16, &structs.Node{Node: "bar", Address: "127.0.0.2"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}); err != nil {
+	if err := s.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if !watchFired(ws) {
@@ -1940,7 +1940,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 
 	// Read everything back.
 	ws = memdb.NewWatchSet()
-	idx, nodes, err = s.ServiceTagNodes(ws, "db", []string{"master"}, nil)
+	idx, nodes, err = s.ServiceTagNodes(ws, "db", []string{"primary"}, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1956,7 +1956,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 	if nodes[0].Address != "127.0.0.1" {
 		t.Fatalf("bad: %v", nodes)
 	}
-	if !stringslice.Contains(nodes[0].ServiceTags, "master") {
+	if !stringslice.Contains(nodes[0].ServiceTags, "primary") {
 		t.Fatalf("bad: %v", nodes)
 	}
 	if nodes[0].ServicePort != 8000 {
@@ -1969,7 +1969,7 @@ func TestStateStore_ServiceTagNodes(t *testing.T) {
 		t.Fatalf("bad")
 	}
 
-	// But removing a node with the "db:master" service should fire the watch.
+	// But removing a node with the "db:primary" service should fire the watch.
 	if err := s.DeleteNode(21, "foo"); err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -1989,25 +1989,25 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := s.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"master", "v2"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(17, "foo", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"primary", "v2"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := s.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave", "v2", "dev"}, Address: "", Port: 8001}); err != nil {
+	if err := s.EnsureService(18, "foo", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"replica", "v2", "dev"}, Address: "", Port: 8001}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	if err := s.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"slave", "v2"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(19, "bar", &structs.NodeService{ID: "db", Service: "db", Tags: []string{"replica", "v2"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	idx, nodes, err := s.ServiceTagNodes(nil, "db", []string{"master"}, nil)
+	idx, nodes, err := s.ServiceTagNodes(nil, "db", []string{"primary"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int(idx), 19)
 	require.Len(t, nodes, 1)
 	require.Equal(t, nodes[0].Node, "foo")
 	require.Equal(t, nodes[0].Address, "127.0.0.1")
-	require.Contains(t, nodes[0].ServiceTags, "master")
+	require.Contains(t, nodes[0].ServiceTags, "primary")
 	require.Equal(t, nodes[0].ServicePort, 8000)
 
 	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2"}, nil)
@@ -2016,14 +2016,14 @@ func TestStateStore_ServiceTagNodes_MultipleTags(t *testing.T) {
 	require.Len(t, nodes, 3)
 
 	// Test filtering on multiple tags
-	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2", "slave"}, nil)
+	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"v2", "replica"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, int(idx), 19)
 	require.Len(t, nodes, 2)
 	require.Contains(t, nodes[0].ServiceTags, "v2")
-	require.Contains(t, nodes[0].ServiceTags, "slave")
+	require.Contains(t, nodes[0].ServiceTags, "replica")
 	require.Contains(t, nodes[1].ServiceTags, "v2")
-	require.Contains(t, nodes[1].ServiceTags, "slave")
+	require.Contains(t, nodes[1].ServiceTags, "replica")
 
 	idx, nodes, err = s.ServiceTagNodes(nil, "db", []string{"dev"}, nil)
 	require.NoError(t, err)
@@ -2110,7 +2110,7 @@ func TestStateStore_ConnectServiceNodes(t *testing.T) {
 	assert.Nil(s.EnsureService(14, "foo", &structs.NodeService{Kind: structs.ServiceKindConnectProxy, ID: "proxy", Service: "proxy", Proxy: structs.ConnectProxyConfig{DestinationServiceName: "db"}, Port: 8000}))
 	assert.Nil(s.EnsureService(15, "bar", &structs.NodeService{Kind: structs.ServiceKindConnectProxy, ID: "proxy", Service: "proxy", Proxy: structs.ConnectProxyConfig{DestinationServiceName: "db"}, Port: 8000}))
 	assert.Nil(s.EnsureService(16, "bar", &structs.NodeService{ID: "native-db", Service: "db", Connect: structs.ServiceConnect{Native: true}}))
-	assert.Nil(s.EnsureService(17, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}))
+	assert.Nil(s.EnsureService(17, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8001}))
 	assert.True(watchFired(ws))
 
 	// Read everything back.
@@ -3562,7 +3562,7 @@ func TestStateStore_CheckConnectServiceNodes(t *testing.T) {
 	assert.Nil(s.EnsureService(13, "bar", &structs.NodeService{ID: "api", Service: "api", Tags: nil, Address: "", Port: 5000}))
 	assert.Nil(s.EnsureService(14, "foo", &structs.NodeService{Kind: structs.ServiceKindConnectProxy, ID: "proxy", Service: "proxy", Proxy: structs.ConnectProxyConfig{DestinationServiceName: "db"}, Port: 8000}))
 	assert.Nil(s.EnsureService(15, "bar", &structs.NodeService{Kind: structs.ServiceKindConnectProxy, ID: "proxy", Service: "proxy", Proxy: structs.ConnectProxyConfig{DestinationServiceName: "db"}, Port: 8000}))
-	assert.Nil(s.EnsureService(16, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"slave"}, Address: "", Port: 8001}))
+	assert.Nil(s.EnsureService(16, "bar", &structs.NodeService{ID: "db2", Service: "db", Tags: []string{"replica"}, Address: "", Port: 8001}))
 	assert.True(watchFired(ws))
 
 	// Register node checks
@@ -3718,7 +3718,7 @@ func BenchmarkCheckServiceNodes(b *testing.B) {
 	if err := s.EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		b.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"primary"}, Address: "", Port: 8000}); err != nil {
 		b.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -3753,7 +3753,7 @@ func TestStateStore_CheckServiceTagNodes(t *testing.T) {
 	if err := s.EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if err := s.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"master"}, Address: "", Port: 8000}); err != nil {
+	if err := s.EnsureService(2, "foo", &structs.NodeService{ID: "db1", Service: "db", Tags: []string{"primary"}, Address: "", Port: 8000}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	check := &structs.HealthCheck{
@@ -3777,7 +3777,7 @@ func TestStateStore_CheckServiceTagNodes(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", []string{"master"}, nil)
+	idx, nodes, err := s.CheckServiceTagNodes(ws, "db", []string{"primary"}, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -2855,7 +2855,7 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "Db",
-				Tags:    []string{"Master"},
+				Tags:    []string{"Primary"},
 				Port:    12345,
 			},
 		}

--- a/agent/dns_test.go
+++ b/agent/dns_test.go
@@ -799,7 +799,7 @@ func TestDNS_EDNS0_ECS(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -1013,7 +1013,7 @@ func TestDNS_ServiceReverseLookup(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 				Address: "127.0.0.2",
 			},
@@ -1061,7 +1061,7 @@ func TestDNS_ServiceReverseLookup_IPV6(t *testing.T) {
 			Address:    "2001:db8::1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 				Address: "2001:db8::ff00:42:8329",
 			},
@@ -1111,7 +1111,7 @@ func TestDNS_ServiceReverseLookup_CustomDomain(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 				Address: "127.0.0.2",
 			},
@@ -1192,7 +1192,7 @@ func TestDNS_ServiceReverseLookupNodeAddress(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 				Address: "127.0.0.1",
 			},
@@ -1427,7 +1427,7 @@ func TestDNS_ServiceLookup(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -2164,7 +2164,7 @@ func TestDNS_ServiceLookup_ServiceAddress_A(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Address: "127.0.0.2",
 				Port:    12345,
 			},
@@ -2267,7 +2267,7 @@ func TestDNS_ServiceLookup_ServiceAddress_SRV(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Address: "www.google.com",
 				Port:    12345,
 			},
@@ -2364,7 +2364,7 @@ func TestDNS_ServiceLookup_ServiceAddressIPV6(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Address: "2607:20:4005:808::200e",
 				Port:    12345,
 			},
@@ -2886,9 +2886,9 @@ func TestDNS_CaseInsensitiveServiceLookup(t *testing.T) {
 
 	// Try some variations to make sure case doesn't matter.
 	questions := []string{
-		"master.db.service.consul.",
-		"mASTER.dB.service.consul.",
-		"MASTER.dB.service.consul.",
+		"primary.db.service.consul.",
+		"pRIMARY.dB.service.consul.",
+		"PRIMARY.dB.service.consul.",
 		"db.service.consul.",
 		"DB.service.consul.",
 		"Db.service.consul.",
@@ -2925,7 +2925,7 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"v1.master"},
+			Tags:    []string{"v1.primary"},
 			Port:    12345,
 		},
 	}
@@ -2936,7 +2936,7 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 
 	m1 := new(dns.Msg)
-	m1.SetQuestion("v1.master2.db.service.consul.", dns.TypeSRV)
+	m1.SetQuestion("v1.primary2.db.service.consul.", dns.TypeSRV)
 
 	c1 := new(dns.Client)
 	in, _, err := c1.Exchange(m1, a.DNSAddr())
@@ -2949,7 +2949,7 @@ func TestDNS_ServiceLookup_TagPeriod(t *testing.T) {
 	}
 
 	m := new(dns.Msg)
-	m.SetQuestion("v1.master.db.service.consul.", dns.TypeSRV)
+	m.SetQuestion("v1.primary.db.service.consul.", dns.TypeSRV)
 
 	c := new(dns.Client)
 	in, _, err = c.Exchange(m, a.DNSAddr())
@@ -3320,7 +3320,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -3337,7 +3337,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 			Service: &structs.NodeService{
 				ID:      "db2",
 				Service: "db",
-				Tags:    []string{"slave"},
+				Tags:    []string{"replica"},
 				Port:    12345,
 			},
 		}
@@ -3352,7 +3352,7 @@ func TestDNS_ServiceLookup_Dedup(t *testing.T) {
 			Service: &structs.NodeService{
 				ID:      "db3",
 				Service: "db",
-				Tags:    []string{"slave"},
+				Tags:    []string{"replica"},
 				Port:    12346,
 			},
 		}
@@ -3423,7 +3423,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -3440,7 +3440,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 			Service: &structs.NodeService{
 				ID:      "db2",
 				Service: "db",
-				Tags:    []string{"slave"},
+				Tags:    []string{"replica"},
 				Port:    12345,
 			},
 		}
@@ -3455,7 +3455,7 @@ func TestDNS_ServiceLookup_Dedup_SRV(t *testing.T) {
 			Service: &structs.NodeService{
 				ID:      "db3",
 				Service: "db",
-				Tags:    []string{"slave"},
+				Tags:    []string{"replica"},
 				Port:    12346,
 			},
 		}
@@ -3671,7 +3671,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3692,7 +3692,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Address:    "127.0.0.2",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3711,7 +3711,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Address:    "127.0.0.2",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3731,7 +3731,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Address:    "127.0.0.3",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -3745,7 +3745,7 @@ func TestDNS_ServiceLookup_FilterCritical(t *testing.T) {
 			Address:    "127.0.0.4",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3827,7 +3827,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3848,7 +3848,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 			Address:    "127.0.0.2",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3867,7 +3867,7 @@ func TestDNS_ServiceLookup_OnlyFailing(t *testing.T) {
 			Address:    "127.0.0.2",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3944,7 +3944,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3966,7 +3966,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 			Address:    "127.0.0.2",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -3987,7 +3987,7 @@ func TestDNS_ServiceLookup_OnlyPassing(t *testing.T) {
 			Address:    "127.0.0.3",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 			Check: &structs.HealthCheck{
@@ -4394,7 +4394,7 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 			Address:    fmt.Sprintf("127.0.0.%d", i+1),
 			Service: &structs.NodeService{
 				Service: longServiceName,
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -4414,7 +4414,7 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 				Name: longServiceName,
 				Service: structs.ServiceQuery{
 					Service: longServiceName,
-					Tags:    []string{"master"},
+					Tags:    []string{"primary"},
 				},
 			},
 		}
@@ -4426,7 +4426,7 @@ func TestDNS_ServiceLookup_LargeResponses(t *testing.T) {
 
 	// Look up the service directly and via prepared query.
 	questions := []string{
-		"_" + longServiceName + "._master.service.consul.",
+		"_" + longServiceName + "._primary.service.consul.",
 		longServiceName + ".query.consul.",
 	}
 	for _, question := range questions {
@@ -5140,7 +5140,7 @@ func TestDNS_ServiceLookup_TTL(t *testing.T) {
 			Address:    address,
 			Service: &structs.NodeService{
 				Service: service,
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345 + idx,
 			},
 		}
@@ -5219,7 +5219,7 @@ func TestDNS_PreparedQuery_TTL(t *testing.T) {
 			Address:    address,
 			Service: &structs.NodeService{
 				Service: service,
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345 + idx,
 			},
 		}
@@ -5438,7 +5438,7 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    12345,
 		},
 	}
@@ -5449,10 +5449,10 @@ func TestDNS_ServiceLookup_SRV_RFC(t *testing.T) {
 	}
 
 	questions := []string{
-		"_db._master.service.dc1.consul.",
-		"_db._master.service.consul.",
-		"_db._master.dc1.consul.",
-		"_db._master.consul.",
+		"_db._primary.service.dc1.consul.",
+		"_db._primary.service.consul.",
+		"_db._primary.dc1.consul.",
+		"_db._primary.consul.",
 	}
 
 	for _, question := range questions {
@@ -5513,7 +5513,7 @@ func TestDNS_ServiceLookup_SRV_RFC_TCP_Default(t *testing.T) {
 		Address:    "127.0.0.1",
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    12345,
 		},
 	}
@@ -5641,7 +5641,7 @@ func TestDNS_ServiceLookup_MetaTXT(t *testing.T) {
 		},
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    12345,
 		},
 	}
@@ -5688,7 +5688,7 @@ func TestDNS_ServiceLookup_SuppressTXT(t *testing.T) {
 		},
 		Service: &structs.NodeService{
 			Service: "db",
-			Tags:    []string{"master"},
+			Tags:    []string{"primary"},
 			Port:    12345,
 		},
 	}
@@ -6035,7 +6035,7 @@ func TestDNS_AltDomains_Service(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}
@@ -6789,7 +6789,7 @@ func TestDNS_Compression_Query(t *testing.T) {
 			Address:    "127.0.0.1",
 			Service: &structs.NodeService{
 				Service: "db",
-				Tags:    []string{"master"},
+				Tags:    []string{"primary"},
 				Port:    12345,
 			},
 		}

--- a/agent/user_event_test.go
+++ b/agent/user_event_test.go
@@ -54,7 +54,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
 		Service: "mysql",
-		Tags:    []string{"test", "foo", "bar", "master"},
+		Tags:    []string{"test", "foo", "bar", "primary"},
 		Port:    5000,
 	}
 	a.State.AddService(srv1, "")
@@ -99,7 +99,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 	// Bad tag name
 	p = &UserEvent{
 		ServiceFilter: ".*sql",
-		TagFilter:     "slave",
+		TagFilter:     "replica",
 	}
 	if a.shouldProcessUserEvent(p) {
 		t.Fatalf("bad")
@@ -108,7 +108,7 @@ func TestShouldProcessUserEvent(t *testing.T) {
 	// Good service name
 	p = &UserEvent{
 		ServiceFilter: ".*sql",
-		TagFilter:     "master",
+		TagFilter:     "primary",
 	}
 	if !a.shouldProcessUserEvent(p) {
 		t.Fatalf("bad")
@@ -154,7 +154,7 @@ func TestFireReceiveEvent(t *testing.T) {
 	srv1 := &structs.NodeService{
 		ID:      "mysql",
 		Service: "mysql",
-		Tags:    []string{"test", "foo", "bar", "master"},
+		Tags:    []string{"test", "foo", "bar", "primary"},
 		Port:    5000,
 	}
 	a.State.AddService(srv1, "")


### PR DESCRIPTION
There shouldn't be any functional changes in this diff, just updating tag names for database services in test files to be a bit friendlier.