### PR TITLE
Add config changes for UI metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,7 +626,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./agent/bindata_assetfs.go
+            - ./agent/uiserver/bindata_assetfs.go
       - run: *notify-slack-failure
 
   # commits static assets to git
@@ -641,16 +641,16 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: commit agent/bindata_assetfs.go if there are changes
+          name: commit agent/uiserver/bindata_assetfs.go if there are changes
           command: |
             exit 0
-            if ! git diff --exit-code agent/bindata_assetfs.go; then
+            if ! git diff --exit-code agent/uiserver/bindata_assetfs.go; then
               git config --local user.email "hashicorp-ci@users.noreply.github.com"
               git config --local user.name "hashicorp-ci"
 
               short_sha=$(git rev-parse --short HEAD)
-              git add agent/bindata_assetfs.go
-              git commit -m "auto-updated agent/bindata_assetfs.go from commit ${short_sha}"
+              git add agent/uiserver/bindata_assetfs.go
+              git commit -m "auto-updated agent/uiserver/bindata_assetfs.go from commit ${short_sha}"
               git push origin master
             else
               echo "no new static assets to publish"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,7 @@ GOARCH?=$(shell go env GOARCH)
 GOPATH=$(shell go env GOPATH)
 MAIN_GOPATH=$(shell go env GOPATH | cut -d: -f1)
 
-ASSETFS_PATH?=agent/bindata_assetfs.go
+ASSETFS_PATH?=agent/uiserver/bindata_assetfs.go
 # Get the git commit
 GIT_COMMIT?=$(shell git rev-parse --short HEAD)
 GIT_COMMIT_YEAR?=$(shell git show -s --format=%cd --date=format:%Y HEAD)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -306,7 +306,7 @@ lint:
 # also run as part of the release build script when it verifies that there are no
 # changes to the UI assets that aren't checked in.
 static-assets:
-	@go-bindata-assetfs -modtime 1 -pkg agent -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
+	@go-bindata-assetfs -modtime 1 -pkg uiserver -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
 	@go fmt $(ASSETFS_PATH)
 
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -334,6 +334,9 @@ func New(bd BaseDeps) (*Agent, error) {
 		cache:           bd.Cache,
 	}
 
+	// Initialize the UI Config
+	a.uiConfig.Store(a.config.UIConfig)
+
 	a.serviceManager = NewServiceManager(&a)
 
 	// TODO: do this somewhere else, maybe move to newBaseDeps
@@ -3822,4 +3825,15 @@ func defaultIfEmpty(val, defaultVal string) string {
 		return val
 	}
 	return defaultVal
+}
+
+// getUIConfig is the canonical way to read the value of the UIConfig at
+// runtime. It is thread safe and returns the most recent configuration which
+// may have changed since the agent started due to config reload.
+func (a *Agent) getUIConfig() config.UIConfig {
+	if cfg, ok := a.uiConfig.Load().(config.UIConfig); ok {
+		return cfg
+	}
+	// Shouldn't happen but be defensive
+	return config.UIConfig{}
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -290,7 +290,6 @@ type Agent struct {
 	// IP.
 	httpConnLimiter connlimit.Limiter
 
-	// enterpriseAgent embeds fields that we only access in consul-enterprise builds
 	enterpriseAgent
 }
 
@@ -3573,6 +3572,9 @@ func (a *Agent) reloadConfigInternal(newCfg *config.RuntimeConfig) error {
 		newCfg.Telemetry.BlockedPrefixes)
 
 	a.State.SetDiscardCheckOutput(newCfg.DiscardCheckOutput)
+
+	// Reload metrics config
+	a.uiConfig.Store(newCfg.UIConfig)
 
 	return nil
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3503,36 +3503,6 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 }
 
-func TestAgent_ReloadConfigUIConfig(t *testing.T) {
-	t.Parallel()
-	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
-	hcl := `
-		data_dir = "` + dataDir + `"
-		ui_config {
-			enabled = true // note that this is _not_ reloadable
-			metrics_provider = "foo"
-		}
-	`
-	a := NewTestAgent(t, hcl)
-	defer a.Shutdown()
-
-	uiCfg := a.getUIConfig()
-	require.Equal(t, "foo", uiCfg.MetricsProvider)
-
-	hcl = `
-		data_dir = "` + dataDir + `"
-		ui_config {
-			enabled = true
-			metrics_provider = "bar"
-		}
-	`
-	c := TestConfig(testutil.Logger(t), config.FileSource{Name: t.Name(), Format: "hcl", Data: hcl})
-	require.NoError(t, a.reloadConfigInternal(c))
-
-	uiCfg = a.getUIConfig()
-	require.Equal(t, "bar", uiCfg.MetricsProvider)
-}
-
 func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -3503,6 +3503,36 @@ func TestAgent_ReloadConfigTLSConfigFailure(t *testing.T) {
 	require.Len(t, tlsConf.RootCAs.Subjects(), 1)
 }
 
+func TestAgent_ReloadConfigUIConfig(t *testing.T) {
+	t.Parallel()
+	dataDir := testutil.TempDir(t, "agent") // we manage the data dir
+	hcl := `
+		data_dir = "` + dataDir + `"
+		ui_config {
+			enabled = true // note that this is _not_ reloadable
+			metrics_provider = "foo"
+		}
+	`
+	a := NewTestAgent(t, hcl)
+	defer a.Shutdown()
+
+	uiCfg := a.getUIConfig()
+	require.Equal(t, "foo", uiCfg.MetricsProvider)
+
+	hcl = `
+		data_dir = "` + dataDir + `"
+		ui_config {
+			enabled = true
+			metrics_provider = "bar"
+		}
+	`
+	c := TestConfig(testutil.Logger(t), config.FileSource{Name: t.Name(), Format: "hcl", Data: hcl})
+	require.NoError(t, a.reloadConfigInternal(c))
+
+	uiCfg = a.getUIConfig()
+	require.Equal(t, "bar", uiCfg.MetricsProvider)
+}
+
 func TestAgent_consulConfig_AutoEncryptAllowTLS(t *testing.T) {
 	t.Parallel()
 	dataDir := testutil.TempDir(t, "agent") // we manage the data dir

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -797,6 +798,26 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		return RuntimeConfig{}, fmt.Errorf("serf_wan_allowed_cidrs: %s", err)
 	}
 
+	// Handle Deprecated UI config fields
+	if c.UI != nil {
+		b.warn("The 'ui' field is deprecated. Use the 'ui_config.enabled' field instead.")
+		if c.UIConfig.Enabled == nil {
+			c.UIConfig.Enabled = c.UI
+		}
+	}
+	if c.UIDir != nil {
+		b.warn("The 'ui_dir' field is deprecated. Use the 'ui_config.dir' field instead.")
+		if c.UIConfig.Dir == nil {
+			c.UIConfig.Dir = c.UIDir
+		}
+	}
+	if c.UIContentPath != nil {
+		b.warn("The 'ui_content_path' field is deprecated. Use the 'ui_config.content_path' field instead.")
+		if c.UIConfig.ContentPath == nil {
+			c.UIConfig.ContentPath = c.UIContentPath
+		}
+	}
+
 	// ----------------------------------------------------------------
 	// build runtime config
 	//
@@ -981,19 +1002,17 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		EnableDebug:                            b.boolVal(c.EnableDebug),
 		EnableRemoteScriptChecks:               enableRemoteScriptChecks,
 		EnableLocalScriptChecks:                enableLocalScriptChecks,
-
-		EnableUI:              b.boolVal(c.UI),
-		EncryptKey:            b.stringVal(c.EncryptKey),
-		EncryptVerifyIncoming: b.boolVal(c.EncryptVerifyIncoming),
-		EncryptVerifyOutgoing: b.boolVal(c.EncryptVerifyOutgoing),
-		GRPCPort:              grpcPort,
-		GRPCAddrs:             grpcAddrs,
-		HTTPMaxConnsPerClient: b.intVal(c.Limits.HTTPMaxConnsPerClient),
-		HTTPSHandshakeTimeout: b.durationVal("limits.https_handshake_timeout", c.Limits.HTTPSHandshakeTimeout),
-		KeyFile:               b.stringVal(c.KeyFile),
-		KVMaxValueSize:        b.uint64Val(c.Limits.KVMaxValueSize),
-		LeaveDrainTime:        b.durationVal("performance.leave_drain_time", c.Performance.LeaveDrainTime),
-		LeaveOnTerm:           leaveOnTerm,
+		EncryptKey:                             b.stringVal(c.EncryptKey),
+		EncryptVerifyIncoming:                  b.boolVal(c.EncryptVerifyIncoming),
+		EncryptVerifyOutgoing:                  b.boolVal(c.EncryptVerifyOutgoing),
+		GRPCPort:                               grpcPort,
+		GRPCAddrs:                              grpcAddrs,
+		HTTPMaxConnsPerClient:                  b.intVal(c.Limits.HTTPMaxConnsPerClient),
+		HTTPSHandshakeTimeout:                  b.durationVal("limits.https_handshake_timeout", c.Limits.HTTPSHandshakeTimeout),
+		KeyFile:                                b.stringVal(c.KeyFile),
+		KVMaxValueSize:                         b.uint64Val(c.Limits.KVMaxValueSize),
+		LeaveDrainTime:                         b.durationVal("performance.leave_drain_time", c.Performance.LeaveDrainTime),
+		LeaveOnTerm:                            leaveOnTerm,
 		Logging: logging.Config{
 			LogLevel:          b.stringVal(c.LogLevel),
 			LogJSON:           b.boolVal(c.LogJSON),
@@ -1058,8 +1077,7 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		TaggedAddresses:             c.TaggedAddresses,
 		TranslateWANAddrs:           b.boolVal(c.TranslateWANAddrs),
 		TxnMaxReqLen:                b.uint64Val(c.Limits.TxnMaxReqLen),
-		UIDir:                       b.stringVal(c.UIDir),
-		UIContentPath:               UIPathBuilder(b.stringVal(c.UIContentPath)),
+		UIConfig:                    b.uiConfigVal(c.UIConfig),
 		UnixSocketGroup:             b.stringVal(c.UnixSocket.Group),
 		UnixSocketMode:              b.stringVal(c.UnixSocket.Mode),
 		UnixSocketUser:              b.stringVal(c.UnixSocket.User),
@@ -1094,7 +1112,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 // Validate performs semantic validation of the runtime configuration.
 func (b *Builder) Validate(rt RuntimeConfig) error {
 	// reDatacenter defines a regexp for a valid datacenter name
-	var reDatacenter = regexp.MustCompile("^[a-z0-9_-]+$")
+	var reBasicName = regexp.MustCompile("^[a-z0-9_-]+$")
+	var reDatacenter = reBasicName
 
 	// validContentPath defines a regexp for a valid content path name.
 	var validContentPath = regexp.MustCompile(`^[A-Za-z0-9/_-]+$`)
@@ -1113,12 +1132,50 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 		return fmt.Errorf("data_dir cannot be empty")
 	}
 
-	if !validContentPath.MatchString(rt.UIContentPath) {
-		return fmt.Errorf("ui-content-path can only contain alphanumeric, -, _, or /. received: %s", rt.UIContentPath)
+	if !validContentPath.MatchString(rt.UIConfig.ContentPath) {
+		return fmt.Errorf("ui-content-path can only contain alphanumeric, -, _, or /. received: %q", rt.UIConfig.ContentPath)
 	}
 
-	if hasVersion.MatchString(rt.UIContentPath) {
-		return fmt.Errorf("ui-content-path cannot have 'v[0-9]'. received: %s", rt.UIContentPath)
+	if hasVersion.MatchString(rt.UIConfig.ContentPath) {
+		return fmt.Errorf("ui-content-path cannot have 'v[0-9]'. received: %q", rt.UIConfig.ContentPath)
+	}
+
+	if rt.UIConfig.MetricsProvider != "" &&
+		!reBasicName.MatchString(rt.UIConfig.MetricsProvider) {
+		return fmt.Errorf("ui_config.metrics_provider can only contain lowercase "+
+			"alphanumeric or _ characters. received: %q", rt.UIConfig.MetricsProvider)
+	}
+	if rt.UIConfig.MetricsProviderOptionsJSON != "" {
+		// Attempt to parse the JSON to ensure it's valid, parsing into a map
+		// ensures we get an object.
+		var dummyMap map[string]interface{}
+		err := json.Unmarshal([]byte(rt.UIConfig.MetricsProviderOptionsJSON),
+			&dummyMap)
+		if err != nil {
+			return fmt.Errorf("ui_config.metrics_provider_options_json must be empty "+
+				"or a string containing a valid JSON object. received: %q",
+				rt.UIConfig.MetricsProviderOptionsJSON)
+		}
+	}
+	if rt.UIConfig.MetricsProxy.BaseURL != "" {
+		u, err := url.Parse(rt.UIConfig.MetricsProxy.BaseURL)
+		if err != nil || !(u.Scheme == "http" || u.Scheme == "https") {
+			return fmt.Errorf("ui_config.metrics_proxy.base_url must be a valid http"+
+				" or https URL. received: %q",
+				rt.UIConfig.MetricsProxy.BaseURL)
+		}
+	}
+	for k, v := range rt.UIConfig.DashboardURLTemplates {
+		if !reBasicName.MatchString(k) {
+			return fmt.Errorf("ui_config.dashboard_url_templates key names can only "+
+				"contain lowercase alphanumeric or _ characters. received: %q", k)
+		}
+		u, err := url.Parse(v)
+		if err != nil || !(u.Scheme == "http" || u.Scheme == "https") {
+			return fmt.Errorf("ui_config.dashboard_url_templates values must be a"+
+				" valid http or https URL. received: %q",
+				rt.UIConfig.MetricsProxy.BaseURL)
+		}
 	}
 
 	if !rt.DevMode {
@@ -1194,11 +1251,11 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 		return fmt.Errorf("acl_datacenter cannot be %q. Please use only [a-z0-9-_]", rt.ACLDatacenter)
 	}
 	// In DevMode, UI is enabled by default, so to enable rt.UIDir, don't perform this check
-	if !rt.DevMode && rt.EnableUI && rt.UIDir != "" {
+	if !rt.DevMode && rt.UIConfig.Enabled && rt.UIConfig.Dir != "" {
 		return fmt.Errorf(
-			"Both the ui and ui-dir flags were specified, please provide only one.\n" +
-				"If trying to use your own web UI resources, use the ui-dir flag.\n" +
-				"The web UI is included in the binary so use ui to enable it")
+			"Both the ui_config.enabled and ui_config.dir (or -ui and -ui-dir) were specified, please provide only one.\n" +
+				"If trying to use your own web UI resources, use ui_config.dir or the -ui-dir flag.\n" +
+				"The web UI is included in the binary so use ui_config.enabled or the -ui flag to enable it")
 	}
 	if rt.DNSUDPAnswerLimit < 0 {
 		return fmt.Errorf("dns_config.udp_answer_limit cannot be %d. Must be greater than or equal to zero", rt.DNSUDPAnswerLimit)
@@ -1644,6 +1701,35 @@ func (b *Builder) serviceConnectVal(v *ServiceConnect) *structs.ServiceConnect {
 	return &structs.ServiceConnect{
 		Native:         b.boolVal(v.Native),
 		SidecarService: sidecar,
+	}
+}
+
+func (b *Builder) uiConfigVal(v RawUIConfig) UIConfig {
+	return UIConfig{
+		Enabled:                    b.boolVal(v.Enabled),
+		Dir:                        b.stringVal(v.Dir),
+		ContentPath:                UIPathBuilder(b.stringVal(v.ContentPath)),
+		MetricsProvider:            b.stringVal(v.MetricsProvider),
+		MetricsProviderFiles:       v.MetricsProviderFiles,
+		MetricsProviderOptionsJSON: b.stringVal(v.MetricsProviderOptionsJSON),
+		MetricsProxy:               b.uiMetricsProxyVal(v.MetricsProxy),
+		DashboardURLTemplates:      v.DashboardURLTemplates,
+	}
+}
+
+func (b *Builder) uiMetricsProxyVal(v RawUIMetricsProxy) UIMetricsProxy {
+	var hdrs []UIMetricsProxyAddHeader
+
+	for _, hdr := range v.AddHeaders {
+		hdrs = append(hdrs, UIMetricsProxyAddHeader{
+			Name:  b.stringVal(hdr.Name),
+			Value: b.stringVal(hdr.Value),
+		})
+	}
+
+	return UIMetricsProxy{
+		BaseURL:    b.stringVal(v.BaseURL),
+		AddHeaders: hdrs,
 	}
 }
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -133,123 +133,129 @@ type Config struct {
 	// DEPRECATED (ACL-Legacy-Compat) - moved into the "acl.tokens" stanza
 	ACLTTL *string `json:"acl_ttl,omitempty" hcl:"acl_ttl" mapstructure:"acl_ttl"`
 	// DEPRECATED (ACL-Legacy-Compat) - moved into the "acl.tokens" stanza
-	ACLToken                         *string                  `json:"acl_token,omitempty" hcl:"acl_token" mapstructure:"acl_token"`
-	ACL                              ACL                      `json:"acl,omitempty" hcl:"acl" mapstructure:"acl"`
-	Addresses                        Addresses                `json:"addresses,omitempty" hcl:"addresses" mapstructure:"addresses"`
-	AdvertiseAddrLAN                 *string                  `json:"advertise_addr,omitempty" hcl:"advertise_addr" mapstructure:"advertise_addr"`
-	AdvertiseAddrLANIPv4             *string                  `json:"advertise_addr_ipv4,omitempty" hcl:"advertise_addr_ipv4" mapstructure:"advertise_addr_ipv4"`
-	AdvertiseAddrLANIPv6             *string                  `json:"advertise_addr_ipv6,omitempty" hcl:"advertise_addr_ipv6" mapstructure:"advertise_addr_ipv6"`
-	AdvertiseAddrWAN                 *string                  `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
-	AdvertiseAddrWANIPv4             *string                  `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
-	AdvertiseAddrWANIPv6             *string                  `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
-	AutoConfig                       AutoConfigRaw            `json:"auto_config,omitempty" hcl:"auto_config" mapstructure:"auto_config"`
-	Autopilot                        Autopilot                `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
-	BindAddr                         *string                  `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
-	Bootstrap                        *bool                    `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`
-	BootstrapExpect                  *int                     `json:"bootstrap_expect,omitempty" hcl:"bootstrap_expect" mapstructure:"bootstrap_expect"`
-	Cache                            Cache                    `json:"cache,omitempty" hcl:"cache" mapstructure:"cache"`
-	CAFile                           *string                  `json:"ca_file,omitempty" hcl:"ca_file" mapstructure:"ca_file"`
-	CAPath                           *string                  `json:"ca_path,omitempty" hcl:"ca_path" mapstructure:"ca_path"`
-	CertFile                         *string                  `json:"cert_file,omitempty" hcl:"cert_file" mapstructure:"cert_file"`
-	Check                            *CheckDefinition         `json:"check,omitempty" hcl:"check" mapstructure:"check"` // needs to be a pointer to avoid partial merges
-	CheckOutputMaxSize               *int                     `json:"check_output_max_size,omitempty" hcl:"check_output_max_size" mapstructure:"check_output_max_size"`
-	CheckUpdateInterval              *string                  `json:"check_update_interval,omitempty" hcl:"check_update_interval" mapstructure:"check_update_interval"`
-	Checks                           []CheckDefinition        `json:"checks,omitempty" hcl:"checks" mapstructure:"checks"`
-	ClientAddr                       *string                  `json:"client_addr,omitempty" hcl:"client_addr" mapstructure:"client_addr"`
-	ConfigEntries                    ConfigEntries            `json:"config_entries,omitempty" hcl:"config_entries" mapstructure:"config_entries"`
-	AutoEncrypt                      AutoEncrypt              `json:"auto_encrypt,omitempty" hcl:"auto_encrypt" mapstructure:"auto_encrypt"`
-	Connect                          Connect                  `json:"connect,omitempty" hcl:"connect" mapstructure:"connect"`
-	DNS                              DNS                      `json:"dns_config,omitempty" hcl:"dns_config" mapstructure:"dns_config"`
-	DNSDomain                        *string                  `json:"domain,omitempty" hcl:"domain" mapstructure:"domain"`
-	DNSAltDomain                     *string                  `json:"alt_domain,omitempty" hcl:"alt_domain" mapstructure:"alt_domain"`
-	DNSRecursors                     []string                 `json:"recursors,omitempty" hcl:"recursors" mapstructure:"recursors"`
-	DataDir                          *string                  `json:"data_dir,omitempty" hcl:"data_dir" mapstructure:"data_dir"`
-	Datacenter                       *string                  `json:"datacenter,omitempty" hcl:"datacenter" mapstructure:"datacenter"`
-	DefaultQueryTime                 *string                  `json:"default_query_time,omitempty" hcl:"default_query_time" mapstructure:"default_query_time"`
-	DisableAnonymousSignature        *bool                    `json:"disable_anonymous_signature,omitempty" hcl:"disable_anonymous_signature" mapstructure:"disable_anonymous_signature"`
-	DisableCoordinates               *bool                    `json:"disable_coordinates,omitempty" hcl:"disable_coordinates" mapstructure:"disable_coordinates"`
-	DisableHostNodeID                *bool                    `json:"disable_host_node_id,omitempty" hcl:"disable_host_node_id" mapstructure:"disable_host_node_id"`
-	DisableHTTPUnprintableCharFilter *bool                    `json:"disable_http_unprintable_char_filter,omitempty" hcl:"disable_http_unprintable_char_filter" mapstructure:"disable_http_unprintable_char_filter"`
-	DisableKeyringFile               *bool                    `json:"disable_keyring_file,omitempty" hcl:"disable_keyring_file" mapstructure:"disable_keyring_file"`
-	DisableRemoteExec                *bool                    `json:"disable_remote_exec,omitempty" hcl:"disable_remote_exec" mapstructure:"disable_remote_exec"`
-	DisableUpdateCheck               *bool                    `json:"disable_update_check,omitempty" hcl:"disable_update_check" mapstructure:"disable_update_check"`
-	DiscardCheckOutput               *bool                    `json:"discard_check_output" hcl:"discard_check_output" mapstructure:"discard_check_output"`
-	DiscoveryMaxStale                *string                  `json:"discovery_max_stale" hcl:"discovery_max_stale" mapstructure:"discovery_max_stale"`
-	EnableACLReplication             *bool                    `json:"enable_acl_replication,omitempty" hcl:"enable_acl_replication" mapstructure:"enable_acl_replication"`
-	EnableAgentTLSForChecks          *bool                    `json:"enable_agent_tls_for_checks,omitempty" hcl:"enable_agent_tls_for_checks" mapstructure:"enable_agent_tls_for_checks"`
-	EnableCentralServiceConfig       *bool                    `json:"enable_central_service_config,omitempty" hcl:"enable_central_service_config" mapstructure:"enable_central_service_config"`
-	EnableDebug                      *bool                    `json:"enable_debug,omitempty" hcl:"enable_debug" mapstructure:"enable_debug"`
-	EnableScriptChecks               *bool                    `json:"enable_script_checks,omitempty" hcl:"enable_script_checks" mapstructure:"enable_script_checks"`
-	EnableLocalScriptChecks          *bool                    `json:"enable_local_script_checks,omitempty" hcl:"enable_local_script_checks" mapstructure:"enable_local_script_checks"`
-	EnableSyslog                     *bool                    `json:"enable_syslog,omitempty" hcl:"enable_syslog" mapstructure:"enable_syslog"`
-	EncryptKey                       *string                  `json:"encrypt,omitempty" hcl:"encrypt" mapstructure:"encrypt"`
-	EncryptVerifyIncoming            *bool                    `json:"encrypt_verify_incoming,omitempty" hcl:"encrypt_verify_incoming" mapstructure:"encrypt_verify_incoming"`
-	EncryptVerifyOutgoing            *bool                    `json:"encrypt_verify_outgoing,omitempty" hcl:"encrypt_verify_outgoing" mapstructure:"encrypt_verify_outgoing"`
-	GossipLAN                        GossipLANConfig          `json:"gossip_lan,omitempty" hcl:"gossip_lan" mapstructure:"gossip_lan"`
-	GossipWAN                        GossipWANConfig          `json:"gossip_wan,omitempty" hcl:"gossip_wan" mapstructure:"gossip_wan"`
-	HTTPConfig                       HTTPConfig               `json:"http_config,omitempty" hcl:"http_config" mapstructure:"http_config"`
-	KeyFile                          *string                  `json:"key_file,omitempty" hcl:"key_file" mapstructure:"key_file"`
-	LeaveOnTerm                      *bool                    `json:"leave_on_terminate,omitempty" hcl:"leave_on_terminate" mapstructure:"leave_on_terminate"`
-	Limits                           Limits                   `json:"limits,omitempty" hcl:"limits" mapstructure:"limits"`
-	LogLevel                         *string                  `json:"log_level,omitempty" hcl:"log_level" mapstructure:"log_level"`
-	LogJSON                          *bool                    `json:"log_json,omitempty" hcl:"log_json" mapstructure:"log_json"`
-	LogFile                          *string                  `json:"log_file,omitempty" hcl:"log_file" mapstructure:"log_file"`
-	LogRotateDuration                *string                  `json:"log_rotate_duration,omitempty" hcl:"log_rotate_duration" mapstructure:"log_rotate_duration"`
-	LogRotateBytes                   *int                     `json:"log_rotate_bytes,omitempty" hcl:"log_rotate_bytes" mapstructure:"log_rotate_bytes"`
-	LogRotateMaxFiles                *int                     `json:"log_rotate_max_files,omitempty" hcl:"log_rotate_max_files" mapstructure:"log_rotate_max_files"`
-	MaxQueryTime                     *string                  `json:"max_query_time,omitempty" hcl:"max_query_time" mapstructure:"max_query_time"`
-	NodeID                           *string                  `json:"node_id,omitempty" hcl:"node_id" mapstructure:"node_id"`
-	NodeMeta                         map[string]string        `json:"node_meta,omitempty" hcl:"node_meta" mapstructure:"node_meta"`
-	NodeName                         *string                  `json:"node_name,omitempty" hcl:"node_name" mapstructure:"node_name"`
-	Performance                      Performance              `json:"performance,omitempty" hcl:"performance" mapstructure:"performance"`
-	PidFile                          *string                  `json:"pid_file,omitempty" hcl:"pid_file" mapstructure:"pid_file"`
-	Ports                            Ports                    `json:"ports,omitempty" hcl:"ports" mapstructure:"ports"`
-	PrimaryDatacenter                *string                  `json:"primary_datacenter,omitempty" hcl:"primary_datacenter" mapstructure:"primary_datacenter"`
-	PrimaryGateways                  []string                 `json:"primary_gateways" hcl:"primary_gateways" mapstructure:"primary_gateways"`
-	PrimaryGatewaysInterval          *string                  `json:"primary_gateways_interval,omitempty" hcl:"primary_gateways_interval" mapstructure:"primary_gateways_interval"`
-	RPCProtocol                      *int                     `json:"protocol,omitempty" hcl:"protocol" mapstructure:"protocol"`
-	RaftProtocol                     *int                     `json:"raft_protocol,omitempty" hcl:"raft_protocol" mapstructure:"raft_protocol"`
-	RaftSnapshotThreshold            *int                     `json:"raft_snapshot_threshold,omitempty" hcl:"raft_snapshot_threshold" mapstructure:"raft_snapshot_threshold"`
-	RaftSnapshotInterval             *string                  `json:"raft_snapshot_interval,omitempty" hcl:"raft_snapshot_interval" mapstructure:"raft_snapshot_interval"`
-	RaftTrailingLogs                 *int                     `json:"raft_trailing_logs,omitempty" hcl:"raft_trailing_logs" mapstructure:"raft_trailing_logs"`
-	ReconnectTimeoutLAN              *string                  `json:"reconnect_timeout,omitempty" hcl:"reconnect_timeout" mapstructure:"reconnect_timeout"`
-	ReconnectTimeoutWAN              *string                  `json:"reconnect_timeout_wan,omitempty" hcl:"reconnect_timeout_wan" mapstructure:"reconnect_timeout_wan"`
-	RejoinAfterLeave                 *bool                    `json:"rejoin_after_leave,omitempty" hcl:"rejoin_after_leave" mapstructure:"rejoin_after_leave"`
-	RetryJoinIntervalLAN             *string                  `json:"retry_interval,omitempty" hcl:"retry_interval" mapstructure:"retry_interval"`
-	RetryJoinIntervalWAN             *string                  `json:"retry_interval_wan,omitempty" hcl:"retry_interval_wan" mapstructure:"retry_interval_wan"`
-	RetryJoinLAN                     []string                 `json:"retry_join,omitempty" hcl:"retry_join" mapstructure:"retry_join"`
-	RetryJoinMaxAttemptsLAN          *int                     `json:"retry_max,omitempty" hcl:"retry_max" mapstructure:"retry_max"`
-	RetryJoinMaxAttemptsWAN          *int                     `json:"retry_max_wan,omitempty" hcl:"retry_max_wan" mapstructure:"retry_max_wan"`
-	RetryJoinWAN                     []string                 `json:"retry_join_wan,omitempty" hcl:"retry_join_wan" mapstructure:"retry_join_wan"`
-	SerfAllowedCIDRsLAN              []string                 `json:"serf_lan_allowed_cidrs,omitempty" hcl:"serf_lan_allowed_cidrs" mapstructure:"serf_lan_allowed_cidrs"`
-	SerfAllowedCIDRsWAN              []string                 `json:"serf_wan_allowed_cidrs,omitempty" hcl:"serf_wan_allowed_cidrs" mapstructure:"serf_wan_allowed_cidrs"`
-	SerfBindAddrLAN                  *string                  `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
-	SerfBindAddrWAN                  *string                  `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
-	ServerMode                       *bool                    `json:"server,omitempty" hcl:"server" mapstructure:"server"`
-	ServerName                       *string                  `json:"server_name,omitempty" hcl:"server_name" mapstructure:"server_name"`
-	Service                          *ServiceDefinition       `json:"service,omitempty" hcl:"service" mapstructure:"service"`
-	Services                         []ServiceDefinition      `json:"services,omitempty" hcl:"services" mapstructure:"services"`
-	SessionTTLMin                    *string                  `json:"session_ttl_min,omitempty" hcl:"session_ttl_min" mapstructure:"session_ttl_min"`
-	SkipLeaveOnInt                   *bool                    `json:"skip_leave_on_interrupt,omitempty" hcl:"skip_leave_on_interrupt" mapstructure:"skip_leave_on_interrupt"`
-	StartJoinAddrsLAN                []string                 `json:"start_join,omitempty" hcl:"start_join" mapstructure:"start_join"`
-	StartJoinAddrsWAN                []string                 `json:"start_join_wan,omitempty" hcl:"start_join_wan" mapstructure:"start_join_wan"`
-	SyslogFacility                   *string                  `json:"syslog_facility,omitempty" hcl:"syslog_facility" mapstructure:"syslog_facility"`
-	TLSCipherSuites                  *string                  `json:"tls_cipher_suites,omitempty" hcl:"tls_cipher_suites" mapstructure:"tls_cipher_suites"`
-	TLSMinVersion                    *string                  `json:"tls_min_version,omitempty" hcl:"tls_min_version" mapstructure:"tls_min_version"`
-	TLSPreferServerCipherSuites      *bool                    `json:"tls_prefer_server_cipher_suites,omitempty" hcl:"tls_prefer_server_cipher_suites" mapstructure:"tls_prefer_server_cipher_suites"`
-	TaggedAddresses                  map[string]string        `json:"tagged_addresses,omitempty" hcl:"tagged_addresses" mapstructure:"tagged_addresses"`
-	Telemetry                        Telemetry                `json:"telemetry,omitempty" hcl:"telemetry" mapstructure:"telemetry"`
-	TranslateWANAddrs                *bool                    `json:"translate_wan_addrs,omitempty" hcl:"translate_wan_addrs" mapstructure:"translate_wan_addrs"`
-	UI                               *bool                    `json:"ui,omitempty" hcl:"ui" mapstructure:"ui"`
-	UIContentPath                    *string                  `json:"ui_content_path,omitempty" hcl:"ui_content_path" mapstructure:"ui_content_path"`
-	UIDir                            *string                  `json:"ui_dir,omitempty" hcl:"ui_dir" mapstructure:"ui_dir"`
-	UnixSocket                       UnixSocket               `json:"unix_sockets,omitempty" hcl:"unix_sockets" mapstructure:"unix_sockets"`
-	VerifyIncoming                   *bool                    `json:"verify_incoming,omitempty" hcl:"verify_incoming" mapstructure:"verify_incoming"`
-	VerifyIncomingHTTPS              *bool                    `json:"verify_incoming_https,omitempty" hcl:"verify_incoming_https" mapstructure:"verify_incoming_https"`
-	VerifyIncomingRPC                *bool                    `json:"verify_incoming_rpc,omitempty" hcl:"verify_incoming_rpc" mapstructure:"verify_incoming_rpc"`
-	VerifyOutgoing                   *bool                    `json:"verify_outgoing,omitempty" hcl:"verify_outgoing" mapstructure:"verify_outgoing"`
-	VerifyServerHostname             *bool                    `json:"verify_server_hostname,omitempty" hcl:"verify_server_hostname" mapstructure:"verify_server_hostname"`
-	Watches                          []map[string]interface{} `json:"watches,omitempty" hcl:"watches" mapstructure:"watches"`
+	ACLToken                         *string             `json:"acl_token,omitempty" hcl:"acl_token" mapstructure:"acl_token"`
+	ACL                              ACL                 `json:"acl,omitempty" hcl:"acl" mapstructure:"acl"`
+	Addresses                        Addresses           `json:"addresses,omitempty" hcl:"addresses" mapstructure:"addresses"`
+	AdvertiseAddrLAN                 *string             `json:"advertise_addr,omitempty" hcl:"advertise_addr" mapstructure:"advertise_addr"`
+	AdvertiseAddrLANIPv4             *string             `json:"advertise_addr_ipv4,omitempty" hcl:"advertise_addr_ipv4" mapstructure:"advertise_addr_ipv4"`
+	AdvertiseAddrLANIPv6             *string             `json:"advertise_addr_ipv6,omitempty" hcl:"advertise_addr_ipv6" mapstructure:"advertise_addr_ipv6"`
+	AdvertiseAddrWAN                 *string             `json:"advertise_addr_wan,omitempty" hcl:"advertise_addr_wan" mapstructure:"advertise_addr_wan"`
+	AdvertiseAddrWANIPv4             *string             `json:"advertise_addr_wan_ipv4,omitempty" hcl:"advertise_addr_wan_ipv4" mapstructure:"advertise_addr_wan_ipv4"`
+	AdvertiseAddrWANIPv6             *string             `json:"advertise_addr_wan_ipv6,omitempty" hcl:"advertise_addr_wan_ipv6" mapstructure:"advertise_addr_ipv6"`
+	AutoConfig                       AutoConfigRaw       `json:"auto_config,omitempty" hcl:"auto_config" mapstructure:"auto_config"`
+	Autopilot                        Autopilot           `json:"autopilot,omitempty" hcl:"autopilot" mapstructure:"autopilot"`
+	BindAddr                         *string             `json:"bind_addr,omitempty" hcl:"bind_addr" mapstructure:"bind_addr"`
+	Bootstrap                        *bool               `json:"bootstrap,omitempty" hcl:"bootstrap" mapstructure:"bootstrap"`
+	BootstrapExpect                  *int                `json:"bootstrap_expect,omitempty" hcl:"bootstrap_expect" mapstructure:"bootstrap_expect"`
+	Cache                            Cache               `json:"cache,omitempty" hcl:"cache" mapstructure:"cache"`
+	CAFile                           *string             `json:"ca_file,omitempty" hcl:"ca_file" mapstructure:"ca_file"`
+	CAPath                           *string             `json:"ca_path,omitempty" hcl:"ca_path" mapstructure:"ca_path"`
+	CertFile                         *string             `json:"cert_file,omitempty" hcl:"cert_file" mapstructure:"cert_file"`
+	Check                            *CheckDefinition    `json:"check,omitempty" hcl:"check" mapstructure:"check"` // needs to be a pointer to avoid partial merges
+	CheckOutputMaxSize               *int                `json:"check_output_max_size,omitempty" hcl:"check_output_max_size" mapstructure:"check_output_max_size"`
+	CheckUpdateInterval              *string             `json:"check_update_interval,omitempty" hcl:"check_update_interval" mapstructure:"check_update_interval"`
+	Checks                           []CheckDefinition   `json:"checks,omitempty" hcl:"checks" mapstructure:"checks"`
+	ClientAddr                       *string             `json:"client_addr,omitempty" hcl:"client_addr" mapstructure:"client_addr"`
+	ConfigEntries                    ConfigEntries       `json:"config_entries,omitempty" hcl:"config_entries" mapstructure:"config_entries"`
+	AutoEncrypt                      AutoEncrypt         `json:"auto_encrypt,omitempty" hcl:"auto_encrypt" mapstructure:"auto_encrypt"`
+	Connect                          Connect             `json:"connect,omitempty" hcl:"connect" mapstructure:"connect"`
+	DNS                              DNS                 `json:"dns_config,omitempty" hcl:"dns_config" mapstructure:"dns_config"`
+	DNSDomain                        *string             `json:"domain,omitempty" hcl:"domain" mapstructure:"domain"`
+	DNSAltDomain                     *string             `json:"alt_domain,omitempty" hcl:"alt_domain" mapstructure:"alt_domain"`
+	DNSRecursors                     []string            `json:"recursors,omitempty" hcl:"recursors" mapstructure:"recursors"`
+	DataDir                          *string             `json:"data_dir,omitempty" hcl:"data_dir" mapstructure:"data_dir"`
+	Datacenter                       *string             `json:"datacenter,omitempty" hcl:"datacenter" mapstructure:"datacenter"`
+	DefaultQueryTime                 *string             `json:"default_query_time,omitempty" hcl:"default_query_time" mapstructure:"default_query_time"`
+	DisableAnonymousSignature        *bool               `json:"disable_anonymous_signature,omitempty" hcl:"disable_anonymous_signature" mapstructure:"disable_anonymous_signature"`
+	DisableCoordinates               *bool               `json:"disable_coordinates,omitempty" hcl:"disable_coordinates" mapstructure:"disable_coordinates"`
+	DisableHostNodeID                *bool               `json:"disable_host_node_id,omitempty" hcl:"disable_host_node_id" mapstructure:"disable_host_node_id"`
+	DisableHTTPUnprintableCharFilter *bool               `json:"disable_http_unprintable_char_filter,omitempty" hcl:"disable_http_unprintable_char_filter" mapstructure:"disable_http_unprintable_char_filter"`
+	DisableKeyringFile               *bool               `json:"disable_keyring_file,omitempty" hcl:"disable_keyring_file" mapstructure:"disable_keyring_file"`
+	DisableRemoteExec                *bool               `json:"disable_remote_exec,omitempty" hcl:"disable_remote_exec" mapstructure:"disable_remote_exec"`
+	DisableUpdateCheck               *bool               `json:"disable_update_check,omitempty" hcl:"disable_update_check" mapstructure:"disable_update_check"`
+	DiscardCheckOutput               *bool               `json:"discard_check_output" hcl:"discard_check_output" mapstructure:"discard_check_output"`
+	DiscoveryMaxStale                *string             `json:"discovery_max_stale" hcl:"discovery_max_stale" mapstructure:"discovery_max_stale"`
+	EnableACLReplication             *bool               `json:"enable_acl_replication,omitempty" hcl:"enable_acl_replication" mapstructure:"enable_acl_replication"`
+	EnableAgentTLSForChecks          *bool               `json:"enable_agent_tls_for_checks,omitempty" hcl:"enable_agent_tls_for_checks" mapstructure:"enable_agent_tls_for_checks"`
+	EnableCentralServiceConfig       *bool               `json:"enable_central_service_config,omitempty" hcl:"enable_central_service_config" mapstructure:"enable_central_service_config"`
+	EnableDebug                      *bool               `json:"enable_debug,omitempty" hcl:"enable_debug" mapstructure:"enable_debug"`
+	EnableScriptChecks               *bool               `json:"enable_script_checks,omitempty" hcl:"enable_script_checks" mapstructure:"enable_script_checks"`
+	EnableLocalScriptChecks          *bool               `json:"enable_local_script_checks,omitempty" hcl:"enable_local_script_checks" mapstructure:"enable_local_script_checks"`
+	EnableSyslog                     *bool               `json:"enable_syslog,omitempty" hcl:"enable_syslog" mapstructure:"enable_syslog"`
+	EncryptKey                       *string             `json:"encrypt,omitempty" hcl:"encrypt" mapstructure:"encrypt"`
+	EncryptVerifyIncoming            *bool               `json:"encrypt_verify_incoming,omitempty" hcl:"encrypt_verify_incoming" mapstructure:"encrypt_verify_incoming"`
+	EncryptVerifyOutgoing            *bool               `json:"encrypt_verify_outgoing,omitempty" hcl:"encrypt_verify_outgoing" mapstructure:"encrypt_verify_outgoing"`
+	GossipLAN                        GossipLANConfig     `json:"gossip_lan,omitempty" hcl:"gossip_lan" mapstructure:"gossip_lan"`
+	GossipWAN                        GossipWANConfig     `json:"gossip_wan,omitempty" hcl:"gossip_wan" mapstructure:"gossip_wan"`
+	HTTPConfig                       HTTPConfig          `json:"http_config,omitempty" hcl:"http_config" mapstructure:"http_config"`
+	KeyFile                          *string             `json:"key_file,omitempty" hcl:"key_file" mapstructure:"key_file"`
+	LeaveOnTerm                      *bool               `json:"leave_on_terminate,omitempty" hcl:"leave_on_terminate" mapstructure:"leave_on_terminate"`
+	Limits                           Limits              `json:"limits,omitempty" hcl:"limits" mapstructure:"limits"`
+	LogLevel                         *string             `json:"log_level,omitempty" hcl:"log_level" mapstructure:"log_level"`
+	LogJSON                          *bool               `json:"log_json,omitempty" hcl:"log_json" mapstructure:"log_json"`
+	LogFile                          *string             `json:"log_file,omitempty" hcl:"log_file" mapstructure:"log_file"`
+	LogRotateDuration                *string             `json:"log_rotate_duration,omitempty" hcl:"log_rotate_duration" mapstructure:"log_rotate_duration"`
+	LogRotateBytes                   *int                `json:"log_rotate_bytes,omitempty" hcl:"log_rotate_bytes" mapstructure:"log_rotate_bytes"`
+	LogRotateMaxFiles                *int                `json:"log_rotate_max_files,omitempty" hcl:"log_rotate_max_files" mapstructure:"log_rotate_max_files"`
+	MaxQueryTime                     *string             `json:"max_query_time,omitempty" hcl:"max_query_time" mapstructure:"max_query_time"`
+	NodeID                           *string             `json:"node_id,omitempty" hcl:"node_id" mapstructure:"node_id"`
+	NodeMeta                         map[string]string   `json:"node_meta,omitempty" hcl:"node_meta" mapstructure:"node_meta"`
+	NodeName                         *string             `json:"node_name,omitempty" hcl:"node_name" mapstructure:"node_name"`
+	Performance                      Performance         `json:"performance,omitempty" hcl:"performance" mapstructure:"performance"`
+	PidFile                          *string             `json:"pid_file,omitempty" hcl:"pid_file" mapstructure:"pid_file"`
+	Ports                            Ports               `json:"ports,omitempty" hcl:"ports" mapstructure:"ports"`
+	PrimaryDatacenter                *string             `json:"primary_datacenter,omitempty" hcl:"primary_datacenter" mapstructure:"primary_datacenter"`
+	PrimaryGateways                  []string            `json:"primary_gateways" hcl:"primary_gateways" mapstructure:"primary_gateways"`
+	PrimaryGatewaysInterval          *string             `json:"primary_gateways_interval,omitempty" hcl:"primary_gateways_interval" mapstructure:"primary_gateways_interval"`
+	RPCProtocol                      *int                `json:"protocol,omitempty" hcl:"protocol" mapstructure:"protocol"`
+	RaftProtocol                     *int                `json:"raft_protocol,omitempty" hcl:"raft_protocol" mapstructure:"raft_protocol"`
+	RaftSnapshotThreshold            *int                `json:"raft_snapshot_threshold,omitempty" hcl:"raft_snapshot_threshold" mapstructure:"raft_snapshot_threshold"`
+	RaftSnapshotInterval             *string             `json:"raft_snapshot_interval,omitempty" hcl:"raft_snapshot_interval" mapstructure:"raft_snapshot_interval"`
+	RaftTrailingLogs                 *int                `json:"raft_trailing_logs,omitempty" hcl:"raft_trailing_logs" mapstructure:"raft_trailing_logs"`
+	ReconnectTimeoutLAN              *string             `json:"reconnect_timeout,omitempty" hcl:"reconnect_timeout" mapstructure:"reconnect_timeout"`
+	ReconnectTimeoutWAN              *string             `json:"reconnect_timeout_wan,omitempty" hcl:"reconnect_timeout_wan" mapstructure:"reconnect_timeout_wan"`
+	RejoinAfterLeave                 *bool               `json:"rejoin_after_leave,omitempty" hcl:"rejoin_after_leave" mapstructure:"rejoin_after_leave"`
+	RetryJoinIntervalLAN             *string             `json:"retry_interval,omitempty" hcl:"retry_interval" mapstructure:"retry_interval"`
+	RetryJoinIntervalWAN             *string             `json:"retry_interval_wan,omitempty" hcl:"retry_interval_wan" mapstructure:"retry_interval_wan"`
+	RetryJoinLAN                     []string            `json:"retry_join,omitempty" hcl:"retry_join" mapstructure:"retry_join"`
+	RetryJoinMaxAttemptsLAN          *int                `json:"retry_max,omitempty" hcl:"retry_max" mapstructure:"retry_max"`
+	RetryJoinMaxAttemptsWAN          *int                `json:"retry_max_wan,omitempty" hcl:"retry_max_wan" mapstructure:"retry_max_wan"`
+	RetryJoinWAN                     []string            `json:"retry_join_wan,omitempty" hcl:"retry_join_wan" mapstructure:"retry_join_wan"`
+	SerfAllowedCIDRsLAN              []string            `json:"serf_lan_allowed_cidrs,omitempty" hcl:"serf_lan_allowed_cidrs" mapstructure:"serf_lan_allowed_cidrs"`
+	SerfAllowedCIDRsWAN              []string            `json:"serf_wan_allowed_cidrs,omitempty" hcl:"serf_wan_allowed_cidrs" mapstructure:"serf_wan_allowed_cidrs"`
+	SerfBindAddrLAN                  *string             `json:"serf_lan,omitempty" hcl:"serf_lan" mapstructure:"serf_lan"`
+	SerfBindAddrWAN                  *string             `json:"serf_wan,omitempty" hcl:"serf_wan" mapstructure:"serf_wan"`
+	ServerMode                       *bool               `json:"server,omitempty" hcl:"server" mapstructure:"server"`
+	ServerName                       *string             `json:"server_name,omitempty" hcl:"server_name" mapstructure:"server_name"`
+	Service                          *ServiceDefinition  `json:"service,omitempty" hcl:"service" mapstructure:"service"`
+	Services                         []ServiceDefinition `json:"services,omitempty" hcl:"services" mapstructure:"services"`
+	SessionTTLMin                    *string             `json:"session_ttl_min,omitempty" hcl:"session_ttl_min" mapstructure:"session_ttl_min"`
+	SkipLeaveOnInt                   *bool               `json:"skip_leave_on_interrupt,omitempty" hcl:"skip_leave_on_interrupt" mapstructure:"skip_leave_on_interrupt"`
+	StartJoinAddrsLAN                []string            `json:"start_join,omitempty" hcl:"start_join" mapstructure:"start_join"`
+	StartJoinAddrsWAN                []string            `json:"start_join_wan,omitempty" hcl:"start_join_wan" mapstructure:"start_join_wan"`
+	SyslogFacility                   *string             `json:"syslog_facility,omitempty" hcl:"syslog_facility" mapstructure:"syslog_facility"`
+	TLSCipherSuites                  *string             `json:"tls_cipher_suites,omitempty" hcl:"tls_cipher_suites" mapstructure:"tls_cipher_suites"`
+	TLSMinVersion                    *string             `json:"tls_min_version,omitempty" hcl:"tls_min_version" mapstructure:"tls_min_version"`
+	TLSPreferServerCipherSuites      *bool               `json:"tls_prefer_server_cipher_suites,omitempty" hcl:"tls_prefer_server_cipher_suites" mapstructure:"tls_prefer_server_cipher_suites"`
+	TaggedAddresses                  map[string]string   `json:"tagged_addresses,omitempty" hcl:"tagged_addresses" mapstructure:"tagged_addresses"`
+	Telemetry                        Telemetry           `json:"telemetry,omitempty" hcl:"telemetry" mapstructure:"telemetry"`
+	TranslateWANAddrs                *bool               `json:"translate_wan_addrs,omitempty" hcl:"translate_wan_addrs" mapstructure:"translate_wan_addrs"`
+
+	// DEPRECATED (ui-config) - moved to the ui_config stanza
+	UI *bool `json:"ui,omitempty" hcl:"ui" mapstructure:"ui"`
+	// DEPRECATED (ui-config) - moved to the ui_config stanza
+	UIContentPath *string `json:"ui_content_path,omitempty" hcl:"ui_content_path" mapstructure:"ui_content_path"`
+	// DEPRECATED (ui-config) - moved to the ui_config stanza
+	UIDir    *string     `json:"ui_dir,omitempty" hcl:"ui_dir" mapstructure:"ui_dir"`
+	UIConfig RawUIConfig `json:"ui_config,omitempty" hcl:"ui_config" mapstructure:"ui_config"`
+
+	UnixSocket           UnixSocket               `json:"unix_sockets,omitempty" hcl:"unix_sockets" mapstructure:"unix_sockets"`
+	VerifyIncoming       *bool                    `json:"verify_incoming,omitempty" hcl:"verify_incoming" mapstructure:"verify_incoming"`
+	VerifyIncomingHTTPS  *bool                    `json:"verify_incoming_https,omitempty" hcl:"verify_incoming_https" mapstructure:"verify_incoming_https"`
+	VerifyIncomingRPC    *bool                    `json:"verify_incoming_rpc,omitempty" hcl:"verify_incoming_rpc" mapstructure:"verify_incoming_rpc"`
+	VerifyOutgoing       *bool                    `json:"verify_outgoing,omitempty" hcl:"verify_outgoing" mapstructure:"verify_outgoing"`
+	VerifyServerHostname *bool                    `json:"verify_server_hostname,omitempty" hcl:"verify_server_hostname" mapstructure:"verify_server_hostname"`
+	Watches              []map[string]interface{} `json:"watches,omitempty" hcl:"watches" mapstructure:"watches"`
 
 	// This isn't used by Consul but we've documented a feature where users
 	// can deploy their snapshot agent configs alongside their Consul configs
@@ -768,4 +774,25 @@ type AutoConfigAuthorizerRaw struct {
 	ExpirationLeeway     *string           `json:"expiration_leeway,omitempty" hcl:"expiration_leeway" mapstructure:"expiration_leeway"`
 	NotBeforeLeeway      *string           `json:"not_before_leeway,omitempty" hcl:"not_before_leeway" mapstructure:"not_before_leeway"`
 	ClockSkewLeeway      *string           `json:"clock_skew_leeway,omitempty" hcl:"clock_skew_leeway" mapstructure:"clock_skew_leeway"`
+}
+
+type RawUIConfig struct {
+	Enabled                    *bool             `json:"enabled,omitempty" hcl:"enabled" mapstructure:"enabled"`
+	Dir                        *string           `json:"dir,omitempty" hcl:"dir" mapstructure:"dir"`
+	ContentPath                *string           `json:"content_path,omitempty" hcl:"content_path" mapstructure:"content_path"`
+	MetricsProvider            *string           `json:"metrics_provider,omitempty" hcl:"metrics_provider" mapstructure:"metrics_provider"`
+	MetricsProviderFiles       []string          `json:"metrics_provider_files,omitempty" hcl:"metrics_provider_files" mapstructure:"metrics_provider_files"`
+	MetricsProviderOptionsJSON *string           `json:"metrics_provider_options_json,omitempty" hcl:"metrics_provider_options_json" mapstructure:"metrics_provider_options_json"`
+	MetricsProxy               RawUIMetricsProxy `json:"metrics_proxy,omitempty" hcl:"metrics_proxy" mapstructure:"metrics_proxy"`
+	DashboardURLTemplates      map[string]string `json:"dashboard_url_templates" hcl:"dashboard_url_templates" mapstructure:"dashboard_url_templates"`
+}
+
+type RawUIMetricsProxy struct {
+	BaseURL    *string                      `json:"base_url,omitempty" hcl:"base_url" mapstructure:"base_url"`
+	AddHeaders []RawUIMetricsProxyAddHeader `json:"add_headers,omitempty" hcl:"add_headers" mapstructure:"add_headers"`
+}
+
+type RawUIMetricsProxyAddHeader struct {
+	Name  *string `json:"name,omitempty" hcl:"name" mapstructure:"name"`
+	Value *string `json:"value,omitempty" hcl:"value" mapstructure:"value"`
 }

--- a/agent/config/default.go
+++ b/agent/config/default.go
@@ -139,7 +139,9 @@ func DevSource() Source {
 		disable_anonymous_signature = true
 		disable_keyring_file = true
 		enable_debug = true
-		ui = true
+		ui_config {
+			enabled = true
+		}
 		log_level = "DEBUG"
 		server = true
 

--- a/agent/config/flags.go
+++ b/agent/config/flags.go
@@ -111,8 +111,8 @@ func AddFlags(fs *flag.FlagSet, f *BuilderOpts) {
 	add(&f.Config.Ports.SerfWAN, "serf-wan-port", "Sets the Serf WAN port to listen on.")
 	add(&f.Config.ServerMode, "server", "Switches agent to server mode.")
 	add(&f.Config.EnableSyslog, "syslog", "Enables logging to syslog.")
-	add(&f.Config.UI, "ui", "Enables the built-in static web UI server.")
-	add(&f.Config.UIContentPath, "ui-content-path", "Sets the external UI path to a string. Defaults to: /ui/ ")
-	add(&f.Config.UIDir, "ui-dir", "Path to directory containing the web UI resources.")
+	add(&f.Config.UIConfig.Enabled, "ui", "Enables the built-in static web UI server.")
+	add(&f.Config.UIConfig.ContentPath, "ui-content-path", "Sets the external UI path to a string. Defaults to: /ui/ ")
+	add(&f.Config.UIConfig.Dir, "ui-dir", "Path to directory containing the web UI resources.")
 	add(&f.HCL, "hcl", "hcl config fragment. Can be specified multiple times.")
 }

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -1712,7 +1712,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 			},
 			json:  []string{`{ "acl_datacenter": "%" }`},
 			hcl:   []string{`acl_datacenter = "%"`},
-			err:   `acl_datacenter cannot be "%". Please use only [a-z0-9-_]`,
+			err:   `acl_datacenter can only contain lowercase alphanumeric, - or _ characters.`,
 			warns: []string{`The 'acl_datacenter' field is deprecated. Use the 'primary_datacenter' field instead.`},
 		},
 		{
@@ -1881,7 +1881,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{ "datacenter": "%" }`},
 			hcl:  []string{`datacenter = "%"`},
-			err:  `datacenter cannot be "%". Please use only [a-z0-9-_]`,
+			err:  `datacenter can only contain lowercase alphanumeric, - or _ characters.`,
 		},
 		{
 			desc: "dns does not allow socket",
@@ -4306,7 +4306,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				metrics_provider = "((((lisp 4 life))))"
 			}
 			`},
-			err: `ui_config.metrics_provider can only contain lowercase alphanumeric or _ characters.`,
+			err: `ui_config.metrics_provider can only contain lowercase alphanumeric, - or _ characters.`,
 		},
 		{
 			desc: "metrics_provider_options_json invalid JSON",
@@ -4393,7 +4393,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				}
 			}
 			`},
-			err: `ui_config.dashboard_url_templates key names can only contain lowercase alphanumeric or _ characters.`,
+			err: `ui_config.dashboard_url_templates key names can only contain lowercase alphanumeric, - or _ characters.`,
 		},
 		{
 			desc: "dashboard_url_templates value format",

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -290,7 +290,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				rt.DisableAnonymousSignature = true
 				rt.DisableKeyringFile = true
 				rt.EnableDebug = true
-				rt.EnableUI = true
+				rt.UIConfig.Enabled = true
 				rt.LeaveOnTerm = false
 				rt.Logging.LogLevel = "DEBUG"
 				rt.RPCAdvertiseAddr = tcpAddr("127.0.0.1:8300")
@@ -850,7 +850,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				`-data-dir=` + dataDir,
 			},
 			patch: func(rt *RuntimeConfig) {
-				rt.EnableUI = true
+				rt.UIConfig.Enabled = true
 				rt.DataDir = dataDir
 			},
 		},
@@ -861,7 +861,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				`-data-dir=` + dataDir,
 			},
 			patch: func(rt *RuntimeConfig) {
-				rt.UIDir = "a"
+				rt.UIConfig.Dir = "a"
 				rt.DataDir = dataDir
 			},
 		},
@@ -873,7 +873,7 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 			},
 
 			patch: func(rt *RuntimeConfig) {
-				rt.UIContentPath = "/a/b/"
+				rt.UIConfig.ContentPath = "/a/b/"
 				rt.DataDir = dataDir
 			},
 		},
@@ -1894,16 +1894,16 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 			err:  "DNS address cannot be a unix socket",
 		},
 		{
-			desc: "ui and ui_dir",
+			desc: "ui enabled and dir specified",
 			args: []string{
 				`-datacenter=a`,
 				`-data-dir=` + dataDir,
 			},
-			json: []string{`{ "ui": true, "ui_dir": "a" }`},
-			hcl:  []string{`ui = true ui_dir = "a"`},
-			err: "Both the ui and ui-dir flags were specified, please provide only one.\n" +
-				"If trying to use your own web UI resources, use the ui-dir flag.\n" +
-				"The web UI is included in the binary so use ui to enable it",
+			json: []string{`{ "ui_config": { "enabled": true, "dir": "a" } }`},
+			hcl:  []string{`ui_config { enabled = true dir = "a"}`},
+			err: "Both the ui_config.enabled and ui_config.dir (or -ui and -ui-dir) were specified, please provide only one.\n" +
+				"If trying to use your own web UI resources, use ui_config.dir or the -ui-dir flag.\n" +
+				"The web UI is included in the binary so use ui_config.enabled or the -ui flag to enable it",
 		},
 
 		// test ANY address failures
@@ -4251,6 +4251,169 @@ func TestBuilder_BuildAndValide_ConfigFlagsAndEdgecases(t *testing.T) {
 				rt.CertFile = "foo"
 			},
 		},
+
+		// UI Config tests
+		{
+			desc: "ui config deprecated",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui": true,
+				"ui_content_path": "/bar"
+			}`},
+			hcl: []string{`
+			ui = true
+			ui_content_path = "/bar"
+			`},
+			warns: []string{
+				`The 'ui' field is deprecated. Use the 'ui_config.enabled' field instead.`,
+				`The 'ui_content_path' field is deprecated. Use the 'ui_config.content_path' field instead.`,
+			},
+			patch: func(rt *RuntimeConfig) {
+				// Should still work!
+				rt.UIConfig.Enabled = true
+				rt.UIConfig.ContentPath = "/bar/"
+				rt.DataDir = dataDir
+			},
+		},
+		{
+			desc: "ui-dir config deprecated",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_dir": "/bar"
+			}`},
+			hcl: []string{`
+			ui_dir = "/bar"
+			`},
+			warns: []string{
+				`The 'ui_dir' field is deprecated. Use the 'ui_config.dir' field instead.`,
+			},
+			patch: func(rt *RuntimeConfig) {
+				// Should still work!
+				rt.UIConfig.Dir = "/bar"
+				rt.DataDir = dataDir
+			},
+		},
+		{
+			desc: "metrics_provider constraint",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"metrics_provider": "((((lisp 4 life))))"
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				metrics_provider = "((((lisp 4 life))))"
+			}
+			`},
+			err: `ui_config.metrics_provider can only contain lowercase alphanumeric or _ characters.`,
+		},
+		{
+			desc: "metrics_provider_options_json invalid JSON",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"metrics_provider_options_json": "not valid JSON"
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				metrics_provider_options_json = "not valid JSON"
+			}
+			`},
+			err: `ui_config.metrics_provider_options_json must be empty or a string containing a valid JSON object.`,
+		},
+		{
+			desc: "metrics_provider_options_json not an object",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"metrics_provider_options_json": "1.0"
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				metrics_provider_options_json = "1.0"
+			}
+			`},
+			err: `ui_config.metrics_provider_options_json must be empty or a string containing a valid JSON object.`,
+		},
+		{
+			desc: "metrics_proxy.base_url valid",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"metrics_proxy": {
+						"base_url": "___"
+					}
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				metrics_proxy {
+					base_url = "___"
+				}
+			}
+			`},
+			err: `ui_config.metrics_proxy.base_url must be a valid http or https URL.`,
+		},
+		{
+			desc: "metrics_proxy.base_url http(s)",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"metrics_proxy": {
+						"base_url": "localhost:1234"
+					}
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				metrics_proxy {
+					base_url = "localhost:1234"
+				}
+			}
+			`},
+			err: `ui_config.metrics_proxy.base_url must be a valid http or https URL.`,
+		},
+		{
+			desc: "dashboard_url_templates key format",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"dashboard_url_templates": {
+						"(*&ASDOUISD)": "localhost:1234"
+					}
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				dashboard_url_templates {
+					"(*&ASDOUISD)" = "localhost:1234"
+				}
+			}
+			`},
+			err: `ui_config.dashboard_url_templates key names can only contain lowercase alphanumeric or _ characters.`,
+		},
+		{
+			desc: "dashboard_url_templates value format",
+			args: []string{`-data-dir=` + dataDir},
+			json: []string{`{
+				"ui_config": {
+					"dashboard_url_templates": {
+						"services": "localhost:1234"
+					}
+				}
+			}`},
+			hcl: []string{`
+			ui_config {
+				dashboard_url_templates {
+					services = "localhost:1234"
+				}
+			}
+			`},
+			err: `ui_config.dashboard_url_templates values must be a valid http or https URL.`,
+		},
 	}
 
 	testConfig(t, tests, dataDir)
@@ -5070,9 +5233,26 @@ func TestFullConfig(t *testing.T) {
 			"tls_min_version": "pAOWafkR",
 			"tls_prefer_server_cipher_suites": true,
 			"translate_wan_addrs": true,
-			"ui": true,
-			"ui_dir": "11IFzAUn",
-			"ui_content_path": "consul",
+			"ui_config": {
+				"enabled": true,
+				"dir": "pVncV4Ey",
+				"content_path": "qp1WRhYH",
+				"metrics_provider": "sgnaoa_lower_case",
+				"metrics_provider_files": ["sgnaMFoa", "dicnwkTH"],
+				"metrics_provider_options_json": "{\"DIbVQadX\": 1}",
+				"metrics_proxy": {
+					"base_url": "http://foo.bar",
+					"add_headers": [
+						{
+							"name": "p3nynwc9",
+							"value": "TYBgnN2F"
+						}
+					]
+				},
+				"dashboard_url_templates": {
+					"u2eziu2n_lower_case": "http://lkjasd.otr"
+				}
+			},
 			"unix_sockets": {
 				"group": "8pFodrV8",
 				"mode": "E8sAwOv4",
@@ -5736,9 +5916,26 @@ func TestFullConfig(t *testing.T) {
 			tls_min_version = "pAOWafkR"
 			tls_prefer_server_cipher_suites = true
 			translate_wan_addrs = true
-			ui = true
-			ui_dir = "11IFzAUn"
-			ui_content_path = "consul"
+			ui_config {
+				enabled = true
+				dir = "pVncV4Ey"
+				content_path = "qp1WRhYH"
+				metrics_provider = "sgnaoa_lower_case"
+				metrics_provider_files = ["sgnaMFoa", "dicnwkTH"]
+				metrics_provider_options_json = "{\"DIbVQadX\": 1}"
+				metrics_proxy {
+					base_url = "http://foo.bar"
+					add_headers = [
+						{
+							name = "p3nynwc9"
+							value = "TYBgnN2F"
+						}
+					]
+				}
+			 	dashboard_url_templates {
+					u2eziu2n_lower_case = "http://lkjasd.otr"
+				}
+			}
 			unix_sockets = {
 				group = "8pFodrV8"
 				mode = "E8sAwOv4"
@@ -6110,7 +6307,6 @@ func TestFullConfig(t *testing.T) {
 		EnableDebug:                            true,
 		EnableRemoteScriptChecks:               true,
 		EnableLocalScriptChecks:                true,
-		EnableUI:                               true,
 		EncryptKey:                             "A4wELWqH",
 		EncryptVerifyIncoming:                  true,
 		EncryptVerifyOutgoing:                  true,
@@ -6507,10 +6703,26 @@ func TestFullConfig(t *testing.T) {
 			"wan":      "78.63.37.19",
 			"wan_ipv4": "78.63.37.19",
 		},
-		TranslateWANAddrs:    true,
-		TxnMaxReqLen:         5678000000000000,
-		UIContentPath:        "/consul/",
-		UIDir:                "11IFzAUn",
+		TranslateWANAddrs: true,
+		TxnMaxReqLen:      5678000000000000,
+		UIConfig: UIConfig{
+			Enabled:                    true,
+			Dir:                        "pVncV4Ey",
+			ContentPath:                "/qp1WRhYH/", // slashes are added in parsing
+			MetricsProvider:            "sgnaoa_lower_case",
+			MetricsProviderFiles:       []string{"sgnaMFoa", "dicnwkTH"},
+			MetricsProviderOptionsJSON: "{\"DIbVQadX\": 1}",
+			MetricsProxy: UIMetricsProxy{
+				BaseURL: "http://foo.bar",
+				AddHeaders: []UIMetricsProxyAddHeader{
+					{
+						Name:  "p3nynwc9",
+						Value: "TYBgnN2F",
+					},
+				},
+			},
+			DashboardURLTemplates: map[string]string{"u2eziu2n_lower_case": "http://lkjasd.otr"},
+		},
 		UnixSocketUser:       "E0nB1DwA",
 		UnixSocketGroup:      "8pFodrV8",
 		UnixSocketMode:       "E8sAwOv4",
@@ -6589,7 +6801,7 @@ func TestFullConfig(t *testing.T) {
 			// we are patching a handful of safe fields to make validation pass.
 			rt.Bootstrap = false
 			rt.DevMode = false
-			rt.EnableUI = false
+			rt.UIConfig.Enabled = false
 			rt.SegmentName = ""
 			rt.Segments = nil
 
@@ -6599,7 +6811,7 @@ func TestFullConfig(t *testing.T) {
 			}
 
 			// check the warnings
-			require.ElementsMatch(t, warns, b.Warnings, "Warnings: %v", b.Warnings)
+			require.ElementsMatch(t, warns, b.Warnings, "Warnings: %#v", b.Warnings)
 		})
 	}
 }
@@ -7005,7 +7217,6 @@ func TestSanitize(t *testing.T) {
 		"EnableCentralServiceConfig": false,
 		"EnableLocalScriptChecks": false,
 		"EnableRemoteScriptChecks": false,
-		"EnableUI": false,
 		"EncryptKey": "hidden",
 		"EncryptVerifyIncoming": false,
 		"EncryptVerifyOutgoing": false,
@@ -7179,8 +7390,19 @@ func TestSanitize(t *testing.T) {
 		},
 		"TranslateWANAddrs": false,
 		"TxnMaxReqLen": 5678000000000000,
-		"UIDir": "",
-		"UIContentPath": "",
+		"UIConfig": {
+			"ContentPath": "",
+			"Dir": "",
+			"Enabled": false,
+			"MetricsProvider": "",
+			"MetricsProviderFiles": [],
+			"MetricsProviderOptionsJSON": "",
+			"MetricsProxy": {
+				"AddHeaders": [],
+				"BaseURL": ""
+			},
+			"DashboardURLTemplates": {}
+		},
 		"UnixSocketGroup": "",
 		"UnixSocketMode": "",
 		"UnixSocketUser": "",

--- a/agent/http.go
+++ b/agent/http.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"github.com/ryboe/q"
 )
 
 // MethodNotAllowedError should be returned by a handler when the HTTP method is not allowed.
@@ -169,6 +170,7 @@ func (fs *settingsInjectedIndexFS) Open(name string) (http.File, error) {
 	}
 
 	content, err := ioutil.ReadAll(file)
+	q.Q(err)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading index.html: %s", err)
 	}
@@ -182,6 +184,7 @@ func (fs *settingsInjectedIndexFS) Open(name string) (http.File, error) {
 
 	// First built an escaped, JSON blob from the settings passed.
 	bs, err := json.Marshal(fs.UISettings)
+	q.Q(string(bs))
 	if err != nil {
 		return nil, fmt.Errorf("failed marshalling UI settings JSON: %s", err)
 	}
@@ -401,10 +404,9 @@ func (s *HTTPHandlers) GetUIENVFromConfig() map[string]interface{} {
 	uiCfg := s.agent.getUIConfig()
 
 	vars := map[string]interface{}{
-		"CONSUL_CONTENT_PATH":             uiCfg.ContentPath,
-		"CONSUL_ACLS_ENABLED":             s.agent.config.ACLsEnabled,
-		"CONSUL_METRICS_PROVIDER":         uiCfg.MetricsProvider,
-		"CONSUL_METRICS_PROVIDER_OPTIONS": json.RawMessage(uiCfg.MetricsProviderOptionsJSON),
+		"CONSUL_CONTENT_PATH":     uiCfg.ContentPath,
+		"CONSUL_ACLS_ENABLED":     s.agent.config.ACLsEnabled,
+		"CONSUL_METRICS_PROVIDER": uiCfg.MetricsProvider,
 		// We explicitly MUST NOT pass the metrics_proxy object since it might
 		// contain add_headers with secrets that the UI shouldn't know e.g. API
 		// tokens for the backend. The provider should either require the proxy to
@@ -412,6 +414,12 @@ func (s *HTTPHandlers) GetUIENVFromConfig() map[string]interface{} {
 		// browser.
 		"CONSUL_METRICS_PROXY_ENABLED":   uiCfg.MetricsProxy.BaseURL != "",
 		"CONSUL_DASHBOARD_URL_TEMPLATES": uiCfg.DashboardURLTemplates,
+	}
+
+	// Only set this if there is some actual JSON or we'll cause a JSON
+	// marshalling error later during serving which ends up being silent.
+	if uiCfg.MetricsProviderOptionsJSON != "" {
+		vars["CONSUL_METRICS_PROVIDER_OPTIONS"] = json.RawMessage(uiCfg.MetricsProviderOptionsJSON)
 	}
 
 	s.addEnterpriseUIENVVars(vars)

--- a/agent/http.go
+++ b/agent/http.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/ryboe/q"
 )
 
 // MethodNotAllowedError should be returned by a handler when the HTTP method is not allowed.
@@ -170,7 +169,6 @@ func (fs *settingsInjectedIndexFS) Open(name string) (http.File, error) {
 	}
 
 	content, err := ioutil.ReadAll(file)
-	q.Q(err)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading index.html: %s", err)
 	}
@@ -184,7 +182,6 @@ func (fs *settingsInjectedIndexFS) Open(name string) (http.File, error) {
 
 	// First built an escaped, JSON blob from the settings passed.
 	bs, err := json.Marshal(fs.UISettings)
-	q.Q(string(bs))
 	if err != nil {
 		return nil, fmt.Errorf("failed marshalling UI settings JSON: %s", err)
 	}

--- a/agent/http_oss.go
+++ b/agent/http_oss.go
@@ -55,8 +55,6 @@ func (s *HTTPHandlers) rewordUnknownEnterpriseFieldError(err error) error {
 	return err
 }
 
-func (s *HTTPHandlers) addEnterpriseUIENVVars(_ map[string]interface{}) {}
-
 func parseACLAuthMethodEnterpriseMeta(req *http.Request, _ *structs.ACLAuthMethodEnterpriseMeta) error {
 	if methodNS := req.URL.Query().Get("authmethod-ns"); methodNS != "" {
 		return BadRequestError{Reason: "Invalid query parameter: \"authmethod-ns\" - Namespaces are a Consul Enterprise feature"}

--- a/agent/reload.go
+++ b/agent/reload.go
@@ -1,0 +1,7 @@
+package agent
+
+import "github.com/hashicorp/consul/agent/config"
+
+// ConfigReloader is a function type which may be implemented to support reloading
+// of configuration.
+type ConfigReloader func(rtConfig *config.RuntimeConfig) error

--- a/agent/testagent.go
+++ b/agent/testagent.go
@@ -213,7 +213,7 @@ func (a *TestAgent) Start(t *testing.T) (err error) {
 	// Start the anti-entropy syncer
 	a.Agent.StartSync()
 
-	a.srv = &HTTPHandlers{agent: agent, denylist: NewDenylist(a.config.HTTPBlockEndpoints)}
+	a.srv = a.Agent.httpHandlers
 
 	if err := a.waitForUp(); err != nil {
 		a.Shutdown()

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -28,18 +28,20 @@ func TestUiIndex(t *testing.T) {
 
 	// Make the server
 	a := NewTestAgent(t, `
-		ui_dir = "`+uiDir+`"
+		ui_config {
+			dir = "`+uiDir+`"
+		}
 	`)
 	defer a.Shutdown()
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Create file
 	path := filepath.Join(a.Config.UIConfig.Dir, "my-file")
-	if err := ioutil.WriteFile(path, []byte("test"), 0777); err != nil {
+	if err := ioutil.WriteFile(path, []byte("test"), 0644); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
-	// Register node
+	// Request the custom file
 	req, _ := http.NewRequest("GET", "/ui/my-file", nil)
 	req.URL.Scheme = "http"
 	req.URL.Host = a.HTTPAddr()

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -34,7 +34,7 @@ func TestUiIndex(t *testing.T) {
 	testrpc.WaitForLeader(t, a.RPC, "dc1")
 
 	// Create file
-	path := filepath.Join(a.Config.UIDir, "my-file")
+	path := filepath.Join(a.Config.UIConfig.Dir, "my-file")
 	if err := ioutil.WriteFile(path, []byte("test"), 0777); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/agent/uiserver/buf_index_fs.go
+++ b/agent/uiserver/buf_index_fs.go
@@ -1,0 +1,21 @@
+package uiserver
+
+import (
+	"net/http"
+	"os"
+)
+
+// bufIndexFS is an implementation of http.FS that intercepts requests for
+// the index.html file and returns a pre-rendered file from memory.
+type bufIndexFS struct {
+	fs            http.FileSystem
+	indexRendered []byte
+	indexInfo     os.FileInfo
+}
+
+func (fs *bufIndexFS) Open(name string) (http.File, error) {
+	if name == "/index.html" {
+		return newBufferedFile(fs.indexRendered, fs.indexInfo), nil
+	}
+	return fs.fs.Open(name)
+}

--- a/agent/uiserver/buffered_file.go
+++ b/agent/uiserver/buffered_file.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// bufferedFile implements os.File and allows us to modify a file from disk by
+// bufferedFile implements http.File and allows us to modify a file from disk by
 // writing out the new version into a buffer and then serving file reads from
 // that.
 type bufferedFile struct {

--- a/agent/uiserver/buffered_file.go
+++ b/agent/uiserver/buffered_file.go
@@ -1,0 +1,67 @@
+package uiserver
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"time"
+)
+
+// bufferedFile implements os.File and allows us to modify a file from disk by
+// writing out the new version into a buffer and then serving file reads from
+// that.
+type bufferedFile struct {
+	buf  *bytes.Reader
+	info os.FileInfo
+}
+
+func newBufferedFile(buf []byte, info os.FileInfo) *bufferedFile {
+	return &bufferedFile{
+		buf:  bytes.NewReader(buf),
+		info: info,
+	}
+}
+
+func (t *bufferedFile) Read(p []byte) (n int, err error) {
+	return t.buf.Read(p)
+}
+
+func (t *bufferedFile) Seek(offset int64, whence int) (int64, error) {
+	return t.buf.Seek(offset, whence)
+}
+
+func (t *bufferedFile) Close() error {
+	return nil
+}
+
+func (t *bufferedFile) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, errors.New("not a directory")
+}
+
+func (t *bufferedFile) Stat() (os.FileInfo, error) {
+	return t, nil
+}
+
+func (t *bufferedFile) Name() string {
+	return t.info.Name()
+}
+
+func (t *bufferedFile) Size() int64 {
+	return int64(t.buf.Len())
+}
+
+func (t *bufferedFile) Mode() os.FileMode {
+	return t.info.Mode()
+}
+
+func (t *bufferedFile) ModTime() time.Time {
+	return t.info.ModTime()
+}
+
+func (t *bufferedFile) IsDir() bool {
+	return false
+}
+
+func (t *bufferedFile) Sys() interface{} {
+	return nil
+}

--- a/agent/uiserver/redirect_fs.go
+++ b/agent/uiserver/redirect_fs.go
@@ -1,0 +1,21 @@
+package uiserver
+
+import "net/http"
+
+// redirectFS is an http.FS that serves the index.html file for any path that is
+// not found on the underlying FS.
+//
+// TODO: it seems better to actually 404 bad paths or at least redirect them
+// rather than pretend index.html is everywhere but this is behavior changing
+// so I don't want to take it on as part of this refactor.
+type redirectFS struct {
+	fs http.FileSystem
+}
+
+func (fs *redirectFS) Open(name string) (http.File, error) {
+	file, err := fs.fs.Open(name)
+	if err != nil {
+		file, err = fs.fs.Open("/index.html")
+	}
+	return file, err
+}

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -1,0 +1,52 @@
+package uiserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/consul/agent/config"
+)
+
+// uiTemplateDataFromConfig returns the set of variables that should be injected
+// into the UI's Env based on the given runtime UI config.
+func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}, error) {
+
+	uiCfg := map[string]interface{}{
+		"metrics_provider": cfg.UIConfig.MetricsProvider,
+		// We explicitly MUST NOT pass the metrics_proxy object since it might
+		// contain add_headers with secrets that the UI shouldn't know e.g. API
+		// tokens for the backend. The provider should either require the proxy to
+		// be configured and then use that or hit the backend directly from the
+		// browser.
+		"metrics_proxy_enabled":   cfg.UIConfig.MetricsProxy.BaseURL != "",
+		"dashboard_url_templates": cfg.UIConfig.DashboardURLTemplates,
+	}
+
+	// Only set this if there is some actual JSON or we'll cause a JSON
+	// marshalling error later during serving which ends up being silent.
+	if cfg.UIConfig.MetricsProviderOptionsJSON != "" {
+		uiCfg["metrics_provider_options"] = json.RawMessage(cfg.UIConfig.MetricsProviderOptionsJSON)
+	}
+
+	d := map[string]interface{}{
+		"ContentPath": cfg.UIConfig.ContentPath,
+		"ACLsEnabled": cfg.ACLsEnabled,
+	}
+
+	err := uiTemplateDataFromConfigEnterprise(cfg, d, uiCfg)
+
+	// Render uiCfg down to JSON ready to inject into the template
+	bs, err := json.Marshal(uiCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed marshalling UI Env JSON: %s", err)
+	}
+	// Need to also URLEncode it as it is passed through a META tag value. Path
+	// variant is correct to avoid converting spaces to "+". Note we don't just
+	// use html/template because it strips comments and uses a different encoding
+	// for this param than Ember which is OK but just one more weird thing to
+	// account for in the source...
+	d["UIConfigJSON"] = url.PathEscape(string(bs))
+
+	return d, err
+}

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -35,6 +35,9 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 	}
 
 	err := uiTemplateDataFromConfigEnterprise(cfg, d, uiCfg)
+	if err != nil {
+		return nil, err
+	}
 
 	// Render uiCfg down to JSON ready to inject into the template
 	bs, err := json.Marshal(uiCfg)

--- a/agent/uiserver/ui_template_data_oss.go
+++ b/agent/uiserver/ui_template_data_oss.go
@@ -1,0 +1,9 @@
+// +build !consulent
+
+package uiserver
+
+import "github.com/hashicorp/consul/agent/config"
+
+func uiTemplateDataFromConfigEnterprise(_ *config.RuntimeConfig, _ map[string]interface{}, _ map[string]interface{}) error {
+	return nil
+}

--- a/agent/uiserver/uiserver.go
+++ b/agent/uiserver/uiserver.go
@@ -1,0 +1,176 @@
+package uiserver
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"text/template"
+
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/logging"
+	"github.com/hashicorp/go-hclog"
+)
+
+// Handler is the http.Handler that serves the Consul UI. It may serve from the
+// compiled-in AssetFS or from and external dir. It provides a few important
+// transformations on the index.html file and includes a proxy for metrics
+// backends.
+type Handler struct {
+	// state is a reloadableState struct accessed through an atomic value to make
+	// it safe to reload at run time. Each call to ServeHTTP will see the latest
+	// version of the state without internal locking needed.
+	state  atomic.Value
+	logger hclog.Logger
+}
+
+// reloadableState encapsulates all the state that might be modified during
+// ReloadConfig.
+type reloadableState struct {
+	cfg *config.UIConfig
+	srv http.Handler
+	err error
+}
+
+// NewHandler returns a Handler that can be used to serve UI http requests. It
+// accepts a full agent config since properties like ACLs being enabled affect
+// the UI so we need more than just UIConfig parts.
+func NewHandler(agentCfg *config.RuntimeConfig, logger hclog.Logger) *Handler {
+	h := &Handler{
+		logger: logger.Named(logging.UIServer),
+	}
+	// Don't return the error since this is likely the result of a
+	// misconfiguration and reloading config could fix it. Instead we'll capture
+	// it and return an error for all calls to ServeHTTP so the misconfiguration
+	// is visible. Sadly we can't log effectively
+	if err := h.ReloadConfig(agentCfg); err != nil {
+		h.state.Store(reloadableState{
+			err: err,
+		})
+	}
+	return h
+}
+
+// ServeHTTP implements http.Handler and serves UI HTTP requests
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// TODO: special case for compiled metrics assets in later PR
+	s := h.getState()
+	if s == nil {
+		panic("nil state")
+	}
+	if s.err != nil {
+		http.Error(w, "UI server is misconfigured.", http.StatusInternalServerError)
+		h.logger.Error("Failed to configure UI server: %s", s.err)
+		return
+	}
+	s.srv.ServeHTTP(w, r)
+}
+
+// ReloadConfig is called by the agent when the configuration is reloaded and
+// updates the UIConfig values the handler uses to serve requests.
+func (h *Handler) ReloadConfig(newCfg *config.RuntimeConfig) error {
+	newState := reloadableState{
+		cfg: &newCfg.UIConfig,
+	}
+
+	var fs http.FileSystem
+
+	if newCfg.UIConfig.Dir == "" {
+		// Serve from assetFS
+		fs = assetFS()
+	} else {
+		fs = http.Dir(newCfg.UIConfig.Dir)
+	}
+
+	// Render a new index.html with the new config values ready to serve.
+	buf, info, err := renderIndex(newCfg, fs)
+	if err != nil {
+		return err
+	}
+
+	// Create a new fs that serves the rendered index file or falls back to the
+	// underlying FS.
+	fs = &bufIndexFS{
+		fs:            fs,
+		indexRendered: buf,
+		indexInfo:     info,
+	}
+
+	// Wrap the buffering FS our redirect FS. This needs to happen later so that
+	// redirected requests for /index.html get served the rendered version not the
+	// original.
+	fs = &redirectFS{fs: fs}
+	newState.srv = http.FileServer(fs)
+
+	// Store the new state
+	h.state.Store(newState)
+	return nil
+}
+
+// getState is a helper to access the atomic internal state
+func (h *Handler) getState() *reloadableState {
+	if cfg, ok := h.state.Load().(reloadableState); ok {
+		return &cfg
+	}
+	return nil
+}
+
+func renderIndex(cfg *config.RuntimeConfig, fs http.FileSystem) ([]byte, os.FileInfo, error) {
+	// Open the original index.html
+	f, err := fs.Open("/index.html")
+	if err != nil {
+		return nil, nil, err
+	}
+	defer f.Close()
+
+	content, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed reading index.html: %s", err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed reading metadata for index.html: %s", err)
+	}
+
+	// Create template data from the current config.
+	tplData, err := uiTemplateDataFromConfig(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed loading UI config for template: %s", err)
+	}
+
+	// Sadly we can't perform all the replacements we need with Go template
+	// because some of them end up being rendered into an escaped json encoded
+	// meta tag by Ember build which messes up the Go template tags. After a few
+	// iterations of grossness, this seemed like the least bad for now. note we
+	// have to match the encoded double quotes around the JSON string value that
+	// is there as a placeholder so the end result is an actual JSON bool not a
+	// string containing "false" etc.
+	re := regexp.MustCompile(`%22__RUNTIME_BOOL_[A-Za-z0-9-_]+__%22`)
+
+	content = []byte(re.ReplaceAllStringFunc(string(content), func(str string) string {
+		// Trim the prefix and __ suffix
+		varName := strings.TrimSuffix(strings.TrimPrefix(str, "%22__RUNTIME_BOOL_"), "__%22")
+		if v, ok := tplData[varName].(bool); ok && v {
+			return "true"
+		}
+		return "false"
+	}))
+
+	tpl, err := template.New("index").Parse(string(content))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed parsing index.html template: %s", err)
+	}
+
+	var buf bytes.Buffer
+
+	err = tpl.Execute(&buf, tplData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to render index.html: %s", err)
+	}
+
+	return buf.Bytes(), info, nil
+}

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -1,0 +1,230 @@
+package uiserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/consul/agent/config"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIServer(t *testing.T) {
+	cases := []struct {
+		name            string
+		cfg             *config.RuntimeConfig
+		path            string
+		wantStatus      int
+		wantContains    []string
+		wantNotContains []string
+		wantEnv         map[string]interface{}
+		wantUICfgJSON   string
+	}{
+		{
+			name:         "basic UI serving",
+			cfg:          basicUIEnabledConfig(),
+			path:         "/", // Note /index.html redirects to /
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantEnv: map[string]interface{}{
+				"CONSUL_ACLS_ENABLED": false,
+			},
+		},
+		{
+			// TODO: is this really what we want? It's what we've always done but
+			// seems a bit odd to not do an actual 301 but instead serve the
+			// index.html from every path... It also breaks the UI probably.
+			name:         "unknown paths to serve index",
+			cfg:          basicUIEnabledConfig(),
+			path:         "/foo-bar-bazz-qux",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+		},
+		{
+			name: "injecting metrics vars",
+			cfg: basicUIEnabledConfig(
+				withMetricsProvider("foo"),
+				withMetricsProviderOptions(`{"bar":1}`),
+			),
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"<!-- CONSUL_VERSION:",
+			},
+			wantEnv: map[string]interface{}{
+				"CONSUL_ACLS_ENABLED": false,
+			},
+			wantUICfgJSON: `{
+				"metrics_provider":         "foo",
+				"metrics_provider_options": {
+					"bar":1
+				},
+				"metrics_proxy_enabled": false,
+				"dashboard_url_templates": null
+			}`,
+		},
+		{
+			name:         "acls enabled",
+			cfg:          basicUIEnabledConfig(withACLs()),
+			path:         "/",
+			wantStatus:   http.StatusOK,
+			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantEnv: map[string]interface{}{
+				"CONSUL_ACLS_ENABLED": true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(tc.cfg, testutil.Logger(t))
+
+			req := httptest.NewRequest("GET", tc.path, nil)
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, tc.wantStatus, rec.Code)
+			for _, want := range tc.wantContains {
+				require.Contains(t, rec.Body.String(), want)
+			}
+			for _, wantNot := range tc.wantNotContains {
+				require.NotContains(t, rec.Body.String(), wantNot)
+			}
+			env := extractEnv(t, rec.Body.String())
+			for k, v := range tc.wantEnv {
+				require.Equal(t, v, env[k])
+			}
+			if tc.wantUICfgJSON != "" {
+				require.JSONEq(t, tc.wantUICfgJSON, extractUIConfig(t, rec.Body.String()))
+			}
+		})
+	}
+}
+
+func extractMetaJSON(t *testing.T, name, content string) string {
+	t.Helper()
+
+	// Find and extract the env meta tag. Why yes I _am_ using regexp to parse
+	// HTML thanks for asking. In this case it's HTML with a very limited format
+	// so I don't feel too bad but maybe I should.
+	// https://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454
+	re := regexp.MustCompile(`<meta name="` + name + `+" content="([^"]*)"`)
+
+	matches := re.FindStringSubmatch(content)
+	require.Len(t, matches, 2, "didn't find the %s meta tag", name)
+
+	// Unescape the JSON
+	jsonStr, err := url.PathUnescape(matches[1])
+	require.NoError(t, err)
+
+	return jsonStr
+}
+
+func extractEnv(t *testing.T, content string) map[string]interface{} {
+	t.Helper()
+
+	js := extractMetaJSON(t, "consul-ui/config/environment", content)
+
+	var env map[string]interface{}
+
+	err := json.Unmarshal([]byte(js), &env)
+	require.NoError(t, err)
+
+	return env
+}
+
+func extractUIConfig(t *testing.T, content string) string {
+	t.Helper()
+	return extractMetaJSON(t, "consul-ui/ui_config", content)
+}
+
+type cfgFunc func(cfg *config.RuntimeConfig)
+
+func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
+	cfg := &config.RuntimeConfig{
+		UIConfig: config.UIConfig{
+			Enabled: true,
+		},
+	}
+	for _, f := range opts {
+		f(cfg)
+	}
+	return cfg
+}
+
+func withACLs() cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.ACLDatacenter = "dc1"
+		cfg.ACLDefaultPolicy = "deny"
+		cfg.ACLsEnabled = true
+	}
+}
+
+func withMetricsProvider(name string) cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.UIConfig.MetricsProvider = name
+	}
+}
+
+func withMetricsProviderOptions(jsonStr string) cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.UIConfig.MetricsProviderOptionsJSON = jsonStr
+	}
+}
+
+// TestMultipleIndexRequests validates that the buffered file mechanism works
+// beyond the first request. The initial implementation did not as it shared an
+// bytes.Reader between callers.
+func TestMultipleIndexRequests(t *testing.T) {
+	h := NewHandler(basicUIEnabledConfig(), testutil.Logger(t))
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "<!-- CONSUL_VERSION:",
+			"request %d didn't return expected content", i+1)
+	}
+}
+
+func TestReload(t *testing.T) {
+	h := NewHandler(basicUIEnabledConfig(), testutil.Logger(t))
+
+	{
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "<!-- CONSUL_VERSION:")
+		require.NotContains(t, rec.Body.String(), "exotic-metrics-provider-name")
+	}
+
+	// Reload the config with the changed metrics provider name
+	newCfg := basicUIEnabledConfig(
+		withMetricsProvider("exotic-metrics-provider-name"),
+	)
+	h.ReloadConfig(newCfg)
+
+	// Now we should see the new provider name in the output of index
+	{
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Contains(t, rec.Body.String(), "<!-- CONSUL_VERSION:")
+		require.Contains(t, rec.Body.String(), "exotic-metrics-provider-name")
+	}
+}

--- a/build-support/functions/20-build.sh
+++ b/build-support/functions/20-build.sh
@@ -165,7 +165,7 @@ function build_assetfs {
       (
          tar -c pkg/web_ui GNUmakefile | docker cp - ${container_id}:/consul &&
          status "Running build in container" && docker start -i ${container_id} &&
-         status "Copying back artifacts" && docker cp ${container_id}:/consul/bindata_assetfs.go ${sdir}/agent/bindata_assetfs.go
+         status "Copying back artifacts" && docker cp ${container_id}:/consul/bindata_assetfs.go ${sdir}/agent/uiserver/bindata_assetfs.go
       )
       ret=$?
       docker rm ${container_id} > /dev/null

--- a/build-support/functions/30-release.sh
+++ b/build-support/functions/30-release.sh
@@ -477,7 +477,7 @@ function build_release {
       
       if is_set "${do_tag}"
       then
-         git add "${sdir}/agent/bindata_assetfs.go"
+         git add "${sdir}/agent/uiserver/bindata_assetfs.go"
          if test $? -ne 0
          then
             err "ERROR: Failed to git add the assetfs file" 

--- a/build-support/functions/40-publish.sh
+++ b/build-support/functions/40-publish.sh
@@ -99,7 +99,7 @@ function confirm_git_push_changes {
                ;;
             ?)
                # bindata_assetfs.go will make these meaningless
-               git_diff "$(pwd)" ":!agent/bindata_assetfs.go"|| ret 1
+               git_diff "$(pwd)" ":!agent/uiserver/bindata_assetfs.go"|| ret 1
                answer=""
                ;;
             * )

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,6 +39,6 @@ github_checks:
   annotations: false
 
 ignore:
-  - "agent/bindata_assetfs.go"
+  - "agent/uiserver/bindata_assetfs.go"
   - "vendor/**/*"
   - "**/*.pb.go"

--- a/logging/names.go
+++ b/logging/names.go
@@ -52,6 +52,7 @@ const (
 	TLSUtil            string = "tlsutil"
 	Transaction        string = "txn"
 	UsageMetrics       string = "usage_metrics"
+	UIServer           string = "ui_server"
 	WAN                string = "wan"
 	Watch              string = "watch"
 	Vault              string = "vault"

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -120,16 +120,18 @@ module.exports = function(environment, $ = process.env) {
       });
       break;
     case environment === 'production':
-      // Make sure all templated variables check for existence first
-      // before outputting them, this means they all should be conditionals
       ENV = Object.assign({}, ENV, {
-        // This ENV var is a special placeholder that Consul will replace
-        // entirely with multiple vars from the runtime config for example
-        // CONSUL_ACLs_ENABLED and CONSUL_NSPACES_ENABLED. The actual key here
-        // won't really exist in the actual ember ENV when it's being served
-        // through Consul. See settingsInjectedIndexFS.Open in Go code for the
-        // details.
-        CONSUL_UI_SETTINGS_PLACEHOLDER: "__CONSUL_UI_SETTINGS_GO_HERE__",
+        // These values are placeholders that are replaced when Consul renders
+        // the index.html based on runtime config. They can't use Go template
+        // syntax since this object ends up JSON and URLencoded in an HTML meta
+        // tag which obscured the Go template tag syntax.
+        //
+        // __RUNTIME_BOOL_Xxxx__ will be replaced with either "true" or "false"
+        // depending on whether the named variable is true or valse in the data
+        // returned from `uiTemplateDataFromConfig`.
+        CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
+        CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
+        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NSpacesEnabled__',
       });
       break;
   }

--- a/ui-v2/lib/startup/templates/head.html.js
+++ b/ui-v2/lib/startup/templates/head.html.js
@@ -1,5 +1,7 @@
 module.exports = ({ appName, environment, rootURL, config }) => `
   <!-- CONSUL_VERSION: ${config.CONSUL_VERSION} -->
+  <meta name="consul-ui/ui_config" content="{{ .UIConfigJSON }}" />
+
   <link rel="icon" type="image/png" href="${rootURL}assets/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="${rootURL}assets/favicon-16x16.png" sizes="16x16">
   <link integrity="" rel="stylesheet" href="${rootURL}assets/vendor.css">


### PR DESCRIPTION
This PR adds new configuration for the UI to support up-coming work on integrating metrics. None of the new configurations do anything yet this is just the wiring for them. Building the features will come in subsequent PRs.

Following the checklist in `/contributing`:

## Adding a Simple Config Field for Client Agents

 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL blobs in
   `TestFullConfig` in `agent/config/runtime_test.go`, it should fail now, then
   add the same random value to the expected struct in that test so it passes
   again.
 - [x] Add the new field and it's default value to `TestSanitize` in the same
   file. (Running the test first gives you a nice diff which can save working
   out where etc.)
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [x] Add validation to Validate in `agent/config/builder.go`.
      - [x] Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.
 - [x] **If** your new config field needs a non-zero-value default.
      - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [ ] Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.
 - [x] **If** your config should take effect on a reload/HUP.
      - [x] Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [x] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [ ] Add documentation to `website/source/docs/agent/options.html.md`.

## TODO

As can be seen above I've not yet added the documentation for these new configurations. I intend to do that in a later PR once more of the feature is working and we can be more accurate about the actual effect in case any of it doesn't work out as planned!

