### PR TITLE
Use errors.Is() in IsErrEOF()

### DIFF
--- a/lib/eof.go
+++ b/lib/eof.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"errors"
 	"io"
 	"strings"
 
@@ -13,13 +14,14 @@ var yamuxSessionShutdown = yamux.ErrSessionShutdown.Error()
 // IsErrEOF returns true if we get an EOF error from the socket itself, or
 // an EOF equivalent error from yamux.
 func IsErrEOF(err error) bool {
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		return true
 	}
 
 	errStr := err.Error()
 	if strings.Contains(errStr, yamuxStreamClosed) ||
-		strings.Contains(errStr, yamuxSessionShutdown) {
+		strings.Contains(errStr, yamuxSessionShutdown) ||
+		strings.HasSuffix(errStr, io.EOF.Error()) {
 		return true
 	}
 

--- a/lib/eof.go
+++ b/lib/eof.go
@@ -26,12 +26,9 @@ func IsErrEOF(err error) bool {
 		return true
 	}
 
-	if srvErr, ok := err.(rpc.ServerError); ok {
-		return strings.HasSuffix(srvErr.Error(), fmt.Sprintf(": %s", io.EOF.Error()))
-	}
-
-	if srvErr, ok := errors.Unwrap(err).(rpc.ServerError); ok {
-		return strings.HasSuffix(srvErr.Error(), fmt.Sprintf(": %s", io.EOF.Error()))
+	var serverError rpc.ServerError
+	if errors.As(err, &serverError) {
+		return strings.HasSuffix(err.Error(), fmt.Sprintf(": %s", io.EOF.Error()))
 	}
 
 	return false

--- a/lib/eof_test.go
+++ b/lib/eof_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestErrIsEOF(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		name string
 		err  error
@@ -23,15 +21,12 @@ func TestErrIsEOF(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			require.True(t, IsErrEOF(tt.err))
 		})
 		t.Run(fmt.Sprintf("Wrapped %s", tt.name), func(t *testing.T) {
-			t.Parallel()
 			require.True(t, IsErrEOF(fmt.Errorf("test: %w", tt.err)))
 		})
 		t.Run(fmt.Sprintf("String suffix is %s", tt.name), func(t *testing.T) {
-			t.Parallel()
 			require.True(t, IsErrEOF(fmt.Errorf("rpc error: %s", tt.err.Error())))
 		})
 	}

--- a/lib/eof_test.go
+++ b/lib/eof_test.go
@@ -1,0 +1,38 @@
+package lib
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/hashicorp/yamux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrIsEOF(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		name string
+		err  error
+	}{
+		{name: "EOF", err: io.EOF},
+		{name: "yamuxStreamClosed", err: yamux.ErrStreamClosed},
+		{name: "yamuxSessionShutdown", err: yamux.ErrSessionShutdown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.True(t, IsErrEOF(tt.err))
+		})
+		t.Run(fmt.Sprintf("Wrapped %s", tt.name), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, IsErrEOF(fmt.Errorf("test: %w", tt.err)))
+		})
+		t.Run(fmt.Sprintf("String suffix is %s", tt.name), func(t *testing.T) {
+			t.Parallel()
+			require.True(t, IsErrEOF(fmt.Errorf("rpc error: %s", tt.err.Error())))
+		})
+	}
+}


### PR DESCRIPTION
IsErrEOF returns false when it should return true in a couple of cases:

1. if the error has been wrapped in another error (for example, if EOF
is wrapped in an RPC error)
2. if the error has been created from an Error field in an RPC response
(as it is the case in CallWithCodec in the net-rpc-msgpackrpc package
for example)