### PR TITLE
server: create new memdb table for storing system metadata

### DIFF
--- a/.changelog/8703.txt
+++ b/.changelog/8703.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+server: create new memdb table for storing system metadata
+```
+

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -577,14 +577,14 @@ func (c *FSM) applySystemMetadataOperation(buf []byte, index uint64) interface{}
 	}
 
 	switch req.Op {
-	case structs.SystemMetadataOpUpsert:
+	case structs.SystemMetadataUpsert:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "upsert"}})
 		if err := c.state.SystemMetadataSet(index, req.Entries); err != nil {
 			return err
 		}
 		return true
-	case structs.SystemMetadataOpDelete:
+	case structs.SystemMetadataDelete:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "delete"}})
 		return c.state.SystemMetadataDelete(index, req.Entries)

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -580,14 +580,14 @@ func (c *FSM) applySystemMetadataOperation(buf []byte, index uint64) interface{}
 	case structs.SystemMetadataUpsert:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "upsert"}})
-		if err := c.state.SystemMetadataSet(index, req.Entries); err != nil {
+		if err := c.state.SystemMetadataSet(index, req.Entry); err != nil {
 			return err
 		}
 		return true
 	case structs.SystemMetadataDelete:
 		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
 			[]metrics.Label{{Name: "op", Value: "delete"}})
-		return c.state.SystemMetadataDelete(index, req.Entries)
+		return c.state.SystemMetadataDelete(index, req.Entry)
 	default:
 		return fmt.Errorf("invalid system metadata operation type: %v", req.Op)
 	}

--- a/agent/consul/fsm/commands_oss.go
+++ b/agent/consul/fsm/commands_oss.go
@@ -37,6 +37,7 @@ func init() {
 	registerCommand(structs.ACLAuthMethodSetRequestType, (*FSM).applyACLAuthMethodSetOperation)
 	registerCommand(structs.ACLAuthMethodDeleteRequestType, (*FSM).applyACLAuthMethodDeleteOperation)
 	registerCommand(structs.FederationStateRequestType, (*FSM).applyFederationStateOperation)
+	registerCommand(structs.SystemMetadataRequestType, (*FSM).applySystemMetadataOperation)
 }
 
 func (c *FSM) applyRegister(buf []byte, index uint64) interface{} {
@@ -566,5 +567,28 @@ func (c *FSM) applyFederationStateOperation(buf []byte, index uint64) interface{
 		return c.state.FederationStateDelete(index, req.State.Datacenter)
 	default:
 		return fmt.Errorf("invalid federation state operation type: %v", req.Op)
+	}
+}
+
+func (c *FSM) applySystemMetadataOperation(buf []byte, index uint64) interface{} {
+	var req structs.SystemMetadataRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	switch req.Op {
+	case structs.SystemMetadataOpUpsert:
+		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
+			[]metrics.Label{{Name: "op", Value: "upsert"}})
+		if err := c.state.SystemMetadataSet(index, req.Entries); err != nil {
+			return err
+		}
+		return true
+	case structs.SystemMetadataOpDelete:
+		defer metrics.MeasureSinceWithLabels([]string{"fsm", "system_metadata"}, time.Now(),
+			[]metrics.Label{{Name: "op", Value: "delete"}})
+		return c.state.SystemMetadataDelete(index, req.Entries)
+	default:
+		return fmt.Errorf("invalid system metadata operation type: %v", req.Op)
 	}
 }

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -400,11 +400,10 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	}))
 
 	// system metadata
-	systemMetadataEntries := []*structs.SystemMetadataEntry{
-		{Key: "key1", Value: "val1"},
-		{Key: "key2", Value: "val2"},
+	systemMetadataEntry := &structs.SystemMetadataEntry{
+		Key: "key1", Value: "val1",
 	}
-	require.NoError(t, fsm.state.SystemMetadataSet(25, systemMetadataEntries))
+	require.NoError(t, fsm.state.SystemMetadataSet(25, systemMetadataEntry))
 
 	// Snapshot
 	snap, err := fsm.Snapshot()
@@ -670,7 +669,8 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	// Verify system metadata is restored.
 	_, systemMetadataLoaded, err := fsm2.state.SystemMetadataList(nil)
 	require.NoError(t, err)
-	require.Len(t, systemMetadataLoaded, len(systemMetadataEntries))
+	require.Len(t, systemMetadataLoaded, 1)
+	require.Equal(t, systemMetadataEntry, systemMetadataLoaded[0])
 
 	// Snapshot
 	snap, err = fsm2.Snapshot()

--- a/agent/consul/fsm/snapshot_oss_test.go
+++ b/agent/consul/fsm/snapshot_oss_test.go
@@ -399,6 +399,13 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 		ServiceID: "web",
 	}))
 
+	// system metadata
+	systemMetadataEntries := []*structs.SystemMetadataEntry{
+		{Key: "key1", Value: "val1"},
+		{Key: "key2", Value: "val2"},
+	}
+	require.NoError(t, fsm.state.SystemMetadataSet(25, systemMetadataEntries))
+
 	// Snapshot
 	snap, err := fsm.Snapshot()
 	require.NoError(t, err)
@@ -659,6 +666,11 @@ func TestFSM_SnapshotRestore_OSS(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(nodes), nodeCount)
 	require.NotZero(t, idx)
+
+	// Verify system metadata is restored.
+	_, systemMetadataLoaded, err := fsm2.state.SystemMetadataList(nil)
+	require.NoError(t, err)
+	require.Len(t, systemMetadataLoaded, len(systemMetadataEntries))
 
 	// Snapshot
 	snap, err = fsm2.Snapshot()

--- a/agent/consul/state/system_metadata.go
+++ b/agent/consul/state/system_metadata.go
@@ -45,12 +45,12 @@ func (s *Snapshot) SystemMetadataEntries() ([]*structs.SystemMetadataEntry, erro
 }
 
 // SystemMetadataEntry is used when restoring from a snapshot.
-func (s *Restore) SystemMetadataEntry(g *structs.SystemMetadataEntry) error {
+func (s *Restore) SystemMetadataEntry(entry *structs.SystemMetadataEntry) error {
 	// Insert
-	if err := s.tx.Insert(systemMetadataTableName, g); err != nil {
+	if err := s.tx.Insert(systemMetadataTableName, entry); err != nil {
 		return fmt.Errorf("failed restoring system metadata object: %s", err)
 	}
-	if err := indexUpdateMaxTxn(s.tx, g.ModifyIndex, systemMetadataTableName); err != nil {
+	if err := indexUpdateMaxTxn(s.tx, entry.ModifyIndex, systemMetadataTableName); err != nil {
 		return fmt.Errorf("failed updating index: %s", err)
 	}
 

--- a/agent/consul/state/system_metadata.go
+++ b/agent/consul/state/system_metadata.go
@@ -133,7 +133,7 @@ func systemMetadataGetTxn(tx ReadTxn, ws memdb.WatchSet, key string) (uint64, *s
 
 	entry, ok := existing.(*structs.SystemMetadataEntry)
 	if !ok {
-		return 0, nil, fmt.Errorf("system metadata %q is an invalid type: %T", key, entry)
+		return 0, nil, fmt.Errorf("system metadata %q is an invalid type: %T", key, existing)
 	}
 
 	return idx, entry, nil

--- a/agent/consul/state/system_metadata.go
+++ b/agent/consul/state/system_metadata.go
@@ -58,14 +58,12 @@ func (s *Restore) SystemMetadataEntry(entry *structs.SystemMetadataEntry) error 
 }
 
 // SystemMetadataSet is called to do an upsert of a set of system metadata entries.
-func (s *Store) SystemMetadataSet(idx uint64, entries []*structs.SystemMetadataEntry) error {
+func (s *Store) SystemMetadataSet(idx uint64, entry *structs.SystemMetadataEntry) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
-	for _, entry := range entries {
-		if err := systemMetadataSetTxn(tx, idx, entry); err != nil {
-			return err
-		}
+	if err := systemMetadataSetTxn(tx, idx, entry); err != nil {
+		return err
 	}
 
 	return tx.Commit()
@@ -163,14 +161,12 @@ func systemMetadataListTxn(tx ReadTxn, ws memdb.WatchSet) (uint64, []*structs.Sy
 	return idx, results, nil
 }
 
-func (s *Store) SystemMetadataDelete(idx uint64, entries []*structs.SystemMetadataEntry) error {
+func (s *Store) SystemMetadataDelete(idx uint64, entry *structs.SystemMetadataEntry) error {
 	tx := s.db.WriteTxn(idx)
 	defer tx.Abort()
 
-	for _, entry := range entries {
-		if err := systemMetadataDeleteTxn(tx, idx, entry.Key); err != nil {
-			return err
-		}
+	if err := systemMetadataDeleteTxn(tx, idx, entry.Key); err != nil {
+		return err
 	}
 
 	return tx.Commit()

--- a/agent/consul/state/system_metadata.go
+++ b/agent/consul/state/system_metadata.go
@@ -1,0 +1,197 @@
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/structs"
+	memdb "github.com/hashicorp/go-memdb"
+)
+
+const systemMetadataTableName = "system-metadata"
+
+func systemMetadataTableSchema() *memdb.TableSchema {
+	return &memdb.TableSchema{
+		Name: systemMetadataTableName,
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.StringFieldIndex{
+					Field:     "Key",
+					Lowercase: true,
+				},
+			},
+		},
+	}
+}
+func init() {
+	registerSchema(systemMetadataTableSchema)
+}
+
+// SystemMetadataEntries used to pull all the system metadata entries for the snapshot.
+func (s *Snapshot) SystemMetadataEntries() ([]*structs.SystemMetadataEntry, error) {
+	entries, err := s.tx.Get(systemMetadataTableName, "id")
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []*structs.SystemMetadataEntry
+	for wrapped := entries.Next(); wrapped != nil; wrapped = entries.Next() {
+		ret = append(ret, wrapped.(*structs.SystemMetadataEntry))
+	}
+
+	return ret, nil
+}
+
+// SystemMetadataEntry is used when restoring from a snapshot.
+func (s *Restore) SystemMetadataEntry(g *structs.SystemMetadataEntry) error {
+	// Insert
+	if err := s.tx.Insert(systemMetadataTableName, g); err != nil {
+		return fmt.Errorf("failed restoring system metadata object: %s", err)
+	}
+	if err := indexUpdateMaxTxn(s.tx, g.ModifyIndex, systemMetadataTableName); err != nil {
+		return fmt.Errorf("failed updating index: %s", err)
+	}
+
+	return nil
+}
+
+// SystemMetadataSet is called to do an upsert of a set of system metadata entries.
+func (s *Store) SystemMetadataSet(idx uint64, entries []*structs.SystemMetadataEntry) error {
+	tx := s.db.WriteTxn(idx)
+	defer tx.Abort()
+
+	for _, entry := range entries {
+		if err := systemMetadataSetTxn(tx, idx, entry); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// systemMetadataSetTxn upserts a system metadata inside of a transaction.
+func systemMetadataSetTxn(tx *txn, idx uint64, entry *structs.SystemMetadataEntry) error {
+	// The only validation we care about is non-empty keys.
+	if entry.Key == "" {
+		return fmt.Errorf("missing key on system metadata")
+	}
+
+	// Check for existing.
+	var existing *structs.SystemMetadataEntry
+	existingRaw, err := tx.First(systemMetadataTableName, "id", entry.Key)
+	if err != nil {
+		return fmt.Errorf("failed system metadata lookup: %s", err)
+	}
+
+	if existingRaw != nil {
+		existing = existingRaw.(*structs.SystemMetadataEntry)
+	}
+
+	// Set the indexes
+	if existing != nil {
+		entry.CreateIndex = existing.CreateIndex
+		entry.ModifyIndex = idx
+	} else {
+		entry.CreateIndex = idx
+		entry.ModifyIndex = idx
+	}
+
+	// Insert the system metadata and update the index
+	if err := tx.Insert(systemMetadataTableName, entry); err != nil {
+		return fmt.Errorf("failed inserting system metadata: %s", err)
+	}
+	if err := tx.Insert("index", &IndexEntry{systemMetadataTableName, idx}); err != nil {
+		return fmt.Errorf("failed updating index: %v", err)
+	}
+
+	return nil
+}
+
+// SystemMetadataGet is called to get a system metadata.
+func (s *Store) SystemMetadataGet(ws memdb.WatchSet, key string) (uint64, *structs.SystemMetadataEntry, error) {
+	tx := s.db.ReadTxn()
+	defer tx.Abort()
+	return systemMetadataGetTxn(tx, ws, key)
+}
+
+func systemMetadataGetTxn(tx ReadTxn, ws memdb.WatchSet, key string) (uint64, *structs.SystemMetadataEntry, error) {
+	// Get the index
+	idx := maxIndexTxn(tx, systemMetadataTableName)
+
+	// Get the existing contents.
+	watchCh, existing, err := tx.FirstWatch(systemMetadataTableName, "id", key)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed system metadata lookup: %s", err)
+	}
+	ws.Add(watchCh)
+
+	if existing == nil {
+		return idx, nil, nil
+	}
+
+	entry, ok := existing.(*structs.SystemMetadataEntry)
+	if !ok {
+		return 0, nil, fmt.Errorf("system metadata %q is an invalid type: %T", key, entry)
+	}
+
+	return idx, entry, nil
+}
+
+// SystemMetadataList is called to get all system metadata objects.
+func (s *Store) SystemMetadataList(ws memdb.WatchSet) (uint64, []*structs.SystemMetadataEntry, error) {
+	tx := s.db.ReadTxn()
+	defer tx.Abort()
+	return systemMetadataListTxn(tx, ws)
+}
+
+func systemMetadataListTxn(tx ReadTxn, ws memdb.WatchSet) (uint64, []*structs.SystemMetadataEntry, error) {
+	// Get the index
+	idx := maxIndexTxn(tx, systemMetadataTableName)
+
+	iter, err := tx.Get(systemMetadataTableName, "id")
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed system metadata lookup: %s", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	var results []*structs.SystemMetadataEntry
+	for v := iter.Next(); v != nil; v = iter.Next() {
+		results = append(results, v.(*structs.SystemMetadataEntry))
+	}
+	return idx, results, nil
+}
+
+func (s *Store) SystemMetadataDelete(idx uint64, entries []*structs.SystemMetadataEntry) error {
+	tx := s.db.WriteTxn(idx)
+	defer tx.Abort()
+
+	for _, entry := range entries {
+		if err := systemMetadataDeleteTxn(tx, idx, entry.Key); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func systemMetadataDeleteTxn(tx *txn, idx uint64, key string) error {
+	// Try to retrieve the existing system metadata.
+	existing, err := tx.First(systemMetadataTableName, "id", key)
+	if err != nil {
+		return fmt.Errorf("failed system metadata lookup: %s", err)
+	}
+	if existing == nil {
+		return nil
+	}
+
+	// Delete the system metadata from the DB and update the index.
+	if err := tx.Delete(systemMetadataTableName, existing); err != nil {
+		return fmt.Errorf("failed removing system metadata: %s", err)
+	}
+	if err := tx.Insert("index", &IndexEntry{systemMetadataTableName, idx}); err != nil {
+		return fmt.Errorf("failed updating index: %s", err)
+	}
+	return nil
+}

--- a/agent/consul/state/system_metadata_test.go
+++ b/agent/consul/state/system_metadata_test.go
@@ -36,11 +36,20 @@ func TestStore_SystemMetadata(t *testing.T) {
 
 	checkListAndGet(t, map[string]string{})
 
+	var nextIndex uint64
+
 	// Create 3 keys
-	require.NoError(t, s.SystemMetadataSet(1, []*structs.SystemMetadataEntry{
-		{Key: "key1", Value: "val1"},
-		{Key: "key2", Value: "val2"},
-		{Key: "key3"},
+	nextIndex++
+	require.NoError(t, s.SystemMetadataSet(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key1", Value: "val1",
+	}))
+	nextIndex++
+	require.NoError(t, s.SystemMetadataSet(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key2", Value: "val2",
+	}))
+	nextIndex++
+	require.NoError(t, s.SystemMetadataSet(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key3",
 	}))
 
 	checkListAndGet(t, map[string]string{
@@ -55,9 +64,13 @@ func TestStore_SystemMetadata(t *testing.T) {
 	require.Nil(t, entry)
 
 	// Delete one that exists and one that does not
-	require.NoError(t, s.SystemMetadataDelete(2, []*structs.SystemMetadataEntry{
-		{Key: "key2"},
-		{Key: "key4"},
+	nextIndex++
+	require.NoError(t, s.SystemMetadataDelete(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key2",
+	}))
+	nextIndex++
+	require.NoError(t, s.SystemMetadataDelete(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key4",
 	}))
 
 	checkListAndGet(t, map[string]string{
@@ -66,9 +79,12 @@ func TestStore_SystemMetadata(t *testing.T) {
 	})
 
 	// Update one that exists and add another one.
-	require.NoError(t, s.SystemMetadataSet(1, []*structs.SystemMetadataEntry{
-		{Key: "key3", Value: "val3"},
-		{Key: "key4", Value: "val4"},
+	nextIndex++
+	require.NoError(t, s.SystemMetadataSet(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key3", Value: "val3",
+	}))
+	require.NoError(t, s.SystemMetadataSet(nextIndex, &structs.SystemMetadataEntry{
+		Key: "key4", Value: "val4",
 	}))
 
 	checkListAndGet(t, map[string]string{

--- a/agent/consul/state/system_metadata_test.go
+++ b/agent/consul/state/system_metadata_test.go
@@ -1,0 +1,80 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_SystemMetadata(t *testing.T) {
+	s := testStateStore(t)
+
+	mapify := func(entries []*structs.SystemMetadataEntry) map[string]string {
+		m := make(map[string]string)
+		for _, entry := range entries {
+			m[entry.Key] = entry.Value
+		}
+		return m
+	}
+
+	checkListAndGet := func(t *testing.T, expect map[string]string) {
+		// List all
+		_, entries, err := s.SystemMetadataList(nil)
+		require.NoError(t, err)
+		require.Len(t, entries, len(expect))
+		require.Equal(t, expect, mapify(entries))
+
+		// Read each
+		for expectKey, expectVal := range expect {
+			_, entry, err := s.SystemMetadataGet(nil, expectKey)
+			require.NoError(t, err)
+			require.NotNil(t, entry)
+			require.Equal(t, expectVal, entry.Value)
+		}
+	}
+
+	checkListAndGet(t, map[string]string{})
+
+	// Create 3 keys
+	require.NoError(t, s.SystemMetadataSet(1, []*structs.SystemMetadataEntry{
+		{Key: "key1", Value: "val1"},
+		{Key: "key2", Value: "val2"},
+		{Key: "key3"},
+	}))
+
+	checkListAndGet(t, map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "",
+	})
+
+	// Missing results are nil
+	_, entry, err := s.SystemMetadataGet(nil, "key4")
+	require.NoError(t, err)
+	require.Nil(t, entry)
+
+	// Delete one that exists and one that does not
+	require.NoError(t, s.SystemMetadataDelete(2, []*structs.SystemMetadataEntry{
+		{Key: "key2"},
+		{Key: "key4"},
+	}))
+
+	checkListAndGet(t, map[string]string{
+		"key1": "val1",
+		"key3": "",
+	})
+
+	// Update one that exists and add another one.
+	require.NoError(t, s.SystemMetadataSet(1, []*structs.SystemMetadataEntry{
+		{Key: "key3", Value: "val3"},
+		{Key: "key4", Value: "val4"},
+	}))
+
+	checkListAndGet(t, map[string]string{
+		"key1": "val1",
+		"key3": "val3",
+		"key4": "val4",
+	})
+
+}

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -71,7 +71,7 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 
 func setSystemMetadataKey(s *Server, key, val string) error {
 	args := &structs.SystemMetadataRequest{
-		Op: structs.SystemMetadataOpUpsert,
+		Op: structs.SystemMetadataUpsert,
 		Entries: []*structs.SystemMetadataEntry{
 			{Key: key, Value: val},
 		},
@@ -90,7 +90,7 @@ func setSystemMetadataKey(s *Server, key, val string) error {
 
 func deleteSystemMetadataKey(s *Server, key string) error {
 	args := &structs.SystemMetadataRequest{
-		Op: structs.SystemMetadataOpDelete,
+		Op: structs.SystemMetadataDelete,
 		Entries: []*structs.SystemMetadataEntry{
 			{Key: key},
 		},

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -1,0 +1,108 @@
+package consul
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/testrpc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeader_SystemMetadata_CRUD(t *testing.T) {
+	// This test is a little strange because it is testing behavior that
+	// doesn't have an exposed RPC. We're just testing the full round trip of
+	// raft+fsm For now,
+
+	dir1, srv := testServerWithConfig(t, nil)
+	defer os.RemoveAll(dir1)
+	defer srv.Shutdown()
+	codec := rpcClient(t, srv)
+	defer codec.Close()
+
+	testrpc.WaitForLeader(t, srv.RPC, "dc1")
+
+	state := srv.fsm.State()
+
+	// Initially empty
+	_, entries, err := state.SystemMetadataList(nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 0)
+
+	// Create 3
+	require.NoError(t, setSystemMetadataKey(srv, "key1", "val1"))
+	require.NoError(t, setSystemMetadataKey(srv, "key2", "val2"))
+	require.NoError(t, setSystemMetadataKey(srv, "key3", ""))
+
+	mapify := func(entries []*structs.SystemMetadataEntry) map[string]string {
+		m := make(map[string]string)
+		for _, entry := range entries {
+			m[entry.Key] = entry.Value
+		}
+		return m
+	}
+
+	_, entries, err = state.SystemMetadataList(nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	require.Equal(t, map[string]string{
+		"key1": "val1",
+		"key2": "val2",
+		"key3": "",
+	}, mapify(entries))
+
+	// Update one and delete one.
+	require.NoError(t, setSystemMetadataKey(srv, "key3", "val3"))
+	require.NoError(t, deleteSystemMetadataKey(srv, "key1"))
+
+	_, entries, err = state.SystemMetadataList(nil)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	require.Equal(t, map[string]string{
+		"key2": "val2",
+		"key3": "val3",
+	}, mapify(entries))
+}
+
+// Note when this behavior is actually used, consider promoting these 2
+// functions out of test code.
+
+func setSystemMetadataKey(s *Server, key, val string) error {
+	args := &structs.SystemMetadataRequest{
+		Op: structs.SystemMetadataOpUpsert,
+		Entries: []*structs.SystemMetadataEntry{
+			{Key: key, Value: val},
+		},
+	}
+
+	resp, err := s.raftApply(structs.SystemMetadataRequestType, args)
+	if err != nil {
+		return err
+	}
+	if respErr, ok := resp.(error); ok {
+		return respErr
+	}
+
+	return nil
+}
+
+func deleteSystemMetadataKey(s *Server, key string) error {
+	args := &structs.SystemMetadataRequest{
+		Op: structs.SystemMetadataOpDelete,
+		Entries: []*structs.SystemMetadataEntry{
+			{Key: key},
+		},
+	}
+
+	resp, err := s.raftApply(structs.SystemMetadataRequestType, args)
+	if err != nil {
+		return err
+	}
+	if respErr, ok := resp.(error); ok {
+		return respErr
+	}
+
+	return nil
+}

--- a/agent/consul/system_metadata_test.go
+++ b/agent/consul/system_metadata_test.go
@@ -72,8 +72,8 @@ func TestLeader_SystemMetadata_CRUD(t *testing.T) {
 func setSystemMetadataKey(s *Server, key, val string) error {
 	args := &structs.SystemMetadataRequest{
 		Op: structs.SystemMetadataUpsert,
-		Entries: []*structs.SystemMetadataEntry{
-			{Key: key, Value: val},
+		Entry: &structs.SystemMetadataEntry{
+			Key: key, Value: val,
 		},
 	}
 
@@ -91,8 +91,8 @@ func setSystemMetadataKey(s *Server, key, val string) error {
 func deleteSystemMetadataKey(s *Server, key string) error {
 	args := &structs.SystemMetadataRequest{
 		Op: structs.SystemMetadataDelete,
-		Entries: []*structs.SystemMetadataEntry{
-			{Key: key},
+		Entry: &structs.SystemMetadataEntry{
+			Key: key,
 		},
 	}
 

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -68,6 +68,7 @@ const (
 	ACLAuthMethodDeleteRequestType              = 28
 	ChunkingStateType                           = 29
 	FederationStateRequestType                  = 30
+	SystemMetadataRequestType                   = 31
 )
 
 const (

--- a/agent/structs/system_metadata.go
+++ b/agent/structs/system_metadata.go
@@ -4,8 +4,8 @@ package structs
 type SystemMetadataOp string
 
 const (
-	SystemMetadataOpUpsert SystemMetadataOp = "upsert"
-	SystemMetadataOpDelete SystemMetadataOp = "delete"
+	SystemMetadataUpsert SystemMetadataOp = "upsert"
+	SystemMetadataDelete SystemMetadataOp = "delete"
 )
 
 // SystemMetadataRequest is used to upsert and delete system metadata.

--- a/agent/structs/system_metadata.go
+++ b/agent/structs/system_metadata.go
@@ -16,8 +16,8 @@ type SystemMetadataRequest struct {
 	// Op is the type of operation being requested.
 	Op SystemMetadataOp
 
-	// Entries is the set of keys to modify.
-	Entries []*SystemMetadataEntry
+	// Entry is the key to modify.
+	Entry *SystemMetadataEntry
 
 	// WriteRequest is a common struct containing ACL tokens and other
 	// write-related common elements for requests.

--- a/agent/structs/system_metadata.go
+++ b/agent/structs/system_metadata.go
@@ -1,0 +1,36 @@
+package structs
+
+// SystemMetadataOp is the operation for a request related to system metadata.
+type SystemMetadataOp string
+
+const (
+	SystemMetadataOpUpsert SystemMetadataOp = "upsert"
+	SystemMetadataOpDelete SystemMetadataOp = "delete"
+)
+
+// SystemMetadataRequest is used to upsert and delete system metadata.
+type SystemMetadataRequest struct {
+	// Datacenter is the target for this request.
+	Datacenter string
+
+	// Op is the type of operation being requested.
+	Op SystemMetadataOp
+
+	// Entries is the set of keys to modify.
+	Entries []*SystemMetadataEntry
+
+	// WriteRequest is a common struct containing ACL tokens and other
+	// write-related common elements for requests.
+	WriteRequest
+}
+
+type SystemMetadataEntry struct {
+	Key   string
+	Value string `json:",omitempty"`
+	RaftIndex
+}
+
+// RequestDatacenter returns the datacenter for a given request.
+func (c *SystemMetadataRequest) RequestDatacenter() string {
+	return c.Datacenter
+}


### PR DESCRIPTION
This adds a new very tiny memdb table and corresponding raft operation
for updating a very small effective map[string]string collection of
"system metadata". This can persistently record a fact about the Consul
state machine itself.

The first use of this feature will come in a later PR.