### PR TITLE
use service datacenter for dns name

### DIFF
--- a/.changelog/8704.txt
+++ b/.changelog/8704.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: show correct datacenter for gateways
+```

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -164,7 +164,7 @@ RPC:
 
 	// Generate the summary
 	// TODO (gateways) (freddy) Have Internal.ServiceDump return ServiceDump instead. Need to add bexpr filtering for type.
-	return summarizeServices(out.Nodes.ToServiceDump(), s.agent.config), nil
+	return summarizeServices(out.Nodes.ToServiceDump(), s.agent.config, args.Datacenter), nil
 }
 
 // UIGatewayServices is used to query all the nodes for services associated with a gateway along with their gateway config
@@ -199,10 +199,10 @@ RPC:
 		return nil, err
 	}
 
-	return summarizeServices(out.Dump, s.agent.config), nil
+	return summarizeServices(out.Dump, s.agent.config, args.Datacenter), nil
 }
 
-func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig) []*ServiceSummary {
+func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig, datacenter string) []*ServiceSummary {
 	// Collect the summary information
 	var services []structs.ServiceID
 	summary := make(map[structs.ServiceID]*ServiceSummary)
@@ -226,7 +226,7 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig) []*S
 		if csn.GatewayService != nil {
 			gwsvc := csn.GatewayService
 			sum := getService(gwsvc.Service.ToServiceID())
-			modifySummaryForGatewayService(cfg, sum, gwsvc)
+			modifySummaryForGatewayService(cfg, datacenter, sum, gwsvc)
 		}
 
 		// Will happen in cases where we only have the GatewayServices mapping
@@ -307,6 +307,7 @@ func summarizeServices(dump structs.ServiceDump, cfg *config.RuntimeConfig) []*S
 
 func modifySummaryForGatewayService(
 	cfg *config.RuntimeConfig,
+	datacenter string,
 	sum *ServiceSummary,
 	gwsvc *structs.GatewayService,
 ) {
@@ -319,7 +320,7 @@ func modifySummaryForGatewayService(
 		}
 		dnsAddresses = append(dnsAddresses, serviceIngressDNSName(
 			gwsvc.Service.Name,
-			cfg.Datacenter,
+			datacenter,
 			domain,
 			&gwsvc.Service.EnterpriseMeta,
 		))

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -793,4 +794,13 @@ func TestUIGatewayIntentions(t *testing.T) {
 		intentions[2].DestinationName,
 	}
 	assert.ElementsMatch(t, expected, actual)
+}
+
+func TestUIEndpoint_modifySummaryForGatewayService_UseRequestedDCInsteadOfConfigured(t *testing.T) {
+	dc := "dc2"
+	cfg := config.RuntimeConfig{Datacenter: "dc1", DNSDomain: "consul"}
+	sum := ServiceSummary{GatewayConfig: GatewayConfig{}}
+	gwsvc := structs.GatewayService{Service: structs.ServiceName{Name: "test"}, Port: 42}
+	modifySummaryForGatewayService(&cfg, dc, &sum, &gwsvc)
+	require.Equal(t, "test.ingress.dc2.consul:42", sum.GatewayConfig.Addresses[0])
 }


### PR DESCRIPTION
I am pretty sure this was an oversight, it should be the service datacenter here. I did not check for the other places, but will be.