### PR TITLE
ui: Go back to expecting falsey values during config env tests

### DIFF
--- a/ui-v2/node-tests/config/environment.js
+++ b/ui-v2/node-tests/config/environment.js
@@ -9,9 +9,9 @@ test(
       {
         environment: 'production',
         CONSUL_BINARY_TYPE: 'oss',
-        CONSUL_ACLS_ENABLED: '{{ if .ACLsEnabled }}{{.ACLsEnabled}}{{ else }}false{{ end }}',
-        CONSUL_SSO_ENABLED: '{{ if .SSOEnabled }}{{.SSOEnabled}}{{ else }}false{{ end }}',
-        CONSUL_NSPACES_ENABLED: '{{ if .NamespacesEnabled }}{{.NamespacesEnabled}}{{ else }}false{{ end }}',
+        CONSUL_ACLS_ENABLED: false,
+        CONSUL_SSO_ENABLED: false,
+        CONSUL_NSPACES_ENABLED: false,
       },
       {
         environment: 'test',


### PR DESCRIPTION
We run some config/environment tests to test the correct configuration as been set for each of our different environments.

In https://github.com/hashicorp/consul/pull/8645 we changed how we pass through various production environment settings from the binary, so this updates the existing test as a result of that.

Extra things of note:

1. It doesn't look like we ever got around to adding these tests into CI, otherwise they would have failed as a result of https://github.com/hashicorp/consul/pull/8645.
2. e are currently discussing improved testing of production settings on the resulting UI artifact file itself. Until its clear how we are moving forwards with that, I've fixed up the code so that the tests pass, which whilst correct, it's questionable how useful these tests actually are now following https://github.com/hashicorp/consul/pull/8645.