### PR TITLE
ci:add check for bindata_assetfs changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,6 +629,29 @@ jobs:
             - ./agent/bindata_assetfs.go
       - run: *notify-slack-failure
 
+  # commits static assets to git
+  publish-static-assets:
+    docker:
+      - image: *GOLANG_IMAGE
+    steps:
+      - checkout
+      - add_ssh_keys: # needs a key to push updated static asset commit back to github
+          fingerprints:
+            - "c9:04:b7:85:bf:0e:ce:93:5f:b8:0e:68:8e:16:f3:71"
+      - attach_workspace:
+          at: .
+      - run:
+          name: commit agent/bindata_assetfs.go if there are changes
+          command: |
+            if git diff --exit-code agent/bindata_assetfs.go; then
+              git add agent/bindata_assetfs.go
+              git commit -m "auto-updated agent/bindata_assetfs.go"
+              git push origin master
+            else
+              echo "no new static assets to publish"
+            fi
+      - run: *notify-slack-failure
+
   # run ember frontend tests
   ember-test-oss:
     docker:
@@ -806,7 +829,6 @@ workflows:
           requires: [dev-build]
       - go-test-race: *filter-ignore-non-go-branches
       - go-test-sdk: *filter-ignore-non-go-branches
-
   build-distros:
     jobs:
       - check-vendor: *filter-ignore-non-go-branches
@@ -828,6 +850,13 @@ workflows:
       - build-static-assets:
           requires:
             - ember-build-prod
+      - publish-static-assets:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build-static-assets
       - dev-build:
           requires:
             - build-static-assets
@@ -871,7 +900,6 @@ workflows:
       - envoy-integration-test-1.15.0:
           requires:
             - dev-build
-
   website:
     jobs:
       - build-website-docker-image:
@@ -880,7 +908,6 @@ workflows:
             branches:
               only:
                 - master
-
       - algolia-index:
           context: consul-docs
           filters:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -306,7 +306,7 @@ lint:
 # also run as part of the release build script when it verifies that there are no
 # changes to the UI assets that aren't checked in.
 static-assets:
-	@go-bindata-assetfs -pkg agent -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
+	@go-bindata-assetfs -modtime 1 -pkg agent -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
 	@go fmt $(ASSETFS_PATH)
 
 

--- a/ui-v2/app/components/hashicorp-consul/index.hbs
+++ b/ui-v2/app/components/hashicorp-consul/index.hbs
@@ -249,5 +249,4 @@
         <a data-test-footer-copyright href="{{env 'CONSUL_COPYRIGHT_URL'}}/" rel="noopener noreferrer" target="_blank">&copy; {{env 'CONSUL_COPYRIGHT_YEAR'}} HashiCorp</a>
         <p data-test-footer-version>Consul {{env 'CONSUL_VERSION'}}</p>
         <a data-test-footer-docs href="{{env 'CONSUL_DOCS_URL'}}" rel="help noopener noreferrer" target="_blank">Documentation</a>
-        {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
     </footer>

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -45,16 +45,6 @@ module.exports = function(environment, $ = process.env) {
         .split('-')
         .shift();
     })(process.env.CONSUL_COPYRIGHT_YEAR),
-    CONSUL_GIT_SHA: (function(val) {
-      if (val) {
-        return val;
-      }
-
-      return require('child_process')
-        .execSync('git rev-parse --short HEAD')
-        .toString()
-        .trim();
-    })(process.env.CONSUL_GIT_SHA),
     CONSUL_VERSION: (function(val) {
       if (val) {
         return val;
@@ -136,7 +126,7 @@ module.exports = function(environment, $ = process.env) {
         // won't really exist in the actual ember ENV when it's being served
         // through Consul. See settingsInjectedIndexFS.Open in Go code for the
         // details.
-        CONSUL_UI_SETTINGS_PLACEHOLDER: "__CONSUL_UI_SETTINGS_GO_HERE__",
+        CONSUL_UI_SETTINGS_PLACEHOLDER: '__CONSUL_UI_SETTINGS_GO_HERE__',
       });
       break;
   }

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -11,6 +11,9 @@ module.exports = function(environment, $ = process.env) {
     // torii provider. We provide this object here to
     // prevent ember from giving a log message when starting ember up
     torii: {},
+    'ember-cli-app-version': {
+      version: 'consul-ui',
+    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -129,7 +129,7 @@ module.exports = function(environment, $ = process.env) {
         // won't really exist in the actual ember ENV when it's being served
         // through Consul. See settingsInjectedIndexFS.Open in Go code for the
         // details.
-        CONSUL_UI_SETTINGS_PLACEHOLDER: '__CONSUL_UI_SETTINGS_GO_HERE__',
+        CONSUL_UI_SETTINGS_PLACEHOLDER: "__CONSUL_UI_SETTINGS_GO_HERE__",
       });
       break;
   }


### PR DESCRIPTION
This PR auto updates `agent/bindata_assetfs.go` if there is a diff of the file built from a new master commit.

This is blocked by generating correct fingerprints for the dist/ javascript files and I will talk to @johncowen about this. I have fixed the other source of diff errors which is setting a static modtime to epoch 1. 