### PR TITLE
Inherit versioned tags from tagged wan/lan addr when available

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1978,23 +1978,24 @@ func (a *Agent) addServiceInternal(req addServiceInternalRequest) error {
 	defer a.ResumeSync()
 
 	// Set default tagged addresses
-	serviceIP := net.ParseIP(service.Address)
-	serviceAddressIs4 := serviceIP != nil && serviceIP.To4() != nil
-	serviceAddressIs6 := serviceIP != nil && serviceIP.To4() == nil
 	if service.TaggedAddresses == nil {
 		service.TaggedAddresses = map[string]structs.ServiceAddress{}
 	}
-	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv4]; !ok && serviceAddressIs4 {
-		service.TaggedAddresses[structs.TaggedAddressLANIPv4] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+
+	lanAddr, isIPv4, isIPv6 := coalesceTaggedAddress(service, false)
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv4]; !ok && isIPv4 {
+		service.TaggedAddresses[structs.TaggedAddressLANIPv4] = lanAddr
 	}
-	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv4]; !ok && serviceAddressIs4 {
-		service.TaggedAddresses[structs.TaggedAddressWANIPv4] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv6]; !ok && isIPv6 {
+		service.TaggedAddresses[structs.TaggedAddressLANIPv6] = lanAddr
 	}
-	if _, ok := service.TaggedAddresses[structs.TaggedAddressLANIPv6]; !ok && serviceAddressIs6 {
-		service.TaggedAddresses[structs.TaggedAddressLANIPv6] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+
+	wanAddr, isIPv4, isIPv6 := coalesceTaggedAddress(service, true)
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv4]; !ok && isIPv4 {
+		service.TaggedAddresses[structs.TaggedAddressWANIPv4] = wanAddr
 	}
-	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv6]; !ok && serviceAddressIs6 {
-		service.TaggedAddresses[structs.TaggedAddressWANIPv6] = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	if _, ok := service.TaggedAddresses[structs.TaggedAddressWANIPv6]; !ok && isIPv6 {
+		service.TaggedAddresses[structs.TaggedAddressWANIPv6] = wanAddr
 	}
 
 	var checks []*structs.HealthCheck
@@ -3883,6 +3884,27 @@ func httpInjectAddr(url string, ip string, port int) string {
 	out = httpAddrRE.ReplaceAllString(out, addrRepl)
 
 	return out
+}
+
+// coalesceTaggedAddress will determine the WAN or LAN address to tag as IPv4 or IPv6 for each
+func coalesceTaggedAddress(service *structs.NodeService, wan bool) (structs.ServiceAddress, bool, bool) {
+	existing := service.TaggedAddresses[structs.TaggedAddressLAN]
+	if wan {
+		existing = service.TaggedAddresses[structs.TaggedAddressWAN]
+	}
+
+	// Prefer an existing lan/wan tagged address when generating version specific tags like lan_ipv4 and wan_ipv6
+	// fall back to service address/port when tagged address is not available
+	resp := structs.ServiceAddress{Address: existing.Address, Port: existing.Port}
+	if resp.Address == "" {
+		resp = structs.ServiceAddress{Address: service.Address, Port: service.Port}
+	}
+
+	ip := net.ParseIP(resp.Address)
+	isIPv4 := ip != nil && ip.To4() != nil
+	isIPv6 := ip != nil && ip.To4() == nil
+
+	return resp, isIPv4, isIPv6
 }
 
 func fixIPv6(address string) string {

--- a/agent/agent_endpoint_test.go
+++ b/agent/agent_endpoint_test.go
@@ -446,6 +446,10 @@ func TestAgent_Service(t *testing.T) {
 				Address: "198.18.0.1",
 				Port:    1818,
 			},
+			"wan_ipv4": {
+				Address: "198.18.0.1",
+				Port:    1818,
+			},
 		},
 		Meta:       map[string]string{},
 		Tags:       []string{},

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -943,148 +943,240 @@ func testAgent_AddServiceNoRemoteExec(t *testing.T, extraHCL string) {
 	}
 }
 
-func TestAddServiceIPv4TaggedDefault(t *testing.T) {
+func TestAddServiceIPTags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("too slow for testing.Short")
 	}
 
-	t.Helper()
-
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-
-	srv := &structs.NodeService{
-		Service: "my_service",
-		ID:      "my_service_id",
-		Port:    8100,
-		Address: "10.0.1.2",
+	type expect struct {
+		expectLANIPv4 structs.ServiceAddress
+		expectLANIPv6 structs.ServiceAddress
+		expectWANIPv4 structs.ServiceAddress
+		expectWANIPv6 structs.ServiceAddress
 	}
-
-	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
-
-	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
-	require.NotNil(t, ns)
-
-	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv4])
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressWANIPv4])
-	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv6]
-	require.False(t, ok)
-	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv6]
-	require.False(t, ok)
-}
-
-func TestAddServiceIPv6TaggedDefault(t *testing.T) {
-	if testing.Short() {
-		t.Skip("too slow for testing.Short")
-	}
-
-	t.Helper()
-
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-
-	srv := &structs.NodeService{
-		Service: "my_service",
-		ID:      "my_service_id",
-		Port:    8100,
-		Address: "::5",
-	}
-
-	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
-
-	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
-	require.NotNil(t, ns)
-
-	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv6])
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressWANIPv6])
-	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv4]
-	require.False(t, ok)
-	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv4]
-	require.False(t, ok)
-}
-
-func TestAddServiceIPv4TaggedSet(t *testing.T) {
-	if testing.Short() {
-		t.Skip("too slow for testing.Short")
-	}
-
-	t.Helper()
-
-	a := NewTestAgent(t, "")
-	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
-
-	srv := &structs.NodeService{
-		Service: "my_service",
-		ID:      "my_service_id",
-		Port:    8100,
-		Address: "10.0.1.2",
-		TaggedAddresses: map[string]structs.ServiceAddress{
-			structs.TaggedAddressWANIPv4: {
-				Address: "10.100.200.5",
+	tt := []struct {
+		name         string
+		registration structs.NodeService
+		expect       expect
+	}{
+		{
+			name: "wan and lan ipv4 get ipv4 svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
 				Port:    8100,
+				Address: "10.0.1.2",
+			},
+			expect: expect{
+				expectLANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+				expectWANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+			},
+		},
+		{
+			name: "wan and lan ipv6 get ipv6 svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "::5",
+			},
+			expect: expect{
+				expectLANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
+				expectWANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
+			},
+		},
+		{
+			name: "tagged lanipv4 not overwritten by svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "10.0.1.2",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressLANIPv4: {
+						Address: "10.100.200.5",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectWANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+				expectLANIPv4: structs.ServiceAddress{Address: "10.100.200.5", Port: 8101},
+			},
+		},
+		{
+			name: "tagged lanipv6 not overwritten by svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "::5",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressLANIPv6: {
+						Address: "::6",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectWANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
+				expectLANIPv6: structs.ServiceAddress{Address: "::6", Port: 8101},
+			},
+		},
+		{
+			name: "tagged wanipv4 not overwritten by svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "10.0.1.2",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressWANIPv4: {
+						Address: "10.100.200.5",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+				expectWANIPv4: structs.ServiceAddress{Address: "10.100.200.5", Port: 8101},
+			},
+		},
+		{
+			name: "tagged wanipv6 not overwritten by svc addr",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "::5",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressWANIPv6: {
+						Address: "::6",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
+				expectWANIPv6: structs.ServiceAddress{Address: "::6", Port: 8101},
+			},
+		},
+		{
+			name: "tagged wanipv4 inherited from tagged wan",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "10.0.1.2",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressWAN: {
+						Address: "10.100.200.5",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+				expectWANIPv4: structs.ServiceAddress{Address: "10.100.200.5", Port: 8101},
+			},
+		},
+		{
+			name: "tagged wanipv6 inherited from tagged wan",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "::5",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressWAN: {
+						Address: "::6",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
+				expectWANIPv6: structs.ServiceAddress{Address: "::6", Port: 8101},
+			},
+		},
+		{
+			name: "tagged lanipv4 inherited from tagged lan",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "10.0.1.2",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressLAN: {
+						Address: "10.100.200.5",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv4: structs.ServiceAddress{Address: "10.100.200.5", Port: 8101},
+				expectWANIPv4: structs.ServiceAddress{Address: "10.0.1.2", Port: 8100},
+			},
+		},
+		{
+			name: "tagged lanipv6 inherited from tagged lan",
+			registration: structs.NodeService{
+				Service: "my_service",
+				ID:      "my_service_id",
+				Port:    8100,
+				Address: "::5",
+				TaggedAddresses: map[string]structs.ServiceAddress{
+					structs.TaggedAddressLAN: {
+						Address: "::6",
+						Port:    8101,
+					},
+				},
+			},
+			expect: expect{
+				expectLANIPv6: structs.ServiceAddress{Address: "::6", Port: 8101},
+				expectWANIPv6: structs.ServiceAddress{Address: "::5", Port: 8100},
 			},
 		},
 	}
 
-	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
-
-	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
-	require.NotNil(t, ns)
-
-	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv4])
-	require.Equal(t, structs.ServiceAddress{Address: "10.100.200.5", Port: 8100}, ns.TaggedAddresses[structs.TaggedAddressWANIPv4])
-	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv6]
-	require.False(t, ok)
-	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv6]
-	require.False(t, ok)
-}
-
-func TestAddServiceIPv6TaggedSet(t *testing.T) {
-	if testing.Short() {
-		t.Skip("too slow for testing.Short")
-	}
-
-	t.Helper()
-
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
-	srv := &structs.NodeService{
-		Service: "my_service",
-		ID:      "my_service_id",
-		Port:    8100,
-		Address: "::5",
-		TaggedAddresses: map[string]structs.ServiceAddress{
-			structs.TaggedAddressWANIPv6: {
-				Address: "::6",
-				Port:    8100,
-			},
-		},
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := a.AddService(AddServiceRequest{
+				Service: &tc.registration,
+				Source:  ConfigSourceRemote,
+			})
+			require.Nil(t, err)
+			ns := a.State.Service(structs.NewServiceID(tc.registration.ID, nil))
+			require.NotNil(t, ns)
+
+			require.Equal(t, tc.expect.expectLANIPv4, ns.TaggedAddresses[structs.TaggedAddressLANIPv4])
+			require.Equal(t, tc.expect.expectLANIPv6, ns.TaggedAddresses[structs.TaggedAddressLANIPv6])
+
+			require.Equal(t, tc.expect.expectWANIPv4, ns.TaggedAddresses[structs.TaggedAddressWANIPv4])
+			require.Equal(t, tc.expect.expectWANIPv6, ns.TaggedAddresses[structs.TaggedAddressWANIPv6])
+
+			if tc.expect.expectLANIPv6.Address != "" || tc.expect.expectWANIPv6.Address != "" {
+				_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv4]
+				require.False(t, ok)
+
+				_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv4]
+				require.False(t, ok)
+
+			}
+			if tc.expect.expectLANIPv4.Address != "" || tc.expect.expectWANIPv4.Address != "" {
+				_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv6]
+				require.False(t, ok)
+
+				_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv6]
+				require.False(t, ok)
+
+			}
+		})
 	}
-
-	err := a.addServiceFromSource(srv, []*structs.CheckType{}, false, "", ConfigSourceRemote)
-	require.Nil(t, err)
-
-	ns := a.State.Service(structs.NewServiceID("my_service_id", nil))
-	require.NotNil(t, ns)
-
-	svcAddr := structs.ServiceAddress{Address: srv.Address, Port: srv.Port}
-	require.Equal(t, svcAddr, ns.TaggedAddresses[structs.TaggedAddressLANIPv6])
-	require.Equal(t, structs.ServiceAddress{Address: "::6", Port: 8100}, ns.TaggedAddresses[structs.TaggedAddressWANIPv6])
-	_, ok := ns.TaggedAddresses[structs.TaggedAddressLANIPv4]
-	require.False(t, ok)
-	_, ok = ns.TaggedAddresses[structs.TaggedAddressWANIPv4]
-	require.False(t, ok)
 }
 
 func TestAgent_RemoveService(t *testing.T) {

--- a/command/services/register/register_test.go
+++ b/command/services/register/register_test.go
@@ -1,6 +1,7 @@
 package register
 
 import (
+	"github.com/hashicorp/consul/api"
 	"os"
 	"strings"
 	"testing"
@@ -156,13 +157,13 @@ func TestCommand_Flags_TaggedAddresses(t *testing.T) {
 
 	svc := svcs["web"]
 	require.NotNil(svc)
-	require.Len(svc.TaggedAddresses, 2)
-	require.Contains(svc.TaggedAddresses, "lan")
-	require.Contains(svc.TaggedAddresses, "v6")
-	require.Equal(svc.TaggedAddresses["lan"].Address, "127.0.0.1")
-	require.Equal(svc.TaggedAddresses["lan"].Port, 1234)
-	require.Equal(svc.TaggedAddresses["v6"].Address, "2001:db8::12")
-	require.Equal(svc.TaggedAddresses["v6"].Port, 1234)
+
+	expect := map[string]api.ServiceAddress{
+		"lan":      {Address: "127.0.0.1", Port: 1234},
+		"lan_ipv4": {Address: "127.0.0.1", Port: 1234},
+		"v6":       {Address: "2001:db8::12", Port: 1234},
+	}
+	require.Equal(expect, svc.TaggedAddresses)
 }
 
 func TestCommand_FileWithUnnamedCheck(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,7 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap/v3 v3.1.3/go.mod h1:3rbOH3jRS2u6jg2rJnKAMLE/xQyCKIveG2Sa/Cohzb8=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=

--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,6 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap/v3 v3.1.3/go.mod h1:3rbOH3jRS2u6jg2rJnKAMLE/xQyCKIveG2Sa/Cohzb8=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=


### PR DESCRIPTION
Fixes #8525

This PR ensures that the tagged `wan` or `lan` address does not differ from versioned addresses like `lan_ipv4`.

When populating the version specific tags now we will check the existing non-versioned tag.