### PR TITLE
Return grpc serving status in health check errors

### DIFF
--- a/.changelog/8726.txt
+++ b/.changelog/8726.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+checks: add health status to the failure message when gRPC healthchecks fail.
+```

--- a/agent/checks/grpc.go
+++ b/agent/checks/grpc.go
@@ -13,8 +13,6 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-var ErrGRPCUnhealthy = fmt.Errorf("gRPC application didn't report service healthy")
-
 // GrpcHealthProbe connects to gRPC application and queries health service for application/service status.
 type GrpcHealthProbe struct {
 	server      string
@@ -69,8 +67,8 @@ func (probe *GrpcHealthProbe) Check(target string) error {
 	if err != nil {
 		return err
 	}
-	if response == nil || response.Status != hv1.HealthCheckResponse_SERVING {
-		return ErrGRPCUnhealthy
+	if response.Status != hv1.HealthCheckResponse_SERVING {
+		return fmt.Errorf("gRPC %s serving status: %s", target, response.Status)
 	}
 
 	return nil


### PR DESCRIPTION
Hi there!

This PR adds serving status to gRPC health check errors, because sometimes it's not clear what causes a failure, `SERVICE_UNKNOWN` due to misconfiguration or `NOT_SERVING` when a service is shutting down.