### PR TITLE
docs: Highlight Vault integration points

### DIFF
--- a/website/data/docs-navigation.js
+++ b/website/data/docs-navigation.js
@@ -231,6 +231,10 @@ export default [
     content: [
       'partnerships',
       {
+        title: 'Vault Integration',
+        href: '/docs/connect/ca/vault',
+      },
+      {
         title: 'Ambassador Integration',
         href: '/docs/k8s/connect/ambassador',
       },


### PR DESCRIPTION
Adds a link to Vault as Service Mesh Certificate Authority to the Integrations section of the docs.

@kaitlincarter-hc It looks like we don't really mention Vault as an RPC TLS Certificate Authority in https://www.consul.io/docs/security/encryption#rpc-encryption-with-tls, should we add a short section there? The Learn tutorial linked from there mentions Vault as an option but doesn't use it.