### PR TITLE
Consul Service meta wrongly computes and exposes non_voter meta

### DIFF
--- a/.changelog/8731.txt
+++ b/.changelog/8731.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+entreprise: properly update consul server meta non_voter for non-voting Entreprise Consul servers
+```

--- a/.changelog/8731.txt
+++ b/.changelog/8731.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-entreprise: properly update consul server meta non_voter for non-voting Entreprise Consul servers
+raft: (Enterprise only) properly update consul server meta non_voter for non-voting Enterprise Consul servers
 ```

--- a/agent/consul/leader.go
+++ b/agent/consul/leader.go
@@ -1184,7 +1184,7 @@ func (s *Server) handleAliveMember(member serf.Member) error {
 				Warning: 1,
 			},
 			Meta: map[string]string{
-				"non_voter":             strconv.FormatBool(member.Tags["non_voter"] == "true"),
+				"non_voter":             strconv.FormatBool(member.Tags["nonvoter"] == "1"),
 				"raft_version":          strconv.Itoa(parts.RaftVersion),
 				"serf_protocol_current": strconv.FormatUint(uint64(member.ProtocolCur), 10),
 				"serf_protocol_min":     strconv.FormatUint(uint64(member.ProtocolMin), 10),

--- a/agent/consul/leader_test.go
+++ b/agent/consul/leader_test.go
@@ -336,7 +336,7 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 	versionToExpect := "19.7.9"
 
 	retry.Run(t, func(r *retry.R) {
-		member.Tags["non_voter"] = "true"
+		member.Tags["nonvoter"] = "1"
 		member.Tags["build"] = versionToExpect
 		err := s1.handleAliveMember(member)
 		if err != nil {
@@ -350,7 +350,7 @@ func TestLeader_CheckServersMeta(t *testing.T) {
 			r.Fatal("client not registered")
 		}
 		if service.Meta["non_voter"] != "true" {
-			r.Fatalf("Expected to be non_voter == false, was: %s", service.Meta["non_voter"])
+			r.Fatalf("Expected to be non_voter == true, was: %s", service.Meta["non_voter"])
 		}
 		newVersion := service.Meta["version"]
 		if newVersion != versionToExpect {


### PR DESCRIPTION
In Serf Tags, entreprise members being non-voters use the tag
`nonvoter=1`, not `non_voter = false`, so non-voters in members
were wrongly displayed as voter.

Demonstration:

```
consul members -detailed|grep voter
consul20-hk5 10.200.100.110:8301   alive   acls=1,build=1.8.4+ent,dc=hk5,expect=3,ft_fs=1,ft_ns=1,id=xxxxxxxx-5629-08f2-3a79-10a1ab3849d5,nonvoter=1,port=8300,raft_vsn=3,role=consul,segment=<all>,use_tls=1,vsn=2,vsn_max=3,vsn_min=2,wan_join_port=8302
```