### PR TITLE
remove nodeName call when using -service

### DIFF
--- a/command/maint/maint.go
+++ b/command/maint/maint.go
@@ -72,13 +72,14 @@ func (c *cmd) Run(args []string) int {
 		return 1
 	}
 	a := client.Agent()
-	nodeName, err := a.NodeName()
-	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error querying Consul agent: %s", err))
-		return 1
-	}
 
 	if !c.enable && !c.disable {
+		nodeName, err := a.NodeName()
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error querying Consul agent: %s", err))
+			return 1
+		}
+
 		// List mode - list nodes/services in maintenance mode
 		checks, err := a.Checks()
 		if err != nil {


### PR DESCRIPTION
Currently we call NodeName even when the information is not needed, this makes tokens for services to fail if they do not have permission to read the agent information. fix #8734