### PR TITLE
1.8.x: manual backports from stable-website

### DIFF
--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -3,6 +3,7 @@ export const ALERT_BANNER_ACTIVE = true
 // https://github.com/hashicorp/web-components/tree/master/packages/alert-banner
 export default {
   tag: 'Announcing',
-  url: 'https://www.hashicorp.com/blog/consul-service-on-azure-general-availability',
-  text: 'HashiCorp Consul Service on Azure General Availability',
+  url: 'https://www.hashicorp.com/blog/consul-service-on-azure-production-tier',
+  text: 'HashiCorp Consul Service on Azure Production SKU',
+  linkText: 'Learn more',
 }

--- a/website/pages/docs/architecture/index.mdx
+++ b/website/pages/docs/architecture/index.mdx
@@ -32,7 +32,7 @@ class support for [multiple datacenters](https://learn.hashicorp.com/tutorials/c
 expects this to be the common case.
 
 Within each datacenter, we have a mixture of clients and servers. It is expected
-that there be between three to five servers. This strikes a balance between
+that there will be between three to five servers. This strikes a balance between
 availability in the case of failure and performance, as consensus gets progressively
 slower as more machines are added. However, there is no limit to the number of clients,
 and they can easily scale into the thousands or tens of thousands.


### PR DESCRIPTION
Just two commits that went through without the `docs-cherrypick` workflow enhancement wired up to pick them back to latest release too.

@alvin-huang It looks like merging PRs from external contributors (#8727) will always fail the `docs-cherrypick` workflow, is there any way around this or should we just manually backport?