### PR TITLE
Fix bad int -> string conversions caught by go vet changes in 1.15

### DIFF
--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -543,7 +543,7 @@ func deprecatedEnsureNodeWithoutIDCanRegister(t *testing.T, s *Store, nodeName s
 		Node:    nodeName,
 		Address: "1.1.1.9",
 		Meta: map[string]string{
-			"version": string(txIdx),
+			"version": fmt.Sprint(txIdx),
 		},
 	}
 	if err := s.EnsureNode(txIdx, in); err != nil {

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -65,7 +65,7 @@ func testRegisterNode(t *testing.T, s *Store, idx uint64, nodeID string) {
 // testRegisterNodeWithChange registers a node and ensures it gets different from previous registration
 func testRegisterNodeWithChange(t *testing.T, s *Store, idx uint64, nodeID string) {
 	testRegisterNodeWithMeta(t, s, idx, nodeID, map[string]string{
-		"version": string(idx),
+		"version": fmt.Sprint(idx),
 	})
 }
 
@@ -92,7 +92,7 @@ func testRegisterNodeWithMeta(t *testing.T, s *Store, idx uint64, nodeID string,
 func testRegisterServiceWithChange(t *testing.T, s *Store, idx uint64, nodeID, serviceID string, modifyAccordingIndex bool) {
 	meta := make(map[string]string)
 	if modifyAccordingIndex {
-		meta["version"] = string(idx)
+		meta["version"] = fmt.Sprint(idx)
 	}
 	svc := &structs.NodeService{
 		ID:      serviceID,

--- a/agent/structs/structs_test.go
+++ b/agent/structs/structs_test.go
@@ -1315,7 +1315,7 @@ func TestStructs_DirEntry_Clone(t *testing.T) {
 func TestStructs_ValidateServiceAndNodeMetadata(t *testing.T) {
 	tooMuchMeta := make(map[string]string)
 	for i := 0; i < metaMaxKeyPairs+1; i++ {
-		tooMuchMeta[string(i)] = "value"
+		tooMuchMeta[fmt.Sprint(i)] = "value"
 	}
 	type testcase struct {
 		Meta              map[string]string


### PR DESCRIPTION
Thought I'd try go1.15 locally.

The only issue was go vet complaining about these conversions now which is caught by my pre-commit hook.

I've not officially updated the build version of Go in the build container or even the job that runs vet on PRs yet but I thought I'd fix these up for anyone using 1.15 locally.