### PR TITLE
Add support for serving additional metrics provider JS in the UI

### DIFF
--- a/agent/uiserver/testdata/bar.js
+++ b/agent/uiserver/testdata/bar.js
@@ -1,0 +1,5 @@
+var Bar = {};
+
+Bar.hello = function(){
+  return "I am a bar";
+}

--- a/agent/uiserver/testdata/compiled-metrics-providers-golden.js
+++ b/agent/uiserver/testdata/compiled-metrics-providers-golden.js
@@ -1,0 +1,16 @@
+// foo.js
+
+var Foo = {};
+
+Foo.hello = function(){
+  return "I am a foo";
+}
+
+// bar.js
+
+var Bar = {};
+
+Bar.hello = function(){
+  return "I am a bar";
+}
+

--- a/agent/uiserver/testdata/foo.js
+++ b/agent/uiserver/testdata/foo.js
@@ -1,0 +1,5 @@
+var Foo = {};
+
+Foo.hello = function(){
+  return "I am a foo";
+}

--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -51,5 +51,13 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 	// account for in the source...
 	d["UIConfigJSON"] = url.PathEscape(string(bs))
 
+	// Also inject additional provider scripts if needed, otherwise strip the
+	// comment.
+	if len(cfg.UIConfig.MetricsProviderFiles) > 0 {
+		d["ExtraScripts"] = []string{
+			cfg.UIConfig.ContentPath + compiledProviderJSPath,
+		}
+	}
+
 	return d, err
 }

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUIServer(t *testing.T) {
+func TestUIServerIndex(t *testing.T) {
 	cases := []struct {
 		name            string
 		cfg             *config.RuntimeConfig
@@ -78,6 +78,19 @@ func TestUIServer(t *testing.T) {
 			wantContains: []string{"<!-- CONSUL_VERSION:"},
 			wantEnv: map[string]interface{}{
 				"CONSUL_ACLS_ENABLED": true,
+			},
+		},
+		{
+			name: "serving metrics provider js",
+			cfg: basicUIEnabledConfig(
+				withMetricsProvider("foo"),
+				withMetricsProviderFiles("testdata/foo.js", "testdata/bar.js"),
+			),
+			path:       "/",
+			wantStatus: http.StatusOK,
+			wantContains: []string{
+				"<!-- CONSUL_VERSION:",
+				`<script src="/ui/assets/compiled-metrics-providers.js">`,
 			},
 		},
 	}
@@ -152,7 +165,8 @@ type cfgFunc func(cfg *config.RuntimeConfig)
 func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 	cfg := &config.RuntimeConfig{
 		UIConfig: config.UIConfig{
-			Enabled: true,
+			Enabled:     true,
+			ContentPath: "/ui/",
 		},
 	}
 	for _, f := range opts {
@@ -172,6 +186,12 @@ func withACLs() cfgFunc {
 func withMetricsProvider(name string) cfgFunc {
 	return func(cfg *config.RuntimeConfig) {
 		cfg.UIConfig.MetricsProvider = name
+	}
+}
+
+func withMetricsProviderFiles(names ...string) cfgFunc {
+	return func(cfg *config.RuntimeConfig) {
+		cfg.UIConfig.MetricsProviderFiles = names
 	}
 }
 
@@ -250,4 +270,44 @@ func TestCustomDir(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "test")
+}
+
+func TestCompiledJS(t *testing.T) {
+	cfg := basicUIEnabledConfig(
+		withMetricsProvider("foo"),
+		withMetricsProviderFiles("testdata/foo.js", "testdata/bar.js"),
+	)
+	h := NewHandler(cfg, testutil.Logger(t))
+
+	paths := []string{
+		"/" + compiledProviderJSPath,
+		// We need to work even without the initial slash because the agent uses
+		// http.StripPrefix with the entire ContentPath which includes a trailing
+		// slash. This apparently works fine for the assetFS etc. so we need to
+		// also tolerate it when the URL doesn't have a slash at the start of the
+		// path.
+		compiledProviderJSPath,
+	}
+
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			// NewRequest doesn't like paths with no leading slash but we need to test
+			// a request with a URL that has that so just create with root path and
+			// then manually modify the URL path so it emulates one that has been
+			// doctored by http.StripPath.
+			req := httptest.NewRequest("GET", "/", nil)
+			req.URL.Path = path
+
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.Equal(t, rec.Result().Header["Content-Type"][0], "application/javascript")
+			wantCompiled, err := ioutil.ReadFile("testdata/compiled-metrics-providers-golden.js")
+			require.NoError(t, err)
+			require.Equal(t, rec.Body.String(), string(wantCompiled))
+		})
+	}
+
 }

--- a/ui-v2/lib/startup/templates/body.html.js
+++ b/ui-v2/lib/startup/templates/body.html.js
@@ -41,5 +41,6 @@ module.exports = ({ appName, environment, rootURL, config }) => `
       }
     };
   </script>
+  ${environment === 'production' ? `{{ range .ExtraScripts }} <script src="{{.}}"></script> {{ end }}` : ``}
   ${environment === 'test' ? `<script src="${rootURL}assets/tests.js"></script>` : ``}
 `;


### PR DESCRIPTION
This PR builds on #8694 and implements the JS provider serving component for the UI.

## TODO

 - All documentation for the new config and features is deferred until they are implemented as things might change but I want to keep PRs small and incremental.