### PR TITLE
server: make sure that the various replication loggers use consistent logging

### DIFF
--- a/.changelog/8745.txt
+++ b/.changelog/8745.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: make sure that the various replication loggers use consistent logging
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -421,11 +421,11 @@ func NewServer(config *Config, flat Deps) (*Server, error) {
 				srv:            s,
 				gatewayLocator: s.gatewayLocator,
 			},
-			Logger: s.logger,
+			Logger: s.loggers.Named(logging.Replication).Named(logging.FederationState),
 		},
 		Rate:             s.config.FederationStateReplicationRate,
 		Burst:            s.config.FederationStateReplicationBurst,
-		Logger:           logger,
+		Logger:           s.logger,
 		SuppressErrorLog: isErrFederationStatesNotSupported,
 	}
 	s.federationStateReplicator, err = NewReplicator(&federationStateReplicatorConfig)


### PR DESCRIPTION
This generic replicator code is used for 3 places: config entries, federation states, and enterprise stuff. This gets all 3 variants to  actually log all of their components with the appropriate prefixes:

```
server.replication.config_entry: finished fetching config entries: amount=0
server.replication.config_entry: Config Entry replication: local=0 remote=0
server.replication.config_entry: Config Entry replication: deletions=0 updates=0
server.replication.config_entry: replication completed through remote index: index=1

server.replication.federation_state: finished fetching remote objects: amount=1
server.replication.federation_state: diffing replication state: local_amount=0 remote_amount=1
server.replication.federation_state: diffed replication state: deletions=0 updates=1
server.replication.federation_state: performing updates: updates=1
server.replication.federation_state: finished updates
server.replication.federation_state: replication completed through remote index: index=14
server.replication.federation_state: finished fetching remote objects: amount=2
server.replication.federation_state: diffing replication state: local_amount=1 remote_amount=2
server.replication.federation_state: diffed replication state: deletions=0 updates=1
server.replication.federation_state: performing updates: updates=1
```