### PR TITLE
agent: when enable_central_service_config is enabled ensure agent reload doesn't revert check state to critical

### DIFF
--- a/.changelog/8747.txt
+++ b/.changelog/8747.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: when enable_central_service_config is enabled ensure agent reload doesn't revert check state to critical
+```

--- a/agent/service_manager.go
+++ b/agent/service_manager.go
@@ -87,7 +87,11 @@ func (s *ServiceManager) registerOnce(args *addServiceRequest) error {
 	s.agent.stateLock.Lock()
 	defer s.agent.stateLock.Unlock()
 
-	err := s.agent.addServiceInternal(args, s.agent.snapshotCheckState())
+	if args.snap == nil {
+		args.snap = s.agent.snapshotCheckState()
+	}
+
+	err := s.agent.addServiceInternal(args)
 	if err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
 	}
@@ -128,7 +132,7 @@ func (s *ServiceManager) AddService(req *addServiceRequest) error {
 		req.persistService = nil
 		req.persistDefaults = nil
 		req.persistServiceConfig = false
-		return s.agent.addServiceInternal(req, s.agent.snapshotCheckState())
+		return s.agent.addServiceInternal(req)
 	}
 
 	var (
@@ -273,7 +277,8 @@ func (w *serviceConfigWatch) RegisterAndStart(
 		token:                 w.registration.token,
 		replaceExistingChecks: w.registration.replaceExistingChecks,
 		source:                w.registration.source,
-	}, w.agent.snapshotCheckState())
+		snap:                  w.agent.snapshotCheckState(),
+	})
 	if err != nil {
 		return fmt.Errorf("error updating service registration: %v", err)
 	}


### PR DESCRIPTION
Likely introduced when #7345 landed.

The backport to 1.8.x is clean but the 1.7.x has conflicts in test code (https://github.com/hashicorp/consul/pull/8748).
