### PR TITLE
Fix typo in Service Discovery/Services documentation

### DIFF
--- a/website/pages/docs/discovery/services.mdx
+++ b/website/pages/docs/discovery/services.mdx
@@ -137,7 +137,7 @@ used for any interaction with the catalog for the service, including
 
 Services registered in Consul clusters where both [Consul Namespaces](/docs/enterprise/namespaces)<EnterpriseAlert inline />
 and the ACL system are enabled can be registered to specific namespaces that are associated with
-ACL tokens scoped to that namespace. Services registed with a service definition
+ACL tokens scoped to that namespace. Services registered with a service definition
 will not inherit the namespace associated with the ACL token specified in the `token`
 field. The `namespace` field, in addition to the `token` field, must be
 included in the service definition for the service to be registered to the


### PR DESCRIPTION
Just a small typo I noticed when ready the docs.