### PR TITLE
Reuse gRPC healthcheck client connections

### DIFF
--- a/agent/checks/check.go
+++ b/agent/checks/check.go
@@ -796,6 +796,7 @@ func (c *CheckGRPC) Stop() {
 	c.stopLock.Lock()
 	defer c.stopLock.Unlock()
 	if !c.stop {
+		c.probe.Stop()
 		c.stop = true
 		close(c.stopCh)
 	}

--- a/agent/checks/grpc.go
+++ b/agent/checks/grpc.go
@@ -15,10 +15,13 @@ import (
 
 // GrpcHealthProbe connects to gRPC application and queries health service for application/service status.
 type GrpcHealthProbe struct {
-	server      string
-	request     *hv1.HealthCheckRequest
-	timeout     time.Duration
-	dialOptions []grpc.DialOption
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	connection *grpc.ClientConn
+	client     hv1.HealthClient
+	request    *hv1.HealthCheckRequest
+	timeout    time.Duration
 }
 
 // NewGrpcHealthProbe constructs GrpcHealthProbe from target string in format
@@ -32,38 +35,39 @@ func NewGrpcHealthProbe(target string, timeout time.Duration, tlsConfig *tls.Con
 		request.Service = serverAndService[1]
 	}
 
-	var dialOptions = []grpc.DialOption{}
-
+	var dialOptions []grpc.DialOption
 	if tlsConfig != nil {
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	}
 
+	serverWithScheme := fmt.Sprintf("%s:///%s", resolver.GetDefaultScheme(), serverAndService[0])
+	connection, err := grpc.DialContext(context.Background(), serverWithScheme, dialOptions...)
+	if err != nil {
+		// dial may return an error only when opts are invalid or grpc.WithBlock is used
+		panic(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 	return &GrpcHealthProbe{
-		request:     &request,
-		timeout:     timeout,
-		dialOptions: dialOptions,
+		ctx:    ctx,
+		cancel: cancel,
+
+		connection: connection,
+		client:     hv1.NewHealthClient(connection),
+		request:    &request,
+		timeout:    timeout,
 	}
 }
 
 // Check if the target of this GrpcHealthProbe is healthy
 // If nil is returned, target is healthy, otherwise target is not healthy
 func (probe *GrpcHealthProbe) Check(target string) error {
-	serverAndService := strings.SplitN(target, "/", 2)
-	serverWithScheme := fmt.Sprintf("%s:///%s", resolver.GetDefaultScheme(), serverAndService[0])
-
-	ctx, cancel := context.WithTimeout(context.Background(), probe.timeout)
+	ctx, cancel := context.WithTimeout(probe.ctx, probe.timeout)
 	defer cancel()
 
-	connection, err := grpc.DialContext(ctx, serverWithScheme, probe.dialOptions...)
-	if err != nil {
-		return err
-	}
-	defer connection.Close()
-
-	client := hv1.NewHealthClient(connection)
-	response, err := client.Check(ctx, probe.request)
+	response, err := probe.client.Check(ctx, probe.request)
 	if err != nil {
 		return err
 	}
@@ -72,4 +76,9 @@ func (probe *GrpcHealthProbe) Check(target string) error {
 	}
 
 	return nil
+}
+
+func (probe *GrpcHealthProbe) Stop() {
+	probe.cancel()
+	probe.connection.Close()
 }

--- a/agent/checks/grpc_test.go
+++ b/agent/checks/grpc_test.go
@@ -171,3 +171,12 @@ func TestGRPC_NotProxied(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkNewGrpcHealthProbe(b *testing.B) {
+	probe := NewGrpcHealthProbe(server, 10*time.Second, nil)
+	for i := 0; i < b.N; i++ {
+		if err := probe.Check(svcHealthy); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This PR reuses `grpc.ClientConn` among `Check`s, it already maintains connection with backends in the background, and if it's lost it tries to reconnect based on [back-off](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md) strategy or right away when a method is invoked (like `http.Transport`). 

Having many frequent gRPC checks, especially that use TLS  may lead to serious performance penalties.

Here's a simple `Check` benchmark (insecure):

```
benchmark                          old ns/op     new ns/op     delta
BenchmarkNewGrpcHealthProbe-12     304544        63741         -79.07%

benchmark                          old allocs     new allocs     delta
BenchmarkNewGrpcHealthProbe-12     514            177            -65.56%

benchmark                          old bytes     new bytes     delta
BenchmarkNewGrpcHealthProbe-12     233113        9649          -95.86%
```