### PR TITLE
api: support GetMeta() and GetNamespace() on all config entry kinds

### DIFF
--- a/.changelog/8764.txt
+++ b/.changelog/8764.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: support GetMeta() and GetNamespace() on all config entry kinds
+```

--- a/api/config_entry.go
+++ b/api/config_entry.go
@@ -26,6 +26,8 @@ const (
 type ConfigEntry interface {
 	GetKind() string
 	GetName() string
+	GetNamespace() string
+	GetMeta() map[string]string
 	GetCreateIndex() uint64
 	GetModifyIndex() uint64
 }
@@ -108,6 +110,14 @@ func (s *ServiceConfigEntry) GetName() string {
 	return s.Name
 }
 
+func (s *ServiceConfigEntry) GetNamespace() string {
+	return s.Namespace
+}
+
+func (s *ServiceConfigEntry) GetMeta() map[string]string {
+	return s.Meta
+}
+
 func (s *ServiceConfigEntry) GetCreateIndex() uint64 {
 	return s.CreateIndex
 }
@@ -134,6 +144,14 @@ func (p *ProxyConfigEntry) GetKind() string {
 
 func (p *ProxyConfigEntry) GetName() string {
 	return p.Name
+}
+
+func (p *ProxyConfigEntry) GetNamespace() string {
+	return p.Namespace
+}
+
+func (p *ProxyConfigEntry) GetMeta() map[string]string {
+	return p.Meta
 }
 
 func (p *ProxyConfigEntry) GetCreateIndex() uint64 {

--- a/api/config_entry_discoverychain.go
+++ b/api/config_entry_discoverychain.go
@@ -17,10 +17,12 @@ type ServiceRouterConfigEntry struct {
 	ModifyIndex uint64
 }
 
-func (e *ServiceRouterConfigEntry) GetKind() string        { return e.Kind }
-func (e *ServiceRouterConfigEntry) GetName() string        { return e.Name }
-func (e *ServiceRouterConfigEntry) GetCreateIndex() uint64 { return e.CreateIndex }
-func (e *ServiceRouterConfigEntry) GetModifyIndex() uint64 { return e.ModifyIndex }
+func (e *ServiceRouterConfigEntry) GetKind() string            { return e.Kind }
+func (e *ServiceRouterConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceRouterConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *ServiceRouterConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *ServiceRouterConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *ServiceRouterConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 type ServiceRoute struct {
 	Match       *ServiceRouteMatch       `json:",omitempty"`
@@ -117,10 +119,12 @@ type ServiceSplitterConfigEntry struct {
 	ModifyIndex uint64
 }
 
-func (e *ServiceSplitterConfigEntry) GetKind() string        { return e.Kind }
-func (e *ServiceSplitterConfigEntry) GetName() string        { return e.Name }
-func (e *ServiceSplitterConfigEntry) GetCreateIndex() uint64 { return e.CreateIndex }
-func (e *ServiceSplitterConfigEntry) GetModifyIndex() uint64 { return e.ModifyIndex }
+func (e *ServiceSplitterConfigEntry) GetKind() string            { return e.Kind }
+func (e *ServiceSplitterConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceSplitterConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *ServiceSplitterConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *ServiceSplitterConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *ServiceSplitterConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 type ServiceSplit struct {
 	Weight        float32
@@ -185,10 +189,12 @@ func (e *ServiceResolverConfigEntry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (e *ServiceResolverConfigEntry) GetKind() string        { return e.Kind }
-func (e *ServiceResolverConfigEntry) GetName() string        { return e.Name }
-func (e *ServiceResolverConfigEntry) GetCreateIndex() uint64 { return e.CreateIndex }
-func (e *ServiceResolverConfigEntry) GetModifyIndex() uint64 { return e.ModifyIndex }
+func (e *ServiceResolverConfigEntry) GetKind() string            { return e.Kind }
+func (e *ServiceResolverConfigEntry) GetName() string            { return e.Name }
+func (e *ServiceResolverConfigEntry) GetNamespace() string       { return e.Namespace }
+func (e *ServiceResolverConfigEntry) GetMeta() map[string]string { return e.Meta }
+func (e *ServiceResolverConfigEntry) GetCreateIndex() uint64     { return e.CreateIndex }
+func (e *ServiceResolverConfigEntry) GetModifyIndex() uint64     { return e.ModifyIndex }
 
 type ServiceResolverSubset struct {
 	Filter      string `json:",omitempty"`

--- a/api/config_entry_discoverychain_test.go
+++ b/api/config_entry_discoverychain_test.go
@@ -32,6 +32,9 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 		require.NotNil(t, qm)
 		require.NotEqual(t, 0, qm.RequestTime)
 
+		// generic verification
+		require.Equal(t, testEntry.Meta, entry.GetMeta())
+
 		// verify it
 		readResolver, ok := entry.(*ServiceResolverConfigEntry)
 		require.True(t, ok)
@@ -61,6 +64,9 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 		require.NotNil(t, qm)
 		require.NotEqual(t, 0, qm.RequestTime)
 
+		// generic verification
+		require.Equal(t, testEntry.Meta, entry.GetMeta())
+
 		// verify it
 		readSplitter, ok := entry.(*ServiceSplitterConfigEntry)
 		require.True(t, ok)
@@ -89,6 +95,9 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, qm)
 		require.NotEqual(t, 0, qm.RequestTime)
+
+		// generic verification
+		require.Equal(t, testEntry.Meta, entry.GetMeta())
 
 		// verify it
 		readRouter, ok := entry.(*ServiceRouterConfigEntry)
@@ -150,6 +159,10 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 					},
 				},
 				ConnectTimeout: 5 * time.Second,
+				Meta: map[string]string{
+					"foo": "bar",
+					"gir": "zim",
+				},
 			},
 			verify: verifyResolver,
 		},
@@ -187,6 +200,10 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 						Namespace: defaultNamespace,
 					},
 				},
+				Meta: map[string]string{
+					"foo": "bar",
+					"gir": "zim",
+				},
 			},
 			verify: verifySplitter,
 		},
@@ -220,6 +237,10 @@ func TestAPI_ConfigEntry_DiscoveryChain(t *testing.T) {
 							RetryOnStatusCodes:    []uint32{500, 503, 401},
 						},
 					},
+				},
+				Meta: map[string]string{
+					"foo": "bar",
+					"gir": "zim",
 				},
 			},
 			verify: verifyRouter,

--- a/api/config_entry_gateways.go
+++ b/api/config_entry_gateways.go
@@ -96,6 +96,14 @@ func (i *IngressGatewayConfigEntry) GetName() string {
 	return i.Name
 }
 
+func (i *IngressGatewayConfigEntry) GetNamespace() string {
+	return i.Namespace
+}
+
+func (i *IngressGatewayConfigEntry) GetMeta() map[string]string {
+	return i.Meta
+}
+
 func (i *IngressGatewayConfigEntry) GetCreateIndex() uint64 {
 	return i.CreateIndex
 }
@@ -163,6 +171,14 @@ func (g *TerminatingGatewayConfigEntry) GetKind() string {
 
 func (g *TerminatingGatewayConfigEntry) GetName() string {
 	return g.Name
+}
+
+func (g *TerminatingGatewayConfigEntry) GetNamespace() string {
+	return g.Namespace
+}
+
+func (g *TerminatingGatewayConfigEntry) GetMeta() map[string]string {
+	return g.Meta
 }
 
 func (g *TerminatingGatewayConfigEntry) GetCreateIndex() uint64 {

--- a/api/config_entry_gateways_test.go
+++ b/api/config_entry_gateways_test.go
@@ -16,6 +16,10 @@ func TestAPI_ConfigEntries_IngressGateway(t *testing.T) {
 	ingress1 := &IngressGatewayConfigEntry{
 		Kind: IngressGateway,
 		Name: "foo",
+		Meta: map[string]string{
+			"foo": "bar",
+			"gir": "zim",
+		},
 	}
 
 	ingress2 := &IngressGatewayConfigEntry{
@@ -62,6 +66,8 @@ func TestAPI_ConfigEntries_IngressGateway(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, ingress1.Kind, readIngress.Kind)
 	require.Equal(t, ingress1.Name, readIngress.Name)
+	require.Equal(t, ingress1.Meta, readIngress.Meta)
+	require.Equal(t, ingress1.Meta, readIngress.GetMeta())
 
 	// update it
 	ingress1.Listeners = []IngressListener{
@@ -164,6 +170,10 @@ func TestAPI_ConfigEntries_TerminatingGateway(t *testing.T) {
 	terminating1 := &TerminatingGatewayConfigEntry{
 		Kind: TerminatingGateway,
 		Name: "foo",
+		Meta: map[string]string{
+			"foo": "bar",
+			"gir": "zim",
+		},
 	}
 
 	terminating2 := &TerminatingGatewayConfigEntry{
@@ -194,6 +204,8 @@ func TestAPI_ConfigEntries_TerminatingGateway(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, terminating1.Kind, readTerminating.Kind)
 	require.Equal(t, terminating1.Name, readTerminating.Name)
+	require.Equal(t, terminating1.Meta, readTerminating.Meta)
+	require.Equal(t, terminating1.Meta, readTerminating.GetMeta())
 
 	// update it
 	terminating1.Services = []LinkedService{

--- a/api/config_entry_test.go
+++ b/api/config_entry_test.go
@@ -23,6 +23,10 @@ func TestAPI_ConfigEntries(t *testing.T) {
 				"foo": "bar",
 				"bar": 1.0,
 			},
+			Meta: map[string]string{
+				"foo": "bar",
+				"gir": "zim",
+			},
 		}
 
 		// set it
@@ -43,6 +47,8 @@ func TestAPI_ConfigEntries(t *testing.T) {
 		require.Equal(t, global_proxy.Kind, readProxy.Kind)
 		require.Equal(t, global_proxy.Name, readProxy.Name)
 		require.Equal(t, global_proxy.Config, readProxy.Config)
+		require.Equal(t, global_proxy.Meta, readProxy.Meta)
+		require.Equal(t, global_proxy.Meta, readProxy.GetMeta())
 
 		global_proxy.Config["baz"] = true
 		// CAS update fail
@@ -92,6 +98,10 @@ func TestAPI_ConfigEntries(t *testing.T) {
 			Kind:     ServiceDefaults,
 			Name:     "foo",
 			Protocol: "udp",
+			Meta: map[string]string{
+				"foo": "bar",
+				"gir": "zim",
+			},
 		}
 
 		service2 := &ServiceConfigEntry{
@@ -124,6 +134,8 @@ func TestAPI_ConfigEntries(t *testing.T) {
 		require.Equal(t, service.Kind, readService.Kind)
 		require.Equal(t, service.Name, readService.Name)
 		require.Equal(t, service.Protocol, readService.Protocol)
+		require.Equal(t, service.Meta, readService.Meta)
+		require.Equal(t, service.Meta, readService.GetMeta())
 
 		// update it
 		service.Protocol = "tcp"


### PR DESCRIPTION
Fixes #8755

Since I was updating the interface, i also added the missing `GetNamespace()`.

Depending upon how you look at it, this is a breaking change since it adds methods to the exported interface `api.ConfigEntry`. Given that you cannot define your own config entry kinds, and all of the machinery of the `api.Client` acts like a factory to construct the canned ones from the rest of the module, this feels like it's not a problematic change as it would only break someone who had reimplemented the `ConfigEntry` interface themselves for no apparent utility?