### PR TITLE
state: use protobuf Topic and and export payload type

### DIFF
--- a/agent/consul/fsm/fsm.go
+++ b/agent/consul/fsm/fsm.go
@@ -42,7 +42,6 @@ func registerCommand(msg structs.MessageType, fn unboundCommand) {
 // this outside the Server to avoid exposing this outside the package.
 type FSM struct {
 	logger hclog.Logger
-	path   string
 
 	// apply is built off the commands global and is used to route apply
 	// operations to their appropriate handlers.

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -1138,7 +1138,7 @@ func evConnectNative(e *stream.Event) error {
 // depending on which topic they are published to and they determin this from
 // the event.
 func evConnectTopic(e *stream.Event) error {
-	e.Topic = TopicServiceHealthConnect
+	e.Topic = topicServiceHealthConnect
 	return nil
 }
 
@@ -1172,7 +1172,7 @@ func evSidecar(e *stream.Event) error {
 
 	// Update event key to be the proxy service name, but only if this is not
 	// already in the connect topic
-	if e.Topic != TopicServiceHealthConnect {
+	if e.Topic != topicServiceHealthConnect {
 		e.Key = csn.Service.Service
 	}
 	return nil
@@ -1262,7 +1262,7 @@ func evRenameService(e *stream.Event) error {
 	csn.Service.Proxy.DestinationServiceName += "_changed"
 
 	// If this is the connect topic we need to change the key too
-	if e.Topic == TopicServiceHealthConnect {
+	if e.Topic == topicServiceHealthConnect {
 		e.Key += "_changed"
 	}
 	return nil
@@ -1392,7 +1392,7 @@ func newTestEventServiceHealthRegister(index uint64, nodeNum int, svc string) st
 	addr := fmt.Sprintf("10.10.%d.%d", nodeNum/256, nodeNum%256)
 
 	return stream.Event{
-		Topic: TopicServiceHealth,
+		Topic: topicServiceHealth,
 		Key:   svc,
 		Index: index,
 		Payload: EventPayloadCheckServiceNode{
@@ -1460,7 +1460,7 @@ func newTestEventServiceHealthRegister(index uint64, nodeNum int, svc string) st
 // adding too many options to callers.
 func newTestEventServiceHealthDeregister(index uint64, nodeNum int, svc string) stream.Event {
 	return stream.Event{
-		Topic: TopicServiceHealth,
+		Topic: topicServiceHealth,
 		Key:   svc,
 		Index: index,
 		Payload: EventPayloadCheckServiceNode{

--- a/agent/consul/state/catalog_events_test.go
+++ b/agent/consul/state/catalog_events_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/proto/pbsubscribe"
 	"github.com/hashicorp/consul/types"
 	"github.com/stretchr/testify/require"
 )
@@ -1394,9 +1395,9 @@ func newTestEventServiceHealthRegister(index uint64, nodeNum int, svc string) st
 		Topic: TopicServiceHealth,
 		Key:   svc,
 		Index: index,
-		Payload: eventPayload{
-			Op: OpCreate,
-			Obj: &structs.CheckServiceNode{
+		Payload: EventPayloadCheckServiceNode{
+			Op: pbsubscribe.CatalogOp_Register,
+			Value: &structs.CheckServiceNode{
 				Node: &structs.Node{
 					ID:         nodeID,
 					Node:       node,
@@ -1462,9 +1463,9 @@ func newTestEventServiceHealthDeregister(index uint64, nodeNum int, svc string) 
 		Topic: TopicServiceHealth,
 		Key:   svc,
 		Index: index,
-		Payload: eventPayload{
-			Op: OpDelete,
-			Obj: &structs.CheckServiceNode{
+		Payload: EventPayloadCheckServiceNode{
+			Op: pbsubscribe.CatalogOp_Deregister,
+			Value: &structs.CheckServiceNode{
 				Node: &structs.Node{
 					Node: fmt.Sprintf("node%d", nodeNum),
 				},

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -37,12 +37,8 @@ type Changes struct {
 // 2. Sent to the eventPublisher which will create and emit change events
 type changeTrackerDB struct {
 	db             *memdb.MemDB
-	publisher      eventPublisher
+	publisher      *stream.EventPublisher
 	processChanges func(ReadTxn, Changes) ([]stream.Event, error)
-}
-
-type eventPublisher interface {
-	Publish(events []stream.Event)
 }
 
 // Txn exists to maintain backwards compatibility with memdb.DB.Txn. Preexisting

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/consul/agent/consul/stream"
+	"github.com/hashicorp/consul/proto/pbsubscribe"
 	"github.com/hashicorp/go-memdb"
 )
 
@@ -158,18 +159,9 @@ func (tx *txn) Commit() error {
 	return nil
 }
 
-// TODO: may be replaced by a gRPC type.
-type topic string
-
-func (t topic) String() string {
-	return string(t)
-}
-
 var (
-	// TopicServiceHealth contains events for all registered service instances.
-	TopicServiceHealth topic = "topic-service-health"
-	// TopicServiceHealthConnect contains events for connect-enabled service instances.
-	TopicServiceHealthConnect topic = "topic-service-health-connect"
+	topicServiceHealth        = pbsubscribe.Topic_ServiceHealth
+	topicServiceHealthConnect = pbsubscribe.Topic_ServiceHealthConnect
 )
 
 func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
@@ -191,7 +183,7 @@ func processDBChanges(tx ReadTxn, changes Changes) ([]stream.Event, error) {
 
 func newSnapshotHandlers(s *Store) stream.SnapshotHandlers {
 	return stream.SnapshotHandlers{
-		TopicServiceHealth:        serviceHealthSnapshot(s, TopicServiceHealth),
-		TopicServiceHealthConnect: serviceHealthSnapshot(s, TopicServiceHealthConnect),
+		topicServiceHealth:        serviceHealthSnapshot(s, topicServiceHealth),
+		topicServiceHealthConnect: serviceHealthSnapshot(s, topicServiceHealthConnect),
 	}
 }

--- a/agent/consul/state/store_integration_test.go
+++ b/agent/consul/state/store_integration_test.go
@@ -28,7 +28,8 @@ func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	publisher := stream.NewEventPublisher(ctx, newTestSnapshotHandlers(s), 0)
+	publisher := stream.NewEventPublisher(newTestSnapshotHandlers(s), 0)
+	go publisher.Run(ctx)
 	s.db.publisher = publisher
 	sub, err := publisher.Subscribe(subscription)
 	require.NoError(err)
@@ -111,7 +112,8 @@ func TestStore_IntegrationWithEventPublisher_ACLPolicyUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	publisher := stream.NewEventPublisher(ctx, newTestSnapshotHandlers(s), 0)
+	publisher := stream.NewEventPublisher(newTestSnapshotHandlers(s), 0)
+	go publisher.Run(ctx)
 	s.db.publisher = publisher
 	sub, err := publisher.Subscribe(subscription)
 	require.NoError(err)
@@ -227,7 +229,8 @@ func TestStore_IntegrationWithEventPublisher_ACLRoleUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	publisher := stream.NewEventPublisher(ctx, newTestSnapshotHandlers(s), 0)
+	publisher := stream.NewEventPublisher(newTestSnapshotHandlers(s), 0)
+	go publisher.Run(ctx)
 	s.db.publisher = publisher
 	sub, err := publisher.Subscribe(subscription)
 	require.NoError(err)
@@ -433,7 +436,9 @@ func createTokenAndWaitForACLEventPublish(t *testing.T, s *Store) *structs.ACLTo
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	publisher := stream.NewEventPublisher(ctx, newTestSnapshotHandlers(s), 0)
+	publisher := stream.NewEventPublisher(newTestSnapshotHandlers(s), 0)
+	go publisher.Run(ctx)
+
 	s.db.publisher = publisher
 	sub, err := publisher.Subscribe(req)
 	require.NoError(t, err)

--- a/agent/consul/state/store_integration_test.go
+++ b/agent/consul/state/store_integration_test.go
@@ -372,7 +372,13 @@ func assertReset(t *testing.T, eventCh <-chan nextResult, allowEOS bool) {
 	}
 }
 
-var topicService stream.Topic = topic("test-topic-service")
+type topic string
+
+func (t topic) String() string {
+	return string(t)
+}
+
+var topicService topic = "test-topic-service"
 
 func newTestSnapshotHandlers(s *Store) stream.SnapshotHandlers {
 	return stream.SnapshotHandlers{

--- a/agent/consul/stream/event_publisher_test.go
+++ b/agent/consul/stream/event_publisher_test.go
@@ -25,7 +25,9 @@ func TestEventPublisher_PublishChangesAndSubscribe_WithSnapshot(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	publisher := NewEventPublisher(ctx, newTestSnapshotHandlers(), 0)
+	publisher := NewEventPublisher(newTestSnapshotHandlers(), 0)
+	go publisher.Run(ctx)
+
 	sub, err := publisher.Subscribe(subscription)
 	require.NoError(t, err)
 	eventCh := consumeSubscription(ctx, sub)
@@ -123,7 +125,8 @@ func TestEventPublisher_ShutdownClosesSubscriptions(t *testing.T) {
 	handlers[intTopic(22)] = fn
 	handlers[intTopic(33)] = fn
 
-	publisher := NewEventPublisher(ctx, handlers, time.Second)
+	publisher := NewEventPublisher(handlers, time.Second)
+	go publisher.Run(ctx)
 
 	sub1, err := publisher.Subscribe(&SubscribeRequest{Topic: intTopic(22)})
 	require.NoError(t, err)


### PR DESCRIPTION
These commits are extracted from #8766 

The changes are small refactors in the `state` and `stream` packages to export some things that will be needed for the subscribe service, and to use protobuf types for enums (Topic and CatalogOp). We could create our own local types and test that the mapping between them is correct and complete, but for now we already have a dependency on protobuf from the `state` package, so it is probably easier to use the protobuf types. In the future it should be relatively easy to change it if we want to remove the dependency.