### PR TITLE
Fix GRPCUseTLS flag HTTP API mapping

### DIFF
--- a/.changelog/8771.txt
+++ b/.changelog/8771.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+api: Fixed a bug where the Check.GRPCUseTLS field could not be set using snake case.
+```
+

--- a/agent/http_decode_test.go
+++ b/agent/http_decode_test.go
@@ -282,6 +282,7 @@ var translateCheckTypeTCs = [][]translateKeyTestCase{
 	translateScriptArgsTCs,
 	translateDeregisterTCs,
 	translateDockerTCs,
+	translateGRPCUseTLSTCs,
 	translateTLSTCs,
 	translateServiceIDTCs,
 }
@@ -557,6 +558,63 @@ var translateTLSTCs = []translateKeyTestCase{
 		want:       false, // zero value
 		jsonFmtStr: "{}",
 		equalityFn: tlsEqFn,
+	},
+}
+
+// GRPCUseTLS: bool
+func grpcUseTLSEqFn(out interface{}, want interface{}) error {
+	var got interface{}
+	switch v := out.(type) {
+	case structs.CheckDefinition:
+		got = v.GRPCUseTLS
+	case *structs.CheckDefinition:
+		got = v.GRPCUseTLS
+	case structs.CheckType:
+		got = v.GRPCUseTLS
+	case *structs.CheckType:
+		got = v.GRPCUseTLS
+	case structs.HealthCheckDefinition:
+		got = v.GRPCUseTLS
+	case *structs.HealthCheckDefinition:
+		got = v.GRPCUseTLS
+	default:
+		panic(fmt.Sprintf("unexpected type %T", out))
+	}
+	if got != want {
+		return fmt.Errorf("expected GRPCUseTLS to be %v, got %v", want, got)
+	}
+	return nil
+}
+
+var grpcUseTLSFields = []string{`"GRPCUseTLS": %s`, `"grpc_use_tls": %s`}
+var translateGRPCUseTLSTCs = []translateKeyTestCase{
+	{
+		desc:       "GRPCUseTLS: both set",
+		in:         []interface{}{"true", "false"},
+		want:       true,
+		jsonFmtStr: "{" + strings.Join(grpcUseTLSFields, ",") + "}",
+		equalityFn: grpcUseTLSEqFn,
+	},
+	{
+		desc:       "GRPCUseTLS: first set",
+		in:         []interface{}{`true`},
+		want:       true,
+		jsonFmtStr: "{" + grpcUseTLSFields[0] + "}",
+		equalityFn: grpcUseTLSEqFn,
+	},
+	{
+		desc:       "GRPCUseTLS: second set",
+		in:         []interface{}{`true`},
+		want:       true,
+		jsonFmtStr: "{" + grpcUseTLSFields[1] + "}",
+		equalityFn: grpcUseTLSEqFn,
+	},
+	{
+		desc:       "GRPCUseTLS: neither set",
+		in:         []interface{}{},
+		want:       false, // zero value
+		jsonFmtStr: "{}",
+		equalityFn: grpcUseTLSEqFn,
 	},
 }
 

--- a/agent/structs/check_definition.go
+++ b/agent/structs/check_definition.go
@@ -63,6 +63,7 @@ func (t *CheckDefinition) UnmarshalJSON(data []byte) (err error) {
 		DeregisterCriticalServiceAfterSnake interface{} `json:"deregister_critical_service_after"`
 		DockerContainerIDSnake              string      `json:"docker_container_id"`
 		TLSSkipVerifySnake                  bool        `json:"tls_skip_verify"`
+		GRPCUseTLSSnake                     bool        `json:"grpc_use_tls"`
 		ServiceIDSnake                      string      `json:"service_id"`
 
 		*Alias
@@ -88,6 +89,9 @@ func (t *CheckDefinition) UnmarshalJSON(data []byte) (err error) {
 	}
 	if aux.TLSSkipVerifySnake {
 		t.TLSSkipVerify = aux.TLSSkipVerifySnake
+	}
+	if aux.GRPCUseTLSSnake {
+		t.GRPCUseTLS = aux.GRPCUseTLSSnake
 	}
 	if t.ServiceID == "" {
 		t.ServiceID = aux.ServiceIDSnake

--- a/agent/structs/check_type.go
+++ b/agent/structs/check_type.go
@@ -76,6 +76,7 @@ func (t *CheckType) UnmarshalJSON(data []byte) (err error) {
 		DeregisterCriticalServiceAfterSnake interface{} `json:"deregister_critical_service_after"`
 		DockerContainerIDSnake              string      `json:"docker_container_id"`
 		TLSSkipVerifySnake                  bool        `json:"tls_skip_verify"`
+		GRPCUseTLSSnake                     bool        `json:"grpc_use_tls"`
 
 		// These are going to be ignored but since we are disallowing unknown fields
 		// during parsing we have to be explicit about parsing but not using these.
@@ -103,6 +104,9 @@ func (t *CheckType) UnmarshalJSON(data []byte) (err error) {
 	}
 	if aux.TLSSkipVerifySnake {
 		t.TLSSkipVerify = aux.TLSSkipVerifySnake
+	}
+	if aux.GRPCUseTLSSnake {
+		t.GRPCUseTLS = aux.GRPCUseTLSSnake
 	}
 
 	if aux.Interval != nil {


### PR DESCRIPTION
Currently HTTP APi doesn't recognize snake-cased `grpc_use_tls` option whereas loading from a config file works as expected, this fixes the following: 

```
curl -X PUT -d '{
  "name": "test",
  "port": 6060,
  "check": {
    "grpc": "127.0.0.1:8080/test",
    "grpc_use_tls": true,
    "interval": "5s"
  }
}' http://127.0.0.1:8500/v1/agent/service/register

Request decode failed: json: unknown field "grpc_use_tls"
```

I know there was a lot of copy-pasting just to make it work :cry: probably it can be improved later for all fields.

Can be worked around now: `"GRPCUseTLS": true` 