### PR TITLE
commit a new bindata file if there are changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,7 +643,7 @@ jobs:
       - run:
           name: commit agent/bindata_assetfs.go if there are changes
           command: |
-            if git diff --exit-code agent/bindata_assetfs.go; then
+            if ! git diff --exit-code agent/bindata_assetfs.go; then
               git add agent/bindata_assetfs.go
               git commit -m "auto-updated agent/bindata_assetfs.go"
               git push origin master


### PR DESCRIPTION
The git diff logic was wrong. It should commit a new file if there _are_ changes rather than _aren't_.