### PR TITLE
only async trigger changes

### DIFF
--- a/agent/consul/server_test.go
+++ b/agent/consul/server_test.go
@@ -1031,8 +1031,8 @@ func TestServer_Leave(t *testing.T) {
 		t.Fatal("leave failed: ", err)
 	}
 
-	// Should lose a peer
-	retry.Run(t, func(r *retry.R) {
+	timer := &retry.Timer{Timeout: 10 * time.Second, Wait: 500 * time.Millisecond}
+	retry.RunWith(timer, t, func(r *retry.R) {
 		r.Check(wantPeers(s1, 1))
 		r.Check(wantPeers(s2, 1))
 	})

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -213,6 +213,16 @@ func TestAPI_HealthChecks(t *testing.T) {
 	}
 
 	retry.Run(t, func(r *retry.R) {
+		services, _, err := c.Catalog().Services(nil)
+		if err != nil {
+			r.Fatal(err)
+		}
+		if _, ok := services["foo"]; !ok {
+			r.Fatal("service foo not synced")
+		}
+	})
+
+	retry.Run(t, func(r *retry.R) {
 		checks := HealthChecks{
 			&HealthCheck{
 				Node:        "node123",

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -234,6 +234,7 @@ func TestAPI_HealthChecks(t *testing.T) {
 		if meta.LastIndex == 0 {
 			r.Fatalf("bad: %v", meta)
 		}
+		require.NotEmpty(t, out)
 		checks[0].CreateIndex = out[0].CreateIndex
 		checks[0].ModifyIndex = out[0].ModifyIndex
 		require.Equal(r, checks, out)

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -244,7 +244,7 @@ func TestAPI_HealthChecks(t *testing.T) {
 		if meta.LastIndex == 0 {
 			r.Fatalf("bad: %v", meta)
 		}
-		require.NotEmpty(t, out)
+		require.NotEmpty(r, out)
 		checks[0].CreateIndex = out[0].CreateIndex
 		checks[0].ModifyIndex = out[0].ModifyIndex
 		require.Equal(r, checks, out)

--- a/command/catalog/list/services/catalog_list_services_test.go
+++ b/command/catalog/list/services/catalog_list_services_test.go
@@ -48,6 +48,8 @@ func TestCatalogListServicesCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1", testrpc.WaitForService("testing"))
+
 	t.Run("simple", func(t *testing.T) {
 		ui := cli.NewMockUi()
 		c := New(ui)

--- a/connect/resolver_test.go
+++ b/connect/resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/consul/agent"
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/testrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,6 +102,8 @@ func TestConsulResolver_Resolve(t *testing.T) {
 		agent.Config.AdvertiseAddrLAN.String() + ":9090",
 		agent.Config.AdvertiseAddrLAN.String() + ":9091",
 	}
+
+	testrpc.WaitForTestAgent(t, agent.RPC, "dc1", testrpc.WaitForService("db"))
 
 	type fields struct {
 		Namespace  string

--- a/sdk/testutil/server.go
+++ b/sdk/testutil/server.go
@@ -250,7 +250,6 @@ func NewTestServerConfigT(t TestingTB, cb ServerConfigCallback) (*TestServer, er
 		return nil, errors.Wrap(err, "failed marshaling json")
 	}
 
-	t.Logf("CONFIG JSON: %s", string(b))
 	configFile := filepath.Join(tmpdir, "config.json")
 	if err := ioutil.WriteFile(configFile, b, 0644); err != nil {
 		cfg.ReturnPorts()

--- a/testrpc/wait.go
+++ b/testrpc/wait.go
@@ -95,10 +95,6 @@ func flattenOptions(options []waitOption) waitOption {
 	return flat
 }
 
-func WaitForSyncedTestAgent(t *testing.T, rpc rpcFn, dc string, options ...waitOption) {
-	t.Helper()
-}
-
 // WaitForTestAgent ensures we have a node with serfHealth check registered
 func WaitForTestAgent(t *testing.T, rpc rpcFn, dc string, options ...waitOption) {
 	t.Helper()


### PR DESCRIPTION
This is a tiny step towards fixing https://github.com/hashicorp/consul/issues/6616.

This PR stops all agent endpoints from syncing the changes synchronously and leaves it to the asynchronous ticker to pick up these changes. And makes changes to how `syncNodeInfo` is called...

The evolution of `syncNodeInfo`:

original:

1. `updateSyncState` -- among other things -- determines if node needs syncing and set `nodeInfoInSync`
2. `SyncChanges` adds node info to every service/check update if `!nodeInfoInSync` and has a manual `syncNodeInfo` call in case everything before failed to updated nodeinfo

after #7189:

1. `updateSyncState` determines if node needs syncing and set `nodeInfoInSync`
2. `SyncChanges` calls `syncNodeInfo` upfront instead of appending nodeinfo to every service/check update

proposed:

1. `updateSyncState` determines if node needs syncing and calls `syncNodeInfo` right away
2. `SyncChanges` doesn't try to sync node info


This PR potentially makes the tests more flaky because services/checks are no longer synced immediately.