### PR TITLE
ui: Outlet Loading

### DIFF
--- a/ui-v2/app/components/app-view/index.hbs
+++ b/ui-v2/app/components/app-view/index.hbs
@@ -1,90 +1,90 @@
-{{yield}}
-<header>
-{{#each flashMessages.queue as |flash|}}
-    <FlashMessage @flash={{flash}} as |component flash|>
-  {{#if flash.dom}}
-        {{{flash.dom}}}
-  {{else}}
-        {{#let (lowercase component.flashType) (lowercase flash.action) as |status type|}}
-          {{! flashes automatically ucfirst the type }}
-
-          <p data-notification role="alert" class={{concat status ' notification-' type}}>
-            <strong>
-              {{capitalize status}}!
-            </strong>
-            {{#yield-slot name="notification" params=(block-params status type flash.item flash.error)}}
-              {{yield}}
-              {{#if (eq type 'logout')}}
-                {{#if (eq status 'success') }}
-                  You are now logged out.
-                {{else}}
-                  There was an error logging out.
-                {{/if}}
-              {{else if (eq type 'authorize')}}
-                {{#if (eq status 'success') }}
-                  You are now logged in.
-                {{else}}
-                  There was an error, please check your SecretID/Token
-                {{/if}}
-              {{/if}}
-            {{else}}
-              {{#if (eq type 'logout')}}
-                {{#if (eq status 'success') }}
-                  You are now logged out.
-                {{else}}
-                  There was an error logging out.
-                {{/if}}
-              {{else if (eq type 'authorize')}}
-                {{#if (eq status 'success') }}
-                  You are now logged in.
-                {{else}}
-                  There was an error, please check your SecretID/Token
-                {{/if}}
-              {{/if}}
-            {{/yield-slot}}
-          </p>
-        {{/let}}
-  {{/if}}
-    </FlashMessage>
-{{/each}}
-    <div>
-        <div>
-  {{#if authorized}}
-            <nav aria-label="Breadcrumb">
-                <YieldSlot @name="breadcrumbs">{{yield}}</YieldSlot>
-            </nav>
-  {{/if}}
-            <div class="title">
-              <YieldSlot @name="header">
-                  {{yield}}
-              </YieldSlot>
-              <div class="actions">
-        {{#if authorized}}
-                  <YieldSlot @name="actions">
-                    <PortalTarget @name="app-view-actions" />
-                    {{yield}}
-                  </YieldSlot>
-        {{/if}}
-              </div>
-            </div>
-            <YieldSlot @name="nav">
-              {{yield}}
-            </YieldSlot>
-        </div>
-    </div>
-  {{#if authorized}}
-    <YieldSlot @name="toolbar">
-      <input type="checkbox" id="toolbar-toggle" />
-      {{yield}}
-    </YieldSlot>
-  {{/if}}
-</header>
-<div>
-    {{#if (not enabled) }}
-      <YieldSlot @name="disabled">{{yield}}</YieldSlot>
-    {{else if (not authorized)}}
-      <YieldSlot @name="authorization">{{yield}}</YieldSlot>
+<div class="app-view">
+  {{yield}}
+  <header>
+  {{#each flashMessages.queue as |flash|}}
+      <FlashMessage @flash={{flash}} as |component flash|>
+    {{#if flash.dom}}
+          {{{flash.dom}}}
     {{else}}
-      <YieldSlot @name="content">{{yield}}</YieldSlot>
+          {{#let (lowercase component.flashType) (lowercase flash.action) as |status type|}}
+            {{! flashes automatically ucfirst the type }}
+
+            <p data-notification role="alert" class={{concat status ' notification-' type}}>
+              <strong>
+                {{capitalize status}}!
+              </strong>
+              {{#yield-slot name="notification" params=(block-params status type flash.item flash.error)}}
+                {{yield}}
+                {{#if (eq type 'logout')}}
+                  {{#if (eq status 'success') }}
+                    You are now logged out.
+                  {{else}}
+                    There was an error logging out.
+                  {{/if}}
+                {{else if (eq type 'authorize')}}
+                  {{#if (eq status 'success') }}
+                    You are now logged in.
+                  {{else}}
+                    There was an error, please check your SecretID/Token
+                  {{/if}}
+                {{/if}}
+              {{else}}
+                {{#if (eq type 'logout')}}
+                  {{#if (eq status 'success') }}
+                    You are now logged out.
+                  {{else}}
+                    There was an error logging out.
+                  {{/if}}
+                {{else if (eq type 'authorize')}}
+                  {{#if (eq status 'success') }}
+                    You are now logged in.
+                  {{else}}
+                    There was an error, please check your SecretID/Token
+                  {{/if}}
+                {{/if}}
+              {{/yield-slot}}
+            </p>
+          {{/let}}
     {{/if}}
+      </FlashMessage>
+  {{/each}}
+      <div>
+          <div>
+    {{#if authorized}}
+              <nav aria-label="Breadcrumb">
+                  <YieldSlot @name="breadcrumbs">{{yield}}</YieldSlot>
+              </nav>
+    {{/if}}
+              <div class="title">
+                <YieldSlot @name="header">
+                    {{yield}}
+                </YieldSlot>
+                <div class="actions">
+          {{#if authorized}}
+                    <YieldSlot @name="actions">
+                      <PortalTarget @name="app-view-actions" />
+                      {{yield}}
+                    </YieldSlot>
+          {{/if}}
+                </div>
+              </div>
+              <YieldSlot @name="nav">
+                {{yield}}
+              </YieldSlot>
+          </div>
+      </div>
+    {{#if authorized}}
+      <YieldSlot @name="toolbar">
+        <input type="checkbox" id="toolbar-toggle" />
+        {{yield}}
+      </YieldSlot>
+    {{/if}}
+  </header>
+  <div>
+      {{#if (not enabled) }}
+        <YieldSlot @name="disabled">{{yield}}</YieldSlot>
+      {{else}}
+        <YieldSlot @name="content">{{yield}}</YieldSlot>
+      {{/if}}
+  </div>
 </div>

--- a/ui-v2/app/components/app-view/index.js
+++ b/ui-v2/app/components/app-view/index.js
@@ -1,46 +1,7 @@
 import Component from '@ember/component';
 import SlotsMixin from 'block-slots';
-import { inject as service } from '@ember/service';
-import templatize from 'consul-ui/utils/templatize';
 export default Component.extend(SlotsMixin, {
+  tagName: '',
   authorized: true,
   enabled: true,
-  classNames: ['app-view'],
-  classNameBindings: ['enabled::disabled', 'authorized::unauthorized'],
-  dom: service('dom'),
-  didReceiveAttrs: function() {
-    this._super(...arguments);
-    // right now only manually added classes are hoisted to <html>
-    const $root = this.dom.root();
-    if (this.loading) {
-      $root.classList.add('loading');
-    } else {
-      $root.classList.remove('loading');
-    }
-    let cls = this['class'] || '';
-    if (cls) {
-      // its possible for 'layout' templates to change after insert
-      // check for these specific layouts and clear them out
-      const receivedClasses = new Set(templatize(cls.split(' ')));
-      const difference = new Set([...$root.classList].filter(item => !receivedClasses.has(item)));
-      [...difference].forEach(function(item, i) {
-        if (templatize(['edit', 'show', 'list']).indexOf(item) !== -1) {
-          $root.classList.remove(item);
-        }
-      });
-      $root.classList.add(...receivedClasses);
-    }
-  },
-  didInsertElement: function() {
-    this._super(...arguments);
-    this.didReceiveAttrs();
-  },
-  didDestroyElement: function() {
-    this._super(...arguments);
-    const cls = this['class'] + ' loading';
-    if (cls) {
-      const $root = this.dom.root();
-      $root.classList.remove(...templatize(cls.split(' ')));
-    }
-  },
 });

--- a/ui-v2/app/components/empty-state/index.hbs
+++ b/ui-v2/app/components/empty-state/index.hbs
@@ -14,7 +14,7 @@
     <div>
       {{yield}}
       {{#if (and (env 'CONSUL_ACLS_ENABLED') allowLogin)}}
-        <label for="login-toggle">
+        <label for="login-toggle" data-test-empty-state-login>
           <DataSource
             @src="settings://consul:token"
             @onchange={{action (mut token) value="data"}}

--- a/ui-v2/app/components/empty-state/pageobject.js
+++ b/ui-v2/app/components/empty-state/pageobject.js
@@ -1,0 +1,6 @@
+export default present => (scope = '.empty-state') => {
+  return {
+    scope: scope,
+    login: present('[data-test-empty-state-login]'),
+  };
+};

--- a/ui-v2/app/components/hashicorp-consul/pageobject.js
+++ b/ui-v2/app/components/hashicorp-consul/pageobject.js
@@ -1,4 +1,4 @@
-export default (collection, clickable, attribute, is, authForm) => scope => {
+export default (collection, clickable, attribute, is, authForm, emptyState) => scope => {
   const page = {
     navigation: [
       'services',
@@ -34,6 +34,7 @@ export default (collection, clickable, attribute, is, authForm) => scope => {
     authdialog: {
       form: authForm(),
     },
+    emptystate: emptyState(),
     // TODO: errors aren't strictly part of this component
     error: {
       status: attribute('data-test-status', '[data-test-status]'),

--- a/ui-v2/app/components/list-collection/index.js
+++ b/ui-v2/app/components/list-collection/index.js
@@ -55,11 +55,11 @@ export default Component.extend(Slotted, {
     resize: function(e) {
       // TODO: This top part is very similar to resize in tabular-collection
       // see if it make sense to DRY out
-      const $appContent = this.dom.element('main > div');
-      if ($appContent) {
+      const dom = get(this, 'dom');
+      const $footer = dom.element('footer[role="contentinfo"]');
+      if ($footer) {
         const border = 1;
         const rect = this.$element.getBoundingClientRect();
-        const $footer = this.dom.element('footer[role="contentinfo"]');
         const space = rect.top + $footer.clientHeight + border;
         const height = e.target.innerHeight - space;
         this.set('height', Math.max(0, height));

--- a/ui-v2/app/components/outlet/index.hbs
+++ b/ui-v2/app/components/outlet/index.hbs
@@ -1,0 +1,8 @@
+<section
+  class="outlet"
+  data-outlet={{name}}
+  data-state={{state.name}}
+  data-transition={{concat previousState.name ' ' state.name}}
+>
+  {{yield}}
+</section>

--- a/ui-v2/app/components/outlet/index.hbs
+++ b/ui-v2/app/components/outlet/index.hbs
@@ -1,8 +1,15 @@
+  {{did-insert this.connect}}
+  {{will-destroy this.disconnect}}
 <section
   class="outlet"
-  data-outlet={{name}}
-  data-state={{state.name}}
-  data-transition={{concat previousState.name ' ' state.name}}
+  data-outlet={{@name}}
+  data-route={{this.route}}
+  data-state={{this.state.name}}
+  data-transition={{concat this.previousState.name ' ' this.state.name}}
 >
-  {{yield}}
+  {{yield (hash
+    state=this.state
+    previousState=this.previousState
+    route=this.route
+  )}}
 </section>

--- a/ui-v2/app/components/outlet/index.js
+++ b/ui-v2/app/components/outlet/index.js
@@ -1,0 +1,83 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { setProperties } from '@ember/object';
+
+class State {
+  constructor(name) {
+    this.name = name;
+  }
+  matches(match) {
+    return this.name === match;
+  }
+}
+const outlets = new Set();
+export default Component.extend({
+  tagName: '',
+  router: service('router'),
+  dom: service('dom'),
+  root: false,
+  init: function() {
+    this._super(...arguments);
+    this._listeners = this.dom.listeners();
+    if (outlets.size === 0) {
+      this.root = true;
+    }
+    if (this.root) {
+      this.setAppRoute(this.router.currentRouteName);
+      this.setAppState('idle');
+    }
+  },
+  didDestroyElement: function() {
+    this._super(...arguments);
+    outlets.delete(this.name);
+    this._listeners.remove();
+  },
+  setAppRoute: function(name) {
+    if (name.startsWith('nspace.')) {
+      name = name.substr(0, 'nspace.'.length);
+    }
+    this.dom.root().dataset.route = name;
+  },
+  setAppState: function(state) {
+    this.dom.root().dataset.state = state;
+  },
+  didInsertElement: function() {
+    this._super(...arguments);
+    outlets.add(this.name);
+    setProperties(this, {
+      state: new State('idle'),
+    });
+    setProperties(this, {
+      previousState: this.state,
+    });
+    this._listeners.add(this.router, {
+      routeWillChange: transition => {
+        const to = transition.to.name;
+        const outlet =
+          [...outlets].reverse().find(item => {
+            return to.indexOf(item) !== -1;
+          }) || 'application';
+        if (this.name === outlet) {
+          setProperties(this, {
+            previousState: this.state,
+            state: new State('loading'),
+          });
+        }
+        if (this.root) {
+          this.setAppState('loading');
+        }
+      },
+      routeDidChange: transition => {
+        setProperties(this, {
+          // route: transition.to.name,
+          previousState: this.state,
+          state: new State('idle'),
+        });
+        if (this.root) {
+          this.setAppRoute(this.router.currentRouteName);
+          this.setAppState('idle');
+        }
+      },
+    });
+  },
+});

--- a/ui-v2/app/components/outlet/index.js
+++ b/ui-v2/app/components/outlet/index.js
@@ -82,6 +82,16 @@ export default class Outlet extends Component {
     this.dom.root().dataset.state = state;
   }
 
+  setOutletRoutes(route) {
+    const keys = [...outlets.keys()];
+    const pos = keys.indexOf(this.name);
+    const key = pos + 1;
+    const parent = outlets.get(keys[key]);
+    parent.route = this.args.name;
+
+    this.route = route;
+  }
+
   @action
   startLoad(transition) {
     const keys = [...outlets.keys()];
@@ -100,16 +110,6 @@ export default class Outlet extends Component {
     }
   }
 
-  setOutletRoutes(route) {
-    const keys = [...outlets.keys()];
-    const pos = keys.indexOf(this.name);
-    const key = pos + 1;
-    const parent = outlets.get(keys[key]);
-    parent.route = this.args.name;
-
-    this.route = route;
-  }
-
   @action
   endLoad(transition) {
     if (this.state.matches('loading')) {
@@ -122,6 +122,7 @@ export default class Outlet extends Component {
       this.setAppRoute(this.router.currentRouteName);
     }
   }
+
   @action
   connect() {
     outlets.set(this.args.name, this);

--- a/ui-v2/app/components/outlet/index.js
+++ b/ui-v2/app/components/outlet/index.js
@@ -45,9 +45,6 @@ class Outlets {
   keys() {
     return this.sorted;
   }
-  get size() {
-    return this.map.size;
-  }
 }
 const outlets = new Outlets();
 
@@ -62,8 +59,8 @@ export default class Outlet extends Component {
   constructor() {
     super(...arguments);
     if (this.args.name === 'application') {
+      this.setAppState('loading');
       this.setAppRoute(this.router.currentRouteName);
-      this.setAppState('idle');
     }
   }
 
@@ -71,8 +68,14 @@ export default class Outlet extends Component {
     if (name.startsWith('nspace.')) {
       name = name.substr(0, 'nspace.'.length);
     }
-    this.dom.root().dataset.route = name;
-    this.dom.root().classList.remove('ember-loading');
+    if (name !== 'loading') {
+      const doc = this.dom.root();
+      if (doc.classList.contains('ember-loading')) {
+        doc.classList.remove('ember-loading');
+      }
+      doc.dataset.route = name;
+      this.setAppState('idle');
+    }
   }
 
   setAppState(state) {
@@ -117,7 +120,6 @@ export default class Outlet extends Component {
     }
     if (this.args.name === 'application') {
       this.setAppRoute(this.router.currentRouteName);
-      this.setAppState('idle');
     }
   }
   @action

--- a/ui-v2/app/components/outlet/index.js
+++ b/ui-v2/app/components/outlet/index.js
@@ -72,6 +72,7 @@ export default class Outlet extends Component {
       name = name.substr(0, 'nspace.'.length);
     }
     this.dom.root().dataset.route = name;
+    this.dom.root().classList.remove('ember-loading');
   }
 
   setAppState(state) {

--- a/ui-v2/app/components/role-selector/index.hbs
+++ b/ui-v2/app/components/role-selector/index.hbs
@@ -1,4 +1,5 @@
 <ModalDialog
+  class="role-selector"
   data-test-role-form
   @onclose={{action (mut state) "role"}}
   @name="new-role-toggle"

--- a/ui-v2/app/components/role-selector/index.scss
+++ b/ui-v2/app/components/role-selector/index.scss
@@ -1,0 +1,9 @@
+.role-selector {
+  [name='role[state]'],
+  [name='role[state]'] + * {
+    display: none;
+  }
+  [name='role[state]']:checked + * {
+    display: block;
+  }
+}

--- a/ui-v2/app/components/tabular-collection/index.js
+++ b/ui-v2/app/components/tabular-collection/index.js
@@ -69,7 +69,7 @@ export default CollectionComponent.extend(Slotted, {
   actions: {
     resize: function(e) {
       const $tbody = this.element;
-      const $appContent = this.dom.element('main > div');
+      const $appContent = this.dom.element('.app-view');
       if ($appContent) {
         const border = 1;
         const rect = $tbody.getBoundingClientRect();

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -16,6 +16,7 @@ export default Route.extend(WithBlockingActions, {
   settings: service('settings'),
   model: function() {
     return hash({
+      routeName: this.routeName,
       router: this.router,
       dcs: this.repo.findAll(),
       nspaces: this.nspacesRepo.findAll().catch(function() {

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -39,14 +39,8 @@ export default Route.extend(WithBlockingActions, {
   },
   actions: {
     loading: function(transition, originRoute) {
-      const from = get(transition, 'from.name') || 'application';
-      const controller = this.controllerFor(from);
-
-      set(controller, 'loading', true);
       const $root = this.dom.root();
-      $root.classList.add('loading');
       transition.promise.finally(() => {
-        set(controller, 'loading', false);
         removeLoading($root);
       });
     },

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -11,7 +11,6 @@ export default Route.extend(WithBlockingActions, {
   settings: service('settings'),
   model: function() {
     return hash({
-      routeName: this.routeName,
       router: this.router,
       dcs: this.repo.findAll(),
       nspaces: this.nspacesRepo.findAll().catch(function() {
@@ -30,6 +29,7 @@ export default Route.extend(WithBlockingActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -1,12 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
-import { get, set } from '@ember/object';
 
 import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
 
 export default Route.extend(WithBlockingActions, {
-  dom: service('dom'),
   router: service('router'),
   nspacesRepo: service('repository/nspace/disabled'),
   repo: service('repository/dc'),
@@ -70,7 +68,6 @@ export default Route.extend(WithBlockingActions, {
       const app = this.modelFor('application') || {};
       const dcs = app.dcs || [model.dc];
       const nspaces = app.nspaces || [model.nspace];
-      const $root = this.dom.root();
       hash({
         dc:
           error.status.toString().indexOf('5') !== 0

--- a/ui-v2/app/routes/application.js
+++ b/ui-v2/app/routes/application.js
@@ -5,9 +5,6 @@ import { get, set } from '@ember/object';
 
 import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
 
-const removeLoading = function($from) {
-  return $from.classList.remove('ember-loading', 'loading');
-};
 export default Route.extend(WithBlockingActions, {
   dom: service('dom'),
   router: service('router'),
@@ -38,12 +35,6 @@ export default Route.extend(WithBlockingActions, {
     controller.setProperties(model);
   },
   actions: {
-    loading: function(transition, originRoute) {
-      const $root = this.dom.root();
-      transition.promise.finally(() => {
-        removeLoading($root);
-      });
-    },
     error: function(e, transition) {
       // TODO: Normalize all this better
       let error = {
@@ -91,14 +82,12 @@ export default Route.extend(WithBlockingActions, {
       })
         .then(model => Promise.all([model, this.repo.clearActive()]))
         .then(([model]) => {
-          removeLoading($root);
           // we can't use setupController as we received an error
           // so we do it manually instead
           this.controllerFor('application').setProperties(model);
           this.controllerFor('error').setProperties({ error: error });
         })
         .catch(e => {
-          removeLoading($root);
           this.controllerFor('error').setProperties({ error: error });
         });
       return true;

--- a/ui-v2/app/routes/dc.js
+++ b/ui-v2/app/routes/dc.js
@@ -67,6 +67,9 @@ export default Route.extend({
     // but we need to wait until we are in this route so we know what the dc
     // and or nspace is if the below changes please revists the comments
     // in routes/application:model
+    controller.setProperties({
+      routeName: this.routeName,
+    });
     this.controllerFor('application').setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routes/dc.js
+++ b/ui-v2/app/routes/dc.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash, Promise } from 'rsvp';
 import { get } from '@ember/object';
@@ -63,13 +63,11 @@ export default Route.extend({
       });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     // the model here is actually required for the entire application
     // but we need to wait until we are in this route so we know what the dc
     // and or nspace is if the below changes please revists the comments
     // in routes/application:model
-    controller.setProperties({
-      routeName: this.routeName,
-    });
     this.controllerFor('application').setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routes/dc/acls.js
+++ b/ui-v2/app/routes/dc/acls.js
@@ -1,3 +1,3 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
 export default Route.extend(WithBlockingActions, {});

--- a/ui-v2/app/routes/dc/acls/create.js
+++ b/ui-v2/app/routes/dc/acls/create.js
@@ -16,6 +16,7 @@ export default Route.extend(WithAclActions, {
       Datacenter: this.modelFor('dc').dc.Name,
     });
     return hash({
+      routeName: this.routeName,
       create: true,
       isLoading: false,
       item: this.item,

--- a/ui-v2/app/routes/dc/acls/create.js
+++ b/ui-v2/app/routes/dc/acls/create.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -16,13 +16,13 @@ export default Route.extend(WithAclActions, {
       Datacenter: this.modelFor('dc').dc.Name,
     });
     return hash({
-      routeName: this.routeName,
       create: true,
       item: this.item,
       types: ['management', 'client'],
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
   deactivate: function() {

--- a/ui-v2/app/routes/dc/acls/create.js
+++ b/ui-v2/app/routes/dc/acls/create.js
@@ -18,7 +18,6 @@ export default Route.extend(WithAclActions, {
     return hash({
       routeName: this.routeName,
       create: true,
-      isLoading: false,
       item: this.item,
       types: ['management', 'client'],
     });

--- a/ui-v2/app/routes/dc/acls/edit.js
+++ b/ui-v2/app/routes/dc/acls/edit.js
@@ -9,6 +9,7 @@ export default Route.extend(WithAclActions, {
   settings: service('settings'),
   model: function(params) {
     return hash({
+      routeName: this.routeName,
       isLoading: false,
       item: this.repo.findBySlug(params.id, this.modelFor('dc').dc.Name),
       types: ['management', 'client'],

--- a/ui-v2/app/routes/dc/acls/edit.js
+++ b/ui-v2/app/routes/dc/acls/edit.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -9,12 +9,12 @@ export default Route.extend(WithAclActions, {
   settings: service('settings'),
   model: function(params) {
     return hash({
-      routeName: this.routeName,
       item: this.repo.findBySlug(params.id, this.modelFor('dc').dc.Name),
       types: ['management', 'client'],
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/edit.js
+++ b/ui-v2/app/routes/dc/acls/edit.js
@@ -10,7 +10,6 @@ export default Route.extend(WithAclActions, {
   model: function(params) {
     return hash({
       routeName: this.routeName,
-      isLoading: false,
       item: this.repo.findBySlug(params.id, this.modelFor('dc').dc.Name),
       types: ['management', 'client'],
     });

--- a/ui-v2/app/routes/dc/acls/index.js
+++ b/ui-v2/app/routes/dc/acls/index.js
@@ -28,6 +28,7 @@ export default Route.extend(WithAclActions, {
   },
   model: function(params) {
     return hash({
+      routeName: this.routeName,
       isLoading: false,
       items: this.repo.findAllByDatacenter(this.modelFor('dc').dc.Name),
       token: this.settings.findBySlug('token'),

--- a/ui-v2/app/routes/dc/acls/index.js
+++ b/ui-v2/app/routes/dc/acls/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -28,12 +28,12 @@ export default Route.extend(WithAclActions, {
   },
   model: function(params) {
     return hash({
-      routeName: this.routeName,
       items: this.repo.findAllByDatacenter(this.modelFor('dc').dc.Name),
       token: this.settings.findBySlug('token'),
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/index.js
+++ b/ui-v2/app/routes/dc/acls/index.js
@@ -29,7 +29,6 @@ export default Route.extend(WithAclActions, {
   model: function(params) {
     return hash({
       routeName: this.routeName,
-      isLoading: false,
       items: this.repo.findAllByDatacenter(this.modelFor('dc').dc.Name),
       token: this.settings.findBySlug('token'),
     });

--- a/ui-v2/app/routes/dc/acls/policies/edit.js
+++ b/ui-v2/app/routes/dc/acls/policies/edit.js
@@ -16,6 +16,7 @@ export default SingleRoute.extend(WithPolicyActions, {
       return hash({
         ...model,
         ...{
+          routeName: this.routeName,
           items: tokenRepo.findByPolicy(get(model.item, 'ID'), dc, nspace).catch(function(e) {
             switch (get(e, 'errors.firstObject.status')) {
               case '403':

--- a/ui-v2/app/routes/dc/acls/policies/edit.js
+++ b/ui-v2/app/routes/dc/acls/policies/edit.js
@@ -31,6 +31,7 @@ export default SingleRoute.extend(WithPolicyActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/policies/index.js
+++ b/ui-v2/app/routes/dc/acls/policies/index.js
@@ -21,6 +21,7 @@ export default Route.extend(WithPolicyActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
+      routeName: this.routeName,
       isLoading: false,
     });
   },

--- a/ui-v2/app/routes/dc/acls/policies/index.js
+++ b/ui-v2/app/routes/dc/acls/policies/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -21,10 +21,10 @@ export default Route.extend(WithPolicyActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
-      routeName: this.routeName,
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/policies/index.js
+++ b/ui-v2/app/routes/dc/acls/policies/index.js
@@ -22,7 +22,6 @@ export default Route.extend(WithPolicyActions, {
         ),
       }),
       routeName: this.routeName,
-      isLoading: false,
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc/acls/roles/edit.js
+++ b/ui-v2/app/routes/dc/acls/roles/edit.js
@@ -16,6 +16,7 @@ export default SingleRoute.extend(WithRoleActions, {
       return hash({
         ...model,
         ...{
+          routeName: this.routeName,
           items: tokenRepo.findByRole(get(model.item, 'ID'), dc, nspace).catch(function(e) {
             switch (get(e, 'errors.firstObject.status')) {
               case '403':

--- a/ui-v2/app/routes/dc/acls/roles/edit.js
+++ b/ui-v2/app/routes/dc/acls/roles/edit.js
@@ -16,7 +16,6 @@ export default SingleRoute.extend(WithRoleActions, {
       return hash({
         ...model,
         ...{
-          routeName: this.routeName,
           items: tokenRepo.findByRole(get(model.item, 'ID'), dc, nspace).catch(function(e) {
             switch (get(e, 'errors.firstObject.status')) {
               case '403':
@@ -31,6 +30,7 @@ export default SingleRoute.extend(WithRoleActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/roles/index.js
+++ b/ui-v2/app/routes/dc/acls/roles/index.js
@@ -21,6 +21,7 @@ export default Route.extend(WithRoleActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
+      routeName: this.routeName,
       isLoading: false,
     });
   },

--- a/ui-v2/app/routes/dc/acls/roles/index.js
+++ b/ui-v2/app/routes/dc/acls/roles/index.js
@@ -22,7 +22,6 @@ export default Route.extend(WithRoleActions, {
         ),
       }),
       routeName: this.routeName,
-      isLoading: false,
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc/acls/roles/index.js
+++ b/ui-v2/app/routes/dc/acls/roles/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -21,10 +21,10 @@ export default Route.extend(WithRoleActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
-      routeName: this.routeName,
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/tokens/edit.js
+++ b/ui-v2/app/routes/dc/acls/tokens/edit.js
@@ -12,6 +12,7 @@ export default SingleRoute.extend(WithTokenActions, {
       return hash({
         ...model,
         ...{
+          routeName: this.routeName,
           token: this.settings.findBySlug('token'),
         },
       });

--- a/ui-v2/app/routes/dc/acls/tokens/edit.js
+++ b/ui-v2/app/routes/dc/acls/tokens/edit.js
@@ -19,6 +19,7 @@ export default SingleRoute.extend(WithTokenActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/acls/tokens/index.js
+++ b/ui-v2/app/routes/dc/acls/tokens/index.js
@@ -32,6 +32,7 @@ export default Route.extend(WithTokenActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
+      routeName: this.routeName,
       nspace: this.modelFor('nspace').nspace.substr(1),
       isLoading: false,
       token: this.settings.findBySlug('token'),

--- a/ui-v2/app/routes/dc/acls/tokens/index.js
+++ b/ui-v2/app/routes/dc/acls/tokens/index.js
@@ -34,7 +34,6 @@ export default Route.extend(WithTokenActions, {
       }),
       routeName: this.routeName,
       nspace: this.modelFor('nspace').nspace.substr(1),
-      isLoading: false,
       token: this.settings.findBySlug('token'),
     });
   },

--- a/ui-v2/app/routes/dc/acls/tokens/index.js
+++ b/ui-v2/app/routes/dc/acls/tokens/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -32,12 +32,12 @@ export default Route.extend(WithTokenActions, {
           this.modelFor('nspace').nspace.substr(1)
         ),
       }),
-      routeName: this.routeName,
       nspace: this.modelFor('nspace').nspace.substr(1),
       token: this.settings.findBySlug('token'),
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/index.js
+++ b/ui-v2/app/routes/dc/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   beforeModel: function() {

--- a/ui-v2/app/routes/dc/intentions/edit.js
+++ b/ui-v2/app/routes/dc/intentions/edit.js
@@ -8,6 +8,7 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = '*';
     return hash({
+      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item:

--- a/ui-v2/app/routes/dc/intentions/edit.js
+++ b/ui-v2/app/routes/dc/intentions/edit.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -8,7 +8,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = '*';
     return hash({
-      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item:
@@ -20,6 +19,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/intentions/index.js
+++ b/ui-v2/app/routes/dc/intentions/index.js
@@ -10,6 +10,7 @@ export default Route.extend({
   },
   model: function(params) {
     return {
+      routeName: this.routeName,
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1) || 'default',
     };

--- a/ui-v2/app/routes/dc/intentions/index.js
+++ b/ui-v2/app/routes/dc/intentions/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   queryParams: {
@@ -10,12 +10,12 @@ export default Route.extend({
   },
   model: function(params) {
     return {
-      routeName: this.routeName,
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1) || 'default',
     };
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -18,6 +18,7 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
+      routeName: this.routeName,
       dc: dc,
       nspace: nspace || 'default',
       parent:

--- a/ui-v2/app/routes/dc/kv/edit.js
+++ b/ui-v2/app/routes/dc/kv/edit.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -18,7 +18,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      routeName: this.routeName,
       dc: dc,
       nspace: nspace || 'default',
       parent:
@@ -49,6 +48,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/kv/folder.js
+++ b/ui-v2/app/routes/dc/kv/folder.js
@@ -1,4 +1,3 @@
-// import Route from '@ember/routing/route';
 import Route from './index';
 
 export default Route.extend({

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -27,6 +27,7 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
       isLoading: false,
+      routeName: this.routeName,
       parent: this.repo.findBySlug(key, dc, nspace),
     }).then(model => {
       return hash({

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -26,7 +26,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      isLoading: false,
       routeName: this.routeName,
       parent: this.repo.findBySlug(key, dc, nspace),
     }).then(model => {

--- a/ui-v2/app/routes/dc/kv/index.js
+++ b/ui-v2/app/routes/dc/kv/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -26,7 +26,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      routeName: this.routeName,
       parent: this.repo.findBySlug(key, dc, nspace),
     }).then(model => {
       return hash({
@@ -54,6 +53,7 @@ export default Route.extend({
     },
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -16,6 +16,7 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = '*';
     return hash({
+      routeName: this.routeName,
       items: this.data.source(uri => uri`/${nspace}/${dc}/nodes`),
       leader: this.repo.findByLeader(dc),
     });

--- a/ui-v2/app/routes/dc/nodes/index.js
+++ b/ui-v2/app/routes/dc/nodes/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -16,12 +16,12 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = '*';
     return hash({
-      routeName: this.routeName,
       items: this.data.source(uri => uri`/${nspace}/${dc}/nodes`),
       leader: this.repo.findByLeader(dc),
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show.js
+++ b/ui-v2/app/routes/dc/nodes/show.js
@@ -9,6 +9,7 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const name = params.name;
     return hash({
+      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item: this.data.source(uri => uri`/${nspace}/${dc}/node/${name}`),
@@ -16,7 +17,6 @@ export default Route.extend({
       return hash({
         ...model,
         tomography: this.data.source(uri => uri`/${nspace}/${dc}/coordinates/for-node/${name}`),
-        sessions: this.data.source(uri => uri`/${nspace}/${dc}/sessions/for-node/${name}`),
       });
     });
   },

--- a/ui-v2/app/routes/dc/nodes/show.js
+++ b/ui-v2/app/routes/dc/nodes/show.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -9,7 +9,6 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const name = params.name;
     return hash({
-      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item: this.data.source(uri => uri`/${nspace}/${dc}/node/${name}`),
@@ -21,6 +20,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show/healthchecks.js
+++ b/ui-v2/app/routes/dc/nodes/show/healthchecks.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/nodes/show/healthchecks.js
+++ b/ui-v2/app/routes/dc/nodes/show/healthchecks.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show/index.js
+++ b/ui-v2/app/routes/dc/nodes/show/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({

--- a/ui-v2/app/routes/dc/nodes/show/metadata.js
+++ b/ui-v2/app/routes/dc/nodes/show/metadata.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/nodes/show/metadata.js
+++ b/ui-v2/app/routes/dc/nodes/show/metadata.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show/rtt.js
+++ b/ui-v2/app/routes/dc/nodes/show/rtt.js
@@ -7,7 +7,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   afterModel: function(model, transition) {
     if (!get(model, 'tomography.distances')) {

--- a/ui-v2/app/routes/dc/nodes/show/rtt.js
+++ b/ui-v2/app/routes/dc/nodes/show/rtt.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({
@@ -7,10 +7,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   afterModel: function(model, transition) {
     if (!get(model, 'tomography.distances')) {
@@ -22,6 +19,7 @@ export default Route.extend({
     }
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show/services.js
+++ b/ui-v2/app/routes/dc/nodes/show/services.js
@@ -12,7 +12,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/nodes/show/services.js
+++ b/ui-v2/app/routes/dc/nodes/show/services.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   queryParams: {
@@ -12,12 +12,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nodes/show/sessions.js
+++ b/ui-v2/app/routes/dc/nodes/show/sessions.js
@@ -1,8 +1,10 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { hash } from 'rsvp';
 import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
 
 export default Route.extend(WithBlockingActions, {
+  data: service('data-source/service'),
   sessionRepo: service('repository/session'),
   feedback: service('feedback'),
   model: function() {
@@ -10,7 +12,16 @@ export default Route.extend(WithBlockingActions, {
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    const dc = this.modelFor('dc').dc.Name;
+    const nspace = this.modelFor('nspace').nspace.substr(1);
+    const node = this.paramsFor(parent).name;
+    return hash({
+      routeName: this.routeName,
+      dc: dc,
+      nspace: nspace,
+      node: node,
+      sessions: this.data.source(uri => uri`/${nspace}/${dc}/sessions/for-node/${node}`),
+    });
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/nodes/show/sessions.js
+++ b/ui-v2/app/routes/dc/nodes/show/sessions.js
@@ -28,16 +28,10 @@ export default Route.extend(WithBlockingActions, {
   },
   actions: {
     invalidateSession: function(item) {
-      const dc = this.modelFor('dc').dc.Name;
-      const nspace = this.modelFor('nspace').nspace.substr(1);
-      const controller = this.controller;
+      const route = this;
       return this.feedback.execute(() => {
         return this.sessionRepo.remove(item).then(() => {
-          return this.sessionRepo.findByNode(item.Node, dc, nspace).then(function(sessions) {
-            controller.setProperties({
-              sessions: sessions,
-            });
-          });
+          route.refresh();
         });
       }, 'delete');
     },

--- a/ui-v2/app/routes/dc/nodes/show/sessions.js
+++ b/ui-v2/app/routes/dc/nodes/show/sessions.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import WithBlockingActions from 'consul-ui/mixins/with-blocking-actions';
@@ -16,7 +16,6 @@ export default Route.extend(WithBlockingActions, {
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const node = this.paramsFor(parent).name;
     return hash({
-      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       node: node,
@@ -24,6 +23,7 @@ export default Route.extend(WithBlockingActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routes/dc/nspaces/edit.js
+++ b/ui-v2/app/routes/dc/nspaces/edit.js
@@ -14,6 +14,7 @@ export default Route.extend(WithNspaceActions, {
     const create = this.isCreate(...arguments);
     const dc = this.modelFor('dc').dc.Name;
     return hash({
+      routeName: this.routeName,
       isLoading: false,
       create: create,
       dc: dc,

--- a/ui-v2/app/routes/dc/nspaces/edit.js
+++ b/ui-v2/app/routes/dc/nspaces/edit.js
@@ -15,7 +15,6 @@ export default Route.extend(WithNspaceActions, {
     const dc = this.modelFor('dc').dc.Name;
     return hash({
       routeName: this.routeName,
-      isLoading: false,
       create: create,
       dc: dc,
       item: create

--- a/ui-v2/app/routes/dc/nspaces/edit.js
+++ b/ui-v2/app/routes/dc/nspaces/edit.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -14,7 +14,6 @@ export default Route.extend(WithNspaceActions, {
     const create = this.isCreate(...arguments);
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      routeName: this.routeName,
       create: create,
       dc: dc,
       item: create
@@ -30,6 +29,7 @@ export default Route.extend(WithNspaceActions, {
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/nspaces/index.js
+++ b/ui-v2/app/routes/dc/nspaces/index.js
@@ -15,6 +15,7 @@ export default Route.extend(WithNspaceActions, {
   },
   model: function(params) {
     return hash({
+      routeName: this.routeName,
       items: this.data.source(uri => uri`/*/*/namespaces`),
       isLoading: false,
     });

--- a/ui-v2/app/routes/dc/nspaces/index.js
+++ b/ui-v2/app/routes/dc/nspaces/index.js
@@ -17,7 +17,6 @@ export default Route.extend(WithNspaceActions, {
     return hash({
       routeName: this.routeName,
       items: this.data.source(uri => uri`/*/*/namespaces`),
-      isLoading: false,
     });
   },
   setupController: function(controller, model) {

--- a/ui-v2/app/routes/dc/nspaces/index.js
+++ b/ui-v2/app/routes/dc/nspaces/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -15,11 +15,11 @@ export default Route.extend(WithNspaceActions, {
   },
   model: function(params) {
     return hash({
-      routeName: this.routeName,
       items: this.data.source(uri => uri`/*/*/namespaces`),
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/index.js
+++ b/ui-v2/app/routes/dc/services/index.js
@@ -32,6 +32,7 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const dc = this.modelFor('dc').dc.Name;
     return hash({
+      routeName: this.routeName,
       nspace: nspace,
       dc: dc,
       terms: terms !== '' ? terms.split('\n') : [],

--- a/ui-v2/app/routes/dc/services/index.js
+++ b/ui-v2/app/routes/dc/services/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 
@@ -32,7 +32,6 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const dc = this.modelFor('dc').dc.Name;
     return hash({
-      routeName: this.routeName,
       nspace: nspace,
       dc: dc,
       terms: terms !== '' ? terms.split('\n') : [],
@@ -40,6 +39,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance.js
+++ b/ui-v2/app/routes/dc/services/instance.js
@@ -9,6 +9,7 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1) || 'default';
     return hash({
+      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item: this.data.source(

--- a/ui-v2/app/routes/dc/services/instance.js
+++ b/ui-v2/app/routes/dc/services/instance.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -9,7 +9,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1) || 'default';
     return hash({
-      routeName: this.routeName,
       dc: dc,
       nspace: nspace,
       item: this.data.source(
@@ -50,6 +49,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/addresses.js
+++ b/ui-v2/app/routes/dc/services/instance/addresses.js
@@ -7,7 +7,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   afterModel: function(model, transition) {
     if (get(model, 'item.Service.Kind') !== 'mesh-gateway') {

--- a/ui-v2/app/routes/dc/services/instance/addresses.js
+++ b/ui-v2/app/routes/dc/services/instance/addresses.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({
@@ -7,10 +7,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   afterModel: function(model, transition) {
     if (get(model, 'item.Service.Kind') !== 'mesh-gateway') {
@@ -22,6 +19,7 @@ export default Route.extend({
     }
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/exposedpaths.js
+++ b/ui-v2/app/routes/dc/services/instance/exposedpaths.js
@@ -7,7 +7,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   afterModel: function(model, transition) {
     if (

--- a/ui-v2/app/routes/dc/services/instance/exposedpaths.js
+++ b/ui-v2/app/routes/dc/services/instance/exposedpaths.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({
@@ -7,10 +7,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   afterModel: function(model, transition) {
     if (
@@ -25,6 +22,7 @@ export default Route.extend({
     }
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/healthchecks.js
+++ b/ui-v2/app/routes/dc/services/instance/healthchecks.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/instance/healthchecks.js
+++ b/ui-v2/app/routes/dc/services/instance/healthchecks.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/index.js
+++ b/ui-v2/app/routes/dc/services/instance/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import to from 'consul-ui/utils/routing/redirect-to';
 
 export default Route.extend({

--- a/ui-v2/app/routes/dc/services/instance/metadata.js
+++ b/ui-v2/app/routes/dc/services/instance/metadata.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/instance/metadata.js
+++ b/ui-v2/app/routes/dc/services/instance/metadata.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/proxy.js
+++ b/ui-v2/app/routes/dc/services/instance/proxy.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/instance/proxy.js
+++ b/ui-v2/app/routes/dc/services/instance/proxy.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/instance/upstreams.js
+++ b/ui-v2/app/routes/dc/services/instance/upstreams.js
@@ -7,7 +7,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   afterModel: function(model, transition) {
     if (get(model, 'item.Service.Kind') !== 'connect-proxy') {

--- a/ui-v2/app/routes/dc/services/instance/upstreams.js
+++ b/ui-v2/app/routes/dc/services/instance/upstreams.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({
@@ -7,10 +7,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   afterModel: function(model, transition) {
     if (get(model, 'item.Service.Kind') !== 'connect-proxy') {
@@ -22,6 +19,7 @@ export default Route.extend({
     }
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/notfound.js
+++ b/ui-v2/app/routes/dc/services/notfound.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   redirect: function(model, transition) {

--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -10,6 +10,7 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
+      routeName: this.routeName,
       slug: params.name,
       dc: dc,
       nspace: nspace,

--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';
@@ -10,7 +10,6 @@ export default Route.extend({
     const dc = this.modelFor('dc').dc.Name;
     const nspace = this.modelFor('nspace').nspace.substr(1);
     return hash({
-      routeName: this.routeName,
       slug: params.name,
       dc: dc,
       nspace: nspace,
@@ -47,6 +46,7 @@ export default Route.extend({
       });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/index.js
+++ b/ui-v2/app/routes/dc/services/show/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import to from 'consul-ui/utils/routing/redirect-to';
 
 export default Route.extend({

--- a/ui-v2/app/routes/dc/services/show/instances.js
+++ b/ui-v2/app/routes/dc/services/show/instances.js
@@ -12,7 +12,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/show/instances.js
+++ b/ui-v2/app/routes/dc/services/show/instances.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   queryParams: {
@@ -12,12 +12,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/intentions.js
+++ b/ui-v2/app/routes/dc/services/show/intentions.js
@@ -1,3 +1,12 @@
 import Route from '@ember/routing/route';
 
-export default Route.extend();
+export default Route.extend({
+  model: function() {
+    return {
+      routeName: this.routeName,
+    };
+  },
+  setupController: function(controller, model) {
+    controller.setProperties(model);
+  },
+});

--- a/ui-v2/app/routes/dc/services/show/intentions.js
+++ b/ui-v2/app/routes/dc/services/show/intentions.js
@@ -1,12 +1,8 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
-  model: function() {
-    return {
-      routeName: this.routeName,
-    };
-  },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/intentions/edit.js
+++ b/ui-v2/app/routes/dc/services/show/intentions/edit.js
@@ -3,6 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
   model: function(params, transition) {
     return {
+      routeName: this.routeName,
       nspace: '*',
       dc: this.paramsFor('dc').dc,
       service: this.paramsFor('dc.services.show').name,

--- a/ui-v2/app/routes/dc/services/show/intentions/edit.js
+++ b/ui-v2/app/routes/dc/services/show/intentions/edit.js
@@ -1,9 +1,8 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function(params, transition) {
     return {
-      routeName: this.routeName,
       nspace: '*',
       dc: this.paramsFor('dc').dc,
       service: this.paramsFor('dc.services.show').name,
@@ -11,6 +10,7 @@ export default Route.extend({
     };
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/intentions/index.js
+++ b/ui-v2/app/routes/dc/services/show/intentions/index.js
@@ -9,6 +9,7 @@ export default Route.extend({
   },
   model: function(params) {
     return {
+      routeName: this.routeName,
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1) || 'default',
       slug: this.paramsFor('dc.services.show').name,

--- a/ui-v2/app/routes/dc/services/show/intentions/index.js
+++ b/ui-v2/app/routes/dc/services/show/intentions/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   queryParams: {
@@ -9,13 +9,13 @@ export default Route.extend({
   },
   model: function(params) {
     return {
-      routeName: this.routeName,
       dc: this.modelFor('dc').dc.Name,
       nspace: this.modelFor('nspace').nspace.substr(1) || 'default',
       slug: this.paramsFor('dc.services.show').name,
     };
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/routing.js
+++ b/ui-v2/app/routes/dc/services/show/routing.js
@@ -7,7 +7,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   afterModel: function(model, transition) {
     if (!get(model, 'chain')) {

--- a/ui-v2/app/routes/dc/services/show/routing.js
+++ b/ui-v2/app/routes/dc/services/show/routing.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { get } from '@ember/object';
 
 export default Route.extend({
@@ -7,10 +7,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   afterModel: function(model, transition) {
     if (!get(model, 'chain')) {
@@ -22,6 +19,7 @@ export default Route.extend({
     }
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/services.js
+++ b/ui-v2/app/routes/dc/services/show/services.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/show/services.js
+++ b/ui-v2/app/routes/dc/services/show/services.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/tags.js
+++ b/ui-v2/app/routes/dc/services/show/tags.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/show/tags.js
+++ b/ui-v2/app/routes/dc/services/show/tags.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/dc/services/show/upstreams.js
+++ b/ui-v2/app/routes/dc/services/show/upstreams.js
@@ -6,7 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return this.modelFor(parent);
+    return {
+      ...this.modelFor(parent),
+      routeName: this.routeName,
+    };
   },
   setupController: function(controller, model) {
     controller.setProperties(model);

--- a/ui-v2/app/routes/dc/services/show/upstreams.js
+++ b/ui-v2/app/routes/dc/services/show/upstreams.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 
 export default Route.extend({
   model: function() {
@@ -6,12 +6,10 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    return {
-      ...this.modelFor(parent),
-      routeName: this.routeName,
-    };
+    return this.modelFor(parent);
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
 });

--- a/ui-v2/app/routes/index.js
+++ b/ui-v2/app/routes/index.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get } from '@ember/object';

--- a/ui-v2/app/routes/notfound.js
+++ b/ui-v2/app/routes/notfound.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import Error from '@ember/error';
 
 export default Route.extend({

--- a/ui-v2/app/routes/nspace.js
+++ b/ui-v2/app/routes/nspace.js
@@ -40,6 +40,7 @@ export default Route.extend({
   },
   model: function(params) {
     return hash({
+      routeName: this.routeName,
       item: this.repo.getActive(),
       nspace: params.nspace,
     });

--- a/ui-v2/app/routes/nspace.js
+++ b/ui-v2/app/routes/nspace.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { getOwner } from '@ember/application';
@@ -40,7 +40,6 @@ export default Route.extend({
   },
   model: function(params) {
     return hash({
-      routeName: this.routeName,
       item: this.repo.getActive(),
       nspace: params.nspace,
     });

--- a/ui-v2/app/routes/settings.js
+++ b/ui-v2/app/routes/settings.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { inject as service } from '@ember/service';
 import { hash } from 'rsvp';
 import { get, set } from '@ember/object';
@@ -22,6 +22,7 @@ export default Route.extend({
     });
   },
   setupController: function(controller, model) {
+    this._super(...arguments);
     controller.setProperties(model);
   },
   actions: {

--- a/ui-v2/app/routing/route.js
+++ b/ui-v2/app/routing/route.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import { setProperties } from '@ember/object';
 
 /**
  * Set the routeName for the controller so that it is
@@ -6,7 +7,9 @@ import Route from '@ember/routing/route';
  */
 export default class BaseRoute extends Route {
   setupController(controller, model) {
-    controller.routeName = this.routeName;
+    setProperties(controller, {
+      routeName: this.routeName,
+    });
     super.setupController(...arguments);
   }
 }

--- a/ui-v2/app/routing/route.js
+++ b/ui-v2/app/routing/route.js
@@ -1,0 +1,12 @@
+import Route from '@ember/routing/route';
+
+/**
+ * Set the routeName for the controller so that it is
+ * available in the template for the route/controller
+ */
+export default class BaseRoute extends Route {
+  setupController(controller, model) {
+    controller.routeName = this.routeName;
+    super.setupController(...arguments);
+  }
+}

--- a/ui-v2/app/routing/single.js
+++ b/ui-v2/app/routing/single.js
@@ -16,7 +16,6 @@ export default Route.extend({
     const nspace = this.modelFor('nspace').nspace.substr(1);
     const create = this.isCreate(...arguments);
     return hash({
-      isLoading: false,
       dc: dc,
       nspace: nspace,
       create: create,

--- a/ui-v2/app/routing/single.js
+++ b/ui-v2/app/routing/single.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import Route from 'consul-ui/routing/route';
 import { assert } from '@ember/debug';
 import { Promise, hash } from 'rsvp';
 export default Route.extend({

--- a/ui-v2/app/services/feedback.js
+++ b/ui-v2/app/services/feedback.js
@@ -1,5 +1,4 @@
 import Service, { inject as service } from '@ember/service';
-import { set } from '@ember/object';
 import callableType from 'consul-ui/utils/callable-type';
 
 const TYPE_SUCCESS = 'success';

--- a/ui-v2/app/services/feedback.js
+++ b/ui-v2/app/services/feedback.js
@@ -17,7 +17,6 @@ export default Service.extend({
   notify: service('flashMessages'),
   logger: service('logger'),
   execute: function(handle, action, status = defaultStatus, controller) {
-    set(controller, 'isLoading', true);
     const getAction = callableType(action);
     const getStatus = callableType(status);
     const notify = this.notify;
@@ -58,9 +57,6 @@ export default Service.extend({
               error: e,
             });
           }
-        })
-        .finally(function() {
-          set(controller, 'isLoading', false);
         })
     );
   },

--- a/ui-v2/app/styles/components.scss
+++ b/ui-v2/app/styles/components.scss
@@ -66,3 +66,4 @@
 @import 'consul-ui/components/consul-intention-permission-list';
 @import 'consul-ui/components/consul-intention-permission-form';
 @import 'consul-ui/components/consul-intention-permission-header-list';
+@import 'consul-ui/components/role-selector';

--- a/ui-v2/app/styles/components/app-view.scss
+++ b/ui-v2/app/styles/components/app-view.scss
@@ -8,8 +8,8 @@ main {
   overflow: visible !important;
 }
 
-%app-view > div.unauthorized,
-%app-view > div.error {
+%app-view .outlet > div.unauthorized,
+%app-view .outlet > div.error {
   @extend %app-view-error;
 }
 %app-view header form {

--- a/ui-v2/app/styles/components/app-view/index.scss
+++ b/ui-v2/app/styles/components/app-view/index.scss
@@ -1,6 +1,6 @@
 @import './skin';
 @import './layout';
-%app-view > div > header {
+%app-view .outlet > div > header {
   @extend %app-view-header;
 }
 %app-view-header .title {
@@ -9,6 +9,6 @@
 %app-view-header .actions {
   @extend %app-view-actions;
 }
-%app-view > div > div {
+%app-view .outlet > div > div {
   @extend %app-view-content;
 }

--- a/ui-v2/app/styles/components/loader.scss
+++ b/ui-v2/app/styles/components/loader.scss
@@ -5,9 +5,9 @@
 %loader circle {
   fill: $magenta-100;
 }
-html:not(.loading) .view-loader {
+html[data-state='idle'] .view-loader {
   display: none;
 }
-html.loading .app-view {
+.outlet[data-state='loading'] {
   display: none;
 }

--- a/ui-v2/app/styles/components/loader.scss
+++ b/ui-v2/app/styles/components/loader.scss
@@ -5,6 +5,7 @@
 %loader circle {
   fill: $magenta-100;
 }
+html.ember-loading .view-loader,
 html[data-state='idle'] .view-loader {
   display: none;
 }

--- a/ui-v2/app/styles/layout.scss
+++ b/ui-v2/app/styles/layout.scss
@@ -28,7 +28,7 @@ main,
 #wrapper > footer {
   @extend %content-container;
 }
-html.template-edit main {
+html[data-route$='.edit'] main {
   @extend %content-container-restricted;
 }
 

--- a/ui-v2/app/styles/routes/dc/acls/index.scss
+++ b/ui-v2/app/styles/routes/dc/acls/index.scss
@@ -1,40 +1,33 @@
-html.template-acl.template-list main td strong {
+html[data-route^='dc.acls.index'] main td strong {
   @extend %pill-500, %frame-gray-900;
   margin-right: 3px;
 }
-html.template-acl.template-list .filter-bar {
+html[data-route^='dc.acls.index'] .filter-bar {
   @extend %filter-bar-reversed;
 }
-html.template-acl.template-list .filter-bar [role='radiogroup'] {
+html[data-route^='dc.acls.index'] .filter-bar [role='radiogroup'] {
   @extend %expanded-single-select;
 }
 @media #{$--horizontal-tabs} {
-  .template-policy.template-list main header .actions,
-  .template-token.template-list main header .actions {
+  html[data-route^='dc.acls.policies.index'] main header .actions,
+  html[data-route^='dc.acls.policies.index'] main header .actions {
     position: relative;
     top: 42px;
   }
 }
 
 @media #{$--lt-wide-form} {
-  html.template-acl.template-edit main header .actions {
+  html[data-route^='dc.acls.edit'] main header .actions {
     float: none;
     display: flex;
     justify-content: space-between;
     margin-bottom: 1em;
   }
-  html.template-acl.template-edit main header .actions .with-feedback {
+  html[data-route^='dc.acls.edit'] main header .actions .with-feedback {
     position: absolute;
     right: 0;
   }
-  html.template-acl.template-edit main header .actions .with-confirmation {
+  html[data-route^='dc.acls.edit'] main header .actions .with-confirmation {
     margin-top: 0;
   }
-}
-[name='role[state]'],
-[name='role[state]'] + * {
-  display: none;
-}
-[name='role[state]']:checked + * {
-  display: block;
 }

--- a/ui-v2/app/styles/routes/dc/kv/index.scss
+++ b/ui-v2/app/styles/routes/dc/kv/index.scss
@@ -1,8 +1,4 @@
-html.template-kv.template-edit div > .with-confirmation {
-  float: none;
-  margin-top: 1.7em;
-}
-html.template-kv.template-edit .type-toggle {
+html[data-route^='dc.kv.edit'] .type-toggle {
   float: right;
   margin-bottom: 0 !important;
 }

--- a/ui-v2/app/styles/routes/dc/nodes/index.scss
+++ b/ui-v2/app/styles/routes/dc/nodes/index.scss
@@ -1,3 +1,3 @@
-html.template-node.template-show #meta-data table tr {
+html[data-route^='dc.nodes.show.metadata'] table tr {
   cursor: default;
 }

--- a/ui-v2/app/styles/routes/dc/services/index.scss
+++ b/ui-v2/app/styles/routes/dc/services/index.scss
@@ -1,10 +1,10 @@
 /* instance detail dl text*/
-html.template-instance.template-show .app-view > header dl {
+html[data-route^='dc.services.instance'] .app-view > header dl {
   float: left;
   margin-top: 19px;
   margin-bottom: 23px;
   margin-right: 50px;
 }
-html.template-instance.template-show .app-view > header dt {
+html[data-route^='dc.services.instance'] .app-view > header dt {
   font-weight: $typo-weight-bold;
 }

--- a/ui-v2/app/templates/application.hbs
+++ b/ui-v2/app/templates/application.hbs
@@ -10,7 +10,11 @@
     @nspace={{or nspace nspaces.firstObject}}
     @onchange={{action "reauthorize"}}
   >
-  {{outlet}}
+  <Outlet
+  @name="application"
+  as |o|>
+    {{outlet}}
+  </Outlet>
     <ConsulLoader class="view-loader" />
   </HashicorpConsul>
 {{/if}}

--- a/ui-v2/app/templates/dc.hbs
+++ b/ui-v2/app/templates/dc.hbs
@@ -1,1 +1,5 @@
-{{outlet}}
+<Outlet
+  @name={{routeName}}
+as |o|>
+  {{outlet}}
+</Outlet>

--- a/ui-v2/app/templates/dc/acls/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/edit.hbs
@@ -1,4 +1,4 @@
-<AppView @class="acl edit" @loading={{isLoading}}>
+<AppView>
     <BlockSlot @name="notification" as |status type|>
       {{partial 'dc/acls/notifications'}}
     </BlockSlot>

--- a/ui-v2/app/templates/dc/acls/index.hbs
+++ b/ui-v2/app/templates/dc/acls/index.hbs
@@ -7,7 +7,7 @@
     )
     as |filter|
   }}
-<AppView @class="acl list" @loading={{isLoading}}>
+<AppView>
   <BlockSlot @name="notification" as |status type|>
     {{partial 'dc/acls/notifications'}}
   </BlockSlot>

--- a/ui-v2/app/templates/dc/acls/policies/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/edit.hbs
@@ -8,8 +8,6 @@
   {{title 'Access Controls'}}
 {{/if}}
 <AppView
-  @class={{concat "policy " (if isAuthorized "edit" "list")}}
-  @loading={{isLoading}}
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >

--- a/ui-v2/app/templates/dc/acls/policies/index.hbs
+++ b/ui-v2/app/templates/dc/acls/policies/index.hbs
@@ -9,8 +9,6 @@
 ) as |filters|}}
   {{#let (or sortBy "Name:asc") as |sort|}}
     <AppView
-      @class="policy list"
-      @loading={{isLoading}}
       @authorized={{isAuthorized}}
       @enabled={{isEnabled}}
       >

--- a/ui-v2/app/templates/dc/acls/roles/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/edit.hbs
@@ -8,8 +8,6 @@
   {{title 'Access Controls'}}
 {{/if}}
 <AppView
-  @class={{concat "role " (if isAuthorized "edit" "list")}}
-  @loading={{isLoading}}
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >

--- a/ui-v2/app/templates/dc/acls/roles/index.hbs
+++ b/ui-v2/app/templates/dc/acls/roles/index.hbs
@@ -6,8 +6,6 @@
 
 {{#let (or sortBy "Name:asc") as |sort|}}
 <AppView
-  @class="role list"
-  @loading={{isLoading}}
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >

--- a/ui-v2/app/templates/dc/acls/tokens/edit.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/edit.hbs
@@ -8,8 +8,6 @@
   {{title 'Access Controls'}}
 {{/if}}
 <AppView
-  @class={{concat "token " (if isAuthorized "edit" "list")}}
-  @loading={{isLoading}}
   @authorized={{isAuthorized}}
   @enabled={{isEnabled}}
   >

--- a/ui-v2/app/templates/dc/acls/tokens/index.hbs
+++ b/ui-v2/app/templates/dc/acls/tokens/index.hbs
@@ -9,8 +9,6 @@
 ) as |filters|}}
   {{#let (or sortBy "CreateTime:desc") as |sort|}}
     <AppView
-      @class="token list"
-      @loading={{isLoading}}
       @authorized={{isAuthorized}}
       @enabled={{isEnabled}}
       >

--- a/ui-v2/app/templates/dc/intentions/edit.hbs
+++ b/ui-v2/app/templates/dc/intentions/edit.hbs
@@ -3,7 +3,7 @@
 {{else}}
     {{title 'New Intention'}}
 {{/if}}
-<AppView @class="intention edit">
+<AppView>
     <BlockSlot @name="breadcrumbs">
         <ol>
           <li><a data-test-back href={{href-to 'dc.intentions'}}>All Intentions</a></li>

--- a/ui-v2/app/templates/dc/intentions/index.hbs
+++ b/ui-v2/app/templates/dc/intentions/index.hbs
@@ -11,7 +11,7 @@
     accesses=(if access (split access ',') undefined)
   ) as |filters|}}
     {{#let (or sortBy "Action:asc") as |sort|}}
-      <AppView @class="intention list">
+      <AppView>
         <BlockSlot @name="header">
             <h1>
                 Intentions <em>{{format-number items.length}} total</em>

--- a/ui-v2/app/templates/dc/kv/edit.hbs
+++ b/ui-v2/app/templates/dc/kv/edit.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{title 'New Key/Value'}}
 {{/if}}
-<AppView @class="kv edit">
+<AppView>
   <BlockSlot @name="breadcrumbs">
     <ol>
         <li><a data-test-back href={{href-to 'dc.kv.index'}}>Key / Values</a></li>

--- a/ui-v2/app/templates/dc/kv/index.hbs
+++ b/ui-v2/app/templates/dc/kv/index.hbs
@@ -1,6 +1,6 @@
 {{title 'Key/Value'}}
 {{#let (or sortBy "isFolder:asc") as |sort|}}
-  <AppView @class="kv list">
+  <AppView>
     <BlockSlot @name="breadcrumbs">
       <ol>
   {{#if (not-eq parent.Key '/') }}

--- a/ui-v2/app/templates/dc/nodes/index.hbs
+++ b/ui-v2/app/templates/dc/nodes/index.hbs
@@ -4,7 +4,7 @@
   statuses=(if status (split status ',') undefined)
 ) as |filters|}}
 {{#let (or sortBy "Node:asc") as |sort|}}
-  <AppView @class="node list">
+  <AppView>
     <BlockSlot @name="header">
       <h1>
         Nodes <em>{{format-number items.length}} total</em>

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -2,7 +2,6 @@
 <DataLoader as |api|>
 
   <BlockSlot @name="data">
-    <EventSource @src={{sessions}} />
     <EventSource @src={{tomography}} />
     <EventSource @src={{item}} @onerror={{queue (action api.dispatchError)}} />
   </BlockSlot>
@@ -62,7 +61,11 @@
           <CopyButton @value={{item.Address}} @name="Address">{{item.Address}}</CopyButton>
         </BlockSlot>
         <BlockSlot @name="content">
-          {{outlet}}
+          <Outlet
+            @name={{routeName}}
+          as |o|>
+            {{outlet}}
+          </Outlet>
         </BlockSlot>
     </AppView>
 

--- a/ui-v2/app/templates/dc/nodes/show.hbs
+++ b/ui-v2/app/templates/dc/nodes/show.hbs
@@ -29,7 +29,7 @@
   </BlockSlot>
 
   <BlockSlot @name="loaded">
-    <AppView @class="node show">
+    <AppView>
         <BlockSlot @name="notification" as |status type|>
           {{!TODO: Move sessions to its own folder within nodes }}
           {{partial 'dc/nodes/notifications'}}

--- a/ui-v2/app/templates/dc/nodes/show/sessions.hbs
+++ b/ui-v2/app/templates/dc/nodes/show/sessions.hbs
@@ -1,3 +1,4 @@
+<EventSource @src={{sessions}} />
 <div id="lock-sessions" class="tab-section">
   <div role="tabpanel">
 {{#if (gt sessions.length 0)}}

--- a/ui-v2/app/templates/dc/nspaces/edit.hbs
+++ b/ui-v2/app/templates/dc/nspaces/edit.hbs
@@ -3,7 +3,7 @@
 {{else}}
   {{title 'Edit Namespace'}}
 {{/if}}
-<AppView @class="nspace edit" @loading={{isLoading}}>
+<AppView>
   <BlockSlot @name="notification" as |status type item error|>
     {{partial 'dc/nspaces/notifications'}}
   </BlockSlot>

--- a/ui-v2/app/templates/dc/nspaces/index.hbs
+++ b/ui-v2/app/templates/dc/nspaces/index.hbs
@@ -1,7 +1,7 @@
 {{title 'Namespaces'}}
 {{#let (or sortBy "Name:asc") as |sort|}}
 <EventSource @src={{items}} />
-<AppView @class="nspace list" @loading={{isLoading}}>
+<AppView>
   <BlockSlot @name="notification" as |status type subject|>
     {{partial 'dc/nspaces/notifications'}}
   </BlockSlot>

--- a/ui-v2/app/templates/dc/services/index.hbs
+++ b/ui-v2/app/templates/dc/services/index.hbs
@@ -6,7 +6,7 @@
   sources=(if source (split source ',') undefined)
 ) as |filters|}}
   {{#let (or sortBy "Name:asc") as |sort|}}
-    <AppView @class="service list">
+    <AppView>
       <BlockSlot @name="notification" as |status type|>
         {{partial 'dc/services/notifications'}}
       </BlockSlot>

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -50,6 +50,10 @@
                       (hash label="Tags & Meta" href=(href-to "dc.services.instance.metadata") selected=(is-href "dc.services.instance.metadata"))
               )
         }}/>
+      <Outlet
+        @name={{routeName}}
+      as |o|>
         {{outlet}}
+      </Outlet>
     </BlockSlot>
 </AppView>

--- a/ui-v2/app/templates/dc/services/instance.hbs
+++ b/ui-v2/app/templates/dc/services/instance.hbs
@@ -2,7 +2,7 @@
 <EventSource @src={{item}} @onerror={{action "error"}} />
 <EventSource @src={{proxy}} />
 <EventSource @src={{proxyMeta}} />
-<AppView @class="instance show">
+<AppView>
     <BlockSlot @name="notification" as |status type|>
       {{partial 'dc/services/notifications'}}
     </BlockSlot>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -51,6 +51,10 @@
     {{/if}}
   </BlockSlot>
   <BlockSlot @name="content">
-    {{outlet}}
+    <Outlet
+      @name={{routeName}}
+    as |o|>
+      {{outlet}}
+    </Outlet>
   </BlockSlot>
 </AppView>

--- a/ui-v2/app/templates/dc/services/show.hbs
+++ b/ui-v2/app/templates/dc/services/show.hbs
@@ -4,7 +4,7 @@
 <EventSource @src={{proxies}} />
 <EventSource @src={{gatewayServices}} />
 {{title item.Service.Service}}
-<AppView @class="service show">
+<AppView>
   <BlockSlot @name="notification" as |status type|>
     {{partial 'dc/services/notifications'}}
   </BlockSlot>

--- a/ui-v2/app/templates/dc/services/show/intentions.hbs
+++ b/ui-v2/app/templates/dc/services/show/intentions.hbs
@@ -1,1 +1,5 @@
-{{outlet}}
+<Outlet
+  @name={{routeName}}
+as |o|>
+  {{outlet}}
+</Outlet>

--- a/ui-v2/app/templates/nspace.hbs
+++ b/ui-v2/app/templates/nspace.hbs
@@ -1,1 +1,5 @@
-{{outlet}}
+<Outlet
+  @name={{routeName}}
+as |o|>
+  {{outlet}}
+</Outlet>

--- a/ui-v2/app/templates/settings.hbs
+++ b/ui-v2/app/templates/settings.hbs
@@ -1,5 +1,5 @@
 {{title "Settings"}}
-<AppView @class="settings show">
+<AppView>
   <BlockSlot @name="header">
     <h1>
       Settings

--- a/ui-v2/tests/acceptance/login-errors.feature
+++ b/ui-v2/tests/acceptance/login-errors.feature
@@ -22,7 +22,7 @@ Feature: login-errors: Login Errors
       dc: dc-1
     ---
     Then the url should be /dc-1/acls/tokens
-    Then ".app-view" has the "unauthorized" class
+    Then I see login on the emptystate
   @notNamespaceable
   Scenario: I get a 500 error from acl/token/self that is the specific legacy one
     Given 1 datacenter model with the value "dc-1"
@@ -42,7 +42,7 @@ Feature: login-errors: Login Errors
       dc: dc-1
     ---
     Then the url should be /dc-1/acls/tokens
-    Then ".app-view" has the "unauthorized" class
+    Then I see login on the emptystate
     And I click login on the navigation
     And I fill in the auth form with yaml
     ---

--- a/ui-v2/tests/acceptance/page-navigation.feature
+++ b/ui-v2/tests/acceptance/page-navigation.feature
@@ -58,7 +58,6 @@ Feature: page-navigation
       - /v1/namespaces
       - /v1/internal/ui/node/node-0?dc=dc-1
       - /v1/coordinate/nodes?dc=dc-1
-      - /v1/session/node/node-0?dc=dc-1&ns=@namespace
     ---
   Scenario: The kv detail page calls the correct API endpoints
     When I visit the kv page for yaml

--- a/ui-v2/tests/pages.js
+++ b/ui-v2/tests/pages.js
@@ -27,6 +27,7 @@ import authFormFactory from 'consul-ui/components/auth-form/pageobject';
 import freetextFilterFactory from 'consul-ui/components/freetext-filter/pageobject';
 
 import searchBarFactory from 'consul-ui/components/search-bar/pageobject';
+import emptyStateFactory from 'consul-ui/components/empty-state/pageobject';
 
 import policyFormFactory from 'consul-ui/components/policy-form/pageobject';
 import policySelectorFactory from 'consul-ui/components/policy-selector/pageobject';
@@ -89,6 +90,7 @@ const roleSelector = roleSelectorFactory(clickable, deletable, collection, alias
 
 const morePopoverMenu = morePopoverMenuFactory(clickable);
 const popoverSelect = popoverSelectFactory(clickable, collection);
+const emptyState = emptyStateFactory(isPresent);
 
 const consulIntentionList = consulIntentionListFactory(collection, clickable, attribute, deletable);
 const consulNspaceList = consulNspaceListFactory(
@@ -121,7 +123,7 @@ const consulPolicyList = consulPolicyListFactory(
   morePopoverMenu
 );
 
-const page = pageFactory(collection, clickable, attribute, is, authForm);
+const page = pageFactory(collection, clickable, attribute, is, authForm, emptyState);
 
 // pages
 const create = function(appView) {


### PR DESCRIPTION
The Route loading logic in the UI has historically been spread out amongst various pieces of the application, in the AppView component (sometimes), the Application route and the Feedback service.

The sprawly nature of this along with the fact that you could easily forget to set certain properties when creating new routes meant it was more than straightforwards for loading to 'just work' especially in sub-routes and sub-sub-routes etc. We took a look at using model hooks and loading.hbs templates, but both options had their downsides, and both required extra things to be done in order for loading to 'just work' whether adding hooks or files.

We realized that if each `{{outlet}}` was  wrapped in a `<Outlet data-outlet="dc">{{outlet}}</Outlet>` component, `dc` being the name/identifier of the current `Route`/`template` (the `Route.routeName`), then we could automatically figure out which outlet in the Route hierarchy was to be loaded by traversing up the tree of outlets and comparing the clicked route name with the name of the outlet.

For example:

```
Clicking: dc.services.show.healthcheck

- Outlet: `application`
  - Outlet: `dc`
    - Outlet: `dc.services.show` <== dc.services.show.healthcheck - Match, this outlet will be loading
      - Outlet: `dc.services.show.intentions` <== dc.services.show.healthcheck - No Match

Clicking: dc.services.index

- Outlet: `application`
  - Outlet: `dc` <== dc.services.index - Match, this outlet will be loading
    - Outlet: `dc.services.show` <== dc.services.index - No Match
      - Outlet: `dc.services.show.intentions` <== dc.services.index - No Match
```

In our case we add a `data-state="loading"` attribute to the outlet when we find the match. Once the router has finished transitioning, we set the state of the loading outlet back to idle.

Using this attribute we can do all of out route loading visuals via CSS by hiding and showing the unloaded and subsequently loaded outlet, which massively reduces the spread of code used to control loading state in the application. Future work could involve a more subtle transition between loading pages, if that was something we wanted to do.

The one downside is that the only way to 'name' the outlets correctly is to have access to the `Route.routeName` property, something that is only available from within the Route. We tried various methods of retrieving this and passing it through to the template, and eventually settled on using a base Route class, which all of our Routes now inherit from. The approach means:

1. We aren't using reopen (not Octane friendly)
2. We don't have to manually set the routeName in every Route or template.
3. We have to remember to inherit from this base class for every route, AND wrap outlets in the Outlet component, something we can probably mitigate somewhat by adding custom blueprints in the future.

Additionally here we took advantage of the work to re-work how we target individual pages via CSS.

Previously we used the AppView component to set classNames on the root of the document (in every single template), say for example on the kv edit page we would add `class="template-kv template-edit"`. We've replaced this by automatically adding the name on the current route as a data attribute on the root of the document using the `application` outlet. For example `html data-route="dc.kv.edit"`, which again we can use to target individual pages via CSS without having to remember to do anything in our templates. Additionally, using selectors such as `html[data-route$='.edit']` etc. lets you can target all edit pages.


