### PR TITLE
ci: only add consul binary to dev tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ jobs:
           at: bin/
       - run:
           name: package binary
-          command: tar -czf consul.tar.gz -C bin/ .
+          command: tar -czf consul.tar.gz -C bin/ consul
       - run:
           name: Upload to s3
           command: |


### PR DESCRIPTION
Previously we hadn't saved the `dist/` folder to the CircleCI workspace since we weren't doing anything with it downstream. Now that we do save it (to auto-publish), the tarball will contain those files. This PR will only tar up the `consul` binary itself which is all we care about. 