### PR TITLE
server: ensure that we also shutdown network segment serf instances on server shutdown

### DIFF
--- a/.changelog/8786.txt
+++ b/.changelog/8786.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: **(Consul Enterprise only)** ensure that we also shutdown network segment serf instances on server shutdown
+```

--- a/agent/consul/server.go
+++ b/agent/consul/server.go
@@ -914,6 +914,10 @@ func (s *Server) Shutdown() error {
 		s.serfLAN.Shutdown()
 	}
 
+	for _, segment := range s.segmentLAN {
+		segment.Shutdown()
+	}
+
 	if s.serfWAN != nil {
 		s.serfWAN.Shutdown()
 		if err := s.router.RemoveArea(types.AreaWAN); err != nil {


### PR DESCRIPTION
This really only matters for unit tests, since typically if an agent shuts down its server, it follows that up by exiting the process, which would also clean up all of the networking anyway.