### PR TITLE
ui: Initialize chain variable to null

### DIFF
--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -17,6 +17,7 @@ export default Route.extend({
         uri => uri`/${nspace}/${dc}/service-instances/for-service/${params.name}`
       ),
       urls: this.settings.findBySlug('urls'),
+      chain: null,
       proxies: [],
     })
       .then(model => {


### PR DESCRIPTION
Following the latest ember upgrade to 3.20 (https://github.com/hashicorp/consul/pull/8761), we noticed that certain variable access within handlebars templates no longer seem to be safe in that accessing a property of something that is `undefined` now throws an error - similar to what you would expect in javascript.

We have some strange cases where we use Ember Proxy objects to pass data around, the contents of these proxy objects can be null/undefined but a property containing the object will obviously not be `undefined`, therefore we check a property of the object to see if it is undefined/falsey instead of the the root property itself (in this case we check `chain.Chain` instead of just `chain`).

There are some areas where a property can be actually `undefined` instead of one of these EmberProxy objects, so as handlebars property access was previously 'safe' we could just check for existence of `chain.Chain` which would cover all eventualities. 

This no longer seems to be a safe way to check for the undefined-ness for both normal properties and Proxy objects that could be `undefined` or proxy to `undefined`

Initializing the variable to `null` instead of leaving it undefined fixes the error and continues to cover all cases.

We had previously considered an 'is-defined/is-undefined' helper which could safely check both normal properties and Proxy objects for undefined-ness - so this might be an argument for bringing that helper back.

`ember-truth-helpers` also has an isEmpty helper, so it would be worthwhile looking to see if this checks the `content` property of an EmberProxy for emptiness.