### PR TITLE
ui: Fix up tab separator CSS to not apply to all tabs

### DIFF
--- a/ui-v2/app/styles/base/components/tabs/layout.scss
+++ b/ui-v2/app/styles/base/components/tabs/layout.scss
@@ -22,12 +22,3 @@
   display: inline-block;
   padding: 16px 13px;
 }
-%tab-section section {
-  padding-bottom: 24px;
-}
-%tab-section section:not(:last-child) {
-  border-bottom: 1px solid $gray-200;
-}
-%tab-section section > h3 {
-  margin: 24px 0 12px 0;
-}

--- a/ui-v2/app/styles/routes/dc/services/index.scss
+++ b/ui-v2/app/styles/routes/dc/services/index.scss
@@ -8,3 +8,10 @@ html[data-route^='dc.services.instance'] .app-view > header dl {
 html[data-route^='dc.services.instance'] .app-view > header dt {
   font-weight: $typo-weight-bold;
 }
+html[data-route^='dc.services.instance'] [role='tabpanel'] section:not(:last-child) {
+  padding-bottom: 24px;
+  border-bottom: 1px solid $gray-200;
+}
+html[data-route^='dc.services.instance'] [role='tabpanel'] section h3 {
+  margin: 24px 0 12px 0;
+}


### PR DESCRIPTION
Fix up tab separator CSS to only apply to instance tabs.

Note the double thickness line between sections:

Before:

<img width="444" alt="Screenshot 2020-10-01 at 13 09 02" src="https://user-images.githubusercontent.com/554604/94807670-e341c880-03e7-11eb-8406-cc599cd7b144.png">

After:

<img width="451" alt="Screenshot 2020-10-01 at 13 08 43" src="https://user-images.githubusercontent.com/554604/94807683-e8067c80-03e7-11eb-8b34-7bdf7de06a8f.png">
