### PR TITLE
ci: fix bindata autoupdate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,10 +641,12 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: commit agent/uiserver/bindata_assetfs.go if there are changes
+          name: commit agent/uiserver/bindata_assetfs.go if there are UI changes
           command: |
-            exit 0
-            if ! git diff --exit-code agent/uiserver/bindata_assetfs.go; then
+            # check if there are any changes in ui-v2/
+            # if there are, we commit the ui static asset file
+            # HEAD^! is shorthand for HEAD^..HEAD (parent of HEAD and HEAD)
+            if ! git diff --quiet --exit-code HEAD^! ui-v2/; then
               git config --local user.email "hashicorp-ci@users.noreply.github.com"
               git config --local user.name "hashicorp-ci"
 
@@ -653,7 +655,7 @@ jobs:
               git commit -m "auto-updated agent/uiserver/bindata_assetfs.go from commit ${short_sha}"
               git push origin master
             else
-              echo "no new static assets to publish"
+              echo "no UI changes so no static assets to publish"
             fi
       - run: *notify-slack-failure
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -306,7 +306,7 @@ lint:
 # also run as part of the release build script when it verifies that there are no
 # changes to the UI assets that aren't checked in.
 static-assets:
-	@go-bindata-assetfs -modtime 1 -pkg uiserver -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
+	@go-bindata-assetfs -pkg uiserver -prefix pkg -o $(ASSETFS_PATH) ./pkg/web_ui/...
 	@go fmt $(ASSETFS_PATH)
 
 

--- a/ui-v2/app/components/hashicorp-consul/index.hbs
+++ b/ui-v2/app/components/hashicorp-consul/index.hbs
@@ -249,4 +249,5 @@
         <a data-test-footer-copyright href="{{env 'CONSUL_COPYRIGHT_URL'}}/" rel="noopener noreferrer" target="_blank">&copy; {{env 'CONSUL_COPYRIGHT_YEAR'}} HashiCorp</a>
         <p data-test-footer-version>Consul {{env 'CONSUL_VERSION'}}</p>
         <a data-test-footer-docs href="{{env 'CONSUL_DOCS_URL'}}" rel="help noopener noreferrer" target="_blank">Documentation</a>
+        {{{concat '<!-- ' (env 'CONSUL_GIT_SHA') '-->'}}}
     </footer>

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -11,9 +11,6 @@ module.exports = function (environment, $ = process.env) {
     // torii provider. We provide this object here to
     // prevent ember from giving a log message when starting ember up
     torii: {},
-    'ember-cli-app-version': {
-      version: 'consul-ui',
-    },
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -1,7 +1,7 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-module.exports = function(environment, $ = process.env) {
+module.exports = function (environment, $ = process.env) {
   let ENV = {
     modulePrefix: 'consul-ui',
     environment,
@@ -37,7 +37,7 @@ module.exports = function(environment, $ = process.env) {
     CONSUL_UI_DISABLE_REALTIME: typeof process.env.CONSUL_UI_DISABLE_REALTIME !== 'undefined',
     CONSUL_UI_DISABLE_ANCHOR_SELECTION:
       typeof process.env.CONSUL_UI_DISABLE_ANCHOR_SELECTION !== 'undefined',
-    CONSUL_COPYRIGHT_YEAR: (function(val) {
+    CONSUL_COPYRIGHT_YEAR: (function (val) {
       if (val) {
         return val;
       }
@@ -48,7 +48,17 @@ module.exports = function(environment, $ = process.env) {
         .split('-')
         .shift();
     })(process.env.CONSUL_COPYRIGHT_YEAR),
-    CONSUL_VERSION: (function(val) {
+    CONSUL_GIT_SHA: (function (val) {
+      if (val) {
+        return val;
+      }
+
+      return require('child_process')
+        .execSync('git rev-parse --short HEAD')
+        .toString()
+        .trim();
+    })(process.env.CONSUL_GIT_SHA),
+    CONSUL_VERSION: (function (val) {
       if (val) {
         return val;
       }
@@ -57,7 +67,7 @@ module.exports = function(environment, $ = process.env) {
       const contents = fs.readFileSync(version_go).toString();
       return contents
         .split('\n')
-        .find(function(item, i, arr) {
+        .find(function (item, i, arr) {
           return item.indexOf('Version =') !== -1;
         })
         .trim()


### PR DESCRIPTION
Unfortunately, the way of checking for bindata diff I had in #8712 doesn't work. While @johncowen helped me with removing the sha from the index.html file and we changed the modtime to be static, there is a [temp directory](https://github.com/broccolijs/broccoli-persistent-filter#warning) that broccoli creates and uses when processing files that cannot be static (the tempdir can be specified but not the actual temp directory that is created in the tempdir).  Each UI build will always generate a random suffix and this create a diff when comparing the bindata files. 

A sample diff is here:
```
< var t=Ember.HTMLBars.template({id:"XjHn8fr1",block:'{"symbols":[],"statements":[[8,"head-layout",[],[[],[]],null],[2,"\\n"],[1,[30,[36,9],["Consul"],[["separator","_deprecate"],[" - ","/tmp/broccoli-242TocyrAt7SQhg/out-504-colocated_template_processor/consul-ui/templates/application.hbs"]]]],[2,"\\n"],[6,[37,12],[[30,[36,11],[[35,10,["currentRouteName"]],"application"],null]],null,[["default"],[{"statements":[[2,"  "],[8,"hashicorp-consul",[[24,1,"wrapper"]],[["@permissions","@dcs","@dc","@nspaces","@nspace","@onchange"],[[34,0],[34,1],[30,[36,3],[[35,2],[35,1,["firstObject"]]],null],[34,4],[30,[36,3],[[35,5],[35,4,["firstObject"]]],null],[30,[36,6],[[32,0],"reauthorize"],null]]],[["default"],[{"statements":[[2,"\\n  "],[1,[30,[36,8],[[30,[36,7],null,null]],null]],[2,"\\n    "],[8,"consul-loader",[[24,0,"view-loader"]],[[],[]],null],[2,"\\n  "]],"parameters":[]}]]],[2,"\\n"]],"parameters":[]}]]]],"hasEval":false,"upvars":["permissions","dcs","dc","or","nspaces","nspace","action","-outlet","component","page-title","router","not-eq","if"]}',meta:{moduleName:"consul-ui/templates/application.hbs"}})
---
> var t=Ember.HTMLBars.template({id:"Dd6a99E9",block:'{"symbols":[],"statements":[[8,"head-layout",[],[[],[]],null],[2,"\\n"],[1,[30,[36,9],["Consul"],[["separator","_deprecate"],[" - ","/tmp/broccoli-1538DFisW1VMpZa/out-504-colocated_template_processor/consul-ui/templates/application.hbs"]]]],[2,"\\n"],[6,[37,12],[[30,[36,11],[[35,10,["currentRouteName"]],"application"],null]],null,[["default"],[{"statements":[[2,"  "],[8,"hashicorp-consul",[[24,1,"wrapper"]],[["@permissions","@dcs","@dc","@nspaces","@nspace","@onchange"],[[34,0],[34,1],[30,[36,3],[[35,2],[35,1,["firstObject"]]],null],[34,4],[30,[36,3],[[35,5],[35,4,["firstObject"]]],null],[30,[36,6],[[32,0],"reauthorize"],null]]],[["default"],[{"statements":[[2,"\\n  "],[1,[30,[36,8],[[30,[36,7],null,null]],null]],[2,"\\n    "],[8,"consul-loader",[[24,0,"view-loader"]],[[],[]],null],[2,"\\n  "]],"parameters":[]}]]],[2,"\\n"]],"parameters":[]}]]]],"hasEval":false,"upvars":["permissions","dcs","dc","or","nspaces","nspace","action","-outlet","component","page-title","router","not-eq","if"]}',meta:{moduleName:"consul-ui/templates/application.hbs"}})
2520c2520
```
The relevant diff is: 
`[" - ","/tmp/broccoli-242TocyrAt7SQhg/out-504-colocated_template_processor/consul-ui/templates/application.hbs"]]]]`
and 
`[" - ","/tmp/broccoli-1538DFisW1VMpZa/out-504-colocated_template_processor/consul-ui/templates/application.hbs"]]]]`

As a result, I have changed the logic to not compare the file but run `git diff --quiet --exit-code HEAD^! ui-v2/`. HEAD^! is better explained [here](https://stackoverflow.com/a/449128). This will check whether a commit (on master) to its parent has a diff with any file in `ui-v2/`. For squashed merges, this will mean the previous commit. For merge commits, this means the immediate parent (parent1 which is the base branch you are merging into, ie: master). This may exclude any changes we make in the Makefile or things outside of the `ui-v2/` folder but for practical purposes, this rarely happens and is probably so important that waiting for the next `ui-v2/` change to rebuild wouldn't be sufficient. 

I have reverted the previous changes to 
* remove the `GIT_SHA` from `index.html` and
* setting a static `ember-cli-app-version`
because these diffs don't matter now as we aren't comparing the resulting compiled javascript `dist/` folder nor the bindata file. 