### PR TITLE
ui: Replace proxy icon with mesh icon

### DIFF
--- a/ui-v2/app/components/consul-service-instance-list/index.hbs
+++ b/ui-v2/app/components/consul-service-instance-list/index.hbs
@@ -21,14 +21,14 @@
       <ConsulInstanceChecks @type="node" @items={{reject-by 'ServiceID' '' item.Checks}} />
     {{/if}}
 {{#if item.ProxyInstance}}
-      <dl class="proxy">
+      <dl class="mesh">
         <dt>
           <Tooltip>
-            Proxy
+            This service uses a proxy for the Consul service mesh
           </Tooltip>
         </dt>
-        <dd data-test-proxy>
-          connected with proxy
+        <dd data-test-mesh>
+          in service mesh with proxy
         </dd>
       </dl>
 {{/if}}

--- a/ui-v2/app/routes/dc/services/show.js
+++ b/ui-v2/app/routes/dc/services/show.js
@@ -29,6 +29,10 @@ export default Route.extend({
           : hash({
               ...model,
               chain: this.data.source(uri => uri`/${nspace}/${dc}/discovery-chain/${params.name}`),
+              // Whilst `proxies` isn't used anywhere in the show templates
+              // it provides a relationship of ProxyInstance on the ServiceInstance
+              // which can respond at a completely different blocking rate to
+              // the ServiceInstance itself
               proxies: this.data.source(
                 uri => uri`/${nspace}/${dc}/proxies/for-service/${params.name}`
               ),


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8775 we replaced the icon and wording we use to show that a Service is available via a proxy. This makes a similar change to Service Instances, although here I don't think we can currently tell whether an instance is fronted with ingress/terminating gateways, so we just change the icon and wording for 'connected with proxy' to 'in service mesh with proxy'

