### PR TITLE
ui: Allow configuring a Datasource to poll an API endpoint instead of using Blocking Queries

### DIFF
--- a/ui-v2/app/services/client/http.js
+++ b/ui-v2/app/services/client/http.js
@@ -70,7 +70,7 @@ const parseBody = function(strs, ...values) {
   return [body, ...values];
 };
 
-const CLIENT_HEADERS = [CACHE_CONTROL, 'X-Request-ID', 'X-Range'];
+const CLIENT_HEADERS = [CACHE_CONTROL, 'X-Request-ID', 'X-Range', 'Refresh'];
 export default Service.extend({
   dom: service('dom'),
   connections: service('client/connections'),

--- a/ui-v2/app/services/data-source/protocols/http/blocking.js
+++ b/ui-v2/app/services/data-source/protocols/http/blocking.js
@@ -17,8 +17,9 @@ export default Service.extend({
       return maybeCall(deleteCursor, ifNotBlocking(this.settings))().then(() => {
         return find(configuration)
           .then(maybeCall(close, ifNotBlocking(this.settings)))
-          .then(function(res) {
-            if (typeof get(res || {}, 'meta.cursor') === 'undefined') {
+          .then(function(res = {}) {
+            const meta = get(res, 'meta') || {};
+            if (typeof meta.cursor === 'undefined' && typeof meta.interval === 'undefined') {
               close();
             }
             return res;

--- a/ui-v2/app/utils/dom/event-source/blocking.js
+++ b/ui-v2/app/utils/dom/event-source/blocking.js
@@ -44,7 +44,7 @@ const throttle = function(configuration, prev, current) {
     return new Promise(function(resolve, reject) {
       setTimeout(function() {
         resolve(obj);
-      }, pause);
+      }, configuration.interval || pause);
     });
   };
 };
@@ -104,6 +104,7 @@ export default function(EventSource, backoff = createErrorBackoff()) {
               // along with cursor validation
               configuration.cursor = validateCursor(meta.cursor, configuration.cursor);
               configuration.cacheControl = meta.cacheControl;
+              configuration.interval = meta.interval;
             }
             if ((configuration.cacheControl || '').indexOf('no-store') === -1) {
               this.currentEvent = event;


### PR DESCRIPTION
Our DataSource service/components allow us to visualize live data in the page using blocking queries - which depend on API endpoints which support blocking queries.

It would be nice to be able to use the same Datasources for endpoints that don't support blocking queries, so here we've added support for polling Datasources, that work the same way as the blocking ones.

Enabling polling on an endpoint requires setting a `Refresh: 30` (30 second poll) HTTP header in the adapter method for the endpoint you would like to poll.