### PR TITLE
Add StreamingHealthServices cache-type

### DIFF
--- a/agent/cache-types/streaming_events_test.go
+++ b/agent/cache-types/streaming_events_test.go
@@ -1,0 +1,174 @@
+package cachetype
+
+import (
+	fmt "fmt"
+
+	"github.com/hashicorp/consul/proto/pbcommon"
+	"github.com/hashicorp/consul/proto/pbservice"
+	"github.com/hashicorp/consul/proto/pbsubscribe"
+	"github.com/hashicorp/consul/types"
+)
+
+func newEndOfSnapshotEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.Event {
+	return &pbsubscribe.Event{
+		Topic:   topic,
+		Index:   index,
+		Payload: &pbsubscribe.Event_EndOfSnapshot{EndOfSnapshot: true},
+	}
+}
+
+func newEndOfEmptySnapshotEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.Event {
+	return &pbsubscribe.Event{
+		Topic:   topic,
+		Index:   index,
+		Payload: &pbsubscribe.Event_EndOfEmptySnapshot{EndOfEmptySnapshot: true},
+	}
+}
+
+// newEventServiceHealthRegister returns a realistically populated service
+// health registration event for tests. The nodeNum is a
+// logical node and is used to create the node name ("node%d") but also change
+// the node ID and IP address to make it a little more realistic for cases that
+// need that. nodeNum should be less than 64k to make the IP address look
+// realistic. Any other changes can be made on the returned event to avoid
+// adding too many options to callers.
+func newEventServiceHealthRegister(index uint64, nodeNum int, svc string) pbsubscribe.Event {
+	node := fmt.Sprintf("node%d", nodeNum)
+	nodeID := types.NodeID(fmt.Sprintf("11111111-2222-3333-4444-%012d", nodeNum))
+	addr := fmt.Sprintf("10.10.%d.%d", nodeNum/256, nodeNum%256)
+
+	return pbsubscribe.Event{
+		Topic: pbsubscribe.Topic_ServiceHealth,
+		Key:   svc,
+		Index: index,
+		Payload: &pbsubscribe.Event_ServiceHealth{
+			ServiceHealth: &pbsubscribe.ServiceHealthUpdate{
+				Op: pbsubscribe.CatalogOp_Register,
+				CheckServiceNode: &pbservice.CheckServiceNode{
+					Node: &pbservice.Node{
+						ID:         nodeID,
+						Node:       node,
+						Address:    addr,
+						Datacenter: "dc1",
+						RaftIndex: pbcommon.RaftIndex{
+							CreateIndex: index,
+							ModifyIndex: index,
+						},
+					},
+					Service: &pbservice.NodeService{
+						ID:      svc,
+						Service: svc,
+						Port:    8080,
+						Weights: &pbservice.Weights{
+							Passing: 1,
+							Warning: 1,
+						},
+						// Empty sadness
+						Proxy: pbservice.ConnectProxyConfig{
+							MeshGateway: pbservice.MeshGatewayConfig{},
+							Expose:      pbservice.ExposeConfig{},
+						},
+						EnterpriseMeta: pbcommon.EnterpriseMeta{},
+						RaftIndex: pbcommon.RaftIndex{
+							CreateIndex: index,
+							ModifyIndex: index,
+						},
+					},
+					Checks: []*pbservice.HealthCheck{
+						{
+							Node:           node,
+							CheckID:        "serf-health",
+							Name:           "serf-health",
+							Status:         "passing",
+							EnterpriseMeta: pbcommon.EnterpriseMeta{},
+							RaftIndex: pbcommon.RaftIndex{
+								CreateIndex: index,
+								ModifyIndex: index,
+							},
+						},
+						{
+							Node:           node,
+							CheckID:        types.CheckID("service:" + svc),
+							Name:           "service:" + svc,
+							ServiceID:      svc,
+							ServiceName:    svc,
+							Type:           "ttl",
+							Status:         "passing",
+							EnterpriseMeta: pbcommon.EnterpriseMeta{},
+							RaftIndex: pbcommon.RaftIndex{
+								CreateIndex: index,
+								ModifyIndex: index,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestEventServiceHealthDeregister returns a realistically populated service
+// health deregistration event for tests. The nodeNum is a
+// logical node and is used to create the node name ("node%d") but also change
+// the node ID and IP address to make it a little more realistic for cases that
+// need that. nodeNum should be less than 64k to make the IP address look
+// realistic. Any other changes can be made on the returned event to avoid
+// adding too many options to callers.
+func newEventServiceHealthDeregister(index uint64, nodeNum int, svc string) pbsubscribe.Event {
+	node := fmt.Sprintf("node%d", nodeNum)
+
+	return pbsubscribe.Event{
+		Topic: pbsubscribe.Topic_ServiceHealth,
+		Key:   svc,
+		Index: index,
+		Payload: &pbsubscribe.Event_ServiceHealth{
+			ServiceHealth: &pbsubscribe.ServiceHealthUpdate{
+				Op: pbsubscribe.CatalogOp_Deregister,
+				CheckServiceNode: &pbservice.CheckServiceNode{
+					Node: &pbservice.Node{
+						Node: node,
+					},
+					Service: &pbservice.NodeService{
+						ID:      svc,
+						Service: svc,
+						Port:    8080,
+						Weights: &pbservice.Weights{
+							Passing: 1,
+							Warning: 1,
+						},
+						// Empty sadness
+						Proxy: pbservice.ConnectProxyConfig{
+							MeshGateway: pbservice.MeshGatewayConfig{},
+							Expose:      pbservice.ExposeConfig{},
+						},
+						EnterpriseMeta: pbcommon.EnterpriseMeta{},
+						RaftIndex: pbcommon.RaftIndex{
+							// The original insertion index since a delete doesn't update
+							// this. This magic value came from state store tests where we
+							// setup at index 10 and then mutate at index 100. It can be
+							// modified by the caller later and makes it easier than having
+							// yet another argument in the common case.
+							CreateIndex: 10,
+							ModifyIndex: 10,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newEventBatchWithEvents(first pbsubscribe.Event, evs ...pbsubscribe.Event) pbsubscribe.Event {
+	events := make([]*pbsubscribe.Event, len(evs)+1)
+	events[0] = &first
+	for i := range evs {
+		events[i+1] = &evs[i]
+	}
+	return pbsubscribe.Event{
+		Topic: first.Topic,
+		Index: first.Index,
+		Payload: &pbsubscribe.Event_EventBatch{
+			EventBatch: &pbsubscribe.EventBatch{Events: events},
+		},
+	}
+}

--- a/agent/cache-types/streaming_events_test.go
+++ b/agent/cache-types/streaming_events_test.go
@@ -17,11 +17,11 @@ func newEndOfSnapshotEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.E
 	}
 }
 
-func newEndOfEmptySnapshotEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.Event {
+func newNewSnapshotToFollowEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.Event {
 	return &pbsubscribe.Event{
 		Topic:   topic,
 		Index:   index,
-		Payload: &pbsubscribe.Event_EndOfEmptySnapshot{EndOfEmptySnapshot: true},
+		Payload: &pbsubscribe.Event_NewSnapshotToFollow{NewSnapshotToFollow: true},
 	}
 }
 

--- a/agent/cache-types/streaming_events_test.go
+++ b/agent/cache-types/streaming_events_test.go
@@ -1,7 +1,7 @@
 package cachetype
 
 import (
-	fmt "fmt"
+	"fmt"
 
 	"github.com/hashicorp/consul/proto/pbcommon"
 	"github.com/hashicorp/consul/proto/pbservice"
@@ -17,10 +17,9 @@ func newEndOfSnapshotEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.E
 	}
 }
 
-func newNewSnapshotToFollowEvent(topic pbsubscribe.Topic, index uint64) *pbsubscribe.Event {
+func newNewSnapshotToFollowEvent(topic pbsubscribe.Topic) *pbsubscribe.Event {
 	return &pbsubscribe.Event{
 		Topic:   topic,
-		Index:   index,
 		Payload: &pbsubscribe.Event_NewSnapshotToFollow{NewSnapshotToFollow: true},
 	}
 }
@@ -32,12 +31,12 @@ func newNewSnapshotToFollowEvent(topic pbsubscribe.Topic, index uint64) *pbsubsc
 // need that. nodeNum should be less than 64k to make the IP address look
 // realistic. Any other changes can be made on the returned event to avoid
 // adding too many options to callers.
-func newEventServiceHealthRegister(index uint64, nodeNum int, svc string) pbsubscribe.Event {
+func newEventServiceHealthRegister(index uint64, nodeNum int, svc string) *pbsubscribe.Event {
 	node := fmt.Sprintf("node%d", nodeNum)
 	nodeID := types.NodeID(fmt.Sprintf("11111111-2222-3333-4444-%012d", nodeNum))
 	addr := fmt.Sprintf("10.10.%d.%d", nodeNum/256, nodeNum%256)
 
-	return pbsubscribe.Event{
+	return &pbsubscribe.Event{
 		Topic: pbsubscribe.Topic_ServiceHealth,
 		Key:   svc,
 		Index: index,
@@ -114,10 +113,10 @@ func newEventServiceHealthRegister(index uint64, nodeNum int, svc string) pbsubs
 // need that. nodeNum should be less than 64k to make the IP address look
 // realistic. Any other changes can be made on the returned event to avoid
 // adding too many options to callers.
-func newEventServiceHealthDeregister(index uint64, nodeNum int, svc string) pbsubscribe.Event {
+func newEventServiceHealthDeregister(index uint64, nodeNum int, svc string) *pbsubscribe.Event {
 	node := fmt.Sprintf("node%d", nodeNum)
 
-	return pbsubscribe.Event{
+	return &pbsubscribe.Event{
 		Topic: pbsubscribe.Topic_ServiceHealth,
 		Key:   svc,
 		Index: index,
@@ -158,13 +157,13 @@ func newEventServiceHealthDeregister(index uint64, nodeNum int, svc string) pbsu
 	}
 }
 
-func newEventBatchWithEvents(first pbsubscribe.Event, evs ...pbsubscribe.Event) pbsubscribe.Event {
+func newEventBatchWithEvents(first *pbsubscribe.Event, evs ...*pbsubscribe.Event) *pbsubscribe.Event {
 	events := make([]*pbsubscribe.Event, len(evs)+1)
-	events[0] = &first
+	events[0] = first
 	for i := range evs {
-		events[i+1] = &evs[i]
+		events[i+1] = evs[i]
 	}
-	return pbsubscribe.Event{
+	return &pbsubscribe.Event{
 		Topic: first.Topic,
 		Index: first.Index,
 		Payload: &pbsubscribe.Event_EventBatch{

--- a/agent/cache-types/streaming_health_services.go
+++ b/agent/cache-types/streaming_health_services.go
@@ -1,0 +1,149 @@
+package cachetype
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul/agent/agentpb"
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-bexpr"
+	"github.com/hashicorp/go-hclog"
+)
+
+const (
+	// Recommended name for registration.
+	StreamingHealthServicesName = "streaming-health-services"
+)
+
+// StreamingHealthServices supports fetching discovering service instances via the
+// catalog using the streaming gRPC endpoint.
+type StreamingHealthServices struct {
+	client StreamingClient
+	logger hclog.Logger
+}
+
+// NewStreamingHealthServices creates a cache-type for watching for service
+// health results via streaming updates.
+func NewStreamingHealthServices(client StreamingClient, logger hclog.Logger) *StreamingHealthServices {
+	return &StreamingHealthServices{
+		client: client,
+		logger: logger,
+	}
+}
+
+// Fetch implements cache.Type
+func (c *StreamingHealthServices) Fetch(opts cache.FetchOptions, req cache.Request) (cache.FetchResult, error) {
+	// The request should be a ServiceSpecificRequest.
+	reqReal, ok := req.(*structs.ServiceSpecificRequest)
+	if !ok {
+		return cache.FetchResult{}, fmt.Errorf(
+			"Internal cache failure: request wrong type: %T", req)
+	}
+
+	r := agentpb.SubscribeRequest{
+		Topic:      agentpb.Topic_ServiceHealth,
+		Key:        reqReal.ServiceName,
+		Token:      reqReal.Token,
+		Index:      reqReal.MinQueryIndex,
+		Filter:     reqReal.Filter,
+		Datacenter: reqReal.Datacenter,
+	}
+
+	// Connect requests need a different topic
+	if reqReal.Connect {
+		r.Topic = agentpb.Topic_ServiceHealthConnect
+	}
+
+	view := MaterializedViewFromFetch(c, opts, r)
+	return view.Fetch(opts)
+}
+
+// SupportsBlocking implements cache.Type
+func (c *StreamingHealthServices) SupportsBlocking() bool {
+	return true
+}
+
+// NewMaterializedView implements StreamingCacheType
+func (c *StreamingHealthServices) NewMaterializedViewState() MaterializedViewState {
+	return &healthViewState{
+		state: make(map[string]structs.CheckServiceNode),
+	}
+}
+
+// StreamingClient implements StreamingCacheType
+func (c *StreamingHealthServices) StreamingClient() StreamingClient {
+	return c.client
+}
+
+// Logger implements StreamingCacheType
+func (c *StreamingHealthServices) Logger() hclog.Logger {
+	return c.logger
+}
+
+// healthViewState implements MaterializedViewState for storing the view state
+// of a service health result. We store it as a map to make updates and
+// deletions a little easier but we could just store a result type
+// (IndexedCheckServiceNodes) and update it in place for each event - that
+// involves re-sorting each time etc. though.
+type healthViewState struct {
+	state  map[string]structs.CheckServiceNode
+	filter *bexpr.Filter
+}
+
+// InitFilter implements MaterializedViewState
+func (s *healthViewState) InitFilter(expression string) error {
+	// We apply filtering to the raw CheckServiceNodes before we are done mutating
+	// state in Update to save from storing stuff in memory we'll only filter
+	// later. Because the state is just a map of those types, we can simply run
+	// that map through filter and it will remove any entries that don't match.
+	filter, err := bexpr.CreateFilter(expression, nil, s.state)
+	if err != nil {
+		return err
+	}
+	s.filter = filter
+	return nil
+}
+
+// Update implements MaterializedViewState
+func (s *healthViewState) Update(events []*agentpb.Event) error {
+	for _, event := range events {
+		serviceHealth := event.GetServiceHealth()
+		if serviceHealth == nil {
+			return fmt.Errorf("unexpected event type for service health view: %T",
+				event.GetPayload())
+		}
+		node := serviceHealth.CheckServiceNode
+		id := fmt.Sprintf("%s/%s", node.Node.Node, node.Service.ID)
+
+		switch serviceHealth.Op {
+		case agentpb.CatalogOp_Register:
+			checkServiceNode, err := serviceHealth.CheckServiceNode.ToStructs()
+			if err != nil {
+				return err
+			}
+			s.state[id] = *checkServiceNode
+		case agentpb.CatalogOp_Deregister:
+			delete(s.state, id)
+		}
+	}
+	if s.filter != nil {
+		filtered, err := s.filter.Execute(s.state)
+		if err != nil {
+			return err
+		}
+		s.state = filtered.(map[string]structs.CheckServiceNode)
+	}
+	return nil
+}
+
+// Result implements MaterializedViewState
+func (s *healthViewState) Result(index uint64) (interface{}, error) {
+	var result structs.IndexedCheckServiceNodes
+	// Avoid a nil slice if there are no results in the view
+	result.Nodes = structs.CheckServiceNodes{}
+	for _, node := range s.state {
+		result.Nodes = append(result.Nodes, node)
+	}
+	result.Index = index
+	return &result, nil
+}

--- a/agent/cache-types/streaming_health_services.go
+++ b/agent/cache-types/streaming_health_services.go
@@ -1,10 +1,14 @@
 package cachetype
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/lib/retry"
 
 	"github.com/hashicorp/consul/agent/cache"
 	"github.com/hashicorp/consul/agent/structs"
@@ -58,8 +62,39 @@ func (c *StreamingHealthServices) Fetch(opts cache.FetchOptions, req cache.Reque
 		r.Topic = pbsubscribe.Topic_ServiceHealthConnect
 	}
 
-	view := MaterializedViewFromFetch(c, opts, r)
+	view, err := c.getMaterializedView(opts, r)
+	if err != nil {
+		return cache.FetchResult{}, err
+	}
 	return view.Fetch(opts)
+}
+
+func (c *StreamingHealthServices) getMaterializedView(opts cache.FetchOptions, r Request) (*Materializer, error) {
+	if opts.LastResult != nil && opts.LastResult.State != nil {
+		return opts.LastResult.State.(*Materializer), nil
+	}
+
+	state, err := newHealthViewState(r.Filter)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithCancel(context.TODO())
+	view := NewMaterializer(ViewDeps{
+		State:  state,
+		Client: c.client,
+		Logger: c.logger,
+		Waiter: &retry.Waiter{
+			MinFailures: 1,
+			MinWait:     0,
+			MaxWait:     60 * time.Second,
+			Jitter:      retry.NewJitter(100),
+		},
+		Request: r,
+		Stop:    cancel,
+		Done:    ctx.Done(),
+	})
+	go view.run(ctx)
+	return view, nil
 }
 
 // SupportsBlocking implements cache.Type
@@ -67,11 +102,16 @@ func (c *StreamingHealthServices) SupportsBlocking() bool {
 	return true
 }
 
-// NewMaterializedView implements StreamingCacheType
-func (c *StreamingHealthServices) NewMaterializedViewState() MaterializedViewState {
-	return &healthViewState{
-		state: make(map[string]structs.CheckServiceNode),
-	}
+func newHealthViewState(filterExpr string) (View, error) {
+	s := &healthViewState{state: make(map[string]structs.CheckServiceNode)}
+
+	// We apply filtering to the raw CheckServiceNodes before we are done mutating
+	// state in Update to save from storing stuff in memory we'll only filter
+	// later. Because the state is just a map of those types, we can simply run
+	// that map through filter and it will remove any entries that don't match.
+	var err error
+	s.filter, err = bexpr.CreateFilter(filterExpr, nil, s.state)
+	return s, err
 }
 
 // StreamingClient implements StreamingCacheType
@@ -84,31 +124,18 @@ func (c *StreamingHealthServices) Logger() hclog.Logger {
 	return c.logger
 }
 
-// healthViewState implements MaterializedViewState for storing the view state
+// healthViewState implements View for storing the view state
 // of a service health result. We store it as a map to make updates and
 // deletions a little easier but we could just store a result type
 // (IndexedCheckServiceNodes) and update it in place for each event - that
 // involves re-sorting each time etc. though.
 type healthViewState struct {
-	state  map[string]structs.CheckServiceNode
+	state map[string]structs.CheckServiceNode
+	// TODO: test case with filter
 	filter *bexpr.Filter
 }
 
-// InitFilter implements MaterializedViewState
-func (s *healthViewState) InitFilter(expression string) error {
-	// We apply filtering to the raw CheckServiceNodes before we are done mutating
-	// state in Update to save from storing stuff in memory we'll only filter
-	// later. Because the state is just a map of those types, we can simply run
-	// that map through filter and it will remove any entries that don't match.
-	filter, err := bexpr.CreateFilter(expression, nil, s.state)
-	if err != nil {
-		return err
-	}
-	s.filter = filter
-	return nil
-}
-
-// Update implements MaterializedViewState
+// Update implements View
 func (s *healthViewState) Update(events []*pbsubscribe.Event) error {
 	for _, event := range events {
 		serviceHealth := event.GetServiceHealth()
@@ -127,6 +154,7 @@ func (s *healthViewState) Update(events []*pbsubscribe.Event) error {
 			delete(s.state, id)
 		}
 	}
+	// TODO: replace with a no-op filter instead of a conditional
 	if s.filter != nil {
 		filtered, err := s.filter.Execute(s.state)
 		if err != nil {
@@ -137,14 +165,19 @@ func (s *healthViewState) Update(events []*pbsubscribe.Event) error {
 	return nil
 }
 
-// Result implements MaterializedViewState
+// Result implements View
 func (s *healthViewState) Result(index uint64) (interface{}, error) {
 	var result structs.IndexedCheckServiceNodes
 	// Avoid a nil slice if there are no results in the view
+	// TODO: why this ^
 	result.Nodes = structs.CheckServiceNodes{}
 	for _, node := range s.state {
 		result.Nodes = append(result.Nodes, node)
 	}
 	result.Index = index
 	return &result, nil
+}
+
+func (s *healthViewState) Reset() {
+	s.state = make(map[string]structs.CheckServiceNode)
 }

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -1,0 +1,485 @@
+package cachetype
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul/agent/agentpb"
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
+	client := NewTestStreamingClient()
+	typ := StreamingHealthServices{
+		client: client,
+		logger: hclog.Default(),
+	}
+
+	// Initially there are no services registered. Server should send an
+	// EndOfSnapshot message immediately with index of 1.
+	eosEv := agentpb.TestEventEndOfSnapshot(t, agentpb.Topic_ServiceHealth, 1)
+	client.QueueEvents(&eosEv)
+
+	// This contains the view state so important we share it between calls.
+	opts := cache.FetchOptions{
+		MinIndex: 0,
+		Timeout:  1 * time.Second,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter:  "dc1",
+		ServiceName: "web",
+	}
+	empty := &structs.IndexedCheckServiceNodes{
+		Nodes: structs.CheckServiceNodes{},
+		QueryMeta: structs.QueryMeta{
+			Index: 1,
+		},
+	}
+
+	require.True(t, t.Run("empty snapshot returned", func(t *testing.T) {
+		// Fetch should return an empty
+		// result of the right type with a non-zero index, and in the background begin
+		// streaming updates.
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(1), result.Index)
+		require.Equal(t, empty, result.Value)
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("blocks for timeout", func(t *testing.T) {
+		// Subsequent fetch should block for the timeout
+		start := time.Now()
+		opts.Timeout = 200 * time.Millisecond
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed >= 200*time.Millisecond,
+			"Fetch should have blocked until timeout")
+
+		require.Equal(t, opts.MinIndex, result.Index, "result index should not have changed")
+		require.Equal(t, empty, result.Value, "result value should not have changed")
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("blocks until update", func(t *testing.T) {
+		// Make another blocking query with a longer timeout and trigger an update
+		// event part way through.
+		start := time.Now()
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+
+			// Then a service registers
+			healthEv := agentpb.TestEventServiceHealthRegister(t, 4, 1, "web")
+			client.QueueEvents(&healthEv)
+		}()
+
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed >= 200*time.Millisecond,
+			"Fetch should have blocked until the event was delivered")
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, uint64(4), result.Index, "result index should not have changed")
+		require.Len(t, result.Value.(*structs.IndexedCheckServiceNodes).Nodes, 1,
+			"result value should contain the new registration")
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("reconnects and resumes after transient stream error", func(t *testing.T) {
+		// Use resetErr just because it's "temporary" this is a stand in for any
+		// network error that uses that same interface though.
+		client.QueueErr(resetErr("broken pipe"))
+
+		// After the error the view should re-subscribe with same index so will get
+		// a "resume stream".
+		resumeEv := agentpb.TestEventResumeStream(t, agentpb.Topic_ServiceHealth, opts.MinIndex)
+		client.QueueEvents(&resumeEv)
+
+		// Next fetch will continue to block until timeout and receive the same
+		// result.
+		start := time.Now()
+		opts.Timeout = 200 * time.Millisecond
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed >= 200*time.Millisecond,
+			"Fetch should have blocked until timeout")
+
+		require.Equal(t, opts.MinIndex, result.Index, "result index should not have changed")
+		require.Equal(t, opts.LastResult.Value, result.Value, "result value should not have changed")
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+
+		// But an update should still be noticed due to reconnection
+		healthEv := agentpb.TestEventServiceHealthRegister(t, 10, 2, "web")
+		client.QueueEvents(&healthEv)
+
+		start = time.Now()
+		opts.Timeout = time.Second
+		result, err = typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed = time.Since(start)
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, uint64(10), result.Index, "result index should not have changed")
+		require.Len(t, result.Value.(*structs.IndexedCheckServiceNodes).Nodes, 2,
+			"result value should contain the new registration")
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("returns non-temporary error to watchers", func(t *testing.T) {
+		// Wait and send the error while fetcher is waiting
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			client.QueueErr(errors.New("invalid request"))
+
+			// After the error the view should re-subscribe with same index so will get
+			// a "resume stream".
+			resumeEv := agentpb.TestEventResumeStream(t, agentpb.Topic_ServiceHealth, opts.MinIndex)
+			client.QueueEvents(&resumeEv)
+		}()
+
+		// Next fetch should return the error
+		start := time.Now()
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.Error(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed >= 200*time.Millisecond,
+			"Fetch should have blocked until error was sent")
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, opts.MinIndex, result.Index, "result index should not have changed")
+		// We don't require instances to be returned in same order so we use
+		// elementsMatch which is recursive.
+		requireResultsSame(t,
+			opts.LastResult.Value.(*structs.IndexedCheckServiceNodes),
+			result.Value.(*structs.IndexedCheckServiceNodes),
+		)
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+
+		// But an update should still be noticed due to reconnection
+		healthEv := agentpb.TestEventServiceHealthRegister(t, opts.MinIndex+5, 3, "web")
+		client.QueueEvents(&healthEv)
+
+		opts.Timeout = time.Second
+		result, err = typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed = time.Since(start)
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, opts.MinIndex+5, result.Index, "result index should not have changed")
+		require.Len(t, result.Value.(*structs.IndexedCheckServiceNodes).Nodes, 3,
+			"result value should contain the new registration")
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+}
+
+// requireResultsSame compares two IndexedCheckServiceNodes without requiring
+// the same order of results (which vary due to map usage internally).
+func requireResultsSame(t *testing.T, want, got *structs.IndexedCheckServiceNodes) {
+	require.Equal(t, want.Index, got.Index)
+
+	svcIDs := func(csns structs.CheckServiceNodes) []string {
+		res := make([]string, 0, len(csns))
+		for _, csn := range csns {
+			res = append(res, fmt.Sprintf("%s/%s", csn.Node.Node, csn.Service.ID))
+		}
+		return res
+	}
+
+	gotIDs := svcIDs(got.Nodes)
+	wantIDs := svcIDs(want.Nodes)
+
+	require.ElementsMatch(t, wantIDs, gotIDs)
+}
+
+func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
+	client := NewTestStreamingClient()
+	typ := StreamingHealthServices{
+		client: client,
+		logger: hclog.Default(),
+	}
+
+	// Create an initial snapshot of 3 instances on different nodes
+	makeReg := func(index uint64, nodeNum int) *agentpb.Event {
+		e := agentpb.TestEventServiceHealthRegister(t, index, nodeNum, "web")
+		return &e
+	}
+	eosEv := agentpb.TestEventEndOfSnapshot(t, agentpb.Topic_ServiceHealth, 5)
+	client.QueueEvents(
+		makeReg(5, 1),
+		makeReg(5, 2),
+		makeReg(5, 3),
+		&eosEv,
+	)
+
+	// This contains the view state so important we share it between calls.
+	opts := cache.FetchOptions{
+		MinIndex: 0,
+		Timeout:  1 * time.Second,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter:  "dc1",
+		ServiceName: "web",
+	}
+
+	gatherNodes := func(res interface{}) []string {
+		nodes := make([]string, 0, 3)
+		r := res.(*structs.IndexedCheckServiceNodes)
+		for _, csn := range r.Nodes {
+			nodes = append(nodes, csn.Node.Node)
+		}
+		return nodes
+	}
+
+	require.True(t, t.Run("full snapshot returned", func(t *testing.T) {
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(5), result.Index)
+		require.ElementsMatch(t, []string{"node1", "node2", "node3"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("blocks until deregistration", func(t *testing.T) {
+		// Make another blocking query with a longer timeout and trigger an update
+		// event part way through.
+		start := time.Now()
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+
+			// Deregister instance on node1
+			healthEv := agentpb.TestEventServiceHealthDeregister(t, 20, 1, "web")
+			client.QueueEvents(&healthEv)
+		}()
+
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed >= 200*time.Millisecond,
+			"Fetch should have blocked until the event was delivered")
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, uint64(20), result.Index)
+		require.ElementsMatch(t, []string{"node2", "node3"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("server reload is respected", func(t *testing.T) {
+		// Simulates the server noticing the request's ACL token privs changing. To
+		// detect this we'll queue up the new snapshot as a different set of nodes
+		// to the first.
+		resetEv := agentpb.TestEventResetStream(t, agentpb.Topic_ServiceHealth, 45)
+		eosEv := agentpb.TestEventEndOfSnapshot(t, agentpb.Topic_ServiceHealth, 50)
+		client.QueueEvents(
+			&resetEv,
+			makeReg(50, 3), // overlap existing node
+			makeReg(50, 4),
+			makeReg(50, 5),
+			&eosEv,
+		)
+
+		// Make another blocking query with THE SAME index. It should immediately
+		// return the new snapshot.
+		start := time.Now()
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+		elapsed := time.Since(start)
+		require.True(t, elapsed < time.Second,
+			"Fetch should have returned before the timeout")
+
+		require.Equal(t, uint64(50), result.Index)
+		require.ElementsMatch(t, []string{"node3", "node4", "node5"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+}
+
+func TestStreamingHealthServices_EventBatches(t *testing.T) {
+	client := NewTestStreamingClient()
+	typ := StreamingHealthServices{
+		client: client,
+		logger: hclog.Default(),
+	}
+
+	// Create an initial snapshot of 3 instances but in a single event batch
+	batchEv := agentpb.TestEventBatchWithEvents(t,
+		agentpb.TestEventServiceHealthRegister(t, 5, 1, "web"),
+		agentpb.TestEventServiceHealthRegister(t, 5, 2, "web"),
+		agentpb.TestEventServiceHealthRegister(t, 5, 3, "web"),
+	)
+	eosEv := agentpb.TestEventEndOfSnapshot(t, agentpb.Topic_ServiceHealth, 5)
+
+	client.QueueEvents(
+		&batchEv,
+		&eosEv,
+	)
+
+	// This contains the view state so important we share it between calls.
+	opts := cache.FetchOptions{
+		MinIndex: 0,
+		Timeout:  1 * time.Second,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter:  "dc1",
+		ServiceName: "web",
+	}
+
+	gatherNodes := func(res interface{}) []string {
+		nodes := make([]string, 0, 3)
+		r := res.(*structs.IndexedCheckServiceNodes)
+		for _, csn := range r.Nodes {
+			nodes = append(nodes, csn.Node.Node)
+		}
+		return nodes
+	}
+
+	require.True(t, t.Run("full snapshot returned", func(t *testing.T) {
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(5), result.Index)
+		require.ElementsMatch(t, []string{"node1", "node2", "node3"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("batched updates work too", func(t *testing.T) {
+		// Simulate multiple registrations happening in one Txn (so all have same
+		// index)
+		batchEv := agentpb.TestEventBatchWithEvents(t,
+			// Deregister an existing node
+			agentpb.TestEventServiceHealthDeregister(t, 20, 1, "web"),
+			// Register another
+			agentpb.TestEventServiceHealthRegister(t, 20, 4, "web"),
+		)
+		client.QueueEvents(&batchEv)
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(20), result.Index)
+		require.ElementsMatch(t, []string{"node2", "node3", "node4"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+}
+
+func TestStreamingHealthServices_Filtering(t *testing.T) {
+	client := NewTestStreamingClient()
+	typ := StreamingHealthServices{
+		client: client,
+		logger: hclog.Default(),
+	}
+
+	// Create an initial snapshot of 3 instances but in a single event batch
+	batchEv := agentpb.TestEventBatchWithEvents(t,
+		agentpb.TestEventServiceHealthRegister(t, 5, 1, "web"),
+		agentpb.TestEventServiceHealthRegister(t, 5, 2, "web"),
+		agentpb.TestEventServiceHealthRegister(t, 5, 3, "web"),
+	)
+	eosEv := agentpb.TestEventEndOfSnapshot(t, agentpb.Topic_ServiceHealth, 5)
+	client.QueueEvents(
+		&batchEv,
+		&eosEv,
+	)
+
+	// This contains the view state so important we share it between calls.
+	opts := cache.FetchOptions{
+		MinIndex: 0,
+		Timeout:  1 * time.Second,
+	}
+	req := &structs.ServiceSpecificRequest{
+		Datacenter:  "dc1",
+		ServiceName: "web",
+		QueryOptions: structs.QueryOptions{
+			Filter: `Node.Node == "node2"`,
+		},
+	}
+
+	gatherNodes := func(res interface{}) []string {
+		nodes := make([]string, 0, 3)
+		r := res.(*structs.IndexedCheckServiceNodes)
+		for _, csn := range r.Nodes {
+			nodes = append(nodes, csn.Node.Node)
+		}
+		return nodes
+	}
+
+	require.True(t, t.Run("filtered snapshot returned", func(t *testing.T) {
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(5), result.Index)
+		require.ElementsMatch(t, []string{"node2"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+
+	require.True(t, t.Run("filtered updates work too", func(t *testing.T) {
+		// Simulate multiple registrations happening in one Txn (so all have same
+		// index)
+		batchEv := agentpb.TestEventBatchWithEvents(t,
+			// Deregister an existing node
+			agentpb.TestEventServiceHealthDeregister(t, 20, 1, "web"),
+			// Register another
+			agentpb.TestEventServiceHealthRegister(t, 20, 4, "web"),
+		)
+		client.QueueEvents(&batchEv)
+		opts.Timeout = time.Second
+		result, err := typ.Fetch(opts, req)
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(20), result.Index)
+		require.ElementsMatch(t, []string{"node2"},
+			gatherNodes(result.Value))
+
+		opts.MinIndex = result.Index
+		opts.LastResult = &result
+	}))
+}

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -107,7 +107,7 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 	runStep(t, "reconnects and resumes after transient stream error", func(t *testing.T) {
 		// Use resetErr just because it's "temporary" this is a stand in for any
 		// network error that uses that same interface though.
-		client.QueueErr(resetErr("broken pipe"))
+		client.QueueErr(tempError("broken pipe"))
 
 		// After the error the view should re-subscribe with same index so will get
 		// a "resume stream".
@@ -200,6 +200,16 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 		opts.MinIndex = result.Index
 		opts.LastResult = &result
 	})
+}
+
+type tempError string
+
+func (e tempError) Error() string {
+	return string(e)
+}
+
+func (e tempError) Temporary() bool {
+	return true
 }
 
 // requireResultsSame compares two IndexedCheckServiceNodes without requiring

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -19,10 +19,10 @@ import (
 
 func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 	client := NewTestStreamingClient()
-	typ := StreamingHealthServices{
-		client: client,
-		logger: hclog.Default(),
-	}
+	typ := StreamingHealthServices{deps: MaterializerDeps{
+		Client: client,
+		Logger: hclog.Default(),
+	}}
 
 	// Initially there are no services registered. Server should send an
 	// EndOfSnapshot message immediately with index of 1.
@@ -233,10 +233,10 @@ func requireResultsSame(t *testing.T, want, got *structs.IndexedCheckServiceNode
 
 func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 	client := NewTestStreamingClient()
-	typ := StreamingHealthServices{
-		client: client,
-		logger: hclog.Default(),
-	}
+	typ := StreamingHealthServices{deps: MaterializerDeps{
+		Client: client,
+		Logger: hclog.Default(),
+	}}
 
 	// Create an initial snapshot of 3 instances on different nodes
 	makeReg := func(index uint64, nodeNum int) *pbsubscribe.Event {
@@ -341,10 +341,10 @@ func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 
 func TestStreamingHealthServices_EventBatches(t *testing.T) {
 	client := NewTestStreamingClient()
-	typ := StreamingHealthServices{
-		client: client,
-		logger: hclog.Default(),
-	}
+	typ := StreamingHealthServices{deps: MaterializerDeps{
+		Client: client,
+		Logger: hclog.Default(),
+	}}
 
 	// Create an initial snapshot of 3 instances but in a single event batch
 	batchEv := newEventBatchWithEvents(
@@ -411,10 +411,10 @@ func TestStreamingHealthServices_EventBatches(t *testing.T) {
 
 func TestStreamingHealthServices_Filtering(t *testing.T) {
 	client := NewTestStreamingClient()
-	typ := StreamingHealthServices{
-		client: client,
-		logger: hclog.Default(),
-	}
+	typ := StreamingHealthServices{deps: MaterializerDeps{
+		Client: client,
+		Logger: hclog.Default(),
+	}}
 
 	// Create an initial snapshot of 3 instances but in a single event batch
 	batchEv := newEventBatchWithEvents(

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -3,6 +3,7 @@ package cachetype
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -254,6 +255,7 @@ func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 		for _, csn := range r.Nodes {
 			nodes = append(nodes, csn.Node.Node)
 		}
+		sort.Strings(nodes)
 		return nodes
 	}
 
@@ -291,8 +293,7 @@ func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(20), result.Index)
-		require.ElementsMatch(t, []string{"node2", "node3"},
-			gatherNodes(result.Value))
+		require.Equal(t, []string{"node2", "node3"}, gatherNodes(result.Value))
 
 		opts.MinIndex = result.Index
 		opts.LastResult = &result
@@ -321,8 +322,7 @@ func TestStreamingHealthServices_FullSnapshot(t *testing.T) {
 			"Fetch should have returned before the timeout")
 
 		require.Equal(t, uint64(50), result.Index)
-		require.ElementsMatch(t, []string{"node3", "node4", "node5"},
-			gatherNodes(result.Value))
+		require.Equal(t, []string{"node3", "node4", "node5"}, gatherNodes(result.Value))
 
 		opts.MinIndex = result.Index
 		opts.LastResult = &result

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -28,10 +28,9 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 	// EndOfSnapshot message immediately with index of 1.
 	client.QueueEvents(newEndOfSnapshotEvent(pbsubscribe.Topic_ServiceHealth, 1))
 
-	// This contains the view state so important we share it between calls.
 	opts := cache.FetchOptions{
 		MinIndex: 0,
-		Timeout:  1 * time.Second,
+		Timeout:  time.Second,
 	}
 	req := &structs.ServiceSpecificRequest{
 		Datacenter:  "dc1",
@@ -111,7 +110,7 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 
 		// After the error the view should re-subscribe with same index so will get
 		// a "resume stream".
-		client.QueueEvents(newEndOfEmptySnapshotEvent(pbsubscribe.Topic_ServiceHealth, opts.MinIndex))
+		client.QueueEvents(newNewSnapshotToFollowEvent(pbsubscribe.Topic_ServiceHealth, opts.MinIndex))
 
 		// Next fetch will continue to block until timeout and receive the same
 		// result.
@@ -157,7 +156,7 @@ func TestStreamingHealthServices_EmptySnapshot(t *testing.T) {
 
 			// After the error the view should re-subscribe with same index so will get
 			// a "resume stream".
-			client.QueueEvents(newEndOfEmptySnapshotEvent(pbsubscribe.Topic_ServiceHealth, opts.MinIndex))
+			client.QueueEvents(newNewSnapshotToFollowEvent(pbsubscribe.Topic_ServiceHealth, opts.MinIndex))
 		}()
 
 		// Next fetch should return the error

--- a/agent/cache-types/streaming_health_services_test.go
+++ b/agent/cache-types/streaming_health_services_test.go
@@ -486,6 +486,7 @@ func TestStreamingHealthServices_Filtering(t *testing.T) {
 }
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
 	if !t.Run(name, fn) {
 		t.FailNow()
 	}

--- a/agent/cache-types/streaming_materialized_view.go
+++ b/agent/cache-types/streaming_materialized_view.go
@@ -1,0 +1,447 @@
+package cachetype
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/consul/agent/agentpb"
+	"github.com/hashicorp/consul/agent/cache"
+	"github.com/hashicorp/consul/lib"
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc"
+)
+
+const (
+	// SubscribeBackoffMax controls the range of exponential backoff when errors
+	// are returned from subscriptions.
+	SubscribeBackoffMax = 60 * time.Second
+)
+
+// StreamingClient is the interface we need from the gRPC client stub. Separate
+// interface simplifies testing.
+type StreamingClient interface {
+	Subscribe(ctx context.Context, in *agentpb.SubscribeRequest, opts ...grpc.CallOption) (agentpb.Consul_SubscribeClient, error)
+}
+
+// MaterializedViewState is the interface used to manage they type-specific
+// materialized view logic.
+type MaterializedViewState interface {
+	// InitFilter is called once when the view is constructed if the subscription
+	// has a non-empty Filter argument. The implementor is expected to create a
+	// *bexpr.Filter and store it locally so it can be used to filter events
+	// and/or results. Ideally filtering should occur inside `Update` calls such
+	// that we don't store objects in the view state that are just filtered when
+	// the result is returned, however in some cases it might not be possible and
+	// the type may choose to store the whole view and only apply filtering in the
+	// Result method just before returning a result.
+	InitFilter(expression string) error
+
+	// Update is called when one or more events are received. The first call will
+	// include _all_ events in the initial snapshot which may be an empty set.
+	// Subsequent calls will contain one or more update events in the order they
+	// are received.
+	Update(events []*agentpb.Event) error
+
+	// Result returns the type-specific cache result based on the state. When no
+	// events have been delivered yet the result should be an empty value type
+	// suitable to return to clients in case there is an empty result on the
+	// servers. The index the materialized view represents is maintained
+	// separately and passed in in case the return type needs an Index field
+	// populating. This allows implementations to not worry about maintaining
+	// indexes seen during Update.
+	Result(index uint64) (interface{}, error)
+}
+
+// StreamingCacheType is the interface a cache-type needs to implement to make
+// use of streaming as the transport for updates from the server.
+type StreamingCacheType interface {
+	NewMaterializedViewState() MaterializedViewState
+	StreamingClient() StreamingClient
+	Logger() hclog.Logger
+}
+
+// temporary is a private interface as used by net and other std lib packages to
+// show error types represent temporary/recoverable errors.
+type temporary interface {
+	Temporary() bool
+}
+
+// resetErr represents a server request to reset the subscription, it's typed so
+// we can mark it as temporary and so attempt to retry first time without
+// notifying clients.
+type resetErr string
+
+// Temporary Implements the internal Temporary interface
+func (e resetErr) Temporary() bool {
+	return true
+}
+
+// Error implements error
+func (e resetErr) Error() string {
+	return string(e)
+}
+
+// MaterializedView is a partial view of the state on servers, maintained via
+// streaming subscriptions. It is specialized for different cache types by
+// providing a MaterializedViewState that encapsulates the logic to update the
+// state and format it as the correct result type.
+//
+// The MaterializedView object becomes the cache.Result.State for a streaming
+// cache type and manages the actual streaming RPC call to the servers behind
+// the scenes until the cache result is discarded when TTL expires.
+type MaterializedView struct {
+	// Properties above the lock are immutable after the view is constructed in
+	// MaterializedViewFromFetch and must not be modified.
+	typ        StreamingCacheType
+	client     StreamingClient
+	logger     hclog.Logger
+	req        agentpb.SubscribeRequest
+	ctx        context.Context
+	cancelFunc func()
+
+	// l protects the mutable state - all fields below it must only be accessed
+	// while holding l.
+	l            sync.Mutex
+	index        uint64
+	state        MaterializedViewState
+	snapshotDone bool
+	updateCh     chan struct{}
+	retryWaiter  *lib.RetryWaiter
+	err          error
+	fatalErr     error
+}
+
+// MaterializedViewFromFetch retrieves an existing view from the cache result
+// state if one exists, otherwise creates a new one. Note that the returned view
+// MUST have Close called eventually to avoid leaking resources. Typically this
+// is done automatically if the view is returned in a cache.Result.State when
+// the cache evicts the result. If the view is not returned in a result state
+// though Close must be called some other way to avoid leaking the goroutine and
+// memory.
+func MaterializedViewFromFetch(t StreamingCacheType, opts cache.FetchOptions,
+	subReq agentpb.SubscribeRequest) *MaterializedView {
+
+	if opts.LastResult == nil || opts.LastResult.State == nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		v := &MaterializedView{
+			typ:        t,
+			client:     t.StreamingClient(),
+			logger:     t.Logger(),
+			req:        subReq,
+			ctx:        ctx,
+			cancelFunc: cancel,
+			// Allow first retry without wait, this is important and we rely on it in
+			// tests.
+			retryWaiter: lib.NewRetryWaiter(1, 0, SubscribeBackoffMax,
+				lib.NewJitterRandomStagger(100)),
+		}
+		// Run init now otherwise there is a race between run() and a call to Fetch
+		// which expects a view state to exist.
+		v.reset()
+		go v.run()
+		return v
+	}
+	return opts.LastResult.State.(*MaterializedView)
+}
+
+// Close implements io.Close and discards view state and stops background view
+// maintenance.
+func (v *MaterializedView) Close() error {
+	v.l.Lock()
+	defer v.l.Unlock()
+	if v.cancelFunc != nil {
+		v.cancelFunc()
+	}
+	return nil
+}
+
+func (v *MaterializedView) run() {
+	if v.ctx.Err() != nil {
+		return
+	}
+
+	// Loop in case stream resets and we need to start over
+	for {
+		// Run a subscribe call until it fails
+		err := v.runSubscription()
+		if err != nil {
+			// Check if the view closed
+			if v.ctx.Err() != nil {
+				// Err doesn't matter and is likely just context cancelled
+				return
+			}
+
+			v.l.Lock()
+			// If this is a temporary error and it's the first consecutive failure,
+			// retry to see if we can get a result without erroring back to clients.
+			// If it's non-temporary or a repeated failure return to clients while we
+			// retry to get back in a good state.
+			if _, ok := err.(temporary); !ok || v.retryWaiter.Failures() > 0 {
+				// Report error to blocked fetchers
+				v.err = err
+				v.notifyUpdateLocked()
+			}
+			waitCh := v.retryWaiter.Failed()
+			failures := v.retryWaiter.Failures()
+			v.l.Unlock()
+
+			// Exponential backoff to avoid hammering servers if they are closing
+			// conns because of overload or resetting based on errors.
+			v.logger.Error("subscribe call failed", "err", err, "topic", v.req.Topic,
+				"key", v.req.Key, "failure_count", failures)
+
+			select {
+			case <-v.ctx.Done():
+				return
+			case <-waitCh:
+			}
+		}
+		// Loop and keep trying to resume subscription after error
+	}
+
+}
+
+// runSubscription opens a new subscribe streaming call to the servers and runs
+// for it's lifetime or until the view is closed.
+func (v *MaterializedView) runSubscription() error {
+	ctx, cancel := context.WithCancel(v.ctx)
+	defer cancel()
+
+	// Copy the request template
+	req := v.req
+
+	v.l.Lock()
+
+	// Update request index to be the current view index in case we are resuming a
+	// broken stream.
+	req.Index = v.index
+
+	// Make local copy so we don't have to read with a lock for every event. We
+	// are the only goroutine that can update so we know it won't change without
+	// us knowing but we do need lock to protect external readers when we update.
+	snapshotDone := v.snapshotDone
+
+	v.l.Unlock()
+
+	s, err := v.client.Subscribe(ctx, &req)
+	if err != nil {
+		return err
+	}
+
+	snapshotEvents := make([]*agentpb.Event, 0)
+
+	for {
+		event, err := s.Recv()
+		if err != nil {
+			return err
+		}
+
+		if event.GetResetStream() {
+			// Server has requested we reset the view and start with a fresh snapshot
+			// - perhaps because our ACL policy changed. We reset the view state and
+			// then return an error to allow the `run` method to retry after a backoff
+			// if necessary.
+			v.reset()
+			return resetErr("stream reset requested")
+		}
+
+		if event.GetEndOfSnapshot() {
+			// Hold lock while mutating view state so implementer doesn't need to
+			// worry about synchronization.
+			v.l.Lock()
+
+			// Deliver snapshot events to the View state
+			if err := v.state.Update(snapshotEvents); err != nil {
+				v.l.Unlock()
+				// This error is kinda fatal to the view - we didn't apply some events
+				// the server sent us which means our view is now not in sync. The only
+				// thing we can do is start over and hope for a better outcome.
+				v.reset()
+				return err
+			}
+			// Done collecting these now
+			snapshotEvents = nil
+			v.snapshotDone = true
+			// update our local copy so we can read it without lock.
+			snapshotDone = true
+			v.index = event.Index
+			// We have a good result, reset the error flag
+			v.err = nil
+			v.retryWaiter.Reset()
+			// Notify watchers of the update to the view
+			v.notifyUpdateLocked()
+			v.l.Unlock()
+			continue
+		}
+
+		if event.GetResumeStream() {
+			// We've opened a new subscribe with a non-zero index to resume a
+			// connection and the server confirms it's not sending a new snapshot.
+			if !snapshotDone {
+				// We've somehow got into a bad state here - the server thinks we have
+				// an up-to-date snapshot but we don't think we do. Reset and start
+				// over.
+				v.reset()
+				return errors.New("stream resume sent but no local snapshot")
+			}
+			// Just continue on as we were!
+			continue
+		}
+
+		// We have an event for the topic
+		events := []*agentpb.Event{event}
+
+		// If the event is a batch, unwrap and deliver the raw events
+		if batch := event.GetEventBatch(); batch != nil {
+			events = batch.Events
+		}
+
+		if snapshotDone {
+			// We've already got a snapshot, this is an update, deliver it right away.
+			v.l.Lock()
+			if err := v.state.Update(events); err != nil {
+				v.l.Unlock()
+				// This error is kinda fatal to the view - we didn't apply some events
+				// the server sent us which means our view is now not in sync. The only
+				// thing we can do is start over and hope for a better outcome.
+				v.reset()
+				return err
+			}
+			// Notify watchers of the update to the view
+			v.index = event.Index
+			// We have a good result, reset the error flag
+			v.err = nil
+			v.retryWaiter.Reset()
+			v.notifyUpdateLocked()
+			v.l.Unlock()
+		} else {
+			snapshotEvents = append(snapshotEvents, events...)
+		}
+	}
+}
+
+// reset clears the state ready to start a new stream from scratch.
+func (v *MaterializedView) reset() {
+	v.l.Lock()
+	defer v.l.Unlock()
+
+	v.state = v.typ.NewMaterializedViewState()
+	if v.req.Filter != "" {
+		if err := v.state.InitFilter(v.req.Filter); err != nil {
+			// If this errors we are stuck - it's fatal for the whole request as it
+			// means there was a bug or an invalid filter string we couldn't parse.
+			// Stop the whole view by closing it and cancelling context, but also set
+			// the error internally so that Fetch calls can return a meaningful error
+			// and not just "context cancelled".
+			v.fatalErr = err
+			if v.cancelFunc != nil {
+				v.cancelFunc()
+			}
+			return
+		}
+	}
+	v.notifyUpdateLocked()
+	// Always start from zero when we have a new state so we load a snapshot from
+	// the servers.
+	v.index = 0
+	v.snapshotDone = false
+	v.err = nil
+	v.retryWaiter.Reset()
+}
+
+// notifyUpdateLocked closes the current update channel and recreates a new
+// one. It must be called while holding the s.l lock.
+func (v *MaterializedView) notifyUpdateLocked() {
+	if v.updateCh != nil {
+		close(v.updateCh)
+	}
+	v.updateCh = make(chan struct{})
+}
+
+// Fetch implements the logic a StreamingCacheType will need during it's Fetch
+// call. Cache types that use streaming should just be able to proxy to this
+// once they have a subscription object and return it's results directly.
+func (v *MaterializedView) Fetch(opts cache.FetchOptions) (cache.FetchResult, error) {
+	var result cache.FetchResult
+
+	// Get current view Result and index
+	v.l.Lock()
+	index := v.index
+	val, err := v.state.Result(v.index)
+	updateCh := v.updateCh
+	v.l.Unlock()
+
+	if err != nil {
+		return result, err
+	}
+
+	result.Index = index
+	result.Value = val
+	result.State = v
+
+	// If our index is > req.Index return right away. If index is zero then we
+	// haven't loaded a snapshot at all yet which means we should wait for one on
+	// the update chan. Note it's opts.MinIndex that the cache is using here the
+	// request min index might be different and from initial user request.
+	if index > 0 && index > opts.MinIndex {
+		return result, nil
+	}
+
+	// Watch for timeout of the Fetch. Note it's opts.Timeout not req.Timeout
+	// since that is the timeout the client requested from the cache Get while the
+	// options one is the internal "background refresh" timeout which is what the
+	// Fetch call should be using.
+	timeoutCh := time.After(opts.Timeout)
+	for {
+		select {
+		case <-updateCh:
+			// View updated, return the new result
+			v.l.Lock()
+			result.Index = v.index
+			// Grab the new updateCh in case we need to keep waiting for the next
+			// update.
+			updateCh = v.updateCh
+			fetchErr := v.err
+			if fetchErr == nil {
+				// Only generate a new result if there was no error to avoid pointless
+				// work potentially shuffling the same data around.
+				result.Value, err = v.state.Result(v.index)
+			}
+			v.l.Unlock()
+
+			// If there was a non-transient error return it
+			if fetchErr != nil {
+				return result, fetchErr
+			}
+			if err != nil {
+				return result, err
+			}
+
+			// Sanity check the update is actually later than the one the user
+			// requested.
+			if result.Index <= opts.MinIndex {
+				// The result is still older/same as the requested index, continue to
+				// wait for further updates.
+				continue
+			}
+
+			// Return the updated result
+			return result, nil
+
+		case <-timeoutCh:
+			// Just return whatever we got originally, might still be empty
+			return result, nil
+
+		case <-v.ctx.Done():
+			v.l.Lock()
+			err := v.fatalErr
+			v.l.Unlock()
+			if err != nil {
+				return result, err
+			}
+			return result, v.ctx.Err()
+		}
+	}
+}

--- a/agent/cache-types/streaming_test.go
+++ b/agent/cache-types/streaming_test.go
@@ -1,0 +1,67 @@
+package cachetype
+
+import (
+	"context"
+
+	"github.com/hashicorp/consul/agent/agentpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestStreamingClient is a mock StreamingClient for testing that allows
+// for queueing up custom events to a subscriber.
+type TestStreamingClient struct {
+	events chan eventOrErr
+	ctx    context.Context
+}
+
+type eventOrErr struct {
+	Err   error
+	Event *agentpb.Event
+}
+
+func NewTestStreamingClient() *TestStreamingClient {
+	return &TestStreamingClient{
+		events: make(chan eventOrErr, 32),
+	}
+}
+
+func (t *TestStreamingClient) Subscribe(ctx context.Context, in *agentpb.SubscribeRequest, opts ...grpc.CallOption) (agentpb.Consul_SubscribeClient, error) {
+	t.ctx = ctx
+
+	return t, nil
+}
+
+func (t *TestStreamingClient) QueueEvents(events ...*agentpb.Event) {
+	for _, e := range events {
+		t.events <- eventOrErr{Event: e}
+	}
+}
+
+func (t *TestStreamingClient) QueueErr(err error) {
+	t.events <- eventOrErr{Err: err}
+}
+
+func (t *TestStreamingClient) Recv() (*agentpb.Event, error) {
+	select {
+	case eoe := <-t.events:
+		if eoe.Err != nil {
+			return nil, eoe.Err
+		}
+		return eoe.Event, nil
+	case <-t.ctx.Done():
+		return nil, t.ctx.Err()
+	}
+}
+
+func (t *TestStreamingClient) Header() (metadata.MD, error) { return nil, nil }
+
+func (t *TestStreamingClient) Trailer() metadata.MD { return nil }
+
+func (t *TestStreamingClient) CloseSend() error { return nil }
+
+func (t *TestStreamingClient) Context() context.Context { return nil }
+
+func (t *TestStreamingClient) SendMsg(m interface{}) error { return nil }
+
+func (t *TestStreamingClient) RecvMsg(m interface{}) error { return nil }

--- a/agent/cache-types/streaming_test.go
+++ b/agent/cache-types/streaming_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/hashicorp/consul/proto/pbsubscribe"
 )
@@ -12,6 +11,7 @@ import (
 // TestStreamingClient is a mock StreamingClient for testing that allows
 // for queueing up custom events to a subscriber.
 type TestStreamingClient struct {
+	pbsubscribe.StateChangeSubscription_SubscribeClient
 	events chan eventOrErr
 	ctx    context.Context
 }
@@ -57,15 +57,3 @@ func (t *TestStreamingClient) Recv() (*pbsubscribe.Event, error) {
 		return nil, t.ctx.Err()
 	}
 }
-
-func (t *TestStreamingClient) Header() (metadata.MD, error) { return nil, nil }
-
-func (t *TestStreamingClient) Trailer() metadata.MD { return nil }
-
-func (t *TestStreamingClient) CloseSend() error { return nil }
-
-func (t *TestStreamingClient) Context() context.Context { return nil }
-
-func (t *TestStreamingClient) SendMsg(m interface{}) error { return nil }
-
-func (t *TestStreamingClient) RecvMsg(m interface{}) error { return nil }

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -18,6 +18,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	io "io"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -772,6 +773,12 @@ func (c *Cache) runExpiryLoop() {
 
 		case <-expiryCh:
 			c.entriesLock.Lock()
+
+			// Perform cleanup operations on the entry's state, if applicable.
+			state := c.entries[entry.Key].State
+			if closer, ok := state.(io.Closer); ok {
+				closer.Close()
+			}
 
 			// Entry expired! Remove it.
 			delete(c.entries, entry.Key)

--- a/agent/cache/cache.go
+++ b/agent/cache/cache.go
@@ -18,15 +18,16 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
-	io "io"
+	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/consul/lib"
 	"golang.org/x/time/rate"
+
+	"github.com/hashicorp/consul/lib"
 )
 
 //go:generate mockery -all -inpkg

--- a/agent/cache/cache_test.go
+++ b/agent/cache/cache_test.go
@@ -856,11 +856,12 @@ func TestCacheGet_expireClose(t *testing.T) {
 
 	require := require.New(t)
 
-	typ := TestType(t)
+	typ := &MockType{}
 	defer typ.AssertExpectations(t)
 	c := New(Options{})
 	typ.On("RegisterOptions").Return(RegisterOptions{
-		LastGetTTL: 100 * time.Millisecond,
+		SupportsBlocking: true,
+		LastGetTTL:       100 * time.Millisecond,
 	})
 
 	// Register the type with a timeout

--- a/agent/consul/stream/event_publisher.go
+++ b/agent/consul/stream/event_publisher.go
@@ -61,6 +61,7 @@ type SnapshotHandlers map[Topic]SnapshotFunc
 
 // SnapshotFunc builds a snapshot for the subscription request, and appends the
 // events to the Snapshot using SnapshotAppender.
+// If err is not nil the SnapshotFunc must return a non-zero index.
 type SnapshotFunc func(SubscribeRequest, SnapshotAppender) (index uint64, err error)
 
 // SnapshotAppender appends groups of events to create a Snapshot of state.

--- a/agent/consul/stream/event_publisher_test.go
+++ b/agent/consul/stream/event_publisher_test.go
@@ -386,6 +386,7 @@ func TestEventPublisher_SubscribeWithIndexNotZero_NewSnapshotFromCache(t *testin
 }
 
 func runStep(t *testing.T, name string, fn func(t *testing.T)) {
+	t.Helper()
 	if !t.Run(name, fn) {
 		t.FailNow()
 	}

--- a/agent/submatview/handler.go
+++ b/agent/submatview/handler.go
@@ -1,8 +1,16 @@
 package submatview
 
-import "github.com/hashicorp/consul/proto/pbsubscribe"
+import (
+	"github.com/hashicorp/consul/proto/pbsubscribe"
+)
 
-type eventHandler func(events *pbsubscribe.Event) (eventHandler, error)
+// eventHandler is a function which performs some operation on the received
+// events, then returns the eventHandler that should be used for the next set
+// of events.
+// If eventHandler fails to handle the events it may return an error. If an
+// error is returned the next eventHandler will be ignored.
+// eventHandler is used to implement a very simple finite-state machine.
+type eventHandler func(events *pbsubscribe.Event) (next eventHandler, err error)
 
 func (m *Materializer) initialHandler(index uint64) eventHandler {
 	if index == 0 {

--- a/agent/submatview/handler.go
+++ b/agent/submatview/handler.go
@@ -1,0 +1,51 @@
+package submatview
+
+import "github.com/hashicorp/consul/proto/pbsubscribe"
+
+type eventHandler func(events *pbsubscribe.Event) (eventHandler, error)
+
+func (m *Materializer) initialHandler(index uint64) eventHandler {
+	if index == 0 {
+		return newSnapshotHandler(m)
+	}
+	return m.resumeStreamHandler
+}
+
+type snapshotHandler struct {
+	material *Materializer
+	events   []*pbsubscribe.Event
+}
+
+func newSnapshotHandler(m *Materializer) eventHandler {
+	return (&snapshotHandler{material: m}).handle
+}
+
+func (h *snapshotHandler) handle(event *pbsubscribe.Event) (eventHandler, error) {
+	if event.GetEndOfSnapshot() {
+		err := h.material.updateView(h.events, event.Index)
+		return h.material.eventStreamHandler, err
+	}
+
+	h.events = append(h.events, eventsFromEvent(event)...)
+	return h.handle, nil
+}
+
+func (m *Materializer) eventStreamHandler(event *pbsubscribe.Event) (eventHandler, error) {
+	err := m.updateView(eventsFromEvent(event), event.Index)
+	return m.eventStreamHandler, err
+}
+
+func eventsFromEvent(event *pbsubscribe.Event) []*pbsubscribe.Event {
+	if batch := event.GetEventBatch(); batch != nil {
+		return batch.Events
+	}
+	return []*pbsubscribe.Event{event}
+}
+
+func (m *Materializer) resumeStreamHandler(event *pbsubscribe.Event) (eventHandler, error) {
+	if event.GetNewSnapshotToFollow() {
+		m.reset()
+		return newSnapshotHandler(m), nil
+	}
+	return m.eventStreamHandler(event)
+}

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -1,4 +1,4 @@
-package cachetype
+package submatview
 
 import (
 	"context"
@@ -131,7 +131,7 @@ func (v *Materializer) Close() error {
 	return nil
 }
 
-func (v *Materializer) run(ctx context.Context) {
+func (v *Materializer) Run(ctx context.Context) {
 	if ctx.Err() != nil {
 		return
 	}

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -56,13 +56,6 @@ func (e resetErr) Error() string {
 	return string(e)
 }
 
-type Request struct {
-	pbsubscribe.SubscribeRequest
-	// Filter is a bexpr filter expression that is used to filter events on the
-	// client side.
-	Filter string
-}
-
 // TODO: update godoc
 // Materializer is a partial view of the state on servers, maintained via
 // streaming subscriptions. It is specialized for different cache types by
@@ -94,7 +87,7 @@ type ViewDeps struct {
 	Client  StreamingClient
 	Logger  hclog.Logger
 	Waiter  *retry.Waiter
-	Request Request
+	Request pbsubscribe.SubscribeRequest
 	Stop    func()
 	Done    <-chan struct{}
 }
@@ -203,7 +196,7 @@ func (v *Materializer) runSubscription(ctx context.Context) error {
 
 	v.l.Unlock()
 
-	s, err := v.deps.Client.Subscribe(ctx, &req.SubscribeRequest)
+	s, err := v.deps.Client.Subscribe(ctx, &req)
 	if err != nil {
 		return err
 	}

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -129,7 +129,7 @@ func (m *Materializer) runSubscription(ctx context.Context, req pbsubscribe.Subs
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	m.handler = m.initialHandler(req.Index)
+	m.handler = initialHandler(req.Index)
 
 	s, err := m.deps.Client.Subscribe(ctx, &req)
 	if err != nil {
@@ -146,7 +146,7 @@ func (m *Materializer) runSubscription(ctx context.Context, req pbsubscribe.Subs
 			return err
 		}
 
-		m.handler, err = m.handler(event)
+		m.handler, err = m.handler(m, event)
 		if err != nil {
 			m.reset()
 			return err

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -117,10 +117,10 @@ func (m *Materializer) Run(ctx context.Context) {
 func isNonTemporaryOrConsecutiveFailure(err error, failures int) bool {
 	// temporary is an interface used by net and other std lib packages to
 	// show error types represent temporary/recoverable errors.
-	_, ok := err.(interface {
+	temp, ok := err.(interface {
 		Temporary() bool
 	})
-	return !ok || failures > 0
+	return !ok || !temp.Temporary() || failures > 0
 }
 
 // runSubscription opens a new subscribe streaming call to the servers and runs

--- a/agent/submatview/materializer.go
+++ b/agent/submatview/materializer.go
@@ -2,7 +2,6 @@ package submatview
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -16,8 +15,9 @@ import (
 	"github.com/hashicorp/consul/proto/pbsubscribe"
 )
 
-// View is the interface used to manage they type-specific
-// materialized view logic.
+// View receives events from, and return results to, Materializer. A view is
+// responsible for converting the pbsubscribe.Event.Payload into the local
+// type, and storing it so that it can be returned by Result().
 type View interface {
 	// Update is called when one or more events are received. The first call will
 	// include _all_ events in the initial snapshot which may be an empty set.
@@ -39,7 +39,129 @@ type View interface {
 	Reset()
 }
 
-type Filter func(seq interface{}) (interface{}, error)
+// Materializer consumes the event stream, handling any framing events, and
+// sends the events to View as they are received.
+//
+// Materializer is used as the cache.Result.State for a streaming
+// cache type and manages the actual streaming RPC call to the servers behind
+// the scenes until the cache result is discarded when TTL expires.
+type Materializer struct {
+	deps        Deps
+	retryWaiter *retry.Waiter
+	handler     eventHandler
+
+	// lock protects the mutable state - all fields below it must only be accessed
+	// while holding lock.
+	lock     sync.Mutex
+	index    uint64
+	view     View
+	updateCh chan struct{}
+	err      error
+}
+
+type Deps struct {
+	View    View
+	Client  StreamClient
+	Logger  hclog.Logger
+	Waiter  *retry.Waiter
+	Request func(index uint64) pbsubscribe.SubscribeRequest
+	Stop    func()
+}
+
+// StreamClient provides a subscription to state change events.
+type StreamClient interface {
+	Subscribe(ctx context.Context, in *pbsubscribe.SubscribeRequest, opts ...grpc.CallOption) (pbsubscribe.StateChangeSubscription_SubscribeClient, error)
+}
+
+// NewMaterializer returns a new Materializer. Run must be called to start it.
+func NewMaterializer(deps Deps) *Materializer {
+	v := &Materializer{
+		deps:        deps,
+		view:        deps.View,
+		retryWaiter: deps.Waiter,
+	}
+	v.reset()
+	return v
+}
+
+// Run receives events from the StreamClient and sends them to the View. It runs
+// until ctx is cancelled, so it is expected to be run in a goroutine.
+func (m *Materializer) Run(ctx context.Context) {
+	for {
+		req := m.deps.Request(m.index)
+		err := m.runSubscription(ctx, req)
+		if ctx.Err() != nil {
+			return
+		}
+
+		m.lock.Lock()
+		// TODO: move this into a func
+		// If this is a temporary error and it's the first consecutive failure,
+		// retry to see if we can get a result without erroring back to clients.
+		// If it's non-temporary or a repeated failure return to clients while we
+		// retry to get back in a good state.
+		if _, ok := err.(temporary); !ok || m.retryWaiter.Failures() > 0 {
+			m.notifyUpdateLocked(err)
+		}
+		waitCh := m.retryWaiter.Failed()
+		failures := m.retryWaiter.Failures()
+		m.lock.Unlock()
+
+		m.deps.Logger.Error("subscribe call failed",
+			"err", err,
+			"topic", req.Topic,
+			"key", req.Key,
+			"failure_count", failures)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-waitCh:
+		}
+	}
+}
+
+// temporary is a private interface as used by net and other std lib packages to
+// show error types represent temporary/recoverable errors.
+type temporary interface {
+	Temporary() bool
+}
+
+// runSubscription opens a new subscribe streaming call to the servers and runs
+// for it's lifetime or until the view is closed.
+func (m *Materializer) runSubscription(ctx context.Context, req pbsubscribe.SubscribeRequest) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	m.handler = m.initialHandler(req.Index)
+
+	s, err := m.deps.Client.Subscribe(ctx, &req)
+	if err != nil {
+		return err
+	}
+
+	for {
+		event, err := s.Recv()
+		switch {
+		case isGrpcStatus(err, codes.Aborted):
+			m.reset()
+			return resetErr("stream reset requested")
+		case err != nil:
+			return err
+		}
+
+		m.handler, err = m.handler(event)
+		if err != nil {
+			m.reset()
+			return err
+		}
+	}
+}
+
+func isGrpcStatus(err error, code codes.Code) bool {
+	s, ok := status.FromError(err)
+	return ok && s.Code() == code
+}
 
 // resetErr represents a server request to reset the subscription, it's typed so
 // we can mark it as temporary and so attempt to retry first time without
@@ -56,279 +178,52 @@ func (e resetErr) Error() string {
 	return string(e)
 }
 
-// TODO: update godoc
-// Materializer is a partial view of the state on servers, maintained via
-// streaming subscriptions. It is specialized for different cache types by
-// providing a View that encapsulates the logic to update the
-// state and format it as the correct result type.
-//
-// The Materializer object becomes the cache.Result.State for a streaming
-// cache type and manages the actual streaming RPC call to the servers behind
-// the scenes until the cache result is discarded when TTL expires.
-type Materializer struct {
-	// Properties above the lock are immutable after the view is constructed in
-	// NewMaterializer and must not be modified.
-	deps ViewDeps
+// reset clears the state ready to start a new stream from scratch.
+func (m *Materializer) reset() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 
-	// l protects the mutable state - all fields below it must only be accessed
-	// while holding l.
-	l            sync.Mutex
-	index        uint64
-	view         View
-	snapshotDone bool
-	updateCh     chan struct{}
-	retryWaiter  *retry.Waiter
-	err          error
+	m.view.Reset()
+	m.index = 0
+	m.notifyUpdateLocked(nil)
+	m.retryWaiter.Reset()
 }
 
-// TODO: rename
-type ViewDeps struct {
-	State   View
-	Client  StreamingClient
-	Logger  hclog.Logger
-	Waiter  *retry.Waiter
-	Request pbsubscribe.SubscribeRequest
-	Stop    func()
-	Done    <-chan struct{}
-}
+func (m *Materializer) updateView(events []*pbsubscribe.Event, index uint64) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 
-// StreamingClient is the interface we need from the gRPC client stub. Separate
-// interface simplifies testing.
-type StreamingClient interface {
-	Subscribe(ctx context.Context, in *pbsubscribe.SubscribeRequest, opts ...grpc.CallOption) (pbsubscribe.StateChangeSubscription_SubscribeClient, error)
-}
-
-// NewMaterializer retrieves an existing view from the cache result
-// state if one exists, otherwise creates a new one. Note that the returned view
-// MUST have Close called eventually to avoid leaking resources. Typically this
-// is done automatically if the view is returned in a cache.Result.State when
-// the cache evicts the result. If the view is not returned in a result state
-// though Close must be called some other way to avoid leaking the goroutine and
-// memory.
-func NewMaterializer(deps ViewDeps) *Materializer {
-	v := &Materializer{
-		deps:        deps,
-		view:        deps.State,
-		retryWaiter: deps.Waiter,
+	if err := m.view.Update(events); err != nil {
+		return err
 	}
-	v.reset()
-	return v
-}
-
-// Close implements io.Close and discards view state and stops background view
-// maintenance.
-func (v *Materializer) Close() error {
-	v.l.Lock()
-	defer v.l.Unlock()
-	v.deps.Stop()
+	m.index = index
+	m.notifyUpdateLocked(nil)
+	m.retryWaiter.Reset()
 	return nil
 }
 
-func (v *Materializer) Run(ctx context.Context) {
-	if ctx.Err() != nil {
-		return
-	}
-
-	// Loop in case stream resets and we need to start over
-	for {
-		err := v.runSubscription(ctx)
-		if err != nil {
-			if ctx.Err() != nil {
-				// Err doesn't matter and is likely just context cancelled
-				return
-			}
-
-			v.l.Lock()
-			// If this is a temporary error and it's the first consecutive failure,
-			// retry to see if we can get a result without erroring back to clients.
-			// If it's non-temporary or a repeated failure return to clients while we
-			// retry to get back in a good state.
-			if _, ok := err.(temporary); !ok || v.retryWaiter.Failures() > 0 {
-				// Report error to blocked fetchers
-				v.err = err
-				v.notifyUpdateLocked()
-			}
-			waitCh := v.retryWaiter.Failed()
-			failures := v.retryWaiter.Failures()
-			v.l.Unlock()
-
-			v.deps.Logger.Error("subscribe call failed",
-				"err", err,
-				"topic", v.deps.Request.Topic,
-				"key", v.deps.Request.Key,
-				"failure_count", failures)
-
-			select {
-			case <-ctx.Done():
-				return
-			case <-waitCh:
-			}
-		}
-		// Loop and keep trying to resume subscription after error
-	}
-}
-
-// temporary is a private interface as used by net and other std lib packages to
-// show error types represent temporary/recoverable errors.
-type temporary interface {
-	Temporary() bool
-}
-
-// runSubscription opens a new subscribe streaming call to the servers and runs
-// for it's lifetime or until the view is closed.
-func (v *Materializer) runSubscription(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Copy the request template
-	req := v.deps.Request
-
-	v.l.Lock()
-
-	// Update request index to be the current view index in case we are resuming a
-	// broken stream.
-	req.Index = v.index
-
-	// Make local copy so we don't have to read with a lock for every event. We
-	// are the only goroutine that can update so we know it won't change without
-	// us knowing but we do need lock to protect external readers when we update.
-	snapshotDone := v.snapshotDone
-
-	v.l.Unlock()
-
-	s, err := v.deps.Client.Subscribe(ctx, &req)
-	if err != nil {
-		return err
-	}
-
-	snapshotEvents := make([]*pbsubscribe.Event, 0)
-
-	for {
-		event, err := s.Recv()
-		switch {
-		case isGrpcStatus(err, codes.Aborted):
-			v.reset()
-			return resetErr("stream reset requested")
-		case err != nil:
-			return err
-		}
-
-		if event.GetEndOfSnapshot() {
-			// Hold lock while mutating view state so implementer doesn't need to
-			// worry about synchronization.
-			v.l.Lock()
-
-			// Deliver snapshot events to the View state
-			if err := v.view.Update(snapshotEvents); err != nil {
-				v.l.Unlock()
-				// This error is kinda fatal to the view - we didn't apply some events
-				// the server sent us which means our view is now not in sync. The only
-				// thing we can do is start over and hope for a better outcome.
-				v.reset()
-				return err
-			}
-			// Done collecting these now
-			snapshotEvents = nil
-			v.snapshotDone = true
-			// update our local copy so we can read it without lock.
-			snapshotDone = true
-			v.index = event.Index
-			// We have a good result, reset the error flag
-			v.err = nil
-			v.retryWaiter.Reset()
-			// Notify watchers of the update to the view
-			v.notifyUpdateLocked()
-			v.l.Unlock()
-			continue
-		}
-
-		if event.GetEndOfEmptySnapshot() {
-			// We've opened a new subscribe with a non-zero index to resume a
-			// connection and the server confirms it's not sending a new snapshot.
-			if !snapshotDone {
-				// We've somehow got into a bad state here - the server thinks we have
-				// an up-to-date snapshot but we don't think we do. Reset and start
-				// over.
-				v.reset()
-				return errors.New("stream resume sent but no local snapshot")
-			}
-			// Just continue on as we were!
-			continue
-		}
-
-		// We have an event for the topic
-		events := []*pbsubscribe.Event{event}
-
-		// If the event is a batch, unwrap and deliver the raw events
-		if batch := event.GetEventBatch(); batch != nil {
-			events = batch.Events
-		}
-
-		if snapshotDone {
-			// We've already got a snapshot, this is an update, deliver it right away.
-			v.l.Lock()
-			if err := v.view.Update(events); err != nil {
-				v.l.Unlock()
-				// This error is kinda fatal to the view - we didn't apply some events
-				// the server sent us which means our view is now not in sync. The only
-				// thing we can do is start over and hope for a better outcome.
-				v.reset()
-				return err
-			}
-			// Notify watchers of the update to the view
-			v.index = event.Index
-			// We have a good result, reset the error flag
-			v.err = nil
-			v.retryWaiter.Reset()
-			v.notifyUpdateLocked()
-			v.l.Unlock()
-		} else {
-			snapshotEvents = append(snapshotEvents, events...)
-		}
-	}
-}
-
-func isGrpcStatus(err error, code codes.Code) bool {
-	s, ok := status.FromError(err)
-	return ok && s.Code() == code
-}
-
-// reset clears the state ready to start a new stream from scratch.
-func (v *Materializer) reset() {
-	v.l.Lock()
-	defer v.l.Unlock()
-
-	v.view.Reset()
-	v.notifyUpdateLocked()
-	// Always start from zero when we have a new state so we load a snapshot from
-	// the servers.
-	v.index = 0
-	v.snapshotDone = false
-	v.err = nil
-	v.retryWaiter.Reset()
-}
-
 // notifyUpdateLocked closes the current update channel and recreates a new
-// one. It must be called while holding the s.l lock.
-func (v *Materializer) notifyUpdateLocked() {
-	if v.updateCh != nil {
-		close(v.updateCh)
+// one. It must be called while holding the s.lock lock.
+func (m *Materializer) notifyUpdateLocked(err error) {
+	m.err = err
+	if m.updateCh != nil {
+		close(m.updateCh)
 	}
-	v.updateCh = make(chan struct{})
+	m.updateCh = make(chan struct{})
 }
 
 // Fetch implements the logic a StreamingCacheType will need during it's Fetch
 // call. Cache types that use streaming should just be able to proxy to this
 // once they have a subscription object and return it's results directly.
-func (v *Materializer) Fetch(opts cache.FetchOptions) (cache.FetchResult, error) {
+func (m *Materializer) Fetch(done <-chan struct{}, opts cache.FetchOptions) (cache.FetchResult, error) {
 	var result cache.FetchResult
 
 	// Get current view Result and index
-	v.l.Lock()
-	index := v.index
-	val, err := v.view.Result(v.index)
-	updateCh := v.updateCh
-	v.l.Unlock()
+	m.lock.Lock()
+	index := m.index
+	val, err := m.view.Result(m.index)
+	updateCh := m.updateCh
+	m.lock.Unlock()
 
 	if err != nil {
 		return result, err
@@ -336,7 +231,6 @@ func (v *Materializer) Fetch(opts cache.FetchOptions) (cache.FetchResult, error)
 
 	result.Index = index
 	result.Value = val
-	result.State = v
 
 	// If our index is > req.Index return right away. If index is zero then we
 	// haven't loaded a snapshot at all yet which means we should wait for one on
@@ -355,18 +249,18 @@ func (v *Materializer) Fetch(opts cache.FetchOptions) (cache.FetchResult, error)
 		select {
 		case <-updateCh:
 			// View updated, return the new result
-			v.l.Lock()
-			result.Index = v.index
+			m.lock.Lock()
+			result.Index = m.index
 			// Grab the new updateCh in case we need to keep waiting for the next
 			// update.
-			updateCh = v.updateCh
-			fetchErr := v.err
+			updateCh = m.updateCh
+			fetchErr := m.err
 			if fetchErr == nil {
 				// Only generate a new result if there was no error to avoid pointless
 				// work potentially shuffling the same data around.
-				result.Value, err = v.view.Result(v.index)
+				result.Value, err = m.view.Result(m.index)
 			}
-			v.l.Unlock()
+			m.lock.Unlock()
 
 			// If there was a non-transient error return it
 			if fetchErr != nil {
@@ -391,7 +285,7 @@ func (v *Materializer) Fetch(opts cache.FetchOptions) (cache.FetchResult, error)
 			// Just return whatever we got originally, might still be empty
 			return result, nil
 
-		case <-v.deps.Done:
+		case <-done:
 			return result, context.Canceled
 		}
 	}


### PR DESCRIPTION
Builds on #8799 #8768 #8802

Adds a new cache-type which uses streaming to populate a materialized view. Values for the cache come from the materialized view.