### PR TITLE
ui: Fixup node tests to account for new runtime env var passing

### DIFF
--- a/ui-v2/node-tests/config/environment.js
+++ b/ui-v2/node-tests/config/environment.js
@@ -9,9 +9,9 @@ test(
       {
         environment: 'production',
         CONSUL_BINARY_TYPE: 'oss',
-        CONSUL_ACLS_ENABLED: false,
-        CONSUL_SSO_ENABLED: false,
-        CONSUL_NSPACES_ENABLED: false,
+        CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
+        CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
+        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NSpacesEnabled__',
       },
       {
         environment: 'test',


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8710 we changed the node tests to reflect the changes made for https://github.com/hashicorp/consul/pull/8710.

This changes things back to use check for the strings that are replaced at runtime.