### PR TITLE
stream: handle batch events as a special case of Event

### DIFF
--- a/agent/consul/state/store_integration_test.go
+++ b/agent/consul/state/store_integration_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/acl"
 	"github.com/hashicorp/consul/agent/consul/stream"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStore_IntegrationWithEventPublisher_ACLTokenUpdate(t *testing.T) {
@@ -294,8 +295,8 @@ func TestStore_IntegrationWithEventPublisher_ACLRoleUpdate(t *testing.T) {
 }
 
 type nextResult struct {
-	Events []stream.Event
-	Err    error
+	Event stream.Event
+	Err   error
 }
 
 func testRunSub(sub *stream.Subscription) <-chan nextResult {
@@ -304,8 +305,8 @@ func testRunSub(sub *stream.Subscription) <-chan nextResult {
 		for {
 			es, err := sub.Next(context.TODO())
 			eventCh <- nextResult{
-				Events: es,
-				Err:    err,
+				Event: es,
+				Err:   err,
 			}
 			if err != nil {
 				return
@@ -320,8 +321,8 @@ func assertNoEvent(t *testing.T, eventCh <-chan nextResult) {
 	select {
 	case next := <-eventCh:
 		require.NoError(t, next.Err)
-		require.Len(t, next.Events, 1)
-		t.Fatalf("got unwanted event: %#v", next.Events[0].Payload)
+		require.Len(t, next.Event, 1)
+		t.Fatalf("got unwanted event: %#v", next.Event.Payload)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -331,8 +332,7 @@ func assertEvent(t *testing.T, eventCh <-chan nextResult) *stream.Event {
 	select {
 	case next := <-eventCh:
 		require.NoError(t, next.Err)
-		require.Len(t, next.Events, 1)
-		return &next.Events[0]
+		return &next.Event
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("no event after 100ms")
 	}
@@ -362,7 +362,7 @@ func assertReset(t *testing.T, eventCh <-chan nextResult, allowEOS bool) {
 		select {
 		case next := <-eventCh:
 			if allowEOS {
-				if next.Err == nil && len(next.Events) == 1 && next.Events[0].IsEndOfSnapshot() {
+				if next.Err == nil && next.Event.IsEndOfSnapshot() {
 					continue
 				}
 			}

--- a/agent/consul/stream/subscription_test.go
+++ b/agent/consul/stream/subscription_test.go
@@ -36,8 +36,7 @@ func TestSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, elapsed < 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
-	require.Len(t, got, 1)
-	require.Equal(t, index, got[0].Index)
+	require.Equal(t, index, got.Index)
 
 	// Schedule an event publish in a while
 	index++
@@ -54,8 +53,7 @@ func TestSubscription(t *testing.T) {
 		"Event should have been delivered after blocking 200ms, took %s", elapsed)
 	require.True(t, elapsed < 2*time.Second,
 		"Event should have been delivered after short time, took %s", elapsed)
-	require.Len(t, got, 1)
-	require.Equal(t, index, got[0].Index)
+	require.Equal(t, index, got.Index)
 
 	// Event with wrong key should not be delivered. Deliver a good message right
 	// so we don't have to block test thread forever or cancel func yet.
@@ -70,9 +68,8 @@ func TestSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, elapsed < 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
-	require.Len(t, got, 1)
-	require.Equal(t, index, got[0].Index)
-	require.Equal(t, "test", got[0].Key)
+	require.Equal(t, index, got.Index)
+	require.Equal(t, "test", got.Key)
 
 	// Cancelling the subscription context should unblock Next
 	start = time.Now()
@@ -91,9 +88,7 @@ func TestSubscription(t *testing.T) {
 
 func TestSubscription_Close(t *testing.T) {
 	eb := newEventBuffer()
-
 	index := uint64(100)
-
 	startHead := eb.Head()
 
 	// Start with an event in the buffer
@@ -115,8 +110,7 @@ func TestSubscription_Close(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, elapsed < 200*time.Millisecond,
 		"Event should have been delivered immediately, took %s", elapsed)
-	require.Len(t, got, 1)
-	require.Equal(t, index, got[0].Index)
+	require.Equal(t, index, got.Index)
 
 	// Schedule a Close simulating the server deciding this subscroption
 	// needs to reset (e.g. on ACL perm change).
@@ -149,46 +143,55 @@ func publishTestEvent(index uint64, b *eventBuffer, key string) {
 
 func TestFilter_NoKey(t *testing.T) {
 	events := make([]Event, 0, 5)
-	events = append(events, Event{Key: "One"}, Event{Key: "Two"})
+	events = append(events, Event{Key: "One", Index: 102}, Event{Key: "Two"})
 
-	actual := filter("", events)
-	require.Equal(t, events, actual)
+	req := SubscribeRequest{Topic: testTopic}
+	actual, ok := filterByKey(req, events)
+	require.True(t, ok)
+	require.Equal(t, Event{Topic: testTopic, Index: 102, Payload: events}, actual)
 
 	// test that a new array was not allocated
-	require.Equal(t, cap(actual), 5)
+	require.Equal(t, cap(actual.Payload.([]Event)), 5)
 }
 
 func TestFilter_WithKey_AllEventsMatch(t *testing.T) {
 	events := make([]Event, 0, 5)
-	events = append(events, Event{Key: "Same"}, Event{Key: "Same"})
+	events = append(events, Event{Key: "Same", Index: 103}, Event{Key: "Same"})
 
-	actual := filter("Same", events)
-	require.Equal(t, events, actual)
+	req := SubscribeRequest{Topic: testTopic, Key: "Same"}
+	actual, ok := filterByKey(req, events)
+	require.True(t, ok)
+	expected := Event{Topic: testTopic, Index: 103, Key: "Same", Payload: events}
+	require.Equal(t, expected, actual)
 
 	// test that a new array was not allocated
-	require.Equal(t, cap(actual), 5)
+	require.Equal(t, 5, cap(actual.Payload.([]Event)))
 }
 
 func TestFilter_WithKey_SomeEventsMatch(t *testing.T) {
 	events := make([]Event, 0, 5)
-	events = append(events, Event{Key: "Same"}, Event{Key: "Other"}, Event{Key: "Same"})
+	events = append(events, Event{Key: "Same", Index: 104}, Event{Key: "Other"}, Event{Key: "Same"})
 
-	actual := filter("Same", events)
-	expected := []Event{{Key: "Same"}, {Key: "Same"}}
+	req := SubscribeRequest{Topic: testTopic, Key: "Same"}
+	actual, ok := filterByKey(req, events)
+	require.True(t, ok)
+	expected := Event{
+		Topic:   testTopic,
+		Index:   104,
+		Key:     "Same",
+		Payload: []Event{{Key: "Same", Index: 104}, {Key: "Same"}},
+	}
 	require.Equal(t, expected, actual)
 
 	// test that a new array was allocated with the correct size
-	require.Equal(t, cap(actual), 2)
+	require.Equal(t, cap(actual.Payload.([]Event)), 2)
 }
 
 func TestFilter_WithKey_NoEventsMatch(t *testing.T) {
 	events := make([]Event, 0, 5)
 	events = append(events, Event{Key: "Same"}, Event{Key: "Same"})
 
-	actual := filter("Other", events)
-	var expected []Event
-	require.Equal(t, expected, actual)
-
-	// test that no array was allocated
-	require.Equal(t, cap(actual), 0)
+	req := SubscribeRequest{Topic: testTopic, Key: "Other"}
+	_, ok := filterByKey(req, events)
+	require.False(t, ok)
 }

--- a/agent/rpc/subscribe/logger.go
+++ b/agent/rpc/subscribe/logger.go
@@ -52,21 +52,17 @@ type eventLogger struct {
 	count        uint64
 }
 
-func (l *eventLogger) Trace(e []stream.Event) {
-	if len(e) == 0 {
-		return
-	}
-
-	first := e[0]
+func (l *eventLogger) Trace(e stream.Event) {
 	switch {
-	case first.IsEndOfSnapshot():
+	case e.IsEndOfSnapshot():
 		l.snapshotDone = true
-		l.logger.Trace("snapshot complete", "index", first.Index, "sent", l.count)
-	case first.IsNewSnapshotToFollow():
+		l.logger.Trace("snapshot complete", "index", e.Index, "sent", l.count)
+	case e.IsNewSnapshotToFollow():
+		l.logger.Trace("starting new snapshot", "sent", l.count)
 		return
 	case l.snapshotDone:
-		l.logger.Trace("sending events", "index", first.Index, "sent", l.count, "batch_size", len(e))
+		l.logger.Trace("sending events", "index", e.Index, "sent", l.count, "batch_size", e.Len())
 	}
 
-	l.count += uint64(len(e))
+	l.count += uint64(e.Len())
 }


### PR DESCRIPTION
Branched from #8768 

This changes the return value of `Subscription.Next()` to return an `Event` instead of `[]Event`. By batching up the events earlier we can simplify the caller a bit.

It also moves filtering to be a method on `Event` so that both ACL filtering and `SubscribeRequest.Key` filtering can use the same mechanism, and benefit from the same optimizations.