### PR TITLE
ui: add ui test-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,6 +659,21 @@ jobs:
             fi
       - run: *notify-slack-failure
 
+  # run node tests
+  node-tests:
+    docker:
+      - image: *EMBER_IMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: *YARN_CACHE_KEY
+      - attach_workspace:
+          at: ui-v2
+      - run:
+          working_directory: ui-v2
+          command: make test-node
+      - run: *notify-slack-failure
+
   # run ember frontend tests
   ember-test-oss:
     docker:
@@ -930,6 +945,9 @@ workflows:
                 - master
                 - ui-staging
                 - /^ui\/.*/
+      - node-tests:
+          requires:
+            - frontend-cache
       - ember-build-oss:
           requires:
             - frontend-cache


### PR DESCRIPTION
This PR adds a CircleCI job to run `make test-node` in the UI tests. This is separate from all the ember tests we run. An example run can be found [here](https://app.circleci.com/pipelines/github/hashicorp/consul/13107/workflows/be2da824-8a0c-4b4a-823c-4dd12bee85a1) and the failing tests should be fixed by #8817. 

![image](https://user-images.githubusercontent.com/17609145/95117737-10a7b280-0717-11eb-9d6e-48eaa0464ca2.png)

The output right now is only in the CircleCI log output so if we want the errors to bubble up in the CircleCI UI then we will need a package that turns the tape output into XML that CircleCI can parse. I found two libraries that can do this: [tape-junit](https://github.com/bvalosek/tape-junit) and [tap-junit](https://github.com/dhershman1/tap-junit)