### PR TITLE
ui: Specify Service instance requests and proxy requests as ranges

### DIFF
--- a/ui-v2/app/adapters/proxy.js
+++ b/ui-v2/app/adapters/proxy.js
@@ -8,6 +8,7 @@ export default Adapter.extend({
     return request`
       GET /v1/catalog/connect/${id}?${{ dc }}
       X-Request-ID: ${uri}
+      X-Range: ${id}
 
       ${{
         ...this.formatNspace(ns),

--- a/ui-v2/app/adapters/service-instance.js
+++ b/ui-v2/app/adapters/service-instance.js
@@ -8,6 +8,7 @@ export default Adapter.extend({
     return request`
       GET /v1/health/service/${id}?${{ dc }}
       X-Request-ID: ${uri}
+      X-Range: ${id}
 
       ${{
         ...this.formatNspace(ns),


### PR DESCRIPTION
All our Service instance requests and Proxy (which are actually proxy instances) 'query' requests only return a subset or range of instances, therefore they should not reconcile the ember-data store on response. If they do the ember-data will think that all other instances have been removed from the backend.

In order to mark a request to expect a subset or range as a response, we add the `X-Range` header, this prevents the reconciliation from happening.