### PR TITLE
ui: Restrict header styling to specific tabs

### DIFF
--- a/ui-v2/app/styles/routes/dc/services/index.scss
+++ b/ui-v2/app/styles/routes/dc/services/index.scss
@@ -12,6 +12,7 @@ html[data-route^='dc.services.instance'] [role='tabpanel'] section:not(:last-chi
   padding-bottom: 24px;
   border-bottom: 1px solid $gray-200;
 }
-html[data-route^='dc.services.instance'] [role='tabpanel'] section h3 {
+html[data-route^='dc.services.instance.metadata'] [role='tabpanel'] section h3,
+html[data-route^='dc.services.instance.proxy'] [role='tabpanel'] section h3 {
   margin: 24px 0 12px 0;
 }


### PR DESCRIPTION
During https://github.com/hashicorp/consul/pull/8796 we altered top/margins borders across the app. One of the changes there caused a CSS slight issue on the Healthchecks tab:

Before:

<img width="452" alt="Screenshot 2020-10-06 at 13 54 29" src="https://user-images.githubusercontent.com/554604/95204049-78bfcc80-07db-11eb-96ea-9d6a8072c98a.png">

After:

<img width="418" alt="Screenshot 2020-10-06 at 13 54 14" src="https://user-images.githubusercontent.com/554604/95204093-8412f800-07db-11eb-8b5c-c94f6c8f3fcd.png">
