### PR TITLE
Remove label trigger on edit

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,7 +1,7 @@
 name: "Issue Labeler"
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   triage:


### PR DESCRIPTION
Issue labeler runs on edit of the first post. This can happen due to formatting, or simply updating the body.

Turns this to running on labels on when opened.