### PR TITLE
Minor updates to NIA partner docs

### DIFF
--- a/website/pages/docs/integrate/nia-integration.mdx
+++ b/website/pages/docs/integrate/nia-integration.mdx
@@ -7,13 +7,13 @@ description: Guide to partnership integrations for Consul NIA
 
 # Network Infrastructure Automation Integration Program
 
-HashiCorp’s Network Infrastructure Integration (NIA) Program allows partners to build integrations that allow customers to automate dynamic application workflows leveraging network and security infrastructure at runtime. Detailed below is the approach to integrate your networking technology along with the clearly defined steps, links to information sources, and checkpoints.
+HashiCorp’s Network Infrastructure Automation (NIA) Integration Program allows partners to build integrations that allow customers to automate dynamic application workflows leveraging network and security infrastructure at runtime. Detailed below is the approach to integrate your networking technology along with the clearly defined steps, links to information sources, and checkpoints.
 
 ## Network Infrastructure Automation
 
-Network Infrastructure Automation (NIA) relies on a declarative, workflow and service driven network automation architecture. NIA leverages an agent `Consul-Terraform-Sync` which leverages Terraform as the underlying automation tool and utilizes the Terraform provider ecosystem to drive relevant change to the network infrastructure. This usage of the Terraform provider in conjunction with Consul-Terraform-Tasks allows for HashiCorp Consul to act as the core data source where it is updated with the state of the infrastructure.
+Network Infrastructure Automation (NIA) relies on a declarative, workflow and service driven network automation architecture. NIA is carried out by [`Consul-Terraform-Sync`](/docs/nia) which leverages Terraform as the underlying automation tool and utilizes the Terraform provider ecosystem to drive relevant change to the network infrastructure. This usage of the Terraform provider in conjunction with Consul-Terraform-Sync allows for HashiCorp Consul to act as the core data source where it is updated with the state of the infrastructure.
 
-The Consul-Terraform-Sync agent executes one or more automation tasks with an appropriate value of service variables based on updates from the Consul service catalog. Each task consists of a runbook automation written as a compatible Terraform module using resources and data sources for the underlying network infrastructure. The Consul-Terraform-Sync agent runs on the same node as a Consul agent.
+Consul-Terraform-Sync executes one or more automation tasks with an appropriate value of service variables based on updates from the Consul service catalog. Each task consists of a runbook automation written as a compatible Terraform module using resources and data sources for the underlying network infrastructure. The Consul-Terraform-Sync daemon runs on the same node as a Consul agent.
 
 [![NIA Architecture](/img/nia-highlevel-diagram.png)](/img/nia-highlevel-diagram.png)
 
@@ -44,14 +44,14 @@ Consul-Terraform-Sync compatible Terraform module development process is fairly 
 - Consul-Terraform-Sync use case [documentation](https://www.consul.io/use-cases/network-infrastructure-automation)
 - Writing Consul-Terraform-Sync compatible Terraform modules [guide](Will link to NIA Tech Preview section - Requirements - Network Integration - How to Create a Module)
 - Example [module](https://registry.terraform.io/modules/findkim/ngfw/panos/0.0.1-beta3) for reference
-- Contributing to Terraform module registry [guidelines](https://www.terraform.io/docs/registry/modules/publish.html)
+- Publishing to Terraform Registry [guidelines](https://www.terraform.io/docs/registry/modules/publish.html)
 
 ### 3. Develop & Test
 
-Terraform modules are written in HashiCorp Configuration Language (HCL). Writing [Terraform modules](https://www.terraform.io/docs/modules/index.html) or a [tutorial to build a module](https://learn.hashicorp.com/tutorials/terraform/module-create) are a good resource to begin writing a new module.
-Consul-Terraform-Sync compatible modules follow the [standard module structure](https://www.terraform.io/docs/modules/index.html#standard-module-structure). Modules can use syntax supported by Terraform version 0.13, or higher. Consul-Terraform-Sync agent is designed to integrate with any module that satisfies these [specifications](https://docs.google.com/document/d/1eP918lf3lu-VVk4pBt4zVJ-eb4gNI6XBhpvZ3UnKNLw/edit#bookmark=id.f7kafih7a9qo). The guide will give you an introduction of the code structure and the basics of authoring a plugin that Terraform can interact with. Additionally developers are encouraged to use the [PAN-OS NGFW](https://registry.terraform.io/modules/findkim/ngfw/panos/0.0.1-beta3) module as an implementation reference.
+Terraform modules are written in HashiCorp Configuration Language (HCL). Writing [Terraform modules](https://www.terraform.io/docs/modules/index.html) or a [tutorial to build a module](https://learn.hashicorp.com/tutorials/terraform/module-create) are good resources to begin writing a new module.
+Consul-Terraform-Sync compatible modules follow the [standard module structure](https://www.terraform.io/docs/modules/index.html#standard-module-structure). Modules can use syntax supported by Terraform version 0.13, or higher. Consul-Terraform-Sync is designed to integrate with any module that satisfies these [specifications](https://docs.google.com/document/d/1eP918lf3lu-VVk4pBt4zVJ-eb4gNI6XBhpvZ3UnKNLw/edit#bookmark=id.f7kafih7a9qo). The guide will give you an introduction of the code structure and the basics of authoring a module for Terraform. Additionally developers are encouraged to use the [PAN-OS NGFW](https://registry.terraform.io/modules/findkim/ngfw/panos/0.0.1-beta3) module as an implementation reference.
 
-It is recommended that partners develop modules that cater to specific workflows on an individual platform in their product portfolio rather than having overarching modules that try to cover multiple workflows across different platforms. This is to keep the automation elegant and modular. Partners are encouraged to the functionality of the modules against their supported platforms.
+It is recommended that partners develop modules that cater to specific workflows on an individual platform in their product portfolio rather than having overarching modules that try to cover multiple workflows across different platforms. This is to keep the automation modular and adoptable by a broad set of users with varying network infrastructure topologies. Partners are encouraged to test the functionality of the modules against their supported platforms.
 
 -> **Important**: All Consul-Terraform-Sync compatible modules listed as Verified must contain one of the following open source licenses:
 
@@ -83,7 +83,7 @@ Once the module development has been completed another email should be sent to n
 
 At this stage, it is expected that the module is fully developed, all tests and documentation are in place, and that HashiCorp has reviewed the module to be compatible with Consul-Terraform-Sync.
 
-Once this is done HashiCorp will get the new module listed as Consul-Terraform-Sync compatible on [consul.io](https://www.consul.io/use-cases/network-infrastructure-automation), and on [Terraform module registry](https://registry.terraform.io/browse/modules).
+Once this is done HashiCorp will get the new module listed as Consul-Terraform-Sync compatible on [consul.io](https://www.consul.io/use-cases/network-infrastructure-automation), and on [Terraform Registry](https://registry.terraform.io/browse/modules).
 
 ### 6. Support
 


### PR DESCRIPTION
* Removes the usage of Sync "agent" to avoid further overloading
the term agent within Consul
* Renames Terraform module registry to its new name Terraform Registry
* Fixes some minor typos and best attempt at missing words

Another suggestion (find the right place was a bit hard): the [NIA integration form for the initial contact](https://docs.google.com/forms/d/1HtJXYQ36n83lFXEX-F_uIB7abUEMj95prSi5TSDMCXc/viewform?gxids=7757&edit_requested=true) it would be useful to also ask for contact email.

@BeenzSyed please take any bits of the diffs here as suggestions to incorporate into your changes! 