### PR TITLE
ui: Fix up Service filtering by whether a Service is in the mesh or not in the mesh

### DIFF
--- a/ui-v2/app/components/consul-service-search-bar/index.hbs
+++ b/ui-v2/app/components/consul-service-search-bar/index.hbs
@@ -44,8 +44,8 @@
           <Option @value="mesh-gateway" @selected={{contains 'mesh-gateway' filter.types}}>Mesh Gateway</Option>
         </Optgroup>
         <Optgroup @label="Mesh">
-          <Option @value="mesh-enabled" @selected={{contains 'mesh-enabled' filter.types}}>In service mesh</Option>
-          <Option @value="mesh-disabled" @selected={{contains 'mesh-disabled' filter.types}}>Not in service mesh</Option>
+          <Option @value="in-mesh" @selected={{contains 'in-mesh' filter.types}}>In service mesh</Option>
+          <Option @value="not-in-mesh" @selected={{contains 'not-in-mesh' filter.types}}>Not in service mesh</Option>
         </Optgroup>
 {{/let}}
       </BlockSlot>

--- a/ui-v2/app/filter/predicates/service.js
+++ b/ui-v2/app/filter/predicates/service.js
@@ -6,8 +6,8 @@ export default () => ({ instances = [], sources = [], statuses = [], types = [] 
     'terminating-gateway',
     'mesh-gateway',
     'service',
-    'mesh-enabled',
-    'mesh-disabled',
+    'in-mesh',
+    'not-in-mesh',
   ].reduce((prev, item) => {
     prev[item] = types.includes(item);
     return prev;
@@ -48,11 +48,15 @@ export default () => ({ instances = [], sources = [], statuses = [], types = [] 
       if (typeIncludes['service'] && typeof item.Kind === 'undefined') {
         return true;
       }
-      if (typeIncludes['mesh-enabled'] && typeof item.Proxy !== 'undefined') {
-        return true;
+      if (typeIncludes['in-mesh']) {
+        if (item.InMesh) {
+          return true;
+        }
       }
-      if (typeIncludes['mesh-disabled'] && typeof item.Proxy === 'undefined') {
-        return true;
+      if (typeIncludes['not-in-mesh']) {
+        if (!item.InMesh) {
+          return true;
+        }
       }
       return false;
     }

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -16,6 +16,7 @@ export default Model.extend({
   InstanceCount: attr('number'),
   ConnectedWithGateway: attr(),
   ConnectedWithProxy: attr(),
+  Proxy: attr(),
   GatewayConfig: attr(),
   Kind: attr('string'),
   ExternalSources: attr(),
@@ -39,6 +40,12 @@ export default Model.extend({
   SyncTime: attr('number'),
   meta: attr(),
   /* Mesh properties involve both the service and the associated proxy */
+  MeshEnabled: computed('ConnectedWithProxy', 'ConnectedWithGateway', function() {
+    return this.ConnectedWithProxy || this.ConnectedWithGateway;
+  }),
+  InMesh: computed('Kind', function() {
+    return this.MeshEnabled || (this.Kind || '').length > 0;
+  }),
   MeshStatus: computed('MeshChecksPassing', 'MeshChecksWarning', 'MeshChecksCritical', function() {
     switch (true) {
       case this.MeshChecksCritical !== 0:


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8775 we added support for new properties on our API endpoints (ConnectedWithGateway and ConnectedWithProxy). This uses those new properties for filtering instead of inferring it from the `Kind` of Service or inspecting the `Proxy` of the Service.