### PR TITLE
Turns PR labeler to only trigger on create

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,7 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  pull_request:
+    types: [opened]
 
 jobs:
   triage:


### PR DESCRIPTION
This tunes the PR labeler to only run on create. The previous setting is shorthand for "all things related to pull request"