### PR TITLE
ui: Add deny SVG lines with icons

### DIFF
--- a/ui-v2/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui-v2/app/components/topology-metrics/down-lines/index.hbs
@@ -1,0 +1,61 @@
+{{on-window 'resize' (action this.getIconPositions)}}
+
+{{#if (gt @lines.length 0)}}
+  <svg
+    {{did-insert this.getIconPositions}}
+    viewBox={{concat @view.x ' ' @view.y ' ' @view.width ' ' @view.height}}
+    preserveAspectRatio="none"
+  >
+    <defs>
+      <marker id="allow-dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
+        <circle
+          cx="6"
+          cy="6"
+          r="6"
+        />
+      </marker>
+      <marker id="allow-arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
+          markerWidth="6" markerHeight="6"
+          orient="auto-start-reverse">
+        <polygon points="0 0 10 5 0 10" />
+      </marker>
+      <marker id="deny-dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
+        <circle
+          cx="6"
+          cy="6"
+          r="6"
+        />
+      </marker>
+      <marker id="deny-arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
+          markerWidth="6" markerHeight="6"
+          orient="auto-start-reverse">
+        <polygon points="0 0 10 5 0 10" />
+      </marker>
+    </defs>
+{{#each @lines as |line|}}
+  {{#if (eq line.permission 'deny')}}
+    <path
+      id={{line.id}}
+      d={{svg-curve line.dest src=line.src}}
+      marker-start="url(#deny-dot)"
+      marker-end="url(#deny-arrow)"
+      data-permission={{line.permission}}
+    />
+  {{else}}
+     <path
+      id={{line.id}}
+      d={{svg-curve line.dest src=line.src}}
+      marker-start="url(#allow-dot)"
+      marker-end="url(#allow-arrow)"
+      data-permission={{line.permission}}
+    />
+  {{/if}}
+{{/each}}
+  </svg>
+{{/if}}
+
+<TopologyMetrics::Icon
+  @positions={{this.iconPositions}}
+  @items={{@items}}
+/>
+

--- a/ui-v2/app/components/topology-metrics/down-lines/index.hbs
+++ b/ui-v2/app/components/topology-metrics/down-lines/index.hbs
@@ -3,6 +3,7 @@
 {{#if (gt @lines.length 0)}}
   <svg
     {{did-insert this.getIconPositions}}
+    {{did-update this.getIconPositions @lines}}
     viewBox={{concat @view.x ' ' @view.y ' ' @view.width ' ' @view.height}}
     preserveAspectRatio="none"
   >

--- a/ui-v2/app/components/topology-metrics/down-lines/index.js
+++ b/ui-v2/app/components/topology-metrics/down-lines/index.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class TopoloyMetricsLines extends Component {
+export default class TopoloyMetricsDownLines extends Component {
   @tracked iconPositions;
 
   @action

--- a/ui-v2/app/components/topology-metrics/down-lines/index.js
+++ b/ui-v2/app/components/topology-metrics/down-lines/index.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class TopoloyMetricsLines extends Component {
+  @tracked iconPositions;
+
+  @action
+  getIconPositions() {
+    const view = this.args.view;
+    const lines = [...document.querySelectorAll('#downstream-lines path')];
+
+    this.iconPositions = lines.map(item => {
+      const pathLen = parseFloat(item.getTotalLength());
+      const thirdLen = item.getPointAtLength(Math.ceil(pathLen / 3));
+
+      return {
+        id: item.id,
+        x: thirdLen.x - view.x,
+        y: thirdLen.y - view.y,
+      };
+    });
+  }
+}

--- a/ui-v2/app/components/topology-metrics/icon.hbs
+++ b/ui-v2/app/components/topology-metrics/icon.hbs
@@ -1,12 +1,12 @@
 {{#each @items as |item|}}
 {{#let (find-by 'id' (concat item.Namespace item.Name) @positions) as |style|}}
-  {{#if (eq item.Intention.Action 'deny')}}
+  {{#if (and (not item.Intention.Allowed) (not item.Intention.HasL7Permissions))}}
     <span class="deny" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
       <Tooltip>
         An intention is set to 'deny' that prohibits these services from connecting.
       </Tooltip>
     </span>
-  {{else if (not item.Intention.Action)}}
+  {{else if item.Intention.HasL7Permissions}}
   <span class="L7" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
     <Tooltip>
       The intention between these services has Layer 7 permissions, so certain requests may or may not be permitted.

--- a/ui-v2/app/components/topology-metrics/icon.hbs
+++ b/ui-v2/app/components/topology-metrics/icon.hbs
@@ -1,0 +1,17 @@
+{{#each @items as |item|}}
+{{#let (find-by 'id' (concat item.Namespace item.Name) @positions) as |style|}}
+  {{#if (eq item.Intention.Action 'deny')}}
+    <span class="deny" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
+      <Tooltip>
+        An intention is set to 'deny' that prohibits these services from connecting.
+      </Tooltip>
+    </span>
+  {{else if (not item.Intention.Action)}}
+  <span class="L7" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
+    <Tooltip>
+      The intention between these services has Layer 7 permissions, so certain requests may or may not be permitted.
+    </Tooltip>
+  </span>
+  {{/if}}
+{{/let}}
+{{/each}}

--- a/ui-v2/app/components/topology-metrics/icon.hbs
+++ b/ui-v2/app/components/topology-metrics/icon.hbs
@@ -1,12 +1,12 @@
 {{#each @items as |item|}}
 {{#let (find-by 'id' (concat item.Namespace item.Name) @positions) as |style|}}
-  {{#if (and (not item.Intention.Allowed) (not item.Intention.HasL7Permissions))}}
+  {{#if (and (not item.Intention.Allowed) (not item.Intention.HasPermissions))}}
     <span class="deny" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
       <Tooltip>
         An intention is set to 'deny' that prohibits these services from connecting.
       </Tooltip>
     </span>
-  {{else if item.Intention.HasL7Permissions}}
+  {{else if item.Intention.HasPermissions}}
   <span class="L7" style={{{ concat 'top:' style.y 'px;left:' style.x 'px;'}}}>
     <Tooltip>
       The intention between these services has Layer 7 permissions, so certain requests may or may not be permitted.

--- a/ui-v2/app/components/topology-metrics/index.hbs
+++ b/ui-v2/app/components/topology-metrics/index.hbs
@@ -12,7 +12,10 @@
       </span>
     </div>
   {{#each @downstreams as |downstream|}}
-    <div class="card">
+    <div class="card"
+      data-permission="{{downstream.Intention.Action}}"
+      id="{{downstream.Namespace}}{{downstream.Name}}"
+    >
       <p>
         {{downstream.Name}}
       </p>
@@ -58,34 +61,13 @@
     </div>
   </div>
   <div id="downstream-lines">
-  {{#if (gt this.downLines.length 0)}}
-    <svg
-      viewBox={{concat downView.x ' ' downView.y ' ' downView.width ' ' downView.height}}
-      preserveAspectRatio="none"
-    >
-      <defs>
-        <marker id="dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
-          <circle
-            cx="6"
-            cy="6"
-            r="6"
-          />
-        </marker>
-        <marker id="arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
-            markerWidth="6" markerHeight="6"
-            orient="auto-start-reverse">
-          <polygon points="0 0 10 5 0 10" />
-        </marker>
-      </defs>
-    {{#each this.downLines as |svg| }}
-      <path
-        d={{svg-curve svg.dest src=svg.src}}
-        marker-start="url(#dot)"
-        marker-end="url(#arrow)"
-      />
-    {{/each}}
-    </svg>
-  {{/if}}
+    <TopologyMetrics::DownLines
+      @type='downstream'
+      @view={{this.downView}}
+      @center={{this.centerDimensions}}
+      @lines={{this.downLines}}
+      @items={{@downstreams}}
+     />
   </div>
 {{#if (gt @upstreams.length 0)}}
   <div id="upstream-column">
@@ -93,7 +75,10 @@
     <div id="upstream-container">
       <p>{{dc}}</p>
       {{#each upstreams as |upstream|}}
-      <div class="card">
+      <div class="card"
+        data-permission="{{upstream.Intention.Action}}"
+        id="{{upstream.Namespace}}{{upstream.Name}}"
+      >
         <p>
           {{upstream.Name}}
         </p>
@@ -142,33 +127,12 @@
   </div>
 {{/if}}
   <div id="upstream-lines">
-  {{#if (gt this.upLines.length 0)}}
-    <svg
-      viewBox={{concat this.centerDimensions.x ' ' upView.y ' ' upView.width ' ' upView.height}}
-      preserveAspectRatio="none"
-    >
-      <defs>
-        <marker id="dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
-          <circle
-            cx="6"
-            cy="6"
-            r="6"
-          />
-        </marker>
-        <marker id="arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
-            markerWidth="6" markerHeight="6"
-            orient="auto-start-reverse">
-          <polygon points="0 0 10 5 0 10" />
-        </marker>
-      </defs>
-    {{#each this.upLines as |svg| }}
-      <path
-        d={{svg-curve svg.dest src=svg.src}}
-        marker-start="url(#dot)"
-        marker-end="url(#arrow)"
-      />
-    {{/each}}
-    </svg>
-  {{/if}}
+    <TopologyMetrics::UpLines
+      @type='upstream'
+      @view={{this.upView}}
+      @center={{this.centerDimensions}}
+      @lines={{this.upLines}}
+      @items={{@upstreams}}
+     />
   </div>
 </div>

--- a/ui-v2/app/components/topology-metrics/index.hbs
+++ b/ui-v2/app/components/topology-metrics/index.hbs
@@ -13,7 +13,7 @@
     </div>
   {{#each @downstreams as |downstream|}}
     <div class="card"
-      data-permission="{{downstream.Intention.Action}}"
+      data-permission={{service/intention-permissions downstream}}
       id="{{downstream.Namespace}}{{downstream.Name}}"
     >
       <p>
@@ -76,7 +76,7 @@
       <p>{{dc}}</p>
       {{#each upstreams as |upstream|}}
       <div class="card"
-        data-permission="{{upstream.Intention.Action}}"
+        data-permission={{service/intention-permissions upstream}}
         id="{{upstream.Namespace}}{{upstream.Name}}"
       >
         <p>

--- a/ui-v2/app/components/topology-metrics/index.js
+++ b/ui-v2/app/components/topology-metrics/index.js
@@ -12,7 +12,7 @@ export default class TopologyMetrics extends Component {
 
   // =methods
   drawDownLines(items) {
-    const order = [null, 'allow', 'deny'];
+    const order = ['allow', 'deny'];
     const dest = {
       x: this.centerDimensions.x,
       y: this.centerDimensions.y + this.centerDimensions.height / 4,
@@ -39,7 +39,7 @@ export default class TopologyMetrics extends Component {
   }
 
   drawUpLines(items) {
-    const order = [null, 'allow', 'deny'];
+    const order = ['allow', 'deny'];
     const src = {
       x: this.centerDimensions.x + 20,
       y: this.centerDimensions.y + this.centerDimensions.height / 4,

--- a/ui-v2/app/components/topology-metrics/index.js
+++ b/ui-v2/app/components/topology-metrics/index.js
@@ -12,15 +12,15 @@ export default class TopologyMetrics extends Component {
 
   // =methods
   drawDownLines(items) {
-    let order = [null, 'allow', 'deny'];
+    const order = [null, 'allow', 'deny'];
+    const dest = {
+      x: this.centerDimensions.x,
+      y: this.centerDimensions.y + this.centerDimensions.height / 4,
+    };
 
     return items
       .map(item => {
         const dimensions = item.getBoundingClientRect();
-        const dest = {
-          x: this.centerDimensions.x,
-          y: this.centerDimensions.y + this.centerDimensions.height / 4,
-        };
         const src = {
           x: dimensions.x + dimensions.width,
           y: dimensions.y + dimensions.height / 2,
@@ -34,16 +34,16 @@ export default class TopologyMetrics extends Component {
         };
       })
       .sort((a, b) => {
-        if (a.permission === b.permission) {
-          return 0;
-        }
-
         return order.indexOf(a.permission) - order.indexOf(b.permission);
       });
   }
 
   drawUpLines(items) {
-    let order = [null, 'allow', 'deny'];
+    const order = [null, 'allow', 'deny'];
+    const src = {
+      x: this.centerDimensions.x + 20,
+      y: this.centerDimensions.y + this.centerDimensions.height / 4,
+    };
 
     return items
       .map(item => {
@@ -51,10 +51,6 @@ export default class TopologyMetrics extends Component {
         const dest = {
           x: dimensions.x - dimensions.width - 26,
           y: dimensions.y + dimensions.height / 2,
-        };
-        const src = {
-          x: this.centerDimensions.x + 20,
-          y: this.centerDimensions.y + this.centerDimensions.height / 4,
         };
 
         return {
@@ -65,10 +61,6 @@ export default class TopologyMetrics extends Component {
         };
       })
       .sort((a, b) => {
-        if (a.permission === b.permission) {
-          return 0;
-        }
-
         return order.indexOf(a.permission) - order.indexOf(b.permission);
       });
   }

--- a/ui-v2/app/components/topology-metrics/index.js
+++ b/ui-v2/app/components/topology-metrics/index.js
@@ -12,41 +12,65 @@ export default class TopologyMetrics extends Component {
 
   // =methods
   drawDownLines(items) {
-    return items.map(item => {
-      const dimensions = item.getBoundingClientRect();
-      const dest = {
-        x: this.centerDimensions.x,
-        y: this.centerDimensions.y + this.centerDimensions.height / 4,
-      };
-      const src = {
-        x: dimensions.x + dimensions.width,
-        y: dimensions.y + dimensions.height / 2,
-      };
+    let order = [null, 'allow', 'deny'];
 
-      return {
-        dest: dest,
-        src: src,
-      };
-    });
+    return items
+      .map(item => {
+        const dimensions = item.getBoundingClientRect();
+        const dest = {
+          x: this.centerDimensions.x,
+          y: this.centerDimensions.y + this.centerDimensions.height / 4,
+        };
+        const src = {
+          x: dimensions.x + dimensions.width,
+          y: dimensions.y + dimensions.height / 2,
+        };
+
+        return {
+          id: item.id,
+          permission: item.getAttribute('data-permission'),
+          dest: dest,
+          src: src,
+        };
+      })
+      .sort((a, b) => {
+        if (a.permission === b.permission) {
+          return 0;
+        }
+
+        return order.indexOf(a.permission) - order.indexOf(b.permission);
+      });
   }
 
   drawUpLines(items) {
-    return items.map(item => {
-      const dimensions = item.getBoundingClientRect();
-      const dest = {
-        x: dimensions.x - dimensions.width - 26,
-        y: dimensions.y + dimensions.height / 2,
-      };
-      const src = {
-        x: this.centerDimensions.x + 20,
-        y: this.centerDimensions.y + this.centerDimensions.height / 4,
-      };
+    let order = [null, 'allow', 'deny'];
 
-      return {
-        dest: dest,
-        src: src,
-      };
-    });
+    return items
+      .map(item => {
+        const dimensions = item.getBoundingClientRect();
+        const dest = {
+          x: dimensions.x - dimensions.width - 26,
+          y: dimensions.y + dimensions.height / 2,
+        };
+        const src = {
+          x: this.centerDimensions.x + 20,
+          y: this.centerDimensions.y + this.centerDimensions.height / 4,
+        };
+
+        return {
+          id: item.id,
+          permission: item.getAttribute('data-permission'),
+          dest: dest,
+          src: src,
+        };
+      })
+      .sort((a, b) => {
+        if (a.permission === b.permission) {
+          return 0;
+        }
+
+        return order.indexOf(a.permission) - order.indexOf(b.permission);
+      });
   }
 
   // =actions

--- a/ui-v2/app/components/topology-metrics/skin.scss
+++ b/ui-v2/app/components/topology-metrics/skin.scss
@@ -94,15 +94,45 @@
   circle {
     fill: $white;
   }
-  polygon {
+  #allow-arrow {
     fill: $gray-300;
     stroke-linejoin: round;
   }
   path,
-  circle,
-  polygon {
+  #allow-dot,
+  #allow-arrow {
     stroke: $gray-300;
     stroke-width: 2;
   }
+  path[data-permission='deny'] {
+    stroke: $red-500;
+  }
+  #deny-dot {
+    stroke: $red-500;
+    stroke-width: 2;
+  }
+  #deny-arrow {
+    fill: $red-500;
+    stroke: $red-500;
+    stroke-linejoin: round;
+  }
+}
 
+
+// Icon on SVG Lines
+#downstream-lines,
+#upstream-lines {
+  .deny::before {
+    @extend %with-cancel-square-fill-color-mask, %as-pseudo;
+    background-color: $red-500;
+  }
+  .L7::before {
+    @extend %with-layers-mask, %as-pseudo;
+    background-color: $gray-300;
+  }
+  span {
+    transform: translate(-50%,-50%);
+    position: absolute;
+    background-color: $white;
+  }
 }

--- a/ui-v2/app/components/topology-metrics/up-lines/index.hbs
+++ b/ui-v2/app/components/topology-metrics/up-lines/index.hbs
@@ -1,0 +1,60 @@
+{{on-window 'resize' (action this.getIconPositions)}}
+
+{{#if (gt @lines.length 0)}}
+  <svg
+    {{did-insert this.getIconPositions}}
+    viewBox={{concat @center.x ' ' @view.y ' ' @view.width ' ' @view.height}}
+    preserveAspectRatio="none"
+  >
+    <defs>
+      <marker id="allow-dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
+        <circle
+          cx="6"
+          cy="6"
+          r="6"
+        />
+      </marker>
+      <marker id="allow-arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
+          markerWidth="6" markerHeight="6"
+          orient="auto-start-reverse">
+        <polygon points="0 0 10 5 0 10" />
+      </marker>
+      <marker id="deny-dot" viewBox="-2 -2 15 15" refX="6" refY="6" markerWidth="6" markerHeight="6">
+        <circle
+          cx="6"
+          cy="6"
+          r="6"
+        />
+      </marker>
+      <marker id="deny-arrow" viewBox="-1 -1 12 12" refX="5" refY="5"
+          markerWidth="6" markerHeight="6"
+          orient="auto-start-reverse">
+        <polygon points="0 0 10 5 0 10" />
+      </marker>
+    </defs>
+{{#each @lines as |line|}}
+  {{#if (eq line.permission 'deny')}}
+    <path
+      id={{line.id}}
+      d={{svg-curve line.dest src=line.src}}
+      marker-start="url(#deny-dot)"
+      marker-end="url(#deny-arrow)"
+      data-permission={{line.permission}}
+    />
+  {{else}}
+     <path
+      id={{line.id}}
+      d={{svg-curve line.dest src=line.src}}
+      marker-start="url(#allow-dot)"
+      marker-end="url(#allow-arrow)"
+      data-permission={{line.permission}}
+    />
+  {{/if}}
+{{/each}}
+  </svg>
+{{/if}}
+
+<TopologyMetrics::Icon
+  @positions={{this.iconPositions}}
+  @items={{@items}}
+/>

--- a/ui-v2/app/components/topology-metrics/up-lines/index.hbs
+++ b/ui-v2/app/components/topology-metrics/up-lines/index.hbs
@@ -3,6 +3,7 @@
 {{#if (gt @lines.length 0)}}
   <svg
     {{did-insert this.getIconPositions}}
+    {{did-update this.getIconPositions @lines}}
     viewBox={{concat @center.x ' ' @view.y ' ' @view.width ' ' @view.height}}
     preserveAspectRatio="none"
   >

--- a/ui-v2/app/components/topology-metrics/up-lines/index.js
+++ b/ui-v2/app/components/topology-metrics/up-lines/index.js
@@ -2,7 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
-export default class TopoloyMetricsLines extends Component {
+export default class TopoloyMetricsUpLines extends Component {
   @tracked iconPositions;
 
   @action

--- a/ui-v2/app/components/topology-metrics/up-lines/index.js
+++ b/ui-v2/app/components/topology-metrics/up-lines/index.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class TopoloyMetricsLines extends Component {
+  @tracked iconPositions;
+
+  @action
+  getIconPositions() {
+    const center = this.args.center;
+    const lines = [...document.querySelectorAll('#upstream-lines path')];
+
+    this.iconPositions = lines.map(item => {
+      const pathLen = parseFloat(item.getTotalLength());
+      const partLen = item.getPointAtLength(Math.ceil(pathLen * 0.666));
+      return {
+        id: item.id,
+        x: partLen.x - center.x,
+        y: partLen.y - center.y * 0.81,
+      };
+    });
+  }
+}

--- a/ui-v2/app/helpers/service/intention-permissions.js
+++ b/ui-v2/app/helpers/service/intention-permissions.js
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function serviceIntentionPermissions([params] /*, hash*/) {
+  const L7Permissions = params.Intention.HasL7Permissions;
+  const permission = params.Intention.Allowed;
+
+  switch (true) {
+    case L7Permissions:
+      return 'allow';
+    case !permission && !L7Permissions:
+      return 'deny';
+    default:
+      return 'allow';
+  }
+});

--- a/ui-v2/app/helpers/service/intention-permissions.js
+++ b/ui-v2/app/helpers/service/intention-permissions.js
@@ -1,13 +1,13 @@
 import { helper } from '@ember/component/helper';
 
 export default helper(function serviceIntentionPermissions([params] /*, hash*/) {
-  const L7Permissions = params.Intention.HasL7Permissions;
-  const permission = params.Intention.Allowed;
+  const hasPermissions = params.Intention.HasPermissions;
+  const allowed = params.Intention.Allowed;
 
   switch (true) {
-    case L7Permissions:
+    case hasPermissions:
       return 'allow';
-    case !permission && !L7Permissions:
+    case !allowed && !hasPermissions:
       return 'deny';
     default:
       return 'allow';

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -56,7 +56,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^5.2.3",
+    "@hashicorp/consul-api-double": "^5.3.2",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -56,7 +56,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^5.3.2",
+    "@hashicorp/consul-api-double": "^5.3.3",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -56,7 +56,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^5.3.3",
+    "@hashicorp/consul-api-double": "^5.3.5",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui-v2/tests/integration/helpers/service/intention-permissions-test.js
+++ b/ui-v2/tests/integration/helpers/service/intention-permissions-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | service/intention-permissions', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', {
+      Intention: {
+        Allowed: false,
+        HasL7Permissions: true,
+      },
+    });
+
+    await render(hbs`{{service/intention-permissions inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), 'allow');
+  });
+});

--- a/ui-v2/tests/integration/helpers/service/intention-permissions-test.js
+++ b/ui-v2/tests/integration/helpers/service/intention-permissions-test.js
@@ -11,7 +11,7 @@ module('Integration | Helper | service/intention-permissions', function(hooks) {
     this.set('inputValue', {
       Intention: {
         Allowed: false,
-        HasL7Permissions: true,
+        HasPermissions: true,
       },
     });
 

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1527,10 +1527,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^5.3.2":
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.3.2.tgz#5a9490ced246850f30ee34e49d6d9edb8bb01971"
-  integrity sha512-jLSliXeZanb2VSr4T+JTE/K6PvxCiVPDdw7TIc9yRdGjww2Mf55+6S26c/bcMEtERfqdCkMyUTJeA/1N+tM8OQ==
+"@hashicorp/consul-api-double@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.3.3.tgz#026eee82c11b6a940b27cba50be9a227f177cb7c"
+  integrity sha512-V8Xpa9p5dvsXPMm3oy+GqVwxcWHnj+P1XkY/rwXqxuCOKsR59jtkSd6xvA38JHQQUgtFvGC1sBhgaCG5tq6tJw==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.2"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1527,10 +1527,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^5.2.3":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.2.3.tgz#c34cec063b519595c49bb3fce799541f7d967f66"
-  integrity sha512-NlnBUHoXLlQwTB1lFzYvaIUZnf5KOGnohXRm4D3B8xVC+D0py6dTP5dj3NpBuxrG5b0xSv2zTF3tz9Y5nehOzQ==
+"@hashicorp/consul-api-double@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.3.2.tgz#5a9490ced246850f30ee34e49d6d9edb8bb01971"
+  integrity sha512-jLSliXeZanb2VSr4T+JTE/K6PvxCiVPDdw7TIc9yRdGjww2Mf55+6S26c/bcMEtERfqdCkMyUTJeA/1N+tM8OQ==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.2"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1527,10 +1527,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^5.3.3":
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.3.3.tgz#026eee82c11b6a940b27cba50be9a227f177cb7c"
-  integrity sha512-V8Xpa9p5dvsXPMm3oy+GqVwxcWHnj+P1XkY/rwXqxuCOKsR59jtkSd6xvA38JHQQUgtFvGC1sBhgaCG5tq6tJw==
+"@hashicorp/consul-api-double@^5.3.5":
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.3.5.tgz#8e39d6af4ab6d32c7d8c469bb4aab23e16971bd3"
+  integrity sha512-SiT2lLk0J8CwsxtuAobrweC5VdOT6b66M1gSLcT/Lcx62fOLH1X/DfMt6F2VKwC4BN8WBFZGTmn0rwdFOjKpmw==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.2"


### PR DESCRIPTION
Use Cases:
1. If intention is set to deny between services, the SVG lines is red with an icon.
2. If intention is set with L7, the line remains gray but has a L7 icon.

New contextual components:
- TopologyMetrics::Icon
- TopologyMetrics::UpLines
- TopologyMetrics::DownLines

<img width="1855" alt="Screen Shot 2020-10-06 at 7 25 53 PM" src="https://user-images.githubusercontent.com/19161242/95270565-c2bfa700-0809-11eb-9222-02e72ce1ce72.png">
