### PR TITLE
Support ingress gateways in mesh viz endpoint

### DIFF
--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -439,7 +439,7 @@ func prepSummaryOutput(summaries map[structs.ServiceName]*ServiceSummary, exclud
 				sum.ChecksCritical++
 			}
 		}
-		if excludeSidecars && sum.Kind != structs.ServiceKindTypical {
+		if excludeSidecars && !(sum.Kind == structs.ServiceKindTypical || sum.Kind == structs.ServiceKindIngressGateway) {
 			continue
 		}
 		resp = append(resp, sum)

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -439,7 +439,7 @@ func prepSummaryOutput(summaries map[structs.ServiceName]*ServiceSummary, exclud
 				sum.ChecksCritical++
 			}
 		}
-		if excludeSidecars && !(sum.Kind == structs.ServiceKindTypical || sum.Kind == structs.ServiceKindIngressGateway) {
+		if excludeSidecars && sum.Kind != structs.ServiceKindTypical && sum.Kind != structs.ServiceKindIngressGateway {
 			continue
 		}
 		resp = append(resp, sum)

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -828,6 +828,7 @@ func TestUIGatewayIntentions(t *testing.T) {
 
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
+	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
 
 	// Register terminating gateway and config entry linking it to postgres + redis
 	{

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -828,7 +828,7 @@ func TestUIGatewayIntentions(t *testing.T) {
 
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
-	testrpc.WaitForTestAgent(t, a.RPC, "dc1")
+	testrpc.WaitForServiceIntentions(t, a.RPC, "dc1")
 
 	// Register terminating gateway and config entry linking it to postgres + redis
 	{

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1339,8 +1339,8 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
-							Allowed:          true,
-							HasL7Permissions: false,
+							Allowed:        true,
+							HasPermissions: false,
 						},
 					},
 				},
@@ -1379,8 +1379,8 @@ func TestUIServiceTopology(t *testing.T) {
 							EnterpriseMeta: *structs.DefaultEnterpriseMeta(),
 						},
 						Intention: structs.IntentionDecisionSummary{
-							Allowed:          true,
-							HasL7Permissions: false,
+							Allowed:        true,
+							HasPermissions: false,
 						},
 					},
 				},


### PR DESCRIPTION
Chained off of: #8853

This PR updates the `service-topology` chain to account for Ingress Gateways. Now whenever the gateway-service mappings are updated, we also update the mesh topology table.

This is so that ingress gateways can show up in the mesh visualization either as downstreams or the target service.