### PR TITLE
Add protocol to the topology endpoint response

### DIFF
--- a/agent/consul/internal_endpoint.go
+++ b/agent/consul/internal_endpoint.go
@@ -173,7 +173,7 @@ func (m *Internal) ServiceTopology(args *structs.ServiceSpecificRequest, reply *
 				defaultAllow = authz.IntentionDefaultAllow(nil)
 			}
 
-			index, topology, err := state.ServiceTopology(ws, args.Datacenter, args.ServiceName, defaultAllow, &args.EnterpriseMeta)
+			index, topology, err := state.ServiceTopology(ws, args.Datacenter, args.ServiceName, args.ServiceKind, defaultAllow, &args.EnterpriseMeta)
 			if err != nil {
 				return err
 			}

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1639,6 +1639,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
+			require.Equal(r, "http", out.ServiceTopology.Protocol)
 
 			// bar/web, bar/web-proxy, baz/web, baz/web-proxy
 			require.Len(r, out.ServiceTopology.Upstreams, 4)
@@ -1664,6 +1665,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
+			require.Equal(r, "http", out.ServiceTopology.Protocol)
 
 			// foo/api, foo/api-proxy
 			require.Len(r, out.ServiceTopology.Downstreams, 2)
@@ -1699,6 +1701,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
+			require.Equal(r, "http", out.ServiceTopology.Protocol)
 
 			require.Len(r, out.ServiceTopology.Upstreams, 0)
 
@@ -1756,6 +1759,7 @@ service "web" { policy = "read" }
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 
 		require.True(t, out.FilteredByACLs)
+		require.Equal(t, "http", out.ServiceTopology.Protocol)
 
 		// The web-proxy upstream gets filtered out from both bar and baz
 		require.Len(t, out.ServiceTopology.Upstreams, 2)
@@ -1775,6 +1779,7 @@ service "web" { policy = "read" }
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 
 		require.True(t, out.FilteredByACLs)
+		require.Equal(t, "http", out.ServiceTopology.Protocol)
 
 		// The redis upstream gets filtered out but the api and proxy downstream are returned
 		require.Len(t, out.ServiceTopology.Upstreams, 0)

--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1639,7 +1639,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
-			require.Equal(r, "http", out.ServiceTopology.Protocol)
+			require.Equal(r, "http", out.ServiceTopology.MetricsProtocol)
 
 			// bar/web, bar/web-proxy, baz/web, baz/web-proxy
 			require.Len(r, out.ServiceTopology.Upstreams, 4)
@@ -1665,7 +1665,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
-			require.Equal(r, "http", out.ServiceTopology.Protocol)
+			require.Equal(r, "http", out.ServiceTopology.MetricsProtocol)
 
 			// foo/api, foo/api-proxy
 			require.Len(r, out.ServiceTopology.Downstreams, 2)
@@ -1701,7 +1701,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 			var out structs.IndexedServiceTopology
 			require.NoError(r, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 			require.False(r, out.FilteredByACLs)
-			require.Equal(r, "http", out.ServiceTopology.Protocol)
+			require.Equal(r, "http", out.ServiceTopology.MetricsProtocol)
 
 			require.Len(r, out.ServiceTopology.Upstreams, 0)
 
@@ -1759,7 +1759,7 @@ service "web" { policy = "read" }
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 
 		require.True(t, out.FilteredByACLs)
-		require.Equal(t, "http", out.ServiceTopology.Protocol)
+		require.Equal(t, "http", out.ServiceTopology.MetricsProtocol)
 
 		// The web-proxy upstream gets filtered out from both bar and baz
 		require.Len(t, out.ServiceTopology.Upstreams, 2)
@@ -1779,7 +1779,7 @@ service "web" { policy = "read" }
 		require.NoError(t, msgpackrpc.CallWithCodec(codec, "Internal.ServiceTopology", &args, &out))
 
 		require.True(t, out.FilteredByACLs)
-		require.Equal(t, "http", out.ServiceTopology.Protocol)
+		require.Equal(t, "http", out.ServiceTopology.MetricsProtocol)
 
 		// The redis upstream gets filtered out but the api and proxy downstream are returned
 		require.Len(t, out.ServiceTopology.Upstreams, 0)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2974,14 +2974,17 @@ func (s *Store) ServiceTopology(
 	case structs.ServiceKindIngressGateway:
 		maxIdx, protocol, err = metricsProtocolForIngressGateway(tx, ws, sn)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
+			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s: %v", sn.String(), err)
+		}
+
+	case structs.ServiceKindTypical:
+		maxIdx, protocol, err = protocolForService(tx, ws, sn)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s: %v", sn.String(), err)
 		}
 
 	default:
-		maxIdx, protocol, err = protocolForService(tx, ws, sn)
-		if err != nil {
-			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
-		}
+		return 0, nil, fmt.Errorf("unsupported kind %q", kind)
 	}
 
 	idx, upstreamNames, err := upstreamsFromRegistrationTxn(tx, ws, sn)

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -2907,6 +2907,36 @@ func serviceGatewayNodes(tx *txn, ws memdb.WatchSet, service string, kind struct
 	return maxIdx, ret, nil
 }
 
+// metricsProtocolForIngressGateway determines the protocol that should be used when fetching metrics for an ingress gateway
+// Since ingress gateways may have listeners with different protocols, favor capturing all traffic by only returning HTTP
+// when all listeners are HTTP-like.
+func metricsProtocolForIngressGateway(tx ReadTxn, ws memdb.WatchSet, sn structs.ServiceName) (uint64, string, error) {
+	idx, conf, err := configEntryTxn(tx, ws, structs.IngressGateway, sn.Name, &sn.EnterpriseMeta)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to get ingress-gateway config entry for %q: %v", sn.String(), err)
+	}
+	if conf == nil {
+		return 0, "", nil
+	}
+	entry, ok := conf.(*structs.IngressGatewayConfigEntry)
+	if !ok {
+		return 0, "", fmt.Errorf("unexpected config entry type: %T", conf)
+	}
+	counts := make(map[string]int)
+	for _, l := range entry.Listeners {
+		if structs.IsProtocolHTTPLike(l.Protocol) {
+			counts["http"] += 1
+		} else {
+			counts["tcp"] += 1
+		}
+	}
+	protocol := "tcp"
+	if counts["tcp"] == 0 && counts["http"] > 0 {
+		protocol = "http"
+	}
+	return idx, protocol, nil
+}
+
 // checkProtocolMatch filters out any GatewayService entries added from a wildcard with a protocol
 // that doesn't match the one configured in their discovery chain.
 func checkProtocolMatch(tx ReadTxn, ws memdb.WatchSet, svc *structs.GatewayService) (uint64, bool, error) {
@@ -2925,6 +2955,7 @@ func checkProtocolMatch(tx ReadTxn, ws memdb.WatchSet, svc *structs.GatewayServi
 func (s *Store) ServiceTopology(
 	ws memdb.WatchSet,
 	dc, service string,
+	kind structs.ServiceKind,
 	defaultAllow acl.EnforcementDecision,
 	entMeta *structs.EnterpriseMeta,
 ) (uint64, *structs.ServiceTopology, error) {
@@ -2932,15 +2963,25 @@ func (s *Store) ServiceTopology(
 	defer tx.Abort()
 
 	var (
-		maxIdx uint64
-		sn     = structs.NewServiceName(service, entMeta)
+		maxIdx   uint64
+		protocol string
+		err      error
+
+		sn = structs.NewServiceName(service, entMeta)
 	)
-	idx, protocol, err := protocolForService(tx, ws, sn)
-	if err != nil {
-		return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
-	}
-	if idx > maxIdx {
-		maxIdx = idx
+
+	switch kind {
+	case structs.ServiceKindIngressGateway:
+		maxIdx, protocol, err = metricsProtocolForIngressGateway(tx, ws, sn)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
+		}
+
+	default:
+		maxIdx, protocol, err = protocolForService(tx, ws, sn)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
+		}
 	}
 
 	idx, upstreamNames, err := upstreamsFromRegistrationTxn(tx, ws, sn)
@@ -3005,7 +3046,7 @@ func (s *Store) ServiceTopology(
 	}
 
 	resp := &structs.ServiceTopology{
-		Protocol:            protocol,
+		MetricsProtocol:     protocol,
 		Upstreams:           upstreams,
 		Downstreams:         downstreams,
 		UpstreamDecisions:   upstreamDecisions,

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3,8 +3,6 @@ package state
 import (
 	"errors"
 	"fmt"
-	"github.com/hashicorp/consul/acl"
-	"github.com/hashicorp/consul/agent/connect"
 	"reflect"
 	"strings"
 
@@ -2937,6 +2935,13 @@ func (s *Store) ServiceTopology(
 		maxIdx uint64
 		sn     = structs.NewServiceName(service, entMeta)
 	)
+	idx, protocol, err := protocolForService(tx, ws, sn)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to fetch protocol for service %s", sn.String())
+	}
+	if idx > maxIdx {
+		maxIdx = idx
+	}
 
 	idx, upstreamNames, err := upstreamsFromRegistrationTxn(tx, ws, sn)
 	if err != nil {
@@ -3000,6 +3005,7 @@ func (s *Store) ServiceTopology(
 	}
 
 	resp := &structs.ServiceTopology{
+		Protocol:            protocol,
 		Upstreams:           upstreams,
 		Downstreams:         downstreams,
 		UpstreamDecisions:   upstreamDecisions,

--- a/agent/consul/state/catalog.go
+++ b/agent/consul/state/catalog.go
@@ -3,6 +3,8 @@ package state
 import (
 	"errors"
 	"fmt"
+	"github.com/hashicorp/consul/acl"
+	"github.com/hashicorp/consul/agent/connect"
 	"reflect"
 	"strings"
 

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -1893,6 +1893,9 @@ type ServiceTopology struct {
 
 	UpstreamDecisions   map[string]IntentionDecisionSummary
 	DownstreamDecisions map[string]IntentionDecisionSummary
+
+	// Protocol is the protocol of the service being queried
+	Protocol string
 }
 
 // IndexedConfigEntries has its own encoding logic which differs from

--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -519,6 +519,7 @@ type ServiceSpecificRequest struct {
 	Datacenter      string
 	NodeMetaFilters map[string]string
 	ServiceName     string
+	ServiceKind     ServiceKind
 	// DEPRECATED (singular-service-tag) - remove this when backwards RPC compat
 	// with 1.2.x is not required.
 	ServiceTag     string
@@ -1894,8 +1895,8 @@ type ServiceTopology struct {
 	UpstreamDecisions   map[string]IntentionDecisionSummary
 	DownstreamDecisions map[string]IntentionDecisionSummary
 
-	// Protocol is the protocol of the service being queried
-	Protocol string
+	// MetricsProtocol is the protocol of the service being queried
+	MetricsProtocol string
 }
 
 // IndexedConfigEntries has its own encoding logic which differs from

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -64,6 +64,7 @@ type ServiceTopologySummary struct {
 }
 
 type ServiceTopology struct {
+	Protocol       string
 	Upstreams      []*ServiceTopologySummary
 	Downstreams    []*ServiceTopologySummary
 	FilteredByACLs bool
@@ -324,6 +325,7 @@ RPC:
 	}
 
 	topo := ServiceTopology{
+		Protocol:       out.ServiceTopology.Protocol,
 		Upstreams:      upstreamResp,
 		Downstreams:    downstreamResp,
 		FilteredByACLs: out.FilteredByACLs,

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -290,6 +290,15 @@ func (s *HTTPHandlers) UIServiceTopology(resp http.ResponseWriter, req *http.Req
 	}
 	args.ServiceKind = structs.ServiceKind(kind[0])
 
+	switch args.ServiceKind {
+	case structs.ServiceKindTypical, structs.ServiceKindIngressGateway:
+		// allowed
+	default:
+		resp.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(resp, "Unsupported service kind %q", args.ServiceKind)
+		return nil, nil
+	}
+
 	// Make the RPC request
 	var out structs.IndexedServiceTopology
 	defer setMeta(resp, &out.QueryMeta)

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -282,6 +282,14 @@ func (s *HTTPHandlers) UIServiceTopology(resp http.ResponseWriter, req *http.Req
 		return nil, nil
 	}
 
+	kind, ok := req.URL.Query()["kind"]
+	if !ok {
+		resp.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(resp, "Missing service kind")
+		return nil, nil
+	}
+	args.ServiceKind = structs.ServiceKind(kind[0])
+
 	// Make the RPC request
 	var out structs.IndexedServiceTopology
 	defer setMeta(resp, &out.QueryMeta)
@@ -325,7 +333,7 @@ RPC:
 	}
 
 	topo := ServiceTopology{
-		Protocol:       out.ServiceTopology.Protocol,
+		Protocol:       out.ServiceTopology.MetricsProtocol,
 		Upstreams:      upstreamResp,
 		Downstreams:    downstreamResp,
 		FilteredByACLs: out.FilteredByACLs,

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1386,7 +1386,7 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "http",
+				Protocol: "tcp",
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1250,6 +1250,14 @@ func TestUIServiceTopology(t *testing.T) {
 			},
 			{
 				Datacenter: "dc1",
+				Entry: &structs.ServiceConfigEntry{
+					Kind:     structs.ServiceDefaults,
+					Name:     "api",
+					Protocol: "tcp",
+				},
+			},
+			{
+				Datacenter: "dc1",
 				Entry: &structs.ServiceIntentionsConfigEntry{
 					Kind: structs.ServiceIntentions,
 					Name: "redis",
@@ -1303,7 +1311,7 @@ func TestUIServiceTopology(t *testing.T) {
 					Listeners: []structs.IngressListener{
 						{
 							Port:     1111,
-							Protocol: "http",
+							Protocol: "tcp",
 							Services: []structs.IngressService{
 								{
 									Name:           "api",
@@ -1321,17 +1329,26 @@ func TestUIServiceTopology(t *testing.T) {
 		}
 	}
 
+	t.Run("request without kind", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/ingress", nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.UIServiceTopology(resp, req)
+		require.Nil(t, err)
+		require.Nil(t, obj)
+		require.Equal(t, "Missing service kind", resp.Body.String())
+	})
+
 	t.Run("ingress", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			// Request topology for ingress
-			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/ingress", nil)
+			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/ingress?kind=ingress-gateway", nil)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.UIServiceTopology(resp, req)
 			assert.Nil(r, err)
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "http",
+				Protocol: "tcp",
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
@@ -1364,7 +1381,7 @@ func TestUIServiceTopology(t *testing.T) {
 	t.Run("api", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			// Request topology for api
-			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/api", nil)
+			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/api?kind=", nil)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.UIServiceTopology(resp, req)
 			assert.Nil(r, err)
@@ -1428,7 +1445,7 @@ func TestUIServiceTopology(t *testing.T) {
 	t.Run("web", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			// Request topology for web
-			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/web", nil)
+			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/web?kind=", nil)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.UIServiceTopology(resp, req)
 			assert.Nil(r, err)
@@ -1490,7 +1507,7 @@ func TestUIServiceTopology(t *testing.T) {
 	t.Run("redis", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			// Request topology for redis
-			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/redis", nil)
+			req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/redis?kind=", nil)
 			resp := httptest.NewRecorder()
 			obj, err := a.srv.UIServiceTopology(resp, req)
 			assert.Nil(r, err)

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1336,6 +1336,15 @@ func TestUIServiceTopology(t *testing.T) {
 		require.Equal(t, "Missing service kind", resp.Body.String())
 	})
 
+	t.Run("request with unsupported kind", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/v1/internal/ui/service-topology/ingress?kind=not-a-kind", nil)
+		resp := httptest.NewRecorder()
+		obj, err := a.srv.UIServiceTopology(resp, req)
+		require.Nil(t, err)
+		require.Nil(t, obj)
+		require.Equal(t, `Unsupported service kind "not-a-kind"`, resp.Body.String())
+	})
+
 	t.Run("ingress", func(t *testing.T) {
 		retry.Run(t, func(r *retry.R) {
 			// Request topology for ingress

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/stretchr/testify/assert"
@@ -940,7 +941,7 @@ func TestUIServiceTopology(t *testing.T) {
 	a := NewTestAgent(t, "")
 	defer a.Shutdown()
 
-	// Register api -> web -> redis
+	// Register ingress -> api -> web -> redis
 	{
 		registrations := map[string]*structs.RegisterRequest{
 			"Node edge": {

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -12,8 +12,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/hashicorp/consul/sdk/testutil/retry"
-
 	"github.com/hashicorp/consul/agent/config"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1331,6 +1331,7 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
+				Protocol: "http",
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
@@ -1370,6 +1371,7 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
+				Protocol: "http",
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
@@ -1433,6 +1435,7 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
+				Protocol: "http",
 				Upstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{
@@ -1494,6 +1497,7 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
+				Protocol: "http",
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{


### PR DESCRIPTION
This PR adds the protocol for the queried service, and is resolved from config entries.

@banks does it make sense for an ingress gateway to have a single protocol when it can have listeners for TCP and HTTP?

Need to fix the chained PR dance, only this commit is relevant: [`d32fda6` (#8868)](https://github.com/hashicorp/consul/pull/8868/commits/d32fda6c7c6a831e69b2698af880378cf60fd141)