### PR TITLE
test(vault): generate test coverage and upload to CodeCov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -814,6 +814,7 @@ jobs:
             make test-connect-ca-providers
       - store_test_results:
           path: *TEST_RESULTS_DIR
+      - run: *codecov_upload
       - run: *notify-slack-failure
 
   # only runs on master: checks latest commit to see if the PR associated has a backport/* or docs* label to cherry-pick

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -356,7 +356,7 @@ test-envoy-integ: $(ENVOY_INTEG_DEPS)
 test-connect-ca-providers:
 ifeq ("$(CIRCLECI)","true")
 # Run in CI
-	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- ./agent/connect/ca
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -cover -coverprofile=coverage.txt -- ./agent/connect/ca
 else
 # Run locally
 	@echo "Running /agent/connect/ca tests in verbose mode"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -356,7 +356,7 @@ test-envoy-integ: $(ENVOY_INTEG_DEPS)
 test-connect-ca-providers:
 ifeq ("$(CIRCLECI)","true")
 # Run in CI
-	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -cover -coverprofile=coverage.txt -- ./agent/connect/ca
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- -cover -coverprofile=coverage.txt ./agent/connect/ca
 else
 # Run locally
 	@echo "Running /agent/connect/ca tests in verbose mode"


### PR DESCRIPTION
This should enable code coverage reporting for the Connect CA providers integration test job, we discovered this was missing when looking at coverage in #8862 