### PR TITLE
backport(1.7.x): test(vault): generate test coverage and upload to CodeCov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,6 +683,7 @@ jobs:
       - run: make test-vault-ca-provider
       - store_test_results:
           path: *TEST_RESULTS_DIR
+      - run: *codecov_upload
 
 workflows:
   version: 2

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -384,7 +384,7 @@ test-envoy-integ: $(ENVOY_INTEG_DEPS)
 test-vault-ca-provider:
 ifeq ("$(CIRCLECI)","true")
 # Run in CI
-	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- $(CURDIR)/agent/connect/ca/* -run 'TestVault(CA)?Provider'
+	gotestsum --format=short-verbose --junitfile "$(TEST_RESULTS_DIR)/gotestsum-report.xml" -- -cover -coverprofile=coverage.txt $(CURDIR)/agent/connect/ca/* -run 'TestVault(CA)?Provider'
 else
 # Run locally
 	@echo "Running /agent/connect/ca TestVault(CA)?Provider tests in verbose mode"


### PR DESCRIPTION
Manual backport of #8870 