### PR TITLE
agent: allow the /v1/connect/intentions/match endpoint to use the agent cache

### DIFF
--- a/.changelog/8875.txt
+++ b/.changelog/8875.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+agent: allow the /v1/connect/intentions/match endpoint to use the agent cache
+```


### PR DESCRIPTION
This is the recommended proxy integration API for listing intentions
which should not require an active connection to the servers to resolve
after the initial cache filling.