### PR TITLE
ui: Use a custom request for nspace deletion

### DIFF
--- a/ui-v2/app/components/consul-nspace-list/index.hbs
+++ b/ui-v2/app/components/consul-nspace-list/index.hbs
@@ -21,6 +21,7 @@
   {{/if}}
     </BlockSlot>
     <BlockSlot @name="actions" as |Actions|>
+{{#if (not item.DeletedAt)}}
       <Actions as |Action|>
         <Action data-test-edit-action @href={{href-to 'dc.nspaces.edit' item.Name}}>
           <BlockSlot @name="label">
@@ -50,6 +51,7 @@
         </Action>
       {{/if}}
       </Actions>
+{{/if}}
     </BlockSlot>
 </ListCollection>
 {{/if}}

--- a/ui-v2/app/services/repository/nspace.js
+++ b/ui-v2/app/services/repository/nspace.js
@@ -12,6 +12,27 @@ export default RepositoryService.extend({
   getModelName: function() {
     return modelName;
   },
+  remove: function(item) {
+    // Namespace deletion is more of a soft delete.
+    // Therefore the namespace still exists once we've requested a delete/removal.
+    // This makes 'removing' more of a custom action rather than a standard
+    // ember-data delete.
+    // Here we use the same request for a delete but we bypass ember-data's
+    // destroyRecord/unloadRecord and serialization so we don't get
+    // ember data error messages when the UI tries to update a 'DeletedAt' property
+    // on an object that ember-data is trying to delete
+    const res = this.store.adapterFor('nspace').rpc(
+      (adapter, request, serialized, unserialized) => {
+        return adapter.requestForDeleteRecord(request, serialized, unserialized);
+      },
+      (serializer, respond, serialized, unserialized) => {
+        return item;
+      },
+      item,
+      'nspace'
+    );
+    return res;
+  },
   findAll: function(configuration = {}) {
     const query = {};
     if (typeof configuration.cursor !== 'undefined') {


### PR DESCRIPTION
Namespace deletion is more of a soft delete, therefore the namespace can still exist once we've requested a delete/removal, and depending on timing ember-data can sometimes throw an error due to the UI trying to update the 'DeletedAt` property on a object that ember-data is trying to delete (if the delete request responds after the blocking query unblocking due to the delete change).

This PR makes `repo.remove` use a custom request rather than the default ember-data delete, this means we can bypass all the things that ember-data does to mark things as deleting/deleted - essentially turning the delete request into an update.

We also hide the Actions button whilst a namespace is being deleted here, so you can't try editing/deleting the namespace or once its marked for deletion.
