### PR TITLE
ui: Fix up positioning of subpage loader animation

### DIFF
--- a/ui-v2/app/styles/components/app-view/layout.scss
+++ b/ui-v2/app/styles/components/app-view/layout.scss
@@ -1,7 +1,4 @@
 /* layout */
-%app-view {
-  position: relative;
-}
 %app-view-title {
   display: flex;
   align-items: center;

--- a/ui-v2/app/styles/components/breadcrumbs.scss
+++ b/ui-v2/app/styles/components/breadcrumbs.scss
@@ -1,6 +1,6 @@
 main header nav:first-child {
   position: absolute;
-  top: -38px;
+  top: 12px;
 }
 main header nav:first-child ol {
   @extend %breadcrumbs;

--- a/ui-v2/app/styles/layout.scss
+++ b/ui-v2/app/styles/layout.scss
@@ -53,6 +53,7 @@ html:not(.has-nspaces) [class*='nspace-'] {
 }
 main {
   @extend %with-sticky-footer-content;
+  position: relative;
 }
 main,
 #wrapper > footer {


### PR DESCRIPTION
In https://github.com/hashicorp/consul/pull/8796/files#diff-c3972e12e254fd8bc979a2b524c085bbR3 we moved `%app-view` to be extended by `.app-view` itself rather than `main`, unfortunately this altered some positioning.

This PR puts things back as they were in regard to positioning.