### PR TITLE
chore(ci): remove docs-cherrypick autolabel

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -71,8 +71,6 @@ type/ci:
 # type/crash:
 type/docs:
     - website/**/*
-type/docs-cherrypick:
-    - website/**/*
 # type/enhancement:
 # type/good-first-issue:
 # type/question:


### PR DESCRIPTION
This label should never be auto-applied to prevent accidentally publishing docs intended for a major release early.