### PR TITLE
ui: Workaround FF and/or ember problem, trying to set a value=""

### DIFF
--- a/ui-v2/app/components/consul-intention-form/fieldsets/layout.scss
+++ b/ui-v2/app/components/consul-intention-form/fieldsets/layout.scss
@@ -18,7 +18,7 @@
     @extend %with-deny-color-icon, %as-pseudo;
   }
   .permissions > button {
-    @extend %anchor;
+    @extend %anchor, %p2;
     float: right;
   }
 }

--- a/ui-v2/app/components/radio-card/index.hbs
+++ b/ui-v2/app/components/radio-card/index.hbs
@@ -3,7 +3,12 @@
   class="radio-card{{if checked ' checked'}}"
 >
   <div>
-    <input type="radio" name={{name}} value={{value}} checked={{checked}} onchange={{action onchange}} />
+    {{! workaround FF/Ember problem where you cannnot set a value to be value="" (empty)}}
+    {{#if (gt value.length 0) }}
+      <input type="radio" name={{name}} value={{value}} checked={{checked}} onchange={{action onchange}} />
+    {{else}}
+      <input type="radio" name={{name}} value="" checked={{checked}} onchange={{action onchange}} />
+    {{/if}}
   </div>
   <div>
     {{yield}}


### PR DESCRIPTION
It seems problematic to try to set an inputs value attribute to `value=""` (empty) in Firefox with Ember, this worksaround the problem.