### PR TITLE
ui: Update instances count for ingress and terminating gateways

### DIFF
--- a/ui-v2/app/components/consul-service-list/index.hbs
+++ b/ui-v2/app/components/consul-service-list/index.hbs
@@ -46,7 +46,7 @@
 {{/if}}
     <ConsulKind @item={{item}} />
     <ConsulExternalSource @item={{item}} />
-  {{#if (not-eq item.InstanceCount 0)}}
+  {{#if (and (not-eq item.InstanceCount 0) (and (not-eq item.Kind 'terminating-gateway') (not-eq item.Kind 'ingress-gateway'))) }}
     <span>
       {{format-number item.InstanceCount}} {{pluralize item.InstanceCount 'Instance' without-count=true}}
     </span>

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -16,7 +16,6 @@ export default Model.extend({
   InstanceCount: attr('number'),
   ConnectedWithGateway: attr(),
   ConnectedWithProxy: attr(),
-  Proxy: attr(),
   GatewayConfig: attr(),
   Kind: attr('string'),
   ExternalSources: attr(),

--- a/ui-v2/app/models/service.js
+++ b/ui-v2/app/models/service.js
@@ -16,6 +16,7 @@ export default Model.extend({
   InstanceCount: attr('number'),
   ConnectedWithGateway: attr(),
   ConnectedWithProxy: attr(),
+  Proxy: attr(),
   GatewayConfig: attr(),
   Kind: attr('string'),
   ExternalSources: attr(),


### PR DESCRIPTION
Not returning instances count for ingress and terminating gateways. Also, I removed a model attribute we no longer use. 

<img width="1137" alt="Screen Shot 2020-10-08 at 3 12 21 PM" src="https://user-images.githubusercontent.com/19161242/95502978-abeb9280-0978-11eb-95fe-d8e5efe55f65.png">
