### PR TITLE
ui: fix the namespace flag

### DIFF
--- a/ui-v2/config/environment.js
+++ b/ui-v2/config/environment.js
@@ -138,7 +138,7 @@ module.exports = function (environment, $ = process.env) {
         // returned from `uiTemplateDataFromConfig`.
         CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
         CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
-        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NSpacesEnabled__',
+        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NamespacesEnabled__',
       });
       break;
   }

--- a/ui-v2/node-tests/config/environment.js
+++ b/ui-v2/node-tests/config/environment.js
@@ -11,7 +11,7 @@ test(
         CONSUL_BINARY_TYPE: 'oss',
         CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
         CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
-        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NSpacesEnabled__',
+        CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NamespacesEnabled__',
       },
       {
         environment: 'test',


### PR DESCRIPTION
This file was actually different in ent vs oss, despite supposedly being an oss file. The ent copy was more correct so i've corrected it here.