### PR TITLE
subscribe: add steps to long test cases, and add new cases for converting Events

### DIFF
--- a/agent/rpc/subscribe/subscribe.go
+++ b/agent/rpc/subscribe/subscribe.go
@@ -83,7 +83,7 @@ func (h *Server) Subscribe(req *pbsubscribe.SubscribeRequest, serverStream pbsub
 		}
 
 		elog.Trace(event)
-		e := newEventFromStreamEvent(req, event)
+		e := newEventFromStreamEvent(req.Topic, event)
 		if err := serverStream.Send(e); err != nil {
 			return err
 		}
@@ -139,10 +139,10 @@ func filterByAuth(authz acl.Authorizer, event stream.Event) (stream.Event, bool)
 	return event.Filter(fn)
 }
 
-func newEventFromStreamEvent(req *pbsubscribe.SubscribeRequest, event stream.Event) *pbsubscribe.Event {
+func newEventFromStreamEvent(topic pbsubscribe.Topic, event stream.Event) *pbsubscribe.Event {
 	e := &pbsubscribe.Event{
-		Topic: req.Topic,
-		Key:   req.Key,
+		Topic: topic,
+		Key:   event.Key,
 		Index: event.Index,
 	}
 	switch {

--- a/agent/user_event.go
+++ b/agent/user_event.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-uuid"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 const (


### PR DESCRIPTION
Follow up to #8768

Adds `runStep` to the longer integration tests of the the subscribe rpc endpoint, as suggested by @kyhavlov . This should make the tests easier to read. It should also make them easier to debug when they fail, as the context about what is happening will be part of the test name.

Also adds new test cases for `newEventFromStreamEvent` to resolve a TODO. The convert function for `CheckServiceNode` is already well tested, so these new tests only cover converting the Events.