### PR TITLE
Optionally format stats section of `/agent/self` with types instead of strings

### DIFF
--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -117,22 +117,31 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 func formatJSON(value reflect.Value) reflect.Value {
 	typ := value.Type()
 	switch {
+	// Check if value is a map
 	case typ.Kind() == reflect.Map:
 		m := map[string]interface{}{}
 		for _, k := range value.MapKeys() {
 			mapKey := k.String()
+			// format the map value and put it in the map
 			m[mapKey] = formatJSON(value.MapIndex(k)).Interface()
 		}
 		return reflect.ValueOf(m)
+	// Check if value is a String
 	case typ.Kind() == reflect.String:
+		// Try to convert to int
 		i, ierr := strconv.Atoi(fmt.Sprintf("%v", value))
 		if ierr == nil {
+			// return the integer if conversion succeded
 			return reflect.ValueOf(i)
 		}
+		// Try to convert to bool
 		b, berr := strconv.ParseBool(fmt.Sprintf("%v", value))
 		if berr == nil {
+			// return the boolean if conversion succeded
 			return reflect.ValueOf(b)
 		}
+
+		// default case assume string
 		return reflect.ValueOf(fmt.Sprintf("%v", value))
 	}
 	return value

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -66,6 +66,7 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 		return nil, acl.ErrPermissionDenied
 	}
 
+	// Check if correct type formatting is requested.
 	keys, ok := req.URL.Query()["format"]
 	formatOn := false
 	if ok && keys[0] == "true" {

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -66,6 +66,12 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 		return nil, acl.ErrPermissionDenied
 	}
 
+	keys, ok := req.URL.Query()["format"]
+	formatOn := false
+	if ok && keys[0] == "true" {
+		formatOn = true
+	}
+
 	var cs lib.CoordinateSet
 	if !s.agent.config.DisableCoordinates {
 		var err error
@@ -81,6 +87,12 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 				"envoy": proxysupport.EnvoyVersions,
 			},
 		}
+	}
+	if formatOn == true {
+		// do correct JSON
+		fmt.Sprintln("got Query")
+	} else {
+		// do current JSON
 	}
 
 	test := formatJSON(reflect.ValueOf(s.agent.Stats())).Interface().(map[string]interface{})

--- a/agent/agent_endpoint.go
+++ b/agent/agent_endpoint.go
@@ -35,7 +35,17 @@ type Self struct {
 	DebugConfig map[string]interface{}
 	Coord       *coordinate.Coordinate
 	Member      serf.Member
-	Stats       map[string]map[string]string
+	Stats       map[string]interface{}
+	Meta        map[string]string
+	XDS         *xdsSelf `json:"xDS,omitempty"`
+}
+
+type Self2 struct {
+	Config      interface{}
+	DebugConfig map[string]interface{}
+	Coord       *coordinate.Coordinate
+	Member      serf.Member
+	Stats       map[string]interface{}
 	Meta        map[string]string
 	XDS         *xdsSelf `json:"xDS,omitempty"`
 }
@@ -75,6 +85,7 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 
 	test := formatJSON(reflect.ValueOf(s.agent.Stats())).Interface().(map[string]interface{})
 
+	//test := s.agent.config.Sanitized()
 	fmt.Sprintf("%v", test)
 
 	config := struct {
@@ -97,7 +108,7 @@ func (s *HTTPHandlers) AgentSelf(resp http.ResponseWriter, req *http.Request) (i
 		DebugConfig: s.agent.config.Sanitized(),
 		Coord:       cs[s.agent.config.SegmentName],
 		Member:      s.agent.LocalMember(),
-		Stats:       s.agent.Stats(),
+		Stats:       test,
 		Meta:        s.agent.State.Metadata(),
 		XDS:         xds,
 	}, nil
@@ -114,13 +125,13 @@ func formatJSON(value reflect.Value) reflect.Value {
 		}
 		return reflect.ValueOf(m)
 	case typ.Kind() == reflect.String:
-		b, berr := strconv.ParseBool(fmt.Sprintf("%v", value))
-		if berr == nil {
-			return reflect.ValueOf(b)
-		}
 		i, ierr := strconv.Atoi(fmt.Sprintf("%v", value))
 		if ierr == nil {
 			return reflect.ValueOf(i)
+		}
+		b, berr := strconv.ParseBool(fmt.Sprintf("%v", value))
+		if berr == nil {
+			return reflect.ValueOf(b)
 		}
 		return reflect.ValueOf(fmt.Sprintf("%v", value))
 	}

--- a/website/content/api-docs/agent/index.mdx
+++ b/website/content/api-docs/agent/index.mdx
@@ -105,6 +105,11 @@ The table below shows this endpoint's support for
 | ---------------- | ----------------- | ------------- | ------------ |
 | `NO`             | `none`            | `none`        | `agent:read` |
 
+### Parameters
+
+- `format` `(bool: <optional>)` - If true properly format response payload with types. 
+  This is specified as part of the URL as a query string parameter.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
In response to issue https://github.com/hashicorp/consul/issues/4031

Added an optional query parameter for formatting the stats section of `/agent/self` with types rather than only strings.

**Request**:
`curl -X GET "http://127.0.0.1:8500/v1/agent/self"`

**Response**:
```json
{
  "bootstrap": "false",
  "known_datacenters": "2",
  "leader": "false",
  "leader_addr": "10.37.3.181:8300",
  "server": "true"
}
```

**Request**:
`curl -X GET "http://127.0.0.1:8500/v1/agent/self?format=true"`

**Response**
```json
{
  "bootstrap": false,
  "known_datacenters": 2,
  "leader": false,
  "leader_addr": "10.37.3.181:8300",
  "server": true
}
```