### PR TITLE
Reuse connect.ParseSigner to support all key types

### DIFF
--- a/tlsutil/generate.go
+++ b/tlsutil/generate.go
@@ -164,18 +164,7 @@ func parseCert(pemValue string) (*x509.Certificate, error) {
 // ParseSigner parses a crypto.Signer from a PEM-encoded key. The private key
 // is expected to be the first block in the PEM value.
 func ParseSigner(pemValue string) (crypto.Signer, error) {
-	// The _ result below is not an error but the remaining PEM bytes.
-	block, _ := pem.Decode([]byte(pemValue))
-	if block == nil {
-		return nil, fmt.Errorf("no PEM-encoded data found")
-	}
-
-	switch block.Type {
-	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
-	default:
-		return nil, fmt.Errorf("unknown PEM block type for signing key: %s", block.Type)
-	}
+	return connect.ParseSigner(pemValue)
 }
 
 func Verify(caString, certString, dns string) error {


### PR DESCRIPTION
We have a `pkcs8` root keypair and it cannot be used by `consul tls cert create` because it only accepts keys of `EC PRIVATE KEY` type.

pkcs8 contains key details in its body, `PRIVATE KEY` comment is the same for all key types `RSA`, `EC`, etc.

Here are steps to reproduce:

```bash
openssl ecparam -name prime256v1 -genkey -noout | openssl pkcs8 -topk8 -nocrypt -out ca.key
openssl req -new -key ca.key -x509 -nodes -days 3650 -out ca.crt -subj '/CN=Root CA'

consul tls cert create -ca=ca.crt -key=ca.key -server
==> WARNING: Server Certificates grants authority to become a
    server and access all state in the cluster including root keys
    and all ACL tokens. Do not distribute them to production hosts
    that are not server nodes. Store them as securely as CA keys.
==> Using ca.crt and ca.key
unknown PEM block type for signing key: PRIVATE KEY
```

I simply reused `connect.ParseSigner` just like it's done for keys generation: 
https://github.com/hashicorp/consul/blob/master/tlsutil/generate.go#L31-L33