### PR TITLE
Remove empty partner module sections

### DIFF
--- a/website/pages/docs/nia/installation/requirements.mdx
+++ b/website/pages/docs/nia/installation/requirements.mdx
@@ -74,14 +74,6 @@ Working with a Terraform provider, you can write an integration task for Consul-
 
 The modules listed below are availabe to use and are compatible with Consul-Terraform-Sync.
 
-#### A10
-
-#### Checkpoint
-
-#### Cisco ACI
-
-#### F5
-
 #### Palo Alto Networks
  - Dynamic Address Group (DAG) Tags: [Terraform Registry](https://registry.terraform.io/modules/devarshishah3/dag-nia/panos) / [GitHub](https://github.com/devarshishah3/terraform-panos-ag-dag-nia)
 


### PR DESCRIPTION
For partners that we don’t have Terraform modules from yet, we’ll remove their sections for now and add back as we have links to modules.