### PR TITLE
go-changelog template with ent support

### DIFF
--- a/.changelog/note.tmpl
+++ b/.changelog/note.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{.Body}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/issues/{{- .Issue -}})]
+{{.Body}}{{if not stringHasPrefix .Issue "_"}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/issues/{{- .Issue -}})]{{end}}
 {{- end -}}


### PR DESCRIPTION
This note template won't render the link to the github issue if the filename is prefixed with an underscore `_`. This is useful for enterprise changelog entries. Uses new functionality from https://github.com/hashicorp/go-changelog/pull/4.