### PR TITLE
ui: Upgrade ember-power-select and ember-basic-dropdown

### DIFF
--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -104,7 +104,7 @@
     "ember-named-blocks-polyfill": "^0.2.3",
     "ember-on-helper": "^0.1.0",
     "ember-page-title": "^5.2.3",
-    "ember-power-select": "^4.0.3",
+    "ember-power-select": "^4.0.5",
     "ember-power-select-with-create": "^0.8.0",
     "ember-qunit": "^4.6.0",
     "ember-ref-modifier": "^1.0.0",
@@ -136,6 +136,9 @@
     "tape": "^5.0.1",
     "text-encoding": "^0.7.0",
     "torii": "^0.10.1"
+  },
+  "resolutions": {
+    "ember-basic-dropdown": "^3.0.10"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/ui-v2/yarn.lock
+++ b/ui-v2/yarn.lock
@@ -1452,6 +1452,26 @@
     ember-cli-typescript "3.0.0"
     ember-compatibility-helpers "^1.1.2"
 
+"@glimmer/component@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.2.tgz#679307972d29a849225c13062ab11c779956ff60"
+  integrity sha512-st6YroDjkvUeYWE36NglNG9hXmJOuOI8t44UEp1tufGc4B1L/CTlt1ziQGkaxkhY7/o2r0ZCcWHvf5bpq838YQ==
+  dependencies:
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/util" "^0.44.0"
+    broccoli-file-creator "^2.1.1"
+    broccoli-merge-trees "^3.0.2"
+    ember-cli-babel "^7.7.3"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "3.0.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-compatibility-helpers "^1.1.2"
+
 "@glimmer/di@^0.1.9":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
@@ -5545,19 +5565,19 @@ ember-auto-import@^1.2.13, ember-auto-import@^1.5.2, ember-auto-import@^1.5.3:
     walk-sync "^0.3.3"
     webpack "~4.28"
 
-ember-basic-dropdown@^3.0.3:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.6.tgz#31c6f959864a03093800a265890f3c9db9fc30d7"
-  integrity sha512-2lUp/EZTTceRytDTtTuEg53i9fUYBfTq/ty4NlnF9EkQS1Shz98VNL3FOkFjvSzPyLG9/26tkmtqLBXmja43ug==
+ember-basic-dropdown@^3.0.10, ember-basic-dropdown@^3.0.3:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/ember-basic-dropdown/-/ember-basic-dropdown-3.0.10.tgz#47ed9fe9ff9e69d1a021771a91823c730985ffe0"
+  integrity sha512-TabEKUIlLPQLZqyXx1N8M/tDhrf/2meXjK2mNw6RfiOvwMHYJ41MwIhJusnlQd/Rn7cL0MbA+EGCnjdI0HhB/w==
   dependencies:
     "@ember/render-modifiers" "^1.0.2"
-    "@glimmer/component" "^1.0.0"
-    "@glimmer/tracking" "^1.0.0"
-    ember-cli-babel "^7.13.0"
-    ember-cli-htmlbars "^4.2.0"
+    "@glimmer/component" "^1.0.1"
+    "@glimmer/tracking" "^1.0.1"
+    ember-cli-babel "^7.21.0"
+    ember-cli-htmlbars "^5.2.0"
     ember-cli-typescript "^3.1.2"
     ember-element-helper "^0.2.0"
-    ember-maybe-in-element "^0.4.0"
+    ember-maybe-in-element "^2.0.1"
     ember-truth-helpers "2.1.0"
 
 ember-changeset-conditional-validations@^0.6.0:
@@ -6222,6 +6242,15 @@ ember-concurrency-decorators@^2.0.0:
     ember-cli-htmlbars "^4.3.1"
     ember-cli-typescript "^3.1.4"
 
+"ember-concurrency@>=1.0.0 <3":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.3.0.tgz#66f90fb792687470bcee1172adc0ebf33f5e8b9c"
+  integrity sha512-DwGlfWFpYyAkTwsedlEtK4t1DznJSculAW6Vq5S1C0shVPc5b6tTpHB2FFYisannSYkm+wpm1f1Pd40qiNPtOQ==
+  dependencies:
+    ember-cli-babel "^7.7.3"
+    ember-compatibility-helpers "^1.2.0"
+    ember-maybe-import-regenerator "^0.1.6"
+
 ember-concurrency@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-1.2.1.tgz#54fb234579638c5c43d4153a4e14567fe2b2e325"
@@ -6378,6 +6407,16 @@ ember-maybe-in-element@^0.4.0:
   dependencies:
     ember-cli-babel "^7.1.0"
 
+ember-maybe-in-element@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-2.0.1.tgz#fa3a26cc2c522a27129d6528b400b9c820943be6"
+  integrity sha512-Mp/HTVOGu9H7kWoq5xncVLEvPFgRuHdsqWyZ1v/gBA8Y3d2q2LdrmDK9Zg59i+cCs4oa9LrMeFyKMAbBS3vyDw==
+  dependencies:
+    ember-cli-babel "^7.21.0"
+    ember-cli-htmlbars "^5.2.0"
+    ember-cli-version-checker "^5.1.1"
+    ember-in-element-polyfill "^1.0.0"
+
 ember-modifier-manager-polyfill@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
@@ -6430,7 +6469,7 @@ ember-power-select-with-create@^0.8.0:
     ember-cli-htmlbars "^5.0.0"
     ember-power-select "^4.0.0"
 
-ember-power-select@^4.0.0, ember-power-select@^4.0.3:
+ember-power-select@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-4.0.3.tgz#73a98154abf9c5c19c11cdae98294a94d082b381"
   integrity sha512-WkMq2eLUgq3oBW/6lxBS5u0oBu8sh9Y0ACgMPe2hP3YmZKnfXCuUzV2QrttbeNnxehmyiXKAleuev7J4BvObdA==
@@ -6444,6 +6483,24 @@ ember-power-select@^4.0.0, ember-power-select@^4.0.3:
     ember-cli-htmlbars "^5.2.0"
     ember-cli-typescript "^3.1.4"
     ember-concurrency "^1.2.1"
+    ember-concurrency-decorators "^2.0.0"
+    ember-text-measurer "^0.6.0"
+    ember-truth-helpers "^2.1.0"
+
+ember-power-select@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-4.0.5.tgz#7a018c102792e070b2f8cddff63ce3264b796dec"
+  integrity sha512-57diMZJ2887u6VNS0rT1ppBGppocZ7WhH37ZdZnSdmApCLUnloLNFA4H9YH1VWV2V62I5/18jViRBEFJxVUUKQ==
+  dependencies:
+    "@ember-decorators/component" "^6.1.0"
+    "@glimmer/component" "^1.0.1"
+    "@glimmer/tracking" "^1.0.0"
+    ember-assign-helper "^0.3.0"
+    ember-basic-dropdown "^3.0.10"
+    ember-cli-babel "^7.21.0"
+    ember-cli-htmlbars "^5.2.0"
+    ember-cli-typescript "^3.1.4"
+    ember-concurrency ">=1.0.0 <3"
     ember-concurrency-decorators "^2.0.0"
     ember-text-measurer "^0.6.0"
     ember-truth-helpers "^2.1.0"


### PR DESCRIPTION
This removes some {{-in-element}} deprecation errors.

`ember-basic-dropdown` is causing the errors, which is pulled in via `ember-power-select`, updating the later doens't fix the errors, so we've temporarily used resolutions to bump the former. Both upgrades are patch releases so should be fairly ok.