### PR TITLE
Include integration docs for NIA with consul-terraform-sync label

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -34,6 +34,7 @@ theme/connect:
 # theme/consul-nomad:
 theme/consul-terraform-sync:
     - website/pages/docs/nia/**/*
+    - website/pages/docs/integrate/nia*
 # theme/consul-vault:
 theme/contributing:
     - .github/**/*


### PR DESCRIPTION
There's another docs page related to NIA `website/pages/docs/integrate/nia-integration.mdx`. This PR includes it to the bot labler. 

Related context: https://github.com/hashicorp/consul/pull/8925