### PR TITLE
ui: Metrics provider - Throw generated xhr errors

### DIFF
--- a/ui-v2/app/components/topology-metrics/series/index.hbs
+++ b/ui-v2/app/components/topology-metrics/series/index.hbs
@@ -4,14 +4,16 @@
   @onerror={{action (mut error) value="error"}}
 />
 
-{{#if (not error)}}
   {{on-window 'resize' (action 'redraw')}}
   <div class="sparkline-wrapper">
     <div class="tooltip">
       <div class="sparkline-time">Timestamp</div>
     </div>
-      <div class="sparkline-loader"><span>Loading Metrics</span></div>
+{{#if error}}
+    <div class="sparkline-error">Unable to load Metrics</div>
+{{else}}
+    <div class="sparkline-loader"><span>Loading Metrics</span></div>
     <svg class="sparkline"></svg>
-  </div>
 {{/if}}
+  </div>
 

--- a/ui-v2/app/components/topology-metrics/series/index.hbs
+++ b/ui-v2/app/components/topology-metrics/series/index.hbs
@@ -1,14 +1,17 @@
 <DataSource
   @src={{uri nspace dc 'metrics' 'summary-for-service' @service @protocol}}
-  @onchange={{action 'change'}} />
+  @onchange={{action 'change'}}
+  @onerror={{action (mut error) value="error"}}
+/>
 
-{{on-window 'resize' (action 'redraw')}}
-
-<div class="sparkline-wrapper">
-  <div class="tooltip">
-    <div class="sparkline-time">Timestamp</div>
+{{#if (not error)}}
+  {{on-window 'resize' (action 'redraw')}}
+  <div class="sparkline-wrapper">
+    <div class="tooltip">
+      <div class="sparkline-time">Timestamp</div>
+    </div>
+      <div class="sparkline-loader"><span>Loading Metrics</span></div>
+    <svg class="sparkline"></svg>
   </div>
-  <div class="sparkline-loader"><span>Loading Metrics</span></div>
-  <svg class="sparkline"></svg>
-</div>
+{{/if}}
 

--- a/ui-v2/app/components/topology-metrics/series/layout.scss
+++ b/ui-v2/app/components/topology-metrics/series/layout.scss
@@ -24,16 +24,17 @@
     display: inline-block;
   }
 
-  div.sparkline-loader {
+  .sparkline-error,
+  .sparkline-loader {
     font-weight: normal;
     padding-top: 15px;
     font-size: 0.875rem;
     color: $gray-500;
     text-align: center;
 
-    span::after {
-      @extend %with-loading-icon, %as-pseudo;
-    }
+  }
+  .sparkline-loader span::after {
+    @extend %with-loading-icon, %as-pseudo;
   }
 }
 

--- a/ui-v2/app/components/topology-metrics/stats/index.hbs
+++ b/ui-v2/app/components/topology-metrics/stats/index.hbs
@@ -1,6 +1,7 @@
 <DataSource
   @src={{uri nspace dc 'metrics' @endpoint @service @protocol}}
   @onchange={{action 'statsUpdate'}}
+  @onerror={{action (mut error) value="error"}}
 />
 
 <div class="stats">
@@ -18,6 +19,8 @@
     {{else}}
       <span>No Metrics Available</span>
     {{/each}}
+  {{else if error}}
+    <span>Unable to load Metrics</span>
   {{else}}
     <span class="loader">Loading Metrics</span>
   {{/if}}

--- a/ui-v2/app/utils/dom/event-source/blocking.js
+++ b/ui-v2/app/utils/dom/event-source/blocking.js
@@ -7,8 +7,11 @@ const pause = 2000;
 export const createErrorBackoff = function(ms = 3000, P = Promise, wait = setTimeout) {
   // This expects an ember-data like error
   return function(err) {
-    const status = get(err, 'errors.firstObject.status');
+    // expect and ember-data error or a http-like error (e.statusCode)
+    let status = get(err, 'errors.firstObject.status') || get(err, 'statusCode');
     if (typeof status !== 'undefined') {
+      // ember-data errors are strings, http errors are numbers
+      status = status.toString();
       switch (true) {
         // Any '5xx' (not 500) errors should back off and try again
         case status.indexOf('5') === 0 && status.length === 3 && status !== '500':

--- a/ui-v2/package.json
+++ b/ui-v2/package.json
@@ -15,7 +15,7 @@
     "lint:dev:js": "eslint -c .dev.eslintrc.js --fix ./*.js ./.*.js app config lib server tests",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
-    "format:js": "prettier --write \"{app,config,lib,server,tests}/**/*.js\" ./*.js ./.*.js",
+    "format:js": "prettier --write \"{app,config,lib,server,vendor,tests}/**/*.js\" ./*.js ./.*.js",
     "format:css": "prettier --write \"app/styles/**/*.*\"",
     "start": "ember serve --port=${EMBER_SERVE_PORT:-4200} --live-reload-port=${EMBER_LIVE_RELOAD_PORT:-7020}",
     "start:staging": "ember serve --port=${EMBER_SERVE_PORT:-4200} --live-reload-port=${EMBER_LIVE_RELOAD_PORT:-7020} --environment staging",

--- a/ui-v2/tests/unit/utils/dom/event-source/blocking-test.js
+++ b/ui-v2/tests/unit/utils/dom/event-source/blocking-test.js
@@ -51,8 +51,8 @@ module('Unit | Utility | dom/event-source/blocking', function() {
       undefined,
       null,
       new Error(),
+      { statusCode: 404 },
       { errors: [] },
-      { errors: [{ status: 501 }] },
       { errors: [{ status: '401' }] },
       { errors: [{ status: '500' }] },
       { errors: [{ status: '5' }] },
@@ -67,6 +67,8 @@ module('Unit | Utility | dom/event-source/blocking', function() {
   });
   test('the 5xx backoff returns a resolve promise on a 5xx (apart from 500)', function(assert) {
     [
+      { statusCode: 501 },
+      { errors: [{ status: 501 }] },
       { errors: [{ status: '501' }] },
       { errors: [{ status: '503' }] },
       { errors: [{ status: '504' }] },

--- a/ui-v2/vendor/metrics-providers/consul.js
+++ b/ui-v2/vendor/metrics-providers/consul.js
@@ -1,51 +1,47 @@
-(
-  function(global) {
-    // Current interface is these three methods.
-    const requiredMethods = [
-      'init',
-      'serviceRecentSummarySeries',
-      'serviceRecentSummaryStats',
-      'upstreamRecentSummaryStats',
-      'downstreamRecentSummaryStats',
-    ];
+(function(global) {
+  // Current interface is these three methods.
+  const requiredMethods = [
+    'init',
+    'serviceRecentSummarySeries',
+    'serviceRecentSummaryStats',
+    'upstreamRecentSummaryStats',
+    'downstreamRecentSummaryStats',
+  ];
 
-    // This is a bit gross but we want to support simple extensibility by
-    // including JS in the browser without forcing operators to setup a whole
-    // transpiling stack. So for now we use a window global as a thin registry for
-    // these providers.
-    class Consul {
-      constructor() {
-        this.registry = {};
-        this.providers = {};
-      }
-
-      registerMetricsProvider(name, provider) {
-        // Basic check that it matches the type we expect
-        for (var m of requiredMethods) {
-          if (typeof provider[m] !== 'function') {
-            throw new Error(`Can't register metrics provider '${name}': missing ${m} method.`);
-          }
-        }
-        this.registry[name] = provider;
-      }
-
-      getMetricsProvider(name, options) {
-        if (!(name in this.registry)) {
-          throw new Error(`Metrics Provider '${name}' is not registered.`);
-        }
-        if (name in this.providers) {
-          return this.providers[name];
-        }
-
-        this.providers[name] = Object.create(this.registry[name]);
-        this.providers[name].init(options);
-
-        return this.providers[name];
-      }
+  // This is a bit gross but we want to support simple extensibility by
+  // including JS in the browser without forcing operators to setup a whole
+  // transpiling stack. So for now we use a window global as a thin registry for
+  // these providers.
+  class Consul {
+    constructor() {
+      this.registry = {};
+      this.providers = {};
     }
 
-    global.consul = new Consul();
+    registerMetricsProvider(name, provider) {
+      // Basic check that it matches the type we expect
+      for (var m of requiredMethods) {
+        if (typeof provider[m] !== 'function') {
+          throw new Error(`Can't register metrics provider '${name}': missing ${m} method.`);
+        }
+      }
+      this.registry[name] = provider;
+    }
 
+    getMetricsProvider(name, options) {
+      if (!(name in this.registry)) {
+        throw new Error(`Metrics Provider '${name}' is not registered.`);
+      }
+      if (name in this.providers) {
+        return this.providers[name];
+      }
+
+      this.providers[name] = Object.create(this.registry[name]);
+      this.providers[name].init(options);
+
+      return this.providers[name];
+    }
   }
-)(window);
 
+  global.consul = new Consul();
+})(window);

--- a/ui-v2/vendor/metrics-providers/prometheus.js
+++ b/ui-v2/vendor/metrics-providers/prometheus.js
@@ -1,5 +1,5 @@
 /*eslint no-console: "off"*/
-(function () {
+(function() {
   var prometheusProvider = {
     options: {},
 
@@ -52,46 +52,45 @@
      */
     serviceRecentSummarySeries: function(serviceName, protocol, options) {
       // Fetch time-series
-      var series = []
-      var labels = []
+      var series = [];
+      var labels = [];
 
       // Set the start and end range here so that all queries end up with
       // identical time axes. Later we might accept these as options.
-      var now = (new Date()).getTime()/1000;
-      options.start = now - (15*60);
+      var now = new Date().getTime() / 1000;
+      options.start = now - 15 * 60;
       options.end = now;
 
       if (this.hasL7Metrics(protocol)) {
-        series.push(this.fetchRequestRateSeries(serviceName, options))
-        labels.push("Requests per second")
-        series.push(this.fetchErrorRateSeries(serviceName, options))
-        labels.push("Errors per second")
+        series.push(this.fetchRequestRateSeries(serviceName, options));
+        labels.push('Requests per second');
+        series.push(this.fetchErrorRateSeries(serviceName, options));
+        labels.push('Errors per second');
       } else {
         // Fallback to just L4 metrics.
-        series.push(this.fetchServiceRxSeries(serviceName, options))
-        labels.push("Data rate received")
-        series.push(this.fetchServiceTxSeries(serviceName, options))
-        labels.push("Data rate transmitted")
+        series.push(this.fetchServiceRxSeries(serviceName, options));
+        labels.push('Data rate received');
+        series.push(this.fetchServiceTxSeries(serviceName, options));
+        labels.push('Data rate transmitted');
       }
 
-      var all = Promise.allSettled(series).
-        then(function(results){
-        var data = { series: [] }
+      var all = Promise.allSettled(series).then(function(results) {
+        var data = { series: [] };
         for (var i = 0; i < series.length; i++) {
           if (results[i].value) {
             data.series.push({
               label: labels[i],
-              data: results[i].value
+              data: results[i].value,
             });
           } else if (results[i].reason) {
-            console.log("ERROR processing series", labels[i], results[i].reason)
+            console.log('ERROR processing series', labels[i], results[i].reason);
           }
         }
-        return data
-      })
+        return data;
+      });
 
       // Fetch the metrics async, and return a promise to the result.
-      return all
+      return all;
     },
 
     /**
@@ -129,18 +128,18 @@
       // Fetch stats
       var stats = [];
       if (this.hasL7Metrics(protocol)) {
-        stats.push(this.fetchRPS(serviceName, "service", options))
-        stats.push(this.fetchER(serviceName, "service", options))
-        stats.push(this.fetchPercentile(50, serviceName, "service", options))
-        stats.push(this.fetchPercentile(99, serviceName, "service", options))
+        stats.push(this.fetchRPS(serviceName, 'service', options));
+        stats.push(this.fetchER(serviceName, 'service', options));
+        stats.push(this.fetchPercentile(50, serviceName, 'service', options));
+        stats.push(this.fetchPercentile(99, serviceName, 'service', options));
       } else {
         // Fallback to just L4 metrics.
-        stats.push(this.fetchConnRate(serviceName, "service", options))
-        stats.push(this.fetchServiceRx(serviceName, "service", options))
-        stats.push(this.fetchServiceTx(serviceName, "service", options))
-        stats.push(this.fetchServiceNoRoute(serviceName, "service", options))
+        stats.push(this.fetchConnRate(serviceName, 'service', options));
+        stats.push(this.fetchServiceRx(serviceName, 'service', options));
+        stats.push(this.fetchServiceTx(serviceName, 'service', options));
+        stats.push(this.fetchServiceNoRoute(serviceName, 'service', options));
       }
-      return this.fetchStats(stats)
+      return this.fetchStats(stats);
     },
 
     /**
@@ -170,7 +169,7 @@
      *   }
      */
     upstreamRecentSummaryStats: function(serviceName, upstreamName, options) {
-      return this.fetchRecentSummaryStats(serviceName, "upstream", options)
+      return this.fetchRecentSummaryStats(serviceName, 'upstream', options);
     },
 
     /**
@@ -200,7 +199,7 @@
      *   }
      */
     downstreamRecentSummaryStats: function(serviceName, options) {
-      return this.fetchRecentSummaryStats(serviceName, "downstream", options)
+      return this.fetchRecentSummaryStats(serviceName, 'downstream', options);
     },
 
     fetchRecentSummaryStats: function(serviceName, type, options) {
@@ -210,386 +209,395 @@
       // We don't know which upstreams are HTTP/TCP so just fetch all of them.
 
       // HTTP
-      stats.push(this.fetchRPS(serviceName, type, options))
-      stats.push(this.fetchER(serviceName, type, options))
-      stats.push(this.fetchPercentile(50, serviceName, type, options))
-      stats.push(this.fetchPercentile(99, serviceName, type, options))
+      stats.push(this.fetchRPS(serviceName, type, options));
+      stats.push(this.fetchER(serviceName, type, options));
+      stats.push(this.fetchPercentile(50, serviceName, type, options));
+      stats.push(this.fetchPercentile(99, serviceName, type, options));
 
       // L4
-      stats.push(this.fetchConnRate(serviceName, type, options))
-      stats.push(this.fetchServiceRx(serviceName, type, options))
-      stats.push(this.fetchServiceTx(serviceName, type, options))
-      stats.push(this.fetchServiceNoRoute(serviceName, type, options))
+      stats.push(this.fetchConnRate(serviceName, type, options));
+      stats.push(this.fetchServiceRx(serviceName, type, options));
+      stats.push(this.fetchServiceTx(serviceName, type, options));
+      stats.push(this.fetchServiceNoRoute(serviceName, type, options));
 
-      return this.fetchStatsGrouped(stats)
+      return this.fetchStatsGrouped(stats);
     },
 
     hasL7Metrics: function(protocol) {
-      return protocol === "http" || protocol === "http2" || protocol === "grpc"
+      return protocol === 'http' || protocol === 'http2' || protocol === 'grpc';
     },
 
     fetchStats: function(statsPromises) {
-      var all = Promise.allSettled(statsPromises).
-        then(function(results){
+      var all = Promise.allSettled(statsPromises).then(function(results) {
         var data = {
-          stats: []
-        }
+          stats: [],
+        };
         // Add all non-empty stats
         for (var i = 0; i < statsPromises.length; i++) {
           if (results[i].value) {
             data.stats.push(results[i].value);
           } else if (results[i].reason) {
-            console.log("ERROR processing stat", results[i].reason)
+            console.log('ERROR processing stat', results[i].reason);
           }
         }
-        return data
-      })
+        return data;
+      });
 
       // Fetch the metrics async, and return a promise to the result.
-      return all
+      return all;
     },
 
     fetchStatsGrouped: function(statsPromises) {
-      var all = Promise.allSettled(statsPromises).
-        then(function(results){
+      var all = Promise.allSettled(statsPromises).then(function(results) {
         var data = {
-          stats: {}
-        }
+          stats: {},
+        };
         // Add all non-empty stats
         for (var i = 0; i < statsPromises.length; i++) {
           if (results[i].value) {
             for (var group in results[i].value) {
               if (!results[i].value.hasOwnProperty(group)) continue;
               if (!data.stats[group]) {
-                data.stats[group] = []
+                data.stats[group] = [];
               }
-              data.stats[group].push(results[i].value[group])
+              data.stats[group].push(results[i].value[group]);
             }
           } else if (results[i].reason) {
-            console.log("ERROR processing stat", results[i].reason)
+            console.log('ERROR processing stat', results[i].reason);
           }
         }
-        return data
-      })
+        return data;
+      });
 
       // Fetch the metrics async, and return a promise to the result.
-      return all
+      return all;
     },
 
     reformatSeries: function(response) {
       // Handle empty results from prometheus.
-      if (!response || !response.data || !response.data.result
-        || response.data.result.length < 1) {
+      if (!response || !response.data || !response.data.result || response.data.result.length < 1) {
         return [];
       }
       // Reformat the prometheus data to be the format we want which is
       // essentially the same but with Date objects instead of unix timestamps.
-      return response.data.result[0].values.map(function(val){
-        return [new Date(val[0]*1000), parseFloat(val[1])]
-      })
+      return response.data.result[0].values.map(function(val) {
+        return [new Date(val[0] * 1000), parseFloat(val[1])];
+      });
     },
 
-    fetchRequestRateSeries: function(serviceName, options){
-      var q = `sum(irate(envoy_listener_http_downstream_rq_xx{local_cluster="${serviceName}",envoy_http_conn_manager_prefix="public_listener_http"}[10m]))`
-      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr){
+    fetchRequestRateSeries: function(serviceName, options) {
+      var q = `sum(irate(envoy_listener_http_downstream_rq_xx{local_cluster="${serviceName}",envoy_http_conn_manager_prefix="public_listener_http"}[10m]))`;
+      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr) {
         // Failure. log to console and return an blank result for now.
-        console.log("ERROR: failed to fetch requestRate", xhr.responseText)
-        return []
-      })
+        console.log('ERROR: failed to fetch requestRate', xhr.responseText);
+        return [];
+      });
     },
 
-    fetchErrorRateSeries: function(serviceName, options){
+    fetchErrorRateSeries: function(serviceName, options) {
       // 100 * to get a result in percent
-      var q = `sum(`+
-          `irate(envoy_listener_http_downstream_rq_xx{`+
-            `local_cluster="${serviceName}",`+
-            `envoy_http_conn_manager_prefix="public_listener_http",`+
-            `envoy_response_code_class="5"}[10m]`+
-          `)`+
+      var q =
+        `sum(` +
+        `irate(envoy_listener_http_downstream_rq_xx{` +
+        `local_cluster="${serviceName}",` +
+        `envoy_http_conn_manager_prefix="public_listener_http",` +
+        `envoy_response_code_class="5"}[10m]` +
+        `)` +
         `)`;
-      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr){
+      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr) {
         // Failure. log to console and return an blank result for now.
-        console.log("ERROR: failed to fetch errorRate", xhr.responseText)
-        return []
-      })
+        console.log('ERROR: failed to fetch errorRate', xhr.responseText);
+        return [];
+      });
     },
 
-    fetchServiceRxSeries: function(serviceName, options){
-      var q = `8 * sum(irate(envoy_tcp_downstream_cx_rx_bytes_total{local_cluster="${serviceName}", envoy_tcp_prefix="public_listener_tcp"}[10m]))`
-      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr){
+    fetchServiceRxSeries: function(serviceName, options) {
+      var q = `8 * sum(irate(envoy_tcp_downstream_cx_rx_bytes_total{local_cluster="${serviceName}", envoy_tcp_prefix="public_listener_tcp"}[10m]))`;
+      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr) {
         // Failure. log to console and return an blank result for now.
-        console.log("ERROR: failed to fetch rx data rate", xhr.responseText)
-        return []
-      })
+        console.log('ERROR: failed to fetch rx data rate', xhr.responseText);
+        return [];
+      });
     },
 
-    fetchServiceTxSeries: function(serviceName, options){
-      var q = `8 * sum(irate(envoy_tcp_downstream_cx_tx_bytes_total{local_cluster="${serviceName}", envoy_tcp_prefix="public_listener_tcp"}[10m]))`
-      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr){
+    fetchServiceTxSeries: function(serviceName, options) {
+      var q = `8 * sum(irate(envoy_tcp_downstream_cx_tx_bytes_total{local_cluster="${serviceName}", envoy_tcp_prefix="public_listener_tcp"}[10m]))`;
+      return this.fetchSeries(q, options).then(this.reformatSeries, function(xhr) {
         // Failure. log to console and return an blank result for now.
-        console.log("ERROR: failed to fetch tx data rate", xhr.responseText)
-        return []
-      })
+        console.log('ERROR: failed to fetch tx data rate', xhr.responseText);
+        return [];
+      });
     },
 
     makeSubject: function(serviceName, type) {
-      if (type == "upstream") {
+      if (type == 'upstream') {
         // {{GROUP}} is a placeholder that is replaced by the upstream name
         return `${serviceName} &rarr; {{GROUP}}`;
       }
-      if (type == "downstream") {
+      if (type == 'downstream') {
         // {{GROUP}} is a placeholder that is replaced by the downstream name
         return `{{GROUP}} &rarr; ${serviceName}`;
       }
-      return serviceName
+      return serviceName;
     },
 
     makeHTTPSelector: function(serviceName, type) {
       // Downstreams are totally different
-      if (type == "downstream") {
-        return `consul_service="${serviceName}"`
+      if (type == 'downstream') {
+        return `consul_service="${serviceName}"`;
       }
-      var lc = `local_cluster="${serviceName}"`
-      if (type == "upstream") {
+      var lc = `local_cluster="${serviceName}"`;
+      if (type == 'upstream') {
         lc += `,envoy_http_conn_manager_prefix=~"upstream_.*"`;
       } else {
         // Only care about inbound public listener
-        lc += `,envoy_http_conn_manager_prefix="public_listener_http"`
+        lc += `,envoy_http_conn_manager_prefix="public_listener_http"`;
       }
-      return lc
+      return lc;
     },
 
     makeTCPSelector: function(serviceName, type) {
       // Downstreams are totally different
-      if (type == "downstream") {
-        return `consul_service="${serviceName}"`
+      if (type == 'downstream') {
+        return `consul_service="${serviceName}"`;
       }
-      var lc = `local_cluster="${serviceName}"`
-      if (type == "upstream") {
+      var lc = `local_cluster="${serviceName}"`;
+      if (type == 'upstream') {
         lc += `,envoy_tcp_prefix=~"upstream_.*"`;
       } else {
         // Only care about inbound public listener
-        lc += `,envoy_tcp_prefix="public_listener_tcp"`
+        lc += `,envoy_tcp_prefix="public_listener_tcp"`;
       }
-      return lc
+      return lc;
     },
 
     groupQueryHTTP: function(type, q) {
-      if (type == "upstream") {
-        q += " by (envoy_http_conn_manager_prefix)"
+      if (type == 'upstream') {
+        q += ' by (envoy_http_conn_manager_prefix)';
         // Extract the raw upstream service name to group results by
-        q = this.upstreamRelabelQueryHTTP(q)
-      } else if (type == "downstream") {
-        q += " by (local_cluster)"
-        q = this.downstreamRelabelQuery(q)
+        q = this.upstreamRelabelQueryHTTP(q);
+      } else if (type == 'downstream') {
+        q += ' by (local_cluster)';
+        q = this.downstreamRelabelQuery(q);
       }
-      return q
+      return q;
     },
 
     groupQueryTCP: function(type, q) {
-      if (type == "upstream") {
-        q += " by (envoy_tcp_prefix)"
+      if (type == 'upstream') {
+        q += ' by (envoy_tcp_prefix)';
         // Extract the raw upstream service name to group results by
-        q = this.upstreamRelabelQueryTCP(q)
-      } else if (type == "downstream") {
-        q += " by (local_cluster)"
-        q = this.downstreamRelabelQuery(q)
+        q = this.upstreamRelabelQueryTCP(q);
+      } else if (type == 'downstream') {
+        q += ' by (local_cluster)';
+        q = this.downstreamRelabelQuery(q);
       }
-      return q
+      return q;
     },
 
     upstreamRelabelQueryHTTP: function(q) {
-      return `label_replace(${q}, "upstream", "$1", "envoy_http_conn_manager_prefix", "upstream_(.*)_http")`
+      return `label_replace(${q}, "upstream", "$1", "envoy_http_conn_manager_prefix", "upstream_(.*)_http")`;
     },
 
     upstreamRelabelQueryTCP: function(q) {
-      return `label_replace(${q}, "upstream", "$1", "envoy_tcp_prefix", "upstream_(.*)_tcp")`
+      return `label_replace(${q}, "upstream", "$1", "envoy_tcp_prefix", "upstream_(.*)_tcp")`;
     },
 
     downstreamRelabelQuery: function(q) {
-      return `label_replace(${q}, "downstream", "$1", "local_cluster", "(.*)")`
+      return `label_replace(${q}, "downstream", "$1", "local_cluster", "(.*)")`;
     },
 
     groupBy: function(type) {
-      if (type == "service") {
-        return false
+      if (type == 'service') {
+        return false;
       }
       return type;
     },
 
     metricPrefixHTTP: function(type) {
-      if (type == "downstream") {
-        return "envoy_cluster_upstream_rq"
+      if (type == 'downstream') {
+        return 'envoy_cluster_upstream_rq';
       }
-      return "envoy_http_downstream_rq";
+      return 'envoy_http_downstream_rq';
     },
 
     metricPrefixTCP: function(type) {
-      if (type == "downstream") {
-        return "envoy_cluster_upstream_cx"
+      if (type == 'downstream') {
+        return 'envoy_cluster_upstream_cx';
       }
-      return "envoy_tcp_downstream_cx";
+      return 'envoy_tcp_downstream_cx';
     },
 
-    fetchRPS: function(serviceName, type, options){
-      var sel = this.makeHTTPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var metricPfx = this.metricPrefixHTTP(type)
-      var q = `sum(rate(${metricPfx}_completed{${sel}}[15m]))`
-      return this.fetchStat(this.groupQueryHTTP(type, q),
-        "RPS",
+    fetchRPS: function(serviceName, type, options) {
+      var sel = this.makeHTTPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var metricPfx = this.metricPrefixHTTP(type);
+      var q = `sum(rate(${metricPfx}_completed{${sel}}[15m]))`;
+      return this.fetchStat(
+        this.groupQueryHTTP(type, q),
+        'RPS',
         `<b>${subject}</b> request rate averaged over the last 15 minutes`,
         shortNumStr,
         this.groupBy(type)
-        )
+      );
     },
 
-    fetchER: function(serviceName, type, options){
-      var sel = this.makeHTTPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var groupBy = ""
-      if (type == "upstream") {
-        groupBy += " by (envoy_http_conn_manager_prefix)"
-      } else if (type == "downstream") {
-        groupBy += " by (local_cluster)"
+    fetchER: function(serviceName, type, options) {
+      var sel = this.makeHTTPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var groupBy = '';
+      if (type == 'upstream') {
+        groupBy += ' by (envoy_http_conn_manager_prefix)';
+      } else if (type == 'downstream') {
+        groupBy += ' by (local_cluster)';
       }
-      var metricPfx = this.metricPrefixHTTP(type)
-      var q = `sum(rate(${metricPfx}_xx{${sel},envoy_response_code_class="5"}[15m]))${groupBy}/sum(rate(${metricPfx}_xx{${sel}}[15m]))${groupBy}`
-      if (type == "upstream") {
-        q = this.upstreamRelabelQueryHTTP(q)
-      } else if (type == "downstream") {
-        q = this.downstreamRelabelQuery(q)
+      var metricPfx = this.metricPrefixHTTP(type);
+      var q = `sum(rate(${metricPfx}_xx{${sel},envoy_response_code_class="5"}[15m]))${groupBy}/sum(rate(${metricPfx}_xx{${sel}}[15m]))${groupBy}`;
+      if (type == 'upstream') {
+        q = this.upstreamRelabelQueryHTTP(q);
+      } else if (type == 'downstream') {
+        q = this.downstreamRelabelQuery(q);
       }
-      return this.fetchStat(q,
-        "ER",
+      return this.fetchStat(
+        q,
+        'ER',
         `Percentage of <b>${subject}</b> requests which were 5xx status over the last 15 minutes`,
-        function(val){
-          return shortNumStr(val)+"%"
+        function(val) {
+          return shortNumStr(val) + '%';
         },
         this.groupBy(type)
-        )
+      );
     },
 
-    fetchPercentile: function(percentile, serviceName, type, options){
-      var sel = this.makeHTTPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var groupBy = "le"
-      if (type == "upstream") {
-        groupBy += ",envoy_http_conn_manager_prefix"
-      } else if (type == "downstream") {
-        groupBy += ",local_cluster"
+    fetchPercentile: function(percentile, serviceName, type, options) {
+      var sel = this.makeHTTPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var groupBy = 'le';
+      if (type == 'upstream') {
+        groupBy += ',envoy_http_conn_manager_prefix';
+      } else if (type == 'downstream') {
+        groupBy += ',local_cluster';
       }
-      var metricPfx = this.metricPrefixHTTP(type)
-      var q = `histogram_quantile(${percentile/100}, sum by(${groupBy}) (rate(${metricPfx}_time_bucket{${sel}}[15m])))`
-      if (type == "upstream") {
-        q = this.upstreamRelabelQueryHTTP(q)
-      } else if (type == "downstream") {
-        q = this.downstreamRelabelQuery(q)
+      var metricPfx = this.metricPrefixHTTP(type);
+      var q = `histogram_quantile(${percentile /
+        100}, sum by(${groupBy}) (rate(${metricPfx}_time_bucket{${sel}}[15m])))`;
+      if (type == 'upstream') {
+        q = this.upstreamRelabelQueryHTTP(q);
+      } else if (type == 'downstream') {
+        q = this.downstreamRelabelQuery(q);
       }
-      return this.fetchStat(q,
+      return this.fetchStat(
+        q,
         `P${percentile}`,
         `<b>${subject}</b> ${percentile}th percentile request service time over the last 15 minutes`,
         shortTimeStr,
         this.groupBy(type)
-        )
+      );
     },
 
     fetchConnRate: function(serviceName, type, options) {
-      var sel = this.makeTCPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var metricPfx = this.metricPrefixTCP(type)
-      var q = `sum(rate(${metricPfx}_total{${sel}}[15m]))`
-      return this.fetchStat(this.groupQueryTCP(type, q),
-        "CR",
+      var sel = this.makeTCPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var metricPfx = this.metricPrefixTCP(type);
+      var q = `sum(rate(${metricPfx}_total{${sel}}[15m]))`;
+      return this.fetchStat(
+        this.groupQueryTCP(type, q),
+        'CR',
         `<b>${subject}</b> inbound TCP connections per second averaged over the last 15 minutes`,
         shortNumStr,
         this.groupBy(type)
-        )
+      );
     },
 
     fetchServiceRx: function(serviceName, type, options) {
-      var sel = this.makeTCPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var metricPfx = this.metricPrefixTCP(type)
-      var q = `8 * sum(rate(${metricPfx}_rx_bytes_total{${sel}}[15m]))`
-      return this.fetchStat(this.groupQueryTCP(type, q),
-        "RX",
+      var sel = this.makeTCPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var metricPfx = this.metricPrefixTCP(type);
+      var q = `8 * sum(rate(${metricPfx}_rx_bytes_total{${sel}}[15m]))`;
+      return this.fetchStat(
+        this.groupQueryTCP(type, q),
+        'RX',
         `<b>${subject}</b> received bits per second averaged over the last 15 minutes`,
         shortNumStr,
         this.groupBy(type)
-        )
+      );
     },
 
     fetchServiceTx: function(serviceName, type, options) {
-      var sel = this.makeTCPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var metricPfx = this.metricPrefixTCP(type)
-      var q = `8 * sum(rate(${metricPfx}_tx_bytes_total{${sel}}[15m]))`
-      var self = this
-      return this.fetchStat(this.groupQueryTCP(type, q),
-        "TX",
+      var sel = this.makeTCPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var metricPfx = this.metricPrefixTCP(type);
+      var q = `8 * sum(rate(${metricPfx}_tx_bytes_total{${sel}}[15m]))`;
+      var self = this;
+      return this.fetchStat(
+        this.groupQueryTCP(type, q),
+        'TX',
         `<b>${subject}</b> transmitted bits per second averaged over the last 15 minutes`,
         shortNumStr,
         this.groupBy(type)
-        )
+      );
     },
 
     fetchServiceNoRoute: function(serviceName, type, options) {
-      var sel = this.makeTCPSelector(serviceName, type)
-      var subject = this.makeSubject(serviceName, type)
-      var metricPfx = this.metricPrefixTCP(type)
-      var metric = "_no_route"
-      if (type == "downstream") {
-        metric = "_connect_fail"
+      var sel = this.makeTCPSelector(serviceName, type);
+      var subject = this.makeSubject(serviceName, type);
+      var metricPfx = this.metricPrefixTCP(type);
+      var metric = '_no_route';
+      if (type == 'downstream') {
+        metric = '_connect_fail';
       }
-      var q = `sum(rate(${metricPfx}${metric}{${sel}}[15m]))`
-      return this.fetchStat(this.groupQueryTCP(type, q),
-        "NR",
+      var q = `sum(rate(${metricPfx}${metric}{${sel}}[15m]))`;
+      return this.fetchStat(
+        this.groupQueryTCP(type, q),
+        'NR',
         `<b>${subject}</b> unroutable (failed) connections per second averaged over the last 15 minutes`,
         shortNumStr,
         this.groupBy(type)
-        )
+      );
     },
 
     fetchStat: function(promql, label, desc, formatter, groupBy) {
       if (!groupBy) {
         // If we don't have a grouped result and its just a single stat, return
         // no result as a zero not a missing stat.
-        promql += " OR on() vector(0)";
+        promql += ' OR on() vector(0)';
       }
       //console.log(promql)
       var params = {
         query: promql,
-        time: (new Date).getTime()/1000
-      }
-      return this.httpGet("/api/v1/query", params).then(function(response){
-        if (!groupBy) {
-          // Not grouped, expect just one stat value return that
-          var v = parseFloat(response.data.result[0].value[1])
-          return {
-            label: label,
-            desc: desc,
-            value: formatter(v)
+        time: new Date().getTime() / 1000,
+      };
+      return this.httpGet('/api/v1/query', params).then(
+        function(response) {
+          if (!groupBy) {
+            // Not grouped, expect just one stat value return that
+            var v = parseFloat(response.data.result[0].value[1]);
+            return {
+              label: label,
+              desc: desc,
+              value: formatter(v),
+            };
           }
-        }
 
-        var data = {};
-        for (var i = 0; i < response.data.result.length; i++) {
-          var res = response.data.result[i];
-          var v = parseFloat(res.value[1]);
-          var groupName = res.metric[groupBy];
-          data[groupName] = {
-            label: label,
-            desc: desc.replace('{{GROUP}}', groupName),
-            value: formatter(v)
+          var data = {};
+          for (var i = 0; i < response.data.result.length; i++) {
+            var res = response.data.result[i];
+            var v = parseFloat(res.value[1]);
+            var groupName = res.metric[groupBy];
+            data[groupName] = {
+              label: label,
+              desc: desc.replace('{{GROUP}}', groupName),
+              value: formatter(v),
+            };
           }
+          return data;
+        },
+        function(xhr) {
+          // Failure. log to console and return an blank result for now.
+          console.log('ERROR: failed to fetch stat', label, xhr.responseText);
+          return {};
         }
-        return data;
-      }, function(xhr){
-        // Failure. log to console and return an blank result for now.
-        console.log("ERROR: failed to fetch stat", label, xhr.responseText)
-        return {}
-      })
+      );
     },
 
     fetchSeries: function(promql, options) {
@@ -597,37 +605,37 @@
         query: promql,
         start: options.start,
         end: options.end,
-        step: "10s",
-        timeout: "8s"
-      }
-      return this.httpGet("/api/v1/query_range", params)
+        step: '10s',
+        timeout: '8s',
+      };
+      return this.httpGet('/api/v1/query_range', params);
     },
 
     httpGet: function(path, params) {
       var xhr = new XMLHttpRequest();
-      var self = this
-      return new Promise(function(resolve, reject){
-        xhr.onreadystatechange = function(){
+      var self = this;
+      return new Promise(function(resolve, reject) {
+        xhr.onreadystatechange = function() {
           if (xhr.readyState !== 4) return;
 
           if (xhr.status == 200) {
             // Attempt to parse response as JSON and return the object
-            var o = JSON.parse(xhr.responseText)
-            resolve(o)
+            var o = JSON.parse(xhr.responseText);
+            resolve(o);
           }
-          reject(xhr)
-        }
+          reject(xhr);
+        };
 
-        var url = self.baseURL()+path;
+        var url = self.baseURL() + path;
         if (params) {
-          var qs = Object.keys(params).
-          map(function(key){
-            return encodeURIComponent(key)+"="+encodeURIComponent(params[key])
-          }).
-          join("&")
-          url = url+"?"+qs
+          var qs = Object.keys(params)
+            .map(function(key) {
+              return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+            })
+            .join('&');
+          url = url + '?' + qs;
         }
-        xhr.open("GET", url, true);
+        xhr.open('GET', url, true);
         xhr.send();
       });
     },
@@ -635,19 +643,20 @@
     baseURL: function() {
       // TODO support configuring a direct Prometheus via
       // metrics_provider_options_json.
-      return "/v1/internal/ui/metrics-proxy"
-    }
-  }
+      return '/v1/internal/ui/metrics-proxy';
+    },
+  };
 
   // Helper functions
   function shortNumStr(n) {
     if (n < 1e3) {
-      if (Number.isInteger(n)) return ""+n
+      if (Number.isInteger(n)) return '' + n;
       if (n >= 100) {
         // Go to 3 significant figures but wrap it in Number to avoid scientific
         // notation lie 2.3e+2 for 230.
-        return Number(n.toPrecision(3))
-      } if (n < 1) {
+        return Number(n.toPrecision(3));
+      }
+      if (n < 1) {
         // Very small numbers show with limited precision to prevent long string
         // of 0.000000.
         return Number(n.toFixed(2));
@@ -656,29 +665,28 @@
         return Number(n.toPrecision(2));
       }
     }
-    if (n >= 1e3 && n < 1e6) return +(n / 1e3).toPrecision(3) + "k";
-    if (n >= 1e6 && n < 1e9) return +(n / 1e6).toPrecision(3) + "m";
-    if (n >= 1e9 && n < 1e12) return +(n / 1e9).toPrecision(3) + "g";
-    if (n >= 1e12) return +(n / 1e12).toFixed(0) + "t";
+    if (n >= 1e3 && n < 1e6) return +(n / 1e3).toPrecision(3) + 'k';
+    if (n >= 1e6 && n < 1e9) return +(n / 1e6).toPrecision(3) + 'm';
+    if (n >= 1e9 && n < 1e12) return +(n / 1e9).toPrecision(3) + 'g';
+    if (n >= 1e12) return +(n / 1e12).toFixed(0) + 't';
   }
 
   function shortTimeStr(n) {
-    if (n < 1e3) return Math.round(n) + "ms";
+    if (n < 1e3) return Math.round(n) + 'ms';
 
-    var secs = n / 1e3
-    if (secs < 60) return secs.toFixed(1) + "s"
+    var secs = n / 1e3;
+    if (secs < 60) return secs.toFixed(1) + 's';
 
-    var mins = secs/60
-    if (mins < 60) return mins.toFixed(1) + "m"
+    var mins = secs / 60;
+    if (mins < 60) return mins.toFixed(1) + 'm';
 
-    var hours = mins/60
-    if (hours < 24) return hours.toFixed(1) + "h"
+    var hours = mins / 60;
+    if (hours < 24) return hours.toFixed(1) + 'h';
 
-    var days = hours/24
-    return days.toFixed(1) + "d"
+    var days = hours / 24;
+    return days.toFixed(1) + 'd';
   }
 
   /* global consul:writable */
-  window.consul.registerMetricsProvider("prometheus", prometheusProvider)
-
-}());
+  window.consul.registerMetricsProvider('prometheus', prometheusProvider);
+})();


### PR DESCRIPTION
This PR replaces https://github.com/hashicorp/consul/pull/8932 and does a lot less.

Previously the metrics provider would swallow any errors and return an empty array for any errors thrown whilst retrieving data from the metrics provider.

This PR throws any HTTP errors back to the UI so we can deal with them there. This does mean that if 1 single error is thrown whilst retrieving data, then the entire retrieval will fail.

We also js formatted the provider, so it might be easier to view the changes there in df1f7ea