### PR TITLE
ui: Move various components to new style template only components

### DIFF
--- a/ui-v2/.ember-cli
+++ b/ui-v2/.ember-cli
@@ -10,9 +10,5 @@
     We use a nested in /components folder structure:
     /components/component-name/index.{hbs,js}
   */
-  "componentStructure": "nested",
-  /**
-    We currently use classic components
-  */
-  "componentClass": "@ember/component"
+  "componentStructure": "nested"
 }

--- a/ui-v2/app/components/app-error/index.hbs
+++ b/ui-v2/app/components/app-error/index.hbs
@@ -1,10 +1,10 @@
-<AppView @class="error show">
-    <BlockSlot @name="header">
-      <h1>
-        Error {{error.status}}
-      </h1>
-    </BlockSlot>
-    <BlockSlot @name="content">
-      <ErrorState @error={{error}} />
-    </BlockSlot>
+<AppView>
+  <BlockSlot @name="header">
+    <h1>
+      Error {{@error.status}}
+    </h1>
+  </BlockSlot>
+  <BlockSlot @name="content">
+    <ErrorState @error={{@error}} />
+  </BlockSlot>
 </AppView>

--- a/ui-v2/app/components/app-error/index.js
+++ b/ui-v2/app/components/app-error/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/auth-profile/index.hbs
+++ b/ui-v2/app/components/auth-profile/index.hbs
@@ -4,6 +4,6 @@
       AccessorID
     </dt>
     <dd>
-      {{substr item.AccessorID -8}}
+      {{substr @item.AccessorID -8}}
     </dd>
 </dl>

--- a/ui-v2/app/components/auth-profile/index.js
+++ b/ui-v2/app/components/auth-profile/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/error-state/index.hbs
+++ b/ui-v2/app/components/error-state/index.hbs
@@ -1,14 +1,15 @@
-{{#if (not-eq error.status "403")}}
+{{#if (not-eq @error.status "403")}}
   <EmptyState
-    class={{concat "status-" error.status}}
+    class={{concat "error-state " "status-" @error.status}}
+    ...attributes
     @allowLogin={{@allowLogin}}
   >
     <BlockSlot @name="header">
-      <h2>{{or error.message "Consul returned an error"}}</h2>
+      <h2>{{or @error.message "Consul returned an error"}}</h2>
     </BlockSlot>
 {{#if error.status }}
     <BlockSlot @name="subheader">
-      <h3 data-test-status={{error.status}}>Error {{error.status}}</h3>
+      <h3 data-test-status={{@error.status}}>Error {{@error.status}}</h3>
     </BlockSlot>
 {{/if}}
     <BlockSlot @name="body">
@@ -27,11 +28,12 @@
   </EmptyState>
 {{else}}
   <EmptyState
-    class="status-403"
+    class="error-state status-403"
+    ...attributes
     @allowLogin={{@allowLogin}}
   >
     <BlockSlot @name="header">
-      <h2 data-test-status={{error.status}}>You are not authorized</h2>
+      <h2 data-test-status={{@error.status}}>You are not authorized</h2>
     </BlockSlot>
     <BlockSlot @name="subheader">
       <h3>Error 403</h3>

--- a/ui-v2/app/components/error-state/index.hbs
+++ b/ui-v2/app/components/error-state/index.hbs
@@ -7,7 +7,7 @@
     <BlockSlot @name="header">
       <h2>{{or @error.message "Consul returned an error"}}</h2>
     </BlockSlot>
-{{#if error.status }}
+{{#if @error.status }}
     <BlockSlot @name="subheader">
       <h3 data-test-status={{@error.status}}>Error {{@error.status}}</h3>
     </BlockSlot>
@@ -33,10 +33,10 @@
     @allowLogin={{@allowLogin}}
   >
     <BlockSlot @name="header">
-      <h2 data-test-status={{@error.status}}>You are not authorized</h2>
+      <h2>You are not authorized</h2>
     </BlockSlot>
     <BlockSlot @name="subheader">
-      <h3>Error 403</h3>
+      <h3 data-test-status={{@error.status}}>Error 403</h3>
     </BlockSlot>
     <BlockSlot @name="body">
       <p>

--- a/ui-v2/app/components/error-state/index.js
+++ b/ui-v2/app/components/error-state/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/healthcheck-list/index.hbs
+++ b/ui-v2/app/components/healthcheck-list/index.hbs
@@ -1,6 +1,9 @@
-<div ...attributes>
+<div
+  class="healthcheck-list"
+  ...attributes
+>
   <ul>
-{{#each items as |item| }}
+{{#each @items as |item| }}
     <li class={{concat 'healthcheck-output ' item.Status}}>
       <div>
         <header>

--- a/ui-v2/app/components/healthcheck-list/index.js
+++ b/ui-v2/app/components/healthcheck-list/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/more-popover-menu/index.hbs
+++ b/ui-v2/app/components/more-popover-menu/index.hbs
@@ -1,4 +1,7 @@
-<div class="more-popover-menu">
+<div
+  class="more-popover-menu"
+  ...attributes
+>
   <PopoverMenu @expanded={{expanded}} @onchange={{action onchange}} @keyboardAccess={{false}} as |components api|>
     <BlockSlot @name="trigger">
       More

--- a/ui-v2/app/components/more-popover-menu/index.hbs
+++ b/ui-v2/app/components/more-popover-menu/index.hbs
@@ -2,7 +2,11 @@
   class="more-popover-menu"
   ...attributes
 >
-  <PopoverMenu @expanded={{expanded}} @onchange={{action onchange}} @keyboardAccess={{false}} as |components api|>
+  <PopoverMenu
+    @expanded={{@expanded}}
+    @onchange={{action @onchange}}
+    @keyboardAccess={{false}}
+  as |components api|>
     <BlockSlot @name="trigger">
       More
     </BlockSlot>

--- a/ui-v2/app/components/more-popover-menu/index.js
+++ b/ui-v2/app/components/more-popover-menu/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/node-identity/index.hbs
+++ b/ui-v2/app/components/node-identity/index.hbs
@@ -1,6 +1,6 @@
 {{#if (env "CONSUL_NSPACES_ENABLED")}}
 namespace "default" {
-  node "{{name}}" {
+  node "{{@name}}" {
 	  policy = "write"
   }
 }
@@ -10,7 +10,7 @@ namespace_prefix "" {
   }
 }
 {{else}}
-node "{{name}}" {
+node "{{@name}}" {
 	policy = "write"
 }
 service_prefix "" {

--- a/ui-v2/app/components/node-identity/index.js
+++ b/ui-v2/app/components/node-identity/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/radio-card/index.hbs
+++ b/ui-v2/app/components/radio-card/index.hbs
@@ -1,13 +1,13 @@
 <label
+  class="radio-card{{if @checked ' checked'}}"
   ...attributes
-  class="radio-card{{if checked ' checked'}}"
 >
   <div>
     {{! workaround FF/Ember problem where you cannnot set a value to be value="" (empty)}}
-    {{#if (gt value.length 0) }}
-      <input type="radio" name={{name}} value={{value}} checked={{checked}} onchange={{action onchange}} />
+    {{#if (gt @value.length 0) }}
+      <input type="radio" name={{@name}} value={{@value}} checked={{@checked}} onchange={{action @onchange}} />
     {{else}}
-      <input type="radio" name={{name}} value="" checked={{checked}} onchange={{action onchange}} />
+      <input type="radio" name={{@name}} value="" checked={{@checked}} onchange={{action @onchange}} />
     {{/if}}
   </div>
   <div>

--- a/ui-v2/app/components/radio-card/index.js
+++ b/ui-v2/app/components/radio-card/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/resolver-card/index.hbs
+++ b/ui-v2/app/components/resolver-card/index.hbs
@@ -1,13 +1,13 @@
 <div class="resolver-card">
-  <header onclick={{onclick}} id={{concat 'resolver:' item.ID}}>
+  <header onclick={{@onclick}} id={{concat 'resolver:' @item.ID}}>
     <a name="">
-      <h3>{{item.Name}}</h3>
-{{#if item.Failover}}
+      <h3>{{@item.Name}}</h3>
+{{#if @item.Failover}}
       <dl class="failover">
-        <dt data-tooltip={{concat item.Failover.Type ' failover'}}>{{concat item.Failover.Type ' failover'}}</dt>
+        <dt data-tooltip={{concat @item.Failover.Type ' failover'}}>{{concat @item.Failover.Type ' failover'}}</dt>
         <dd>
           <ol>
-  {{#each item.Failover.Targets as |item|}}
+  {{#each @item.Failover.Targets as |item|}}
             <li>
               <span>{{item}}</span>
             </li>
@@ -18,10 +18,10 @@
 {{/if}}
     </a>
   </header>
-{{#if (gt item.Children.length 0)}}
+{{#if (gt @item.Children.length 0)}}
     <ul>
-  {{#each item.Children as |child|}}
-      <li onclick={{onclick}} id={{concat 'resolver:' child.ID}}>
+  {{#each @item.Children as |child|}}
+      <li onclick={{@onclick}} id={{concat 'resolver:' child.ID}}>
         <a name="">
     {{#if child.Redirect}}
           <dl class="redirect">

--- a/ui-v2/app/components/resolver-card/index.js
+++ b/ui-v2/app/components/resolver-card/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/secret-button/index.hbs
+++ b/ui-v2/app/components/secret-button/index.hbs
@@ -1,5 +1,10 @@
-<label class="type-reveal">
-  <input type="checkbox" />
-  <span>Reveal</span>
-  <em>{{yield}}</em>
-</label>
+<div
+  class="secret-button"
+  ...attributes
+>
+  <label class="type-reveal">
+    <input type="checkbox" />
+    <span>Reveal</span>
+    <em>{{yield}}</em>
+  </label>
+</div>

--- a/ui-v2/app/components/secret-button/index.js
+++ b/ui-v2/app/components/secret-button/index.js
@@ -1,3 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({});

--- a/ui-v2/app/components/service-identity/index.hbs
+++ b/ui-v2/app/components/service-identity/index.hbs
@@ -1,9 +1,9 @@
 {{#if (env "CONSUL_NSPACES_ENABLED")}}
-namespace "{{nspace}}" {
-  service "{{name}}" {
+namespace "{{@nspace}}" {
+  service "{{@name}}" {
 	  policy = "write"
   }
-  service "{{name}}-sidecar-proxy" {
+  service "{{@name}}-sidecar-proxy" {
 	  policy = "write"
   }
   service_prefix "" {
@@ -14,10 +14,10 @@ namespace "{{nspace}}" {
   }
 }
 {{else}}
-service "{{name}}" {
+service "{{@name}}" {
 	policy = "write"
 }
-service "{{name}}-sidecar-proxy" {
+service "{{@name}}-sidecar-proxy" {
 	policy = "write"
 }
 service_prefix "" {

--- a/ui-v2/app/components/service-identity/index.js
+++ b/ui-v2/app/components/service-identity/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/splitter-card/index.hbs
+++ b/ui-v2/app/components/splitter-card/index.hbs
@@ -1,5 +1,9 @@
-<a class="splitter-card" onclick={{onclick}} id={{item.ID}}>
-  <header>
-    <h3>{{item.Name}}</h3>
-  </header>
-</a>
+<div
+  ...attributes
+>
+  <a class="splitter-card" onclick={{@onclick}} id={{@item.ID}}>
+    <header>
+      <h3>{{@item.Name}}</h3>
+    </header>
+  </a>
+</div>

--- a/ui-v2/app/components/splitter-card/index.js
+++ b/ui-v2/app/components/splitter-card/index.js
@@ -1,3 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({});

--- a/ui-v2/app/components/tag-list/index.hbs
+++ b/ui-v2/app/components/tag-list/index.hbs
@@ -1,7 +1,7 @@
-{{#if (gt item.Tags.length 0)}}
+{{#if (gt @item.Tags.length 0)}}
   {{#if (has-block)}}
     {{yield
-      (component 'tag-list' item=item)
+      (component 'tag-list' item=@item)
     }}
   {{else}}
     <dl class="tag-list">
@@ -11,7 +11,7 @@
         </Tooltip>
       </dt>
       <dd data-test-tags>
-        {{#each item.Tags as |item|}}
+        {{#each @item.Tags as |item|}}
           <span>{{item}}</span>
         {{/each}}
       </dd>

--- a/ui-v2/app/components/tag-list/index.js
+++ b/ui-v2/app/components/tag-list/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});

--- a/ui-v2/app/components/tooltip/index.hbs
+++ b/ui-v2/app/components/tooltip/index.hbs
@@ -1,11 +1,11 @@
 <EmberTooltip
-  @targetId={{targetId}}
-  @onHide={{oncomplete}}
-  @isShown={{isShown}}
-  @duration={{duration}}
-  @event={{if isShown 'none' (or event 'hover')}}
+  @targetId={{@targetId}}
+  @onHide={{@oncomplete}}
+  @isShown={{@isShown}}
+  @duration={{@duration}}
+  @event={{if @isShown 'none' (or @event 'hover')}}
   @popperContainer=".app-view"
-  @side={{or position 'top'}}
+  @side={{or @position 'top'}}
 >
   {{yield}}
 </EmberTooltip>

--- a/ui-v2/app/components/tooltip/index.js
+++ b/ui-v2/app/components/tooltip/index.js
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({
-  tagName: '',
-});


### PR DESCRIPTION
A lot of our components followed the old style 'empty tagName' components, now with Glimmer components we can have true template only components.

This PR moves some of our simpler UI components to use the new Glimmer template-only component style.

We change the app to default to use Glimmer components for the component blueprints.