### PR TITLE
website: add v1.9.0-beta1 download callout

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -11,6 +11,11 @@ export default function DownloadsPage({ releaseData }) {
         product="Consul"
         version={VERSION}
         releaseData={releaseData}
+        prerelease={{
+          type: 'beta', // the type of prerelease: beta, release candidate, etc.
+          name: 'v1.9.0', // the name displayed in text on the website
+          version: '1.9.0-beta1', // the actual version tag that was pushed to releases.hashicorp.com
+        }}
       >
         <p>
           <a href="/docs/download-tools">&raquo; Download Consul Tools</a>


### PR DESCRIPTION
How to do this completely changed in the web replatforming, should verify intended functionality from the Netlify preview deployment.