### PR TITLE
docs: Add a note about auto-renewing the Vault token

### DIFF
--- a/website/pages/docs/agent/options.mdx
+++ b/website/pages/docs/agent/options.mdx
@@ -1230,7 +1230,10 @@ Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h'."
     - `address` ((#vault_ca_address)) The address of the Vault server to
       connect to.
 
-    - `token` ((#vault_ca_token)) The Vault token to use.
+    - `token` ((#vault_ca_token)) The Vault token to use. In Consul 1.8.5 and later, if
+      the token has the [renewable](https://www.vaultproject.io/api-docs/auth/token#renewable)
+      flag set, Consul will attempt to renew its lease periodically after half the
+      duration has expired.
 
     - `root_pki_path` ((#vault_ca_root_pki)) The path to use for the root
       CA pki backend in Vault. This can be an existing backend with a CA already

--- a/website/pages/docs/connect/ca/vault.mdx
+++ b/website/pages/docs/connect/ca/vault.mdx
@@ -57,7 +57,11 @@ is used if you're adding configuring to the agent's configuration file.
 
 - `Token` / `token` (`string: <required>`) - A token for accessing Vault.
   This is write-only and will not be exposed when reading the CA configuration.
-  This token must have proper privileges for the PKI paths configured.
+  This token must have proper privileges for the PKI paths configured. In Consul
+  1.8.5 and later, if the token has the [renewable]
+  (https://www.vaultproject.io/api-docs/auth/token#renewable)
+  flag set, Consul will attempt to renew its lease periodically after half the
+  duration has expired.
 
 - `RootPKIPath` / `root_pki_path` (`string: <required>`) - The path to
   a PKI secrets engine for the root certificate. If the path doesn't


### PR DESCRIPTION
Adds a note about the new auto-renew behavior for the Vault token used by the Connect CA to the docs.