### PR TITLE
ui: [BUGFIX] Fixup gateway services API call

### DIFF
--- a/ui-v2/app/routes/dc/services/show/services.js
+++ b/ui-v2/app/routes/dc/services/show/services.js
@@ -11,7 +11,7 @@ export default Route.extend({
       .split('.')
       .slice(0, -1)
       .join('.');
-    const name = this.modelFor(parent).name;
+    const name = this.modelFor(parent).slug;
     return hash({
       dc: dc,
       nspace: nspace,


### PR DESCRIPTION
This fills in a missing parameter name when calling the `gateway-services-nodes` endpoint and prevents a 400 error when visiting an gateway detail page.