### PR TITLE
agent/grpc: fix some test flakes and handle duplicate server IDs in the pool

### DIFF
--- a/agent/grpc/client.go
+++ b/agent/grpc/client.go
@@ -61,8 +61,7 @@ func (c *ClientConnPool) ClientConn(datacenter string) (*grpc.ClientConn, error)
 		grpc.WithInsecure(),
 		grpc.WithContextDialer(c.dialer),
 		grpc.WithDisableRetry(),
-		// TODO: previously this statsHandler was shared with the Handler. Is that necessary?
-		grpc.WithStatsHandler(newStatsHandler()),
+		grpc.WithStatsHandler(newStatsHandler(defaultMetrics)),
 		// nolint:staticcheck // there is no other supported alternative to WithBalancerName
 		grpc.WithBalancerName("pick_first"))
 	if err != nil {

--- a/agent/grpc/client_test.go
+++ b/agent/grpc/client_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/grpc/internal/testservice"
 	"github.com/hashicorp/consul/agent/grpc/resolver"
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewDialer_WithTLSWrapper(t *testing.T) {

--- a/agent/grpc/client_test.go
+++ b/agent/grpc/client_test.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul/agent/grpc/internal/testservice"
 	"github.com/hashicorp/consul/agent/grpc/resolver"
 	"github.com/hashicorp/consul/agent/metadata"
+	"github.com/hashicorp/consul/tlsutil"
 )
 
 func TestNewDialer_WithTLSWrapper(t *testing.T) {
@@ -42,14 +45,43 @@ func TestNewDialer_WithTLSWrapper(t *testing.T) {
 	require.True(t, called, "expected TLSWrapper to be called")
 }
 
-// TODO: integration test TestNewDialer with TLS and rcp server, when the rpc
-// exists as an isolated component.
+func TestNewDialer_IntegrationWithTLSEnabledHandler(t *testing.T) {
+	res := resolver.NewServerResolverBuilder(newConfig(t))
+	registerWithGRPC(t, res)
+
+	srv := newTestServer(t, "server-1", "dc1")
+	tlsConf, err := tlsutil.NewConfigurator(tlsutil.Config{
+		VerifyIncoming: true,
+		VerifyOutgoing: true,
+		CAFile:         "../../test/hostname/CertAuth.crt",
+		CertFile:       "../../test/hostname/Alice.crt",
+		KeyFile:        "../../test/hostname/Alice.key",
+	}, hclog.New(nil))
+	require.NoError(t, err)
+	srv.rpc.tlsConf = tlsConf
+
+	res.AddServer(srv.Metadata())
+	t.Cleanup(srv.shutdown)
+
+	pool := NewClientConnPool(res, TLSWrapper(tlsConf.OutgoingRPCWrapper()))
+
+	conn, err := pool.ClientConn("dc1")
+	require.NoError(t, err)
+	client := testservice.NewSimpleClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	resp, err := client.Something(ctx, &testservice.Req{})
+	require.NoError(t, err)
+	require.Equal(t, "server-1", resp.ServerName)
+	require.True(t, atomic.LoadInt32(&srv.rpc.tlsConnEstablished) > 0)
+}
 
 func TestClientConnPool_IntegrationWithGRPCResolver_Failover(t *testing.T) {
 	count := 4
-	cfg := resolver.Config{Scheme: newScheme(t.Name())}
-	res := resolver.NewServerResolverBuilder(cfg)
-	resolver.RegisterWithGRPC(res)
+	res := resolver.NewServerResolverBuilder(newConfig(t))
+	registerWithGRPC(t, res)
 	pool := NewClientConnPool(res, nil)
 
 	for i := 0; i < count; i++ {
@@ -76,17 +108,17 @@ func TestClientConnPool_IntegrationWithGRPCResolver_Failover(t *testing.T) {
 	require.NotEqual(t, resp.ServerName, first.ServerName)
 }
 
-func newScheme(n string) string {
+func newConfig(t *testing.T) resolver.Config {
+	n := t.Name()
 	s := strings.Replace(n, "/", "", -1)
 	s = strings.Replace(s, "_", "", -1)
-	return strings.ToLower(s)
+	return resolver.Config{Scheme: strings.ToLower(s)}
 }
 
 func TestClientConnPool_IntegrationWithGRPCResolver_Rebalance(t *testing.T) {
 	count := 5
-	cfg := resolver.Config{Scheme: newScheme(t.Name())}
-	res := resolver.NewServerResolverBuilder(cfg)
-	resolver.RegisterWithGRPC(res)
+	res := resolver.NewServerResolverBuilder(newConfig(t))
+	registerWithGRPC(t, res)
 	pool := NewClientConnPool(res, nil)
 
 	for i := 0; i < count; i++ {
@@ -134,9 +166,8 @@ func TestClientConnPool_IntegrationWithGRPCResolver_Rebalance(t *testing.T) {
 func TestClientConnPool_IntegrationWithGRPCResolver_MultiDC(t *testing.T) {
 	dcs := []string{"dc1", "dc2", "dc3"}
 
-	cfg := resolver.Config{Scheme: newScheme(t.Name())}
-	res := resolver.NewServerResolverBuilder(cfg)
-	resolver.RegisterWithGRPC(res)
+	res := resolver.NewServerResolverBuilder(newConfig(t))
+	registerWithGRPC(t, res)
 	pool := NewClientConnPool(res, nil)
 
 	for _, dc := range dcs {

--- a/agent/grpc/handler.go
+++ b/agent/grpc/handler.go
@@ -22,7 +22,7 @@ func NewHandler(addr net.Addr, register func(server *grpc.Server)) *Handler {
 	)
 	register(srv)
 
-	lis := &chanListener{addr: addr, conns: make(chan net.Conn)}
+	lis := &chanListener{addr: addr, conns: make(chan net.Conn), done: make(chan struct{})}
 	return &Handler{srv: srv, listener: lis}
 }
 
@@ -51,22 +51,22 @@ func (h *Handler) Shutdown() error {
 type chanListener struct {
 	conns chan net.Conn
 	addr  net.Addr
+	done  chan struct{}
 }
 
 // Accept blocks until a connection is received from Handle, and then returns the
 // connection. Accept implements part of the net.Listener interface for grpc.Server.
 func (l *chanListener) Accept() (net.Conn, error) {
 	select {
-	case c, ok := <-l.conns:
-		if !ok {
-			return nil, &net.OpError{
-				Op:   "accept",
-				Net:  l.addr.Network(),
-				Addr: l.addr,
-				Err:  fmt.Errorf("listener closed"),
-			}
-		}
+	case c := <-l.conns:
 		return c, nil
+	case <-l.done:
+		return nil, &net.OpError{
+			Op:   "accept",
+			Net:  l.addr.Network(),
+			Addr: l.addr,
+			Err:  fmt.Errorf("listener closed"),
+		}
 	}
 }
 
@@ -75,7 +75,7 @@ func (l *chanListener) Addr() net.Addr {
 }
 
 func (l *chanListener) Close() error {
-	close(l.conns)
+	close(l.done)
 	return nil
 }
 

--- a/agent/grpc/handler.go
+++ b/agent/grpc/handler.go
@@ -17,8 +17,8 @@ func NewHandler(addr net.Addr, register func(server *grpc.Server)) *Handler {
 	// We don't need to pass tls.Config to the server since it's multiplexed
 	// behind the RPC listener, which already has TLS configured.
 	srv := grpc.NewServer(
-		grpc.StatsHandler(newStatsHandler()),
-		grpc.StreamInterceptor((&activeStreamCounter{}).Intercept),
+		grpc.StatsHandler(newStatsHandler(defaultMetrics)),
+		grpc.StreamInterceptor((&activeStreamCounter{metrics: defaultMetrics}).Intercept),
 	)
 	register(srv)
 

--- a/agent/grpc/resolver/resolver.go
+++ b/agent/grpc/resolver/resolver.go
@@ -12,19 +12,6 @@ import (
 	"github.com/hashicorp/consul/agent/metadata"
 )
 
-var registerLock sync.Mutex
-
-// RegisterWithGRPC registers the ServerResolverBuilder as a grpc/resolver.
-// This function exists to synchronize registrations with a lock.
-// grpc/resolver.Register expects all registration to happen at init and does
-// not allow for concurrent registration. This function exists to support
-// parallel testing.
-func RegisterWithGRPC(b *ServerResolverBuilder) {
-	registerLock.Lock()
-	defer registerLock.Unlock()
-	resolver.Register(b)
-}
-
 // ServerResolverBuilder tracks the current server list and keeps any
 // ServerResolvers updated when changes occur.
 type ServerResolverBuilder struct {

--- a/agent/grpc/stats_test.go
+++ b/agent/grpc/stats_test.go
@@ -15,7 +15,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/hashicorp/consul/agent/grpc/internal/testservice"
-	"github.com/hashicorp/consul/sdk/testutil/retry"
 )
 
 func noopRegister(*grpc.Server) {}
@@ -92,8 +91,6 @@ func TestHandler_EmitsStats(t *testing.T) {
 	}
 	assertDeepEqual(t, expectedCounter, sink.incrCounterCalls, cmpMetricCalls)
 }
-
-var fastRetry = &retry.Timer{Timeout: 7 * time.Second, Wait: 2 * time.Millisecond}
 
 func assertDeepEqual(t *testing.T, x, y interface{}, opts ...cmp.Option) {
 	t.Helper()

--- a/agent/grpc/stats_test.go
+++ b/agent/grpc/stats_test.go
@@ -30,7 +30,6 @@ func TestHandler_EmitsStats(t *testing.T) {
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	t.Cleanup(logError(t, lis.Close))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -50,7 +49,7 @@ func TestHandler_EmitsStats(t *testing.T) {
 
 	conn, err := grpc.DialContext(ctx, lis.Addr().String(), grpc.WithInsecure())
 	require.NoError(t, err)
-	t.Cleanup(logError(t, conn.Close))
+	t.Cleanup(func() { conn.Close() })
 
 	client := testservice.NewSimpleClient(conn)
 	fClient, err := client.Flow(ctx, &testservice.Req{Datacenter: "mine"})

--- a/tlsutil/config.go
+++ b/tlsutil/config.go
@@ -13,8 +13,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/consul/logging"
 )
 
 // ALPNWrapper is a function that is used to wrap a non-TLS connection and
@@ -79,9 +80,6 @@ type Config struct {
 	// enabled by default with VerifyOutgoing, but for legacy reasons we
 	// cannot break existing clients.
 	VerifyServerHostname bool
-
-	// UseTLS is used to enable outgoing TLS connections to Consul servers.
-	UseTLS bool
 
 	// CAFile is a path to a certificate authority file. This is used with
 	// VerifyIncoming or VerifyOutgoing to verify the TLS connection.


### PR DESCRIPTION
This PR does a bunch of cleanup in `agent/grpc`, primarily in the tests. Best viewed by individual commit.

Adds a test, and fixes most of the test flakes (see comment below).