### PR TITLE
speed up envoy integ tests by not politely stopping containers before destroying them

### DIFF
--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -72,7 +72,7 @@ function start_consul {
   local DC=${1:-primary}
 
   # Start consul now as setup script needs it up
-  docker-compose rm -s -v -f consul-${DC} || true
+  docker-compose rm -v -f consul-${DC} || true
   docker-compose up -d consul-${DC}
 }
 
@@ -95,7 +95,7 @@ function start_services {
   
   # Start containers required
   if [ ! -z "$REQUIRED_SERVICES" ] ; then
-    docker-compose rm -s -v -f $REQUIRED_SERVICES || true
+    docker-compose rm -v -f $REQUIRED_SERVICES || true
     docker-compose up --build -d $REQUIRED_SERVICES
   fi
 
@@ -112,7 +112,7 @@ function verify {
   res=0
 
   # Nuke any previous case's verify container.
-  docker-compose rm -s -v -f verify-${DC} || true
+  docker-compose rm -v -f verify-${DC} || true
 
   if docker-compose up --abort-on-container-exit --exit-code-from verify-${DC} verify-${DC} ; then
     echogreen "✓ PASS"
@@ -156,7 +156,7 @@ function stop_services {
   if [ -f "${CASE_DIR}/teardown.sh" ] ; then
     source "${CASE_DIR}/teardown.sh"
   fi
-  docker-compose rm -s -v -f $REQUIRED_SERVICES || true
+  docker-compose rm -v -f $REQUIRED_SERVICES || true
 }
 
 function init_vars {

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -72,6 +72,7 @@ function start_consul {
   local DC=${1:-primary}
 
   # Start consul now as setup script needs it up
+  docker-compose kill consul-${DC} || true
   docker-compose rm -v -f consul-${DC} || true
   docker-compose up -d consul-${DC}
 }
@@ -95,6 +96,7 @@ function start_services {
   
   # Start containers required
   if [ ! -z "$REQUIRED_SERVICES" ] ; then
+    docker-compose kill $REQUIRED_SERVICES || true
     docker-compose rm -v -f $REQUIRED_SERVICES || true
     docker-compose up --build -d $REQUIRED_SERVICES
   fi
@@ -112,6 +114,7 @@ function verify {
   res=0
 
   # Nuke any previous case's verify container.
+  docker-compose kill verify-${DC} || true
   docker-compose rm -v -f verify-${DC} || true
 
   if docker-compose up --abort-on-container-exit --exit-code-from verify-${DC} verify-${DC} ; then
@@ -156,6 +159,7 @@ function stop_services {
   if [ -f "${CASE_DIR}/teardown.sh" ] ; then
     source "${CASE_DIR}/teardown.sh"
   fi
+  docker-compose kill $REQUIRED_SERVICES || true
   docker-compose rm -v -f $REQUIRED_SERVICES || true
 }
 


### PR DESCRIPTION
In local testing this sped up the `stop_services` call from 11s to 1s per test.