### PR TITLE
agent/router: improve  the test for refreshServerRebalanceTimer

### DIFF
--- a/agent/router/manager_internal_test.go
+++ b/agent/router/manager_internal_test.go
@@ -281,12 +281,15 @@ func TestManager_refreshServerRebalanceTimer(t *testing.T) {
 		{servers: 1, nodes: 1024},
 		{servers: 1, nodes: 8192},
 		{servers: 1, nodes: 11520},
+		{servers: 1, nodes: 11521, expected: 3*time.Minute + 15625*time.Microsecond},
 		{servers: 1, nodes: 16384, expected: 4*time.Minute + 16*time.Second},
 		{servers: 1, nodes: 65535, expected: 17*time.Minute + 3984375000},
 		{servers: 1, nodes: 1000000, expected: 4*time.Hour + 20*time.Minute + 25*time.Second},
 
 		{servers: 2, nodes: 100},
 		{servers: 2, nodes: 16384},
+		{servers: 2, nodes: 23040},
+		{servers: 2, nodes: 23041, expected: 3*time.Minute + 7812500},
 		{servers: 2, nodes: 65535, expected: 8*time.Minute + 31992187500},
 		{servers: 2, nodes: 1000000, expected: 2*time.Hour + 10*time.Minute + 12500*time.Millisecond},
 
@@ -294,7 +297,8 @@ func TestManager_refreshServerRebalanceTimer(t *testing.T) {
 		{servers: 3, nodes: 100},
 		{servers: 3, nodes: 1024},
 		{servers: 3, nodes: 16384},
-		{servers: 3, nodes: 32768},
+		{servers: 3, nodes: 34560},
+		{servers: 3, nodes: 34561, expected: 3*time.Minute + 5208333},
 		{servers: 3, nodes: 65535, expected: 5*time.Minute + 41328125000},
 		{servers: 3, nodes: 1000000, expected: 86*time.Minute + 48333333333},
 
@@ -302,7 +306,7 @@ func TestManager_refreshServerRebalanceTimer(t *testing.T) {
 		{servers: 5, nodes: 1024},
 		{servers: 5, nodes: 16384},
 		{servers: 5, nodes: 32768},
-		{servers: 5, nodes: 56000},
+		{servers: 5, nodes: 57600},
 		{servers: 5, nodes: 65535, expected: 3*time.Minute + 24796875000},
 		{servers: 5, nodes: 1000000, expected: 52*time.Minute + 5*time.Second},
 


### PR DESCRIPTION
I was reading over `refreshServerRebalanceTimer` attempting to understand the delay that it calculates based on some common cluster configurations. I found it very difficult to understand because the test was only making very weak assertions about the values.

It only checked a minimum value making it look like the value was always random (because of the jitter), but in some cases the value is not random at all, it can be known ahead of time. 

This PR improves the test by:
* assert an exact value when possible
* check the maximum bound when a random value is used
* make the two cases (exact, or random range) more explicit in the test cases by excluding the random range. There is only ever 1 random range (2min-3min), so we can omit it  in the test cases to make it more obvious when the random range is not used.
* arrange the test cases into groups by the number of servers, and ordered by number of nodes within the groups, so that it's more obvious how the values changes with the size of the cluster