### PR TITLE
WIP: speed up envoy integration tests

### DIFF
--- a/test/integration/connect/envoy/docker-compose.yml
+++ b/test/integration/connect/envoy/docker-compose.yml
@@ -155,7 +155,7 @@ services:
      - "-redirect-port"
      - "disabled"
     network_mode: service:consul-primary
-    
+
   s3-alt:
     depends_on:
       - consul-primary
@@ -334,7 +334,7 @@ services:
     volumes:
       - *workdir-volume
     network_mode: service:consul-primary
-    
+
   s3-alt-sidecar-proxy:
     depends_on:
       - consul-primary
@@ -557,7 +557,7 @@ services:
     volumes:
       - *workdir-volume
     network_mode: service:consul-primary
-  
+
   gateway-secondary:
     depends_on:
       - consul-secondary
@@ -653,28 +653,26 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-tcpdump
-      
+
     # we cant do this in circle but its only here to temporarily enable.
-    volumes: 
+    volumes:
       - type: bind
         source: ./${LOG_DIR}
         target: /data
     command: -v -i any -w /data/primary.pcap
     network_mode: service:consul-primary
-    
+
   tcpdump-secondary:
     depends_on:
       - consul-secondary
     build:
       context: .
       dockerfile: Dockerfile-tcpdump
-      
+
     # we cant do this in circle but its only here to temporarily enable.
-    volumes: 
+    volumes:
       - type: bind
         source: ./${LOG_DIR}
         target: /data
     command: -v -i any -w /data/secondary.pcap
     network_mode: service:consul-secondary
-    
-    

--- a/test/integration/connect/envoy/docker-compose.yml
+++ b/test/integration/connect/envoy/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     command:
       - sleep
       - "86400"
+    network_mode: "none"
 
   consul-primary:
     image: "consul-dev"
@@ -417,6 +418,7 @@ services:
       - sh
       - -c
       - 'rm -rf /workdir/*'
+    network_mode: "none"
 
   # This is a debugging tool run docker-compose up dump-volumes to see the
   # current state.
@@ -430,6 +432,7 @@ services:
       - -r
       - /workdir/.
       - /cwd/workdir/
+    network_mode: "none"
 
   zipkin:
     volumes:

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -73,9 +73,11 @@ function init_workdir {
 function docker_kill_rm {
   local name
   for name in "$@"; do
-    local name="envoy_${1}_1"
+    name="envoy_${name}_1"
     if docker container inspect $name &>/dev/null; then
-      docker rm -f $name
+      echo -n "Killing and removing $name..."
+      docker rm -v -f $name &> /dev/null
+      echo "done"
     fi
   done
 }


### PR DESCRIPTION
- `docker-compose` has ~500ms of startup penalty, so selectively avoid using it when `docker` can solve the same problem
- ...