### PR TITLE
agent/router: refactor calculation of delay between rebalances.

### DIFF
--- a/agent/router/manager_internal_test.go
+++ b/agent/router/manager_internal_test.go
@@ -264,7 +264,7 @@ func test_reconcileServerList(maxServers int) (bool, error) {
 	return true, nil
 }
 
-func TestManager_refreshServerRebalanceTimer(t *testing.T) {
+func TestRebalanceDelayer(t *testing.T) {
 	type testCase struct {
 		servers  int
 		nodes    int
@@ -319,9 +319,7 @@ func TestManager_refreshServerRebalanceTimer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		m := &Manager{clusterInfo: &fauxSerf{numNodes: tc.nodes}, rebalanceTimer: time.NewTimer(0)}
-		m.saveServerList(serverList{servers: make([]*metadata.Server, tc.servers)})
-		delay := m.refreshServerRebalanceTimer()
+		delay := delayer.Delay(tc.servers, tc.nodes)
 
 		if tc.expected != 0 {
 			assert.Equal(t, tc.expected, delay, "nodes=%d, servers=%d", tc.nodes, tc.servers)

--- a/agent/router/router.go
+++ b/agent/router/router.go
@@ -5,14 +5,15 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/serf/coordinate"
+	"github.com/hashicorp/serf/serf"
+
 	"github.com/hashicorp/consul/agent/metadata"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/lib"
 	"github.com/hashicorp/consul/logging"
 	"github.com/hashicorp/consul/types"
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/serf/coordinate"
-	"github.com/hashicorp/serf/serf"
 )
 
 // Router keeps track of a set of network areas and their associated Serf
@@ -269,7 +270,7 @@ func (r *Router) maybeInitializeManager(area *areaInfo, dc string) *Manager {
 
 	managers := r.managers[dc]
 	r.managers[dc] = append(managers, manager)
-	go manager.Start()
+	go manager.Run()
 
 	return manager
 }


### PR DESCRIPTION
Branched from #8970

This change attempts to make the delay logic more obvious by:

* removing indirection, inline a bunch of function calls
* move all the code and constants next to each other
* replace the two constant values with a single value
* reword the comments

To anyone reviewing this change:

Do the new names and comments help you understand how this works?
Did I miss anything relevant from the old comments that should be included?