### PR TITLE
Wrap rpc error object

### DIFF
--- a/agent/pool/pool.go
+++ b/agent/pool/pool.go
@@ -594,7 +594,7 @@ func (p *ConnPool) rpc(dc string, nodeName string, addr net.Addr, method string,
 	// Get a usable client
 	conn, sc, err := p.getClient(dc, nodeName, addr)
 	if err != nil {
-		return fmt.Errorf("rpc error getting client: %v", err)
+		return fmt.Errorf("rpc error getting client: %w", err)
 	}
 
 	// Make the RPC call
@@ -611,7 +611,7 @@ func (p *ConnPool) rpc(dc string, nodeName string, addr net.Addr, method string,
 		}
 
 		p.releaseConn(conn)
-		return fmt.Errorf("rpc error making call: %v", err)
+		return fmt.Errorf("rpc error making call: %w", err)
 	}
 
 	// Done with the connection


### PR DESCRIPTION
Formatting the error with `%v` eats up the error type of `rpc.ServerError`.  Wrapping the error with `%w` allows checking the error type without string comparison.

This change pairs with my colleague's PR #8698, which uses the error type.  In the case I'm working on, the error is handled in agent/consul/client.go:RPC(), where `canRetry(args, rpcErr)` should be able to understand the type of error.