### PR TITLE
RPC Timeout/Retries account for blocking requests

### DIFF
--- a/agent/structs/structs.go
+++ b/agent/structs/structs.go
@@ -160,6 +160,12 @@ const (
 	// we multiply by time.Second
 	lockDelayMinThreshold = 1000
 
+	// JitterFraction is a the limit to the amount of jitter we apply
+	// to a user specified MaxQueryTime. We divide the specified time by
+	// the fraction. So 16 == 6.25% limit of jitter. This same fraction
+	// is applied to the RPCHoldTimeout
+	JitterFraction = 16
+
 	// WildcardSpecifier is the string which should be used for specifying a wildcard
 	// The exact semantics of the wildcard is left up to the code where its used.
 	WildcardSpecifier = "*"
@@ -194,6 +200,7 @@ type RPCInfo interface {
 	AllowStaleRead() bool
 	TokenSecret() string
 	SetTokenSecret(string)
+	HasTimedOut(since time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool
 }
 
 // QueryOptions is used to specify various flags for read queries
@@ -292,6 +299,20 @@ func (q *QueryOptions) SetTokenSecret(s string) {
 	q.Token = s
 }
 
+func (q QueryOptions) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
+	if q.MinQueryIndex > 0 {
+		if q.MaxQueryTime > maxQueryTime {
+			q.MaxQueryTime = maxQueryTime
+		} else if q.MaxQueryTime <= 0 {
+			q.MaxQueryTime = defaultQueryTime
+		}
+		q.MaxQueryTime += lib.RandomStagger(q.MaxQueryTime / JitterFraction)
+
+		return time.Since(start) > (q.MaxQueryTime + rpcHoldTimeout)
+	}
+	return time.Since(start) > rpcHoldTimeout
+}
+
 type WriteRequest struct {
 	// Token is the ACL token ID. If not provided, the 'anonymous'
 	// token is assumed for backwards compatibility.
@@ -313,6 +334,10 @@ func (w WriteRequest) TokenSecret() string {
 
 func (w *WriteRequest) SetTokenSecret(s string) {
 	w.Token = s
+}
+
+func (w WriteRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
+	return time.Since(start) > rpcHoldTimeout
 }
 
 // QueryMeta allows a query response to include potentially

--- a/lib/eof.go
+++ b/lib/eof.go
@@ -13,6 +13,9 @@ var yamuxSessionShutdown = yamux.ErrSessionShutdown.Error()
 // IsErrEOF returns true if we get an EOF error from the socket itself, or
 // an EOF equivalent error from yamux.
 func IsErrEOF(err error) bool {
+	if err == nil {
+		return false
+	}
 	if err == io.EOF {
 		return true
 	}

--- a/proto/pbautoconf/auto_config.go
+++ b/proto/pbautoconf/auto_config.go
@@ -1,5 +1,7 @@
 package pbautoconf
 
+import "time"
+
 func (req *AutoConfigRequest) RequestDatacenter() string {
 	return req.Datacenter
 }
@@ -18,4 +20,8 @@ func (req *AutoConfigRequest) TokenSecret() string {
 
 func (req *AutoConfigRequest) SetTokenSecret(token string) {
 	req.ConsulToken = token
+}
+
+func (req *AutoConfigRequest) HasTimedOut(start time.Time, rpcHoldTimeout, maxQueryTime, defaultQueryTime time.Duration) bool {
+	return time.Since(start) > rpcHoldTimeout
 }


### PR DESCRIPTION
I've ported the Nomad fixes from hashicorp/nomad#8921 and hashicorp/nomad#9064.

The only major differences:
* Consul has a configurable MaxQueryTime and DefaultQueryTime, which is a `const` in Nomad.
* agent/consul/rpc.go:ForwardRPC() didn't start the `firstCheck` timer until _after_ the first call.  I did not see any motivation for it to be different than agent/consul/client.go:RPC() and Nomad's client/rpc.go:RPC(), so I moved it to the top of the function.