### PR TITLE
ui: Remove nspace value from routeName

### DIFF
--- a/ui-v2/app/components/outlet/index.js
+++ b/ui-v2/app/components/outlet/index.js
@@ -65,8 +65,9 @@ export default class Outlet extends Component {
   }
 
   setAppRoute(name) {
-    if (name.startsWith('nspace.')) {
-      name = name.substr(0, 'nspace.'.length);
+    const nspace = 'nspace.';
+    if (name.startsWith(nspace)) {
+      name = name.substr(nspace.length);
     }
     if (name !== 'loading') {
       const doc = this.dom.root();


### PR DESCRIPTION
Previously we removed the routeName and left the nspace value, where we should have been removing the nspace value and leaving the routeName