### PR TITLE
stream: stop snapshot cache timers on shutdown

### DIFF
--- a/agent/consul/stream/event_publisher_test.go
+++ b/agent/consul/stream/event_publisher_test.go
@@ -172,7 +172,7 @@ func TestEventPublisher_SubscribeWithIndex0_FromCache(t *testing.T) {
 	_, err := publisher.Subscribe(req)
 	require.NoError(t, err)
 
-	publisher.snapshotHandlers[testTopic] = func(_ SubscribeRequest, _ SnapshotAppender) (uint64, error) {
+	publisher.snapshots.handlers[testTopic] = func(_ SubscribeRequest, _ SnapshotAppender) (uint64, error) {
 		return 0, fmt.Errorf("error should not be seen, cache should have been used")
 	}
 
@@ -348,7 +348,7 @@ func TestEventPublisher_SubscribeWithIndexNotZero_NewSnapshotFromCache(t *testin
 		publisher.publishEvent([]Event{nextEvent})
 	})
 
-	publisher.snapshotHandlers[testTopic] = func(_ SubscribeRequest, _ SnapshotAppender) (uint64, error) {
+	publisher.snapshots.handlers[testTopic] = func(_ SubscribeRequest, _ SnapshotAppender) (uint64, error) {
 		return 0, fmt.Errorf("error should not be seen, cache should have been used")
 	}
 


### PR DESCRIPTION
@mkeeler noticed in an earlier PR that the snapshot cache used `time.AfterFunc` and did not track the goroutines or the timers that it created.

My understanding is that `time.AfterFunc` doesn't create a goroutine until the timer fires. Once the timer goes off it creates a goroutine, which should be short lived because all it does is lock and remove an entry from a map.

This PR attempts to track those timers, and calls `Stop` on them when the EventPublisher is shutdown. I'm not sure how safe this is, but it appears to work.