### PR TITLE
Refactor metrics provider interface for time series.

### DIFF
--- a/ui-v2/app/components/topology-metrics/index.js
+++ b/ui-v2/app/components/topology-metrics/index.js
@@ -16,7 +16,7 @@ export default class TopologyMetrics extends Component {
 
   constructor(owner, args) {
     super(owner, args);
-    this.hasMetricsProvider = !!this.cfg.get().metrics_provider
+    this.hasMetricsProvider = !!this.cfg.get().metrics_provider;
   }
 
   // =methods

--- a/ui-v2/app/components/topology-metrics/series/index.hbs
+++ b/ui-v2/app/components/topology-metrics/series/index.hbs
@@ -4,6 +4,10 @@
 
 {{on-window 'resize' (action 'redraw')}}
 
+{{#if data.labels}}
+<a class="sparkline-key-link" {{action (mut shouldShowKey) true}}>Key</a>
+{{/if}}
+
 <div class="sparkline-wrapper">
   <div class="tooltip">
     <div class="sparkline-time">Timestamp</div>
@@ -12,3 +16,36 @@
   <svg class="sparkline"></svg>
 </div>
 
+{{#if shouldShowKey}}
+<ModalDialog
+  class="sparkline-key"
+  @onclose={{action (mut shouldShowKey) false}}
+  as |modal|>
+    <BlockSlot @name="header">
+      <h3>Metrics Key</h3>
+    </BlockSlot>
+    <BlockSlot @name="body">
+      <div class="sparkline-key-content">
+        <p>This key describes the metrics corresponding to the graph tooltip labels in more detail.</p>
+        <dl>
+          {{#each-in data.labels as |label desc| }}
+            <dt>{{label}}</dt>
+            <dd>{{{desc}}}</dd>
+          {{/each-in}}
+        </dl>
+        {{#unless data.labels}}
+          <span class="no-data">No metrics loaded.</span>
+        {{/unless}}
+      </div>
+    </BlockSlot>
+    <BlockSlot @name="actions">
+      <button
+        type="button"
+        class="type-cancel"
+        onclick={{action modal.close}}
+      >
+        Close
+      </button>
+    </BlockSlot>
+</ModalDialog>
+{{/if}}

--- a/ui-v2/app/components/topology-metrics/series/layout.scss
+++ b/ui-v2/app/components/topology-metrics/series/layout.scss
@@ -17,7 +17,7 @@
     position: absolute;
     z-index: 100;
     bottom: 78px;
-    width: 250px;
+    width: 217px;
   }
 
   .sparkline-tt-legend-color {
@@ -37,3 +37,35 @@
   }
 }
 
+// Key modal
+.sparkline-key {
+  .sparkline-key-content {
+    width: 500px;
+    min-height: 100px;
+
+    dl {
+      padding: 10px 0 0 0;
+    }
+    dt {
+      width: 125px;
+      float: left;
+    }
+    dd {
+      margin: 0 0 12px 135px;
+    }
+  }
+}
+
+.sparkline-key-link {
+  visibility: hidden;
+  float: right;
+  // TODO: this is a massive hack but we want it to be actually outside of the
+  // bounding box of this component. We could move it into the parent component
+  // but it's pretty tied up to the state - should only show if we have metrics
+  // loaded etc. I expect there is a cleaner way to refactor this though.
+  margin-top: -35px;
+  margin-right: 12px;
+}
+#metrics-container:hover .sparkline-key-link {
+  visibility: visible;
+}

--- a/ui-v2/app/components/topology-metrics/series/skin.scss
+++ b/ui-v2/app/components/topology-metrics/series/skin.scss
@@ -1,37 +1,52 @@
-#metrics-container div .sparkline-wrapper {
+#metrics-container .sparkline-wrapper {
   svg path {
     stroke-width: 0;
   }
 
   .tooltip {
-    padding: 5px 10px 10px 10px;
+    padding: 0 0 10px;
     font-size: 0.875em;
     line-height: 1.5em;
     font-weight: normal;
-    border: 1px solid #BAC1CC;
+    border: 1px solid $gray-300;
     background: #fff;
     border-radius: 2px;
     box-sizing: border-box;
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.05), 0px 4px 4px rgba(0, 0, 0, 0.1);
 
     .sparkline-time {
-      padding: 0;
+      padding: 8px 10px;
       font-weight: bold;
       font-size: 14px;
       color: #000;
-      margin-bottom: 5px;
+      border-bottom: 1px solid $gray-200;
+      margin-bottom: 4px;
+      text-align: center;
     }
 
-    .sparkline-tt-legend {
+    .sparkline-tt-legend,
+    .sparkline-tt-sum {
       border: 0;
+      padding: 3px 10px 0 10px;
     }
-  
+
+    .sparkline-tt-sum {
+      border-top: 1px solid $gray-200;
+      margin-top: 4px;
+      padding: 8px 10px 0 10px;
+    }
+
     .sparkline-tt-legend-color {
       width: 12px;
       height: 12px;
       border-radius: 2px;
       margin: 0 5px 0 0;
       padding: 0;
+    }
+
+    .sparkline-tt-legend-value,
+    .sparkline-tt-sum-value {
+      float: right;
     }
   }
 
@@ -43,7 +58,7 @@
     height: 12px;
     left: 15px;
     bottom: -7px;
-    border: 1px solid #BAC1CC;
+    border: 1px solid $gray-300;
     border-top: 0;
     border-left: 0;
     background: #fff;
@@ -51,3 +66,37 @@
   }
 }
 
+// Key modal
+.sparkline-key {
+  h3::before {
+      @extend %with-info-circle-fill-mask, %as-pseudo;
+      margin: 2px 3px 0 0;
+      font-size: 14px;
+  }
+
+  h3 {
+    color: $gray-900;
+    font-size: 16px;
+  }
+
+  .sparkline-key-content {
+    dt {
+      font-weight: 600;
+    }
+    dd {
+      color: $gray-500;
+    }
+  }
+}
+
+.sparkline-key-link {
+  color: $gray-500;
+}
+.sparkline-key-link:hover {
+  color: $blue-500;
+}
+#metrics-container:hover .sparkline-key-link::before {
+  @extend %with-info-circle-fill-mask, %as-pseudo;
+  margin: 1px 3px 0 0;
+  font-size: 12px;
+}


### PR DESCRIPTION
This PR has a few things in:

## Metrics Provider Interface Refactor

The main thing is a refactor of the metics provider interface to make it a but less clunky to meet the strict requirements of the actual stacked series graphs we show. This format makes it more explicit that we need stacked values with same timestamps on same scale etc to be able to show them meaningfully.

This refactor depends on https://github.com/hashicorp/consul-api-double/pull/44.

## Improved graph labels

This also changes the format for labels and descriptions the provider returns which enabled both a cleaner tooltip with more detailed modal to allow full description of the metrics being shown for quick reference without cluttering up the tooltip.

![legend](https://user-images.githubusercontent.com/120915/96577580-bb010780-12cb-11eb-87c3-47c8ce80ba57.gif)

## Handle Provider Init Errors

The provider currently hard codes the proxy endpoint so should per our own provider docs inline throw if that isn't configured. I've made it do that and made sure the metrics repository handles that gracefully.

For now if you don't configure a metrics proxy but _do_ attempt to configure prometheus, you'll see indefinite loading spinners for the metrics (an error state would be even better but couldn't work out how to propagate that without changing too much), as well as a meaningful error in console.log)

![image](https://user-images.githubusercontent.com/120915/96578437-18e21f00-12cd-11eb-9394-d309d468e337.png)

![image](https://user-images.githubusercontent.com/120915/96578415-1089e400-12cd-11eb-8964-289d4f0fdc3a.png)

@johncowen is there an easy way for the DataSource to propagate this error so the UI can show "Error Loading Metrics" or something instead of just spinning forever - if users don't look in the console then it's hard to work out that the config was wrong. Or do we have a better way to surface error messages somewhere? I think this is OK for now if it's hard to do though at least it's somewhat gracefully handled for now.

# TODO:

- [x] Once https://github.com/hashicorp/consul-api-double/pull/44 is merged, add the new dependency
