### PR TITLE
docs: Remove sentence about pluggable CAs

### DIFF
--- a/website/pages/docs/connect/ca/index.mdx
+++ b/website/pages/docs/connect/ca/index.mdx
@@ -19,8 +19,7 @@ storing and signing certificates. Consul ships with a
 root certificate and private key on the Consul servers. Consul also has
 built-in support for
 [Vault as a CA](/docs/connect/ca/vault). With Vault, the root certificate
-and private key material remain with the Vault cluster. A future version of
-Consul will support pluggable CA systems using external binaries.
+and private key material remain with the Vault cluster.
 
 ## CA Bootstrapping
 


### PR DESCRIPTION
Consul's Connect CA documentation mentions future releases will support a pluggable CA system. This sentence has existed in the docs for over two years, however there are currently no plans to develop this feature on the near-term roadmap.

This commit removes this sentence to avoid giving the impression that this feature will be available in an upcoming release.