### PR TITLE
UI metrics provider dc

### DIFF
--- a/agent/uiserver/ui_template_data.go
+++ b/agent/uiserver/ui_template_data.go
@@ -28,9 +28,10 @@ func uiTemplateDataFromConfig(cfg *config.RuntimeConfig) (map[string]interface{}
 	}
 
 	d := map[string]interface{}{
-		"ContentPath": cfg.UIConfig.ContentPath,
-		"ACLsEnabled": cfg.ACLsEnabled,
-		"UIConfig":    uiCfg,
+		"ContentPath":     cfg.UIConfig.ContentPath,
+		"ACLsEnabled":     cfg.ACLsEnabled,
+		"UIConfig":        uiCfg,
+		"LocalDatacenter": cfg.Datacenter,
 	}
 
 	// Also inject additional provider scripts if needed, otherwise strip the

--- a/agent/uiserver/uiserver_test.go
+++ b/agent/uiserver/uiserver_test.go
@@ -34,14 +34,19 @@ func TestUIServerIndex(t *testing.T) {
 			path:         "/", // Note /index.html redirects to /
 			wantStatus:   http.StatusOK,
 			wantContains: []string{"<!-- CONSUL_VERSION:"},
+			wantNotContains: []string{
+				"__RUNTIME_BOOL_",
+				"__RUNTIME_STRING_",
+			},
 			wantEnv: map[string]interface{}{
-				"CONSUL_ACLS_ENABLED": false,
+				"CONSUL_ACLS_ENABLED":     false,
+				"CONSUL_DATACENTER_LOCAL": "dc1",
 			},
 		},
 		{
-			// TODO: is this really what we want? It's what we've always done but
-			// seems a bit odd to not do an actual 301 but instead serve the
-			// index.html from every path... It also breaks the UI probably.
+			// We do this redirect just for UI dir since the app is a single page app
+			// and any URL under the path should just load the index and let Ember do
+			// it's thing unless it's a specific asset URL in the filesystem.
 			name:         "unknown paths to serve index",
 			cfg:          basicUIEnabledConfig(),
 			path:         "/foo-bar-bazz-qux",
@@ -202,6 +207,7 @@ func basicUIEnabledConfig(opts ...cfgFunc) *config.RuntimeConfig {
 			Enabled:     true,
 			ContentPath: "/ui/",
 		},
+		Datacenter: "dc1",
 	}
 	for _, f := range opts {
 		f(cfg)

--- a/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/card.hbs
@@ -47,9 +47,19 @@
   </div>
   {{#if @hasMetricsProvider }}
     {{#if (eq @type 'upstream')}}
-      <TopologyMetrics::Stats @endpoint='upstream-summary-for-service' @service={{@service}} @item={{item.Name}} />
+      <TopologyMetrics::Stats
+        @endpoint='upstream-summary-for-service'
+        @service={{@service}}
+        @item={{item.Name}}
+        @noMetricsReason={{@noMetricsReason}}
+      />
     {{else}}
-      <TopologyMetrics::Stats @endpoint='downstream-summary-for-service' @service={{@service}} @item={{item.Name}} />
+      <TopologyMetrics::Stats
+        @endpoint='downstream-summary-for-service'
+        @service={{@service}}
+        @item={{item.Name}}
+        @noMetricsReason={{@noMetricsReason}}
+      />
     {{/if}}
   {{/if}}
 </a>

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -16,6 +16,7 @@
       @service={{@service.Service.Service}}
       @dc={{@dc}}
       @hasMetricsProvider={{this.hasMetricsProvider}}
+      @noMetricsReason={{noMetricsReason}}
     />
   </div>
 {{/if}}
@@ -24,8 +25,19 @@
       {{@service.Service.Service}}
     </div>
     {{#if this.hasMetricsProvider }}
-      <TopologyMetrics::Series @service={{@service.Service.Service}} @protocol={{@protocol}} />
-      <TopologyMetrics::Stats @endpoint='summary-for-service' @service={{@service.Service.Service}} @protocol={{@protocol}} />
+      <TopologyMetrics::Series
+        @service={{@service.Service.Service}}
+        @dc={{@dc}}
+        @protocol={{@protocol}}
+        @noMetricsReason={{noMetricsReason}}
+      />
+      <TopologyMetrics::Stats
+        @endpoint='summary-for-service'
+        @service={{@service.Service.Service}}
+        @dc={{@dc}}
+        @protocol={{@protocol}}
+        @noMetricsReason={{noMetricsReason}}
+      />
     {{/if}}
     <div class="link">
      {{#if @metricsHref}}
@@ -55,6 +67,7 @@
         @dc={{@dc}}
         @type='upstream'
         @hasMetricsProvider={{this.hasMetricsProvider}}
+        @noMetricsReason={{noMetricsReason}}
       />
     </div>
   {{/each-in}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -29,7 +29,6 @@ export default class TopologyMetrics extends Component {
     if (this.env.var('CONSUL_DATACENTER_LOCAL') != this.args.dc) {
       this.noMetricsReason = 'Unable to fetch metrics for a remote datacenter';
     }
-    console.log(this.env.var('CONSUL_DATACENTER_LOCAL'), this.args.dc);
   }
 
   // =methods

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 
 export default class TopologyMetrics extends Component {
   @service('ui-config') cfg;
+  @service('env') env;
 
   // =attributes
   @tracked centerDimensions;
@@ -13,10 +14,22 @@ export default class TopologyMetrics extends Component {
   @tracked upView;
   @tracked upLines = [];
   @tracked hasMetricsProvider = false;
+  @tracked noMetricsReason = null;
 
   constructor(owner, args) {
     super(owner, args);
     this.hasMetricsProvider = !!this.cfg.get().metrics_provider;
+
+    // Disable metrics fetching if we are not in the local DC since we don't
+    // currently support that for all providers.
+    //
+    // TODO we can make the configurable even before we have a full solution for
+    // multi-DC forwarding for Prometheus so providers that are global for all
+    // DCs like an external managed APM can still load in all DCs.
+    if (this.env.var('CONSUL_DATACENTER_LOCAL') != this.args.dc) {
+      this.noMetricsReason = 'Unable to fetch metrics for a remote datacenter';
+    }
+    console.log(this.env.var('CONSUL_DATACENTER_LOCAL'), this.args.dc);
   }
 
   // =methods

--- a/ui/packages/consul-ui/app/components/topology-metrics/series/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/index.hbs
@@ -1,6 +1,10 @@
-<DataSource
-  @src={{uri nspace dc 'metrics' 'summary-for-service' @service @protocol}}
-  @onchange={{action 'change'}} />
+{{#unless @noMetricsReason}}
+  <DataSource
+    @src={{uri nspace dc 'metrics' 'summary-for-service' @service @protocol}}
+    @onchange={{action 'change'}}
+    @onerror={{action (mut error) value="error"}}
+  />
+{{/unless}}
 
 {{on-window 'resize' (action 'redraw')}}
 
@@ -12,7 +16,12 @@
   <div class="tooltip">
     <div class="sparkline-time">Timestamp</div>
   </div>
-  <div class="sparkline-loader"><span>Loading Metrics</span></div>
+  {{#unless data}}
+    <TopologyMetrics::Status
+      @noMetricsReason={{@noMetricsReason}}
+      @error={{error}}
+    />
+  {{/unless}}
   <svg class="sparkline"></svg>
 </div>
 
@@ -30,7 +39,7 @@
         <dl>
           {{#each-in data.labels as |label desc| }}
             <dt>{{label}}</dt>
-            <dd>{{{desc}}}</dd>
+            <dd>{{desc}}</dd>
           {{/each-in}}
         </dl>
         {{#unless data.labels}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/series/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/index.js
@@ -28,7 +28,6 @@ export default Component.extend({
     },
     change: function(evt) {
       this.set('data', evt.data.series);
-      this.element.querySelector('.sparkline-loader').style.display = 'none';
       this.drawGraphs();
       this.rerender();
     },

--- a/ui/packages/consul-ui/app/components/topology-metrics/series/layout.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/layout.scss
@@ -25,16 +25,11 @@
     display: inline-block;
   }
 
-  div.sparkline-loader {
-    font-weight: normal;
+  // extra padding for the status sub-component that's not needed for the stats
+  // status
+  .topology-metrics-error,
+  .topology-metrics-loader {
     padding-top: 15px;
-    font-size: 0.875rem;
-    color: $gray-500;
-    text-align: center;
-
-    span::after {
-      @extend %with-loading-icon, %as-pseudo;
-    }
   }
 }
 

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.hbs
@@ -1,7 +1,10 @@
-<DataSource
-  @src={{uri nspace dc 'metrics' @endpoint @service @protocol}}
-  @onchange={{action 'statsUpdate'}}
-/>
+{{#unless @noMetricsReason}}
+  <DataSource
+    @src={{uri nspace dc 'metrics' @endpoint @service @protocol}}
+    @onchange={{action 'statsUpdate'}}
+    @onerror={{action (mut error) value="error"}}
+  />
+{{/unless}}
 
 <div class="stats">
   {{#if hasLoaded }}
@@ -19,6 +22,9 @@
       <span>No Metrics Available</span>
     {{/each}}
   {{else}}
-    <span class="loader">Loading Metrics</span>
+    <TopologyMetrics::Status
+      @noMetricsReason={{@noMetricsReason}}
+      @error={{error}}
+    />
   {{/if}}
 </div>

--- a/ui/packages/consul-ui/app/components/topology-metrics/stats/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/stats/index.scss
@@ -18,11 +18,4 @@
   dd {
     color: $gray-400 !important;
   }
-  span {
-    margin: 0 auto !important;
-    color: $gray-500;
-  }
-  span.loader::after {
-    @extend %with-loading-icon, %as-pseudo;
-  }
 }

--- a/ui/packages/consul-ui/app/components/topology-metrics/status/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/status/index.hbs
@@ -1,0 +1,12 @@
+{{#if @noMetricsReason}}
+  <span class="topology-metrics-error">
+    Unable to load metrics
+    <span>
+      <Tooltip>{{@noMetricsReason}}</Tooltip>
+    </span>
+  </span>
+{{else if @error}}
+  <span class="topology-metrics-error">Unable to load metrics</span>
+{{else}}
+  <span class="topology-metrics-loader">Loading Metrics</span>
+{{/if}}

--- a/ui/packages/consul-ui/app/components/topology-metrics/status/index.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/status/index.scss
@@ -1,0 +1,18 @@
+.topology-metrics-error,
+.topology-metrics-loader {
+  font-weight: normal;
+  font-size: 0.875rem;
+  color: $gray-500;
+  text-align: center;
+  margin: 0 auto !important;
+  display: block;
+
+  span::before {
+    @extend %with-info-circle-outline-mask, %as-pseudo;
+    background-color: $gray-500;
+  }
+}
+
+span.topology-metrics-loader::after {
+  @extend %with-loading-icon, %as-pseudo;
+}

--- a/ui/packages/consul-ui/app/services/repository/metrics.js
+++ b/ui/packages/consul-ui/app/services/repository/metrics.js
@@ -38,7 +38,6 @@ export default RepositoryService.extend({
       return Promise.reject(this.error);
     }
     const promises = [
-      // TODO: support namespaces in providers
       this.provider.serviceRecentSummarySeries(dc, nspace, slug, protocol, {}),
       this.provider.serviceRecentSummaryStats(dc, nspace, slug, protocol, {}),
     ];

--- a/ui/packages/consul-ui/app/services/repository/metrics.js
+++ b/ui/packages/consul-ui/app/services/repository/metrics.js
@@ -39,8 +39,8 @@ export default RepositoryService.extend({
     }
     const promises = [
       // TODO: support namespaces in providers
-      this.provider.serviceRecentSummarySeries(slug, protocol, {}),
-      this.provider.serviceRecentSummaryStats(slug, protocol, {}),
+      this.provider.serviceRecentSummarySeries(dc, nspace, slug, protocol, {}),
+      this.provider.serviceRecentSummaryStats(dc, nspace, slug, protocol, {}),
     ];
     return Promise.all(promises).then(function(results) {
       return {
@@ -55,7 +55,7 @@ export default RepositoryService.extend({
     if (this.error) {
       return Promise.reject(this.error);
     }
-    return this.provider.upstreamRecentSummaryStats(slug, {}).then(function(result) {
+    return this.provider.upstreamRecentSummaryStats(dc, nspace, slug, {}).then(function(result) {
       result.meta = meta;
       return result;
     });
@@ -65,7 +65,7 @@ export default RepositoryService.extend({
     if (this.error) {
       return Promise.reject(this.error);
     }
-    return this.provider.downstreamRecentSummaryStats(slug, {}).then(function(result) {
+    return this.provider.downstreamRecentSummaryStats(dc, nspace, slug, {}).then(function(result) {
       result.meta = meta;
       return result;
     });

--- a/ui/packages/consul-ui/app/styles/components.scss
+++ b/ui/packages/consul-ui/app/styles/components.scss
@@ -64,3 +64,4 @@
 @import 'consul-ui/components/topology-metrics';
 @import 'consul-ui/components/topology-metrics/series';
 @import 'consul-ui/components/topology-metrics/stats';
+@import 'consul-ui/components/topology-metrics/status';

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const utils = require('./utils');
 
-const repositoryRoot = path.resolve(__dirname, '../../');
+const repositoryRoot = path.resolve(__dirname, '../../../../');
 
 const repositoryYear = utils.repositoryYear;
 const repositorySHA = utils.repositorySHA;
@@ -96,6 +96,7 @@ module.exports = function(environment, $ = process.env) {
     CONSUL_ACLS_ENABLED: false,
     CONSUL_NSPACES_ENABLED: false,
     CONSUL_SSO_ENABLED: false,
+    CONSUL_DATACENTER_LOCAL: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
 
     // Static variables used in multiple places throughout the UI
     CONSUL_HOME_URL: 'https://www.consul.io',
@@ -114,7 +115,6 @@ module.exports = function(environment, $ = process.env) {
         CONSUL_ACLS_ENABLED: env('CONSUL_ACLS_ENABLED', true),
         CONSUL_NSPACES_ENABLED: env('CONSUL_NSPACES_ENABLED', false),
         CONSUL_SSO_ENABLED: env('CONSUL_SSO_ENABLED', false),
-        CONSUL_DATACENTER_LOCAL: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
 
         '@hashicorp/ember-cli-api-double': {
           'auto-import': false,
@@ -146,7 +146,6 @@ module.exports = function(environment, $ = process.env) {
         CONSUL_ACLS_ENABLED: env('CONSUL_ACLS_ENABLED', true),
         CONSUL_NSPACES_ENABLED: env('CONSUL_NSPACES_ENABLED', true),
         CONSUL_SSO_ENABLED: env('CONSUL_SSO_ENABLED', true),
-        CONSUL_DATACENTER_LOCAL: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
 
         '@hashicorp/ember-cli-api-double': {
           enabled: true,

--- a/ui/packages/consul-ui/config/environment.js
+++ b/ui/packages/consul-ui/config/environment.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const utils = require('./utils');
 
-const repositoryRoot = path.resolve(__dirname, '../../../../');
+const repositoryRoot = path.resolve(__dirname, '../../');
 
 const repositoryYear = utils.repositoryYear;
 const repositorySHA = utils.repositorySHA;
@@ -114,6 +114,7 @@ module.exports = function(environment, $ = process.env) {
         CONSUL_ACLS_ENABLED: env('CONSUL_ACLS_ENABLED', true),
         CONSUL_NSPACES_ENABLED: env('CONSUL_NSPACES_ENABLED', false),
         CONSUL_SSO_ENABLED: env('CONSUL_SSO_ENABLED', false),
+        CONSUL_DATACENTER_LOCAL: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
 
         '@hashicorp/ember-cli-api-double': {
           'auto-import': false,
@@ -145,6 +146,7 @@ module.exports = function(environment, $ = process.env) {
         CONSUL_ACLS_ENABLED: env('CONSUL_ACLS_ENABLED', true),
         CONSUL_NSPACES_ENABLED: env('CONSUL_NSPACES_ENABLED', true),
         CONSUL_SSO_ENABLED: env('CONSUL_SSO_ENABLED', true),
+        CONSUL_DATACENTER_LOCAL: env('CONSUL_DATACENTER_LOCAL', 'dc1'),
 
         '@hashicorp/ember-cli-api-double': {
           enabled: true,
@@ -164,9 +166,14 @@ module.exports = function(environment, $ = process.env) {
         // __RUNTIME_BOOL_Xxxx__ will be replaced with either "true" or "false"
         // depending on whether the named variable is true or false in the data
         // returned from `uiTemplateDataFromConfig`.
+        //
+        // __RUNTIME_STRING_Xxxx__ will be replaced with the literal string in
+        // the named variable in the data returned from
+        // `uiTemplateDataFromConfig`. It may be empty.
         CONSUL_ACLS_ENABLED: '__RUNTIME_BOOL_ACLsEnabled__',
         CONSUL_SSO_ENABLED: '__RUNTIME_BOOL_SSOEnabled__',
         CONSUL_NSPACES_ENABLED: '__RUNTIME_BOOL_NamespacesEnabled__',
+        CONSUL_DATACENTER_LOCAL: '__RUNTIME_STRING_LocalDatacenter__',
       });
       break;
   }

--- a/ui/packages/consul-ui/package.json
+++ b/ui/packages/consul-ui/package.json
@@ -56,7 +56,7 @@
     "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
-    "@hashicorp/consul-api-double": "^5.3.7",
+    "@hashicorp/consul-api-double": "^6.1.0",
     "@hashicorp/ember-cli-api-double": "^3.1.0",
     "@xstate/fsm": "^1.4.0",
     "babel-eslint": "^10.0.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1243,10 +1243,10 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^5.3.7":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-5.4.0.tgz#fc75e064c3e50385f4fb8c5dd9068875806d8901"
-  integrity sha512-vAi580MyPoFhjDl8WhSviMzFJ1/PZesLqYCuGy8vuxqFaKCQET4AR8gRuungWSdRf5432aJXUNtXLhMHdJeNPg==
+"@hashicorp/consul-api-double@^6.1.0":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-6.1.2.tgz#06f1d5e81014b34d6cf5d4935cec1c2eafec1000"
+  integrity sha512-UtM0TuViKS79QD9MuS2LwOassjrNlO0+yy858gXCo1CsxYDRdDNaeFSfKmp2mMmhjxXlxUeXwl4eSZPRczKdAQ==
 
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.2"


### PR DESCRIPTION
This plumbs DC and namespace through to the provider.

It's not actually used yet since we don't yet label metrics with those things CC @freddygv.

This should be last change needed for now before we can document the provider interface.

@freddygv one thing I've proposed here is that in the future if we support cross-DC metrics fetching, we would encode that as an option in this API rather than have another field "metricsDC" which might be different to "serviceDC" (e.g. because downstream metrics come from the source proxies which might be in a different DC to the one you are viewing.

## TODO

- [x] Given the lack if cross DC metrics fetching for now, I intend to add a check to the topology tab that will use the new CONSUL_DATACENTER_LOCAL env var plumbed here to just disable showing metrics in remote DCs for now to avoid showing the wrong ones potentially or just broken graphs. I will probably put that in this PR later.
- [x] Rebase on master once upstream merges.