### PR TITLE
server: break up Intention.Apply monolithic method

### DIFF
--- a/.changelog/9007.txt
+++ b/.changelog/9007.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: break up Intention.Apply monolithic method
+```

--- a/agent/consul/intention_endpoint.go
+++ b/agent/consul/intention_endpoint.go
@@ -212,8 +212,13 @@ func (s *Intention) computeApplyChangesLegacyCreate(
 	// validation, if we do them here too we can generate error messages that
 	// make more sense for legacy edits.
 	if !args.Intention.CanWrite(authz) {
+		sn := args.Intention.SourceServiceName()
+		dn := args.Intention.DestinationServiceName()
 		// todo(kit) Migrate intention access denial logging over to audit logging when we implement it
-		s.logger.Warn("Intention creation denied due to ACLs", "accessorID", accessorID)
+		s.logger.Warn("Intention creation denied due to ACLs",
+			"source", sn.String(),
+			"destination", dn.String(),
+			"accessorID", accessorID)
 		return "", nil, acl.ErrPermissionDenied
 	}
 

--- a/agent/structs/config_entry_intentions.go
+++ b/agent/structs/config_entry_intentions.go
@@ -59,6 +59,59 @@ func (e *ServiceIntentionsConfigEntry) DestinationServiceName() ServiceName {
 	return NewServiceName(e.Name, &e.EnterpriseMeta)
 }
 
+func (e *ServiceIntentionsConfigEntry) UpdateSourceByLegacyID(legacyID string, update *SourceIntention) bool {
+	for i, src := range e.Sources {
+		if src.LegacyID == legacyID {
+			e.Sources[i] = update
+			return true
+		}
+	}
+	return false
+}
+
+func (e *ServiceIntentionsConfigEntry) UpsertSourceByName(sn ServiceName, upsert *SourceIntention) {
+	for i, src := range e.Sources {
+		if src.SourceServiceName() == sn {
+			e.Sources[i] = upsert
+			return
+		}
+	}
+
+	e.Sources = append(e.Sources, upsert)
+}
+
+func (e *ServiceIntentionsConfigEntry) DeleteSourceByLegacyID(legacyID string) bool {
+	for i, src := range e.Sources {
+		if src.LegacyID == legacyID {
+			// Delete slice element: https://github.com/golang/go/wiki/SliceTricks#delete
+			//    a = append(a[:i], a[i+1:]...)
+			e.Sources = append(e.Sources[:i], e.Sources[i+1:]...)
+
+			if len(e.Sources) == 0 {
+				e.Sources = nil
+			}
+			return true
+		}
+	}
+	return false
+}
+
+func (e *ServiceIntentionsConfigEntry) DeleteSourceByName(sn ServiceName) bool {
+	for i, src := range e.Sources {
+		if src.SourceServiceName() == sn {
+			// Delete slice element: https://github.com/golang/go/wiki/SliceTricks#delete
+			//    a = append(a[:i], a[i+1:]...)
+			e.Sources = append(e.Sources[:i], e.Sources[i+1:]...)
+
+			if len(e.Sources) == 0 {
+				e.Sources = nil
+			}
+			return true
+		}
+	}
+	return false
+}
+
 func (e *ServiceIntentionsConfigEntry) ToIntention(src *SourceIntention) *Intention {
 	meta := e.Meta
 	if src.LegacyID != "" {


### PR DESCRIPTION
The `Intention.Apply` RPC is quite large, so this PR attempts to break it down into smaller functions and dissolves the pre-config-entry approach to the breakdown as it only confused things.