### PR TITLE
ui: Prevent redirect to topology url and hide Topology tab if service has no services

### DIFF
--- a/ui/packages/consul-ui/app/models/topology.js
+++ b/ui/packages/consul-ui/app/models/topology.js
@@ -1,6 +1,5 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
-import { computed } from '@ember/object';
 
 export const PRIMARY_KEY = 'uid';
 export const SLUG_KEY = 'ServiceName';

--- a/ui/packages/consul-ui/app/models/topology.js
+++ b/ui/packages/consul-ui/app/models/topology.js
@@ -13,7 +13,4 @@ export default Model.extend({
   Downstreams: attr(),
   Protocol: attr(),
   meta: attr(),
-  Exists: computed(function() {
-    return true;
-  }),
 });

--- a/ui/packages/consul-ui/app/routes/dc/services/show/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/index.js
@@ -19,7 +19,7 @@ export default Route.extend({
     } else {
       switch (kind) {
         case 'ingress-gateway':
-          if (!get(parentModel, 'topology.Exists')) {
+          if (!get(parentModel, 'topology.Datacenter')) {
             to = 'upstreams';
           }
           break;
@@ -30,7 +30,7 @@ export default Route.extend({
           to = 'instances';
           break;
         default:
-          if (!get(parentModel, 'topology.Exists')) {
+          if (!get(parentModel, 'topology.Datacenter')) {
             to = 'instances';
           }
       }

--- a/ui/packages/consul-ui/app/routes/dc/services/show/index.js
+++ b/ui/packages/consul-ui/app/routes/dc/services/show/index.js
@@ -11,25 +11,29 @@ export default Route.extend({
     // so check the length here.
     let to = 'topology';
     const parentModel = this.modelFor(parent);
-
+    const hasProxy = get(parentModel, 'proxies');
     const kind = get(parentModel, 'items.firstObject.Service.Kind');
 
-    switch (kind) {
-      case 'ingress-gateway':
-        if (!get(parentModel, 'topology.Exists')) {
-          to = 'upstreams';
-        }
-        break;
-      case 'terminating-gateway':
-        to = 'services';
-        break;
-      case 'mesh-gateway':
-        to = 'instances';
-        break;
-      default:
-        if (!get(parentModel, 'topology.Exists')) {
+    if (hasProxy.length === 0) {
+      to = 'instances';
+    } else {
+      switch (kind) {
+        case 'ingress-gateway':
+          if (!get(parentModel, 'topology.Exists')) {
+            to = 'upstreams';
+          }
+          break;
+        case 'terminating-gateway':
+          to = 'services';
+          break;
+        case 'mesh-gateway':
           to = 'instances';
-        }
+          break;
+        default:
+          if (!get(parentModel, 'topology.Exists')) {
+            to = 'instances';
+          }
+      }
     }
 
     this.replaceWith(`${parent}.${to}`, parentModel);

--- a/ui/packages/consul-ui/app/templates/dc/services/show.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show.hbs
@@ -29,7 +29,7 @@
     <TabNav @items={{
       compact
           (array
-(if topology.Datacenter
+(if (and topology.Datacenter (gt proxies.length 0))
             (hash label="Topology" href=(href-to "dc.services.show.topology") selected=(is-href "dc.services.show.topology"))
 '')
 (if (eq item.Service.Kind 'terminating-gateway')

--- a/ui/packages/consul-ui/tests/acceptance/dc/services/show-topology.feature
+++ b/ui/packages/consul-ui/tests/acceptance/dc/services/show-topology.feature
@@ -1,0 +1,40 @@
+@setupApplicationTest
+Feature: dc / services / show-topology: Show Topology tab for Service
+  Scenario: Given a service, the Topology tab should display
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Name: service-0
+        ID: service-0-with-id
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I see topology on the tabs
+    Then the url should be /dc1/services/service-0/topology
+  Scenario: Given connect is disabled, the Topology tab should not display or error
+    Given 1 datacenter model with the value "dc1"
+    And 1 node models
+    And 1 service model from yaml
+    ---
+    - Service:
+        Name: service-0
+        ID: service-0-with-id
+    ---
+    And the url "/v1/discovery-chain/service-0?dc=dc1&ns=@namespace" responds with from yaml
+    ---
+    status: 500
+    body: "Connect must be enabled in order to use this endpoint"
+    ---
+    When I visit the service page for yaml
+    ---
+      dc: dc1
+      service: service-0
+    ---
+    And I don't see topology on the tabs
+    Then the url should be /dc1/services/service-0/instances
+

--- a/ui/packages/consul-ui/tests/acceptance/steps/dc/services/show-topology-steps.js
+++ b/ui/packages/consul-ui/tests/acceptance/steps/dc/services/show-topology-steps.js
@@ -1,0 +1,10 @@
+import steps from '../../steps';
+
+// step definitions that are shared between features should be moved to the
+// tests/acceptance/steps/steps.js file
+
+export default function(assert) {
+  return steps(assert).then('I should find a file', function() {
+    assert.ok(true, this.step);
+  });
+}

--- a/ui/packages/consul-ui/tests/pages/dc/services/show.js
+++ b/ui/packages/consul-ui/tests/pages/dc/services/show.js
@@ -8,6 +8,7 @@ export default function(visitable, attribute, collection, text, intentions, filt
       href: attribute('href', '[data-test-dashboard-anchor]'),
     },
     tabs: tabs('tab', [
+      'topology',
       'instances',
       'linked-services',
       'upstreams',


### PR DESCRIPTION
Two conditions apply to see Topology tab:

1. Connect must be enabled
2. Service must have at least 1 proxy

Previously we covered just the first condition. This PR covers the 2nd. 

cc @banks 