### PR TITLE
Add HasExact to topology endpoint

### DIFF
--- a/agent/consul/internal_endpoint_test.go
+++ b/agent/consul/internal_endpoint_test.go
@@ -1622,6 +1622,8 @@ func TestInternal_ServiceTopology(t *testing.T) {
 	// web and web-proxy on node bar - upstream: redis
 	// web and web-proxy on node baz - upstream: redis
 	// redis and redis-proxy on node zip
+	// wildcard deny intention
+	// web -> redis exact intentino
 	registerTestTopologyEntries(t, codec, "")
 
 	var (
@@ -1650,6 +1652,9 @@ func TestInternal_ServiceTopology(t *testing.T) {
 					Allowed:        false,
 					HasPermissions: false,
 					ExternalSource: "nomad",
+
+					// From wildcard deny
+					HasExact: false,
 				},
 			}
 			require.Equal(r, expectUp, out.ServiceTopology.UpstreamDecisions)
@@ -1675,6 +1680,9 @@ func TestInternal_ServiceTopology(t *testing.T) {
 					Allowed:        false,
 					HasPermissions: false,
 					ExternalSource: "nomad",
+
+					// From wildcard deny
+					HasExact: false,
 				},
 			}
 			require.Equal(r, expectDown, out.ServiceTopology.DownstreamDecisions)
@@ -1686,6 +1694,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 				redis.String(): {
 					Allowed:        false,
 					HasPermissions: true,
+					HasExact:       true,
 				},
 			}
 			require.Equal(r, expectUp, out.ServiceTopology.UpstreamDecisions)
@@ -1712,6 +1721,7 @@ func TestInternal_ServiceTopology(t *testing.T) {
 				web.String(): {
 					Allowed:        false,
 					HasPermissions: true,
+					HasExact:       true,
 				},
 			}
 			require.Equal(r, expectDown, out.ServiceTopology.DownstreamDecisions)

--- a/agent/consul/state/intention.go
+++ b/agent/consul/state/intention.go
@@ -500,6 +500,12 @@ func (s *Store) IntentionDecision(
 	}
 	resp.ExternalSource = ixnMatch.Meta[structs.MetaExternalSource]
 
+	// Intentions with wildcard namespaces but specific names are not allowed (*/web -> */api)
+	// So we don't check namespaces to see if there's an exact intention
+	if ixnMatch.SourceName != structs.WildcardSpecifier && ixnMatch.DestinationName != structs.WildcardSpecifier {
+		resp.HasExact = true
+	}
+
 	return resp, nil
 }
 

--- a/agent/consul/state/intention_test.go
+++ b/agent/consul/state/intention_test.go
@@ -1132,6 +1132,16 @@ func TestStore_IntentionDecision(t *testing.T) {
 				},
 			},
 		},
+		&structs.ServiceIntentionsConfigEntry{
+			Kind: structs.ServiceIntentions,
+			Name: "mysql",
+			Sources: []*structs.SourceIntention{
+				{
+					Name:   "*",
+					Action: structs.IntentionActionAllow,
+				},
+			},
+		},
 	}
 
 	s := testConfigStateStore(t)
@@ -1167,6 +1177,7 @@ func TestStore_IntentionDecision(t *testing.T) {
 			expect: structs.IntentionDecisionSummary{
 				Allowed:        false,
 				HasPermissions: true,
+				HasExact:       true,
 			},
 		},
 		{
@@ -1176,6 +1187,7 @@ func TestStore_IntentionDecision(t *testing.T) {
 			expect: structs.IntentionDecisionSummary{
 				Allowed:        false,
 				HasPermissions: false,
+				HasExact:       true,
 			},
 		},
 		{
@@ -1186,6 +1198,17 @@ func TestStore_IntentionDecision(t *testing.T) {
 				Allowed:        true,
 				HasPermissions: false,
 				ExternalSource: "nomad",
+				HasExact:       true,
+			},
+		},
+		{
+			name: "allowed by source wildcard not exact",
+			src:  "anything",
+			dst:  "mysql",
+			expect: structs.IntentionDecisionSummary{
+				Allowed:        true,
+				HasPermissions: false,
+				HasExact:       false,
 			},
 		},
 	}

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -26,8 +26,6 @@ const (
 	// fix up all the places where this was used with the proper namespace
 	// value.
 	IntentionDefaultNamespace = "default"
-
-	MaxIntentionPrecedence = 9
 )
 
 // Intention defines an intention for the Connect Service Graph. This defines
@@ -349,7 +347,7 @@ func (x *Intention) UpdatePrecedence() {
 	var max int
 	switch x.countExact(x.DestinationNS, x.DestinationName) {
 	case 2:
-		max = MaxIntentionPrecedence
+		max = 9
 	case 1:
 		max = 6
 	case 0:

--- a/agent/structs/intention.go
+++ b/agent/structs/intention.go
@@ -26,6 +26,8 @@ const (
 	// fix up all the places where this was used with the proper namespace
 	// value.
 	IntentionDefaultNamespace = "default"
+
+	MaxIntentionPrecedence = 9
 )
 
 // Intention defines an intention for the Connect Service Graph. This defines
@@ -347,7 +349,7 @@ func (x *Intention) UpdatePrecedence() {
 	var max int
 	switch x.countExact(x.DestinationNS, x.DestinationName) {
 	case 2:
-		max = 9
+		max = MaxIntentionPrecedence
 	case 1:
 		max = 6
 	case 0:
@@ -645,11 +647,13 @@ type IntentionQueryCheckResponse struct {
 // Currently contains:
 // - Whether all actions are allowed
 // - Whether the matching intention has L7 permissions attached
-// - Whether the intention is managed by an external source like k8s,
+// - Whether the intention is managed by an external source like k8s
+// - Whether there is an exact, on-wildcard, intention referencing the two services
 type IntentionDecisionSummary struct {
 	Allowed        bool
 	HasPermissions bool
 	ExternalSource string
+	HasExact       bool
 }
 
 // IntentionQueryExact holds the parameters for performing a lookup of an

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -316,8 +316,8 @@ RPC:
 	downstreams, _ := summarizeServices(out.ServiceTopology.Downstreams.ToServiceDump(), nil, "")
 
 	var (
-		upstreamResp   []*ServiceTopologySummary
-		downstreamResp []*ServiceTopologySummary
+		upstreamResp   = make([]*ServiceTopologySummary, 0)
+		downstreamResp = make([]*ServiceTopologySummary, 0)
 	)
 
 	// Sort and attach intention data for upstreams and downstreams

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1373,6 +1373,7 @@ func TestUIServiceTopology(t *testing.T) {
 						},
 					},
 				},
+				Downstreams:    []*ServiceTopologySummary{},
 				FilteredByACLs: false,
 			}
 			result := obj.(ServiceTopology)
@@ -1530,7 +1531,8 @@ func TestUIServiceTopology(t *testing.T) {
 			require.NoError(r, checkIndex(resp))
 
 			expect := ServiceTopology{
-				Protocol: "http",
+				Protocol:  "http",
+				Upstreams: []*ServiceTopologySummary{},
 				Downstreams: []*ServiceTopologySummary{
 					{
 						ServiceSummary: ServiceSummary{

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1369,6 +1369,7 @@ func TestUIServiceTopology(t *testing.T) {
 						Intention: structs.IntentionDecisionSummary{
 							Allowed:        true,
 							HasPermissions: false,
+							HasExact:       true,
 						},
 					},
 				},
@@ -1410,6 +1411,7 @@ func TestUIServiceTopology(t *testing.T) {
 						Intention: structs.IntentionDecisionSummary{
 							Allowed:        true,
 							HasPermissions: false,
+							HasExact:       true,
 						},
 					},
 				},
@@ -1429,6 +1431,9 @@ func TestUIServiceTopology(t *testing.T) {
 							Allowed:        false,
 							HasPermissions: false,
 							ExternalSource: "nomad",
+
+							// From wildcard deny
+							HasExact: false,
 						},
 					},
 				},
@@ -1474,6 +1479,7 @@ func TestUIServiceTopology(t *testing.T) {
 						Intention: structs.IntentionDecisionSummary{
 							Allowed:        false,
 							HasPermissions: true,
+							HasExact:       true,
 						},
 					},
 				},
@@ -1491,6 +1497,9 @@ func TestUIServiceTopology(t *testing.T) {
 							Allowed:        false,
 							HasPermissions: false,
 							ExternalSource: "nomad",
+
+							// From wildcard deny
+							HasExact: false,
 						},
 					},
 				},
@@ -1537,6 +1546,7 @@ func TestUIServiceTopology(t *testing.T) {
 						Intention: structs.IntentionDecisionSummary{
 							Allowed:        false,
 							HasPermissions: true,
+							HasExact:       true,
 						},
 					},
 				},


### PR DESCRIPTION
This flag is being added so that the UI can know whether an exact intention exists between two services. 

If an exact intention exists users will be sent to an "edit" page to avoid overwriting an existing intention.

Now the Intention object attached to each upstream/downstream in the response will look like this:

```
"Intention": {
  "Allowed": false,
  "HasPermissions": true,
  "HasExact: true
}
```