### PR TITLE
Fix even more test flakes in intentions related envoy integration tests

### DIFF
--- a/test/integration/connect/envoy/case-badauthz/setup.sh
+++ b/test/integration/connect/envoy/case-badauthz/setup.sh
@@ -3,7 +3,7 @@
 set -eEuo pipefail
 
 # Setup deny intention
-upsert_l4_intention s1 s2 deny
+setup_upsert_l4_intention s1 s2 deny
 
 gen_envoy_bootstrap s1 19000 primary
 gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-badauthz/setup.sh
+++ b/test/integration/connect/envoy/case-badauthz/setup.sh
@@ -3,7 +3,7 @@
 set -eEuo pipefail
 
 # Setup deny intention
-docker_consul primary intention create -deny s1 s2
+upsert_l4_intention s1 s2 deny
 
 gen_envoy_bootstrap s1 19000 primary
 gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-badauthz/teardown.sh
+++ b/test/integration/connect/envoy/case-badauthz/teardown.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eEuo pipefail
-
-# Remove deny intention
-docker_consul primary intention delete s1 s2

--- a/test/integration/connect/envoy/case-badauthz/verify.bats
+++ b/test/integration/connect/envoy/case-badauthz/verify.bats
@@ -31,9 +31,5 @@ load helpers
 }
 
 @test "s1 upstream should NOT be able to connect to s2" {
-  run retry_default must_fail_tcp_connection localhost:5000
-
-  echo "OUTPUT $output"
-
-  [ "$status" == "0" ]
+  retry_default must_fail_tcp_connection localhost:5000
 }

--- a/test/integration/connect/envoy/case-http-badauthz/setup.sh
+++ b/test/integration/connect/envoy/case-http-badauthz/setup.sh
@@ -3,7 +3,7 @@
 set -eEuo pipefail
 
 # Setup deny intention
-upsert_l4_intention s1 s2 deny
+setup_upsert_l4_intention s1 s2 deny
 
 gen_envoy_bootstrap s1 19000 primary
 gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-http-badauthz/setup.sh
+++ b/test/integration/connect/envoy/case-http-badauthz/setup.sh
@@ -3,7 +3,7 @@
 set -eEuo pipefail
 
 # Setup deny intention
-docker_consul primary intention create -deny s1 s2
+upsert_l4_intention s1 s2 deny
 
 gen_envoy_bootstrap s1 19000 primary
 gen_envoy_bootstrap s2 19001 primary

--- a/test/integration/connect/envoy/case-http-badauthz/teardown.sh
+++ b/test/integration/connect/envoy/case-http-badauthz/teardown.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -eEuo pipefail
-
-# Remove deny intention
-docker_consul primary intention delete s1 s2

--- a/test/integration/connect/envoy/case-l7-intentions/verify.bats
+++ b/test/integration/connect/envoy/case-l7-intentions/verify.bats
@@ -29,50 +29,50 @@ load helpers
 # these all use the same context: "s1 upstream should be able to connect to s2 via upstream s2"
 
 @test "test exact path" {
-  must_pass_http_request GET localhost:5000/exact
-  must_fail_http_request GET localhost:5000/exact-nope
+  retry_default must_pass_http_request GET localhost:5000/exact
+  retry_default must_fail_http_request GET localhost:5000/exact-nope
 }
 
 @test "test prefix path" {
-  must_pass_http_request GET localhost:5000/prefix
-  must_fail_http_request GET localhost:5000/nope-prefix
+  retry_default must_pass_http_request GET localhost:5000/prefix
+  retry_default must_fail_http_request GET localhost:5000/nope-prefix
 }
 
 @test "test regex path" {
-  must_pass_http_request GET localhost:5000/regex
-  must_fail_http_request GET localhost:5000/reggex
+  retry_default must_pass_http_request GET localhost:5000/regex
+  retry_default must_fail_http_request GET localhost:5000/reggex
 }
 
 @test "test present header" {
-  must_pass_http_request GET localhost:5000/hdr-present anything
-  must_fail_http_request GET localhost:5000/hdr-present ""
+  retry_default must_pass_http_request GET localhost:5000/hdr-present anything
+  retry_default must_fail_http_request GET localhost:5000/hdr-present ""
 }
 
 @test "test exact header" {
-  must_pass_http_request GET localhost:5000/hdr-exact exact
-  must_fail_http_request GET localhost:5000/hdr-exact exact-nope
+  retry_default must_pass_http_request GET localhost:5000/hdr-exact exact
+  retry_default must_fail_http_request GET localhost:5000/hdr-exact exact-nope
 }
 
 @test "test prefix header" {
-  must_pass_http_request GET localhost:5000/hdr-prefix prefix
-  must_fail_http_request GET localhost:5000/hdr-prefix nope-prefix
+  retry_default must_pass_http_request GET localhost:5000/hdr-prefix prefix
+  retry_default must_fail_http_request GET localhost:5000/hdr-prefix nope-prefix
 }
 
 @test "test suffix header" {
-  must_pass_http_request GET localhost:5000/hdr-suffix suffix
-  must_fail_http_request GET localhost:5000/hdr-suffix suffix-nope
+  retry_default must_pass_http_request GET localhost:5000/hdr-suffix suffix
+  retry_default must_fail_http_request GET localhost:5000/hdr-suffix suffix-nope
 }
 
 @test "test regex header" {
-  must_pass_http_request GET localhost:5000/hdr-regex regex
-  must_fail_http_request GET localhost:5000/hdr-regex reggex
+  retry_default must_pass_http_request GET localhost:5000/hdr-regex regex
+  retry_default must_fail_http_request GET localhost:5000/hdr-regex reggex
 }
 
 @test "test method match" {
-  must_pass_http_request GET localhost:5000/method-match
-  must_pass_http_request PUT localhost:5000/method-match
-  must_fail_http_request POST localhost:5000/method-match
-  must_fail_http_request HEAD localhost:5000/method-match
+  retry_default must_pass_http_request GET localhost:5000/method-match
+  retry_default must_pass_http_request PUT localhost:5000/method-match
+  retry_default must_fail_http_request POST localhost:5000/method-match
+  retry_default must_fail_http_request HEAD localhost:5000/method-match
 }
 
 # @test "s1 upstream should NOT be able to connect to s2" {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -694,12 +694,21 @@ function delete_config_entry {
   retry_default curl -sL -XDELETE "http://127.0.0.1:8500/v1/config/${KIND}/${NAME}"
 }
 
+function setup_upsert_l4_intention {
+  local SOURCE=$1
+  local DESTINATION=$2
+  local ACTION=$3
+
+  retry_default docker_curl primary -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+      -d"{\"Action\": \"${ACTION}\"}" >/dev/null
+}
+
 function upsert_l4_intention {
   local SOURCE=$1
   local DESTINATION=$2
   local ACTION=$3
 
-  retry_default curl -sL -XPUT "http://localhost:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+  retry_default curl -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
       -d"{\"Action\": \"${ACTION}\"}" >/dev/null
 }
 

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -433,14 +433,18 @@ function assert_intention_allowed {
   local SOURCE=$1
   local DESTINATION=$2
 
-  [ "$(check_intention "${SOURCE}" "${DESTINATION}")" == "true" ]
+  run check_intention "${SOURCE}" "${DESTINATION}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
 }
 
 function assert_intention_denied {
   local SOURCE=$1
   local DESTINATION=$2
 
-  [ "$(check_intention "${SOURCE}" "${DESTINATION}")" == "false" ]
+  run check_intention "${SOURCE}" "${DESTINATION}"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
 }
 
 function docker_consul {
@@ -541,7 +545,7 @@ function must_match_in_stats_proxy_response {
 # Envoy rather than a connection-level error.
 function must_fail_tcp_connection {
   # Attempt to curl through upstream
-  run curl -s -v -f -d hello $1
+  run curl --no-keepalive -s -v -f -d hello $1
 
   echo "OUTPUT $output"
 
@@ -552,11 +556,20 @@ function must_fail_tcp_connection {
   echo "$output" | grep 'Empty reply from server'
 }
 
+function must_pass_tcp_connection {
+  run curl --no-keepalive -s -f -d hello $1
+
+  echo "OUTPUT $output"
+
+  [ "$status" == "0" ]
+  [ "$output" = "hello" ]
+}
+
 # must_fail_http_connection see must_fail_tcp_connection but this expects Envoy
 # to generate a 503 response since the upstreams have refused connection.
 function must_fail_http_connection {
   # Attempt to curl through upstream
-  run curl -s -i -d hello "$1"
+  run curl --no-keepalive -s -i -d hello "$1"
 
   echo "OUTPUT $output"
 
@@ -593,7 +606,7 @@ function must_pass_http_request {
       ;;
   esac
 
-  run retry_default curl -v -s -f $extra_args "$URL"
+  run curl --no-keepalive -v -s -f $extra_args "$URL"
   [ "$status" == 0 ]
 }
 
@@ -627,7 +640,7 @@ function must_fail_http_request {
   esac
 
   # Attempt to curl through upstream
-  run retry_default curl -s -i $extra_args "$URL"
+  run curl --no-keepalive -s -i $extra_args "$URL"
 
   echo "OUTPUT $output"
 
@@ -681,52 +694,13 @@ function delete_config_entry {
   retry_default curl -sL -XDELETE "http://127.0.0.1:8500/v1/config/${KIND}/${NAME}"
 }
 
-function list_intentions {
-  curl -s -f "http://localhost:8500/v1/connect/intentions"
-}
-
-function get_intention_target_name {
-  awk -F / '{ if ( NF == 1 ) { print $0 } else { print $2 }}'
-}
-
-function get_intention_target_namespace {
-  awk -F / '{ if ( NF != 1 ) { print $1 } }'
-}
-
-function get_intention_by_targets {
-  local SOURCE=$1
-  local DESTINATION=$2
-
-  local SOURCE_NS=$(get_intention_target_namespace <<< "${SOURCE}")
-  local SOURCE_NAME=$(get_intention_target_name <<< "${SOURCE}")
-  local DESTINATION_NS=$(get_intention_target_namespace <<< "${DESTINATION}")
-  local DESTINATION_NAME=$(get_intention_target_name <<< "${DESTINATION}")
-
-  existing=$(list_intentions | jq ".[] | select(.SourceNS == \"$SOURCE_NS\" and .SourceName == \"$SOURCE_NAME\" and .DestinationNS == \"$DESTINATION_NS\" and .DestinationName == \"$DESTINATION_NAME\")")
-  if test -z "$existing"
-  then
-    return 1
-  fi
-  echo "$existing"
-  return 0
-}
-
-function update_intention {
+function upsert_l4_intention {
   local SOURCE=$1
   local DESTINATION=$2
   local ACTION=$3
 
-  intention=$(get_intention_by_targets "${SOURCE}" "${DESTINATION}")
-  if test $? -ne 0
-  then
-    return 1
-  fi
-
-  id=$(jq -r .ID <<< "${intention}")
-  updated=$(jq ".Action = \"$ACTION\"" <<< "${intention}")
-
-  curl -s -X PUT "http://localhost:8500/v1/connect/intentions/${id}" -d "${updated}"
-  return $?
+  retry_default curl -sL -XPUT "http://localhost:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+      -d"{\"Action\": \"${ACTION}\"}" >/dev/null
 }
 
 function get_ca_root {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -699,8 +699,8 @@ function upsert_l4_intention {
   local DESTINATION=$2
   local ACTION=$3
 
-  retry_default curl -sL -XPUT "http://localhost:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
-      -d"{\"Action\": \"${ACTION}\"}" >/dev/null
+  retry_default curl -v -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+      -d"{\"Action\": \"${ACTION}\"}"
 }
 
 function get_ca_root {

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -699,8 +699,8 @@ function upsert_l4_intention {
   local DESTINATION=$2
   local ACTION=$3
 
-  retry_default curl -v -sL -XPUT "http://127.0.0.1:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
-      -d"{\"Action\": \"${ACTION}\"}"
+  retry_default curl -sL -XPUT "http://localhost:8500/v1/connect/intentions/exact?source=${SOURCE}&destination=${DESTINATION}" \
+      -d"{\"Action\": \"${ACTION}\"}" >/dev/null
 }
 
 function get_ca_root {

--- a/test/integration/connect/envoy/run-tests.sh
+++ b/test/integration/connect/envoy/run-tests.sh
@@ -223,9 +223,6 @@ function capture_logs {
 
 function stop_services {
   # Teardown
-  if [ -f "${CASE_DIR}/teardown.sh" ] ; then
-    source "${CASE_DIR}/teardown.sh"
-  fi
   docker_kill_rm $REQUIRED_SERVICES
 
   docker_kill_rm consul-primary consul-secondary


### PR DESCRIPTION
The key thing here is to use `curl --no-keepalive` so that envoy
pre-1.15 tests will reliably use the latest listener every time.

Extra:

- Switched away from editing line-item intentions the legacy way.

- Removed some teardown scripts, as we don't share anything between cases anyway

- Removed unnecessary use of `run` in some places.