### PR TITLE
ui: Fix the pointer events to view the tooltips when hovering over the icons

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -20,7 +20,7 @@
   </div>
 {{/if}}
   <div id="metrics-container">
-    <div>
+    <div id="metrics-header">
       {{@service.Service.Service}}
     </div>
     {{#if this.hasMetricsProvider }}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.hbs
@@ -20,7 +20,7 @@
   </div>
 {{/if}}
   <div id="metrics-container">
-    <div id="metrics-header">
+    <div class="metrics-header">
       {{@service.Service.Service}}
     </div>
     {{#if this.hasMetricsProvider }}

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -24,7 +24,7 @@ export default class TopologyMetrics extends Component {
     const order = ['allow', 'deny'];
     const dest = {
       x: this.centerDimensions.x,
-      y: this.centerDimensions.y + this.centerDimensions.height / 4,
+      y: this.centerDimensions.y + this.centerDimensions.height / 2,
     };
 
     return items
@@ -51,7 +51,7 @@ export default class TopologyMetrics extends Component {
     const order = ['allow', 'deny'];
     const src = {
       x: this.centerDimensions.x + 20,
-      y: this.centerDimensions.y + this.centerDimensions.height / 4,
+      y: this.centerDimensions.y + this.centerDimensions.height / 2,
     };
 
     return items
@@ -83,7 +83,7 @@ export default class TopologyMetrics extends Component {
 
     // Get Card elements positions
     const downCards = [...document.querySelectorAll('#downstream-container .card')];
-    const grafanaCard = document.querySelector('#metrics-container');
+    const grafanaCard = document.querySelector('#metrics-header');
     const upCards = [...document.querySelectorAll('#upstream-column .card')];
 
     // Set center positioning points

--- a/ui/packages/consul-ui/app/components/topology-metrics/index.js
+++ b/ui/packages/consul-ui/app/components/topology-metrics/index.js
@@ -83,7 +83,7 @@ export default class TopologyMetrics extends Component {
 
     // Get Card elements positions
     const downCards = [...document.querySelectorAll('#downstream-container .card')];
-    const grafanaCard = document.querySelector('#metrics-header');
+    const grafanaCard = document.querySelector('.metrics-header');
     const upCards = [...document.querySelectorAll('#upstream-column .card')];
 
     // Set center positioning points

--- a/ui/packages/consul-ui/app/components/topology-metrics/layout.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/layout.scss
@@ -14,12 +14,10 @@
 #downstream-lines {
   grid-row: 1 / 3;
   grid-column: 2 / 5;
-  pointer-events: none;
 }
 #upstream-lines {
   grid-row: 1 / 3;
   grid-column: 6 / 9;
-  pointer-events: none;
 }
 #upstream-column {
   grid-row: 1 / 3;

--- a/ui/packages/consul-ui/app/components/topology-metrics/series/layout.scss
+++ b/ui/packages/consul-ui/app/components/topology-metrics/series/layout.scss
@@ -4,6 +4,7 @@
   padding: 0;
   margin: 0;
   height: 70px;
+  z-index: 2;
 
   svg.sparkline {
     width: 100%;


### PR DESCRIPTION
Bug: The use of `pointer-events: none;` prevents the Tooltips from showing up.

Fixes:
- Moving the the lines to point towards the header of the metrics container.
- Using z-index to avoid the issue of overlapping divs. 

<img width="1034" alt="Screen Shot 2020-10-22 at 5 19 46 PM" src="https://user-images.githubusercontent.com/19161242/96931122-ccdcd900-148a-11eb-931c-8db35f43f61e.png">
