### PR TITLE
move static-assets dist to new path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,7 +622,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ./pkg
-      - run: mv pkg/dist pkg/web_ui # 'make static-assets' looks for the 'pkg/web_ui' path
+      - run: mv pkg/packages/consul-ui/dist pkg/web_ui # 'make static-assets' looks for the 'pkg/web_ui' path
       - run: make tools
       - run: make static-assets
       - persist_to_workspace:


### PR DESCRIPTION
The UI was moved to a new workspace folder structure in https://github.com/hashicorp/consul/pull/8994 and therefore the  build is not in `pkg/dist/` but `pkg/packages/consul-ui/dist/` instead. 