### PR TITLE
ui: Fixup CSS for create pages

### DIFF
--- a/ui/packages/consul-ui/app/styles/components/tabular-collection.scss
+++ b/ui/packages/consul-ui/app/styles/components/tabular-collection.scss
@@ -69,10 +69,10 @@ table.has-actions tr > *:nth-last-child(5):first-child ~ * {
 }
 
 /*TODO: trs only live in tables, get rid of table */
-html[data-route^='dc.acls.policies.edit'] [role='dialog'] table tr,
-html[data-route^='dc.acls.policies.edit'] table tr,
-html[data-route^='dc.acls.roles.edit'] [role='dialog'] table tr,
-html[data-route^='dc.acls.roles.edit'] main table.token-list tr {
+html[data-route^='dc.acls.policies'] [role='dialog'] table tr,
+html[data-route^='dc.acls.policies'] table tr,
+html[data-route^='dc.acls.roles'] [role='dialog'] table tr,
+html[data-route^='dc.acls.roles'] main table.token-list tr {
   @extend %tokens-minimal-row;
 }
 // this will get auto calculated later in tabular-collection.js

--- a/ui/packages/consul-ui/app/styles/layout.scss
+++ b/ui/packages/consul-ui/app/styles/layout.scss
@@ -1,8 +1,8 @@
 @import 'layouts/index';
 
 /* all forms have a margin below the header */
-html[data-route$='.create'] .app-view > header + div > *:first-child,
-html[data-route$='.edit'] .app-view > header + div > *:first-child {
+html[data-route$='create'] .app-view > header + div > *:first-child,
+html[data-route$='edit'] .app-view > header + div > *:first-child {
   margin-top: 1.8em;
 }
 /* most tabs have margin after the tab bar, unless the tab has a filter bar */
@@ -59,7 +59,8 @@ main,
 #wrapper > footer {
   @extend %content-container;
 }
-html[data-route$='.edit'] main {
+html[data-route$='create'] main,
+html[data-route$='edit'] main {
   @extend %content-container-restricted;
 }
 

--- a/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/acls/index.scss
@@ -17,16 +17,19 @@ html[data-route^='dc.acls.index'] .filter-bar [role='radiogroup'] {
 }
 
 @media #{$--lt-wide-form} {
+  html[data-route^='dc.acls.create'] main header .actions,
   html[data-route^='dc.acls.edit'] main header .actions {
     float: none;
     display: flex;
     justify-content: space-between;
     margin-bottom: 1em;
   }
+  html[data-route^='dc.acls.create'] main header .actions .with-feedback,
   html[data-route^='dc.acls.edit'] main header .actions .with-feedback {
     position: absolute;
     right: 0;
   }
+  html[data-route^='dc.acls.create'] main header .actions .with-confirmation,
   html[data-route^='dc.acls.edit'] main header .actions .with-confirmation {
     margin-top: 0;
   }

--- a/ui/packages/consul-ui/app/styles/routes/dc/kv/index.scss
+++ b/ui/packages/consul-ui/app/styles/routes/dc/kv/index.scss
@@ -1,4 +1,4 @@
-html[data-route^='dc.kv.edit'] .type-toggle {
+html[data-route^='dc.kv'] .type-toggle {
   float: right;
   margin-bottom: 0 !important;
 }


### PR DESCRIPTION
Since we changed our approach of globally targeting pages with CSS we missed a couple of places where we needed to refer to both create and edit pages (previously both create and edit pages where targeted using `edit`)

Before:

<img width="1320" alt="Screenshot 2020-10-23 at 14 33 56" src="https://user-images.githubusercontent.com/554604/97010052-d3c42400-153c-11eb-8730-90f8f1d09a2f.png">

After:

<img width="919" alt="Screenshot 2020-10-23 at 14 33 33" src="https://user-images.githubusercontent.com/554604/97010070-d9216e80-153c-11eb-87e2-0d88e8df29b6.png">
