### PR TITLE
acl: ensure incompletely replicated policies, roles, and tokens are corrected on restart

### DIFF
--- a/agent/consul/acl_replication_test.go
+++ b/agent/consul/acl_replication_test.go
@@ -1343,7 +1343,7 @@ func TestACLReplication_AllTypes_CorrectedAfterUpgrade(t *testing.T) {
 // It's a heavily trimmed down version of "CopyDir" from
 // https://github.com/moby/moby/blob/master/daemon/graphdriver/copy/copy.go
 func testCopyDir(srcDir, dstDir string) error {
-	testCopyFile := func(srcPath, dstPath string, fileinfo os.FileInfo) error {
+	testCopyFile := func(srcPath, dstPath string) error {
 		srcFile, err := os.Open(srcPath)
 		if err != nil {
 			return err
@@ -1378,7 +1378,7 @@ func testCopyDir(srcDir, dstDir string) error {
 
 		switch mode := f.Mode(); {
 		case mode.IsRegular():
-			if err2 := testCopyFile(srcPath, dstPath, f); err2 != nil {
+			if err2 := testCopyFile(srcPath, dstPath); err2 != nil {
 				return err2
 			}
 		case mode.IsDir():

--- a/agent/consul/acl_replication_types.go
+++ b/agent/consul/acl_replication_types.go
@@ -1,6 +1,7 @@
 package consul
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -52,9 +53,16 @@ func (r *aclTokenReplicator) SortState() (int, int) {
 
 	return len(r.local), len(r.remote)
 }
-func (r *aclTokenReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte) {
+func (r *aclTokenReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte, hashMismatch bool) {
 	v := r.local[i]
-	return v.AccessorID, v.ModifyIndex, v.Hash
+	// Ignore the stored hash during replication.
+	freshHash := v.ComputeHash()
+	hashMismatch = !bytes.Equal(freshHash, v.Hash)
+	return v.AccessorID, v.ModifyIndex, freshHash, hashMismatch
+}
+func (r *aclTokenReplicator) LocalID(i int) string {
+	v := r.local[i]
+	return v.AccessorID
 }
 func (r *aclTokenReplicator) RemoteMeta(i int) (id string, modIndex uint64, hash []byte) {
 	v := r.remote[i]
@@ -170,9 +178,16 @@ func (r *aclPolicyReplicator) SortState() (int, int) {
 
 	return len(r.local), len(r.remote)
 }
-func (r *aclPolicyReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte) {
+func (r *aclPolicyReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte, hashMismatch bool) {
 	v := r.local[i]
-	return v.ID, v.ModifyIndex, v.Hash
+	// Ignore the stored hash during replication.
+	freshHash := v.ComputeHash()
+	hashMismatch = !bytes.Equal(freshHash, v.Hash)
+	return v.ID, v.ModifyIndex, freshHash, hashMismatch
+}
+func (r *aclPolicyReplicator) LocalID(i int) string {
+	v := r.local[i]
+	return v.ID
 }
 func (r *aclPolicyReplicator) RemoteMeta(i int) (id string, modIndex uint64, hash []byte) {
 	v := r.remote[i]
@@ -281,9 +296,16 @@ func (r *aclRoleReplicator) SortState() (int, int) {
 
 	return len(r.local), len(r.remote)
 }
-func (r *aclRoleReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte) {
+func (r *aclRoleReplicator) LocalMeta(i int) (id string, modIndex uint64, hash []byte, hashMismatch bool) {
 	v := r.local[i]
-	return v.ID, v.ModifyIndex, v.Hash
+	// Ignore the stored hash during replication.
+	freshHash := v.ComputeHash()
+	hashMismatch = !bytes.Equal(freshHash, v.Hash)
+	return v.ID, v.ModifyIndex, freshHash, hashMismatch
+}
+func (r *aclRoleReplicator) LocalID(i int) string {
+	v := r.local[i]
+	return v.ID
 }
 func (r *aclRoleReplicator) RemoteMeta(i int) (id string, modIndex uint64, hash []byte) {
 	v := r.remote[i]


### PR DESCRIPTION
If during an in-flight cross-datacenter consul version upgrade the
primary datacenter is updated first and an operator elects to persist a
field into a policy, role, or token that did not exist in the prior consul
version then it can lead to the secondary datacenters replicating the
portion they understand. The entire item is hashed by the primary
datacenter and persisted in the item itself.

Unfortunately replication uses the hash field on both ends to short
circuit re-replication. This means that after the secondary datacenter
is eventually updated to the latest code that COULD understand the new
field, it will never go back and try to re-replicate it to correct it.

Luckily on secondary leader election, when the replication routines are
spinning up for the first iteration they do load all of the IDs and
hashes from the primary and secondary to do a comparison to "catch up".
We hook into this and completely disregard the replicated hashes during
this differencing, preferring to recompute them based on whatever fields
we have stored locally with out CURRENT code.

This means that each restart of a secondary leader gives us another
opportunity to correct incompletely replicated data, and eventually it
should land on a compatible version and stop having to search for
corrections.