### PR TITLE
server: config entry replication now correctly uses namespaces in comparisons

### DIFF
--- a/.changelog/9024.txt
+++ b/.changelog/9024.txt
@@ -1,0 +1,3 @@
+```release-note:security
+Fix Consul Enterprise Namespace Config Entry Replication DoS. Previously an operator with service:write ACL permissions in a Consul Enterprise cluster could write a malicious config entry that caused infinite raft writes due to issues with the namespace replication logic. [CVE-2020-25201] (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25201)
+```

--- a/agent/consul/config_replication_test.go
+++ b/agent/consul/config_replication_test.go
@@ -4,12 +4,92 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil/retry"
 	"github.com/hashicorp/consul/testrpc"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReplication_ConfigSort(t *testing.T) {
+	newDefaults := func(name, protocol string) *structs.ServiceConfigEntry {
+		return &structs.ServiceConfigEntry{
+			Kind:     structs.ServiceDefaults,
+			Name:     name,
+			Protocol: protocol,
+		}
+	}
+	newResolver := func(name string, timeout time.Duration) *structs.ServiceResolverConfigEntry {
+		return &structs.ServiceResolverConfigEntry{
+			Kind:           structs.ServiceResolver,
+			Name:           name,
+			ConnectTimeout: timeout,
+		}
+	}
+
+	type testcase struct {
+		configs []structs.ConfigEntry
+		expect  []structs.ConfigEntry
+	}
+
+	cases := map[string]testcase{
+		"none": {},
+		"one": {
+			configs: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+			},
+		},
+		"just kinds": {
+			configs: []structs.ConfigEntry{
+				newResolver("web", 33*time.Second),
+				newDefaults("web", "grpc"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("web", "grpc"),
+				newResolver("web", 33*time.Second),
+			},
+		},
+		"just names": {
+			configs: []structs.ConfigEntry{
+				newDefaults("db", "grpc"),
+				newDefaults("api", "http2"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("api", "http2"),
+				newDefaults("db", "grpc"),
+			},
+		},
+		"all": {
+			configs: []structs.ConfigEntry{
+				newResolver("web", 33*time.Second),
+				newDefaults("web", "grpc"),
+				newDefaults("db", "grpc"),
+				newDefaults("api", "http2"),
+			},
+			expect: []structs.ConfigEntry{
+				newDefaults("api", "http2"),
+				newDefaults("db", "grpc"),
+				newDefaults("web", "grpc"),
+				newResolver("web", 33*time.Second),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			configSort(tc.configs)
+			require.Equal(t, tc.expect, tc.configs)
+			// and it should be stable
+			configSort(tc.configs)
+			require.Equal(t, tc.expect, tc.configs)
+		})
+	}
+}
 
 func TestReplication_ConfigEntries(t *testing.T) {
 	t.Parallel()

--- a/agent/structs/config_entry.go
+++ b/agent/structs/config_entry.go
@@ -97,6 +97,12 @@ type ServiceConfigEntry struct {
 	RaftIndex
 }
 
+func (e *ServiceConfigEntry) Clone() *ServiceConfigEntry {
+	e2 := *e
+	e2.Expose = e.Expose.Clone()
+	return &e2
+}
+
 func (e *ServiceConfigEntry) GetKind() string {
 	return ServiceDefaults
 }

--- a/agent/structs/connect_proxy_config.go
+++ b/agent/structs/connect_proxy_config.go
@@ -418,6 +418,17 @@ type ExposeConfig struct {
 	Paths []ExposePath `json:",omitempty"`
 }
 
+func (e ExposeConfig) Clone() ExposeConfig {
+	e2 := e
+	if len(e.Paths) > 0 {
+		e2.Paths = make([]ExposePath, 0, len(e.Paths))
+		for _, p := range e.Paths {
+			e2.Paths = append(e2.Paths, p)
+		}
+	}
+	return e2
+}
+
 type ExposePath struct {
 	// ListenerPort defines the port of the proxy's listener for exposed paths.
 	ListenerPort int `json:",omitempty" alias:"listener_port"`


### PR DESCRIPTION
## Summary
An operator with `service:write` ACL permissions in a Consul Enterprise cluster can write a malicious config entry that causes infinite raft writes due to issues with the namespace replication logic. This can lead to an operator with access to one namespace to be able to temporarily delete a doppelgänger configuration in another namespace they should not have access to modify.

This is CVE-2020-25201

## Bug

Previously config entries sharing a kind & name but in different
namespaces could occasionally cause "stuck states" in replication
because the namespace fields were ignored during the differential
comparison phase.

Example:

Two config entries written to the primary:
```
    kind=A,name=web,namespace=bar
    kind=A,name=web,namespace=foo
```
Under the covers these both get saved to memdb, so they are sorted by
all 3 components (kind,name,namespace) during natural iteration. This
means that before the replication code does it's own incomplete sort,
the underlying data IS sorted by namespace ascending (bar comes before
foo).

After one pass of replication the primary and secondary datacenters have
the same set of config entries present. If
`"kind=A,name=web,namespace=bar"` were to be deleted, then things get
weird. Before replication the two sides look like:
```
primary: [
    kind=A,name=web,namespace=foo
]
secondary: [
    kind=A,name=web,namespace=bar
    kind=A,name=web,namespace=foo
]
```
The differential comparison phase walks these two lists in sorted order
and first compares `"kind=A,name=web,namespace=foo"` vs
`"kind=A,name=web,namespace=bar"` and falsely determines they are the SAME
and are thus cause an update of `"kind=A,name=web,namespace=foo"`. Then it
compares `"<nothing>"` with `"kind=A,name=web,namespace=foo"` and falsely
determines that the latter should be DELETED.

During reconciliation the deletes are processed before updates, and so
for a brief moment in the secondary `"kind=A,name=web,namespace=foo"` is
erroneously deleted and then immediately restored.

Unfortunately after this replication phase the final state is identical
to the initial state, so when it loops around again (rate limited) it
repeats the same set of operations indefinitely.