### PR TITLE
streaming: Use a no-op event publisher if streaming is disabled

### DIFF
--- a/agent/connect/ca/provider_consul_test.go
+++ b/agent/connect/ca/provider_consul_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/connect"
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
-	"github.com/stretchr/testify/require"
 )
 
 type consulCAMockDelegate struct {
@@ -48,10 +49,7 @@ func (c *consulCAMockDelegate) ApplyCARequest(req *structs.CARequest) (interface
 }
 
 func newMockDelegate(t *testing.T, conf *structs.CAConfiguration) *consulCAMockDelegate {
-	s, err := state.NewStateStore(nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	s := state.NewStateStore(nil)
 	if s == nil {
 		t.Fatalf("missing state store")
 	}

--- a/agent/consul/gateway_locator_test.go
+++ b/agent/consul/gateway_locator_test.go
@@ -5,18 +5,18 @@ import (
 	"testing"
 	"time"
 
+	memdb "github.com/hashicorp/go-memdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/consul/sdk/testutil"
-	memdb "github.com/hashicorp/go-memdb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGatewayLocator(t *testing.T) {
-	state, err := state.NewStateStore(nil)
-	require.NoError(t, err)
+	state := state.NewStateStore(nil)
 
 	dc1 := &structs.FederationState{
 		Datacenter: "dc1",
@@ -360,10 +360,6 @@ func (d *testServerDelegate) blockingQuery(
 	}
 
 	return err
-}
-
-func newFakeStateStore() (*state.Store, error) {
-	return state.NewStateStore(nil)
 }
 
 func (d *testServerDelegate) IsLeader() bool {

--- a/agent/consul/state/catalog_events.go
+++ b/agent/consul/state/catalog_events.go
@@ -19,9 +19,9 @@ type EventPayloadCheckServiceNode struct {
 // of stream.Events that describe the current state of a service health query.
 //
 // TODO: no tests for this yet
-func serviceHealthSnapshot(s *Store, topic stream.Topic) stream.SnapshotFunc {
+func serviceHealthSnapshot(db ReadDB, topic stream.Topic) stream.SnapshotFunc {
 	return func(req stream.SubscribeRequest, buf stream.SnapshotAppender) (index uint64, err error) {
-		tx := s.db.Txn(false)
+		tx := db.ReadTxn()
 		defer tx.Abort()
 
 		connect := topic == topicServiceHealthConnect

--- a/agent/consul/state/catalog_test.go
+++ b/agent/consul/state/catalog_test.go
@@ -7,14 +7,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/lib/stringslice"
-	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-memdb"
 	uuid "github.com/hashicorp/go-uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/lib/stringslice"
+	"github.com/hashicorp/consul/types"
 )
 
 func makeRandomNodeID(t *testing.T) types.NodeID {
@@ -1080,10 +1081,7 @@ func TestStateStore_GetNodes(t *testing.T) {
 }
 
 func BenchmarkGetNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
-	if err != nil {
-		b.Fatalf("err: %s", err)
-	}
+	s := NewStateStore(nil)
 
 	if err := s.EnsureNode(100, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		b.Fatalf("err: %v", err)
@@ -3710,10 +3708,7 @@ func TestStateStore_CheckConnectServiceNodes_Gateways(t *testing.T) {
 }
 
 func BenchmarkCheckServiceNodes(b *testing.B) {
-	s, err := NewStateStore(nil)
-	if err != nil {
-		b.Fatalf("err: %s", err)
-	}
+	s := NewStateStore(nil)
 
 	if err := s.EnsureNode(1, &structs.Node{Node: "foo", Address: "127.0.0.1"}); err != nil {
 		b.Fatalf("err: %v", err)

--- a/agent/consul/state/kvs_test.go
+++ b/agent/consul/state/kvs_test.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/go-memdb"
+
+	"github.com/hashicorp/consul/agent/structs"
 )
 
 func TestStateStore_ReapTombstones(t *testing.T) {
@@ -91,10 +92,7 @@ func TestStateStore_GC(t *testing.T) {
 
 	// Enable it and attach it to the state store.
 	gc.SetEnabled(true)
-	s, err := NewStateStore(gc)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	s := NewStateStore(gc)
 
 	// Create some KV pairs.
 	testSetKey(t, s, 1, "foo", "foo", nil)

--- a/agent/consul/state/memdb.go
+++ b/agent/consul/state/memdb.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/go-memdb"
@@ -51,8 +52,14 @@ type Changes struct {
 // 2. Sent to the eventPublisher which will create and emit change events
 type changeTrackerDB struct {
 	db             *memdb.MemDB
-	publisher      *stream.EventPublisher
+	publisher      EventPublisher
 	processChanges func(ReadTxn, Changes) ([]stream.Event, error)
+}
+
+type EventPublisher interface {
+	Publish([]stream.Event)
+	Run(context.Context)
+	Subscribe(*stream.SubscribeRequest) (*stream.Subscription, error)
 }
 
 // Txn exists to maintain backwards compatibility with memdb.DB.Txn. Preexisting

--- a/agent/consul/state/state_store_test.go
+++ b/agent/consul/state/state_store_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul/agent/structs"
-	"github.com/hashicorp/consul/types"
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul/agent/structs"
+	"github.com/hashicorp/consul/types"
 )
 
 func testUUID() string {
@@ -48,10 +49,7 @@ func restoreIndexes(indexes []*IndexEntry, r *Restore) error {
 }
 
 func testStateStore(t *testing.T) *Store {
-	s, err := NewStateStore(nil)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	s := NewStateStore(nil)
 	if s == nil {
 		t.Fatalf("missing state store")
 	}

--- a/agent/consul/stream/noop.go
+++ b/agent/consul/stream/noop.go
@@ -1,0 +1,16 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+)
+
+type NoOpEventPublisher struct{}
+
+func (NoOpEventPublisher) Publish([]Event) {}
+
+func (NoOpEventPublisher) Run(context.Context) {}
+
+func (NoOpEventPublisher) Subscribe(*SubscribeRequest) (*Subscription, error) {
+	return nil, fmt.Errorf("stream event publisher is disabled")
+}

--- a/agent/consul/usagemetrics/usagemetrics_oss_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_oss_test.go
@@ -7,13 +7,14 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
-func newStateStore() (*state.Store, error) {
+func newStateStore() *state.Store {
 	return state.NewStateStore(nil)
 }
 
@@ -91,8 +92,7 @@ func TestUsageReporter_emitServiceUsage_OSS(t *testing.T) {
 			metrics.NewGlobal(cfg, sink)
 
 			mockStateProvider := &mockStateProvider{}
-			s, err := newStateStore()
-			require.NoError(t, err)
+			s := state.NewStateStore(nil)
 			if tcase.modfiyStateStore != nil {
 				tcase.modfiyStateStore(t, s)
 			}

--- a/agent/consul/usagemetrics/usagemetrics_test.go
+++ b/agent/consul/usagemetrics/usagemetrics_test.go
@@ -5,11 +5,12 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/hashicorp/consul/agent/consul/state"
 	"github.com/hashicorp/consul/agent/structs"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type mockStateProvider struct {
@@ -61,8 +62,7 @@ func TestUsageReporter_Run_Nodes(t *testing.T) {
 			metrics.NewGlobal(cfg, sink)
 
 			mockStateProvider := &mockStateProvider{}
-			s, err := newStateStore()
-			require.NoError(t, err)
+			s := newStateStore()
 			if tcase.modfiyStateStore != nil {
 				tcase.modfiyStateStore(t, s)
 			}

--- a/agent/rpc/subscribe/subscribe_test.go
+++ b/agent/rpc/subscribe/subscribe_test.go
@@ -308,10 +308,7 @@ func newTestBackend() (*testBackend, error) {
 	if err != nil {
 		return nil, err
 	}
-	store, err := state.NewStateStore(gc)
-	if err != nil {
-		return nil, err
-	}
+	store := state.NewStateStoreWithEventPublisher(gc)
 	allowAll := func(_ string) acl.Authorizer {
 		return acl.AllowAll()
 	}


### PR DESCRIPTION
Branched from #8618

If streaming is disable we can avoid doing any of the work of creating events from memdb changes. This is an additional safeguard to ensure that the new streaming feature does not inadvertently negatively impact any existing clusters.