### PR TITLE
Create load-test job queue and lambda function to spawn workers

### DIFF
--- a/test/load/lambda/README.md
+++ b/test/load/lambda/README.md
@@ -1,0 +1,15 @@
+# startLoadTest Lambda Function
+
+startLoadTest is an AWS lambda function that responds to events containing a deployment string. Currently there are two deployments accepted, `"load-test", "pull-request"`.
+    - `"load-test"` will create a Consul cluster, ELB, and ec2 instances w/ k6. Then it will configure and run the K6 processes to apply traffic to the Consul cluster.
+    - `"pull-request"` is not yet implemented.
+    
+startLoadTest uses a job queue via SQS to begin jobs and accept input. In the future, we intend on generating job events from a slack bot and webhooks created from Pull Requests. Anything that can generate an HTTP request to issue a job event on SQS will be capable of issuing jobs to startLoadTest workers, which are spawned as-needed via AWS Lambda.
+
+## To Deploy
+- Build the binary with `env GOARCH=amd64 GOOS=linux go build startLoadTest.go`
+- Zip the build artifact with `zip startLoadTest.zip startLoadTest`
+- Upload the zip containing the binary to https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/startLoadTest/versions/$LATEST
+
+## To Run
+- TODO

--- a/test/load/lambda/startLoadTest.go
+++ b/test/load/lambda/startLoadTest.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+// Event defines all of our input and configuration
+type Event struct {
+	Deployment string `json:"deployment"`
+	// Version and SHA are optional. If both are missing, default to latest version
+	Version string `json:"version",omitempty`
+	SHA     string `json:"sha",omitempty`
+	// DeploymentID is required when tearing down an existing deployment
+	DeploymentID string `json:deployment_id,omitempty`
+}
+
+// FSM contains the current state of the build and enforces state transitions to only occur between valid states.
+type FSM struct{ state state }
+type state string
+
+// Declare all of our FSM states as const types
+var (
+	Start     state = "start"
+	Build     state = "build"
+	Provision state = "provision"
+	Run       state = "run"
+	Teardown  state = "teardown"
+	Done      state = "done"
+)
+
+func newFSM() FSM {
+	return FSM{state: Build}
+}
+
+// advance currently steps down the list of states, we will add support for more valid state transitions as needed.
+func (m *FSM) advance(next state) (state, error) {
+	switch state := m.state; state {
+	// TODO PR deployments will need to support teardowns of running deploys. Add support for transition from New to Teardown
+	case Start:
+		m.state = Build
+		return m.state, nil
+	case Build:
+		s.state = Provision
+		return m.state, nil
+	case Provision:
+		s.state = Run
+		return m.state, nil
+
+	// TODO PR deployment creation will need to support teardowns of running deploys. Add support for transition from Run to Done
+	case Run:
+		s.state = Teardown
+		return m.state, nil
+
+	case Teardown:
+		s.state = Done
+		return m.state, nil
+
+	case Done:
+		return m.state, fmt.Error("unable to advance FSM, deployment is done")
+	}
+}
+
+func handleLoadTest(ctx context.Context, event Event) (string, error) {
+	// Start a fresh FSM
+	fsm := newFSM()
+
+	// TODO Build the package images from Consul binary taking version or SHA - store the AMI ID
+	state, err := fsm.advance(Build)
+	// TODO Move err string generation to fsm.advance()
+	if state != Build {
+		return nil, fmt.Errorf("attempted to perform build while state is %s", state)
+	}
+
+	// TODO Provision all the server by running `terraform apply` with the AMI ID
+	// TODO Generate a deployment_id that will allow us to delete long-running deployments e.g. pull-request deploys
+	state, err := fsm.advance(Provision)
+	if state != Provision {
+		return nil, fmt.Errorf("attempted to perform provision while state is %s", state)
+	}
+
+	// TODO wait for tests to run
+	state, err := fsm.advance(Run)
+	if state != Run {
+		return nil, fmt.Errorf("attempted to perform run while state is %s", state)
+	}
+
+	// TODO Teardown the terraform cluster
+	state, err := fsm.advance(Teardown)
+	if state != Teardown {
+		return nil, fmt.Errorf("attempted to perform teardown while state is %s", state)
+	}
+
+	// TODO Finish
+	state, err := fsm.advance(Done)
+	if state != Done {
+		return nil, fmt.Errorf("attempted to set state to done while state is %s", state)
+	}
+
+	return fmt.Sprintf("Deployment is %s, %s success", state, event.Deployment), nil
+}
+
+func handlePullRequest(ctx context.Context, event Event) (string, error) {
+	// TODO Fresh PR deploy: Start -> Build -> Provision -> Run -> Done
+	// TODO Delete PR deploy: If deployment_id != nil { New -> Teardown -> Done }
+	return "", fmt.Errorf("cannot deploy pull-request, not yet implemented")
+}
+
+func HandleRequest(ctx context.Context, event Event) (string, error) {
+	switch deployment := event.Deployment; deployment {
+	case "load-test":
+		return handleLoadTest(ctx, event)
+	case "pull-request":
+		return handlePullRequest(ctx, event)
+	default:
+		return "", fmt.Errorf("unknown deployment: %s", deployment)
+	}
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}


### PR DESCRIPTION
@s-christoff and I have been hacking on a way to spawn load-test clusters whenever we want. Some use cases include: running a load-test via a slack bot command or a webhook from CI. And also creating Consul clusters for PR review via Github's webhooks.

Today we ran some experiments, creating a FIFO job queue at https://sqs.us-east-1.amazonaws.com/977604411308/load-test.fifo. Then we decided to implement the worker as lambda function in go, so AWS can spin up new workers ad-hoc to serve job requests.

Included in this draft PR are the src and current deployment steps for the startLoadTest worker.

The `startLoadTest` has an event struct which maps to the JSON fields included in the body of job events. As an MVP, we would have begun accepting events containing `{deployment: "load-test"}`. This will soon run the packer build step, the terraform apply step, wait for the test to run, then use terraform to teardown the created resources. This encodes a simple and linear "create, wait, and delete" cycle to spawn a load test and return its result. Reporting in the logs should be done at each step.

After the load-testing MVP, we can explore the more complicated arrangement of supporting long-running deployments like PR review deploys. We can expect this to exist longer than the max lambda function timeout of 15 minutes, so we need to be able to move to the Done step after the Run step, and also support Start -> Teardown transitions ad-hoc. These steps are encoded in a state machine, which will make enforcing more complicated state transitions possible. See `FSM.advance()` for more on this.