### PR TITLE
ui: Topology limited access banner

### DIFF
--- a/ui/packages/consul-ui/app/components/topology-metrics/banner.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/banner.hbs
@@ -1,0 +1,16 @@
+<Notice
+  class="topology-limited-access-banner"
+  ...attributes
+  @type={{or @type "info"}}
+as |notice|>
+    <notice.Header>
+    <h3>
+      Limited Access
+    </h3>
+  </notice.Header>
+  <notice.Body>
+    <p>
+      This service may have dependencies you won’t see because you don’t have access to them.
+    </p>
+  </notice.Body>
+</Notice>

--- a/ui/packages/consul-ui/app/components/topology-metrics/notice/limited-access.hbs
+++ b/ui/packages/consul-ui/app/components/topology-metrics/notice/limited-access.hbs
@@ -1,5 +1,5 @@
 <Notice
-  class="topology-limited-access-banner"
+  class="topology-metrics-notice-limited-access"
   ...attributes
   @type={{or @type "info"}}
 as |notice|>

--- a/ui/packages/consul-ui/app/models/topology.js
+++ b/ui/packages/consul-ui/app/models/topology.js
@@ -11,5 +11,6 @@ export default Model.extend({
   Upstreams: attr(),
   Downstreams: attr(),
   Protocol: attr(),
+  FilteredByACLs: attr(),
   meta: attr(),
 });

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -1,5 +1,8 @@
 <div id="tags" class="tab-section">
   <div role="tabpanel">
+  {{#if topology.FilteredByACLs}}
+    <TopologyMetrics::Banner />
+  {{/if}}
   {{#if topology}}
     <TopologyMetrics
       @service={{items.firstObject}}

--- a/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
+++ b/ui/packages/consul-ui/app/templates/dc/services/show/topology.hbs
@@ -1,7 +1,7 @@
 <div id="tags" class="tab-section">
   <div role="tabpanel">
   {{#if topology.FilteredByACLs}}
-    <TopologyMetrics::Banner />
+    <TopologyMetrics::Notice::LimitedAccess />
   {{/if}}
   {{#if topology}}
     <TopologyMetrics


### PR DESCRIPTION
Creates a banner for limited access from ACLs.

<img width="1830" alt="Screen Shot 2020-10-26 at 9 20 14 PM" src="https://user-images.githubusercontent.com/19161242/97245257-0b4afe80-17d1-11eb-8a61-9150d721cc03.png">
