### PR TITLE
ui: Metrics - Don't swallow metrics errors

### DIFF
--- a/ui/packages/consul-ui/app/utils/dom/event-source/blocking.js
+++ b/ui/packages/consul-ui/app/utils/dom/event-source/blocking.js
@@ -7,8 +7,11 @@ const pause = 2000;
 export const createErrorBackoff = function(ms = 3000, P = Promise, wait = setTimeout) {
   // This expects an ember-data like error
   return function(err) {
-    const status = get(err, 'errors.firstObject.status');
+    // expect and ember-data error or a http-like error (e.statusCode)
+    let status = get(err, 'errors.firstObject.status') || get(err, 'statusCode');
     if (typeof status !== 'undefined') {
+      // ember-data errors are strings, http errors are numbers
+      status = status.toString();
       switch (true) {
         // Any '5xx' (not 500) errors should back off and try again
         case status.indexOf('5') === 0 && status.length === 3 && status !== '500':

--- a/ui/packages/consul-ui/tests/unit/utils/dom/event-source/blocking-test.js
+++ b/ui/packages/consul-ui/tests/unit/utils/dom/event-source/blocking-test.js
@@ -51,8 +51,8 @@ module('Unit | Utility | dom/event-source/blocking', function() {
       undefined,
       null,
       new Error(),
+      { statusCode: 404 },
       { errors: [] },
-      { errors: [{ status: 501 }] },
       { errors: [{ status: '401' }] },
       { errors: [{ status: '500' }] },
       { errors: [{ status: '5' }] },
@@ -67,6 +67,8 @@ module('Unit | Utility | dom/event-source/blocking', function() {
   });
   test('the 5xx backoff returns a resolve promise on a 5xx (apart from 500)', function(assert) {
     [
+      { statusCode: 501 },
+      { errors: [{ status: 501 }] },
       { errors: [{ status: '501' }] },
       { errors: [{ status: '503' }] },
       { errors: [{ status: '504' }] },


### PR DESCRIPTION
Previously errors were being caught in the provider and replaced with empty data. This meant that the UI would happily keep retrying the provider thinking that it was returning valid empty data even though the proxy was erroring with 404s.

This PR instead passes any errors through to the UI where it will be handled like any other event source/blocking query errors. Anything 50x-like will retry, anything 40x-like will just stop trying.

~~(Guessing tests will fail here until I can submit a PR for an error in the mocks and rebase)~~