### PR TITLE
Remove auto-docs-cherrypick and update UI label

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -70,7 +70,7 @@ theme/testing:
 theme/tls:
     - '(mtls|mTLS|tls|TLS)'
 theme/ui:
-    - '(browser|chrome|firefox|IE|ie|Chrome)'
+    - '(browser|chrome|firefox|IE|Chrome)'
 theme/windows:
     - '(windows|Windows|Microsoft|microsoft)'
 # thinking:

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -52,7 +52,7 @@ theme/testing:
 theme/tls:
     - tlsutil/**/*
 theme/ui:
-    - ui-v2/**/*
+    - ui/**/*
 # theme/windows:
 # thinking:
 # type/bug:
@@ -60,6 +60,4 @@ type/ci:
     - .circleci/*
 # type/crash:
 type/docs:
-    - website/**/*
-type/docs-cherrypick:
     - website/**/*


### PR DESCRIPTION
Follows up on https://github.com/hashicorp/consul/pull/8994 to update the labeler.