### PR TITLE
connect: Use the lookup-self endpoint for Vault token

### DIFF
--- a/agent/connect/ca/provider_vault.go
+++ b/agent/connect/ca/provider_vault.go
@@ -79,7 +79,7 @@ func (v *VaultProvider) Configure(cfg ProviderConfig) error {
 	v.spiffeID = connect.SpiffeIDSigningForCluster(&structs.CAConfiguration{ClusterID: v.clusterID})
 
 	// Look up the token to see if we can auto-renew its lease.
-	secret, err := client.Auth().Token().Lookup(config.Token)
+	secret, err := client.Auth().Token().LookupSelf()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's possible for a Vault token to not have access to the `/auth/token/lookup` endpoint, so use `/auth/token/lookup-self` instead to fetch info about renewal.