### PR TITLE
agent: introduce path allow list for requests going through the metrics proxy

### DIFF
--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -1105,8 +1105,8 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 
 	if rt.UIConfig.MetricsProvider == "prometheus" {
 		// Handle defaulting for the built-in version of prometheus.
-		if len(rt.UIConfig.MetricsProxy.AllowedPaths) == 0 {
-			rt.UIConfig.MetricsProxy.AllowedPaths = []string{
+		if len(rt.UIConfig.MetricsProxy.PathAllowlist) == 0 {
+			rt.UIConfig.MetricsProxy.PathAllowlist = []string{
 				"/api/v1/query",
 				"/api/v1/query_range",
 			}
@@ -1191,9 +1191,9 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 				rt.UIConfig.MetricsProxy.BaseURL)
 		}
 	}
-	for _, allowedPath := range rt.UIConfig.MetricsProxy.AllowedPaths {
+	for _, allowedPath := range rt.UIConfig.MetricsProxy.PathAllowlist {
 		if err := validateAbsoluteURLPath(allowedPath); err != nil {
-			return fmt.Errorf("ui_config.metrics_proxy.allowed_paths: %v", err)
+			return fmt.Errorf("ui_config.metrics_proxy.path_allowlist: %v", err)
 		}
 	}
 	for k, v := range rt.UIConfig.DashboardURLTemplates {
@@ -1762,9 +1762,9 @@ func (b *Builder) uiMetricsProxyVal(v RawUIMetricsProxy) UIMetricsProxy {
 	}
 
 	return UIMetricsProxy{
-		BaseURL:      b.stringVal(v.BaseURL),
-		AddHeaders:   hdrs,
-		AllowedPaths: v.AllowedPaths,
+		BaseURL:       b.stringVal(v.BaseURL),
+		AddHeaders:    hdrs,
+		PathAllowlist: v.PathAllowlist,
 	}
 }
 

--- a/agent/config/builder.go
+++ b/agent/config/builder.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -1102,6 +1103,16 @@ func (b *Builder) Build() (rt RuntimeConfig, err error) {
 		return RuntimeConfig{}, fmt.Errorf("cache.entry_fetch_rate must be strictly positive, was: %v", rt.Cache.EntryFetchRate)
 	}
 
+	if rt.UIConfig.MetricsProvider == "prometheus" {
+		// Handle defaulting for the built-in version of prometheus.
+		if len(rt.UIConfig.MetricsProxy.AllowedPaths) == 0 {
+			rt.UIConfig.MetricsProxy.AllowedPaths = []string{
+				"/api/v1/query",
+				"/api/v1/query_range",
+			}
+		}
+	}
+
 	if err := b.BuildEnterpriseRuntimeConfig(&rt, &c); err != nil {
 		return rt, err
 	}
@@ -1178,6 +1189,11 @@ func (b *Builder) Validate(rt RuntimeConfig) error {
 			return fmt.Errorf("ui_config.metrics_proxy.base_url must be a valid http"+
 				" or https URL. received: %q",
 				rt.UIConfig.MetricsProxy.BaseURL)
+		}
+	}
+	for _, allowedPath := range rt.UIConfig.MetricsProxy.AllowedPaths {
+		if err := validateAbsoluteURLPath(allowedPath); err != nil {
+			return fmt.Errorf("ui_config.metrics_proxy.allowed_paths: %v", err)
 		}
 	}
 	for k, v := range rt.UIConfig.DashboardURLTemplates {
@@ -1746,8 +1762,9 @@ func (b *Builder) uiMetricsProxyVal(v RawUIMetricsProxy) UIMetricsProxy {
 	}
 
 	return UIMetricsProxy{
-		BaseURL:    b.stringVal(v.BaseURL),
-		AddHeaders: hdrs,
+		BaseURL:      b.stringVal(v.BaseURL),
+		AddHeaders:   hdrs,
+		AllowedPaths: v.AllowedPaths,
 	}
 }
 
@@ -2323,5 +2340,26 @@ func validateRemoteScriptsChecks(conf RuntimeConfig) error {
 	if conf.EnableRemoteScriptChecks && !conf.ACLsEnabled && len(conf.AllowWriteHTTPFrom) == 0 {
 		return errors.New(remoteScriptCheckSecurityWarning)
 	}
+	return nil
+}
+
+func validateAbsoluteURLPath(p string) error {
+	if !path.IsAbs(p) {
+		return fmt.Errorf("path %q is not an absolute path", p)
+	}
+
+	// A bit more extra validation that these are actually paths.
+	u, err := url.Parse(p)
+	if err != nil ||
+		u.Scheme != "" ||
+		u.Opaque != "" ||
+		u.User != nil ||
+		u.Host != "" ||
+		u.RawQuery != "" ||
+		u.Fragment != "" ||
+		u.Path != p {
+		return fmt.Errorf("path %q is not an absolute path", p)
+	}
+
 	return nil
 }

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -797,8 +797,9 @@ type RawUIConfig struct {
 }
 
 type RawUIMetricsProxy struct {
-	BaseURL    *string                      `json:"base_url,omitempty" hcl:"base_url" mapstructure:"base_url"`
-	AddHeaders []RawUIMetricsProxyAddHeader `json:"add_headers,omitempty" hcl:"add_headers" mapstructure:"add_headers"`
+	BaseURL      *string                      `json:"base_url,omitempty" hcl:"base_url" mapstructure:"base_url"`
+	AddHeaders   []RawUIMetricsProxyAddHeader `json:"add_headers,omitempty" hcl:"add_headers" mapstructure:"add_headers"`
+	AllowedPaths []string                     `json:"allowed_paths,omitempty" hcl:"allowed_paths" mapstructure:"allowed_Paths"`
 }
 
 type RawUIMetricsProxyAddHeader struct {

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -797,9 +797,9 @@ type RawUIConfig struct {
 }
 
 type RawUIMetricsProxy struct {
-	BaseURL      *string                      `json:"base_url,omitempty" hcl:"base_url" mapstructure:"base_url"`
-	AddHeaders   []RawUIMetricsProxyAddHeader `json:"add_headers,omitempty" hcl:"add_headers" mapstructure:"add_headers"`
-	AllowedPaths []string                     `json:"allowed_paths,omitempty" hcl:"allowed_paths" mapstructure:"allowed_Paths"`
+	BaseURL       *string                      `json:"base_url,omitempty" hcl:"base_url" mapstructure:"base_url"`
+	AddHeaders    []RawUIMetricsProxyAddHeader `json:"add_headers,omitempty" hcl:"add_headers" mapstructure:"add_headers"`
+	PathAllowlist []string                     `json:"path_allowlist,omitempty" hcl:"path_allowlist" mapstructure:"path_allowlist"`
 }
 
 type RawUIMetricsProxyAddHeader struct {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1540,9 +1540,9 @@ type UIConfig struct {
 }
 
 type UIMetricsProxy struct {
-	BaseURL      string
-	AddHeaders   []UIMetricsProxyAddHeader
-	AllowedPaths []string
+	BaseURL       string
+	AddHeaders    []UIMetricsProxyAddHeader
+	PathAllowlist []string
 }
 
 type UIMetricsProxyAddHeader struct {

--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1540,8 +1540,9 @@ type UIConfig struct {
 }
 
 type UIMetricsProxy struct {
-	BaseURL    string
-	AddHeaders []UIMetricsProxyAddHeader
+	BaseURL      string
+	AddHeaders   []UIMetricsProxyAddHeader
+	AllowedPaths []string
 }
 
 type UIMetricsProxyAddHeader struct {

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -4546,143 +4546,143 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 			err: `ui_config.metrics_proxy.base_url must be a valid http or https URL.`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (empty)",
+			desc: "metrics_proxy.path_allowlist invalid (empty)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["", "/foo"]
+						"path_allowlist": ["", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["", "/foo"]
+					path_allowlist = ["", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (relative)",
+			desc: "metrics_proxy.path_allowlist invalid (relative)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["bar/baz", "/foo"]
+						"path_allowlist": ["bar/baz", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["bar/baz", "/foo"]
+					path_allowlist = ["bar/baz", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "bar/baz" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "bar/baz" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (weird)",
+			desc: "metrics_proxy.path_allowlist invalid (weird)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["://bar/baz", "/foo"]
+						"path_allowlist": ["://bar/baz", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["://bar/baz", "/foo"]
+					path_allowlist = ["://bar/baz", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "://bar/baz" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "://bar/baz" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (fragment)",
+			desc: "metrics_proxy.path_allowlist invalid (fragment)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["/bar/baz#stuff", "/foo"]
+						"path_allowlist": ["/bar/baz#stuff", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["/bar/baz#stuff", "/foo"]
+					path_allowlist = ["/bar/baz#stuff", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "/bar/baz#stuff" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "/bar/baz#stuff" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (querystring)",
+			desc: "metrics_proxy.path_allowlist invalid (querystring)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["/bar/baz?stu=ff", "/foo"]
+						"path_allowlist": ["/bar/baz?stu=ff", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["/bar/baz?stu=ff", "/foo"]
+					path_allowlist = ["/bar/baz?stu=ff", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "/bar/baz?stu=ff" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "/bar/baz?stu=ff" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths invalid (encoded slash)",
+			desc: "metrics_proxy.path_allowlist invalid (encoded slash)",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["/bar%2fbaz", "/foo"]
+						"path_allowlist": ["/bar%2fbaz", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["/bar%2fbaz", "/foo"]
+					path_allowlist = ["/bar%2fbaz", "/foo"]
 				}
 			}
 			`},
-			err: `ui_config.metrics_proxy.allowed_paths: path "/bar%2fbaz" is not an absolute path`,
+			err: `ui_config.metrics_proxy.path_allowlist: path "/bar%2fbaz" is not an absolute path`,
 		},
 		{
-			desc: "metrics_proxy.allowed_paths ok",
+			desc: "metrics_proxy.path_allowlist ok",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_proxy": {
-						"allowed_paths": ["/bar/baz", "/foo"]
+						"path_allowlist": ["/bar/baz", "/foo"]
 					}
 				}
 			}`},
 			hcl: []string{`
 			ui_config {
 				metrics_proxy {
-					allowed_paths = ["/bar/baz", "/foo"]
+					path_allowlist = ["/bar/baz", "/foo"]
 				}
 			}
 			`},
 			patch: func(rt *RuntimeConfig) {
-				rt.UIConfig.MetricsProxy.AllowedPaths = []string{"/bar/baz", "/foo"}
+				rt.UIConfig.MetricsProxy.PathAllowlist = []string{"/bar/baz", "/foo"}
 				rt.DataDir = dataDir
 			},
 		},
 		{
-			desc: "metrics_proxy.allowed_paths defaulted for prometheus",
+			desc: "metrics_proxy.path_allowlist defaulted for prometheus",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
@@ -4696,7 +4696,7 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 			`},
 			patch: func(rt *RuntimeConfig) {
 				rt.UIConfig.MetricsProvider = "prometheus"
-				rt.UIConfig.MetricsProxy.AllowedPaths = []string{
+				rt.UIConfig.MetricsProxy.PathAllowlist = []string{
 					"/api/v1/query",
 					"/api/v1/query_range",
 				}
@@ -4704,13 +4704,13 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 			},
 		},
 		{
-			desc: "metrics_proxy.allowed_paths not overridden with defaults for prometheus",
+			desc: "metrics_proxy.path_allowlist not overridden with defaults for prometheus",
 			args: []string{`-data-dir=` + dataDir},
 			json: []string{`{
 				"ui_config": {
 					"metrics_provider": "prometheus",
 					"metrics_proxy": {
-						"allowed_paths": ["/bar/baz", "/foo"]
+						"path_allowlist": ["/bar/baz", "/foo"]
 					}
 				}
 			}`},
@@ -4718,13 +4718,13 @@ func TestBuilder_BuildAndValidate_ConfigFlagsAndEdgecases(t *testing.T) {
 			ui_config {
 				metrics_provider = "prometheus"
 				metrics_proxy {
-					allowed_paths = ["/bar/baz", "/foo"]
+					path_allowlist = ["/bar/baz", "/foo"]
 				}
 			}
 			`},
 			patch: func(rt *RuntimeConfig) {
 				rt.UIConfig.MetricsProvider = "prometheus"
-				rt.UIConfig.MetricsProxy.AllowedPaths = []string{"/bar/baz", "/foo"}
+				rt.UIConfig.MetricsProxy.PathAllowlist = []string{"/bar/baz", "/foo"}
 				rt.DataDir = dataDir
 			},
 		},
@@ -5643,7 +5643,7 @@ func TestFullConfig(t *testing.T) {
 							"value": "TYBgnN2F"
 						}
 					],
-					"allowed_paths": ["/aSh3cu", "/eiK/2Th"]
+					"path_allowlist": ["/aSh3cu", "/eiK/2Th"]
 				},
 				"dashboard_url_templates": {
 					"u2eziu2n_lower_case": "http://lkjasd.otr"
@@ -6333,7 +6333,7 @@ func TestFullConfig(t *testing.T) {
 							value = "TYBgnN2F"
 						}
 					]
-					allowed_paths = ["/aSh3cu", "/eiK/2Th"]
+					path_allowlist = ["/aSh3cu", "/eiK/2Th"]
 				}
 			 	dashboard_url_templates {
 					u2eziu2n_lower_case = "http://lkjasd.otr"
@@ -7127,7 +7127,7 @@ func TestFullConfig(t *testing.T) {
 						Value: "TYBgnN2F",
 					},
 				},
-				AllowedPaths: []string{"/aSh3cu", "/eiK/2Th"},
+				PathAllowlist: []string{"/aSh3cu", "/eiK/2Th"},
 			},
 			DashboardURLTemplates: map[string]string{"u2eziu2n_lower_case": "http://lkjasd.otr"},
 		},
@@ -7813,8 +7813,8 @@ func TestSanitize(t *testing.T) {
 			"MetricsProviderOptionsJSON": "",
 			"MetricsProxy": {
 				"AddHeaders": [],
-				"AllowedPaths": [],
-				"BaseURL": ""
+				"BaseURL": "",
+				"PathAllowlist": []
 			},
 			"DashboardURLTemplates": {}
 		},

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -589,12 +589,12 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 	// double slashes etc.
 	u.Path = path.Clean(u.Path)
 
-	if len(cfg.AllowedPaths) > 0 {
+	if len(cfg.PathAllowlist) > 0 {
 		// This could be done better with a map, but for the prometheus default
 		// integration this list has two items in it, so the straight iteration
 		// isn't awful.
 		denied := true
-		for _, allowedPath := range cfg.AllowedPaths {
+		for _, allowedPath := range cfg.PathAllowlist {
 			if u.Path == allowedPath {
 				denied = false
 				break
@@ -605,7 +605,7 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 				"base_url", cfg.BaseURL,
 				"path", subPath,
 				"target_url", u.String(),
-				"allowed_paths", cfg.AllowedPaths,
+				"path_allowlist", cfg.PathAllowlist,
 			)
 			resp.WriteHeader(http.StatusForbidden)
 			return nil, nil

--- a/agent/ui_endpoint.go
+++ b/agent/ui_endpoint.go
@@ -589,6 +589,29 @@ func (s *HTTPHandlers) UIMetricsProxy(resp http.ResponseWriter, req *http.Reques
 	// double slashes etc.
 	u.Path = path.Clean(u.Path)
 
+	if len(cfg.AllowedPaths) > 0 {
+		// This could be done better with a map, but for the prometheus default
+		// integration this list has two items in it, so the straight iteration
+		// isn't awful.
+		denied := true
+		for _, allowedPath := range cfg.AllowedPaths {
+			if u.Path == allowedPath {
+				denied = false
+				break
+			}
+		}
+		if denied {
+			log.Error("target URL path is not allowed",
+				"base_url", cfg.BaseURL,
+				"path", subPath,
+				"target_url", u.String(),
+				"allowed_paths", cfg.AllowedPaths,
+			)
+			resp.WriteHeader(http.StatusForbidden)
+			return nil, nil
+		}
+	}
+
 	// Pass through query params
 	u.RawQuery = req.URL.RawQuery
 

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1634,8 +1634,8 @@ func TestUIEndpoint_MetricsProxy(t *testing.T) {
 		{
 			name: "blocked path",
 			config: config.UIMetricsProxy{
-				BaseURL:      backendURL,
-				AllowedPaths: []string{"/some/other-prefix/ok"},
+				BaseURL:       backendURL,
+				PathAllowlist: []string{"/some/other-prefix/ok"},
 			},
 			path:     endpointPath + "/ok",
 			wantCode: http.StatusForbidden,
@@ -1643,8 +1643,8 @@ func TestUIEndpoint_MetricsProxy(t *testing.T) {
 		{
 			name: "allowed path",
 			config: config.UIMetricsProxy{
-				BaseURL:      backendURL,
-				AllowedPaths: []string{"/some/prefix/ok"},
+				BaseURL:       backendURL,
+				PathAllowlist: []string{"/some/prefix/ok"},
 			},
 			path:         endpointPath + "/ok",
 			wantCode:     http.StatusOK,

--- a/agent/ui_endpoint_test.go
+++ b/agent/ui_endpoint_test.go
@@ -1632,6 +1632,25 @@ func TestUIEndpoint_MetricsProxy(t *testing.T) {
 			wantCode: http.StatusNotFound,
 		},
 		{
+			name: "blocked path",
+			config: config.UIMetricsProxy{
+				BaseURL:      backendURL,
+				AllowedPaths: []string{"/some/other-prefix/ok"},
+			},
+			path:     endpointPath + "/ok",
+			wantCode: http.StatusForbidden,
+		},
+		{
+			name: "allowed path",
+			config: config.UIMetricsProxy{
+				BaseURL:      backendURL,
+				AllowedPaths: []string{"/some/prefix/ok"},
+			},
+			path:         endpointPath + "/ok",
+			wantCode:     http.StatusOK,
+			wantContains: "OK",
+		},
+		{
 			name: "basic proxying",
 			config: config.UIMetricsProxy{
 				BaseURL: backendURL,

--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -157,6 +157,7 @@ function assert_envoy_http_rbac_policy_count {
   local EXPECT_COUNT=$2
 
   GOT_COUNT=$(get_envoy_http_rbac_once $HOSTPORT | jq '.rules.policies | length')
+  echo "GOT_COUNT = $GOT_COUNT"
   [ "${GOT_COUNT:-0}" -eq $EXPECT_COUNT ]
 }
 
@@ -172,6 +173,7 @@ function assert_envoy_network_rbac_policy_count {
   local EXPECT_COUNT=$2
 
   GOT_COUNT=$(get_envoy_network_rbac_once $HOSTPORT | jq '.rules.policies | length')
+  echo "GOT_COUNT = $GOT_COUNT"
   [ "${GOT_COUNT:-0}" -eq $EXPECT_COUNT ]
 }
 


### PR DESCRIPTION
Added a new option `ui_config.metrics_proxy.path_allowlist`. This defaults to `["/api/v1/query", "/api/v1/query_range"]` when the metrics provider is set to `prometheus`.

Requests that do not use one of the allow-listed paths (via exact match) get a 403 Forbidden response instead.

## checklist

 - [x] Add the field to the Config struct (or an appropriate sub-struct) in
   `agent/config/config.go`.
 - [x] Add the field to the actual RuntimeConfig struct in
   `agent/config/runtime.go`.
 - [x] Add an appropriate parser/setter in `agent/config/builder.go` to
   translate.
 - [x] Add the new field with a random value to both the JSON and HCL blobs in
   `TestFullConfig` in `agent/config/runtime_test.go`, it should fail now, then
   add the same random value to the expected struct in that test so it passes
   again.
 - [x] Add the new field and it's default value to `TestSanitize` in the same
   file. (Running the test first gives you a nice diff which can save working
   out where etc.)
 - [x] **If** your new config field needed some validation as it's only valid in
   some cases or with some values (often true).
      - [x] Add validation to Validate in `agent/config/builder.go`.
      - [x] Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.
 - [ ] **If** your new config field needs a non-zero-value default.
      - [ ] Add that to `DefaultSource` in `agent/config/defaults.go`.
      - [ ] Add a test case to the table test `TestConfigFlagsAndEdgeCases` in
        `agent/config/runtime_test.go`.
 - [x] **If** your config should take effect on a reload/HUP.
      - [ ] Add necessary code to to trigger a safe (locked or atomic) update to
        any state the feature needs changing. This needs to be added to one or
        more of the following places:
         - `ReloadConfig` in `agent/agent.go` if it needs to affect the local
           client state or another client agent component.
         - `ReloadConfig` in `agent/consul/client.go` if it needs to affect
           state for client agent's RPC client.
      - [ ] Add a test to `agent/agent_test.go` similar to others with prefix
        `TestAgent_reloadConfig*`.
 - [ ] Add documentation to `website/pages/docs/agent/options.mdx`.
