### PR TITLE
ui: Update node_modules deps path in GNUMakefile

### DIFF
--- a/ui/packages/consul-ui/GNUmakefile
+++ b/ui/packages/consul-ui/GNUmakefile
@@ -3,7 +3,7 @@ CONSUL_UI_INSTALL_FLAGS?=
 
 all: build
 
-deps: node_modules clean
+deps: ../../node_modules clean
 
 clean:
 	rm -rf ./tmp


### PR DESCRIPTION
Updates `node_modules` path/makefile target to fix top-level `make ui` command.