### PR TITLE
ui: Remove string casting when passing index/checked for dropmenus

### DIFF
--- a/ui/packages/consul-ui/app/components/list-collection/index.js
+++ b/ui/packages/consul-ui/app/components/list-collection/index.js
@@ -71,7 +71,7 @@ export default Component.extend(Slotted, {
       return this.dom.clickFirstAnchor(e, '.list-collection > ul > li');
     },
     change: function(index, e = {}) {
-      if (e.target.checked && index != get(this, 'checked')) {
+      if (e.target.checked && index !== get(this, 'checked')) {
         set(this, 'checked', parseInt(index));
         this.$row = this.dom.closest('li', e.target);
         this.$row.style.zIndex = 1;

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.hbs
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.hbs
@@ -18,7 +18,7 @@
       <YieldSlot @name="row">{{yield cell.item index}}</YieldSlot>
 {{#if hasActions }}
       <td class="actions">
-        <YieldSlot @name="actions" @params={{block-params (concat cell.index) (action "change") checked}}>
+        <YieldSlot @name="actions" @params={{block-params cell.index (action "change") checked}}>
           {{yield cell.item index}}
         </YieldSlot>
       </td>

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.js
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.js
@@ -98,7 +98,7 @@ export default CollectionComponent.extend(Slotted, {
       if (this.$tr) {
         this.$tr.style.zIndex = null;
       }
-      if (e.target.checked && index !== get(this, 'checked')) {
+      if (e.target && e.target.checked && index !== get(this, 'checked')) {
         set(this, 'checked', parseInt(index));
         const target = e.target;
         const $tr = this.dom.closest('tr', target);

--- a/ui/packages/consul-ui/app/components/tabular-collection/index.js
+++ b/ui/packages/consul-ui/app/components/tabular-collection/index.js
@@ -95,13 +95,10 @@ export default CollectionComponent.extend(Slotted, {
       return this.dom.clickFirstAnchor(e);
     },
     change: function(index, e = {}) {
-      if (typeof index !== 'string') {
-        return;
-      }
       if (this.$tr) {
         this.$tr.style.zIndex = null;
       }
-      if (e.target.checked && index != get(this, 'checked')) {
+      if (e.target.checked && index !== get(this, 'checked')) {
         set(this, 'checked', parseInt(index));
         const target = e.target;
         const $tr = this.dom.closest('tr', target);


### PR DESCRIPTION
This PR fixes an issue that has appeared since our Ember upgrade from https://github.com/hashicorp/consul/pull/8761 where our dropdown action menus would not close when the user clicks outside them.

From my vague memory (I can't find any description in history for it) the code I've removed here was added a result of a previous upgrade, so I'm guessing a regression was fixed somewhere that affected us.

Before:

![before](https://user-images.githubusercontent.com/554604/97867902-9f9fee80-1d06-11eb-921c-ef258d076501.gif)

After:

![after](https://user-images.githubusercontent.com/554604/97867911-a464a280-1d06-11eb-9021-4c311fab5517.gif)


