### PR TITLE
use hashicorp docker mirror in envoy helper

### DIFF
--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -224,7 +224,7 @@ function snapshot_envoy_admin {
   local ENVOY_NAME=$2
   local DC=${3:-primary}
   local OUTDIR="${LOG_DIR}/envoy-snapshots/${DC}/${ENVOY_NAME}"
-  
+
   mkdir -p "${OUTDIR}"
   docker_wget "$DC" "http://${HOSTPORT}/config_dump" -q -O - > "${OUTDIR}/config_dump.json"
   docker_wget "$DC" "http://${HOSTPORT}/clusters?format=json" -q -O - > "${OUTDIR}/clusters.json"
@@ -458,7 +458,7 @@ function docker_consul {
 function docker_wget {
   local DC=$1
   shift 1
-  docker run --rm --network container:envoy_consul-${DC}_1 alpine:3.9 wget "$@"
+  docker run --rm --network container:envoy_consul-${DC}_1 docker.mirror.hashicorp.services/alpine:3.9 wget "$@"
 }
 
 function docker_curl {


### PR DESCRIPTION
Missed this one in the initial sweep. 