### PR TITLE
fix envoy integ test wait_for_namespace to actually work on CI

### DIFF
--- a/test/integration/connect/envoy/helpers.bash
+++ b/test/integration/connect/envoy/helpers.bash
@@ -687,7 +687,8 @@ function read_config_entry {
 }
 
 function wait_for_namespace {
-  retry_default curl -sL -f "http://127.0.0.1:8500/v1/namespace/${1}" >/dev/null
+  local DC=${1:-primary}
+  retry_default docker_curl "$DC" -sLf "http://127.0.0.1:8500/v1/namespace/${1}" >/dev/null
 }
 
 function wait_for_config_entry {


### PR DESCRIPTION
This is used in `setup.sh` scripts in bats, which do _not_ run in the `verify` container, so need to get access to the appropriate consul instance.