### PR TITLE
Correcting text on when default was changed in Consul

### DIFF
--- a/website/pages/docs/upgrading/upgrade-specific.mdx
+++ b/website/pages/docs/upgrading/upgrade-specific.mdx
@@ -128,8 +128,8 @@ Starting with Consul 1.7.1 this is the new default.
 ### Vault: default `http_max_conns_per_client` too low to run Vault properly
 
 Consul 1.6.3 introduced [limiting of connections per client](/docs/agent/options#http_max_conns_per_client). The default value
-was 100, but Vault could use up to 128, which caused problems. If you want to use Vault with Consul 1.6.3, you should change the value to 200.
-Starting with Consul 1.6.4 this is the new default.
+was 100, but Vault could use up to 128, which caused problems. If you want to use Vault with Consul 1.6.3 through 1.7.0, you should change the value to 200.
+Starting with Consul 1.7.1 this is the new default.
 
 ## Consul 1.6.0
 


### PR DESCRIPTION
Found that the default setting for `http_max_conns_per_client` wasn't increased as stated in the upgrade guide for any of the v1.6.4+ releases, [as seen here](https://github.com/hashicorp/consul/blob/v1.6.9/agent/config/default.go#L104).  Correcting text to advise explicitly setting it if upgrading to v1.6.3-v1.7.0.