### PR TITLE
ui: Metrics - Provide a fetch-like http client that automatically adds the current ACL token

### DIFF
--- a/ui/packages/consul-ui/app/services/client/http.js
+++ b/ui/packages/consul-ui/app/services/client/http.js
@@ -152,6 +152,17 @@ export default Service.extend({
     params.headers[CONTENT_TYPE] = 'application/json; charset=utf-8';
     return params;
   },
+  fetchWithToken: function(path, params) {
+    return this.settings.findBySlug('token').then(token => {
+      return fetch(`${path}`, {
+        ...params,
+        headers: {
+          'X-Consul-Token': typeof token.SecretID === 'undefined' ? '' : token.SecretID,
+          ...params.headers,
+        },
+      });
+    });
+  },
   request: function(cb) {
     const client = this;
     return cb(function(strs, ...values) {

--- a/ui/packages/consul-ui/app/services/repository/metrics.js
+++ b/ui/packages/consul-ui/app/services/repository/metrics.js
@@ -11,6 +11,7 @@ const meta = {
 
 export default RepositoryService.extend({
   cfg: service('ui-config'),
+  settings: service('settings'),
   error: null,
 
   init: function() {
@@ -20,6 +21,10 @@ export default RepositoryService.extend({
     // JSON options the user provided.
     const opts = uiCfg.metrics_provider_options || {};
     opts.metrics_proxy_enabled = uiCfg.metrics_proxy_enabled;
+    // Inject a convenience function for dialing through the metrics proxy.
+    opts.httpGet = (path, params) => {
+      return this.httpGet(path, params);
+    };
     // Inject the base app URL
     const provider = uiCfg.metrics_provider || 'prometheus';
 
@@ -31,6 +36,44 @@ export default RepositoryService.extend({
       // Dev.
       console.error(this.error); // eslint-disable-line no-console
     }
+  },
+
+  httpGet: function(path, params) {
+    var xhr = new XMLHttpRequest();
+    var self = this;
+    return self.settings.findBySlug('token').then(token => {
+      var tokenValue = typeof token.SecretID === 'undefined' ? '' : token.SecretID;
+
+      return new Promise(function(resolve, reject) {
+        xhr.onreadystatechange = function() {
+          if (xhr.readyState !== 4) return;
+
+          if (xhr.status == 200) {
+            // Attempt to parse response as JSON and return the object
+            var o = JSON.parse(xhr.responseText);
+            resolve(o);
+          }
+          const e = new Error(xhr.statusText);
+          e.statusCode = xhr.status;
+          reject(e);
+        };
+
+        var url = '/v1/internal/ui/metrics-proxy' + path;
+        if (params) {
+          var qs = Object.keys(params)
+            .map(function(key) {
+              return encodeURIComponent(key) + '=' + encodeURIComponent(params[key]);
+            })
+            .join('&');
+          url = url + '?' + qs;
+        }
+        xhr.open('GET', url, true);
+        if (tokenValue) {
+          xhr.setRequestHeader('X-Consul-Token', tokenValue);
+        }
+        xhr.send();
+      });
+    });
   },
 
   findServiceSummary: function(protocol, slug, dc, nspace, configuration = {}) {

--- a/ui/packages/consul-ui/vendor/metrics-providers/prometheus.js
+++ b/ui/packages/consul-ui/vendor/metrics-providers/prometheus.js
@@ -22,6 +22,10 @@
       if (!this.options.metrics_proxy_enabled) {
         throw new Error("prometheus metrics provider currently requires the ui_config.metrics_proxy to be configured in the Consul agent.");
       }
+      if (!this.options.httpGet) {
+        throw new Error("missing required option 'httpGet'");
+      }
+      this.httpGet = this.options.httpGet;
     },
 
     /**
@@ -656,42 +660,6 @@
       return this.httpGet("/api/v1/query_range", params)
     },
 
-    httpGet: function(path, params) {
-      var xhr = new XMLHttpRequest();
-      var self = this
-      return new Promise(function(resolve, reject){
-        xhr.onreadystatechange = function(){
-          if (xhr.readyState !== 4) return;
-
-          if (xhr.status == 200) {
-            // Attempt to parse response as JSON and return the object
-            var o = JSON.parse(xhr.responseText)
-            resolve(o)
-          }
-          const e = new Error(xhr.statusText);
-          e.statusCode = xhr.status;
-          reject(e);
-        }
-
-        var url = self.baseURL()+path;
-        if (params) {
-          var qs = Object.keys(params).
-          map(function(key){
-            return encodeURIComponent(key)+"="+encodeURIComponent(params[key])
-          }).
-          join("&")
-          url = url+"?"+qs
-        }
-        xhr.open("GET", url, true);
-        xhr.send();
-      });
-    },
-
-    baseURL: function() {
-      // TODO support configuring a direct Prometheus via
-      // metrics_provider_options_json.
-      return "/v1/internal/ui/metrics-proxy"
-    }
   }
 
   // Helper functions


### PR DESCRIPTION
This PR creates wraps up `window.fetch` with an additional piece of functionality to shim in:

1. Consul's metrics proxy path prefixed on
2. Any current ACL token in use in the UI will be added to fetch's headers.

And passes this through to the provider as `options.fetch`.

I figured that in using `fetch` we are sticking to a recognisable interface that is simpler to use than XHR and means that we have a documented interface to stick to aswell as anyone writing custom providers.

I moved any additional functionality (query param encoding) back into the provider so we keep as close to fetch as possible.