### PR TITLE
agent: sanitize ui metrics proxy header values on agent/self endpoint

### DIFF
--- a/agent/config/runtime.go
+++ b/agent/config/runtime.go
@@ -1843,6 +1843,21 @@ func sanitize(name string, v reflect.Value) reflect.Value {
 
 	case isArray(typ) || isSlice(typ):
 		ma := make([]interface{}, 0, v.Len())
+
+		if name == "AddHeaders" {
+			// must be UIConfig.MetricsProxy.AddHeaders
+			for i := 0; i < v.Len(); i++ {
+				addr := v.Index(i).Addr()
+				hdr := addr.Interface().(*UIMetricsProxyAddHeader)
+				hm := map[string]interface{}{
+					"Name":  hdr.Name,
+					"Value": "hidden",
+				}
+				ma = append(ma, hm)
+			}
+			return reflect.ValueOf(ma)
+		}
+
 		if strings.HasPrefix(name, "SerfAllowedCIDRs") {
 			for i := 0; i < v.Len(); i++ {
 				addr := v.Index(i).Addr()

--- a/agent/config/runtime_test.go
+++ b/agent/config/runtime_test.go
@@ -7470,6 +7470,13 @@ func TestSanitize(t *testing.T) {
 			*parseCIDR(t, "127.0.0.0/8"),
 		},
 		TxnMaxReqLen: 5678000000000000,
+		UIConfig: UIConfig{
+			MetricsProxy: UIMetricsProxy{
+				AddHeaders: []UIMetricsProxyAddHeader{
+					{Name: "foo", Value: "secret"},
+				},
+			},
+		},
 	}
 
 	rtJSON := `{
@@ -7812,7 +7819,12 @@ func TestSanitize(t *testing.T) {
 			"MetricsProviderFiles": [],
 			"MetricsProviderOptionsJSON": "",
 			"MetricsProxy": {
-				"AddHeaders": [],
+				"AddHeaders": [
+					{
+						"Name": "foo",
+						"Value": "hidden"
+					}
+				],
 				"BaseURL": "",
 				"PathAllowlist": []
 			},


### PR DESCRIPTION
The documentation indicates that the "add_headers" config option for the UI metrics proxy can be used to add additional credentials for the metrics backend which implies the value portion of this may contain secrets.

This PR replaces all header values with `"hidden"` when accessed via the `/v1/agent/self` endpoint.