### PR TITLE
Add namespaces to prepared query API docs

### DIFF
--- a/website/content/api-docs/query.mdx
+++ b/website/content/api-docs/query.mdx
@@ -177,6 +177,9 @@ The table below shows this endpoint's support for
 
   - `Service` `(string: <required>)` - Specifies the name of the service to
     query.
+    
+  - `Namespace` `(string: "")` <EnterpriseAlert inline /> - Specifies the Consul namespace
+    to query. If not provided the query will use Consul default namespace for resolution. 
 
   - `Failover` contains two fields, both of which are optional, and determine
     what happens if no healthy nodes are available in the local datacenter when


### PR DESCRIPTION
Add missing section on creating prepared query for namespaced services