### PR TITLE
ui: remove consul-api-double from yarn.lock

### DIFF
--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1530,11 +1530,6 @@
     faker "^4.1.0"
     js-yaml "^3.13.1"
 
-"@hashicorp/consul-api-double@^6.1.4":
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/@hashicorp/consul-api-double/-/consul-api-double-6.1.4.tgz#ef86f6d3bf0871374b108190081d535cd8db8165"
-  integrity sha512-7DLR0KE66164ju2MIFzC3A5LE09gfxz12MfbWaKmaVAGfgN7aO/mZ3nKHZjSlEwLUUHhftZ6GvuveAP/wlKabw==
-
 "@hashicorp/ember-cli-api-double@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@hashicorp/ember-cli-api-double/-/ember-cli-api-double-3.1.2.tgz#0eaee116da1431ed63e55eea9ff9c28028cf9f8c"


### PR DESCRIPTION
Followup to #9084, just found it while running `yarn`