### PR TITLE
connect: Switch the default gateway port from 443 to 8443

### DIFF
--- a/.changelog/9113.txt
+++ b/.changelog/9113.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+connect: Switch the default gateway port from 443 to 8443 to avoid assumptiuon of Envoy running as root.
+```

--- a/.changelog/9113.txt
+++ b/.changelog/9113.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-connect: Switch the default gateway port from 443 to 8443 to avoid assumptiuon of Envoy running as root.
+connect: Switch the default gateway port from 443 to 8443 to avoid assumption of Envoy running as root.
 ```

--- a/command/connect/envoy/flags.go
+++ b/command/connect/envoy/flags.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/go-sockaddr/template"
 )
 
-const defaultGatewayPort int = 443
+const defaultGatewayPort int = 8443
 
 // ServiceAddressValue implements a flag.Value that may be used to parse an
 // addr:port string into an api.ServiceAddress.

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -31,12 +31,12 @@ func TestServiceAddressValue_Value(t *testing.T) {
 func TestServiceAddressValue_String(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-		require.Equal(t, addr.String(), ":443")
+        require.Equal(t, addr.String(), ":8443")
 	})
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-		require.Equal(t, addr.String(), ":443")
+        require.Equal(t, addr.String(), ":8443")
 	})
 
 	t.Run("set value", func(t *testing.T) {

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -31,7 +31,7 @@ func TestServiceAddressValue_Value(t *testing.T) {
 func TestServiceAddressValue_String(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var addr *ServiceAddressValue
-        require.Equal(t, addr.String(), ":8443")
+		require.Equal(t, addr.String(), ":8443")
 	})
 
 	t.Run("default value", func(t *testing.T) {

--- a/command/connect/envoy/flags_test.go
+++ b/command/connect/envoy/flags_test.go
@@ -36,7 +36,7 @@ func TestServiceAddressValue_String(t *testing.T) {
 
 	t.Run("default value", func(t *testing.T) {
 		addr := &ServiceAddressValue{}
-        require.Equal(t, addr.String(), ":8443")
+		require.Equal(t, addr.String(), ":8443")
 	})
 
 	t.Run("set value", func(t *testing.T) {

--- a/command/connect/envoy/testdata/ingress-gateway.golden
+++ b/command/connect/envoy/testdata/ingress-gateway.golden
@@ -53,7 +53,7 @@
         "address": {
           "socket_address": {
             "address": "127.0.0.1",
-            "port_value": 443
+            "port_value": 8443
           }
         },
         "filter_chains": [


### PR DESCRIPTION
To avoid assumption of Envoy running as root.

Fixes #8948

/cc @shoenig 